### PR TITLE
Trim down ES6 polyfills to the absolute minimum.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -28,6 +28,9 @@ var srcGlobs = srcGlobs.concat([
 
 var dedicatedCopyrightNoteSources = /(\.js|.css)$/;
 
+var es6polyfill = 'Not available because we do not currently' +
+    ' ship with a needed ES6 polyfill.';
+
 // Terms that must not appear in our source files.
 var forbiddenTerms = {
   'DO NOT SUBMIT': '',
@@ -44,6 +47,16 @@ var forbiddenTerms = {
   'requestFileSystem': '',
   'webkitRequestFileSystem': '',
   'debugger': '',
+
+  // ES6. These are only the most commonly used.
+  'Array\\.from': es6polyfill,
+  'Array\\.of': es6polyfill,
+  // These currently depend on core-js/modules/web.dom.iterable which
+  // we don't want. That decision could be reconsidered.
+  'Promise\\.all': es6polyfill,
+  'Promise\\.race': es6polyfill,
+  '\\.startsWith': es6polyfill,
+  '\\.endsWith': es6polyfill,
 };
 
 var bannedTermsHelpString = 'Please review viewport.js for a helper method ' +

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -35,7 +35,7 @@ class AmpIframe extends AMP.BaseElement {
     var url = parseUrl(src);
     assert(
         url.protocol == 'https:' ||
-            url.origin.startsWith('http://iframe.localhost:'),
+            url.origin.indexOf('http://iframe.localhost:') == 0,
         'Invalid <amp-iframe> src. Must start with https://. Found %s',
         this.element);
     var containerUrl = parseUrl(containerSrc);

--- a/src/custom-core-js-shim.js
+++ b/src/custom-core-js-shim.js
@@ -26,7 +26,7 @@
 // This is temporary until we can build out something more sophisticated with
 // gulp + browserify + cli or switch to webpack.
 
-require('core-js/modules/es5');
+//require('core-js/modules/es5');
 //require('core-js/modules/es6.symbol');
 //require('core-js/modules/es6.object.assign');
 //require('core-js/modules/es6.object.is');
@@ -76,18 +76,18 @@ require('core-js/modules/es6.math.sign');
 require('core-js/modules/es6.string.trim');
 //require('core-js/modules/es6.string.iterator');
 //require('core-js/modules/es6.string.code-point-at');
-require('core-js/modules/es6.string.ends-with');
-require('core-js/modules/es6.string.includes');
+//require('core-js/modules/es6.string.ends-with');
+//require('core-js/modules/es6.string.includes');
 //require('core-js/modules/es6.string.repeat');
-require('core-js/modules/es6.string.starts-with');
-require('core-js/modules/es6.array.from');
-require('core-js/modules/es6.array.of');
+//require('core-js/modules/es6.string.starts-with');
+//require('core-js/modules/es6.array.from');
+//require('core-js/modules/es6.array.of');
 //require('core-js/modules/es6.array.iterator');
 //require('core-js/modules/es6.array.species');
 //require('core-js/modules/es6.array.copy-within');
-require('core-js/modules/es6.array.fill');
-require('core-js/modules/es6.array.find');
-require('core-js/modules/es6.array.find-index');
+//require('core-js/modules/es6.array.fill');
+//require('core-js/modules/es6.array.find');
+//require('core-js/modules/es6.array.find-index');
 //require('core-js/modules/es6.regexp.constructor');
 //require('core-js/modules/es6.regexp.flags');
 //require('core-js/modules/es6.regexp.match');
@@ -128,6 +128,6 @@ require('core-js/modules/es6.promise');
 //require('core-js/modules/js.array.statics');
 //require('core-js/modules/web.timers');
 //require('core-js/modules/web.immediate');
-require('core-js/modules/web.dom.iterable');
+//require('core-js/modules/web.dom.iterable');
 /** @const  */
 module.exports = require('core-js/modules/$.core');

--- a/src/timer.js
+++ b/src/timer.js
@@ -139,7 +139,11 @@ export class Timer {
     if (!opt_racePromise) {
       return delayPromise;
     }
-    return Promise.race([delayPromise, opt_racePromise]);
+    // Avoids Promise->race due to presubmit check against it.
+    return new Promise((resolve, reject) => {
+      delayPromise.then(resolve, reject);
+      opt_racePromise.then(resolve, reject);
+    });
   }
 }
 

--- a/src/url.js
+++ b/src/url.js
@@ -52,7 +52,10 @@ export function assertHttpsUrl(urlString, elementContext) {
   var url = parseUrl(urlString);
   assert(
       url.protocol == 'https:' || /^(\/\/)/.test(urlString) ||
-      url.hostname == 'localhost' || url.hostname.endsWith('.localhost'),
+      url.hostname == 'localhost' ||
+          url.hostname.lastIndexOf('.localhost') ==
+          // Poor person's endsWith
+          url.hostname.length - '.localhost'.length,
       '%s source must start with ' +
       '"https://" or "//" or be relative and served from ' +
       'https. Invalid value: %s',
@@ -71,7 +74,7 @@ export function parseQueryString(queryString) {
   if (!queryString) {
     return params;
   }
-  if (queryString.startsWith('?') || queryString.startsWith('#')) {
+  if (queryString.indexOf('?') == 0 || queryString.indexOf('#') == 0) {
     queryString = queryString.substr(1);
   }
   let pairs = queryString.split('&');

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -28,7 +28,7 @@ export function maybeValidate(win) {
     return;
   }
   var filename = win.location.href;
-  if (filename.startsWith('about:')) {  // Should only happen in tests.
+  if (filename.indexOf('about:') == 0) {  // Should only happen in tests.
     return;
   }
   var s = document.createElement('script');

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -197,14 +197,16 @@ describe('HistoryBindingNatural', () => {
         clock.tick(100);
       });
       let popPromise = history.pop(stackIndex);
-      return Promise.all([histPromise, popPromise]).then((results) => {
-        expect(results[1]).to.equal(window.history.length - 2);
-        expect(history.stackIndex_).to.equal(window.history.length - 2);
-        expect(history.unsupportedState_['AMP.History']).to.equal(
-            window.history.length - 2);
-        expect(onStackIndexUpdated.callCount).to.equal(2);
-        expect(onStackIndexUpdated.getCall(1).args[0]).to.equal(
-            window.history.length - 2);
+      return histPromise.then(hist => {
+        return popPromise.then(pop => {
+          expect(pop).to.equal(window.history.length - 2);
+          expect(history.stackIndex_).to.equal(window.history.length - 2);
+          expect(history.unsupportedState_['AMP.History']).to.equal(
+              window.history.length - 2);
+          expect(onStackIndexUpdated.callCount).to.equal(2);
+          expect(onStackIndexUpdated.getCall(1).args[0]).to.equal(
+              window.history.length - 2);
+        });
       });
     });
   });


### PR DESCRIPTION
This breaks IE8 support because we no longer polyfill ES5.
But we also never supported it in the first place.

Reduces main binary file size from 138KB to 126KB. Hopefully has good run time impact because those polyfills do some weird shit to detect whether they are needed.