### PR TITLE
Fix test in Safari.

### DIFF
--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -125,7 +125,6 @@ describe('Viewer Visibility State', () => {
 
     afterEach(() => {
       sandbox.restore();
-      fixture.iframe.parentNode.removeChild(fixture.iframe);
     });
 
     describe.skip('from in the PRERENDER state', () => {


### PR DESCRIPTION
It really hates it when you remove iframes in an afterEach handler. It leads to parts of the tests running after this happened.