### PR TITLE
Load amp-pixel and amp-analytics independent of where on the page they appear.

### DIFF
--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -19,6 +19,7 @@ import {Layout} from '../src/layout';
 import {urlReplacementsFor} from '../src/url-replacements';
 import {assert} from '../src/asserts';
 import {registerElement} from '../src/custom-element';
+import {toggle} from '../src/style';
 
 
 /**
@@ -44,6 +45,9 @@ export function installPixel(win) {
 
     /** @override */
     layoutCallback() {
+      // Now that we are rendered, stop rendering the element to reduce
+      // resource consumption.
+      toggle(this.element, false);
       const src = this.element.getAttribute('src');
       return urlReplacementsFor(this.getWin()).expand(this.assertSource(src))
           .then(src => {

--- a/css/amp.css
+++ b/css/amp.css
@@ -306,7 +306,8 @@ template {
 }
 
 amp-pixel {
-  position: absolute !important;
+  /* Fixed to make position independent of page other elements. */
+  position: fixed !important;
   top: 0 !important;
   width: 1px !important;
   height: 1px !important; /* Only things with height are ever loaded. */
@@ -344,7 +345,8 @@ amp-instagram {
  * Analytics tags should never be visible. keep them hidden.
  */
 amp-analytics {
-  position: absolute !important;
+  /* Fixed to make position independent of page other elements. */
+  position: fixed !important;
   top: 0 !important;
   width: 1px !important;
   height: 1px !important;

--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -12,12 +12,20 @@
       padding: 10px;
       margin: 10px;
     }
+    #container {
+      position: absolute;
+      top: 10000px;
+      height: 10px;
+    }
   </style>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
+
+<div id="container">
+Container for analytics tags. Positioned far away from top to make sure that doesn't matter.
 
 <amp-analytics id="analytics1">
 <script type="application/json">
@@ -156,6 +164,8 @@
 </script>
 </amp-analytics>
 <!-- End comScore example -->
+
+</div>
 
 <div class="logo"></div>
 <h1 id="top">AMP Analytics</h1>

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -26,6 +26,7 @@ import {sendRequest} from './transport';
 import {urlReplacementsFor} from '../../../src/url-replacements';
 import {userNotificationManagerFor} from '../../../src/user-notification';
 import {xhrFor} from '../../../src/xhr';
+import {toggle} from '../../../src/style';
 
 
 installCidService(AMP.win);
@@ -53,7 +54,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-
+    this.element.setAttribute('aria-hidden', 'true');
     /**
      * The html id of the `amp-user-notification` element.
      * @private @const {?string}
@@ -72,8 +73,9 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-
-    this.element.setAttribute('aria-hidden', 'true');
+    // Now that we are rendered, stop rendering the element to reduce
+    // resource consumption.
+    toggle(this.element, false);
 
     /**
      * @private {?string} Predefinedtype associated with the tag. If specified,

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -93,7 +93,9 @@ describe('amp-analytics', function() {
   }
 
   function waitForSendRequest(analytics, opt_max) {
+    expect(analytics.element.style.display).to.equal('');
     return analytics.layoutCallback().then(() => {
+      expect(analytics.element.style.display).to.equal('none');
       if (sendRequestSpy.callCount > 0) {
         return;
       }

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -30,6 +30,7 @@ describe('amp-pixel', () => {
       link.setAttribute('href', 'https://pinterest.com/pin1');
       link.setAttribute('rel', 'canonical');
       iframe.doc.head.appendChild(link);
+      expect(p.style.display).to.equal('');
       return iframe.addElement(p);
     });
   }
@@ -38,6 +39,7 @@ describe('amp-pixel', () => {
     return getPixel(
         'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?'
         ).then(p => {
+          expect(p.style.display).to.equal('none');
           expect(p.querySelector('img')).to.not.be.null;
           expect(p.children[0].src).to.equal(
               'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?');


### PR DESCRIPTION
Before this, based on position, analytics may e.g. not load immediately when the page starts out scrolled down.

Also adds `display:none` to the tags, because they have no layout anyway. This slightly improves rendering speed. Especially now that they are `position:fixed`.

Fixes #1864