### PR TITLE
Several small optimizations:

### DIFF
--- a/src/pass.js
+++ b/src/pass.js
@@ -42,6 +42,9 @@ export class Pass {
 
     /** @private {number} */
     this.nextTime_ = 0;
+
+    /** @private {boolean} */
+    this.running_ = false;
   }
 
   /**
@@ -66,7 +69,12 @@ export class Pass {
    * @return {boolean}
    */
   schedule(opt_delay) {
-    const delay = opt_delay || this.defaultDelay_;
+    let delay = opt_delay || this.defaultDelay_;
+    if (this.running_ && delay < 10) {
+      // If we get called recursively, wait at least 10ms for the next
+      // execution.
+      delay = 10;
+    }
     const nextTime = timer.now() + delay;
     // Schedule anew if nothing is scheduled currently of if the new time is
     // sooner then previously requested.
@@ -78,7 +86,9 @@ export class Pass {
       this.scheduled_ = timer.delay(() => {
         this.scheduled_ = -1;
         this.nextTime_ = 0;
+        this.running_ = true;
         this.handler_();
+        this.running_ = false;
       }, delay);
       return true;
     }

--- a/src/resources.js
+++ b/src/resources.js
@@ -99,7 +99,7 @@ export class Resources {
     this.firstPassAfterDocumentReady_ = true;
 
     /** @private {boolean} */
-    this.relayoutAll_ = false;
+    this.relayoutAll_ = true;
 
     /** @private {number} */
     this.relayoutTop_ = -1;
@@ -160,15 +160,6 @@ export class Resources {
       this.lastScrollTime_ = timer.now();
     });
 
-    // Ensure that we attempt to rebuild things when DOM is ready.
-    this.docState_.onReady(() => {
-      this.documentReady_ = true;
-      this.forceBuild_ = true;
-      this.relayoutAll_ = true;
-      this.schedulePass();
-      this.monitorInput_();
-    });
-
     // When document becomes visible, e.g. from "prerender" mode, do a
     // simple pass.
     this.viewer_.onVisibilityChanged(() => {
@@ -185,7 +176,15 @@ export class Resources {
       this.checkPendingChangeHeight_(element);
     });
 
-    this.relayoutAll_ = true;
+    // Ensure that we attempt to rebuild things when DOM is ready.
+    this.docState_.onReady(() => {
+      this.documentReady_ = true;
+      this.forceBuild_ = true;
+      this.relayoutAll_ = true;
+      this.schedulePass();
+      this.monitorInput_();
+    });
+
     this.schedulePass();
   }
 

--- a/test/functional/test-pass.js
+++ b/test/functional/test-pass.js
@@ -96,4 +96,34 @@ describe('Pass', () => {
     expect(isScheduled).to.equal(true);
   });
 
+  it('should have a min delay for recursive schedule', () => {
+    pass = new Pass(() => {
+      expect(pass.running_).to.equal(true);
+      if (handlerCalled++ == 0) {
+        pass.schedule();
+      }
+    });
+    let delayedFunc0 = null;
+    let delayedFunc1 = null;
+    timerMock.expects('delay').withExactArgs(sinon.match(value => {
+      delayedFunc0 = value;
+      return true;
+    }), 0).returns(1).once();
+    timerMock.expects('delay').withExactArgs(sinon.match(value => {
+      delayedFunc1 = value;
+      return true;
+    }), 10).returns(1).once();
+    pass.schedule();
+    expect(pass.isPending()).to.equal(true);
+
+    delayedFunc0();
+    expect(handlerCalled).to.equal(1);
+    delayedFunc1();
+    expect(handlerCalled).to.equal(2);
+    expect(pass.isPending()).to.equal(false);
+    expect(pass.running_).to.equal(false);
+
+    // RESET
+    handlerCalled = 0;
+  });
 });


### PR DESCRIPTION
1. Don't run two resource passes in the same microtask. The 2nd should never find anything.
2. The above is done by making passes scheduled from passes have a min-delay of 10ms.
3. Don't eagerly instantiate the viewport (must be a left over from long ago). This makes the time before we install the styles earlier. Not sure that is really a win, but it makes stack traces make more sense.