### PR TITLE
Fixes regex typo for dedicatedCopyrightNoteSources

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -26,7 +26,7 @@ var srcGlobs = srcGlobs.concat([
   '!gulpfile.js',
 ]);
 
-var dedicatedCopyrightNoteSources = /(\.js|.css)$/;
+var dedicatedCopyrightNoteSources = /(\.js|\.css)$/;
 
 var es6polyfill = 'Not available because we do not currently' +
     ' ship with a needed ES6 polyfill.';


### PR DESCRIPTION
The previous regex was not looking for '.' specifically prior to the
css file extension which could cause it to accidentally match scss
as well as .css. I changed it to match same way javascript extensions
are being matched.