### PR TITLE
Performance measurements adjustments.

### DIFF
--- a/src/performance.js
+++ b/src/performance.js
@@ -106,6 +106,7 @@ export class Performance {
     // Tick window.onload event.
     loadPromise(win).then(() => {
       this.tick('ol');
+      this.flush();
     });
   }
 
@@ -159,6 +160,7 @@ export class Performance {
         // time since the viewer initialized the timer)
         this.tick('pc');
       }
+      this.flush();
     });
   }
 

--- a/src/service/framerate-impl.js
+++ b/src/service/framerate-impl.js
@@ -127,9 +127,12 @@ export class Framerate {
       const duration = now - this.collectStartTime_;
       const framerate = 1000 / (duration / this.frameCount_);
       const performance = performanceFor(this.win);
-      performance.tickDelta('fps', framerate);
+      // We want good values to be low and CSI hates negative values, so we
+      // shift everything by 60.
+      const reportedValue = Math.max(60 - framerate, 0);
+      performance.tickDelta('fps', reportedValue);
       if (this.loadedAd_) {
-        performance.tickDelta('fal', framerate);
+        performance.tickDelta('fal', reportedValue);
       }
       performance.flush();
       this.reset_();

--- a/test/functional/test-framerate.js
+++ b/test/functional/test-framerate.js
@@ -96,7 +96,7 @@ describe('the framerate service', () => {
     expect(performance.tickDelta.callCount).to.equal(1);
     expect(performance.flush.callCount).to.equal(1);
     expect(performance.tickDelta.args[0][0]).to.equal('fps');
-    expect(performance.tickDelta.args[0][1]).to.within(15, 16);
+    expect(performance.tickDelta.args[0][1]).to.within(44, 45);
     expect(fr.frameCount_).to.equal(0);
 
     // Second round
@@ -118,7 +118,7 @@ describe('the framerate service', () => {
     expect(performance.tickDelta.callCount).to.equal(2);
     expect(performance.flush.callCount).to.equal(2);
     expect(performance.tickDelta.args[1][0]).to.equal('fps');
-    expect(performance.tickDelta.args[1][1]).to.within(9, 10);
+    expect(performance.tickDelta.args[1][1]).to.within(50, 51);
   });
 
   it('does nothing with an invisible window', () => {
@@ -153,9 +153,9 @@ describe('the framerate service', () => {
     expect(performance.tickDelta.callCount).to.equal(2);
     expect(performance.flush.callCount).to.equal(1);
     expect(performance.tickDelta.args[0][0]).to.equal('fps');
-    expect(performance.tickDelta.args[0][1]).to.within(15, 16);
+    expect(performance.tickDelta.args[0][1]).to.within(44, 45);
     expect(performance.tickDelta.args[1][0]).to.equal('fal');
-    expect(performance.tickDelta.args[1][1]).to.within(15, 16);
+    expect(performance.tickDelta.args[1][1]).to.within(44, 45);
     // Second round
     fr.collect();
     for (let i = 0; i < 50; i++) {


### PR DESCRIPTION
- Flush more often to make sure we don't miss important measurements.
- Shift framerate values, so that smaller values are better, because our reporting tool thinks these are ms.