### PR TITLE
feature(amp-ad): yieldbot ad type

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -59,6 +59,7 @@ import {rubicon} from '../ads/rubicon';
 import {imobile} from '../ads/imobile';
 import {webediads} from '../ads/webediads';
 import {pubmatic} from '../ads/pubmatic';
+import {yieldbot} from '../ads/yieldbot';
 import {user} from '../src/log';
 import {gmossp} from '../ads/gmossp';
 import {weboramaDisplay} from '../ads/weborama';
@@ -108,6 +109,7 @@ register('webediads', webediads);
 register('pubmatic', pubmatic);
 register('gmossp', gmossp);
 register('weborama-display', weboramaDisplay);
+register('yieldbot', yieldbot);
 
 // For backward compat, we always allow these types without the iframe
 // opting in.
@@ -119,6 +121,7 @@ const defaultAllowedTypesInCustomFrame = [
   'facebook',
   'twitter',
   'doubleclick',
+  'yieldbot',
   '_ping_',
 ];
 

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -47,6 +47,7 @@ export const adPrefetch = {
     'https://cstatic.weborama.fr/js/advertiserv2/adperf_launch_1.0.0_scrambled.js',
     'https://cstatic.weborama.fr/js/advertiserv2/adperf_core_1.0.0_scrambled.js',
   ],
+  yieldbot: 'https://cdn.yldbt.com/js/yieldbot.intent.js',
 };
 
 /**
@@ -126,6 +127,7 @@ export const adPreconnect = {
     'https://eu1.wbdds.com',
   ],
   gmossp: 'https://cdn.gmossp-sp.jp',
+  yieldbot: 'https://i.yldbt.com',
 };
 
 /**

--- a/ads/yieldbot.js
+++ b/ads/yieldbot.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {validateDataExists, checkData, loadScript} from '../src/3p';
+import {doubleclick} from '../ads/google/doubleclick';
+import {rethrowAsync} from '../src/log';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function yieldbot(global, data) {
+  checkData(data, ['psn', 'ybSlot', 'slot',
+                   'targeting', 'categoryExclusions',
+                   'tagForChildDirectedTreatment', 'cookieOptions',
+                   'overrideWidth', 'overrideHeight']);
+  validateDataExists(data, ['psn', 'ybSlot', 'slot']);
+
+  global.ybotq = global.ybotq || [];
+
+  loadScript(global, 'https://cdn.yldbt.com/js/yieldbot.intent.js', () => {
+    global.ybotq.push(() => {
+      try {
+        const dimensions = [[
+          parseInt(data.overrideWidth || data.width, 10),
+          parseInt(data.overrideHeight || data.height, 10),
+        ]];
+
+        global.yieldbot.psn(data.psn);
+        global.yieldbot.enableAsync();
+        if (window.context.isMaster) {
+          global.yieldbot.defineSlot(data.ybSlot, {sizes: dimensions});
+          global.yieldbot.go();
+        } else {
+          const slots = {};
+          slots[data.ybSlot] = dimensions;
+          global.yieldbot.nextPageview(slots);
+        }
+      } catch (e) {
+        rethrowAsync(e);
+      }
+    });
+
+    global.ybotq.push(() => {
+      try {
+        const targeting = global.yieldbot.getSlotCriteria(data['ybSlot']);
+        data['targeting'] = data['targeting'] || {};
+        for (const key in targeting) {
+          data.targeting[key] = targeting[key];
+        }
+      } catch (e) {
+        rethrowAsync(e);
+      }
+      delete data['ybSlot'];
+      delete data['psn'];
+      doubleclick(global, data);
+    });
+  });
+}
+

--- a/ads/yieldbot.md
+++ b/ads/yieldbot.md
@@ -1,0 +1,70 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Yieldbot
+
+## Example
+
+### Basic
+
+```html
+<amp-ad width="300" height="250"
+          type="yieldbot"
+          data-psn="1234"
+          data-yb-slot="medrec"
+          data-slot="/2476204/medium-rectangle">
+</amp-ad>
+```
+
+### With Doubleclick `amp-ad` data attributes
+
+To specify Doubleclick `amp-ad` data attributes, see [Doubleclick](./google/doubleclick.md) for details. Use the
+Doubleclick attributes as you would with an `<amp-ad type="doubleclick"/>` element.
+
+```html
+<amp-ad width="300" height="250"
+          type="yieldbot"
+          data-psn="1234"
+          data-yb-slot="medrec"
+          data-slot="/2476204/medium-rectangle"
+          json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
+</amp-ad>
+```
+
+## Configuration
+
+For further Yieldbot configuration information, please check our [documentation](https://ui.yieldbot.com/documentation/tags/async_gpt_advanced) or [contact us](mailto:pubops@yieldbot.com).
+
+### Yieldbot Required parameters
+
+| Parameter     | Description |
+|:------------- |:-------------|
+| **`data-psn`**    | Yieldbot publisher site number |
+| **`data-yb-slot`**    | Yieldbot slot identifier |
+| **`data-slot`**    | Doubleclick for Publishers (DFP) slot identifier |
+
+### Yieldbot Integration Testing
+
+For integration testing, the Yieldbot Platform can be set to always return a bid for requested slots.
+
+The Yieldbot `amp-ad` type can be tested with the following file:
+- [test/manual/amp-ad.yieldbot.amp.html](../test/manual/amp-ad.yieldbot.amp.html)
+
+When Yieldbot testing mode is enabled, a cookie (`ybotc__`) on the domain `i.yldbt.com` tells the Yieldbot ad server to always return a bid and when creative is requested, return a static integration testing creative.
+
+- No ad serving metrics are impacted when integration testing mode is enabled.
+- The `ybotc__` cookie expires in 24 hours.
+ - It is good practice to click "Stop testing" when testing is complete, to return to normal ad delivery.

--- a/builtins/amp-ad.md
+++ b/builtins/amp-ad.md
@@ -82,6 +82,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [PubMatic](../ads/pubmatic.md)
 - [GMOSSP](../ads/gmossp.md)
 - [Weborama](../ads/weborama.md)
+- [Yieldbot](../ads/yieldbot.md)
 
 ## Styling
 

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -352,5 +352,14 @@
       data-id="10014">
   </amp-ad>
 
+  <h2>Yieldbot 300x250</h2>
+  <amp-ad width="300" height="250"
+          type="yieldbot"
+          data-psn="1234"
+          data-yb-slot="medrec"
+          data-slot="/2476204/medium-rectangle"
+          json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
+  </amp-ad>
+
 </body>
 </html>

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -53,6 +53,7 @@ describe('3p integration.js', () => {
     expect(registrations).to.include.key('imobile');
     expect(registrations).to.include.key('gmossp');
     expect(registrations).to.include.key('weborama-display');
+    expect(registrations).to.include.key('yieldbot');
   });
 
   it('should validateParentOrigin without ancestorOrigins', () => {

--- a/test/manual/amp-ad.yieldbot.amp.html
+++ b/test/manual/amp-ad.yieldbot.amp.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP-AD.yieldbot</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="../../dist/amp.js"></script>
+  <script async custom-element="amp-iframe" src="../../dist/v0/amp-iframe-0.1.max.js"></script>
+</head>
+<body>
+  <!-- Sets i.yldbt.com integration testing cookie __ybot_test -->
+  <amp-iframe width=336 height=35
+              sandbox="allow-scripts allow-same-origin"
+              frameborder="0"
+              scrolling="no"
+              src="https://i.yldbt.com/m/start-testing">
+    <amp-img width=336 height=70 layout="fill" src="https://www.yieldbot.com/wp-content/themes/yieldbot/img/logo-mobile-size@2x.png" placeholder></amp-img>
+  </amp-iframe>
+  <ul>
+      <li>See also, <a href="https://ui.yieldbot.com/documentation/tags/async_gpt_advanced#testing">Yieldbot Integration Testing</a></li>
+  </ul>
+  <h2>Yieldbot 300x250</h2>
+  <amp-ad width="300" height="250"
+          type="yieldbot"
+          data-psn="1234"
+          data-yb-slot="medrec"
+          data-slot="/2476204/medium-rectangle"
+          json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
+  </amp-ad>
+</body>
+</html>


### PR DESCRIPTION
Resolves #2849 

Adds a Yieldbot ad type: `<amp-ad type="yieldbot">`.

e.g.
```html
<amp-ad width="300" height="250"
          type="yieldbot"
          data-psn="1234"
          data-yb-slot="medrec"
          data-slot="/2476204/medium-rectangle">
</amp-ad>
```


Google Corporate Contributor License Agreement signed as: `Yieldbot, Inc.`