### PR TITLE
Remove isRelayoutNeeded from amp-ad

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -75,11 +75,6 @@ export function installAd(win) {
     }
 
     /** @override */
-    isRelayoutNeeded() {
-      return true;
-    }
-
-    /** @override */
     buildCallback() {
       /** @private {?Element} */
       this.iframe_ = null;


### PR DESCRIPTION
Added in https://github.com/ampproject/amphtml/pull/1801, which was reverted in https://github.com/ampproject/amphtml/commit/eddee059f38e6d8e44c61c566bdf6f8c2aa0e93a.