### PR TITLE
Do not leak the fact that an ad slot could not be filled through the creative id.

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -234,7 +234,7 @@ export function installAd(win) {
           // Triggered by context.reportRenderedEntityIdentifier(…) inside the ad
           // iframe.
           listenOnce(this.iframe_, 'entity-id', info => {
-            this.element.setAttribute('creative-id', info.id);
+            this.element.creativeId = info.id;
           }, /* opt_is3P */ true);
           listen(this.iframe_, 'embed-size', data => {
             if (data.width !== undefined) {

--- a/test/integration/test-amp-ad-doubleclick.js
+++ b/test/integration/test-amp-ad-doubleclick.js
@@ -107,7 +107,7 @@ describe('Rendering of one ad', () => {
         return;
       }
       return poll('Creative id transmitted. Ad fully rendered.', () => {
-        return ampAd.getAttribute('creative-id');
+        return ampAd.creativeId;
       }, null, 15000);
     }).then(creativeId => {
       if (isEdge) { // TODO(cramforce): Get this to pass in Edge


### PR DESCRIPTION
This is an interesting lesson in that every debugging tool becomes an API.

Fixes #2178