### PR TITLE
Remove ad after the page becomes inactive

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -27,6 +27,7 @@ import {adPrefetch, adPreconnect} from '../ads/_config';
 import {timer} from '../src/timer';
 import {user} from '../src/log';
 import {viewerFor} from '../src/viewer';
+import {removeElement} from '../src/dom';
 
 
 /** @private @const These tags are allowed to have fixed positioning */
@@ -286,6 +287,27 @@ export function installAd(win) {
     }
 
     /** @override  */
+    unlayoutCallback() {
+      if (!this.iframe_) {
+        return true;
+      }
+
+      removeElement(this.iframe_);
+      if (this.placeholder_) {
+        this.togglePlaceholder(true);
+      }
+      if (this.fallback_) {
+        this.toggleFallback(false);
+      }
+
+      this.iframe_ = null;
+      // IntersectionObserver's listeners were cleaned up by
+      // setInViewport(false) before #unlayoutCallback
+      this.intersectionObserver_ = null;
+      return true;
+    }
+
+    /** @override  */
     viewportCallback(inViewport) {
       if (this.intersectionObserver_) {
         this.intersectionObserver_.onViewportCallback(inViewport);
@@ -364,7 +386,7 @@ export function installAd(win) {
         }
         // Remove the iframe only if it is not the master.
         if (this.iframe_.name.indexOf('_master') == -1) {
-          this.element.removeChild(this.iframe_);
+          removeElement(this.iframe_);
           this.iframe_ = null;
         }
       });

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -339,6 +339,8 @@ export class AmpIframe extends AMP.BaseElement {
       }
 
       this.iframe_ = null;
+      // IntersectionObserver's listeners were cleaned up by
+      // setInViewport(false) before #unlayoutCallback
       this.intersectionObserver_ = null;
     }
     return true;


### PR DESCRIPTION
This is a slight change from #2697. Instead of immediately removing the ad when the user swipes, we will remove it when the swipe ends and the doc has become inactive.