### PR TITLE
Add a .text() accessor to FetchResponse

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -387,6 +387,15 @@ class FetchResponse {
   }
 
   /**
+   * Drains the response and returns a promise that resolves with the response
+   * text.
+   * @returns {!Promise.<string>}
+   */
+  text() {
+    return this.drainText_();
+  }
+
+  /**
    * Drains the response and returns the JSON object.
    * @return {!Promise<!JSONValue>}
    */

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -357,7 +357,7 @@ function assertSuccess(response) {
  *
  * See https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
  */
-class FetchResponse {
+export class FetchResponse {
   /**
    * @param {!XMLHttpRequest} xhr
    */
@@ -389,7 +389,7 @@ class FetchResponse {
   /**
    * Drains the response and returns a promise that resolves with the response
    * text.
-   * @returns {!Promise.<string>}
+   * @return {!Promise<string>}
    */
   text() {
     return this.drainText_();

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -17,7 +17,7 @@
 import * as sinon from 'sinon';
 import {xhrFor, fetchPolyfill, FetchResponse} from '../../src/xhr';
 
-describe.only('XHR', function() {
+describe('XHR', function() {
   let sandbox;
   let requests;
 

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -415,23 +415,25 @@ describe('XHR', function() {
   });
 
   describe('FetchResponse', () => {
+    const TEST_TEXT = 'this is some test text';
     const mockXhr = {
       status: 200,
-      responseText: 'this is some test text',
+      responseText: TEST_TEXT,
     };
 
     it('should provide text', () => {
       const response = new FetchResponse(mockXhr);
       return response.text().then(result => {
-        expect(result).to.equal('this is some test text');
+        expect(result).to.equal(TEST_TEXT);
       });
     });
 
     it('should provide text only once', () => {
       const response = new FetchResponse(mockXhr);
       return response.text().then(result => {
-        expect(result).to.equal('this is some test text');
-        expect(response.text, 'should throw').to.throw(Error);
+        expect(result).to.equal(TEST_TEXT);
+        expect(response.text.bind(response), 'should throw').to.throw(Error,
+            /Body already used/);
       });
     });
 
@@ -446,12 +448,12 @@ describe('XHR', function() {
                 response => {
                   expect(response).to.be.instanceof(FetchResponse);
                   return response.text().then(result => {
-                    expect(result).to.equal('this is some test text');
+                    expect(result).to.equal(TEST_TEXT);
                   });
                 });
             requests[0].respond(200, {
               'Content-Type': 'text/plain',
-            }, 'this is some test text');
+            }, TEST_TEXT);
             return promise;
           });
         });


### PR DESCRIPTION
Add .text() accessor to FetchResponse to allow retrieving text without converting it to JSON first.  (I.e., extending FetchResponse to cover one additional method from the Response / Body API.)