### PR TITLE
Trivial formatting change to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,11 @@ limitations under the License.
 
 **Google Individual Contributor License**
 
-Code contributors to the AMP HTML project must sign a Contributor License Agreement, either for an individual or corporation. The CLA is meant to protect contributors, users of the AMP HTML runtime, and Google in issues of intellectual property.  You can fill out the appropriate Contributor License Agreement at:
+Code contributors to the AMP HTML project must sign a Contributor License Agreement, either for an individual or corporation. The CLA is meant to protect contributors, users of the AMP HTML runtime, and Google in issues of intellectual property. You can fill out the appropriate Contributor License Agreement at:
 
-https://developers.google.com/open-source/cla/individual
-https://developers.google.com/open-source/cla/corporate
+Individuals - https://developers.google.com/open-source/cla/individual
+
+Corporate - https://developers.google.com/open-source/cla/corporate
 
 ### Contributing
 


### PR DESCRIPTION
It's not immediately obvious in the current format that the two separate CLA links are present, this change aims to reduce any potential confusion. Also fixes a double space in `Google Individual Contributor License` content section.