### PR TITLE
Run our integration tests with optimized JS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
   - gulp test
   # Integration tests with all saucelabs browsers
   - gulp test --saucelabs --integration
+  - gulp test --saucelabs --integration --compiled
   # All unit tests with an old chrome (best we can do right now to pass tests
   # and not start relying on new features).
   - gulp test --saucelabs --oldchrome

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -61,7 +61,10 @@ var karma = {
     configFile: karmaConf,
     singleRun: true,
     client: {
-      captureConsole: false
+      captureConsole: false,
+      amp: {
+        useCompiledJs: false
+      }
     }
   },
   firefox: {

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -84,6 +84,13 @@ gulp.task('test', 'Runs tests in chrome', ['build'], function(done) {
     c.files = config.testPaths;
   }
 
+  if (argv.compiled) {
+    if (!argv.integration) {
+      throw new Error('Compiled tests are only supported for integration tests');
+    }
+    c.client.amp.useCompiledJs = true;
+  }
+
   karma.start(c, done);
 }, {
   options: {
@@ -93,6 +100,8 @@ gulp.task('test', 'Runs tests in chrome', ['build'], function(done) {
     'safari': '  Runs tests in Safari',
     'firefox': '  Runs tests in Firefox',
     'integration': 'Run only integration tests.',
+    'compiled': 'Changes integration tests to use production JS ' +
+        'binaries for execution',
     'oldchrome': 'Runs test with an old chrome. Saucelabs only.',
   }
 });

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -21,6 +21,10 @@ import {adopt} from '../src/runtime';
 
 adopt(global);
 
+// Make amp section in karma config readable by tests.
+global.ampTestRuntimeConfig = parent.karma.config.amp;
+
+
 // Hack for skipping tests on Travis that don't work there.
 // Get permission before use!
 /**

--- a/test/fixtures/carousels.html
+++ b/test/fixtures/carousels.html
@@ -12,7 +12,7 @@
       font-family: Arial;
     }
   </style>
-  <script async custom-element="amp-carousel" src="/base/dist/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="/base/dist/v0/amp-carousel-0.1.max.js"></script>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <script async src="/base/dist/amp.js"></script>
 </head>

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -59,6 +59,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, done) {
     if (!html) {
       throw new Error('Cannot find fixture: ' + fixture);
     }
+    html = maybeSwitchToCompiledJs(html);
     let firstLoad = true;
     window.ENABLE_LOG = true;
     // This global function will be called by the iframe immediately when it
@@ -287,4 +288,26 @@ export function expectBodyToBecomeVisible(win) {
             && win.document.body.style.opacity != '0')
         || win.document.body.style.opacity == '1');
   });
+}
+
+/**
+ * Takes a HTML document that is pointing to unminified JS and HTML
+ * binaries and massages the URLs to pointed to compiled binaries
+ * instead.
+ * @param {string} html
+ * @return {string}
+ */
+function maybeSwitchToCompiledJs(html) {
+  if (window.ampTestRuntimeConfig.useCompiledJs) {
+    return html
+        // Main JS
+        .replace(/\/dist\/amp\.js/, '/dist/v0.js')
+        // Extensions
+        .replace(/\.max\.js/g, '.js')
+        // 3p html binary
+        .replace(/\.max\.html/g, '.html')
+        // 3p path
+        .replace(/dist\.3p\/current\//g, 'dist.3p/current-min/');
+  }
+  return html;
 }


### PR DESCRIPTION
The previous testing mode is still in tact. Since we have great sourcemap support we might consider turing off uncompiled integration tests.

Preparation for #86 and #1390, so we can change production codegen with higher confidence.