### PR TITLE
Make request transport for amp-analytics configurable.

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -22,9 +22,9 @@
 <amp-analytics id="analytics1">
 <script type="application/json">
 {
-  "host": "example.com",
+  "transport": {"beacon": false, "xhrpost": false},
   "requests": {
-    "base": "?domain=${canonicalHost}&path=${canonicalPath}&title=${title}",
+    "base": "https://example.com/?domain=${canonicalHost}&path=${canonicalPath}&title=${title}",
     "event": "${base}&name=${eventName}&type=${eventId}&time=${timestamp}&tz=${timezone}&pid=${pageViewId}&screenSize=${screenWidth}x${screenHeight}"
   },
   "vars": {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -18,11 +18,11 @@ import {isExperimentOn} from '../../../src/experiments';
 import {installCidService} from '../../../src/service/cid-impl';
 import {Layout} from '../../../src/layout';
 import {log} from '../../../src/log';
-import {loadPromise} from '../../../src/event-helper';
 import {urlReplacementsFor} from '../../../src/url-replacements';
 import {expandTemplate} from '../../../src/string';
 
 import {addListener} from './instrumentation';
+import {sendRequest} from './transport';
 import {ANALYTICS_CONFIG} from './vendors';
 
 
@@ -223,9 +223,10 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @private
    */
   handleEvent_(trigger, event) {
-    const host = this.config_['host'];
     let request = this.requests_[trigger['request']];
-    if (!host || !request) {
+    if (!request) {
+      log.warn(this.getName_(),
+          'Ignoring event. Request string not found', trigger['request']);
       return;
     }
 
@@ -243,30 +244,20 @@ export class AmpAnalytics extends AMP.BaseElement {
     });
 
     // For consistentcy with amp-pixel we also expand any url replacements.
-    urlReplacementsFor(this.getWin()).expand(request).then(request => {
-      // TODO(btownsend, #1061): Add support for sendBeacon.
-      if (host && request) {
-        this.sendRequest_('https://' + host + request);
-      }
-    });
+    urlReplacementsFor(this.getWin()).expand(request).then(
+        request => this.sendRequest_(request));
   }
 
   /**
-   * Sends a request via GET method.
-   *
-   * @param {!string} request The request to be sent over wire.
+   * @param {string} request The full request string to send.
    * @private
    */
   sendRequest_(request) {
-    const image = new Image();
-    image.src = request;
-    image.width = 1;
-    image.height = 1;
-    loadPromise(image).then(() => {
-      log.fine(this.getName_(), 'Sent request: ', request);
-    }).catch(() => {
-      log.warn(this.getName_(), 'Failed to send request: ', request);
-    });
+    if (!request) {
+      log.warn(this.getName_(), 'Request not sent. Contents empty.');
+      return;
+    }
+    sendRequest(this.getWin(), request, this.config_['transport'] || {});
   }
 
   /**

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -71,8 +71,7 @@ describe('amp-analytics', function() {
 
   it('is blocked when experiment is off', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/bar'},
+      'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
 
@@ -84,8 +83,7 @@ describe('amp-analytics', function() {
 
   it('sends a basic hit', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/bar'},
+      'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
 
@@ -97,8 +95,7 @@ describe('amp-analytics', function() {
 
   it('does not send a hit when config is not in a script tag', function() {
     const config = JSON.stringify({
-      'host': 'example.com',
-      'requests': {'foo': '/bar'},
+      'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
     const el = document.createElement('amp-analytics');
@@ -116,8 +113,7 @@ describe('amp-analytics', function() {
 
   it('does not send a hit when multiple child tags exist', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/bar'},
+      'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
     const script2 = document.createElement('script');
@@ -133,8 +129,7 @@ describe('amp-analytics', function() {
         const el = document.createElement('amp-analytics');
         const script = document.createElement('script');
         script.textContent = JSON.stringify({
-          'host': 'example.com',
-          'requests': {'foo': '/bar'},
+          'requests': {'foo': 'https://example.com/bar'},
           'triggers': [{'on': 'visible', 'request': 'foo'}]
         });
         el.appendChild(script);
@@ -149,21 +144,9 @@ describe('amp-analytics', function() {
         });
       });
 
-  it('does not send a hit when host is not provided', function() {
-    const analytics = getAnalyticsTag({
-      'requests': {'foo': '/bar'},
-      'triggers': [{'on': 'visible', 'request': 'foo'}]
-    });
-
-    return analytics.layoutCallback().then(() => {
-      expect(sendRequestSpy.callCount).to.equal(0);
-    });
-  });
-
   it('does not send a hit when request is not provided', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/bar'},
+      'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible'}]
     });
 
@@ -174,7 +157,6 @@ describe('amp-analytics', function() {
 
   it('does not send a hit when request type is not defined', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
 
@@ -185,8 +167,8 @@ describe('amp-analytics', function() {
 
   it('expands nested requests', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/bar&${foobar}&baz', 'foobar': 'f1'},
+      'requests': {'foo':
+        'https://example.com/bar&${foobar}&baz', 'foobar': 'f1'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
 
@@ -199,8 +181,8 @@ describe('amp-analytics', function() {
 
   it('expands nested requests', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/bar&${foobar}', 'foobar': '${baz}', 'baz': 'b1'},
+      'requests': {'foo':
+        'https://example.com/bar&${foobar}', 'foobar': '${baz}', 'baz': 'b1'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
 
@@ -212,7 +194,6 @@ describe('amp-analytics', function() {
 
   it('expands recursive requests', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
       'requests': {'foo': '/bar&${foobar}&baz', 'foobar': '${foo}'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
@@ -220,7 +201,7 @@ describe('amp-analytics', function() {
     return analytics.layoutCallback().then(() => {
       expect(sendRequestSpy.calledOnce).to.be.true;
       expect(sendRequestSpy.args[0][0])
-          .to.equal('https://example.com/bar&/bar&/bar&&baz&baz&baz');
+          .to.equal('/bar&/bar&/bar&&baz&baz&baz');
     });
   });
 
@@ -235,8 +216,7 @@ describe('amp-analytics', function() {
     };
     windowApi.location.href = '/c/www.test.com/abc';
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': 'cid=${clientId(analytics-abc)}'},
+      'requests': {'foo': 'https://example.com/cid=${clientId(analytics-abc)}'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
 
@@ -248,27 +228,9 @@ describe('amp-analytics', function() {
     });
   });
 
-  it('merges host correctly', function() {
-    const analytics = getAnalyticsTag({
-      'requests': {'foo': '/bar'},
-      'triggers': [{'on': 'visible', 'request': 'foo'}]
-    }, {'type': 'xyz'});
-
-    analytics.predefinedConfig_ = {
-      'xyz': {
-        'host': 'example.com'
-      }
-    };
-    return analytics.layoutCallback().then(() => {
-      expect(sendRequestSpy.calledOnce).to.be.true;
-      expect(sendRequestSpy.args[0][0]).to.equal('https://example.com/bar');
-    });
-  });
-
   it('merges requests correctly', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/${bar}'},
+      'requests': {'foo': 'https://example.com/${bar}'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     }, {'type': 'xyz'});
 
@@ -285,8 +247,7 @@ describe('amp-analytics', function() {
 
   it('merges objects correctly', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/bar'},
+      'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
 
@@ -322,8 +283,8 @@ describe('amp-analytics', function() {
 
   it('expands trigger vars', () => {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'pageview': '/test1=${var1}&test2=${var2}'},
+      'requests': {'pageview':
+        'https://example.com/test1=${var1}&test2=${var2}'},
       'triggers': [{
         'on': 'visible',
         'request': 'pageview',
@@ -341,12 +302,12 @@ describe('amp-analytics', function() {
 
   it('expands config vars', () => {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
       'vars': {
         'var1': 'x',
         'var2': 'test2'
       },
-      'requests': {'pageview': '/test1=${var1}&test2=${var2}'},
+      'requests': {'pageview':
+        'https://example.com/test1=${var1}&test2=${var2}'},
       'triggers': [{'on': 'visible', 'request': 'pageview'}]});
     return analytics.layoutCallback().then(() => {
       expect(sendRequestSpy.calledOnce).to.be.true;
@@ -357,8 +318,8 @@ describe('amp-analytics', function() {
 
   it('expands platform vars', () => {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'pageview': '/title=${title}&ref=${documentReferrer}'},
+      'requests': {'pageview':
+        'https://example.com/title=${title}&ref=${documentReferrer}'},
       'triggers': [{'on': 'visible', 'request': 'pageview'}]});
     return analytics.layoutCallback().then(() => {
       expect(sendRequestSpy.calledOnce).to.be.true;
@@ -370,8 +331,7 @@ describe('amp-analytics', function() {
 
   it('expands url-replacements vars', function() {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'foo': '/AMPDOC_URL&TITLE'},
+      'requests': {'foo': 'https://example.com/AMPDOC_URL&TITLE'},
       'triggers': [{'on': 'visible', 'request': 'foo'}]
     });
 
@@ -384,12 +344,12 @@ describe('amp-analytics', function() {
 
   it('expands trigger vars with higher precedence than config vars', () => {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
       'vars': {
         'var1': 'config1',
         'var2': 'config2'
       },
-      'requests': {'pageview': '/test1=${var1}&test2=${var2}'},
+      'requests': {'pageview':
+        'https://example.com/test1=${var1}&test2=${var2}'},
       'triggers': [{
         'on': 'visible',
         'request': 'pageview',
@@ -405,9 +365,9 @@ describe('amp-analytics', function() {
 
   it('expands config vars with higher precedence than platform vars', () => {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
       'vars': {'random': 428},
-      'requests': {'pageview': '/test1=${title}&test2=${random}'},
+      'requests': {'pageview':
+        'https://example.com/test1=${title}&test2=${random}'},
       'triggers': [{'on': 'visible', 'request': 'pageview',}]
     });
     return analytics.layoutCallback().then(() => {
@@ -419,8 +379,7 @@ describe('amp-analytics', function() {
 
   it('does not expand nested vars', () => {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'pageview': '/test=${var1}'},
+      'requests': {'pageview': 'https://example.com/test=${var1}'},
       'triggers': [{
         'on': 'visible',
         'request': 'pageview',
@@ -437,13 +396,12 @@ describe('amp-analytics', function() {
 
   it('expands and encodes requests, config vars, and trigger vars', () => {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
       'vars': {
         'c1': 'config 1',
         'c2': 'config&2'
       },
       'requests': {
-        'base': '/test?c1=${c1}&t1=${t1}',
+        'base': 'https://example.com/test?c1=${c1}&t1=${t1}',
         'pageview': '${base}&c2=${c2}&t2=${t2}'
       },
       'triggers': [{
@@ -463,8 +421,8 @@ describe('amp-analytics', function() {
 
   it('expands url-replacements vars', () => {
     const analytics = getAnalyticsTag({
-      'host': 'example.com',
-      'requests': {'pageview': '/test1=${var1}&test2=${var2}&title=TITLE'},
+      'requests': {'pageview':
+        'https://example.com/test1=${var1}&test2=${var2}&title=TITLE'},
       'triggers': [{
         'on': 'visible',
         'request': 'pageview',
@@ -483,8 +441,7 @@ describe('amp-analytics', function() {
 
   it('respects optout', function() {
     const config = {
-      'host': 'example.com',
-      'requests': {'foo': '/bar'},
+      'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible', 'request': 'foo'}],
       'optout': 'foo.bar'
     };

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {sendRequest, Transport} from '../transport';
+import {adopt} from '../../../../src/runtime';
+import * as sinon from 'sinon';
+
+adopt(window);
+
+describe('transport', () => {
+
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function setupStubs(beaconRetval, xhrRetval) {
+    sandbox.stub(Transport, 'sendRequestUsingImage');
+    sandbox.stub(Transport, 'sendRequestUsingBeacon').returns(beaconRetval);
+    sandbox.stub(Transport, 'sendRequestUsingXhr').returns(xhrRetval);
+  }
+
+  function assertCallCounts(
+      expectedBeaconCalls, expectedXhrCalls, expectedImageCalls) {
+    expect(Transport.sendRequestUsingBeacon.callCount,
+        'sendRequestUsingBeacon call count').to.equal(expectedBeaconCalls);
+    expect(Transport.sendRequestUsingXhr.callCount,
+        'sendRequestUsingXhr call count').to.equal(expectedXhrCalls);
+    expect(Transport.sendRequestUsingImage.callCount,
+        'sendRequestUsingImage call count').to.equal(expectedImageCalls);
+  }
+
+  it('prefers beacon over xhrpost and image', () => {
+    setupStubs(true, true);
+    sendRequest(window, 'https://example.com/test', {
+      beacon: true, xhrpost: true, image: true
+    });
+    assertCallCounts(1, 0, 0);
+  });
+
+  it('prefers xhrpost over image', () => {
+    setupStubs(true, true);
+    sendRequest(window, 'https://example.com/test', {
+      beacon: false, xhrpost: true, image: true
+    });
+    assertCallCounts(0, 1, 0);
+  });
+
+  it('reluctantly uses image if nothing else is enabled', () => {
+    setupStubs(true, true);
+    sendRequest(window, 'https://example.com/test', {
+      image: true
+    });
+    assertCallCounts(0, 0, 1);
+  });
+
+  it('falls back to xhrpost when enabled and beacon is not available', () => {
+    setupStubs(false, true);
+    sendRequest(window, 'https://example.com/test', {
+      beacon: true, xhrpost: true, image: true
+    });
+    assertCallCounts(1, 1, 0);
+  });
+
+  it('falls back to image when beacon not found and xhr disabled', () => {
+    setupStubs(false, true);
+    sendRequest(window, 'https://example.com/test', {
+      beacon: true, xhrpost: false, image: true
+    });
+    assertCallCounts(1, 0, 1);
+  });
+
+  it('falls back to image when beacon and xhr are not available', () => {
+    setupStubs(false, false);
+    sendRequest(window, 'https://example.com/test', {
+      beacon: true, xhrpost: true, image: true
+    });
+    assertCallCounts(1, 1, 1);
+  });
+
+  it('does not send a request when no transport methods are enabled', () => {
+    setupStubs(true, true);
+    beaconRetval = false;
+    xhrRetval = false;
+    sendRequest(window, 'https://example.com/test', {});
+    assertCallCounts(0, 0, 0);
+  });
+
+  it('asserts that urls are https', () => {
+    expect(() => {
+      sendRequest(window, 'http://example.com/test');
+    }).to.throw(Error);
+  });
+});
+

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assertHttpsUrl} from '../../../src/url';
+import {log} from '../../../src/log';
+import {loadPromise} from '../../../src/event-helper';
+
+/** @const {string} */
+const TAG_ = 'AmpAnalytics.Transport';
+
+/**
+ * @param {!Window} win
+ * @param {string} request
+ * @param {!Object<string, string>} transportOptions
+ */
+export function sendRequest(win, request, transportOptions) {
+  assertHttpsUrl(request);
+  if (transportOptions['beacon'] &&
+      Transport.sendRequestUsingBeacon(win, request)) {
+    return;
+  }
+  if (transportOptions['xhrpost'] &&
+      Transport.sendRequestUsingXhr(win, request)) {
+    return;
+  }
+  if (transportOptions['image']) {
+    Transport.sendRequestUsingImage(win, request);
+    return;
+  }
+  log.warn(TAG_, 'Failed to send request', request, transportOptions);
+}
+
+/**
+ * @visibleForTesting
+ */
+export class Transport {
+
+  /**
+   * @param {!Window} win
+   * @param {string} request
+   */
+  static sendRequestUsingImage(win, request) {
+    const image = new Image();
+    image.src = request;
+    image.width = 1;
+    image.height = 1;
+    loadPromise(image).then(() => {
+      log.fine(TAG_, 'Sent image request', request);
+    }).catch(() => {
+      log.warn(TAG_, 'Failed to send image request', request);
+    });
+  }
+
+  /**
+   * @param {!Window} win
+   * @param {string} request
+   * @return {boolean} True if this browser supports navigator.sendBeacon.
+   */
+  static sendRequestUsingBeacon(win, request) {
+    if (!win.navigator.sendBeacon) {
+      return false;
+    }
+    win.navigator.sendBeacon(request, '');
+    log.fine(TAG_, 'Sent beacon request', request);
+    return true;
+  }
+
+  /**
+   * @param {!Window} win
+   * @param {string} request
+   * @return {boolean} True if this browser supports cross-domain XHR.
+   */
+  static sendRequestUsingXhr(win, request) {
+    if (!win.XMLHttpRequest) {
+      return false;
+    }
+    const xhr = new win.XMLHttpRequest();
+    if (!('withCredentials' in xhr)) {
+      return false; // Looks like XHR level 1 - CORS is not supported.
+    }
+    xhr.open('POST', request, true);
+    xhr.withCredentials = true;
+
+    // Prevent pre-flight HEAD request.
+    xhr.setRequestHeader('Content-Type', 'text/plain');
+
+    xhr.onreadystatechange = () => {
+      if (xhr.readystate == 4) {
+        log.fine(TAG_, 'Sent XHR request', request);
+      }
+    };
+
+    xhr.send('');
+    return true;
+  }
+}
+

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -21,6 +21,7 @@ export const ANALYTICS_CONFIG = {
 
   // Default parent configuration applied to all amp-analytics tags.
   'default': {
+    'transport': {'beacon': true, 'xhrpost': true, 'image': true},
     'vars': {
       'random': 'RANDOM',
       'canonicalUrl': 'CANONICAL_URL',
@@ -46,17 +47,20 @@ export const ANALYTICS_CONFIG = {
   },
 
   'googleanalytics': {
-    'host': 'www.google-analytics.com',
-    'method': 'GET',
     'requests': {
-      'baseHit': '/collect?v=1&_v=a0&aip=true&_s=${hitCount}&' +
-          'dl=${canonicalUrl}&dt=${title}&sr=${screenWidth}x${screenHeight}&' +
-          '_utmht=${timestamp}&jid=&cid=${clientId(_ga)}&tid=${account}',
-      'pageview': '/r${baseHit}&t=pageview&_r=1',
-      'event': '${baseHit}&t=event&ec=${eventCategory}&ea=${eventAction}&' +
-          'el=${eventLabel}&ev=${eventValue}',
-      'social': '${baseHit}&t=social&sa=${socialAction}&sn=${socialNetwork}&' +
-          'st=${socialActionTarget}'
+      'host': 'https://www.google-analytics.com',
+      'basePrefix': 'v=1&_v=a0&aip=true&_s=${hitCount}&dl=${canonicalUrl}&' +
+          'dt=${title}&sr=${screenWidth}x${screenHeight}&_utmht=${timestamp}&' +
+          'jid=&cid=${clientId(_ga)}&tid=${account}',
+      'baseSuffix': '&z=${random}',
+      'pageview': '${host}/r/collect?${basePrefix}&t=pageview&' +
+          '_r=1${baseSuffix}',
+      'event': '${host}/collect?${basePrefix}&t=event&' +
+          'ec=${eventCategory}&ea=${eventAction}&el=${eventLabel}&' +
+          'ev=${eventValue}${baseSuffix}',
+      'social': '${host}/collect?${basePrefix}&t=social&' +
+          'sa=${socialAction}&sn=${socialNetwork}&st=${socialActionTarget}' +
+          '${baseSuffix}'
     },
     'optout': '_gaUserPrefs.ioo'
   }


### PR DESCRIPTION
Removes `host` config attribute.

Adds new `transport` config attribute whose value is an array of request transport mechanisms, in order of preference. The first transport in the list available on the user's browser will be used. The default `transport` value is set to `["beacon", "xhrpost", "image"]` but can be overridden in the built-in vendor config objects and/or remote config and/or inline config.

Alternative to the implementation in #1162 
