### PR TITLE
allow amp-ad to be blocked by amp-user-notification even when no amp-ad scope exists

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -292,7 +292,9 @@ export function installAd(win) {
      */
     getAdCid_() {
       const scope = clientIdScope[this.element.getAttribute('type')];
-      if (!scope) {
+      const consentId = this.element.getAttribute(
+          'data-consent-notification-id');
+      if (!(scope || consentId)) {
         return Promise.resolve();
       }
       return cidForOrNull(this.getWin()).then(cidService => {
@@ -300,12 +302,13 @@ export function installAd(win) {
           return;
         }
         let consent = Promise.resolve();
-        const consentId = this.element.getAttribute(
-            'data-consent-notification-id');
         if (consentId) {
           consent = userNotificationManagerFor(this.getWin()).then(service => {
             return service.get(consentId);
           });
+          if (!scope && consentId) {
+            return consent;
+          }
         }
         return cidService.get(scope, consent);
       });

--- a/src/3p.js
+++ b/src/3p.js
@@ -245,6 +245,7 @@ export function validateData(data, allowedFields) {
     pageViewId: true,
     location: true,
     mode: true,
+    consentNotificationId: true,
   };
   for (const field in data) {
     if (!data.hasOwnProperty(field) ||


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/2633