### PR TITLE
Consistent amp-youtube examples: specify responsive layout

### DIFF
--- a/examples/youtube.amp.html
+++ b/examples/youtube.amp.html
@@ -15,6 +15,7 @@
 
     <amp-youtube
             data-videoid="mGENRKrdoGY"
+            layout="responsive"
             width="480" height="270"></amp-youtube>
 
     <!-- YouTube video that doesn't have sddefault.jpg -->


### PR DESCRIPTION
Keep `amp-youtube` examples consistent by specifying `layout="responsive"`.

/review @mkhatib 