### PR TITLE
Allowing different aspect ratios on base-component

### DIFF
--- a/examples/responsive.amp.html
+++ b/examples/responsive.amp.html
@@ -1,0 +1,324 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Lorem Ipsum | PublisherName</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    body {
+      margin: 0;
+      font-family: 'Georgia', Serif;
+    }
+
+    .brand-logo {
+      font-family: 'Open Sans';
+    }
+
+    .ad-container {
+      display: flex;
+      justify-content: center;
+    }
+
+    .content-container p {
+      line-height: 24px;
+    }
+
+    header,
+    .article-body {
+      padding: 15px;
+    }
+
+    .lightbox {
+      background: #222;
+    }
+
+    .full-bleed {
+      margin: 0 -15px;
+    }
+
+    .lightbox-content {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+
+      display: flex;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .lightbox-content p {
+      color: #fff;
+      padding: 15px;
+    }
+
+    .lightbox amp-img {
+      width: 100%;
+    }
+
+    figure {
+      margin: 0;
+    }
+
+    figcaption {
+      color: #6f757a;
+      padding: 15px 0;
+      font-size: .9em;
+    }
+
+    .author {
+      display: flex;
+      align-items: center;
+
+      background: #f4f4f4;
+      padding: 0 15px;
+
+      font-size: .8em;
+
+      border: solid #dcdcdc;
+      border-width: 1px 0;
+    }
+
+    .header-time {
+      color: #a8a3ae;
+      font-family: 'Roboto';
+      font-size: 12px;
+    }
+
+    .author p {
+      margin: 5px;
+    }
+
+    .byline {
+      font-family: 'Roboto';
+      display: inline-block;
+    }
+
+    .byline p {
+      line-height: normal;
+    }
+
+    .byline .brand {
+      color: #6f757a;
+    }
+
+    .standfirst {
+      color: #6f757a;
+    }
+
+    .mailto {
+      text-decoration: none;
+    }
+
+    #author-avatar {
+      margin: 10px;
+      border: 5px solid #fff;
+      width: 50px;
+      height: 50px;
+      border-radius: 50%;
+    }
+
+    h1 {
+      margin: 5px 0;
+      font-weight: normal;
+    }
+
+    footer {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 226px;
+      background: #f4f4f4;
+    }
+
+    hr {
+      margin: 0;
+    }
+
+    amp-img {
+      background-color: #f4f4f4;
+    }
+  </style>
+  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+  <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <header>
+    <div class="brand-logo">
+      PublisherLogo
+    </div>
+  </header>
+  <main role="main">
+    <article>
+      <figure>
+        <amp-img
+            src="img/hero@1x.jpg"
+            srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+            layout="responsive" width="360" placeholder
+            heights="(min-width:1420px) 20%, (min-width:1320px) 25%, (min-width:1000px) 40%, (min-width:760px)  85%, (min-width:500px) 100%, 120%"
+            alt="Curabitur convallis, urna quis pulvinar feugiat, purus diam posuere turpis, sit amet tincidunt purus justo et mi."
+            height="216" on="tap:headline-img-lightbox">
+        </amp-img>
+      </figure>
+
+      <amp-lightbox id="headline-img-lightbox" class="lightbox"
+          layout="nodisplay">
+
+        <div class="lightbox-content">
+          <amp-img id="floating-headline-img"
+              src="img/hero@1x.jpg"
+              srcset="hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+              placeholder
+              width="360" height="216" layout="responsive">
+          </amp-img>
+          <p>
+            Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+          </p>
+        </div>
+      </amp-lightbox>
+
+      <div class="content-container">
+        <header>
+          <h1 itemprop="headline">Lorem Ipsum</h1>
+          <time class="header-time" itemprop="datePublished"
+              datetime="2015-09-14 13:00">September 14, 2015</time>
+          <p class="standfirst">
+            Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+          </p>
+        </header>
+
+        <div class="author">
+          <amp-img src="img/sample.jpg" id="author-avatar" placeholder
+              height="50" width="50">
+          </amp-img>
+          <div class="byline">
+            <p>
+              by <span itemscope itemtype="http://schema.org/Person"
+              itemprop="author"><b>Lorem Ipsum</b>
+              <a class="mailto" href="mailto:lorem.ipsum@">
+              lorem.ipsum@</a></span>
+            </p>
+            <p class="brand">PublisherName News Reporter<p>
+          </div>
+        </div>
+        <div class="article-body" itemprop="articleBody">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+            luctus nunc ut elit cursus, et imperdiet diam vehicula.
+            Duis et nisi sed urna blandit bibendum et sit amet erat.
+            Suspendisse potenti. Curabitur consequat volutpat arcu nec
+            elementum. Etiam a turpis ac libero varius condimentum.
+            Maecenas sollicitudin felis aliquam tortor vulputate,
+            ac posuere velit semper.
+          </p>
+          <p>
+            Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+            Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+            ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+            et lectus. Sed tempus eget enim eget lobortis.
+            Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+            Nullam in libero nisi.
+          </p>
+
+          <div class="ad-container">
+            <amp-ad width=300 height=250
+                type="a9"
+                data-aax_size="300x250"
+                data-aax_pubname="abc123"
+                data-aax_src="302">
+            </amp-ad>
+          </div>
+
+          <p>
+            Sed pharetra semper fringilla. Nulla fringilla, neque eget
+            varius suscipit, mi turpis congue odio, quis dignissim nisi
+            nulla at erat. Duis non nibh vel erat vehicula hendrerit eget
+            vel velit. Donec congue augue magna, nec eleifend dui porttitor
+            sed. Cras orci quam, dignissim nec elementum ac, bibendum et purus.
+            Ut elementum mi eget felis ultrices tempus. Maecenas nec sodales
+            ex. Phasellus ultrices, purus non egestas ullamcorper, felis
+            lorem ultrices nibh, in tristique mauris justo sed ante.
+            Nunc commodo purus feugiat metus bibendum consequat. Duis
+            finibus urna ut ligula auctor, sed vehicula ex aliquam.
+            Sed sed augue auctor, porta turpis ultrices, cursus diam.
+            In venenatis aliquet porta. Sed volutpat fermentum quam,
+            ac molestie nulla porttitor ac. Donec porta risus ut enim
+            pellentesque, id placerat elit ornare.
+          </p>
+          <p>
+            Curabitur convallis, urna quis pulvinar feugiat, purus diam
+            posuere turpis, sit amet tincidunt purus justo et mi. Donec
+            sapien urna, aliquam ut lacinia quis, varius vitae ex.
+            Maecenas efficitur iaculis lorem, at imperdiet orci viverra
+            in. Nullam eu erat eu metus ultrices viverra a sit amet leo.
+            Pellentesque est felis, pulvinar mollis sollicitudin et,
+            suscipit eget massa. Nunc bibendum non nunc et consequat.
+            Quisque auctor est vel leo faucibus, non faucibus magna ultricies.
+            Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+            posuere cubilia Curae; Vestibulum tortor lacus, bibendum et
+            enim eu, vehicula placerat erat. Nullam gravida rhoncus accumsan.
+            Integer suscipit iaculis elit nec mollis. Vestibulum eget arcu
+            nec lectus finibus rutrum vel sed orci.
+          </p>
+
+          <figure>
+            <amp-img class="full-bleed" placeholder
+                src="img/sea@1x.jpg"
+                srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
+                layout="responsive" width="360"
+                alt="Fusce pretium tempor justo, vitae consequat dolor maximus eget."
+                height="216">
+            </amp-img>
+            <figcaption>
+              Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+            </figcaption>
+          </figure>
+          <hr>
+
+          <p>
+            Cum sociis natoque penatibus et magnis dis parturient montes,
+            nascetur ridiculus mus. Nulla et viverra turpis. Fusce
+            viverra enim eget elit blandit, in finibus enim blandit. Integer
+            fermentum eleifend felis non posuere. In vulputate et metus at
+            aliquam. Praesent a varius est. Quisque et tincidunt nisi.
+            Nam porta urna at turpis lacinia, sit amet mattis eros elementum.
+            Etiam vel mauris mattis, dignissim tortor in, pulvinar arcu.
+            In molestie sem elit, tincidunt venenatis tortor aliquet sodales.
+            Ut elementum velit fermentum felis volutpat sodales in non libero.
+            Aliquam erat volutpat.
+          </p>
+
+          <div class="ad-container">
+            <amp-ad width=300 height=200
+                type="adsense"
+                data-ad-client="ca-pub-9350112648257122">
+            </amp-ad>
+          </div>
+
+          <p>
+            Morbi at velit vitae eros congue congue venenatis non dui.
+            Sed lacus sem, feugiat sed elementum sed, maximus sed lacus.
+            Integer accumsan magna in sagittis pharetra. Class aptent taciti
+            sociosqu ad litora torquent per conubia nostra, per inceptos
+            himenaeos. Suspendisse ac nisl efficitur ligula aliquam lacinia
+            eu in magna. Vestibulum non felis odio. Ut consectetur venenatis
+            felis aliquet maximus. Class aptent taciti sociosqu ad litora
+            torquent per conubia nostra, per inceptos himenaeos.
+          </p>
+        </div>
+      </div>
+    </article>
+  </main>
+
+  <footer>
+    <div class="brand-logo">PublisherLogo</div>
+  </footer>
+</body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -313,6 +313,7 @@ function buildExamples(watch) {
   buildExample('ads.amp.html');
   buildExample('analytics.amp.html');
   buildExample('article.amp.html');
+  buildExample('responsive.amp.html');
   buildExample('article-access.amp.html');
   buildExample('csp.amp.html');
   buildExample('metadata-examples/article-json-ld.amp.html');

--- a/src/layout.js
+++ b/src/layout.js
@@ -158,14 +158,30 @@ export function parseLength(s) {
 }
 
 
+
 /**
- * Asserts that the supplied value is a CSS Length value.
+ * Asserts that the supplied value is a non-percent CSS Length value.
  * @param {!LengthDef|string} length
  * @return {!LengthDef}
  */
 export function assertLength(length) {
   assert(/^\d+(\.\d+)?(px|em|rem|vh|vw|vmin|vmax)$/.test(length),
       'Invalid length value: %s', length);
+  return length;
+}
+
+
+
+
+/**
+ * Asserts that the supplied value is a CSS Length value
+ * (including percent unit).
+ * @param {!LengthDef|string} length
+ * @return {!LengthDef}
+ */
+export function assertLengthOrPercent(length) {
+  assert(/^\d+(\.\d+)?(px|em|rem|vh|vw|vmin|vmax|%)$/.test(length),
+      'Invalid length or percent value: %s', length);
   return length;
 }
 

--- a/src/size-list.js
+++ b/src/size-list.js
@@ -15,7 +15,7 @@
  */
 
 import {assert} from './asserts';
-import {assertLength} from './layout';
+import {assertLength, assertLengthOrPercent} from './layout';
 
 
 /**
@@ -39,9 +39,10 @@ let SizeListOptionDef;
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes
  * See http://www.w3.org/html/wg/drafts/html/master/semantics.html#attr-img-sizes
  * @param {string} s
+ * @param {boolean=} opt_allowPercentAsLength when parsing heights
  * @return {!SizeList}
  */
-export function parseSizeList(s) {
+export function parseSizeList(s, opt_allowPercentAsLength) {
   const sSizes = s.split(',');
   assert(sSizes.length > 0, 'sizes has to have at least one size');
   const sizes = [];
@@ -61,7 +62,10 @@ export function parseSizeList(s) {
       sizeStr = sSize;
       mediaStr = undefined;
     }
-    sizes.push({mediaQuery: mediaStr, size: assertLength(sizeStr)});
+    sizes.push({mediaQuery: mediaStr,
+      size: opt_allowPercentAsLength ?
+          assertLengthOrPercent(sizeStr) :
+          assertLength(sizeStr)});
   });
   return new SizeList(sizes);
 };

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -568,6 +568,28 @@ describe('CustomElement', () => {
     expect(element2.style.width).to.equal('50vw');
   });
 
+  it('should apply heights condition', () => {
+    const element1 = new ElementClass();
+    element1.sizerElement_ = document.createElement('div');
+    element1.setAttribute('layout', 'responsive');
+    element1.setAttribute('width', '200px');
+    element1.setAttribute('height', '200px');
+    element1.setAttribute('heights', '(min-width: 1px) 99%, 1%');
+    element1.attachedCallback();
+    element1.applySizesAndMediaQuery();
+    expect(element1.sizerElement_.style.paddingTop).to.equal('99%');
+
+    const element2 = new ElementClass();
+    element2.sizerElement_ = document.createElement('div');
+    element2.setAttribute('layout', 'responsive');
+    element2.setAttribute('width', '200px');
+    element2.setAttribute('height', '200px');
+    element2.setAttribute('heights', '(min-width: 1111111px) 99%, 1%');
+    element2.attachedCallback();
+    element2.applySizesAndMediaQuery();
+    expect(element2.sizerElement_.style.paddingTop).to.equal('1%');
+  });
+
   it('should change height without sizer', () => {
     const element = new ElementClass();
     element.changeHeight(111);

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -15,7 +15,7 @@
  */
 
 import {Layout, assertLength, getLengthNumeral, getLengthUnits, parseLength,
-    parseLayout} from '../../src/layout';
+    parseLayout, assertLengthOrPercent} from '../../src/layout';
 import {applyLayout_} from '../../src/custom-element';
 
 
@@ -90,6 +90,9 @@ describe('Layout', () => {
     expect(assertLength('10.1vmin')).to.equal('10.1vmin');
 
     expect(function() {
+      assertLength('10%');
+    }).to.throw(/Invalid length value/);
+    expect(function() {
       assertLength(10);
     }).to.throw(/Invalid length value/);
     expect(function() {
@@ -104,6 +107,34 @@ describe('Layout', () => {
     expect(function() {
       assertLength('');
     }).to.throw(/Invalid length value/);
+  });
+
+
+  it('assertLengthOrPercent', () => {
+    expect(assertLengthOrPercent('10px')).to.equal('10px');
+    expect(assertLengthOrPercent('10em')).to.equal('10em');
+    expect(assertLengthOrPercent('10vmin')).to.equal('10vmin');
+
+    expect(assertLengthOrPercent('10.1px')).to.equal('10.1px');
+    expect(assertLengthOrPercent('10.1em')).to.equal('10.1em');
+    expect(assertLengthOrPercent('10.1vmin')).to.equal('10.1vmin');
+    expect(assertLengthOrPercent('10.1%')).to.equal('10.1%');
+
+    expect(function() {
+      assertLengthOrPercent(10);
+    }).to.throw(/Invalid length or percent value/);
+    expect(function() {
+      assertLengthOrPercent('10');
+    }).to.throw(/Invalid length or percent value/);
+    expect(function() {
+      assertLengthOrPercent(undefined);
+    }).to.throw(/Invalid length or percent value/);
+    expect(function() {
+      assertLengthOrPercent(null);
+    }).to.throw(/Invalid length or percent value/);
+    expect(function() {
+      assertLengthOrPercent('');
+    }).to.throw(/Invalid length or percent value/);
   });
 
 

--- a/test/functional/test-size-list.js
+++ b/test/functional/test-size-list.js
@@ -66,6 +66,20 @@ describe('SizeList parseSizeList', () => {
     expect(res.sizes_[0].size).to.equal('111vw');
   });
 
+  it('should accept different length units including percent', () => {
+    const res = parseSizeList(' \n 111% \n ',
+        /* opt_allowPercentAsLength */ true);
+    expect(res.sizes_.length).to.equal(1);
+    expect(res.sizes_[0].mediaQuery).to.equal(undefined);
+    expect(res.sizes_[0].size).to.equal('111%');
+  });
+
+  it('should fail bad length', () => {
+    expect(() => {
+      parseSizeList(' \n 111% \n ', /* opt_allowPercentAsLength */ false);
+    }).to.throw(/Invalid length value/);
+  });
+
   it('should fail bad length', () => {
     expect(() => {
       parseSizeList(' \n 111 \n ');
@@ -88,7 +102,7 @@ describe('SizeList construct', () => {
     }).to.throw(/The last option must not have a media condition/);
     expect(() => {
       new SizeList([{mediaQuery: 'print', size: '222px'},
-          {mediaQuery: 'screen', size: '111px'}]);
+        {mediaQuery: 'screen', size: '111px'}]);
     }).to.throw(/The last option must not have a media condition/);
   });
 
@@ -103,43 +117,49 @@ describe('SizeList construct', () => {
 describe('SizeList select', () => {
   it('should select default last option', () => {
     const sizeList = new SizeList([
-        {mediaQuery: 'media1', size: '444px'},
-        {mediaQuery: 'media2', size: '333px'},
-        {mediaQuery: 'media3', size: '222px'},
-        {size: '111px'}
+      {mediaQuery: 'media1', size: '444px'},
+      {mediaQuery: 'media2', size: '333px'},
+      {mediaQuery: 'media3', size: '222px'},
+      {size: '111px'}
     ]);
-    expect(sizeList.select({matchMedia: () => {
-      return {};
-    }})).to.equal('111px');
+    expect(sizeList.select({
+      matchMedia: () => {
+        return {};
+      }
+    })).to.equal('111px');
   });
 
   it('should select a matching option', () => {
     const sizeList = new SizeList([
-        {mediaQuery: 'media1', size: '444px'},
-        {mediaQuery: 'media2', size: '333px'},
-        {mediaQuery: 'media3', size: '222px'},
-        {size: '111px'}
+      {mediaQuery: 'media1', size: '444px'},
+      {mediaQuery: 'media2', size: '333px'},
+      {mediaQuery: 'media3', size: '222px'},
+      {size: '111px'}
     ]);
-    expect(sizeList.select({matchMedia: mq => {
-      if (mq == 'media2') {
-        return {matches: true};
+    expect(sizeList.select({
+      matchMedia: mq => {
+        if (mq == 'media2') {
+          return {matches: true};
+        }
+        return {};
       }
-      return {};
-    }})).to.equal('333px');
+    })).to.equal('333px');
   });
 
   it('should select first matching option', () => {
     const sizeList = new SizeList([
-        {mediaQuery: 'media1', size: '444px'},
-        {mediaQuery: 'media2', size: '333px'},
-        {mediaQuery: 'media3', size: '222px'},
-        {size: '111px'}
+      {mediaQuery: 'media1', size: '444px'},
+      {mediaQuery: 'media2', size: '333px'},
+      {mediaQuery: 'media3', size: '222px'},
+      {size: '111px'}
     ]);
-    expect(sizeList.select({matchMedia: mq => {
-      if (mq == 'media1' || mq == 'media2') {
-        return {matches: true};
+    expect(sizeList.select({
+      matchMedia: mq => {
+        if (mq == 'media1' || mq == 'media2') {
+          return {matches: true};
+        }
+        return {};
       }
-      return {};
-    }})).to.equal('444px');
+    })).to.equal('444px');
   });
 });

--- a/test/manual/amp-img.amp.html
+++ b/test/manual/amp-img.amp.html
@@ -28,7 +28,8 @@
     <div placeholder>Waiting for the image!</div>
   </amp-img>
 
-  <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
+  <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout=responsive
+      heights="(min-width:760px)  33%, (min-width:500px) 75%, 125%" ></amp-img>
 
   <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
 


### PR DESCRIPTION
The current implementation assumes that in a responsive scenario the aspect ratio of a component remains the same across all the responsive breakpoints. This behaviour may not always be desired as in some cases a different aspect ratio may be needed for different screen sizes. 
This pull request adds a "aspects" attribute to the base component, which accepts a series of media queries and a desired aspect ratio in % units (similar to the sizes css attribute)
See: examples/responsive.amp.html which was also added as a part of this request 


 