### PR TITLE
Mark errors as user errors in a way that works reliable in less good browsers.

### DIFF
--- a/src/asserts.js
+++ b/src/asserts.js
@@ -15,6 +15,11 @@
  */
 
 
+// Triple zero width space.
+// This is added to assert error messages, so that we can later identify
+// them, when the only thing that we have is the message. This is the
+// case in many browsers when the global exception handler is invoked.
+export const ASSERT_SENTINEL = '\u200B\u200B\u200B';
 
 /**
  * Throws an error if the first argument isn't trueish.
@@ -55,7 +60,7 @@ export function assert(shouldBeTrueish, message, var_args) {
       pushIfNonEmpty(messageArray, nextConstant.trim());
       formatted += toString(val) + nextConstant;
     }
-    const e = new Error(formatted);
+    const e = new Error(formatted + ASSERT_SENTINEL);
     e.fromAssert = true;
     e.associatedElement = firstElement;
     e.messageArray = messageArray;
@@ -82,6 +87,13 @@ export function assertEnumValue(enumObj, s, opt_enumName) {
     }
   }
   throw new Error(`Unknown ${opt_enumName || 'enum'} value: "${s}"`);
+}
+
+/**
+ * @return {boolean} Whether this message was created from an assert.
+ */
+export function isAssertErrorMessage(message) {
+  return message.indexOf(ASSERT_SENTINEL) >= 0;
 }
 
 /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -79,7 +79,8 @@ export function upgradeOrRegisterElement(win, name, toClass) {
     return;
   }
   assert(knownElements[name] == ElementStub,
-      'Expected ' + name + ' to be an ElementStub.');
+      '%s is already registered. The script tag for ' +
+      '%s is likely included twice in the page.', name, name);
   for (let i = 0; i < stubbedElements.length; i++) {
     const stub = stubbedElements[i];
     // There are 3 possible states here:

--- a/src/error.js
+++ b/src/error.js
@@ -17,6 +17,7 @@
 
 import {getMode} from './mode';
 import {exponentialBackoff} from './exponential-backoff';
+import {ASSERT_SENTINEL, isAssertErrorMessage} from './asserts';
 import {makeBodyVisible} from './styles';
 
 const globalExponentialBackoff = exponentialBackoff(1.5);
@@ -129,7 +130,8 @@ export function getErrorReportUrl(message, filename, line, col, error) {
   // for analyzing production issues.
   let url = 'https://amp-error-reporting.appspot.com/r' +
       '?v=' + encodeURIComponent('$internalRuntimeVersion$') +
-      '&m=' + encodeURIComponent(message);
+      '&m=' + encodeURIComponent(message.replace(ASSERT_SENTINEL, '')) +
+      '&a=' + (isAssertErrorMessage(message) ? 1 : 0);
   if (window.context && window.context.location) {
     url += '&3p=1';
   }
@@ -141,10 +143,7 @@ export function getErrorReportUrl(message, filename, line, col, error) {
     const tagName = error && error.associatedElement
       ? error.associatedElement.tagName
       : 'u';  // Unknown
-    // We may want to consider not reporting asserts but for now
-    // this should be helpful.
-    url += '&a=' + (error.fromAssert ? 1 : 0) +
-        '&el=' + encodeURIComponent(tagName) +
+    url += '&el=' + encodeURIComponent(tagName) +
         '&s=' + encodeURIComponent(error.stack || '');
     error.message += ' _reported_';
   } else {

--- a/test/functional/test-asserts.js
+++ b/test/functional/test-asserts.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {assert, assertEnumValue} from '../../src/asserts';
+import {ASSERT_SENTINEL, assert, assertEnumValue, isAssertErrorMessage} from
+    '../../src/asserts';
 
 describe('asserts', () => {
 
@@ -22,6 +23,14 @@ describe('asserts', () => {
     expect(function() {
       assert(false, 'xyz');
     }).to.throw(/xyz/);
+    try {
+      assert(false, '123');
+    } catch (e) {
+      expect(e.message).to.equal('123' + ASSERT_SENTINEL);
+      return;
+    }
+    // Unreachable
+    expect(false).to.be.true;
   });
 
   it('should not fail', () => {
@@ -51,7 +60,7 @@ describe('asserts', () => {
       error = e;
     }
     expect(error).to.be.instanceof(Error);
-    expect(error.message).to.equal('1 a 2 b 3');
+    expect(error.message).to.equal('1 a 2 b 3' + ASSERT_SENTINEL);
     expect(error.messageArray).to.deep.equal([1, 'a', 2, 'b', 3]);
   });
 
@@ -66,6 +75,28 @@ describe('asserts', () => {
     expect(error).to.be.instanceof(Error);
     expect(error.associatedElement).to.equal(div);
     expect(error.fromAssert).to.equal(true);
+  });
+
+  it('should recognize asserts', () => {
+    try {
+      assert(false, '123');
+    } catch (e) {
+      expect(isAssertErrorMessage(e.message)).to.be.true;
+      return;
+    }
+    // Unreachable
+    expect(false).to.be.true;
+  });
+
+  it('should recognize non-asserts', () => {
+    try {
+      throw new Error('123');
+    } catch (e) {
+      expect(isAssertErrorMessage(e.message)).to.be.false;
+      return;
+    }
+    // Unreachable
+    expect(false).to.be.true;
   });
 });
 

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {assert} from '../../src/asserts';
 import {getErrorReportUrl} from '../../src/error';
 import {setModeForTesting} from '../../src/mode';
 import {parseUrl, parseQueryString} from '../../src/url';
@@ -68,10 +69,30 @@ describe('reportErrorToServer', () => {
   });
 
   it('reportError mark asserts', () => {
-    const e = new Error('XYZ');
-    e.fromAssert = true;
+    let e = '';
+    try {
+      assert(false, 'XYZ');
+    } catch (error) {
+      e = error;
+    }
     const url = parseUrl(
         getErrorReportUrl(undefined, undefined, undefined, undefined, e));
+    const query = parseQueryString(url.search);
+
+    expect(query.m).to.equal('XYZ');
+    expect(query.a).to.equal('1');
+    expect(query.v).to.equal('$internalRuntimeVersion$');
+  });
+
+  it('reportError mark asserts without error object', () => {
+    let e = '';
+    try {
+      assert(false, 'XYZ');
+    } catch (error) {
+      e = error;
+    }
+    const url = parseUrl(
+        getErrorReportUrl(e.message, undefined, undefined, undefined));
     const query = parseQueryString(url.search);
 
     expect(query.m).to.equal('XYZ');


### PR DESCRIPTION
Many browsers do not provide the error object in window.error. Instead we mark the error message with invisible spaces, because we have access to that one.

When creating a load promise for a Window, don't listen for error events because they fire for JS errors, not load errors.

Slightly improves the error message if an extension script tag is included twice.