### PR TITLE
Append ad iframe _after_ registering listeners

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -242,7 +242,6 @@ export function installAd(win) {
             this.element);
           this.iframe_.setAttribute('scrolling', 'no');
           this.applyFillContent(this.iframe_);
-          this.element.appendChild(this.iframe_);
           this.intersectionObserver_ =
               new IntersectionObserver(this, this.iframe_, /* opt_is3P */true);
           // Triggered by context.noContentAvailable() inside the ad iframe.
@@ -280,6 +279,7 @@ export function installAd(win) {
           this.viewer_.onVisibilityChanged(() => {
             this.sendEmbedInfo_(this.isInViewport());
           });
+          this.element.appendChild(this.iframe_);
           return loadPromise(this.iframe_);
         });
       }


### PR DESCRIPTION
When the ad's iframe is already cached, we can end up running it's code
before we register our event listeners on it. That really stinks for
ads, because they need to send a `render-start` event to us for us to
show them and we're not even listening for it when they send. :sadpanda:

Fixes https://github.com/ampproject/amphtml/issues/2933.