### PR TITLE
Adds amp-analytics support for 'click' events.

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -5,6 +5,14 @@
   <title>AMP Analytics</title>
   <link rel="canonical" href="analytics.amp.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    .box {
+      background: #ccc;
+      border: 1px solid #aaa;
+      padding: 10px;
+      margin: 10px;
+    }
+  </style>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -43,8 +51,24 @@
   "triggers": [{
     "on": "visible",
     "request": "pageview",
-    "vars" : {
+    "vars": {
       "title": "Example Pageview"
+    }
+  }, {
+    "on": "click",
+    "selector": "#test1",
+    "request": "event",
+    "vars": {
+      "eventCategory": "examples",
+      "eventAction": "clicked-test1"
+    }
+  }, {
+    "on": "click",
+    "selector": "#top",
+    "request": "event",
+    "vars": {
+      "eventCategory": "examples",
+      "eventAction": "clicked-header"
     }
   }]
 }
@@ -53,6 +77,11 @@
 
 <div class="logo"></div>
 <h1 id="top">AMP Analytics</h1>
+
+<span id="test1" class="box">
+  Click here to generate an event
+</span>
+
 </body>
 </html>
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -109,7 +109,7 @@ export class AmpAnalytics extends AMP.BaseElement {
         continue;
       }
       addListener(this.getWin(), trigger['on'],
-          this.handleEvent_.bind(this, trigger));
+          this.handleEvent_.bind(this, trigger), trigger['selector']);
     }
     return Promise.resolve();
   }

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {addListener, instrumentationServiceFor} from '../instrumentation.js';
+import {adopt} from '../../../../src/runtime';
+import * as sinon from 'sinon';
+
+adopt(window);
+
+describe('instrumentation', function() {
+
+  let ins;
+
+  beforeEach(() => {
+    ins = instrumentationServiceFor(window);
+  });
+
+  it('always fires click listeners when selector is set to *', () => {
+    const el1 = document.createElement('test');
+    const fn1 = sinon.stub();
+    addListener(window, 'click', fn1, '*');
+    ins.onClick_({target: el1});
+    expect(fn1.calledOnce).to.be.true;
+
+    const el2 = document.createElement('test2');
+    const fn2 = sinon.stub();
+    addListener(window, 'click', fn2, '*');
+    ins.onClick_({target: el2});
+    expect(fn1.calledTwice).to.be.true;
+    expect(fn2.calledOnce).to.be.true;
+  });
+
+  it('never fires click listeners when the selector is empty', () => {
+    const el1 = document.createElement('test');
+    const fn1 = sinon.stub();
+    addListener(window, 'click', fn1, '');
+    ins.onClick_({target: el1});
+    expect(fn1.callCount).to.equal(0);
+
+    const el2 = document.createElement('test2');
+    const fn2 = sinon.stub();
+    addListener(window, 'click', fn2);
+    ins.onClick_({target: el2});
+    expect(fn1.callCount).to.equal(0);
+    expect(fn2.callCount).to.equal(0);
+  });
+
+  it('only fires on matching elements', () => {
+    const el1 = document.createElement('div');
+
+    const el2 = document.createElement('div');
+    el2.className = 'x';
+
+    const el3 = document.createElement('div');
+    el3.className = 'x';
+    el3.id = 'y';
+
+    const fnClassX = sinon.stub();
+    addListener(window, 'click', fnClassX, '.x');
+
+    const fnIdY = sinon.stub();
+    addListener(window, 'click', fnIdY, '#y');
+
+    ins.onClick_({target: el1});
+    expect(fnClassX.callCount).to.equal(0);
+    expect(fnIdY.callCount).to.equal(0);
+
+    ins.onClick_({target: el2});
+    expect(fnClassX.callCount).to.equal(1);
+    expect(fnIdY.callCount).to.equal(0);
+
+    ins.onClick_({target: el3});
+    expect(fnClassX.callCount).to.equal(2);
+    expect(fnIdY.callCount).to.equal(1);
+  });
+
+});


### PR DESCRIPTION
This is a first attempt at adding support for firing amp-analytics requests in response to click events, with support for selectors. 

@dvoytenko  I'd like to get feedback on this approach before adding tests. In particular how I should handle event dispatching in a performance-friendly way (not sure the current vsync'ing on each observer is helpful.)