### PR TITLE
Revert "Fix preload warning for invalid as attribute."

### DIFF
--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -156,9 +156,7 @@ export function addDataAndJsonAttributes_(element, attributes) {
 export function prefetchBootstrap(window) {
   const url = getBootstrapBaseUrl(window);
   const preconnect = preconnectFor(window);
-  // `as=document` attribute is left out on purpose for lack of support and is
-  // an invalid value that is thrown as a warning message in the logs.
-  preconnect.prefetch(url);
+  preconnect.prefetch(url, 'document');
   // While the URL may point to a custom domain, this URL will always be
   // fetched by it.
   preconnect.prefetch(

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -183,7 +183,7 @@ describe('3p-frame', () => {
     expect(fetches).to.have.length(2);
     expect(fetches[0].href).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
-    expect(fetches[0].getAttribute('as')).to.be.null;
+    expect(fetches[0].getAttribute('as')).to.equal('document');
     expect(fetches[1].href).to.equal(
         'https://3p.ampproject.net/$internalRuntimeVersion$/f.js');
     expect(fetches[1].getAttribute('as')).to.equal('script');


### PR DESCRIPTION
This reverts commit 61dce50299b143da13a7da785c0fc3554533c5ac.

See #2372