### PR TITLE
AMP List element skeleton.

### DIFF
--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -28,6 +28,7 @@ import {registerElement} from '../src/custom-element';
  */
 export function installPixel(win) {
 
+  /** @const {!UrlReplacements} */
   const urlReplacements = new UrlReplacements(win);
 
   class AmpPixel extends BaseElement {

--- a/builtins/amp-pixel.md
+++ b/builtins/amp-pixel.md
@@ -37,7 +37,7 @@ For instance:
 ```html
 <amp-pixel src="https://foo.com/pixel?RANDOM"></amp-pixel>
 ```
-may make a request to something like `https://foo.com/pixel?0.8390278471201` where the $RANDOM value is randomly generated upon each impression.
+may make a request to something like `https://foo.com/pixel?0.8390278471201` where the RANDOM value is randomly generated upon each impression.
 
 #### Styling
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {UrlReplacements} from '../../../src/url-replacements';
+import {assertHttpsUrl} from '../../../src/url';
+import {isLayoutSizeDefined} from '../../../src/layout';
+import {templatesFor} from '../../../src/template';
+import {xhrFor} from '../../../src/xhr';
+
+/** @const {!Function} */
+const assert = AMP.assert;
+
+
+/**
+ * The implementation of `amp-list` component. See {@link ../amp-list.md} for
+ * the spec.
+ */
+export class AmpList extends AMP.BaseElement {
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
+  /** @override */
+  buildCallback() {
+    /** @const {!Element} */
+    this.container_ = this.getWin().document.createElement('div');
+    this.applyFillContent(this.container_, true);
+    this.element.appendChild(this.container_);
+    if (!this.element.hasAttribute('role')) {
+      this.element.setAttribute('role', 'list');
+    }
+
+    /** @private @const {!UrlReplacements} */
+    this.urlReplacements_ = new UrlReplacements(this.getWin());
+  }
+
+  /** @override */
+  layoutCallback() {
+    const src = this.urlReplacements_.expand(assertHttpsUrl(
+        this.element.getAttribute('src'), this.element));
+    const opts = {
+      credentials: this.element.getAttribute('credentials')
+    };
+    return xhrFor(this.getWin()).fetchJson(src, opts).then(data => {
+      assert(typeof data == 'object' && Array.isArray(data['items']),
+          'Response must be {items: []} object %s %s',
+          this.element, data);
+      const items = data['items'];
+      return templatesFor(this.getWin()).findAndRenderTemplateArray(
+          this.element, items).then(this.rendered_.bind(this));
+    });
+  }
+
+  /**
+   * @param {!Array<!Element>} elements
+   * @private
+   */
+  rendered_(elements) {
+    elements.forEach(element => {
+      if (!element.hasAttribute('role')) {
+        element.setAttribute('role', 'listitem');
+      }
+      this.container_.appendChild(element);
+    });
+
+    // Change height if needed.
+    this.getVsync().measure(() => {
+      const scrollHeight = this.container_./*OK*/scrollHeight;
+      const height = this.element./*OK*/offsetHeight;
+      if (scrollHeight > height) {
+        this.requestChangeHeight(scrollHeight, newHeight => {
+          // TODO(dvoytenko): Implement fallback.
+        });
+      }
+    });
+  }
+}
+
+AMP.registerElement('amp-list', AmpList);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpList} from '../amp-list';
+import {templatesFor} from '../../../../src/template';
+import {xhrFor} from '../../../../src/xhr';
+import * as promise from '../../../../src/promise';
+import * as sinon from 'sinon';
+
+
+describe('amp-list component', () => {
+
+  let sandbox;
+  let templates;
+  let templatesMock;
+  let xhr;
+  let xhrMock;
+  let element;
+  let list;
+  let listMock;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    templates = templatesFor(window);
+    templatesMock = sandbox.mock(templates);
+
+    xhr = xhrFor(window);
+    xhrMock = sandbox.mock(xhr);
+
+    element = document.createElement('div');
+    element.setAttribute('src', 'https://data.com/list.json');
+    list = new AmpList(element);
+    list.buildCallback();
+    listMock = sandbox.mock(list);
+
+    element.style.height = '10px';
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(element);
+    templatesMock.verify();
+    templatesMock.restore();
+    templatesMock = null;
+    xhrMock.verify();
+    xhrMock.restore();
+    xhrMock = null;
+    listMock.verify();
+    listMock.restore();
+    listMock = null;
+    sandbox.restore();
+    sandbox = null;
+  });
+
+  it('should load and render', () => {
+    const items = [
+      {title: 'Title1'}
+    ];
+    const newHeight = 127;
+    const itemElement = document.createElement('div');
+    itemElement.style.height = newHeight + 'px';
+    const xhrPromise = Promise.resolve({items: items});
+    const renderPromise = Promise.resolve([itemElement]);
+    let measureFunc;
+    xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
+        sinon.match(opts => !opts.credentials))
+        .returns(xhrPromise).once();
+    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
+        element, items)
+        .returns(renderPromise).once();
+    listMock.expects('getVsync').returns({
+      measure: func => {
+        measureFunc = func;
+      }
+    }).once();
+    listMock.expects('requestChangeHeight').withExactArgs(newHeight,
+        sinon.match.func);
+    return list.layoutCallback().then(() => {
+      return promise.all([xhrPromise, renderPromise]).then(() => {
+        expect(list.container_.contains(itemElement)).to.be.true;
+        expect(measureFunc).to.exist;
+        measureFunc();
+      });
+    });
+  });
+
+  it('should set accessibility roles', () => {
+    const items = [
+      {title: 'Title1'}
+    ];
+    const itemElement = document.createElement('div');
+    const xhrPromise = Promise.resolve({items: items});
+    const renderPromise = Promise.resolve([itemElement]);
+    xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
+        sinon.match(opts => !opts.credentials))
+        .returns(xhrPromise).once();
+    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
+        element, items)
+        .returns(renderPromise).once();
+    return list.layoutCallback().then(() => {
+      return promise.all([xhrPromise, renderPromise]).then(() => {
+        expect(list.element.getAttribute('role')).to.equal('list');
+        expect(itemElement.getAttribute('role')).to.equal('listitem');
+      });
+    });
+  });
+
+  it('should preserve accessibility roles', () => {
+    const items = [
+      {title: 'Title1'}
+    ];
+    element.setAttribute('role', 'list1');
+    const itemElement = document.createElement('div');
+    itemElement.setAttribute('role', 'listitem1');
+    const xhrPromise = Promise.resolve({items: items});
+    const renderPromise = Promise.resolve([itemElement]);
+    xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
+        sinon.match(opts => !opts.credentials))
+        .returns(xhrPromise).once();
+    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
+        element, items)
+        .returns(renderPromise).once();
+    return list.layoutCallback().then(() => {
+      return promise.all([xhrPromise, renderPromise]).then(() => {
+        expect(list.element.getAttribute('role')).to.equal('list1');
+        expect(itemElement.getAttribute('role')).to.equal('listitem1');
+      });
+    });
+  });
+
+  it('should request credentials', () => {
+    const items = [];
+    const xhrPromise = Promise.resolve({items: items});
+    element.setAttribute('credentials', 'include');
+    xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
+        sinon.match(opts => opts.credentials == 'include'))
+        .returns(xhrPromise).once();
+    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
+        element, items)
+        .returns(Promise.resolve([])).once();
+    return list.layoutCallback();
+  });
+});

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -1,0 +1,82 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+### <a name="amp-list"></a> `amp-list`
+
+The `amp-list` fetches the dynamic content from a CORS JSON endpoint and renders it
+using a supplied template.
+
+#### Usage
+
+The `amp-list` defines data source using the following attributes:
+
+- `src` defines a CORS URL. The URL's protocol must be HTTPS.
+- `credentials` defines a `credentials` option as specified by the
+[Fetch API](https://fetch.spec.whatwg.org/). To send credentials, pass the
+value of "include".
+
+The request URL is allowed to contain the following substitutions:
+
+- CANONICAL_URL
+- TODO
+
+The response must be a JSON object that contains an array property "items":
+```json
+{
+  "items": []
+}
+```
+
+The template can be specified using either of the following two ways:
+
+- `template` attribute that references an ID of an existing `template` element.
+- `template` element nested directly inside of this `amp-list` element.
+
+For more details on templates see [AMP HTML Templates](../../spec/amp-html-templates.md).
+
+An example:
+```html
+<amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
+  <template type="amp-mustache">
+    <div>
+      <amp-img src="{{imageUrl}}" width=50 height=50></amp-img>
+      {{title}}
+    </div>
+  </template>
+</amp-list>
+```
+
+#### Substitutions
+
+The `amp-list` allows all standard URL variable substitutions.
+See (Substitutions Guide)[../../spec/amp-var-substitutions.md] for more info.
+
+For instance:
+```html
+<amp-list src="https://foo.com/list.json?RANDOM"></amp-list>
+```
+may make a request to something like `https://foo.com/list.json?0.8390278471201` where the RANDOM value is randomly generated upon each impression.
+
+#### Behavior
+
+The loading is triggered using normal AMP rules depending on how far the element is from
+the current viewport.
+
+If `amp-list` needs more space after loading it requests the AMP runtime to update its
+height using the normal AMP flow.
+
+By default, `amp-list` adds `list` ARIA role to the list element and `listitem` role to item
+elements rendered via the template.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,6 +74,7 @@ function buildExtensions(options) {
   buildExtension('amp-image-lightbox', '0.1', true, options);
   buildExtension('amp-instagram', '0.1', false, options);
   buildExtension('amp-lightbox', '0.1', false, options);
+  buildExtension('amp-list', '0.1', false, options);
   buildExtension('amp-mustache', '0.1', false, options);
   buildExtension('amp-pinterest', '0.1', true, options);
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -671,8 +671,6 @@ export function createAmpElementProto(win, name, implementationClass) {
     const promise = this.implementation_.layoutCallback();
     this.preconnect(/* onLayout */ true);
     this.classList.add('-amp-layout');
-    assert(promise instanceof Promise,
-        'layoutCallback must return a promise');
     return promise.then(() => {
       this.readyState = 'complete';
       this.layoutCount_++;

--- a/src/layout.js
+++ b/src/layout.js
@@ -75,6 +75,7 @@ export const LOADING_ELEMENTS_ = {
   'AMP-IFRAME': true,
   'AMP-IMG': true,
   'AMP-INSTAGRAM': true,
+  'AMP-LIST': true,
   'AMP-PINTEREST': true,
   'AMP-VIDEO': true
 };

--- a/test/manual/amp-list-data.json
+++ b/test/manual/amp-list-data.json
@@ -1,0 +1,13 @@
+{
+  "items": [
+    {
+      "title": "Best news 1",
+      "imageUrl": "https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n"
+    },
+
+    {
+      "title": "Best news 2",
+      "imageUrl": "https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n"
+    }
+  ]
+}

--- a/test/manual/amp-list.amp.html
+++ b/test/manual/amp-list.amp.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    body {
+      font-family: 'Questrial', Arial;
+    }
+    article {
+      display: block;
+      margin: 8px;
+    }
+    figure {
+      margin: 0;
+    }
+    amp-list {
+      border: 1px solid green;
+    }
+    .story-entry {
+      padding: 40px;
+      border-bottom: 1px solid green;
+    }
+  </style>
+  <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+  <script async src="../../dist/amp.js" development></script>
+  <script async custom-element="amp-list" src="../../dist/v0/amp-list-0.1.max.js"></script>
+  <script async custom-template="amp-mustache" src="../../dist/v0/amp-mustache-0.1.max.js"></script>
+</head>
+<body>
+<article>
+  <h1>amp-list</h1>
+
+  <amp-list width="396" height="200" layout=responsive
+      src="http://localhost:8000/test/manual/amp-list-data.json?RANDOM">
+    <template type="amp-mustache">
+      <div class="story-entry">
+        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
+        {{title}}
+      </div>
+    </template>
+  </amp-list>
+</article>
+</body>
+</html>


### PR DESCRIPTION
Partial for #657.

This PR essentially brings `amp-list` and `amp-mustache` elements to a functional state. The "mustache" experiment has to be on to try it.

Some of the key outstanding questions here:
1. Data attributes vs plain attributes? "data-src" and "data-credentials" are used in this component, but I'm wondering if it'd be better to drop "data-" here.
2. We will need to refactor URL substitutions that feeds into amp-pixel to use it here as well
3. This implementation is missing a fallback for when the AMP runtime refuses to change the height
4. Some of the height change rules might need to be expanded to cover "at the footer" case where the element is within the viewport but very close to the footer.

/cc @erwinmombay 
