### PR TITLE
make global config testing non string

### DIFF
--- a/build-system/window-config.js
+++ b/build-system/window-config.js
@@ -19,6 +19,11 @@ var minimist = require('minimist');
 var argv = minimist(process.argv.slice(2));
 var isCanary = argv.type === 'canary';
 
+var config = {
+  'canary': isCanary,
+};
+
 exports.getTemplate = function() {
-  return `window.AMP_CONFIG={canary:${isCanary}};/*AMP_CONFIG*/`;
+  var configStr = JSON.stringify(config);
+  return `window.AMP_CONFIG=${configStr};/*AMP_CONFIG*/`;
 };


### PR DESCRIPTION
@tdrl made update here. unfortunately when you need to make changes to the options you'll have to kill the server then run `gulp clean` and then start the server again `gulp`. the config doesnt get hot reloaded on refresh since the code is in the build system.

/cc @dvoytenko for review