### PR TITLE
Improve GPT support and add Glade as an experiment

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -22,7 +22,10 @@
  * @const {!Object<string, (string|!Array<string>)>}
  */
 export const adPrefetch = {
-  doubleclick: 'https://www.googletagservices.com/tag/js/gpt.js',
+  doubleclick: [
+    'https://www.googletagservices.com/tag/js/gpt.js',
+    'https://securepubads.g.doubleclick.net/static/glade.js',
+  ],
   a9: 'https://c.amazon-adsystem.com/aax2/assoc.js',
   adsense: 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js',
   dotandads: 'https://amp.ad.dotandad.com/dotandadsAmp.js',

--- a/ads/doubleclick.md
+++ b/ads/doubleclick.md
@@ -33,7 +33,7 @@ limitations under the License.
 <amp-ad width=320 height=50
     type="doubleclick"
     data-slot="/4119129/mobile_ad_banner"
-    json='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusion":"health","tagForChildDirectedTreatment":1}'>
+    json='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusions":["health"],"tagForChildDirectedTreatment":1}'>
 </amp-ad>
 ```
 
@@ -63,7 +63,7 @@ Example:
 
 Supported via `json` attribute:
 
-- `categoryExclusion`
+- `categoryExclusions`
 - `cookieOptions`
 - `tagForChildDirectedTreatment`
 - `targeting`

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -73,7 +73,7 @@
   <amp-ad width=320 height=50
       type="doubleclick"
       data-slot="/4119129/mobile_ad_banner"
-      json='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusion":"health","tagForChildDirectedTreatment":false}'
+      json='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusions":["health"],"tagForChildDirectedTreatment":0}'
       >
   </amp-ad>
 

--- a/test/fixtures/doubleclick.html
+++ b/test/fixtures/doubleclick.html
@@ -14,7 +14,7 @@
   <amp-ad width=320 height=50
       type="doubleclick"
       data-slot="/4119129/mobile_ad_banner"
-      json='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusion":"health","tagForChildDirectedTreatment":false}'
+      json='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusions":["health"],"tagForChildDirectedTreatment":0}'
       >
   </amp-ad>
 </body>

--- a/test/integration/test-amp-ad-doubleclick.js
+++ b/test/integration/test-amp-ad-doubleclick.js
@@ -39,7 +39,7 @@ describe('Rendering of one ad', () => {
       iframe = iframeElement;
       expect(fixture.doc.querySelectorAll('iframe')).to.have.length(1);
       ampAd = iframe.parentElement;
-      expect(iframe.src).to.contain('categoryExclusion');
+      expect(iframe.src).to.contain('categoryExclusions');
       expect(iframe.src).to.contain('health');
       expect(iframe.src).to.contain('tagForChildDirectedTreatment');
       expect(iframe.src).to.match(/http\:\/\/localhost:9876\/base\/dist\.3p\//);
@@ -60,8 +60,8 @@ describe('Rendering of one ad', () => {
             '/context.html');
       }
       expect(context.pageViewId).to.be.greaterThan(0);
-      expect(context.data.tagForChildDirectedTreatment).to.be.false;
-      expect(context.data.categoryExclusion).to.be.equal('health');
+      expect(context.data.tagForChildDirectedTreatment).to.equal(0);
+      expect(context.data.categoryExclusions).to.be.jsonEqual(['health']);
       expect(context.data.targeting).to.be.jsonEqual(
           {sport: ['rugby', 'cricket']});
       return poll('main ad JS is injected', () => {


### PR DESCRIPTION
This PR changes two things:

1. It fixes the way category exclusions are handled since GPT supports multiple category exclusions. `categoryExclusion` is renamed to `categoryExclusions` to reflect this fact and can now be either a string or an array of strings.

2. Update the example where TFCD is set to use a number instead of a boolean.