### PR TITLE
Documentation fix: amp-pinterest uses data- attribs.

### DIFF
--- a/extensions/amp-pinterest/amp-pinterest.md
+++ b/extensions/amp-pinterest/amp-pinterest.md
@@ -42,11 +42,11 @@ Embedded pin widget: `data-do="embedPin"`
 
 Required when `data-do` is `buttonPin`.  Contains the fully-qualified URL intended to be pinned or re-made into a widget.
 
-**pinMedia**
+**data-media**
 
 Required when `data-do` is `buttonPin`.  Contains the fully-qualified URL of the image intended to be pinned. If the pin will eventually contain multimedia (such as YouTube), should point to a high-resolution thumbnail.
 
-**pinDescription**
+**data-description**
 
 Required when `data-do` is `buttonPin`.  Contains the default description that appears in the pin create form; please choose carefully, since many Pinners will close the form without pinning if it doesn't make sense.
 


### PR DESCRIPTION
@erwinmombay @kentbrew @dvoytenko @Gregable 

Sorry about the earlier mess. I'll close the other pull request for the same little fix (https://github.com/ampproject/amphtml/pull/654).