### PR TITLE
Add more valid Adform hosts

### DIFF
--- a/ads/adform.js
+++ b/ads/adform.js
@@ -18,8 +18,12 @@ import {writeScript, validateSrcPrefix, validateExactlyOne} from '../src/3p';
 
 // Valid adform ad source hosts
 const hosts = {
-  track: 'https://track.adform.net/',
-  adx: 'https://adx.adform.net/',
+  track: 'https://track.adform.net',
+  adx: 'https://adx.adform.net',
+  a2: 'https://a2.adform.net',
+  adx2: 'https://adx2.adform.net',
+  asia: 'https://asia.adform.net',
+  adx3: 'https://adx3.adform.net',
 };
 
 /**
@@ -42,11 +46,11 @@ export function adform(global, data) {
   }
   // Ad tag using "data-bn" attribute
   else if (bn) {
-    url = hosts.track + 'adfscript/?bn=' + encodeURIComponent(bn) + ';msrc=1';
+    url = hosts.track + '/adfscript/?bn=' + encodeURIComponent(bn) + ';msrc=1';
   }
   // Ad placement using "data-mid" attribute
   else if (mid) {
-    url = hosts.adx + 'adx/?mid=' + encodeURIComponent(mid);
+    url = hosts.adx + '/adx/?mid=' + encodeURIComponent(mid);
   }
 
   writeScript(global, url);

--- a/ads/adform.md
+++ b/ads/adform.md
@@ -57,7 +57,4 @@ information on how to get required ad tag or placement IDs.
 Only one of the mentioned parameters should be used at the same time.
 
 The `src` parameter must use **https** protocol and must be from one of the
-allowed hosts:
-
-- `https://track.adform.net/...`
-- `https://adx.adform.net/...`
+allowed Adform hosts.


### PR DESCRIPTION
This PR adds a couple more valid Adform hosts (to be used with “src” amp-ad attribute).