### PR TITLE
Provide an initial intersection change record to ads.

### DIFF
--- a/ads/taboola.js
+++ b/ads/taboola.js
@@ -23,8 +23,7 @@ import {loadScript, validateDataExists, validateExactlyOne} from '../src/3p';
 export function taboola(global, data) {
   // do not copy the following attributes from the 'data' object
   // to _tablloa global object
-  const blackList = ['height', 'initialWindowHeight', 'initialWindowWidth',
-    'type', 'width', 'placement', 'mode'];
+  const blackList = ['height', 'type', 'width', 'placement', 'mode'];
 
   // ensure we have vlid publisher, placement and mode
   // and exactly one page-type

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -19,10 +19,13 @@ import {getLengthNumeral} from '../src/layout';
 import {getService} from './service';
 import {documentInfoFor} from './document-info';
 import {getMode} from './mode';
+import {getIntersectionChangeEntry} from './intersection-observer';
 import {preconnectFor} from './preconnect';
 import {dashToCamelCase} from './string';
 import {parseUrl, assertHttpsUrl} from './url';
+import {timer} from './timer';
 import {user} from './log';
+import {viewportFor} from './viewport';
 import {viewerFor} from './viewer';
 
 
@@ -51,9 +54,6 @@ function getFrameAttributes(parentWindow, element, opt_type) {
   addDataAndJsonAttributes_(element, attributes);
   attributes.width = getLengthNumeral(width);
   attributes.height = getLengthNumeral(height);
-  const box = element.getLayoutBox();
-  attributes.initialWindowWidth = box.width;
-  attributes.initialWindowHeight = box.height;
   attributes.type = type;
   const docInfo = documentInfoFor(parentWindow);
   const viewer = viewerFor(parentWindow);
@@ -75,6 +75,10 @@ function getFrameAttributes(parentWindow, element, opt_type) {
     tagName: element.tagName,
     mode: getMode(),
     hidden: !viewer.isVisible(),
+    initialIntersection: getIntersectionChangeEntry(
+        timer.now(),
+        viewportFor(parentWindow).getRect(),
+        element.getLayoutBox()),
   };
   const adSrc = element.getAttribute('src');
   if (adSrc) {

--- a/src/3p.js
+++ b/src/3p.js
@@ -93,6 +93,22 @@ export function loadScript(win, url, cb) {
 }
 
 /**
+ * Call function in micro task or timeout as a fallback.
+ * This is a lightweight helper, because we cannot guarantee that
+ * Promises are available inside the 3p frame.
+ * @param {!Window} win
+ * @param {function} fn
+ */
+export function nextTick(win, fn) {
+  const P = win.Promise;
+  if (P) {
+    P.resolve().then/*OK*/(fn);
+  } else {
+    win.setTimeout(fn, 0);
+  }
+}
+
+/**
  * Run the function after all currently waiting sync scripts have been
  * executed.
  * @param {!Window} win
@@ -237,8 +253,6 @@ export function validateData(data, allowedFields) {
   const defaultAvailableFields = {
     width: true,
     height: true,
-    initialWindowWidth: true,
-    initialWindowHeight: true,
     type: true,
     referrer: true,
     canonicalUrl: true,

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -25,11 +25,16 @@ import {viewerFor} from '../../src/viewer';
 
 describe('3p-frame', () => {
 
+  let clock;
+  let sandbox;
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
   });
 
   afterEach(() => {
+    sandbox.restore();
     resetServiceForTesting(window, 'bootstrapBaseUrl');
     setModeForTesting(null);
     const m = document.querySelector(
@@ -37,7 +42,6 @@ describe('3p-frame', () => {
     if (m) {
       m.parentElement.removeChild(m);
     }
-    sandbox.restore();
   });
 
   function addCustomBootstrap(url) {
@@ -71,7 +75,7 @@ describe('3p-frame', () => {
   });
 
   it('should create an iframe', () => {
-
+    clock.tick(1234567888);
     const link = document.createElement('link');
     link.setAttribute('rel', 'canonical');
     link.setAttribute('href', 'https://foo.bar/baz');
@@ -103,15 +107,23 @@ describe('3p-frame', () => {
     expect(locationHref).to.not.be.empty;
     const docInfo = documentInfoFor(window);
     expect(docInfo.pageViewId).to.not.be.empty;
+    const width = window.innerWidth;
+    const height = window.innerHeight;
     const fragment =
         '#{"testAttr":"value","ping":"pong","width":50,"height":100,' +
-        '"initialWindowWidth":100,"initialWindowHeight":200,"type":"_ping_"' +
+        '"type":"_ping_"' +
         ',"_context":{"referrer":"http://acme.org/",' +
         '"canonicalUrl":"https://foo.bar/baz",' +
         '"pageViewId":"' + docInfo.pageViewId + '","clientId":"cidValue",' +
         '"location":{"href":"' + locationHref + '"},"tagName":"MY-ELEMENT",' +
         '"mode":{"localDev":true,"development":false,"minified":false}' +
-        ',"hidden":false}}';
+        ',"hidden":false,"initialIntersection":{"time":1234567888,' +
+        '"rootBounds":{"left":0,"top":0,"width":' + width + ',"height":' +
+        height + ',"bottom":' + height + ',"right":' + width +
+        ',"x":0,"y":0},"boundingClientRect":' +
+        '{"width":100,"height":200},"intersectionRect":{' +
+        '"left":0,"top":0,"width":0,"height":0,"bottom":0,' +
+        '"right":0,"x":0,"y":0}}}}';
     expect(src).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html' +
         fragment);

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import {computeInMasterFrame, validateSrcPrefix, validateSrcContains,
-    checkData, validateData, validateDataExists, validateExactlyOne,}
-    from '../../src/3p';
+import {
+  computeInMasterFrame,
+  validateSrcPrefix,
+  validateSrcContains,
+  checkData,
+  nextTick,
+  validateData,
+  validateDataExists,
+  validateExactlyOne,
+} from '../../src/3p';
 import * as sinon from 'sinon';
 
 describe('3p', () => {
@@ -72,8 +79,6 @@ describe('3p', () => {
     checkData({
       width: '',
       height: false,
-      initialWindowWidth: 1,
-      initialWindowHeight: 2,
       type: true,
       referrer: true,
       canonicalUrl: true,
@@ -95,8 +100,6 @@ describe('3p', () => {
     validateDataExists({
       width: '',
       height: false,
-      initialWindowWidth: 1,
-      initialWindowHeight: 2,
       type: 'taboola',
       referrer: true,
       canonicalUrl: true,
@@ -165,6 +168,28 @@ describe('3p', () => {
       }, ['red', 'green', 'blue']);
     }).to.throw(
         /xxxxxx must contain exactly one of attributes: red, green, blue./);
+  });
+
+  it('should run in next tick', () => {
+    let called = 0;
+    nextTick(window, () => {
+      called++;
+    });
+    return Promise.resolve(() => {
+      expect(called).to.equal(1);
+    });
+  });
+
+  it('should run in next tick (setTimeout)', () => {
+    let called = 0;
+    nextTick({
+      setTimeout: fn => {
+        fn();
+      },
+    }, () => {
+      called++;
+    });
+    expect(called).to.equal(1);
   });
 
   it('should do work only in master', () => {

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -101,7 +101,7 @@ describe('3p integration.js', () => {
 
   it('should parse JSON from fragment unencoded (most browsers)', () => {
     const unencoded = '#{"tweetid":"638793490521001985","width":390,' +
-        '"height":50,"initialWindowWidth":1290,"initialWindowHeight":165,' +
+        '"height":50,' +
         '"type":"twitter","_context":{"referrer":"http://localhost:8000/' +
         'examples.build/","canonicalUrl":"http://localhost:8000/' +
         'examples.build/amps.html","location":{"href":"http://' +


### PR DESCRIPTION
So they know where they were when the iframe was drawn.

This change has 1 potentially backwards incompatible change: Removes an existing similar API that was originall used in the Twitter integration. There appear to be no users of this.

Fixes #2878