### PR TITLE
Add support for Parsely analytics

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -119,6 +119,17 @@
 </script>
 </amp-analytics>
 
+<!-- Parsely tracking -->
+<amp-analytics type="parsely">
+<script type="application/json">
+{
+  "vars": {
+    "apikey": "example.com"
+  }
+}
+</script>
+</amp-analytics>
+
 <amp-analytics id="analytics3" config="./analytics.config.json"></amp-analytics>
 
 <amp-analytics id="analytics4">

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -159,6 +159,37 @@ export const ANALYTICS_CONFIG = {
           'clt=${contentLoadTime}&dit=${domInteractiveTime}${baseSuffix}'
     },
     'optout': '_gaUserPrefs.ioo'
+  },
+
+  'parsely': {
+    'requests': {
+      'host': 'https://srv.pixel.parsely.com',
+      'basePrefix': '${host}/plogger/?' +
+        'rand=${timestamp}&' +
+        'idsite=${apikey}&' +
+        'url=${ampdocUrl}&' +
+        'urlref=${documentReferrer}&' +
+        'screen=${screenWidth}x${screenHeight}%7C' +
+          '${availableScreenWidth}x${availableScreenHeight}%7C' +
+          '${screenColorDepth}&' +
+        'title=${title}&' +
+        'date=${timestamp}&' +
+        'ampid=${clientId(_parsely_visitor)}',
+      'pageview': '${basePrefix}&action=pageview'
+      // TODO(#1612): client-side session support
+      // TODO(#1296): active engaged time support
+      // 'heartbeat': '${basePrefix}&action=heartbeat&inc=${engagedTime}'
+    },
+    'triggers': {
+      'defaultPageview': {
+        'on': 'visible',
+        'request': 'pageview'
+      }
+    },
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true
+    }
   }
 };
-

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -63,6 +63,7 @@ when the document is first loaded, and each time an `<a>` tag is clicked:
     - `chartbeat`: Adds support for Chartbeat. More details for adding Chartbeat support can be found at [support.chartbeat.com](http://support.chartbeat.com/docs/).
     - `comscore`: Supports comScore Unified Digital Measurement™ pageview analytics. Requires defining *var* `c2` with comScore-provided *c2 id*.
     - `googleanalytics`: Adds support for Google Analytics. More details for adding Google Analytics support can be found at [developers.google.com](https://developers.google.com/analytics/devguides/collection/amp-analytics/).
+    - `parsely`: Adds support for Parsely. Configuration details can be found at [parsely.com/docs](http://parsely.com/docs/integration/tracking/google-amp.html).
 
     ```
     <amp-analytics type="XYZ"> ... </amp-analytics>


### PR DESCRIPTION
See #1500 for additional information. This PR adds vendor configuration support for Parse.ly analytics.

Outstanding issues are the additional configuration variables we're requesting and the open discussions on client-side sessionization and engaged time implementations.