### PR TITLE
Change amp-analytics triggers from arrays to objects.

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -30,14 +30,16 @@
   "vars": {
     "title": "Example Request"
   },
-  "triggers": [{
-    "on": "visible",
-    "request": "event",
-    "vars": {
-      "eventName": "page-loaded",
-      "eventId": "42"
+  "triggers": {
+    "default pageview": {
+      "on": "visible",
+      "request": "event",
+      "vars": {
+        "eventName": "page-loaded",
+        "eventId": "42"
+      }
     }
-  }]
+  }
 }
 </script>
 </amp-analytics>
@@ -48,29 +50,33 @@
   "vars": {
     "account": "UA-XXXX-Y"
   },
-  "triggers": [{
-    "on": "visible",
-    "request": "pageview",
-    "vars": {
-      "title": "Example Pageview"
+  "triggers": {
+    "default pageview": {
+      "on": "visible",
+      "request": "pageview",
+      "vars": {
+        "title": "Example Pageview"
+      }
+    },
+    "click on #test1 trigger": {
+      "on": "click",
+      "selector": "#test1",
+      "request": "event",
+      "vars": {
+        "eventCategory": "examples",
+        "eventAction": "clicked-test1"
+      }
+    },
+    "click on #top trigger": {
+      "on": "click",
+      "selector": "#top",
+      "request": "event",
+      "vars": {
+        "eventCategory": "examples",
+        "eventAction": "clicked-header"
+      }
     }
-  }, {
-    "on": "click",
-    "selector": "#test1",
-    "request": "event",
-    "vars": {
-      "eventCategory": "examples",
-      "eventAction": "clicked-test1"
-    }
-  }, {
-    "on": "click",
-    "selector": "#top",
-    "request": "event",
-    "vars": {
-      "eventCategory": "examples",
-      "eventAction": "clicked-header"
-    }
-  }]
+  }
 }
 </script>
 </amp-analytics>

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -94,22 +94,24 @@ export class AmpAnalytics extends AMP.BaseElement {
 
     this.generateRequests_();
 
-    if (!Array.isArray(this.config_['triggers'])) {
+    if (!this.config_['triggers']) {
       log.error(this.getName_(), 'No triggers were found in the config. No ' +
           'analytics data will be sent.');
       return Promise.resolve();
     }
 
     // Trigger callback can be synchronous. Do the registration at the end.
-    for (let k = 0; k < this.config_['triggers'].length; k++) {
-      const trigger = this.config_['triggers'][k];
-      if (!trigger['on'] || !trigger['request']) {
-        log.warn(this.getName_(), '"on" and "request" attributes are ' +
-            'required for data to be collected.');
-        continue;
+    for (const k in this.config_['triggers']) {
+      if (this.config_['triggers'].hasOwnProperty(k)) {
+        const trigger = this.config_['triggers'][k];
+        if (!trigger['on'] || !trigger['request']) {
+          log.warn(this.getName_(), '"on" and "request" attributes are ' +
+              'required for data to be collected.');
+          continue;
+        }
+        addListener(this.getWin(), trigger['on'],
+            this.handleEvent_.bind(this, trigger), trigger['selector']);
       }
-      addListener(this.getWin(), trigger['on'],
-          this.handleEvent_.bind(this, trigger), trigger['selector']);
     }
     return Promise.resolve();
   }


### PR DESCRIPTION
This changes how amp-analytics triggers are configured. Instead of specifying triggers as an array of objects, triggers are now specified as an object of objects. 

This change was made because the way we merge configuration objects (built-in + vendor + inline + remote) is not effective for arrays.

The key for each trigger is an id string, used  only when merging triggers from multiple configs (e.g. to override a inline trigger with a remote trigger.)
