### PR TITLE
Schedule nested amp placeholder for managed scheduling

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1328,11 +1328,9 @@ export class Resources {
     if (element.classList.contains('-amp-element')) {
       callback(this.getResourceForElement(element));
       // Also schedule amp-element that is a placeholder for the element.
-      if (!element.classList.contains('-amp-layout')) {
-        const placeholder = element.getPlaceholder();
-        if (placeholder) {
-          this.discoverResourcesForElement_(placeholder, callback);
-        }
+      const placeholder = element.getPlaceholder();
+      if (placeholder) {
+        this.discoverResourcesForElement_(placeholder, callback);
       }
     } else {
       const ampElements = element.getElementsByClassName('-amp-element');

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1328,11 +1328,11 @@ export class Resources {
     if (element.classList.contains('-amp-element')) {
       callback(this.getResourceForElement(element));
       // Also schedule amp-element that is a placeholder for the element.
-      const placeholder = element.getPlaceholder();
-      const hasAmpPlaceholder = (!element.classList.contains('-amp-layout') &&
-          placeholder && placeholder.classList.contains('-amp-element'));
-      if (hasAmpPlaceholder) {
-        callback(this.getResourceForElement(placeholder));
+      if (!element.classList.contains('-amp-layout')) {
+        const placeholder = element.getPlaceholder();
+        if (placeholder && placeholder.classList.contains('-amp-element')) {
+          callback(this.getResourceForElement(placeholder));
+        }
       }
     } else {
       const ampElements = element.getElementsByClassName('-amp-element');

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1330,8 +1330,8 @@ export class Resources {
       // Also schedule amp-element that is a placeholder for the element.
       if (!element.classList.contains('-amp-layout')) {
         const placeholder = element.getPlaceholder();
-        if (placeholder && placeholder.classList.contains('-amp-element')) {
-          callback(this.getResourceForElement(placeholder));
+        if (placeholder) {
+          this.discoverResourcesForElement_(placeholder, callback);
         }
       }
     } else {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1327,6 +1327,13 @@ export class Resources {
     // Breadth-first search.
     if (element.classList.contains('-amp-element')) {
       callback(this.getResourceForElement(element));
+      // Also schedule amp-element that is a placeholder for the element.
+      const placeholder = element.getPlaceholder();
+      const hasAmpPlaceholder = (!element.classList.contains('-amp-layout') &&
+          placeholder && placeholder.classList.contains('-amp-element'));
+      if (hasAmpPlaceholder) {
+        callback(this.getResourceForElement(placeholder));
+      }
     } else {
       const ampElements = element.getElementsByClassName('-amp-element');
       const seen = [];

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -454,7 +454,7 @@ describe('Resources schedulePreload', () => {
 
     const insidePlaceholder1 = createElementWithResource(4)[0];
     const placeholder1 = document.createElement('div');
-    child0.getElementsByClassName = classname => [insidePlaceholder1];
+    child0.getElementsByClassName = () => [insidePlaceholder1];
     child0.getPlaceholder = () => placeholder1;
 
     resources.schedulePreload(parent, children);

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -436,11 +436,11 @@ describe('Resources schedulePreload', () => {
   it('should schedule on nested custom element placeholder', () => {
     const stub1 = sandbox.stub(resources, 'schedule_');
 
-    placeholder1 = createElementWithResource(4)[0];
+    const placeholder1 = createElementWithResource(4)[0];
     child1.getPlaceholder = () => placeholder1;
     child1.classList.contains = name => name != '-amp-layout';
 
-    placeholder2 = createElementWithResource(5)[0];
+    const placeholder2 = createElementWithResource(5)[0];
     child2.getPlaceholder = () => placeholder2;
     child2.classList.contains = name => name != '-amp-layout';
 
@@ -449,6 +449,18 @@ describe('Resources schedulePreload', () => {
     expect(stub1.callCount).to.be.equal(4);
   });
 
+  it('should schedule amp-* placeholder inside non-amp element', () => {
+    const stub1 = sandbox.stub(resources, 'schedule_');
+
+    const insidePlaceholder1 = createElementWithResource(4)[0];
+    const placeholder1 = document.createElement('div');
+    child0.getElementsByClassName = classname => [insidePlaceholder1];
+    child0.getPlaceholder = () => placeholder1;
+
+    resources.schedulePreload(parent, children);
+    expect(stub1.called).to.be.true;
+    expect(stub1.callCount).to.be.equal(3);
+  });
 });
 
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -438,11 +438,9 @@ describe('Resources schedulePreload', () => {
 
     const placeholder1 = createElementWithResource(4)[0];
     child1.getPlaceholder = () => placeholder1;
-    child1.classList.contains = name => name != '-amp-layout';
 
     const placeholder2 = createElementWithResource(5)[0];
     child2.getPlaceholder = () => placeholder2;
-    child2.classList.contains = name => name != '-amp-layout';
 
     resources.schedulePreload(parent, children);
     expect(stub1.called).to.be.true;


### PR DESCRIPTION
Fixes #2828 

As @dvoytenko mentioned in the issue #2828 resources should only auto schedule the nested placeholders and not nested elements - these are still left to the owner element to schedule.

You can [demo this on this deployment](https://amp-mk-1.herokuapp.com/examples.build/carousel.amp.max.html#visibilityState=hidden) and see nested placeholder of `amp-anim` inside `amp-carousel` being scheduled correctly. 