### PR TITLE
Properly wrap our main binary in a IEFE.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,8 @@ function compile(watch, shouldMinify) {
     minify: shouldMinify,
     // If there is a sync JS error during initial load,
     // at least try to unhide the body.
-    wrapper: 'try{<%= contents %>}catch(e){setTimeout(function(){' +
+    wrapper: 'try{(function(){<%= contents %>})()}catch(e){' +
+        'setTimeout(function(){' +
         'var s=document.body.style;' +
         's.opacity=1;' +
         's.visibility="visible";' +

--- a/test/integration/test-released.js
+++ b/test/integration/test-released.js
@@ -51,6 +51,7 @@ function runTest(shouldKillPolyfillableApis) {
         expect(fixture.doc.querySelectorAll('.-amp-layout'))
             .to.have.length(13);
         expect(fixture.doc.querySelectorAll('.-amp-error')).to.have.length(0);
+        checkGlobalScope(fixture.win);
       }).then(() => {
         return expectBodyToBecomeVisible(fixture.win);
       });
@@ -67,4 +68,15 @@ function runTest(shouldKillPolyfillableApis) {
       });
     });
   });
+}
+
+function checkGlobalScope(win) {
+  // Checks that we don't leak certain symbols to the global scope.
+  // This could happen if we do not wrap all our code in a closure.
+  const commonSymbols = [
+      '$', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'x', 'z', '_', 'log'];
+  expect(win).to.not.include.keys(commonSymbols);
+  expect(win).to.not.include.keys(commonSymbols.map(symbol => {
+    return symbol.toUpperCase();
+  }));
 }


### PR DESCRIPTION
This avoids problems with chrome extensions and similar browser interference.

This is necessary now with closure compiler because it does not keep module functions in tact.

Adds a regression test for not leaking global symbols.

Fixes #1679