### PR TITLE
Fix seizure inducing Twitter embeds flickering.

### DIFF
--- a/ads/ads.js
+++ b/ads/ads.js
@@ -19,6 +19,7 @@
  * one of them.
  */
 
+import '../src/polyfills';
 import {a9} from './a9';
 import {adreactor} from './adreactor';
 import {adsense} from './adsense';
@@ -49,5 +50,6 @@ window.drawAd = function() {
   var fragment = location.hash
   var data = fragment ? JSON.parse(fragment.substr(1)) : {};
   window.context = data._context;
+  delete data._context;
   drawAd(window, data);
 };

--- a/examples/twitter.amp.html
+++ b/examples/twitter.amp.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Twitter examples</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script custom-element="amp-twitter" src="../dist/v0/amp-twitter-0.1.max.js" async></script>
+  <script src="../dist/amp.js" development></script>
+</head>
+<body>
+
+  <h2>Twitter</h2>
+  <amp-twitter width=390 height=267
+      layout="responsive"
+      data-tweetid="585110598171631616"
+      data-cards="hidden">
+  </amp-twitter>
+
+
+  <amp-twitter width=390 height=223
+      layout="responsive"
+      data-tweetid="641653602164060160"
+      data-conversation="none"
+      data-cards="hidden">
+  </amp-twitter>
+
+  <amp-twitter width=390 height=337
+      layout="responsive"
+      data-tweetid="641653602164060160"
+      data-cards="hidden">
+  </amp-twitter>
+
+</body>
+</html>

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -16,12 +16,13 @@
 
 
 import {assert} from './asserts';
+import {getLengthNumeral} from '../src/layout';
 import {documentInfoFor} from './document-info';
 import {getMode} from './mode';
 
 
-/** @type {number} Number of ads on the page. */
-var count = 0;
+/** @type {!Object<string,number>} Number of 3p frames on the for that type. */
+var count = {};
 
 
 /**
@@ -43,13 +44,14 @@ function getFrameAttributes(parentWindow, element, opt_type) {
   var attributes = {};
   // Do these first, as the other attributes have precedence.
   addDataAttributes(element, attributes);
-  attributes.width = width;
-  attributes.height = height;
+  attributes.width = getLengthNumeral(width);
+  attributes.height = getLengthNumeral(height);
   attributes.type = type;
   attributes._context = {
     location: {
       href: documentInfoFor(parentWindow).canonicalUrl
-    }
+    },
+    mode: getMode()
   };
   var adSrc = element.getAttribute('src');
   if (adSrc) {
@@ -69,15 +71,18 @@ function getFrameAttributes(parentWindow, element, opt_type) {
 export function getIframe(parentWindow, element, opt_type) {
   var attributes = getFrameAttributes(parentWindow, element, opt_type)
   var iframe = document.createElement('iframe');
-  iframe.name = 'frame_' + attributes.type + '_' + count++;
+  if (!count[attributes.type]) {
+    count[attributes.type] = 0;
+  }
+  iframe.name = 'frame_' + attributes.type + '_' + count[attributes.type]++;
 
   // Pass ad attributes to iframe via the fragment.
   var src = getBootstrapBaseUrl(parentWindow) + '#' +
       JSON.stringify(attributes);
 
   iframe.src = src;
-  iframe.width = attributes.width + 'px';
-  iframe.height = attributes.height + 'px';
+  iframe.width = attributes.width;
+  iframe.height = attributes.height;
   iframe.style.border = 'none';
   iframe.setAttribute('scrolling', 'no');
   return iframe;

--- a/test/functional/test-amp-ad.js
+++ b/test/functional/test-amp-ad.js
@@ -61,8 +61,8 @@ describe('amp-ad', () => {
 
     expect(data.type).to.equal('a9');
     expect(data.src).to.equal('testsrc');
-    expect(data.width).to.equal('300');
-    expect(data.height).to.equal('250');
+    expect(data.width).to.equal(300);
+    expect(data.height).to.equal(250);
     expect(data._context.location.href).to.equal('https://schema.org/');
     expect(data.aax_size).to.equal('300x250');
   });


### PR DESCRIPTION
And output ideal size for Twitter embed at given (measured really) width.

Also fixes the following bugs:
- Adds polyfills to ad iframe.
- Correctly sizes the 3p iframes
