### PR TITLE
Add timer trigger for amp-analytics

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -83,6 +83,30 @@
 
 <amp-analytics id="analytics3" config="./analytics.config.json"></amp-analytics>
 
+<amp-analytics id="analytics4">
+<script type="application/json">
+{
+  "requests": {
+    "test-ping": "https://my-analytics.com/ping?title=${title}&acct=${account}"
+  },
+  "vars": {
+    "title": "A page that sends a ping",
+    "account": "12345"
+  },
+  "triggers": {
+    "timer": {
+      "on": "timer",
+      "timer-spec": {
+        "interval": 5,
+        "max-timer-length": 300
+      },
+      "request": "test-ping"
+    }
+  }
+}
+</script>
+</amp-analytics>
+
 <!-- comScore UDM pageview tracking -->
 <amp-analytics type="comscore">
 <script type="application/json">

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -132,7 +132,8 @@ export class AmpAnalytics extends AMP.BaseElement {
           continue;
         }
         addListener(this.getWin(), trigger['on'],
-            this.handleEvent_.bind(this, trigger), trigger['selector']);
+            this.handleEvent_.bind(this, trigger), trigger['selector'],
+            trigger['timer-spec']);
       }
     }
   }

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -18,6 +18,9 @@ import {getService} from '../../../src/service';
 import {viewerFor} from '../../../src/viewer';
 import {Observable} from '../../../src/observable';
 
+const MIN_TIMER_INTERVAL_SECONDS_ = 0.5;
+const DEFAULT_MAX_TIMER_LENGTH_SECONDS_ = 7200;
+
 /**
  * This type signifies a callback that gets called when an analytics event that
  * the listener subscribed to fires.
@@ -32,10 +35,13 @@ let AnalyticsEventListenerDef;
  *          fires.
  * @param {string=} opt_selector If specified, the given listener
  *   should only be called if the event target matches this selector.
+ * @param {JSONObject=} opt_timerSpec If specified, the specification on how
+ *   the timer should fire.
  */
-export function addListener(window, type, listener, opt_selector) {
+export function addListener(window, type, listener, opt_selector,
+    opt_timerSpec) {
   return instrumentationServiceFor(window).addListener(
-      type, listener, opt_selector);
+      type, listener, opt_selector, opt_timerSpec);
 }
 
 /**
@@ -45,7 +51,8 @@ export function addListener(window, type, listener, opt_selector) {
  */
 export const AnalyticsEventType = {
   VISIBLE: 'visible',
-  CLICK: 'click'
+  CLICK: 'click',
+  TIMER: 'timer'
 };
 
 /**
@@ -93,8 +100,10 @@ class InstrumentationService {
    *   occurs.
    * @param {string=} opt_selector If specified, the given listener
    *   should only be called if the event target matches this selector.
+   * @param {JSONObject=} opt_timerSpec If specified, the specification on how
+   *   the timer should fire.
    */
-  addListener(eventType, listener, opt_selector) {
+  addListener(eventType, listener, opt_selector, opt_timerSpec) {
     if (eventType === AnalyticsEventType.VISIBLE) {
       if (this.viewer_.isVisible()) {
         listener(new AnalyticsEvent(AnalyticsEventType.VISIBLE));
@@ -113,6 +122,10 @@ class InstrumentationService {
         this.ensureClickListener_();
         this.clickObservable_.add(
             this.createSelectiveListener_(listener, opt_selector));
+      }
+    } else if (eventType === AnalyticsEventType.TIMER) {
+      if (this.isTimerSpecValid_(opt_timerSpec)) {
+        this.createTimerListener_(listener, opt_timerSpec);
       }
     } else {
       let observers = this.observers_[eventType];
@@ -193,6 +206,48 @@ class InstrumentationService {
           selectorError);
     }
     return false;
+  }
+
+  /**
+   * @param {JSONObject} timerSpec
+   * @private
+   */
+  isTimerSpecValid_(timerSpec) {
+    if (!timerSpec) {
+      console./*OK*/error(this.TAG_, 'Bad timer specification');
+      return false;
+    } else if (!timerSpec.hasOwnProperty('interval')) {
+      console./*OK*/error(this.TAG_, 'Timer interval specification required');
+      return false;
+    } else if (typeof timerSpec['interval'] !== 'number' ||
+               timerSpec['interval'] < MIN_TIMER_INTERVAL_SECONDS_) {
+      console./*OK*/error(this.TAG_, 'Bad timer interval specification');
+      return false;
+    } else if (timerSpec.hasOwnProperty('max-timer-length') &&
+              (typeof timerSpec['max-timer-length'] !== 'number' ||
+                  timerSpec['max-timer-length'] <= 0)) {
+      console./*OK*/error(this.TAG_, 'Bad max-timer-length specification');
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * @param {!Function} listener
+   * @param {JSONObject} timerSpec
+   * @private
+   */
+  createTimerListener_(listener, timerSpec) {
+    const intervalId = this.win_.setInterval(
+        listener.bind(null, new AnalyticsEvent(AnalyticsEventType.TIMER)),
+        timerSpec['interval'] * 1000);
+    listener(new AnalyticsEvent(AnalyticsEventType.TIMER));
+
+    const maxTimerLength = timerSpec['max-timer-length'] ||
+        DEFAULT_MAX_TIMER_LENGTH_SECONDS_;
+    this.win_.setTimeout(this.win_.clearInterval.bind(this.win_, intervalId),
+        maxTimerLength * 1000);
   }
 }
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -140,9 +140,12 @@ The `triggers` attribute describes when an analytics request should be sent. It 
  trigger-configuration. Trigger name can be any string comprised of alphanumeric characters (a-zA-Z0-9). Triggers from a
  configuration with lower precedence are overridden by triggers with the same names from a configuration with higher precedence.
 
-  - `on` (required) The event to listener for. Valid values are `visible` and `click`.
+  - `on` (required) The event to listener for. Valid values are `visible`,`click`, and `timer`.
   - `request` (required) Name of the request to send (as specified in the `requests` section).
   - `selector` A CSS selector used to refine which elements should be tracked. Use value `*` to track all elements.
+  - `timer-spec` Specification for the timer. The timer will trigger immediately and then at a specified interval thereafter.
+    - `interval` Length of the timer interval, in seconds.
+    - `max-timer-length` Maximum duration for which the timer will fire, in seconds.
   - `vars` An object containing key-value pairs used to override `vars` defined in the top level config, or to specify
     vars unique to this trigger.
 
@@ -159,6 +162,14 @@ The `triggers` attribute describes when an analytics request should be sent. It 
     "vars": {
       "eventId": 128
     }
+  },
+  "pageTimer": {
+    "on": "timer",
+    "timer-spec": {
+      "interval": 10,
+      "max-timer-length": 600
+    },
+    "request": "pagetime"
   }
 }
 ```


### PR DESCRIPTION
This is an initial PR to address issue #1489. I'm putting up a light implementation with the hope of soliciting feedback and confirming direction.

The following code implements the timer trigger on the following analytics tag:
```
    <amp-analytics>
    <script type="application/json">
    {
      "requests": {
        "test-ping": "https://my-analytics.com/ping?title=${title}&acct=${account}"
      },
      "vars": {
        "title": "A page that sends a ping",
        "account": "12345"
      },
      "triggers": {
        "TRIGGER_NAME": {
          "on": "**timer**",
          "timer-spec": { "**interval**": 3 /* seconds */ },
          "request": "test-ping"
        }
      }
    }
    </script>
    </amp-analytics>
```
We put a minimum on the length of the timer interval at half a second because we don't want to encourage a process that is constantly firing.

While we were thinking through this implementation, we wished to get feedback on a number of possible refinements to this approach (listed in roughly decreasing order of importance):

1. Handling the trailing ping. We would like to be able to capture data between the most recent timer event and the close of a user session. This becomes increasingly important as the length of the timer interval increases. We agree with the feedback to avoid use of the unload and beforeunload events to accomplish this, but we would like to open the conversation about how best to proceed.
2. Max Session Length.  The initial specification for the timer-spec included a max-count parameter. We think that a more intuitive/useful specification would be max-session-length. In either case, we recognize that we probably do not want an idle session to ping forever. I have additional code implementing this that I am happy to add to this PR.
3. Session Backoff.  We have found it useful to ping progressively less frequently when the user is not engaged.
4. Sequence Number. It can be useful for sessionization to expose the sequence number of a user session (e.g., &seq-no=3 to indicate a ping was the third ping in the session). This is a very easy, if perhaps non-essential, extension.
5. Error Handling. We attach onerror functions to pings so that we can halt the timer on a specified client error code.