### PR TITLE
Remove amp_js_* paramters from the source url.

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -25,6 +25,9 @@ const a = document.createElement('a');
 // but we often parse the same one over and over again.
 const cache = Object.create(null);
 
+/** @private @const Matches amp_js_* paramters in query string. */
+const AMP_JS_PARAMS_REGEX = /[?&]amp_js[^&]*/;
+
 /**
  * Returns a Location-like object for the given URL. If it is relative,
  * the URL gets resolved.
@@ -210,6 +213,22 @@ export function isProxyOrigin(url) {
 }
 
 /**
+ * Removes parameters that start with amp js parameter pattern and returns the new
+ * search string.
+ * @param {string} urlSearch
+ * @return {string}
+ */
+function removeAmpJsParams(urlSearch) {
+  if (!urlSearch || urlSearch == '?') {
+    return '';
+  }
+  const search = urlSearch
+      .replace(AMP_JS_PARAMS_REGEX, '')
+      .replace(/^[?&]/, '');  // Removes first ? or &.
+  return search ? '?' + search : '';
+}
+
+/**
  * Returns the source URL of an AMP document for documents served
  * on a proxy origin or directly.
  * @param {string|!Location} url URL of an AMP document.
@@ -240,7 +259,8 @@ export function getSourceUrl(url) {
   // Sanity test that what we found looks like a domain.
   assert(origin.indexOf('.') > 0, 'Expected a . in origin %s', origin);
   path.splice(1, domainOrHttpsSignal == 's' ? 3 : 2);
-  return origin + path.join('/') + (url.search || '') + (url.hash || '');
+  return origin + path.join('/') + removeAmpJsParams(url.search) +
+      (url.hash || '');
 }
 
 /**

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -373,6 +373,29 @@ describe('getSourceOrigin/Url', () => {
       'https://cdn.ampproject.org/c/s/origin.com%3A81/foo/?f=0',
       'https://origin.com:81/foo/?f=0');
 
+  // Removes amp-related paramters.
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?amp_js_param=5',
+      'http://o.com/foo/');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?f=0&amp_js_v=5#something',
+      'http://o.com/foo/?f=0#something');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?amp_js_v=5&f=0#bar',
+      'http://o.com/foo/?f=0#bar');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?f=0&amp_js_param=5&d=5#baz',
+      'http://o.com/foo/?f=0&d=5#baz');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?f_amp_js_param=5&d=5',
+      'http://o.com/foo/?f_amp_js_param=5&d=5');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?amp_js_param=5?d=5',
+      'http://o.com/foo/');  // Treats amp_js_param=5?d=5 as one param.
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/&amp_js_param=5&d=5',
+      'http://o.com/foo/&amp_js_param=5&d=5');  // Treats &... as part of path.
+
   // Non-CDN.
   testOrigin(
       'https://origin.com/foo/?f=0',


### PR DESCRIPTION
This removes the amp_js_v and other parameters that appear in analytics
reports today.