### PR TITLE
Added a very basic version of analytics for AMP.

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -321,3 +321,16 @@ amp-ad iframe {
 amp-instagram {
   padding: 48px 8px !important;
 }
+
+
+/**
+ * Analytics tags should never be visible. keep them hidden.
+ */
+amp-analytics {
+  position: absolute !important;
+  top: 0 !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  visibility: hidden;
+}

--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    amp-img {
+      max-width: 80%;
+      max-height: 80%;
+      width: 100%;
+    }
+  </style>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+<article>
+  <amp-analytics id="analytics1">
+  {
+    "host": "my-analytics.com",
+    "requests": {
+      "default": "/log?domain=DOMAIN&amp;path=PATH"
+    },
+    "triggers": [{
+      "on": "visible",
+      "request": "default"
+    }]
+  }
+  </amp-analytics>
+  <amp-analytics type="googleanalytics" id="analytics2">
+  {
+    "vars": {
+      "account": "UA-123456-1",
+      "anonymize_ip": true
+    },
+    "triggers": [{
+      "on": "visible",
+      "request": "pageview"
+    }]
+  }
+  </amp-analytics>
+<div class="logo"></div>
+
+<h1 id="top">AMP #0</h1>
+  <p>
+    <amp-fit-text width="300" height="200" layout="responsive" class="box1">
+      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
+    </amp-fit-text>
+  </p>
+  <p>
+    <div class="box1">
+      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
+    </div>
+  </p>
+  <p>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse semper aliquet turpis ac fringilla. Cras dolor nisi, malesuada eu semper non, faucibus sed nisl. Quisque urna velit, accumsan non ante ac, fermentum dignissim justo. Etiam libero massa, commodo a dignissim eu, fringilla eu ante. Nam neque diam, tincidunt in rhoncus a, luctus ac eros. Integer tellus mauris, convallis quis mauris et, tincidunt venenatis lorem. Maecenas vulputate pulvinar quam. Phasellus nec felis ultrices, faucibus dui eu, sodales arcu. Nullam pellentesque erat at lorem volutpat vehicula. Phasellus id lectus risus. Proin consectetur dapibus nulla eget viverra. Donec a scelerisque metus. Morbi vitae diam tempor, facilisis risus id, cursus erat.
+
+  Maecenas tellus dolor, euismod eget porta eu, pretium in diam. Nulla fermentum iaculis leo et ornare. Mauris euismod, risus vitae auctor lacinia, massa elit eleifend neque, sit amet tincidunt nisi diam quis quam. Donec id vestibulum leo, tempor lobortis erat. Nunc eget porta eros. Proin mi leo, iaculis vitae dui at, euismod auctor ante. Integer ut mi nisl. Morbi ut ipsum vel quam fermentum maximus. Morbi aliquet massa quis justo malesuada, sit amet tempus est tempor. Nulla tincidunt orci odio, sed porta nisl fermentum quis. Etiam rhoncus vel eros ut mollis. Nulla vitae risus vel diam porta rutrum vitae a mi. Curabitur id bibendum mi. Morbi sagittis id dui eu suscipit. Pellentesque porttitor placerat nisi non volutpat.
+
+  Curabitur mattis libero a venenatis porta. Integer ac aliquam nulla. Nunc non orci sit amet metus consectetur fermentum. Suspendisse et velit sit amet nulla rhoncus semper. Vivamus et dolor tempus, ultricies metus at, lacinia nisi. Nunc justo dui, efficitur ut orci eget, vehicula feugiat est. Suspendisse non urna congue, feugiat est nec, tempus nisi. In convallis vitae lectus eu finibus. Vestibulum ullamcorper id turpis id pulvinar. Nulla facilisi. Aenean purus odio, imperdiet sed nisl ut, luctus ullamcorper leo. Aenean sit amet pharetra nunc. Integer maximus diam vitae tortor lobortis, sed facilisis ante vehicula. Mauris rutrum pharetra pretium. Praesent laoreet faucibus odio, quis fringilla libero convallis quis.
+
+  Suspendisse viverra augue nec elementum ornare. Nulla vel dui at leo pharetra dapibus non nec risus. Vestibulum hendrerit leo felis, vel accumsan mi molestie vel. Aenean nisi quam, iaculis eu erat euismod, tristique euismod magna. Maecenas sem ante, consectetur et magna ut, pulvinar euismod arcu. Nullam eget mollis dolor, ac tristique ex. Nulla at elit pretium elit aliquam facilisis nec ut sapien. Duis et sem dapibus, pharetra risus sit amet, vulputate libero. Fusce commodo tellus sit amet arcu egestas varius. Integer nunc nisl, maximus tincidunt magna sed, aliquam molestie lectus. Suspendisse mollis ac diam et ornare. Nam ut suscipit odio. Integer arcu tellus, sagittis in tempus gravida, elementum sit amet nulla. Sed non nisl odio.
+
+  Nunc a ipsum nisi. Proin sodales vestibulum nisl, non viverra ipsum efficitur eu. Sed vitae mi congue, vestibulum diam nec, semper odio. Nulla nec luctus mauris. Pellentesque ornare nulla at mi tempor bibendum. Cras quis viverra nunc. Nulla condimentum neque a dictum ullamcorper.
+
+  </p>
+  <p>
+    <amp-img id="img1" src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" width=800 height=600></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300></amp-img>
+  </p>
+</article>
+</body>
+</html>

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -1,0 +1,305 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isExperimentOn} from '../../../src/experiments';
+import {Layout} from '../../../src/layout';
+import {log} from '../../../src/log';
+import {loadPromise} from '../../../src/event-helper';
+import {urlReplacementsFor} from '../../../src/url-replacements';
+
+import {addListener} from './instrumentation';
+import {ANALYTICS_CONFIG} from './vendors';
+
+
+/** @const */
+const EXPERIMENT = 'amp-analytics';
+
+export class AmpAnalytics extends AMP.BaseElement {
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  isExperimentOn_() {
+    return isExperimentOn(this.getWin(), EXPERIMENT);
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return true;
+  }
+
+  /**
+   * @override
+   */
+  createdCallback() {
+    if (!this.isExperimentOn_()) {
+      return;
+    }
+
+    /**
+     * @const {!JSONObject} Copied here for tests.
+     * @private
+     */
+    this.predefinedConfig_ = ANALYTICS_CONFIG;
+  }
+
+  /** @override */
+  buildCallback() {
+    if (!this.isExperimentOn_()) {
+      return;
+    }
+
+    /**
+     * @private {!JSONObject} The analytics config associated with the tag
+     */
+    this.config_ = this.mergeConfigs_();
+
+    /**
+     * @private {?string} Predefinedtype associated with the tag. If specified,
+     * the config from the predefined type is merged with the inline config
+     */
+    this.type_ = null;
+
+    /**
+     * @private {Object<string, string>} A map of request names to the request
+     * format string used by the tag to send data
+     */
+    this.requests_ = {};
+    this.element.setAttribute('aria-hidden', 'true');
+
+    if (this.hasOptedOut_()) {
+      // Nothing to do when the user has opted out.
+      log.fine(this.getName_(), "User has opted out. No hits will be sent.");
+      return;
+    }
+
+    this.generateRequests_();
+
+    if (!Array.isArray(this.config_['triggers'])) {
+      log.error(this.getName_(), 'No triggers were found in the config. No ' +
+          'analytics data will be sent.');
+      return;
+    }
+
+    // Trigger callback can be synchronous. Do the registration at the end.
+    for (let k = 0; k < this.config_['triggers'].length; k++) {
+      const trigger = this.config_['triggers'][k];
+      if (!trigger['on'] || !trigger['request']) {
+        log.warn(this.getName_(), '"on" and "request" attributes are ' +
+            'required for data to be collected.');
+        continue;
+      }
+      addListener(this.getWin(), trigger['on'],
+          this.handleEvent_.bind(this, trigger));
+    }
+  }
+
+  /**
+   * Merges various sources of configs and stores them in a member variable.
+   *
+   * Order of precedence for configs from highest to lowest:
+   * - Remote config: specified through an attribute of the tag.
+   * - Inline config: specified insize the tag.
+   * - Predefined config: Defined as part of the platform.
+   *
+   * @return {!JSONObject} the merged config.
+   * @private
+   */
+  mergeConfigs_() {
+    // TODO(btownsend, #871): Implement support for remote configuration.
+    const remote = {};
+
+    let inline = {};
+    try {
+      inline = JSON.parse(this.element.textContent);
+    }
+    catch (er) {
+      log.warn(this.getName(), "Analytics config could not be parsed.");
+    }
+    const config = this.predefinedConfig_[this.element.getAttribute('type')]
+        || {};
+    return this.mergeObjects_(remote, this.mergeObjects_(inline, config));
+  }
+
+  /**
+   * @return {boolean} true if the user has opted out.
+   */
+  hasOptedOut_() {
+    if (!this.config_['optout']) {
+      return false;
+    }
+
+    const props = this.config_['optout'].split('.');
+    let k = this.getWin();
+    for (let i = 0; i < props.length; i++) {
+      if (!k) {
+        return false;
+      }
+      k = k[props[i]];
+    }
+    return k();
+  }
+
+  /**
+   * Goes through all the requests in predefined vendor config and tag's config
+   * and creates a map of request name to request template. These requests can
+   * then be used while sending a request to a server.
+   *
+   * @private
+   */
+  generateRequests_() {
+    const requests = {};
+    if (!this.config_ || !this.config_['requests']) {
+      log.error(this.getName_(), 'No request strings defined. Analytics data ' +
+          'will not be sent from this page.');
+      return;
+    }
+
+    for (const k in this.config_['requests']) {
+      if (this.config_['requests'].hasOwnProperty(k)) {
+        requests[k] = this.config_['requests'][k];
+      }
+    }
+    this.requests_ = requests;
+
+    // Now replace any request templates with their values.
+    const all = Object.keys(this.requests_).join('|');
+    const requestExpr = new RegExp('\{(' + all + ')\}', 'g');
+    for (const k in this.requests_) {
+      this.requests_[k] = this.expandRequest_(this.requests_[k], requestExpr,
+          this.requests_, 5);
+    }
+  }
+
+  /**
+   * Replaces template variables corresponding to a request with the value of
+   * that request. If no request is found, an empty string is inserted instead.
+   *
+   * @param {string} formatString The request string to be expanded
+   * @param {!RegExp} expression The regular expression used to detect request
+   *          templates
+   * @param {!Object<string, string> requests Map of requests to lookup template
+   *          values from
+   * @param {number} depth Depth of recursion for nested templates
+   * @return {string} the expanded request string
+   * @private
+   */
+  expandRequest_(formatString, expression, requests, depth) {
+    if (depth <= 0) {
+      return '';
+    }
+    depth--;
+    return formatString.replace(expression, (match, name) => {
+      return this.expandRequest_(requests[name], expression, requests, depth) ||
+          '';
+    });
+  }
+
+  /**
+   * Callback for events that are registered by the config's triggers. This
+   * method generates the request and sends the request out.
+   *
+   * @param {!JSONObject} trigger JSON config block that resulted in this event.
+   * @param {!Object} event Object with details about the event.
+   * @private
+   */
+  handleEvent_(trigger, event) {
+    const host = this.config_['host'];
+    let request = this.requests_[trigger['request']];
+    if (!host || !request) {
+      return;
+    }
+
+    // TODO(btownsend, #871): Add support for variables from inline config.
+    request = urlReplacementsFor(this.getWin()).expand(request);
+
+    // TODO(btownsend, #1061): Add support for sendBeacon.
+    if (host && request) {
+      this.sendRequest_('https://' + host + request);
+    }
+  }
+
+  /**
+   * Sends a request via GET method.
+   *
+   * @param {!string} request The request to be sent over wire.
+   * @private
+   */
+  sendRequest_(request) {
+    const image = new Image();
+    image.src = request;
+    image.width = 1;
+    image.height = 1;
+    loadPromise(image).then(() => {
+      log.fine(this.getName_(), 'Sent request: ', request);
+    }).catch(() => {
+      log.warn(this.getName_(), 'Failed to send request: ', request);
+    });
+  }
+
+  /**
+   * @return {string} Returns a string to identify this tag. May not be unique
+   * if the element id is not unique.
+   * @private
+   */
+  getName_() {
+    return 'AmpAnalytics ' +
+        (this.element.getAttribute('id') || '<unknown id>');
+  }
+
+  /**
+   * Merges two objects. If the value is array or plain object, the values are
+   * merged otherwise the value is overwritten.
+   *
+   * @param {Object|Array} from Object or array to merge from
+   * @param {Object|Array} to Object or Array to merge into
+   * @private
+   */
+  mergeObjects_(from, to) {
+    // Checks if the given object is a plain object.
+    const isObject = function(someObj) {
+      return Object.prototype.toString.call(someObj) === '[object Object]';
+    };
+
+    if (to === null || to === undefined) {
+      return from;
+    }
+
+    for (const property in from) {
+      if (from.hasOwnProperty(property)) {
+        // Only deal with own properties.
+        if (Array.isArray(from[property])) {
+          if (!Array.isArray(to[property])) {
+            to[property] = [];
+          }
+          to[property] = this.mergeObjects_(from[property], to[property]);
+        } else if (isObject(from[property])) {
+          if (!isObject(to[property])) {
+            to[property] = {};
+          }
+          to[property] = this.mergeObjects_(from[property],
+              to[property]);
+        } else {
+          to[property] = from[property];
+        }
+      }
+    }
+    return to;
+  }
+}
+
+AMP.registerElement('amp-analytics', AmpAnalytics);

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getService} from '../../../src/service';
+import {viewerFor} from '../../../src/viewer';
+import {Observable} from '../../../src/observable';
+
+/**
+ * This type signifies a callback that gets called when an analytics event that
+ * the listener subscribed to fires.
+ * @typedef {function(!AnalyticsEvent)}
+ */
+let AnalyticsEventListener;
+
+/**
+ * @param {!Window} window Window object to listen on.
+ * @param {!AnalyticsEventType} type Event type to listen to.
+ * @param {!AnalyticsEventListener} listener Callback to call when the event
+ *          fires.
+ */
+export function addListener(window, type, listener) {
+  return instrumentationServiceFor(window).addListener(type, listener);
+}
+
+/**
+ * Events that can result in analytics data to be sent.
+ * @const
+ * @enum {string}
+ */
+export const AnalyticsEventType = {
+  VISIBLE: 'visible',
+  TIMER: 'timer', // Not supported yet.
+  CLICK: 'click', // Not supported yet.
+  TAP: 'tap', // Not supported yet.
+  HIDDEN: 'hidden' // Not supported yet.
+};
+
+/**
+ * Ignore Most of this class as it has not been thought through yet. It will
+ * change completely.
+ */
+class AnalyticsEvent {
+
+  /**
+   * @param {!AnalyticsEventType} type The type of event.
+   */
+  constructor(type) {
+    this.type = type;
+  }
+}
+
+/** @private */
+class InstrumentationService {
+  /**
+   * @param {!Window} window
+   */
+  constructor(window) {
+
+    /**
+     * @consti {!Viewer}
+     */
+    this.viewer_ = viewerFor(window);
+  }
+
+  /**
+   * @param {!AnalyticsEventType} eventType The type of event
+   * @param {!AnalyticsEventListener} The callback to call when the event
+   *          occurs.
+   */
+  addListener(eventType, listener) {
+
+    // TODO(btownsend, #871): Add support for clicks, timers, scroll etc.
+    if (eventType === AnalyticsEventType.VISIBLE) {
+      if (this.viewer_.isVisible()) {
+        listener(new AnalyticsEvent(AnalyticsEventType.VISIBLE));
+      } else {
+        this.viewer_.onVisibilityChanged(() => {
+          if (this.viewer_.isVisible()) {
+            listener(new AnalyticsEvent(AnalyticsEventType.VISIBLE));
+          }
+        });
+      }
+    }
+  }
+}
+
+/**
+ * @param {!Window} window
+ * @return {!InstrumentationService}
+ */
+function instrumentationServiceFor(window) {
+  return getService(window, 'amp-analytics-instrumentation', () => {
+    return new InstrumentationService(window);
+  });
+}

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -1,0 +1,232 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpAnalytics} from '../../../../build/all/v0/amp-analytics-0.1.max';
+import {adopt} from '../../../../src/runtime';
+import * as sinon from 'sinon';
+
+adopt(window);
+
+describe('amp-analytics', function() {
+
+  let sandbox;
+  let windowApi;
+  let sendRequestSpy;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    const WindowApi = function() {};
+    windowApi = new WindowApi();
+    windowApi.location = {hash: '', href: '/test/viewer'};
+    windowApi.Object = window.Object;
+    windowApi.document = document;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    sandbox = null;
+    windowApi = null;
+    sendRequestSpy = null;
+  });
+
+  function getAnalyticsTag(config, attrs) {
+    config = JSON.stringify(config);
+    const el = document.createElement('amp-analytics');
+    el.textContent = config;
+    for (const k in attrs) {
+      el.setAttribute(k, attrs[k]);
+    }
+    const analytics = new AmpAnalytics(el);
+    sandbox.stub(analytics, 'getWin').returns(windowApi);
+    analytics.isExperimentOn_ = () => true;
+    analytics.createdCallback();
+    sendRequestSpy = sandbox.spy(analytics, 'sendRequest_');
+    return analytics;
+  }
+
+  it('is blocked when experiment is off', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/bar'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.isExperimentOn_ = () => false;
+    analytics.buildCallback();
+    expect(sendRequestSpy.callCount).to.equal(0);
+  });
+
+  it('sends a basic hit', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/bar'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.buildCallback();
+    expect(sendRequestSpy.withArgs('https://example.com/bar').calledOnce).to.be.true;
+  });
+
+  it('does not send a hit when host is not provided', function() {
+    const analytics = getAnalyticsTag({
+      'requests': {'foo': '/bar'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.buildCallback();
+    expect(sendRequestSpy.callCount).to.equal(0);
+  });
+
+  it('does not send a hit when request is not provided', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/bar'},
+      'triggers': [{'on': 'visible'}]
+    });
+
+    analytics.buildCallback();
+    expect(sendRequestSpy.callCount).to.equal(0);
+  });
+
+  it('does not send a hit when request type is not defined', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.buildCallback();
+    expect(sendRequestSpy.callCount).to.equal(0);
+  });
+
+  it('expands nested requests', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/bar&{foobar}&baz', 'foobar': 'foobar'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.buildCallback();
+    expect(sendRequestSpy.calledOnce).to.be.true;
+    expect(sendRequestSpy.args[0][0])
+        .to.equal('https://example.com/bar&foobar&baz');
+  });
+
+  it('expands nested requests', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/bar&{foobar}', 'foobar': '{baz}', 'baz': 'baz'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.buildCallback();
+    expect(sendRequestSpy.calledOnce).to.be.true;
+    expect(sendRequestSpy.args[0][0]).to.equal('https://example.com/bar&baz');
+  });
+
+  it('expands recursive requests', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/bar&{foobar}&baz', 'foobar': '{foo}'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.buildCallback();
+    expect(sendRequestSpy.calledOnce).to.be.true;
+    expect(sendRequestSpy.args[0][0])
+        .to.equal('https://example.com/bar&/bar&/bar&&baz&baz&baz');
+  });
+
+  it('fills in the platform variables', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/AMPDOC_URL&TITLE'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.buildCallback();
+    expect(sendRequestSpy.calledOnce).to.be.true;
+    expect(sendRequestSpy.args[0][0]).to.not.match(/AMPDOC_URL/);
+  });
+
+  it('merges host correctly', function() {
+    const analytics = getAnalyticsTag({
+      'requests': {'foo': '/bar'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    }, {'type': 'xyz'});
+
+    analytics.predefinedConfig_ = {
+      'xyz': {
+        'host': 'example.com'
+      }
+    };
+    analytics.buildCallback();
+    expect(sendRequestSpy.calledOnce).to.be.true;
+    expect(sendRequestSpy.args[0][0]).to.equal('https://example.com/bar');
+  });
+
+  it('merges requests correctly', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/{bar}'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    }, {'type': 'xyz'});
+
+    analytics.predefinedConfig_ = {
+      'xyz': {
+        'requests': {'foo': '/bar', 'bar': 'foobar'}
+      }
+    };
+    analytics.buildCallback();
+    expect(sendRequestSpy.calledOnce).to.be.true;
+    expect(sendRequestSpy.args[0][0]).to.equal('https://example.com/foobar');
+  });
+
+  it('merges objects correctly', function() {
+    const analytics = getAnalyticsTag({
+      'host': 'example.com',
+      'requests': {'foo': '/bar'},
+      'triggers': [{'on': 'visible', 'request': 'foo'}]
+    });
+
+    analytics.buildCallback();
+    expect(analytics.mergeObjects_({}, {})).to.deep.equal({});
+    expect(analytics.mergeObjects_({'foo': 1}, {'1': 1}))
+        .to.deep.equal({'foo': 1, '1': 1});
+    expect(analytics.mergeObjects_({'1': 1}, {'bar': 'bar'}))
+        .to.deep.equal({'1': 1, 'bar': 'bar'});
+    expect(analytics.mergeObjects_(
+        {'foo': [1, 2, 3, 4]},
+        {'bar': [4, 5, 6, 7]}))
+        .to.deep.equal(
+            {'foo': [1,2, 3, 4], 'bar': [4, 5, 6, 7]});
+    expect(analytics.mergeObjects_(
+        null,
+        {'foo': 'bar', 'baz': {'foobar': ['abc', 'def']}}))
+        .to.deep.equal({'foo': 'bar', 'baz': {'foobar': ['abc', 'def']}});
+    expect(analytics.mergeObjects_(
+        undefined,
+        {'foo': 'bar', 'baz': {'foobar': ['abc', 'def']}}))
+        .to.deep.equal({'foo': 'bar', 'baz': {'foobar': ['abc', 'def']}});
+    expect(analytics.mergeObjects_(
+        {'baz': 'bar', 'foobar': {'foobar': ['abc', 'def']}},
+        {'foo': 'bar', 'baz': {'foobar': ['abc', 'def']}}))
+        .to.deep.equal({
+          'foo': 'bar',
+          'baz': 'bar',
+          'foobar': {'foobar': ['abc', 'def']}
+        });
+  });
+});

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @const {!JSONObject}
+ */
+export const ANALYTICS_CONFIG = {
+  // TODO(btownsend, #871): Add a generic hit format to make custom analytics
+  // easier.
+
+  'googleanalytics': {
+    'host': 'www.google-analytics.com',
+    'method': 'GET',
+    'requests': {
+      'baseHit': '/collect?v=1&_v=a0&aip=true&_s=HIT_COUNT&dp=PATH&' +
+          'dl=DOMAIN&dt=TITLE&sr=SCREEN_WIDTHxSCREEN_HEIGHT&' +
+          '_utmht=TIMESTAMP&jid=&cid=CLIENT_IDENTIFIER&tid=ACCOUNT',
+      'pageview': '/r{baseHit}&t=pageview&_r=1',
+      'event': '{baseHit}&t=event&ec=EVENT_CATEGORY&ea=EVENT_ACTION&' +
+          'el=EVENT_LABEL&ev=EVENT_VALUE',
+      'timing': '{baseHit}&t=timing&plt={}&dns={}&pdt={}&rrt={}&tcp={}&' +
+          'srt={}&dit={}&clt={}',
+      'social': '{baseHit}&t=social&sa=SOCIAL_ACTION&sn=SOCIAL_NETWORK&' +
+          'st=SOCIAL_ACTION_TARGET'
+    },
+    'optout': '_gaUserPrefs.ioo'
+  }
+};
+
+

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -1,0 +1,97 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+**This extension is still a work in progress. Details below can change.**
+
+### <a name="amp-analytics"></a> `amp-analytics`
+
+A generic framework to collect and send analytics data to multiple analytics vendors.
+
+#### <a name="behavior"></a>Behavior
+
+`<amp-analytics>` tag can be used to define events of interest, collect analytics data and then send it off to any URL.
+
+This tag provides built-in support for most widely used analytics services. In addition, the tag allows for the analytics config to be specified such that the analytics data can be sent to any specified URL is a custom format.
+
+The tag is driven by JSON config that can be specified in one of the three places:
+
+**Remote configs**: This config is loaded in the page via a URL. The URL can be specified in the `config` attribute of the `amp-analytics` tag.
+**Inline configs**: This config is specified directly on the AMP page inside the `amp-analytics` tag.
+**Built in configs**: The AMP platform has these configs built into the platform. These can be loaded onto the page via the `type` attribute on the `amp-analytics` tag.
+
+If more than one methods of specifying the config are used, the configs are merged together in the order above (highest to lowest precedence).
+
+
+##### <a name="inline"></a>Inline Config with a custom host & url format
+```javascript
+<amp-analytics>
+{
+  "host": "my-analytics.com:8080",
+  "requests": {
+    "base_hit": "/collect?v=1&_v=a0&aip=true&_s=HIT_COUNT&dl=DOMAIN&dt=TITLE&sr=SCREEN_WIDTHxSCREEN_HEIGHT&ht=TIMESTAMP&cid=CLIENT_IDENTIFIER&tid=ACCOUNT"
+    "pageview": "/r/{base_hit}&t=pageview&_r=1"
+  }
+  "vars": {
+    "account_id": "123456",
+  }
+  "triggers": [{
+    "on": "LOAD",
+    "request": "pageview"
+  }]
+}
+</amp-analytics>
+```
+##### <a name="builtin"></a>Built-in tag for a service `XYZ` with inline config
+
+```javascript
+<amp-analytics type="xyz">
+{
+  "vars": { "account_id": "123456" }
+  "triggers": [{
+    "on": "LOAD",
+    "request": "pageview"
+  }]
+}
+</amp-analytics>
+```
+
+##### <a name="remote"></a>Remote config
+
+```html
+<amp-analytics
+  config="my-config.com/pub=123456"></amp-analytics>
+```
+
+####  <a name="format"></a>Config Format
+
+At the top level, the config has following properties:
+- **host**: This is the domain:port pair to which the data is going to be sent.
+-  **requests**: This is a mapping of request name to request format. The request name is used in triggers defined below to specify the format that should be used to send the analytics data to the server. The request format uses the same format as [Amp Var Substitution](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md).
+- **vars**: This property is a mapping of variable name to variable value. The values are then used to construct the requests from the request format strings.
+- **triggers**: This array defines the events that cause analytics data to be sent from the page. It can contain following properties:
+    -  **on**: This property defines the type of event that results in this trigger to be fired. Typically, a hit will be sent out based on the request property whenever this event fires.
+    -  **request**: The name of the request that was defined in the requests block to be used as the format string for the analytics data to be sent.
+    -  **vars**: This property is same as the property of same name in parent block. Values specified here take precedence over the values specified in the platform and the parent block. 
+
+
+#### <a name="attributes"></a>Attributes
+
+**type**
+This optional attribute can be specified to use one of the built-in analytics providers. Currently supported types:
+- `googleanalytics`: This type defines the basic requests like `pageview`,  `event`, `social` and `timing`.
+
+**config**
+This attribute can be used to load a configuration from some remote url. The url specified here should use https scheme.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,6 +65,7 @@ function buildExtensions(options) {
   // We pass watch further in to have browserify watch the built file
   // and update it if any of its required deps changed.
   // Each extension and version must be listed individually here.
+  buildExtension('amp-analytics', '0.1', false, options);
   buildExtension('amp-anim', '0.1', false, options);
   buildExtension('amp-audio', '0.1', false, options);
   buildExtension('amp-carousel', '0.1', true, options);
@@ -291,6 +292,7 @@ function buildExamples(watch) {
 
   // Also update test-example-validation.js
   buildExample('ads.amp.html');
+  buildExample('analytics.amp.html');
   buildExample('article.amp.html');
   buildExample('metadata-examples/article-json-ld.amp.html');
   buildExample('metadata-examples/article-microdata.amp.html');

--- a/src/layout.js
+++ b/src/layout.js
@@ -60,6 +60,7 @@ let Dimensions;
  */
 export const naturalDimensions_ = {
   'AMP-PIXEL': {width: 1, height: 1},
+  'AMP-ANALYTICS': {width: 1, height: 1},
   'AMP-AUDIO': null
 };
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -55,6 +55,14 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
         'amp-mustache/amp-mustache.md',
   },
+
+  // Amp Analytics
+  {
+    id: 'amp-analytics',
+    name: 'Amp Analytics)',
+    spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
+        'amp-analytics/amp-analytics.md',
+  },
 ];
 
 


### PR DESCRIPTION
This is the first PR in a series of PRs to implement the spec  outlined in #871.

In this commit, the tag parses the inline config and uses one builtin type to listen for
document.load events and sends a GET request when that happens. There is
primitive support for request templates and platform variables.

Things that are still to come:
- Support for more platform variables (future PR)
- Better instrumentation class (future PR)
- User specified variables (future PR)
- Readme.md (Future PR)