### PR TITLE
Virtual viewport and Viewer configuration and event propagation.

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -36,6 +36,7 @@
 
 .-amp-layout-container {
   display: block;
+  position: relative;
 }
 
 .-amp-layout-fill {
@@ -125,6 +126,7 @@ i-amp-sizer {
 .-amp-element-error {
   background: red !important;
   color: white !important;
+  position: relative !important;
 }
 
 .-amp-element-error::before {

--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -18,9 +18,10 @@
   <script custom-element="amp-twitter" src="../dist/v0/amp-twitter-0.1.max.js" async></script>
   <script custom-element="amp-youtube" src="../dist/v0/amp-youtube-0.1.max.js" async></script>
   <script src="../dist/amp.js" development></script>
+  <script src="./viewer-integr.js" async></script>
   <style>
     body {
-      max-width: 527px;
+      max-width: 736px;
       font-family: 'Questrial', Arial;
     }
     amp-extended-sample.amp-element {

--- a/examples/viewer-integr.js
+++ b/examples/viewer-integr.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * This is a very naive implementation of Viewer/AMP integration, but it
+ * showcases all main APIs exposed by Viewer which are
+ * {@link Viewer.receiveMessage} and {@link Viewer.setMessageDeliverer}.
+ *
+ * The main thing that's missing in this file is any form of security
+ * validation. In the real world, postMessage and message event handler
+ * should both set origin information and validate it when received.
+ */
+(window.AMP = window.AMP || []).push(function(AMP) {
+
+  var SENTINEL = '__AMP__';
+
+  var viewer = AMP.viewer;
+
+  function onMessage(event) {
+    var data = event.data;
+
+    // TODO: must check for origin/target.
+    if (data['sentinel'] == SENTINEL) {
+      viewer.receiveMessage(data['type'], data);
+    }
+  }
+
+  window.addEventListener('message', onMessage, false);
+
+
+  function sendMessage(eventType, data) {
+    // TODO: must check for origin/target.
+    data['sentinel'] = SENTINEL;
+    data['type'] = eventType;
+    window.parent.postMessage(data, '*');
+  }
+
+  viewer.setMessageDeliverer(sendMessage);
+});

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -1,0 +1,246 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Viewer</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style>
+    html, body {
+      overflow: hidden;
+    }
+
+    body {
+      font-family: 'Questrial', Arial;
+    }
+
+    body, viewer {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      overflow: hidden;
+      margin: 0;
+      padding: 0;
+    }
+
+    viewer {
+      background: #eee;
+    }
+
+    header {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 50px;
+      background: #4285F4;
+      opacity: 0.7;
+      color: #fff;
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: center;
+      padding: 0 8px;
+    }
+
+    @media screen and (min-width: 500px) {
+      header {
+        height: 64px;
+      }
+    }
+
+    header h1 {
+      font-size: 22px;
+    }
+
+    .wait {
+      position: absolute;
+      z-index: 3;
+      top: 100px;
+      left: 20px;
+      font-size: 12px;
+    }
+
+    container {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      overflow-x: hidden;
+      overflow-y: auto;
+    }
+
+    container iframe {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+  <script>
+
+    var SENTINEL = '__AMP__';
+
+    function Viewer() {
+      this.alreadyLoaded_ = false;
+
+      this.header = document.querySelector('header');
+      this.container = document.querySelector('container');
+      this.iframe = document.createElement('iframe');
+      this.iframe.style.width = '100%';
+      this.iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+      this.iframe.setAttribute('scrolling', 'no');
+
+      window.addEventListener('message', this.onMessage_.bind(this));
+      this.container.addEventListener('scroll', this.onScroll_.bind(this));
+      window.addEventListener('resize', this.onResize_.bind(this));
+    };
+
+
+    Viewer.prototype.start = function() {
+      var params = {
+        viewportType: 'virtual',
+        width: this.container.offsetWidth,
+        height: this.container.offsetHeight,
+        paddingTop: this.header.offsetHeight
+      };
+      log('Params:' + JSON.stringify(params));
+
+      var url = 'http://localhost:8000/examples/everything.amp.html#' +
+          paramsStr(params);
+      log('AMP URL = ' + url);
+      this.iframe.style.display = 'none';
+      this.container.appendChild(this.iframe);
+
+      // Notice that name can only be set once the IFrame is in the DOM.
+      this.iframe.contentWindow.name = SENTINEL + paramsStr(params);
+
+      this.iframe.onload = this.loaded_.bind(this);
+      setTimeout(function() {
+        this.iframe.style.visibility = 'hidden';
+        this.iframe.style.height = this.container.offsetHeight + 'px';
+        this.iframe.style.display = '';
+        this.iframe.setAttribute('src', url);
+      }.bind(this));
+    };
+
+
+    Viewer.prototype.loaded_ = function() {
+      if (this.alreadyLoaded_) {
+        return;
+      }
+      log('AMP Loaded');
+      this.alreadyLoaded_ = true;
+
+      var waiter = document.querySelector('.wait');
+      if (waiter) {
+        waiter.parentElement.removeChild(waiter);
+      }
+
+      this.iframe.style.display = '';
+      this.iframe.style.visibility = '';
+    };
+
+
+    Viewer.prototype.documentReady_ = function() {
+      log('AMP document ready');
+      this.loaded_();
+    };
+
+
+    Viewer.prototype.documentHeight_ = function(documentHeight) {
+      log('AMP document height:', documentHeight);
+      this.iframe.style.height = Math.max(documentHeight,
+          this.container.offsetHeight) + 'px';
+    };
+
+
+    Viewer.prototype.onScroll_ = function() {
+      this.sendMessage_('viewport', {scrollTop: this.container.scrollTop});
+    };
+
+
+    Viewer.prototype.onResize_ = function() {
+      log('Resized to ', this.container.offsetWidth,
+          this.container.offsetHeight,
+          this.header.offsetHeight,
+          this.container.scrollTop);
+      this.sendMessage_('viewport', {
+        scrollTop: this.container.scrollTop,
+        width: this.container.offsetWidth,
+        height: this.container.offsetHeight,
+        paddingTop: this.header.offsetHeight
+      });
+    };
+
+
+    Viewer.prototype.sendMessage_ = function(type, message) {
+      message['type'] = type;
+      message['sentinel'] = SENTINEL;
+      if (this.iframe.contentWindow) {
+        this.iframe.contentWindow.postMessage(message, '*');
+      }
+    };
+
+
+    Viewer.prototype.onMessage_ = function() {
+      var data = event.data;
+      if (data.sentinel != SENTINEL) {
+        return;
+      }
+      if (data.type == 'documentLoaded') {
+        this.documentReady_();
+      } else if (data.type == 'documentResized') {
+        this.documentHeight_(data.height);
+      }
+    };
+
+
+    function log() {
+      var var_args = Array.prototype.slice.call(arguments, 0);
+      var_args.unshift('[VIEWER]');
+      console.log.apply(console, var_args);
+    }
+
+
+    function paramsStr(params) {
+      var s = '';
+      for (var k in params) {
+        var v = params[k];
+        if (v === null || v === undefined) {
+          continue;
+        }
+        if (s.length > 0) {
+          s += '&';
+        }
+        s += encodeURIComponent(k) + '=' + encodeURIComponent(v);
+      }
+      return s;
+    }
+
+
+    var viewer;
+
+    function loadAmpDoc() {
+      viewer = new Viewer();
+      viewer.start();
+    }
+
+    window.onload = loadAmpDoc;
+  </script>
+</head>
+<body>
+  <viewer>
+    <header>
+      <h1>Viewer</h1>
+    </header>
+    <container>
+      <div class="wait">
+        Please wait, the AMP doc will appear here...
+      </div>
+    </container>
+  </viewer>
+</body>
+</html>

--- a/src/amp.js
+++ b/src/amp.js
@@ -16,6 +16,8 @@
 
 import './polyfills';
 
+import {viewerFor} from './viewer';
+
 import {installAd} from '../builtins/amp-ad';
 import {installImg} from '../builtins/amp-img';
 import {installVideo} from '../builtins/amp-video';
@@ -28,6 +30,8 @@ import {cssText} from '../build/css.js';
 import {action} from './action';
 import {installHistory} from './history';
 import {maybeValidate} from './validator-integration';
+
+viewerFor(window);
 
 installAd(window);
 installImg(window);

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -20,7 +20,7 @@ import {timer} from './timer';
 /**
  * Listens for the specified event on the element and removes the listener
  * as soon as event has been received.
- * @param {!Element} element
+ * @param {!EventTarget} element
  * @param {string} eventType
  * @param {function(Event)} listener
  * @param {boolean=} opt_capture
@@ -45,7 +45,7 @@ export function listenOnce(element, eventType, listener, opt_capture) {
  * Returns  a promise that will resolve as soon as the specified event has
  * fired on the element. Optionally, opt_timeout can be specified that will
  * reject the promise if the event has not fired by then.
- * @param {!Element} element
+ * @param {!EventTarget} element
  * @param {string} eventType
  * @param {boolean=} opt_capture
  * @param {number=} opt_timeout

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -19,6 +19,7 @@ import {assert} from './asserts';
 import {installStyles} from './styles';
 import {registerElement} from './custom-element';
 import {registerExtendedElement} from './extended-element';
+import {viewerFor} from './viewer';
 
 
 /** @type {!Array} */
@@ -63,6 +64,8 @@ export function adopt(global) {
   global.AMP.BaseElement = BaseElement;
   /** @const */
   global.AMP.assert = assert;
+  /** @const */
+  global.AMP.viewer = viewerFor(global);
   /**
    * Registers a new custom element.
    * @param {GlobalAmp} fn

--- a/src/url.js
+++ b/src/url.js
@@ -40,6 +40,39 @@ export function parseUrl(url) {
   return info;
 }
 
+
+/**
+ * Parses the query string of an URL. This method returns a simple key/value
+ * map. If there are duplicate keys the latest value is returned.
+ * @param {string} queryString
+ * @return {!Object<string, string>}
+ */
+export function parseQueryString(queryString) {
+  var params = Object.create(null);
+  if (!queryString) {
+    return params;
+  }
+  let pairs = queryString.split('&');
+  for (let i = 0; i < pairs.length; i++) {
+    let pair = pairs[i];
+    let eqIndex = pair.indexOf('=');
+    let name;
+    let value;
+    if (eqIndex != -1) {
+      name = decodeURIComponent(pair.substring(0, eqIndex)).trim();
+      value = decodeURIComponent(pair.substring(eqIndex + 1)).trim();
+    } else {
+      name = decodeURIComponent(pair).trim();
+      value = '';
+    }
+    if (name) {
+      params[name] = value;
+    }
+  }
+  return params;
+}
+
+
 /**
  * @param {!Location} info
  * @return {string}

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,0 +1,317 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Observable} from './observable';
+import {assert} from './asserts';
+import {getService} from './service';
+import {installStyles} from './styles';
+import {log} from './log';
+import {parseQueryString} from './url';
+import * as st from './style';
+
+
+let TAG_ = 'Viewer';
+let SENTINEL_ = '__AMP__';
+
+
+/**
+ * An AMP representation of the Viewer. This class doesn't do any work itself
+ * but instead delegates everything to the actual viewer. This class and the
+ * actual Viewer are connected via "AMP.viewer" using three methods:
+ * {@link getParam}, {@link receiveMessage} and {@link setMessageDeliverer}.
+ */
+export class Viewer {
+
+  /**
+   * @param {!Window} win
+   */
+  constructor(win) {
+    /** @const {!Window} */
+    this.win = win;
+
+    /** @private {string} */
+    this.viewportType_ = 'natural';
+
+    /** @private {number} */
+    this.viewportWidth_ = 0;
+
+    /** @private {number} */
+    this.viewportHeight_ = 0;
+
+    /** @private {number} */
+    this.scrollTop_ = 0;
+
+    /** @private {number} */
+    this.paddingTop_ = 0;
+
+    /** @private {!Observable<!ViewerViewportEvent>} */
+    this.viewportObservable_ = new Observable();
+
+    /** @private {?function(string, *)} */
+    this.messageDeliverer_ = null;
+
+    /** @private {!Array<!{eventType: string, data: *}>} */
+    this.messageQueue_ = [];
+
+    /** @const @private {!Object<string, string>} */
+    this.params_ = {};
+
+    // Params can be passed either via iframe name or via hash. Hash currently
+    // has precedence.
+    if (this.win.name && this.win.name.indexOf(SENTINEL_) == 0) {
+      parseParams_(this.win.name.substring(SENTINEL_.length), this.params_);
+    }
+    if (this.win.location.hash) {
+      let hash = this.win.location.hash;
+      if (hash.substring(0, 1) == '#') {
+        hash = hash.substring(1);
+      }
+      if (hash) {
+        parseParams_(hash, this.params_);
+      }
+    }
+
+    log.fine(TAG_, 'Viewer params:', this.params_);
+    this.viewportType_ = this.params_['viewportType'] || this.viewportType_;
+    log.fine(TAG_, '- viewportType:', this.viewportType_);
+
+    this.viewportWidth_ = parseInt(this.params_['width']) ||
+        this.viewportWidth_;
+    log.fine(TAG_, '- viewportWidth:', this.viewportWidth_);
+
+    this.viewportHeight_ = parseInt(this.params_['height']) ||
+        this.viewportHeight_;
+    log.fine(TAG_, '- viewportHeight:', this.viewportHeight_);
+
+    this.scrollTop_ = parseInt(this.params_['scrollTop']) || this.scrollTop_;
+    log.fine(TAG_, '- scrollTop:', this.scrollTop_);
+
+    let paddingTop = parseInt(this.params_['paddingTop']) || this.paddingTop_;
+    log.fine(TAG_, '- padding-top:', paddingTop);
+    this.updatePaddingTop_(paddingTop);
+
+    // Remove hash - no reason to keep it around.
+    var newUrl = this.win.location.href;
+    if (newUrl.indexOf('#') != -1) {
+      newUrl = newUrl.substring(0, newUrl.indexOf('#'));
+      if (this.win.history.replaceState) {
+        this.win.history.replaceState({}, '', newUrl);
+        log.fine(TAG_, 'replace url:' + this.win.location.href);
+      }
+    }
+  }
+
+  /**
+   * Returns the value of a viewer's startup parameter with the specified
+   * name or "undefined" if the parameter wasn't defined at startup time.
+   * @param {string} name
+   * @return {string|undefined}
+   * @expose
+   */
+  getParam(name) {
+    return this.params_[name];
+  }
+
+  /**
+   * There are two types of viewports: "natural" and "virtual". "Natural" is
+   * the viewport of the AMP document's window. "Virtual" is the viewport
+   * provided by the viewer.
+   * See {@link Viewport} and {@link ViewportBinding} for more details.
+   * @return {string}
+   */
+  getViewportType() {
+    return this.viewportType_;
+  }
+
+  /**
+   * Returns the width of the viewport provided by the viewer. This value only
+   * used when viewport type is "virtual."
+   * @return {number}
+   */
+  getViewportWidth() {
+    return this.viewportWidth_;
+  }
+
+  /**
+   * Returns the height of the viewport provided by the viewer. This value only
+   * used when viewport type is "virtual."
+   * @return {number}
+   */
+  getViewportHeight() {
+    return this.viewportHeight_;
+  }
+
+  /**
+   * Returns the scroll position of the viewport provided by the viewer. This
+   * value only used when viewport type is "virtual."
+   * @return {number}
+   */
+  getScrollTop() {
+    return this.scrollTop_;
+  }
+
+  /**
+   * Returns the top padding requested by the viewer.
+   * @return {number}
+   */
+  getPaddingTop() {
+    return this.paddingTop_;
+  }
+
+  /**
+   * Adds a viewport event listener for viewer events.
+   * @param {function(!ViewerViewportEvent)} handler
+   * @return {!Unlisten}
+   */
+  onViewportEvent(handler) {
+    return this.viewportObservable_.add(handler);
+  }
+
+  /**
+   * Triggers "documentLoaded" event for the viewer.
+   * @param {number} width
+   * @param {number} height
+   */
+  postDocumentReady(width, height) {
+    this.sendMessage_('documentLoaded', {width: width, height: height});
+  }
+
+  /**
+   * Triggers "documentResized" event for the viewer.
+   * @param {number} width
+   * @param {number} height
+   */
+  postDocumentResized(width, height) {
+    this.sendMessage_('documentResized', {width: width, height: height});
+  }
+
+  /**
+   * Requests AMP document to receive a message from Viewer.
+   * @param {string} eventType
+   * @param {*} data
+   * @package
+   * @expose
+   */
+  receiveMessage(eventType, data) {
+    if (eventType == 'viewport') {
+      this.viewportObservable_.fire({
+        scrollTop: data['scrollTop'],
+        scrollLeft: data['scrollLeft'],
+        width: data['width'],
+        height: data['height']
+      });
+      let paddingTop = data['paddingTop'];
+      if (paddingTop !== undefined) {
+        this.updatePaddingTop_(paddingTop);
+      }
+    }
+  }
+
+  /**
+   * Provides a message delivery mechanism by which AMP document can send
+   * messages to the viewer.
+   * @param {function(string, *)} deliverer
+   * @package
+   * @expose
+   */
+  setMessageDeliverer(deliverer) {
+    assert(!this.messageDeliverer_, 'message deliverer can only be set once');
+    this.messageDeliverer_ = deliverer;
+    if (this.messageQueue_.length > 0) {
+      let queue = this.messageQueue_.slice(0);
+      this.messageQueue_ = [];
+      queue.forEach((message) => {
+        this.messageDeliverer_(message.eventType, message.data);
+      });
+    }
+  }
+
+  /**
+   * @param {string} eventType
+   * @param {*} data
+   * @private
+   */
+  sendMessage_(eventType, data) {
+    if (this.messageDeliverer_) {
+      this.messageDeliverer_(eventType, data);
+    } else {
+      // Store only a last version for an event type.
+      let found = null;
+      for (let i = 0; i < this.messageQueue_.length; i++) {
+        if (this.messageQueue_[i].eventType == eventType) {
+          found = this.messageQueue_[i];
+          break;
+        }
+      }
+      if (found) {
+        found.data = data;
+      } else {
+        this.messageQueue_.push({eventType: eventType, data: data});
+      }
+    }
+  }
+
+  /**
+   * @param {number} paddingTop
+   */
+  updatePaddingTop_(paddingTop) {
+    if (paddingTop != this.paddingTop_) {
+      this.paddingTop_ = paddingTop;
+      this.win.document.documentElement.style.paddingTop = st.px(paddingTop);
+    }
+  }
+}
+
+
+/**
+ * Parses the viewer parameters as a string.
+ *
+ * Visible for testing only.
+ *
+ * @param {string} str
+ * @param {!Object<string, string>} allParams
+ * @private
+ */
+export function parseParams_(str, allParams) {
+  let params = parseQueryString(str);
+  for (let k in params) {
+    allParams[k] = params[k];
+  }
+}
+
+
+/**
+ * @typedef {{
+ *   scrollTop: (number|undefined),
+ *   scrollLeft: (number|undefined),
+ *   width: (number|undefined),
+ *   height: (number|undefined)
+ * }}
+ */
+var ViewerViewportEvent;
+
+
+/**
+ * @param {!Window} window
+ * @return {!Viewer}
+ */
+export function viewerFor(window) {
+  return getService(window, 'viewer', () => {
+    return new Viewer(window);
+  });
+};
+
+export const viewer = viewerFor(window);

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {parseUrl} from '../../src/url';
+import {parseQueryString, parseUrl} from '../../src/url';
 
 describe('url', () => {
 
@@ -107,4 +107,45 @@ describe('url', () => {
     });
   });
 
+});
+
+
+describe('parseQueryString', () => {
+  it('should return empty params when query string is empty or null', () => {
+    expect(parseQueryString(null)).to.deep.equal({});
+    expect(parseQueryString('')).to.deep.equal({});
+  });
+  it('should parse single key-value', () => {
+    expect(parseQueryString('a=1')).to.deep.equal({
+      'a': '1'
+    });
+  });
+  it('should parse two key-values', () => {
+    expect(parseQueryString('a=1&b=2')).to.deep.equal({
+      'a': '1',
+      'b': '2'
+    });
+  });
+  it('should parse empty value', () => {
+    expect(parseQueryString('a=&b=2')).to.deep.equal({
+      'a': '',
+      'b': '2'
+    });
+    expect(parseQueryString('a&b=2')).to.deep.equal({
+      'a': '',
+      'b': '2'
+    });
+  });
+  it('should decode names and values', () => {
+    expect(parseQueryString('a%26=1%26&b=2')).to.deep.equal({
+      'a&': '1&',
+      'b': '2'
+    });
+  });
+  it('should return last dupe', () => {
+    expect(parseQueryString('a=1&b=2&a=3')).to.deep.equal({
+      'a': '3',
+      'b': '2'
+    });
+  });
 });

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Viewer} from '../../src/viewer';
+
+describe('Viewer', () => {
+
+  let sandbox;
+  let windowMock;
+  let viewer;
+  let windowApi;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    var WindowApi = function() {};
+    WindowApi.prototype.setTimeout = function(callback, delay) {};
+    windowApi = new WindowApi();
+    windowApi.location = {hash: '', href: '/test/viewer'};
+    windowMock = sandbox.mock(windowApi);
+    viewer = new Viewer(windowApi);
+  });
+
+  afterEach(() => {
+    viewer = null;
+    windowMock.verify();
+    windowMock = null;
+    sandbox.restore();
+    sandbox = null;
+  });
+
+  it('should configure as natural viewport by default', () => {
+    expect(viewer.getViewportType()).to.equal('natural');
+    expect(viewer.getViewportWidth()).to.equal(0);
+    expect(viewer.getViewportHeight()).to.equal(0);
+    expect(viewer.getScrollTop()).to.equal(0);
+    expect(viewer.getPaddingTop()).to.equal(0);
+  });
+
+  it('should configure correctly based on window name and hash', () => {
+    windowApi.name = '__AMP__viewportType=virtual&width=222&height=333' +
+        '&scrollTop=15';
+    windowApi.location.hash = '#width=111&paddingTop=17&other=something';
+    windowApi.document = {documentElement: {style: {}}};
+    let viewer = new Viewer(windowApi);
+    expect(viewer.getViewportType()).to.equal('virtual');
+    expect(viewer.getViewportWidth()).to.equal(111);
+    expect(viewer.getViewportHeight()).to.equal(333);
+    expect(viewer.getScrollTop()).to.equal(15);
+    expect(viewer.getPaddingTop()).to.equal(17);
+    expect(windowApi.document.documentElement.style.paddingTop).to.
+        equal('17px');
+
+    // All of the startup params are also available via getParam.
+    expect(viewer.getParam('paddingTop')).to.equal('17');
+    expect(viewer.getParam('width')).to.equal('111');
+    expect(viewer.getParam('other')).to.equal('something');
+  });
+
+  it('should receive viewport event', () => {
+    let viewportEvent = null;
+    viewer.onViewportEvent((event) => {
+      viewportEvent = event;
+    });
+    viewer.receiveMessage('viewport', {
+      scrollTop: 11,
+      scrollLeft: 12,
+      width: 13,
+      height: 14
+    });
+    expect(viewportEvent).to.not.equal(null);
+    expect(viewportEvent.scrollTop).to.equal(11);
+    expect(viewportEvent.scrollLeft).to.equal(12);
+    expect(viewportEvent.width).to.equal(13);
+    expect(viewportEvent.height).to.equal(14);
+  });
+
+  it('should apply paddingTop in viewport event', () => {
+    windowApi.document = {documentElement: {style: {}}};
+    viewer.receiveMessage('viewport', {
+      paddingTop: 17
+    });
+    expect(windowApi.document.documentElement.style.paddingTop).to.
+        equal('17px');
+  });
+
+  it('should post documentLoaded event', () => {
+    viewer.postDocumentReady(11, 12);
+    let m = viewer.messageQueue_[0];
+    expect(m.eventType).to.equal('documentLoaded');
+    expect(m.data.width).to.equal(11);
+    expect(m.data.height).to.equal(12);
+  });
+
+  it('should post documentResized event', () => {
+    viewer.postDocumentResized(13, 14);
+    let m = viewer.messageQueue_[0];
+    expect(m.eventType).to.equal('documentResized');
+    expect(m.data.width).to.equal(13);
+    expect(m.data.height).to.equal(14);
+  });
+
+  it('should queue non-dupe events', () => {
+    viewer.postDocumentReady(11, 12);
+    viewer.postDocumentResized(13, 14);
+    viewer.postDocumentResized(15, 16);
+    expect(viewer.messageQueue_.length).to.equal(2);
+    expect(viewer.messageQueue_[0].eventType).to.equal('documentLoaded');
+    let m = viewer.messageQueue_[1];
+    expect(m.eventType).to.equal('documentResized');
+    expect(m.data.width).to.equal(15);
+    expect(m.data.height).to.equal(16);
+  });
+
+  it('should dequeue events when deliverer set', () => {
+    viewer.postDocumentReady(11, 12);
+    viewer.postDocumentResized(13, 14);
+    expect(viewer.messageQueue_.length).to.equal(2);
+
+    let delivered = [];
+    viewer.setMessageDeliverer((eventType, data) => {
+      delivered.push({eventType: eventType, data: data});
+    });
+
+    expect(viewer.messageQueue_.length).to.equal(0);
+    expect(delivered.length).to.equal(2);
+    expect(delivered[0].eventType).to.equal('documentLoaded');
+    expect(delivered[0].data.width).to.equal(11);
+    expect(delivered[1].eventType).to.equal('documentResized');
+    expect(delivered[1].data.width).to.equal(13);
+  });
+});

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -1,0 +1,289 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Viewport, ViewportBindingNatural_, ViewportBindingVirtual_} from
+    '../../src/viewport';
+import * as sinon from 'sinon';
+
+
+describe('Viewport', () => {
+  let sandbox;
+  let clock;
+  let viewport;
+  let binding;
+  let viewer;
+  let viewerViewportHandler;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
+    viewerViewportHandler = undefined;
+    viewer = {
+      getViewportWidth: () => 111,
+      getViewportHeight: () => 222,
+      getScrollTop: () => 17,
+      onViewportEvent: (handler) => {
+        viewerViewportHandler = handler;
+      }
+    };
+    binding = new ViewportBindingVirtual_(viewer);
+    viewport = new Viewport(binding);
+  });
+
+  afterEach(() => {
+    viewport = null;
+    binding = null;
+    viewer = null;
+    clock.restore();
+    clock = null;
+    sandbox.restore();
+    sandbox = null;
+  });
+
+  it('should pass through size and scroll', () => {
+    expect(viewport.getSize().width).to.equal(111);
+    expect(viewport.getSize().height).to.equal(222);
+    expect(viewport.getTop()).to.equal(17);
+    expect(viewport.getRect().left).to.equal(0);
+    expect(viewport.getRect().top).to.equal(17);
+    expect(viewport.getRect().width).to.equal(111);
+    expect(viewport.getRect().height).to.equal(222);
+  });
+
+  it('should not relayout on height resize', () => {
+    let changeEvent = null;
+    viewport.onChanged((event) => {
+      changeEvent = event;
+    });
+    viewerViewportHandler({height: 223});
+    expect(changeEvent).to.not.equal(null);
+    expect(changeEvent.relayoutAll).to.equal(false);
+    expect(changeEvent.velocity).to.equal(0);
+  });
+
+  it('should relayout on width resize', () => {
+    let changeEvent = null;
+    viewport.onChanged((event) => {
+      changeEvent = event;
+    });
+    viewerViewportHandler({width: 112});
+    expect(changeEvent).to.not.equal(null);
+    expect(changeEvent.relayoutAll).to.equal(true);
+    expect(changeEvent.velocity).to.equal(0);
+  });
+
+  it('should defer scroll events', () => {
+    let changeEvent = null;
+    viewport.onChanged((event) => {
+      changeEvent = event;
+    });
+    viewerViewportHandler({scrollTop: 34});
+    expect(changeEvent).to.equal(null);
+
+    // Not enough time past.
+    clock.tick(100);
+    viewerViewportHandler({scrollTop: 35});
+    expect(changeEvent).to.equal(null);
+
+    // A bit more time.
+    clock.tick(750);
+    expect(changeEvent).to.not.equal(null);
+    expect(changeEvent.relayoutAll).to.equal(false);
+    expect(changeEvent.velocity).to.be.closeTo(0.002, 1e-4);
+  });
+});
+
+
+describe('ViewportBindingNatural', () => {
+  let sandbox;
+  let windowMock;
+  let binding;
+  let windowApi;
+  let windowEventHandlers;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    var WindowApi = function() {};
+    windowEventHandlers = {};
+    WindowApi.prototype.addEventListener = function(eventType, handler) {
+      windowEventHandlers[eventType] = handler;
+    };
+    windowApi = new WindowApi();
+    windowMock = sandbox.mock(windowApi);
+    binding = new ViewportBindingNatural_(windowApi);
+  });
+
+  afterEach(() => {
+    binding = null;
+    windowMock.verify();
+    windowMock = null;
+    sandbox.restore();
+    sandbox = null;
+  });
+
+  it('should subscribe to scroll and resize events', () => {
+    expect(windowEventHandlers['scroll']).to.not.equal(undefined);
+    expect(windowEventHandlers['resize']).to.not.equal(undefined);
+  });
+
+  it('should calculate size', () => {
+    windowApi.innerWidth = 111;
+    windowApi.innerHeight = 222;
+    windowApi.document = {
+      documentElement: {
+        clientWidth: 111,
+        clientHeight: 222
+      }
+    };
+    let size = binding.getSize();
+    expect(size.width).to.equal(111);
+    expect(size.height).to.equal(222);
+  });
+
+  it('should calculate scrollTop from scrollElement', () => {
+    windowApi.pageYOffset = 11;
+    windowApi.document = {
+      scrollingElement: {
+        scrollTop: 17
+      }
+    };
+    expect(binding.getScrollTop()).to.equal(17);
+  });
+
+  it('should fallback scrollTop to pageYOffset', () => {
+    windowApi.pageYOffset = 11;
+    windowApi.document = {scrollingElement: {}};
+    expect(binding.getScrollTop()).to.equal(11);
+  });
+
+  it('should offset client rect for layout', () => {
+    windowApi.pageXOffset = 100;
+    windowApi.pageYOffset = 200;
+    windowApi.document = {scrollingElement: {}};
+    let el = {
+      getBoundingClientRect: () => {
+        return {left: 11.5, top: 12.5, width: 13.5, height: 14.5};
+      }
+    };
+    let rect = binding.getLayoutRect(el);
+    expect(rect.left).to.equal(112);  // round(100 + 11.5)
+    expect(rect.top).to.equal(213);  // round(200 + 12.5)
+    expect(rect.width).to.equal(14);  // round(13.5)
+    expect(rect.height).to.equal(15);  // round(14.5)
+  });
+});
+
+
+describe('ViewportBindingVirtual', () => {
+  let sandbox;
+  let binding;
+  let viewer;
+  let viewerViewportHandler;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    viewerViewportHandler = undefined;
+    viewer = {
+      getViewportWidth: () => 111,
+      getViewportHeight: () => 222,
+      getScrollTop: () => 17,
+      onViewportEvent: (handler) => {
+        viewerViewportHandler = handler;
+      }
+    };
+    binding = new ViewportBindingVirtual_(viewer);
+  });
+
+  afterEach(() => {
+    binding = null;
+    viewer = null;
+    sandbox.restore();
+    sandbox = null;
+  });
+
+  it('should configure viewport parameters', () => {
+    expect(binding.getSize().width).to.equal(111);
+    expect(binding.getSize().height).to.equal(222);
+    expect(binding.getScrollTop()).to.equal(17);
+  });
+
+  it('should subscribe to viewer viewport events', () => {
+    expect(viewerViewportHandler).to.not.equal(undefined);
+  });
+
+  it('should send event on scroll changed', () => {
+    let scrollHandler = sinon.spy();
+    binding.onScroll(scrollHandler);
+    expect(scrollHandler.callCount).to.equal(0);
+
+    // No value.
+    viewerViewportHandler({});
+    expect(scrollHandler.callCount).to.equal(0);
+    expect(binding.getScrollTop()).to.equal(17);
+
+    // Value didn't change.
+    viewerViewportHandler({scrollTop: 17});
+    expect(scrollHandler.callCount).to.equal(0);
+    expect(binding.getScrollTop()).to.equal(17);
+
+    // Value changed.
+    viewerViewportHandler({scrollTop: 19});
+    expect(scrollHandler.callCount).to.equal(1);
+    expect(binding.getScrollTop()).to.equal(19);
+  });
+
+  it('should send event on size changed', () => {
+    let resizeHandler = sinon.spy();
+    binding.onResize(resizeHandler);
+    expect(resizeHandler.callCount).to.equal(0);
+
+    // No size.
+    viewerViewportHandler({});
+    expect(resizeHandler.callCount).to.equal(0);
+    expect(binding.getSize().width).to.equal(111);
+
+    // Size didn't change.
+    viewerViewportHandler({width: 111, height: 222});
+    expect(resizeHandler.callCount).to.equal(0);
+    expect(binding.getSize().width).to.equal(111);
+    expect(binding.getSize().height).to.equal(222);
+
+    // Width changed.
+    viewerViewportHandler({width: 112});
+    expect(resizeHandler.callCount).to.equal(1);
+    expect(binding.getSize().width).to.equal(112);
+    expect(binding.getSize().height).to.equal(222);
+
+    // Height changed.
+    viewerViewportHandler({height: 223});
+    expect(resizeHandler.callCount).to.equal(2);
+    expect(binding.getSize().width).to.equal(112);
+    expect(binding.getSize().height).to.equal(223);
+  });
+
+  it('should NOT offset client rect for layout', () => {
+    let el = {
+      getBoundingClientRect: () => {
+        return {left: 11.5, top: 12.5, width: 13.5, height: 14.5};
+      }
+    };
+    let rect = binding.getLayoutRect(el);
+    expect(rect.left).to.equal(12);  // round(11.5)
+    expect(rect.top).to.equal(13);  // round(12.5)
+    expect(rect.width).to.equal(14);  // round(13.5)
+    expect(rect.height).to.equal(15);  // round(14.5)
+  });
+});


### PR DESCRIPTION
A sample viewer.html and viewer-integr.js provided for review. I can keep or remove them from submit. But I think they provide good documentation.

To note:
1. The viewer integration script that currently sets up postMessage link with the viewer is added (injected) to everything.html: <script src="./viewer-integr.js" async></script>
2. The actual viewer has two hooks into AMP runtime via Viewer class: receiveMessage and setMessageDeliverer - these are two parts of a two-way communication channel.
3. Viewer.html and viewer-integr.js currently do nothing as far as origin/target checks. This is, of course, not for PROD use.
4. Viewport split into two parts: Viewport and Viewporter. Viewport is a logical entity and Viewporter is a physical entities that's attached either to Window or Viewer.
