### PR TITLE
Implement URL replacement for client ids available to amp-analytics

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -29,6 +29,10 @@ var requiresReviewPrivacy =
     'being privacy sensitive. Please file an issue asking for permission' +
     ' to use if you have not yet done so.';
 
+var privateServiceFactory = 'This service should only be installed in ' +
+    'the whitelisted files. Other modules should use a public function ' +
+    'typically called serviceNameFor.';
+
 // Terms that must not appear in our source files.
 var forbiddenTerms = {
   'DO NOT SUBMIT': '',
@@ -44,11 +48,24 @@ var forbiddenTerms = {
       'validator/validator-in-browser.js',
     ]
   },
+  // Service factories that should only be installed once.
+  'installCidService': {
+    message: privateServiceFactory,
+    whitelist: [
+      'src/service/cid-impl.js',
+      'extensions/amp-analytics/0.1/amp-analytics.js',
+      'extensions/amp-analytics/0.1/test/test-amp-analytics.js',
+      'test/functional/test-cid.js',
+      'test/functional/test-url-replacements.js'
+    ],
+  },
+  // Privacy sensitive
   'cidFor': {
     message: requiresReviewPrivacy,
     whitelist: [
       'src/cid.js',
       'src/service/cid-impl.js',
+      'src/url-replacements.js',
       'test/functional/test-cid.js',
     ],
   },
@@ -78,6 +95,7 @@ var forbiddenTerms = {
       'src/cookies.js',
       'src/experiments.js',
       'test/functional/test-cookies.js',
+      'test/functional/test-url-replacements.js',
       'tools/experiments/experiments.js',
     ]
   },
@@ -85,6 +103,7 @@ var forbiddenTerms = {
   'localStorage': {
     message: requiresReviewPrivacy,
     whitelist: [
+      'extensions/amp-analytics/0.1/test/test-amp-analytics.js',
       'test/_init_tests.js',
       'src/service/cid-impl.js',
       'test/functional/test-cid.js',

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -44,16 +44,17 @@ export function installPixel(win) {
 
     /** @override */
     layoutCallback() {
-      let src = this.element.getAttribute('src');
-      src = urlReplacementsFor(this.getWin()).expand(this.assertSource(src));
-      const image = new Image();
-      image.src = src;
-      image.width = 1;
-      image.height = 1;
-      // Make it take zero space
-      this.element.style.width = 0;
-      this.element.appendChild(image);
-      return Promise.resolve();
+      const src = this.element.getAttribute('src');
+      return urlReplacementsFor(this.getWin()).expand(this.assertSource(src))
+          .then(src => {
+            const image = new Image();
+            image.src = src;
+            image.width = 1;
+            image.height = 1;
+            // Make it take zero space
+            this.element.style.width = 0;
+            this.element.appendChild(image);
+          });
     }
 
     assertSource(src) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -56,19 +56,20 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const src = this.urlReplacements_.expand(assertHttpsUrl(
-        this.element.getAttribute('src'), this.element));
-    const opts = {
-      credentials: this.element.getAttribute('credentials')
-    };
-    return xhrFor(this.getWin()).fetchJson(src, opts).then(data => {
-      assert(typeof data == 'object' && Array.isArray(data['items']),
-          'Response must be {items: []} object %s %s',
-          this.element, data);
-      const items = data['items'];
-      return templatesFor(this.getWin()).findAndRenderTemplateArray(
-          this.element, items).then(this.rendered_.bind(this));
-    });
+    return this.urlReplacements_.expand(assertHttpsUrl(
+        this.element.getAttribute('src'), this.element)).then(src => {
+          const opts = {
+            credentials: this.element.getAttribute('credentials')
+          };
+          return xhrFor(this.getWin()).fetchJson(src, opts);
+        }).then(data => {
+          assert(typeof data == 'object' && Array.isArray(data['items']),
+              'Response must be {items: []} object %s %s',
+              this.element, data);
+          const items = data['items'];
+          return templatesFor(this.getWin()).findAndRenderTemplateArray(
+              this.element, items).then(this.rendered_.bind(this));
+        });
   }
 
   /**

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -47,7 +47,9 @@ export function adopt(global) {
   // of functions
   const preregisteredElements = global.AMP || [];
 
-  global.AMP = {};
+  global.AMP = {
+    win: global
+  };
 
   /**
    * Registers an extended element and installs its styles.

--- a/src/service.js
+++ b/src/service.js
@@ -75,8 +75,9 @@ export function getService(win, id, opt_factory) {
 export function getElementService(win, id, providedByElement) {
   assert(isElementScheduled(win, providedByElement),
       'Service %s was requested to be provided through %s, ' +
-      'but %s is not loaded in the current page.',
-      id, providedByElement, providedByElement);
+      'but %s is not loaded in the current page. To fix this ' +
+      'problem load the JavaScript file for %s in this page.',
+      id, providedByElement, providedByElement, providedByElement);
   const services = getServices(win, id);
   const s = services[id];
   if (s) {
@@ -113,6 +114,20 @@ export function getElementService(win, id, providedByElement) {
 function isElementScheduled(win, elementName) {
   assert(win.ampExtendedElements, 'win.ampExtendedElements not created yet');
   return !!win.ampExtendedElements[elementName];
+}
+
+/**
+ * In order to provide better error messages we only allow to retrieve
+ * services from other elements if those elements are loaded in the page.
+ * This makes it possible to mark an element as loaded in a test.
+ * @param {!Window} win
+ * @param {string} elementName Name of an extended custom element.
+ */
+export function markElementScheduledForTesting(win, elementName) {
+  if (!win.ampExtendedElements) {
+    win.ampExtendedElements = {};
+  }
+  win.ampExtendedElements[elementName] = true;
 }
 
 /**

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -84,6 +84,9 @@ class Cid {
    *      given.
    */
   get(externalCidScope, consent, opt_persistenceConsent) {
+    assert(/^[a-zA-Z0-9-_]+$/.test(externalCidScope),
+        'The client id name must match only use the characters ' +
+        '[a-zA-Z0-9-_]+\nInstead found %s', externalCidScope);
     return consent.then(() => {
       return getExternalCid(this, externalCidScope,
           opt_persistenceConsent || consent);

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -15,8 +15,9 @@
  */
 
 import {assert} from './asserts';
+import {cidFor} from './cid';
 import {documentInfoFor} from './document-info';
-import {getService} from './service';
+import {getService, getElementService} from './service';
 import {parseUrl, removeFragment} from './url';
 
 
@@ -82,7 +83,16 @@ class UrlReplacements {
     // single page view. It should have sufficient entropy to be unique for
     // all the page views a single user is making at a time.
     this.set_('PAGE_VIEW_ID', () => {
-      documentInfoFor(this.win_).pageViewId;
+      return documentInfoFor(this.win_).pageViewId;
+    });
+
+    this.set_('CLIENT_ID', (data, name) => {
+      return cidFor(this.win_).then(cid => {
+        return cid.get(name,
+            // TODO(@cramforce): Hook up mechanism to get consent to id
+            // generation.
+            Promise.resolve());
+      });
     });
   }
 
@@ -95,8 +105,6 @@ class UrlReplacements {
    * @private
    */
   set_(varName, resolver) {
-    assert(varName == varName.toUpperCase(),
-        'Variable name must be in upper case: %s', varName);
     this.replacements_[varName] = resolver;
     this.replacementExpr_ = undefined;
     return this;
@@ -107,19 +115,42 @@ class UrlReplacements {
    * resolved values.
    * @param {string} url
    * @param {*} opt_data
-   * @return {string}
+   * @return {!Promise<string>}
    */
   expand(url, opt_data) {
     const expr = this.getExpr_();
-    return url.replace(expr, (match, name) => {
-      let val = this.replacements_[name](opt_data);
+    let replacementPromise;
+    const encodeValue = val => {
       // Value 0 is specialcased because the numeric 0 is a valid substitution
       // value.
       if (!val && val !== 0) {
         val = '';
       }
       return encodeURIComponent(val);
+    };
+    url = url.replace(expr, (match, name, arg) => {
+      const val = this.replacements_[name](opt_data, arg);
+      // In case the produced value is a promise, we don't actually
+      // replace anything here, but do it again when the promise resolves.
+      if (val && val.then) {
+        const p = val.then(v => {
+          url = url.replace(match, encodeValue(v));
+        });
+        if (replacementPromise) {
+          replacementPromise = replacementPromise.then(() => p);
+        } else {
+          replacementPromise = p;
+        }
+        return match;
+      }
+      return encodeValue(val);
     });
+
+    if (replacementPromise) {
+      replacementPromise = replacementPromise.then(() => url);
+    }
+
+    return replacementPromise || Promise.resolve(url);
   }
 
   /**
@@ -132,7 +163,13 @@ class UrlReplacements {
       for (const k in this.replacements_) {
         all += (all.length > 0 ? '|' : '') + k;
       }
-      this.replacementExpr_ = new RegExp('\\$?(' + all + ')', 'g');
+      this.replacementExpr_ =
+          // Match the given replacement patterns, as well as optionally
+          // arguments to the replacement behind it in parantheses.
+          // Example string that match
+          // FOO_BAR
+          // FOO_BAR(arg1)
+          new RegExp('\\$?(' + all + ')(?:\\(([a-zA-Z-_]+)\\))?', 'g');
     }
     return this.replacementExpr_;
   }

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -61,6 +61,7 @@ afterEach(() => {
     }
   }
   window.localStorage.clear();
+  window.ampExtendedElements = {};
 });
 
 chai.Assertion.addMethod('attribute', function(attr) {

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -235,7 +235,7 @@ describe('cid', () => {
     const consent = timer.promise(100).then(() => {
       nonce = 'timer fired';
     });
-    const p = cid.get('', consent).then(c => {
+    const p = cid.get('test', consent).then(c => {
       expect(nonce).to.equal('timer fired');
     });
     clock.tick(100);
@@ -244,6 +244,12 @@ describe('cid', () => {
 
   it('should fail on failed consent', () => {
     return expect(cid.get('abc', Promise.reject())).to.be.rejected;
+  });
+
+  it('should fail on invalid scope', () => {
+    expect(() => {
+      cid.get('$$$', Promise.resolve());
+    }).to.throw(/\$\$\$/);
   });
 
   it('should not store until persistence promise resolves', () => {


### PR DESCRIPTION
Also makes the following changes

- Switches `amp-analytics` to use layoutCallback instead of `buildCallback`. Closes #1141 and makes the tests more straight forward since they are now async.
- Support for promised based URL replacement
- Support for (right now only one) arguments to URL replacement functions.

Related to #961 #871
Fixes #1124