### PR TITLE
Fix amp-analytics related bugs.

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -41,25 +41,30 @@ export const ANALYTICS_CONFIG = {
       'scrollHeight': 'SCROLL_HEIGHT',
       'screenWidth': 'SCREEN_WIDTH',
       'screenHeight': 'SCREEN_HEIGHT'
+      // Vars that GA can use: documentEncoding, userLanguage
     }
     // TODO(btownsend, #871): Add a generic hit format to make custom analytics
     // easier.
   },
 
   'googleanalytics': {
+    'vars': {
+      'eventValue': "0",
+      'documentLocation': 'AMPDOC_URL'
+    },
     'requests': {
       'host': 'https://www.google-analytics.com',
-      'basePrefix': 'v=1&_v=a0&aip=true&_s=${hitCount}&dl=${canonicalUrl}&' +
+      'basePrefix': 'v=1&_v=a0&aip=true&_s=${hitCount}&dr=${documentReferrer}' +
           'dt=${title}&sr=${screenWidth}x${screenHeight}&_utmht=${timestamp}&' +
-          'jid=&cid=${clientId(_ga)}&tid=${account}',
-      'baseSuffix': '&z=${random}',
+          'jid=&cid=${clientId(_ga)}&tid=${account}&dl=${documentLocation}',
+      'baseSuffix': '&a=${pageViewId}&z=${random}',
       'pageview': '${host}/r/collect?${basePrefix}&t=pageview&' +
           '_r=1${baseSuffix}',
       'event': '${host}/collect?${basePrefix}&t=event&' +
           'ec=${eventCategory}&ea=${eventAction}&el=${eventLabel}&' +
           'ev=${eventValue}${baseSuffix}',
       'social': '${host}/collect?${basePrefix}&t=social&' +
-          'sa=${socialAction}&sn=${socialNetwork}&st=${socialActionTarget}' +
+          'sa=${socialAction}&sn=${socialNetwork}&st=${socialTarget}' +
           '${baseSuffix}'
     },
     'optout': '_gaUserPrefs.ioo'


### PR DESCRIPTION
- Added a default value for eventValue. "0" was used instead of 0 because amp-analytics does not fill in falsey values. 
- Have a more customizable documentLocation for GA. This way, if a person wants to send both canonicalUrl and ampdocUrl in a hit, they can.
- Renamed socialActionTarget to socialTarget

Fixes #1494 
Fixes #1491

cc: @btownsend 