### PR TITLE
Refactor iframe listening

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -19,7 +19,7 @@ import {IntersectionObserver} from '../src/intersection-observer';
 import {getAdCid} from '../src/ad-cid';
 import {getIframe, prefetchBootstrap} from '../src/3p-frame';
 import {isLayoutSizeDefined} from '../src/layout';
-import {listen, listenOnce, postMessage} from '../src/iframe-helper';
+import {listenFor, listenForOnce, postMessage} from '../src/iframe-helper';
 import {loadPromise} from '../src/event-helper';
 import {parseUrl} from '../src/url';
 import {registerElement} from '../src/custom-element';
@@ -236,15 +236,15 @@ export function installAd(win) {
           this.intersectionObserver_ =
               new IntersectionObserver(this, this.iframe_, /* opt_is3P */true);
           // Triggered by context.noContentAvailable() inside the ad iframe.
-          listenOnce(this.iframe_, 'no-content', () => {
+          listenForOnce(this.iframe_, 'no-content', () => {
             this.noContentHandler_();
           }, /* opt_is3P */ true);
           // Triggered by context.reportRenderedEntityIdentifier(…) inside the ad
           // iframe.
-          listenOnce(this.iframe_, 'entity-id', info => {
+          listenForOnce(this.iframe_, 'entity-id', info => {
             this.element.creativeId = info.id;
           }, /* opt_is3P */ true);
-          listen(this.iframe_, 'embed-size', data => {
+          listenFor(this.iframe_, 'embed-size', data => {
             let newHeight, newWidth;
             if (data.width !== undefined) {
               newWidth = Math.max(this.element./*OK*/offsetWidth +
@@ -263,7 +263,7 @@ export function installAd(win) {
             }
           }, /* opt_is3P */ true);
           this.iframe_.style.visibility = 'hidden';
-          listenOnce(this.iframe_, 'render-start', () => {
+          listenForOnce(this.iframe_, 'render-start', () => {
             this.iframe_.style.visibility = '';
             this.sendEmbedInfo_(this.isInViewport());
           }, /* opt_is3P */ true);

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -16,7 +16,7 @@
 
 
 import {getIframe, prefetchBootstrap} from '../../../src/3p-frame';
-import {listen} from '../../../src/iframe-helper';
+import {listenFor} from '../../../src/iframe-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
 
@@ -42,7 +42,7 @@ class AmpFacebook extends AMP.BaseElement {
         this.element, 'facebook');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
-    listen(iframe, 'embed-size', data => {
+    listenFor(iframe, 'embed-size', data => {
       iframe.height = data.height;
       iframe.width = data.width;
       const amp = iframe.parentElement;

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -17,7 +17,7 @@
 import {IntersectionObserver} from '../../../src/intersection-observer';
 import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
 import {endsWith} from '../../../src/string';
-import {listen} from '../../../src/iframe-helper';
+import {listenFor} from '../../../src/iframe-helper';
 import {loadPromise} from '../../../src/event-helper';
 import {parseUrl} from '../../../src/url';
 import {removeElement} from '../../../src/dom';
@@ -280,7 +280,7 @@ export class AmpIframe extends AMP.BaseElement {
       }
     };
 
-    listen(iframe, 'embed-size', data => {
+    listenFor(iframe, 'embed-size', data => {
       let newHeight, newWidth;
       if (data.width !== undefined) {
         newWidth = Math.max(this.element./*OK*/offsetWidth +
@@ -301,7 +301,7 @@ export class AmpIframe extends AMP.BaseElement {
     });
 
     if (this.isClickToPlay_) {
-      listen(iframe, 'embed-ready', this.activateIframe_.bind(this));
+      listenFor(iframe, 'embed-ready', this.activateIframe_.bind(this));
     }
 
     this.container_.appendChild(iframe);

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -17,7 +17,7 @@
 
 import {getIframe, prefetchBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {listen} from '../../../src/iframe-helper';
+import {listenFor} from '../../../src/iframe-helper';
 import {loadPromise} from '../../../src/event-helper';
 
 
@@ -51,7 +51,7 @@ class AmpTwitter extends AMP.BaseElement {
         this.element, 'twitter');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
-    listen(iframe, 'embed-size', data => {
+    listenFor(iframe, 'embed-size', data => {
       // We only get the message if and when there is a tweet to display,
       // so hide the placeholder.
       this.togglePlaceholder(false);

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -29,7 +29,7 @@ import {parseUrl} from './url';
  * @param {boolean=} opt_is3P set to true if the iframe is 3p.
  * @return {!Unlisten}
  */
-export function listen(iframe, typeOfMessage, callback, opt_is3P) {
+export function listenFor(iframe, typeOfMessage, callback, opt_is3P) {
   dev.assert(iframe.src, 'only iframes with src supported');
   dev.assert(!iframe.parentNode, 'cannot register events on an attached ' +
       'iframe. It will cause hair-pulling bugs like #2942');
@@ -89,8 +89,8 @@ export function listen(iframe, typeOfMessage, callback, opt_is3P) {
  * @param {boolean=} opt_is3P set to true if the iframe is 3p.
  * @return {!Unlisten}
  */
-export function listenOnce(iframe, typeOfMessage, callback, opt_is3P) {
-  const unlisten = listen(iframe, typeOfMessage, data => {
+export function listenForOnce(iframe, typeOfMessage, callback, opt_is3P) {
+  const unlisten = listenFor(iframe, typeOfMessage, data => {
     unlisten();
     return callback(data);
   }, opt_is3P);

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -76,6 +76,7 @@ function getOrCreateListenForEvents(parentWin, iframe) {
     const we = listenOrigin[i];
     if (we.frame === iframe) {
       windowEvents = we;
+      break;
     }
   }
 
@@ -170,7 +171,7 @@ function registerGlobalListenerIfNeeded(parentWin) {
     // during iteration. We could move to a Doubly Linked List with
     // backtracking, but that's overly complicated.
     events = events.slice();
-    for (let i = 0; i < 0; i++) {
+    for (let i = 0; i < events.length; i++) {
       const event = events[i];
       event(data);
     }

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -110,7 +110,7 @@ function getListenForEvents(parentWin, origin, triggerWin) {
     const we = listenOrigin[i];
     const contentWindow = we.frame.contentWindow;
     if (!contentWindow) {
-      setTimeout(dropListenFors, 0, listenOrigin);
+      setTimeout(dropListenOrigin, 0, listenOrigin);
     } else if (contentWindow === triggerWin) {
       windowEvents = we;
       break;
@@ -120,19 +120,24 @@ function getListenForEvents(parentWin, origin, triggerWin) {
   return windowEvents ? windowEvents.events : null;
 }
 
-function dropListenFors(listenOrigin) {
+/**
+ * Removes any listenFors registed on listenOrigin that do not have
+ * a contentWindow (the frame was removed from the DOM tree).
+ * @param {!Array<!WindowEventsDef>} listenOrigin
+ */
+function dropListenOrigin(listenOrigin) {
   const noopData = {sentinel: 'no-content-window'};
 
   for (let i = listenOrigin.length - 1; i >= 0; i--) {
     const windowEvents = listenOrigin[i];
 
-    if (!windowEvents.contentWindow) {
+    if (!windowEvents.frame.contentWindow) {
       listenOrigin.splice(i, 1);
 
-      for (const name in windowEvents) {
-        const events = windowEvents[name];
+      const events = windowEvents.events;
+      for (const name in events) {
         // Splice here, so that each unlisten does not shift the array
-        events.splice(0, Infinity).forEach(event => {
+        events[name].splice(0, Infinity).forEach(event => {
           event(noopData);
         });
       }

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -18,6 +18,12 @@ import {dev} from './log';
 import {parseUrl} from './url';
 
 /**
+ * Sentinel used to force unlistening after a iframe is detached.
+ * @type {string}
+ */
+const UNLISTEN_SENTINEL = 'unlisten';
+
+/**
  * @typedef {{
  *   frame: !Element,
  *   events: !Object<string, !Array<function(!Object)>>
@@ -126,7 +132,7 @@ function getListenForEvents(parentWin, origin, triggerWin) {
  * @param {!Array<!WindowEventsDef>} listenOrigin
  */
 function dropListenOrigin(listenOrigin) {
-  const noopData = {sentinel: 'no-content-window'};
+  const noopData = {sentinel: UNLISTEN_SENTINEL};
 
   for (let i = listenOrigin.length - 1; i >= 0; i--) {
     const windowEvents = listenOrigin[i];
@@ -218,7 +224,7 @@ export function listenFor(iframe, typeOfMessage, callback, opt_is3P) {
     // If this iframe no longer has a contentWindow is was removed
     // from the DOM. Unlisten immediately as we can never again receive
     // messages for it (
-    if (!iframe.contentWindow) {
+    if (data.sentinel == UNLISTEN_SENTINEL) {
       unlisten();
       return;
     }
@@ -238,7 +244,6 @@ export function listenFor(iframe, typeOfMessage, callback, opt_is3P) {
       // Make sure references to the unlisten function do not keep
       // alive too much.
       listener = null;
-      iframe = null;
       events = null;
       callback = null;
     }

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -17,7 +17,7 @@
 import {Observable} from './observable';
 import {dev} from './log';
 import {layoutRectLtwh, rectIntersection, moveLayoutRect} from './layout-rect';
-import {listen, postMessage} from './iframe-helper';
+import {listenFor, postMessage} from './iframe-helper';
 import {parseUrl} from './url';
 import {timer} from './timer';
 
@@ -126,7 +126,7 @@ export class IntersectionObserver extends Observable {
     // The second time this is called, it doesn't do much but it
     // guarantees that the receiver gets an initial intersection change
     // record.
-    listen(this.iframe_, 'send-intersections', () => {
+    listenFor(this.iframe_, 'send-intersections', () => {
       this.startSendingIntersectionChanges_();
     }, this.is3p_);
 

--- a/test/fixtures/served/iframe-intersection.html
+++ b/test/fixtures/served/iframe-intersection.html
@@ -1,34 +1,14 @@
 <!doctype html>
 <body style="background-color: red">
 Iframe with Inersection
-
-<textarea id=log-el style="width:100%; height: 50vh;"></textarea>
-
 <script>
-var startTime = new Date().getTime();
-
-function log(m) {
-  var el = document.getElementById('log-el');
-  el.value =
-      el.value + '\n[' + (new Date().getTime() - startTime) + '] ' + (m || '');
+function sendPostMessage() {
+  parent./*OK*/postMessage({
+    sentinel: 'amp',
+    type: 'send-intersections'
+  }, '*');
 }
-parent./*OK*/postMessage({
-  sentinel: 'amp',
-  type: 'send-intersections'
-}, '*');
-
-window.addEventListener('message', function(event) {
-  if (event.data) {
-    if (event.data.type == 'intersection') {
-      log('Received intersection message');
-      parent.parent./*OK*/postMessage({
-        sentinel: 'amp',
-        changes: event.data.changes,
-        type: 'received-intersection'
-      }, '*');
-    }
-  }
-});
-
+sendPostMessage();
+setInterval(sendPostMessage, 10);
 </script>
 </body>

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -48,7 +48,7 @@ describe('iframe-helper', function() {
     const iframe = container.doc.createElement('iframe');
     iframe.srcdoc = '<html>';
     expect(() => {
-      IframeHelper.listen(iframe, 'test', () => {});
+      IframeHelper.listenFor(iframe, 'test', () => {});
     }).to.throw('only iframes with src supported');
   });
 
@@ -57,7 +57,7 @@ describe('iframe-helper', function() {
     iframe.src = iframeSrc;
     insert(iframe);
     expect(() => {
-      IframeHelper.listen(iframe, 'test', () => {});
+      IframeHelper.listenFor(iframe, 'test', () => {});
     }).to.throw('cannot register events on an attached iframe');
   });
 

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -63,40 +63,63 @@ describe('iframe-helper', function() {
   });
 
   it('should listen to iframe messages', () => {
-    const removeEventListenerSpy = sandbox.spy(container.win,
-        'removeEventListener');
     let unlisten;
+    let calls = 0;
     return new Promise(resolve => {
       unlisten = IframeHelper.listenFor(testIframe, 'send-intersections',
-          resolve);
+          () => {
+            calls++;
+            resolve();
+          });
       insert(testIframe);
     }).then(() => {
-      expect(removeEventListenerSpy.callCount).to.equal(0);
+      const total = calls;
       unlisten();
-      expect(removeEventListenerSpy.callCount).to.equal(1);
+      return new Promise(resolve => {
+        setTimeout(resolve, 50);
+      }).then(() => {
+        expect(calls).to.equal(total);
+      });
     });
   });
 
   it('should un-listen after first hit', () => {
-    const removeEventListenerSpy = sandbox.spy(container.win,
-        'removeEventListener');
+    let calls = 0;
     return new Promise(resolve => {
-      IframeHelper.listenForOnce(testIframe, 'send-intersections', resolve);
+      IframeHelper.listenForOnce(testIframe, 'send-intersections', () => {
+        calls++;
+        resolve();
+      });
       insert(testIframe);
     }).then(() => {
-      expect(removeEventListenerSpy.callCount).to.equal(1);
+      const total = calls;
+      return new Promise(resolve => {
+        setTimeout(resolve, 50);
+      }).then(() => {
+        expect(calls).to.equal(total);
+      });
     });
   });
 
   it('should un-listen on next message when iframe is unattached', () => {
-    const removeEventListenerSpy = sandbox.spy(container.win,
-        'removeEventListener');
-    IframeHelper.listenFor(testIframe, 'send-intersections', function() {});
-    expect(removeEventListenerSpy.callCount).to.equal(0);
-    container.win.postMessage('hello world', '*');
-    expect(removeEventListenerSpy.callCount).to.equal(0);
-    return timer.promise(1).then(() => {
-      expect(removeEventListenerSpy.callCount).to.equal(1);
+    let unlisten;
+    let calls = 0;
+    return new Promise(resolve => {
+      unlisten = IframeHelper.listenFor(testIframe, 'send-intersections',
+          () => {
+            calls++;
+            resolve();
+          });
+      insert(testIframe);
+    }).then(() => {
+      const total = calls;
+      testIframe.parentElement.removeChild(testIframe);
+      container.win.postMessage('hello world', '*');
+      return new Promise(resolve => {
+        setTimeout(resolve, 50);
+      }).then(() => {
+        expect(calls).to.equal(total);
+      });
     });
   });
 

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -16,7 +16,6 @@
 import * as IframeHelper from '../../src/iframe-helper';
 import * as sinon from 'sinon';
 import {createIframePromise} from '../../testing/iframe';
-import {timer} from '../../src/timer';
 
 describe('iframe-helper', function() {
   const iframeSrc = 'http://iframe.localhost:' + location.port +
@@ -102,14 +101,12 @@ describe('iframe-helper', function() {
   });
 
   it('should un-listen on next message when iframe is unattached', () => {
-    let unlisten;
     let calls = 0;
     return new Promise(resolve => {
-      unlisten = IframeHelper.listenFor(testIframe, 'send-intersections',
-          () => {
-            calls++;
-            resolve();
-          });
+      IframeHelper.listenFor(testIframe, 'send-intersections', () => {
+        calls++;
+        resolve();
+      });
       insert(testIframe);
     }).then(() => {
       const total = calls;

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -67,7 +67,7 @@ describe('iframe-helper', function() {
         'removeEventListener');
     let unlisten;
     return new Promise(resolve => {
-      unlisten = IframeHelper.listen(testIframe, 'send-intersections',
+      unlisten = IframeHelper.listenFor(testIframe, 'send-intersections',
           resolve);
       insert(testIframe);
     }).then(() => {
@@ -81,7 +81,7 @@ describe('iframe-helper', function() {
     const removeEventListenerSpy = sandbox.spy(container.win,
         'removeEventListener');
     return new Promise(resolve => {
-      IframeHelper.listenOnce(testIframe, 'send-intersections', resolve);
+      IframeHelper.listenForOnce(testIframe, 'send-intersections', resolve);
       insert(testIframe);
     }).then(() => {
       expect(removeEventListenerSpy.callCount).to.equal(1);
@@ -91,7 +91,7 @@ describe('iframe-helper', function() {
   it('should un-listen on next message when iframe is unattached', () => {
     const removeEventListenerSpy = sandbox.spy(container.win,
         'removeEventListener');
-    IframeHelper.listen(testIframe, 'send-intersections', function() {});
+    IframeHelper.listenFor(testIframe, 'send-intersections', function() {});
     expect(removeEventListenerSpy.callCount).to.equal(0);
     container.win.postMessage('hello world', '*');
     expect(removeEventListenerSpy.callCount).to.equal(0);

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -40,7 +40,6 @@ describe('iframe-helper', function() {
   });
 
   afterEach(() => {
-    container.iframe.parentNode.removeChild(container.iframe);
     sandbox.restore();
   });
 
@@ -102,20 +101,30 @@ describe('iframe-helper', function() {
 
   it('should un-listen on next message when iframe is unattached', () => {
     let calls = 0;
+    let otherCalls = 0;
+    let other;
+
     return new Promise(resolve => {
       IframeHelper.listenFor(testIframe, 'send-intersections', () => {
         calls++;
         resolve();
       });
       insert(testIframe);
+      other = container.doc.createElement('iframe');
+      other.src = iframeSrc;
+      IframeHelper.listenFor(other, 'send-intersections', () => {
+        otherCalls++;
+      });
+      insert(other);
     }).then(() => {
       const total = calls;
+      const otherTotal = otherCalls;
       testIframe.parentElement.removeChild(testIframe);
-      container.win.postMessage('hello world', '*');
       return new Promise(resolve => {
         setTimeout(resolve, 50);
       }).then(() => {
         expect(calls).to.equal(total);
+        expect(otherCalls).to.be.above(otherTotal + 4);
       });
     });
   });

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -115,6 +115,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
         console.error.apply(console, arguments);
       };
       // Make time go 10x as fast
+      let setTimeout = win.setTimeout;
       win.setTimeout = function(fn, ms) {
         ms = ms || 0;
         setTimeout(fn, ms / 10);


### PR DESCRIPTION
To make listening to events sent from an iframe a little more performant, this registers a single global event listener. When it's triggered, it will try to find any matching "listenFors" registered to that iframe.

Fixes https://github.com/ampproject/amphtml/issues/2836.