### PR TITLE
Faster Trusted Viewer Regex

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -109,7 +109,20 @@ export const VisibilityState = {
  * @export {!Array<!RegExp>}
  */
 export const TRUSTED_VIEWER_HOSTS = [
-  /^(.*\.)?(google)(\.com?)?(\.[a-z]{2})?$/,
+  /**
+   * Google domains, including country-codes and subdomains:
+   * - google.com
+   * - www.google.com
+   * - google.co
+   * - www.google.co
+   * - google.az
+   * - www.google..az
+   * - google.com.az
+   * - www.google.com.az
+   * - google.co.az
+   * - www.google.co.az
+   */
+  /(^|\.)google\.(com?|[a-z]{2}|com?\.[a-z]{2})$/,
 ];
 
 

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -621,6 +621,9 @@ describe('Viewer', () => {
       test('https://google.com', true);
       test('https://www.google.com', true);
       test('https://news.google.com', true);
+      test('https://google.co', true);
+      test('https://www.google.co', true);
+      test('https://news.google.co', true);
       test('https://www.google.co.uk', true);
       test('https://www.google.co.au', true);
       test('https://news.google.co.uk', true);
@@ -628,6 +631,7 @@ describe('Viewer', () => {
       test('https://google.de', true);
       test('https://www.google.de', true);
       test('https://news.google.de', true);
+      test('https://abc.www.google.com', true);
     });
 
     it('should not trust host as referrer with http', () => {
@@ -640,6 +644,8 @@ describe('Viewer', () => {
       test('https://www.google.other.com', false);
       test('https://withgoogle.com', false);
       test('https://acme.com', false);
+      test('https://google', false);
+      test('https://www.google', false);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/2393. Also bans `^(.*\.)?google$` as a trusted domains.

http://jsperf.com/amp-th-regex