### PR TITLE
3 signficant speedups for iframe communication

### DIFF
--- a/3p/environment.js
+++ b/3p/environment.js
@@ -264,7 +264,7 @@ function minTime(time) {
   return time;
 }
 
-listenParent('embed-state', function(data) {
+listenParent(window, 'embed-state', function(data) {
   inViewport = data.inViewport;
   if (inViewport) {
     becomeVisible();

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -191,7 +191,7 @@ function triggerResizeRequest(width, height) {
 function observeIntersection(observerCallback) {
   // Send request to received records.
   nonSensitiveDataPostMessage('send-intersections');
-  return listenParent('intersection', data => {
+  return listenParent(window, 'intersection', data => {
     observerCallback(data.changes);
   });
 }
@@ -202,7 +202,7 @@ function observeIntersection(observerCallback) {
  * @param {!Window} global
  */
 function updateVisibilityState(global) {
-  listenParent('embed-state', function(data) {
+  listenParent(window, 'embed-state', function(data) {
     global.context.hidden = data.pageHidden;
     const event = global.document.createEvent('Event');
     event.data = {
@@ -220,7 +220,7 @@ function updateVisibilityState(global) {
  *    observes for resize status messages.
  */
 function onResizeSuccess(observerCallback) {
-  return listenParent('embed-resize-changed', data => {
+  return listenParent(window, 'embed-resize-changed', data => {
     observerCallback(data.requestedHeight);
   });
 }
@@ -232,7 +232,7 @@ function onResizeSuccess(observerCallback) {
  *    observes for resize status messages.
  */
 function onResizeDenied(observerCallback) {
-  return listenParent('embed-resize-denied', data => {
+  return listenParent(window, 'embed-resize-denied', data => {
     observerCallback(data.requestedHeight);
   });
 }

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -89,6 +89,10 @@ export function postMessage(iframe, type, object, targetOrigin, opt_is3P) {
   }
   object.type = type;
   object.sentinel = getSentinel_(opt_is3P);
+  if (opt_is3P) {
+    // Serialize ourselves because that is much faster in Chrome.
+    object = 'amp-' + JSON.stringify(object);
+  }
   iframe.contentWindow./*OK*/postMessage(object, targetOrigin);
 }
 

--- a/test/functional/test-3p-environment.js
+++ b/test/functional/test-3p-environment.js
@@ -23,6 +23,8 @@ import * as lolex from 'lolex';
 
 describe('3p environment', () => {
 
+  let testWin;
+
   beforeEach(() => {
     iframeCount = 0;
     return createIframePromise(true).then(iframe => {

--- a/test/functional/test-messaging.js
+++ b/test/functional/test-messaging.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createIframePromise} from '../../testing/iframe';
+import {listenParent} from '../../3p/messaging';
+import {postMessage} from '../../src/iframe-helper';
+import {timer} from '../../src/timer';
+
+describe('3p messaging', () => {
+
+  let testWin;
+  let iframe;
+
+  beforeEach(() => {
+    return createIframePromise(true).then(i => {
+      testWin = i.win;
+      testWin.context = {
+        location: window.location
+      };
+      iframe = {
+        contentWindow: testWin,
+      };
+    });
+  });
+
+  it('should receive messages', () => {
+    let progress = '';
+    listenParent(testWin, 'test', function(d) {
+      progress += d.s;
+    });
+    postMessage(iframe, 'test', {s: 'a'}, '*', true);
+    postMessage(iframe, 'test', {s: 'b'}, '*', false);
+    postMessage(iframe, 'other', {s: 'c'}, '*', true);
+    postMessage(iframe, 'test', {s: 'd'}, '*', true);
+    return timer.promise(10).then(() => {
+      expect(progress).to.equal('ad');
+    });
+  });
+
+  it('should receive more messages', () => {
+    let progress = '';
+    listenParent(testWin, 'test', function(d) {
+      progress += d.s;
+    });
+    listenParent(testWin, 'test', function(d) {
+      progress += d.s;
+    });
+    listenParent(testWin, 'test2', function(d) {
+      progress += d.s;
+    });
+    postMessage(iframe, 'test', {s: 'a'}, '*', true);
+    postMessage(iframe, 'test2', {s: 'a'}, '*', true);
+    postMessage(iframe, 'test2', {s: 'a'}, '*', true);
+    postMessage(iframe, 'test', {s: 'b'}, '*', false);
+    postMessage(iframe, 'other', {s: 'c'}, '*', true);
+    postMessage(iframe, 'test2', {s: 'a'}, '*', true);
+    postMessage(iframe, 'test', {s: 'd'}, '*', true);
+    return timer.promise(10).then(() => {
+      expect(progress).to.equal('aaaaadd');
+    });
+  });
+
+  it('should support unlisten', () => {
+    let progress = '';
+    const unlisten0 = listenParent(testWin, 'test', function(d) {
+      progress += d.s;
+    });
+    const unlisten1 = listenParent(testWin, 'test', function(d) {
+      progress += d.s;
+    });
+    const unlisten2 = listenParent(testWin, 'test2', function(d) {
+      progress += d.s;
+    });
+    postMessage(iframe, 'test', {s: 'a'}, '*', true);
+    return timer.promise(10).then(() => {
+      expect(progress).to.equal('aa');
+      unlisten0();
+      postMessage(iframe, 'test2', {s: 'a'}, '*', true);
+      postMessage(iframe, 'test2', {s: 'a'}, '*', true);
+      postMessage(iframe, 'test', {s: 'b'}, '*', true);
+      return timer.promise(10).then(() => {
+        unlisten2();
+        unlisten1();
+        postMessage(iframe, 'test2', {s: 'a'}, '*', true);
+        postMessage(iframe, 'test', {s: 'd'}, '*', true);
+        return timer.promise(10).then(() => {
+          expect(progress).to.equal('aaaab');
+        });
+      });
+    });
+  });
+
+  it('should not stop on errors', () => {
+    let progress = '';
+    listenParent(testWin, 'test', function() {
+      throw new Error('expected');
+    });
+    listenParent(testWin, 'test', function(d) {
+      progress += d.s;
+    });
+    postMessage(iframe, 'test', {s: 'a'}, '*', true);
+    postMessage(iframe, 'test', {s: 'd'}, '*', true);
+    return timer.promise(10).then(() => {
+      expect(progress).to.equal('ad');
+    });
+  });
+});


### PR DESCRIPTION
1. Send messages encoded as JSON. This is faster than the algorithm that is mandated by the spec for objects.
2. Only parse a response once and do the listener dispatch in user land. 
3. Call stopImmediatePropagation on our messages, so others don't have to loop at them.