### PR TITLE
Speed up instagram and twitter embeds.

### DIFF
--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -41,7 +41,7 @@ import {loadPromise} from '../../../src/event-helper';
 class AmpInstagram extends AMP.BaseElement {
   /** @override */
   preconnectCallback(onLayout) {
-    this.preconnect.url('https://instagram.com', onLayout);
+    this.preconnect.url('https://www.instagram.com', onLayout);
   }
 
   /** @override */
@@ -63,7 +63,7 @@ class AmpInstagram extends AMP.BaseElement {
     const iframe = document.createElement('iframe');
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowtransparency', 'true');
-    iframe.src = 'https://instagram.com/p/' +
+    iframe.src = 'https://www.instagram.com/p/' +
         encodeURIComponent(shortcode) + '/embed/?v=4';
     this.applyFillContent(iframe);
     iframe.width = width;

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -40,7 +40,7 @@ describe('amp-instagram', () => {
       const iframe = ins.firstChild;
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
-      expect(iframe.src).to.equal('https://instagram.com/p/fBwFP/embed/?v=4');
+      expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?v=4');
       expect(iframe.getAttribute('width')).to.equal('111');
       expect(iframe.getAttribute('height')).to.equal('222');
     });

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -26,6 +26,8 @@ class AmpTwitter extends AMP.BaseElement {
   preconnectCallback(onLayout) {
     // This domain serves the actual tweets as JSONP.
     this.preconnect.url('https://syndication.twitter.com', onLayout);
+    // All images
+    this.preconnect.url('https://pbs.twimg.com', onLayout);
     // Hosts the script that renders tweets.
     this.preconnect.prefetch('https://platform.twitter.com/widgets.js');
     prefetchBootstrap(this.getWin());


### PR DESCRIPTION
1. Avoid redirect for instagram iframe (by going directly to www).
2. Preconnect to Twitter image host.
3. Preconnect to Instagram image host.