### PR TITLE
point out that localhost urls are also fine

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -61,7 +61,7 @@ export function assertHttpsUrl(urlString, elementContext) {
           url.hostname.length - '.localhost'.length,
       '%s source must start with ' +
       '"https://" or "//" or be relative and served from ' +
-      'https. Invalid value: %s',
+      'either https or from localhost. Invalid value: %s',
       elementContext, urlString);
   return urlString;
 }


### PR DESCRIPTION
In the error message we can't use relative urls, but if it were localhost it would be fine.  Since when developing locally we often use www.thegulocal.com as a convention for localhost, it would be better to point out the problem in the message.

It would actually be better to allow relative urls, but it would require the google cache to make a note of the original hostname when rewriting the URLs.  If you could do that, it would be ideal.