### PR TITLE
Switch doubleclick ads to use async rendering.

### DIFF
--- a/ads/doubleclick.js
+++ b/ads/doubleclick.js
@@ -21,46 +21,48 @@ import {writeScript} from '../src/3p';
  * @param {!Object} data
  */
 export function doubleclick(global, data) {
-  writeScript(global,
-      'https://www.googletagservices.com/tag/js/gpt.js',
-      function() {
-        global.googletag.cmd.push(function() {
-          var dimensions = [[
-            parseInt(data.width, 10),
-            parseInt(data.height, 10)
-          ]];
-          var slot = googletag.defineSlot(data.slot, dimensions, 'c')
-              .addService(googletag.pubads());
-          googletag.pubads().enableSingleRequest();
-          googletag.pubads().enableSyncRendering();
-          googletag.pubads().set('page_url', context.location.href);
-          googletag.enableServices();
+  var loaded = new Promise((resolve, reject) => {
+    var s = document.createElement('script');
+    s.src = 'https://www.googletagservices.com/tag/js/gpt.js';
+    s.onload = resolve;
+    s.onerror = reject;
+    global.document.body.appendChild(s);
+  });
 
-          if (data.targeting) {
-            for (var key in data.targeting) {
-              slot.setTargeting(key, data.targeting[key]);
-            }
-          }
+  loaded.then(() => {
+    global.googletag.cmd.push(function() {
+      var dimensions = [[
+        parseInt(data.width, 10),
+        parseInt(data.height, 10)
+      ]];
+      var slot = googletag.defineSlot(data.slot, dimensions, 'c')
+          .addService(googletag.pubads());
+      googletag.pubads().enableSingleRequest();
+      googletag.pubads().set('page_url', context.location.href);
+      googletag.enableServices();
 
-          if (data.categoryExclusion) {
-            slot.setCategoryExclusion(data.categoryExclusion);
-          }
+      if (data.targeting) {
+        for (var key in data.targeting) {
+          slot.setTargeting(key, data.targeting[key]);
+        }
+      }
 
-          if (data.tagForChildDirectedTreatment != undefined) {
-            slot.TagForChildDirectedTreatment(
-                data.tagForChildDirectedTreatment);
-          }
+      if (data.categoryExclusion) {
+        slot.setCategoryExclusion(data.categoryExclusion);
+      }
 
-          googletag.pubads().addEventListener('slotRenderEnded', function(event) {
-            if (event.isEmpty) {
-              context.noContentAvailable();
-            }
-          });
+      if (data.tagForChildDirectedTreatment != undefined) {
+        googletag.pubads().setTagForChildDirectedTreatment(
+            data.tagForChildDirectedTreatment);
+      }
 
-          // This must be called from its own script tag.
-          global.docEndCallback = function() {
-            global.googletag.display('c');
-          };
-        });
+      googletag.pubads().addEventListener('slotRenderEnded', function(event) {
+        if (event.isEmpty) {
+          context.noContentAvailable();
+        }
       });
+
+      global.googletag.display('c');
+    });
+  });
 }


### PR DESCRIPTION
This fixes an issue where ads would sometimes be displayed under
the target diff when they were delivered from backfill.
