### PR TITLE
Delegate to viewer for cid generation if AMP is embedded.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -69,6 +69,14 @@ var forbiddenTerms = {
       'test/functional/test-cid.js',
     ],
   },
+  'getBaseCid': {
+    message: requiresReviewPrivacy,
+    whitelist: [
+      'src/service/cid-impl.js',
+      'src/viewer.js',
+      'test/functional/test-cid.js',
+    ],
+  },
   'cookie\\W': {
     message: requiresReviewPrivacy,
     whitelist: [

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -420,6 +420,14 @@ export class Viewer {
   }
 
   /**
+   * Retrieves the Base CID from the viewer
+   * @return {!Promise<string>}
+   */
+  getBaseCid() {
+    return this.sendMessage_('cid', undefined, true);
+  }
+
+  /**
    * Requests AMP document to receive a message from Viewer.
    * @param {string} eventType
    * @param {*} data

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -19,10 +19,12 @@ import {installCidService, getSourceOrigin, isProxyOrigin} from
     '../../src/service/cid-impl';
 import {parseUrl} from '../../src/url';
 import {timer} from '../../src/timer';
+import {viewerFor} from '../../src/viewer';
 import * as sinon from 'sinon';
 
 describe('cid', () => {
 
+  let isEmbedded;
   let sandbox;
   let clock;
   let fakeWin;
@@ -32,6 +34,7 @@ describe('cid', () => {
 
   beforeEach(() => {
     let call = 1;
+    isEmbedded = false;
     sandbox = sinon.sandbox.create();
     clock = sandbox.useFakeTimers();
     storage = {};
@@ -63,6 +66,13 @@ describe('cid', () => {
         'amp-analytics': true
       }
     };
+    const viewer = viewerFor(fakeWin);
+    sandbox.stub(viewer, 'isEmbedded', function() {
+      return isEmbedded;
+    });
+    sandbox.stub(viewer, 'getBaseCid', function() {
+      return Promise.resolve('from-viewer');
+    });
     installCidService(fakeWin);
     return cidFor(fakeWin).then(c => {
       cid = c;
@@ -162,6 +172,25 @@ describe('cid', () => {
         'sha384(YYYhttp://www.origin.come2)');
   });
 
+  it('should retrieve cid from viewer if embedded', () => {
+    isEmbedded = true;
+    return compare(
+        'e2',
+        'sha384(from-viewerhttp://www.origin.come2)');
+  });
+
+  it('should prefer value in storage if present', () => {
+    isEmbedded = true;
+    storage['amp-cid'] = JSON.stringify({
+      cid: 'in-storage',
+      time: timer.now(),
+    });
+    return compare(
+        'e2',
+        'sha384(in-storagehttp://www.origin.come2)');
+  });
+
+
   it('should work without mocking', () => {
     const win = {
       location: {
@@ -174,6 +203,7 @@ describe('cid', () => {
     };
     win.__proto__ = window;
     expect(win.location.href).to.equal('https://cdn.ampproject.org/v/www.origin.com/');
+    viewerFor(win).isEmbedded = () => false;
     installCidService(win);
     return cidFor(win).then(cid => {
       return cid.get('foo', hasConsent).then(c1 => {


### PR DESCRIPTION
Related to #961. Only missing item it that the viewer needs to actually respond.

Wraps localStorage access in try-blocks, because it may fail. Fixes #1148