### PR TITLE
Adding SOURCE_PATH URL variable substitution

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -55,6 +55,7 @@ export const ANALYTICS_CONFIG = {
       'serverResponseTime': 'SERVER_RESPONSE_TIME',
       'sourceUrl': 'SOURCE_URL',
       'sourceHost': 'SOURCE_HOST',
+      'sourcePath': 'SOURCE_PATH',
       'tcpConnectTime': 'TCP_CONNECT_TIME',
       'timestamp': 'TIMESTAMP',
       'timezone': 'TIMEZONE',

--- a/extensions/amp-analytics/analytics-vars.md
+++ b/extensions/amp-analytics/analytics-vars.md
@@ -92,6 +92,18 @@ Parses and provides the source URL of the current document to the URL.
 
 The source URL is extracted from the proxy URL if the document is being served from a *known* proxy. Otherwise the original document URL is returned. For instance, if the URL is served via the proxy `https://cdn.ampproject.org` from the URL `https://cdn.ampproject.org/c/s/example.com/page.html`, then `SOURCE_URL` would return `https://example.com/page.html`. If the URL is served directly from `https://example.com/page.html`, `https://example.com/page.html` will be returned.
 
+### sourceHost
+
+Parses and provides the source URL's host. See the description of `sourceUrl` for more details.
+
+Example value: `example.com`
+
+### sourcePath
+
+Parses and provides the source URL's path part. See the description of `sourceUrl` for more details.
+
+Example value: `%2Fpage.html`
+
 ### title
 
 Provides the title of the current document.

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -98,6 +98,16 @@ For instance:
 ```
 may make a request to something like `https://foo.com/pixel?host=pinterest.com`.
 
+### SOURCE_PATH
+
+Use the special string `SOURCE_PATH` to add the source URL's path of the current document to the URL. See the description of `SOURCE_URL` for more details.
+
+For instance:
+```html
+<amp-pixel src="https://foo.com/pixel?path=SOURCE_PATH"></amp-pixel>
+```
+may make a request to something like `https://foo.com/pixel?path=%2Fpage2.html`.
+
 ### DOCUMENT_CHARSET
 
 Provides the character encoding of the current document.

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -101,6 +101,11 @@ class UrlReplacements {
       return parseUrl(getSourceUrl(this.win_.location.href)).hostname;
     });
 
+    // Returns the path of the Source URL for this AMP document.
+    this.set_('SOURCE_PATH', () => {
+      return parseUrl(getSourceUrl(this.win_.location.href)).pathname;
+    });
+
     // Returns a random string that will be the constant for the duration of
     // single page view. It should have sufficient entropy to be unique for
     // all the page views a single user is making at a time.

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -148,6 +148,12 @@ describe('UrlReplacements', () => {
     });
   });
 
+  it('should replace SOURCE_PATH', () => {
+    return expand('?path=SOURCE_PATH').then(res => {
+      expect(res).to.not.match(/SOURCE_PATH/);
+    });
+  });
+
   it('should replace PAGE_VIEW_ID', () => {
     return expand('?pid=PAGE_VIEW_ID').then(res => {
       expect(res).to.match(/pid=\d+/);


### PR DESCRIPTION
This pull adds a `SOURCE_PATH` URL variable substitution, similar to the existing `CANONICAL_PATH` substitution, along with a corresponding `sourcePath` variable for `amp-analytics`.  I've also added some documentation currently missing for `sourceHost` under the `amp-analytics` variables guide.