### PR TITLE
Implement API for ad viewability.

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -17,6 +17,9 @@
 /**
  * @fileoverview Registers all known ad network factories and then executes
  * one of them.
+ *
+ * This files gets minified and published to
+ * https://3p.ampproject.net/$version/f.js
  */
 
 import './polyfills';
@@ -28,6 +31,7 @@ import {doubleclick} from '../ads/doubleclick';
 import {twitter} from './twitter';
 import {register, run} from '../src/3p';
 import {parseUrl} from '../src/url';
+import {assert} from '../src/asserts';
 
 register('a9', a9);
 register('adreactor', adreactor);
@@ -47,6 +51,8 @@ register('twitter', twitter);
  */
 export function draw3p(win, data) {
   var type = data.type;
+  assert(window.context.location.originValidated != null,
+      'Origin should have been validated');
   run(type, win, data);
 };
 
@@ -84,6 +90,8 @@ window.draw3p = function() {
   var fragment = location.hash;
   var data = fragment ? JSON.parse(fragment.substr(1)) : {};
   window.context = data._context;
+  window.context.location = parseUrl(data._context.location.href);
+  validateParentOrigin(window, window.context.location);
   window.context.master = masterSelection(data.type);
   window.context.isMaster = window.context.master == window;
   window.context.data = data;
@@ -94,6 +102,8 @@ window.draw3p = function() {
     // is being implemented.
     window.context.updateDimensions = triggerDimensions;
   }
+  // This only actually works for ads.
+  window.context.observeIntersection = observeIntersection;
   delete data._context;
   draw3p(window, data);
 };
@@ -113,6 +123,53 @@ function nonSensitiveDataPostMessage(type, opt_object) {
   var object = opt_object || {};
   object.type = type;
   object.sentinel = 'amp-3p';
-  // Use of * is OK. We are not worried who gets this message.
-  window.parent./*OK*/postMessage(object, '*');
+  window.parent./*OK*/postMessage(object,
+      window.context.location.origin);
+}
+
+/**
+ * Registers a callback for intersections of this iframe with the current
+ * viewport.
+ * The passed in array has entries that aim to be compatible with
+ * the IntersectionObserver spec callback.
+ * http://rawgit.com/slightlyoff/IntersectionObserver/master/index.html#callbackdef-intersectionobservercallback
+ * @param {function(!Array<IntersectionObserverEntry>)} observerCallback
+ */
+function observeIntersection(observerCallback) {
+  // Send request to received records.
+  nonSensitiveDataPostMessage('send-intersections');
+  window.addEventListener('message', function(event) {
+    if (event.source != window.parent ||
+        event.origin != window.context.location.origin ||
+        !event.data ||
+        event.data.sentinel != 'amp-3p' ||
+        event.data.type != 'intersection') {
+      return;
+    }
+    observerCallback(event.data.changes);
+  });
+}
+
+/**
+ * Throws if the current frame's parent origin is not equal to
+ * the claimed origin.
+ * For browsers that don't support ancestorOrigins it adds
+ * `originValidated = false` to the location object.
+ * @param {!Window} window
+ * @param {!Location} parentLocation
+ * @visibleForTesting
+ */
+export function validateParentOrigin(window, parentLocation) {
+  const ancestors = window.location.ancestorOrigins;
+  // Currently only webkit and blink based browsers support
+  // ancestorOrigins. In that case we proceed but mark the origin
+  // as non-validated.
+  if (!ancestors || !ancestors.length) {
+    parentLocation.originValidated = false;
+    return;
+  }
+  assert(ancestors[0] == parentLocation.origin,
+      'Parent origin mismatch: %s, %s, %s',
+      ancestors[0], parentLocation.origin);
+  parentLocation.originValidated = true;
 }

--- a/ads/README.md
+++ b/ads/README.md
@@ -29,12 +29,31 @@ We will provide the following information to the ad:
 
 - `window.context.referrer` contains the origin of the referrer value of the primary document if available.
 - `document.referrer` will typically contain the URL of the primary document. This may change in the future (See next value for a more reliable method).
-- `window.context.location.href` contains the sanitized location.href value of the primary document.
+- `window.context.location` contains the sanitized `Location` object of the primary document.
+  This object contains keys like `href`, `origin` and other keys common for [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location) objects.
+  In browsers that support `location.ancestorOrigins` you can trust that the `origin` of the
+  location is actually correct (So rogue pages cannot claim they represent an origin they do not actually represent).
 - `window.context.canonicalUrl` contains the canonical URL of the primary document as defined by its `link rel=canonical` tag.
-- ad viewability: Tracked in https://github.com/ampproject/amphtml/issues/720
+- [ad viewability](#ad-viewability)
 - `window.context.noContentAvailable` is a function that the ad system can call if the ad slot was not filled. The container page will then react by showing placeholder content (not by collapsing the ad slot; sizing rules apply).
 
 More information can be provided in a similar fashion if needed (Please file an issue).
+
+### Ad viewability
+
+Ads can call the special API `window.context.observeIntersection(changesCallback)` to receive IntersectionObserver style [change records](http://rawgit.com/slightlyoff/IntersectionObserver/master/index.html#intersectionobserverentry) of the ad's intersection with the parent viewport.
+
+The API allows specifying a callback that fires with change records when AMP observes that an ad becomes visible and then while it is visible, changes are reported as they happen.
+
+Example usage:
+
+```js
+  window.context.observeIntersection(function(changes) {
+    changes.forEach(function(c) {
+      console.info('Height of intersection', c.intersectionRect.height);
+    });
+  });
+```
 
 ### Minimizing HTTP requests
 

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -99,7 +99,7 @@ module.exports = {
     '!{node_modules,build,dist,dist.3p,third_party,build-system}/**/*.*'
   ],
   presubmitGlobs: [
-    '**/*.{css,js,html,md}',
+    '**/*.{css,js}',
     // This does match dist.3p/current, so we run presubmit checks on the
     // built 3p binary. This is done, so we make sure our special 3p checks
     // run against the entire transitive closure of deps.

--- a/css/amp.css
+++ b/css/amp.css
@@ -290,6 +290,16 @@ amp-pixel {
 }
 
 /**
+ * Force the layout box of the ad iframe to be exactly as big as the actual
+ * iframe. The `amp-ad` tag itself can be freely styled.
+ */
+amp-ad iframe {
+  border: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/**
  * Instagram wraps the standard image into a fixed size container.
  * With these offsets, users can simply specify the the size of the
  * instagram images and things have the right size.

--- a/src/3p.js
+++ b/src/3p.js
@@ -26,13 +26,17 @@ import {assert} from './asserts';
 
 
 /** @typedef {function(!Window, !Object)}  */
-var ThirdPartyFunction;
+let ThirdPartyFunction;
 
 
-/** @const {!Object<ThirdPartyFunction>} */
-var registrations = {};
+/**
+ * @const {!Object<ThirdPartyFunction>}
+ * @visibleForTesting
+ */
+export const registrations = {};
 
-var syncScriptLoads = 0;
+/** @type {number} */
+let syncScriptLoads = 0;
 
 /**
  * @param {string} id The specific 3p integration.

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from './asserts';
+import {layoutRectLtwh, rectIntersection, moveLayoutRect} from
+    './layout-rect';
+
+/**
+ * Produces a change entry for that should be compatible with
+ * IntersectionObserverEntry.
+ *
+ * Mutates passed in rootBounds to have x and y according to spec.
+ *
+ * @param {number} time Time when values below were measured.
+ * @param {!LayoutRect} rootBounds Equivalent to viewport.getRect()
+ * @param {!LayoutRect} elementLayoutBox Layout box of the element
+ *     that may intersect with the rootBounds.
+ * @return {!IntersectionObserverEntry} A change entry.
+ * @private
+ */
+export function getIntersectionChangeEntry(
+    measureTime, rootBounds, elementLayoutBox) {
+  // Building an IntersectionObserverEntry.
+  // http://rawgit.com/slightlyoff/IntersectionObserver/master/index.html#intersectionobserverentry
+  // These should always be equal assuming rootBounds cannot have negative
+  // dimension.
+  rootBounds.x = rootBounds.left;
+  rootBounds.y = rootBounds.top;
+
+  const boundingClientRect =
+      moveLayoutRect(elementLayoutBox, -1 * rootBounds.x, -1 * rootBounds.y);
+  assert(boundingClientRect.width >= 0 &&
+      boundingClientRect.height >= 0, 'Negative dimensions in ad.');
+  boundingClientRect.x = boundingClientRect.left;
+  boundingClientRect.y = boundingClientRect.top;
+
+  const intersectionRect =
+      rectIntersection(rootBounds, elementLayoutBox) ||
+      // No intersection.
+      layoutRectLtwh(0, 0, 0, 0);
+  intersectionRect.x = intersectionRect.left;
+  intersectionRect.y = intersectionRect.top;
+
+  return {
+    time: measureTime,
+    rootBounds,
+    boundingClientRect,
+    intersectionRect,
+  };
+}

--- a/src/layout-rect.js
+++ b/src/layout-rect.js
@@ -83,6 +83,28 @@ export function layoutRectsOverlap(r1, r2) {
 
 
 /**
+ * Returns the intersection between a, b or null if there is none.
+ * @param {!LayoutRect} a
+ * @param {!LayoutRect} b
+ * @return {?LayoutRect}
+ */
+export function rectIntersection(a, b) {
+  const x0 = Math.max(a.left, b.left);
+  const x1 = Math.min(a.left + a.width, b.left + b.width);
+
+  if (x0 <= x1) {
+    const y0 = Math.max(a.top, b.top);
+    const y1 = Math.min(a.top + a.height, b.top + b.height);
+
+    if (y0 <= y1) {
+      return layoutRectLtwh(x0, y0, x1 - x0, y1 - y0);
+    }
+  }
+  return null;
+}
+
+
+/**
  * Expand the layout rect using multiples of width and height.
  * @param {!LayoutRect} rect Original rect.
  * @param {number} dw Expansion in width, specified as a multiple of width.

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -202,9 +202,9 @@ export class Viewport {
    * @return {!LayoutRect}
    */
   getRect() {
-    var scrollTop = this.binding_.getScrollTop();
-    var scrollLeft = this.binding_.getScrollLeft();
-    var size = this.binding_.getSize();
+    const scrollTop = this.getScrollTop();
+    const scrollLeft = this.getScrollLeft();
+    const size = this.getSize();
     return layoutRectLtwh(scrollLeft, scrollTop, size.width, size.height);
   }
 

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -129,3 +129,17 @@ chai.Assertion.addMethod('display', function(display) {
     value
   );
 });
+
+chai.Assertion.addMethod('jsonEqual', function(compare) {
+  var obj = this._obj;
+  var a = JSON.stringify(compare);
+  var b = JSON.stringify(obj);
+  this.assert(
+    a == b,
+    'expected JSON to be equal.\nExp: #{exp}\nAct: #{act}',
+    'expected JSON to not be equal.\nExp: #{exp}\nAct: #{act}',
+    a,
+    b
+  );
+});
+

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -107,8 +107,16 @@ describe('3p-frame', () => {
       var win = iframe.contentWindow;
       expect(win.context.canonicalUrl).to.equal('https://foo.bar/baz');
       expect(win.context.location.href).to.equal(locationHref);
+      expect(win.context.location.origin).to.equal('http://localhost:9876');
+      if (location.ancestorOrigins) {
+        expect(win.context.location.originValidated).to.be.true;
+      } else {
+        expect(win.context.location.originValidated).to.be.false;
+      }
       expect(win.context.referrer).to.equal(referrer);
       expect(win.context.data.testAttr).to.equal('value');
+      expect(win.context.noContentAvailable).to.be.function;
+      expect(win.context.observeIntersection).to.be.function;
       var c = win.document.getElementById('c');
       expect(c).to.not.be.null;
       expect(c.textContent).to.contain('pong');

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests integration.js
+// Most coverage through test-3p-frame
+
+import {validateParentOrigin} from '../../3p/integration';
+import {registrations} from '../../src/3p';
+
+describe('3p integration.js', () => {
+  it('should register integrations', () => {
+    expect(registrations).to.include.key('a9');
+    expect(registrations).to.include.key('adsense');
+    expect(registrations).to.include.key('adtech');
+    expect(registrations).to.include.key('adreactor');
+    expect(registrations).to.include.key('doubleclick');
+    expect(registrations).to.include.key('twitter');
+    expect(registrations).to.include.key('_ping_');
+  });
+
+  it('should validateParentOrigin without ancestorOrigins', () => {
+    let parent = {};
+    validateParentOrigin({
+      location: {}
+    }, parent);
+    expect(parent.originValidated).to.be.false;
+
+    parent = {};
+    validateParentOrigin({
+      location: {
+        ancestorOrigins: []
+      }
+    }, parent);
+    expect(parent.originValidated).to.be.false;
+  });
+
+  it('should validateParentOrigin with correct ancestorOrigins', () => {
+    const parent = {
+      origin: 'abc'
+    };
+    validateParentOrigin({
+      location: {
+        ancestorOrigins: ['abc', 'xyz']
+      }
+    }, parent);
+
+    expect(parent.originValidated).to.be.true;
+  });
+
+  it('should throw in validateParentOrigin with incorrect ancestorOrigins',
+    () => {
+      const parent = {
+        origin: 'abc'
+      };
+      expect(() => {
+        validateParentOrigin({
+          location: {
+            ancestorOrigins: ['xyz']
+          }
+        }, parent);
+      }).to.throw(/Parent origin mismatch/);
+    });
+});

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getIntersectionChangeEntry} from '../../src/intersection-observer';
+import {layoutRectLtwh} from '../../src/layout-rect';
+
+describe('getIntersectionChangeEntry', () => {
+
+  it('intersect correctly base', () => {
+    const time = 123;
+    const rootBounds = layoutRectLtwh(0, 100, 100, 100);
+    const layoutBox = layoutRectLtwh(50, 50, 150, 200);
+    const change = getIntersectionChangeEntry(time, rootBounds, layoutBox);
+
+    expect(change).to.be.object;
+    expect(change.time).to.equal(123);
+
+    expect(change.rootBounds).to.equal(rootBounds);
+    expect(change.rootBounds.x).to.equal(0);
+    expect(change.rootBounds.y).to.equal(100);
+    expect(change.boundingClientRect).to.jsonEqual({
+      "left": 50,
+      "top": -50,
+      "width": 150,
+      "height": 200,
+      "bottom": 150,
+      "right": 200,
+      "x": 50,
+      "y": -50
+    });
+    expect(change.intersectionRect.height).to.equal(100);
+    expect(change.intersectionRect).to.jsonEqual({
+      "left": 50,
+      "top": 100,
+      "width": 50,
+      "height": 100,
+      "bottom": 200,
+      "right": 100,
+      "x": 50,
+      "y": 100
+    });
+  });
+
+  it('intersect correctly 2', () => {
+    const time = 111;
+    const rootBounds = layoutRectLtwh(0, 100, 100, 100);
+    const layoutBox = layoutRectLtwh(50, 199, 150, 200);
+    const change = getIntersectionChangeEntry(time, rootBounds, layoutBox);
+    expect(change.time).to.equal(111);
+
+    expect(change.intersectionRect.height).to.equal(1);
+    expect(change.intersectionRect).to.jsonEqual({
+      "left": 50,
+      "top": 199,
+      "width": 50,
+      "height": 1,
+      "bottom": 200,
+      "right": 100,
+      "x": 50,
+      "y": 199
+    });
+  });
+
+  it('intersect correctly 3', () => {
+    const rootBounds = layoutRectLtwh(198, 299, 100, 100);
+    const layoutBox = layoutRectLtwh(50, 100, 150, 200);
+    const change = getIntersectionChangeEntry(111, rootBounds, layoutBox);
+
+    expect(change.intersectionRect.height).to.equal(1);
+    expect(change.intersectionRect.width).to.equal(2);
+  });
+
+  it('intersect correctly 3', () => {
+    const rootBounds = layoutRectLtwh(202, 299, 100, 100);
+    const layoutBox = layoutRectLtwh(50, 100, 150, 200);
+    const change = getIntersectionChangeEntry(111, rootBounds, layoutBox);
+
+    expect(change.intersectionRect.height).to.equal(0);
+    expect(change.intersectionRect.width).to.equal(0);
+  });
+});

--- a/test/functional/test-layout-rect.js
+++ b/test/functional/test-layout-rect.js
@@ -69,4 +69,20 @@ describe('LayoutRect', () => {
     expect(rect.bottom).to.equal(11 + 222);
     expect(rect.right).to.equal(12 + 111);
   });
+
+  it('rectIntersection', () => {
+    const rect1 = lr.layoutRectLtwh(10, 20, 40, 50);
+    const rect2 = lr.layoutRectLtwh(40, 60, 10, 10);
+    const rect3 = lr.layoutRectLtwh(1000, 60, 10, 10);
+    expect(lr.rectIntersection(rect1, rect2)).to.jsonEqual({
+      "left": 40,
+      "top": 60,
+      "width": 10,
+      "height": 10,
+      "bottom": 70,
+      "right": 50
+    });
+    expect(lr.rectIntersection(rect1, rect3)).to.be.null;
+    expect(lr.rectIntersection(rect2, rect3)).to.be.null;
+  });
 });

--- a/test/functional/test-vsync.js
+++ b/test/functional/test-vsync.js
@@ -59,8 +59,12 @@ describe('vsync', () => {
         result += 'mu4';
         resolve();
       });
+      vsync.measure(() => {
+        result += 'me4';
+        resolve();
+      });
     }).then(() => {
-      expect(result).to.equal('me1me2me3mu1mu2mu3mu4');
+      expect(result).to.equal('me1me2me3me4mu1mu2mu3mu4');
     });
   });
 

--- a/test/manual/ad-scrolling.amp.html
+++ b/test/manual/ad-scrolling.amp.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Ad examples</title>
+  <link rel="canonical" href="http://nonblocking.io/" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    amp-ad {
+      max-width: 500px;
+    }
+    .fixed {
+      position: fixed;
+      top: 0;
+      right: 0;
+    }
+  </style>
+  <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+  <script async src="../../dist/amp.js" development></script>
+</head>
+<body>
+
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <amp-ad width=300 height=250
+      type="a9"
+      data-aax_size="300x250"
+      data-aax_pubname="test123"
+      data-aax_src="302">
+  </amp-ad>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <amp-ad width=300 height=250
+      type="a9"
+      data-aax_size="300x250"
+      data-aax_pubname="test123"
+      data-aax_src="302">
+  </amp-ad>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+  <h2>A9</h2>
+
+</body>
+</html>


### PR DESCRIPTION
Exposes `window.context.observeIntersection` to ads that provides largely IntersectionObserver compatible change records of the ad's position in the container viewport.

Also makes the following advancements:
- 3p frames now check that the claimed origin of the parent is correct. This helps ads trust the parent.
- Adds tests for integration.js
- adds `3p-frame/listenOnce,postMessage`
- adds `rectIntersection` to layout-rect.js

Fixes #720

Filed #873 to track increasing fidelity of change records.