### PR TITLE
#686 Adds help information to gulp 

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -17,8 +17,8 @@
 
 var argv = require('minimist')(process.argv.slice(2));
 var config = require('../config');
+var gulp = require('gulp-help')(require('gulp'));
 var eslint = require('gulp-eslint');
-var gulp = require('gulp');
 var lazypipe = require('lazypipe');
 var util = require('gulp-util');
 var watch = require('gulp-watch');
@@ -57,4 +57,9 @@ function lint() {
     });
 }
 
-gulp.task('lint', lint);
+gulp.task('lint', 'Validates against Google Closure Linter', lint,
+{
+  options: {
+    'watch': 'Watches for changes in files, validates against the linter'
+  }
+});

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var gulp = require('gulp');
+var gulp = require('gulp-help')(require('gulp'));
 var path = require('path');
 var srcGlobs = require('../config').presubmitGlobs;
 var util = require('gulp-util');
@@ -270,4 +270,5 @@ function checkForbiddenAndRequiredTerms() {
     });
 }
 
-gulp.task('presubmit', checkForbiddenAndRequiredTerms);
+gulp.task('presubmit', 'Run validation against files to check for forbidden '+
+  'and required terms', checkForbiddenAndRequiredTerms);

--- a/build-system/tasks/size.js
+++ b/build-system/tasks/size.js
@@ -17,7 +17,7 @@
 var table = require('text-table');
 var del = require('del');
 var fs = require('fs');
-var gulp = require('gulp');
+var gulp = require('gulp-help')(require('gulp'));
 var gutil = require('gulp-util');
 var gzipSize = require('gzip-size');
 var prettyBytes = require('pretty-bytes');
@@ -103,4 +103,4 @@ function sizeTask() {
     .on('end', del.bind(null, [tempFolderName]));
 }
 
-gulp.task('size', sizeTask);
+gulp.task('size', 'Runs a report on artifact size', sizeTask);

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -15,7 +15,7 @@
  */
 
 var argv = require('minimist')(process.argv.slice(2));
-var gulp = require('gulp');
+var gulp = require('gulp-help')(require('gulp'));
 var karma = require('karma').server;
 var config = require('../config');
 var karmaConfig = config.karma;
@@ -51,7 +51,7 @@ function getConfig() {
 /**
  * Run tests.
  */
-gulp.task('test', ['build'], function(done) {
+gulp.task('test', 'Runs tests in chrome', ['build'], function(done) {
   if (argv.saucelabs && process.env.MAIN_REPO &&
       // Sauce Labs does not work on Pull Requests directly.
       // The @ampsauce bot builds these.
@@ -72,4 +72,12 @@ gulp.task('test', ['build'], function(done) {
   }
 
   karma.start(config, done);
+}, {
+  options: {
+    'verbose': 'With logging enabled',
+    'watch': 'Watches for changes in files, runs corresponding test(s)',
+    'saucelabs': 'Runs test on saucelabs (requires setup)',
+    'safari': 'Runs tests in Safari',
+    'firefox': 'Runs tests in Firefox'
+  }
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var gulp = require('gulp');
+var gulp = require('gulp-help')(require('gulp'));
 var del = require('del');
 var file = require('gulp-file');
 var gulpWatch = require('gulp-watch');
@@ -265,18 +265,18 @@ function build() {
   compile();
 }
 
-gulp.task('css', compileCss);
-gulp.task('extensions', buildExtensions);
-gulp.task('clean', clean);
-gulp.task('build', build);
-gulp.task('watch', watch);
-gulp.task('minify', function() {
+gulp.task('css', 'Recompile css to build directory', compileCss);
+gulp.task('extensions', 'Build AMP Extensions', buildExtensions);
+gulp.task('clean', 'Removes build output', clean);
+gulp.task('build', 'Builds the AMP library', build);
+gulp.task('watch', 'Watches for changes in files, re-build', watch);
+gulp.task('minify', 'Build production binaries', function() {
   process.env.NODE_ENV = 'production';
   compile(false, true);
   buildExtensions({minify: true});
 });
 
-gulp.task('default', ['watch']);
+gulp.task('default', 'Same as "watch"', ['watch']);
 
 /**
  * Build the examples
@@ -443,3 +443,4 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     rebundle();
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "through2": "2.0.0",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0",
-    "watchify": "3.3.1"
+    "watchify": "3.3.1",
+    "gulp-help": "1.6.1"
   }
 }


### PR DESCRIPTION
All tasks are listed with help information using [gulp-help](https://www.npmjs.com/package/gulp-help).

I used the descriptions I found in the `DEVELOPING.md` file for most of it and made some guesses on the rest. 
![2015-10-20 08_53_58-ubuntu_default_1441824855171_86120 running - oracle vm virtualbox](https://cloud.githubusercontent.com/assets/912941/10610448/70893fba-770d-11e5-8738-fa313f89ab2d.png)
