### PR TITLE
Get viewer from this.win rather than global window object

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -115,7 +115,7 @@ export class Viewer {
     this.isEmbedded_ = (this.win.parent && this.win.parent != this.win);
 
     /** @const {!DocumentState} */
-    this.docState_ = documentStateFor(window);
+    this.docState_ = documentStateFor(this.win);
 
     /** @private {boolean} */
     this.isRuntimeOn_ = true;


### PR DESCRIPTION
Addresses issue https://github.com/ampproject/amphtml/issues/1989.

This change *should* have no impact on functionality. All tests passed after making the change.

The reason for the change is to allow greater flexibility in testing components which make use of the `Viewer` by allowing mocking of the `DocumentState` used by the `Viewer`. Additionally, using the `win` constructor argument for service retrieval is the common pattern elsewhere in `amphtml` code.