### PR TITLE
Unflake iframe tests

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -97,6 +97,14 @@ i-amp-sizer {
   display: none;
 }
 
+.-amp-layout {
+  /* Just state. */
+}
+
+.-amp-error {
+  /* Just state. */
+}
+
 [placeholder] {
   display: block;
 }

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -82,6 +82,10 @@ class AmpIframe extends AMP.BaseElement {
     iframe.width = getLengthNumeral(width);
     iframe.height = getLengthNumeral(height);
     iframe.name = 'amp_iframe' + count++;
+    iframe.onload = function() {
+      // Chrome does not reflect the iframe readystate.
+      this.readyState = 'complete';
+    };
     /** @const {!Element} */
     this.propagateAttributes(
         ['frameborder', 'allowfullscreen', 'allowtransparency'],

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -16,7 +16,7 @@
 
 import {Timer} from '../../../../src/timer';
 import {adopt} from '../../../../src/runtime';
-import {createIframePromise} from '../../../../testing/iframe';
+import {createIframePromise, pollForLayout} from '../../../../testing/iframe';
 import {loadPromise} from '../../../../src/event-helper';
 import {resources} from '../../../../src/resources';
 require('../amp-iframe');
@@ -26,7 +26,7 @@ adopt(window);
 describe('amp-iframe', () => {
 
   var iframeSrc = 'http://iframe.localhost:' + location.port +
-          '/base/fixtures/served/iframe.html';
+      '/base/fixtures/served/iframe.html';
 
   var timer = new Timer(window);
   var ranJs = 0;
@@ -57,7 +57,7 @@ describe('amp-iframe', () => {
       }
       iframe.doc.body.appendChild(i);
       // Wait an event loop for the iframe to be created.
-      return timer.promise(0).then(() => {
+      return pollForLayout(iframe.win, 1).then(() => {
         var created = i.lastChild;
         if (created && created.tagName == 'IFRAME') {
           // Wait for the iframe to load

--- a/fixtures/served/iframe.html
+++ b/fixtures/served/iframe.html
@@ -3,5 +3,6 @@
 iframe
 <script>
 parent.parent.postMessage('loaded-iframe', '*');
+console.error('Poll me')
 </script>
 </body>

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -372,6 +372,7 @@ export function createAmpElementProto(win, name, implementationClass) {
         'Must be upgraded and built to receive viewport events');
     this.dispatchCustomEvent('amp:load:start');
     var promise = this.implementation_.layoutCallback();
+    this.classList.add('-amp-layout')
     assert(promise instanceof Promise,
         'layoutCallback must return a promise');
     return promise.then(() => {

--- a/src/error.js
+++ b/src/error.js
@@ -37,9 +37,12 @@ export function reportErrorToDeveloper(error, opt_associatedElement) {
   }
   error.reported = true;
   var element = opt_associatedElement || error.associatedElement;
-  if (element && getMode().development) {
-    element.classList.add('-amp-element-error');
-    element.setAttribute('error-message', error.message);
+  if (element) {
+    element.classList.add('-amp-error');
+    if (getMode().development) {
+      element.classList.add('-amp-element-error');
+      element.setAttribute('error-message', error.message);
+    }
   }
   if (error.messageArray) {
     (console.error || console.log).apply(console,


### PR DESCRIPTION
Add robust utility for polling for element initialization and fix a bug 
where we'd sometimes miss the load event for an iframe. Turns out Chrome
does not maintain iframe.readyState, so one has to attach an onload
listener early on.
