### PR TITLE
Allow DoubleClick ads to explicitly request an ad size.

### DIFF
--- a/ads/doubleclick.js
+++ b/ads/doubleclick.js
@@ -29,8 +29,8 @@ export function doubleclick(global, data) {
     global.googletag.cmd.push(function() {
       const googletag = global.googletag;
       const dimensions = [[
-        parseInt(data.width, 10),
-        parseInt(data.height, 10)
+        parseInt(data.overrideWidth || data.width, 10),
+        parseInt(data.overrideHeight || data.height, 10)
       ]];
       const pubads = googletag.pubads();
       const slot = googletag.defineSlot(data.slot, dimensions, 'c')

--- a/ads/doubleclick.md
+++ b/ads/doubleclick.md
@@ -39,15 +39,31 @@ limitations under the License.
 
 ## Configuration
 
-For semantics of configuration, please see ad network documentation.
+For semantics of configuration, please see [ad network documentation](https://developers.google.com/doubleclick-gpt/reference).
 
-Supported parameters:
 
-- data-slot
+### Ad size
+
+By default the ad size is based on the `width` and `height` attributes of the `amp-ad` tag. In order to explicitly request different ad dimensions from those values, pass the attributes `data-override-width` and `data-override-height` to the ad.
+
+Example:
+
+```html
+<amp-ad width=320 height=50
+    data-override-width=111
+    data-override-height=222
+    type="doubleclick"
+    data-slot="/4119129/mobile_ad_banner">
+</amp-ad>
+```
+
+### Supported parameters
+
+- `data-slot`
 
 Supported via `json` attribute:
 
-- categoryExclusion
-- cookieOptions
-- tagForChildDirectedTreatment
-- targeting
+- `categoryExclusion`
+- `cookieOptions`
+- `tagForChildDirectedTreatment`
+- `targeting`

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -14,6 +14,9 @@
       top: 0;
       right: 0;
     }
+    .red {
+      background-color: red;
+    }
   </style>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -99,6 +102,15 @@
 
         <p>You got lucky! We have no ad to show to you!</p>
       </div>
+  </amp-ad>
+
+  <h2>Doubleclick with overriden size</h2>
+  <amp-ad width=420 height=100
+      data-override-width=320 data-override-height=50
+      type="doubleclick"
+      data-slot="/4119129/mobile_ad_banner"
+      class="red"
+      >
   </amp-ad>
 </body>
 </html>


### PR DESCRIPTION
The default continues to be to infer the size from the size of the ad slot.

Closes #1429