### PR TITLE
WIP: Adding prerender cycle for elements

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -84,6 +84,14 @@ export class AmpImg extends BaseElement {
     return promise;
   }
 
+  /** @override */
+  layoutCallback() {
+    // This is specifically needed for elements that does its work on prerender
+    // e.g. amp-img. This is only needed because currently prerendering
+    // undisplayed elements does not work. See issue #2742.
+    return this.updateImageSrc_();
+  }
+
   /**
    * @return {!Promise}
    * @private

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -64,17 +64,12 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override */
-  prerenderAllowed() {
-    return true;
-  }
-
-  /** @override */
   isRelayoutNeeded() {
     return true;
   }
 
   /** @override */
-  layoutCallback() {
+  prerenderCallback() {
     let promise = this.updateImageSrc_();
 
     // We only allow to fallback on error on the initial layoutCallback

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -147,6 +147,7 @@
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="./viewer-integr.js"></script>
 </head>
 <body>
   <header>

--- a/examples/instagram.amp.html
+++ b/examples/instagram.amp.html
@@ -14,6 +14,7 @@
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="./viewer-integr.js"></script>
 </head>
 <body>
 

--- a/examples/twitter.amp.html
+++ b/examples/twitter.amp.html
@@ -9,6 +9,7 @@
   <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="./viewer-integr.js"></script>
 </head>
 <body>
 

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -481,47 +481,32 @@
 
     function loadAmpDoc() {
       new Viewer(
-              'container1',
-              '1',
-              './article.amp.max.html',
-              true).start();
+          'container1',
+          '1',
+          './instagram.amp.max.html',
+          true).start();
       addShowContainer('1');
 
       new Viewer(
-              'container2',
-              '2',
-              './everything.amp.max.html',
-              false).start();
+          'container2',
+          '2',
+          './article.amp.max.html',
+          false).start();
       addShowContainer('2');
 
+      new Viewer(
+          'container3',
+          '3',
+          './youtube.amp.max.html',
+          false).start();
+      addShowContainer('3');
 
-//      new Viewer(
-//          'container1',
-//          '1',
-//          './instagram.amp.max.html',
-//          true).start();
-//      addShowContainer('1');
-//
-//      new Viewer(
-//          'container2',
-//          '2',
-//          './article.amp.max.html',
-//          false).start();
-//      addShowContainer('2');
-//
-//      new Viewer(
-//          'container3',
-//          '3',
-//          './youtube.amp.max.html',
-//          false).start();
-//      addShowContainer('3');
-//
-//      new Viewer(
-//              'container4',
-//              '4',
-//              './everything.amp.max.html',
-//              false).start();
-//      addShowContainer('4');
+      new Viewer(
+          'container4',
+          '4',
+          './everything.amp.max.html',
+          false).start();
+      addShowContainer('4');
 
       showContainer('1');
     }

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -111,6 +111,14 @@
       text-decoration: underline;
     }
 
+    viewer[data-show-container="4"] #container4 {
+      visibility: visible;
+    }
+
+    viewer[data-show-container="4"] #show-container4-anchor {
+      text-decoration: underline;
+    }
+
     viewer.natural container {
       overflow-y: hidden;
     }
@@ -473,25 +481,47 @@
 
     function loadAmpDoc() {
       new Viewer(
-          'container1',
-          '1',
-          './everything.amp.max.html',
-          true).start();
+              'container1',
+              '1',
+              './article.amp.max.html',
+              true).start();
       addShowContainer('1');
 
       new Viewer(
-          'container2',
-          '2',
-          './article-access.amp.max.html',
-          false).start();
+              'container2',
+              '2',
+              './everything.amp.max.html',
+              false).start();
       addShowContainer('2');
 
-      new Viewer(
-          'container3',
-          '3',
-          './article-access.amp.max.html',
-          false).start();
-      addShowContainer('3');
+
+//      new Viewer(
+//          'container1',
+//          '1',
+//          './instagram.amp.max.html',
+//          true).start();
+//      addShowContainer('1');
+//
+//      new Viewer(
+//          'container2',
+//          '2',
+//          './article.amp.max.html',
+//          false).start();
+//      addShowContainer('2');
+//
+//      new Viewer(
+//          'container3',
+//          '3',
+//          './youtube.amp.max.html',
+//          false).start();
+//      addShowContainer('3');
+//
+//      new Viewer(
+//              'container4',
+//              '4',
+//              './everything.amp.max.html',
+//              false).start();
+//      addShowContainer('4');
 
       showContainer('1');
     }
@@ -522,6 +552,7 @@
       <a class="show-container-anchor" id="show-container1-anchor">One</a>
       <a class="show-container-anchor" id="show-container2-anchor">Two</a>
       <a class="show-container-anchor" id="show-container3-anchor">Three</a>
+      <a class="show-container-anchor" id="show-container4-anchor">Four</a>
       <a>|</a>
       <a id="visibilityToggle">Visible</a>
     </header>
@@ -536,6 +567,11 @@
       </div>
     </container>
     <container id="container3">
+      <div class="wait">
+        Please wait, the AMP doc will appear here...
+      </div>
+    </container>
+    <container id="container4">
       <div class="wait">
         Please wait, the AMP doc will appear here...
       </div>

--- a/examples/youtube.amp.html
+++ b/examples/youtube.amp.html
@@ -8,6 +8,7 @@
     <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async src="./viewer-integr.js"></script>
 </head>
 <body>
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -63,11 +63,6 @@ export class BaseCarousel extends AMP.BaseElement {
   }
 
   /** @override */
-  prerenderAllowed() {
-    return true;
-  }
-
-  /** @override */
   isRelayoutNeeded() {
     return true;
   }

--- a/extensions/amp-carousel/0.1/carousel.js
+++ b/extensions/amp-carousel/0.1/carousel.js
@@ -65,7 +65,7 @@ export class AmpCarousel extends BaseCarousel {
 
   /** @override */
   prerenderCallback() {
-    this.doLayout_(this.pos_);
+    this.doPreload_(this.pos_);
     this.preloadNext_(this.pos_, 1);
     this.setControlsState();
     return Promise.resolve();
@@ -162,8 +162,17 @@ export class AmpCarousel extends BaseCarousel {
    */
   doLayout_(pos) {
     this.withinWindow_(pos, cell => {
-      console.log('schedule layout for cell');
       this.scheduleLayout(cell);
+    });
+  }
+
+  /**
+   * @param {number} pos
+   * @private
+   */
+  doPreload_(pos) {
+    this.withinWindow_(pos, cell => {
+      this.schedulePreload(cell);
     });
   }
 
@@ -175,9 +184,7 @@ export class AmpCarousel extends BaseCarousel {
   preloadNext_(pos, dir) {
     const nextPos = this.nextPos_(pos, dir);
     if (nextPos != pos) {
-      this.withinWindow_(nextPos, cell => {
-        this.schedulePreload(cell);
-      });
+      this.doPreload_(nextPos);
     }
   }
 

--- a/extensions/amp-carousel/0.1/carousel.js
+++ b/extensions/amp-carousel/0.1/carousel.js
@@ -64,6 +64,14 @@ export class AmpCarousel extends BaseCarousel {
   }
 
   /** @override */
+  prerenderCallback() {
+    this.doLayout_(this.pos_);
+    this.preloadNext_(this.pos_, 1);
+    this.setControlsState();
+    return Promise.resolve();
+  }
+
+  /** @override */
   layoutCallback() {
     this.doLayout_(this.pos_);
     this.preloadNext_(this.pos_, 1);
@@ -154,6 +162,7 @@ export class AmpCarousel extends BaseCarousel {
    */
   doLayout_(pos) {
     this.withinWindow_(pos, cell => {
+      console.log('schedule layout for cell');
       this.scheduleLayout(cell);
     });
   }

--- a/extensions/amp-carousel/0.1/slides.js
+++ b/extensions/amp-carousel/0.1/slides.js
@@ -68,7 +68,7 @@ export class AmpSlides extends BaseCarousel {
   prerenderCallback() {
     const curSlide = this.curSlide_();
     if (curSlide) {
-      this.scheduleLayout(curSlide);
+      this.schedulePreload(curSlide);
       this.preloadNext_(1);
     }
     return Promise.resolve();
@@ -288,6 +288,8 @@ export class AmpSlides extends BaseCarousel {
   preloadNext_(dir) {
     // TODO(dvoytenko): can we actually preload it here? There's no
     // guarantee of it has display!=none.
+    // Note(mkhatib): We're actually not preloading anything here for the
+    // reason mentioned above - display=none => no measurement => width=0.
     const nextIndex = this.nextIndex_(dir);
     if (nextIndex != this.currentIndex_) {
       this.schedulePreload(this.slides_[nextIndex]);

--- a/extensions/amp-carousel/0.1/slides.js
+++ b/extensions/amp-carousel/0.1/slides.js
@@ -65,6 +65,15 @@ export class AmpSlides extends BaseCarousel {
   }
 
   /** @override */
+  prerenderCallback() {
+    const curSlide = this.curSlide_();
+    if (curSlide) {
+      this.scheduleLayout(curSlide);
+      this.preloadNext_(1);
+    }
+    return Promise.resolve();
+  }
+
   layoutCallback() {
     const curSlide = this.curSlide_();
     if (curSlide) {

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -79,13 +79,14 @@ class AmpFitText extends AMP.BaseElement {
   }
 
   /** @override */
-  prerenderAllowed() {
+  isRelayoutNeeded() {
     return true;
   }
 
   /** @override */
-  isRelayoutNeeded() {
-    return true;
+  prerenderCallback() {
+    this.updateFontSize_();
+    return Promise.resolve();
   }
 
   /** @override */

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -91,8 +91,7 @@ class AmpFitText extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    this.updateFontSize_();
-    return Promise.resolve();
+    return this.prerenderCallback();
   }
 
   /** @private */

--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -78,13 +78,6 @@ const CACHED_FONT_LOAD_TIME_ = 100;
 
 export class AmpFont extends AMP.BaseElement {
 
-
-  /** @override */
-  prerenderAllowed() {
-    return true;
-  }
-
-
   /** @override */
   buildCallback() {
     /** @private @const {string} */

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -41,6 +41,12 @@ import {removeElement} from '../../../src/dom';
 
 
 class AmpInstagram extends AMP.BaseElement {
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
   /** @override */
   preconnectCallback(onLayout) {
     // See
@@ -76,48 +82,7 @@ class AmpInstagram extends AMP.BaseElement {
   }
 
   /** @override */
-  prerenderAllowed() {
-    return true;
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return isLayoutSizeDefined(layout);
-  }
-
-  maybeRenderIframe_() {
-    if (this.iframePromise_) {
-      return this.iframePromise_;
-    }
-    const iframe = document.createElement('iframe');
-    this.iframe_ = iframe;
-    iframe.setAttribute('frameborder', '0');
-    iframe.setAttribute('allowtransparency', 'true');
-    iframe.src = 'https://www.instagram.com/p/' +
-        encodeURIComponent(this.shortcode_) + '/embed/?v=4';
-    this.applyFillContent(iframe);
-    iframe.width = this.element.getAttribute('width');
-    iframe.height = this.element.getAttribute('height');
-    this.element.appendChild(iframe);
-    setStyles(iframe, {
-      'opacity': 0,
-    });
-    return this.iframePromise_ = loadPromise(iframe).then(() => {
-      this.getVsync().mutate(() => {
-        setStyles(iframe, {
-          'opacity': 1,
-        });
-
-        // Hide the initial rendered image to avoid overlaying videos.
-        setStyles(this.placeholderWrapper_, {
-          'display': 'none',
-        });
-      });
-    });
-  }
-
-  /** @override */
-  layoutCallback() {
+  prerenderCallback() {
     const image = new Image();
     // This will redirect to the image URL. By experimentation this is
     // always the same URL that is actually used inside of the embed.
@@ -142,20 +107,49 @@ class AmpInstagram extends AMP.BaseElement {
     this.placeholderWrapper_ = wrapper;
     this.applyFillContent(image);
     this.element.appendChild(wrapper);
-    // The iframe takes up a lot of resources. We only render it of we are in
-    // in the viewport.
-    if (this.isInViewport()) {
-      return this.maybeRenderIframe_();
-    }
+
+    // Need a way to cancel this if the layout promise is ready to resolve.
     return loadPromise(image);
   }
 
   /** @override */
-  viewportCallback(inViewport) {
-    // We might not have been rendered this yet. Lets do it now.
-    if (inViewport) {
-      this.maybeRenderIframe_();
+  prerenderCancelled() {
+    setStyles(this.placeholderWrapper_, {
+      'visibility': 'hidden',
+    });
+  }
+
+  /** @override */
+  layoutCallback() {
+    if (this.iframePromise_) {
+      return this.iframePromise_;
     }
+    const iframe = document.createElement('iframe');
+    this.iframe_ = iframe;
+    iframe.setAttribute('frameborder', '0');
+    iframe.setAttribute('allowtransparency', 'true');
+    iframe.src = 'https://www.instagram.com/p/' +
+        encodeURIComponent(this.shortcode_) + '/embed/?v=4';
+    this.applyFillContent(iframe);
+    iframe.width = this.element.getAttribute('width');
+    iframe.height = this.element.getAttribute('height');
+    this.element.appendChild(iframe);
+    setStyles(iframe, {
+      'opacity': 0,
+    });
+    return this.iframePromise_ = loadPromise(iframe).then(() => {
+      this.getVsync().mutate(() => {
+        setStyles(iframe, {
+          'opacity': 1,
+        });
+
+        // TODO(mkhatib): See if you can make this into a normal placeholder.
+        // Hide the initial rendered image to avoid overlaying videos.
+        setStyles(this.placeholderWrapper_, {
+          'display': 'none',
+        });
+      });
+    });
   }
 
   /** @override */

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -107,8 +107,6 @@ class AmpInstagram extends AMP.BaseElement {
     this.placeholderWrapper_ = wrapper;
     this.applyFillContent(image);
     this.element.appendChild(wrapper);
-
-    // Need a way to cancel this if the layout promise is ready to resolve.
     return loadPromise(image);
   }
 

--- a/extensions/amp-slides/0.1/amp-slides.js
+++ b/extensions/amp-slides/0.1/amp-slides.js
@@ -88,13 +88,15 @@ class AmpSlides extends AMP.BaseElement {
   }
 
   /** @override */
-  prerenderAllowed() {
+  isRelayoutNeeded() {
     return true;
   }
 
   /** @override */
-  isRelayoutNeeded() {
-    return true;
+  prerenderCallback() {
+    this.schedulePreload(this.slides_[this.currentIndex_]);
+    this.preloadNext_(1);
+    return Promise.resolve();
   }
 
   /** @override */

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -87,7 +87,7 @@ import {vsyncFor} from './vsync';
  * after layoutCallback.
  *
  * The prerenderCallback is always called before layoutCallback, however
- * they both can have loading work in parallel and either can resovle
+ * they both can have loading work in parallel and either can resolve
  * first. Best case is prerender load promise resolves first. However if
  * layout load promise resolves before prerender does, the resource will
  * be marked to be notified about that through the prerenderCancelled callback.

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -65,6 +65,8 @@ import {vsyncFor} from './vsync';
  *           \/
  *    State: <BUILT>
  *           ||
+ *           || prerenderCallback -> Can be cancelled if layoutCallback finishes first.
+ *           || prerenderCancelled -> Called when prerender resolves after layout.
  *           || layoutCallback        <==
  *           || (firstLayoutCompleted)  ||
  *           ||                         ||
@@ -83,6 +85,17 @@ import {vsyncFor} from './vsync';
  * to preconnect to hosts needed by an element. It will never be called
  * before buildCallback and it might be called multiple times including
  * after layoutCallback.
+ *
+ * The prerenderCallback is always called before layoutCallback, however
+ * they both can have loading work in parallel and either can resovle
+ * first. Best case is prerender load promise resolves first. However if
+ * layout load promise resolves before prerender does, the resource will
+ * be marked to be notified about that through the prerenderCancelled callback.
+ *
+ * prerenderCancelled callback will be called AFTER the prerender load promise
+ * resolves/rejects and only in the case mentioned above. This allows the
+ * element to cleanup or hide any visible placeholder DOM created during
+ * the prerender process.
  *
  * The pauseCallback is called when when the document becomes inactive, e.g.
  * when the user swipes away from the document, or when the element is no
@@ -250,12 +263,12 @@ export class BaseElement {
   }
 
   /**
-   * Subclasses can override this method to opt-in into being called to
+   * Subclasses can override this method to opt-out into being called to
    * prerender when document itself is not yet visible (pre-render mode).
    * @return {boolean}
    */
   prerenderAllowed() {
-    return false;
+    return true;
   }
 
   /**
@@ -275,6 +288,29 @@ export class BaseElement {
    */
   isRelayoutNeeded() {
     return false;
+  }
+
+  /**
+   * Called when the element should render any light-weight placeholder for
+   * users to be able to see something before layoutCallback be called and
+   * the element render itself fully.
+   *
+   * For example, amp-youtube prerenders a thumbnail placeholder for the
+   * element and then "upgrade" to the full iframe YT player on layoutCallback.
+   *
+   * @return {!Promise}
+   */
+  prerenderCallback() {
+    return Promise.resolve();
+  }
+
+  /**
+   * Called when the layout load promise is resolved before the prerender load promise
+   * does. This is called after the prerender load promise has finally resolved to allow
+   * the element to cleanup or hide any unnecessary DOM.
+   */
+  prerenderCancelled() {
+    // Subclasses may override.
   }
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -681,6 +681,30 @@ export function createAmpElementProto(win, name, implementationClass) {
   };
 
   /**
+   *
+   * @returns {!Promise}
+   */
+  ElementProto.prerenderCallback = function() {
+    this.assertNotTemplate_();
+    dev.assert(this.isUpgraded() && this.isBuilt(),
+        'Must be upgraded and built to receive viewport events');
+    const promise = this.implementation_.prerenderCallback();
+    this.preconnect(/* onLayout */ false);
+    return promise;
+  };
+
+  /**
+   * Instructs the element to cleanup prerender work if the prerender load promise
+   * has resolved after the layout load promise did.
+   */
+  ElementProto.prerenderCancelled = function () {
+    this.assertNotTemplate_();
+    dev.assert(this.isUpgraded() && this.isBuilt(),
+        'Must be upgraded and built to receive viewport events');
+    this.implementation_.prerenderCancelled();
+  };
+
+  /**
    * Whether the element should ever render when it is not in viewport.
    * @return {boolean}
    * @final

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1278,13 +1278,11 @@ export class Resources {
         resources.push(resource);
       }
     });
-    console.log('scheduling for subresources of', parentResource.debugid);
     if (resources.length > 0) {
       resources.forEach(resource => {
         resource.measure();
         if (resource.getState() == ResourceState_.READY_FOR_LAYOUT &&
                 resource.isDisplayed()) {
-          console.log('scheduling for subresource', resource.debugid);
           this.scheduleLayoutOrPreload_(resource, layout,
               parentResource.getPriority());
         }


### PR DESCRIPTION
This follows the `prerenderCallback` `prerenderCancelled` flow discussed earlier. I didn't experiment with the load/mutate suggestion yet, but it can be translated to it, once we figure out the ins and outs of this.

This does a good job overall but still failing for subresources scheduling, I am still working on that part. Please ignore the carousel changes.

During this I've uncovered two bugs: #2742 and #2732, this change doesn't address these yet. 