### PR TITLE
Alternative implementation of amp-analytics built-in vars

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -16,8 +16,8 @@
 {
   "host": "example.com",
   "requests": {
-    "base": "/log?domain=DOMAIN&path=PATH&title=${title}",
-    "event": "${base}&name=${eventName}&type=${eventId}"
+    "base": "?domain=${canonicalHost}&path=${canonicalPath}&title=${title}",
+    "event": "${base}&name=${eventName}&type=${eventId}&time=${timestamp}&tz=${timezone}&pid=${pageViewId}&screenSize=${screenWidth}x${screenHeight}"
   },
   "vars": {
     "title": "Example Request"

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -18,29 +18,40 @@
  * @const {!JSONObject}
  */
 export const ANALYTICS_CONFIG = {
-  // TODO(btownsend, #871): Add a generic hit format to make custom analytics
-  // easier.
+
+  // Default parent configuration applied to all amp-analytics tags.
+  'default': {
+    'vars': {
+      'random': 'RANDOM',
+      'canonicalUrl': 'CANONICAL_URL',
+      'canonicalHost': 'CANONICAL_HOST',
+      'canonicalPath': 'CANONICAL_PATH',
+      'documentReferrer': 'DOCUMENT_REFERRER',
+      'title': 'TITLE',
+      'ampdocUrl': 'AMPDOC_URL',
+      'ampdocHost': 'AMPDOC_HOST',
+      'pageViewId': 'PAGE_VIEW_ID',
+      'clientId': 'CLIENT_ID',
+      'timestamp': 'TIMESTAMP',
+      'timezone': 'TIMEZONE',
+      'scrollTop': 'SCROLL_TOP',
+      'scrollLeft': 'SCROLL_LEFT',
+      'scrollWidth': 'SCROLL_WIDTH',
+      'scrollHeight': 'SCROLL_HEIGHT',
+      'screenWidth': 'SCREEN_WIDTH',
+      'screenHeight': 'SCREEN_HEIGHT'
+    }
+    // TODO(btownsend, #871): Add a generic hit format to make custom analytics
+    // easier.
+  },
 
   'googleanalytics': {
     'host': 'www.google-analytics.com',
     'method': 'GET',
-    'vars': {
-      // TODO(btownsend, #1116) These are placeholders to temporarily simulate
-      // built-in vars. To be removed when amp-analytics.js is updated with
-      // real built-in var support.
-      'title': 'TITLE',
-      'domain': 'CANONICAL_HOST',
-      'path': 'CANONICAL_PATH',
-      'hitCount': 'HIT_COUNT',
-      'screenWidth': 'SCREEN_WIDTH',
-      'screenHeight': 'SCREEN_HEIGHT',
-      'timestamp': 'TIMESTAMP',
-      'clientId': 'CLIENT_IDENTIFIER'
-    },
     'requests': {
-      'baseHit': '/collect?v=1&_v=a0&aip=true&_s=${hitCount}&dp=${path}&' +
-          'dl=${domain}&dt=${title}&sr=${screenWidth}x${screenHeight}&' +
-          '_utmht=${timestamp}&jid=&cid=${clientId}&tid=${account}',
+      'baseHit': '/collect?v=1&_v=a0&aip=true&_s=${hitCount}&' +
+          'dl=${canonicalUrl}&dt=${title}&sr=${screenWidth}x${screenHeight}&' +
+          '_utmht=${timestamp}&jid=&cid=${clientId(_ga)}&tid=${account}',
       'pageview': '/r${baseHit}&t=pageview&_r=1',
       'event': '${baseHit}&t=event&ec=${eventCategory}&ea=${eventAction}&' +
           'el=${eventLabel}&ev=${eventValue}',

--- a/src/string.js
+++ b/src/string.js
@@ -43,7 +43,7 @@ export function expandTemplate(template, getter, opt_maxIterations) {
   const maxIterations = opt_maxIterations || 1;
   for (let i = 0; i < maxIterations; i++) {
     let matches = 0;
-    template = template.replace(/\${([^}]*)}/g, (a,b) => {
+    template = template.replace(/\${([^}]*)}/g, (a, b) => {
       matches++;
       return getter(b);
     });

--- a/src/vsync.js
+++ b/src/vsync.js
@@ -138,6 +138,19 @@ export class Vsync {
   }
 
   /**
+   * @param {function():TYPE} measurer
+   * @return {!Promise<TYPE>}
+   * @templates TYPE
+   */
+  measurePromise(measurer) {
+    return new Promise(resolve => {
+      this.measure(() => {
+        resolve(measurer());
+      });
+    });
+  }
+
+  /**
    * Whether the runtime is allowed to animate at this time.
    * @return {boolean}
    */

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -103,6 +103,48 @@ describe('UrlReplacements', () => {
         });
   });
 
+  it('should replace TIMESTAMP', () => {
+    return expand('?ts=TIMESTAMP').then(res => {
+      expect(res).to.match(/ts=\d+/);
+    });
+  });
+
+  it('should replace TIMEZONE', () => {
+    return expand('?tz=TIMEZONE').then(res => {
+      expect(res).to.match(/tz=\d+/);
+    });
+  });
+
+  it('should replace SCROLL_TOP', () => {
+    return expand('?scrollTop=SCROLL_TOP').then(res => {
+      expect(res).to.match(/scrollTop=\d+/);
+    });
+  });
+
+  it('should replace SCROLL_LEFT', () => {
+    return expand('?scrollLeft=SCROLL_LEFT').then(res => {
+      expect(res).to.match(/scrollLeft=\d+/);
+    });
+  });
+
+  it('should replace SCROLL_HEIGHT', () => {
+    return expand('?scrollHeight=SCROLL_HEIGHT').then(res => {
+      expect(res).to.match(/scrollHeight=\d+/);
+    });
+  });
+
+  it('should replace SCREEN_WIDTH', () => {
+    return expand('?sw=SCREEN_WIDTH').then(res => {
+      expect(res).to.match(/sw=\d+/);
+    });
+  });
+
+  it('should replace SCREEN_HEIGHT', () => {
+    return expand('?sh=SCREEN_HEIGHT').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
   it('should accept $expressions', () => {
     return expand('?href=$CANONICAL_URL').then(res => {
       expect(res).to.equal('?href=https%3A%2F%2Fpinterest.com%2Fpin1');

--- a/test/functional/test-vsync.js
+++ b/test/functional/test-vsync.js
@@ -124,6 +124,15 @@ describe('vsync', () => {
     });
   });
 
+  it('should return a promise from measurePromise that runs measurer', () => {
+    let measured = false;
+    return vsync.measurePromise(() => {
+      measured = true;
+    }).then(() => {
+      expect(measured).to.be.true;
+    });
+  });
+
   it('should schedule via animation frames when doc is visible', () => {
     let rafHandler;
     vsync.raf_ = handler => rafHandler = handler;


### PR DESCRIPTION
Adds support for expanding platform vars in amp-analytics elements as described in #1116.

This implementation is a possible alternative to PR #1136. If this approach is preferable, I'll close the previous PR and finish this one up instead (still needs tests, etc.)