### PR TITLE
Update amp-var-substitutions.md

### DIFF
--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -383,7 +383,7 @@ For instance:
 
 Provides the total time the user has been enagaged with the page since the page
 first became visible in the viewport. Total engaged time will be 0 until the
-page first becomes visible.
+page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
 
 ## Access
 


### PR DESCRIPTION
Total Engaged Time variable results in an error when amp-analytics is not included in the page. Documented that fact. An alternative would be to remove this variable from this document completely.

/cc @rudygalfi 