### PR TITLE
running tests in locations eastern to greenwich time

### DIFF
--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -111,7 +111,7 @@ describe('UrlReplacements', () => {
 
   it('should replace TIMEZONE', () => {
     return expand('?tz=TIMEZONE').then(res => {
-      expect(res).to.match(/tz=\d+/);
+      expect(res).to.match(/tz=-?\d+/);
     });
   });
 


### PR DESCRIPTION
Added '-?' to test regexp to accommodate negative timezone when running tests in locations eastern to greenwich time (negative timezone offset)