### PR TITLE
Fixed the error on checking history stack index

### DIFF
--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -56,8 +56,8 @@ describe('History', () => {
     sandbox = null;
   });
 
-  it.skipOnFirefox('should initialize correctly', () => {
-    expect(history.stackIndex_).to.equal(window.history.length - 1);
+  it('should initialize correctly', () => {
+    expect(history.stackIndex_).to.equal(0);
     expect(history.stackOnPop_.length).to.equal(0);
     expect(onStackIndexUpdated).to.not.equal(null);
   });


### PR DESCRIPTION
Test wasn't fixed when "window.history" part was extracted into a separate binding class.

Closes #242.