### PR TITLE
Add the validator files to a whitelist.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -232,8 +232,17 @@ var forbiddenTerms = {
   '\\.startsWith': {
     message: es6polyfill,
     whitelist: [
+      // validator uses goog.string.startsWith.
+      'validator/css-selectors.js',
+      'validator/htmlparser_test.js',
+      'validator/parse-css.js',
       'validator/tokenize-css.js',
-      'validator/validator.js'
+      'validator/validator.js',
+      'validator/htmlparser.js',
+      'validator/json-testutil.js',
+      'validator/parse-css_test.js',
+      'validator/validator-in-browser.js',
+      'validator/validator_test.js',
     ]
   },
   '\\.endsWith': es6polyfill,
@@ -248,6 +257,17 @@ var forbiddenTerms = {
     message: es6polyfill,
     whitelist: [
       'extensions/amp-access/0.1/access-expr-impl.js',
+      // validator uses goog.string.endsWith.
+      'validator/css-selectors.js',
+      'validator/htmlparser_test.js',
+      'validator/parse-css.js',
+      'validator/tokenize-css.js',
+      'validator/validator.js',
+      'validator/htmlparser.js',
+      'validator/json-testutil.js',
+      'validator/parse-css_test.js',
+      'validator/validator-in-browser.js',
+      'validator/validator_test.js',
     ],
   },
 


### PR DESCRIPTION
I'd be happy to try doing something fancier, but not sure what.
Choices:
- Implement glob matching for this whitelist, to exempt
  validator/* dir. Doesn't catch the actual problems either, if
  someone writes someString.startsWith by accident.
- Implement positive matches, e.g. we could whitelist certain content
  strings, as opposed to entire files. E.g., we could whitelist
  goog.string.startsWith. But this is surprisingly tricky because
  the existing matching is very crude and broad. E.g. think about
  (some expression).startsWith
  if (foo.startsWith
  Tokenizer.prototype.startsWithAnIdentifier
  etc.
- Change our code to not use that string, e.g. make a library
  which has methods hasPrefixString / hasSuffixString. Still doesn't
  fix the Tokenizer.prototype.startsWithAnIdentifier case.
So anyways for now I figure this simplest thing might be the least
bad for the moment? Please lemme know. Thanks.