### PR TITLE
Dockerize validate & support validation from stdin

### DIFF
--- a/validator/.dockerignore
+++ b/validator/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:5.5.0
+MAINTAINER jkingyens@google.com
+RUN apt-get -y update
+RUN apt-get -y install openjdk-7-jre protobuf-compiler python-protobuf python2.7
+WORKDIR /root
+ADD package.json /root/
+RUN npm install
+ADD . /root
+RUN python build.py
+ENTRYPOINT [ "/usr/local/bin/node", "/root/dist/validate", "-" ]

--- a/validator/README.md
+++ b/validator/README.md
@@ -58,3 +58,18 @@ empty.html:1:0 MANDATORY_TAG_MISSING noscript enclosure for mandatory style (see
 empty.html:1:0 MANDATORY_TAG_MISSING body (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#crps)
 empty.html:1:0 MANDATORY_TAG_MISSING amphtml engine v0.js script (see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#scrpt)
 ```
+
+###Docker
+
+Build a docker image that contains the amp validator:
+
+```
+docker build -t=amp-validator .
+```
+
+Validate an amp html file by piping a file through a container:
+
+```
+cat examples\facebook.amp.html | docker run -i amp-validator
+PASS
+```

--- a/validator/build.py
+++ b/validator/build.py
@@ -252,37 +252,47 @@ def GenerateValidateBin(out_dir, nodejs_cmd):
 
       function main() {
         if (process.argv.length < 3) {
-          console.error('usage: validate <file.html or url>');
+          console.error('usage: validate <file.html>|<url>|-');
           process.exit(1)
         }
         var args = process.argv.slice(2);
         var full_path = args[0];
 
-        if (full_path.indexOf('http://') === 0 ||
-            full_path.indexOf('https://') === 0) {
-          var callback = function(response) {
-            var chunks = [];
+        var callback = function(response) {
+          var chunks = [];
 
-            response.on('data', function (chunk) {
-              chunks.push(chunk);
-            });
+          response.on('data', function (chunk) {
+            chunks.push(chunk);
+          });
 
-            response.on('end', function () {
-              validateFile(chunks.join(''), full_path);
-            });
-          };
+          response.on('end', function () {
+            validateFile(chunks.join(''), full_path);
+          });
 
-          var clientModule = http;
-          if (full_path.indexOf('https://') === 0) {
-            clientModule = https;
+        };
+
+        if (full_path === '-') {
+          callback(process.stdin);
+          process.stdin.resume();
+        } else {
+
+          if (full_path.indexOf('http://') === 0 ||
+              full_path.indexOf('https://') === 0) {
+
+            var clientModule = http;
+            if (full_path.indexOf('https://') === 0) {
+              clientModule = https;
+            }
+            clientModule.request(url.parse(full_path), callback).end();
+
+          } else {
+            var filename = path.basename(full_path);
+            var contents = fs.readFileSync(full_path, 'utf8');
+            validateFile(contents, filename);
           }
 
-          clientModule.request(url.parse(full_path), callback).end();
-        } else {
-          var filename = path.basename(full_path);
-          var contents = fs.readFileSync(full_path, 'utf8');
-          validateFile(contents, filename);
         }
+
       }
 
       if (require.main === module) {


### PR DESCRIPTION
This patch does two things:
 1. enables "validate" CLI to take input from stdin by specifying '-' as the single argument
 2. adds a Dockerfile to containerize the amp validator

These work together to support validation through a docker container ex)
```
cat facebook.amp.html | docker run -i amp-validate:latest
PASS
```