### PR TITLE
Increase amp-youtube timeout to 5s.

### DIFF
--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -22,7 +22,8 @@ import * as sinon from 'sinon';
 
 adopt(window);
 
-describe('amp-youtube', () => {
+describe('amp-youtube', function() {
+  this.timeout(5000);
   let sandbox;
 
   beforeEach(() => {


### PR DESCRIPTION
Just experimenting to see if this kills the flakyness in amp-youtube tests. If not, we might need to avoid rendering YT iframe all together?

See #2615 

