### PR TITLE
Tunes ad loading heuristic.

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -148,11 +148,7 @@ window.draw3p = function(opt_configCallback) {
   window.context.reportRenderedEntityIdentifier =
       reportRenderedEntityIdentifier;
   delete data._context;
-  // Run this only in canary and local dev for the time being.
-  if (location.pathname.indexOf('-canary') ||
-      location.pathname.indexOf('current')) {
-    manageWin(window);
-  }
+  manageWin(window);
   draw3p(window, data, opt_configCallback);
   nonSensitiveDataPostMessage('render-start');
 };

--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -51,12 +51,6 @@ export function installAd(win) {
 
     /** @override  */
     renderOutsideViewport() {
-      // Before the user has scrolled we only render ads in view. This prevents
-      // excessive jank in situations like swiping through a lot of articles.
-      if (!this.getViewport().hasScrolled()) {
-        return false;
-      };
-
       // If another ad is currently loading we only load ads that are currently
       // in viewport.
       if (loadingAdsCount > 0) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -57,7 +57,7 @@ export function getElementPriority(tagName) {
   if (tagName == 'amp-ad') {
     return 2;
   }
-  if (tagName == 'amp-pixel') {
+  if (tagName == 'amp-pixel' || tagName == 'amp-analytics') {
     return 1;
   }
   return 0;


### PR DESCRIPTION
We now load out of viewport ads before initial scrolling. Given recent performance improvements this seems a better trade off for UX, as ads below initial viewport are more likely to be done.

Also puts `amp-analytics` on the same priority as `amp-pixel`.