### PR TITLE
Srcset implementation for amp-img, amp-anim, amp-video and other

### DIFF
--- a/src/srcset.js
+++ b/src/srcset.js
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from './asserts';
+
+
+/**
+ * A single source within a srcset. Only one: width or DPR can be specified at
+ * a time.
+ * @typedef {{
+ *   url: string,
+ *   width: (number|undefined),
+ *   dpr: (number|undefined)
+ * }}
+ */
+var SrcsetSource;
+
+
+/**
+ * Parses the text representation of srcset into Srcset object.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes.
+ * @param {string} s
+ * @return {!Srcset}
+ */
+export function parseSrcset(s) {
+  let sSources = s.split(',');
+  assert(sSources.length > 0, 'srcset has to have at least one source');
+  let sources = [];
+  sSources.forEach((sSource) => {
+    let parts = sSource.trim().split(/\s+/, 2);
+    if (parts.length == 0 ||
+          parts.length == 1 && !parts[0] ||
+          parts.length == 2 && !parts[0] && !parts[1]) {
+      return;
+    }
+    let url = parts[0].trim();
+    if (parts.length == 1 || parts.length == 2 && !parts[1]) {
+      sources.push({url: url});
+    } else {
+      let spec = parts[1].trim().toLowerCase();
+      let lastChar = spec.substring(spec.length - 1);
+      if (lastChar == 'w') {
+        sources.push({url: url, width: parseFloat(spec)});
+      } else if (lastChar == 'x') {
+        sources.push({url: url, dpr: parseFloat(spec)});
+      }
+    }
+  });
+  return new Srcset(sources);
+};
+
+
+/**
+ * A srcset object contains one or more sources.
+ *
+ * There are two types of sources: width-based and DPR-based. Only one type
+ * of sources allowed to be specified within a single srcset. Depending on a
+ * usecase, the components are free to choose any source that best corresponds
+ * to the required rendering quality and network and CPU conditions. See
+ * "select" method for details on how this selection is performed.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes
+ */
+export class Srcset {
+
+  /**
+   * @param {!Array<!SrcsetSource>} sources
+   */
+  constructor(sources) {
+    assert(sources.length > 0, 'Srcset must have at least one source');
+    /** @private @const {!Array<!SrcsetSource>} */
+    this.sources_ = sources;
+
+    // Only one type of source specified can be used - width or DPR.
+    let hasWidth = false;
+    let hasDpr = false;
+    this.sources_.forEach((source) => {
+      hasWidth = hasWidth || !!source.width;
+      hasDpr = hasDpr || !!source.dpr;
+    });
+    assert(!hasWidth || !hasDpr,
+        'Srcset cannot have both width and dpr sources');
+
+    // The last source must not have either width or DPR specified.
+    let last = this.sources_[this.sources_.length - 1];
+    assert(!last.width && !last.dpr,
+        'Last source in a srcset must not have width or DPR');
+
+    /** @private @const {boolean} */
+    this.widthBased_ = hasWidth;
+
+    /** @private @const {boolean} */
+    this.dprBased_ = hasDpr;
+  }
+
+  /**
+   * Performs selection for specified width and DPR. Here, width is the width
+   * in screen pixels and DPR is the device-pixel-ratio or pixel density of
+   * the device. Depending on the circumstances, such as low network conditions,
+   * it's possible to manipulate the result of this method by passing a lower
+   * DPR value.
+   *
+   * The source selection depends on whether this is width-based or DPR-based
+   * srcset.
+   *
+   * In a width-based source, the source's width is the physical width of a
+   * resource (e.g. an image). Depending on the provided DPR, this width is
+   * converted to the screen pixels as following:
+   *   pixelWidth = sourceWidth / DPR
+   *
+   * Then, the source closest to the requested "width" is selected using
+   * the "pixelWidth". The slight preference is given to the bigger sources to
+   * ensure the most optimal quality.
+   *
+   * In a DPR-based source, the source's DPR is used to return the source that
+   * is closest to the requested DPR.
+   *
+   * Based on
+   * http://www.w3.org/html/wg/drafts/html/master/semantics.html#attr-img-srcset.
+   * @param {number} width
+   * @param {number} dpr
+   * @return {!SrcsetSource}
+   */
+  select(width, dpr) {
+    assert(width);
+    assert(dpr);
+    let index = -1;
+    if (this.widthBased_) {
+      index = this.selectByWidth_(width, dpr);
+    } else if (this.dprBased_) {
+      index = this.selectByDpr_(width, dpr);
+    }
+    if (index != -1) {
+      return this.sources_[index];
+    }
+    return this.getLast();
+  }
+
+  /**
+   * @param {number} width
+   * @param {number} dpr
+   * @return {number}
+   * @private
+   */
+  selectByWidth_(width, dpr) {
+    let minIndex = -1;
+    let minWidth = 1000000;
+    let minScore = 1000000;
+    for (let i = 0; i < this.sources_.length; i++) {
+      let source = this.sources_[i];
+      let sourceWidth;
+      if (source.width) {
+        sourceWidth = source.width / dpr;
+      } else {
+        // Default source: no width: assume values are half of of the
+        // minimum values seen.
+        sourceWidth = minWidth / 2;
+      }
+      minWidth = Math.min(minWidth, sourceWidth);
+      // The calculation is slightly biased toward higher width by offsetting
+      // score by negative 0.2.
+      let score = Math.abs((sourceWidth - width) / width - 0.2);
+      if (score < minScore) {
+        minScore = score;
+        minIndex = i;
+      }
+    }
+    return minIndex;
+  }
+
+  /**
+   * @param {number} width
+   * @param {number} dpr
+   * @return {number}
+   * @private
+   */
+  selectByDpr_(width, dpr) {
+    let minIndex = -1;
+    let minScore = 1000000;
+    for (let i = 0; i < this.sources_.length; i++) {
+      let source = this.sources_[i];
+      // Default DPR = 1.
+      let sourceDpr = source.dpr || 1;
+      let score = Math.abs(sourceDpr - dpr);
+      if (score < minScore) {
+        minScore = score;
+        minIndex = i;
+      }
+    }
+    return minIndex;
+  }
+
+  /**
+   * Returns the last source in the srcset, which is the default source.
+   * @return {!SrcsetSource}
+   */
+  getLast() {
+    return this.sources_[this.sources_.length - 1];
+  }
+}

--- a/test/functional/test-srcset.js
+++ b/test/functional/test-srcset.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Srcset, parseSrcset} from '../../src/srcset';
+
+describe('Srcset', () => {
+
+  it('parseSrcset - single source', () => {
+    var res = parseSrcset(' \n image \n ');
+    expect(res.sources_.length).to.equal(1);
+    expect(res.sources_[0].url).to.equal('image');
+    expect(res.sources_[0].width).to.equal(undefined);
+    expect(res.sources_[0].dpr).to.equal(undefined);
+  });
+
+  it('parseSrcset - empty source', () => {
+    var res = parseSrcset(' \n image \n, ');
+    expect(res.sources_.length).to.equal(1);
+    expect(res.sources_[0].url).to.equal('image');
+  });
+
+  it('parseSrcset - multiple sources', () => {
+    var res = parseSrcset(' \n image \n, image2 \n');
+    expect(res.sources_.length).to.equal(2);
+    expect(res.sources_[0].url).to.equal('image');
+    expect(res.sources_[1].url).to.equal('image2');
+  });
+
+  it('parseSrcset - width sources', () => {
+    var res = parseSrcset(' \n image-100 100w\n, image');
+    expect(res.sources_.length).to.equal(2);
+    expect(res.sources_[0].url).to.equal('image-100');
+    expect(res.sources_[0].width).to.equal(100);
+    expect(res.sources_[0].dpr).to.equal(undefined);
+    expect(res.sources_[1].url).to.equal('image');
+  });
+
+  it('parseSrcset - dpr sources', () => {
+    var res = parseSrcset(' \n image-x1.5 1.5x\n , image');
+    expect(res.sources_.length).to.equal(2);
+    expect(res.sources_[0].url).to.equal('image-x1.5');
+    expect(res.sources_[0].width).to.equal(undefined);
+    expect(res.sources_[0].dpr).to.equal(1.5);
+    expect(res.sources_[1].url).to.equal('image');
+  });
+
+  it('parseSrcset - several sources', () => {
+    var res = parseSrcset(' \n image1 100w\n , \n image2 50w\n , image3 ');
+    expect(res.sources_.length).to.equal(3);
+    expect(res.sources_[0].url).to.equal('image1');
+    expect(res.sources_[0].width).to.equal(100);
+    expect(res.sources_[0].dpr).to.equal(undefined);
+
+    expect(res.sources_[1].url).to.equal('image2');
+    expect(res.sources_[1].width).to.equal(50);
+    expect(res.sources_[1].dpr).to.equal(undefined);
+
+    expect(res.sources_[2].url).to.equal('image3');
+    expect(res.sources_[2].width).to.equal(undefined);
+    expect(res.sources_[2].dpr).to.equal(undefined);
+  });
+
+  it('parseSrcset - mixed sources', () => {
+    expect(() => {
+      parseSrcset(' \n image1 100w\n , \n image2 1.5x\n , image3 ');
+    }).to.throw(/Srcset cannot have both width and dpr sources/);
+  });
+
+  it('parseSrcset - non-default last source', () => {
+    expect(() => {
+      parseSrcset(' \n image1 100w\n , image3 1w');
+    }).to.throw(/Last source in a srcset must not have width or DPR/);
+  });
+
+  it('select by width', () => {
+    let srcset = new Srcset([
+        {url: 'image-1000', width: 1000},
+        {url: 'image-500', width: 500},
+        {url: 'image-250', width: 250},
+        {url: 'image'}
+      ]);
+
+    // DPR = 1
+    expect(srcset.select(2000, 1).url).to.equal('image-1000');
+    expect(srcset.select(1100, 1).url).to.equal('image-1000');
+    expect(srcset.select(1000, 1).url).to.equal('image-1000');
+    expect(srcset.select(900, 1).url).to.equal('image-1000');
+    expect(srcset.select(700, 1).url).to.equal('image-1000');
+    expect(srcset.select(600, 1).url).to.equal('image-500');
+    expect(srcset.select(500, 1).url).to.equal('image-500');
+    expect(srcset.select(400, 1).url).to.equal('image-500');
+    expect(srcset.select(300, 1).url).to.equal('image-250');
+    expect(srcset.select(200, 1).url).to.equal('image-250');
+    expect(srcset.select(100, 1).url).to.equal('image');
+    expect(srcset.select(50, 1).url).to.equal('image');
+    expect(srcset.select(1, 1).url).to.equal('image');
+
+    // DPR = 2
+    expect(srcset.select(2000, 2).url).to.equal('image-1000');
+    expect(srcset.select(1100, 2).url).to.equal('image-1000');
+    expect(srcset.select(1000, 2).url).to.equal('image-1000');
+    expect(srcset.select(900, 2).url).to.equal('image-1000');
+    expect(srcset.select(700, 2).url).to.equal('image-1000');
+    expect(srcset.select(600, 2).url).to.equal('image-1000');
+    expect(srcset.select(500, 2).url).to.equal('image-1000');
+    expect(srcset.select(400, 2).url).to.equal('image-1000');
+    expect(srcset.select(300, 2).url).to.equal('image-500');
+    expect(srcset.select(200, 2).url).to.equal('image-500');
+    expect(srcset.select(100, 2).url).to.equal('image-250');
+    expect(srcset.select(50, 2).url).to.equal('image');
+    expect(srcset.select(1, 2).url).to.equal('image');
+  });
+
+  it('select by dpr', () => {
+    let srcset = new Srcset([
+        {url: 'image-3x', dpr: 3},
+        {url: 'image-2x', dpr: 2},
+        {url: 'image'}
+      ]);
+
+    expect(srcset.select(2000, 4).url).to.equal('image-3x', 'dpr=4');
+    expect(srcset.select(2000, 3.5).url).to.equal('image-3x', 'dpr=3.5');
+    expect(srcset.select(2000, 3).url).to.equal('image-3x', 'dpr=3');
+    expect(srcset.select(2000, 2.7).url).to.equal('image-3x', 'dpr=2.7');
+    expect(srcset.select(2000, 2.5).url).to.equal('image-3x', 'dpr=2.5');
+    expect(srcset.select(2000, 2.3).url).to.equal('image-2x', 'dpr=2.3');
+    expect(srcset.select(2000, 2).url).to.equal('image-2x', 'dpr=2');
+    expect(srcset.select(2000, 1.7).url).to.equal('image-2x', 'dpr=1.7');
+    expect(srcset.select(2000, 1.5).url).to.equal('image-2x', 'dpr=1.5');
+    expect(srcset.select(2000, 1.3).url).to.equal('image', 'dpr=1.3');
+    expect(srcset.select(2000, 1.2).url).to.equal('image', 'dpr=1.2');
+    expect(srcset.select(2000, 1).url).to.equal('image', 'dpr=1');
+  });
+});


### PR DESCRIPTION
This is a specific take on "srcset" for AMP. This implementation is mostly within the HTML5 spec but with one caveat that it doesn't need "sizes" attribute. See Srcset.select method for the detail explanation, but in short:
1. Either DPR-based (2x) or width-based (100w) sources are allowed. They cannot be mixed. As in HTML5 spec.
2. In a width-based source "w" is always physical image width, NOT in screen pixels.
3. In AMP DPR- or width-based srcsets are interchangeable, but width-based would work better for responsive elements since the width gives more information.
4. The selection depends on the type of srcset, but it always looks for a source closest to the request screen-pixel width and DPR. When there's no exact match, the algorithm currently prioritizes higher quality sources slightly higher for better quality. However, this can be easily customized by providing a custom DPR that would incorporate network quality as needed.

An example with DPR-based srcset:

<amp-img srcset="image2x 2x, image1x">

In this example:
- select(_, 3) would return image2x
- select(_, 2) would return image2x
- select(_, 1.5) would return image2x
- select(_, 1.4) would return image1x
- select(_, 1) would return image1x

An example with DPR-based srcset:

<amp-img srcset="image1000 1000w, image500 500w, image">

Here:
- select(1000, 1) would return image1000
- select(700, 1) would return image1000 due to slightly higher priority for bigger images
- select(600, 1) would return image500
- select(500, 1) would return image500
- select(200, 1) would return image
- select(1000, 2) would return image1000
- select(500, 2) would return image1000 b/c you need 1000 physical pixels to render on 500px with DPR=2
- select(200, 2) would return image500 b/c of DPR=2
