### PR TITLE
Assorted fixes to amp-analytics

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -39,6 +39,13 @@ Container for analytics tags. Positioned far away from top to make sure that doe
   "vars": {
     "title": "Example Request"
   },
+  "extraUrlParams": {
+    "param1": "Interesting value",
+    "platform": "AMP"
+  },
+  "extraUrlParamsReplaceMap": {
+    "param": "p"
+  },
   "triggers": {
     "defaultPageview": {
       "on": "visible",
@@ -69,11 +76,11 @@ Container for analytics tags. Positioned far away from top to make sure that doe
 <script type="application/json">
   {
     "vars": {
-      "site": "123456", // Site number
-      "log": "logs", // Secured collect log
-      "domain": ".xiti.com", // Collect domain name
-      "title": "pageChapter::pageTitle", // Page label
-      "level2": "10" // Page level 2
+      "site": "123456",
+      "log": "logs",
+      "domain": ".xiti.com",
+      "title": "pageChapter::pageTitle",
+      "level2": "10"
     },
     "triggers": {
       "defaultPageview": {
@@ -85,9 +92,9 @@ Container for analytics tags. Positioned far away from top to make sure that doe
         "selector": "#test1",
         "request": "click",
         "vars": {
-          "label": "clickChapter::clickLabel", // Click label
-          "level2Click": "12", // Click level 2
-          "type": "a" // Click type (a = action, t = download, n = navigation, s  exit)
+          "label": "clickChapter::clickLabel",
+          "level2Click": "12",
+          "type": "a"
         }
       }
     }
@@ -122,9 +129,13 @@ Container for analytics tags. Positioned far away from top to make sure that doe
 </amp-analytics>
 <!-- End comScore example -->
 
-<amp-analytics type="googleanalytics" id="analytics2">
+<amp-analytics type="googleanalytics" id="googleanalytics">
 <script type="application/json">
 {
+  "extraUrlParams" : {
+    "dimension5": "AMP",
+    "metric17": "10"
+  },
   "vars": {
     "account": "UA-YYYY-Y"
   },

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -168,14 +168,14 @@ export const ANALYTICS_CONFIG = {
   'googleanalytics': {
     'vars': {
       'eventValue': '0',
-      'documentLocation': 'AMPDOC_URL',
+      'documentLocation': 'SOURCE_URL',
+      'clientId': 'CLIENT_ID(AMP_ECID_GOOGLE)',
     },
     'requests': {
       'host': 'https://www.google-analytics.com',
       'basePrefix': 'v=1&_v=a0&aip=true&_s=${requestCount}&' +
           'dt=${title}&sr=${screenWidth}x${screenHeight}&_utmht=${timestamp}&' +
-          'jid=&cid=${clientId(AMP_ECID_GOOGLE)}&tid=${account}&' +
-          'dl=${documentLocation}&' +
+          'jid=&cid=${clientId}&tid=${account}&dl=${documentLocation}&' +
           'dr=${documentReferrer}&sd=${screenColorDepth}&' +
           'ul=${browserLanguage}&de=${documentCharset}' ,
       'baseSuffix': '&a=${pageViewId}&z=${random}',
@@ -191,6 +191,10 @@ export const ANALYTICS_CONFIG = {
           'dns=${domainLookupTime}&tcp=${tcpConnectTime}&rrt=${redirectTime}&' +
           'srt=${serverResponseTime}&pdt=${pageDownloadTime}&' +
           'clt=${contentLoadTime}&dit=${domInteractiveTime}${baseSuffix}',
+    },
+    'extraUrlParamsReplaceMap': {
+      'dimension': 'cd',
+      'metric': 'cm',
     },
     'optout': '_gaUserPrefs.ioo',
   },

--- a/extensions/amp-analytics/analytics-vars.md
+++ b/extensions/amp-analytics/analytics-vars.md
@@ -86,6 +86,12 @@ Provides the referrer where the user came from. It is read from `document.referr
 
 Example value: `https://www.google.com`
 
+### sourceUrl
+
+Parses and provides the source URL of the current document to the URL.
+
+The source URL is extracted from the proxy URL if the document is being served from a *known* proxy. Otherwise the original document URL is returned. For instance, if the URL is served via the proxy `https://cdn.ampproject.org` from the URL `https://cdn.ampproject.org/c/s/example.com/page.html`, then `SOURCE_URL` would return `https://example.com/page.html`. If the URL is served directly from `https://example.com/page.html`, `https://example.com/page.html` will be returned.
+
 ### title
 
 Provides the title of the current document.
@@ -243,18 +249,6 @@ Provides a string that is intended to be random and likely to be unique per URL,
 
 Example value: `978`
 
-### random
-
-Provides a random value every time a request is being constructed.
-
-Example value: `0.12345632345`
-
-### timestamp
-
-Provides the number of seconds that have elapsed since 1970. (Epoch time)
-
-Example value: `1452710304312`
-
 ### queryParam
 
 Pulls a value from the query string
@@ -269,9 +263,29 @@ Please see below the required and optional arguments you may pass into `queryPar
 Example usage: `${queryParam(foo)}` - if foo is available its associated value will be returned, if not an empty string will be returned
                `${queryParam(foo,bar)}` - if foo is available its associated value will be returned, if not bar will be returned
 
-## requestCount
+### random
+
+Provides a random value every time a request is being constructed.
+
+Example value: `0.12345632345`
+
+### requestCount
 
 Provides the number of requests sent out from a particular `amp-analytics` tag. This value can be used to reconstruct the sequence in which requests were sent from a tag. The value starts from 1 and increases monotonically. Note that there may be a gap in requestCount numbers if the request sending fails due to network issues.
 
 Example value: `6`
+
+### timestamp
+
+Provides the number of seconds that have elapsed since 1970. (Epoch time)
+
+Example value: `1452710304312`
+
+### totalEngagedTime
+
+Provides the total time (in seconds) the user has been enagaged with the page since the page
+first became visible in the viewport. Total engaged time will be 0 until the
+page first becomes visible.
+
+Example value: `36`
 


### PR DESCRIPTION
This PR includes:
- Removed comments from example for `atinternet`. Comments are not allowed
  in JSON.
- Added example of `extraUrlParams` in `googleanalytics` and custom config
  examples. Fixes #1991.
- Added `extraUrlParamsReplaceMap` for `googleanalytics`. The feature is
  used for (custom dimensions and metrics)[https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets].
- Pulled out `clientId` var. This allows publishers to override the value.
  Partly fixes #1940. Part 2 to follow.
- Added trailing commas in a few places.
