### PR TITLE
Add HTML file ext for license presubmit tasks; escape .css

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -26,7 +26,7 @@ var srcGlobs = [
   '!gulpfile.js'
 ];
 
-var dedicatedCopyrightNoteSources = /(\.js|.css|\.md)$/;
+var dedicatedCopyrightNoteSources = /(\.js|\.css|\.md|\.html)$/;
 
 // Terms that must not appear in our source files.
 var forbiddenTerms = {


### PR DESCRIPTION
Resolves #389 

Likely requires run-through to add license headers to HTML files
