### PR TITLE
Only create fake modules if they don't exists yet.

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -145,7 +145,9 @@ function compile(entryModuleFilename, outputDir,
       );
     }
     unneededFiles.forEach(function(fake) {
-      fs.writeFileSync(fake, '// Not needed in closure compiler\n');
+      if (!fs.existsSync(fake)) {
+        fs.writeFileSync(fake, '// Not needed in closure compiler\n');
+      }
     });
     /*eslint "google-camelcase/google-camelcase": 0*/
     return gulp.src(srcs)


### PR DESCRIPTION
Fixes a crash that can happen during concurrent compilation.

Fixes #2179