### PR TITLE
Run the validator build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required  # See http://docs.travis-ci.com/user/trusty-ci-environment/
 dist: trusty
 node_js:
   - "stable"
+python:
+  - "2.7"
 notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
@@ -11,12 +13,17 @@ addons:
   hosts:
     - ads.localhost
     - iframe.localhost
+  apt:
+    packages:
+    - protobuf-compiler
+    - python-protobuf
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 before_script:
   - npm install -g gulp
+  - pip install --user protobuf
 script:
   - gulp lint
   - gulp build
@@ -31,3 +38,4 @@ script:
   # All unit tests with an old chrome (best we can do right now to pass tests
   # and not start relying on new features).
   - gulp test --saucelabs --oldchrome
+  - gulp validator

--- a/build-system/tasks/validator.js
+++ b/build-system/tasks/validator.js
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-require('./babel-helpers');
-require('./changelog');
-require('./clean');
-require('./compile');
-require('./compile-access-expr');
-require('./lint');
-require('./make-golden');
-require('./presubmit-checks');
-require('./serve');
-require('./size');
-require('./test');
-require('./validator');
+var gulp = require('gulp-help')(require('gulp'));
+var execSync = require('child_process').execSync;
+
+
+/**
+ * Simple wrapper around the python based validator build.
+ */
+function validator() {
+  execSync('cd validator && python build.py')
+}
+
+gulp.task('validator', 'Builds and tests the AMP validator.', validator);

--- a/validator/build.py
+++ b/validator/build.py
@@ -231,7 +231,7 @@ def GenerateValidateBin(out_dir):
 def RunSmokeTest(out_dir):
   logging.info('entering ...')
   # Run dist/validate on the minimum valid amp and observe that it passes.
-  p = subprocess.Popen(['%s/validate' % out_dir,
+  p = subprocess.Popen(['node', '%s/validate' % out_dir,
                         'testdata/feature_tests/minimum_valid_amp.html'],
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   (stdout, stderr) = p.communicate()
@@ -241,7 +241,7 @@ def RunSmokeTest(out_dir):
 
   # Run dist/validate on an empty file and observe that it fails.
   open('%s/empty.html' % out_dir, 'w').close()
-  p = subprocess.Popen(['%s/validate' % out_dir, '%s/empty.html' % out_dir],
+  p = subprocess.Popen(['node', '%s/validate' % out_dir, '%s/empty.html' % out_dir],
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   (stdout, stderr) = p.communicate()
   if p.returncode != 1:
@@ -305,7 +305,7 @@ def GenerateTestRunner(out_dir):
 
 def RunTests(out_dir):
   logging.info('entering ...')
-  subprocess.check_call(['%s/test_runner' % out_dir])
+  subprocess.check_call(['node', '%s/test_runner' % out_dir])
   logging.info('... success')
 
 


### PR DESCRIPTION
This will catch build and test failures in pre/post-submit.

- Removes assumption that there is a node.js in /usr/bin/nodejs. That is a weird ubuntuism. Instead just invokes node. I think it is reasonable that everyone has one of those in their path.
- Creates a simple gulp task to wrap the validator build through our standard idiom.