### PR TITLE
Run a subset of test files

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -118,6 +118,9 @@ var karma = {
 module.exports = {
   testPaths: testPaths,
   integrationTestPaths: integrationTestPaths,
+  customTestPaths: function(path) {
+    return commonTestPaths.concat(path);
+  },
   karma: karma,
   lintGlobs: [
     '**/*.js',

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -80,6 +80,8 @@ gulp.task('test', 'Runs tests in chrome', ['build'], function(done) {
 
   if (argv.integration) {
     c.files = config.integrationTestPaths;
+  } else if (argv.path) {
+    c.files = config.customTestPaths(argv.path);
   } else {
     c.files = config.testPaths;
   }


### PR DESCRIPTION
Instead of running the full test suite, allow passing the path (or regex) to the tests you want to run.

```bash
$ gulp test --watch --path 'extensions/X/*/test/**/*.js'
```