### PR TITLE
Lightbox(es) should support exiting with escape and x button

### DIFF
--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -197,7 +197,7 @@
 
   <amp-lightbox id="lightbox1" class="lightbox1" layout="nodisplay">
     <div class="lightbox1-content">
-      <amp-img id="img0" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w452-h900-p/PANO_20150726_171347%257E2.jpg" width=226 height=450 layout="responsive"></amp-img>
+      <amp-img id="img0" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w452-h900-p/PANO_20150726_171347%257E2.jpg" width=226 height=450 layout="responsive" on="tap:lightbox1.close"></amp-img>
     </div>
   </amp-lightbox>
 

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -706,6 +706,11 @@ class AmpImageLightbox extends AMP.BaseElement {
     this.reset_();
     this.init_(source);
 
+    /**  @private {function(this:AmpImageLightbox, Event)}*/
+    this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
+    this.getWin().document.documentElement.addEventListener(
+        'keydown', this.boundCloseOnEscape_);
+
     // Prepare to enter in lightbox
     this.requestFullOverlay();
     this.getViewport().disableTouchZoom();
@@ -721,6 +726,17 @@ class AmpImageLightbox extends AMP.BaseElement {
     this.getHistory_().push(this.close.bind(this)).then(historyId => {
       this.historyId_ = historyId;
     });
+  }
+
+  /**
+   * Handles closing the lightbox when the ESC key is pressed.
+   * @param {!Event} event.
+   * @private
+   */
+  closeOnEscape_(event) {
+    if (event.keyCode == 27) {
+      this.close();
+    }
   }
 
   /**
@@ -745,6 +761,9 @@ class AmpImageLightbox extends AMP.BaseElement {
     if (this.historyId_ != -1) {
       this.getHistory_().pop(this.historyId_);
     }
+    this.getWin().document.documentElement.removeEventListener(
+        'keydown', this.boundCloseOnEscape_);
+    this.boundCloseOnEscape_ = null;
   }
 
   /**

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -131,6 +131,39 @@ describe('amp-image-lightbox component', () => {
       expect(historyPop.callCount).to.equal(1);
     });
   });
+
+  it('should close on ESC', () => {
+    return getImageLightbox().then(lightbox => {
+      const impl = lightbox.implementation_;
+      const setupCloseSpy = sinon.spy(impl, 'close');
+      const viewportOnChanged = sinon.spy();
+      const disableTouchZoom = sinon.spy();
+      const restoreOriginalTouchZoom = sinon.spy();
+      impl.getViewport = () => {return {
+        onChanged: viewportOnChanged,
+        disableTouchZoom: disableTouchZoom,
+        restoreOriginalTouchZoom: restoreOriginalTouchZoom
+      };};
+      const historyPush = sinon.spy();
+      impl.getHistory_ = () => {
+        return {push: () => {
+          historyPush();
+          return Promise.resolve(11);
+        }};
+      };
+      const enter = sinon.spy();
+      impl.enter_ = enter;
+
+      const ampImage = document.createElement('amp-img');
+      ampImage.setAttribute('src', 'data:');
+      ampImage.setAttribute('width', '100');
+      ampImage.setAttribute('height', '100');
+      impl.activate({source: ampImage});
+      impl.closeOnEscape_({keyCode: 27});
+      expect(setupCloseSpy.callCount).to.equal(1);
+      setupCloseSpy.restore();
+    });
+  });
 });
 
 
@@ -353,7 +386,6 @@ describe('amp-image-lightbox image viewer gestures', () => {
     sandbox.restore();
     sandbox = null;
   });
-
 
   it('should have initial bounds', () => {
     expect(imageViewer.minX_).to.equal(0);

--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -46,6 +46,7 @@ at the bottom of the viewport. The caption is discovered as following:
 
 Among other things the `amp-image-lightbox` allows the following user manipulations:
 zooming, panning, showing/hiding of the description.
+Pressing the escape key on the keyboard will close the lightbox.
 
 #### Styling
 

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -57,10 +57,9 @@ class AmpLightbox extends AMP.BaseElement {
       this.container_.appendChild(child);
     });
 
+    this.registerAction('close', this.close.bind(this));
+
     const gestures = Gestures.get(this.element);
-    // TODO(dvoytenko): configure how to close. Or maybe leave it completely
-    // up to "on" element.
-    this.element.addEventListener('click', () => this.close());
     gestures.onGesture(TapRecognizer, () => this.close());
     gestures.onGesture(SwipeXYRecognizer, () => {
       // Consume to block scroll events and side-swipe.
@@ -77,6 +76,10 @@ class AmpLightbox extends AMP.BaseElement {
 
   /** @override */
   activate() {
+    /**  @private {function(this:AmpLightbox, Event)}*/
+    this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
+    this.getWin().document.documentElement.addEventListener(
+        'keydown', this.boundCloseOnEscape_);
     this.requestFullOverlay();
     this.getViewport().resetTouchZoom();
     this.element.style.display = '';
@@ -96,12 +99,26 @@ class AmpLightbox extends AMP.BaseElement {
     });
   }
 
+  /**
+   * Handles closing the lightbox when the ESC key is pressed.
+   * @param {!Event} event.
+   * @private
+   */
+  closeOnEscape_(event) {
+    if (event.keyCode == 27) {
+      this.close();
+    }
+  }
+
   close() {
     this.cancelFullOverlay();
     this.element.style.display = 'none';
     if (this.historyId_ != -1) {
       this.getHistory_().pop(this.historyId_);
     }
+    this.getWin().document.documentElement.removeEventListener(
+        'keydown', this.boundCloseOnEscape_);
+    this.boundCloseOnEscape_ = null;
   }
 
   getHistory_() {

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -22,16 +22,17 @@ The `amp-lightbox` component allows for a “lightbox” or similar experience -
 
 The `amp-lightbox` component defines the child elements that will be displayed in a full-viewport overlay. It is triggered to take up the viewport when the user taps or clicks on an element with `on` attribute that targets `amp-lightbox` element’s `id`.
 
-One or more elements within the lightbox can be optionally given a `close` attribute, which when tapped or clicked will close the lightbox. If no element is given a `close` attribute, a tap or click anywhere on the screen will close it.
+#####Closing the lightbox
+Pressing the escape key on the keyboard will close the lightbox.
+Alternatively setting the `on` attribute on one or more elements within the lightbox and setting it's method to `close` will close the lightbox when the element is tapped or clicked.
 
-For example:
+Example:
 ```html
 <button on="tap:my-lightbox">Open lightbox</button>
 
 <amp-lightbox id="my-lightbox" layout="nodisplay">
   <div class="lightbox">
-    <amp-img src="my-full-image.jpg" width=300 height=800>
-    <div close>Close</div>
+    <amp-img src="my-full-image.jpg" width=300 height=800 on="tap:my-lightbox.close">
   </div>
 </amp-lightbox>
 ```

--- a/test/manual/amp-lightbox.amp.html
+++ b/test/manual/amp-lightbox.amp.html
@@ -66,8 +66,12 @@
   <amp-lightbox id="lightbox1" class="lightbox1" layout="nodisplay">
     <div class="lightbox1-content">
       <amp-img id="img0" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w452-h900-p/PANO_20150726_171347%257E2.jpg" width=226 height=450 layout="responsive"></amp-img>
+      <button on="tap:lightbox1.close">Close using on Attribute</button>
+      <strong style="background:#fff;"> You can also hit the ESC key to close </strong>
     </div>
   </amp-lightbox>
+
+
 
   <p>
     Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.


### PR DESCRIPTION
Lightbox(es) should support exiting
 - When ESC key is hit
 - When a child element with `close` attribute is clicked
 - When a child element with on attribute is set to "tap:lightbox-id.close"
Remove functionality that closes lightbox when tapped anywhere.

Image Lightbox(es) should support exiting
 - When ESC key is hit
This is being tracked in #342 