### PR TITLE
request for integrating adman ad-server

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -27,6 +27,7 @@ import {installEmbedStateListener} from './environment';
 import {a9} from '../ads/a9';
 import {adblade, industrybrains} from '../ads/adblade';
 import {adform} from '../ads/adform';
+import {adman} from '../ads/adman';
 import {adreactor} from '../ads/adreactor';
 import {adsense} from '../ads/google/adsense';
 import {adtech} from '../ads/adtech';
@@ -69,6 +70,7 @@ const AMP_EMBED_ALLOWED = {
 register('a9', a9);
 register('adblade', adblade);
 register('adform', adform);
+register('adman', adman);
 register('adreactor', adreactor);
 register('adsense', adsense);
 register('adtech', adtech);

--- a/ads/adman.js
+++ b/ads/adman.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {checkData, validateDataExists} from '../src/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function adman(global, data) {
+  const script = global.document.createElement('script');
+  const fields = ['ws', 'host', 's'];
+
+  checkData(data, fields);
+  validateDataExists(data, fields);
+
+  script.setAttribute('data-ws', data.ws);
+  script.setAttribute('data-h', data.host);
+  script.setAttribute('data-s', data.s);
+  script.setAttribute('data-tech', 'amp');
+
+  script.src = 'https://static.adman.gr/adman.js';
+
+  global.document.body.appendChild(script);
+}

--- a/ads/adman.md
+++ b/ads/adman.md
@@ -1,0 +1,38 @@
+<!---
+Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Adman
+
+## Example
+
+```html
+<amp-ad width="300" height="250"
+    type="adman"
+    data-ws="17342"
+    data-s="300x250"
+    data-host="talos.adman.gr">
+  </amp-ad>
+```
+
+## Configuration
+
+For semantics of configuration, please see Adman [documentation](http://www.adman.gr/docs).
+
+__Required:__
+
+- `data-ws` - Adunit unique id
+- `data-s` - Adunit size
+- `data-host` - SSL enabled Adman service domain

--- a/builtins/amp-ad.md
+++ b/builtins/amp-ad.md
@@ -57,6 +57,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [A9](../ads/a9.md)
 - [Adblade](../ads/adblade.md)
 - [Adform](../ads/adform.md)
+- [Adman](../ads/adman.md)
 - [AdReactor](../ads/adreactor.md)
 - [AdSense](../ads/google/adsense.md)
 - [AdTech](../ads/adtech.md)

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -56,6 +56,14 @@
       data-height="250"
       data-cid="19626-3798936394">
   </amp-ad>
+  <h2>Adman</h2>
+
+  <amp-ad width="300" height="250"
+      type="adman"
+      data-ws="17342"
+      data-s="300x250"
+      data-host="talos.adman.gr">
+    </amp-ad>
 
   <h2>AdReactor</h2>
   <amp-ad width=728 height=90


### PR DESCRIPTION
This PR provides support for ADMAN, the most widely used Ad Server in Greece. It is also used by publishers, advertisers and agencies in various other countries and serves many dozens of billions impressions per month.