### PR TITLE
Inline env variables

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,6 +15,7 @@
     "es6.properties.computed",
     "es6.properties.shorthand",
     "es6.templateLiterals",
-    "es6.spread"
+    "es6.spread",
+    "utility.inlineEnvironmentVariables"
   ]
 }


### PR DESCRIPTION
Without this, we leave a `process.env.NODE_ENV == 'production'` in `mode.js`

It’s a wonder we don’t have 3489327499879873928479834329581793857 errors coming in every second.