### PR TITLE
AMP Validator feature to support disallowed ancestor tags.

### DIFF
--- a/validator/testdata/feature_tests/template.html
+++ b/validator/testdata/feature_tests/template.html
@@ -89,5 +89,14 @@
   <!-- comment --{{foo}}><script><!-- -->
 
 </template>
+
+<template type="amp-mustache">
+  <div>
+    <template type="amp-mustache">
+      Nested Template tags are not allowed.
+    </template>
+  </div>
+</template>
+
 </body>
 </html>

--- a/validator/testdata/feature_tests/template.out
+++ b/validator/testdata/feature_tests/template.out
@@ -32,3 +32,4 @@ feature_tests/template.html:67:2 UNESCAPED_TEMPLATE_IN_ATTR_VALUE title={{& nota
 feature_tests/template.html:68:2 TEMPLATE_PARTIAL_IN_ATTR_VALUE title={{> notallowed }} (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md)
 feature_tests/template.html:69:2 UNESCAPED_TEMPLATE_IN_ATTR_VALUE title={{ & notallowed }} (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md)
 feature_tests/template.html:70:2 TEMPLATE_PARTIAL_IN_ATTR_VALUE title={{ > notallowed }} (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md)
+feature_tests/template.html:95:4 DISALLOWED_TAG_ANCESTOR template > ... > template (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md)

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -186,7 +186,7 @@ message AmpLayout {
 // Some tags are mandatory. Note that the tag name is not unique, that is,
 // there can be multiple tag specs covering the same name, e.g., for
 // multiple meta tags (with different attributes).
-// NEXT AVAILABLE TAG: 13
+// NEXT AVAILABLE TAG: 14
 message TagSpec {
   // Use lower-case tag names only.
   optional string name = 1;
@@ -211,6 +211,9 @@ message TagSpec {
   //   specified mandatory parent tag.
   optional string mandatory_parent = 6;
 
+  // This tag may not descend from any tag with any of these tag names.
+  repeated string disallowed_ancestor = 13;
+
   // Attribute specifications related to this tag.
   repeated AttrSpec attrs = 7;
   // Top level attr lists of shared tags, identified by unique key
@@ -232,7 +235,7 @@ message TagSpec {
 
 // Top level message - start reading here.
 // The validator knows about a set of tag specifications.
-// NEXT AVAILABLE TAG: 8
+// NEXT AVAILABLE TAG: 9
 message ValidatorRules {
   repeated TagSpec tags = 1;
   repeated AttrList attr_lists = 7;
@@ -289,6 +292,7 @@ message ValidationError {
     TEMPLATE_IN_ATTR_NAME = 20;
     INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT = 21;
     IMPLIED_LAYOUT_INVALID = 22;
+    DISALLOWED_TAG_ANCESTOR = 23;
   }
   optional Code code = 1;
   optional int32 line = 2 [ default = 1 ];

--- a/validator/validator.protoascii
+++ b/validator/validator.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 67
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file requires updating this revision id.
-spec_file_revision: 97
+spec_file_revision: 98
 # Rules for AMP HTML
 # (https://github.com/google/amphtml/blob/master/spec/amp-html-format.md).
 # These rules are just enough to validate the example from the spec.
@@ -1522,6 +1522,8 @@ tags: { name: "xmp" }
 # 4.11.3 The template element
 tags: {
   name: "template"
+  # <template> tags may not be nested inside other <template> tags.
+  disallowed_ancestor: "template"
   spec_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md"
   attrs: {
     name: "type"


### PR DESCRIPTION
First usage is to disallow nested template tags.