### PR TITLE
Added scroll trigger.

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -24,8 +24,9 @@
 {
   "transport": {"beacon": false, "xhrpost": false},
   "requests": {
-    "base": "https://example.com/?domain=${canonicalHost}&path=${canonicalPath}&title=${title}",
-    "event": "${base}&name=${eventName}&type=${eventId}&time=${timestamp}&tz=${timezone}&pid=${pageViewId}&screenSize=${screenWidth}x${screenHeight}"
+    "base": "https://example.com/?domain=${canonicalHost}&path=${canonicalPath}&title=${title}&time=${timestamp}&tz=${timezone}&pid=${pageViewId}&_=${random}",
+    "pageview": "${base}&name=${eventName}&type=${eventId}&screenSize=${screenWidth}x${screenHeight}",
+    "event": "${base}&name=${eventName}&scrollY=${scrollTop}&scrollX=${scrollLeft}&height=${availableScreenHeight}&width=${availableScreenWidth}"
   },
   "vars": {
     "title": "Example Request"
@@ -33,10 +34,21 @@
   "triggers": {
     "defaultPageview": {
       "on": "visible",
-      "request": "event",
+      "request": "pageview",
       "vars": {
         "eventName": "page-loaded",
         "eventId": "42"
+      }
+    },
+    "scrollPings": {
+      "on": "scroll",
+      "request": "event",
+      "scrollSpec": {
+        "verticalBoundaries" : [1, 50, 90],
+        "horizontalBoundaries": [100]
+      },
+      "vars": {
+        "eventName": "scroll"
       }
     }
   }
@@ -122,7 +134,7 @@
   "triggers": {
     "timer": {
       "on": "timer",
-      "timer-spec": {
+      "timerSpec": {
         "interval": 5,
         "max-timer-length": 300
       },
@@ -151,7 +163,58 @@
 <span id="test1" class="box">
   Click here to generate an event
 </span>
-
+<p>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pellentesque augue quis elementum tempus. Pellentesque sit amet neque bibendum, sagittis purus vitae, pellentesque magna. Vestibulum non viverra metus, eget feugiat lacus. Nulla in maximus orci. Maecenas id turpis vel ipsum vestibulum bibendum ut sit amet magna. Nullam hendrerit ex at est eleifend, nec dignissim nibh rutrum. Aliquam quis tellus et nibh faucibus laoreet in eget turpis. Nam quam nisl, porttitor vel ex eget, dapibus placerat dui. Mauris commodo pellentesque leo, eu tempus quam. In hac habitasse platea dictumst. Suspendisse non ante finibus, luctus augue non, luctus orci. Vestibulum ornare lacinia aliquam. In sollicitudin vehicula vulputate. Sed mi elit, commodo nec sapien nec, pretium bibendum leo. Donec id justo tortor. Ut in mauris dapibus, laoreet metus vitae, dictum nisi.
+</p>
+<p>
+Integer dapibus egestas arcu. Nunc vitae velit congue, placerat augue quis, suscipit nisi. Donec suscipit imperdiet turpis pharetra feugiat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus aliquam eleifend dolor, at lacinia orci semper vel. Nunc semper sem vel tincidunt posuere. Nunc lobortis velit vitae condimentum mollis. Morbi eu ullamcorper mauris. Pellentesque ac eros maximus, pulvinar sapien vitae, semper nisi. Curabitur imperdiet non mauris vitae sollicitudin.
+</p>
+<p>
+Nam posuere velit euismod risus pulvinar, in sollicitudin sapien consectetur. Vestibulum nec ex odio. Quisque at elit nec nunc ultricies lacinia nec non lorem. Maecenas porttitor consequat mauris, vitae porttitor ligula pellentesque ut. Pellentesque rhoncus diam vel lacus lobortis imperdiet. Sed maximus dictum hendrerit. Vivamus ornare, purus in laoreet sagittis, est ante pretium mauris, vel vulputate arcu erat eget mauris. Suspendisse eu lorem metus. Aliquam tempus aliquet urna, vitae mollis lacus pretium vitae. Etiam semper gravida commodo. Maecenas at pulvinar quam. Nullam dolor ipsum, ornare a sollicitudin et, sodales porttitor neque.
+</p>
+<p>
+Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor mollis finibus, tortor elit elementum dolor, vel vulputate lorem dui id ante. Vivamus in velit at lectus blandit gravida vitae quis arcu. Nam et magna magna. Fusce condimentum diam lacus, ac ullamcorper purus malesuada eu. Mauris ullamcorper elit et venenatis faucibus. Nullam lobortis molestie purus quis pellentesque. Sed at libero id nisi rhoncus tincidunt. Praesent vestibulum vehicula tristique. Etiam rutrum, nunc id porta interdum, nulla nisi molestie leo, at fermentum justo dolor at lorem. Duis in egestas sapien.
+</p>
+<p>
+Donec pharetra molestie sollicitudin. Duis mattis eleifend rutrum. Quisque luctus tincidunt lacus, vitae lobortis nisi malesuada ac. Aliquam mattis leo vel elit rutrum, nec consequat massa vestibulum. Maecenas bibendum metus nec ante feugiat, eu faucibus orci mattis. Cras tristique sem non elit congue malesuada. Proin ornare, lacus et porttitor consequat, sapien urna rutrum diam, ac pellentesque ligula est eget nisi. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec ultrices sollicitudin eros a placerat. Proin eget pulvinar est. Donec posuere ultrices odio at ultrices. Suspendisse potenti. Phasellus id orci id purus porttitor consectetur a at erat. Nullam volutpat ultricies nisl id maximus. Morbi porta ex ante, et egestas odio ultricies consequat.
+</p>
+<p>
+</p><ul>
+<li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
+<li>Aliquam in ex porta, imperdiet elit sit amet, condimentum diam.</li>
+<li>Etiam fermentum nisi at porta pulvinar.</li>
+</ul>
+<p></p>
+<p>
+</p><ul>
+<li>Proin mattis neque vel elit posuere molestie.</li>
+<li>Integer tincidunt sem sed nunc auctor elementum.</li>
+<li>Integer a felis in ipsum aliquet auctor sit amet a neque.</li>
+</ul>
+<p></p>
+<p>
+</p><ul>
+<li>Sed suscipit dolor molestie, rhoncus quam ac, lacinia ex.</li>
+<li>Curabitur et tellus vel justo ultrices aliquet sed id turpis.</li>
+<li>Nam finibus risus at justo elementum bibendum.</li>
+<li>In non lacus non urna congue feugiat at vel diam.</li>
+</ul>
+<p></p>
+<p>
+</p><ul>
+<li>Integer hendrerit augue interdum dui venenatis, sit amet tristique mauris cursus.</li>
+<li>Etiam quis eros viverra, tincidunt justo in, facilisis nunc.</li>
+<li>Aliquam at lacus faucibus, congue lorem interdum, semper mauris.</li>
+<li>Ut vulputate erat vel feugiat pharetra.</li>
+<li>Morbi id augue id orci sagittis tempus.</li>
+<li>Vestibulum varius libero ac dignissim sodales.</li>
+</ul>
+<p></p>
+<p>
+</p><ul>
+<li>Aenean ac sem eget libero varius viverra sit amet vitae nunc.</li>
+</ul>
+<p></p>
 </body>
 </html>
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -131,9 +131,8 @@ export class AmpAnalytics extends AMP.BaseElement {
               'attributes are required for data to be collected.');
           continue;
         }
-        addListener(this.getWin(), trigger['on'],
-            this.handleEvent_.bind(this, trigger), trigger['selector'],
-            trigger['timer-spec']);
+        addListener(this.getWin(), trigger,
+            this.handleEvent_.bind(this, trigger));
       }
     }
   }

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -23,27 +23,40 @@ adopt(window);
 describe('instrumentation', function() {
 
   let ins;
+  let fakeViewport;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     ins = instrumentationServiceFor(window);
+    fakeViewport = {
+      'getSize': sandbox.stub().returns(
+          {top: 0, left: 0, height: 200, width: 200}),
+      'getScrollTop': sandbox.stub().returns(0),
+      'getScrollLeft': sandbox.stub().returns(0),
+      'getScrollHeight': sandbox.stub().returns(500),
+      'getScrollWidth': sandbox.stub().returns(500),
+      'onChanged': sandbox.stub(),
+    };
+    ins.viewport_ = fakeViewport;
   });
 
   afterEach(() => {
     sandbox.restore();
     sandbox = null;
+    fakeViewport = null;
+    ins = null;
   });
 
   it('always fires click listeners when selector is set to *', () => {
     const el1 = document.createElement('test');
     const fn1 = sandbox.stub();
-    addListener(window, 'click', fn1, '*');
+    addListener(window, {'on': 'click', 'selector': '*'}, fn1);
     ins.onClick_({target: el1});
     expect(fn1.calledOnce).to.be.true;
 
     const el2 = document.createElement('test2');
     const fn2 = sandbox.stub();
-    addListener(window, 'click', fn2, '*');
+    addListener(window, {'on': 'click', 'selector': '*'}, fn2);
     ins.onClick_({target: el2});
     expect(fn1.calledTwice).to.be.true;
     expect(fn2.calledOnce).to.be.true;
@@ -52,13 +65,13 @@ describe('instrumentation', function() {
   it('never fires click listeners when the selector is empty', () => {
     const el1 = document.createElement('test');
     const fn1 = sandbox.stub();
-    addListener(window, 'click', fn1, '');
+    addListener(window, {'on': 'click', 'selector': ''}, fn1);
     ins.onClick_({target: el1});
     expect(fn1.callCount).to.equal(0);
 
     const el2 = document.createElement('test2');
     const fn2 = sandbox.stub();
-    addListener(window, 'click', fn2);
+    addListener(window, {'on': 'click'}, fn2);
     ins.onClick_({target: el2});
     expect(fn1.callCount).to.equal(0);
     expect(fn2.callCount).to.equal(0);
@@ -75,10 +88,10 @@ describe('instrumentation', function() {
     el3.id = 'y';
 
     const fnClassX = sandbox.stub();
-    addListener(window, 'click', fnClassX, '.x');
+    addListener(window, {'on': 'click', 'selector': '.x'}, fnClassX);
 
     const fnIdY = sandbox.stub();
-    addListener(window, 'click', fnIdY, '#y');
+    addListener(window, {'on': 'click', 'selector': '#y'}, fnIdY);
 
     ins.onClick_({target: el1});
     expect(fnClassX.callCount).to.equal(0);
@@ -96,8 +109,8 @@ describe('instrumentation', function() {
   it('should listen on custom events', () => {
     const handler1 = sinon.spy();
     const handler2 = sinon.spy();
-    ins.addListener('custom-event-1', handler1);
-    ins.addListener('custom-event-2', handler2);
+    ins.addListener({'on': 'custom-event-1'}, handler1);
+    ins.addListener({'on': 'custom-event-2'}, handler2);
 
     ins.triggerEvent('custom-event-1');
     expect(handler1.callCount).to.equal(1);
@@ -114,54 +127,60 @@ describe('instrumentation', function() {
 
   it('only fires when the timer interval exceeds the minimum', () => {
     const fn1 = sandbox.stub();
-    addListener(window, 'timer', fn1, null, {"interval": 0});
+    addListener(window, {'on': 'timer', 'timerSpec': {"interval": 0}}, fn1);
     expect(fn1.callCount).to.equal(0);
 
     const fn2 = sandbox.stub();
-    addListener(window, 'timer', fn2, null, {"interval": 1});
+    addListener(window, {'on': 'timer', 'timerSpec': {"interval": 1}}, fn2);
     expect(fn2.callCount).to.equal(1);
   });
 
   it('never fires when the timer spec is malformed', () => {
     const fn1 = sandbox.stub();
-    addListener(window, 'timer', fn1, null, null);
+    addListener(window, {'on': 'timer'}, fn1);
     expect(fn1.callCount).to.equal(0);
 
     const fn2 = sandbox.stub();
-    addListener(window, 'timer', fn2, null, 1);
+    addListener(window, {'on': 'timer', 'timerSpec': 1}, fn2);
     expect(fn2.callCount).to.equal(0);
 
     const fn3 = sandbox.stub();
-    addListener(window, 'timer', fn3, null, {'misc': 1});
+    addListener(window, {'on': 'timer', 'timerSpec': {'misc': 1}}, fn3);
     expect(fn3.callCount).to.equal(0);
 
     const fn4 = sandbox.stub();
-    addListener(window, 'timer', fn4, null, {'interval': 'two'});
+    addListener(window,
+        {'on': 'timer', 'timerSpec': {'interval': 'two'}}, fn4);
     expect(fn4.callCount).to.equal(0);
 
     const fn5 = sandbox.stub();
-    addListener(window, 'timer', fn5, null, {'interval': null});
+    addListener(window,
+        {'on': 'timer', 'timerSpec': {'interval': null}}, fn5);
     expect(fn5.callCount).to.equal(0);
 
     const fn6 = sandbox.stub();
-    addListener(window, 'timer', fn6, null,
-        {'interval': 2, 'max-timer-length': 0});
+    addListener(window, {
+      'on': 'timer',
+      'timerSpec': {'interval': 2, 'maxTimerLength': 0}
+    }, fn6);
     expect(fn6.callCount).to.equal(0);
 
     const fn7 = sandbox.stub();
-    addListener(window, 'timer', fn7, null,
-        {'interval': 2, 'max-timer-length': null});
+    addListener(window, {
+      'on': 'timer',
+      'timerSpec': {'interval': 2, 'maxTimerLength': null}
+    }, fn7);
     expect(fn7.callCount).to.equal(0);
   });
 
   it('fires on the appropriate interval', () => {
     const clock = sandbox.useFakeTimers();
     const fn1 = sandbox.stub();
-    addListener(window, 'timer', fn1, null, {"interval": 10});
+    addListener(window, {'on': 'timer', 'timerSpec': {"interval": 10}}, fn1);
     expect(fn1.callCount).to.equal(1);
 
     const fn2 = sandbox.stub();
-    addListener(window, 'timer', fn2, null, {"interval": 15});
+    addListener(window, {'on': 'timer', 'timerSpec': {"interval": 15}}, fn2);
     expect(fn2.callCount).to.equal(1);
 
     clock.tick(10 * 1000); // 10 seconds
@@ -177,20 +196,22 @@ describe('instrumentation', function() {
     expect(fn2.callCount).to.equal(3);
   });
 
-  it('stops firing after the max-timer-length is exceeded', () => {
+  it('stops firing after the maxTimerLength is exceeded', () => {
     const clock = sandbox.useFakeTimers();
     const fn1 = sandbox.stub();
-    addListener(window, 'timer', fn1, null,
-        {"interval": 10, "max-timer-length": 15});
+    addListener(window, {
+      'on': 'timer', 'timerSpec': {"interval": 10, "maxTimerLength": 15}
+    }, fn1);
     expect(fn1.callCount).to.equal(1);
 
     const fn2 = sandbox.stub();
-    addListener(window, 'timer', fn2, null,
-        {"interval": 10, "max-timer-length": 20});
+    addListener(window, {
+      'on': 'timer', 'timerSpec': {"interval": 10, "maxTimerLength": 20}
+    }, fn2);
     expect(fn2.callCount).to.equal(1);
 
     const fn3 = sandbox.stub();
-    addListener(window, 'timer', fn3, null, {"interval": 3600});
+    addListener(window, {'on': 'timer', 'timerSpec': {"interval": 3600}}, fn3);
     expect(fn3.callCount).to.equal(1);
 
     clock.tick(10 * 1000); // 10 seconds
@@ -205,8 +226,108 @@ describe('instrumentation', function() {
     expect(fn1.callCount).to.equal(2);
     expect(fn2.callCount).to.equal(3);
 
-    // Default max-timer-length is 2 hours
+    // Default maxTimerLength is 2 hours
     clock.tick(3 * 3600 * 1000); // 3 hours
     expect(fn3.callCount).to.equal(3);
+  });
+
+  it('fires on scroll', () => {
+    const fn1 = sandbox.stub();
+    const fn2 = sandbox.stub();
+    addListener(window, {
+      'on': 'scroll',
+      'scrollSpec': {
+        'verticalBoundaries': [0, 100],
+        'horizontalBoundaries': [0, 100]
+      }},
+      fn1);
+    addListener(window, {'on': 'scroll', 'scrollSpec': {
+      'verticalBoundaries': [90], 'horizontalBoundaries': [90]}}, fn2);
+
+    expect(fn1.callCount).to.equal(2);
+    expect(fn2.callCount).to.equal(0);
+
+    // Scroll Down
+    fakeViewport.getScrollTop.returns(500);
+    fakeViewport.getScrollLeft.returns(500);
+    ins.onScroll_({top: 500, left: 500, height: 250, width: 250});
+
+    expect(fn1.callCount).to.equal(4);
+    expect(fn2.callCount).to.equal(2);
+  });
+
+  it('does not fire duplicates on scroll', () => {
+    const fn1 = sandbox.stub();
+    addListener(window, {
+      'on': 'scroll',
+      'scrollSpec': {
+        'verticalBoundaries': [0, 100],
+        'horizontalBoundaries': [0, 100]
+      }},
+      fn1);
+
+    // Scroll Down
+    fakeViewport.getScrollTop.returns(10);
+    fakeViewport.getScrollLeft.returns(10);
+    ins.onScroll_({top: 10, left: 10, height: 250, width: 250});
+
+    expect(fn1.callCount).to.equal(2);
+  });
+
+  it('fails gracefully on bad scroll config', () => {
+    const fn1 = sandbox.stub();
+
+    addListener(window, {'on': 'scroll'}, fn1);
+    expect(fn1.callCount).to.equal(0);
+
+    addListener(window, {'on': 'scroll', 'scrollSpec': {}}, fn1);
+    expect(fn1.callCount).to.equal(0);
+
+    addListener(window, {
+      'on': 'scroll',
+      'scrollSpec': {
+        'verticalBoundaries': undefined, 'horizontalBoundaries': undefined
+      }},
+      fn1);
+    expect(fn1.callCount).to.equal(0);
+
+    addListener(window, {
+      'on': 'scroll',
+      'scrollSpec': {'verticalBoundaries': [], 'horizontalBoundaries': []}},
+      fn1);
+    expect(fn1.callCount).to.equal(0);
+
+    addListener(window, {
+      'on': 'scroll',
+      'scrollSpec': {
+        'verticalBoundaries': ['foo'], 'horizontalBoundaries': ['foo']
+      }},
+      fn1);
+    expect(fn1.callCount).to.equal(0);
+  });
+
+  it('normalizes boundaries correctly.', () => {
+    expect(ins.normalizeBoundaries_([])).to.be.empty;
+    expect(ins.normalizeBoundaries_(undefined)).to.be.empty;
+    expect(ins.normalizeBoundaries_(['foo'])).to.be.empty;
+    expect(ins.normalizeBoundaries_(['0', '1'])).to.be.empty;
+    expect(ins.normalizeBoundaries_([1])).to.deep.equal({0: false});
+    expect(ins.normalizeBoundaries_([1, 4, 99, 1001])).to.deep.equal({
+      0: false,
+      5: false,
+      100: false,
+    });
+  });
+
+  it('fires events on normalized boundaries.', () => {
+    const fn1 = sandbox.stub();
+    const fn2 = sandbox.stub();
+    addListener(window,
+        {'on': 'scroll', 'scrollSpec': {'verticalBoundaries': [1]}},
+        fn1);
+    addListener(window,
+        {'on': 'scroll', 'scrollSpec': {'verticalBoundaries': [4]}},
+        fn2);
+    expect(fn2.callCount).to.equal(1);
   });
 });

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -83,9 +83,9 @@ export const ANALYTICS_CONFIG = {
     'triggers': {
       'trackInterval': {
         'on': 'timer',
-        'timer-spec': {
+        'timerSpec': {
           'interval': 15,
-          'max-timer-length': 7200
+          'maxTimerLength': 7200
         },
         'request': 'interval',
         'vars': {

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -144,12 +144,15 @@ The `triggers` attribute describes when an analytics request should be sent. It 
 
   - `on` (required) The event to listener for. Valid values are `visible`,`click`, and `timer`.
   - `request` (required) Name of the request to send (as specified in the `requests` section).
-  - `selector` A CSS selector used to refine which elements should be tracked. Use value `*` to track all elements.
-  - `timer-spec` Specification for the timer. The timer will trigger immediately and then at a specified interval thereafter.
-    - `interval` Length of the timer interval, in seconds.
-    - `max-timer-length` Maximum duration for which the timer will fire, in seconds.
   - `vars` An object containing key-value pairs used to override `vars` defined in the top level config, or to specify
     vars unique to this trigger.
+
+Following configuration only applies to specific values of `on`.
+  - `selector` A CSS selector used to refine which elements should be tracked. Use value `*` to track all elements. Used in triggers where `on` is set to `click`.
+  - `scrollSpec` An object used when `on` is set to `scroll`. This object can contain `verticalBoundaries` and `horizontalBoundaries`. At least one of the two property is required for scroll event to fire. The values for both the properties should be arrays of numbers containing the boundaries on which a scroll event is generated. For instance, in the following code snippet, the scroll event will be fired when page is scrolled vertically by 25%, 50% and 90%. Additionally, the event will also fire when the page is horizontally scrolled to 90% of scroll width.
+  - `timerSpec` Specification for triggers of type `timer`. The timer will trigger immediately and then at a specified interval thereafter.
+    - `interval` Length of the timer interval, in seconds.
+    - `maxTimerLength` Maximum duration for which the timer will fire, in seconds.
 
 ```javascript
 "triggers": {
@@ -167,11 +170,18 @@ The `triggers` attribute describes when an analytics request should be sent. It 
   },
   "pageTimer": {
     "on": "timer",
-    "timer-spec": {
+    "timerSpec": {
       "interval": 10,
-      "max-timer-length": 600
+      "maxTimerLength": 600
     },
     "request": "pagetime"
+  },
+  "scrollPings": {
+    "on": "scroll",
+    "scrollSpec": {
+      "verticalBoundaries": [25, 50, 90],
+      "horizontalBoundaries": [90]
+    }
   }
 }
 ```

--- a/extensions/amp-analytics/analytics-vars.md
+++ b/extensions/amp-analytics/analytics-vars.md
@@ -90,13 +90,13 @@ Example value: `The New York Times - Breaking News, World News...`
 
 ### availableScreenHeight
 
-Provides the screen height in pixels available for the page rendering.
+Provides the screen height in pixels available for the page rendering. Note that this can be slightly more or less than the actual viewport height due to various browser quirks.
 
 Example value: `1480`
 
 ### availableScreenWidth
 
-Provides the screen width in pixels available for the page rendering.
+Provides the screen width in pixels available for the page rendering. Note that this can be slightly more or less than the actual viewport height due to various browser quirks.
 
 Example value: `2500`
 
@@ -132,7 +132,7 @@ Example value: `2560`
 
 ### scrollHeight
 
-Provides the total size of the page in pixels.
+Provides the total height of the page in pixels.
 
 Example value: `400`
 
@@ -147,6 +147,12 @@ Example value: `100`
 Provides the number of pixels that the user has scrolled from top.
 
 Example value: `0`
+
+### scrollWidth
+
+Provides the total width of the page in pixels.
+
+Example value: `600`
 
 ### timezone
 

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -174,7 +174,7 @@ For instance:
 
 ### AVAILABLE_SCREEN_HEIGHT
 
-Provides the screen height in pixels available for the page rendering.
+Provides the screen height in pixels available for the page rendering. Note that this value can be slightly more or less than the actual viewport size because of various browser quirks.
 
 For instance:
 ```html
@@ -183,7 +183,7 @@ For instance:
 
 ### AVAILABLE_SCREEN_WIDTH
 
-Provides the screen width in pixels available for the page rendering.
+Provides the screen width in pixels available for the page rendering. Note that this can be slightly more or less than the actual viewport height due to various browser quirks.
 
 For instance:
 ```html

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -33,6 +33,7 @@ const TAG_ = 'Viewport';
  * @typedef {{
  *   relayoutAll: boolean,
  *   top: number,
+ *   left: number,
  *   width: number,
  *   height: number,
  *   velocity: number
@@ -371,14 +372,17 @@ export class Viewport {
   changed_(relayoutAll, velocity) {
     const size = this.getSize();
     const scrollTop = this.getScrollTop();
+    const scrollLeft = this.getScrollLeft();
     log.fine(TAG_, 'changed event:',
         'relayoutAll=', relayoutAll,
         'top=', scrollTop,
+        'top=', scrollLeft,
         'bottom=', (scrollTop + size.height),
         'velocity=', velocity);
     this.changeObservable_.fire({
       relayoutAll: relayoutAll,
       top: scrollTop,
+      left: scrollLeft,
       width: size.width,
       height: size.height,
       velocity: velocity

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -153,6 +153,12 @@ class UrlReplacements {
         () => viewportFor(this.win_).getScrollHeight());
     });
 
+    // Returns a promise resolving to viewport.getScrollWidth.
+    this.set_('SCROLL_WIDTH', () => {
+      return vsyncFor(this.win_).measurePromise(
+        () => viewportFor(this.win_).getScrollWidth());
+    });
+
     // Returns screen.width.
     this.set_('SCREEN_WIDTH', () => {
       return this.win_.screen.width;


### PR DESCRIPTION
- Updated the example file to have more content so that scroll events can be changed.
- Instead of passing individual config params, pass in whole config into `addListener`.
- Added `scrollWidth`
- Added `scroll` event
- Updated `test-amp-analytics` to use an actual `window` object instead of a fake. As functionality increases, mocking all the properties of window will become painful.
- Updated documentation.

Fixes #1490 

cc @rudygalfi 