### PR TITLE
Prevent rendering far outside viewport

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -61,6 +61,8 @@ export function installAd(win) {
 
       // Ad opts into lazier loading strategy where we only load ads that are
       // at closer than 1.25 viewports away.
+      // TODO(jridgewell): Can this be moved to the new number based
+      // renderOutsideViewport?
       if (this.element.getAttribute('data-loading-strategy') ==
           'prefer-viewability-over-views') {
         const box = this.getIntersectionElementLayoutBox();
@@ -73,7 +75,7 @@ export function installAd(win) {
       }
 
       // Otherwise the ad is good to go.
-      return true;
+      return super.renderOutsideViewport();
     }
 
     /** @override */

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -69,8 +69,9 @@ describe('amp-iframe', () => {
       if (opt_height) {
         iframe.iframe.style.height = opt_height;
       }
-      viewportFor(iframe.win).resize_();
       const top = opt_top || '600px';
+      const viewport = viewportFor(iframe.win);
+      viewport.resize_();
       i.style.position = 'absolute';
       i.style.top = top;
       if (opt_translateY) {
@@ -89,6 +90,7 @@ describe('amp-iframe', () => {
         i.appendChild(img);
       }
       iframe.doc.body.appendChild(i);
+      viewport.setScrollTop(parseInt(top, 10));
       if (opt_onAppend) {
         opt_onAppend(iframe.doc);
       }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -262,8 +262,9 @@ export class BaseElement {
    * Subclasses can override this method to opt-out of rendering the element
    * when it is not currently visible.
    * Returning a boolean allows or prevents rendering outside the viewport at
-   * any distance, while returning a number allows rendering only when the
-   * element is within X viewports of the current viewport.
+   * any distance, while returning a positive number allows rendering only when
+   * the element is within X viewports of the current viewport. Returning a
+   * zero causes the element to only render inside the viewport.
    * @return {boolean|number}
    */
   renderOutsideViewport() {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -261,10 +261,13 @@ export class BaseElement {
   /**
    * Subclasses can override this method to opt-out of rendering the element
    * when it is not currently visible.
-   * @return {boolean}
+   * Returning a boolean allows or prevents rendering outside the viewport at
+   * any distance, while returning a number allows rendering only when the
+   * element is within X viewports of the current viewport.
+   * @return {boolean|number}
    */
   renderOutsideViewport() {
-    return true;
+    return 3;
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1794,7 +1794,7 @@ export class Resource {
       }
     } else if (viewportBox.top > layoutBox.bottom) {
       // Element is above viewport
-      distance = viewport.top - layoutBox.bottom;
+      distance = viewportBox.top - layoutBox.bottom;
 
       // If we're scrolling away from the element
       if (scrollDirection == 1) {
@@ -1804,7 +1804,7 @@ export class Resource {
       // Element is in viewport
       return true;
     }
-    return distance <= viewportBox.height * multipler / scrollPenalty;
+    return distance < viewportBox.height * multipler / scrollPenalty;
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1751,7 +1751,17 @@ export class Resource {
    * @return {boolean}
    */
   renderOutsideViewport() {
-    return this.element.renderOutsideViewport();
+    const renders = this.element.renderOutsideViewport();
+    // Boolean interface, element is either always allowed or never allowed to
+    // render outside viewport.
+    if (renders === true || renders === false) {
+      return renders;
+    }
+    // Numeric interface, element is allowed to render outside viewport when it
+    // is within X times the viewport height of the current viewport.
+    const viewportBox = this.viewport_.getRect();
+    const distanceFromViewport = this.layoutBox_.top - viewportBox.bottom;
+    return distanceFromViewport <= renders * viewportBox.height;
   }
 
   /**
@@ -1789,7 +1799,7 @@ export class Resource {
       return Promise.resolve();
     }
 
-    if (!this.renderOutsideViewport() && !this.isInViewport()) {
+    if (!this.isInViewport() && !this.renderOutsideViewport()) {
       dev.fine(TAG_, 'layout canceled due to element not being in viewport:',
           this.debugid, this.state_);
       this.state_ = ResourceState_.READY_FOR_LAYOUT;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -319,6 +319,14 @@ export class Resources {
   }
 
   /**
+   * Returns the viewport instance
+   * @return {!Viewport}
+   */
+  getViewport() {
+    return this.viewport_;
+  }
+
+  /**
    * Signals that an element has been added to the DOM. Resources manager
    * will start tracking it from this point on.
    * @param {!AmpElement} element
@@ -1759,7 +1767,7 @@ export class Resource {
     }
     // Numeric interface, element is allowed to render outside viewport when it
     // is within X times the viewport height of the current viewport.
-    const viewportBox = this.viewport_.getRect();
+    const viewportBox = this.resources_.getViewport().getRect();
     const distanceFromViewport = this.layoutBox_.top - viewportBox.bottom;
     return distanceFromViewport <= renders * viewportBox.height;
   }

--- a/test/functional/test-amp-ad.js
+++ b/test/functional/test-amp-ad.js
@@ -578,10 +578,10 @@ function tests(name, installer) {
         }, layoutCb);
       }
 
-      it('should return true after scrolling and then false for 1s', () => {
+      it('should not return false after scrolling, then false for 1s', () => {
         let clock;
         return getGoodAd(ad => {
-          expect(ad.renderOutsideViewport()).to.be.true;
+          expect(ad.renderOutsideViewport()).not.to.be.false;
         }, () => {
           clock = sandbox.useFakeTimers();
         }).then(ad => {
@@ -590,7 +590,7 @@ function tests(name, installer) {
           clock.tick(900);
           expect(ad.renderOutsideViewport()).to.be.false;
           clock.tick(100);
-          expect(ad.renderOutsideViewport()).to.be.true;
+          expect(ad.renderOutsideViewport()).not.to.be.false;
         });
       });
 

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -51,25 +51,25 @@ describe('amp-img', () => {
 
   it('should load an img', () => {
     return getImg({
-      src: 'test.jpg',
+      src: '/base/examples/img/sample.jpg',
       width: 300,
       height: 200,
     }).then(ampImg => {
       const img = ampImg.querySelector('img');
       expect(img.tagName).to.equal('IMG');
-      expect(img.getAttribute('src')).to.equal('test.jpg');
+      expect(img.getAttribute('src')).to.equal('/base/examples/img/sample.jpg');
     });
   });
 
   it('should load an img with srcset', () => {
     return getImg({
-      srcset: 'test-2000.jpg 2000w, test-1000.jpg 1000w',
+      srcset: 'bad.jpg 2000w, /base/examples/img/sample.jpg 1000w',
       width: 300,
       height: 200,
     }).then(ampImg => {
       const img = ampImg.querySelector('img');
       expect(img.tagName).to.equal('IMG');
-      expect(img.getAttribute('src')).to.equal('test-1000.jpg');
+      expect(img.getAttribute('src')).to.equal('/base/examples/img/sample.jpg');
     });
   });
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1823,173 +1823,270 @@ describe('Resource renderOutsideViewport', () => {
 
 
   describe('boolean API', () => {
-    it('should allow rendering when element returns true', () => {
-      elementMock.expects('renderOutsideViewport').returns(true).exactly(20);
+    describe('when element returns true', () => {
+      beforeEach(() => {
+        elementMock.expects('renderOutsideViewport').returns(true).once();
+      });
 
-      // Element in viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
+      describe('when element is inside viewport', () => {
+        it('should allow rendering when bottom falls outside', () => {
+          resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
 
-      // Element just below viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling towards
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling away
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      resources.lastVelocity_ = 0;
+        it('should allow rendering when top falls outside', () => {
+          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
 
-      // Element marginally below viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling towards
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling away
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      resources.lastVelocity_ = 0;
+      describe('when element is just below viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
+        });
 
-      // Element wayyy below viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling towards
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling away
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      resources.lastVelocity_ = 0;
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
 
-      // Element just above viewport
-      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling towards
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling away
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      resources.lastVelocity_ = 0;
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
 
-      // Element marginally above viewport
-      resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling towards
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling away
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      resources.lastVelocity_ = 0;
+      describe('when element is marginally below viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
+        });
 
-      // Element wayyy above viewport
-      resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling towards
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      // Scrolling away
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      resources.lastVelocity_ = 0;
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
+
+      describe('when element is wayyy below viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
+        });
+
+        it('should allow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
+
+      describe('when element is just above viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
+
+      describe('when element is marginally above viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
+
+      describe('when element is wayyy above viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
+        });
+
+        it('should allow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
     });
 
-    it('should disallow rendering when element returns false', () => {
-      elementMock.expects('renderOutsideViewport').returns(false).exactly(20);
+    describe('when element returns false', () => {
+      beforeEach(() => {
+        elementMock.expects('renderOutsideViewport').returns(false).once();
+      });
 
-      // Element in viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(false);
+      describe('when element is inside viewport', () => {
+        it('should allow rendering when bottom falls outside', () => {
+          resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
 
-      // Element just below viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling towards
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling away
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      resources.lastVelocity_ = 0;
+        it('should allow rendering when top falls outside', () => {
+          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+      });
 
-      // Element marginally below viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling towards
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling away
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      resources.lastVelocity_ = 0;
+      describe('when element is just below viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
+        });
 
-      // Element wayyy below viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling towards
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling away
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      resources.lastVelocity_ = 0;
+        it('should disallow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
 
-      // Element just above viewport
-      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling towards
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling away
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      resources.lastVelocity_ = 0;
+        it('should disallow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+      });
 
-      // Element marginally above viewport
-      resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling towards
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling away
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      resources.lastVelocity_ = 0;
+      describe('when element is marginally below viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
+        });
 
-      // Element wayyy above viewport
-      resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling towards
-      resources.lastVelocity_ = -2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      // Scrolling away
-      resources.lastVelocity_ = 2;
-      expect(resource.renderOutsideViewport()).to.equal(false);
-      resources.lastVelocity_ = 0;
+        it('should disallow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        it('should disallow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+      });
+
+      describe('when element is wayyy below viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
+        });
+
+        it('should disallow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        it('should disallow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        it('should disallow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+      });
+
+      describe('when element is just above viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+        });
+
+        it('should disallow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        it('should disallow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+      });
+
+      describe('when element is marginally above viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
+        });
+
+        it('should disallow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        it('should disallow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+      });
+
+      describe('when element is wayyy above viewport', () => {
+        beforeEach(() => {
+          resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
+        });
+
+        it('should disallow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        it('should disallow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        it('should disallow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+      });
     });
   });
 
   describe('number API', () => {
-    it('should allow rendering when element inside viewport', () => {
-      elementMock.expects('renderOutsideViewport').returns(3).exactly(2);
+    beforeEach(() => {
+      elementMock.expects('renderOutsideViewport').returns(3).once();
+    });
 
-      // Element in viewport
-      resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
-      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
-      expect(resource.renderOutsideViewport()).to.equal(true);
+    describe('when element is inside viewport', () => {
+      it('should allow rendering when bottom falls outside', () => {
+        resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should allow rendering when top falls outside', () => {
+        resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
     });
 
     describe('when element is just below viewport', () => {
       beforeEach(() => {
-        elementMock.expects('renderOutsideViewport').returns(3).once();
         resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
       });
 
@@ -2006,7 +2103,6 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is marginally below viewport', () => {
       beforeEach(() => {
-        elementMock.expects('renderOutsideViewport').returns(3).once();
         resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
       });
 
@@ -2023,7 +2119,6 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is wayyy below viewport', () => {
       beforeEach(() => {
-        elementMock.expects('renderOutsideViewport').returns(3).once();
         resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
       });
 
@@ -2044,7 +2139,6 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is just above viewport', () => {
       beforeEach(() => {
-        elementMock.expects('renderOutsideViewport').returns(3).once();
         resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
       });
 
@@ -2061,7 +2155,6 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is marginally above viewport', () => {
       beforeEach(() => {
-        elementMock.expects('renderOutsideViewport').returns(3).once();
         resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
       });
 
@@ -2078,7 +2171,6 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is wayyy above viewport', () => {
       beforeEach(() => {
-        elementMock.expects('renderOutsideViewport').returns(3).once();
         resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
       });
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1778,3 +1778,323 @@ describe('Resources.Resource', () => {
     });
   });
 });
+
+describe('Resource renderOutsideViewport', () => {
+  let sandbox;
+  let element;
+  let elementMock;
+  let resources;
+  let resource;
+  let viewport;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    element = {
+      tagName: 'AMP-AD',
+      isBuilt: () => false,
+      isUpgraded: () => false,
+      prerenderAllowed: () => false,
+      renderOutsideViewport: () => true,
+      build: unused_force => false,
+      getBoundingClientRect: () => null,
+      updateLayoutBox: () => {},
+      isRelayoutNeeded: () => false,
+      layoutCallback: () => {},
+      changeSize: () => {},
+      unlayoutOnPause: () => false,
+      unlayoutCallback: () => true,
+      pauseCallback: () => false,
+      resumeCallback: () => false,
+      viewportCallback: () => {},
+    };
+    elementMock = sandbox.mock(element);
+
+    resources = new Resources(window);
+    resource = new Resource(1, element, resources);
+    viewport = resources.viewport_;
+    sandbox.stub(viewport, 'getRect').returns(layoutRectLtwh(0, 0, 100, 100));
+  });
+
+  afterEach(() => {
+    elementMock.verify();
+    sandbox.restore();
+  });
+
+
+  describe('boolean API', () => {
+    it('should allow rendering when element returns true', () => {
+      elementMock.expects('renderOutsideViewport').returns(true).exactly(20);
+
+      // Element in viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+
+      // Element just below viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling towards
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling away
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      resources.lastVelocity_ = 0;
+
+      // Element marginally below viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling towards
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling away
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      resources.lastVelocity_ = 0;
+
+      // Element wayyy below viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling towards
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling away
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      resources.lastVelocity_ = 0;
+
+      // Element just above viewport
+      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling towards
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling away
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      resources.lastVelocity_ = 0;
+
+      // Element marginally above viewport
+      resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling towards
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling away
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      resources.lastVelocity_ = 0;
+
+      // Element wayyy above viewport
+      resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling towards
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      // Scrolling away
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      resources.lastVelocity_ = 0;
+    });
+
+    it('should disallow rendering when element returns false', () => {
+      elementMock.expects('renderOutsideViewport').returns(false).exactly(20);
+
+      // Element in viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(false);
+
+      // Element just below viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling towards
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling away
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      resources.lastVelocity_ = 0;
+
+      // Element marginally below viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling towards
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling away
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      resources.lastVelocity_ = 0;
+
+      // Element wayyy below viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling towards
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling away
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      resources.lastVelocity_ = 0;
+
+      // Element just above viewport
+      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling towards
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling away
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      resources.lastVelocity_ = 0;
+
+      // Element marginally above viewport
+      resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling towards
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling away
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      resources.lastVelocity_ = 0;
+
+      // Element wayyy above viewport
+      resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling towards
+      resources.lastVelocity_ = -2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      // Scrolling away
+      resources.lastVelocity_ = 2;
+      expect(resource.renderOutsideViewport()).to.equal(false);
+      resources.lastVelocity_ = 0;
+    });
+  });
+
+  describe('number API', () => {
+    it('should allow rendering when element inside viewport', () => {
+      elementMock.expects('renderOutsideViewport').returns(3).exactly(2);
+
+      // Element in viewport
+      resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+      resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+      expect(resource.renderOutsideViewport()).to.equal(true);
+    });
+
+    describe('when element is just below viewport', () => {
+      beforeEach(() => {
+        elementMock.expects('renderOutsideViewport').returns(3).once();
+        resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
+      });
+
+      it('should allow rendering when scrolling towards', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should allow rendering when scrolling away', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+    });
+
+    describe('when element is marginally below viewport', () => {
+      beforeEach(() => {
+        elementMock.expects('renderOutsideViewport').returns(3).once();
+        resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
+      });
+
+      it('should allow rendering when scrolling towards', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should disallow rendering when scrolling away', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+    });
+
+    describe('when element is wayyy below viewport', () => {
+      beforeEach(() => {
+        elementMock.expects('renderOutsideViewport').returns(3).once();
+        resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
+      });
+
+      it('should disallow rendering', () => {
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      it('should disallow rendering when scrolling towards', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      it('should disallow rendering when scrolling away', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+    });
+
+    describe('when element is just above viewport', () => {
+      beforeEach(() => {
+        elementMock.expects('renderOutsideViewport').returns(3).once();
+        resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+      });
+
+      it('should allow rendering when scrolling towards', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should allow rendering when scrolling away', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+    });
+
+    describe('when element is marginally above viewport', () => {
+      beforeEach(() => {
+        elementMock.expects('renderOutsideViewport').returns(3).once();
+        resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
+      });
+
+      it('should allow rendering when scrolling towards', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should disallow rendering when scrolling away', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+    });
+
+    describe('when element is wayyy above viewport', () => {
+      beforeEach(() => {
+        elementMock.expects('renderOutsideViewport').returns(3).once();
+        resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
+      });
+
+      it('should disallow rendering', () => {
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      it('should disallow rendering when scrolling towards', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      it('should disallow rendering when scrolling away', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is incomplete, and meant to spur discussion.

- I've prevented rendering outside 3 viewport heights.
  - Should this be increased to e.g. 5?
- I've implemented inside our BaseElement class so that cheap elements
  can override to render further outside or expensive elements closer to
  the viewport.
  - Should we move this to `Resources`, which will give us a little
    better performance?
  - We could also pass data to `#renderOutsideViewport`, which will give
    us a perf boost.

/cc @dvoytenko