### PR TITLE
Adjust amp-social-share CSS so that SVG logo backgrounds are centered

### DIFF
--- a/extensions/amp-social-share/0.1/amp-social-share.css
+++ b/extensions/amp-social-share/0.1/amp-social-share.css
@@ -24,15 +24,17 @@ amp-social-share {
 amp-social-share span {
   display: block;
   border-radius: 5px;
-  height: 44px;
-  width: 60px;
+  height: 100%;
+  width: 100%;
 }
 
 amp-social-share a {
   display: block;
-  padding: 12px;
+  width: 100%;
+  height: 100%;
   background-repeat: no-repeat;
   background-position: center;
+  background-size: contain;
   text-decoration: none;
 }
 


### PR DESCRIPTION
Adjust amp-social-share CSS so that SVG logo backgrounds are centered in amp-social-share elements of any width/height (other than 60x44) (Issue #2628)