### PR TITLE
Propagate mode into 3p frames and correct identify mode in error reporting.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -90,7 +90,7 @@ function reportErrorToServer(message, filename, line, col, error) {
     makeBodyVisible(this.document);
   }
   const mode = getMode();
-  if (mode.isLocalDev || mode.development || mode.test) {
+  if (mode.localDev || mode.development || mode.test) {
     return;
   }
   const url = getErrorReportUrl(message, filename, line, col, error);
@@ -124,6 +124,9 @@ export function getErrorReportUrl(message, filename, line, col, error) {
   let url = 'https://amp-error-reporting.appspot.com/r' +
       '?v=' + encodeURIComponent('$internalRuntimeVersion$') +
       '&m=' + encodeURIComponent(message);
+  if (window.context && window.context.location) {
+    url += '&3p=1';
+  }
 
   if (error) {
     const tagName = error && error.associatedElement

--- a/src/mode.js
+++ b/src/mode.js
@@ -51,6 +51,9 @@ export function setModeForTesting(m) {
  * @return {!ModeDef}
  */
 function getMode_() {
+  if (window.context && window.context.mode) {
+    return window.context.mode;
+  }
   const isLocalDev = (location.hostname == 'localhost' ||
       (location.ancestorOrigins && location.ancestorOrigins[0] &&
           location.ancestorOrigins[0].indexOf('http://localhost:') == 0)) &&

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -98,6 +98,7 @@ afterEach(() => {
   window.ampExtendedElements = {};
   window.ENABLE_LOG = false;
   window.AMP_DEV_MODE = false;
+  window.context = undefined;
   if (!/native/.test(window.setTimeout)) {
     throw new Error('You likely forgot to restore sinon timers ' +
         '(installed via sandbox.useFakeTimers).');

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -49,6 +49,7 @@ describe('reportErrorToServer', () => {
     expect(query.el).to.equal('u');
     expect(query.a).to.equal('0');
     expect(query.s).to.equal(e.stack);
+    expect(query['3p']).to.equal(undefined);
     expect(e.message).to.contain('_reported_');
   });
 
@@ -76,6 +77,20 @@ describe('reportErrorToServer', () => {
     expect(query.m).to.equal('XYZ');
     expect(query.a).to.equal('1');
     expect(query.v).to.equal('$internalRuntimeVersion$');
+  });
+
+  it('reportError marks 3p', () => {
+    window.context = {
+      location: {},
+    };
+    const e = new Error('XYZ');
+    e.fromAssert = true;
+    const url = parseUrl(
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e));
+    const query = parseQueryString(url.search);
+
+    expect(query.m).to.equal('XYZ');
+    expect(query['3p']).to.equal('1');
   });
 
   it('reportError without error object', () => {

--- a/tools/errortracker/app.yaml
+++ b/tools/errortracker/app.yaml
@@ -1,5 +1,5 @@
 application: amp-error-reporting
-version: 4
+version: 5
 runtime: go
 api_version: go1
 

--- a/tools/errortracker/errortracker.go
+++ b/tools/errortracker/errortracker.go
@@ -115,11 +115,14 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		level = logging.Error
 		errorType += "-cdn"
 	}
+	if r.URL.Query().Get("3p") == "1" {
+		errorType = "-3p"
+	}
 
 	event := &ErrorEvent{
 		Message:     r.URL.Query().Get("m"),
 		Exception:   r.URL.Query().Get("s"),
-		Version:     r.URL.Query().Get("v"),
+		Version:     errorType + "-" + r.URL.Query().Get("v"),
 		Environment: "prod",
 		Application: errorType,
 		AppID:       appengine.AppID(c),


### PR DESCRIPTION
Report to error reporting whether error occured inside 3p frame and reflect that in the error type.

Inserts more info into version string in error reporting, for better filtering in Cloud Error Console.

Fixes #2008.