### PR TITLE
Proposal: switch travis to U14 Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+sudo: required  # See http://docs.travis-ci.com/user/trusty-ci-environment/
+dist: trusty
 node_js:
   - "stable"
 notifications:


### PR DESCRIPTION
Trusty version comes with some fresher libraries, including Phantom2. For more details see: 

http://docs.travis-ci.com/user/trusty-ci-environment/
