### PR TITLE
Tune heuristic when to load ads.

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -86,6 +86,9 @@ export class Viewport {
     /** @private {boolean} */
     this.scrollTracking_ = false;
 
+    /** @private {number} */
+    this.scrollCount_ = 0;
+
     /** @private @const {!Observable<!ViewportChangedEvent>} */
     this.changeObservable_ = new Observable();
 
@@ -300,6 +303,14 @@ export class Viewport {
   }
 
   /**
+   * Returns whether the user has scrolled yet.
+   * @return {boolean}
+   */
+  hasScrolled() {
+    return this.scrollCount_ > 0;
+  }
+
+  /**
    * Updates touch zoom meta data. Returns `true` if any actual
    * changes have been done.
    * @return {boolean}
@@ -357,6 +368,7 @@ export class Viewport {
 
   /** @private */
   scroll_() {
+    this.scrollCount_++;
     this.scrollObservable_.fire();
 
     this.scrollLeft_ = this.binding_.getScrollLeft();

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -145,6 +145,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, done) {
  *   that element. When the promise is resolved we will have called the entire
  *   lifecycle including layoutCallback.
  * @param {boolean=} opt_runtimeOff Whether runtime should be turned off.
+ * @param {function()=} opt_beforeLayoutCallback
  * @return {!Promise<{
  *   win: !Window,
  *   doc: !Document,
@@ -152,7 +153,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, done) {
  *   addElement: function(!Element):!Promise
  * }>}
  */
-export function createIframePromise(opt_runtimeOff) {
+export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
   return new Promise(function(resolve, reject) {
     var iframe = document.createElement('iframe');
     iframe.name = 'test_' + iframeCount++;
@@ -179,6 +180,9 @@ export function createIframePromise(opt_runtimeOff) {
             element.style.display = 'block';
             element.build(true);
             if (element.layoutCount_ == 0) {
+              if (opt_beforeLayoutCallback) {
+                opt_beforeLayoutCallback();
+              }
               element.layoutCallback();
             }
             return element;


### PR DESCRIPTION
Instead of only loading them when they are in viewport, we also load
them if they are outside the viewport:

- if the user has ever scrolled (So we don't interfere with e.g. swiping through articles).
- we haven't started loading another ad in the last second.

In practice this should load a large percentage of ads before they enter the viewport
while interference with scrolling is kept to a similar value as with the old heuristic.