### PR TITLE
update script order to comply with amp-html format specification

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -68,8 +68,8 @@ In concrete terms this means that:
   }
   </script>
   <script custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js" async></script>
-  <script src="https://cdn.ampproject.org/v0.js" async></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+  <script src="https://cdn.ampproject.org/v0.js" async></script>
 </head>
 <body>
 <h1>Sample document</h1>


### PR DESCRIPTION
The amp-html format spec says the document MUST:

 * contain a &lt;script src="https://cdn.ampproject.org/v0.js" async&gt;&lt;/script&gt; tag as the last element in their head.