### PR TITLE
Disallow default events in action definitions.

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -24,12 +24,6 @@ const TAG_ = 'Action';
 /** @const {string} */
 const ACTION_MAP_ = '__AMP_ACTION_MAP__' + Math.random();
 
-/**
- * TODO(dvoytenko, #291): remove
- * @const {string}
- */
-const DEFAULT_EVENT_ = 'tap';
-
 /** @const {string} */
 const DEFAULT_METHOD_ = 'activate';
 
@@ -269,14 +263,13 @@ export class Action {
     let eventSep = s.indexOf(':');
     let methodSep = s.indexOf('.', eventSep + 1);
     let event = (eventSep != -1 ? s.substring(0, eventSep) : '').toLowerCase().
-        trim() || DEFAULT_EVENT_;
+        trim() || null;
     let target = s.substring(eventSep + 1, methodSep != -1 ? methodSep :
         s.length).trim();
     let method = (methodSep != -1 ? s.substring(methodSep + 1) : '').
         trim() || DEFAULT_METHOD_;
 
-    if (!target) {
-      // TODO(dvoytenko): report action info parse errors separately
+    if (!event || !target) {
       log.error(TAG_, 'invalid action definition: ' + s);
       return null;
     }

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -34,18 +34,9 @@ describe('Action parseAction', () => {
   });
 
 
-  it('should parse with default event and method', () => {
-    let a = action.parseAction_('target1');
-    expect(a.event).to.equal('tap');
-    expect(a.target).to.equal('target1');
-    expect(a.method).to.equal('activate');
-  });
-
-  it('should parse with default event', () => {
+  it('should fail parse without event', () => {
     let a = action.parseAction_('target1.method1');
-    expect(a.event).to.equal('tap');
-    expect(a.target).to.equal('target1');
-    expect(a.method).to.equal('method1');
+    expect(a).to.equal(null);
   });
 
   it('should parse with default method', () => {


### PR DESCRIPTION
Closes #291.

Already reflected in the spec.
