### PR TITLE
Simplify extension code generation.

### DIFF
--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-access-0.1.css';
 import {actionServiceFor} from '../../../src/action';
 import {analyticsFor} from '../../../src/analytics';
 import {assert, assertEnumValue} from '../../../src/asserts';
@@ -90,7 +91,7 @@ export class AccessService {
   constructor(win) {
     /** @const {!Window} */
     this.win = win;
-    installStyles(this.win.document, $CSS$, () => {}, false, 'amp-access');
+    installStyles(this.win.document, CSS, () => {}, false, 'amp-access');
 
     const accessElement = document.getElementById('amp-access');
 

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AccessService} from '../../../../build/all/v0/amp-access-0.1.max';
+import {AccessService} from '../amp-access';
 import {Observable} from '../../../../src/observable';
 import {installCidService} from '../../../../src/service/cid-impl';
 import {markElementScheduledForTesting} from '../../../../src/custom-element';

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-accordion-0.1.css';
 import {Layout} from '../../../src/layout';
 import {assert} from '../../../src/asserts';
 import {isExperimentOn} from '../../../src/experiments';
@@ -86,4 +87,4 @@ class AmpAccordion extends AMP.BaseElement {
   }
 }
 
-AMP.registerElement('amp-accordion', AmpAccordion, $CSS$);
+AMP.registerElement('amp-accordion', AmpAccordion, CSS);

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -18,7 +18,7 @@ import {Timer} from '../../../../src/timer';
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';
-require('../../../../build/all/v0/amp-accordion-0.1.max');
+require('../amp-accordion');
 
 adopt(window);
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -15,10 +15,10 @@
  */
 
 import {ANALYTICS_CONFIG} from '../vendors';
-import {AmpAnalytics} from '../../../../build/all/v0/amp-analytics-0.1.max';
+import {AmpAnalytics} from '../amp-analytics';
 import {
   installUserNotificationManager,
-} from '../../../../build/all/v0/amp-user-notification-0.1.max';
+} from '../../../amp-user-notification/0.1/amp-user-notification';
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
 import {getService} from '../../../../src/service';

--- a/extensions/amp-carousel/0.1/amp-carousel.js
+++ b/extensions/amp-carousel/0.1/amp-carousel.js
@@ -16,7 +16,7 @@
 
 import {AmpSlides} from './slides';
 import {AmpCarousel} from './carousel';
-
+import {CSS} from '../../../build/amp-carousel-0.1.css';
 
 class CarouselSelector {
 
@@ -29,4 +29,4 @@ class CarouselSelector {
   }
 }
 
-AMP.registerElement('amp-carousel', CarouselSelector, $CSS$);
+AMP.registerElement('amp-carousel', CarouselSelector, CSS);

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-fit-text-0.1.css';
 import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
 import * as st from '../../../src/style';
 
@@ -151,4 +152,4 @@ export function updateOverflow_(content, measurer, maxHeight, fontSize) {
 };
 
 
-AMP.registerElement('amp-fit-text', AmpFitText, $CSS$);
+AMP.registerElement('amp-fit-text', AmpFitText, CSS);

--- a/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
@@ -16,11 +16,11 @@
 
 import {Timer} from '../../../../src/timer';
 import {createIframePromise} from '../../../../testing/iframe';
-require('../../../../build/all/v0/amp-fit-text-0.1.max');
+require('../amp-fit-text');
 import {
   calculateFontSize_,
   updateOverflow_,
-} from '../../../../build/all/v0/amp-fit-text-0.1.max';
+} from '../amp-fit-text';
 import {adopt} from '../../../../src/runtime';
 
 adopt(window);

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -15,6 +15,7 @@
  */
 
 import {Animation} from '../../../src/animation';
+import {CSS} from '../../../build/amp-image-lightbox-0.1.css';
 import {Gestures} from '../../../src/gesture';
 import {
   DoubletapRecognizer,
@@ -999,4 +1000,4 @@ class AmpImageLightbox extends AMP.BaseElement {
   }
 }
 
-AMP.registerElement('amp-image-lightbox', AmpImageLightbox, $CSS$);
+AMP.registerElement('amp-image-lightbox', AmpImageLightbox, CSS);

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -16,10 +16,10 @@
 
 import {Timer} from '../../../../src/timer';
 import {createIframePromise} from '../../../../testing/iframe';
-require('../../../../build/all/v0/amp-image-lightbox-0.1.max');
+require('../amp-image-lightbox');
 import {
   ImageViewer,
-} from '../../../../build/all/v0/amp-image-lightbox-0.1.max';
+} from '../amp-image-lightbox';
 import {adopt} from '../../../../src/runtime';
 import {parseSrcset} from '../../../../src/srcset';
 import * as sinon from 'sinon';

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-require('../../../../build/all/v0/amp-install-serviceworker-0.1.max');
+require('../amp-install-serviceworker');
 import {adopt} from '../../../../src/runtime';
 
 adopt(window);

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -16,7 +16,7 @@
 
 import {
   AmpMustache,
-} from '../../../../build/all/v0/amp-mustache-0.1.max';
+} from '../amp-mustache';
 
 describe('amp-mustache template', () => {
 

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -35,6 +35,7 @@
  * </code>
  */
 
+import {CSS} from '../../../build/amp-pinterest-0.1.css';
 import {isLayoutSizeDefined} from '../../../src/layout';
 
 import {FollowButton} from './follow-button';
@@ -85,4 +86,4 @@ class AmpPinterest extends AMP.BaseElement {
 
 };
 
-AMP.registerElement('amp-pinterest', AmpPinterest, $CSS$);
+AMP.registerElement('amp-pinterest', AmpPinterest, CSS);

--- a/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-    require('../../../../build/all/v0/amp-pinterest-0.1.max');
+    require('../amp-pinterest');
     import {adopt} from '../../../../src/runtime';
     import {Timer} from '../../../../src/timer';
 

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-user-notification-0.1.css';
 import {assertHttpsUrl, addParamsToUrl} from '../../../src/url';
 import {assert} from '../../../src/asserts';
 import {cidFor} from '../../../src/cid';
@@ -407,4 +408,4 @@ export function installUserNotificationManager(window) {
 
 installUserNotificationManager(AMP.win);
 
-AMP.registerElement('amp-user-notification', AmpUserNotification, $CSS$);
+AMP.registerElement('amp-user-notification', AmpUserNotification, CSS);

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -18,7 +18,7 @@ import * as sinon from 'sinon';
 import {
   AmpUserNotification,
   UserNotificationManager,
-} from '../../../../build/all/v0/amp-user-notification-0.1.max';
+} from '../amp-user-notification';
 import {createIframePromise} from '../../../../testing/iframe';
 
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -57,9 +57,8 @@ export function adopt(global) {
    * Registers an extended element and installs its styles.
    * @param {string} name
    * @param {!Function} implementationClass
-   * @param {string=} opt_css Optional CSS to install with the component. Use
-   *     the special variable $CSS$ in your code. It will be replaced with the
-   *     CSS file associated with the element.
+   * @param {string=} opt_css Optional CSS to install with the component.
+   *     Typically imported from generated CSS-in-JS file for each component.
    */
   global.AMP.registerElement = function(name, implementationClass, opt_css) {
     const register = function() {

--- a/test/functional/test-amp-ad.js
+++ b/test/functional/test-amp-ad.js
@@ -21,7 +21,7 @@ import {installEmbed} from '../../builtins/amp-embed';
 import {installCidService} from '../../src/service/cid-impl';
 import {
   installUserNotificationManager,
-} from '../../build/all/v0/amp-user-notification-0.1.max';
+} from '../../extensions/amp-user-notification/0.1/amp-user-notification';
 import {markElementScheduledForTesting} from '../../src/custom-element';
 import {setCookie} from '../../src/cookies';
 import * as sinon from 'sinon';


### PR DESCRIPTION
If you have a pending pull request with a new extension you may need to adapt to this.

With this CL we no longer copy extensions and insert their CSS. Instead they just depend on the CSS if any via a generated JS file.

The main benefit of this is that the main source of an extension no longer lives in a generated file which unbreaks source maps in production for this important use case.

Fixes #2170