### PR TITLE
amp-brightcove - pass custom params and allow `data-player`

### DIFF
--- a/ads/integration-guide.md
+++ b/ads/integration-guide.md
@@ -51,7 +51,7 @@ A brightcove player can be invoked by the following:
 <amp-brightcove
       data-account="906043040001"
       data-video-id="1401169490001"
-      data-player-id="180a5658-8be8-4f33-8eba-d562ab41b40c"
+      data-player="180a5658-8be8-4f33-8eba-d562ab41b40c"
       layout="responsive" width="480" height="270">
   </amp-brightcove>
 ```

--- a/examples/brightcove.amp.html
+++ b/examples/brightcove.amp.html
@@ -16,7 +16,7 @@
   <amp-brightcove
       data-account="906043040001"
       data-video-id="1401169490001"
-      data-player-id="180a5658-8be8-4f33-8eba-d562ab41b40c"
+      data-player="180a5658-8be8-4f33-8eba-d562ab41b40c"
       layout="responsive" width="480" height="270">
   </amp-brightcove>
 

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -17,20 +17,20 @@
 import {createIframePromise} from '../../../../testing/iframe';
 require('../amp-brightcove');
 import {adopt} from '../../../../src/runtime';
+import {parseUrl} from '../../../../src/url';
 
 adopt(window);
 
 describe('amp-brightcove', () => {
 
-  function getBrightcove(accountId, videoId, opt_responsive) {
+  function getBrightcove(attributes, opt_responsive) {
     return createIframePromise().then(iframe => {
       const bc = iframe.doc.createElement('amp-brightcove');
-      bc.setAttribute('data-account', accountId);
+      for (const key in attributes) {
+        bc.setAttribute(key, attributes[key]);
+      }
       bc.setAttribute('width', '111');
       bc.setAttribute('height', '222');
-      if (videoId) {
-        bc.setAttribute('data-video-id', videoId);
-      }
       if (opt_responsive) {
         bc.setAttribute('layout', 'responsive');
       }
@@ -41,7 +41,10 @@ describe('amp-brightcove', () => {
   }
 
   it('renders', () => {
-    return getBrightcove('906043040001','ref:ampdemo').then(bc => {
+    return getBrightcove({
+      'data-account': '906043040001',
+      'data-video-id': 'ref:ampdemo'
+    }).then(bc => {
       const iframe = bc.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
@@ -53,7 +56,10 @@ describe('amp-brightcove', () => {
   });
 
   it('renders responsively', () => {
-    return getBrightcove('906043040001', 'ref:ampdemo', true).then(bc => {
+    return getBrightcove({
+      'data-account': '906043040001',
+      'data-video-id': 'ref:ampdemo'
+    }, true).then(bc => {
       const iframe = bc.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.className).to.match(/-amp-fill-content/);
@@ -61,7 +67,19 @@ describe('amp-brightcove', () => {
   });
 
   it('requires data-account', () => {
-    return getBrightcove('').should.eventually.be.rejectedWith(
+    return getBrightcove({}).should.eventually.be.rejectedWith(
         /The data-account attribute is required for/);
+  });
+
+  it('should pass data-param-* attributes to the iframe src', () => {
+    return getBrightcove({
+      'data-account': '906043040001',
+      'data-video-id': 'ref:ampdemo',
+      'data-param-my-param': 'hello world'
+    }).then(bc => {
+      const iframe = bc.querySelector('iframe');
+      const params = parseUrl(iframe.src).search.split('&');
+      expect(params).to.contain('myParam=hello%20world');
+    });
   });
 });

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -16,13 +16,13 @@ limitations under the License.
 
 ### <a name="amp-brightcove"></a> `amp-brightcove`
 
-An `amp-brightcove` component displays a Brightcove [Video Cloud](https://www.brightcove.com/en/online-video-platform) or [Perform](https://www.brightcove.com/en/perform) player.
+An `amp-brightcove` component displays the Brightcove Player as used in Brightcove's [Video Cloud](https://www.brightcove.com/en/online-video-platform) or [Perform](https://www.brightcove.com/en/perform) products.
 
 Example:
 ```html
 <amp-brightcove
     data-account="12345"
-    data-player-id="default"
+    data-player="default"
     data-embed="default"
     data-video-id="1234"
     layout="responsive"
@@ -36,11 +36,13 @@ The width and height will determine the aspect ratio of the player embed in resp
 
 **data-account**
 
-The Brightcove Video Cloud or Perform account id
+The Brightcove Video Cloud or Perform account id.
 
-**data-player-id**
+**data-player** or **data-player-id**
 
-The Brightcove player id. This is a GUID or "default". The default value is "default".
+The Brightcove player id. This is a GUID, shortid or "default". The default value is "default".
+
+`data-player` is preferred. `data-player-id` is also supported for backwards-compatibility.
 
 **data-embed**
 
@@ -49,12 +51,23 @@ The Brightcove player id. This is a GUID or "default". The default value and mos
 **data-video-id**
 
 The Video Cloud video id. Most Video Cloud players will need this.
-This is not used for Perform players.
+
+This is not used for Perform players by default; use it if you have added a plugin that expects a `videoId` param in the query string.
 
 **data-playlist-id**
 
 The Video Cloud playlist id. For AMP HTML uses a video id will normally be used instead. If both a playlist and a video are specified, the playlist takes precedence.
-This is not used for Perform players.
+
+This is not used for Perform players by default; use it if you have added a plugin that expects a `playlistId` param in the query string.
+
+**data-param-***
+
+All `data-param-*` attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
+
+Keys and values will be URI encoded. Keys will be camel cased.
+
+- `data-param-language="de"` becomes `&language=de`
+- `data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`
 
 #### Player configuration
 


### PR DESCRIPTION
A few updates to amp-brightcove

- Some publishers need to pass custom parameters through to plugins specific to their players, e.g. article-specific values that need to be included in ad tags. All `data-param-*` attributes will now be passed camel cased in the query string of the player iframe src, in line with #1537
- Documentation for `data-param-*`
- Tests for `data-param-*`
- `amp-brightcove` uses `data-player-id` as an attribute whereas the standard non-AMP embed for the Brightcove Player uses `data-player`. `data-player` had been intended, hence the confusion in the docs (#1793). Since publishers may well assume the same attribute as the non-AMP embed, `amp-brightcove` now supports either.
- Docs and examples have been updated to standardise on `data-player` but note the compatibility with `data-player-id`