### PR TITLE
'element alias' registration

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1090,6 +1090,37 @@ function isElementScheduled(win, elementName) {
 }
 
 /**
+ * Registers a new alias for an existing custom element.
+ * @param {!Window} win The window in which to register the elements.
+ * @param {string} aliasName Additional name for an existing custom element.
+ * @param {string} sourceName Name of an existing custom element
+ * @param {Object} state Optional map to be merged into the prototype
+ *                 to override the original state with new default values
+ */
+export function registerElementAlias(win, aliasName, sourceName, state) {
+  var implementationClass = knownElements[sourceName];
+
+  if (implementationClass) {
+    const proto = createAmpElementProto(win, aliasName, implementationClass);
+    const originalCreatedCallback = proto.createdCallback;
+
+    if (state) {
+      proto.createdCallback = function () {
+        originalCreatedCallback.call(this);
+        Object.keys(state).forEach(p = > this.setAttribute(p, state[p]));
+      };
+    }
+
+    win.document.registerElement(aliasName, {
+      prototype: proto
+    });
+
+  } else {
+    throw new Error('Element name is unknown: ' + sourceName + '. Alias ' + aliasName + ' was not registered.');
+  }
+}
+
+/**
  * In order to provide better error messages we only allow to retrieve
  * services from other elements if those elements are loaded in the page.
  * This makes it possible to mark an element as loaded in a test.

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -22,7 +22,7 @@ import {installStyles} from './styles';
 import {installCoreServices} from './amp-core-service';
 import {isExperimentOn, toggleExperiment} from './experiments';
 import {performanceFor} from './performance';
-import {registerElement} from './custom-element';
+import {registerElement, registerElementAlias} from './custom-element';
 import {registerExtendedElement} from './extended-element';
 import {resourcesFor} from './resources';
 import {timer} from './timer';
@@ -74,6 +74,17 @@ export function adopt(global) {
     } else {
       register();
     }
+  };
+
+  /**
+   * Registers an extended element based on existing element.
+   * @param {string} aliasName Additional name for an existing custom element.
+   * @param {string} sourceName Name of an existing custom element
+   * @param {Object} state Optional map to be merged into the prototype to
+   *     override the original state with new default values.
+   */
+  global.AMP.registerElementAlias = function(aliasName, sourceName, state) {
+    registerElementAlias(global, aliasName, sourceName, state);
   };
 
   /** @const */


### PR DESCRIPTION
Create the ability to register elements as aliases to other elements. 
Allows code re-use when a required tag functionality already exists, but required for a different tag. 
Specific use case is amp-taboola which derives it's functionality from amp-ad but requires a different name.
separating this PR from the amp-taboola PR to allow separate discussions.