### PR TITLE
add microformats2 markup to examples folder

### DIFF
--- a/examples/article-metadata/README.md
+++ b/examples/article-metadata/README.md
@@ -1,9 +1,11 @@
 This directory contains examples of news articles written with AMP marked up
-with standard schema.org markup in two different formats: JSON-LD and microdata.
+with standard schema.org markup in three different formats: JSON-LD,
+microdata and microformats2.
 
 Though they are effectively equivalent, we generally recommend JSON-LD as it
 more easily pairs with AMP HTML Components.
 <pre>
   json-ld.amp.html       - JSON-LD   structured data markup format
   microdata.amp.html     - microdata structured data markup format
+  microformats.amp.html  - microformats2 structured data markup format
 </pre>

--- a/examples/article-metadata/microformats.amp.html
+++ b/examples/article-metadata/microformats.amp.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<!--
+      This sample AMP HTML file aims to be a minimalist document that
+      follows best practices and guidances for publishers to mark up
+      content for inclusion in various platforms.
+-->
+<html AMP lang="en">
+  <!-- you can use "amp" or "AMP" or "⚡" -->
+  <head>
+    <meta charset="utf-8">
+    <title>Lorem Ipsum</title>
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <!--
+        The canonical document for this article should be linked, as above.
+
+        The canonical document should also have a corresponding <link> tag
+        within pointing at this AMP HTML file:
+
+          <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" />
+
+        It is possible that this AMP HTML document is the canonical document
+        for this article, in which case, the canonical URL should point to this
+        document, and no "amphtml" link is required.
+
+        Also, please be aware that some platforms that use AMP HTML have
+        further restrictions with regards to some schema components.
+
+         For example:
+
+           * All marked-up URL's should be absolute.
+           * The "logo" dimensions must not exceed 600x60.
+    -->
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+    <!-- this style tag is required -->
+    <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+    <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+    <style amp-custom>
+      <!-- any custom style goes here; and remember, body margin can not be declared -->
+      body {
+        background-color: white;
+      }
+      amp-img {
+        background-color: gray;
+      }
+    </style>
+    <script src="https://cdn.ampproject.org/v0.js" async></script>
+  </head>
+  <body class="h-entry">
+    <h1 class="p-name">Lorem Ipsum</h1>
+    <h2 class="p-author h-card">Jordan M Adler</h2>
+    <a class="u-url" href="http://example.ampproject.org/article-metadata.html">
+      <time class="dt-published" datetime="1907-05-05T12:02:41Z">Sunday, May 5th 1907</time>
+    </a>
+    <div class="p-publisher h-card">
+      <a href="http://cdn.ampproject.org/logo.jpg" class="u-logo"><amp-img width="600" height="60" src="http://cdn.ampproject.org/logo.jpg"></amp-img></a>
+      <a class="p-name u-url" href="http://google.com/">Google</a>
+    </div>
+    <a class="u-featured" href="http://cdn.ampproject.org/leader.jpg">
+      <amp-img src="http://cdn.ampproject.org/leader.jpg" alt="Lorem Ipsum?" height="2000" width="800"></amp-img>
+    </a>
+    <div class="e-content">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
+         odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
+         quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent
+         mauris. Fusce nec tellus sed augue semper porta. Mauris massa.
+         Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad
+         litora torquent per conubia nostra, per inceptos himenaeos.</p>
+      <p>`Curabitur sodales ligula in libero. Sed dignissim lacinia nunc.
+         Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at
+         dolor.  Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc
+         egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non,
+         massa.  Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum.</p>
+      <p>Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.
+         Quisque volutpat condimentum velit. Class aptent taciti sociosqu ad
+         litora torquent per conubia nostra, per inceptos himenaeos. Nam nec
+         ante. Sed lacinia, urna non tincidunt mattis, tortor neque adipiscing
+         diam, a cursus ipsum ante quis turpis. Nulla facilisi. Ut fringilla.
+         Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet.
+         Vestibulum sapien. Proin quam.</p>
+      <blockquote>
+        <p>Quo usque tandem abutere, Catilina, patientia nostra? Quam diu etiam
+           furor iste tuus nos eludet? Quem ad finem sese effrenata iactabit
+           audacia?</p>
+        <p>CICERO</p>
+      </blockquote>
+      <p>Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. Sed
+         lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+         pharetra auctor, sem massa mattis sem, at interdum magna augue eget diam.
+         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+         cubilia Curae; Morbi lacinia molestie dui. Praesent blandit dolor. Sed
+         non quam. In vel mi sit amet augue congue elementum. Morbi in ipsum sit
+         amet pede facilisis laoreet. Donec lacus nunc, viverra nec, blandit vel,
+         egestas et, augue. Vestibulum tincidunt malesuada tellus. Ut ultrices
+         ultrices enim.</p>
+      <p>Curabitur sit amet mauris. Morbi in dui quis est pulvinar ullamcorper.
+         Nulla facilisi. Integer lacinia sollicitudin massa. Cras metus. Sed
+         aliquet risus a tortor. Integer id quam. Morbi mi. Quisque nisl felis,
+         venenatis tristique, dignissim in, ultrices sit amet, augue. Proin
+         sodales libero eget ante. Nulla quam. Aenean laoreet. Vestibulum nisi
+         lectus, commodo ac, facilisis ac, ultricies eu, pede.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a new example showing the same article with Microformats2 markup. You can see the [parsed result in JSON format](http://glennjones.net/tools/microformats/?url=https%3A%2F%2Fraw.githubusercontent.com%2Faaronpk%2Famphtml%2Fmaster%2Fexamples%2Farticle-metadata%2Fmicroformats.amp.html).

For more details and background on Microformats2, see the following links:
* http://microformats.org/wiki/h-entry
* http://microformats.org/2014/03/05/getting-started-with-microformats2
