### PR TITLE
INFOnline iframe embed must be on publisher domain

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -237,7 +237,13 @@ Container for analytics tags. Positioned far away from top to make sure that doe
 </amp-analytics>
 <!-- End comScore example -->
 
-<!-- INFOnline example -->
+<!--
+  INFOnline example
+
+  Important: url needs to point to a copy of
+  amp-analytics-infonline.html on a different subdomain
+  than your AMP files.
+-->
 <amp-analytics type="infonline" id="infonline">
 <script type="application/json">
 {
@@ -245,6 +251,9 @@ Container for analytics tags. Positioned far away from top to make sure that doe
     "st":  "angebotskennung",
     "co":  "comment",
     "cp":  "code"
+  },
+  "requests": {
+    "url":  "https://3p.ampproject.net/custom/amp-analytics-infonline.html"
   }
 }
 </script>

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -310,7 +310,7 @@ export const ANALYTICS_CONFIG = {
     },
     'transport': {'beacon': false, 'xhrpost': false, 'image': true},
     'requests': {
-      'pageview': 'https://3p.ampproject.net/custom/amp-analytics-infonline.html?st=${st}' +
+      'pageview': '${url}?st=${st}' +
         '&sv=${sv}' +
         '&ap=${ap}' +
         '&co=${co}' +

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -100,11 +100,16 @@ Adds support for Google Analytics. More details for adding Google Analytics supp
 
 Type attribute value: `infonline`
 
-Adds support for [INFOnline](https://www.infonline.de) / [IVW](http://www.ivw.de). Requires the following variables
+Adds support for [INFOnline](https://www.infonline.de) / [IVW](http://www.ivw.de). Requires a copy of [amp-analytics-infonline.html](https://3p.ampproject.net/custom/amp-analytics-infonline.html) on a different subdomain than the including AMP file ([why?](https://github.com/ampproject/amphtml/blob/master/spec/amp-iframe-origin-policy.md)). Example: if your AMP files are hosted on `www.example.com`, then `amp-analytics-infonline.html` needs to be on another subdomain such as `iframe.example.com` or `assets.example.com`.
 
-* `st` (Angebotskennung)
-* `co` (Comment)
-* `cp` (Code)
+Additionally, the following variables must be defined:
+
+* `st`: Angebotskennung
+* `co`: comment
+* `cp`: code
+* `url`: location of `amp-analytics-infonline.html`
+
+More details for adding INFOnline / IVW support can be found at [www.infonline.de](https://www.infonline.de/downloads/web-mew-und-ctv/).
 
 ##### Krux
 


### PR DESCRIPTION
The analytics request referer must come from the publisher's domain. 