### PR TITLE
Added a var for Viewer.

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -23,8 +23,10 @@ export const ANALYTICS_CONFIG = {
   'default': {
     'transport': {'beacon': true, 'xhrpost': true, 'image': true},
     'vars': {
+      'accessReaderId': 'ACCESS_READER_ID',
       'ampdocHost': 'AMPDOC_HOST',
       'ampdocUrl': 'AMPDOC_URL',
+      'authdata': 'AUTHDATA',
       'availableScreenHeight': 'AVAILABLE_SCREEN_HEIGHT',
       'availableScreenWidth': 'AVAILABLE_SCREEN_WIDTH',
       'browserLanguage': 'BROWSER_LANGUAGE',
@@ -57,8 +59,7 @@ export const ANALYTICS_CONFIG = {
       'timestamp': 'TIMESTAMP',
       'timezone': 'TIMEZONE',
       'title': 'TITLE',
-      'accessReaderId': 'ACCESS_READER_ID',
-      'authdata': 'AUTHDATA',
+      'viewer': 'VIEWER',
     }
   },
 

--- a/extensions/amp-analytics/analytics-vars.md
+++ b/extensions/amp-analytics/analytics-vars.md
@@ -74,6 +74,12 @@ Provides the canonical URL of the current document.
 
 Example value: `http%3A%2F%2Fexample.com%3A8000%2Fanalytics.html`
 
+### documentCharset
+
+Provides the character encoding of the current document.
+
+Example value: `UTF-8`
+
 ### documentReferrer
 
 Provides the referrer where the user came from. It is read from `document.referrer`. The value is empty for direct visitors.
@@ -85,6 +91,11 @@ Example value: `https://www.google.com`
 Provides the title of the current document.
 
 Example value: `The New York Times - Breaking News, World News...`
+
+### viewer
+Provides an identifier for the viewer that contains the AMP document. Empty string if the document is loaded directly in a browser or if the id is not found.
+
+Example value: `www.google.com`
 
 ## Device and Browser
 
@@ -105,12 +116,6 @@ Example value: `2500`
 Provides a string representing the preferred language of the user, usually the language of the browser UI.
 
 Example value: `en-us`
-
-### documentCharset
-
-Provides the character encoding of the current document.
-
-Example value: `UTF-8`
 
 ### screenColorDepth
 

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -98,6 +98,15 @@ For instance:
 ```
 may make a request to something like `https://foo.com/pixel?host=pinterest.com`.
 
+### DOCUMENT_CHARSET
+
+Provides the character encoding of the current document.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?charSet=DOCUMENT_CHARSET"></amp-pixel>
+```
+
 ### DOCUMENT_REFERRER
 
 Use the special string `DOCUMENT_REFERRER` to add the current document's referrer to the URL.
@@ -116,6 +125,14 @@ For instance:
 <amp-pixel src="https://foo.com/pixel?title=TITLE"></amp-pixel>
 ```
 may make a request to something like `https://foo.com/pixel?title=Breaking%20News`.
+
+### VIEWER
+
+Provides an identifier for the viewer that contains the AMP document. Empty string is provided when the document is loaded directly in the browser or if the id is not found.
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?viewer=VIEWER"></amp-pixel>
+```
 
 ## Performance
 
@@ -219,15 +236,6 @@ Provides a string representing the preferred language of the user, usually the l
 For instance:
 ```html
 <amp-pixel src="https://foo.com/pixel?lang=BROWSER_LANGUAGE"></amp-pixel>
-```
-
-### DOCUMENT_CHARSET
-
-Provides the character encoding of the current document.
-
-For instance:
-```html
-<amp-pixel src="https://foo.com/pixel?charSet=DOCUMENT_CHARSET"></amp-pixel>
 ```
 
 ### SCREEN_COLOR_DEPTH

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -270,6 +270,11 @@ class UrlReplacements {
         return accessService.getAuthdataField(field);
       }, 'AUTHDATA');
     });
+
+    // Returns an identifier for the viewer.
+    this.set_('VIEWER', () => {
+      return viewerFor(this.win_).getViewerOrigin();
+    });
   }
 
   /**


### PR DESCRIPTION
This var is returns the hostname found in the 'origin' param of the
viewer or the referrer.

There are a couple of open issues in this PR. Comments and suggestions welcome.

1. The code currently reads the origin param from the iframe and parses the domain out of it. Should it return the value without any processing instead? That way, apps don't have to pass in a domain or a URL and can instead just pass in a string.
2. The code returns the referrer information if the origin is not found. I am not sure if that should be done or if it makes sense.

Fixes #1493 