### PR TITLE
Small clarification for how some natural dimensions get calculated.

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -52,9 +52,12 @@ let Dimensions;
 
 
 /**
- * Set or cached browser natural dimensions for elements. The tagname
- * initialized here will return true `hasNaturalDimensions`, even if yet to be
- * calculated. Exported for testing.
+ * The set of elements with natural dimensions, that is, elements
+ * which have a known dimension either based on their value specified here,
+ * or, if the value is null, a dimension specific to the browser.
+ * `hasNaturalDimensions` checks for membership in this set.
+ * `getNaturalDimensions` determines the dimensions for an element in the
+ *    set and caches it.
  * @type {!Object<string, Dimensions>}
  * @private  Visible for testing only!
  */
@@ -202,11 +205,14 @@ export function hasNaturalDimensions(tagName) {
 /**
  * Determines the default dimensions for an element which could vary across
  * different browser implementations, like <audio> for instance.
+ * This operation can only be completed for an element whitelisted by
+ * `hasNaturalDimensions`.
  * @param {string} tagName The element tag name.
  * @return {Dimensions}
  */
 export function getNaturalDimensions(tagName) {
   tagName = tagName.toUpperCase();
+  assert(naturalDimensions_[tagName] !== undefined);
   if (!naturalDimensions_[tagName]) {
     const naturalTagName = tagName.replace(/^AMP\-/, '');
     const temp = document.createElement(naturalTagName);


### PR DESCRIPTION
I like an explicit === null check better because it makes sure
this only triggers when there's an existing entry in the
table with a null value. I think in practice, while the
getNaturalDimensions function would fill in values for tags that
don't have an entry (say, amp-video), this doesn't happen
because it only gets called if hasNaturalDimensions returns false.
That's my reading anyways. No offense taken if I'm wrong or this
doesn't make things clearer.