### PR TITLE
Monitor amp-youtube player state

### DIFF
--- a/examples/youtube.amp.html
+++ b/examples/youtube.amp.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>AMP #0</title>
+    <link rel="canonical" href="amps.html" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+<article>
+
+    <amp-youtube
+            data-videoid="mGENRKrdoGY"
+            width="480" height="270"></amp-youtube>
+
+    <!-- YouTube video that doesn't have sddefault.jpg -->
+    <amp-youtube
+            data-videoid="oofSnsGkops"
+            width="480" height="270"></amp-youtube>
+
+</article>
+</body>
+</html>

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -17,15 +17,35 @@
 import {createIframePromise} from '../../../../testing/iframe';
 require('../amp-youtube');
 import {adopt} from '../../../../src/runtime';
+import {timer} from '../../../../src/timer';
+import * as sinon from 'sinon';
 
 adopt(window);
 
 describe('amp-youtube', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    sandbox = null;
+  });
 
   function getYt(videoId, opt_responsive, opt_beforeLayoutCallback) {
     return createIframePromise(
         true, opt_beforeLayoutCallback).then(iframe => {
           const yt = iframe.doc.createElement('amp-youtube');
+
+          // TODO(mkhatib): During tests, messages are not being correctly
+          // caught and hence the ready promise will never resolve.
+          // For now, this resolves the ready promise after a while.
+          timer.promise(50).then(() => {
+            yt.implementation_.playerReadyResolver_();
+          });
+
           yt.setAttribute('data-videoid', videoId);
           yt.setAttribute('width', '111');
           yt.setAttribute('height', '222');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -351,6 +351,7 @@ function buildExamples(watch) {
   buildExample('vimeo.amp.html');
   buildExample('vine.amp.html');
   buildExample('multiple-docs.html');
+  buildExample('youtube.amp.html');
 
   // TODO(dvoytenko, #1393): Enable for proxy-testing.
   // // Examples are also copied into `c/` directory for AMP-proxy testing.


### PR DESCRIPTION
And only pause the player if it is in playing state.

This is a bit hacky, any idea if this is a fine approach? Or if we should look into re-implementing amp-youtube as a 3p integration similar to amp-facebook?

I have a [jsfiddle here to play with YT postMessage api](https://jsfiddle.net/kpLj0yeg/2/).

Addresses #1915 

Update: This also fixes #2050 

cc @malteubl @dvoytenko 