### PR TITLE
Normalize Referrer classes across devices

### DIFF
--- a/extensions/amp-dynamic-css-classes/0.1/test/test-dynamic-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/test/test-dynamic-classes.js
@@ -19,7 +19,7 @@ import {referrers_} from '../amp-dynamic-css-classes';
 describe('amp-dynamic-css-classes', () => {
   describe('referrers_', () => {
     describe('when referrer is TLD-less', () => {
-      const referrer = 'http://localhost/test/ing?this#referrer';
+      const referrer = 'localhost';
 
       it('contains the domain', () => {
         expect(referrers_(referrer)).to.deep.equal(['localhost']);
@@ -27,7 +27,7 @@ describe('amp-dynamic-css-classes', () => {
     });
 
     describe('when referrer has no subdomains', () => {
-      const referrer = 'http://google.com/test/ing?this#referrer';
+      const referrer = 'google.com';
       const referrers = referrers_(referrer);
 
       it('contains the TLD', () => {
@@ -35,13 +35,13 @@ describe('amp-dynamic-css-classes', () => {
       });
 
       it('contains the domain', () => {
-        expect(referrers).to.contain('google-com');
+        expect(referrers).to.contain('google.com');
         expect(referrers.length).to.equal(2);
       });
     });
 
     describe('when referrer has subdomains', () => {
-      const referrer = 'http://a.b.c.google.com/test/ing?this#referrer';
+      const referrer = 'a.b.c.google.com';
       const referrers = referrers_(referrer);
 
       it('contains the TLD', () => {
@@ -49,14 +49,14 @@ describe('amp-dynamic-css-classes', () => {
       });
 
       it('contains the domain', () => {
-        expect(referrers).to.contain('google-com');
+        expect(referrers).to.contain('google.com');
       });
 
       it('contains each subdomain', () => {
         expect(referrers).to.include.members([
-          'c-google-com',
-          'b-c-google-com',
-          'a-b-c-google-com'
+          'c.google.com',
+          'b.c.google.com',
+          'a.b.c.google.com'
         ]);
         expect(referrers.length).to.equal(5);
       });

--- a/extensions/amp-dynamic-css-classes/0.1/test/test-runtime-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/test/test-runtime-classes.js
@@ -17,21 +17,46 @@
 import {createServedIframe} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';
 
+function overwrite(object, property, value) {
+  Object.defineProperty(object, property, {
+    enumerable: true,
+    writeable: false,
+    configurable: true,
+    value: value
+  });
+}
+
 const iframeSrc = '/base/test/fixtures/served/amp-dynamic-css-classes.html';
 
+const tcoReferrer = 'http://t.co/xyzabc123';
+const PinterestUA = 'Mozilla/5.0 (Linux; Android 5.1.1; SM-G920F' +
+  ' Build/LMY47X; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0' +
+  ' Chrome/47.0.2526.100 Mobile Safari/537.36 [Pinterest/Android]';
+
 describe('dynamic classes are inserted at runtime', () => {
-  let documentElement, win;
-  beforeEach(() => {
+  let documentElement;
+
+  function setup(enabled, userAgent, referrer) {
     return createServedIframe(iframeSrc).then(fixture => {
-      win = fixture.win;
+      const win = fixture.win;
       documentElement = fixture.doc.documentElement;
+
+      toggleExperiment(win, 'dynamic-css-classes', enabled);
+
+      if (userAgent !== undefined) {
+        overwrite(win.navigator, 'userAgent', userAgent);
+      }
+      if (referrer !== undefined) {
+        overwrite(fixture.doc, 'referrer', referrer);
+      }
+
+      return win.insertDynamicCssScript();
     });
-  });
+  }
 
   describe('when experiment is disabled', () => {
     beforeEach(() => {
-      toggleExperiment(win, 'dynamic-css-classes', false);
-      return win.insertDynamicCssScript();
+      return setup(false);
     });
 
     it('should not include referrer classes', () => {
@@ -45,8 +70,7 @@ describe('dynamic classes are inserted at runtime', () => {
 
   describe('when experiment is enabled', () => {
     beforeEach(() => {
-      toggleExperiment(win, 'dynamic-css-classes', true);
-      return win.insertDynamicCssScript();
+      return setup(true);
     });
 
     it('should include referrer classes', () => {
@@ -55,6 +79,23 @@ describe('dynamic classes are inserted at runtime', () => {
 
     it('should include viewer class', () => {
       expect(documentElement).to.have.class('amp-viewer');
+    });
+  });
+
+  describe('Normalizing Referrers', () => {
+    it('should normalize twitter shortlinks to twitter', () => {
+      return setup(true, '', tcoReferrer).then(() => {
+        expect(documentElement).to.have.class('amp-referrer-com');
+        expect(documentElement).to.have.class('amp-referrer-twitter-com');
+      });
+    });
+
+    it('should normalize pinterest on android', () => {
+      return setup(true, PinterestUA, '').then(() => {
+        expect(documentElement).to.have.class('amp-referrer-com');
+        expect(documentElement).to.have.class('amp-referrer-pinterest-com');
+        expect(documentElement).to.have.class('amp-referrer-www-pinterest-com');
+      });
     });
   });
 });

--- a/extensions/amp-dynamic-css-classes/amp-dynamic-css-classes.md
+++ b/extensions/amp-dynamic-css-classes/amp-dynamic-css-classes.md
@@ -31,6 +31,13 @@ subdomain specificity. For example, `www.google.com` will add three
 classes: `amp-referrer-www-google-com`, `amp-referrer-google-com`, and
 `amp-referrer-com`.
 
+We currently have a few special cases:
+
+- When the user came through a Twitter `t.co` short link, we instead use
+  `twitter.com` as the referrer.
+- When the string "Pinterest" is present in the User Agent string and
+  there is no referrer, we use `www.pinterest.com` as the referrer.
+
 **amp-viewer**
 
 The `amp-viewer` class will be set if the current document is being

--- a/src/platform.js
+++ b/src/platform.js
@@ -27,8 +27,8 @@ export class Platform {
    * @param {!Window} win
    */
   constructor(win) {
-    /** @const {!Window} */
-    this.win = win;
+    /** @const {!Navigator} */
+    this.navigator = win.navigator;
   }
 
   /**
@@ -36,7 +36,7 @@ export class Platform {
    * @return {boolean}
    */
   isIos() {
-    return /iPhone|iPad|iPod/i.test(this.win.navigator.userAgent);
+    return /iPhone|iPad|iPod/i.test(this.navigator.userAgent);
   }
 
   /**
@@ -44,16 +44,16 @@ export class Platform {
    * @return {boolean}
    */
   isSafari() {
-    return /Safari/i.test(this.win.navigator.userAgent) && !this.isChrome();
+    return /Safari/i.test(this.navigator.userAgent) && !this.isChrome();
   }
 
   /**
-   * Whether the current browser a Chrome browser.
+   * Whether the current browser is a Chrome browser.
    * @return {boolean}
    */
   isChrome() {
     // Also true for MS Edge :)
-    return /Chrome|CriOS/i.test(this.win.navigator.userAgent);
+    return /Chrome|CriOS/i.test(this.navigator.userAgent);
   }
 };
 


### PR DESCRIPTION
For now, these include Facebook, Twitter, and Pinterest with `amp-ua-${SERVICE}`.

Fixes #1263.