### PR TITLE
Added performance vars for amp-analytics.

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -40,11 +40,16 @@ export const ANALYTICS_CONFIG = {
       'scrollWidth': 'SCROLL_WIDTH',
       'scrollHeight': 'SCROLL_HEIGHT',
       'screenWidth': 'SCREEN_WIDTH',
-      'screenHeight': 'SCREEN_HEIGHT'
-      // Vars that GA can use: documentEncoding, userLanguage
+      'screenHeight': 'SCREEN_HEIGHT',
+      'pageLoadTime': 'PAGE_LOAD_TIME',
+      'domainLookupTime': 'DOMAIN_LOOKUP_TIME',
+      'tcpConnectTime': 'TCP_CONNECT_TIME',
+      'serverResponseTime': 'SERVER_RESPONSE_TIME',
+      'pageDownloadTime': 'PAGE_DOWNLOAD_TIME',
+      'redirectTime': 'REDIRECT_TIME',
+      'domInteractiveTime': 'DOM_INTERACTIVE_TIME',
+      'contentLoadTime': 'CONTENT_LOAD_TIME'
     }
-    // TODO(btownsend, #871): Add a generic hit format to make custom analytics
-    // easier.
   },
 
   'googleanalytics': {
@@ -65,7 +70,11 @@ export const ANALYTICS_CONFIG = {
           'ev=${eventValue}${baseSuffix}',
       'social': '${host}/collect?${basePrefix}&t=social&' +
           'sa=${socialAction}&sn=${socialNetwork}&st=${socialTarget}' +
-          '${baseSuffix}'
+          '${baseSuffix}',
+      'timing': '${host}/collect?${basePrefix}&t=timing&plt=${pageLoadTime}&' +
+          'dns=${domainLookupTime}&tcp=${tcpConnectTime}&rrt=${redirectTime}&' +
+          'srt=${serverResponseTime}&pdt=${pageDownloadTime}&' +
+          'clt=${contentLoadTime}&dit=${domInteractiveTime}${baseSuffix}'
     },
     'optout': '_gaUserPrefs.ioo'
   }

--- a/extensions/amp-analytics/analytics-vars.md
+++ b/extensions/amp-analytics/analytics-vars.md
@@ -42,31 +42,144 @@ When the same `var` is defined in multiple locations, the value is picked in the
 
 The remainder of this doc lists and describes the variables supported in `amp-analytics`.
 
-## random
+## Page and content
 
-Provides a random value every time a request is being constructed.
+### ampdocHost
 
-Example value: `0.12345632345`
+Provides the AMP document's URL host.
 
-## canonicalUrl
+Example value: `example.com`
 
-Provides the canonical URL of the current document.
+### ampdocUrl
 
-Example value: `http%3A%2F%2Fexample.com%3A8000%2Fanalytics.html`
+Provides the AMP document's URL. The URL contains the scheme, domain, port and full path. It does not contain the fragment part of the URL.
 
-## canonicalHost
+Example value: `http://example.com:8000/examples.build/analytics.amp.max.html`
+
+### canonicalHost
 
 Provides the canonical URL's host.
 
 Example value: `example.com`
 
-## canonicalPath
+### canonicalPath
 
 Provides the canonical URL's path part.
 
 Example value: `%2Fanalytics.html`
 
-## clientId
+### canonicalUrl
+
+Provides the canonical URL of the current document.
+
+Example value: `http%3A%2F%2Fexample.com%3A8000%2Fanalytics.html`
+
+### documentReferrer
+
+Provides the referrer where the user came from. It is read from `document.referrer`. The value is empty for direct visitors.
+
+Example value: `https://www.google.com`
+
+### title
+
+Provides the title of the current document.
+
+Example value: `The New York Times - Breaking News, World News...`
+
+## Device and Browser
+
+### screenHeight
+
+Provides the screen height in pixels. The value is retrieved from `window.screen.height`.
+
+Example value: `1600`
+
+### screenWidth
+
+Provides the screen width in pixels. The value is retrieved from `window.screen.width`.
+
+Example value: `2560`
+
+### scrollHeight
+
+Provides the total size of the page in pixels.
+
+Example value: `400`
+
+### scrollLeft
+
+Provides the number of pixels that the user has scrolled from left.
+
+Example value: `100`
+
+### scrollTop
+
+Provides the number of pixels that the user has scrolled from top.
+
+Example value: `0`
+
+### timezone
+
+Provides the user's time-zone offset from UTC, in minutes.
+
+Example value: `480` for [Pacific Standard Time](https://en.wikipedia.org/wiki/Pacific_Time_Zone).
+
+## Performance
+
+Provides various navigation timing metrics. Since the metrics below are only available after the respective events occur, the dispatching of request will get delayed till either a) a value for the event is found or b) the event results in a `0` value.
+
+### contentLoadTime
+
+Provides the time the page takes to fire the `DOMContentLoaded` event from the time the previous page is unloaded. The value is in milliseconds.
+
+Example value: `40`
+
+### domainLookupTime
+
+Provides the time it took to perform the DNS lookup for the current page. The value is in milliseconds.
+
+Example value: `1`
+
+### domInteractiveTime
+
+Provides the time the page to become interactive from the time the previous page
+is unloaded. The value is in milliseconds.
+
+Example value: `40`
+
+### pageDownloadTime
+
+Provides the time between receiving the first and the last byte of response. The value is in milliseconds.
+
+Example value: `100`
+
+### pageLoadTime
+
+Provides the time taken to load the whole page. The value is calculated from the time `unload` event handler on previous page ends to the time `load` event for the current page is fired. If there is no previous page, the duration starts from the time the user agent is ready to fetch the document using an HTTP requesti. The value is in milliseconds.
+
+Example value: `220`
+
+### redirectTime
+
+Provides the time taken to complete all the redirects before the request for the current page is made. The value is in milliseconds.
+
+Example value: `0`
+
+### serverResponseTime
+
+Provides the time taken by the server to start sending the response after it starts receiving the request. The value is in milliseconds.
+
+Example value: `10`
+
+### tcpConnectTime
+
+Provides the time it took for HTTP connection to be setup. The duration includes connection handshake time and SOCKS authentication. The value is in milliseconds.
+
+Example value `10`
+
+## Miscellaneous
+
+### clientId
 
 Provides a per document-source-origin (the origin of the website where you publish your AMP doc) and user identifier. The client id will be the same for the same user if they visit again within one year.
 
@@ -81,76 +194,21 @@ Example usage: `${clientId(foo)}`
 
 Example value: `U6XEpUs3yaeQyR2DKATQH1pTZ6kg140fvuLbtl5nynbUWtIodJxP5TEIYBic4qcV`
 
-
-## documentReferrer
-
-Provides the referrer where the user came from. It is read from `document.referrer`. The value is empty for direct visitors.
-
-Example value: `https://www.google.com`
-
-## title
-
-Provides the title of the current document.
-
-Example value: `The New York Times - Breaking News, World News...`
-
-## ampdocUrl
-
-Provides the AMP document's URL. The URL contains the scheme, domain, port and full path. It does not contain the fragment part of the URL.
-
-Example value: `http://example.com:8000/examples.build/analytics.amp.max.html`
-
-## ampdocHost
-
-Provides the AMP document's URL host.
-
-Example value: `example.com`
-
-## pageViewId
+### pageViewId
 
 Provides a string that is intended to be random and likely to be unique per URL, user and day.
 
 Example value: `978`
 
-## timestamp
+### random
+
+Provides a random value every time a request is being constructed.
+
+Example value: `0.12345632345`
+
+### timestamp
 
 Provides the number of seconds that have elapsed since 1970. (Epoch time)
 
 Example value: `1452710304312`
-
-## timezone
-
-Provides the user's time-zone offset from UTC, in minutes.
-
-Example value: `480` for [Pacific Standard Time](https://en.wikipedia.org/wiki/Pacific_Time_Zone).
-
-## scrollTop
-
-Provides the number of pixels that the user has scrolled from top.
-
-Example value: `0`
-
-## scrollLeft
-
-Provides the number of pixels that the user has scrolled from left.
-
-Example value: `100`
-
-## scrollHeight
-
-Provides the total size of the page in pixels.
-
-Example value: `400`
-
-## screenHeight
-
-Provides the screen height in pixels. The value is retrieved from `window.screen.height`.
-
-Example value: `1600`
-
-## screenWidth
-
-Provides the screen width in pixels. The value is retrieved from `window.screen.width`.
-
-Example value: `2560`
 

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -21,29 +21,30 @@ limitations under the License.
 Some components such as [`amp-pixel`](../builtins/amp-pixel.md) and
 [`amp-list`](../extensions/amp-list/amp-list.md) allow variables to be substituted
 in the relevant URLs. AMP provides a number of standard variable substitutions and
-allows each component to add their own.
+allows each component to add their own. The rest of this document talks about
+the variables supported by the platform.
 
-## Standard Variable Substitutions
+## Page and Content
 
-### RANDOM
+### AMPDOC_HOST
 
-Use the special string `RANDOM` to add a random number to the URL if required.
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?RANDOM"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?0.8390278471201` where the $RANDOM value is randomly generated upon each impression.
-
-### CANONICAL_URL
-
-Use the special string `CANONICAL_URL` to add the canonical URL of the current document to the URL
+Use the special string `AMPDOC_HOST` to add the AMP document's URL host.
 
 For instance:
 ```html
-<amp-pixel src="https://foo.com/pixel?href=CANONICAL_URL"></amp-pixel>
+<amp-pixel src="https://foo.com/pixel?host=AMPDOC_HOST"></amp-pixel>
 ```
-may make a request to something like `https://foo.com/pixel?href=https%3A%2F%2Fpinterest.com%2F`.
+may make a request to something like `https://foo.com/pixel?host=example.com`.
+
+### AMPDOC_URL
+
+Use the special string `AMPDOC_URL` to add the AMP document's URL.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?ref=AMPDOC_URL"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?ref=https%3A%2F%2Fexample.com%2F`.
 
 ### CANONICAL_HOST
 
@@ -65,9 +66,115 @@ For instance:
 ```
 may make a request to something like `https://foo.com/pixel?path=%2Fpage1.html`.
 
-**CLIENT_ID**
+### CANONICAL_URL
 
-Use the special string `CLIENT_ID` to add a per document-source-origin (The origin of the website where you publish your AMP doc) and user identifier. The `CLIENT_ID` will be the same for the same user if they visit again within one year. It should behave roughly similar to a cookie storing a session id for one year. If the AMP document is not served through the AMP CDN, the `CLIENT_ID` will be replaced with a cookie of the name of the cid scope below. If the cookie is not present, the empty string will be returned.
+Use the special string `CANONICAL_URL` to add the canonical URL of the current document to the URL
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?href=CANONICAL_URL"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?href=https%3A%2F%2Fpinterest.com%2F`.
+
+### DOCUMENT_REFERRER
+
+Use the special string `DOCUMENT_REFERRER` to add the current document's referrer to the URL.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?referrer=DOCUMENT_REFERRER"></amp-pixel>
+```
+
+### TITLE
+
+Use the special string `TITLE` to add the title of the current document to the URL
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?title=TITLE"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?title=Breaking%20News`.
+
+## Performance
+
+### CONTENT_LOAD_TIME
+
+Provides the time the page takes to fire the `DOMContentLoaded` event from the time the previous page is unloaded. The value is in milliseconds.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?contentLoadTime=CONTENT_LOAD_TIME"></amp-pixel>
+```
+
+### DOMAIN_LOOKUP_TIME
+
+Provides the time it took to perform the DNS lookup for the current page. The value is in milliseconds.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?domainLookupTime=DOMAIN_LOOKUP_TIME"></amp-pixel>
+```
+
+### DOM_INTERACTIVE_TIME
+
+Provides the time the page to become interactive from the time the previous page
+is unloaded. The value is in milliseconds.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?domInteractiveTime=DOM_INTERACTIVE_TIME"></amp-pixel>
+```
+
+### PAGE_DOWNLOAD_TIME
+
+Provides the time between receiving the first and the last byte of response. The value is in milliseconds.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?pageDownloadTime=PAGE_DOWNLOAD_TIME"></amp-pixel>
+```
+
+### PAGE_LOAD_TIME
+
+Provides the time taken to load the whole page. The value is calculated from the time `unload` event handler on previous page ends to the time `load` event for the current page is fired. If there is no previous page, the duration starts from the time the user agent is ready to fetch the document using an HTTP requesti. The value is in milliseconds.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?pageLoadTime=PAGE_LOAD_TIME"></amp-pixel>
+```
+
+### REDIRECT_TIME
+
+Provides the time taken to complete all the redirects before the request for the current page is made. The value is in milliseconds.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?redirectTime=REDIRECT_TIME"></amp-pixel>
+```
+
+### SERVER_RESPONSE_TIME
+
+Provides the time taken by the server to start sending the response after it starts receiving the request. The value is in milliseconds.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?serverResponseTime=SERVER_RESPONSE_TIME"></amp-pixel>
+```
+
+### TCP_CONNECT_TIME
+
+Provides the time it took for HTTP connection to be setup. The duration includes connection handshake time and SOCKS authentication. The value is in milliseconds.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?tcpConnectTime=TCP_CONNECT_TIME"></amp-pixel>
+```
+
+## Miscellaneous
+
+### CLIENT_ID
+
+Use the special string `CLIENT_ID` to add a per document-source-origin (the origin of the website where you publish your AMP doc) and user identifier. The `CLIENT_ID` will be the same for the same user if they visit again within one year. It should behave roughly similar to a cookie storing a session id for one year. If the AMP document is not served through the AMP CDN, the `CLIENT_ID` will be replaced with a cookie of the name of the cid scope below. If the cookie is not present, the empty string will be returned.
 
 Please see below the required and optional arguments you may
 pass into `CLIENT_ID` like a function. (spaces between arguments and values are not allowed)
@@ -98,48 +205,19 @@ For instance:
 <amp-pixel src="https://foo.com/pixel?cid=CLIENT_ID(google-analytics,user-consent)"></amp-pixel>
 ```
 
-### DOCUMENT_REFERRER
-
-Use the special string `DOCUMENT_REFERRER` to add the current document's referrer to the URL.
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?referrer=DOCUMENT_REFERRER"></amp-pixel>
-```
-
-### TITLE
-
-Use the special string `TITLE` to add the title of the current document to the URL
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?title=TITLE"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?title=Breaking%20News`.
-
-### AMPDOC_URL
-
-Use the special string `AMPDOC_URL` to add the AMP document's URL.
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?ref=AMPDOC_URL"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?ref=https%3A%2F%2Fexample.com%2F`.
-
-### AMPDOC_HOST
-
-Use the special string `AMPDOC_HOST` to add the AMP document's URL host.
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?host=AMPDOC_HOST"></amp-pixel>
-```
-may make a request to something like `https://foo.com/pixel?host=example.com`.
-
 ### PAGE_VIEW_ID
 
 Contains a string that is intended to be random and likely to be unique per URL, user and day.
+
+### RANDOM
+
+Use the special string `RANDOM` to add a random number to the URL if required.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?RANDOM"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?0.8390278471201` where the $RANDOM value is randomly generated upon each impression.
 
 ### TIMESTAMP
 
@@ -150,3 +228,4 @@ For instance:
 ```html
 <amp-pixel src="https://foo.com/pixel?timestamp=TIMESTAMP"></amp-pixel>
 ```
+


### PR DESCRIPTION
Adds `pageLoadTime`, `domainLookupTime`, `tcpConnectTime`, `serverResponseTime`, `pageDownloadTime`, `redirectTime`, `domInteractiveTime` and `contentLoadTime` for use in `amp-analytics` tags

Fixes #1295 