### PR TITLE
Delay Penalized Elements After First Visible Time

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -47,8 +47,7 @@ export class Timer {
    * @return {number}
    */
   now() {
-    // TODO(dvoytenko): when can we use Date.now?
-    return Number(new Date());
+    return Date.now();
   }
 
  /**

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -126,6 +126,11 @@ describe('Resources', () => {
     expect(resources.calcTaskTimeout_(task_p0)).to.equal(0);
     expect(resources.calcTaskTimeout_(task_p1)).to.equal(0);
 
+    // Idle render penalty after first visible
+    resources.firstVisibleTime_ = 0;
+    expect(resources.calcTaskTimeout_(task_p0)).to.equal(0);
+    expect(resources.calcTaskTimeout_(task_p1)).to.equal(1000);
+
     // Hight priority task in pool
     resources.exec_.tasks_ = [task_p0];
     expect(resources.calcTaskTimeout_(task_p0)).to.equal(0);


### PR DESCRIPTION
In the first moments after first visible time, we will delay penalized elements (based on their element priority).

If the document has already been visible for a while, no penalty will be added.

Fixes #2561.