### PR TITLE
Modifies the Glade code in doubleclick.js to use "fill" size

### DIFF
--- a/ads/doubleclick.js
+++ b/ads/doubleclick.js
@@ -114,8 +114,8 @@ function doubleClickWithGpt(global, data) {
  * @param {!Object} data
  */
 function doubleClickWithGlade(global, data) {
-  const height = parseInt(data.overrideHeight || data.height, 10);
-  const width = parseInt(data.overrideWidth || data.width, 10);
+  const requestHeight = parseInt(data.overrideHeight || data.height, 10);
+  const requestWidth = parseInt(data.overrideWidth || data.width, 10);
 
   const jsonParameters = {};
   if (data.categoryExclusions) {
@@ -140,8 +140,16 @@ function doubleClickWithGlade(global, data) {
     slot.setAttribute('data-json', JSON.stringify(jsonParameters));
   }
   slot.setAttribute('data-page-url', global.context.canonicalUrl);
-  slot.setAttribute('height', height);
-  slot.setAttribute('width', width);
+
+  // Size setup.
+  // The ad container should simply fill the amp-ad iframe, but we still
+  // need to request a specific size from the ad server.
+  // The ad container size will be relative to the amp-iframe, so if the
+  // latter changes the ad container will match it.
+  slot.setAttribute('width', 'fill');
+  slot.setAttribute('height', 'fill');
+  slot.setAttribute('data-request-height', requestHeight);
+  slot.setAttribute('data-request-width', requestWidth);
 
   window.glade = {correlator: getCorrelator(global)};
   loadScript(global, 'https://securepubads.g.doubleclick.net/static/glade.js');


### PR DESCRIPTION
Use "fill" size for the ad container which results in the ad container filling 100% of its parent (in this case the amp-ad iframe). Using size override will now make more sense with Glade as the creative will automatically fill the amp-ad element without the need for manually resizing its iframe (which does not work with x-domain iframes).

Internally Glade simply uses {width:100%; height:100%} to achieve this, so there is no extra JS overhead involved.