### PR TITLE
Optimize page load time on mobile

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -458,7 +458,16 @@ export function createAmpElementProto(win, name, implementationClass) {
    * @param {boolean} onLayout Whether this was called after a layout.
    */
   ElementProto.preconnect = function(onLayout) {
-    this.implementation_.preconnectCallback(onLayout);
+    if (onLayout) {
+      this.implementation_.preconnectCallback(onLayout);
+    } else {
+      // If we do early preconnects we delay them a bit. This is kind of
+      // an unfortunate trade off, but it seems faster, because the DOM
+      // operations themselves are not free and might delay
+      timer.delay(() => {
+        this.implementation_.preconnectCallback(onLayout);
+      }, 1);
+    }
   };
 
   /**

--- a/src/url.js
+++ b/src/url.js
@@ -16,6 +16,7 @@
 
 import {assert} from './asserts';
 
+const a = document.createElement('a');
 
 /**
  * Returns a Location-like object for the given URL. If it is relative,
@@ -24,7 +25,6 @@ import {assert} from './asserts';
  * @return {!Location}
  */
 export function parseUrl(url) {
-  const a = document.createElement('a');
   a.href = url;
   const info = {
     href: a.href,

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -223,13 +223,15 @@ describe('CustomElement', () => {
     expect(res).to.equal(true);
     expect(element.isBuilt()).to.equal(true);
     expect(testElementBuildCallback.callCount).to.equal(1);
-    expect(testElementPreconnectCallback.callCount).to.equal(1);
+    expect(testElementPreconnectCallback.callCount).to.equal(0);
 
     // Call again.
     res = element.build(false);
     expect(res).to.equal(true);
     expect(element.isBuilt()).to.equal(true);
     expect(testElementBuildCallback.callCount).to.equal(1);
+    expect(testElementPreconnectCallback.callCount).to.equal(0);
+    clock.tick(1);
     expect(testElementPreconnectCallback.callCount).to.equal(1);
   });
 
@@ -412,6 +414,7 @@ describe('CustomElement', () => {
     element.build(true);
     expect(element.isBuilt()).to.equal(true);
     expect(testElementLayoutCallback.callCount).to.equal(0);
+    clock.tick(1);
     expect(testElementPreconnectCallback.callCount).to.equal(1);
     expect(testElementPreconnectCallback.getCall(0).args[0]).to.be.false;
 


### PR DESCRIPTION
- don't allocate an a tag per URL parse
- delay preconnect during build phase a bit. This is kind of a bummer, but it really slims down the initial JS execution.