### PR TITLE
dont throw error on changelog failure since it is not critical.

### DIFF
--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -325,7 +325,6 @@ function errHandler(err) {
     msg = err.message;
   }
   util.log(util.colors.red(msg));
-  throw err;
 }
 
 /**


### PR DESCRIPTION
to stop internal release script from failing even with api/changelog errors