### PR TITLE
Implements a Chrome Extension for testing of existing public AMP docs with the current local development version.

### DIFF
--- a/testing/local-amp-chrome-extension/README.md
+++ b/testing/local-amp-chrome-extension/README.md
@@ -1,0 +1,25 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Chrome extension for loading public websites with a local AMP.
+
+Install this extension to test existing public AMP docs against the current version in your development tree.
+
+- Please turn this extension off when you aren't currently working on AMP.
+- Should be used as an unpacked extension.
+  - Open chrome://extensions/
+  - Select "Load unpacked extension".
+- Only works with HTTP host pages.

--- a/testing/local-amp-chrome-extension/background.js
+++ b/testing/local-amp-chrome-extension/background.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// Rewrite cdn.ampproject.org
+chrome.webRequest.onBeforeRequest.addListener(
+  function(details) {
+    // Massage to local path patterns.
+    var path = details.url.substr('https://cdn.ampproject.org/'.length);
+    if (/^v\d+\.js$/.test(path)) {
+      path = 'dist/amp.js';
+    } else {
+      path = 'dist/' + path;
+      path = path.replace(/\.js$/, '.max.js');
+    }
+    return {
+      redirectUrl: 'http://localhost:8000/' + path
+    };
+  },
+  {
+    urls: ['https://cdn.ampproject.org/*']
+  },
+  ['blocking']);
+
+
+// Rewrite 3p.ampproject.net
+chrome.webRequest.onBeforeRequest.addListener(
+  function(details) {
+    // Massage to local path patterns.
+    var path = details.url.substr('https://3p.ampproject.net/'.length);
+    path = path.replace(/^\d+/, 'dist.3p/current');
+    path = path.replace(/\/frame\.html/, '/frame.max.html');
+    if (/\/f\.js$/.test(path)) {
+      path = path.replace(/\/f\.js$/, '/integration.js');
+    }
+    return {
+      redirectUrl: 'http://localhost:8000/' + path
+    };
+  },
+  {
+    urls: ['https://3p.ampproject.net/*']
+  },
+  ['blocking']);

--- a/testing/local-amp-chrome-extension/manifest.json
+++ b/testing/local-amp-chrome-extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Local AMP",
+  "version": "0.0.1",
+  "manifest_version": 2,
+  "description": "Run prod AMP pages with the local AMP runtime.",
+  "homepage_url": "https://www.ampproject.org",
+  "background": {
+    "scripts": [
+      "background.js"
+    ],
+    "persistent": true
+  },
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "*://*/*"
+  ]
+}


### PR DESCRIPTION
Closes #372
