### PR TITLE
Don't swallow errors in URL replacements promises.

### DIFF
--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -366,6 +366,33 @@ describe('UrlReplacements', () => {
         .to.eventually.equal('?a=b&b=b');
   });
 
+  it('should report errors & replace them with empty string (sync)', () => {
+    const clock = sandbox.useFakeTimers();
+    const replacements = urlReplacementsFor(window);
+    replacements.set_('ONE', () => {
+      throw new Error('boom');
+    });
+    const p = expect(replacements.expand('?a=ONE')).to.eventually.equal('?a=');
+    expect(() => {
+      clock.tick(1);
+    }).to.throw(/boom/);
+    return p;
+  });
+
+  it('should report errors & replace them with empty string (promise)', () => {
+    const clock = sandbox.useFakeTimers();
+    const replacements = urlReplacementsFor(window);
+    replacements.set_('ONE', () => {
+      return Promise.reject(new Error('boom'));
+    });
+    return expect(replacements.expand('?a=ONE')).to.eventually.equal('?a=')
+        .then(() => {
+          expect(() => {
+            clock.tick(1);
+          }).to.throw(/boom/);
+        });
+  });
+
   it('should support positional arguments', () => {
     const replacements = urlReplacementsFor(window);
     replacements.set_('FN', one => one);


### PR DESCRIPTION
And unifies the behavior across sync and non-sync replacements.
Both now replace with the empty string and report the error to the console and the server where applicable. It would have been an option to fail the URL generation instead (previous that was the behavior for sync errors, but I believe that erring on the side of producing a URL is the right thing to do.

Fixes #2418