### PR TITLE
Add support for getting URL parameters from URL and passing along using amp-analytics

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -40,6 +40,7 @@ export const ANALYTICS_CONFIG = {
       'pageDownloadTime': 'PAGE_DOWNLOAD_TIME',
       'pageLoadTime': 'PAGE_LOAD_TIME',
       'pageViewId': 'PAGE_VIEW_ID',
+      'queryParam': 'QUERY_PARAM',
       'random': 'RANDOM',
       'redirectTime': 'REDIRECT_TIME',
       'screenColorDepth': 'SCREEN_COLOR_DEPTH',

--- a/extensions/amp-analytics/analytics-vars.md
+++ b/extensions/amp-analytics/analytics-vars.md
@@ -250,6 +250,20 @@ Provides the number of seconds that have elapsed since 1970. (Epoch time)
 
 Example value: `1452710304312`
 
+### queryParam
+
+Pulls a value from the query string
+
+Please see below the required and optional arguments you may pass into `queryParam` like a function. Spaces between arguments and values are not allowed.
+
+**arguments**
+
+ - `query string param` (Required) - The query string param for which you want the value
+ - `default value` (Optional) - If the query string param is not available use this default instead
+
+Example usage: `${queryParam(foo)}` - if foo is available its associated value will be returned, if not an empty string will be returned
+               `${queryParam(foo,bar)}` - if foo is available its associated value will be returned, if not bar will be returned
+
 ## requestCount
 
 Provides the number of requests sent out from a particular `amp-analytics` tag. This value can be used to reconstruct the sequence in which requests were sent from a tag. The value starts from 0 and increases monotonically. Note that there may be a gap in requestCount numbers if the request sending fails due to network issues.

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -252,6 +252,21 @@ For instance:
 <amp-pixel src="https://foo.com/pixel?cid=CLIENT_ID(cid-scope-cookie-fallback-name,user-consent-id)"></amp-pixel>
 ```
 
+### QUERY_PARAM
+
+Provides access to query string params.
+
+arguments:
+  - `param` (Required) - The key for the query string parameter to be inserted
+  - `defaultValue` - The value to use if the provide key is not present on the query string. Defaults to ""
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?bar=QUERY_PARAM(baz,biz)"</amp-pixel>
+```
+
+If a query string parameter baz is provided then the corresponding value will be insterted into the pixel src, if no, the default "biz" will be used.
+
 ### PAGE_VIEW_ID
 
 Contains a string that is intended to be random and likely to be unique per URL, user and day.

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -20,7 +20,7 @@ import {documentInfoFor} from './document-info';
 import {getService} from './service';
 import {loadPromise} from './event-helper';
 import {log} from './log';
-import {getSourceUrl, parseUrl, removeFragment} from './url';
+import {getSourceUrl, parseUrl, removeFragment, parseQueryString} from './url';
 import {viewerFor} from './viewer';
 import {viewportFor} from './viewport';
 import {vsyncFor} from './vsync';
@@ -103,6 +103,17 @@ class UrlReplacements {
     // all the page views a single user is making at a time.
     this.set_('PAGE_VIEW_ID', () => {
       return documentInfoFor(this.win_).pageViewId;
+    });
+
+    this.set_('QUERY_PARAM', (param, defaultValue = "") => {
+      assert(param, 'The first argument to QUERY_PARAM, the query string ' +
+          /*OK*/'param is required');
+      const url = parseUrl(this.win_.location.href);
+      const params = parseQueryString(url.search);
+
+      return (typeof params[param] !== "undefined") ?
+        params[param] :
+        defaultValue;
     });
 
     this.set_('CLIENT_ID', (scope, opt_userNotificationId) => {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -20,6 +20,7 @@ import {urlReplacementsFor} from '../../src/url-replacements';
 import {markElementScheduledForTesting} from '../../src/custom-element';
 import {installCidService} from '../../src/service/cid-impl';
 import {setCookie} from '../../src/cookies';
+import {parseUrl} from '../../src/url';
 
 
 describe('UrlReplacements', () => {
@@ -422,5 +423,35 @@ describe('UrlReplacements', () => {
     }).then(res => {
       expect(res).to.match(/a=aaa&b=bbb\?$/);
     });
+  });
+
+  it('should replace QUERY_PARAM with foo', () => {
+    const win = getFakeWindow();
+    win.location = parseUrl("https://example.com?query_string_param1=foo");
+    return urlReplacementsFor(win)
+      .expand('?sh=QUERY_PARAM(query_string_param1)&s')
+      .then(res => {
+        expect(res).to.match(/sh=foo&s/);
+      });
+  });
+
+  it('should replace QUERY_PARAM with ""', () => {
+    const win = getFakeWindow();
+    win.location = parseUrl("https://example.com");
+    return urlReplacementsFor(win)
+      .expand('?sh=QUERY_PARAM(query_string_param1)&s')
+      .then(res => {
+        expect(res).to.match(/sh=&s/);
+      });
+  });
+
+  it('should replace QUERY_PARAM with default_value', () => {
+    const win = getFakeWindow();
+    win.location = parseUrl("https://example.com");
+    return urlReplacementsFor(win)
+      .expand('?sh=QUERY_PARAM(query_string_param1,default_value)&s')
+      .then(res => {
+        expect(res).to.match(/sh=default_value&s/);
+      });
   });
 });


### PR DESCRIPTION
Added var substitution function to grab params from the query string
Added documentation for the same