### PR TITLE
Remove 404 polyfills from iframe tests

### DIFF
--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -182,7 +182,6 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
     let iframe = document.createElement('iframe');
     iframe.name = 'test_' + iframeCount++;
     iframe.srcdoc = '<!doctype><html><head>' +
-        '<script src="/base/build/polyfills.js"></script>' +
         '<body style="margin:0"><div id=parent></div>';
     iframe.onload = function() {
       // Flag as being a test window.


### PR DESCRIPTION
We don't serve this file while testing, so it's only polluting our test logs.