### PR TITLE
Updating amp-twitter exmaple with more accurate content height

### DIFF
--- a/examples/twitter.amp.html
+++ b/examples/twitter.amp.html
@@ -16,33 +16,30 @@
 
   <h2>Twitter</h2>
 
-  <amp-twitter width=390 height=50
+  <amp-twitter width=375 height=472
       layout="responsive"
       data-tweetid="638793490521001985">
   </amp-twitter>
 
-  <amp-twitter width=390 height=50
+  <amp-twitter width=390 height=330
       data-tweetid="585110598171631616"
       data-cards="hidden">
   </amp-twitter>
 
-
-
-  <amp-twitter width=390 height=267
+  <amp-twitter width=390 height=330
       layout="responsive"
       data-tweetid="585110598171631616"
       data-cards="hidden">
   </amp-twitter>
 
-
-  <amp-twitter width=390 height=50
+  <amp-twitter width=390 height=330
       layout="responsive"
       data-tweetid="641653602164060160"
       data-conversation="none"
       data-cards="hidden">
   </amp-twitter>
 
-  <amp-twitter width=390 height=30
+  <amp-twitter width=390 height=330
       layout="responsive"
       data-tweetid="641653602164060160"
       data-cards="hidden">


### PR DESCRIPTION
* Using more accurate heights for tweets
  * 472 for image tweets
  * 330 for regular tweets