### PR TITLE
Creates a timeout for preconnects 

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -176,8 +176,6 @@ export function installAd(win) {
       /** @private {boolean} */
       this.shouldSendIntersectionChanges_ = false;
 
-      this.prefetchAd_();
-
       if (!this.fallback_) {
         this.isDefaultFallback_ = true;
 
@@ -189,9 +187,9 @@ export function installAd(win) {
 
     /**
      * Prefetches and preconnects URLs related to the ad.
-     * @private
+     * @override
      */
-    prefetchAd_() {
+    preconnectCallback(onLayout) {
       // We always need the bootstrap.
       prefetchBootstrap(this.getWin());
       const type = this.element.getAttribute('type');
@@ -205,10 +203,10 @@ export function installAd(win) {
         });
       }
       if (typeof preconnect == 'string') {
-        this.preconnect.url(preconnect);
+        this.preconnect.url(preconnect, onLayout);
       } else if (preconnect) {
         preconnect.forEach(p => {
-          this.preconnect.url(p);
+          this.preconnect.url(p, onLayout);
         });
       }
       // If fully qualified src for ad script is specified we preconnect to it.

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -95,7 +95,13 @@ class AmpIframe extends AMP.BaseElement {
         this.transformSrcDoc();
     this.iframeSrc = this.assertSource(iframeSrc, window.location.href,
         this.element.getAttribute('sandbox'));
-    this.preconnect.url(this.iframeSrc);
+  }
+
+  /** @override */
+  preconnectCallback(onLayout) {
+    if (this.iframeSrc) {
+      this.preconnect.url(this.iframeSrc, onLayout);
+    }
   }
 
   /** @override */

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -40,8 +40,8 @@ import {loadPromise} from '../../../src/event-helper';
 
 class AmpInstagram extends AMP.BaseElement {
   /** @override */
-  createdCallback() {
-    this.preconnect.url('https://instagram.com');
+  preconnectCallback(onLayout) {
+    this.preconnect.url('https://instagram.com', onLayout);
   }
 
   /** @override */

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -49,9 +49,9 @@ const BASE60 = '0123456789ABCDEFGHJKLMNPQRSTUVWXYZ_abcdefghijkmnopqrstuvwxyz';
 
 class AmpPinterest extends AMP.BaseElement {
   /** @override */
-  createdCallback() {
+  preconnectCallback(onLayout) {
     // preconnect to widget API
-    this.preconnect.url('https://widgets.pinterest.com');
+    this.preconnect.url('https://widgets.pinterest.com', onLayout);
   }
   /** @override */
   isLayoutSupported(layout) {

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -22,9 +22,9 @@ import {loadPromise} from '../../../src/event-helper';
 
 class AmpTwitter extends AMP.BaseElement {
   /** @override */
-  createdCallback() {
+  preconnectCallback(onLayout) {
     // This domain serves the actual tweets as JSONP.
-    this.preconnect.url('https://syndication.twitter.com');
+    this.preconnect.url('https://syndication.twitter.com', onLayout);
     // Hosts the script that renders tweets.
     this.preconnect.prefetch('https://platform.twitter.com/widgets.js');
     prefetchBootstrap(this.getWin());

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -21,8 +21,10 @@ import {loadPromise} from '../../../src/event-helper';
 class AmpYoutube extends AMP.BaseElement {
 
   /** @override */
-  createdCallback() {
-    this.preconnect.url('https://www.youtube.com');
+  preconnectCallback(onLayout) {
+    this.preconnect.url('https://www.youtube.com', onLayout);
+    // Host that YT uses to serve JS needed by player.
+    this.preconnect.url('https://s.ytimg.com', onLayout);
   }
 
   /** @override */

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -59,6 +59,7 @@ import {vsyncFor} from './vsync';
  *    State: <NOT BUILT>
  *           ||
  *           || buildCallback
+ *           || preconnectCallback may be called N times after this.
  *           ||
  *           \/
  *    State: <BUILT>
@@ -75,6 +76,11 @@ import {vsyncFor} from './vsync';
  *           ||
  *           \/
  *    State: <IN VIEWPORT>
+ *
+ * The preconnectCallback is called when the systems thinks it is good
+ * to preconnect to hosts needed by an element. It will never be called
+ * before buildCallback and it might be called multiple times including
+ * after layoutCallback.
  *
  * Additionally whenever the dimensions of an element might have changed
  * AMP remeasures its dimensions and calls `onLayoutMeasure` on the
@@ -202,6 +208,15 @@ export class BaseElement {
    * consulted in the later case.
    */
   buildCallback() {
+    // Subclasses may override.
+  }
+
+  /**
+   * Called by the framework to give the element a chance to preconnect to
+   * hosts and prefetch resources it is likely to need. May be called
+   * multiple times because connections can time out.
+   */
+  preconnectCallback() {
     // Subclasses may override.
   }
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -412,6 +412,7 @@ export function createAmpElementProto(win, name, implementationClass) {
     }
     try {
       this.implementation_.buildCallback();
+      this.preconnect(/* onLayout */ false);
       this.built_ = true;
       this.classList.remove('-amp-notbuilt');
       this.classList.remove('amp-notbuilt');
@@ -432,6 +433,15 @@ export function createAmpElementProto(win, name, implementationClass) {
       }
     }
     return true;
+  };
+
+  /**
+   * Called to instruct the element to preconnect to hosts it uses during
+   * layout.
+   * @param {boolean} onLayout Whether this was called after a layout.
+   */
+  ElementProto.preconnect = function(onLayout) {
+    this.implementation_.preconnectCallback(onLayout);
   };
 
   /**
@@ -659,6 +669,7 @@ export function createAmpElementProto(win, name, implementationClass) {
         'Must be upgraded and built to receive viewport events');
     this.dispatchCustomEvent('amp:load:start');
     const promise = this.implementation_.layoutCallback();
+    this.preconnect(/* onLayout */ true);
     this.classList.add('-amp-layout');
     assert(promise instanceof Promise,
         'layoutCallback must return a promise');

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -27,6 +27,7 @@ describe('CustomElement', () => {
 
   const resources = resourcesFor(window);
   let testElementCreatedCallback;
+  let testElementPreconnectCallback;
   let testElementFirstAttachedCallback;
   let testElementBuildCallback;
   let testElementLayoutCallback;
@@ -41,6 +42,9 @@ describe('CustomElement', () => {
     }
     createdCallback() {
       testElementCreatedCallback();
+    }
+    preconnectCallback(onLayout) {
+      testElementPreconnectCallback(onLayout);
     }
     firstAttachedCallback() {
       testElementFirstAttachedCallback();
@@ -85,6 +89,7 @@ describe('CustomElement', () => {
     clock = sandbox.useFakeTimers();
 
     testElementCreatedCallback = sinon.spy();
+    testElementPreconnectCallback = sinon.spy();
     testElementFirstAttachedCallback = sinon.spy();
     testElementBuildCallback = sinon.spy();
     testElementLayoutCallback = sinon.spy();
@@ -200,12 +205,14 @@ describe('CustomElement', () => {
     expect(res).to.equal(true);
     expect(element.isBuilt()).to.equal(true);
     expect(testElementBuildCallback.callCount).to.equal(1);
+    expect(testElementPreconnectCallback.callCount).to.equal(1);
 
     // Call again.
     res = element.build(false);
     expect(res).to.equal(true);
     expect(element.isBuilt()).to.equal(true);
     expect(testElementBuildCallback.callCount).to.equal(1);
+    expect(testElementPreconnectCallback.callCount).to.equal(1);
   });
 
   it('Element - build not allowed', () => {
@@ -387,9 +394,13 @@ describe('CustomElement', () => {
     element.build(true);
     expect(element.isBuilt()).to.equal(true);
     expect(testElementLayoutCallback.callCount).to.equal(0);
+    expect(testElementPreconnectCallback.callCount).to.equal(1);
+    expect(testElementPreconnectCallback.getCall(0).args[0]).to.be.false;
 
     const p = element.layoutCallback();
     expect(testElementLayoutCallback.callCount).to.equal(1);
+    expect(testElementPreconnectCallback.callCount).to.equal(2);
+    expect(testElementPreconnectCallback.getCall(1).args[0]).to.be.true;
     return p.then(() => {
       expect(element.readyState).to.equal('complete');
     });

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -34,7 +34,7 @@ describe('preconnect', () => {
   });
 
   afterEach(() => {
-    clock.tick(20000);
+    clock.tick(200000);
     clock.restore();
     sandbox.restore();
   });
@@ -85,6 +85,40 @@ describe('preconnect', () => {
         .to.equal('https://e.preconnect.com/');
     expect(document.querySelectorAll('link[rel=preconnect]'))
         .to.have.length(2);
+  });
+
+  it('should timeout preconnects', () => {
+    preconnect.url('https://x.preconnect.com/foo/bar');
+    expect(document.querySelectorAll('link[rel=preconnect]'))
+        .to.have.length(1);
+    clock.tick(9000);
+    preconnect.url('https://x.preconnect.com/foo/bar');
+    expect(document.querySelectorAll('link[rel=preconnect]'))
+        .to.have.length(1);
+    clock.tick(1000);
+    expect(document.querySelectorAll('link[rel=preconnect]'))
+        .to.have.length(0);
+    // After timeout preconnect creates a new tag.
+    preconnect.url('https://x.preconnect.com/foo/bar');
+    expect(document.querySelectorAll('link[rel=preconnect]'))
+        .to.have.length(1);
+  });
+
+  it('should timeout preconnects longer with active connect', () => {
+    preconnect.url('https://y.preconnect.com/foo/bar',
+        /* opt_alsoConnecting */ true);
+    expect(document.querySelectorAll('link[rel=preconnect]'))
+        .to.have.length(1);
+    clock.tick(10000);
+    expect(document.querySelectorAll('link[rel=preconnect]'))
+        .to.have.length(0);
+    preconnect.url('https://y.preconnect.com/foo/bar');
+    expect(document.querySelectorAll('link[rel=preconnect]'))
+        .to.have.length(0);
+    clock.tick(180 * 1000);
+    preconnect.url('https://y.preconnect.com/foo/bar');
+    expect(document.querySelectorAll('link[rel=preconnect]'))
+        .to.have.length(1);
   });
 
   it('should prefetch', () => {


### PR DESCRIPTION
after which they will be done again if requests. This may happen when we preconnect super early but when do not actually render the element for a while.

Switches preconnecting to a callback that gets called 2x per element:

1. At built time.
2. Just after layoutCallback to parallelize requests.

Related #870 (Does not affect only calling preconnect when doc becomes visible)