### PR TITLE
chore: change `Widnow` typo to `Window`

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -21,7 +21,7 @@
 export class Log {
 
   /**
-   * @param {!Widnow} win
+   * @param {!Window} win
    */
   constructor(win) {
     /** @const {!Window} */

--- a/src/timer.js
+++ b/src/timer.js
@@ -20,7 +20,7 @@
 export class Timer {
 
   /**
-   * @param {!Widnow} win
+   * @param {!Window} win
    */
   constructor(win) {
     /** @const {!Window} */

--- a/src/vsync.js
+++ b/src/vsync.js
@@ -38,7 +38,7 @@ class VsyncTaskSpec {}
 export class Vsync {
 
   /**
-   * @param {!Widnow} win
+   * @param {!Window} win
    */
   constructor(win) {
     /** @const {!Window} */


### PR DESCRIPTION
minor typo fixes.
