### PR TITLE
Fix: Install in install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-before_script:
+install:
   - npm install -g gulp
 script:
   - gulp lint


### PR DESCRIPTION
This PR

* [x] renames the `before_script` section to `install`

:information_desk_person: Seems like it makes more sense to install dependencies in the `install` section, rather than the `before_script` section, doesn't it?