### PR TITLE
Configure and activate SauceLabs for AMP.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
 node_js:
   - "stable"
+notifications:
+  webhooks:
+    - http://savage.nonblocking.io/savage/travis
 addons:
+  sauce_connect: true
   hosts:
     - ads.localhost
     - iframe.localhost
@@ -17,3 +21,4 @@ script:
   - gulp build
   - gulp minify
   - gulp test
+  - gulp test --saucelabs

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -75,6 +75,17 @@ var karma = {
       },
       captureConsole: false
     }
+  },
+  saucelabs: {
+    configFile: karmaConf,
+    files: testPaths,
+    reporters: ['dots', 'saucelabs'],
+    browsers: ['SL_Chrome'],
+    singleRun: true,
+    client: {
+      captureConsole: false
+    },
+    browserDisconnectTimeout: 30000,
   }
 };
 

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -35,6 +35,16 @@ function getConfig() {
     return extend(obj, karmaConfig.firefox);
   }
 
+  if (argv.saucelabs) {
+    if (!process.env.SAUCE_USERNAME) {
+      throw new Error('Missing SAUCE_USERNAME Env variable');
+    }
+    if (!process.env.SAUCE_ACCESS_KEY) {
+      throw new Error('Missing SAUCE_ACCESS_KEY Env variable');
+    }
+    return extend(obj, karmaConfig.saucelabs);
+  }
+
   return extend(obj, karmaConfig.default);
 }
 
@@ -42,6 +52,11 @@ function getConfig() {
  * Run tests.
  */
 gulp.task('test', ['build'], function(done) {
+  if (argv.saucelabs && process.env.MAIN_REPO) {
+    console./*OK*/info('Deactivated for main repo');
+    return;
+  }
+
   var config = getConfig();
   var browsers = [];
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -60,14 +60,28 @@ module.exports = function(config) {
       /*eslint "google-camelcase/google-camelcase": 0*/
       Chrome_travis_ci: {
         base: 'Chrome',
-        flags: ['--no-sandbox']
+        flags: ['--no-sandbox'],
+      },
+      SL_Chrome: {
+        base: 'SauceLabs',
+        browserName: 'chrome',
+      },
+    },
+
+    sauceLabs: {
+      testName: 'AMP HTML on Sauce',
+      tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
+      startConnect: false,
+      connectOptions: {
+        port: 5757,
+        logfile: 'sauce_connect.log'
       }
     },
 
     // change Karma's debug.html to the mocha web reporter
     client: {
       mocha: {
-        reporter: 'html'
+        reporter: 'html',
       },
       captureConsole: false
     }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "karma-html2js-preprocessor": "0.1.0",
     "karma-mocha": "0.2.0",
     "karma-safari-launcher": "0.1.1",
+    "karma-sauce-launcher": "0.2.14",
     "karma-sinon-chai": "1.0.0",
     "minimist": "1.2.0",
     "mocha": "2.3.3",


### PR DESCRIPTION
Currently only runs our existing tests in Chrome. But this is now super easy to extend to other browsers.