### PR TITLE
Fixes for amp-soundcloud.

### DIFF
--- a/extensions/amp-soundcloud/0.1/amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/amp-soundcloud.js
@@ -24,11 +24,8 @@
  *   height=166
  *   data-trackid="243169232"
  *   data-color="ff5500"
- *   data-autoplay="true"
  *   layout="fixed-height">
  * </amp-soundcloud>
- *
- *
  */
 
 import {Layout} from '../../../src/layout';
@@ -65,7 +62,7 @@ class AmpSoundcloud extends AMP.BaseElement {
     iframe.src = "https://w.soundcloud.com/player/?" +
       "url=" + encodeURIComponent(url + trackid);
 
-    if (visual) {
+    if (visual === 'true') {
       iframe.src += "&visual=true";
     } else if (color) {
       iframe.src += "&color=" + encodeURIComponent(color);
@@ -81,7 +78,7 @@ class AmpSoundcloud extends AMP.BaseElement {
     return loadPromise(iframe);
   }
 
-    /** @override */
+  /** @override */
   documentInactiveCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
       this.iframe_.contentWindow./*OK*/postMessage(

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -34,19 +34,29 @@ Example Classic Mode:
     data-color="ff5500"></amp-soundcloud>
 ```
 
-#### Attributes
+#### Required attributes
 
 **data-trackid**
 
-The ID of the track.
+The ID of the track, an integer.
+
+#### Optional attributes
 
 **data-visual**
 
-Displays full width "Visual" mode.
+Value: `"true"` or `"false"`
+
+Default value: `"false"`
+
+If set to true, displays full width "Visual" mode. Otherwise, displays "Classic"
+mode.
 
 **data-color**
 
-Custom color override. Only works with "Classic" Mode. Will be ignored in "Visual" Mode.
+Value: Hexadecimal color value (without the leading #).
+E.g. `data-color="e540ff"`
+
+Custom color override for the "Classic" mode. Ignored in "Visual" mode.
 
 **width and height**
-Layout is `fixed-height` and will fill all the available horizontal space. This is ideal for `classic mode`, but for `visual-mode`, height is recommended to be 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.
+Layout is `fixed-height` and will fill all the available horizontal space. This is ideal for "Classic" mode, but for "Visual", height is recommended to be 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.


### PR DESCRIPTION
The check for the visual attribute seems incorrect. It says
if (visual) ..., but if visual were "false", then this would
evaluate to true, and so the visual mode would be enabled.
So I'd like to compare with "true" here, and I've edited the
spec to state that if set the value must be "true" or "false".
Also clarified the spec a bit more with respect to required / optional
attrs.

PS: I haven't run the tests yet (my nodejs is too old it seems),
will rely on our Github setup to do that for convenience. So please
stand by til the check is done.