### PR TITLE
Enable SauceLabs builds on non-PR builds.

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -30,11 +30,6 @@ var commonTestPaths = [
     included: false,
   },
   {
-    pattern: 'build/**/*.js',
-    included: false,
-    served: true
-  },
-  {
     pattern: 'examples/**/*',
     included: false,
     served: true

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -65,8 +65,9 @@ gulp.task('test', 'Runs tests', prerequisites, function(done) {
   if (argv.saucelabs && process.env.MAIN_REPO &&
       // Sauce Labs does not work on Pull Requests directly.
       // The @ampsauce bot builds these.
-      process.env.TRAVIS_PULL_REQUEST) {
-    console./*OK*/info('Deactivated for main repo');
+      process.env.TRAVIS_PULL_REQUEST != 'false') {
+    console./*OK*/info('Deactivated for pull requests. ' +
+        'The @ampsauce bots build eligible PRs.');
     return;
   }
 

--- a/test/integration/test-amp-ad-doubleclick.js
+++ b/test/integration/test-amp-ad-doubleclick.js
@@ -51,8 +51,13 @@ describe('Rendering of one ad', () => {
       return poll('3p JS to load.', () => iframe.contentWindow.context);
     }).then(context => {
       expect(context.hidden).to.be.false;
-      expect(context.referrer).to.equal('http://localhost:' + location.port +
-          '/context.html');
+      // In some browsers the referrer is empty. But in Chrome it works, so
+      // we always check there.
+      if (context.referrer !== '' ||
+          (navigator.userAgent.match(/Chrome/) && !isEdge)) {
+        expect(context.referrer).to.equal('http://localhost:' + location.port +
+            '/context.html');
+      }
       expect(context.pageViewId).to.be.greaterThan(0);
       expect(context.data.tagForChildDirectedTreatment).to.be.false;
       expect(context.data.categoryExclusion).to.be.equal('health');


### PR DESCRIPTION
This should have been on, but wasn't due to misunderstanding of Travis ENV vars.

With this PR, if we let through a breakage our main line build will start failing.