### PR TITLE
Point Validator specifications at new locations.

### DIFF
--- a/builtins/amp-ad.md
+++ b/builtins/amp-ad.md
@@ -180,7 +180,7 @@ draw3p(function(config, done) {
 ## Validation errors
 
 The following lists validation errors specific to the `amp-ad` tag
-(see also `amp-ad` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-ad` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii)):
 
 <table>
   <tr>

--- a/builtins/amp-embed.md
+++ b/builtins/amp-embed.md
@@ -51,7 +51,7 @@ The `<amp-embed>` is actually an alias to the [`<amp-ad>`](amp-ad.md) tag, deriv
 ## Validation errors
 
 The following lists validation errors specific to the `amp-embed` tag
-(see also `amp-embed` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-embed` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii)):
 
 <table>
   <tr>

--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -79,7 +79,7 @@ amp-img {
 ## Validation errors
 
 The following lists validation errors specific to the `amp-img` tag
-(see also `amp-img` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-img` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii)):
 
 <table>
   <tr>

--- a/builtins/amp-pixel.md
+++ b/builtins/amp-pixel.md
@@ -59,7 +59,7 @@ may make a request to something like `https://foo.com/pixel?0.8390278471201` whe
 ## Validation errors
 
 The following lists validation errors specific to the `amp-pixel` tag
-(see also `amp-pixel` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-pixel` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii)):
 
 <table>
   <tr>

--- a/builtins/amp-video.md
+++ b/builtins/amp-video.md
@@ -87,7 +87,7 @@ If present, will mute the audio by default.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-video` tag
-(see also `amp-video` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-video` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -485,7 +485,7 @@ This section will cover a detailed explanation of the design underlying the amp-
 ## Validation errors
 
 The following lists validation errors specific to the `amp-access` tag
-(see also `amp-access` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-access` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-access/0.1/validator-amp-access.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -381,7 +381,7 @@ The `extraUrlParamsReplaceMap` attribute specifies a map of keys and values that
 ## Validation errors
 
 The following lists validation errors specific to the `amp-analytics` tag
-(see also `amp-analytics` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-analytics` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/0.1/validator-amp-analytics.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-anim/amp-anim.md
+++ b/extensions/amp-anim/amp-anim.md
@@ -79,7 +79,7 @@ amp-anim {
 ## Validation errors
 
 The following lists validation errors specific to the `amp-anim` tag
-(see also `amp-anim` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-anim` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-anim/0.1/validator-amp-anim.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -78,7 +78,7 @@ If present, will mute the audio by default.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-audio` tag
-(see also `amp-audio` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-audio` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-audio/0.1/validator-amp-audio.protoascii)):
 
 <!---
 What does fixed height and fixed width mean for audio layout?

--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -36,7 +36,7 @@ limitations under the License.
 </table>
 
 The following lists validation errors specific to the `amp-brid-player` tag
-(see also `amp-brid-player` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-brid-player` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-brid-player/0.1/validator-amp-brid-player.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -98,7 +98,7 @@ This script should be added to the configuration of Brightcove Players used with
 ## Validation errors
 
 The following lists validation errors specific to the `amp-brightcove` tag
-(see also `amp-brightcove` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-brightcove` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -119,7 +119,7 @@ You may override this with your own svg or image like so:
 ## Validation errors
 
 The following lists validation errors specific to the `amp-carousel` tag
-(see also `amp-carousel` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-carousel` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -113,7 +113,7 @@ Default value: `"true"`
 ## Validation errors
 
 The following lists validation errors specific to the `amp-dailymotion` tag
-(see also `amp-dailymotion` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-dailymotion` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -71,7 +71,7 @@ Checkout the documentation for differences between [post embeds](https://develop
 ## Validation errors
 
 The following lists validation errors specific to the `amp-facebook` tag
-(see also `amp-facebook` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-facebook` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-facebook/0.1/validator-amp-facebook.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -79,7 +79,7 @@ properties with the main exception of `font-size`.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-fit-text` tag
-(see also `amp-fit-text` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-fit-text` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-fit-text/0.1/validator-amp-fit-text.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-font/amp-font.md
+++ b/extensions/amp-font/amp-font.md
@@ -101,7 +101,7 @@ The attributes above should all behave like they do on standard elements.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-font` tag
-(see also `amp-font` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-font` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-font/0.1/validator-amp-font.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -179,7 +179,7 @@ Iframes are identified as tracking/analytics iframes if they appear to serve no 
 ## Validation errors
 
 The following lists validation errors specific to the `amp-iframe` tag
-(see also `amp-iframe` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-iframe` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -74,7 +74,7 @@ section.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-image-lightbox` tag
-(see also `amp-image-lightbox` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-image-lightbox` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-image-lightbox/0.1/validator-amp-image-lightbox.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -73,7 +73,7 @@ E.g. in https://instagram.com/p/fBwFP fBwFP is the data-shortcode.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-instagram` tag
-(see also `amp-instagram` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-instagram` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-instagram/0.1/validator-amp-instagram.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -72,7 +72,7 @@ Must have the value `nodisplay`.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-install-serviceworker` tag
-(see also `amp-install-serviceworker` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-install-serviceworker` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-install-serviceworker/0.1/validator-amp-install-serviceworker.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -36,7 +36,7 @@ limitations under the License.
 </table>
 
 The following lists validation errors specific to the `amp-jwplayer` tag
-(see also `amp-jwplayer` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii):
+(see also `amp-jwplayer` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-jwplayer/0.1/validator-amp-jwplayer.protoascii):
 
 <table>
   <tr>

--- a/extensions/amp-kaltura-player/amp-kaltura-player.md
+++ b/extensions/amp-kaltura-player/amp-kaltura-player.md
@@ -36,7 +36,7 @@ limitations under the License.
 </table>
 
 The following lists validation errors specific to the `amp-kaltura-player` tag
-(see also `amp-kaltura-player` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-kaltura-player` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-kaltura-player/0.1/validator-amp-kaltura-player.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -61,7 +61,7 @@ The `amp-lightbox` component can be styled with standard CSS.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-lightbox` tag
-(see also `amp-lightbox` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-lightbox` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-lightbox/0.1/validator-amp-lightbox.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -117,7 +117,7 @@ elements rendered via the template.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-list` tag
-(see also `amp-list` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-list` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-list/0.1/validator-amp-list.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-mustache/amp-mustache.md
+++ b/extensions/amp-mustache/amp-mustache.md
@@ -80,7 +80,7 @@ impossible to specify `{{&var}}` expressions - they will always be escaped as `{
 ## Validation errors
 
 The following lists validation errors specific to `amp-mustache`
-(see also `template` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `template` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-mustache/0.1/validator-amp-mustache.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-pinterest/amp-pinterest.md
+++ b/extensions/amp-pinterest/amp-pinterest.md
@@ -123,7 +123,7 @@ When building the Embedded Pin widget, `data-url` is required and must contain t
 ## Validation errors
 
 The following lists validation errors specific to the `amp-pinterest` tag
-(see also `amp-pinterest` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-pinterest` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-pinterest/0.1/validator-amp-pinterest.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -83,7 +83,7 @@ Layout is `fixed-height` and will fill all the available horizontal space. This 
 ## Validation errors
 
 The following lists validation errors specific to the `amp-soundcloud` tag
-(see also `amp-soundcloud` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-soundcloud` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-soundcloud/0.1/validator-amp-soundcloud.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-springboard-player/amp-springboard-player.md
+++ b/extensions/amp-springboard-player/amp-springboard-player.md
@@ -36,7 +36,7 @@ limitations under the License.
 </table>
 
 The following lists validation errors specific to the `amp-springboard-player` tag
-(see also `amp-springboard-player` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-springboard-player` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-springboard-player/0.1/validator-amp-springboard-player.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -67,7 +67,7 @@ Options for the Tweet appearance can be set using `data-` attributes. E.g. `data
 ## Validation errors
 
 The following lists validation errors specific to the `amp-twitter` tag
-(see also `amp-twitter` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-twitter` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-twitter/0.1/validator-amp-twitter.protoascii)):
 
 <!---
 What does fixed height and fixed width mean for audio layout?

--- a/extensions/amp-user-notification/amp-user-notification.md
+++ b/extensions/amp-user-notification/amp-user-notification.md
@@ -253,7 +253,7 @@ Optionally one can delay generation of Client IDs used for analytics and similar
 ## Validation errors
 
 The following lists validation errors specific to the `amp-user-notification` tag
-(see also `amp-user-notification` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-user-notification` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-user-notification/0.1/validator-amp-user-notification.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -57,7 +57,7 @@ E.g. in https://vimeo.com/27246366 27246366 is the video id.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-vimeo` tag
-(see also `amp-vimeo` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-vimeo` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-vimeo/0.1/validator-amp-vimeo.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-vine/amp-vine.md
+++ b/extensions/amp-vine/amp-vine.md
@@ -54,7 +54,7 @@ The ID of the Vine. In a URL like https://vine.co/v/MdKjXez002d `MdKjXez002d` is
 ## Validation errors
 
 The following lists validation errors specific to the `amp-vine` tag
-(see also `amp-vine` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-vine` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-vine/0.1/validator-amp-vine.protoascii)):
 
 <table>
   <tr>

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -57,7 +57,7 @@ E.g. in https://www.youtube.com/watch?v=Z1q71gFeRqM Z1q71gFeRqM is the video id.
 ## Validation errors
 
 The following lists validation errors specific to the `amp-youtube` tag
-(see also `amp-youtube` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/validator/validator.protoascii)):
+(see also `amp-youtube` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii)):
 
 <table>
   <tr>


### PR DESCRIPTION
Previously we broke up validator.protoascii into validator-main.protoascii
and one .protoascii file per extension. This updates the links
in the .md documentation.