### PR TITLE
Fix minor documentation differences

### DIFF
--- a/docs/create_page.md
+++ b/docs/create_page.md
@@ -61,7 +61,7 @@ here's the basic AMP HTML page now with an image:
 
 ```html
 <!doctype html>
-<html AMP lang="en">
+<html amp lang="en">
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
@@ -101,7 +101,7 @@ inlined stylesheet:
 
 ```html
 <!doctype html>
-<html AMP lang="en">
+<html amp lang="en">
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>

--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -159,7 +159,7 @@ Major semantic tags and the AMP custom elements come with default styles to make
 
 The following @-rules are allowed in stylesheets:
 
-`@font-face`, '@keyframes', `@media`.
+`@font-face`, `@keyframes`, `@media`.
 
 `@import` will not be allowed. Other may be added in the future.
 


### PR DESCRIPTION
Lowercase `amp` for better gzipping and fix code markup on `@keyframes`