### PR TITLE
AdSense responsive ads and links

### DIFF
--- a/ads/adsense.js
+++ b/ads/adsense.js
@@ -21,7 +21,7 @@ import {checkData} from '../src/3p';
  * @param {!Object} data
  */
 export function adsense(global, data) {
-  checkData(data, ['adClient', 'adSlot']);
+  checkData(data, ['adClient', 'adSlot', 'adFormat']);
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.
     global.gaGlobal = {
@@ -37,6 +37,9 @@ export function adsense(global, data) {
   i.setAttribute('data-ad-client', data['adClient']);
   if (data['adSlot']) {
     i.setAttribute('data-ad-slot', data['adSlot']);
+  }
+  if (data['adFormat'] && data['adFormat'].match("link|autorelaxed")) {
+    i.setAttribute('data-ad-format', data['adFormat']);
   }
   i.setAttribute('data-page-url', global.context.canonicalUrl);
   i.setAttribute('class', 'adsbygoogle');

--- a/ads/adsense.md
+++ b/ads/adsense.md
@@ -18,13 +18,57 @@ limitations under the License.
 
 ## Example
 
+### Standard size
+
 ```html
-<amp-ad width=300 height=200
+<amp-ad width=300 height=250
     type="adsense"
     data-ad-client="ca-pub-8125901705757971"
     data-ad-slot="7783467241">
 </amp-ad>
 ```
+
+### Responsive ad unit
+
+```html
+<amp-ad width=320 height=100
+    heights="(min-width:468px) 60px, (min-width:336px) 280px, (min-width:320px) 100px, (min-width:300px) 250px, 100px"
+    type="adsense"
+    data-ad-client="ca-pub-8125901705757971"
+    data-ad-slot="7783467241">
+</amp-ad>
+```
+
+Note: `data-ad-slot` should be responsive ad slot ID.
+
+### Responsive ad unit (on the top of the page)
+
+```html
+<amp-ad width=320 height=100
+    heights="(min-width:468px) 60px, 100px"
+    type="adsense"
+    data-ad-client="ca-pub-8125901705757971"
+    data-ad-slot="7783467241">
+</amp-ad>
+```
+
+More info: ["AdSense policy FAQs: Is placing a 300x250 ad unit on top of a high-end mobile optimized page considered a policy violation?"](https://support.google.com/adsense/answer/3394713?hl=en#3)
+
+Note: `data-ad-slot` should be responsive ad slot ID.
+
+### Responsive link unit
+
+```html
+<amp-ad width=200 height=90
+    heights="(min-width:468px) 15px, 90px"
+    type="adsense"
+    data-ad-format="link"
+    data-ad-client="ca-pub-8125901705757971"
+    data-ad-slot="7783467241">
+</amp-ad>
+```
+
+Note: `data-ad-slot` should be responsive link slot ID.
 
 ## Configuration
 
@@ -34,3 +78,12 @@ Supported parameters:
 
 - data-ad-client
 - data-ad-slot
+- data-ad-format
+
+`data-ad-format` is optional.
+
+`auto`, `horizontal` and `vertical` are not supported values for `data-ad-format`, and will be ignored.
+
+## Todo
+
+- [ ] Matched content unit example.

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -58,7 +58,7 @@
   </amp-ad>
 
   <h2>AdSense</h2>
-  <amp-ad width=300 height=200
+  <amp-ad width=300 height=250
       type="adsense"
       data-ad-client="ca-pub-8125901705757971"
       data-ad-slot="7783467241">

--- a/examples/adsense.amp.html
+++ b/examples/adsense.amp.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Ad examples - AdSense</title>
+  <link rel="canonical" href="http://nonblocking.io/" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    amp-ad {
+      max-width: 500px;
+    }
+    .fixed {
+      position: fixed;
+      top: 0;
+      right: 0;
+    }
+    .red {
+      background-color: red;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+  <amp-ad width=320 height=100
+      heights="(min-width:468px) 60px, 100px"
+      type="adsense"
+      data-ad-client="ca-pub-8125901705757971"
+      data-ad-slot="7783467241">
+  </amp-ad>
+
+  <h1>Ad examples - AdSense</h1>
+
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+    luctus nunc ut elit cursus, et imperdiet diam vehicula.
+  </p>
+  <p>
+    Duis et nisi sed urna blandit bibendum et sit amet erat.
+    Suspendisse potenti. Curabitur consequat volutpat arcu nec
+    elementum. Etiam a turpis ac libero varius condimentum.
+  </p>
+  <p>
+    Maecenas sollicitudin felis aliquam tortor vulputate,
+    ac posuere velit semper.
+  </p>
+  <p>
+    Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+    Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+    ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+    et lectus. Sed tempus eget enim eget lobortis.
+    Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+    Nullam in libero nisi.
+  </p>
+
+  <h2>Standard size</h2>
+  <amp-ad width=300 height=250
+      type="adsense"
+      data-ad-client="ca-pub-8125901705757971"
+      data-ad-slot="7783467241">
+  </amp-ad>
+
+  <p>
+    Posuere turpis, sit amet tincidunt purus justo et mi. Donec
+    sapien urna, aliquam ut lacinia quis, varius vitae ex.
+    Maecenas efficitur iaculis lorem, at imperdiet orci viverra
+    in. Nullam eu erat eu metus ultrices viverra a sit amet leo.
+    Pellentesque est felis, pulvinar mollis sollicitudin et,
+    suscipit eget massa. Nunc bibendum non nunc et consequat.
+  </p>
+
+  <h2>Responsive ad unit</h2>
+  <amp-ad width=320 height=100
+      heights="(min-width:468px) 60px, (min-width:336px) 280px, (min-width:320px) 100px, (min-width:300px) 250px, 100px"
+      type="adsense"
+      data-ad-client="ca-pub-8125901705757971"
+      data-ad-slot="7783467241">
+  </amp-ad>
+
+  <p>
+    Quisque auctor est vel leo faucibus, non faucibus magna ultricies.
+    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+    posuere cubilia Curae; Vestibulum tortor lacus, bibendum et
+    enim eu, vehicula placerat erat. Nullam gravida rhoncus accumsan.
+    Integer suscipit iaculis elit nec mollis. Vestibulum eget arcu
+    nec lectus finibus rutrum vel sed orci.
+  </p>
+
+  <h2>Responsive link unit</h2>
+  <amp-ad width=200 height=90
+      heights="(min-width:468px) 15px, 90px"
+      type="adsense"
+      data-ad-format="link"
+      data-ad-client="ca-pub-8125901705757971"
+      data-ad-slot="7783467241">
+  </amp-ad>
+
+  <p>
+    In venenatis aliquet porta. Sed volutpat fermentum quam,
+    ac molestie nulla porttitor ac. Donec porta risus ut enim
+    pellentesque, id placerat elit ornare.
+  </p>
+
+</body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -316,6 +316,7 @@ function buildExamples(watch) {
 
   // Also update test-example-validation.js
   buildExample('ads.amp.html');
+  buildExample('adsense.amp.html');
   buildExample('analytics-notification.amp.html');
   buildExample('analytics.amp.html');
   buildExample('article.amp.html');


### PR DESCRIPTION
- AdSense responsive content units (exact size, with `@media` queries)
- AdSense responsive link units

Examples added to `adsense.md` page, and to `examples/ads.amp.html` page.

I believe matched content units could be implemented (`data-ad-format="autorelaxed"`), but I'm not able to provide an example, yet.
