### PR TITLE
Implement cross origin ServiceWorker installation.

### DIFF
--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -16,10 +16,25 @@
 
 require('../amp-install-serviceworker');
 import {adopt} from '../../../../src/runtime';
+import {getService} from '../../../../src/service';
+import * as sinon from 'sinon';
 
 adopt(window);
 
 describe('amp-install-serviceworker', () => {
+
+  let clock;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   it('should install for same origin', () => {
     const install = document.createElement('amp-install-serviceworker');
     const implementation = install.implementation_;
@@ -69,7 +84,6 @@ describe('amp-install-serviceworker', () => {
     const implementation = install.implementation_;
     expect(implementation).to.be.defined;
     install.setAttribute('src', 'https://other-origin.com/sw.js');
-    let calledSrc;
     const p = new Promise(() => {});
     implementation.getWin = () => {
       return {
@@ -87,10 +101,10 @@ describe('amp-install-serviceworker', () => {
       };
     };
     implementation.buildCallback();
-    expect(calledSrc).to.undefined;
+    expect(install.children).to.have.length(0);
   });
 
-  it('should do nothing on proxy', () => {
+  it('should do nothing on proxy without iframe URL', () => {
     const install = document.createElement('amp-install-serviceworker');
     const implementation = install.implementation_;
     expect(implementation).to.be.defined;
@@ -114,5 +128,111 @@ describe('amp-install-serviceworker', () => {
     };
     implementation.buildCallback();
     expect(calledSrc).to.undefined;
+    expect(install.children).to.have.length(0);
+  });
+
+  describe('proxy iframe injection', () => {
+
+    let documentInfo;
+    let install;
+    let implementation;
+    let whenVisible;
+    let calledSrc;
+
+    beforeEach(() => {
+      install = document.createElement('amp-install-serviceworker');
+      implementation = install.implementation_;
+      expect(implementation).to.be.defined;
+      install.setAttribute('src', 'https://www.example.com/sw.js');
+      calledSrc = undefined;
+      const p = new Promise(() => {});
+      const win = {
+        location: {
+          href: 'https://cdn.ampproject.org/c/s/www.example.com/path',
+        },
+        navigator: {
+          serviceWorker: {
+            register: src => {
+              calledSrc = src;
+              return p;
+            },
+          },
+        },
+      };
+      implementation.getWin = () => win;
+      documentInfo = {
+        canonicalUrl: 'https://www.example.com/path',
+        sourceUrl: 'https://source.example.com/path',
+      };
+      getService(win, 'documentInfo', () => {
+        return documentInfo;
+      });
+      whenVisible = Promise.resolve();
+      getService(win, 'viewer', () => {
+        return {
+          whenFirstVisible: () => whenVisible,
+          isVisible: () => true,
+        };
+      });
+    });
+
+    function testIframe() {
+      const iframeSrc = 'https://www.example.com/install-sw.html';
+      install.setAttribute('data-iframe-src', iframeSrc);
+      implementation.buildCallback();
+      let iframe;
+      const appendChild = install.appendChild;
+      install.appendChild = child => {
+        iframe = child;
+        iframe.complete = true;  // Mark as loaded.
+        expect(iframe.src).to.equal(iframeSrc);
+        iframe.src = 'about:blank';
+        appendChild.call(install, iframe);
+      };
+      let deferredMutate;
+      implementation.deferMutate = fn => {
+        expect(deferredMutate).to.be.undefined;
+        deferredMutate = fn;
+      };
+      return whenVisible.then(() => {
+        clock.tick(19999);
+        expect(deferredMutate).to.be.undefined;
+        expect(iframe).to.be.undefined;
+        clock.tick(1);
+        expect(deferredMutate).to.not.be.undefined;
+        expect(iframe).to.be.undefined;
+        deferredMutate();
+        expect(iframe).to.not.be.undefined;
+        expect(calledSrc).to.undefined;
+        expect(install.style.display).to.equal('none');
+        expect(iframe.tagName).to.equal('IFRAME');
+        expect(iframe.getAttribute('sandbox')).to.equal(
+            'allow-same-origin allow-scripts');
+      });
+    }
+
+    it('should inject iframe on proxy if provided (valid canonical)',
+        testIframe);
+
+    it('should inject iframe on proxy if provided (valid source)', () => {
+      documentInfo = {
+        canonicalUrl: 'https://canonical.example.com/path',
+        sourceUrl: 'https://www.example.com/path',
+      };
+      testIframe();
+    });
+
+    it('should reject bad iframe URLs', () => {
+      const iframeSrc = 'https://www2.example.com/install-sw.html';
+      install.setAttribute('data-iframe-src', iframeSrc);
+      expect(() => {
+        implementation.buildCallback();
+      }).to.throw(/should be a URL on the same origin as the source/);
+      install.setAttribute('data-iframe-src',
+          'http://www.example.com/install-sw.html');
+      expect(() => {
+        implementation.buildCallback();
+      }).to.throw(/https/);
+    });
   });
 });

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 ## Behavior
 
-Registers the ServiceWorker given by the `src` attribute. If the current origin is different from the origin of the ServiceWorker, this custom element does nothing (emits warning in development mode).
+Registers the ServiceWorker given by the `src` attribute if the AMP document is loaded from the same origin as the given ServiceWorker URL. If the `data-iframe-src` is set, loads that URL as an iframe when the AMP document is served from an AMP cache. This allows ServiceWorker installation from the AMP cache, so that the ServiceWorker is installed by the time users visit the origin site.
 
 This ServiceWorker runs whenever the AMP file is served from the origin where you publish the AMP file. The ServiceWorker will not be loaded when the document is loaded from an AMP cache.
 
@@ -49,6 +49,7 @@ Example
 
   <amp-install-serviceworker
       src="https://www.your-domain.com/serviceworker.js"
+      data-iframe-src="https://www.your-domain.com/install-serviceworker.html"
       layout="nodisplay">
   </amp-install-serviceworker>
 
@@ -59,6 +60,10 @@ Example
 ### `src`
 
 URL of the ServiceWorker to register.
+
+### `data-iframe-src` (optional)
+
+URL of a HTML document that install a ServiceWorker.
 
 ### `layout`
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -55,6 +55,8 @@ const FOUR_FRAME_DELAY_ = 70;
  * @return {number}
  */
 export function getElementPriority(tagName) {
+  // Filed https://github.com/ampproject/amphtml/issues/2714 to get this
+  // method into the element implementation classes.
   tagName = tagName.toLowerCase();
   if (tagName == 'amp-ad') {
     return 2;

--- a/test/manual/amp-install-serviceworker.amp.html
+++ b/test/manual/amp-install-serviceworker.amp.html
@@ -18,7 +18,8 @@
 <body>
   <h1>Should install a ServiceWorker if browser supports it.</h1>
   <amp-install-serviceworker
-      src="./test-sw.js"
+      src="https://cdn.ampproject.org/test-sw.js"
+      data-iframe-src="http://localhost:8000/test/manual/test-sw.html"
       layout="nodisplay">
   </amp-install-serviceworker>
 </body>

--- a/test/manual/test-sw.html
+++ b/test/manual/test-sw.html
@@ -1,0 +1,8 @@
+<script>
+  navigator.serviceWorker.register('./test-sw.js').then(function(registration) {
+    console.info('Iframe: ServiceWorker registration successful with scope: ',
+        registration.scope);
+  }).catch(function(e) {
+    console.error('Iframe: ServiceWorker registration failed: ', e.message);
+  });
+</script>


### PR DESCRIPTION
In particular this allows installing a ServiceWorker for AMP documents that are served from the AMP cache.

Fixes #981 

CC @slightlyoff