### PR TITLE
Minor grammar mistake in documentation

### DIFF
--- a/builtins/amp-ad.md
+++ b/builtins/amp-ad.md
@@ -187,7 +187,7 @@ The following lists validation errors specific to the `amp-ad` tag
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> attribute is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> attribute is missing its URL.</td>
   </tr>
   <tr>
   <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/builtins/amp-embed.md
+++ b/builtins/amp-embed.md
@@ -64,7 +64,7 @@ The following lists validation errors specific to the `amp-embed` tag
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> attribute is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> attribute is missing its URL.</td>
   </tr>
   <tr>
   <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -96,7 +96,7 @@ The following lists validation errors specific to the `amp-img` tag
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> or <code>srcset</code> attribute is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> or <code>srcset</code> attribute is missing its URL.</td>
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/builtins/amp-pixel.md
+++ b/builtins/amp-pixel.md
@@ -72,7 +72,7 @@ The following lists validation errors specific to the `amp-pixel` tag
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> attribute is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> attribute is missing its URL.</td>
   </tr>
   <tr>
   <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/builtins/amp-video.md
+++ b/builtins/amp-video.md
@@ -100,7 +100,7 @@ The following lists validation errors specific to the `amp-video` tag
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> attribute is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> attribute is missing its URL.</td>
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -100,7 +100,7 @@ May need to add something to this table based on technical review.
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> attribute is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> attribute is missing its URL.</td>
   </tr>
   <tr>
     <td class="col-fourty"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -196,7 +196,7 @@ The following lists validation errors specific to the `amp-iframe` tag
   </tr>
     <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> or <code>srcdoc</code> is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> or <code>srcdoc</code> is missing its URL.</td>
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -91,7 +91,7 @@ The following lists validation errors specific to the `amp-instagram` tag
   </tr>
     <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>data-shortcode</code> or <code>src</code> is missing it's URL.</td>
+    <td>Error thrown when <code>data-shortcode</code> or <code>src</code> is missing its URL.</td>
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -80,7 +80,7 @@ The following lists validation errors specific to the `amp-install-serviceworker
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> attribute is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> attribute is missing its URL.</td>
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -134,7 +134,7 @@ The following lists validation errors specific to the `amp-list` tag
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>src</code> attribute is missing it's URL.</td>
+    <td>Error thrown when <code>src</code> attribute is missing its URL.</td>
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -89,7 +89,7 @@ May need to add something to this table based on technical review.
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>data-tweetid</code> or <code>src</code> is missing it's URL.</td>
+    <td>Error thrown when <code>data-tweetid</code> or <code>src</code> is missing its URL.</td>
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -74,7 +74,7 @@ The following lists validation errors specific to the `amp-youtube` tag
   </tr>
     <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#missing-url">Missing URL for attribute 'example1' in tag 'example2'.</a></td>
-    <td>Error thrown when <code>data-videoid</code> or <code>src</code> is missing it's URL.</td>
+    <td>Error thrown when <code>data-videoid</code> or <code>src</code> is missing its URL.</td>
   </tr>
   <tr>
     <td width="40%"><a href="https://www.ampproject.org/docs/reference/validation_errors.html#invalid-url">Malformed URL 'example3' for attribute 'example1' in tag 'example2'.</a></td>


### PR DESCRIPTION
"it's" with the apostrophe is incorrectly used in various places throughout the documentation.