### PR TITLE
Change instagram embed to automatically account for the space/chrome

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -226,6 +226,21 @@ amp-pixel {
   animation-delay: .2s;
 }
 
+/**
+ * Instagram wraps the standard image into a fixed size container.
+ * With these offsets, users can simply specify the the size of the
+ * instagram images and things have the right size.
+ * In particular the effect of adding padding to this container is
+ * that with responsive layouts the responsiveness is based on the
+ * asset while the padding stays constant.
+ * This information is here instead of living with the CSS of the
+ * component, so that the runtime can reserve the correct space
+ * before the instagram implementation loads.
+ */
+amp-instagram {
+  padding: 48px 8px !important;
+}
+
 @keyframes -amp-loader-dots {
   0%, 100% {
     transform: scale(.7);

--- a/examples/instagram.amp.html
+++ b/examples/instagram.amp.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Instagram examples</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
+  <script src="https://cdn.ampproject.org/v0.js" async></script>
+  <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+  <style amp-custom>
+    body {
+      background-color: blue;
+    }
+  </style>
+</head>
+<body>
+
+
+
+  <h2>Instagram</h2>
+
+  <amp-instagram
+      shortcode="fBwFP"
+      width="381"
+      height="381"
+      layout="responsive">
+  </amp-instagram>
+
+  <amp-instagram
+      shortcode="6f8K16iZiK"
+      width="500"
+      height="500"
+      layout="responsive">
+  </amp-instagram>
+
+</body>
+</html>

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -21,12 +21,18 @@ Displays an instagram embed.
 Example:
     <amp-instagram
       shortcode="fBwFP"
-      width="320"
-      height="392"
+      width="400"
+      height="400"
       layout="responsive">
     </amp-instagram>
 
-The width/height given in the example should be correct for responsive layouts with square (instagram's default) pictures. Other aspect ratios will require different values.
+The `width` and `height` attributes are special for the instagram embed.
+These should be the actual width and height of the instagram image.
+The system automatically adds space for the "chrome" that instagram adds around the image.
+
+Many instagrams are square. When you set `layout="responsive"` any value where `width` and `height` are the same will work. If the instagram is not square you will need to enter the actual dimensions of the image.
+
+When using non-responsive layout you will need to account for the extra space added for the "instagram chrome" around the image. This is currently 48px above and below the image and 8px on the sides.
 
 #### Attributes
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -233,11 +233,13 @@ function buildExamples(watch) {
     });
   }
 
+  // Also update test-example-validation.js
   buildExample('ads.amp.html');
-  buildExample('everything.amp.html');
-  buildExample('released.amp.html');
   buildExample('article.amp.html');
   buildExample('article-metadata.amp.html');
+  buildExample('everything.amp.html');
+  buildExample('instagram.amp.html');
+  buildExample('released.amp.html');
   buildExample('twitter.amp.html');
 }
 

--- a/test/integration/test-example-validation.js
+++ b/test/integration/test-example-validation.js
@@ -39,6 +39,9 @@ describe('example', function() {
     'article-metadata.amp.html',
     'article.amp.html',
     'everything.amp.html',
+    'instagram.amp.html',
+    'released.amp.html',
+    'twitter.amp.html',
   ];
 
   // Only add to this whitelist to temporarily manage discrepancies


### PR DESCRIPTION
that instagram adds around the image. This way document authors can
enter the dimensions of the image and then everything works fine.

Closes #419
