### PR TITLE
Remove language about the development attribute from the spec doc.

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -241,13 +241,8 @@ The AMP runtime is loaded via the mandatory `<script src="https://cdn.ampproject
 The AMP runtime can be placed into a development mode for any page. Development
 mode will trigger AMP validation on the embedded page, which will emit the
 validation status and any errors to the javascript developer console.
-
-Development mode may be triggered in either of these ways:
-
- - Appending `#development=1` to the URL of the page.
- - Adding the `development` attribute to the AMP runtime script tag, e.g. `<script src="https://cdn.ampproject.org/v0.js" development></script>`.
-
-The latter approach of triggering development mode with a `development` attribute causes the validator to emit a warning to the javascript developer console which will read `DEV_MODE_ENABLED development - please remove for prod`. This warning becomes an error in a production environment and causes validation to fail for performance reasons. The `development` attribute thus should not be used publicly, and is provided primarily for use with toolchains.
+Development mode may be triggered by appending `#development=1` to the URL of
+the page.
 
 
 ## Resources


### PR DESCRIPTION
Move away from the development attribute mode of triggering errors towards the `#development=1` option. See https://github.com/ampproject/amphtml/issues/999 for background.