### PR TITLE
Removes a redundant call to function

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -87,7 +87,6 @@ export function makeBodyVisible(doc) {
     }
   };
   interval = setInterval(set, 4);
-  set();
 }
 
 


### PR DESCRIPTION
Another micro-optimization. The 'set' function is being setup and called by
the intervel timer. Calling it again immediately after shouldn't be necessary.