### PR TITLE
Make examples copy-pasteable by referring to prod-AMP by default.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,13 +97,20 @@ For testing documents on arbitrary URLs with your current local version of the A
 <pre>
   3p/             - Implementation of third party sandbox iframes.
   ads/            - Modules implementing specific ad networks used in <amp-ad>
+  build/          - (generated) intermediate generated files
   build-system/   - build infrastructure
   builtins/       - tags built into the core AMP runtime
       *.md        - documentation for use of the builtin
       *.js        - source code for builtin tag
   css/            - default css
+  dist/           - (generated) main JS binaries are created here. This is what
+                    gets deployed to cdn.ampproject.org.
+  dist.3p/        - (generated) JS binaries and HTML files for 3p embeds and ads.
+                    This is what gets deployed to 3p.ampproject.net.
   docs/           - documentation
   examples/       - example AMP HTML files and corresponding assets
+  examples.build/ - (generated) Same as examples with files pointing to the
+                    local AMP.
   extensions/     - plugins which extend the AMP HTML runtime's core set of tags
   spec/           - The AMP HTML Specification files
   src/            - source code for the AMP runtime

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -5,7 +5,7 @@
   <title>Ad examples</title>
   <link rel="canonical" href="http://schema.org/" >
   <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
-  <script src="../dist/amp.js" development async></script>
+  <script src="https://cdn.ampproject.org/v0.js" async></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <style amp-custom>
   amp-ad {

--- a/examples/article-metadata.amp.html
+++ b/examples/article-metadata.amp.html
@@ -2,7 +2,7 @@
 <!--
       This sample AMP HTML file aims to be a minimalist document that
       follows best practices and guidances for publishers to mark up
-      content for inclusion in various platforms. 
+      content for inclusion in various platforms.
 -->
 <html AMP lang="en">
   <!-- you can use "amp" or "AMP" or "⚡" -->
@@ -15,7 +15,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
     <script type="application/ld+json">
         //
-        // The HTML file referenced in mainEntityOfPage should be the same as the 
+        // The HTML file referenced in mainEntityOfPage should be the same as the
         // canonical link above.
         //
         // That file should should have a corresponding <link> tag within
@@ -36,7 +36,7 @@
         //   * All marked-up URL's should be absolute
         //
         //   * The "logo" dimensions must not exceed 600x60
-        // 
+        //
       {
         "@context": "http://schema.org",
         "@type": "NewsArticle",
@@ -59,7 +59,7 @@
         },
         "image": {
           "@type": "ImageObject",
-          "url": "http://cdn.ampproject.org/leader.jpg",
+          "url": "/examples/img/hero@1x.jpg",
           "height": 2000,
           "width": 800
         }
@@ -79,7 +79,13 @@
   </head>
   <body>
     <h1>Lorem Ipsum</h1>
-    <amp-img src="http://cdn.ampproject.org/leader.jpg" alt="Lorem Ipsum?" height="2000" width="800"></amp-img>
+    <amp-img
+            src="/examples/img/hero@1x.jpg"
+            srcset="/examples/img/hero@1x.jpg 1x, /examples/img/hero@2x.jpg 2x"
+            layout="responsive" width="360" placeholder
+            alt="Curabitur convallis, urna quis pulvinar feugiat, purus diam posuere turpis, sit amet tincidunt purus justo et mi."
+            height="216" on="tap:headline-img-lightbox">
+        </amp-img>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
        odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
        quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -6,8 +6,8 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
-  <script custom-element="amp-lightbox" src="../dist/v0/amp-lightbox-0.1.max.js" async></script>
-  <script src="../dist/amp.js" development async></script>
+  <script custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js" async></script>
+  <script src="https://cdn.ampproject.org/v0.js" async></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <style amp-custom>
     body {

--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -6,17 +6,17 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script custom-element="amp-anim" src="../dist/v0/amp-anim-0.1.max.js" async></script>
-  <script custom-element="amp-audio" src="../dist/v0/amp-audio-0.1.max.js" async></script>
-  <script custom-element="amp-carousel" src="../dist/v0/amp-carousel-0.1.max.js" async></script>
-  <script custom-element="amp-fit-text" src="../dist/v0/amp-fit-text-0.1.max.js" async></script>
-  <script custom-element="amp-iframe" src="../dist/v0/amp-iframe-0.1.max.js" async></script>
-  <script custom-element="amp-instagram" src="../dist/v0/amp-instagram-0.1.max.js" async></script>
-  <script custom-element="amp-image-lightbox" src="../dist/v0/amp-image-lightbox-0.1.max.js" async></script>
-  <script custom-element="amp-lightbox" src="../dist/v0/amp-lightbox-0.1.max.js" async></script>
-  <script custom-element="amp-twitter" src="../dist/v0/amp-twitter-0.1.max.js" async></script>
-  <script custom-element="amp-youtube" src="../dist/v0/amp-youtube-0.1.max.js" async></script>
-  <script src="../dist/amp.js" development async></script>
+  <script custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js" async></script>
+  <script custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js" async></script>
+  <script custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js" async></script>
+  <script custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js" async></script>
+  <script custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js" async></script>
+  <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
+  <script custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js" async></script>
+  <script custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js" async></script>
+  <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
+  <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
+  <script src="https://cdn.ampproject.org/v0.js" async></script>
   <script src="./viewer-integr.js" async></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <style amp-custom>

--- a/examples/released.amp.html
+++ b/examples/released.amp.html
@@ -6,16 +6,16 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script custom-element="amp-audio" src="../dist/v0/amp-audio-0.1.max.js" async></script>
-  <script custom-element="amp-anim" src="../dist/v0/amp-anim-0.1.max.js" async></script>
-  <script custom-element="amp-carousel" src="../dist/v0/amp-carousel-0.1.max.js" async></script>
-  <script custom-element="amp-iframe" src="../dist/v0/amp-iframe-0.1.max.js" async></script>
-  <script custom-element="amp-image-lightbox" src="../dist/v0/amp-image-lightbox-0.1.max.js" async></script>
-  <script custom-element="amp-instagram" src="../dist/v0/amp-instagram-0.1.max.js" async></script>
-  <script custom-element="amp-fit-text" src="../dist/v0/amp-fit-text-0.1.max.js" async></script>
-  <script custom-element="amp-twitter" src="../dist/v0/amp-twitter-0.1.max.js" async></script>
-  <script custom-element="amp-youtube" src="../dist/v0/amp-youtube-0.1.max.js" async></script>
-  <script src="../dist/amp.js" development async></script>
+  <script custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js" async></script>
+  <script custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js" async></script>
+  <script custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js" async></script>
+  <script custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js" async></script>
+  <script custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js" async></script>
+  <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
+  <script custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js" async></script>
+  <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
+  <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
+  <script src="https://cdn.ampproject.org/v0.js" async></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <style amp-custom>
     body {

--- a/examples/twitter.amp.html
+++ b/examples/twitter.amp.html
@@ -6,8 +6,8 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <script custom-element="amp-twitter" src="../dist/v0/amp-twitter-0.1.max.js" async></script>
-  <script src="../dist/amp.js" development async></script>
+  <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
+  <script src="https://cdn.ampproject.org/v0.js" async></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
 </head>
 <body>


### PR DESCRIPTION
Instead continuously build local versions into the examples.build
directory.

Closes #424

CC @dvoytenko @erwinmombay 
