### PR TITLE
Use location.replace for click interception and only when iframed

### DIFF
--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -88,6 +88,10 @@
     .comic-amp-font-missing .comic-amp {
       color: #f00;
     }
+
+    #amp-iframe:target {
+      border: 1px solid green;
+    }
   </style>
   <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
   <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -279,6 +279,12 @@
 
       this.iframe.style.display = '';
       this.iframe.style.visibility = '';
+
+      this.iframe.contentWindow.onbeforeunload = (function() {
+        this.container.style.paddingTop = '120px';
+        this.container.textContent =
+            'Unload of the AMP iframe is not allowed!';
+      }).bind(this);
     };
 
 

--- a/test/functional/test-document-click.js
+++ b/test/functional/test-document-click.js
@@ -29,13 +29,13 @@ describe('test-document-click onDocumentElementClick_', () => {
   let preventDefaultSpy;
   let scrollIntoViewSpy;
   let querySelectorSpy;
-  let replaceStateSpy;
+  let replaceLocSpy;
   let viewport;
 
   beforeEach(() => {
     preventDefaultSpy = sinon.spy();
     scrollIntoViewSpy = sinon.spy();
-    replaceStateSpy = sinon.spy();
+    replaceLocSpy = sinon.spy();
     elem = {};
     getElementByIdSpy = sinon.stub();
     querySelectorSpy = sinon.stub();
@@ -47,9 +47,7 @@ describe('test-document-click onDocumentElementClick_', () => {
       defaultView: {
         location: {
           href: 'https://www.google.com/some-path?hello=world#link',
-        },
-        history: {
-          replaceState: replaceStateSpy,
+          replace: replaceLocSpy,
         },
       },
     };
@@ -174,8 +172,8 @@ describe('test-document-click onDocumentElementClick_', () => {
       onDocumentElementClick_(evt, viewport);
       expect(getElementByIdSpy.callCount).to.equal(1);
       expect(scrollIntoViewSpy.callCount).to.equal(0);
-      expect(replaceStateSpy.callCount).to.equal(1);
-      expect(replaceStateSpy.args[0][2]).to.equal('#test');
+      expect(replaceLocSpy.callCount).to.equal(1);
+      expect(replaceLocSpy.args[0][0]).to.equal('#test');
     });
 
     it('should call scrollIntoView if element with id is found', () => {
@@ -184,8 +182,8 @@ describe('test-document-click onDocumentElementClick_', () => {
       expect(scrollIntoViewSpy.callCount).to.equal(0);
       onDocumentElementClick_(evt, viewport);
       expect(scrollIntoViewSpy.callCount).to.equal(1);
-      expect(replaceStateSpy.callCount).to.equal(1);
-      expect(replaceStateSpy.args[0][2]).to.equal('#test');
+      expect(replaceLocSpy.callCount).to.equal(1);
+      expect(replaceLocSpy.args[0][0]).to.equal('#test');
     });
 
     it('should call scrollIntoView if element with name is found', () => {
@@ -195,8 +193,8 @@ describe('test-document-click onDocumentElementClick_', () => {
       expect(scrollIntoViewSpy.callCount).to.equal(0);
       onDocumentElementClick_(evt, viewport);
       expect(scrollIntoViewSpy.callCount).to.equal(1);
-      expect(replaceStateSpy.callCount).to.equal(1);
-      expect(replaceStateSpy.args[0][2]).to.equal('#test');
+      expect(replaceLocSpy.callCount).to.equal(1);
+      expect(replaceLocSpy.args[0][0]).to.equal('#test');
     });
   });
 


### PR DESCRIPTION
Partial for #2440, #827.

This works around an issue where `replaceState` does not trigger `:target` pseudo-selector, but `location.replace` does. I found no side-effects of this change. A lot of detail can be found here: http://www.zachleat.com/web/moving-target/

/cc @jridgewell @Nemo64 @steffenweber
