### PR TITLE
Fix small typo under Iframe Click-To-Play section.

### DIFF
--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -91,7 +91,7 @@ Here are some factors that affect how fast the resize will be executed:
 - Whether the resize is requested for an IFrame below the viewport or above the viewport.
 
 #### Iframe Click-To-Play
-It is possible to have an `amp-iframe` appear on the top of a document when the `amp-ifame` has a `placeholder` element as shown in the example below.
+It is possible to have an `amp-iframe` appear on the top of a document when the `amp-iframe` has a `placeholder` element as shown in the example below.
 
 ```html
 <amp-iframe width=300 height=300


### PR DESCRIPTION
This pull request fixes a small typo under [Iframe Click-To-Play](https://github.com/ampproject/amphtml/blob/master/extensions/amp-iframe/amp-iframe.md#iframe-click-to-play) referenced in [Issue 1372](https://github.com/ampproject/amphtml/issues/1372):

*  It is possible to have an `amp-iframe` appear on the top of a document when the ~~amp-ifame~~ `amp-iframe` has a `placeholder` element as shown in the example below.

