### PR TITLE
Remove entries from whitelist for integration test

### DIFF
--- a/test/integration/test-example-validation.js
+++ b/test/integration/test-example-validation.js
@@ -70,6 +70,15 @@ describe('example', function() {
             // We only look at individual error lines.
             continue;
           }
+          if (/DEV_MODE_ENABLED/.test(line)) {
+            // This error is expected since we have to be in dev mode to
+            // run the validator. It is only a warning and we'd probably
+            // see that by looking for PASS / FAIL. By itself it doesn't
+            // make things fail.
+            // TODO(johannes): Add warning prefixes to such events so they
+            // can be detected systematically.
+            continue;
+          }
           for (let n = 0; n < errorWhitelist.length; n++) {
             var ok = errorWhitelist[n];
             if (ok.test(rendered)) {


### PR DESCRIPTION
These entries should no longer be necessary with today's validator update.
@dvoytenko @erwinmombay @cramforce thanks much for taking a look.
Sorry I haven't run this particular test since I have yet to learn how to do that.
