### PR TITLE
Fix 3p embeds in Firefox

### DIFF
--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -17,7 +17,7 @@
 // Tests integration.js
 // Most coverage through test-3p-frame
 
-import {validateParentOrigin} from '../../3p/integration';
+import {validateParentOrigin, parseFragment} from '../../3p/integration';
 import {registrations} from '../../src/3p';
 
 describe('3p integration.js', () => {
@@ -73,4 +73,40 @@ describe('3p integration.js', () => {
         }, parent);
       }).to.throw(/Parent origin mismatch/);
     });
+
+  it('should parse JSON from fragment unencoded (most browsers)', () => {
+    const unencoded = '#{"tweetid":"638793490521001985","width":390,' +
+        '"height":50,"initialWindowWidth":1290,"initialWindowHeight":165,' +
+        '"type":"twitter","_context":{"referrer":"http://localhost:8000/' +
+        'examples.build/","canonicalUrl":"http://localhost:8000/' +
+        'examples.build/amps.html","location":{"href":"http://' +
+        'localhost:8000/examples.build/twitter.amp.max.html"},' +
+        '"mode":{"localDev":true,"development":false,"minified":false}}}';
+    const data = parseFragment(unencoded);
+    expect(data).to.be.object;
+    expect(data.tweetid).to.equal('638793490521001985');
+    expect(data._context.location.href).to.equal(
+        'http://localhost:8000/examples.build/twitter.amp.max.html');
+  });
+
+  it('should parse JSON from fragment encoded (Firefox)', () => {
+    const encoded = '#{%22tweetid%22:%22638793490521001985%22,%22width' +
+        '%22:390,%22height%22:50,%22initialWindowWidth%22:1290,%22initial' +
+        'WindowHeight%22:165,%22type%22:%22twitter%22,%22_context%22:{%22' +
+        'referrer%22:%22http://localhost:8000/examples.build/%22,%22canoni' +
+        'calUrl%22:%22http://localhost:8000/examples.build/amps.html%22,%22' +
+        'location%22:{%22href%22:%22http://localhost:8000/examples.build/t' +
+        'witter.amp.max.html%22},%22mode%22:{%22localDev%22:true,%22develop' +
+        'ment%22:false,%22minified%22:false}}}';
+    const data = parseFragment(encoded);
+    expect(data).to.be.object;
+    expect(data.tweetid).to.equal('638793490521001985');
+    expect(data._context.location.href).to.equal(
+        'http://localhost:8000/examples.build/twitter.amp.max.html');
+  });
+
+  it('should be ok with empty fragment', () => {
+    expect(parseFragment('')).to.be.empty;
+    expect(parseFragment('#')).to.be.empty;
+  });
 });


### PR DESCRIPTION
Fixes Firefox-only (or at least limited to some browsers) bug where data passed via fragment was encoded and thus failed JSON parsing.

Fixes #959