### PR TITLE
Fix sending viewport records for elements that are initially in viewport

### DIFF
--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -105,6 +105,8 @@ export class IntersectionObserver extends Observable {
     this.shouldSendIntersectionChanges_ = false;
     /** @private {Array<function>} */
     this.unlisteners_ = [];
+    /** @private {boolean} */
+    this.inViewport_ = false;
 
     this.init_();
   }
@@ -145,7 +147,10 @@ export class IntersectionObserver extends Observable {
   startSendingIntersectionChanges_() {
     this.shouldSendIntersectionChanges_ = true;
     this.baseElement_.getVsync().measure(() => {
-      this.sendElementIntersection_();
+      if (this.baseElement_.isInViewport()) {
+        this.onViewportCallback(true);
+      }
+      this.fire();
     });
   }
 
@@ -155,6 +160,10 @@ export class IntersectionObserver extends Observable {
    * @param {boolean} inViewport true if the element is in viewport.
    */
   onViewportCallback(inViewport) {
+    if (this.inViewport_ == inViewport) {
+      return;
+    }
+    this.inViewport_ = inViewport;
     // Lets the ad know that it became visible or no longer is.
     this.fire();
     // And update the ad about its position in the viewport while

--- a/test/functional/test-amp-ad.js
+++ b/test/functional/test-amp-ad.js
@@ -105,7 +105,7 @@ function runAdTestSuiteAgainstInstaller(name, installer) {
         expect(data._context.canonicalUrl).to.equal('https://schema.org/');
         expect(data.aax_size).to.equal('300x250');
 
-        describe('ad intersection', () => {
+        describe('ad preconnect', () => {
           const doc = iframe.ownerDocument;
           const fetches = doc.querySelectorAll(
               'link[rel=prefetch]');


### PR DESCRIPTION
They did not get intermittent record until after they left the viewport.
Fixes #1821 

Added test but also filed #1822 to improve the tests in general.