### PR TITLE
chore(*): switch from for...of to normal c style loops to iterate over array

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -182,7 +182,8 @@ export class Action {
     let actionMap = null;
     let actions = s.split(';');
     if (actions && actions.length > 0) {
-      for (let actionStr of actions) {
+      for (let i = 0; i < actions.length; i++) {
+        let actionStr = actions[i];
         let actionInfo = this.parseAction_(actionStr);
         if (actionInfo) {
           if (!actionMap) {

--- a/src/animation.js
+++ b/src/animation.js
@@ -132,7 +132,8 @@ class AnimationPlayer {
 
     /** @private @const {!Array<!SegmentRuntime_>} */
     this.segments_ = [];
-    for (let segment of segments) {
+    for (let i = 0; i < segments.length; i++) {
+      let segment = segments[i];
       this.segments_.push({
         delay: segment.delay,
         func: segment.func,
@@ -282,14 +283,16 @@ class AnimationPlayer {
         this.duration_, 1);
 
     // Start segments due to be started
-    for (let segment of this.segments_) {
+    for (let i = 0; i < this.segments_.length; i++) {
+      let segment = this.segments_[i];
       if (!segment.started && normLinearTime >= segment.delay) {
         segment.started = true;
       }
     }
 
     // Execute all pending segments.
-    for (let segment of this.segments_) {
+    for (let i = 0; i < this.segments_.length; i++) {
+      let segment = this.segments_[i];
       if (!segment.started || segment.completed) {
         continue;
       }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -132,7 +132,8 @@ export class BaseElement {
    * @protected @final
    */
   propagateAttributes(attributes, element) {
-    for (let attr of attributes) {
+    for (let i = 0; i < attributes.length; i++) {
+      let attr = attributes[i];
       if (!this.element.hasAttribute(attr)) {
         continue;
       }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -45,7 +45,8 @@ export function upgradeOrRegisterElement(win, name, toClass) {
   }
   assert(knownElements[name] == ElementStub,
       'Expected ' + name + ' to be an ElementStub.');
-  for (let stub of stubbedElements) {
+  for (let i = 0; i < stubbedElements.length; i++) {
+    let stub = stubbedElements[i];
     // There are 3 possible states here:
     // 1. We never made the stub because the extended impl. loaded first.
     //    In that case the element won't be in the array.

--- a/src/element-stub.js
+++ b/src/element-stub.js
@@ -18,6 +18,7 @@ import {BaseElement} from './base-element';
 import {Layout} from './layout';
 
 
+/** @type {!Array} */
 export const stubbedElements = [];
 
 export class ElementStub extends BaseElement {

--- a/src/resources.js
+++ b/src/resources.js
@@ -80,7 +80,8 @@ export class Resources {
 
     // Phase 1: Relayout as needed.
     let relayoutCount = 0;
-    for (let r of this.resources_) {
+    for (let i = 0; i < this.resources_.length; i++) {
+      let r = this.resources_[i];
       if (!r.isLayoutReady() || rebuild) {
         r.applyMediaQuery();
         r.layout();
@@ -92,7 +93,8 @@ export class Resources {
     if (relayoutCount > 0) {
       // TODO(dvoytenko): optimize: most likely not everything has to be
       // re-measured.
-      for (let r of this.resources_) {
+      for (let i = 0; i < this.resources_.length; i++) {
+        let r = this.resources_[i];
         r.measure();
       }
       this.resources_.sort((r1, r2) => {
@@ -128,7 +130,8 @@ export class Resources {
     // TODO(dvoytenko): what about slides? All of its content is at the same
     // box.top, but only few are visible at a time.
     // TODO(dvoytenko): some elements are explicitly not visible (amp-pixel)
-    for (let r of this.resources_) {
+    for (let i = 0; i < this.resources_.length; i++) {
+      let r = this.resources_[i];
       let box = r.getLayoutBox();
       if (box.height == 0) {
         // Not visible
@@ -146,7 +149,8 @@ export class Resources {
     var activeBottom = viewportBottom + viewportHeight / 4;
     log.fine(TAG_, 'activate window: ' + activeTop + '/' + activeBottom + ', ' +
         viewportBottom + ', ' + viewportHeight);
-    for (let r of this.resources_) {
+    for (let i = 0; i < this.resources_.length; i++) {
+      let r = this.resources_[i];
       let box = r.getLayoutBox();
       if (box.height == 0) {
         // Not visible
@@ -167,7 +171,8 @@ export class Resources {
     // Phase 5: Idle loading
     // TODO(dvoytenko): document/estimate IDLE timeouts and other constants
     if (now > this.lastLoading_ + 3000) {
-      for (let r of this.resources_) {
+      for (let i = 0; i < this.resources_.length; i++) {
+        let r = this.resources_[i];
         let box = r.getLayoutBox();
         if (box.height == 0) {
           // Not visible

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -21,6 +21,7 @@ import {registerElement} from './custom-element';
 import {registerExtendedElement} from './extended-element';
 
 
+/** @type {!Array} */
 const elementsForTesting = [];
 
 
@@ -72,7 +73,8 @@ export function adopt(global) {
   };
 
   // Execute asynchronously scheduled elements.
-  for (let fn of preregisteredElements) {
+  for (let i = 0; i < preregisteredElements.length; i++) {
+    let fn = preregisteredElements[i];
     fn(global.AMP);
   }
 };
@@ -86,7 +88,8 @@ export function adopt(global) {
  * @param {!Window} global Global scope to adopt.
  */
 export function registerForUnitTest(win) {
-  for (let element of elementsForTesting) {
+  for (let i = 0; i < elementsForTesting.length; i++) {
+    let element = elementsForTesting[i];
     registerElement(win, element.name, element.implementationClass);
   }
 }

--- a/src/transition.js
+++ b/src/transition.js
@@ -37,7 +37,8 @@ export var NULL = function(time) {return null;};
  */
 export function all(transitions) {
   return (time) => {
-    for (let tr of transitions) {
+    for (let i = 0; i < transitions.length; i++) {
+      let tr = transitions[i];
       tr(time);
     }
   };

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -57,4 +57,34 @@ describe('BaseElement', () => {
     expect(elements[0].tagName.toLowerCase()).to.equal('content');
   });
 
+  it('propagateAttributes - niente', () => {
+    let target = document.createElement('div');
+    expect(target.hasAttributes()).to.be.false;
+
+    element.propagateAttributes(['data-test1'], target);
+    expect(target.hasAttributes()).to.be.false;
+
+    element.propagateAttributes(['data-test2', 'data-test3'], target);
+    expect(target.hasAttributes()).to.be.false;
+  });
+
+  it('propagateAttributes', () => {
+    let target = document.createElement('div');
+    expect(target.hasAttributes()).to.be.false;
+
+    div.setAttribute('data-test1', 'abc');
+    div.setAttribute('data-test2', 'xyz');
+    div.setAttribute('data-test3', '123');
+
+    element.propagateAttributes(['data-test1'], target);
+    expect(target.hasAttributes()).to.be.true;
+
+    expect(target.getAttribute('data-test1')).to.equal('abc');
+    expect(target.getAttribute('data-test2')).to.be.null;
+    expect(target.getAttribute('data-test3')).to.be.null;
+
+    element.propagateAttributes(['data-test2', 'data-test3'], target);
+    expect(target.getAttribute('data-test2')).to.equal('xyz');
+    expect(target.getAttribute('data-test3')).to.equal('123');
+  });
 });

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Layout, getLengthNumeral, getLengthUnits, parseLength} from
+import {Layout, getLengthNumeral, getLengthUnits, parseLength, parseLayout} from
     '../../src/layout';
 import {applyLayout_} from '../../src/custom-element';
 
@@ -24,6 +24,19 @@ describe('Layout', () => {
 
   beforeEach(() => {
     div = document.createElement('div');
+  });
+
+  it('parseLayout', () => {
+    expect(parseLayout('nodisplay')).to.equal('nodisplay');
+    expect(parseLayout('fixed')).to.equal('fixed');
+    expect(parseLayout('responsive')).to.equal('responsive');
+    expect(parseLayout('container')).to.equal('container');
+    expect(parseLayout('fill')).to.equal('fill');
+  });
+
+  it('parseLayout - failure', () => {
+    expect(parseLayout('abc')).to.be.undefined;
+    expect(parseLayout('xyz')).to.be.undefined;
   });
 
   it('parseLength', () => {


### PR DESCRIPTION
babel currently creates 2 try blocks if it can't infer that the
object being iterated over is an array and relies on the iterator
protocol mechanisms.
