### PR TITLE
Misc cleanups

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -33,6 +33,7 @@ import {installViewerService, VisibilityState} from './viewer-impl';
 import {installViewportService} from './viewport-impl';
 import {installVsyncService} from './vsync-impl';
 import {FiniteStateMachine} from '../finite-state-machine';
+import {isArray} from '../types';
 
 
 const TAG_ = 'Resources';
@@ -2182,10 +2183,7 @@ export class TaskQueue_ {
  * @return {!Array<!Element>}
  */
 function elements_(elements) {
-  if (elements.length !== undefined) {
-    return elements;
-  }
-  return [elements];
+  return isArray(elements) ? elements : [elements];
 }
 
 

--- a/src/string.js
+++ b/src/string.js
@@ -35,7 +35,8 @@ export function endsWith(string, suffix) {
   if (suffix.length > string.length) {
     return false;
   }
-  return string.lastIndexOf(suffix) == string.length - suffix.length;
+  const index = string.length - suffix.length;
+  return string.indexOf(suffix, index) == index;
 }
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -32,7 +32,7 @@ function toString(value) {
  * @return {boolean}
  */
 export function isArray(value) {
-  return toString(value) === '[object Array]';
+  return Array.isArray(value);
 }
 
 /**

--- a/src/url.js
+++ b/src/url.js
@@ -135,7 +135,7 @@ export function assertHttpsUrl(urlString, elementContext) {
  * @return {string}
  */
 export function assertAbsoluteHttpOrHttpsUrl(urlString) {
-  user.assert(/^(http\:|https\:)/i.test(urlString),
+  user.assert(/^https?\:/i.test(urlString),
       'URL must start with "http://" or "https://". Invalid value: %s',
       urlString);
   return parseUrl(urlString).href;


### PR DESCRIPTION
- Use faster `Array.isArray` (it’s available everywhere we care about)
- Use isArray
- Speed up `endsWith` checking
- Condense regex