### PR TITLE
Install templates service right away

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -21,6 +21,7 @@ import {installPullToRefreshBlocker} from './pull-to-refresh';
 import {performanceFor} from './performance';
 import {viewerFor} from './viewer';
 import {vsyncFor} from './vsync';
+import {templatesFor} from './template';
 
 import {installAd} from '../builtins/amp-ad';
 import {installGlobalClickListener} from './document-click';
@@ -49,6 +50,7 @@ try {
       installHistoryService(window);
       viewerFor(window);
       vsyncFor(window);
+      templatesFor(window);
 
       installImg(window);
       installAd(window);

--- a/test/manual/amp-list.amp.html
+++ b/test/manual/amp-list.amp.html
@@ -70,8 +70,6 @@
       <div class="story-entry">
         <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
         {{title}}
-        {{=<% %>=}}
-        <% title %>
       </div>
     </template>
     <div overflow>


### PR DESCRIPTION
Since templates are always compiled into base runtime, there's no real cost to install right away, rather risk the custom element override it.