### PR TITLE
Updated article-metadata examples

### DIFF
--- a/examples/article-metadata/README.md
+++ b/examples/article-metadata/README.md
@@ -1,0 +1,9 @@
+This directory contains examples of news articles written with AMP marked up
+with standard schema.org markup in two different formats: JSON-LD and microdata.
+
+Though they are effectively equivalent, we generally recommend JSON-LD as it
+more easily pairs with AMP HMTL Components.
+<pre>
+  json-ld.amp.html       - JSON-LD   structured data markup format
+  microdata.amp.html     - microdata structured data markup format
+</pre>

--- a/examples/article-metadata/json-ld.amp.html
+++ b/examples/article-metadata/json-ld.amp.html
@@ -2,7 +2,7 @@
 <!--
       This sample AMP HTML file aims to be a minimalist document that
       follows best practices and guidances for publishers to mark up
-      content for inclusion in various platforms.
+      content for inclusion in various platforms. 
 -->
 <html AMP lang="en">
   <!-- you can use "amp" or "AMP" or "⚡" -->
@@ -10,17 +10,36 @@
     <meta charset="utf-8">
     <title>Lorem Ipsum</title>
     <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
-    <script src="https://cdn.ampproject.org/v0.js" async development></script>
-    <!-- remove the 'development' attribute above after publishing -->
+    <!-- 
+        The canonical document for this article should be linked, as above.
+
+        The canonical document should also have a corresponding <link> tag
+        within pointing at this AMP HTML file: 
+        
+          <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" /> 
+        
+        It is possible that this AMP HTML document is the canonical document
+        for this article, in which case, the canonical URL should point to this
+        document, and no "amphtml" link is required.
+    -->
+    <script src="https://cdn.ampproject.org/v0.js" async></script>
     <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+    <!-- this style tag is required -->
+    <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+    <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+    <style amp-custom>
+      <!-- any custom style goes here; and remember, body margin can not be declared -->
+      body {
+        background-color: white;
+      }
+      amp-img {
+        background-color: gray;
+      }
+    </style>
     <script type="application/ld+json">
         //
-        // The HTML file referenced in mainEntityOfPage should be the same as the
+        // The document referenced in mainEntityOfPage should be the same as the 
         // canonical link above.
-        //
-        // That file should should have a corresponding <link> tag within
-        // pointing at this AMP HTML file:
-        //    <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" />
         //
         // Also, please be aware that some platforms that use AMP HTML have
         // further restrictions with regards to some schema components.
@@ -31,12 +50,12 @@
         //   somewhere on the AMP HTML document itself.
         //
         //   * The URL for that "image" must precisely match the src of the
-        //   amp-img tag
+        //   amp-img tag.
         //
-        //   * All marked-up URL's should be absolute
+        //   * All marked-up URLs should be absolute.
         //
-        //   * The "logo" dimensions must not exceed 600x60
-        //
+        //   * The "logo" dimensions must not exceed 600x60.
+        // 
       {
         "@context": "http://schema.org",
         "@type": "NewsArticle",
@@ -59,33 +78,16 @@
         },
         "image": {
           "@type": "ImageObject",
-          "url": "/examples/img/hero@1x.jpg",
+          "url": "http://cdn.ampproject.org/leader.jpg",
           "height": 2000,
           "width": 800
         }
       }
     </script>
-    <!-- this style tag is required -->
-    <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
-    <style amp-custom>
-      <!-- any custom style goes here; and remember, body margin can not be declared -->
-      body {
-        background-color: white;
-      }
-      amp-img {
-        background-color: gray;
-      }
-    </style>
   </head>
   <body>
     <h1>Lorem Ipsum</h1>
-    <amp-img
-            src="/examples/img/hero@1x.jpg"
-            srcset="/examples/img/hero@1x.jpg 1x, /examples/img/hero@2x.jpg 2x"
-            layout="responsive" width="360" placeholder
-            alt="Curabitur convallis, urna quis pulvinar feugiat, purus diam posuere turpis, sit amet tincidunt purus justo et mi."
-            height="216" on="tap:headline-img-lightbox">
-        </amp-img>
+    <amp-img src="http://cdn.ampproject.org/leader.jpg" alt="Lorem Ipsum?" height="2000" width="800"></amp-img>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
        odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
        quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent

--- a/examples/article-metadata/microdata.amp.html
+++ b/examples/article-metadata/microdata.amp.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<!--
+      This sample AMP HTML file aims to be a minimalist document that
+      follows best practices and guidances for publishers to mark up
+      content for inclusion in various platforms. 
+-->
+<html AMP lang="en" itemscope itemtype="http://schema.org/NewsArticle">
+  <!-- you can use "amp" or "AMP" or "⚡" -->
+  <head>
+    <meta charset="utf-8">
+    <title>Lorem Ipsum</title>
+    <link itemprop="mainEntityOfPage" rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <!-- 
+        The canonical document for this article should be linked, as above.
+
+        The canonical document should also have a corresponding <link> tag
+        within pointing at this AMP HTML file: 
+        
+          <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" /> 
+        
+        It is possible that this AMP HTML document is the canonical document
+        for this article, in which case, the canonical URL should point to this
+        document, and no "amphtml" link is required.
+
+        Also, please be aware that some platforms that use AMP HTML have
+        further restrictions with regards to some schema components.
+        
+         For example:
+        
+           * All marked-up URL's should be absolute.
+           * The "logo" dimensions must not exceed 600x60.
+    -->
+    <script src="https://cdn.ampproject.org/v0.js" async></script>
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+    </script>
+    <!-- this style tag is required -->
+    <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+    <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+    <style amp-custom>
+      <!-- any custom style goes here; and remember, body margin can not be declared -->
+      body {
+        background-color: white;
+      }
+      amp-img {
+        background-color: gray;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 itemprop="headline">Lorem Ipsum</h1>
+    <h2 itemprop="author" itemscope itemtype="https://schema.org/Person">
+      <span itemprop="name">Jordan M Adler</span>
+    </h2>
+    <time itemprop="datePublished" datetime="1907-05-05T12:02:41Z">Sunday, May 5th 1907</time>
+    <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+      <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+        <amp-img width="600" height="60" src="http://cdn.ampproject.org/logo.jpg"></amp-img>
+        <meta itemprop="url" content="http://cdn.ampproject.org/logo.jpg"></meta>
+        <meta itemprop="width" content="600"></meta>
+        <meta itemprop="height" content="60"></meta>
+      </div>
+      <meta itemprop="name" content="Google"></meta>
+    </div>
+    <div itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+      <amp-img src="http://cdn.ampproject.org/leader.jpg" alt="Lorem Ipsum?" height="2000" width="800"></amp-img>
+      <meta itemprop="url" content="http://cdn.ampproject.org/leader.jpg"></meta>
+      <meta itemprop="width" content="2000"></meta>
+      <meta itemprop="height" content="800"></meta>
+    </div>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
+       odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
+       quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent
+       mauris. Fusce nec tellus sed augue semper porta. Mauris massa.
+       Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad
+       litora torquent per conubia nostra, per inceptos himenaeos.</p>
+    <p>`Curabitur sodales ligula in libero. Sed dignissim lacinia nunc.
+       Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at
+       dolor.  Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc
+       egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non,
+       massa.  Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum.</p>
+    <p>Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.
+       Quisque volutpat condimentum velit. Class aptent taciti sociosqu ad
+       litora torquent per conubia nostra, per inceptos himenaeos. Nam nec
+       ante. Sed lacinia, urna non tincidunt mattis, tortor neque adipiscing
+       diam, a cursus ipsum ante quis turpis. Nulla facilisi. Ut fringilla.
+       Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet.
+       Vestibulum sapien. Proin quam.</p>
+    <blockquote>
+      <p>Quo usque tandem abutere, Catilina, patientia nostra? Quam diu etiam
+         furor iste tuus nos eludet? Quem ad finem sese effrenata iactabit
+         audacia?</p>
+      <p>CICERO</p>
+    </blockquote>
+    <p>Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. Sed
+       lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+       pharetra auctor, sem massa mattis sem, at interdum magna augue eget diam.
+       Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+       cubilia Curae; Morbi lacinia molestie dui. Praesent blandit dolor. Sed
+       non quam. In vel mi sit amet augue congue elementum. Morbi in ipsum sit
+       amet pede facilisis laoreet. Donec lacus nunc, viverra nec, blandit vel,
+       egestas et, augue. Vestibulum tincidunt malesuada tellus. Ut ultrices
+       ultrices enim.</p>
+    <p>Curabitur sit amet mauris. Morbi in dui quis est pulvinar ullamcorper.
+       Nulla facilisi. Integer lacinia sollicitudin massa. Cras metus. Sed
+       aliquet risus a tortor. Integer id quam. Morbi mi. Quisque nisl felis,
+       venenatis tristique, dignissim in, ultrices sit amet, augue. Proin
+       sodales libero eget ante. Nulla quam. Aenean laoreet. Vestibulum nisi
+       lectus, commodo ac, facilisis ac, ultricies eu, pede.</p>
+  </body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -237,7 +237,8 @@ function buildExamples(watch) {
   // Also update test-example-validation.js
   buildExample('ads.amp.html');
   buildExample('article.amp.html');
-  buildExample('article-metadata.amp.html');
+  buildExample('article-metadata/json-ld.amp.html');
+  buildExample('article-metadata/microdata.amp.html');
   buildExample('everything.amp.html');
   buildExample('instagram.amp.html');
   buildExample('released.amp.html');

--- a/test/integration/test-example-validation.js
+++ b/test/integration/test-example-validation.js
@@ -36,7 +36,8 @@ describe('example', function() {
 
   var examples = [
     'ads.amp.html',
-    'article-metadata.amp.html',
+    'article-metadata/json-ld.amp.html',
+    'article-metadata/microdata.amp.html',
     'article.amp.html',
     'everything.amp.html',
     'instagram.amp.html',


### PR DESCRIPTION
- Created Microdata format sample with same content as LD-JSON format sample
- Added README file explaining article-metadata samples
- Replaced <p> tags in samples with <div> to prevent possible gotchas with <p> tags in both samples
- Added comment clarifying amp-custom attr to both samples
- Added comment clarifying that style tag must be copied verbatim to both samples
- Removed "development" attribute from pages to prevent them leaking into production environments in both samples
- Added license to both samples

Resolves #279 
