### PR TITLE
Always log when channel with parent cannot be established.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -283,6 +283,7 @@ var forbiddenTerms = {
     message: 'Use Viewer.getReferrerUrl() instead.',
     whitelist: [
       'src/service/viewer-impl.js',
+      'src/error.js',
     ],
   },
   'getUnconfirmedReferrerUrl': {

--- a/src/error.js
+++ b/src/error.js
@@ -155,6 +155,12 @@ export function getErrorReportUrl(message, filename, line, col, error) {
   if (window.AMP_CONFIG && window.AMP_CONFIG.canary) {
     url += '&ca=1';
   }
+  if (window.location.ancestorOrigins && window.location.ancestorOrigins[0]) {
+    url += '&or=' + encodeURIComponent(window.location.ancestorOrigins[0]);
+  }
+  if (window.viewerState) {
+    url += '&vs=' + encodeURIComponent(window.viewerState);
+  }
 
   if (error) {
     const tagName = error && error.associatedElement
@@ -168,6 +174,7 @@ export function getErrorReportUrl(message, filename, line, col, error) {
         '&l=' + encodeURIComponent(line) +
         '&c=' + encodeURIComponent(col || '');
   }
+  url += '&r=' + encodeURIComponent(document.referrer);
 
   // Shorten URLs to a value all browsers will send.
   return url.substr(0, 2000);

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -36,6 +36,7 @@ describe('reportErrorToServer', () => {
     window.onerror = onError;
     sandbox.restore();
     setModeForTesting(null);
+    window.viewerState = undefined;
   });
 
   it('reportError with error object', () => {
@@ -52,6 +53,9 @@ describe('reportErrorToServer', () => {
     expect(query.s).to.equal(e.stack);
     expect(query['3p']).to.equal(undefined);
     expect(e.message).to.contain('_reported_');
+    expect(query.or).to.contain('http://localhost');
+    expect(query.vs).to.be.undefined;
+    expect(query.r).to.contain('http://localhost');
   });
 
   it('reportError with associatedElement', () => {
@@ -114,7 +118,8 @@ describe('reportErrorToServer', () => {
     expect(query['3p']).to.equal('1');
   });
 
-  it('reportError marks canary', () => {
+  it('reportError marks canary and viewerState', () => {
+    window.viewerState = 'some-state';
     window.AMP_CONFIG = {
       canary: true,
     };
@@ -126,6 +131,7 @@ describe('reportErrorToServer', () => {
 
     expect(query.m).to.equal('XYZ');
     expect(query['ca']).to.equal('1');
+    expect(query['vs']).to.equal('some-state');
   });
 
   it('reportError without error object', () => {


### PR DESCRIPTION
Also adds ancestor info to error requests and allows the viewer integration to pass some state into the request.

CC @ericfs @dvoytenko 