### PR TITLE
Change error integration test to use fragment based dev-mode inference

### DIFF
--- a/src/mode.js
+++ b/src/mode.js
@@ -59,11 +59,13 @@ function getMode_() {
       // occur during local dev.
       !!document.querySelector('script[src*="/dist/"],script[src*="/base/"]');
 
-  const overrideDevelopment = parseQueryString(location.hash)['development'];
+  const overrideDevelopment = parseQueryString(
+      // location.originalHash is set by the viewer when it removes the fragment
+      // from the URL.
+      location.originalHash || location.hash)['development'];
   const development = overrideDevelopment != undefined
       ? overrideDevelopment == '1'
       : !!document.querySelector('script[development]');
-
   return {
     localDev: isLocalDev,
     // Triggers validation

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -208,6 +208,9 @@ export class Viewer {
     if (this.isEmbedded_) {
       const newUrl = removeFragment(this.win.location.href);
       if (newUrl != this.win.location.href && this.win.history.replaceState) {
+        // Persist the hash that we removed has location.originalHash.
+        // This is currently used my mode.js to infer development mode.
+        this.win.location.originalHash = this.win.location.hash;
         this.win.history.replaceState({}, '', newUrl);
         log.fine(TAG_, 'replace url:' + this.win.location.href);
       }

--- a/test/fixtures/errors.html
+++ b/test/fixtures/errors.html
@@ -8,7 +8,7 @@
   <script async custom-element="amp-iframe" src="/base/dist/v0/amp-iframe-0.1.max.js"></script>
   <script async custom-element="amp-youtube" src="/base/dist/v0/amp-youtube-0.1.max.js"></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
-  <script async src="/base/dist/amp.js" development></script>
+  <script async src="/base/dist/amp.js"></script>
 </head>
 <body>
 

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -20,7 +20,11 @@ import {createFixtureIframe, poll, expectBodyToBecomeVisible} from
 describe('error page', () => {
   let fixture;
   beforeEach(() => {
-    return createFixtureIframe('test/fixtures/errors.html', 500).then(f => {
+    return createFixtureIframe('test/fixtures/errors.html', 500, win => {
+      // Trigger dev mode.
+      win.history.pushState({}, '', 'test2.html#development=1');
+      console.error('updated', win.location.hash);
+    }).then(f => {
       fixture = f;
       return poll('errors to happen', () => {
         return fixture.doc.querySelectorAll('[error-message]').length >= 2;

--- a/test/integration/test-example-validation.js
+++ b/test/integration/test-example-validation.js
@@ -24,7 +24,7 @@ import {loadPromise} from '../../src/event-helper';
 if (!window.validatorLoad) {
   window.validatorLoad = (function() {
     const s = document.createElement('script');
-    s.src = 'https://www.gstatic.com/amphtml/v0/validator.js';
+    s.src = 'https://cdn.ampproject.org/v0/validator.js';
     document.body.appendChild(s);
     return loadPromise(s);
   })();

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -39,6 +39,8 @@ let iframeCount = 0;
  *
  * @param {string} fixture The name of the fixture file.
  * @param {number} initialIframeHeight in px.
+ * @param {function(!Window)} opt_beforeLoad Called just before any other JS
+ *     executes in the window.
  * @return {!Promise<{
  *   win: !Window,
  *   doc: !Document,
@@ -46,7 +48,7 @@ let iframeCount = 0;
  *   awaitEvent: function(string, number):!Promise
  * }>}
  */
-export function createFixtureIframe(fixture, initialIframeHeight, done) {
+export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad) {
   return new Promise((resolve, reject) => {
     // Counts the supported custom events.
     const events = {
@@ -68,6 +70,9 @@ export function createFixtureIframe(fixture, initialIframeHeight, done) {
     window.beforeLoad = function(win) {
       // Flag as being a test window.
       win.AMP_TEST = true;
+      if (opt_beforeLoad) {
+        opt_beforeLoad(win);
+      }
       // Function that returns a promise for when the given event fired at
       // least count times.
       let awaitEvent = (eventName, count) => {
@@ -100,6 +105,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, done) {
       let errors = [];
       win.console.error = function() {
         errors.push('Error: ' + [].slice.call(arguments).join(' '));
+        console.error.apply(console, arguments);
       };
       // Make time go 10x as fast
       win.setTimeout = function(fn, ms) {


### PR DESCRIPTION
instead of the legacy attribute based code path.

Also fixes the validator integration test to use the new validator URL and provides for a way to turn on dev mode while a page is embedded into a viewer (through the viewer).

Part of #999