### PR TITLE
Revcontent AdNetwork Service 1.0 (RELEASE)

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -42,6 +42,7 @@ import {parseUrl} from '../src/url';
 import {assert} from '../src/asserts';
 import {taboola} from '../ads/taboola';
 import {smartadserver} from '../ads/smartadserver';
+import {revcontent} from '../ads/revcontent';
 
 /**
  * Whether the embed type may be used with amp-embed tag.
@@ -67,6 +68,7 @@ register('_ping_', function(win, data) {
 register('twitter', twitter);
 register('facebook', facebook);
 register('smartadserver', smartadserver);
+register('revcontent', revcontent);
 
 /**
  * Visible for testing.

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -28,6 +28,7 @@ export const adPrefetch = {
   dotandads: 'https://amp.ad.dotandad.com/dotandadsAmp.js',
   smartadserver: 'https://ec-ns.sascdn.com/diff/js/smart.js',
   yieldmo: 'https://static.yieldmo.com/ym.amp1.js',
+  revcontent: 'https://labs-cdn.revcontent.com/build/amphtml/revcontent.amp.min.js',
 };
 
 /**
@@ -57,6 +58,11 @@ export const adPreconnect = {
     'https://s.yieldmo.com',
     'https://ads.yieldmo.com',
   ],
+  revcontent: [
+    'https://trends.revcontent.com',
+    'https://cdn.revcontent.com',
+    'https://img.revcontent.com',
+  ]
 };
 
 /**

--- a/ads/revcontent.js
+++ b/ads/revcontent.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {writeScript, checkData} from '../src/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function revcontent(global, data) {
+  checkData(data, ['id', 'width', 'height', 'endpoint', 'ssl', 'wrapper']);
+  const revampServiceUrl = 'https://labs-cdn.revcontent.com/build/amphtml/revcontent.amp.min.js';
+  global.data = data;
+  writeScript(window, revampServiceUrl);
+}

--- a/ads/revcontent.md
+++ b/ads/revcontent.md
@@ -1,0 +1,40 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Revcontent
+
+## Example
+
+```html
+<amp-ad width=320 height=420
+        type="revcontent"
+        data-wrapper="rcjsload_2ff711"
+        data-endpoint="trends.revcontent.com"
+        data-id="203">
+</amp-ad>
+```
+
+## Configuration
+
+For semantics of configuration, please see [ad network documentation](http://faq.revcontent.com/support/solutions/5000137293).
+
+Supported parameters:
+
+- data-id
+- data-wrapper
+- data-endpoint
+- data-ssl
+- data-testing

--- a/builtins/amp-ad.md
+++ b/builtins/amp-ad.md
@@ -51,6 +51,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [plista](../ads/plista.md)
 - [Smart AdServer](../ads/smartadserver.md)
 - [Yieldmo](../ads/yieldmo.md)
+- [Revcontent](../ads/revcontent.md)
 
 #### Styling
 

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -17,6 +17,13 @@
     .red {
       background-color: red;
     }
+
+    amp-ad[type="revcontent"] {
+      width: 100%;
+      max-width: 1280px;
+      margin: 18px 0;
+      padding: 0;
+    }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -176,5 +183,18 @@
       type="yieldmo"
       data-ymid="1349317029731662884">
   </amp-ad>
+
+  <h2>Revcontent Widget with placeholder and fallback</h2>
+  <amp-ad width="320" height="420"
+      layout="responsive"
+      type="revcontent"
+      data-wrapper="rcjsload_2ff711"
+      data-endpoint="trends.revcontent.com"
+      data-id="203">
+
+    <div placeholder>200 Billion Content recommendations!</div>
+    <div fallback>200 Billion Content recommendations!</div>
+  </amp-ad>
+
 </body>
 </html>

--- a/src/3p.js
+++ b/src/3p.js
@@ -109,17 +109,17 @@ function executeAfterWriteScript(win, fn) {
  * @param {string} src
  */
 export function validateSrcPrefix(prefix, src) {
-
   if (!isArray(prefix)) {
     prefix = [prefix];
   }
-
-  for (const p of prefix) {
-    if (src.indexOf(p) === 0) {
-      return;
+  if (src !== undefined) {
+    for (let p = 0; p <= prefix.length; p++) {
+      const protocolIndex = src.indexOf(prefix[p]);
+      if (protocolIndex == 0) {
+        return;
+      }
     }
   }
-
   throw new Error('Invalid src ' + src);
 }
 


### PR DESCRIPTION
Integrating Revcontent as a Native Ad provider type for AMPHTML. This is a 1.0 release package.

Signed-off-by: Julien Chinapen <j.c@shogun.io>