### PR TITLE
show stack to developer

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -51,7 +51,11 @@ export function reportError(error, opt_associatedElement) {
     (console.error || console.log).apply(console,
         error.messageArray);
   } else {
-    (console.error || console.log).call(console, error.message);
+    if (process.env.NODE_ENV == 'production') {
+      (console.error || console.log).call(console, error.message);
+    } else {
+      (console.error || console.log).call(console, error.stack);
+    }
   }
   if (element && element.dispatchCustomEvent) {
     element.dispatchCustomEvent('amp:error', error.message);


### PR DESCRIPTION
the former is much more useful for debugging.

<img width="503" alt="screen shot 2015-09-21 at 10 07 09 pm" src="https://cloud.githubusercontent.com/assets/354746/10011345/86eb5804-60ad-11e5-8e3d-c84b676b6dfc.png">

vs

<img width="551" alt="screen shot 2015-09-21 at 10 09 12 pm" src="https://cloud.githubusercontent.com/assets/354746/10011346/8b2b9668-60ad-11e5-8dcf-01f323b83a8b.png">
