### PR TITLE
Use a micro task for 0 timers instead of a timeout.

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -134,7 +134,7 @@ export class History {
       for (let i = 0; i < toPop.length; i++) {
         // With the same delay timeouts must observe the order, although
         // there's no hard requirement in this case to follow the pop order.
-        timer.delay(toPop[i]);
+        timer.delay(toPop[i], 1);
       }
     }
   }

--- a/src/pass.js
+++ b/src/pass.js
@@ -34,10 +34,10 @@ export class Pass {
     /** @private @const {function()} */
     this.handler_ = handler;
 
-    /** @private @const {number} */
+    /** @private @const {number|string} */
     this.defaultDelay_ = opt_defaultDelay || 0;
 
-    /** @private {number} */
+    /** @private {number|string} */
     this.scheduled_ = -1;
 
     /** @private {number} */

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -48,17 +48,28 @@ describe('Timer', () => {
     timer.delay(handler, 111);
   });
 
-  it('delay default', () => {
-    let handler = () => {};
-    windowMock.expects('setTimeout').withExactArgs(handler, 0).
-        returns(1).once();
+  it('delay default', (done) => {
+    windowMock.expects('setTimeout').never();
     windowMock.expects('clearTimeout').never();
-    timer.delay(handler);
+    timer.delay(done);
   });
 
   it('cancel', () => {
     windowMock.expects('clearTimeout').withExactArgs(1).once();
     timer.cancel(1);
+  });
+
+  it('cancel default', (done) => {
+    windowMock.expects('setTimeout').never();
+    windowMock.expects('clearTimeout').never();
+    var id = timer.delay(() => {
+      throw new Error('should have been cancelled');
+    });
+    timer.cancel(id);
+
+    // This makes sure the error has time to throw while this test
+    // is still running.
+    timer.delay(done);
   });
 
   it('promise', () => {


### PR DESCRIPTION
This makes several tasks during our initial load 10ms quicker or better.
