### PR TITLE
Ensure Python bindings are installed

### DIFF
--- a/validator/docs/building_a_command_line_amp_validator_for_mac_os_x.md
+++ b/validator/docs/building_a_command_line_amp_validator_for_mac_os_x.md
@@ -83,7 +83,7 @@ Not strictly initially necessary for the validator, but good not to forget:
 
 ```
 $ brew tap homebrew/versions
-$ brew install protobuf --c++11
+$ brew install protobuf --c++11 --with-python # and follow instructions to add modules to Python sys.path
 $ brew link protobuf
 $ protoc --version
 libprotoc 2.6.1


### PR DESCRIPTION
For some reason installing the `protobuf` brew didn't install the Python bindings for me.

Also, the `brew tap homebrew/versions` on the previous line wasn't necessary--what is that for? 

/cc @pietergreyling 
