### PR TITLE
Replaced 'node' by 'nodejs' in Popen() and check_call() calls

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -260,7 +260,7 @@ def GenerateValidateBin(out_dir):
 def RunSmokeTest(out_dir):
   logging.info('entering ...')
   # Run dist/validate on the minimum valid amp and observe that it passes.
-  p = subprocess.Popen(['node', '%s/validate' % out_dir,
+  p = subprocess.Popen(['nodejs', '%s/validate' % out_dir,
                         'testdata/feature_tests/minimum_valid_amp.html'],
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   (stdout, stderr) = p.communicate()
@@ -270,7 +270,7 @@ def RunSmokeTest(out_dir):
 
   # Run dist/validate on an empty file and observe that it fails.
   open('%s/empty.html' % out_dir, 'w').close()
-  p = subprocess.Popen(['node', '%s/validate' % out_dir, '%s/empty.html' % out_dir],
+  p = subprocess.Popen(['nodejs', '%s/validate' % out_dir, '%s/empty.html' % out_dir],
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   (stdout, stderr) = p.communicate()
   if p.returncode != 1:
@@ -334,7 +334,7 @@ def GenerateTestRunner(out_dir):
 
 def RunTests(out_dir):
   logging.info('entering ...')
-  subprocess.check_call(['node', '%s/test_runner' % out_dir])
+  subprocess.check_call(['nodejs', '%s/test_runner' % out_dir])
   logging.info('... success')
 
 


### PR DESCRIPTION
Since the commit https://github.com/ampproject/amphtml/commit/bf31fc090e50b10e54dc9d7decfc7328ae660ab4, I get this error message when I run the build script build.py :

>[[build.py RunSmokeTest]] - entering ...
>Traceback (most recent call last):
>  File "./build.py", line 350, in <module>
>    RunSmokeTest(out_dir='dist')
>  File "./build.py", line 265, in RunSmokeTest
>    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
>  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
>    errread, errwrite)
>  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
>    raise child_exception
>OSError: [Errno 2] No such file or directory

I think that 'node' should be replaced by 'nodejs' in subprocess.Popen() and subprocess.check_call() calls to fix it.