### PR TITLE
Enable retrieving amp-analytics remote config with credentials.

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -151,13 +151,20 @@ export class AmpAnalytics extends AMP.BaseElement {
     }
     assertHttpsUrl(remoteConfigUrl);
     log.fine(this.getName_(), 'Fetching remote config', remoteConfigUrl);
-    return xhrFor(this.getWin()).fetchJson(remoteConfigUrl).then(jsonValue => {
-      this.remoteConfig_ = jsonValue;
-      log.fine(this.getName_(), 'Remote config loaded', remoteConfigUrl);
-    }, err => {
-      console./*OK*/error(this.getName_(), 'Error loading remote config: ',
-          remoteConfigUrl, err);
-    });
+    const fetchConfig = {
+      requireAmpResponseSourceOrigin: true,
+    };
+    if (this.element.hasAttribute('data-credentials')) {
+      fetchConfig.credentials = this.element.getAttribute('data-credentials');
+    }
+    return xhrFor(this.getWin()).fetchJson(remoteConfigUrl, fetchConfig)
+        .then(jsonValue => {
+          this.remoteConfig_ = jsonValue;
+          log.fine(this.getName_(), 'Remote config loaded', remoteConfigUrl);
+        }, err => {
+          console./*OK*/error(this.getName_(), 'Error loading remote config: ',
+              remoteConfigUrl, err);
+        });
   }
 
   /**

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -68,12 +68,13 @@ when the document is first loaded, and each time an `<a>` tag is clicked:
     <amp-analytics type="XYZ"> ... </amp-analytics>
     ```
 
-  - `config` This attribute can be used to load a configuration from a specified remote URL. The URL specified here should use https scheme.
+  - `config` This attribute can be used to load a configuration from a specified remote URL. The URL specified here should use https scheme. See also `data-include-credentials` attribute below.
 
     ```
     <amp-analytics config="https://example.com/analytics.config.json"></amp-analytics>
     ```
-
+    The response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
+  - `data-credentials` Optional. If set to `include` turns on the ability to read and write cookies on the request specified via `config` above.
   - `data-consent-notification-id` Optional attribute. If provided will stop
     processing the analytics request until a [amp-user-notification](../../extensions/amp-user-notification/amp-user-notification.md) with
     the given HTML-id was confirmed by the user.

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -57,6 +57,9 @@ export class AmpList extends AMP.BaseElement {
           const opts = {
             credentials: this.element.getAttribute('credentials')
           };
+          if (opts.credentials) {
+            opts.requireAmpResponseSourceOrigin = true;
+          }
           return xhrFor(this.getWin()).fetchJson(src, opts);
         }).then(data => {
           assert(typeof data == 'object' && Array.isArray(data['items']),

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -143,7 +143,10 @@ describe('amp-list component', () => {
     const xhrPromise = Promise.resolve({items: items});
     element.setAttribute('credentials', 'include');
     xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
-        sinon.match(opts => opts.credentials == 'include'))
+        sinon.match(opts => {
+          return opts.credentials == 'include' &&
+              opts.requireAmpResponseSourceOrigin;
+        }))
         .returns(xhrPromise).once();
     templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
         element, items)

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -26,7 +26,7 @@ The `amp-list` defines data source using the following attributes:
 - `src` defines a CORS URL. The URL's protocol must be HTTPS.
 - `credentials` defines a `credentials` option as specified by the
 [Fetch API](https://fetch.spec.whatwg.org/). To send credentials, pass the
-value of "include".
+value of "include". If this is set, the response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
 
 The response must be a JSON object that contains an array property "items":
 ```json


### PR DESCRIPTION
Also starts mandating AMP CORS protocol for credentialed requests to amp-list.
Verified that the guardian is currently not including credentials in their requests.