### PR TITLE
Updates documentation to reference "placeholder" rather than "click-to-play"

### DIFF
--- a/3p/README.md
+++ b/3p/README.md
@@ -11,7 +11,7 @@ We highly prefer integrations that do not use iframes. JSONP cannot be used for 
 Examples: Youtube, Vimeo videos; Tweets, Instagrams; comment systems; polls; quizzes; document viewers
 
 - Our intent is to provide first class support for all embeds that fulfill the notability guidelines laid out in [CONTRIBUTING.md](../CONTRIBUTING.md).
-- Consider whether a click-to-play solution fits your use case where iframe generation is not done immediately (can be done before user action for instant loading of iframe).
+- Consider whether a iframe-with-placeholder solution fits your use case where iframe generation is not done immediately (can be done before user action for instant loading of iframe).
 - Consider whether all that is needed is some documentation for how to use the embed with `amp-iframe`.
 - Iframes and all sub resources must be served from HTTPS.
 - Avoid client side rendering of iframe content.

--- a/docs/include_features.md
+++ b/docs/include_features.md
@@ -14,7 +14,7 @@ Display an iframe in your page using the
 
 `amp-iframe` requirements:
 
-* Must be at least 600px or 75% of the first viewport away from the top (except for `click-to-play` iframes as described below).
+* Must be at least 600px or 75% of the first viewport away from the top (except for iframes implemented with a placeholder, as described below).
 * Can only request resources via HTTPS, and they must not be in the same origin as the container,
 unless they do not specify allow-same-origin.
 

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -90,7 +90,7 @@ Here are some factors that affect how fast the resize will be executed:
 - Whether the resize is requested for a currently active IFrame;
 - Whether the resize is requested for an IFrame below the viewport or above the viewport.
 
-#### Iframe Click-To-Play
+#### Iframe with Placeholder
 It is possible to have an `amp-iframe` appear on the top of a document when the `amp-iframe` has a `placeholder` element as shown in the example below.
 
 ```html


### PR DESCRIPTION
Addresses #1361. We should also consider updating the example files and tests, but want to check on that with @sriramkrish85.