### PR TITLE
Simplify the warnings (PROD_WARNING->WARNING, DEV_WARNING->ERROR).

### DIFF
--- a/validator/validator-in-browser.js
+++ b/validator/validator-in-browser.js
@@ -80,7 +80,7 @@ amp.validator.validateTapActionsA11y = function(doc, validationResult) {
     }
     if (!element.hasAttribute('role')) {
       const error = new amp.validator.ValidationError();
-      error.severity = amp.validator.ValidationError.Severity.PROD_WARNING;
+      error.severity = amp.validator.ValidationError.Severity.ERROR;
       error.code = amp.validator.ValidationError.Code.MANDATORY_ATTR_MISSING;
       error.detail =
           'A11Y: ' + printElementRef(element) + ' must have "role" attribute ' +
@@ -90,7 +90,7 @@ amp.validator.validateTapActionsA11y = function(doc, validationResult) {
     }
     if (!element.hasAttribute('tabindex')) {
       const error = new amp.validator.ValidationError();
-      error.severity = amp.validator.ValidationError.Severity.PROD_WARNING;
+      error.severity = amp.validator.ValidationError.Severity.ERROR;
       error.code = amp.validator.ValidationError.Code.MANDATORY_ATTR_MISSING;
       error.detail =
           'A11Y: ' + printElementRef(element) + ' must have "tabindex" ' +

--- a/validator/validator.js
+++ b/validator/validator.js
@@ -292,9 +292,7 @@ amp.validator.ValidationResult.prototype.outputToTerminal =
   }
   for (const error of this.errors) {
     if (error.severity ===
-        amp.validator.ValidationError.Severity.ERROR ||
-        error.severity ===
-        amp.validator.ValidationError.Severity.PROD_WARNING) {
+        amp.validator.ValidationError.Severity.ERROR) {
       terminal.error(errorLine(url, error));
     } else {
       terminal.warn(errorLine(url, error));
@@ -631,15 +629,12 @@ CdataMatcher.prototype.getLineCol = function() {
  * @return {amp.validator.ValidationError.Severity}
  */
 function SeverityFor(code) {
-  if (code === amp.validator.ValidationError.Code.DEV_MODE_ENABLED) {
-    return amp.validator.ValidationError.Severity.DEV_WARNING;
+  if (code === amp.validator.ValidationError.Code.DEPRECATED_TAG) {
+    return amp.validator.ValidationError.Severity.WARNING;
   } else if (code === amp.validator.ValidationError.Code.DEPRECATED_ATTR) {
-    return amp.validator.ValidationError.Severity.PROD_WARNING;
-  } else if (code === amp.validator.ValidationError.Code.DEPRECATED_TAG) {
-    return amp.validator.ValidationError.Severity.PROD_WARNING;
-  } else {
-    return amp.validator.ValidationError.Severity.ERROR;
+    return amp.validator.ValidationError.Severity.WARNING;
   }
+  return amp.validator.ValidationError.Severity.ERROR;
 }
 
 
@@ -762,9 +757,8 @@ Context.prototype.addErrorWithLineCol = function(
   }
   const severity = SeverityFor(validationErrorCode);
 
-  // The Javascript Validator is always in dev mode, so unless the severity
-  // is a DEV_WARNING we have a failure.
-  if (severity !== amp.validator.ValidationError.Severity.DEV_WARNING) {
+  // If any of the errors amount to more than a WARNING, validation fails.
+  if (severity !== amp.validator.ValidationError.Severity.WARNING) {
     validationResult.status = amp.validator.ValidationResult.Status.FAIL;
   }
   if (progress.wantsMoreErrors) {
@@ -1366,7 +1360,7 @@ ParsedValidatorRules.prototype.validateTag = function(
       // went fine.
 
       // However we still want to merge the "errors" because warnings should
-      // be reported as well (e.g., the development mode warning).
+      // be reported as well (e.g., the deprecation warnings).
       validationResult.mergeFrom(resultForAttempt);
 
       if (parsedSpec.getSpec().mandatory)

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -69,10 +69,12 @@ message AttrSpec {
   // If set, then the attribute value may not match this regex, which is
   // always applied case-insensitively.
   optional string blacklisted_value_regex = 6;
-  // If set, generates a DEPRECATED_ATTR error of severity PROD_WARNING.
+  // If set, generates a DEPRECATED_ATTR error with severity WARNING.
   optional string deprecation = 7;
   optional string deprecation_url = 8;
-  // If set, generates a DEV_MODE_ENABLED error of severity DEV_WARNING.
+  // This feature specifically addresses the development attribute on
+  // the top-level html tag. When set, a DEV_MODE_ENABLED error with
+  // severity ERROR is generated.
   optional string dev_mode_enabled = 9;
   optional string dev_mode_enabled_url = 10;
 }
@@ -215,13 +217,18 @@ message ValidatorRules {
 message ValidationError {
   enum Severity {
     UNKNOWN_SEVERITY = 0;
+    // A document with at least one error of this severity fails validation.
     ERROR = 1;
+    // A document may have warnings and still pass validation.
+    WARNING = 4;
+    // No longer used.
     // A prod warning is OK in prod mode (the overall status of a validation
     // result is still PASS) but an error in dev mode.
-    PROD_WARNING = 2;
+    PROD_WARNING = 2; // DEPRECATED DO NOT USE.
+    // No longer used.
     // A dev warning is OK in dev mode (the overall status of a validation
     // result is still PASS) but an error in prod mode.
-    DEV_WARNING = 3;
+    DEV_WARNING = 3; // DEPRECATED DO NOT USE.
   }
   optional Severity severity = 6 [ default = ERROR ];
   enum Code {


### PR DESCRIPTION
Instead of distinguishing PROD_WARNING, DEV_WARNING and interpreting
those as WARNING or ERROR depending on the mode in which the
validator runs (this Javascript implementation was always in dev mode),
just make it ERROR or WARNING in the first place. This puts to rest
the complicated scheme which I introduced a while ago,
https://github.com/ampproject/amphtml/issues/174#issuecomment-140871721,
which for the most part treated the development tag on the top-level
html attribute. But since #development=1 has been introduced, suppressing
this error is less important.

Practical changes:
The development attribute: Now always ERROR, even here in Javascript.
So, putting this attribute will make validation fail, but the error
is descriptive and also, the #development=1 alternative is
available.
A11Y errors: These are errors, but they're only implemented in Javascript
thus far and were already errors.
Deprecation: These are warnings, both in Javascript and C++. What changes
is the Javascript, these used to be marked as errors in DEV mode; now
they're warnings, just like in production. I think this is more
straight-forward.