### PR TITLE
Presubmit bug

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -54,10 +54,6 @@ var forbiddenTerms = {
   'Promise\\.race': es6polyfill,
   '\\.startsWith': es6polyfill,
   '\\.endsWith': es6polyfill,
-  // TODO: (erwinm) rewrite the destructure and spread warnings as
-  // eslint rules (takes more time than this quick regex fix).
-  // No destructuring allowed since we dont ship with Array polyfills.
-  '^\\s*(?:let|const|var).*(?:\\[|{).*=': es6polyfill,
   // No spread (eg. test(...args) allowed since we dont ship with Array
   // polyfills except `arguments` spread as babel does not polyfill
   // it since it can assume that it can `slice` w/o the use of helpers.


### PR DESCRIPTION
@cramforce removing it for now since it should be safe as i havent submitted https://github.com/ampproject/amphtml/pull/701 yet. ill have a eslint rule for it by monday which should be more correct than the regex i wrote.

created issue for me to track https://github.com/ampproject/amphtml/issues/808