### PR TITLE
Report load errors as assert and give them a actionable error message.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -74,6 +74,9 @@ export function reportError(error, opt_associatedElement) {
  */
 export function installErrorReporting(win) {
   win.onerror = reportErrorToServer;
+  win.addEventListener('unhandledrejection', event => {
+    reportError(event.reason);
+  });
 }
 
 /**

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -15,6 +15,7 @@
  */
 
 import {timer} from './timer';
+import {assert} from './asserts';
 
 
 /**
@@ -110,7 +111,15 @@ export function loadPromise(element, opt_timeout) {
       } else {
         unlistenLoad = listenOnce(element, 'load', () => resolve(element));
       }
-      unlistenError = listenOnce(element, 'error', reject);
+      unlistenError = listenOnce(element, 'error', () => {
+        try {
+          // Report failed loads as asserts so that they automatically go into
+          // the "document error" bucket.
+          assert(false, 'Failed HTTP request for %s.', element);
+        } catch (e) {
+          reject(e);
+        }
+      });
     }
   });
   return racePromise_(loadingPromise, () => {

--- a/test/functional/test-event-helper.js
+++ b/test/functional/test-event-helper.js
@@ -203,7 +203,10 @@ describe('EventHelper', () => {
   it('loadPromise - error event', () => {
     const promise = loadPromise(element).then(result => {
       assert.fail('must never be here: ' + result);
-    }).catch(unusedReason => {
+    }).then(() => {
+      throw new Error('Should not be reached.');
+    }, reason => {
+      expect(reason.message).to.include('Failed HTTP request for');
     });
     errorObservable.fire(getEvent('error'));
     return promise;


### PR DESCRIPTION
Also starts reporting the "unhandledrejection" event that we will start seeing when we switch to native promises.

Fixes #1988
Fixes #1529
Fixes #1974

@sriramkrish85 Turns out we already did #1529, just super badly. This change kinda makes it better. We should still most likely not report this at all.