### PR TITLE
Changed cid-impl to handle a racy condition.

### DIFF
--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -382,6 +382,34 @@ describe('cid', () => {
     });
   });
 
+  it('should return same value for multiple calls on non-proxied urls', () => {
+    fakeWin.location.href = 'https://abc.org/foo/?f=0';
+    fakeWin.location.hostname = 'foo.abc.org';
+    const cid1 = cid.get({scope: 'cookie', createCookieIfNotPresent: true},
+        hasConsent);
+    const cid2 = cid.get({scope: 'cookie', createCookieIfNotPresent: true},
+        hasConsent);
+    return cid1.then(c1 => {
+      return cid2.then(c2 => {
+        expect(c1).to.equal(c2);
+      });
+    });
+  });
+
+  it('should return same value for multiple calls on proxied urls', () => {
+    fakeWin.location.href = 'https://cdn.ampproject.org/v/abc.org/foo/?f=0';
+    fakeWin.location.hostname = 'cdn.ampproject.org';
+    const cid1 = cid.get({scope: 'cookie', createCookieIfNotPresent: true},
+        hasConsent);
+    const cid2 = cid.get({scope: 'cookie', createCookieIfNotPresent: true},
+        hasConsent);
+    return cid1.then(c1 => {
+      return cid2.then(c2 => {
+        expect(c1).to.equal(c2);
+      });
+    });
+  });
+
   function compare(externalCidScope, compareValue) {
     return cid.get(externalCidScope, hasConsent).then(c => {
       expect(c).to.equal(compareValue);


### PR DESCRIPTION
When the cid is requested twice in a row and no cookie is present, the
cid in the first call is different from the seconed one.