### PR TITLE
Removes redundant existance check

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -123,14 +123,13 @@ export function getErrorReportUrl(message, filename, line, col, error) {
     url += '&a=' + (error.fromAssert ? 1 : 0) +
         '&el=' + encodeURIComponent(tagName) +
         '&s=' + encodeURIComponent(error.stack || '');
-    } else {
+    error.message += ' _reported_';
+  } else {
     url += '&f=' + encodeURIComponent(filename) +
         '&l=' + encodeURIComponent(line) +
         '&c=' + encodeURIComponent(col || '');
   }
-  if (error) {
-    error.message += ' _reported_';
-  }
+
   // Shorten URLs to a value all browsers will send.
   return url.substr(0, 2000);
 }


### PR DESCRIPTION
A micro-optimization, but the block immediately prior to this makes an
identical check and doesn't modify the condition in any way. This should
save a check.