### PR TITLE
sports article sample with json-ld meta data

### DIFF
--- a/examples/metadata-examples/README.md
+++ b/examples/metadata-examples/README.md
@@ -7,12 +7,13 @@ more easily pairs with AMP HTML Components.
 The fields used and their types listed in each example should be considered best practices, but different platforms may have other requirements for inclusion.
 
 <pre>
-  article-json-ld.amp.html       - JSON-LD   structured data markup format for Articles
-  article-microdata.amp.html     - microdata structured data markup format for Articles
-  recipe-json-ld.amp.html        - JSON-LD   structured data markup format for Recipes
-  recipe-microdata.amp.html      - microdata structured data markup format for Recipes
-  review-json-ld.amp.html        - JSON-LD   structured data markup format for Reviews
-  review-microdata.amp.html      - microdata structured data markup format for Reviews
-  video-json-ld.amp.html         - JSON-LD   structured data markup format for Videos
-  video-microdata.amp.html       - microdata structured data markup format for Videos
+  article-json-ld.amp.html         - JSON-LD   structured data markup format for Articles
+  article-microdata.amp.html       - microdata structured data markup format for Articles
+  recipe-json-ld.amp.html          - JSON-LD   structured data markup format for Recipes
+  recipe-microdata.amp.html        - microdata structured data markup format for Recipes
+  review-json-ld.amp.html          - JSON-LD   structured data markup format for Reviews
+  review-microdata.amp.html        - microdata structured data markup format for Reviews
+  sports-article-json-ld.amp.html  - JSON-LD   structured data markup format for SportsEvent Articles
+  video-json-ld.amp.html           - JSON-LD   structured data markup format for Videos
+  video-microdata.amp.html         - microdata structured data markup format for Videos
 </pre>

--- a/examples/metadata-examples/sports-article-json-ld.amp.html
+++ b/examples/metadata-examples/sports-article-json-ld.amp.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<!--
+      This sample AMP HTML file aims to be a minimalist document that
+      follows best practices and guidances for publishers to mark up
+      content for inclusion in various platforms.
+-->
+<html AMP lang="en">
+  <!-- you can use "amp" or "AMP" or "⚡" -->
+  <head>
+    <meta charset="utf-8">
+    <title>Lorem Ipsum</title>
+    <link rel="canonical" href="https://intense-heat-6570.firebaseapp.com/index.html" />
+    <!--
+        The canonical document for this article should be linked, as above.
+
+        The canonical document should also have a corresponding <link> tag
+        within pointing at this AMP HTML file:
+
+          <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" />
+
+        It is possible that this AMP HTML document is the canonical document
+        for this article, in which case, the canonical URL should point to this
+        document, and no "amphtml" link is required.
+    -->
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+    <style amp-custom>
+      body {
+        background-color: white;
+      }
+      amp-img {
+        background-color: gray;
+      }
+    </style>
+    <script type="application/ld+json">
+        //
+        // The document referenced in mainEntityOfPage should be the same as the
+        // canonical link above.
+        //
+        // Also, please be aware that some platforms that use AMP HTML have
+        // further restrictions with regards to some schema components.
+        //
+        // For example:
+        //
+        //   * The leader "image" referenced in the markup below must appear
+        //   somewhere on the AMP HTML document itself.
+        //
+        //   * The URL for that "image" must precisely match the src of the
+        //   amp-img tag.
+        //
+        //   * All marked-up URLs should be absolute.
+        //
+        //   * The "logo" dimensions must not exceed 600x60.
+        //
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "mainEntityOfPage": "https://intense-heat-6570.firebaseapp.com/index.html",
+        "headline": "The Toronto Wildcats defeat the San Jose Stars 4-2",
+        "url": "https://intense-heat-6570.firebaseapp.com/index.html",
+        "datePublished": "2016-04-01T12:00:00Z",
+        "dateModified": "2016-04-01T12:00:00Z",
+        "description": "The Toronto Wildcats defeat the San Jose Stars 4-2",
+        "author": {
+          "@type": "Person",
+          "name": "Jeff Kingyens"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Google",
+          "url": "https://google.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://intense-heat-6570.firebaseapp.com/logo.png",
+            "width": 600,
+            "height": 60
+          }
+        },
+        "about": {
+          "@context": "http://schema.org",
+          "@type": "SportsEvent",
+          "name": "Toronto Wildcats vs San Jose Stars | 2015-2015 Regular Season | FHL",
+          "startDate": "2016-04-01T02:30:00Z",
+          "location": {
+            "@context": "http://schema.org",
+            "@type": "LocalBusiness",
+            "address": {
+              "@type": "PostalAddress",
+              "addressLocality": "The SAP Center",
+              "addressRegion": "CA",
+              "streetAddress": "525 W Santa Clara St, San Jose, CA 95113, United States"
+            },
+            "name": "The SAP Center",
+            "description": "an indoor arena located in San Jose, California. Its primary tenant is the San Jose Sharks of the National Hockey League, for which the arena has earned the nickname \"The Shark Tank\"",
+            "telephone": "850-648-4200"
+          }
+        },
+        "image": {
+          "@type": "ImageObject",
+          "url": "https://upload.wikimedia.org/wikipedia/commons/4/4b/Ice_Hockey_sharks_ducks.jpg",
+          "height": 614,
+          "width": 922
+        }
+      }
+    </script>
+    <!-- this style tag is required -->
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+  </head>
+  <body>
+    <h1>The Toronto Wildcats defeat the San Jose Stars 4-2</h1>
+    <amp-img src="https://upload.wikimedia.org/wikipedia/commons/4/4b/Ice_Hockey_sharks_ducks.jpg" alt="Lorem Ipsum?" height="614" width="922"></amp-img>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
+       odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
+       quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent
+       mauris. Fusce nec tellus sed augue semper porta. Mauris massa.
+       Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad
+       litora torquent per conubia nostra, per inceptos himenaeos.</p>
+    <p>Curabitur sodales ligula in libero. Sed dignissim lacinia nunc.
+       Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at
+       dolor.  Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc
+       egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non,
+       massa.  Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum.</p>
+    <p>Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.
+       Quisque volutpat condimentum velit. Class aptent taciti sociosqu ad
+       litora torquent per conubia nostra, per inceptos himenaeos. Nam nec
+       ante. Sed lacinia, urna non tincidunt mattis, tortor neque adipiscing
+       diam, a cursus ipsum ante quis turpis. Nulla facilisi. Ut fringilla.
+       Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet.
+       Vestibulum sapien. Proin quam.</p>
+    <blockquote>
+      <p>Quo usque tandem abutere, Catilina, patientia nostra? Quam diu etiam
+         furor iste tuus nos eludet? Quem ad finem sese effrenata iactabit
+         audacia?</p>
+      <p>CICERO</p>
+    </blockquote>
+    <p>Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. Sed
+       lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+       pharetra auctor, sem massa mattis sem, at interdum magna augue eget diam.
+       Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+       cubilia Curae; Morbi lacinia molestie dui. Praesent blandit dolor. Sed
+       non quam. In vel mi sit amet augue congue elementum. Morbi in ipsum sit
+       amet pede facilisis laoreet. Donec lacus nunc, viverra nec, blandit vel,
+       egestas et, augue. Vestibulum tincidunt malesuada tellus. Ut ultrices
+       ultrices enim.</p>
+    <p>Curabitur sit amet mauris. Morbi in dui quis est pulvinar ullamcorper.
+       Nulla facilisi. Integer lacinia sollicitudin massa. Cras metus. Sed
+       aliquet risus a tortor. Integer id quam. Morbi mi. Quisque nisl felis,
+       venenatis tristique, dignissim in, ultrices sit amet, augue. Proin
+       sodales libero eget ante. Nulla quam. Aenean laoreet. Vestibulum nisi
+       lectus, commodo ac, facilisis ac, ultricies eu, pede.</p>
+  </body>
+</html>


### PR DESCRIPTION
This example illustrates how to add a SportsEvent description to the "about" property of a NewsArticle.
This resolves issue #2700 