### PR TITLE
Don't break all Ads when one is position-fixed

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -223,10 +223,10 @@ export function installAd(win) {
     /** @override */
     layoutCallback() {
       if (!this.iframe_) {
-        loadingAdsCount++;
         user.assert(!this.isInFixedContainer_,
             '<amp-ad> is not allowed to be placed in elements with ' +
             'position:fixed: %s', this.element);
+        loadingAdsCount++;
         timer.delay(() => {
           // Unfortunately we don't really have a good way to measure how long it
           // takes to load an ad, so we'll just pretend it takes 1 second for


### PR DESCRIPTION
If an ad fails the not position-fixed assertion, we will have incremented to total loading ads without ever decrementing. That'd cause mayhem for any other ads that haven't loaded yet that aren't breaking the rules.