### PR TITLE
Accept adtech ads to be loaded from other domains

### DIFF
--- a/ads/adtech.js
+++ b/ads/adtech.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {writeScript, validateSrcPrefix} from '../src/3p';
+import {writeScript, validateSrcPrefix, validateSrcContains} from '../src/3p';
 
 /**
  * @param {!Window} global
@@ -22,6 +22,7 @@ import {writeScript, validateSrcPrefix} from '../src/3p';
  */
 export function adtech(global, data) {
   var src = data.src;
-  validateSrcPrefix('https://adserver.adtechus.com/addyn/', src);
+  validateSrcPrefix('https:', src);
+  validateSrcContains('/addyn/', src);
   writeScript(global, src);
 }

--- a/ads/adtech.md
+++ b/ads/adtech.md
@@ -31,4 +31,4 @@ For semantics of configuration, please see ad network documentation.
 
 Supported parameters:
 
-- src. Value must start with "https://adserver.adtechus.com/addyn/"
+- src. Value must start with `https:` and contain `/addyn/`

--- a/src/3p.js
+++ b/src/3p.js
@@ -104,7 +104,18 @@ function executeAfterWriteScript(win, fn) {
  * @param {string} src
  */
 export function validateSrcPrefix(prefix, src) {
-  if (src.indexOf(prefix) != 0) {
+  if (src.indexOf(prefix) !== 0) {
+    throw new Error('Invalid src ' + src);
+  }
+}
+
+/**
+ * Throws if the given src doesn't contain the string
+ * @param {string} string
+ * @param {string} src
+ */
+export function validateSrcContains(string, src) {
+  if (src.indexOf(string) === -1) {
     throw new Error('Invalid src ' + src);
   }
 }

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import {validateSrcPrefix, validateSrcContains} from '../../src/3p';
+
+ describe('3p', () => {
+  it('should throw an error if prefix is not https:', () => {
+    expect(() => {
+      validateSrcPrefix('https:', 'http://adserver.adtechus.com');
+    }).to.throw(/Invalid src/);
+  });
+
+  it('should not throw if source starts with https', () => {
+    expect(
+      validateSrcPrefix('https:', 'https://adserver.adtechus.com')
+    ).to.not.throw;
+  });
+
+  it('should throw an error if src does not contain addyn', () => {
+    expect(() => {
+      validateSrcContains('/addyn/', 'http://adserver.adtechus.com/');
+    }).to.throw(/Invalid src/);
+  });
+
+  it('should not throw if source contains /addyn/', () => {
+    expect(
+      validateSrcContains('/addyn/', 'http://adserver.adtechus.com/addyn/')
+    ).to.not.throw;
+  });
+ });
+


### PR DESCRIPTION
Adtech also have an european server(https://adserver.adtech.de), and it allows CNAMES(ie. helios.e24.no.		600	IN	CNAME	adserver.adtech.de.)