### PR TITLE
Add special whitelisted iframe ping transport.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -60,6 +60,13 @@ var forbiddenTerms = {
       'validator/validator-in-browser.js',
     ]
   },
+  'iframePing': {
+    message: 'This is only available in vendor config for ' +
+        'temporary workarounds.',
+    whitelist: [
+      'extensions/amp-analytics/0.1/amp-analytics.js',
+    ],
+  },
   // Service factories that should only be installed once.
   'installActionService': {
     message: privateServiceFactory,

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -576,6 +576,43 @@ describe('amp-analytics', function() {
     });
   });
 
+  describe('iframePing', () => {
+    it('fails for iframePing config outside of vendor config', function() {
+      const analytics = getAnalyticsTag({
+        'requests': {'foo': 'https://example.com/bar'},
+        'triggers': [{'on': 'visible', 'iframePing': true}]
+      });
+      return expect(waitForNoSendRequest(analytics)).to.be
+          .rejectedWith(
+              /iframePing config is only available to vendor config/);
+    });
+
+    it('succeeds for iframePing config in vendor config', function() {
+      const analytics = getAnalyticsTag({}, {'type': 'testVendor'});
+      const url = 'http://iframe.localhost:9876/base/test/' +
+              'fixtures/served/iframe.html?title=${title}';
+      analytics.predefinedConfig_.testVendor = {
+        'requests': {
+          'pageview': url
+        },
+        'triggers': {
+          'pageview': {
+            'on': 'visible',
+            'request': 'pageview',
+            'iframePing': true
+          }
+        }
+      };
+      return waitForSendRequest(analytics).then(() => {
+        const iframe = analytics.element
+            .ownerDocument.querySelector('iframe[amp-analytics]');
+        expect(iframe).to.not.be.null;
+        expect(iframe.src).to.contain('served/iframe.html');
+        expect(iframe.src).to.contain('Test%20Title');
+      });
+    });
+  });
+
   describe('data-consent-notification-id', () => {
 
     it('should resume fetch when consent is given', () => {


### PR DESCRIPTION
This allows analytics vendors to transition into amp-analytics before they are ready to fully use it.
It only works for page view pings and cannot be used from customer configs.