### PR TITLE
Simplify templates API

### DIFF
--- a/spec/amp-html-templates.md
+++ b/spec/amp-html-templates.md
@@ -63,7 +63,7 @@ may (in the future) use a CORS endpoint and an AMP template to load and render a
 
 ## API
 
-AMP elements can use `AMP.renderTemplate(templateElement, data)` method to render a template. It is up to
+AMP elements can use `templates.renderTemplate` methods to render a template. It is up to
 a specific AMP element how `templateElement` and `data` are provided.
 
 ## Templates

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -15,8 +15,7 @@
  */
 
 import {BaseElement} from './base-element';
-import {BaseTemplate, findAndRenderTemplate, registerExtendedTemplate,
-    renderTemplate} from './template';
+import {BaseTemplate, registerExtendedTemplate} from './template';
 import {assert} from './asserts';
 import {getMode} from './mode';
 import {installStyles} from './styles';
@@ -85,29 +84,6 @@ export function adopt(global) {
    */
   global.AMP.registerTemplate = function(name, implementationClass) {
     registerExtendedTemplate(global, name, implementationClass);
-  };
-
-  /**
-   * Renders the specified element template using the supplied data.
-   * See {@link template.renderTemplate} for more info.
-   * @param {!Element} templateElement
-   * @param {!Object<string, *>} data
-   * @return {!Promise<!Element>}
-   */
-  global.AMP.renderTemplate = function(templateElement, data) {
-    return renderTemplate(templateElement, data);
-  };
-
-  /**
-   * Discovers the template for the specified parent and renders it using the
-   * supplied data.
-   * See {@link template.findAndRenderTemplate} for more info.
-   * @param {!Element} parent
-   * @param {!Object<string, *>} data
-   * @return {!Promise<!Element>}
-   */
-  global.AMP.findAndRenderTemplate = function(parent, data) {
-    return findAndRenderTemplate(parent, data);
   };
 
   /** @const */


### PR DESCRIPTION
The refactoring changes:
1. Remove Promisable response from Template.render. This has proven to NOT be useful.
2. Remove render APIs from runtime.js
