### PR TITLE
Set Karma Log Level to WARN

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -50,7 +50,7 @@ module.exports = function(config) {
 
     colors: true,
 
-    logLevel: config.LOG_DEBUG,
+    logLevel: config.LOG_WARN,
 
     autoWatch: true,
 


### PR DESCRIPTION
`LOG_DEBUG` spits out so much it's hard to debug. Oh, the irony.