### PR TITLE
Fixes issue with build generating undefined for env var

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -258,6 +258,7 @@ function buildExtensionJs(js, path, name, version, options) {
  * Main Build
  */
 function build() {
+  process.env.NODE_ENV = 'development';
   polyfillsForTests();
   buildExtensions();
   buildExamples(false);


### PR DESCRIPTION
Babel is replacing instances of process.env.NODE_ENV with undefined
for the non-production build [gulp build] since we aren't defining the
value. This results in confusing output in the amp.js artifact.
This change causes the undefined to be replaced by "development" by specifying
the NODE_ENV value as part of the gulp build target.