### PR TITLE
Adding 'svg' as an allowed SVG element. Fixes #488

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -333,7 +333,7 @@ The AMP HTML format is designed so that is always the case.
 
 Currently, the following SVG elements are allowed:
 
-* basics: "g", "path", "glyph", "glyphRef", "marker", "view"
+* basics: "svg", "g", "path", "glyph", "glyphRef", "marker", "view"
 * shapes: "circle", "line", "polygon", "polyline", "rect"
 * text: "text", "textPath", "tref", "tspan"
 * rendering: "clipPath", "filter", "linearGradient", "radialGradient", "mask", "pattern", "vkern", "hkern"


### PR DESCRIPTION
[Fixes issue 488, where SVG was not included in the list of allowed SVG elements.](https://github.com/ampproject/amphtml/issues/488)