### PR TITLE
chore(karma): add `bundleDelay` option to karma config

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,7 +29,8 @@ module.exports = function(config) {
     browserify: {
       watch: true,
       debug: true,
-      transform: ['babelify']
+      transform: ['babelify'],
+      bundleDelay: 900
     },
 
     reporters: ['progress'],


### PR DESCRIPTION
added a `bundleDelay` option. seems to fix the issue where karma stops running. will need more people to test it out but from my initial tests (i kept on refreshing the test by pressing save every time it finished) it seems to be working fine now.

references:
https://github.com/nikku/karma-browserify/issues/140
https://github.com/nikku/karma-browserify (bundleDelay option)
