### PR TITLE
Major improvements to instagram extension.

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -347,6 +347,7 @@ amp-ad iframe {
  */
 amp-instagram {
   padding: 48px 8px !important;
+  background-color: white;
 }
 
 

--- a/examples/instagram.amp.html
+++ b/examples/instagram.amp.html
@@ -35,5 +35,18 @@
       layout="responsive">
   </amp-instagram>
 
+  <amp-instagram
+      data-shortcode="fBwFP"
+      width="381"
+      height="381">
+  </amp-instagram>
+
+  <amp-instagram
+      data-shortcode="6f8K16iZiK"
+      width="500"
+      height="500"
+      layout="responsive">
+  </amp-instagram>
+
 </body>
 </html>

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -36,11 +36,15 @@
 
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
+import {setStyles} from '../../../src/style';
+import {removeElement} from '../../../src/dom';
 
 
 class AmpInstagram extends AMP.BaseElement {
   /** @override */
   preconnectCallback(onLayout) {
+    // See
+    // https://instagram.com/developer/embedding/?hl=en
     this.preconnect.url('https://www.instagram.com', onLayout);
     // Host instagram used for image serving. While the host name is
     // funky this appears to be stable in the post-domain sharding era.
@@ -48,31 +52,111 @@ class AmpInstagram extends AMP.BaseElement {
   }
 
   /** @override */
-  isLayoutSupported(layout) {
-    return isLayoutSizeDefined(layout);
-  }
+  buildCallback() {
+    /**
+     * @private {?Element}
+     */
+    this.iframe_ = null;
+    /**
+     * @private {?Promise}
+     */
+    this.iframePromise_ = null;
 
-  /** @override */
-  layoutCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
-    const shortcode = AMP.assert(
+    /**
+     * @private @const
+     */
+    this.shortcode_ = AMP.assert(
         (this.element.getAttribute('data-shortcode') ||
         this.element.getAttribute('shortcode')),
         'The data-shortcode attribute is required for <amp-instagram> %s',
         this.element);
-    // See
-    // https://instagram.com/developer/embedding/?hl=en
+  }
+
+  /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
+  maybeRenderIframe_() {
+    if (this.iframePromise_) {
+      return this.iframePromise_;
+    }
     const iframe = document.createElement('iframe');
+    this.iframe_ = iframe;
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowtransparency', 'true');
     iframe.src = 'https://www.instagram.com/p/' +
-        encodeURIComponent(shortcode) + '/embed/?v=4';
+        encodeURIComponent(this.shortcode_) + '/embed/?v=4';
     this.applyFillContent(iframe);
-    iframe.width = width;
-    iframe.height = height;
+    iframe.width = this.element.getAttribute('width');
+    iframe.height = this.element.getAttribute('height');
     this.element.appendChild(iframe);
-    return loadPromise(iframe);
+    setStyles(iframe, {
+      'opacity': 0,
+    });
+    return this.iframePromise_ = loadPromise(iframe).then(() => {
+      this.getVsync().mutate(() => {
+        setStyles(iframe, {
+          'opacity': 1,
+        });
+      });
+    });
+  }
+
+  /** @override */
+  layoutCallback() {
+    const image = new Image();
+    // This will redirect to the image URL. By experimentation this is
+    // always the same URL that is actually used inside of the embed.
+    image.src = 'https://www.instagram.com/p/' +
+        encodeURIComponent(this.shortcode_) + '/media/?size=l';
+    image.width = this.element.getAttribute('width');
+    image.height = this.element.getAttribute('height');
+    setStyles(image, {
+      'object-fit': 'cover',
+    });
+    const wrapper = document.createElement('wrapper');
+    // This makes the non-iframe image appear in the exact same spot
+    // where it will be inside of the iframe.
+    setStyles(wrapper, {
+      'position': 'absolute',
+      'top': '48px',
+      'bottom': '48px',
+      'left': '8px',
+      'right': '8px',
+    });
+    wrapper.appendChild(image);
+    this.applyFillContent(image);
+    this.element.appendChild(wrapper);
+    // The iframe takes up a lot of resources. We only render it of we are in
+    // in the viewport.
+    if (this.isInViewport()) {
+      return this.maybeRenderIframe_();
+    }
+    return loadPromise(image);
+  }
+
+  /** @override */
+  viewportCallback(inViewport) {
+    // We might not have been rendered this yet. Lets do it now.
+    if (inViewport) {
+      this.maybeRenderIframe_();
+    }
+  }
+
+  /** @override */
+  documentInactiveCallback() {
+    if (this.iframe_) {
+      removeElement(this.iframe_);
+      this.iframe_ = null;
+      this.iframePromise_ = null;
+    }
+    return true;  // Call layoutCallback again.
   }
 };
 

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -17,10 +17,22 @@
 import {createIframePromise} from '../../../../testing/iframe';
 require('../amp-instagram');
 import {adopt} from '../../../../src/runtime';
+import * as sinon from 'sinon';
 
 adopt(window);
 
 describe('amp-instagram', () => {
+  let sandbox;
+  let inViewport;
+
+  beforeEach(() => {
+    inViewport = true;
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   function getIns(shortcode, opt_responsive) {
     return createIframePromise().then(iframe => {
@@ -31,18 +43,59 @@ describe('amp-instagram', () => {
       if (opt_responsive) {
         ins.setAttribute('layout', 'responsive');
       }
+      sandbox.stub(ins.implementation_, 'isInViewport', () => {
+        return inViewport;
+      });
       return iframe.addElement(ins);
     });
   }
 
-  it('renders', () => {
+  function testImage(image) {
+    expect(image).to.not.be.null;
+    expect(image.src).to.equal('https://www.instagram.com/p/fBwFP/media/?size=l');
+    expect(image.getAttribute('width')).to.equal('111');
+    expect(image.getAttribute('height')).to.equal('222');
+  }
+
+  function testIframe(iframe) {
+    expect(iframe).to.not.be.null;
+    expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?v=4');
+    expect(iframe.getAttribute('width')).to.equal('111');
+    expect(iframe.getAttribute('height')).to.equal('222');
+  }
+
+  it('renders in viewport', () => {
     return getIns('fBwFP').then(ins => {
-      const iframe = ins.firstChild;
-      expect(iframe).to.not.be.null;
-      expect(iframe.tagName).to.equal('IFRAME');
-      expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?v=4');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
+      testIframe(ins.querySelector('iframe'));
+      testImage(ins.querySelector('img'));
+    });
+  });
+
+  it('renders outside viewport', () => {
+    inViewport = false;
+    return getIns('fBwFP').then(ins => {
+      let iframe = ins.querySelector('iframe');
+      expect(iframe).to.be.null;
+      // Still not in viewport
+      ins.implementation_.viewportCallback(false);
+      iframe = ins.querySelector('iframe');
+      expect(iframe).to.be.null;
+      // In viewport
+      ins.implementation_.viewportCallback(true);
+      iframe = ins.querySelector('iframe');
+      testIframe(iframe);
+      testImage(ins.querySelector('img'));
+    });
+  });
+
+  it('removes iframe after documentInactiveCallback', () => {
+    return getIns('fBwFP').then(ins => {
+      testIframe(ins.querySelector('iframe'));
+      const obj = ins.implementation_;
+      obj.documentInactiveCallback();
+      expect(ins.querySelector('iframe')).to.be.null;
+      expect(obj.iframe_).to.be.null;
+      expect(obj.iframePromise_).to.be.null;
     });
   });
 


### PR DESCRIPTION
- Support for prerender. Load image only, no iframe.
- Loads image and iframe in parallel. Image is in exact place where it appears in iframe.
- Lazy loads iframe when in viewport. By default only loads image.
- Removes iframes when swiping away page (would also stop video).

CC @adewale 