### PR TITLE
Expose the initial intersection info as a variable.

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -219,7 +219,6 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
 
     // This only actually works for ads.
     const initialIntersection = window.context.initialIntersection;
-    delete window.context.initialIntersection;
     window.context.observeIntersection = cb => {
       observeIntersection(cb);
       // Call the callback with the value that was transmitted when the

--- a/ads/README.md
+++ b/ads/README.md
@@ -57,6 +57,8 @@ Ads can call the special API `window.context.observeIntersection(changesCallback
 
 The API allows specifying a callback that fires with change records when AMP observes that an ad becomes visible and then while it is visible, changes are reported as they happen.
 
+When a listener is registered, it will be called 2x in short order. Once with the position of the ad when its iframe was created and then again with the current position.
+
 Example usage:
 
 ```javascript
@@ -81,6 +83,10 @@ Example usage:
   // condition to stop listening to intersection messages.
   unlisten();
 ```
+
+##### Initial position
+
+The value `window.context.initialIntersection` contains the initial intersection record at the time the iframe was created.
 
 #### Page visibility
 

--- a/test/integration/test-amp-ad-doubleclick.js
+++ b/test/integration/test-amp-ad-doubleclick.js
@@ -87,6 +87,8 @@ describe('Rendering of one ad', () => {
         expect(context.referrer).to.contain('http://localhost:' + location.port);
       }
       expect(context.pageViewId).to.be.greaterThan(0);
+      expect(context.initialIntersection).to.be.defined;
+      expect(context.initialIntersection.rootBounds).to.be.defined;
       expect(context.data.tagForChildDirectedTreatment).to.equal(0);
       expect(context.data.categoryExclusions).to.be.jsonEqual(['health']);
       expect(context.data.targeting).to.be.jsonEqual(


### PR DESCRIPTION
This makes simple use cases that only want to read this value simpler to implement (and avoids immediate unlistening).

Add on to #2878