### PR TITLE
Adds support for analytics platform variables

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -16,8 +16,8 @@
 {
   "host": "example.com",
   "requests": {
-    "base": "/log?domain=DOMAIN&path=PATH&title=${title}",
-    "event": "${base}&name=${eventName}&type=${eventId}"
+    "base": "/log?domain=${canonicalHost}&path=${canonicalPath}&title=${title}",
+    "event": "${base}&name=${eventName}&type=${eventId}&time=${timestamp}&tz=${timezone}&pid=${pageViewId}"
   },
   "vars": {
     "title": "Example Request"

--- a/extensions/amp-analytics/0.1/analytics-platform-vars.js
+++ b/extensions/amp-analytics/0.1/analytics-platform-vars.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getService} from '../../../src/service';
+import {urlReplacementsFor} from '../../../src/url-replacements';
+import {viewportFor} from '../../../src/viewport';
+
+export class AnalyticsPlatformVars {
+
+  /**
+   * @param {!Window} win
+   * @param {!UrlReplacements} urlReplacements
+   * @param {!Viewport} viewport
+   */
+  constructor(win, urlReplacements, viewport) {
+
+    /** @private {!Map} */
+    this.resolvers_ = new Map();
+
+    /**
+     * @param {!string} name
+     * @param {!Function} resolver
+     */
+    const set = (name, fn) => {this.resolvers_.set(name, fn);};
+
+    /**
+     * @param {string} name
+     * @returns {Function}
+     */
+    const delegateToUrlReplacements = name => {
+      return urlReplacements.get.bind(urlReplacements, name);
+    };
+
+    // Document
+    set('canonicalUrl', delegateToUrlReplacements('CANONICAL_URL'));
+    set('canonicalHost', delegateToUrlReplacements('CANONICAL_HOST'));
+    set('canonicalPath', delegateToUrlReplacements('CANONICAL_PATH'));
+    set('referrer', delegateToUrlReplacements('DOCUMENT_REFERRER'));
+    set('title', delegateToUrlReplacements('TITLE'));
+    set('ampUrl', delegateToUrlReplacements('AMPDOC_URL'));
+    set('ampHost', delegateToUrlReplacements('AMPDOC_HOST'));
+
+    // Time
+    set('timestamp', () => new Date().getTime());
+    set('timezone', () => new Date().getTimezoneOffset());
+
+    // Metrics
+    set('scrollTop', viewport.getScrollTop.bind(viewport));
+    set('scrollLeft', viewport.getScrollLeft.bind(viewport));
+    set('scrollWidth', viewport.getScrollWidth.bind(viewport));
+    set('scrollHeight', viewport.getScrollHeight.bind(viewport));
+    set('screenWidth', () => win.screen.width);
+    set('screenHeight', () => win.screen.height);
+
+    // Misc.
+    set('pageViewId', delegateToUrlReplacements('PAGE_VIEW_ID'));
+    set('random', delegateToUrlReplacements('RANDOM'));
+  }
+
+  /**
+   * @param {string} name
+   * @return {*} value for the given var, or null if no matching var exists.
+   */
+  get(name) {
+    return this.resolvers_.has(name) ? this.resolvers_.get(name)() : null;
+  }
+}
+
+/**
+ * @param {!Window} window
+ * @return {!AnalyticsPlatformVars}
+ */
+export function analyticsPlatformVarsFor(win) {
+  return getService(win, 'analytics-platform-vars',
+      () => new AnalyticsPlatformVars(
+          win, urlReplacementsFor(win), viewportFor(win)));
+}
+

--- a/extensions/amp-analytics/0.1/test/test-analytics-platform-vars.js
+++ b/extensions/amp-analytics/0.1/test/test-analytics-platform-vars.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AnalyticsPlatformVars} from '../analytics-platform-vars.js';
+import {urlReplacementsFor} from '../../../../src/url-replacements';
+import {adopt} from '../../../../src/runtime';
+import * as sinon from 'sinon';
+
+adopt(window);
+
+describe('analytics-platform-vars', function() {
+  let sandbox;
+  let fakeWin;
+  let fakeViewport;
+  let apv;
+
+  const canonicalUrl = 'https://example.com/news?id=1234';
+  const ampDocUrl = 'https://ampdoc.com/c/' + canonicalUrl;
+  const referrer = 'https://www.google.com/';
+  const title = 'Test Title';
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    fakeWin = {
+      location: {href: ampDocUrl},
+      document: {
+        createElement: document.createElement,
+        querySelector: () => {return {href: canonicalUrl};},
+        title: title,
+        referrer: referrer,
+        documentElement: {style: {}}
+      },
+      screen: {width: 99, height: 49},
+      Math: {random: () => {return 42;}},
+      Object: window.Object,
+      addEventListener: () => {}
+    };
+    fakeViewport = {
+      getScrollTop: () => {return 0;},
+      getScrollLeft: () => {return 10;},
+      getScrollWidth: () => {return 20;},
+      getScrollHeight: () => {return 30;}
+    };
+    apv = new AnalyticsPlatformVars(
+        fakeWin, urlReplacementsFor(fakeWin), fakeViewport);
+  });
+
+  afterEach(() => {
+    sinon.sandbox.restore();
+    sandbox = null;
+    fakeWin = null;
+    fakeViewport = null;
+    apv = null;
+  });
+
+  it('gets all expected vars', () => {
+    expect(apv.get('random')).to.match(/\d\.\d+/);
+    expect(apv.get('canonicalUrl')).to.equal(canonicalUrl);
+    expect(apv.get('canonicalHost')).to.equal('example.com');
+    expect(apv.get('canonicalPath')).to.equal('/news');
+    expect(apv.get('referrer')).to.equal(referrer);
+    expect(apv.get('title')).to.equal(title);
+    expect(apv.get('ampUrl')).to.equal(ampDocUrl);
+    expect(apv.get('ampHost')).to.equal('ampdoc.com');
+    expect(apv.get('timestamp')).to.match(/\d+/);
+    expect(apv.get('timezone')).to.match(/\d+/);
+    expect(apv.get('scrollTop')).to.equal(0);
+    expect(apv.get('scrollLeft')).to.equal(10);
+    expect(apv.get('scrollWidth')).to.equal(20);
+    expect(apv.get('scrollHeight')).to.equal(30);
+    expect(apv.get('screenWidth')).to.equal(99);
+    expect(apv.get('screenHeight')).to.equal(49);
+    expect(apv.get('pageViewId')).to.match(/\d+/);
+    expect(apv.get('random')).to.match(/\d\.\d+/);
+  });
+
+  it('returns null for unknown vars', () => {
+    expect(apv.get(null)).to.equal(null);
+    expect(apv.get('')).to.equal(null);
+    expect(apv.get('unknown')).to.equal(null);
+  });
+});

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -24,30 +24,19 @@ export const ANALYTICS_CONFIG = {
   'googleanalytics': {
     'host': 'www.google-analytics.com',
     'method': 'GET',
-    'vars': {
-      // TODO(btownsend, #1116) These are placeholders to temporarily simulate
-      // built-in vars. To be removed when amp-analytics.js is updated with
-      // real built-in var support.
-      'title': 'TITLE',
-      'domain': 'CANONICAL_HOST',
-      'path': 'CANONICAL_PATH',
-      'hitCount': 'HIT_COUNT',
-      'screenWidth': 'SCREEN_WIDTH',
-      'screenHeight': 'SCREEN_HEIGHT',
-      'timestamp': 'TIMESTAMP',
-      'clientId': 'CLIENT_IDENTIFIER'
-    },
+    'optout': '_gaUserPrefs.ioo',
     'requests': {
-      'baseHit': '/collect?v=1&_v=a0&aip=true&_s=${hitCount}&dp=${path}&' +
-          'dl=${domain}&dt=${title}&sr=${screenWidth}x${screenHeight}&' +
+      'basePrefix': '/collect?v=1&_v=a0&aip=true&_s=${hitCount}&' +
+          'dp=${canonicalPath}&dl=${canonicalUrl}&dt=${title}&' +
+          'sr=${screenWidth}x${screenHeight}&' +
           '_utmht=${timestamp}&jid=&cid=${clientId}&tid=${account}',
-      'pageview': '/r${baseHit}&t=pageview&_r=1',
-      'event': '${baseHit}&t=event&ec=${eventCategory}&ea=${eventAction}&' +
-          'el=${eventLabel}&ev=${eventValue}',
-      'social': '${baseHit}&t=social&sa=${socialAction}&sn=${socialNetwork}&' +
-          'st=${socialActionTarget}'
-    },
-    'optout': '_gaUserPrefs.ioo'
+      'baseSuffix': '&z=${random}',
+      'pageview': '/r${basePrefix}&t=pageview&_r=1${baseSuffix}',
+      'event': '${basePrefix}&t=event&ec=${eventCategory}&ea=${eventAction}&' +
+          'el=${eventLabel}&ev=${eventValue}${baseSuffix}',
+      'social': '${basePrefix}&t=social&sa=${socialAction}&' +
+          'sn=${socialNetwork}&st=${socialActionTarget}${baseSuffix}'
+    }
   }
 };
 

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -82,7 +82,7 @@ class UrlReplacements {
     // single page view. It should have sufficient entropy to be unique for
     // all the page views a single user is making at a time.
     this.set_('PAGE_VIEW_ID', () => {
-      documentInfoFor(this.win_).pageViewId;
+      return documentInfoFor(this.win_).pageViewId;
     });
   }
 
@@ -103,6 +103,19 @@ class UrlReplacements {
   }
 
   /**
+   * Returns the value associated with the given variable name, or null if no
+   * such variable exists.
+   * @param {string} varName
+   * @param {*} opt_data
+   * @return {string|null}
+   */
+  get(varName, opt_data) {
+    const val = this.replacements_[varName] &&
+        this.replacements_[varName](opt_data);
+    return val || val === 0 ? val : '';
+  }
+
+  /**
    * Expands the provided URL by replacing all known variables with their
    * resolved values.
    * @param {string} url
@@ -111,15 +124,8 @@ class UrlReplacements {
    */
   expand(url, opt_data) {
     const expr = this.getExpr_();
-    return url.replace(expr, (match, name) => {
-      let val = this.replacements_[name](opt_data);
-      // Value 0 is specialcased because the numeric 0 is a valid substitution
-      // value.
-      if (!val && val !== 0) {
-        val = '';
-      }
-      return encodeURIComponent(val);
-    });
+    return url.replace(expr, (match, name) =>
+        encodeURIComponent(this.get(name, opt_data)));
   }
 
   /**


### PR DESCRIPTION
Adds support for expanding platform vars in amp-analytics elements as described in #1116.

Expansion precedence is trigger.vars > config.vars > platform.vars. I used camelCase to name the placeholder variables (instead of names-with-dashes in the original spec) as this seems more consistent with how JSON variables are typically named.
