### PR TITLE
Test the URL generated for the predefined requests of all vendor configs.

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -323,7 +323,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     if (!request) {
       console./*OK*/error(this.getName_(), 'Ignoring event. Request string ' +
           'not found: ', trigger['request']);
-      return;
+      return Promise.resolve();
     }
 
     // Add any given extraUrlParams as query string param
@@ -342,21 +342,23 @@ export class AmpAnalytics extends AMP.BaseElement {
       const argList = match[2] || '';
       const raw = (trigger['vars'] && trigger['vars'][name] ||
           this.config_['vars'] && this.config_['vars'][name]);
-      const val = this.encodeVars_(raw != null ? raw : '');
+      const val = this.encodeVars_(raw != null ? raw : '', name);
       return val + argList;
     });
 
-    // For consistentcy with amp-pixel we also expand any url replacements.
-    urlReplacementsFor(this.getWin()).expand(request).then(request => {
+    // For consistency with amp-pixel we also expand any url replacements.
+    return urlReplacementsFor(this.getWin()).expand(request).then(request => {
       this.sendRequest_(request, trigger);
+      return request;
     });
   }
 
   /**
    * @param {string} raw The values to URI encode.
+   * @param {string} unusedName Name of the variable.
    * @private
    */
-  encodeVars_(raw) {
+  encodeVars_(raw, unusedName) {
     if (isArray(raw)) {
       return raw.map(encodeURIComponent).join(',');
     }

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -1,0 +1,60 @@
+{
+  "atinternet": {
+    "base": "https://$log$domain/hit.xiti?s=$site&ts=_timestamp_&r=_screen_width_x_screen_height_x_screen_color_depth_&re=_available_screen_width_x_available_screen_height_",
+    "suffix": "&ref=_document_referrer_",
+    "pageview": "https://$log$domain/hit.xiti?s=$site&ts=_timestamp_&r=_screen_width_x_screen_height_x_screen_color_depth_&re=_available_screen_width_x_available_screen_height_&p=_title_&s2=$level2&ref=_document_referrer_",
+    "click": "https://$log$domain/hit.xiti?s=$site&ts=_timestamp_&r=_screen_width_x_screen_height_x_screen_color_depth_&re=_available_screen_width_x_available_screen_height_&pclick=_title_&s2click=$level2&p=$label&s2=$level2Click&type=click&click=$type&ref=_document_referrer_"
+  },
+  "chartbeat": {
+    "host": "https://ping.chartbeat.net",
+    "basePrefix": "/ping?h=$domain&p=_canonical_path_&u=_client_id_&d=_canonical_host_&g=$uid&g0=$sections&g1=$authors&g2=$zone&g3=$sponsorName&g4=$contentType&x=_scroll_top_&y=_scroll_height_&j=$decayTime&r=_document_referrer_&b=_page_load_time_&t=_client_id__page_view_id_&i=_title_&T=_timestamp_&E=_total_engaged_time_&C=2&R=1&W=0&I=0&c=120",
+    "baseSuffix": "&_",
+    "interval": "https://ping.chartbeat.net/ping?h=$domain&p=_canonical_path_&u=_client_id_&d=_canonical_host_&g=$uid&g0=$sections&g1=$authors&g2=$zone&g3=$sponsorName&g4=$contentType&x=_scroll_top_&y=_scroll_height_&j=$decayTime&r=_document_referrer_&b=_page_load_time_&t=_client_id__page_view_id_&i=_title_&T=_timestamp_&E=_total_engaged_time_&C=2&R=1&W=0&I=0&c=120&_",
+    "anchorClick": "https://ping.chartbeat.net/ping?h=$domain&p=_canonical_path_&u=_client_id_&d=_canonical_host_&g=$uid&g0=$sections&g1=$authors&g2=$zone&g3=$sponsorName&g4=$contentType&x=_scroll_top_&y=_scroll_height_&j=$decayTime&r=_document_referrer_&b=_page_load_time_&t=_client_id__page_view_id_&i=_title_&T=_timestamp_&E=_total_engaged_time_&C=2&R=1&W=0&I=0&c=120&_"
+  },
+  "comscore": {
+    "host": "https://sb.scorecardresearch.com",
+    "base": "https://sb.scorecardresearch.com/b?",
+    "pageview": "https://sb.scorecardresearch.com/b?c1=2&c2=$c2&rn=_random_&c8=_title_&c7=_canonical_url_&c9=_document_referrer_&cs_c7amp=_ampdoc_url_"
+  },
+  "googleanalytics": {
+    "host": "https://www.google-analytics.com",
+    "basePrefix": "v=1&_v=a0&aip=true&_s=1&dt=_title_&sr=_screen_width_x_screen_height_&_utmht=_timestamp_&jid=&cid=_client_id_&tid=$account&dl=$documentLocation&dr=_document_referrer_&sd=_screen_color_depth_&ul=_browser_language_&de=_document_charset_",
+    "baseSuffix": "&a=_page_view_id_&z=_random_",
+    "pageview": "https://www.google-analytics.com/r/collect?v=1&_v=a0&aip=true&_s=1&dt=_title_&sr=_screen_width_x_screen_height_&_utmht=_timestamp_&jid=&cid=_client_id_&tid=$account&dl=$documentLocation&dr=_document_referrer_&sd=_screen_color_depth_&ul=_browser_language_&de=_document_charset_&t=pageview&_r=1&a=_page_view_id_&z=_random_",
+    "event": "https://www.google-analytics.com/collect?v=1&_v=a0&aip=true&_s=1&dt=_title_&sr=_screen_width_x_screen_height_&_utmht=_timestamp_&jid=&cid=_client_id_&tid=$account&dl=$documentLocation&dr=_document_referrer_&sd=_screen_color_depth_&ul=_browser_language_&de=_document_charset_&t=event&ec=$eventCategory&ea=$eventAction&el=$eventLabel&ev=$eventValue&a=_page_view_id_&z=_random_",
+    "social": "https://www.google-analytics.com/collect?v=1&_v=a0&aip=true&_s=1&dt=_title_&sr=_screen_width_x_screen_height_&_utmht=_timestamp_&jid=&cid=_client_id_&tid=$account&dl=$documentLocation&dr=_document_referrer_&sd=_screen_color_depth_&ul=_browser_language_&de=_document_charset_&t=social&sa=$socialAction&sn=$socialNetwork&st=$socialTarget&a=_page_view_id_&z=_random_",
+    "timing": "https://www.google-analytics.com/collect?v=1&_v=a0&aip=true&_s=1&dt=_title_&sr=_screen_width_x_screen_height_&_utmht=_timestamp_&jid=&cid=_client_id_&tid=$account&dl=$documentLocation&dr=_document_referrer_&sd=_screen_color_depth_&ul=_browser_language_&de=_document_charset_&t=timing&plt=_page_load_time_&dns=_domain_lookup_time_&tcp=_tcp_connect_time_&rrt=_redirect_time_&srt=_server_response_time_&pdt=_page_download_time_&clt=_content_load_time_&dit=_dom_interactive_time_&a=_page_view_id_&z=_random_"
+  },
+  "krux": {
+    "beaconHost": "https://beacon.krxd.net",
+    "timing": "t_navigation_type=0&t_dns=_domain_lookup_time_&t_tcp=_tcp_connect_time_&t_http_request=_server_response_time_&t_http_response=_page_download_time_&t_content_ready=_content_load_time_&t_window_load=_page_load_time_&t_redirect=_redirect_time_",
+    "common": "source=amp&confid=$confid&_kpid=$pubid&_kcp_s=$site&_kcp_sc=$section&_kcp_ssc=$subsection&_kcp_d=_canonical_host_&_kpref_=_document_referrer_&_kua_kx_amp_client_id=_client_id_&_kua_kx_lang=_browser_language_&_kua_kx_tech_browser_language=_browser_language_&_kua_kx_tz=_timezone_",
+    "pageview": "https://beacon.krxd.net/pixel.gif?source=amp&confid=$confid&_kpid=$pubid&_kcp_s=$site&_kcp_sc=$section&_kcp_ssc=$subsection&_kcp_d=_canonical_host_&_kpref_=_document_referrer_&_kua_kx_amp_client_id=_client_id_&_kua_kx_lang=_browser_language_&_kua_kx_tech_browser_language=_browser_language_&_kua_kx_tz=_timezone_&t_navigation_type=0&t_dns=_domain_lookup_time_&t_tcp=_tcp_connect_time_&t_http_request=_server_response_time_&t_http_response=_page_download_time_&t_content_ready=_content_load_time_&t_window_load=_page_load_time_&t_redirect=_redirect_time_",
+    "event": "https://beacon.krxd.net/event.gif?source=amp&confid=$confid&_kpid=$pubid&_kcp_s=$site&_kcp_sc=$section&_kcp_ssc=$subsection&_kcp_d=_canonical_host_&_kpref_=_document_referrer_&_kua_kx_amp_client_id=_client_id_&_kua_kx_lang=_browser_language_&_kua_kx_tech_browser_language=_browser_language_&_kua_kx_tz=_timezone_&t_navigation_type=0&t_dns=_domain_lookup_time_&t_tcp=_tcp_connect_time_&t_http_request=_server_response_time_&t_http_response=_page_download_time_&t_content_ready=_content_load_time_&t_window_load=_page_load_time_&t_redirect=_redirect_time_&pageview=false"
+  },
+  "parsely": {
+    "host": "https://srv.pixel.parsely.com",
+    "basePrefix": "https://srv.pixel.parsely.com/plogger/?rand=_timestamp_&idsite=$apikey&url=_ampdoc_url_&urlref=_document_referrer_&screen=_screen_width_x_screen_height_%7C_available_screen_width_x_available_screen_height_%7C_screen_color_depth_&title=_title_&date=_timestamp_&ampid=_client_id_",
+    "pageview": "https://srv.pixel.parsely.com/plogger/?rand=_timestamp_&idsite=$apikey&url=_ampdoc_url_&urlref=_document_referrer_&screen=_screen_width_x_screen_height_%7C_available_screen_width_x_available_screen_height_%7C_screen_color_depth_&title=_title_&date=_timestamp_&ampid=_client_id_&action=pageview"
+  },
+  "quantcast": {
+    "host": "https://pixel.quantserve.com/pixel",
+    "pageview": "https://pixel.quantserve.com/pixel;r=_random_;a=$pcode;labels=$labels;fpan=;fpa=_client_id_;ns=0;ce=1;cm=;je=0;sr=_screen_width_x_screen_height_x_screen_color_depth_;enc=n;et=_timestamp_;ref=_document_referrer_;url=_canonical_url_"
+  },
+  "adobeanalytics": {
+    "requestPath": "/b/ss/$reportSuites/0/amp-1.0/s_random_",
+    "basePrefix": "vid=z_client_id_&ndh=0&ce=_document_charset_&pageName=$pageName&g=_ampdoc_url_&r=_document_referrer_&bh=_available_screen_height_&bw=_available_screen_width_&c=_screen_color_depth_&j=amp&s=_screen_width_x_screen_height_",
+    "pageview": "https://$host/b/ss/$reportSuites/0/amp-1.0/s_random_?vid=z_client_id_&ndh=0&ce=_document_charset_&pageName=$pageName&g=_ampdoc_url_&r=_document_referrer_&bh=_available_screen_height_&bw=_available_screen_width_&c=_screen_color_depth_&j=amp&s=_screen_width_x_screen_height_",
+    "click": "https://$host/b/ss/$reportSuites/0/amp-1.0/s_random_?vid=z_client_id_&ndh=0&ce=_document_charset_&pageName=$pageName&g=_ampdoc_url_&r=_document_referrer_&bh=_available_screen_height_&bw=_available_screen_width_&c=_screen_color_depth_&j=amp&s=_screen_width_x_screen_height_&pe=lnk_$linkType&pev1=$linkUrl&pev2=$linkName"
+  },
+  "infonline": {
+    "pageview": "$url?st=$st&sv=$sv&ap=$ap&co=$co&cp=$cp&host=_canonical_host_&path=_canonical_path_"
+  },
+  "simplereach": {
+    "host": "https://edge.simplereach.com",
+    "baseParams": "amp=true&pid=$pid&title=_title_&url=_canonical_url_&date=$published_at&authors=$authors&channels=$categories&tags=$tags&referrer=_document_referrer_&page_url=_source_url_&user_id=_client_id_&domain=_canonical_host_",
+    "visible": "https://edge.simplereach.com/n?amp=true&pid=$pid&title=_title_&url=_canonical_url_&date=$published_at&authors=$authors&channels=$categories&tags=$tags&referrer=_document_referrer_&page_url=_source_url_&user_id=_client_id_&domain=_canonical_host_",
+    "timer": "https://edge.simplereach.com/t?amp=true&pid=$pid&title=_title_&url=_canonical_url_&date=$published_at&authors=$authors&channels=$categories&tags=$tags&referrer=_document_referrer_&page_url=_source_url_&user_id=_client_id_&domain=_canonical_host_&t=5000&e=5000"
+  }
+}

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -377,7 +377,7 @@ class UrlReplacements {
         args = opt_strargs.split(',');
       }
       const binding = (opt_bindings && (name in opt_bindings)) ?
-          opt_bindings[name] : this.replacements_[name];
+          opt_bindings[name] : this.getReplacement_(name);
       const val = (typeof binding == 'function') ?
           binding.apply(null, args) : binding;
       // In case the produced value is a promise, we don't actually
@@ -403,6 +403,14 @@ class UrlReplacements {
     }
 
     return replacementPromise || Promise.resolve(url);
+  }
+
+  /**
+   * @param {string} name
+   * @return {function(*):*}
+   */
+  getReplacement_(name) {
+    return this.replacements_[name];
   }
 
   /**


### PR DESCRIPTION
This will make:

- inadvertent changes in the future harder.
- provides some easy to see reference how the generated URLs will look like.