### PR TITLE
Added support for Snowplow Analytics in AMP analytics suite (closes #1354)

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -296,6 +296,43 @@ Container for analytics tags. Positioned far away from top to make sure that doe
 </amp-analytics>
 <!-- End SimpleReach Example -->
 
+<!-- Snowplow Analytics tracking -->
+<amp-analytics type="snowplow" id="snowplow">
+<script type="application/json">
+{
+  "vars": {
+    "collectorHost": "d3rkrsqld9gmqf.cloudfront.net",
+    "appId": "amp-examples"
+  },
+  "triggers": {
+    "defaultPageview": {
+      "on": "visible",
+      "request": "pageView"
+    },
+    "clickOnTest1Trigger": {
+      "on": "click",
+      "selector": "#test1",
+      "request": "structEvent",
+      "vars": {
+        "structEventCategory": "examples",
+        "structEventAction": "clicked-test1"
+      }
+    },
+    "clickOnTopTrigger": {
+      "on": "click",
+      "selector": "#top",
+      "request": "structEvent",
+      "vars": {
+        "structEventCategory": "examples",
+        "structEventAction": "clicked-header"
+      }
+    }
+  }
+}
+</script>
+</amp-analytics>
+<!-- End Snowplow Analytics example -->
+
 <!-- Webtrekk tracking -->
 <amp-analytics type="webtrekk">
 <script type="application/json">

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -61,6 +61,12 @@
     "visible": "https://edge.simplereach.com/n?amp=true&pid=$pid&title=_title_&url=_canonical_url_&date=$published_at&authors=$authors&channels=$categories&tags=$tags&referrer=_document_referrer_&page_url=_source_url_&user_id=_client_id_&domain=_canonical_host_",
     "timer": "https://edge.simplereach.com/t?amp=true&pid=$pid&title=_title_&url=_canonical_url_&date=$published_at&authors=$authors&channels=$categories&tags=$tags&referrer=_document_referrer_&page_url=_source_url_&user_id=_client_id_&domain=_canonical_host_&t=5000&e=5000"
   },
+  "snowplow": {
+    "aaVersion": "amp-0.1",
+    "basePrefix": "https://$collectorHost/i?url=_canonical_url_&page=_title_&res=_screen_width_x_screen_height_&stm=_timestamp_&tz=_timezone_&aid=$appId&p=web&tv=amp-0.1",
+    "pageView": "https://$collectorHost/i?url=_canonical_url_&page=_title_&res=_screen_width_x_screen_height_&stm=_timestamp_&tz=_timezone_&aid=$appId&p=web&tv=amp-0.1&e=pv",
+    "structEvent": "https://$collectorHost/i?url=_canonical_url_&page=_title_&res=_screen_width_x_screen_height_&stm=_timestamp_&tz=_timezone_&aid=$appId&p=web&tv=amp-0.1&e=se&se_ca=$structEventCategory&se_ac=$structEventAction&se_la=$structEventLabel&se_pr=$structEventProperty&se_va=$structEventValue"
+  },
   "webtrekk": {
     "trackURL": "https://$trackDomain/$trackId/wt",
     "parameterPrefix": "?p=431,$contentId,1,_screen_width_x_screen_height_,_screen_color_depth_,_document_referrer_,_timestamp_,0,,0&tz=_timezone_&eid=_client_id_&la=_browser_language_",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -407,6 +407,25 @@ export const ANALYTICS_CONFIG = {
     },
   },
 
+  'snowplow': {
+    'requests': {
+      'aaVersion': 'amp-0.1',
+      'basePrefix': 'https://${collectorHost}/i?url=${canonicalUrl}&page=${title}&' +
+          'res=${screenWidth}x${screenHeight}&stm=${timestamp}&' +
+          'tz=${timezone}&aid=${appId}&p=web&tv=${aaVersion}',
+      'pageView': '${basePrefix}&e=pv',
+      'structEvent': '${basePrefix}&e=se&' +
+          'se_ca=${structEventCategory}&se_ac=${structEventAction}&' +
+          'se_la=${structEventLabel}&se_pr=${structEventProperty}&' +
+          'se_va=${structEventValue}',
+    },
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true,
+    },
+  },
+
   'webtrekk': {
     'requests': {
       'trackURL': 'https://${trackDomain}/${trackId}/wt',

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -176,6 +176,12 @@ Type attribute value: `simplereach`
 
 Adds support for SimpleReach.  Configuration details can be found at [simplereach.com/docs](http://docs.simplereach.com/dev-guide/implementation/google-amp-implementation)
 
+### Snowplow Analytics
+
+Type attribute value: `snowplow`
+
+Adds support for Snowplow Analytics. More details for adding Snowplow Analytics support can be found at [github.com/snowplow/snowplow/wiki](https://github.com/snowplow/snowplow/wiki/Google-AMP-Tracker).
+
 ### Webtrekk
 
 Type attribute value: `webtrekk`


### PR DESCRIPTION
Implements a minimal subset of the Snowplow Tracker Protocol (https://github.com/snowplow/snowplow/wiki/snowplow-tracker-protocol).

The user will need to set the following variables:

- 'host' to their collector endpoint, starting with http(s):// and *not* including a trailing slash
- 'appId' to identify their application ID

There is scope for adding more functionality in the future but this should get us started.

/cc @httpheaders, @luishgoncalves