### PR TITLE
Fixes bug in order of build and firstAttachedCallback and speed up image loading

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -32,7 +32,7 @@ var paths = [
     served: true
   },
   {
-    pattern: 'examples/**/*.html',
+    pattern: 'examples/**/*',
     included: false,
     served: true
   }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -27,6 +27,10 @@ import {registerElement} from '../src/custom-element';
  * @return {undefined}
  */
 export function installImg(win) {
+
+  /** @type {number} Count of images */
+  var count = 0;
+
   class AmpImg extends BaseElement {
 
     /** @override */
@@ -52,6 +56,13 @@ export function installImg(win) {
       /** @private @const {!Srcset} */
       this.srcset_ = parseSrcset(this.element.getAttribute('srcset') ||
           this.element.getAttribute('src'));
+
+      // TODO(@dvoytenko) Remove when #254 is fixed.
+      // Always immediately request the first two images to make sure
+      // we start the HTTP requests for them as early as possible.
+      if (count++ < 2 && this.element.offsetWidth) {
+        this.updateImageSrc_();
+      }
     }
 
     /** @override */

--- a/css/amp.css
+++ b/css/amp.css
@@ -167,7 +167,7 @@ i-amp-scroll-container {
 amp-pixel {
   position: absolute !important;
   top: 0 !important;
-  width: 1 !important;
+  width: 1px !important;
   height: 1px !important; /* Only things with height are ever loaded. */
   overflow: hidden !important;
   visibility: hidden;

--- a/src/amp.js
+++ b/src/amp.js
@@ -38,8 +38,8 @@ installStyles(document, cssText, () => {
   historyFor(window);
   viewerFor(window);
 
-  installAd(window);
   installImg(window);
+  installAd(window);
   installPixel(window);
   installVideo(window);
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -299,7 +299,6 @@ export function createAmpElementProto(win, name, implementationClass) {
    * @final
    */
   ElementProto.attachedCallback = function() {
-    resources.add(this);
     if (!this.everAttached) {
       this.everAttached = true;
       try {
@@ -309,6 +308,7 @@ export function createAmpElementProto(win, name, implementationClass) {
         reportError(e, this);
       }
     }
+    resources.add(this);
   }
 
   /**

--- a/src/log.js
+++ b/src/log.js
@@ -16,6 +16,9 @@
 
 import {getMode} from './mode';
 
+/** @const Time when this JS loaded.  */
+var start = new Date().getTime();
+
 
 /**
  * Logging.
@@ -73,7 +76,7 @@ export class Log {
       } else if (level == 'WARN') {
         fn = this.win.console.warn || fn;
       }
-      messages.unshift('[' + tag + ']');
+      messages.unshift(new Date().getTime() - start, '[' + tag + ']');
       fn.apply(this.win.console, messages);
     }
   }

--- a/test/integration/test-released.js
+++ b/test/integration/test-released.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {createFixtureIframe} from '../../testing/iframe.js';
+import {createFixtureIframe, pollForLayout} from '../../testing/iframe.js';
 
 describe('Rendering of released components', () => {
   var fixture;
@@ -26,7 +26,7 @@ describe('Rendering of released components', () => {
 
   it('all components should get loaded', function() {
     this.timeout(5000);
-    return fixture.awaitEvent('amp:load:start', 13).then(function() {
+    return pollForLayout(fixture.win, 13, 5500).then(function() {
       expect(fixture.doc.querySelectorAll('.-amp-element')).to.have.length(16);
       expect(fixture.doc.querySelectorAll('.-amp-layout')).to.have.length(13);
       expect(fixture.doc.querySelectorAll('.-amp-error')).to.have.length(0);


### PR DESCRIPTION
We now apply layout before calling build in accordance with the state diagram. That means that elements have dimensions by the time build() is called.

Adds optimization that first 2 <amg-img> are always loaded
right away to get those HTTP requests started early.
It is worth investigation why there is often such a break
between first add and first layout.

Adds timing to all log output. Seems useful to me.
