### PR TITLE
Delay unhiding body until Dynamic CSS is loaded

### DIFF
--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -17,7 +17,7 @@
 import {AccessService} from '../../../../build/all/v0/amp-access-0.1.max';
 import {Observable} from '../../../../src/observable';
 import {installCidService} from '../../../../src/service/cid-impl';
-import {markElementScheduledForTesting} from '../../../../src/service';
+import {markElementScheduledForTesting} from '../../../../src/custom-element';
 import * as sinon from 'sinon';
 
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -17,7 +17,7 @@
 import {AmpAnalytics} from '../../../../build/all/v0/amp-analytics-0.1.max';
 import {adopt} from '../../../../src/runtime';
 import {getService} from '../../../../src/service';
-import {markElementScheduledForTesting} from '../../../../src/service';
+import {markElementScheduledForTesting} from '../../../../src/custom-element';
 import {installCidService} from '../../../../src/service/cid-impl';
 import {installViewerService} from '../../../../src/service/viewer-impl';
 import * as sinon from 'sinon';

--- a/src/amp.js
+++ b/src/amp.js
@@ -30,6 +30,7 @@ import {stubElements} from './custom-element';
 import {adopt} from './runtime';
 import {cssText} from '../build/css';
 import {maybeValidate} from './validator-integration';
+import {waitForExtensions} from './render-delaying-extensions';
 
 // We must under all circumstances call makeBodyVisible.
 // It is much better to have AMP tags not rendered than having
@@ -57,8 +58,10 @@ try {
       installGlobalClickListener(window);
 
       maybeValidate(window);
-    } finally {
+      makeBodyVisible(document, waitForExtensions(window));
+    } catch (e) {
       makeBodyVisible(document);
+    } finally {
       perf.tick('e_is');
       // TODO(erwinm): move invocation of the `flush` method when we have the
       // new ticks in place to batch the ticks properly.

--- a/src/cid.js
+++ b/src/cid.js
@@ -18,7 +18,7 @@
  * @fileoverview Factory for ./service/cid-impl.js
  */
 
-import {getElementService} from './service';
+import {getElementService} from './custom-element';
 
 /**
  * @param {!Window} window

--- a/src/promise.js
+++ b/src/promise.js
@@ -29,7 +29,7 @@ export function all(promises) {
     return Promise.resolve([]);
   }
 
-  const results = [];
+  const results = Array(left);
   return new Promise((resolve, reject) => {
     promises.forEach((promise, index) => {
       promise.then(result => {
@@ -38,9 +38,7 @@ export function all(promises) {
         if (left == 0) {
           resolve(results);
         }
-      }, error => {
-        reject(error);
-      });
+      }, reject);
     });
   });
 }

--- a/src/render-delaying-extensions.js
+++ b/src/render-delaying-extensions.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getServicePromise} from './service';
+import {all} from './promise';
+import {timer} from './timer';
+
+/**
+ * List of extensions that, if they're included on the page, must be loaded
+ * before the page should be shown to users.
+ * Do not add an extension unless absolutely necessary.
+ * @const {!Array<string>}
+ */
+const EXTENSIONS = [
+  'amp-dynamic-css-classes'
+];
+
+/**
+ * Maximum milliseconds to wait for all extensions to load before erroring.
+ * @const
+ */
+const LOAD_TIMEOUT = 3000;
+
+
+/**
+ * Detects any extensions that are were included on the page that need to
+ * delay unhiding the body (to avoid Flash of Unstyled Content), and returns
+ * a promise that will resolve when they have loaded or reject after a timeout.
+ * @param {!Window} win
+ * @return {?Promise}
+ */
+export function waitForExtensions(win) {
+  const extensions = includedExtensions(win);
+
+  if (extensions.length) {
+    return timer.timeoutPromise(LOAD_TIMEOUT, all(extensions));
+  }
+}
+
+/**
+ * Detects which, if any, render-delaying extensions are included on the page.
+ * @param {!Window} win
+ * @return {!Array<string>}
+ */
+export function includedExtensions(win) {
+  const document = win.document;
+
+  return EXTENSIONS.filter(extension => {
+    return document.querySelector(`[custom-element="${extension}"]`);
+  }).map(extension => {
+    return getServicePromise(win, extension);
+  });
+}

--- a/src/styles.js
+++ b/src/styles.js
@@ -16,6 +16,7 @@
 
 import {setStyles} from './style';
 
+
 /**
  * Adds the given css text to the given document.
  *
@@ -77,8 +78,10 @@ export function installStyles(doc, cssText, cb, opt_isRuntimeCss) {
  * If the body is not yet available (because our script was loaded
  * synchronously), polls until it is.
  * @param {!Document} doc The document who's body we should make visible.
+ * @param {?Promise=} extensionsPromise A loading promise for special extensions
+ *     which must load before the body can be made visible
  */
-export function makeBodyVisible(doc) {
+export function makeBodyVisible(doc, extensionsPromise) {
   let interval;
   const set = () => {
     if (doc.body) {
@@ -90,8 +93,16 @@ export function makeBodyVisible(doc) {
       clearInterval(interval);
     }
   };
-  interval = setInterval(set, 4);
-  set();
+  const poll = () => {
+    interval = setInterval(set, 4);
+    set();
+  };
+
+  if (extensionsPromise) {
+    extensionsPromise.then(poll, poll);
+  } else {
+    poll();
+  }
 }
 
 

--- a/src/user-notification.js
+++ b/src/user-notification.js
@@ -18,7 +18,7 @@
  * @fileoverview Factory for amp-user-notification
  */
 
-import {getElementService} from './service';
+import {getElementService} from './custom-element';
 
 
 /**

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -100,8 +100,9 @@ chai.Assertion.addMethod('class', function(className) {
 
 chai.Assertion.addProperty('visible', function() {
   const obj = this._obj;
-  const visibility = window.getComputedStyle(obj).getPropertyValue('visibility');
-  const opacity = window.getComputedStyle(obj).getPropertyValue('opacity');
+  const computedStyle = window.getComputedStyle(obj);
+  const visibility = computedStyle.getPropertyValue('visibility');
+  const opacity = computedStyle.getPropertyValue('opacity');
   const tagName = obj.tagName.toLowerCase();
   this.assert(
     visibility === 'visible' || parseInt(opacity, 10) > 0,
@@ -116,8 +117,9 @@ chai.Assertion.addProperty('visible', function() {
 
 chai.Assertion.addProperty('hidden', function() {
   const obj = this._obj;
-  const visibility = window.getComputedStyle(obj).getPropertyValue('visibility');
-  const opacity = window.getComputedStyle(obj).getPropertyValue('opacity');
+  const computedStyle = window.getComputedStyle(obj);
+  const visibility = computedStyle.getPropertyValue('visibility');
+  const opacity = computedStyle.getPropertyValue('opacity');
   const tagName = obj.tagName.toLowerCase();
   this.assert(
      visibility === 'hidden' || parseInt(opacity, 10) == 0,

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -22,7 +22,7 @@ import {adopt} from '../src/runtime';
 adopt(global);
 
 // Make amp section in karma config readable by tests.
-global.ampTestRuntimeConfig = parent.karma.config.amp;
+global.ampTestRuntimeConfig = parent.karma ? parent.karma.config.amp : {};
 
 
 // Hack for skipping tests on Travis that don't work there.
@@ -100,32 +100,33 @@ chai.Assertion.addMethod('class', function(className) {
 
 chai.Assertion.addProperty('visible', function() {
   const obj = this._obj;
-  const value = window.getComputedStyle(obj)
-      .getPropertyValue('visibility');
+  const visibility = window.getComputedStyle(obj).getPropertyValue('visibility');
+  const opacity = window.getComputedStyle(obj).getPropertyValue('opacity');
   const tagName = obj.tagName.toLowerCase();
   this.assert(
-    value === 'visible',
+    visibility === 'visible' || parseInt(opacity, 10) > 0,
     'expected element \'' +
         tagName + '\' to be #{exp}, got #{act}. with classes: ' + obj.className,
     'expected element \'' +
         tagName + '\' not to be #{act}. with classes: ' + obj.className,
     'visible',
-    value
+    visibility
   );
 });
 
 chai.Assertion.addProperty('hidden', function() {
   const obj = this._obj;
-  const value = window.getComputedStyle(obj).getPropertyValue('visibility');
+  const visibility = window.getComputedStyle(obj).getPropertyValue('visibility');
+  const opacity = window.getComputedStyle(obj).getPropertyValue('opacity');
   const tagName = obj.tagName.toLowerCase();
   this.assert(
-     value === 'hidden',
+     visibility === 'hidden' || parseInt(opacity, 10) == 0,
     'expected element \'' +
         tagName + '\' to be #{exp}, got #{act}. with classes: ' + obj.className,
     'expected element \'' +
         tagName + '\' not to be #{act}. with classes: ' + obj.className,
     'hidden',
-    value
+    visibility
   );
 });
 

--- a/test/fixtures/served/amp-dynamic-css-classes.html
+++ b/test/fixtures/served/amp-dynamic-css-classes.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <script async src="/base/dist/amp.js"></script>
+  <script async custom-element="amp-dynamic-css-classes"></script>
   <script>
       function insertDynamicCssScript() {
           return new Promise(function(resolve, reject) {

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {getService, getElementService} from '../../src/service';
+import {
+  getService,
+  getServicePromise,
+  resetServiceForTesting
+} from '../../src/service';
 
 describe('service', () => {
 
@@ -24,7 +28,10 @@ describe('service', () => {
   }
 
   beforeEach(() => {
-    window.ampExtendedElements = {};
+    resetServiceForTesting(window, 'a');
+    resetServiceForTesting(window, 'b');
+    resetServiceForTesting(window, 'c');
+    resetServiceForTesting(window, 'e1');
   });
 
   it('should make per window singletons', () => {
@@ -50,30 +57,17 @@ describe('service', () => {
     }).to.throw(/Factory not given and service missing not-present/);
   });
 
-  it('should be provided by element', () => {
-    window.ampExtendedElements['element-1'] = true;
-    const p1 = getElementService(window, 'e1', 'element-1');
-    const p2 = getElementService(window, 'e1', 'element-1');
+  it('should provide a promise that resolves when registered', () => {
+    const p1 = getServicePromise(window, 'e1');
+    const p2 = getServicePromise(window, 'e1');
     getService(window, 'e1', function() {
       return 'from e1';
     });
     return p1.then(s1 => {
       expect(s1).to.equal('from e1');
       return p2.then(s2 => {
-        expect(s1).to.equal(s2);
+        expect(s2).to.equal(s1);
       });
-    });
-  });
-
-  it('should fail if element is not in page.', () => {
-    window.ampExtendedElements['element-foo'] = true;
-    return getElementService(window, 'e1', 'element-bar').then(() => {
-      return 'SUCCESS';
-    }, error => {
-      return 'ERROR ' + error;
-    }).then(result => {
-      expect(result).to.match(
-          /Service e1 was requested to be provided through element-bar/);
     });
   });
 });

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -16,7 +16,7 @@
 
 import {createIframePromise} from '../../testing/iframe';
 import {urlReplacementsFor} from '../../src/url-replacements';
-import {markElementScheduledForTesting} from '../../src/service';
+import {markElementScheduledForTesting} from '../../src/custom-element';
 import {installCidService} from '../../src/service/cid-impl';
 import {setCookie} from '../../src/cookies';
 


### PR DESCRIPTION
But only if we’ve included the extension.

Also included:
- Divorces Element Services from Service Promises
- Misc testing fixes
    - Fixes issue with `useCompiledJS` on the debug page
    - Adds `opacity` checks to `#hidden` and `#visible` matchers