### PR TITLE
Update the URL when a fragment link to that navigates the current doc is clicked

### DIFF
--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -104,6 +104,7 @@
 <div class="logo"></div>
 
 <h1 id="top">AMP #0</h1>
+<a href="#amp-iframe">Go to iframe</a>
   <p class="comic-amp">
     Quisque ultricies id augue a convallis. Vivamus euismod est quis tellus laoreet lacinia. In quam tellus, mollis nec porta eget, volutpat sit amet nibh. Duis ac odio sem. Sed consequat, ante gravida fringilla suscipit, libero libero ullamcorper metus, nec porta est elit at est. Curabitur vel diam ligula. Nulla bibendum malesuada odio.
   </p>
@@ -305,7 +306,7 @@
     layout="responsive">
   </amp-instagram>
 
-  <h2>IFrame</h2>
+  <h2 id="amp-iframe">IFrame</h2>
   <amp-iframe width=300 height=300
       sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
       layout="responsive"

--- a/src/document-click.js
+++ b/src/document-click.js
@@ -105,13 +105,14 @@ export function onDocumentElementClick_(e, viewport) {
   let elem = null;
   const docElement = e.currentTarget;
   const doc = docElement.ownerDocument;
+  const win = doc.defaultView;
 
   const tgtLoc = parseUrl(target.href);
   if (!tgtLoc.hash) {
     return;
   }
 
-  const curLoc = parseUrl(doc.location.href);
+  const curLoc = parseUrl(win.location.href);
   const tgtHref = `${tgtLoc.origin}${tgtLoc.pathname}${tgtLoc.search}`;
   const curHref = `${curLoc.origin}${curLoc.pathname}${curLoc.search}`;
 
@@ -142,5 +143,11 @@ export function onDocumentElementClick_(e, viewport) {
   } else {
     log.warn('documentElement',
         `failed to find element with id=${hash} or a[name=${hash}]`);
+  }
+  const history = win.history;
+  // If possible do update the URL with the hash. As explained above
+  // we do replaceState to avoid messing with the container's history.
+  if (history.replaceState) {
+    history.replaceState(null, '', `#${hash}`);
   }
 };

--- a/src/platform.js
+++ b/src/platform.js
@@ -55,6 +55,15 @@ export class Platform {
     // Also true for MS Edge :)
     return /Chrome|CriOS/i.test(this.navigator.userAgent);
   }
+
+  /**
+   * Whether the current browser is a Chrome browser.
+   * @return {boolean}
+   */
+  isFirefox() {
+    // Also true for MS Edge :)
+    return /Firefox/i.test(this.navigator.userAgent);
+  }
 };
 
 

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -645,7 +645,12 @@ export class ViewportBindingNatural_ {
     if (doc./*OK*/scrollingElement) {
       return doc./*OK*/scrollingElement;
     }
-    if (doc.body) {
+    if (doc.body
+        // Firefox does not support scrollTop on doc.body for default
+        // scrolling.
+        // See https://github.com/ampproject/amphtml/issues/1398
+        // Unfortunately there is no way to feature detect this.
+        && !platform.isFirefox()) {
       return doc.body;
     }
     return doc.documentElement;

--- a/test/functional/test-platform.js
+++ b/test/functional/test-platform.js
@@ -20,11 +20,13 @@ describe('Platform', () => {
 
   let isIos;
   let isChrome;
+  let isFirefox;
 
   beforeEach(() => {
     isIos = false;
     isChrome = false;
     isSafari = false;
+    isFirefox = false;
   });
 
   function testUserAgent(userAgentString) {
@@ -32,6 +34,7 @@ describe('Platform', () => {
     expect(platform.isIos()).to.equal(isIos);
     expect(platform.isChrome()).to.equal(isChrome);
     expect(platform.isSafari()).to.equal(isSafari);
+    expect(platform.isFirefox()).to.equal(isFirefox);
   }
 
   it('iPhone 6 Plus', () => {
@@ -62,5 +65,11 @@ describe('Platform', () => {
     testUserAgent('Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E)' +
         ' AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.20' +
         ' Mobile Safari/537.36');
+  });
+
+  it('firefox', () => {
+    isFirefox = true;
+    testUserAgent('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) ' +
+        'Gecko/20100101 Firefox/40.1');
   });
 });


### PR DESCRIPTION
Also fixes fragment navigation in Firefox. It does that by deleting the code path that chose `document.body`. At least with Safari 9 all other major browsers appear to be supporting `document.scrollingElement`, to that it should be safe to pick the object here that is correct for FF. I might be missing something, though.

Fixes #1398
Fixes #1397
Fixes https://github.com/webcompat/web-bugs/issues/1793