### PR TITLE
Customize return URL query form

### DIFF
--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -25,6 +25,9 @@ const TAG = 'AmpAccessLogin';
 /** @const {!Function} */
 const assert = AMP.assert;
 
+/** @const {!RegExp} */
+const RETURN_URL_REGEX = new RegExp('RETURN_URL');
+
 
 /**
  * Opens the login dialog for the specified URL. If the login dialog succeeds,
@@ -221,6 +224,12 @@ class LoginDialog {
    * @private
    */
   buildLoginUrl_(url, returnUrl) {
+    // RETURN_URL has to arrive here unreplaced by UrlReplacements for two
+    // reasons: (1) sync replacement and (2) if we need to propagate this
+    // replacement to the viewer.
+    if (RETURN_URL_REGEX.test(url)) {
+      return url.replace(RETURN_URL_REGEX, encodeURIComponent(returnUrl));
+    }
     return url +
         (url.indexOf('?') == -1 ? '?' : '&') +
         'return=' + encodeURIComponent(returnUrl);

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -873,6 +873,20 @@ describe('AccessService login', () => {
     });
   });
 
+  it('should build login url with RETURN_URL', () => {
+    service.config_.login = 'https://acme.com/l?rid=READER_ID&ret=RETURN_URL';
+    cidMock.expects('get')
+        .withExactArgs(
+            {scope: 'amp-access', createCookieIfNotPresent: true},
+            sinon.match(() => true))
+        .returns(Promise.resolve('reader1'))
+        .once();
+    return service.buildLoginUrl_().then(url => {
+      expect(url).to.equal('https://acme.com/l?rid=reader1&ret=RETURN_URL');
+      expect(service.loginUrl_).to.equal(url);
+    });
+  });
+
   it('should open dialog in the same microtask', () => {
     service.openLoginDialog_ = sandbox.stub();
     service.openLoginDialog_.returns(Promise.resolve());

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -195,6 +195,26 @@ describe('LoginDialog', () => {
         });
   });
 
+  it('should substitute return URL', () => {
+    windowMock.expects('open')
+        .withExactArgs(
+            'http://acme.com/login?a=1&ret1=' + RETURN_URL_ESC,
+            '_blank',
+            'height=450,width=700,left=150,top=275')
+        .returns(dialog)
+        .once();
+    const promise = openLoginDialog(windowApi,
+        'http://acme.com/login?a=1&ret1=RETURN_URL');
+    return Promise.resolve()
+        .then(() => {
+          succeed();
+          return promise;
+        })
+        .then(result => {
+          expect(result).to.equal('#success=true');
+        });
+  });
+
   it('should respond with empty string when dialog is closed', () => {
     windowMock.expects('open')
         .returns(dialog)

--- a/extensions/amp-access/amp-access-spec.md
+++ b/extensions/amp-access/amp-access-spec.md
@@ -124,6 +124,7 @@ Var               | Description
 ----------------- | -----------
 READER_ID         | The AMP Reader ID.
 AUTHDATA(field)   | The value of the field in the authorization response.
+RETURN_URL        | The placeholder for the return URL specified by the AMP runtime for a Login Dialog to return to.
 AMPDOC_URL        | The URL of this AMP Document.
 CANONICAL_URL     | The canonical URL of this AMP Document.
 DOCUMENT_REFERRER | The Referrer URL.
@@ -293,7 +294,9 @@ AMP makes no distinction between login or subscribe. This distinction can be mad
 
 The link to the Login Page is configured via the ```login``` property in the [AMP Access Configuration][8] section.
 
-The link can take any parameters as defined in the [Access URL Variables][7] section. For instance, it could pass AMP Reader ID and document URL.
+The link can take any parameters as defined in the [Access URL Variables][7] section. For instance, it could pass AMP Reader ID and document URL. `RETURN_URL` query substitution can be used to specify query parameter for return URL, e.g. `?ret=RETURN_URL`. The return URL is
+required and if the `RETURN_URL` substitution is not specified, it will be injected automatically with the default query parameter name of
+"return".
 
 Login Page is simply a normal Web page with no special constraints, other than it should function well as a [browser dialog](https://developer.mozilla.org/en-US/docs/Web/API/Window/open). See the “Login Flow” section for more details.
 
@@ -302,19 +305,18 @@ The request format is:
 https://publisher.com/amp-login.html?
    rid={READER_ID}
   &url={AMPDOC_URL}
-  &return=<return-url>
+  &return={RETURN_URL}
 ```
-Notice that the “return” URL parameter is added by the AMP Runtime automatically. Once Login Page completes its work, it must redirect back to the specified “Return URL” with the following format:
+Notice that the “return” URL parameter is added by the AMP Runtime automatically if `RETURN_URL` substitution is not
+specified. Once Login Page completes its work, it must redirect back to the specified “Return URL” with the following format:
 ```
-<return-url>#status=true|false
+RETURN_URL#status=true|false
 ```
 Notice the use of a URL hash parameter “status”. The value is either “true” or “false” depending on whether the login succeeds or is abandoned. Ideally the Login Page, when possible, will send the signal in cases of both success or failure.
 
-If Return URL is not specified, the Login Page must redirect to the Document URL.
-
 #Integration with *amp-analytics*
 
-An integration with *amp-analytics* is under development and can be tracked on [Issue #1556][10]. This document will be updated when more details on the integration are available. 
+An integration with *amp-analytics* is under development and can be tracked on [Issue #1556][10]. This document will be updated when more details on the integration are available.
 
 #CORS Origin Security
 CORS endpoints can be (and recommended) to be only allowed to the following origins:
@@ -331,6 +333,9 @@ CORS endpoints can be (and recommended) to be only allowed to the following orig
  - **CORS endpoint** - cross-origin HTTPS endpoint. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS for more info. See [CORS Origin Security][9] for a list of origins that should be allowed.
  - **Reader** - the actual person viewing AMP documents.
  - **AMP Prerendering** - AMP Viewers may take advantage of prerendering, which renders a hidden document before it can be shown. This adds a significant performance boost. But it is important to take into account the fact that the document prerendering does not constitute a view since the Reader may never actually see the document.
+
+#Revisions
+- Feb 1: "return" query parameter for Login Page can be customized using RETURN_URL URL substitution.
 
 #Appendix A: “amp-access” expression grammar
 

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -266,6 +266,7 @@ class UrlReplacements {
    * @private
    */
   set_(varName, resolver) {
+    assert(varName.indexOf('RETURN') == -1);
     this.replacements_[varName] = resolver;
     this.replacementExpr_ = undefined;
     return this;


### PR DESCRIPTION
Closes #1574.

Few words why UrlReplacements is not used here directly: this code must be sync and it has to be part of the `login-dialog.js` because other methods of login (e.g. via viewer) will use different ways of assigning this value and thus it should propagate as `RETURN_URL` in the URL directly.