### PR TITLE
Fix capturing of scroll activity for engaged time calculation

### DIFF
--- a/src/service/activity-impl.js
+++ b/src/service/activity-impl.js
@@ -21,6 +21,7 @@
 
 import {getService} from '../service';
 import {viewerFor} from '../viewer';
+import {viewportFor} from '../viewport';
 import {listen} from '../event-helper';
 
 
@@ -110,12 +111,13 @@ class ActivityHistory {
 
 
 /**
- * Array of event types which will be listened for on the document element to
- * indicate activity.
+ * Array of event types which will be listened for on the document to indicate
+ * activity. Other activities are also observed on the Viewer and Viewport
+ * objects. See {@link setUpActivityListeners_} for listener implementation.
  * @private @const {Array<string>}
  */
 const ACTIVE_EVENT_TYPES = [
-  'scroll', 'mousedown', 'mouseup', 'mousemove', 'keydown', 'keyup'
+  'mousedown', 'mouseup', 'mousemove', 'keydown', 'keyup'
 ];
 
 export class Activity {
@@ -170,6 +172,9 @@ export class Activity {
     /** @private @const {!Viewer} */
     this.viewer_ = viewerFor(this.win_);
 
+    /** @private @const {!Viewport} */
+    this.viewport_ = viewportFor(this.win_);
+
     this.viewer_.whenFirstVisible().then(this.start_.bind(this));
   }
 
@@ -204,11 +209,17 @@ export class Activity {
   /** @private */
   setUpActivityListeners_() {
     for (let i = 0; i < ACTIVE_EVENT_TYPES.length; i++) {
-      this.unlistenFuncs_.push(listen(this.win_.document.documentElement,
+      this.unlistenFuncs_.push(listen(this.win_.document,
         ACTIVE_EVENT_TYPES[i], this.boundHandleActivity_));
     }
 
-    this.viewer_.onVisibilityChanged(this.boundHandleVisibilityChange_);
+    this.unlistenFuncs_.push(
+        this.viewer_.onVisibilityChanged(this.boundHandleVisibilityChange_));
+
+    // Viewport.onScroll does not return an unlisten function.
+    // TODO(britice): If Viewport is updated to return an unlisten function,
+    // update this to capture the unlisten function.
+    this.viewport_.onScroll(this.boundHandleActivity_);
   }
 
   /** @private */

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -18,6 +18,8 @@ import {installActivityService} from '../../src/service/activity-impl';
 import {activityFor} from '../../src/activity';
 import {installViewerService} from '../../src/service/viewer-impl';
 import {viewerFor} from '../../src/viewer';
+import {installViewportService} from '../../src/service/viewport-impl';
+import {viewportFor} from '../../src/viewport';
 import {Observable} from '../../src/observable';
 import * as sinon from 'sinon';
 
@@ -28,9 +30,11 @@ describe('Activity getTotalEngagedTime', () => {
   let fakeDoc;
   let fakeWin;
   let viewer;
+  let viewport;
   let activity;
   let whenFirstVisibleResolve;
   let visibilityObservable;
+  let mousedownObservable;
   let scrollObservable;
 
   beforeEach(() => {
@@ -41,14 +45,19 @@ describe('Activity getTotalEngagedTime', () => {
     clock.tick(123456);
 
     visibilityObservable = new Observable();
+    mousedownObservable = new Observable();
     scrollObservable = new Observable();
 
     fakeDoc = {
+      addEventListener: function(eventName, callback) {
+        if (eventName === 'mousedown') {
+          mousedownObservable.add(callback);
+        }
+      },
       documentElement: {
-        addEventListener: function(eventName, callback) {
-          if (eventName === 'scroll') {
-            scrollObservable.add(callback);
-          }
+        style: {
+          // required to instantiate Viewport service
+          paddingTop: 0
         }
       }
     };
@@ -60,7 +69,9 @@ describe('Activity getTotalEngagedTime', () => {
       },
       location: {
         href: 'https://cdn.ampproject.org/v/www.origin.com/foo/?f=0',
-      }
+      },
+      // required to instantiate Viewport service
+      addEventListener: () => {}
     };
 
     installViewerService(fakeWin);
@@ -74,6 +85,13 @@ describe('Activity getTotalEngagedTime', () => {
       visibilityObservable.add(handler);
     });
 
+    installViewportService(fakeWin);
+    viewport = viewportFor(fakeWin);
+
+    sandbox.stub(viewport, 'onScroll', handler => {
+      scrollObservable.add(handler);
+    });
+
     installActivityService(fakeWin);
 
     return activityFor(fakeWin).then(a => {
@@ -82,8 +100,15 @@ describe('Activity getTotalEngagedTime', () => {
   });
 
   afterEach(() => {
-    whenFirstVisibleResolve = null;
+    fakeDoc = null;
+    fakeWin = null;
     viewer = null;
+    viewport = null;
+    activity = null;
+    whenFirstVisibleResolve = null;
+    visibilityObservable = null;
+    mousedownObservable = null;
+    scrollObservable = null;
     sandbox.restore();
   });
 
@@ -116,7 +141,7 @@ describe('Activity getTotalEngagedTime', () => {
     whenFirstVisibleResolve();
     return viewer.whenFirstVisible().then(() => {
       clock.tick(6000);
-      scrollObservable.fire();
+      mousedownObservable.fire();
       clock.tick(20000);
       return expect(activity.getTotalEngagedTime()).to.equal(10);
     });
@@ -126,7 +151,7 @@ describe('Activity getTotalEngagedTime', () => {
     whenFirstVisibleResolve();
     return viewer.whenFirstVisible().then(() => {
       clock.tick(3456);
-      scrollObservable.fire();
+      mousedownObservable.fire();
       clock.tick(10232);
       const first = activity.getTotalEngagedTime();
       clock.tick(25255);
@@ -139,7 +164,7 @@ describe('Activity getTotalEngagedTime', () => {
     whenFirstVisibleResolve();
     return viewer.whenFirstVisible().then(() => {
       clock.tick(3000);
-      scrollObservable.fire();
+      mousedownObservable.fire();
       clock.tick(1000);
       isVisibleStub.returns(false);
       visibilityObservable.fire();
@@ -152,22 +177,19 @@ describe('Activity getTotalEngagedTime', () => {
     whenFirstVisibleResolve();
     return viewer.whenFirstVisible().then(() => {
       clock.tick(10000);
-      scrollObservable.fire();
+      mousedownObservable.fire();
       clock.tick(10000);
       scrollObservable.fire();
       clock.tick(10000);
-      scrollObservable.fire();
+      mousedownObservable.fire();
       clock.tick(10000);
       return expect(activity.getTotalEngagedTime()).to.equal(20);
     });
   });
 
-  it('should set event listeners on the documentElement for' +
-     ' "scroll", "mousedown", "mousemove", "keyup", "keydown"', () => {
-    const addEventListenerSpy = sandbox.spy(fakeDoc.documentElement,
-        'addEventListener');
-    expect(addEventListenerSpy).to.not.have.been.calledWith('scroll',
-        activity.boundHandleActivity_);
+  it('should set event listeners on the document for' +
+     ' "mousedown", "mouseup", "mousemove", "keyup", "keydown"', () => {
+    const addEventListenerSpy = sandbox.spy(fakeDoc, 'addEventListener');
     expect(addEventListenerSpy).to.not.have.been.calledWith('mousedown',
         activity.boundHandleActivity_);
     expect(addEventListenerSpy).to.not.have.been.calledWith('mouseup',
@@ -180,8 +202,6 @@ describe('Activity getTotalEngagedTime', () => {
         activity.boundHandleActivity_);
     whenFirstVisibleResolve();
     return viewer.whenFirstVisible().then(() => {
-      expect(addEventListenerSpy).to.have.been.calledWith('scroll',
-          activity.boundHandleActivity_);
       expect(addEventListenerSpy).to.have.been.calledWith('mousedown',
           activity.boundHandleActivity_);
       expect(addEventListenerSpy).to.have.been.calledWith('mouseup',


### PR DESCRIPTION
Addresses issue https://github.com/ampproject/amphtml/issues/2226.

The problem described in the issue was solved by using `viewport.onScroll` to listen for scroll activity. Additionally, other activity listeners were moved from `document.documentElement` to `document`.