### PR TITLE
Strictly follow prerenderSize given by viewer (or default) during prerendering.

### DIFF
--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -321,7 +321,7 @@ describe('Resources discoverWork', () => {
     resources.visible_ = false;
     resources.prerenderSize_ = 1;
     viewportMock.expects('getRect').returns(
-        layoutRectLtwh(0, 0, 300, 400)).once();
+        layoutRectLtwh(0, 0, 300, 1009)).once();
 
     resources.discoverWork_();
 

--- a/test/manual/amp-img.amp.html
+++ b/test/manual/amp-img.amp.html
@@ -31,5 +31,9 @@
   <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
 
   <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
+
+  <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
+
+  <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
 </body>
 </html>


### PR DESCRIPTION
Do not expand by the 25% that we typically use. We really want to minimize bandwidth to the smallest value that gives a sense of visual completeness.

Fixes #1379