### PR TITLE
Adds support for comScore

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -83,6 +83,18 @@
 
 <amp-analytics id="analytics3" config="./analytics.config.json"></amp-analytics>
 
+<!-- comScore UDM pageview tracking -->
+<amp-analytics type="comscore">
+<script type="application/json">
+{
+  "vars": {
+    "c2": "1000001"
+  }
+}
+</script>
+</amp-analytics>
+<!-- End comScore example -->
+
 <div class="logo"></div>
 <h1 id="top">AMP Analytics</h1>
 

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -77,6 +77,29 @@ export const ANALYTICS_CONFIG = {
           'clt=${contentLoadTime}&dit=${domInteractiveTime}${baseSuffix}'
     },
     'optout': '_gaUserPrefs.ioo'
+  },
+
+  'comscore': {
+    'vars': {
+      'c2': '1000001'
+    },
+    'requests': {
+      'host': 'https://sb.scorecardresearch.com',
+      'base': '${host}/b?',
+      'pageview': '${base}c1=2&c2=${c2}&rn=${random}&c8=${title}' +
+        '&c7=${canonicalUrl}&c9=${documentReferrer}&cs_c7amp=${ampdocUrl}'
+    },
+    'triggers': {
+      'defaultPageview': {
+        'on': 'visible',
+        'request': 'pageview'
+      }
+    },
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true
+    }
   }
 };
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -61,6 +61,7 @@ when the document is first loaded, and each time an `<a>` tag is clicked:
 
   - `type` This optional attribute can be specified to use one of the built-in analytics providers. Currently supported values for type are:
     - `googleanalytics`: Adds support for Google Analytics. More details for adding Google Analytics support can be found at [developers.google.com](https://developers.google.com/analytics/devguides/collection/amp-analytics/).
+    - `comscore`: Supports comScore Unified Digital Measurement™ pageview analytics. Requires defining *var* `c2` with comScore-provided *c2 id*.
 
     ```
     <amp-analytics type="XYZ"> ... </amp-analytics>


### PR DESCRIPTION
This PR adds support for comScore UDM pageview analytics.

Var *c2* must be defined containing customer id. A brief note about this requirement has been added to `amp-analytics.md` documentation.