### PR TITLE
Implement an alternative loading strategy for ads.

### DIFF
--- a/ads/doubleclick.js
+++ b/ads/doubleclick.js
@@ -26,7 +26,8 @@ export function doubleclick(global, data) {
   checkData(data, [
     'slot', 'targeting', 'categoryExclusions',
     'tagForChildDirectedTreatment', 'cookieOptions',
-    'overrideWidth', 'overrideHeight',
+    'overrideWidth', 'overrideHeight', 'loadingStrategy',
+    'consentNotificationId',
   ]);
 
   const dice = Math.random();

--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -58,6 +58,19 @@ export function installAd(win) {
         return false;
       }
 
+      // Ad opts into lazier loading strategy where we only load ads that are
+      // at closer than 1.25 viewports away.
+      if (this.element.getAttribute('data-loading-strategy') ==
+          'prefer-viewability-over-views') {
+        const box = this.getIntersectionElementLayoutBox();
+        const viewportBox = this.getViewport().getRect();
+        const distanceFromViewport = box.top - viewportBox.bottom;
+        if (distanceFromViewport <= 1.25 * (viewportBox.height)) {
+          return true;
+        }
+        return false;
+      }
+
       // Otherwise the ad is good to go.
       return true;
     }
@@ -174,7 +187,10 @@ export function installAd(win) {
     /**
      * @override
      */
-    getInsersectionElementLayoutBox() {
+    getIntersectionElementLayoutBox() {
+      if (!this.iframe_) {
+        return super.getIntersectionElementLayoutBox();
+      }
       if (!this.iframeLayoutBox_) {
         this.measureIframeLayoutBox_();
       }

--- a/builtins/amp-ad.md
+++ b/builtins/amp-ad.md
@@ -135,6 +135,10 @@ Optional attribute to pass configuration to the ad as an arbitrarily complex JSO
 
 Optional attribute. If provided will require confirming the [amp-user-notification](../extensions/amp-user-notification/amp-user-notification.md) with the given HTML-id until the "AMP client id" for the user (similar to a cookie) is passed to the ad. The means ad rendering is delayed until the user confirmed the notification.
 
+### Experimental: data-loading-strategy
+
+Supported value: `prefer-viewability-over-views`. Instructs AMP to load ads in a way that prefers a high degree of viewability, while sometimes loading too late to generate a view.
+
 ## Placeholder
 
 Optionally `amp-ad` supports a child element with the `placeholder` attribute. If supported by the ad network, this element is shown until the ad is available for viewing.

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -297,7 +297,8 @@
           <div class="ad-container">
             <amp-ad width=300 height=200
                 type="adsense"
-                data-ad-client="ca-pub-9350112648257122">
+                data-ad-client="ca-pub-9350112648257122"
+                data-loading-strategy="prefer-viewability-over-views">
             </amp-ad>
           </div>
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -204,7 +204,7 @@ export class AmpIframe extends AMP.BaseElement {
   /**
    * @override
    */
-  getInsersectionElementLayoutBox() {
+  getIntersectionElementLayoutBox() {
     if (!this.iframeLayoutBox_) {
       this.measureIframeLayoutBox_();
     }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -484,7 +484,7 @@ export class BaseElement {
   * Returns a previously measured layout box of the element.
   * @return {!LayoutRect}
   */
-  getInsersectionElementLayoutBox() {
+  getIntersectionElementLayoutBox() {
     return this.resources_.getResourceForElement(this.element).getLayoutBox();
   }
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -692,7 +692,7 @@ export function createAmpElementProto(win, name, implementationClass) {
   * @final
   */
   ElementProto.getIntersectionChangeEntry = function() {
-    const box = this.implementation_.getInsersectionElementLayoutBox();
+    const box = this.implementation_.getIntersectionElementLayoutBox();
     const rootBounds = this.implementation_.getViewport().getRect();
     return getIntersectionChangeEntry(
         timer.now(),

--- a/test/functional/test-amp-ad.js
+++ b/test/functional/test-amp-ad.js
@@ -397,8 +397,8 @@ function tests(name, installer) {
     });
 
     describe('renderOutsideViewport', () => {
-      function getGoodAd(cb, layoutCb) {
-        return getAd({
+      function getGoodAd(cb, layoutCb, opt_loadingStrategy) {
+        const attributes = {
           width: 300,
           height: 250,
           type: 'a9',
@@ -408,7 +408,11 @@ function tests(name, installer) {
           'data-aax_src': '302',
           // Test precedence
           'data-width': '6666',
-        }, 'https://schema.org', element => {
+        };
+        if (opt_loadingStrategy) {
+          attributes['data-loading-strategy'] = opt_loadingStrategy;
+        }
+        return getAd(attributes, 'https://schema.org', element => {
           cb(element.implementation_);
           return element;
         }, layoutCb);
@@ -426,6 +430,40 @@ function tests(name, installer) {
           clock.tick(900);
           expect(ad.renderOutsideViewport()).to.be.false;
           clock.tick(100);
+          expect(ad.renderOutsideViewport()).to.be.true;
+        });
+      });
+
+      it('should prefer-viewability-over-views', () => {
+        let clock;
+        const elementBox = {
+          top: 4000,
+        };
+        const viewportRect = {
+          height: 1000,
+          bottom: 1000,
+        };
+        return getGoodAd(ad => {
+          ad.resources_.add(ad.element);
+          sandbox.stub(ad, 'getIntersectionElementLayoutBox', () => {
+            return elementBox;
+          });
+          sandbox.stub(ad.getViewport(), 'getRect', () => {
+            return viewportRect;
+          });
+        }, () => {
+          clock = sandbox.useFakeTimers();
+        }, 'prefer-viewability-over-views').then(ad => {
+          clock.tick(10000);
+          // False because we just rendered one.
+          expect(ad.renderOutsideViewport()).to.be.false;
+          viewportRect.bottom = '2749';
+          expect(ad.renderOutsideViewport()).to.be.false;
+          // 125% of viewport away
+          viewportRect.bottom = '2750';
+          expect(ad.renderOutsideViewport()).to.be.true;
+          // We currently render above viewport.
+          viewportRect.bottom = '6000';
           expect(ad.renderOutsideViewport()).to.be.true;
         });
       });

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -73,7 +73,7 @@ describe('CustomElement', () => {
     viewportCallback(inViewport) {
       testElementViewportCallback(inViewport);
     }
-    getInsersectionElementLayoutBox() {
+    getIntersectionElementLayoutBox() {
       testElementGetInsersectionElementLayoutBox();
       return {top: 10, left: 10, width: 11, height: 1};
     }

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -141,7 +141,7 @@ describe('IntersectionObserver', () => {
     viewportCallback(inViewport) {
       testElementViewportCallback(inViewport);
     }
-    getInsersectionElementLayoutBox() {
+    getIntersectionElementLayoutBox() {
       testElementGetInsersectionElementLayoutBox();
       return {top: 10, left: 10, width: 11, height: 1};
     }


### PR DESCRIPTION
This is opt-in per `amp-ad` tag and recommends to AMP to optimize for what is called viewability instead of views. This means that it is more likely that a layout will turn into a view.

We happily do this, since it means we render fewer ads :)

Implementation of #2407