### PR TITLE
Do not close lightbox on tap

### DIFF
--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -16,8 +16,7 @@
 
 import {Gestures} from '../../../src/gesture';
 import {Layout} from '../../../src/layout';
-import {SwipeXYRecognizer, TapRecognizer}
-    from '../../../src/gesture-recognizers';
+import {SwipeXYRecognizer} from '../../../src/gesture-recognizers';
 import {historyFor} from '../../../src/history';
 import * as st from '../../../src/style';
 
@@ -59,7 +58,6 @@ class AmpLightbox extends AMP.BaseElement {
     this.registerAction('close', this.close.bind(this));
 
     const gestures = Gestures.get(this.element);
-    gestures.onGesture(TapRecognizer, () => this.close());
     gestures.onGesture(SwipeXYRecognizer, () => {
       // Consume to block scroll events and side-swipe.
     });


### PR DESCRIPTION
Do not close lightbox on tap as it is not supported in the spec and also causes #1274 

see https://github.com/ampproject/amphtml/blob/master/extensions/amp-lightbox/amp-lightbox.md#closing-the-lightbox  - for help on closing a lightbox