### PR TITLE
Fix two typos in element names

### DIFF
--- a/spec/amp-tag-addendum.md
+++ b/spec/amp-tag-addendum.md
@@ -91,7 +91,7 @@ Below we list the allowed tags in the order in which they are appear in the HTML
 4.5.27 `<bdo>`  
 4.5.28 `<span>`  
 4.5.29 `<br>`  
-4.5.30 `<wb>`  
+4.5.30 `<wbr>`  
 ### 4.6 Edits
 4.6.1 `<insert>`  
 4.6.2 `<del>`  

--- a/spec/amp-tag-addendum.md
+++ b/spec/amp-tag-addendum.md
@@ -93,7 +93,7 @@ Below we list the allowed tags in the order in which they are appear in the HTML
 4.5.29 `<br>`  
 4.5.30 `<wbr>`  
 ### 4.6 Edits
-4.6.1 `<insert>`  
+4.6.1 `<ins>`  
 4.6.2 `<del>`  
 ### 4.7 Embedded Content
 AMP HTML allows only limited embedded content except via its own tags (ex: amp-img).


### PR DESCRIPTION
The HTML WHATWG spec doesn't list a <wb> element, but lists <wbr> (word break): https://html.spec.whatwg.org/ . The addendum doesn't list <wbr>, hence it's the most likely typo.