### PR TITLE
Disable text size adjustment to avoid iOS Safari bugs in viewer

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -24,10 +24,10 @@ body {
   margin: 0 !important;
 }
 
-/** Overridable properties. */
+/** These properties can be overriden by user stylesheets. */
 body {
   /* Text adjust is set to 100% to avoid iOS Safari bugs where the font-size is
-     sometimes not restored during orientation. */
+     sometimes not restored during orientation. See #449. */
   text-size-adjust: 100%;
 }
 


### PR DESCRIPTION
/cc @ericfs

Closes #449.
