### PR TITLE
Add remote config loading support to amp-analytics.

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -81,6 +81,8 @@
 </script>
 </amp-analytics>
 
+<amp-analytics id="analytics3" config="./analytics.config.json"></amp-analytics>
+
 <div class="logo"></div>
 <h1 id="top">AMP Analytics</h1>
 

--- a/examples/analytics.config.json
+++ b/examples/analytics.config.json
@@ -1,0 +1,15 @@
+{
+  "requests": {
+    "event": "https://example.com?remote-test&title=${title}&r=${random}"
+  },
+  "vars": {
+    "title": "Example Request"
+  },
+  "triggers": {
+    "remote pageview": {
+      "on": "visible",
+      "request": "event"
+    }
+  }
+}
+


### PR DESCRIPTION
Adds support for loading remote config from a URL specified in an `amp-analytics` tag's `config` attribute.