### PR TITLE
fix(perf): make sure to flush once the perf functions are set

### DIFF
--- a/src/performance.js
+++ b/src/performance.js
@@ -150,6 +150,10 @@ export class Performance {
     this.tick_ = tick;
     this.flush_ = opt_flush;
     this.flushQueuedTicks_();
+    // We need to call flush right away in case `setTickFunction` is called
+    // later than the amp codebase had invoked the performance services'
+    // `flush` method to forward ticks.
+    this.flush();
   }
 }
 

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -188,11 +188,13 @@ describe('performance', () => {
     it('should call the flush callback', () => {
       perf.setTickFunction(function() {}, spy);
 
-      expect(spy.callCount).to.equal(0);
-      perf.flush();
+      // We start at 1 since setting the tick function and flush
+      // causes 1 flush call for any queued events.
       expect(spy.callCount).to.equal(1);
       perf.flush();
       expect(spy.callCount).to.equal(2);
+      perf.flush();
+      expect(spy.callCount).to.equal(3);
     });
   });
 
@@ -222,5 +224,16 @@ describe('performance', () => {
     expect(spy.firstCall.args[1]).to.equal(fn);
 
     spy.restore();
+  });
+
+  it('should call the flush function after its set', () => {
+    const perf = performanceFor(window);
+    const flushSpy = sinon.spy();
+
+    adopt(window);
+
+    window.AMP.setTickFunction(function() {}, flushSpy);
+
+    expect(flushSpy.calledOnce).to.be.true;
   });
 });


### PR DESCRIPTION
the runtime sometimes executes a call to `flush` earlier than the actual viewer forwarding code is set.