### PR TITLE
Do not allow cookies on .ampproject.org

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -84,9 +84,22 @@ export function setCookie(win, name, value, expirationTime, opt_options) {
  * @param {string|undefined} domain
  */
 function trySetCookie(win, name, value, expirationTime, domain) {
+  // We do not allow setting cookies on the domain that contains both
+  // the cdn. and www. hosts.
+  if (domain == 'ampproject.org') {
+    // Actively delete them.
+    value = 'delete';
+    expirationTime = 0;
+  }
   win.document.cookie = encodeURIComponent(name) + '=' +
       encodeURIComponent(value) +
       '; path=/' +
       (domain ? '; domain=' + domain : '') +
       '; expires=' + new Date(expirationTime).toUTCString();
+}
+
+// Clean up cookies set by www.ampproject.org to 2nd level.
+if (location.hostname.indexOf('.ampproject.org') != 0) {
+  trySetCookie(window, '_ga', '', 0, 'ampproject.org');
+  trySetCookie(window, 'AMP_ECID_GOOGLE', '', 0, 'ampproject.org');
 }

--- a/test/functional/test-cookies.js
+++ b/test/functional/test-cookies.js
@@ -62,6 +62,12 @@ describe('getCookie', () => {
       let cookie;
       const doc = {
         set cookie(val) {
+          // Delete cookies on ampproject.org
+          if (val.indexOf('domain=ampproject.org; ' +
+              'expires=Thu, 01 Jan 1970 00:00:00 GMT') != -1) {
+            cookie = undefined;
+            return;
+          }
           if (val.indexOf('; domain=' + targetDomain) != -1) {
             cookie = val;
           }
@@ -89,5 +95,9 @@ describe('getCookie', () => {
     test('123.www.example.com', '123.www.example.com');
     test('www.example.net', 'example.com', true);
     test('example.net', 'example.com', true);
+    test('www.ampproject.org', 'ampproject.org', true);
+    test('cdn.ampproject.org', 'ampproject.org', true);
+    test('www.ampproject.org', 'www.ampproject.org');
+    test('cdn.ampproject.org', 'cdn.ampproject.org');
   });
 });


### PR DESCRIPTION
Instead they must go onto the explicit sub domains.
And make sure if there are any, that they go away.