### PR TITLE
don't assign to window.AMP_CONFIG if it exists

### DIFF
--- a/build-system/window-config.js
+++ b/build-system/window-config.js
@@ -25,5 +25,8 @@ var config = {
 
 exports.getTemplate = function() {
   var configStr = JSON.stringify(config);
-  return `window.AMP_CONFIG=${configStr};/*AMP_CONFIG*/`;
+  // If window.AMP_CONFIG already exists don't clobber it.
+  // This can be useful for testing where we need to setup experiments before
+  // the main binary has loaded (setting up builtins for example).
+  return `window.AMP_CONFIG||(window.AMP_CONFIG=${configStr});/*AMP_CONFIG*/`;
 };


### PR DESCRIPTION
/cc @tdrl

will also need to update this internally for prod builds but this should fix local testing issue for now.