### PR TITLE
Updates link to documentation.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -107,7 +107,7 @@ In particular, we try to maintain "it might not be perfect but isn't broken"-sup
 ## Eng docs
 
 - [Life of an AMP *](https://docs.google.com/document/d/1WdNj3qNFDmtI--c2PqyRYrPrxSg2a-93z5iX0SzoQS0/edit#)
-- [AMP Layout system](https://docs.google.com/document/d/1YjFk_B6r97CCaQJf2nXRVuBOuNi_3Fn87Zyf1U7Xoz4/edit)
+- [AMP Layout system](spec/amp-html-layout.md)
 
 We also recommend scanning the [spec](spec/). The non-element part should help understand some of the design aspects.
 

--- a/css/amp.css
+++ b/css/amp.css
@@ -16,7 +16,8 @@
 
 /**
  * Margin:0 is currently needed for iOS viewer embeds.
- * See https://docs.google.com/document/d/1YjFk_B6r97CCaQJf2nXRVuBOuNi_3Fn87Zyf1U7Xoz4/edit
+ * See:
+ * https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md
  * and {@link ViewportBindingNaturalIosEmbed_} for more info.
  */
 body {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -47,7 +47,8 @@ export const ViewportType = {
    * This is AMP-specific type and doesn't come from viewer. This is the type
    * that AMP sets when Viewer has requested "natural" viewport on a iOS
    * device.
-   * See https://docs.google.com/document/d/1YjFk_B6r97CCaQJf2nXRVuBOuNi_3Fn87Zyf1U7Xoz4/edit
+   * See:
+   * https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md
    * and {@link ViewportBindingNaturalIosEmbed_} for more details.
    */
   NATURAL_IOS_EMBED: 'natural-ios-embed'


### PR DESCRIPTION

![2015-10-19 13_44_25-amp layout system - google docs - firefox developer edition](https://cloud.githubusercontent.com/assets/912941/10587619/8ebb02b2-7667-11e5-8fe9-31acce9c42bb.png)
The comment link was still pointing at a google doc that had been
converted to a markdown file and added to the repo.