### PR TITLE
Alternative production code generation for AMP based on the closure compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - gulp build
   - gulp dist
   - gulp presubmit
+  - gulp compile
   # Unit tests with Travis' default chromium
   - gulp test
   # Integration tests with all saucelabs browsers

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var closureCompiler = require('gulp-closure-compiler');
+var gulp = require('gulp');
+var rename = require('gulp-rename');
+var uglify = require('gulp-uglify');
+
+// Compiles AMP with the closure compiler. This is intended only for
+// production use. During development we intent to continue using
+// babel, as it has much faster incremental compilation.
+// This currently only works for the main AMP JS binary, but should be
+// straight forward to extend to the rest of our code base.
+gulp.task('compile', function() {
+  /*eslint "google-camelcase/google-camelcase": 0*/
+  return gulp.src([
+    'ads/**/*.js',
+    'extensions/**/*.js',
+    'build/css.js',
+    'src/**/*.js',
+    // We do not want to load the entry point that loads the babel helpers.
+    '!src/amp-babel.js',
+    'builtins/**.js',
+    'third_party/caja/html-sanitizer.js',
+    'third_party/closure-library/sha384-generated.js',
+    'third_party/mustache/**/*.js',
+    'node_modules/document-register-element/build/' +
+        'document-register-element.max.js',
+    'node_modules/core-js/modules/**.js',
+    // Not sure what these files are, but they seem to duplicate code
+    // one level below and confuse the compiler.
+    '!node_modules/core-js/modules/library/**.js',
+    // Don't include tests.
+    '!**_test.js',
+    '!**/test-*.js',
+  ])
+  .pipe(closureCompiler({
+    // Temporary shipping with our own compiler that has a single patch
+    // applied
+    compilerPath: 'third_party/closure-compiler/compiler.jar',
+    fileName: 'build/cc-amp.js',
+    compilerFlags: {
+      // Transpile from ES6 to ES5.
+      language_in: 'ECMASCRIPT6',
+      language_out: 'ECMASCRIPT5',
+      js_module_root: 'node_modules/',
+      common_js_entry_module: 'src/amp.js',
+      process_common_js_modules: true,
+      // This strips all files from the input set that aren't explicitly
+      // required.
+      only_closure_dependencies: true,
+      output_wrapper: '(function(){var process={env:{}};%output%})();'
+    }
+  }))
+  .on('error', function(err) {
+    if (/0 error\(s\)/.test(err.message)) {
+      // emit warning
+      console./*OK*/warn(err.message);
+      this.emit('end');
+    } else {
+      throw err;
+    }
+  })
+  .on('end', function() {
+    console./*OK*/log('Minify closure compiler result');
+    // Somewhat ironically we use uglify to further minify the result.
+    // This is needed because we currently use only very basic optimizations
+    // in closure compiler and it doesn't minify global variables at this
+    // stage.
+    return gulp.src(['build/cc-amp.js'])
+        .pipe(uglify({
+          preserveComments: 'some'
+        }))
+        .pipe(rename('cc-v0.js'))
+        .pipe(gulp.dest('dist'))
+  });
+});

--- a/build-system/tasks/index.js
+++ b/build-system/tasks/index.js
@@ -17,6 +17,7 @@
 require('./babel-helpers');
 require('./changelog');
 require('./clean');
+require('./compile');
 require('./lint');
 require('./make-golden');
 require('./presubmit-checks');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,10 @@ function polyfillsForTests() {
  */
 function compile(watch, shouldMinify) {
   compileCss();
-  compileJs('./src/', 'amp.js', './dist', {
+  // For compilation with babel we start with the amp-babel entry point,
+  // but then rename to the amp.js which we've been using all along.
+  compileJs('./src/', 'amp-babel.js', './dist', {
+    toName: 'amp.js',
     minifiedName: 'v0.js',
     watch: watch,
     minify: shouldMinify,
@@ -418,6 +421,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     bundler.bundle()
       .on('error', function(err) { console.error(err); this.emit('end'); })
       .pipe(lazybuild())
+      .pipe(rename(options.toName || srcFilename))
       .pipe(lazywrite());
   }
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "finalhandler": "0.4.0",
     "fs-extra": "0.26.0",
     "gulp": "3.9.0",
+    "gulp-closure-compiler": "^0.4.0",
     "gulp-eslint": "1.1.0",
     "gulp-exec": "2.1.2",
     "gulp-file": "0.2.0",

--- a/src/amp-babel.js
+++ b/src/amp-babel.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Entry point into AMP for compilation with babel. Just loads amp.js and
+// Babel's helpers.
+
+import '../third_party/babel/custom-babel-helpers';
+import './amp';

--- a/src/amp.js
+++ b/src/amp.js
@@ -28,7 +28,7 @@ import {installStyles, makeBodyVisible} from './styles';
 import {installErrorReporting} from './error';
 import {stubElements} from './custom-element';
 import {adopt} from './runtime';
-import {cssText} from '../build/css.js';
+import {cssText} from '../build/css';
 import {action} from './action';
 import {maybeValidate} from './validator-integration';
 

--- a/src/error.js
+++ b/src/error.js
@@ -16,7 +16,7 @@
 
 
 import {getMode} from './mode';
-import {exponentialBackoff} from './exponential-backoff.js';
+import {exponentialBackoff} from './exponential-backoff';
 import {makeBodyVisible} from './styles';
 
 const globalExponentialBackoff = exponentialBackoff(1.5);

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -14,11 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * @fileoverview Loads all polyfills needed by the AMP runtime.
- */
-
-
 import 'document-register-element/build/document-register-element.max';
-import '../third_party/babel/custom-babel-helpers';
 import './custom-core-js-shim';

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -15,6 +15,7 @@
  */
 
 // This must load before all other tests.
+import '../third_party/babel/custom-babel-helpers';
 import '../src/polyfills';
 import {adopt} from '../src/runtime';
 

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -15,7 +15,6 @@
  */
 
 
-require('../src/polyfills');
 import {Timer} from '../src/timer';
 import {installCoreServices} from '../src/amp-core-service';
 import {registerForUnitTest} from '../src/runtime';

--- a/third_party/closure-compiler/LICENSE
+++ b/third_party/closure-compiler/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/closure-compiler/README.amp
+++ b/third_party/closure-compiler/README.amp
@@ -1,0 +1,7 @@
+URL: https://github.com/google/closure-compiler
+License: Apache License
+License File: https://github.com/google/closure-compiler/blob/master/COPYING
+
+Description:
+Temporary check in of a compiled closure compiler while we wait for
+a patch to land.


### PR DESCRIPTION
- Currently a 15K win on main binary and likely much faster initial JS compilation due to simpler code.
- Includes a compiled compiler binary while we wait for a patch to land that is needed to compiler core-js.
- Doesn't yet activate (and benefit in code size) from type checking.