### PR TITLE
Avoid emoji in example code

### DIFF
--- a/3p/frame.max.html
+++ b/3p/frame.max.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<html>
 <head>
 <meta charset="utf-8">
 <meta name="robots" content="noindex">

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ AMP HTML works by including the AMP JS library and adding a bit of boilerplate t
 
 ```html
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="hello-world.html" >

--- a/docs/create_page.md
+++ b/docs/create_page.md
@@ -9,7 +9,7 @@ The basic AMP HTML page includes the following mark-up:
 
 ```html
     <!doctype html>
-    <html amp lang="en">
+    <html amp>
       <head>
         <meta charset="utf-8">
         <title>Hello, AMPs</title>
@@ -40,7 +40,7 @@ The basic AMP HTML page includes the following mark-up:
 AMP HTML documents MUST
 
 - <a name="dctp"></a>start with the doctype `<!doctype html>`.
-- <a name="ampd"></a>contain a top-level `<html ⚡>` tag (`<html amp>` is accepted as well).
+- <a name="ampd"></a>contain a top-level `<html ⚡>` tag or `<html amp>` tag (note that the `⚡` is the high voltage sign emoji ⚡).
 - <a name="crps"></a>contain `<head>` and `<body>` tags (They are optional in HTML).
 - <a name="canon"></a>contain a `<link rel="canonical" href="$SOME_URL" />` tag inside their head that points to the regular HTML version of the AMP HTML document or to itself if no such HTML version exists.
 - <a name="chrs"></a>contain a `<meta charset="utf-8">` tag as the first child of their head tag.
@@ -61,7 +61,7 @@ here's the basic AMP HTML page now with an image:
 
 ```html
     <!doctype html>
-    <html AMP lang="en">
+    <html amp>
       <head>
         <meta charset="utf-8">
         <title>Hello, AMPs</title>
@@ -102,7 +102,7 @@ inlined stylesheet:
 
 ```html
     <!doctype html>
-    <html AMP lang="en">
+    <html amp>
       <head>
         <meta charset="utf-8">
         <title>Hello, AMPs</title>

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>Ad examples</title>

--- a/examples/article-metadata/json-ld.amp.html
+++ b/examples/article-metadata/json-ld.amp.html
@@ -4,7 +4,7 @@
       follows best practices and guidances for publishers to mark up
       content for inclusion in various platforms.
 -->
-<html AMP lang="en">
+<html amp>
   <!-- you can use "amp" or "AMP" or "⚡" -->
   <head>
     <meta charset="utf-8">

--- a/examples/article-metadata/microdata.amp.html
+++ b/examples/article-metadata/microdata.amp.html
@@ -4,7 +4,7 @@
       follows best practices and guidances for publishers to mark up
       content for inclusion in various platforms.
 -->
-<html AMP lang="en" itemscope itemtype="http://schema.org/NewsArticle">
+<html amp lang="en" itemscope itemtype="http://schema.org/NewsArticle">
   <!-- you can use "amp" or "AMP" or "⚡" -->
   <head>
     <meta charset="utf-8">

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/instagram.amp.html
+++ b/examples/instagram.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>Instagram examples</title>

--- a/examples/released.amp.html
+++ b/examples/released.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>Released AMP components</title>

--- a/examples/twitter.amp.html
+++ b/examples/twitter.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>Twitter examples</title>

--- a/spec/amp-html-components.md
+++ b/spec/amp-html-components.md
@@ -45,7 +45,7 @@ author-defined, inlined stylesheet, using most common CSS properties. For
 example:
 
     <!doctype html>
-    <html ⚡>
+    <html amp>
       <head>
         <style>
           amp-img {
@@ -78,7 +78,7 @@ runtime, to achieve the desired style. This way the AMP author does not need to
 know the internals of the component, only its styleable properties. For example:
 
     <!doctype html>
-    <html ⚡>
+    <html amp>
       <head>
         <style>
           amp-carousel {

--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -47,7 +47,7 @@ In concrete terms this means that:
 
 ```html
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>Sample document</title>

--- a/test/fixtures/carousels.html
+++ b/test/fixtures/carousels.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/errors.html
+++ b/test/fixtures/errors.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/released.html
+++ b/test/fixtures/released.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>Released AMP components</title>

--- a/test/manual/amp-ad.amp.html
+++ b/test/manual/amp-ad.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-anim.amp.html
+++ b/test/manual/amp-anim.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-audio.amp.html
+++ b/test/manual/amp-audio.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-carousel.amp.html
+++ b/test/manual/amp-carousel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-fit-text.amp.html
+++ b/test/manual/amp-fit-text.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-iframe.amp.html
+++ b/test/manual/amp-iframe.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>amp-iframe</title>

--- a/test/manual/amp-image-lightbox.amp.html
+++ b/test/manual/amp-image-lightbox.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-img.amp.html
+++ b/test/manual/amp-img.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-instagram.amp.html
+++ b/test/manual/amp-instagram.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-lightbox.amp.html
+++ b/test/manual/amp-lightbox.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-pixel.amp.html
+++ b/test/manual/amp-pixel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-twitter.amp.html
+++ b/test/manual/amp-twitter.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>amp-twitter</title>

--- a/test/manual/amp-video.amp.html
+++ b/test/manual/amp-video.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-youtube.amp.html
+++ b/test/manual/amp-youtube.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html amp>
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>


### PR DESCRIPTION
Its an interesting idea to have an emoji in the code. Most editors, however, will show the char as a an empty square. Also the code examples on Github and the default view of .js files on Github will show a replacement char.

All in all it creates unnecessary confusion when new people try to understand what AMP is all about.