### PR TITLE
Add "-cdn" to "app deployment" in error reporting to make it easy to filter for errors reported from the CDN.

### DIFF
--- a/tools/errortracker/errortracker.go
+++ b/tools/errortracker/errortracker.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/net/context"
@@ -102,6 +103,9 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	errorType := "default"
 	if r.URL.Query().Get("a") == "1" {
 		errorType = "assert"
+	}
+	if strings.HasPrefix(r.Referer(), "https://cdn.ampproject.org/") {
+		errorType += "-cdn"
 	}
 
 	event := &ErrorEvent{


### PR DESCRIPTION
General error reporting is almost too spammy from invalid AMP pages. I'm considering to turn it off entirely, but will leave for a while and see how it develops.