### PR TITLE
Remove stray 'a' at the end of comment.

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS-IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->a
+-->
 
 # AMP HTML ⚡
 


### PR DESCRIPTION
I think this stray 'a' was introduced by accident and it makes it so that Markdown/Github renders the Apache License notice above the text of the spec. It looks cleaner with the 'a' removed.
