### PR TITLE
Cache Karma Serving

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -24,22 +24,26 @@ var commonTestPaths = [
   {
     pattern: 'dist/**/*.js',
     included: false,
-    nocache: true,
+    nocache: false,
+    watched: true,
   },
   {
     pattern: 'dist.tools/**/*.js',
     included: false,
-    nocache: true,
+    nocache: false,
+    watched: true,
   },
   {
     pattern: 'examples/**/*',
     included: false,
-    nocache: true,
+    nocache: false,
+    watched: true,
   },
   {
     pattern: 'dist.3p/**/*',
     included: false,
-    nocache: true,
+    nocache: false,
+    watched: true,
   },
 ]
 


### PR DESCRIPTION
Serve Karma files from cache instead of always from disk. Might help our
test flake.

Reverts a change from #1860.