### PR TITLE
Remove ambiguity of keys matching by requiring longer keys to match first

### DIFF
--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -351,6 +351,9 @@ class UrlReplacements {
    * @private
    */
   buildExpr_(keys) {
+    // The keys must be sorted to ensure that the longest keys are considered
+    // first. This avoids a problem where a RANDOM conflicts with RANDOM_ONE.
+    keys.sort((s1, s2) => s2.length - s1.length);
     const all = keys.join('|');
     // Match the given replacement patterns, as well as optionally
     // arguments to the replacement behind it in parantheses.

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -399,4 +399,21 @@ describe('UrlReplacements', () => {
       expect(res).to.equal('v=false');
     });
   });
+
+  it('should resolve sub-included bindings', () => {
+    // RANDOM is a standard property and we add RANDOM_OTHER.
+    return expand('r=RANDOM&ro=RANDOM_OTHER?', false, {'RANDOM_OTHER': 'ABC'})
+        .then(res => {
+          expect(res).to.match(/r=(\d\.\d+)&ro=ABC\?$/);
+        });
+  });
+
+  it('should expand multiple vars', () => {
+    return expand('a=VALUEA&b=VALUEB?', false, {
+      'VALUEA': 'aaa',
+      'VALUEB': 'bbb',
+    }).then(res => {
+      expect(res).to.match(/a=aaa&b=bbb\?$/);
+    });
+  });
 });


### PR DESCRIPTION
This prevents a key CANONICAL to match an expression CANONICAL_PATH.