### PR TITLE
Fixed bug with wrong params in amp-analytics

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -64,7 +64,7 @@ export const ANALYTICS_CONFIG = {
     },
     'requests': {
       'host': 'https://www.google-analytics.com',
-      'basePrefix': 'v=1&_v=a0&aip=true&_s=${requestCount}' +
+      'basePrefix': 'v=1&_v=a0&aip=true&_s=${requestCount}&' +
           'dt=${title}&sr=${screenWidth}x${screenHeight}&_utmht=${timestamp}&' +
           'jid=&cid=${clientId(AMP_ECID_GOOGLE)}&tid=${account}&' +
           'dl=${documentLocation}&' +


### PR DESCRIPTION
Fixed bug when you get
`_s:1dt=title`
instead of
`_s:1`
`dt:title`
in the request.