### PR TITLE
Switch production codegen to use closure compiler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,9 @@ script:
   - gulp build
   - gulp dist
   - gulp presubmit
-  - gulp compile
   # Unit tests with Travis' default chromium
-  - gulp test
+  - gulp test --compiled
   # Integration tests with all saucelabs browsers
-  - gulp test --saucelabs --integration
   - gulp test --saucelabs --integration --compiled
   # All unit tests with an old chrome (best we can do right now to pass tests
   # and not start relying on new features).

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -14,80 +14,137 @@
  * limitations under the License.
  */
 
+var fs = require('fs-extra');
 var closureCompiler = require('gulp-closure-compiler');
 var gulp = require('gulp');
 var rename = require('gulp-rename');
-var uglify = require('gulp-uglify');
+var replace = require('gulp-replace');
+var internalRuntimeVersion = require('../internal-version').VERSION;
+
+var queue = [];
+var inProgress = 0;
+var MAX_PARALLEL_CLOSURE_INVOCATIONS = 4;
 
 // Compiles AMP with the closure compiler. This is intended only for
 // production use. During development we intent to continue using
 // babel, as it has much faster incremental compilation.
-// This currently only works for the main AMP JS binary, but should be
-// straight forward to extend to the rest of our code base.
-gulp.task('compile', function() {
-  /*eslint "google-camelcase/google-camelcase": 0*/
-  return gulp.src([
-    'ads/**/*.js',
-    'extensions/**/*.js',
-    'build/css.js',
-    'src/**/*.js',
-    // We do not want to load the entry point that loads the babel helpers.
-    '!src/amp-babel.js',
-    '!third_party/babel/custom-babel-helpers.js',
-    // Exclude since it's not part of the runtime/extension binaries.
-    '!extensions/amp-access/0.1/amp-login-done.js',
-    'builtins/**.js',
-    'third_party/caja/html-sanitizer.js',
-    'third_party/closure-library/sha384-generated.js',
-    'third_party/mustache/**/*.js',
-    'node_modules/document-register-element/build/' +
-        'document-register-element.max.js',
-    'node_modules/core-js/modules/**.js',
-    // Not sure what these files are, but they seem to duplicate code
-    // one level below and confuse the compiler.
-    '!node_modules/core-js/modules/library/**.js',
-    // Don't include tests.
-    '!**_test.js',
-    '!**/test-*.js',
-  ])
-  .pipe(closureCompiler({
-    // Temporary shipping with our own compiler that has a single patch
-    // applied
-    compilerPath: 'third_party/closure-compiler/compiler.jar',
-    fileName: 'build/cc-amp.js',
-    compilerFlags: {
-      // Transpile from ES6 to ES5.
-      language_in: 'ECMASCRIPT6',
-      language_out: 'ECMASCRIPT5',
-      js_module_root: 'node_modules/',
-      common_js_entry_module: 'src/amp.js',
-      process_common_js_modules: true,
-      // This strips all files from the input set that aren't explicitly
-      // required.
-      only_closure_dependencies: true,
-      output_wrapper: '(function(){var process={env:{}};%output%})();'
+exports.closureCompile = function(entryModuleFilename, outputDir,
+    outputFilename, options) {
+  // Rate limit closure compilation to MAX_PARALLEL_CLOSURE_INVOCATIONS
+  // concurrent processes.
+  return new Promise(function(resolve) {
+    function start() {
+      inProgress++;
+      compile(entryModuleFilename, outputDir, outputFilename, options)
+          .then(function() {
+            inProgress--;
+            next();
+            resolve();
+          }, function(e) {
+            console./*OK*/error('Compilation error', e.message);
+            process.exit(1);
+          });
     }
-  }))
-  .on('error', function(err) {
-    if (/0 error\(s\)/.test(err.message)) {
-      // emit warning
-      console./*OK*/warn(err.message);
-      this.emit('end');
-    } else {
-      throw err;
+    function next() {
+      if (!queue.length) {
+        return;
+      }
+      if (inProgress < MAX_PARALLEL_CLOSURE_INVOCATIONS) {
+        queue.shift()();
+      }
     }
-  })
-  .on('end', function() {
-    console./*OK*/log('Minify closure compiler result');
-    // Somewhat ironically we use uglify to further minify the result.
-    // This is needed because we currently use only very basic optimizations
-    // in closure compiler and it doesn't minify global variables at this
-    // stage.
-    return gulp.src(['build/cc-amp.js'])
-        .pipe(uglify({
-          preserveComments: 'some'
-        }))
-        .pipe(rename('cc-v0.js'))
-        .pipe(gulp.dest('dist'))
+    queue.push(start);
+    next();
   });
-});
+};
+
+function compile(entryModuleFilename, outputDir,
+    outputFilename, options) {
+  return new Promise(function(resolve, reject) {
+    var intermediateFilename = 'build/cc/' +
+        entryModuleFilename.replace(/\//g, '_').replace(/^\./, '');
+    console./*OK*/log('Starting closure compiler for ', entryModuleFilename);
+    fs.mkdirsSync('build/cc');
+    fs.mkdirsSync('build/fake-module/third_party/babel');
+    fs.writeFileSync(
+        'build/fake-module/third_party/babel/custom-babel-helpers.js',
+        '// Not needed in closure compiler\n');
+    var wrapper = '(function(){var process={env:{}};%output%})();';
+    if (options.wrapper) {
+      wrapper = options.wrapper.replace('<%= contents %>',
+          'var process={env:{}};%output%');
+    }
+    wrapper += '\n//# sourceMappingURL=' +
+        outputFilename + '.map\n';
+    if (fs.existsSync(intermediateFilename)) {
+      fs.unlinkSync(intermediateFilename);
+    }
+    /*eslint "google-camelcase/google-camelcase": 0*/
+    return gulp.src([
+      '3p/**/*.js',
+      'ads/**/*.js',
+      'extensions/**/*.js',
+      'build/**/*.js',
+      '!build/cc/**',
+      '!build/polyfills.js',
+      'src/**/*.js',
+      '!third_party/babel/custom-babel-helpers.js',
+      // Exclude since it's not part of the runtime/extension binaries.
+      '!extensions/amp-access/0.1/amp-login-done.js',
+      'builtins/**.js',
+      'third_party/caja/html-sanitizer.js',
+      'third_party/closure-library/sha384-generated.js',
+      'third_party/mustache/**/*.js',
+      'node_modules/document-register-element/build/' +
+          'document-register-element.max.js',
+      'node_modules/core-js/modules/**.js',
+      // Not sure what these files are, but they seem to duplicate code
+      // one level below and confuse the compiler.
+      '!node_modules/core-js/modules/library/**.js',
+      // Don't include tests.
+      '!**_test.js',
+      '!**/test-*.js',
+    ])
+    .pipe(closureCompiler({
+      // Temporary shipping with our own compiler that has a single patch
+      // applied
+      compilerPath: 'third_party/closure-compiler/compiler.jar',
+      fileName: intermediateFilename,
+      continueWithWarnings: true,
+      tieredCompilation: true,  // Magic speed up.
+      compilerFlags: {
+        // Custom compilation level. Trying to land this in the core
+        // compiler.
+        compilation_level: 'SIMPLE_PLUS_OPTIMIZATIONS',
+        // Transpile from ES6 to ES5.
+        language_in: 'ECMASCRIPT6',
+        language_out: 'ECMASCRIPT5',
+        js_module_root: ['node_modules/', 'build/fake-module/'],
+        common_js_entry_module: entryModuleFilename,
+        process_common_js_modules: true,
+        // This strips all files from the input set that aren't explicitly
+        // required.
+        only_closure_dependencies: true,
+        output_wrapper: wrapper,
+        create_source_map: intermediateFilename + '.map',
+        source_map_location_mapping: '|http://localhost:8000/',
+        warning_level: process.env.TRAVIS ? 'QUIET' : 'DEFAULT',
+      }
+    }))
+    .on('error', function(err) {
+      console./*OK*/error(err.message);
+      process.exit(1);
+    })
+    .pipe(rename(outputFilename))
+    .pipe(replace(/\$internalRuntimeVersion\$/g, internalRuntimeVersion))
+    .pipe(gulp.dest(outputDir))
+    .on('end', function() {
+      console./*OK*/log('Compiled ', entryModuleFilename, 'to',
+          outputDir + '/' + outputFilename, 'via', intermediateFilename);
+      gulp.src(intermediateFilename + '.map')
+          .pipe(rename(outputFilename + '.map'))
+          .pipe(gulp.dest(outputDir))
+          .on('end', resolve);
+    });
+  });
+};

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -92,9 +92,7 @@ gulp.task('test', 'Runs tests', prerequisites, function(done) {
   }
 
   if (argv.compiled) {
-    if (!argv.integration) {
-      throw new Error('Compiled tests are only supported for integration tests');
-    }
+    // Only applies to integration tests.
     c.client.amp.useCompiledJs = true;
   }
 

--- a/extensions/amp-carousel/0.1/amp-carousel.js
+++ b/extensions/amp-carousel/0.1/amp-carousel.js
@@ -23,9 +23,9 @@ class CarouselSelector {
   constructor(element) {
     if (element.hasAttribute('type') &&
         element.getAttribute('type') == 'slides') {
-      return new AmpSlides(...arguments);
+      return new AmpSlides(element);
     }
-    return new AmpCarousel(...arguments);
+    return new AmpCarousel(element);
   }
 }
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -486,7 +486,6 @@ export class Viewer {
    * @param {*} data
    * @param {boolean} unusedAwaitResponse
    * @return {(!Promise<*>|undefined)}
-   * @package
    * @export
    */
   receiveMessage(eventType, data, unusedAwaitResponse) {
@@ -536,7 +535,6 @@ export class Viewer {
    * Provides a message delivery mechanism by which AMP document can send
    * messages to the viewer.
    * @param {function(string, *, boolean):(!Promise<*>|undefined)} deliverer
-   * @package
    * @export
    */
   setMessageDeliverer(deliverer) {

--- a/test/manual/amp-list.amp.html
+++ b/test/manual/amp-list.amp.html
@@ -41,9 +41,9 @@
     }
   </style>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
-  <script async src="../../dist/amp.js" development></script>
-  <script async custom-element="amp-list" src="../../dist/v0/amp-list-0.1.max.js"></script>
-  <script async custom-template="amp-mustache" src="../../dist/v0/amp-mustache-0.1.max.js"></script>
+  <script async src="../../dist/v0.js" development></script>
+  <script async custom-element="amp-list" src="../../dist/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="../../dist/v0/amp-mustache-0.1.js"></script>
 </head>
 <body>
 <article>

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,26 +1,26 @@
-      max   |        min   |       gzip   |   file
-      ---   |        ---   |        ---   |   ---
-476.23 kB   |   153.9 kB   |   42.26 kB   |   v0.js / amp.js
-157.15 kB   |   48.74 kB   |   14.78 kB   |   v0/amp-access-0.1.js
-113.91 kB   |   38.55 kB   |   13.97 kB   |   v0/amp-analytics-0.1.js
- 38.35 kB   |   10.24 kB   |     3.9 kB   |   v0/amp-anim-0.1.js
-  28.7 kB   |    7.91 kB   |    3.19 kB   |   v0/amp-audio-0.1.js
- 24.74 kB   |    6.98 kB   |    2.78 kB   |   v0/amp-brightcove-0.1.js
-154.75 kB   |   48.72 kB   |    12.8 kB   |   v0/amp-carousel-0.1.js
- 36.77 kB   |    9.89 kB   |     3.8 kB   |   v0/amp-dynamic-css-classes-0.1.js
- 22.15 kB   |    6.91 kB   |    2.81 kB   |   v0/amp-fit-text-0.1.js
- 39.97 kB   |   10.64 kB   |    3.71 kB   |   v0/amp-font-0.1.js
- 47.31 kB   |   15.02 kB   |    5.61 kB   |   v0/amp-iframe-0.1.js
-178.78 kB   |   55.02 kB   |   14.69 kB   |   v0/amp-image-lightbox-0.1.js
- 23.69 kB   |     6.3 kB   |    2.61 kB   |   v0/amp-instagram-0.1.js
- 16.12 kB   |    5.28 kB   |    2.35 kB   |   v0/amp-install-serviceworker-0.1.js
- 91.26 kB   |   27.14 kB   |    6.96 kB   |   v0/amp-lightbox-0.1.js
- 71.61 kB   |   21.16 kB   |    7.14 kB   |   v0/amp-list-0.1.js
-102.97 kB   |   34.63 kB   |   11.78 kB   |   v0/amp-mustache-0.1.js
- 58.92 kB   |   24.56 kB   |    7.57 kB   |   v0/amp-pinterest-0.1.js
- 73.89 kB   |   20.32 kB   |    6.96 kB   |   v0/amp-slides-0.1.js
- 60.86 kB   |   16.61 kB   |    6.13 kB   |   v0/amp-twitter-0.1.js
- 85.21 kB   |   25.41 kB   |     7.9 kB   |   v0/amp-user-notification-0.1.js
-  23.5 kB   |    6.41 kB   |    2.64 kB   |   v0/amp-vine-0.1.js
- 23.88 kB   |    6.57 kB   |    2.71 kB   |   v0/amp-youtube-0.1.js
- 36.43 kB   |   11.28 kB   |    4.39 kB   |   current-min/f.js / current/integration.js
+      max   |         min   |       gzip   |   file
+      ---   |         ---   |        ---   |   ---
+476.47 kB   |   133.85 kB   |   38.02 kB   |   v0.js / amp.js
+157.15 kB   |     42.7 kB   |   13.59 kB   |   v0/amp-access-0.1.js
+113.91 kB   |    34.67 kB   |   13.12 kB   |   v0/amp-analytics-0.1.js
+ 38.35 kB   |    10.13 kB   |    3.86 kB   |   v0/amp-anim-0.1.js
+  28.7 kB   |     7.98 kB   |    3.19 kB   |   v0/amp-audio-0.1.js
+ 24.74 kB   |     7.22 kB   |    2.82 kB   |   v0/amp-brightcove-0.1.js
+154.61 kB   |    37.03 kB   |   11.03 kB   |   v0/amp-carousel-0.1.js
+ 36.77 kB   |     7.22 kB   |    2.93 kB   |   v0/amp-dynamic-css-classes-0.1.js
+ 22.15 kB   |     7.19 kB   |    2.82 kB   |   v0/amp-fit-text-0.1.js
+ 39.97 kB   |    10.38 kB   |    3.64 kB   |   v0/amp-font-0.1.js
+ 47.31 kB   |    13.63 kB   |    5.14 kB   |   v0/amp-iframe-0.1.js
+178.78 kB   |    46.97 kB   |   13.37 kB   |   v0/amp-image-lightbox-0.1.js
+ 23.69 kB   |     6.55 kB   |    2.65 kB   |   v0/amp-instagram-0.1.js
+ 16.12 kB   |     4.71 kB   |    2.05 kB   |   v0/amp-install-serviceworker-0.1.js
+ 91.26 kB   |    18.74 kB   |    5.87 kB   |   v0/amp-lightbox-0.1.js
+ 71.61 kB   |    18.62 kB   |    6.53 kB   |   v0/amp-list-0.1.js
+102.97 kB   |    34.02 kB   |   11.69 kB   |   v0/amp-mustache-0.1.js
+ 58.92 kB   |    23.73 kB   |    7.41 kB   |   v0/amp-pinterest-0.1.js
+ 73.89 kB   |    18.34 kB   |    6.44 kB   |   v0/amp-slides-0.1.js
+ 60.86 kB   |    14.65 kB   |    5.54 kB   |   v0/amp-twitter-0.1.js
+ 85.21 kB   |    21.72 kB   |    7.13 kB   |   v0/amp-user-notification-0.1.js
+  23.5 kB   |     6.65 kB   |    2.68 kB   |   v0/amp-vine-0.1.js
+ 23.88 kB   |     6.81 kB   |    2.75 kB   |   v0/amp-youtube-0.1.js
+ 36.43 kB   |     7.83 kB   |    3.25 kB   |   current-min/f.js / current/integration.js


### PR DESCRIPTION
- Still need to avoid running N java processes in parallel. Kills the machine :)
- Had to work around bug in CC where rest params with new fails. Created https://github.com/google/closure-compiler/issues/1384

Production part of #86. Does not implement type checking.