### PR TITLE
Add a way to force AMP document into development mode by loading it with #development=1

### DIFF
--- a/src/mode.js
+++ b/src/mode.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {parseQueryString} from './url';
+
 
 /**
  * @typedef {{
@@ -57,10 +59,15 @@ function getMode_() {
       // occur during local dev.
       !!document.querySelector('script[src*="/dist/"],script[src*="/base/"]');
 
+  var overrideDevelopment = parseQueryString(location.hash)['development'];
+  var development = overrideDevelopment != undefined
+      ? overrideDevelopment == '1'
+      : !!document.querySelector('script[development]')
+
   return {
     localDev: isLocalDev,
     // Triggers validation
-    development: !!document.querySelector('script[development]'),
+    development:  development,
     minified: process.env.NODE_ENV == 'production',
     test: window.AMP_TEST
   };

--- a/src/url.js
+++ b/src/url.js
@@ -71,7 +71,7 @@ export function parseQueryString(queryString) {
   if (!queryString) {
     return params;
   }
-  if (queryString.startsWith('?')) {
+  if (queryString.startsWith('?') || queryString.startsWith('#')) {
     queryString = queryString.substr(1);
   }
   let pairs = queryString.split('&');

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -140,13 +140,7 @@ export class Viewer {
       parseParams_(this.win.name.substring(SENTINEL_.length), this.params_);
     }
     if (this.win.location.hash) {
-      let hash = this.win.location.hash;
-      if (hash.substring(0, 1) == '#') {
-        hash = hash.substring(1);
-      }
-      if (hash) {
-        parseParams_(hash, this.params_);
-      }
+      parseParams_(this.win.location.hash, this.params_);
     }
 
     log.fine(TAG_, 'Viewer params:', this.params_);

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -132,6 +132,12 @@ describe('parseQueryString', () => {
       'b': '2'
     });
   });
+  it('should ignore leading #', () => {
+    expect(parseQueryString('#a=1&b=2')).to.deep.equal({
+      'a': '1',
+      'b': '2'
+    });
+  });
   it('should parse empty value', () => {
     expect(parseQueryString('a=&b=2')).to.deep.equal({
       'a': '',


### PR DESCRIPTION
Changes query string parser to diretly allow leading # on top of
leading ?.
