### PR TITLE
Pass the document to validateUrlAndLog

### DIFF
--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -37,7 +37,7 @@ export function maybeValidate(win) {
   s.src = 'https://www.gstatic.com/amphtml/v0/validator.js';
   s.onload = () => {
     win.document.head.removeChild(s);
-    amp.validator.validateUrlAndLog(filename);
+    amp.validator.validateUrlAndLog(filename, win.document);
   };
   win.document.head.appendChild(s);
 }


### PR DESCRIPTION
... to enable DOM validation.
If something similar can be done at reasonable cost for
  test/integration/test-example-validation.js,
  please let me know (we'd need a browser dom).
