### PR TITLE
misleading way to trigger development

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -239,7 +239,7 @@ The AMP runtime is a piece of JavaScript that runs inside every AMP document. It
 
 The AMP runtime is loaded via the mandatory `<script src="https://cdn.ampproject.org/v0.js"></script>` tag in the AMP document head.
 
-Development mode is triggered by including the attribute "development" in the script tag: `<script src="https://cdn.ampproject.org/v0.js" development></script>`
+Development mode is triggered by adding "#development=1" to the URL of the page.
 
 
 ## Resources


### PR DESCRIPTION
If the attribute development is used in the script the validator itself runs and invalidates such attribute. Using `#development=1` in the URL seems to be accepted and, indeed, suggested in the README too.