### PR TITLE
Treat timeouts as user errors and provide a special error for cancellations.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -355,6 +355,13 @@ var forbiddenTermsSrcInclusive = {
   '\\.webkitConvertPointFromNodeToPage(?!_)': bannedTermsHelpString,
   '\\.webkitConvertPointFromPageToNode(?!_)': bannedTermsHelpString,
   '\\.changeHeight(?!_)': bannedTermsHelpString,
+  'reject\\(\\)': {
+    message: 'Always supply a reason in rejections. ' +
+        'error.cancellation() may be applicable.',
+    whitelist: [
+      'extensions/amp-access/0.1/access-expr-impl.js',
+    ],
+  }
 };
 
 // Terms that must appear in a source file.

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -18,6 +18,7 @@ import {actionServiceFor} from '../../../src/action';
 import {analyticsFor} from '../../../src/analytics';
 import {assert, assertEnumValue} from '../../../src/asserts';
 import {assertHttpsUrl, getSourceOrigin} from '../../../src/url';
+import {cancellation} from '../../../src/error';
 import {cidFor} from '../../../src/cid';
 import {documentStateFor} from '../../../src/document-state';
 import {evaluateAccessExpr} from './access-expr';
@@ -625,7 +626,7 @@ export class AccessService {
       // 1. Document becomes invisible again: cancel.
       unlistenSet.push(this.viewer_.onVisibilityChanged(() => {
         if (!this.viewer_.isVisible()) {
-          reject();
+          reject(cancellation());
         }
       }));
 

--- a/src/asserts.js
+++ b/src/asserts.js
@@ -60,7 +60,7 @@ export function assert(shouldBeTrueish, message, var_args) {
       pushIfNonEmpty(messageArray, nextConstant.trim());
       formatted += toString(val) + nextConstant;
     }
-    const e = new Error(formatted + ASSERT_SENTINEL);
+    const e = userError(formatted);
     e.fromAssert = true;
     e.associatedElement = firstElement;
     e.messageArray = messageArray;
@@ -87,6 +87,18 @@ export function assertEnumValue(enumObj, s, opt_enumName) {
     }
   }
   throw new Error(`Unknown ${opt_enumName || 'enum'} value: "${s}"`);
+}
+
+/**
+ * Returns an error object that will be treated as user originated error
+ * by the system.
+ * User in this case means: 'Error caused by doc as opposed internal AMP
+ * error'.
+ * @param {string} message
+ * @return {!Error}
+ */
+export function userError(message) {
+  return new Error(message + ASSERT_SENTINEL);
 }
 
 /**

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -15,6 +15,7 @@
  */
 
 import {Pass} from '../pass';
+import {cancellation} from '../error';
 import {getService} from '../service';
 import {log} from '../log';
 import {timer} from '../timer';
@@ -243,7 +244,7 @@ export class Vsync {
    */
   runAnimMutateSeries(mutator, opt_timeout) {
     if (!this.canAnimate()) {
-      return Promise.reject();
+      return Promise.reject(cancellation());
     }
     return new Promise((resolve, reject) => {
       const startTime = timer.now();

--- a/src/timer.js
+++ b/src/timer.js
@@ -17,6 +17,8 @@
 // Requires polyfills in immediate side effect.
 import './polyfills';
 
+import {userError} from './asserts';
+
 /**
  * Helper with all things Timer.
  */
@@ -138,7 +140,7 @@ export class Timer {
     const delayPromise = new Promise((_resolve, reject) => {
       timerKey = this.delay(() => {
         timerKey = -1;
-        reject(new Error('timeout'));
+        reject(userError('timeout'));
       }, delay);
       if (timerKey == -1) {
         reject(new Error('Failed to schedule timer.'));

--- a/test/functional/test-asserts.js
+++ b/test/functional/test-asserts.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {ASSERT_SENTINEL, assert, assertEnumValue, isAssertErrorMessage} from
-    '../../src/asserts';
+import {ASSERT_SENTINEL, assert, assertEnumValue, isAssertErrorMessage,
+    userError} from '../../src/asserts';
 
 describe('asserts', () => {
 
@@ -97,6 +97,12 @@ describe('asserts', () => {
     }
     // Unreachable
     expect(false).to.be.true;
+  });
+
+  it('should create user errors', () => {
+    expect(userError('test')).to.be.instanceof(Error);
+    expect(isAssertErrorMessage(userError('test').message)).to.be.true;
+    expect(userError('test').message).to.contain('test');
   });
 });
 

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -15,7 +15,7 @@
  */
 
 import {assert} from '../../src/asserts';
-import {getErrorReportUrl} from '../../src/error';
+import {getErrorReportUrl, cancellation} from '../../src/error';
 import {setModeForTesting} from '../../src/mode';
 import {parseUrl, parseQueryString} from '../../src/url';
 import * as sinon from 'sinon';
@@ -139,5 +139,19 @@ describe('reportErrorToServer', () => {
     expect(query.f).to.equal('foo.js');
     expect(query.l).to.equal('11');
     expect(query.c).to.equal('22');
+  });
+
+  it('should not double report', () => {
+    const e = new Error('something _reported_');
+    const url =
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e);
+    expect(url).to.be.undefined;
+  });
+
+  it('reportError with error object', () => {
+    const e = cancellation();
+    const url =
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e);
+    expect(url).to.be.undefined;
   });
 });

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -100,7 +100,7 @@ describe('Timer', () => {
     }).catch(reason => {
       c++;
       expect(c).to.equal(1);
-      expect(reason.message).to.equal('timeout');
+      expect(reason.message).to.contain('timeout');
     });
   });
 
@@ -132,7 +132,7 @@ describe('Timer', () => {
     }).catch(reason => {
       c++;
       expect(c).to.equal(1);
-      expect(reason.message).to.equal('timeout');
+      expect(reason.message).to.contain('timeout');
     });
   });
 });


### PR DESCRIPTION
Cancellations are not reported to the server as errors.

Also creates a presubmit rule that prevents bare `reject()` in our code base.