### PR TITLE
Adds `gulp serve` task for simple http server

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -32,9 +32,8 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 
 1. Install [NodeJS](https://nodejs.org).
 2. In the repo directory, run `npm i` command to install the required npm packages.
-4. run `sudo npm i -g gulp` command to install gulp in your local bin folder ('/usr/local/bin/' on Mac).
-5. run `sudo npm i -g http-server` command to install http server in your local bin folder ('/usr/local/bin/' on Mac).
-6. `edit /etc/hosts` and map `ads.localhost` and `iframe.localhost` to `127.0.0.1`.
+3. run `sudo npm i -g gulp` command to install gulp in your local bin folder ('/usr/local/bin/' on Mac).
+4. `edit /etc/hosts` and map `ads.localhost` and `iframe.localhost` to `127.0.0.1`.
 <pre>
   127.0.0.1               ads.localhost iframe.localhost
 </pre>
@@ -43,7 +42,7 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 
 | Command                       | Description                                                           |
 | ----------------------------- | --------------------------------------------------------------------- |
-| `gulp`                        | Same as "watch".                                                      |
+| `gulp`                        | Runs "watch" and "serve".                                             |
 | `gulp dist`                   | Builds production binaries.                                           |
 | `gulp lint`                   | Validates against Google Closure Linter.                              |
 | `gulp lint --watch`           | Watches for changes in files, Validates against Google Closure Linter.|
@@ -57,10 +56,11 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 | `gulp test --verbose`         | Runs tests in Chrome with logging enabled.                            |
 | `gulp test --watch`           | Watches for changes in files, runs corresponding test(s) in Chrome.   |
 | `gulp test --watch --verbose` | Same as "watch" with logging enabled.                                 |
-| `gulp test --saucelabs`       | Runs test on saucelabs (requires [setup](#saucelabs))                 |
+| `gulp test --saucelabs`       | Runs test on saucelabs (requires [setup](#saucelabs)).                |
 | `gulp test --safari`          | Runs tests in Safari.                                                 |
 | `gulp test --firefox`         | Runs tests in Firefox.                                                |
-| `http-server -p 8000 -c-1`    | Serves content in current working dir over http://localhost:8000/     |
+| `gulp serve`                  | Serves content in repo root dir over http://localhost:8000/.          |
+|-------------------------------|-----------------------------------------------------------------------|
 
 To fix issues with Safari test runner launching multiple instances of the test, run:
 <pre>

--- a/build-system/tasks/index.js
+++ b/build-system/tasks/index.js
@@ -20,4 +20,5 @@ require('./lint');
 require('./make-golden');
 require('./presubmit-checks');
 require('./size');
+require('./server');
 require('./test');

--- a/build-system/tasks/server.js
+++ b/build-system/tasks/server.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var argv = require('minimist')(process.argv.slice(2));
+var gulp = require('gulp-help')(require('gulp'));
+var gls = require('gulp-live-server');
+var util = require('gulp-util');
+
+var port = argv.port || process.env.PORT || 8000;
+
+/**
+ * Starts a simple http server at the repository root
+ */
+function serve() {
+  var server = gls.static(argv.path || '/', port);
+  server.start();
+  util.log(util.colors.yellow(
+    'Run `gulp build` then go to http://localhost:' + port + '/examples.build/article.amp.max.html'
+  ));
+}
+
+gulp.task('serve', 'Serves content in root dir over http://localhost:' +
+  port + '/', serve, {
+    options: {
+      'port': '  Specifies alternative port to use instead of default (8000)'
+    }
+  }
+);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -442,7 +442,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
  */
 gulp.task('build', 'Builds the AMP library', build);
 gulp.task('css', 'Recompile css to build directory', compileCss);
-gulp.task('default', 'Same as "watch"', ['watch']);
+gulp.task('default', 'Same as "watch"', ['watch', 'serve']);
 gulp.task('dist', 'Build production binaries', dist);
 gulp.task('extensions', 'Build AMP Extensions', buildExtensions);
 gulp.task('watch', 'Watches for changes in files, re-build', watch);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-file": "0.2.0",
     "gulp-help": "1.6.1",
     "gulp-image-diff": "0.3.0",
+    "gulp-live-server": "0.0.29",
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
     "gulp-sourcemaps": "1.5.2",


### PR DESCRIPTION
Previously developers had to install http-server globally to run a server
for amp. This change adds a gulp task to run a simple http server using
gulp-live-server. Documentation is updated to reflect the change.
![2015-10-27 14_41_27-start](https://cloud.githubusercontent.com/assets/912941/10770364/e68e06cc-7cb8-11e5-87ba-2d5022ca33a6.png)

Fixes #748 
