### PR TITLE
Reduce assumptions regarding node path

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -223,7 +223,7 @@ def GenerateValidateBin(out_dir, nodejs_cmd):
   """
   logging.info('entering ...')
   f = open('%s/validate' % out_dir, 'w')
-  f.write('#!/usr/bin/%s\n' % nodejs_cmd)
+  f.write('#!/usr/bin/env %s\n' % nodejs_cmd)
   for l in open('%s/validator_minified.js' % out_dir):
     f.write(l)
   f.write("""


### PR DESCRIPTION
Use "env" unix command to locate where node is installed and build node path. This makes "validate" execute without errors on my mac and shouldn't break for others.