### PR TITLE
AMP Validator: Support `<amp-instagram data-shortcode>` attribute and deprecation warnings

### DIFF
--- a/validator/testdata/feature_tests/mandatory_dimensions.html
+++ b/validator/testdata/feature_tests/mandatory_dimensions.html
@@ -91,9 +91,9 @@
     <!-- disallow a src or srcset -->
     <amp-fit-text></amp-fit-text>
     <amp-carousel></amp-carousel>
-    <amp-youtube video-id=""></amp-youtube>
+    <amp-youtube data-videoid=""></amp-youtube>
     <amp-twitter data-tweetid=""></amp-twitter>
-    <amp-instagram shortcode=""></amp-instagram>
+    <amp-instagram data-shortcode=""></amp-instagram>
     <amp-lightbox></amp-lightbox>
   <!-- /Valid Examples -->
 
@@ -119,9 +119,9 @@
     <!-- disallow a src or srcset -->
     <amp-fit-text src=""></amp-fit-text>
     <amp-carousel src=""></amp-carousel>
-    <amp-youtube video-id="" srcset=""></amp-youtube>
+    <amp-youtube data-videoid="" srcset=""></amp-youtube>
     <amp-twitter data-tweetid="" srcset=""></amp-twitter>
-    <amp-instagram shortcode="" srcset=""></amp-instagram>
+    <amp-instagram data-shortcode="" srcset=""></amp-instagram>
     <amp-lightbox src=""></amp-lightbox>
 
     <!-- Not-whitelisted attributes -->

--- a/validator/testdata/feature_tests/youtube.html
+++ b/validator/testdata/feature_tests/youtube.html
@@ -27,7 +27,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <!-- This is OK, it's the older version. We may deprecate it at a later time. -->
+  <!-- This is deprecated, we now prefer data-videoid. -->
   <amp-youtube video-id="https://www.youtube.com/watch?v=9bZkp7q19f0">
   </amp-youtube>
   <!-- This is the current way to do it, according to
@@ -36,8 +36,8 @@ https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/amp-you
   </amp-youtube>
   <!-- This is invalid, the video id is missing. -->
   <amp-youtube></amp-youtube>
-  <!-- This is invalid, one can only have one videoid. -->
-  <amp-youtube video-id="https://www.youtube.com/watch?v=9bZkp7q19f0"
+  <!-- This is invalid, one can only have one of these two. -->
+  <amp-youtube src="https://www.youtube.com/watch?v=9bZkp7q19f0"
                data-videoid="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
   </amp-youtube>
 </body>

--- a/validator/testdata/feature_tests/youtube.out
+++ b/validator/testdata/feature_tests/youtube.out
@@ -1,3 +1,4 @@
 FAIL
-feature_tests/youtube.html:38:2 MANDATORY_ATTR_MISSING src or data-videoid or video-id (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/amp-youtube.md)
-feature_tests/youtube.html:40:2 MUTUALLY_EXCLUSIVE_ATTRS src or data-videoid or video-id (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/amp-youtube.md)
+feature_tests/youtube.html:31:2 DEPRECATED_ATTR video-id - use data-videoid instead (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/amp-youtube.md)
+feature_tests/youtube.html:38:2 MANDATORY_ATTR_MISSING src or data-videoid (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/amp-youtube.md)
+feature_tests/youtube.html:40:2 MUTUALLY_EXCLUSIVE_ATTRS src or data-videoid (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/amp-youtube.md)

--- a/validator/validator.protoascii
+++ b/validator/validator.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 63
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file requires updating this revision id.
-spec_file_revision: 91
+spec_file_revision: 92
 
 # Rules for AMP HTML
 # (https://github.com/google/amphtml/blob/master/spec/amp-html-format.md).
@@ -1834,15 +1834,17 @@ attr_lists: {
   name: "amp-youtube-nonlayout-attrs"
   attrs: {
     name: "src"
-    mandatory_oneof: "src or data-videoid or video-id"
+    mandatory_oneof: "src or data-videoid"
   }
   attrs: {
     name: "data-videoid"
-    mandatory_oneof: "src or data-videoid or video-id"
+    mandatory_oneof: "src or data-videoid"
   }
   attrs: {
     name: "video-id"
-    mandatory_oneof: "src or data-videoid or video-id"
+    deprecation: "use data-videoid instead"
+    deprecation_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/amp-youtube.md"
+    mandatory_oneof: "src or data-videoid"
   }
 }
 tags: {
@@ -1959,12 +1961,18 @@ tags: {
 attr_lists: {
   name: "amp-instagram-nonlayout-attrs"
   attrs: {
-    name: "shortcode"
-    mandatory_oneof: "shortcode or src"
+    name: "data-shortcode"
+    mandatory_oneof: "data-shortcode or src"
   }
   attrs: {
     name: "src"
-    mandatory_oneof: "shortcode or src"
+    mandatory_oneof: "data-shortcode or src"
+  }
+  attrs: {
+    name: "shortcode"
+    deprecation: "use data-shortcode instead"
+    deprecation_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-instagram/amp-instagram.md"
+    mandatory_oneof: "data-shortcode or src"
   }
 }
 tags: {


### PR DESCRIPTION
Support `<amp-instagram data-shortcode>` attribute and add deprecation warnings for:
 - `<amp-instagram shortcode>`
 - `<amp-youtube video-id>`