### PR TITLE
Resend pingback after successfull and wait for the most recent auth request to resolve analytics values

### DIFF
--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -145,11 +145,14 @@ export class AccessService {
     /** @private {?JSONObject} */
     this.authResponse_ = null;
 
-    /** @private {!Promise} */
+    /** @const @private {!Promise} */
     this.firstAuthorizationPromise_ = new Promise(resolve => {
       /** @private {!Promise} */
       this.firstAuthorizationResolver_ = resolve;
     });
+
+    /** @private {!Promise} */
+    this.lastAuthorizationPromise_ = this.firstAuthorizationPromise_;
 
     /** @private {?Promise} */
     this.reportViewPromise_ = null;
@@ -281,7 +284,7 @@ export class AccessService {
     this.runAuthorization_();
 
     // Wait for the "view" signal.
-    this.scheduleView_();
+    this.scheduleView_(VIEW_TIMEOUT);
 
     // Listen to amp-access broadcasts from other pages.
     this.listenToBroadcasts_();
@@ -346,10 +349,14 @@ export class AccessService {
   }
 
   /**
+   * Returns the promise that resolves when all authorization work has
+   * completed, including authorization endpoint call and UI update.
+   * Note that this promise never fails.
+   * @param {boolean=} opt_disableFallback
    * @return {!Promise}
    * @private
    */
-  runAuthorization_() {
+  runAuthorization_(opt_disableFallback) {
     if (this.config_.type == AccessType.OTHER) {
       log.fine(TAG, 'Ignore authorization due to type=other');
       this.firstAuthorizationResolver_();
@@ -358,9 +365,9 @@ export class AccessService {
 
     log.fine(TAG, 'Start authorization via ', this.config_.authorization);
     this.toggleTopClass_('amp-access-loading', true);
-    const promise = this.buildUrl_(
+    const urlPromise = this.buildUrl_(
         this.config_.authorization, /* useAuthData */ false);
-    return promise.then(url => {
+    const promise = urlPromise.then(url => {
       log.fine(TAG, 'Authorization URL: ', url);
       return this.timer_.timeoutPromise(
           AUTHORIZATION_TIMEOUT,
@@ -370,7 +377,7 @@ export class AccessService {
           }));
     }).catch(error => {
       this.analyticsEvent_('access-authorization-failed');
-      if (this.config_.authorizationFallbackResponse) {
+      if (this.config_.authorizationFallbackResponse && !opt_disableFallback) {
         // Use fallback.
         setTimeout(() => {throw error;});
         return this.config_.authorizationFallbackResponse;
@@ -394,6 +401,10 @@ export class AccessService {
       this.toggleTopClass_('amp-access-loading', false);
       this.toggleTopClass_('amp-access-error', true);
     });
+    // The "first" promise must always succeed first.
+    this.lastAuthorizationPromise_ = Promise.all(
+        [this.firstAuthorizationPromise_, promise]);
+    return promise;
   }
 
   /**
@@ -420,21 +431,26 @@ export class AccessService {
   }
 
   /**
-   * Returns the field from the authorization response. If the authorization
-   * response have not been received yet, the result will be `null`.
+   * Returns the promise that will yield the value of the specified field from
+   * the authorization response. This method will wait for the most recent
+   * authorization request to complete.
    *
    * This is a restricted API.
    *
    * @param {string} field
-   * @return {*|null}
+   * @return {?Promise<*|null>}
    */
   getAuthdataField(field) {
-    if (!this.enabled_ || !this.authResponse_) {
+    if (!this.enabled_) {
       return null;
     }
-    return getValueForExpr(this.authResponse_, field) || null;
+    return this.lastAuthorizationPromise_.then(() => {
+      if (!this.authResponse_) {
+        return null;
+      }
+      return getValueForExpr(this.authResponse_, field) || null;
+    });
   }
-
 
   /**
    * @return {!Promise} Returns a promise for the initial authorization.
@@ -554,44 +570,48 @@ export class AccessService {
   }
 
   /**
+   * @param {time} timeToView
    * @private
    */
-  scheduleView_() {
+  scheduleView_(timeToView) {
     onDocumentReady(this.win.document, () => {
       if (this.viewer_.isVisible()) {
-        this.reportWhenViewed_();
+        this.reportWhenViewed_(timeToView);
       }
       this.viewer_.onVisibilityChanged(() => {
         if (this.viewer_.isVisible()) {
-          this.reportWhenViewed_();
+          this.reportWhenViewed_(timeToView);
         }
       });
     });
   }
 
   /**
+   * @param {time} timeToView
    * @return {!Promise}
    * @private
    */
-  reportWhenViewed_() {
+  reportWhenViewed_(timeToView) {
     if (this.reportViewPromise_) {
       return this.reportViewPromise_;
     }
     log.fine(TAG, 'start view monitoring');
-    this.reportViewPromise_ = this.whenViewed_()
+    this.reportViewPromise_ = this.whenViewed_(timeToView)
         .then(() => {
-          this.analyticsEvent_('access-viewed');
-          // Wait for the first authorization flow to complete.
-          return this.firstAuthorizationPromise_;
+          // Wait for the most recent authorization flow to complete.
+          return this.lastAuthorizationPromise_;
         })
-        .then(
-            this.reportViewToServer_.bind(this),
-            reason => {
-              // Ignore - view has been canceled.
-              log.fine(TAG, 'view cancelled:', reason);
-              this.reportViewPromise_ = null;
-              throw reason;
-            });
+        .then(() => {
+          // Report the analytics event.
+          this.analyticsEvent_('access-viewed');
+          return this.reportViewToServer_();
+        })
+        .catch(reason => {
+          // Ignore - view has been canceled.
+          log.fine(TAG, 'view cancelled:', reason);
+          this.reportViewPromise_ = null;
+          throw reason;
+        });
     this.reportViewPromise_.then(this.broadcastReauthorize_.bind(this));
     return this.reportViewPromise_;
   }
@@ -599,10 +619,18 @@ export class AccessService {
   /**
    * The promise will be resolved when a view of this document has occurred. It
    * will be rejected if the current impression should not be counted as a view.
+   * @param {time} timeToView Pass the value of 0 when this method is called
+   *   as the result of the user action.
    * @return {!Promise}
    * @private
    */
-  whenViewed_() {
+  whenViewed_(timeToView) {
+    if (timeToView == 0) {
+      // Immediate view has been registered. This will happen when this method
+      // is called as the result of the user action.
+      return Promise.resolve();
+    }
+
     // Viewing kick off: document is visible.
     const unlistenSet = [];
     return new Promise((resolve, reject) => {
@@ -614,7 +642,7 @@ export class AccessService {
       }));
 
       // 2. After a few seconds: register a view.
-      const timeoutId = this.timer_.delay(resolve, VIEW_TIMEOUT);
+      const timeoutId = this.timer_.delay(resolve, timeToView);
       unlistenSet.push(() => this.timer_.cancel(timeoutId));
 
       // 3. If scrolled: register a view.
@@ -731,8 +759,12 @@ export class AccessService {
       if (success) {
         this.loginAnalyticsEvent_(type, 'success');
         this.broadcastReauthorize_();
-        // Repeat the authorization flow.
-        return this.runAuthorization_();
+        // Repeat the authorization and pingback flows. Pingback is repeated
+        // in this case since this is now a new "view" with a different access
+        // profile.
+        return this.runAuthorization_(/* disableFallback */ true).then(() => {
+          this.scheduleView_(/* timeToView */ 0);
+        });
       } else {
         this.loginAnalyticsEvent_(type, 'rejected');
       }

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -214,6 +214,7 @@ describe('AccessService', () => {
     expect(service.buildLoginUrls_.callCount).to.equal(1);
     expect(service.runAuthorization_.callCount).to.equal(1);
     expect(service.scheduleView_.callCount).to.equal(1);
+    expect(service.scheduleView_.firstCall.args[0]).to.equal(2000);
     expect(service.listenToBroadcasts_.callCount).to.equal(1);
   });
 
@@ -350,7 +351,11 @@ describe('AccessService authorization', () => {
         .returns(Promise.resolve({access: true}))
         .once();
     service.buildLoginUrls_ = sandbox.spy();
+    expect(service.lastAuthorizationPromise_).to.equal(
+        service.firstAuthorizationPromise_);
     const promise = service.runAuthorization_();
+    const lastPromise = service.lastAuthorizationPromise_;
+    expect(lastPromise).to.not.equal(service.firstAuthorizationPromise_);
     expect(document.documentElement).to.have.class('amp-access-loading');
     expect(document.documentElement).not.to.have.class('amp-access-error');
     expect(service.buildLoginUrls_.callCount).to.equal(0);
@@ -362,6 +367,8 @@ describe('AccessService authorization', () => {
       expect(service.authResponse_).to.exist;
       expect(service.authResponse_.access).to.be.true;
       expect(service.buildLoginUrls_.callCount).to.equal(1);
+      // Last authorization promise stays unchanged.
+      expect(service.lastAuthorizationPromise_).to.equal(lastPromise);
     });
   });
 
@@ -382,6 +389,38 @@ describe('AccessService authorization', () => {
       expect(document.documentElement).to.have.class('amp-access-error');
       expect(elementOn).not.to.have.attribute('amp-access-hide');
       expect(elementOff).not.to.have.attribute('amp-access-hide');
+    });
+  });
+
+  it('should NOT resolve last promise until first success', () => {
+    expectGetReaderId('reader1');
+    xhrMock.expects('fetchJson')
+        .withExactArgs('https://acme.com/a?rid=reader1', {
+          credentials: 'include',
+          requireAmpResponseSourceOrigin: true,
+        })
+        .returns(Promise.reject('intentional'))
+        .once();
+    const promise = service.runAuthorization_();
+    let lastResolved = false;
+    service.lastAuthorizationPromise_.then(() => {
+      lastResolved = true;
+    });
+    expect(service.lastAuthorizationPromise_).to.not.equal(promise);
+    expect(service.lastAuthorizationPromise_).to.not.equal(
+        service.firstAuthorizationPromise_);
+    return promise.then(() => {
+      // Skip microtask.
+    }).then(() => {
+      // The authorization promise succeeded, but not the last promise.
+      expect(lastResolved).to.be.false;
+      // Resolve the first promise.
+      service.firstAuthorizationResolver_();
+      return service.lastAuthorizationPromise_;
+    }).then(() => {
+      // After first promise has been resolved, the last promised is resolved
+      // as well.
+      expect(lastResolved).to.be.true;
     });
   });
 
@@ -430,6 +469,24 @@ describe('AccessService authorization', () => {
       expect(elementOn).to.have.attribute('amp-access-hide');
       expect(elementOff).not.to.have.attribute('amp-access-hide');
       expect(elementError).not.to.have.attribute('amp-access-hide');
+    });
+  });
+
+  it('should NOT fallback on authorization failure when disabled', () => {
+    expectGetReaderId('reader1');
+    xhrMock.expects('fetchJson')
+        .withExactArgs('https://acme.com/a?rid=reader1', {
+          credentials: 'include',
+          requireAmpResponseSourceOrigin: true,
+        })
+        .returns(Promise.reject('intentional'))
+        .once();
+    service.config_.authorizationFallbackResponse = {'error': true};
+    const promise = service.runAuthorization_(/* disableFallback */ true);
+    expect(document.documentElement).to.have.class('amp-access-loading');
+    expect(document.documentElement).not.to.have.class('amp-access-error');
+    return promise.then(() => {
+      expect(document.documentElement).to.have.class('amp-access-error');
     });
   });
 
@@ -651,6 +708,7 @@ describe('AccessService pingback', () => {
   let configElement;
   let xhrMock;
   let cidMock;
+  let analytics;
   let analyticsMock;
   let visibilityChanged;
   let scrolled;
@@ -683,7 +741,7 @@ describe('AccessService pingback', () => {
     cidMock = sandbox.mock(cid);
     service.cid_ = Promise.resolve(cid);
 
-    const analytics = {
+    analytics = {
       triggerEvent: () => {},
     };
     analyticsMock = sandbox.mock(analytics);
@@ -733,7 +791,7 @@ describe('AccessService pingback', () => {
     analyticsMock.expects('triggerEvent')
         .withExactArgs('access-viewed')
         .once();
-    const p = service.reportWhenViewed_();
+    const p = service.reportWhenViewed_(/* timeToView */ 2000);
     return Promise.resolve().then(() => {
       clock.tick(2001);
       return p;
@@ -749,7 +807,7 @@ describe('AccessService pingback', () => {
     analyticsMock.expects('triggerEvent')
         .withExactArgs('access-viewed')
         .once();
-    const p = service.reportWhenViewed_();
+    const p = service.reportWhenViewed_(/* timeToView */ 2000);
     return Promise.resolve().then(() => {
       scrolled.fire();
       return p;
@@ -765,7 +823,7 @@ describe('AccessService pingback', () => {
     analyticsMock.expects('triggerEvent')
         .withExactArgs('access-viewed')
         .once();
-    const p = service.reportWhenViewed_();
+    const p = service.reportWhenViewed_(/* timeToView */ 2000);
     return Promise.resolve().then(() => {
       let clickEvent;
       if (document.createEvent) {
@@ -784,32 +842,61 @@ describe('AccessService pingback', () => {
     });
   });
 
-  it('should wait for authorization completion', () => {
+  it('should wait for first authorization completion', () => {
     expect(service.firstAuthorizationPromise_).to.exist;
     let firstAuthorizationResolver;
     service.firstAuthorizationPromise_ = new Promise(resolve => {
       firstAuthorizationResolver = resolve;
     });
-    analyticsMock.expects('triggerEvent')
-        .withExactArgs('access-viewed')
-        .once();
+    const triggerEventStub = sandbox.stub(analytics, 'triggerEvent');
+    const triggerStart = 1;  // First event is "access-authorization-received".
     service.reportViewToServer_ = sandbox.spy();
-    service.reportWhenViewed_();
+    service.reportWhenViewed_(/* timeToView */ 2000);
     return Promise.resolve().then(() => {
       clock.tick(2001);
       return Promise.resolve();
-    }).then(() => {}, () => {}).then(() => {
+    }).then(() => {
       expect(service.reportViewToServer_.callCount).to.equal(0);
+      expect(triggerEventStub.callCount).to.equal(triggerStart);
       firstAuthorizationResolver();
       return service.firstAuthorizationPromise_;
-    }).then(() => {}, () => {}).then(() => {
+    }).then(() => {
       expect(service.reportViewToServer_.callCount).to.equal(1);
+      expect(triggerEventStub.callCount).to.equal(triggerStart + 1);
+      expect(triggerEventStub.getCall(triggerStart).args[0])
+          .to.equal('access-viewed');
+    });
+  });
+
+  it('should wait for last authorization completion', () => {
+    expect(service.lastAuthorizationPromise_).to.exist;
+    let lastAuthorizationResolver;
+    service.lastAuthorizationPromise_ = new Promise(resolve => {
+      lastAuthorizationResolver = resolve;
+    });
+    const triggerEventStub = sandbox.stub(analytics, 'triggerEvent');
+    const triggerStart = 1;  // First event is "access-authorization-received".
+    service.reportViewToServer_ = sandbox.spy();
+    service.reportWhenViewed_(/* timeToView */ 2000);
+    return Promise.resolve().then(() => {
+      clock.tick(2001);
+      return Promise.resolve();
+    }).then(() => {
+      expect(service.reportViewToServer_.callCount).to.equal(0);
+      expect(triggerEventStub.callCount).to.equal(triggerStart);
+      lastAuthorizationResolver();
+      return service.lastAuthorizationPromise_;
+    }).then(() => {
+      expect(service.reportViewToServer_.callCount).to.equal(1);
+      expect(triggerEventStub.callCount).to.equal(triggerStart + 1);
+      expect(triggerEventStub.getCall(triggerStart).args[0])
+          .to.equal('access-viewed');
     });
   });
 
   it('should cancel "viewed" signal after click', () => {
     service.reportViewToServer_ = sandbox.spy();
-    const p = service.reportWhenViewed_();
+    const p = service.reportWhenViewed_(/* timeToView */ 2000);
     return Promise.resolve().then(() => {
       service.viewer_.isVisible = () => false;
       visibilityChanged.fire();
@@ -822,13 +909,17 @@ describe('AccessService pingback', () => {
   });
 
   it('should schedule "viewed" monitoring only once', () => {
-    service.whenViewed_ = () => Promise.resolve();
+    const timeToView = 2000;
+    service.whenViewed_ = ttv => {
+      expect(ttv).to.equal(timeToView);
+      return Promise.resolve();
+    };
     service.reportViewToServer_ = sandbox.spy();
-    const p1 = service.reportWhenViewed_();
-    const p2 = service.reportWhenViewed_();
+    const p1 = service.reportWhenViewed_(timeToView);
+    const p2 = service.reportWhenViewed_(timeToView);
     expect(p2).to.equal(p1);
     return p1.then(() => {
-      const p3 = service.reportWhenViewed_();
+      const p3 = service.reportWhenViewed_(timeToView);
       expect(p3).to.equal(p1);
       return p3;
     }).then(() => {
@@ -839,7 +930,7 @@ describe('AccessService pingback', () => {
   it('should re-schedule "viewed" monitoring after visibility change', () => {
     service.reportViewToServer_ = sandbox.spy();
 
-    service.scheduleView_();
+    service.scheduleView_(/* timeToView */ 2000);
 
     // 1. First attempt fails due to document becoming invisible.
     const p1 = service.reportViewPromise_;
@@ -945,7 +1036,7 @@ describe('AccessService pingback', () => {
   it('should broadcast "viewed" signal to other documents', () => {
     service.reportViewToServer_ = sandbox.stub().returns(Promise.resolve());
     const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
-    const p = service.reportWhenViewed_();
+    const p = service.reportWhenViewed_(/* timeToView */ 2000);
     return Promise.resolve().then(() => {
       clock.tick(2001);
       return p;
@@ -1118,7 +1209,9 @@ describe('AccessService login', () => {
   });
 
   it('should succeed login with success=true', () => {
-    service.runAuthorization_ = sandbox.spy();
+    const authorizationStub = sandbox.stub(service, 'runAuthorization_',
+        () => Promise.resolve());
+    const viewStub = sandbox.stub(service, 'scheduleView_');
     const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
     serviceMock.expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
@@ -1132,7 +1225,11 @@ describe('AccessService login', () => {
         .once();
     return service.login('').then(() => {
       expect(service.loginPromise_).to.not.exist;
-      expect(service.runAuthorization_.callCount).to.equal(1);
+      expect(authorizationStub.callCount).to.equal(1);
+      expect(authorizationStub.calledWithExactly(
+          /* disableFallback */ true)).to.be.true;
+      expect(viewStub.callCount).to.equal(1);
+      expect(viewStub.calledWithExactly(/* timeToView */ 0)).to.be.true;
       expect(broadcastStub.callCount).to.equal(1);
       expect(broadcastStub.firstCall.args[0]).to.deep.equal({
         'type': 'amp-access-reauthorize',
@@ -1199,7 +1296,8 @@ describe('AccessService login', () => {
       'login1': 'https://acme.com/l1?rid=R',
       'login2': 'https://acme.com/l2?rid=R',
     };
-    service.runAuthorization_ = sandbox.spy();
+    const authorizationStub = sandbox.stub(service, 'runAuthorization_',
+        () => Promise.resolve());
     const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
     serviceMock.expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l2?rid=R')
@@ -1219,7 +1317,7 @@ describe('AccessService login', () => {
         .once();
     return service.login('login2').then(() => {
       expect(service.loginPromise_).to.not.exist;
-      expect(service.runAuthorization_.callCount).to.equal(1);
+      expect(authorizationStub.callCount).to.equal(1);
       expect(broadcastStub.callCount).to.equal(1);
       expect(broadcastStub.firstCall.args[0]).to.deep.equal({
         'type': 'amp-access-reauthorize',
@@ -1312,15 +1410,56 @@ describe('AccessService analytics', () => {
   });
 
   it('should return authdata', () => {
-    expect(service.getAuthdataField('views')).to.equal(3);
-    expect(service.getAuthdataField('child.type')).to.equal('premium');
-    expect(service.getAuthdataField('other')).to.be.null;
-    expect(service.getAuthdataField('child.other')).to.be.null;
+    service.firstAuthorizationResolver_();
+    return Promise.all([
+      service.getAuthdataField('views'),
+      service.getAuthdataField('child.type'),
+      service.getAuthdataField('other'),
+      service.getAuthdataField('child.other'),
+    ]).then(res => {
+      expect(res[0]).to.equal(3);
+      expect(res[1]).to.equal('premium');
+      expect(res[2]).to.be.null;
+      expect(res[3]).to.be.null;
+    });
   });
 
-  it('should return null before authdata initialized', () => {
-    service.setAuthResponse_(null);
-    expect(service.getAuthdataField('views')).to.be.null;
+  it('should wait the first authorization for authdata', () => {
+    let viewsValue;
+    const promise = service.getAuthdataField('views').then(res => {
+      viewsValue = res;
+    });
+    return Promise.resolve().then(() => {
+      expect(viewsValue).to.be.undefined;
+      // Resolve the authorization.
+      service.firstAuthorizationResolver_();
+      return promise;
+    }).then(() => {
+      expect(viewsValue).to.equal(3);
+    });
+  });
+
+  it('should wait the latest authorization for authdata if started', () => {
+    let resolver;
+    service.lastAuthorizationPromise_ = new Promise(resolve => {
+      resolver = resolve;
+    });
+    let viewsValue;
+    const promise = service.getAuthdataField('views').then(res => {
+      viewsValue = res;
+    });
+    return Promise.resolve().then(() => {
+      expect(viewsValue).to.be.undefined;
+      // Resolve the first authorization.
+      service.firstAuthorizationResolver_();
+    }).then(() => {
+      expect(viewsValue).to.be.undefined;
+      // Resolve the second authorization.
+      resolver();
+      return promise;
+    }).then(() => {
+      expect(viewsValue).to.equal(3);
+    });
   });
 });
 
@@ -1383,6 +1522,9 @@ describe('AccessService type=other', () => {
       expect(document.documentElement).not.to.have.class('amp-access-error');
       expect(service.firstAuthorizationPromise_).to.exist;
       return service.firstAuthorizationPromise_;
+    }).then(() => {
+      expect(service.lastAuthorizationPromise_).to.equal(
+          service.firstAuthorizationPromise_);
     });
   });
 

--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -111,7 +111,7 @@ Authorization is an endpoint provided by the publisher and called by AMP Runtime
 
 ### Pingback Endpoint
 
-Pingback is an endpoint provided by the publisher and called by AMP Runtime or Google AMP Cache. It is a credentialed CORS endpoint. AMP Runtime calls this endpoint automatically when the Reader has started viewing the document. On of the main goals of the Pingback is for the Publisher to update metering information.
+Pingback is an endpoint provided by the publisher and called by AMP Runtime or Google AMP Cache. It is a credentialed CORS endpoint. AMP Runtime calls this endpoint automatically when the Reader has started viewing the document. This endpoint is also called after the Reader has successfully completed the Login Flow. On of the main goals of the Pingback is for the Publisher to update metering information.
 
 ### Login Page and Login Link
 
@@ -119,7 +119,7 @@ Login Page is implemented and served by the Publisher and called by the AMP Runt
 
 Login Page is triggered when the Reader taps on the Login Link which can be placed by the Publisher anywhere in the document.
 
-## Specification v0.4
+## Specification v0.5
 
 ### Configuration
 
@@ -322,6 +322,8 @@ Pingback URL can take any parameters as defined in the [Access URL Variables][7]
 
 Pingback does not produce a response - any response is ignored by AMP runtime.
 
+Pingback endpoint is called when the reader has started viewing the document and after the Rser has successfully completed the Login Flow.
+
 The publisher may choose to use the pingback as:
  - One of the main purposes for pingback is to count down meter when it is used.
  - As a credentialed CORS endpoint it may contain publisher cookies. Thus it can be used to map AMP Reader ID to the Publisher’s identity.
@@ -373,6 +375,8 @@ specified. Once Login Page completes its work, it must redirect back to the spec
 RETURN_URL#success=true|false
 ```
 Notice the use of a URL hash parameter “success”. The value is either “true” or “false” depending on whether the login succeeds or is abandoned. Ideally the Login Page, when possible, will send the signal in cases of both success or failure.
+
+If the `success=true` signal is returned, the AMP runtime will repeat calls to Authorization and Pingback endpoints to update the document's state and report the "view" with the new access profile.
 
 #### Login Link
 
@@ -437,6 +441,7 @@ Both steps are covered by the AMP Access spec. The referrer can be injected into
 - Feb 11: Authorization request timeout in [Authorization Endpoint][4].
 - Feb 15: [Configuration][8] and [Authorization Endpoint][4] now allow "authorizationFallbackResponse" property that can be used when authorization fails.
 - Feb 19: Corrected samples to remove `{}` from URL var substitutions.
+- Mar 3: Resend pingback after login (v0.5).
 
 ## Appendix A: “amp-access” expression grammar
 

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -268,9 +268,7 @@ class UrlReplacements {
     this.set_('AUTHDATA', field => {
       assert(field, 'The first argument to AUTHDATA, the field, is required');
       return this.getAccessValue_(accessService => {
-        return accessService.whenFirstAuthorized().then(() => {
-          return accessService.getAuthdataField(field);
-        });
+        return accessService.getAuthdataField(field);
       }, 'AUTHDATA');
     });
 

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -530,7 +530,6 @@ describe('UrlReplacements', () => {
       accessService = {
         getAccessReaderId: () => {},
         getAuthdataField: () => {},
-        whenFirstAuthorized: () => {},
       };
       accessServiceMock = sandbox.mock(accessService);
       reportDevSpy = sandbox.spy();
@@ -571,12 +570,9 @@ describe('UrlReplacements', () => {
     });
 
     it('should replace AUTHDATA', () => {
-      accessServiceMock.expects('whenFirstAuthorized')
-          .returns(Promise.resolve())
-          .once();
       accessServiceMock.expects('getAuthdataField')
           .withExactArgs('field1')
-          .returns('value1')
+          .returns(Promise.resolve('value1'))
           .once();
       return expand('?a=AUTHDATA(field1)').then(res => {
         expect(res).to.match(/a=value1/);


### PR DESCRIPTION
Two important changes in spec:

1. Pingback will be resend after successful login to signify a new view with the new access profile.
2. The analytics values and pingback wait for the most recent authorization call to complete, but do tolerate some failures.

Closes #2340

/cc @ashwinlimaye @rudygalfi @sebastianbenz @andreban @adaybujeda @georgecrawford