### PR TITLE
Make AUTHDATA substitution wait for that data to be available.

### DIFF
--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -429,6 +429,14 @@ export class AccessService {
     return getValueForExpr(this.authResponse_, field) || null;
   }
 
+
+  /**
+   * @return {!Promise} Returns a promise for the initial authorization.
+   */
+  whenFirstAuthorized() {
+    return this.firstAuthorizationPromise_;
+  }
+
   /**
    * @param {!JSONObjectDef} response
    * @return {!Promise}

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -438,9 +438,9 @@ describe('AccessService authorization', () => {
     analyticsMock.expects('triggerEvent')
         .withExactArgs('access-authorization-received')
         .once();
+    expect(service.firstAuthorizationPromise_).to.exist;
     return service.runAuthorization_().then(() => {
-      expect(service.firstAuthorizationPromise_).to.exist;
-      return service.firstAuthorizationPromise_;
+      return service.whenFirstAuthorized();
     });
   });
 

--- a/extensions/amp-access/amp-access-analytics.md
+++ b/extensions/amp-access/amp-access-analytics.md
@@ -156,6 +156,6 @@ The `ACCESS_READER_ID` variable is substituted with the Reader ID used for acces
 
 The `AUTHDATA(field)` variable is substituted with the value of the field in the authorization response. The nested fields are allowed, such as `AUTHDATA(nested.field)`.
 
-This variable is replaced with empty string if queried before the authorization response is received.
+This variable will wait until authorization is complete before being available.
 
 Data contained in `AUTHDATA` may be sensitive and care should be taken in sharing it. Please ensure that any data you pass to a third party complies with its terms of service.

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -267,7 +267,9 @@ class UrlReplacements {
     this.set_('AUTHDATA', field => {
       assert(field, 'The first argument to AUTHDATA, the field, is required');
       return this.getAccessValue_(accessService => {
-        return accessService.getAuthdataField(field);
+        return accessService.whenFirstAuthorized().then(() => {
+          return accessService.getAuthdataField(field);
+        });
       }, 'AUTHDATA');
     });
 

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -514,6 +514,7 @@ describe('UrlReplacements', () => {
       accessService = {
         getAccessReaderId: () => {},
         getAuthdataField: () => {},
+        whenFirstAuthorized: () => {},
       };
       accessServiceMock = sandbox.mock(accessService);
       reportDevSpy = sandbox.spy();
@@ -554,6 +555,9 @@ describe('UrlReplacements', () => {
     });
 
     it('should replace AUTHDATA', () => {
+      accessServiceMock.expects('whenFirstAuthorized')
+          .returns(Promise.resolve())
+          .once();
       accessServiceMock.expects('getAuthdataField')
           .withExactArgs('field1')
           .returns('value1')


### PR DESCRIPTION
That makes it possible to use it in calls that are uncoordinated with `amp-access`.

Fixes #2157 (Although that fully working is still pending launch of the experiment).