### PR TITLE
add additional viewer info to error logs

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -161,6 +161,21 @@ export function getErrorReportUrl(message, filename, line, col, error) {
   if (window.viewerState) {
     url += '&vs=' + encodeURIComponent(window.viewerState);
   }
+  // Is embedded?
+  if (window.parent && window.parent != window) {
+    url += '&iem=1';
+  }
+
+  if (window.AMP.viewer) {
+    const resolvedViewerUrl = window.AMP.viewer.getResolvedViewerUrl();
+    const messagingOrigin = window.AMP.viewer.maybeGetMessagingOrigin();
+    if (resolvedViewerUrl) {
+      url += `&rvu=${encodeURIComponent(resolvedViewerUrl)}`;
+    }
+    if (messagingOrigin) {
+      url += `&mso=${encodeURIComponent(messagingOrigin)}`;
+    }
+  }
 
   if (error) {
     const tagName = error && error.associatedElement

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -655,6 +655,15 @@ export class Viewer {
   }
 
   /**
+   * Possibly return the messaging origin if set. This would be the origin
+   * of the parent viewer.
+   * @return {?string}
+   */
+  maybeGetMessagingOrigin() {
+    return this.messagingOrigin_;
+  }
+
+  /**
    * Returns an unconfirmed "referrer" URL that can be optionally customized by
    * the viewer. Consider using `getReferrerUrl()` instead, which returns the
    * promise that will yield the confirmed "referrer" URL.


### PR DESCRIPTION
using the global `AMP.viewer` reference since error reporting is the first thing to be installed and i dont want to have to initialize viewer as early as error reporting