### PR TITLE
Fail test if it does not restore fake timers.

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -68,6 +68,10 @@ afterEach(() => {
   window.localStorage.clear();
   window.ampExtendedElements = {};
   window.ENABLE_LOG = false;
+  if (!/native/.test(window.setTimeout)) {
+    throw new Error('You likely forgot to restore sinon timers ' +
+        '(installed via sandbox.useFakeTimers).');
+  }
 });
 
 chai.Assertion.addMethod('attribute', function(attr) {


### PR DESCRIPTION
This is much better than random unpredictable side effects for unrelated tests.