### PR TITLE
Send hit using GET method instead in POST method for mediametrie analytics.

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -317,6 +317,11 @@ export const ANALYTICS_CONFIG = {
         'request': 'pageview',
       },
     },
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true,
+    },
   },
 
   'parsely': {


### PR DESCRIPTION
We just changed the way to send the request in GET instead in POST.