### PR TITLE
Make timer-delay-0 behave more like a macrotask in that the callback doesn't fire if the window went away.

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -73,6 +73,9 @@ export class Timer {
       // they are predictably fast.
       const id = 'p' + this.taskCount_++;
       this.resolved_.then(() => {
+        if (!this.win.document) {
+          return;  // Do not fire callback if document has been destroyed.
+        }
         if (this.canceled_[id]) {
           delete this.canceled_[id];
           return;

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -27,6 +27,7 @@ describe('Timer', () => {
     const WindowApi = function() {};
     WindowApi.prototype.setTimeout = function(unusedCallback, unusedDelay) {};
     WindowApi.prototype.clearTimeout = function(unusedTimerId) {};
+    WindowApi.prototype.document = {};
     const windowApi = new WindowApi();
     windowMock = sandbox.mock(windowApi);
     timer = new Timer(windowApi);

--- a/test/integration/test-released.js
+++ b/test/integration/test-released.js
@@ -27,8 +27,10 @@ describe('released components with polyfills: ', function() {
 
 function runTest(shouldKillPolyfillableApis) {
   describe('Rendering of released components', function() {
+    this.timeout(5000);
     let fixture;
     beforeEach(() => {
+      this.timeout(3100);
       return createFixtureIframe('test/fixtures/released.html', 3000, win => {
         if (shouldKillPolyfillableApis) {
           win.Promise = undefined;


### PR DESCRIPTION
Also increases some timeouts for happier tests.