### PR TITLE
Redirect-avoidance through AMP-side click measurement.

### DIFF
--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  addParamToUrl,
+  parseQueryString,
+} from '../../src/url';
+import {closest} from '../../src/dom';
+
+
+
+/**
+ * Install a click listener that transforms navigation to the AMP cache
+ * to a form that directly navigates to the doc and transmits the original
+ * URL as a click logging info passed via a fragment param.
+ * Expects to find a URL starting with "https://cdn.ampproject.org/c/"
+ * to be available via a param call "adurl" (or defined by the
+ * `data-url-param-name` attribute on the a tag.
+ * @param {!Window} win
+ */
+export function installAlpClickHandler(win) {
+  win.document.documentElement.addEventListener('click', handleClick);
+  // Start loading destination doc when finger is down.
+  // Needs experiment whether this is a good idea.
+  win.document.documentElement.addEventListener('touchstart', warmupDynamic);
+}
+
+/**
+ * Filter click event and then transform URL for direct AMP navigation
+ * with impression logging.
+ * @param {!MouseEvent} e
+ * @visibleForTesting
+ */
+export function handleClick(e) {
+  if (e.defaultPrevented) {
+    return;
+  }
+  // Only handle simple clicks with the left mouse button/touch and without
+  // modifier keys.
+  if (e.buttons != 0 && e.buttons != 1) {
+    return;
+  }
+  if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
+    return;
+  }
+
+  const link = getLinkInfo(e);
+  if (!link || !link.eventualUrl) {
+    return;
+  }
+
+  // Tag the original href with &amp=1 and make it a fragment param with
+  // name click.
+  const fragment = 'click=' + encodeURIComponent(
+      addParamToUrl(link.a.href, 'amp', '1'));
+  let destination = link.eventualUrl;
+  if (link.eventualUrl.indexOf('#') == -1) {
+    destination += '#' + fragment;
+  } else {
+    destination += '&' + fragment;
+  }
+  const win = link.a.ownerDocument.defaultView;
+  const ancestors = win.location.ancestorOrigins;
+  if (ancestors && ancestors[ancestors.length - 1] == 'http://localhost:8000') {
+    destination = destination.replace('https://cdn.ampproject.org/c/',
+        'http://localhost:8000/max/');
+  }
+
+  e.preventDefault();
+  navigateTo(win, link.a, destination);
+}
+
+/**
+ * For an event, see if there is an anchor tag in the target
+ * ancestor chain and if yes, check whether we can figure
+ * out an AMP target URL.
+ * @param {!Event} e
+ * @return {{
+ *   eventualUrl: (string|undefined),
+ *   a: !Element
+ * }|undefined} A URL on the AMP Cache.
+ */
+function getLinkInfo(e) {
+  const a = closest(e.target, element => {
+    return element.tagName == 'A' && element.href;
+  });
+  if (!a) {
+    return;
+  }
+  return {
+    eventualUrl: getEventualUrl(a),
+    a,
+  };
+}
+
+/**
+ * Given an anchor tag, figure out whether this goes to an AMP destination
+ * via a redirect.
+ * @param {!Element} a An anchor tag.
+ * @return {string|undefined} A URL on the AMP Cache.
+ */
+function getEventualUrl(a) {
+  const urlParamName = a.getAttribute('data-url-param-name') || 'adurl';
+  const eventualUrl = parseQueryString(a.search)[urlParamName];
+  if (!eventualUrl) {
+    return;
+  }
+  if (!eventualUrl.indexOf('https://cdn.ampproject.org/c/') == 0) {
+    return;
+  }
+  return eventualUrl;
+}
+
+/**
+ * Navigate to the given URL. Infers the target from the given anchor
+ * tag.
+ * @param {!Window} win
+ * @param {!Element} a Anchor element
+ * @param {string} url
+ */
+function navigateTo(win, a, url) {
+  const target = (a.target || '_top').toLowerCase();
+  win.open(url, target);
+}
+
+/**
+ * Establishes a connection to the AMP Cache and makes sure
+ * the AMP JS is cached.
+ * @param {!Window} win
+ */
+export function warmupStatic(win) {
+  // Preconnect using an image, because that works on all browsers.
+  // The image has a 1 minute cache time to avoid duplicate
+  // preconnects.
+  new win.Image().src = 'https://cdn.ampproject.org/preconnect.gif';
+  // Preload the primary AMP JS that is render blocking.
+  const linkRel = /*OK*/document.createElement('link');
+  linkRel.rel = 'preload';
+  linkRel.setAttribute('as', 'script');
+  linkRel.href =
+      'https://cdn.ampproject.org/rtv/01$internalRuntimeVersion$/v0.js';
+  getHeadOrFallback(win.document).appendChild(linkRel);
+}
+
+/**
+ * For events (such as touch events) that point to an eligible URL, preload
+ * that URL.
+ * @param {!Event} e
+ * @visibleForTesting
+ */
+export function warmupDynamic(e) {
+  const link = getLinkInfo(e);
+  if (!link || !link.eventualUrl) {
+    return;
+  }
+  const linkRel = /*OK*/document.createElement('link');
+  linkRel.rel = 'preload';
+  linkRel.setAttribute('as', 'document');
+  linkRel.href = link.eventualUrl;
+  getHeadOrFallback(e.target.ownerDocument).appendChild(linkRel);
+}
+
+/**
+ * Return <head> if present or just the document element.
+ * @param {!Document} doc
+ * @return {!Element}
+ */
+function getHeadOrFallback(doc) {
+  return doc.head || doc.documentElement;
+}

--- a/ads/alp/install-alp.js
+++ b/ads/alp/install-alp.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Utility file that generates URLs suitable for AMP's impression tracking.
+
+import '../../third_party/babel/custom-babel-helpers';
+
+import {installAlpClickHandler, warmupStatic} from './handler';
+
+installAlpClickHandler(window);
+warmupStatic(window);

--- a/examples/alp.amp.html
+++ b/examples/alp.amp.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>ALP examples</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h2>ALP</h2>
+
+  <h3>target=_blank</h3>
+  <amp-ad
+      width=300
+      height=250
+      type="doubleclick"
+      data-slot="/35096353/amptesting/landingpagesjs">
+  </amp-ad>
+
+  <h3>target=_top</h3>
+  <amp-ad
+      width=300
+      height=250
+      type="doubleclick"
+      data-slot="/35096353/amptesting/landing_sub/_top">
+  </amp-ad>
+</body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,8 +156,11 @@ function watch() {
   $$.watch('css/**/*.css', function() {
     compileCss();
   });
+  buildAlp({
+    watch: true,
+  });
   buildExtensions({
-    watch: true
+    watch: true,
   });
   buildExamples(true);
   compile(true);
@@ -240,6 +243,7 @@ function buildExtensionJs(path, name, version, options) {
 function build() {
   process.env.NODE_ENV = 'development';
   polyfillsForTests();
+  buildAlp();
   buildExtensions();
   buildExamples(false);
   compile();
@@ -252,6 +256,7 @@ function dist() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   compile(false, true, true);
+  buildAlp({minify: true, watch: false, preventRemoveAndMakeDir: true});
   buildExtensions({minify: true, preventRemoveAndMakeDir: true});
   buildExperiments({minify: true, watch: false, preventRemoveAndMakeDir: true});
   buildLoginDone({minify: true, watch: false, preventRemoveAndMakeDir: true});
@@ -279,6 +284,7 @@ function buildExamples(watch) {
 
   // Also update test-example-validation.js
   buildExample('ads.amp.html');
+  buildExample('alp.amp.html');
   buildExample('analytics-notification.amp.html');
   buildExample('analytics.amp.html');
   buildExample('article.amp.html');
@@ -644,6 +650,24 @@ function buildLoginDoneVersion(version, options) {
           latestName: latestName,
         });
       });
+}
+
+/**
+ * Build ALP JS
+ *
+ * @param {!Object} options
+ */
+function buildAlp(options) {
+  options = options || {};
+  console.log('Bundling alp.js');
+
+  compileJs('./ads/alp/', 'install-alp.js', './dist/', {
+    watch: options.watch,
+    minify: options.minify || argv.minify,
+    includePolyfills: true,
+    minifiedName: 'alp.js',
+    preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
+  });
 }
 
 /**

--- a/src/amp.js
+++ b/src/amp.js
@@ -31,6 +31,7 @@ import {stubElements} from './custom-element';
 import {adopt} from './runtime';
 import {cssText} from '../build/css';
 import {maybeValidate} from './validator-integration';
+import {maybeTrackImpression} from './impression';
 
 // We must under all circumstances call makeBodyVisible.
 // It is much better to have AMP tags not rendered than having
@@ -46,6 +47,7 @@ try {
       installCoreServices(window);
       // We need the core services (viewer/resources) to start instrumenting
       perf.coreServicesAvailable();
+      maybeTrackImpression(window);
       templatesFor(window);
 
       installImg(window);

--- a/src/impression.js
+++ b/src/impression.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {user} from './log';
+import {isExperimentOn} from './experiments';
+import {viewerFor} from './viewer';
+import {xhrFor} from './xhr';
+
+
+/**
+ * Emit a HTTP request to a destination defined on the incoming URL.
+ * Protected by experiment.
+ * @param {!Window} win
+ */
+export function maybeTrackImpression(win) {
+  if (!isExperimentOn(win, 'alp')) {
+    return;
+  }
+  const viewer = viewerFor(win);
+  const clickUrl = viewer.getParam('click');
+  if (!clickUrl) {
+    return;
+  }
+  if (clickUrl.indexOf('https://') != 0) {
+    user.warn('Impression',
+        'click fragment param should start with https://. Found ',
+        clickUrl);
+    return;
+  }
+  if (win.location.hash) {
+    // This is typically done using replaceState inside the viewer.
+    // If for some reason it failed, get rid of the fragment here to
+    // avoid duplicate tracking.
+    win.location.hash = '';
+  }
+  viewer.whenFirstVisible().then(() => {
+    invoke(win, clickUrl);
+  });
+}
+
+function invoke(win, clickUrl) {
+  xhrFor(win).fetchJson(clickUrl, {
+    credentials: 'include',
+    requireAmpResponseSourceOrigin: true,
+  });
+  // TODO(@cramforce): Do something with the result.
+}

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -409,8 +409,9 @@ export class Viewer {
       }
     });
 
-    // Remove hash - no reason to keep it around, but only when embedded.
-    if (this.isEmbedded_) {
+    // Remove hash - no reason to keep it around, but only when embedded or we have
+    // an incoming click tracking string (see impression.js).
+    if (this.isEmbedded_ || this.params_['click']) {
       const newUrl = removeFragment(this.win.location.href);
       if (newUrl != this.win.location.href && this.win.history.replaceState) {
         // Persist the hash that we removed has location.originalHash.

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -35,7 +35,8 @@ import {isArray, isObject} from '../types';
  *   body: (!Object|!Array|undefined),
  *   credentials: (string|undefined),
  *   headers: (!Object|undefined),
- *   method: (string|undefined)
+ *   method: (string|undefined),
+ *   requireAmpResponseSourceOrigin: (boolean|undefined)
  * }}
  */
 let FetchInitDef;

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {handleClick, warmupDynamic, warmupStatic} from '../../ads/alp/handler';
+import {parseUrl} from '../../src/url';
+import * as sinon from 'sinon';
+
+describe('alp-handler', () => {
+
+  let sandbox;
+  let event;
+  let anchor;
+  let open;
+  let win;
+  let image;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    open = sandbox.spy();
+    image = undefined;
+    win = {
+      location: {},
+      open: open,
+      Image: function() {
+        image = this;
+      },
+    };
+    const doc = {
+      defaultView: win,
+      head: {
+        appendChild: sandbox.spy(),
+      },
+    };
+    win.document = doc;
+    anchor = {
+      tagName: 'A',
+      href: 'https://test.com?adurl=' +
+        encodeURIComponent(
+            'https://cdn.ampproject.org/c/www.example.com/amp.html'),
+      ownerDocument: doc,
+      getAttribute: sandbox.stub(),
+      get search() {
+        return parseUrl(this.href).search;
+      },
+    };
+    event = {
+      buttons: 0,
+      target: anchor,
+      preventDefault: sandbox.spy(),
+      defaultPrevented: false,
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function simpleSuccess() {
+    handleClick(event);
+    expect(open.callCount).to.equal(1);
+    expect(open.lastCall.args).to.jsonEqual([
+      'https://cdn.ampproject.org/c/www.example.com/amp.html#click=' +
+          'https%3A%2F%2Ftest.com%3Fadurl%3Dhttps%253A%252F%252F' +
+          'cdn.ampproject.org%252Fc%252Fwww.example.com%252Famp.html%26' +
+          'amp%3D1',
+      '_top',
+    ]);
+    expect(event.preventDefault.callCount).to.equal(1);
+  }
+
+  function noNavigation() {
+    handleClick(event);
+    expect(open.callCount).to.equal(0);
+    expect(event.preventDefault.callCount).to.equal(0);
+  }
+
+  it('should navigate to correct destination', () => {
+    simpleSuccess();
+  });
+
+  it('should navigate to correct destination (left mouse button)', () => {
+    event.button = 1;
+    simpleSuccess();
+  });
+
+  it('should support custom arg name', () => {
+    anchor.getAttribute.withArgs('data-url-param-name').returns('TEST');
+    anchor.href = 'https://test.com?TEST=' +
+        encodeURIComponent(
+            'https://cdn.ampproject.org/c/www.example.com/amp.html');
+    handleClick(event);
+    expect(open.lastCall.args).to.jsonEqual([
+      'https://cdn.ampproject.org/c/www.example.com/amp.html#click=' +
+          'https%3A%2F%2Ftest.com%3FTEST%3Dhttps%253A%252F%252F' +
+          'cdn.ampproject.org%252Fc%252Fwww.example.com%252Famp.html%26' +
+          'amp%3D1',
+      '_top',
+    ]);
+  });
+
+  it('should support existing fragments', () => {
+    anchor.href = 'https://test.com?adurl=' +
+        encodeURIComponent(
+            'https://cdn.ampproject.org/c/www.example.com/amp.html#test=1');
+    handleClick(event);
+    expect(open.lastCall.args).to.jsonEqual([
+      'https://cdn.ampproject.org/c/www.example.com/amp.html#test=1&click=' +
+          'https%3A%2F%2Ftest.com%3Fadurl%3Dhttps%253A%252F%252F' +
+          'cdn.ampproject.org%252Fc%252Fwww.example.com%252Famp.html' +
+          '%2523test%253D1%26amp%3D1',
+      '_top',
+    ]);
+  });
+
+  it('should support other targets', () => {
+    anchor.target = '_blank';
+    handleClick(event);
+    expect(open.lastCall.args[1]).to.equal('_blank');
+  });
+
+  it('should find the closest a tag', () => {
+    const a = anchor;
+    event.target = {
+      parentElement: {
+        parentElement: a,
+      },
+    };
+    simpleSuccess();
+  });
+
+  it('should require an a tag', () => {
+    event.target = {};
+    noNavigation();
+  });
+
+  it('should ignore other mouse buttons', () => {
+    event.buttons = 2;
+    noNavigation();
+  });
+
+  it('should ignore special keys', () => {
+    event.ctrlKey = true;
+    noNavigation();
+  });
+
+  it('should only navigate to AMP', () => {
+    anchor.href = 'https://test.com?adurl=' +
+        encodeURIComponent(
+            'https://notamp.com/c/www.example.com/amp.html');
+    noNavigation();
+  });
+
+  it('should require a destination', () => {
+    anchor.href = 'https://test.com?adurl=';
+    noNavigation();
+  });
+
+  it('should warmup statically', () => {
+    warmupStatic(win);
+    expect(image).to.be.defined;
+    expect(image.src).to.equal('https://cdn.ampproject.org/preconnect.gif');
+    expect(win.document.head.appendChild.callCount).to.equal(1);
+    const link = win.document.head.appendChild.lastCall.args[0];
+    expect(link.rel).to.equal('preload');
+    expect(link.href).to.equal(
+        'https://cdn.ampproject.org/rtv/01$internalRuntimeVersion$/v0.js');
+  });
+
+  it('should warmup dynamically', () => {
+    warmupDynamic(event);
+    expect(win.document.head.appendChild.callCount).to.equal(1);
+    const link = win.document.head.appendChild.lastCall.args[0];
+    expect(link.rel).to.equal('preload');
+    expect(link.href).to.equal(
+        'https://cdn.ampproject.org/c/www.example.com/amp.html');
+  });
+
+  it('should ignore irrelevant events for warmup (bad target)', () => {
+    event.target = {};
+    warmupDynamic(event);
+    expect(win.document.head.appendChild.callCount).to.equal(0);
+  });
+
+  it('should ignore irrelevant events for warmup (bad href)', () => {
+    anchor.href = 'https://www.example.com';
+    warmupDynamic(event);
+    expect(win.document.head.appendChild.callCount).to.equal(0);
+  });
+});

--- a/test/functional/test-impression.js
+++ b/test/functional/test-impression.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {maybeTrackImpression} from '../../src/impression';
+import {toggleExperiment} from '../../src/experiments';
+import {viewerFor} from '../../src/viewer';
+import {xhrFor} from '../../src/xhr';
+import * as sinon from 'sinon';
+
+describe('impression', () => {
+
+  let sandbox;
+  let viewer;
+  let xhr;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    viewer = viewerFor(window);
+    sandbox.stub(viewer, 'getParam');
+    xhr = xhrFor(window);
+    expect(xhr.fetchJson).to.be.defined;
+    xhr.fetchJson = function() {};
+    sandbox.spy(xhr, 'fetchJson');
+    sandbox.stub(viewer, 'whenFirstVisible').returns(Promise.resolve());
+  });
+
+  afterEach(() => {
+    toggleExperiment(window, 'alp', false);
+    sandbox.restore();
+  });
+
+
+  it('should do nothing if the experiment is off', () => {
+    viewer.getParam.throws(new Error('Should not be called'));
+    maybeTrackImpression(window);
+  });
+
+  it('should do nothing if there is no click arg', () => {
+    toggleExperiment(window, 'alp', true);
+    viewer.getParam.withArgs('click').returns('');
+    maybeTrackImpression(window);
+    expect(xhr.fetchJson.callCount).to.equal(0);
+  });
+
+  it('should do nothing if there is the click arg is http', () => {
+    toggleExperiment(window, 'alp', true);
+    viewer.getParam.withArgs('click').returns('http://www.example.com');
+    maybeTrackImpression(window);
+    expect(xhr.fetchJson.callCount).to.equal(0);
+  });
+
+  it('should invoke URL', () => {
+    toggleExperiment(window, 'alp', true);
+    viewer.getParam.withArgs('click').returns('https://www.example.com');
+    maybeTrackImpression(window);
+    expect(xhr.fetchJson.callCount).to.equal(0);
+    return Promise.resolve().then(() => {
+      expect(xhr.fetchJson.callCount).to.equal(1);
+      const url = xhr.fetchJson.lastCall.args[0];
+      const params = xhr.fetchJson.lastCall.args[1];
+      expect(url).to.equal('https://www.example.com');
+      expect(params).to.jsonEqual({
+        credentials: 'include',
+        requireAmpResponseSourceOrigin: true,
+      });
+    });
+  });
+});

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -51,6 +51,11 @@ const EXPERIMENTS = [
         'README.md#amp-dev-channel',
   },
   {
+    id: 'alp',
+    name: 'Activates support for measuring incoming clicks.',
+    spec: 'https://github.com/ampproject/amphtml/issues/2934',
+  },
+  {
     id: 'amp-social-share',
     name: 'AMP Social Share',
     spec: 'https://github.com/ampproject/amphtml/blob/master/' +


### PR DESCRIPTION
Introduces a redirect-avoidance mechanism that enables referrers to track a link invocation without an intermediate redirect by passing a URL to AMP via a fragment param. This change is experiment guarded.

Also introduces a small new binary for use on the referrer side (e.g. inside of an ad creative) that helps with constructing the respective URLs and preconnects to AMP.

Primary implementation of #2934