### PR TITLE
Request count starts at one, not zero

### DIFF
--- a/extensions/amp-analytics/analytics-vars.md
+++ b/extensions/amp-analytics/analytics-vars.md
@@ -271,7 +271,7 @@ Example usage: `${queryParam(foo)}` - if foo is available its associated value w
 
 ## requestCount
 
-Provides the number of requests sent out from a particular `amp-analytics` tag. This value can be used to reconstruct the sequence in which requests were sent from a tag. The value starts from 0 and increases monotonically. Note that there may be a gap in requestCount numbers if the request sending fails due to network issues.
+Provides the number of requests sent out from a particular `amp-analytics` tag. This value can be used to reconstruct the sequence in which requests were sent from a tag. The value starts from 1 and increases monotonically. Note that there may be a gap in requestCount numbers if the request sending fails due to network issues.
 
 Example value: `6`
 


### PR DESCRIPTION
I don't know what the intended behaviour is, but the docs says it starts at zero (`0`), but it actually starts at one (`1`).

Looking at the code ([here](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/0.1/amp-analytics.js#L250) and [here](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/0.1/amp-analytics.js#L334)), the variable has zero as default value, but is increased before the request is sent.