### PR TITLE
Fix 3 bugs in environment instrumentation

### DIFF
--- a/test/functional/test-3p-environment.js
+++ b/test/functional/test-3p-environment.js
@@ -110,6 +110,7 @@ describe('3p environment', () => {
       win.cancelAnimationFrame = function(id) {
         win.clearTimeout(id);
       };
+      return clock;
     }
 
     function add(p) {
@@ -176,6 +177,23 @@ describe('3p environment', () => {
       clock.tick(20);
       expect(progress).to.equal(
           'aaaaaaaaabaaaaaaaaaacbaabcaaaaaaaaaaaaaaaaaababb');
+      testWin.ran = false;
+      testWin.setInterval('ran=true', 1);
+      clock.tick(1);
+      expect(window.ran).to.be.equal(undefined);
+      expect(testWin.ran).to.be.true;
+    });
+
+    it('should cancel uninstrumented timeouts', () => {
+      const timeout = testWin.setTimeout(() => {
+        throw new Error('should not happen: timeout');
+      }, 0);
+      const interval = testWin.setInterval(() => {
+        throw new Error('should not happen: interval');
+      }, 0);
+      manageWin(testWin);
+      testWin.clearTimeout(timeout);
+      testWin.clearInterval(interval);
     });
 
     it('throttle requestAnimationFrame', () => {


### PR DESCRIPTION
1. Allow clearInterval from a different window to clear an interval
2. Allow string args to setInterval
3. Make clearInterval also clear non-instrumented intervals.