### PR TITLE
Clarify spec on -amp- and i-amp CSS selectors.

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -191,7 +191,10 @@ Pseudo selectors are generally forbidden and must be whitelisted 1 by 1. Initial
 
 CSS variables are used to style custom elements.
 
-Class names in author stylesheets may not starts with the string `-amp-`. These are reserved for internal use by the AMP runtime.
+Class names in author stylesheets may not starts with the string `-amp-`. These are reserved for internal use by the AMP runtime. It follows,
+that user stylesheet may not reference CSS selectors for `-amp-` classes and `i-amp` tags. These classes and elements are not meant to
+be customized by authors. Authors, however, can override styles of `amp-` classes and tags for any CSS properties not explicitly
+forbidden by these components' spec.
 
 Usage of the !important qualifier is not allowed.
 


### PR DESCRIPTION
Closes #278.
