### PR TITLE
Simplify scroll tracking and greatly increase frequency of viewability events

### DIFF
--- a/test/functional/test-amp-ad.js
+++ b/test/functional/test-amp-ad.js
@@ -19,7 +19,7 @@ import {installAd, AD_LOAD_TIME_MS} from '../../builtins/amp-ad';
 import {viewportFor} from
     '../../src/viewport';
 import {timer} from '../../src/timer';
-import {vsync} from '../../src/vsync';
+import {vsyncFor} from '../../src/vsync';
 import * as sinon from 'sinon';
 
 describe('amp-ad', () => {
@@ -230,12 +230,12 @@ describe('amp-ad', () => {
       expect(posts).to.have.length(1);
       ampAd.viewportCallback(true);
       expect(posts).to.have.length(2);
-      viewport.changed_(false, 0);
+      viewport.scroll_();
       expect(posts).to.have.length(3);
       ampAd.viewportCallback(false);
       expect(posts).to.have.length(4);
       // No longer listening.
-      viewport.changed_(false, 0);
+      viewport.scroll_();
       expect(posts).to.have.length(4);
     });
   });

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -48,7 +48,10 @@ describe('Viewport', () => {
     windowApi = {
       document: {
         documentElement: {style: {}}
-      }
+      },
+      location: {},
+      setTimeout: window.setTimeout,
+      requestAnimationFrame: fn => window.setTimeout(fn, 16)
     };
     binding = new ViewportBindingVirtual_(windowApi, viewer);
     viewport = new Viewport(windowApi, binding, viewer);
@@ -132,44 +135,27 @@ describe('Viewport', () => {
     viewport.onChanged(event => {
       changeEvent = event;
     });
-    viewer.getScrollTop = () => {return 34;};
+    viewer.getScrollTop = () => 34;
     viewerViewportHandler();
     expect(changeEvent).to.equal(null);
 
     // Not enough time past.
-    clock.tick(100);
-    viewer.getScrollTop = () => {return 35;};
+    clock.tick(8);
+    expect(changeEvent).to.equal(null);
+    clock.tick(8);
+    expect(changeEvent).to.equal(null);
+    viewer.getScrollTop = () => 35;
     viewerViewportHandler();
+    clock.tick(16);
     expect(changeEvent).to.equal(null);
 
     // A bit more time.
-    clock.tick(750);
+    clock.tick(16);
+    expect(changeEvent).to.equal(null);
+    clock.tick(4);
     expect(changeEvent).to.not.equal(null);
     expect(changeEvent.relayoutAll).to.equal(false);
-    expect(changeEvent.velocity).to.be.closeTo(0.002, 1e-4);
-  });
-
-  it('should defer scroll events and react to reset of scroll pos', () => {
-    let changeEvent = null;
-    viewport.onChanged(event => {
-      changeEvent = event;
-    });
-    viewer.getScrollTop = () => {return 34;};
-    viewerViewportHandler();
-    expect(changeEvent).to.equal(null);
-
-    // Not enough time past.
-    clock.tick(100);
-    viewer.getScrollTop = () => {return 35;};
-    viewerViewportHandler();
-    expect(changeEvent).to.equal(null);
-
-    // Reset and wait a bit more time.
-    viewport./*OK*/scrollTop_ = null;
-    clock.tick(750);
-    expect(changeEvent).to.not.equal(null);
-    expect(changeEvent.relayoutAll).to.equal(false);
-    expect(changeEvent.velocity).to.equal(0);
+    expect(changeEvent.velocity).to.be.closeTo(0.019230, 1e-4);
   });
 
   it('should update scroll pos and reset cache', () => {
@@ -363,7 +349,8 @@ describe('Viewport META', () => {
             }
             return undefined;
           }
-        }
+        },
+        location: {}
       };
 
       binding = new ViewportBindingVirtual_(windowApi, viewer);


### PR DESCRIPTION

- The scroll event now always fires in vsync and always measures
scrollTop.
- The viewport change event now happens at the latest 3 frames after
scrolling ended.
- Increased speed at which we send change event. Needed due to resolution at slow speed, but I also feel the value is better.

Changes ad intersection to fire "on scroll". Fixes #873

Fixes a bug where only the first viewability provider in an ad would get an initial viewability change record. Fixes #1126