### PR TITLE
Fix several bugs in CSI collection

### DIFF
--- a/src/service/framerate-impl.js
+++ b/src/service/framerate-impl.js
@@ -117,9 +117,9 @@ export class Framerate {
       const duration = now - this.collectStartTime_;
       const framerate = 1000 / (duration / this.frameCount_);
       const performance = performanceFor(this.win);
-      performance.tick('fps', undefined, framerate);
+      performance.tickDelta('fps', framerate);
       if (this.loadedAd_) {
-        performance.tick('fal', undefined, framerate);
+        performance.tickDelta('fal', framerate);
       }
       performance.flush();
       this.reset_();

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1348,6 +1348,9 @@ export class Resource {
     /** @private {boolean} */
     this.isInViewport_ = false;
 
+    /** @private {?Promise<undefined>} */
+    this.layoutPromise_ = null;
+
     /**
      * Only used in the "runtime off" case when the monitoring code needs to
      * known when the element is upgraded.
@@ -1359,13 +1362,13 @@ export class Resource {
      * Pending change height that was requested but could not be satisfied.
      * @private {number|undefined}
      */
-    this.pendingChangeHeight_;
+    this.pendingChangeHeight_ = undefined;
 
-    /** @private {?function(*)} */
-    this.whenFirstLayoutCompleteResolve_ = null;
-
-    /** @private @const {?Promise} */
-    this.whenFirstLayoutCompletePromise_ = null;
+    /** @private @const {!Promise} */
+    this.loadPromise_ = new Promise(resolve => {
+      /** @const  */
+      this.loadPromiseResolve_ = resolve;
+    });
   }
 
   /**
@@ -1681,6 +1684,7 @@ export class Resource {
    * @return {!Promise|undefined}
    */
   layoutComplete_(success, opt_reason) {
+    this.loadPromiseResolve_();
     this.layoutPromise_ = null;
     this.state_ = success ? ResourceState_.LAYOUT_COMPLETE :
         ResourceState_.LAYOUT_FAILED;
@@ -1694,16 +1698,11 @@ export class Resource {
 
   /**
    * Returns a promise that is resolved when this resource is laid out
-   * for the first time.
+   * for the first time and the resource was loaded.
    * @return {!Promise}
    */
-  whenFirstLayoutComplete() {
-    if (!this.whenFirstLayoutCompletePromise_) {
-      this.whenFirstLayoutCompletePromise_ = new Promise(resolve => {
-        this.whenFirstLayoutCompleteResolve_ = resolve;
-      });
-    }
-    return this.whenFirstLayoutCompletePromise_;
+  loaded() {
+    return this.loadPromise_;
   }
 
   /**

--- a/test/functional/test-framerate.js
+++ b/test/functional/test-framerate.js
@@ -35,7 +35,7 @@ describe('the framerate service', () => {
     lastRafCallback = null;
     visible = true;
     performance = {
-      tick: sinon.spy(),
+      tickDelta: sinon.spy(),
       flush: sinon.spy()
     };
     viewer = {
@@ -88,10 +88,10 @@ describe('the framerate service', () => {
     }
     clock.tick(5000);
     lastRafCallback();
-    expect(performance.tick.callCount).to.equal(1);
+    expect(performance.tickDelta.callCount).to.equal(1);
     expect(performance.flush.callCount).to.equal(1);
-    expect(performance.tick.args[0][0]).to.equal('fps');
-    expect(performance.tick.args[0][2]).to.within(15, 16);
+    expect(performance.tickDelta.args[0][0]).to.equal('fps');
+    expect(performance.tickDelta.args[0][1]).to.within(15, 16);
     expect(fr.frameCount_).to.equal(0);
 
     // Second round
@@ -110,10 +110,10 @@ describe('the framerate service', () => {
     }
     clock.tick(5000);
     lastRafCallback();
-    expect(performance.tick.callCount).to.equal(2);
+    expect(performance.tickDelta.callCount).to.equal(2);
     expect(performance.flush.callCount).to.equal(2);
-    expect(performance.tick.args[1][0]).to.equal('fps');
-    expect(performance.tick.args[1][2]).to.within(9, 10);
+    expect(performance.tickDelta.args[1][0]).to.equal('fps');
+    expect(performance.tickDelta.args[1][1]).to.within(9, 10);
   });
 
   it('does nothing with an invisible window', () => {
@@ -145,12 +145,12 @@ describe('the framerate service', () => {
     }
     clock.tick(5000);
     lastRafCallback();
-    expect(performance.tick.callCount).to.equal(2);
+    expect(performance.tickDelta.callCount).to.equal(2);
     expect(performance.flush.callCount).to.equal(1);
-    expect(performance.tick.args[0][0]).to.equal('fps');
-    expect(performance.tick.args[0][2]).to.within(15, 16);
-    expect(performance.tick.args[1][0]).to.equal('fal');
-    expect(performance.tick.args[1][2]).to.within(15, 16);
+    expect(performance.tickDelta.args[0][0]).to.equal('fps');
+    expect(performance.tickDelta.args[0][1]).to.within(15, 16);
+    expect(performance.tickDelta.args[1][0]).to.equal('fal');
+    expect(performance.tickDelta.args[1][1]).to.within(15, 16);
     // Second round
     fr.collect();
     for (let i = 0; i < 50; i++) {
@@ -159,9 +159,9 @@ describe('the framerate service', () => {
     }
     clock.tick(5000);
     lastRafCallback();
-    expect(performance.tick.callCount).to.equal(4);
+    expect(performance.tickDelta.callCount).to.equal(4);
     expect(performance.flush.callCount).to.equal(2);
-    expect(performance.tick.args[2][0]).to.equal('fps');
-    expect(performance.tick.args[3][0]).to.equal('fal');
+    expect(performance.tickDelta.args[2][0]).to.equal('fps');
+    expect(performance.tickDelta.args[3][0]).to.equal('fal');
   });
 });

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -55,6 +55,19 @@ describe('performance', () => {
       expect(perf.events_.length).to.equal(2);
     });
 
+    it('should map tickDelta to tick', () => {
+      expect(perf.events_.length).to.equal(0);
+
+      perf.tickDelta('test', 99);
+      expect(perf.events_.length).to.equal(2);
+      expect(perf.events_[0]).to.jsonEqual({label: '_test', opt_value: 0});
+      expect(perf.events_[1]).to.jsonEqual({
+        label: 'test',
+        opt_from: '_test',
+        opt_value: 99
+      });
+    });
+
     it('should have max 50 queued events', () => {
       expect(perf.events_.length).to.equal(0);
 
@@ -285,9 +298,12 @@ describe('performance', () => {
           whenReadyToRetrieveResourcesResolve();
           whenViewportLayoutCompleteResolve();
           return perf.whenViewportLayoutComplete_().then(() => {
-            expect(tickSpy.callCount).to.equal(1);
-            expect(tickSpy.firstCall.args[0]).to.equal('pc');
-            expect(Number(tickSpy.firstCall.args[2])).to.equal(400);;
+            expect(tickSpy.callCount).to.equal(2);
+            expect(tickSpy.firstCall.args[0]).to.equal('_pc');
+            expect(tickSpy.secondCall.args[0]).to.equal('pc');
+            expect(tickSpy.secondCall.args[1]).to.equal('_pc');
+            expect(Number(tickSpy.firstCall.args[2])).to.equal(0);
+            expect(Number(tickSpy.secondCall.args[2])).to.equal(400);
           });
         });
       });
@@ -298,9 +314,12 @@ describe('performance', () => {
         whenReadyToRetrieveResourcesResolve();
         whenViewportLayoutCompleteResolve();
         return perf.whenViewportLayoutComplete_().then(() => {
-          expect(tickSpy.callCount).to.equal(1);
-          expect(tickSpy.firstCall.args[0]).to.equal('pc');
-          expect(tickSpy.firstCall.args[2]).to.equal(0);
+          expect(tickSpy.callCount).to.equal(2);
+          expect(tickSpy.firstCall.args[0]).to.equal('_pc');
+          expect(tickSpy.secondCall.args[0]).to.equal('pc');
+          expect(tickSpy.secondCall.args[1]).to.equal('_pc');
+          expect(Number(tickSpy.firstCall.args[2])).to.equal(0);
+          expect(Number(tickSpy.secondCall.args[2])).to.equal(1);
         });
       });
     });

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1290,6 +1290,7 @@ describe('Resources.Resource', () => {
 
     resource.state_ = ResourceState_.READY_FOR_LAYOUT;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
+    const loaded = resource.loaded();
     const promise = resource.startLayout(true);
     expect(resource.layoutPromise_).to.not.equal(null);
     expect(resource.getState()).to.equal(ResourceState_.LAYOUT_SCHEDULED);
@@ -1297,6 +1298,7 @@ describe('Resources.Resource', () => {
     return promise.then(() => {
       expect(resource.getState()).to.equal(ResourceState_.LAYOUT_COMPLETE);
       expect(resource.layoutPromise_).to.equal(null);
+      return loaded;  // Just making sure this doesn't time out.
     });
   });
 


### PR DESCRIPTION
- miunderstanding of API: To tick absolute deltas one needs to use the relative tick feature with an awkward call pattern. Added `tickDelta` method to make that less weird.
- the pc-tick never fired if the layout promises had already started by the time we started measuring 1st viewport performance. Instead added a simpler `loaded` promise to each resource that can always be subscribed to.