### PR TITLE
Extend timeout for vis-state integration tests

### DIFF
--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -94,7 +94,8 @@ describe('Viewer Visibility State', () => {
       resumeCallback = sandbox.spy(protoElement, 'resumeCallback');
     }
 
-    beforeEach(() => {
+    beforeEach(function() {
+      this.timeout(5000);
       sandbox = sinon.sandbox.create();
       notifyPass = noop;
       shouldPass = false;


### PR DESCRIPTION
Hopefully, this will reduce the flake.