### PR TITLE
update broken CDN link in social-share example

### DIFF
--- a/examples/social-share.amp.html
+++ b/examples/social-share.amp.html
@@ -16,7 +16,7 @@
         ]
       }
     </script>
-    <script custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.max.js" async></script>
+    <script custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js" async></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
   </head>


### PR DESCRIPTION
Recently used this code as a reference to building my own share tools and noticed the amp-social-share CDN is 404ing. This updates to the correct path.