### PR TITLE
Do not load unneeded polyfills into 3p iframe.

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -19,7 +19,7 @@
  * one of them.
  */
 
-import '../src/polyfills';
+import './polyfills';
 import {a9} from '../ads/a9';
 import {adreactor} from '../ads/adreactor';
 import {adsense} from '../ads/adsense';

--- a/3p/polyfills.js
+++ b/3p/polyfills.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Loads all polyfills needed by the AMP 3p integration frame.
+ */
+
+
+// This list should not get longer without a very good reason.
+import 'babel-core/external-helpers';

--- a/src/3p.js
+++ b/src/3p.js
@@ -19,6 +19,8 @@
  * party iframe.
  */
 
+// Note: loaded by 3p system. Cannot rely on babel polyfills.
+
 
 import {assert} from './asserts';
 

--- a/src/style.js
+++ b/src/style.js
@@ -15,6 +15,8 @@
  */
 
 
+// Note: loaded by 3p system. Cannot rely on babel polyfills.
+
 /** @private @const {!Object<string>} */
 const propertyNameCache_ = Object.create(null);
 


### PR DESCRIPTION
Reduces size from, ahem, 48KB to 15KB.

Fixes #604