### PR TITLE
AMP Templates small pieces

### DIFF
--- a/validator/testdata/feature_tests/template.html
+++ b/validator/testdata/feature_tests/template.html
@@ -98,5 +98,15 @@
   </div>
 </template>
 
+<!-- Not descendant from a template, so mustache attribute values are OK -->
+<p title="{{{allowed }}}"></p>
+<p title="{{&allowed }}"></p>
+<p title="{{>allowed }}"></p>
+
+<!-- Inside a template, attribute value restrictions are relaxed. -->
+<amp-audio src="" layout="fixed" autoplay="{{invalid}}">
+<template type="amp-mustache">
+<amp-audio src="" layout="fixed" autoplay="{{valid}}">
+</template>
 </body>
 </html>

--- a/validator/testdata/feature_tests/template.out
+++ b/validator/testdata/feature_tests/template.out
@@ -33,3 +33,4 @@ feature_tests/template.html:68:2 TEMPLATE_PARTIAL_IN_ATTR_VALUE title={{> notall
 feature_tests/template.html:69:2 UNESCAPED_TEMPLATE_IN_ATTR_VALUE title={{ & notallowed }} (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md)
 feature_tests/template.html:70:2 TEMPLATE_PARTIAL_IN_ATTR_VALUE title={{ > notallowed }} (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md)
 feature_tests/template.html:95:4 DISALLOWED_TAG_ANCESTOR template > ... > template (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-templates.md)
+feature_tests/template.html:107:0 INVALID_ATTR_VALUE autoplay={{invalid}} (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-audio/amp-audio.md)


### PR DESCRIPTION
- Re-allow unescaped mustache tags outside of a <template> section.
- Allow mustache variable values inside attribute values regardless
  of the value constraints in the validator config.