### PR TITLE
Validator CSS Parsing. 

### DIFF
--- a/validator/tokenize-css.js
+++ b/validator/tokenize-css.js
@@ -394,7 +394,7 @@ const MarkedPosition = function MarkedPosition(tokenizer) {
 
 /**
  * Adds position data to the given token, returning it for chaining.
- * @param {!parse_css.CSSParserToken|!parse_css.ErrorToken} token
+ * @param {!parse_css.CSSParserToken} token
  * @return {!parse_css.CSSParserToken}
  */
 MarkedPosition.prototype.addPositionTo = function(token) {


### PR DESCRIPTION
Clean up all of the types. No more type unions. We only parse things once for each call to parseAStylesheet, instead of reparsing parts of the parse tree multiple times.