### PR TITLE
fix(third_party): patch caja html-sanitizer.js to not use octal literals

### DIFF
--- a/third_party/caja/README.amp
+++ b/third_party/caja/README.amp
@@ -8,3 +8,4 @@ Run compile.sh to generate a new version.
 
 Local Modifications:
 Export to ES6.
+Change unicode literal to unicode escaped character. (see https://github.com/google/caja/issues/1978)

--- a/third_party/caja/html-sanitizer.js
+++ b/third_party/caja/html-sanitizer.js
@@ -1450,7 +1450,7 @@ var html = (function(html4) {
     'AMP': '&',
     'quot': '"',
     'apos': '\'',
-    'nbsp': '\240'
+    'nbsp': '\u00A0'
   };
 
   // Patterns for types of entity/character reference names.


### PR DESCRIPTION
Reference: https://github.com/google/caja/issues/1978

this allows us to migrate to babel6