### PR TITLE
Be robust against promise callbacks running when window was already destroyed.

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -541,6 +541,11 @@ export class Resources {
       log.fine(TAG_, 'runtime is off');
       return;
     }
+    // Sometimes in Safari these passes run after the document has already been
+    // destroyed. To avoid errors we bail out here.
+    if (!this.win.document) {
+      return;
+    }
 
     const prevVisible = this.visible_;
     this.visible_ = this.viewer_.isVisible();


### PR DESCRIPTION

This happens in Safari when the window was removed from the DOM.