### PR TITLE
Add vendor configuration support for Chartbeat analytics

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -44,6 +44,32 @@
 </script>
 </amp-analytics>
 
+<!-- Chartbeat tracking -->
+<amp-analytics type="chartbeat">
+<script type="application/json">
+{
+  "vars": {
+    "uid": "12345",
+    "domain": "my-site.com",
+    "sections": "section 1, section 2"
+  }
+}
+</script>
+</amp-analytics>
+<!-- End Chartbeat example -->
+
+<!-- comScore UDM pageview tracking -->
+<amp-analytics type="comscore">
+<script type="application/json">
+{
+  "vars": {
+    "c2": "1000001"
+  }
+}
+</script>
+</amp-analytics>
+<!-- End comScore example -->
+
 <amp-analytics type="googleanalytics" id="analytics2">
 <script type="application/json">
 {
@@ -82,18 +108,6 @@
 </amp-analytics>
 
 <amp-analytics id="analytics3" config="./analytics.config.json"></amp-analytics>
-
-<!-- comScore UDM pageview tracking -->
-<amp-analytics type="comscore">
-<script type="application/json">
-{
-  "vars": {
-    "c2": "1000001"
-  }
-}
-</script>
-</amp-analytics>
-<!-- End comScore example -->
 
 <div class="logo"></div>
 <h1 id="top">AMP Analytics</h1>

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -57,6 +57,80 @@ export const ANALYTICS_CONFIG = {
     }
   },
 
+  'chartbeat': {
+    'requests': {
+      'host': 'https://ping.chartbeat.net',
+      'basePrefix': '/ping?h=${domain}&' +
+        'p=${canonicalPath}&' +
+        'u=${clientId(_cb)}&' +
+        'd=${canonicalHost}&' +
+        'g=${uid}&' +
+        'g0=${sections}&' +
+        'g1=${authors}&' +
+        'g2=${zone}&' +
+        'g3=${sponsorName}&' +
+        'g4=${contentType}&' +
+        'x=${scrollTop}&' +
+        'w=${screenHeight}&' +
+        'j=${decayTime}&' +
+        'r=${documentReferrer}&' +
+        't=${clientId(_cb_amp)}${pageViewId}&' +
+        'i=${title}',
+      'baseSuffix': '&_',
+      'interval': '${host}${basePrefix}&${baseSuffix}',
+      'anchorClick': '${host}${basePrefix}&${baseSuffix}'
+    },
+    'triggers': {
+      'trackInterval': {
+        'on': 'timer',
+        'timer-spec': {
+          'interval': 15,
+          'max-timer-length': 7200
+        },
+        'request': 'interval',
+        'vars': {
+          'decayTime': 30
+        }
+      },
+      'trackAnchorClick': {
+        'on': 'click',
+        'selector': 'a',
+        'request': 'anchorClick',
+        'vars': {
+          'decayTime': 30
+        }
+      }
+    },
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true
+    }
+  },
+
+  'comscore': {
+    'vars': {
+      'c2': '1000001'
+    },
+    'requests': {
+      'host': 'https://sb.scorecardresearch.com',
+      'base': '${host}/b?',
+      'pageview': '${base}c1=2&c2=${c2}&rn=${random}&c8=${title}' +
+        '&c7=${canonicalUrl}&c9=${documentReferrer}&cs_c7amp=${ampdocUrl}'
+    },
+    'triggers': {
+      'defaultPageview': {
+        'on': 'visible',
+        'request': 'pageview'
+      }
+    },
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true
+    }
+  },
+
   'googleanalytics': {
     'vars': {
       'eventValue': "0",
@@ -85,29 +159,6 @@ export const ANALYTICS_CONFIG = {
           'clt=${contentLoadTime}&dit=${domInteractiveTime}${baseSuffix}'
     },
     'optout': '_gaUserPrefs.ioo'
-  },
-
-  'comscore': {
-    'vars': {
-      'c2': '1000001'
-    },
-    'requests': {
-      'host': 'https://sb.scorecardresearch.com',
-      'base': '${host}/b?',
-      'pageview': '${base}c1=2&c2=${c2}&rn=${random}&c8=${title}' +
-        '&c7=${canonicalUrl}&c9=${documentReferrer}&cs_c7amp=${ampdocUrl}'
-    },
-    'triggers': {
-      'defaultPageview': {
-        'on': 'visible',
-        'request': 'pageview'
-      }
-    },
-    'transport': {
-      'beacon': false,
-      'xhrpost': false,
-      'image': true
-    }
   }
 };
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -60,8 +60,9 @@ when the document is first loaded, and each time an `<a>` tag is clicked:
 ## <a name="attributes"></a>Attributes
 
   - `type` This optional attribute can be specified to use one of the built-in analytics providers. Currently supported values for type are:
-    - `googleanalytics`: Adds support for Google Analytics. More details for adding Google Analytics support can be found at [developers.google.com](https://developers.google.com/analytics/devguides/collection/amp-analytics/).
+    - `chartbeat`: Adds support for Chartbeat. More details for adding Chartbeat support can be found at [support.chartbeat.com](http://support.chartbeat.com/docs/).
     - `comscore`: Supports comScore Unified Digital Measurement™ pageview analytics. Requires defining *var* `c2` with comScore-provided *c2 id*.
+    - `googleanalytics`: Adds support for Google Analytics. More details for adding Google Analytics support can be found at [developers.google.com](https://developers.google.com/analytics/devguides/collection/amp-analytics/).
 
     ```
     <amp-analytics type="XYZ"> ... </amp-analytics>


### PR DESCRIPTION
Addresses issue https://github.com/ampproject/amphtml/issues/1436.

This implementation is dependent upon PR https://github.com/ampproject/amphtml/pull/1702 for interval requests.

An outstanding issue is the engaged time metrics (as described in issue https://github.com/ampproject/amphtml/issues/1296) which are needed to have a more complete implementation.