### PR TITLE
UrlReplacements refactoring for amp-pixel and amp-list

### DIFF
--- a/builtins/amp-pixel.md
+++ b/builtins/amp-pixel.md
@@ -28,88 +28,16 @@ The `amp-pixel` component behaves like a simple tracking pixel `img`. It takes a
 
 A simple URL to send a GET request to when the tracking pixel is loaded.
 
-The variables listed under the Substitutions paragraph can be used to interpolate certain values into the pixel URL.
-
 #### Substitutions
 
-**RANDOM**
-
-Use the special string `RANDOM` to add a random number to the URL if required.
+The `amp-pixel` allows all standard URL variable substitutions.
+See (Substitutions Guide)[../spec/amp-var-substitutions.md] for more info.
 
 For instance:
 ```html
 <amp-pixel src="https://foo.com/pixel?RANDOM"></amp-pixel>
 ```
 may make a request to something like `https://foo.com/pixel?0.8390278471201` where the $RANDOM value is randomly generated upon each impression.
-
-**CANONICAL_URL**
-
-Use the special string `CANONICAL_URL` to add the canonical URL of the current document to the URL
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?href=CANONICAL_URL"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?href=https%3A%2F%2Fpinterest.com%2F`.
-
-**CANONICAL_HOST**
-
-Use the special string `CANONICAL_HOST` to add the canonical URL's host of the current document to the URL
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?host=CANONICAL_HOST"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?host=pinterest.com`.
-
-**CANONICAL_PATH**
-
-Use the special string `CANONICAL_PATH` to add the canonical URL's path of the current document to the URL
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?path=CANONICAL_PATH"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?path=%2Fpage1.html`.
-
-**DOCUMENT_REFERRER**
-
-Use the special string `DOCUMENT_REFERRER` to add the current document's referrer to the URL.
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?referrer=DOCUMENT_REFERRER"></amp-pixel>
-```
-
-**TITLE**
-
-Use the special string `TITLE` to add the title of the current document to the URL
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?title=TITLE"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?title=Breaking%20News`.
-
-**AMPDOC_URL**
-
-Use the special string `AMPDOC_URL` to add the AMP document's URL.
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?ref=AMPDOC_URL"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?ref=https%3A%2F%2Fexample.com%2F`.
-
-**AMPDOC_HOST**
-
-Use the special string `AMPDOC_HOST` to add the AMP document's URL host.
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?host=AMPDOC_HOST"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?host=example.com`.
 
 #### Styling
 

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -1,0 +1,105 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# AMP HTML URL Variable Substitutions
+
+## Overview
+
+Some components such as [`amp-pixel`](../builtins/amp-pixel.md) and
+[`amp-list`](../extensions/amp-list/amp-list.md) allow variables to be substituted
+in the relevant URLs. AMP provides a number of standard variable substitutions and
+allows each component to add their own.
+
+## Standard Variable Substitutions
+
+**RANDOM**
+
+Use the special string `RANDOM` to add a random number to the URL if required.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?RANDOM"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?0.8390278471201` where the $RANDOM value is randomly generated upon each impression.
+
+**CANONICAL_URL**
+
+Use the special string `CANONICAL_URL` to add the canonical URL of the current document to the URL
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?href=CANONICAL_URL"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?href=https%3A%2F%2Fpinterest.com%2F`.
+
+**CANONICAL_HOST**
+
+Use the special string `CANONICAL_HOST` to add the canonical URL's host of the current document to the URL
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?host=CANONICAL_HOST"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?host=pinterest.com`.
+
+**CANONICAL_PATH**
+
+Use the special string `CANONICAL_PATH` to add the canonical URL's path of the current document to the URL
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?path=CANONICAL_PATH"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?path=%2Fpage1.html`.
+
+**DOCUMENT_REFERRER**
+
+Use the special string `DOCUMENT_REFERRER` to add the current document's referrer to the URL.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?referrer=DOCUMENT_REFERRER"></amp-pixel>
+```
+
+**TITLE**
+
+Use the special string `TITLE` to add the title of the current document to the URL
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?title=TITLE"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?title=Breaking%20News`.
+
+**AMPDOC_URL**
+
+Use the special string `AMPDOC_URL` to add the AMP document's URL.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?ref=AMPDOC_URL"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?ref=https%3A%2F%2Fexample.com%2F`.
+
+**AMPDOC_HOST**
+
+Use the special string `AMPDOC_HOST` to add the AMP document's URL host.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?host=AMPDOC_HOST"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?host=example.com`.

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from '../src/asserts';
+import {documentInfoFor} from '../src/document-info';
+import {parseUrl, removeFragment} from '../src/url';
+
+
+/**
+ * This class replaces substitution variables with their values.
+ */
+export class UrlReplacements {
+  /** @param {!Window} win */
+  constructor(win) {
+    /** @private @const {!Window} */
+    this.win_ = win;
+
+    /** @private {!RegExp|undefined} */
+    this.replacementExpr_;
+
+    /** @private @const {!Object<string, function(*):*>} */
+    this.replacements_ = this.win_.Object.create(null);
+
+    // Returns a random value for cache busters.
+    this.set('RANDOM', () => {
+      return Math.random();
+    });
+
+    // Returns the canonical URL for this AMP document.
+    this.set('CANONICAL_URL', () => {
+      return documentInfoFor(this.win_).canonicalUrl;
+    });
+
+    // Returns the host of the canonical URL for this AMP document.
+    this.set('CANONICAL_HOST', () => {
+      const url = parseUrl(documentInfoFor(this.win_).canonicalUrl);
+      return url && url.hostname;
+    });
+
+    // Returns the path of the canonical URL for this AMP document.
+    this.set('CANONICAL_PATH', () => {
+      const url = parseUrl(documentInfoFor(this.win_).canonicalUrl);
+      return url && url.pathname;
+    });
+
+    // Returns the referrer URL.
+    this.set('DOCUMENT_REFERRER', () => {
+      return this.win_.document.referrer;
+    });
+
+    // Returns the title of this AMP document.
+    this.set('TITLE', () => {
+      return this.win_.document.title;
+    });
+
+    // Returns the URL for this AMP document.
+    this.set('AMPDOC_URL', () => {
+      return removeFragment(this.win_.location.href);
+    });
+
+    // Returns the host of the URL for this AMP document.
+    this.set('AMPDOC_HOST', () => {
+      const url = parseUrl(this.win_.location.href);
+      return url && url.hostname;
+    });
+  }
+
+  /**
+   * Sets the value resolver for the variable with the specified name. The
+   * value resolver may optionally take an extra parameter.
+   * @param {string} varName
+   * @param {function(*):*} resolver
+   * @return {!UrlReplacements}
+   */
+  set(varName, resolver) {
+    assert(varName == varName.toUpperCase(),
+        'Variable name must be in upper case: %s', varName);
+    this.replacements_[varName] = resolver;
+    this.replacementExpr_ = undefined;
+    return this;
+  }
+
+  /**
+   * Expands the provided URL by replacing all known variables with their
+   * resolved values.
+   * @param {string} url
+   * @param {*} opt_data
+   * @return {string}
+   */
+  expand(url, opt_data) {
+    const expr = this.getExpr_();
+    return url.replace(expr, (match, name) => {
+      let val = this.replacements_[name](opt_data);
+      // Value 0 is specialcased because the numeric 0 is a valid substitution
+      // value.
+      if (!val && val !== 0) {
+        val = '';
+      }
+      return encodeURIComponent(val);
+    });
+  }
+
+  /**
+   * @return {!RegExp}
+   * @private
+   */
+  getExpr_() {
+    if (!this.replacementExpr_) {
+      let all = '';
+      for (const k in this.replacements_) {
+        all += (all.length > 0 ? '|' : '') + k;
+      }
+      this.replacementExpr_ = new RegExp('\\$?(' + all + ')', 'g');
+    }
+    return this.replacementExpr_;
+  }
+}

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -56,7 +56,7 @@ describe('amp-pixel', () => {
         });
   });
 
-  it('replace RANDOM', () => {
+  it('should replace RANDOM', () => {
     return getPixel(
         'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=RANDOM?'
         ).then(p => {
@@ -65,96 +65,13 @@ describe('amp-pixel', () => {
         });
   });
 
-  it('replace CANONICAL_URL', () => {
+  it('should replace CANONICAL_URL', () => {
     return getPixel(
         'https://foo.com?href=CANONICAL_URL'
         ).then(p => {
           expect(p.querySelector('img')).to.not.be.null;
           expect(p.children[0].src).to.equal(
               'https://foo.com/?href=https%3A%2F%2Fpinterest.com%2Fpin1');
-        });
-  });
-
-  it('replace CANONICAL_HOST', () => {
-    return getPixel(
-        'https://foo.com?host=CANONICAL_HOST'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'https://foo.com/?host=pinterest.com');
-        });
-  });
-
-  it('replace CANONICAL_PATH', () => {
-    return getPixel(
-        'https://foo.com?path=CANONICAL_PATH'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'https://foo.com/?path=%2Fpin1');
-        });
-  });
-
-  it('replace DOCUMENT_REFERRER', () => {
-    return getPixel(
-        'https://foo.com?ref=DOCUMENT_REFERRER'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'https://foo.com/?ref=' +
-              'http%3A%2F%2Flocalhost%3A9876%2Fcontext.html');
-        });
-  });
-
-  it('replace TITLE', () => {
-    return getPixel(
-        'https://foo.com?title=TITLE'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'https://foo.com/?title=Pixel%20Test');
-        });
-  });
-
-  it('replace AMPDOC_URL', () => {
-    return getPixel(
-        'https://foo.com?ref=AMPDOC_URL'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          const query = parseQueryString(parseUrl(p.children[0].src).search);
-          expect(query['ref']).to.not.equal('$AMPDOC_URL');
-        });
-  });
-
-  it('replace AMPDOC_HOST', () => {
-    return getPixel(
-        'https://foo.com?ref=AMPDOC_HOST'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          const query = parseQueryString(parseUrl(p.children[0].src).search);
-          expect(query['ref']).to.not.equal('$AMPDOC_HOST');
-        });
-  });
-
-  it('replace $CANONICAL_URL', () => {
-    return getPixel(
-        'https://foo.com?href=$CANONICAL_URL'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'https://foo.com/?href=https%3A%2F%2Fpinterest.com%2Fpin1');
-        });
-  });
-
-  it('replace several substitutions', () => {
-    return getPixel(
-        'https://foo.com/?a=UNKNOWN&href=CANONICAL_URL&title=TITLE'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'https://foo.com/?a=UNKNOWN' +
-              '&href=https%3A%2F%2Fpinterest.com%2Fpin1' +
-              '&title=Pixel%20Test');
         });
   });
 

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createIframePromise} from '../../testing/iframe';
+import {UrlReplacements} from '../../src/url-replacements';
+
+
+describe('UrlReplacements', () => {
+
+  function expand(url) {
+    return createIframePromise().then(iframe => {
+      iframe.doc.title = 'Pixel Test';
+      const link = iframe.doc.createElement('link');
+      link.setAttribute('href', 'https://pinterest.com/pin1');
+      link.setAttribute('rel', 'canonical');
+      iframe.doc.head.appendChild(link);
+      const replacements = new UrlReplacements(iframe.win);
+      return replacements.expand(url);
+    });
+  }
+
+  it('should replace RANDOM', () => {
+    return expand('ord=RANDOM?').then(res => {
+      expect(res).to.match(/ord=(\d\.\d+)\?$/);
+    });
+  });
+
+  it('should replace CANONICAL_URL', () => {
+    return expand('?href=CANONICAL_URL').then(res => {
+      expect(res).to.equal('?href=https%3A%2F%2Fpinterest.com%2Fpin1');
+    });
+  });
+
+  it('should replace CANONICAL_HOST', () => {
+    return expand('?host=CANONICAL_HOST').then(res => {
+      expect(res).to.equal('?host=pinterest.com');
+    });
+  });
+
+  it('should replace CANONICAL_PATH', () => {
+    return expand('?path=CANONICAL_PATH').then(res => {
+      expect(res).to.equal('?path=%2Fpin1');
+    });
+  });
+
+  it('should replace DOCUMENT_REFERRER', () => {
+    return expand('?ref=DOCUMENT_REFERRER').then(res => {
+      expect(res).to.equal('?ref=http%3A%2F%2Flocalhost%3A9876%2Fcontext.html');
+    });
+  });
+
+  it('should replace TITLE', () => {
+    return expand('?title=TITLE').then(res => {
+      expect(res).to.equal('?title=Pixel%20Test');
+    });
+  });
+
+  it('should replace AMPDOC_URL', () => {
+    return expand('?ref=AMPDOC_URL').then(res => {
+      expect(res).to.not.match(/AMPDOC_URL/);
+    });
+  });
+
+  it('should replace AMPDOC_HOST', () => {
+    return expand('?ref=AMPDOC_HOST').then(res => {
+      expect(res).to.not.match(/AMPDOC_HOST/);
+    });
+  });
+
+  it('should accept $expressions', () => {
+    return expand('?href=$CANONICAL_URL').then(res => {
+      expect(res).to.equal('?href=https%3A%2F%2Fpinterest.com%2Fpin1');
+    });
+  });
+
+  it('should ignore unknown substitutions', () => {
+    return expand('?a=UNKNOWN').then(res => {
+      expect(res).to.equal('?a=UNKNOWN');
+    });
+  });
+
+  it('should replace several substitutions', () => {
+    return expand('?a=UNKNOWN&href=CANONICAL_URL&title=TITLE').then(res => {
+      expect(res).to.equal('?a=UNKNOWN' +
+          '&href=https%3A%2F%2Fpinterest.com%2Fpin1' +
+          '&title=Pixel%20Test');
+    });
+  });
+
+  it('should replace new substitutions', () => {
+    const replacements = new UrlReplacements(window);
+    replacements.set('ONE', () => 'a');
+    expect(replacements.expand('?a=ONE')).to.equal('?a=a');
+
+    replacements.set('ONE', () => 'b');
+    expect(replacements.expand('?a=ONE')).to.equal('?a=b');
+
+    replacements.set('TWO', () => 'b');
+    expect(replacements.expand('?b=TWO')).to.equal('?b=b');
+  });
+});


### PR DESCRIPTION
Both amp-pixel and amp-list (and others in the future) will be able to take advantage of default substitutions and customize for their own needs.

Partial for #657.

/cc @cramforce 