### PR TITLE
remove reference to whenFirstLayoutCompleteResolve_

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1689,7 +1689,6 @@ export class Resource {
 
     this.layoutPromise_ = promise.then(() => this.layoutComplete_(true),
         reason => this.layoutComplete_(false, reason));
-    this.layoutPromise_.then(this.whenFirstLayoutCompleteResolve_);
     return this.layoutPromise_;
   }
 


### PR DESCRIPTION
removal was done in https://github.com/ampproject/amphtml/commit/60a1f40b17d3614c58f6b9c09eded87e7e8598a1 and replaced with an eagerly assigned promise to fix a race condition. (loadPromise_)

Closes https://github.com/ampproject/amphtml/issues/2428