### PR TITLE
Increase timeout for flaky amp-facebook test.

### DIFF
--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -68,7 +68,8 @@ describe('amp-facebook', () => {
     });
   });
 
-  it('resizes facebook posts', () => {
+  it('resizes facebook posts', function() {
+    this.timeout(5000);
     const iframeSrc = 'http://ads.localhost:' + location.port +
         '/base/test/fixtures/served/iframe.html';
     return getFBPost(fbPostHref).then(ampFB => {


### PR DESCRIPTION
We need to port these tests to a more reliable method.

Fixes #2893