### PR TITLE
Remove support and documentation for the adsense responsive feature

### DIFF
--- a/ads/adsense.js
+++ b/ads/adsense.js
@@ -32,9 +32,6 @@ export function adsense(global, data) {
   if (data['adSlot']) {
     i.setAttribute('data-ad-slot', data['adSlot']);
   }
-  if (data['adFormat']) {
-    i.setAttribute('data-ad-format', data['adFormat']);
-  }
   i.setAttribute('class', 'adsbygoogle');
   i.style.cssText = 'display:inline-block;width:100%;height:100%;';
   global.document.getElementById('c').appendChild(i);

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -53,15 +53,6 @@
       data-ad-slot="7783467241">
   </amp-ad>
 
-  <h2>AdSense responsive</h2>
-  <amp-ad width=300 height=75
-      type="adsense"
-      layout="responsive"
-      data-ad-client="ca-pub-8125901705757971"
-      data-ad-slot="7783467241"
-      data-ad-format="auto">
-  </amp-ad>
-
   <h2>AdTech</h2>
   <amp-ad width=300 height=250
       type="adtech"


### PR DESCRIPTION
Does not currently work as intended.
The data-ad-format="auto" behavior will attempt to set the height of the <ins adsbygoogle> tag based on some JS logic, however the size of the ad container and iframe surrounding it aren't fixed, and won't flow vertically in the way this code expects them to.

The end result is that either excessive white-space shows below the ad or the ad element is clipped within the containing AMP iframe, unless the size of the containing element exactly matches the size that the responsive JS logic will chose.