### PR TITLE
Workaround against _top login navigation where assigning URL is not possible

### DIFF
--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -17,7 +17,7 @@
 import {getMode} from '../../../src/mode';
 import {listen} from '../../../src/event-helper';
 import {log} from '../../../src/log';
-import {parseUrl} from '../../../src/url';
+import {parseUrl, removeFragment} from '../../../src/url';
 
 /** @const */
 const TAG = 'AmpAccessLogin';
@@ -231,11 +231,15 @@ class LoginDialog {
    * @private
    */
   getReturnUrl_() {
+    const currentUrl = removeFragment(this.win.location.href);
+    let returnUrl;
     if (getMode().localDev) {
       const loc = this.win.location;
-      return loc.protocol + '//' + loc.host +
+      returnUrl = loc.protocol + '//' + loc.host +
           '/extensions/amp-access/0.1/amp-login-done.html';
+    } else {
+      returnUrl = 'https://cdn.ampproject.org/v0/amp-login-done-0.1.html';
     }
-    return 'https://cdn.ampproject.org/v0/amp-login-done-0.1.html';
+    return returnUrl + '?url=' + encodeURIComponent(currentUrl);
   }
 }

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -17,8 +17,9 @@
 import {openLoginDialog} from '../login-dialog';
 import * as sinon from 'sinon';
 
-const RETURN_URL_ESC = 'http%3A%2F%2Flocalhost%3A8000%2Fextensions' +
-    '%2Famp-access%2F0.1%2Famp-login-done.html';
+const RETURN_URL_ESC = encodeURIComponent('http://localhost:8000/extensions' +
+    '/amp-access/0.1/amp-login-done.html?url=' +
+    encodeURIComponent('http://localhost:8000/test-login-dialog'));
 
 
 describe('LoginDialog', () => {


### PR DESCRIPTION
This appears to happen in a WebView on Twitter Android. From what I can reconstruct:

1. We are asking to open login dialog with `window.open('', '_blank')`.
2. As expected for a WebView, this essentially does `window.open('', '_top')`
3. It appears that the script then doesn't have enough time to set location before it's unloaded.

Doesn't seem to happen at all in a normal Chrome browser. Must be something to do with how WebView unloads pages.

So, what this PR does is basically two things:

1. It always opens with the actual string URL, not promise. Thus it always calls `window.open(url, '_blank')`. There's no chance that location won't be overwritten this way. There's a negligible chance that the login URL somehow won't be ready yet, but I can't imagine this ever possible in a real-world circumstances.
2. "Login done" page now redirects back to the original page if opener is not available. This is a good default in general.

/cc @sebastianbenz @andreban @ashwinlimaye 