### PR TITLE
Use _top to open custom protocols on iOS Safari

### DIFF
--- a/src/document-click.js
+++ b/src/document-click.js
@@ -130,10 +130,17 @@ export function onDocumentElementClick_(e, viewport, history) {
   // document is iframed - in order to go around this, we set the top.location
   // to the custom protocol href.
   const isSafariIOS = platform.isIos() && platform.isSafari();
-  const isEmbedded = win.parent && win.parent != win;
-  const isNormalProtocol = /^(https?|mailto):$/.test(tgtLoc.protocol);
-  if (isSafariIOS && isEmbedded && !isNormalProtocol) {
+  const isFTP = tgtLoc.protocol == 'ftp:';
+
+  // In case of FTP Links in embedded documents always open then in _blank.
+  if (isFTP) {
     win.open(target.href, '_blank');
+    e.preventDefault();
+  }
+
+  const isNormalProtocol = /^(https?|mailto):$/.test(tgtLoc.protocol);
+  if (isSafariIOS && !isNormalProtocol) {
+    win.open(target.href, '_top');
     // Without preventing default the page would should an alert error twice
     // in the case where there's no app to handle the custom protocol.
     e.preventDefault();

--- a/test/functional/test-document-click.js
+++ b/test/functional/test-document-click.js
@@ -255,6 +255,27 @@ describe('test-document-click onDocumentElementClick_', () => {
     });
   });
 
+  describe('when linking to ftp: protocol', () => {
+    beforeEach(() => {
+      win.open = sandbox.spy();
+      win.parent = {};
+      win.top = {
+        location: {
+          href: 'https://google.com',
+        },
+      };
+      tgt.href = 'ftp://example.com/a';
+    });
+
+    it('should always open in _blank when embedded', () => {
+      onDocumentElementClick_(evt, viewport, history);
+      expect(win.open.called).to.be.true;
+      expect(win.open.calledWith(
+          'ftp://example.com/a', '_blank')).to.be.true;
+      expect(preventDefaultSpy.callCount).to.equal(1);
+    });
+  });
+
   describe('when linking to custom protocols e.g. whatsapp:', () => {
     beforeEach(() => {
       win.open = sandbox.spy();
@@ -267,13 +288,13 @@ describe('test-document-click onDocumentElementClick_', () => {
       tgt.href = 'whatsapp://send?text=hello';
     });
 
-    it('should set top.location.href on Safari iOS when embedded', () => {
+    it('should open link in _top on Safari iOS when embedded', () => {
       sandbox.stub(platform, 'isIos').returns(true);
       sandbox.stub(platform, 'isSafari').returns(true);
       onDocumentElementClick_(evt, viewport, history);
       expect(win.open.called).to.be.true;
       expect(win.open.calledWith(
-          'whatsapp://send?text=hello', '_blank')).to.be.true;
+          'whatsapp://send?text=hello', '_top')).to.be.true;
       expect(preventDefaultSpy.callCount).to.equal(1);
     });
 
@@ -299,15 +320,6 @@ describe('test-document-click onDocumentElementClick_', () => {
       sandbox.stub(platform, 'isSafari').returns(false);
       onDocumentElementClick_(evt, viewport, history);
       expect(win.top.location.href).to.equal('https://google.com');
-      expect(preventDefaultSpy.callCount).to.equal(0);
-    });
-
-    it('should not do anything if not embedded', () => {
-      sandbox.stub(platform, 'isIos').returns(true);
-      sandbox.stub(platform, 'isSafari').returns(true);
-      win.parent = undefined;
-      onDocumentElementClick_(evt, viewport, history);
-      expect(win.open.called).to.be.false;
       expect(preventDefaultSpy.callCount).to.equal(0);
     });
   });


### PR DESCRIPTION
and always use `_blank for ftp links - when embedded.

As discussed in #2357 and in person. 

@dvoytenko I am writing a doc with table to explain different scenarios as you suggested. I've also tested this out on iOS Safari and works well - no history changes seem to happen so we should be good to use `_top`