### PR TITLE
Reduce the number of recalc styles during a typically AMP boot procedure from 4 to 2

### DIFF
--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -18,7 +18,7 @@ import {Timer} from '../../../../src/timer';
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise, pollForLayout} from '../../../../testing/iframe';
 import {loadPromise} from '../../../../src/event-helper';
-import {resources} from '../../../../src/resources';
+import {resourcesFor} from '../../../../src/resources';
 require('../amp-iframe');
 
 adopt(window);

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -17,7 +17,7 @@
 import {Layout} from './layout';
 import {assert} from './asserts';
 import {preconnectFor} from './preconnect';
-import {resources} from './resources';
+import {resourcesFor} from './resources';
 import {viewerFor} from './viewer';
 import {viewportFor} from './viewport';
 
@@ -100,6 +100,9 @@ export class BaseElement {
 
     /** @protected {!Preconnect} */
     this.preconnect = preconnectFor(element.ownerDocument.defaultView);
+
+    /** @private {!Resources}  */
+    this.resources_ = resourcesFor(element.ownerDocument.defaultView);
   }
 
   /** @return {!Layout} */
@@ -195,7 +198,7 @@ export class BaseElement {
    * @param {!Element} element
    */
   setAsOwner(element) {
-    resources.setOwner(element, this.element);
+    this.resources_.setOwner(element, this.element);
   }
 
   /**
@@ -320,7 +323,7 @@ export class BaseElement {
    * @return {number}
    */
   getMaxDpr() {
-    return resources.getMaxDpr();
+    return this.resources_.getMaxDpr();
   }
 
   /**
@@ -328,7 +331,7 @@ export class BaseElement {
    * @return {number}
    */
   getDpr() {
-    return resources.getDpr();
+    return this.resources_.getDpr();
   }
 
   /**
@@ -423,7 +426,7 @@ export class BaseElement {
    * @protected
    */
   scheduleLayout(elements) {
-    resources.scheduleLayout(this.element, elements);
+    this.resources_.scheduleLayout(this.element, elements);
   }
 
   /**
@@ -435,7 +438,7 @@ export class BaseElement {
    * @protected
    */
   schedulePreload(elements) {
-    resources.schedulePreload(this.element, elements);
+    this.resources_.schedulePreload(this.element, elements);
   }
 
   /**
@@ -447,7 +450,7 @@ export class BaseElement {
    * @protected
    */
   updateInViewport(elements, inLocalViewport) {
-    resources.updateInViewport(this.element, elements, inLocalViewport);
+    this.resources_.updateInViewport(this.element, elements, inLocalViewport);
   }
 
   /**
@@ -458,7 +461,7 @@ export class BaseElement {
    * @protected
    */
   changeHeight(newHeight) {
-    resources.changeHeight(this.element, newHeight);
+    this.resources_.changeHeight(this.element, newHeight);
   }
 
   /**
@@ -467,7 +470,7 @@ export class BaseElement {
    * @param {!Function} callback
    */
   deferMutate(callback) {
-    resources.deferMutate(this.element, callback);
+    this.resources_.deferMutate(this.element, callback);
   }
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -21,7 +21,7 @@ import {ElementStub, stubbedElements} from './element-stub';
 import {assert} from './asserts';
 import {log} from './log';
 import {reportError} from './error';
-import {resources} from './resources';
+import {resourcesFor} from './resources';
 import {timer} from './timer';
 import * as dom from './dom';
 
@@ -243,6 +243,9 @@ export function createAmpElementProto(win, name, implementationClass) {
     this.readyState = 'loading';
     this.everAttached = false;
 
+    /** @private @const {!Resources}  */
+    this.resources_ = resourcesFor(win);
+
     /** @private {!Layout} */
     this.layout_ = Layout.NODISPLAY;
 
@@ -307,7 +310,7 @@ export function createAmpElementProto(win, name, implementationClass) {
       this.implementation_.firstAttachedCallback();
       this.dispatchCustomEvent('amp:attached');
     }
-    resources.upgraded(this);
+    this.resources_.upgraded(this);
   };
 
   /**
@@ -439,7 +442,7 @@ export function createAmpElementProto(win, name, implementationClass) {
         reportError(e, this);
       }
     }
-    resources.add(this);
+    this.resources_.add(this);
   };
 
   /**
@@ -447,7 +450,7 @@ export function createAmpElementProto(win, name, implementationClass) {
    * @final
    */
   ElementProto.detachedCallback = function() {
-    resources.remove(this);
+    this.resources_.remove(this);
   };
 
   /**
@@ -514,7 +517,7 @@ export function createAmpElementProto(win, name, implementationClass) {
    * @final
    */
   ElementProto.getLayoutBox = function() {
-    return resources.getResourceForElement(this).getLayoutBox();
+    return this.resources_.getResourceForElement(this).getLayoutBox();
   };
 
   /**

--- a/src/resources.js
+++ b/src/resources.js
@@ -21,8 +21,10 @@ import {expandLayoutRect, layoutRectLtwh, layoutRectsOverlap} from
 import {inputFor} from './input';
 import {log} from './log';
 import {documentStateFor} from './document-state';
+import {getService} from './service';
 import {reportError} from './error';
 import {timer} from './timer';
+import {makeBodyVisible} from './styles';
 import {viewerFor} from './viewer';
 import {viewportFor} from './viewport';
 import {vsync} from './vsync';
@@ -85,6 +87,13 @@ export class Resources {
     /** @private {boolean} */
     this.documentReady_ = false;
 
+    /**
+     * We want to do some work in the first pass after
+     * the document is ready.
+     * @private {boolean}
+     */
+    this.firstPassAfterDocumentReady_ = true;
+
     /** @private {boolean} */
     this.relayoutAll_ = false;
 
@@ -133,7 +142,7 @@ export class Resources {
 
     // Ensure that we attempt to rebuild things when DOM is ready.
     this.docState_.onReady(() => {
-      this.setDocumentReady_();
+      this.documentReady_ = true;
       this.forceBuild_ = true;
       this.relayoutAll_ = true;
       this.schedulePass();
@@ -179,14 +188,6 @@ export class Resources {
     vsync.mutate(() => {
       this.win.document.body.classList.toggle(clazz, on);
     });
-  }
-
-  /** @private */
-  setDocumentReady_() {
-    this.documentReady_ = true;
-    this.viewer_.postDocumentReady(this.viewport_.getSize().width,
-        this.win.document.body./*OK*/scrollHeight);
-    this.updateScrollHeight_();
   }
 
   /** @private */
@@ -395,6 +396,13 @@ export class Resources {
     let prevVisible = this.visible_;
     this.visible_ = this.viewer_.isVisible();
     this.prerenderSize_ = this.viewer_.getPrerenderSize();
+
+    if (this.documentReady_ && this.firstPassAfterDocumentReady_) {
+      this.firstPassAfterDocumentReady_ = false;
+      this.viewer_.postDocumentReady(this.viewport_.getSize().width,
+        this.win.document.body./*OK*/scrollHeight);
+      this.updateScrollHeight_();
+    }
 
     let viewportSize = this.viewport_.getSize();
     log.fine(TAG_, 'PASS: at ' + timer.now() +
@@ -1491,5 +1499,12 @@ export const ResourceState_ = {
  */
 var Task_;
 
-
-export const resources = new Resources(window);
+/**
+ * @param {!Window} window
+ * @return {!Resources}
+ */
+export function resourcesFor(window) {
+  return getService(window, 'resources', () => {
+    return new Resources(window);
+  });
+};

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -554,5 +554,3 @@ export function viewerFor(window) {
     return new Viewer(window);
   });
 };
-
-export const viewer = viewerFor(window);

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -18,12 +18,13 @@ import {BaseElement} from '../../src/base-element';
 import {ElementStub} from '../../src/element-stub';
 import {Layout} from '../../src/layout';
 import {createAmpElementProto} from '../../src/custom-element';
-import {resources} from '../../src/resources';
+import {resourcesFor} from '../../src/resources';
 import * as sinon from 'sinon';
 
 
 describe('CustomElement', () => {
 
+  let resources = resourcesFor(window);
   let testElementCreatedCallback;
   let testElementFirstAttachedCallback;
   let testElementBuildCallback;

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -52,6 +52,7 @@ describe('Viewport', () => {
     };
     binding = new ViewportBindingVirtual_(windowApi, viewer);
     viewport = new Viewport(windowApi, binding, viewer);
+    viewport.getSize();
   });
 
   afterEach(() => {


### PR DESCRIPTION
 which is likely the minimum possible right now.

Refactors both viewport and resources to use the service pattern
instead of being magic global singletons.