### PR TITLE
Use unique iframe names based on unique domain

### DIFF
--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -103,13 +103,15 @@ export function getIframe(parentWindow, element, opt_type) {
   if (!count[attributes.type]) {
     count[attributes.type] = 0;
   }
-  iframe.name = 'frame_' + attributes.type + '_' + count[attributes.type]++;
 
+  const baseUrl = getBootstrapBaseUrl(parentWindow);
+  const host = parseUrl(baseUrl).hostname;
   // Pass ad attributes to iframe via the fragment.
-  const src = getBootstrapBaseUrl(parentWindow) + '#' +
-      JSON.stringify(attributes);
+  const src = baseUrl + '#' + JSON.stringify(attributes);
+  const name = host + '_' + attributes.type + '_' + count[attributes.type]++;
 
   iframe.src = src;
+  iframe.name = name;
   iframe.ampLocation = parseUrl(src);
   iframe.width = attributes.width;
   iframe.height = attributes.height;

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -192,17 +192,15 @@ export function getBootstrapBaseUrl(parentWindow, opt_strictForUnitTest) {
  * @return {string}
  */
 function getDefaultBootstrapBaseUrl(parentWindow) {
-  let url =
-      'https://' + getSubDomain(parentWindow) +
-      '.ampproject.net/$internalRuntimeVersion$/frame.html';
   if (getMode().localDev) {
-    url = 'http://ads.localhost:' +
+    return 'http://ads.localhost:' +
         (parentWindow.location.port || parentWindow.parent.location.port) +
         '/dist.3p/current' +
         (getMode().minified ? '-min/frame' : '/frame.max') +
         '.html';
   }
-  return url;
+  return 'https://' + getSubDomain(parentWindow) +
+      '.ampproject.net/$internalRuntimeVersion$/frame.html';
 }
 
 /**
@@ -252,6 +250,6 @@ function getCustomBootstrapBaseUrl(parentWindow, opt_strictForUnitTest) {
       '3p iframe url must not be on the same origin as the current doc' +
       'ument %s (%s) in element %s. See https://github.com/ampproject/amphtml' +
       '/blob/master/spec/amp-iframe-origin-policy.md for details.', url,
-      parseUrl(url).origin, meta);
+      parsed.origin, meta);
   return url + '?$internalRuntimeVersion$';
 }

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -30,7 +30,7 @@ import {viewerFor} from './viewer';
 
 
 /** @type {!Object<string,number>} Number of 3p frames on the for that type. */
-const count = {};
+let count = {};
 
 
 /**
@@ -252,4 +252,12 @@ function getCustomBootstrapBaseUrl(parentWindow, opt_strictForUnitTest) {
       '/blob/master/spec/amp-iframe-origin-policy.md for details.', url,
       parsed.origin, meta);
   return url + '?$internalRuntimeVersion$';
+}
+
+/**
+ * Resets the count of each 3p frame type
+ * @visibleForTesting
+ */
+export function resetCountForTesting() {
+  count = {};
 }


### PR DESCRIPTION
Browsers are weird. If an iframe has a `name` attribute, it’s window
will be cached. When you click a link, then go back, it will insert the
**same** src window into the iframe regardless of a different `src`.

Well, that hurts us since we generate a unique domain to load 3p
frames. We’ll continue to use an old domain’s window, even though the
src points to a new domain. Worse, when we post messages to the 3p
frame, we will send it with an origin parsed from the `src` attribute
even though that is not the real URL of the frame’s window.

Fixes https://github.com/ampproject/amphtml/issues/2943.