### PR TITLE
Provide default layout for amp-pixel

### DIFF
--- a/examples/everything.html
+++ b/examples/everything.html
@@ -273,6 +273,6 @@
       data-ad-client="ca-pub-9350112648257122">
   </amp-ad>
 
-  <amp-pixel width=1 height=1 src="https://pubads.g.doubleclick.net/activity;dc_iu=/12344/pixel;ord=$RANDOM?"></amp-pixel>
+  <amp-pixel src="https://pubads.g.doubleclick.net/activity;dc_iu=/12344/pixel;ord=$RANDOM?"></amp-pixel>
 </body>
 </html>

--- a/src/amp-pixel.js
+++ b/src/amp-pixel.js
@@ -31,6 +31,16 @@ export function installPixel(win) {
     }
 
     /** @override */
+    createdCallback() {
+      if (!this.element.hasAttribute('height')) {
+        this.element.setAttribute('height', '1');
+      }
+      if (!this.element.hasAttribute('width')) {
+        this.element.setAttribute('width', '1');
+      }
+    }
+
+    /** @override */
     buildCallback() {
       // Remove user defined size. Pixels should always be the default size.
       this.element.style.width = '';


### PR DESCRIPTION
Fix for #81.

It currently works only because amp-pixel is a builtin component.
