### PR TITLE
Cut dependency between many extensions and the core custom elements class

### DIFF
--- a/src/access-service.js
+++ b/src/access-service.js
@@ -17,7 +17,7 @@
 import {
   getElementService,
   getElementServiceIfAvailable,
-} from './custom-element';
+} from './element-service';
 
 
 /**

--- a/src/activity.js
+++ b/src/activity.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getElementService} from './custom-element';
+import {getElementService} from './element-service';
 
 /**
  * @param {!Window} win

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getElementService} from './custom-element';
+import {getElementService} from './element-service';
 
 
 /**

--- a/src/cid.js
+++ b/src/cid.js
@@ -21,7 +21,7 @@
 import {
   getElementService,
   getElementServiceIfAvailable,
-} from './custom-element';
+} from './element-service';
 
 /**
  * @param {!Window} window

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -27,7 +27,6 @@ import {reportError} from './error';
 import {resourcesFor} from './resources';
 import {timer} from './timer';
 import {vsyncFor} from './vsync';
-import {getServicePromise, getServicePromiseOrNull} from './service';
 import * as dom from './dom';
 
 
@@ -1165,17 +1164,6 @@ export function registerElement(win, name, implementationClass) {
 }
 
 /**
- * @param {!Window} win
- * @param {string} elementName Name of an extended custom element.
- * @return {boolean} Whether this element is scheduled to be loaded.
- */
-function isElementScheduled(win, elementName) {
-  dev.assert(win.ampExtendedElements,
-      'win.ampExtendedElements not created yet');
-  return !!win.ampExtendedElements[elementName];
-}
-
-/**
  * Registers a new alias for an existing custom element.
  * @param {!Window} win The window in which to register the elements.
  * @param {string} aliasName Additional name for an existing custom element.
@@ -1222,57 +1210,3 @@ export function resetScheduledElementForTesting(win, elementName) {
   delete knownElements[elementName];
 }
 
-
-/**
- * Returns a promise for a service for the given id and window. Also expects
- * an element that has the actual implementation. The promise resolves when
- * the implementation loaded.
- * Users should typically wrap this as a special purpose function (e.g.
- * viewportFor(win)) for type safety and because the factory should not be
- * passed around.
- * @param {!Window} win
- * @param {string} id of the service.
- * @param {string} provideByElement Name of the custom element that provides
- *     the implementation of this service.
- * @return {!Promise<*>}
- */
-export function getElementService(win, id, providedByElement) {
-  return getElementServiceIfAvailable(win, id, providedByElement).then(
-      service => {
-        return user.assert(service,
-            'Service %s was requested to be provided through %s, ' +
-            'but %s is not loaded in the current page. To fix this ' +
-            'problem load the JavaScript file for %s in this page.',
-            id, providedByElement, providedByElement, providedByElement);
-      });
-}
-
-/**
- * Same as getElementService but produces null if the given element is not
- * actually available on the current page.
- * @param {!Window} win
- * @param {string} id of the service.
- * @param {string} provideByElement Name of the custom element that provides
- *     the implementation of this service.
- * @return {!Promise<*>}
- */
-export function getElementServiceIfAvailable(win, id, providedByElement) {
-  const s = getServicePromiseOrNull(win, id);
-  if (s) {
-    return s;
-  }
-  // Microtask is necessary to ensure that window.ampExtendedElements has been
-  // initialized.
-  return Promise.resolve().then(() => {
-    if (isElementScheduled(win, providedByElement)) {
-      return getServicePromise(win, id);
-    }
-    // Wait for HEAD to fully form before denying access to the service.
-    return dom.waitForBodyPromise(win.document).then(() => {
-      if (isElementScheduled(win, providedByElement)) {
-        return getServicePromise(win, id);
-      }
-      return null;
-    });
-  });
-}

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getServicePromise, getServicePromiseOrNull} from './service';
+import {dev, user} from './log';
+import * as dom from './dom';
+
+/**
+ * Returns a promise for a service for the given id and window. Also expects
+ * an element that has the actual implementation. The promise resolves when
+ * the implementation loaded.
+ * Users should typically wrap this as a special purpose function (e.g.
+ * viewportFor(win)) for type safety and because the factory should not be
+ * passed around.
+ * @param {!Window} win
+ * @param {string} id of the service.
+ * @param {string} provideByElement Name of the custom element that provides
+ *     the implementation of this service.
+ * @return {!Promise<*>}
+ */
+export function getElementService(win, id, providedByElement) {
+  return getElementServiceIfAvailable(win, id, providedByElement).then(
+      service => {
+        return user.assert(service,
+            'Service %s was requested to be provided through %s, ' +
+            'but %s is not loaded in the current page. To fix this ' +
+            'problem load the JavaScript file for %s in this page.',
+            id, providedByElement, providedByElement, providedByElement);
+      });
+}
+
+/**
+ * Same as getElementService but produces null if the given element is not
+ * actually available on the current page.
+ * @param {!Window} win
+ * @param {string} id of the service.
+ * @param {string} provideByElement Name of the custom element that provides
+ *     the implementation of this service.
+ * @return {!Promise<*>}
+ */
+export function getElementServiceIfAvailable(win, id, providedByElement) {
+  const s = getServicePromiseOrNull(win, id);
+  if (s) {
+    return s;
+  }
+  // Microtask is necessary to ensure that window.ampExtendedElements has been
+  // initialized.
+  return Promise.resolve().then(() => {
+    if (isElementScheduled(win, providedByElement)) {
+      return getServicePromise(win, id);
+    }
+    // Wait for HEAD to fully form before denying access to the service.
+    return dom.waitForBodyPromise(win.document).then(() => {
+      if (isElementScheduled(win, providedByElement)) {
+        return getServicePromise(win, id);
+      }
+      return null;
+    });
+  });
+}
+
+/**
+ * @param {!Window} win
+ * @param {string} elementName Name of an extended custom element.
+ * @return {boolean} Whether this element is scheduled to be loaded.
+ */
+function isElementScheduled(win, elementName) {
+  // Set in custom-element.js
+  dev.assert(win.ampExtendedElements,
+      'win.ampExtendedElements not created yet');
+  return !!win.ampExtendedElements[elementName];
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getElementService} from './custom-element';
+import {getElementService} from './element-service';
 
 
 /**

--- a/src/user-notification.js
+++ b/src/user-notification.js
@@ -18,7 +18,7 @@
  * @fileoverview Factory for amp-user-notification
  */
 
-import {getElementService} from './custom-element';
+import {getElementService} from './element-service';
 
 
 /**

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getElementService} from './custom-element';
+import {getElementService} from './element-service';
 
 /**
  * @param {!Window} win

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -24,12 +24,15 @@ import * as sinon from 'sinon';
 import {getService, resetServiceForTesting} from '../../src/service';
 import {
   createAmpElementProto,
-  getElementService,
-  getElementServiceIfAvailable,
   markElementScheduledForTesting,
   resetScheduledElementForTesting,
   stubElements,
 } from '../../src/custom-element';
+// TODO(@cramforce): Move tests into their own file.
+import {
+  getElementService,
+  getElementServiceIfAvailable,
+} from '../../src/element-service';
 
 
 describe('CustomElement', () => {

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,38 +1,38 @@
-      max   |         min   |       gzip   |   file
-      ---   |         ---   |        ---   |   ---
-629.49 kB   |   161.32 kB   |   44.95 kB   |   v0.js / amp.js
- 318.3 kB   |    37.76 kB   |   12.15 kB   |   v0/amp-access-0.1.js
- 27.06 kB   |     5.96 kB   |    2.35 kB   |   v0/amp-accordion-0.1.js
-346.11 kB   |    54.63 kB   |   19.06 kB   |   v0/amp-analytics-0.1.js
- 87.73 kB   |     9.49 kB   |    3.62 kB   |   v0/amp-anim-0.1.js
- 84.57 kB   |     7.22 kB   |    2.92 kB   |   v0/amp-audio-0.1.js
- 79.42 kB   |     8.33 kB   |    3.16 kB   |   v0/amp-brid-player-0.1.js
- 95.11 kB   |     7.98 kB   |    3.05 kB   |   v0/amp-brightcove-0.1.js
-191.56 kB   |    33.17 kB   |    9.53 kB   |   v0/amp-carousel-0.1.js
-    72 kB   |     6.96 kB   |    2.78 kB   |   v0/amp-dailymotion-0.1.js
- 82.33 kB   |     5.28 kB   |    2.27 kB   |   v0/amp-dynamic-css-classes-0.1.js
-132.67 kB   |    14.45 kB   |     5.7 kB   |   v0/amp-facebook-0.1.js
- 34.57 kB   |     6.72 kB   |    2.64 kB   |   v0/amp-fit-text-0.1.js
- 88.99 kB   |     9.66 kB   |     3.5 kB   |   v0/amp-font-0.1.js
-124.25 kB   |     14.6 kB   |    5.27 kB   |   v0/amp-iframe-0.1.js
-217.45 kB   |    40.04 kB   |   11.23 kB   |   v0/amp-image-lightbox-0.1.js
- 87.92 kB   |     8.12 kB   |    3.14 kB   |   v0/amp-instagram-0.1.js
- 81.58 kB   |     8.63 kB   |    3.49 kB   |   v0/amp-install-serviceworker-0.1.js
- 78.85 kB   |     7.79 kB   |    3.03 kB   |   v0/amp-jwplayer-0.1.js
- 92.84 kB   |     8.66 kB   |    3.37 kB   |   v0/amp-kaltura-player-0.1.js
-137.26 kB   |    15.35 kB   |    4.83 kB   |   v0/amp-lightbox-0.1.js
-100.73 kB   |     9.04 kB   |     3.4 kB   |   v0/amp-list-0.1.js
-143.99 kB   |     40.5 kB   |   14.27 kB   |   v0/amp-mustache-0.1.js
-107.21 kB   |    20.46 kB   |    6.04 kB   |   v0/amp-pinterest-0.1.js
- 71.11 kB   |     6.52 kB   |    2.61 kB   |   v0/amp-reach-player-0.1.js
- 95.78 kB   |     11.6 kB   |    4.16 kB   |   v0/amp-sidebar-0.1.js
-106.34 kB   |    12.75 kB   |    4.54 kB   |   v0/amp-slides-0.1.js
- 114.6 kB   |    16.11 kB   |    5.82 kB   |   v0/amp-social-share-0.1.js
- 71.69 kB   |     6.67 kB   |    2.66 kB   |   v0/amp-soundcloud-0.1.js
- 79.66 kB   |     8.51 kB   |    3.14 kB   |   v0/amp-springboard-player-0.1.js
-133.14 kB   |    14.57 kB   |    5.74 kB   |   v0/amp-twitter-0.1.js
-237.49 kB   |    13.43 kB   |    4.73 kB   |   v0/amp-user-notification-0.1.js
- 71.62 kB   |     6.62 kB   |    2.65 kB   |   v0/amp-vimeo-0.1.js
- 71.15 kB   |     6.49 kB   |    2.61 kB   |   v0/amp-vine-0.1.js
- 82.11 kB   |      8.8 kB   |    3.38 kB   |   v0/amp-youtube-0.1.js
-135.66 kB   |    30.41 kB   |   10.74 kB   |   current-min/f.js / current/integration.js
+      max   |        min   |       gzip   |   file
+      ---   |        ---   |        ---   |   ---
+630.44 kB   |   161.4 kB   |   44.95 kB   |   v0.js / amp.js
+214.04 kB   |   37.72 kB   |   12.14 kB   |   v0/amp-access-0.1.js
+ 27.06 kB   |    5.96 kB   |    2.35 kB   |   v0/amp-accordion-0.1.js
+225.47 kB   |   54.03 kB   |   18.88 kB   |   v0/amp-analytics-0.1.js
+ 87.72 kB   |    9.49 kB   |    3.62 kB   |   v0/amp-anim-0.1.js
+ 84.56 kB   |    7.22 kB   |    2.92 kB   |   v0/amp-audio-0.1.js
+ 79.41 kB   |    8.33 kB   |    3.16 kB   |   v0/amp-brid-player-0.1.js
+ 95.11 kB   |    7.98 kB   |    3.05 kB   |   v0/amp-brightcove-0.1.js
+191.56 kB   |   33.17 kB   |    9.53 kB   |   v0/amp-carousel-0.1.js
+    72 kB   |    6.96 kB   |    2.78 kB   |   v0/amp-dailymotion-0.1.js
+ 82.32 kB   |    5.28 kB   |    2.27 kB   |   v0/amp-dynamic-css-classes-0.1.js
+132.66 kB   |   14.45 kB   |    5.69 kB   |   v0/amp-facebook-0.1.js
+ 34.57 kB   |    6.72 kB   |    2.64 kB   |   v0/amp-fit-text-0.1.js
+ 88.98 kB   |    9.66 kB   |     3.5 kB   |   v0/amp-font-0.1.js
+124.25 kB   |    14.6 kB   |    5.26 kB   |   v0/amp-iframe-0.1.js
+217.45 kB   |   40.04 kB   |   11.22 kB   |   v0/amp-image-lightbox-0.1.js
+ 87.92 kB   |    8.12 kB   |    3.14 kB   |   v0/amp-instagram-0.1.js
+ 81.58 kB   |    8.63 kB   |    3.49 kB   |   v0/amp-install-serviceworker-0.1.js
+ 78.84 kB   |    7.79 kB   |    3.03 kB   |   v0/amp-jwplayer-0.1.js
+ 92.83 kB   |    8.66 kB   |    3.37 kB   |   v0/amp-kaltura-player-0.1.js
+137.25 kB   |   15.35 kB   |    4.83 kB   |   v0/amp-lightbox-0.1.js
+100.72 kB   |    9.04 kB   |     3.4 kB   |   v0/amp-list-0.1.js
+143.99 kB   |    40.5 kB   |   14.27 kB   |   v0/amp-mustache-0.1.js
+107.21 kB   |   20.46 kB   |    6.04 kB   |   v0/amp-pinterest-0.1.js
+ 71.11 kB   |    6.52 kB   |    2.61 kB   |   v0/amp-reach-player-0.1.js
+ 95.78 kB   |    11.6 kB   |    4.16 kB   |   v0/amp-sidebar-0.1.js
+106.34 kB   |   12.75 kB   |    4.54 kB   |   v0/amp-slides-0.1.js
+ 114.6 kB   |   16.11 kB   |    5.82 kB   |   v0/amp-social-share-0.1.js
+ 71.69 kB   |    6.67 kB   |    2.66 kB   |   v0/amp-soundcloud-0.1.js
+ 79.66 kB   |    8.51 kB   |    3.14 kB   |   v0/amp-springboard-player-0.1.js
+133.13 kB   |   14.57 kB   |    5.74 kB   |   v0/amp-twitter-0.1.js
+101.14 kB   |   11.31 kB   |    4.12 kB   |   v0/amp-user-notification-0.1.js
+ 71.61 kB   |    6.62 kB   |    2.65 kB   |   v0/amp-vimeo-0.1.js
+ 71.15 kB   |    6.49 kB   |    2.61 kB   |   v0/amp-vine-0.1.js
+ 82.11 kB   |     8.8 kB   |    3.38 kB   |   v0/amp-youtube-0.1.js
+137.41 kB   |   30.86 kB   |   10.87 kB   |   current-min/f.js / current/integration.js


### PR DESCRIPTION
This pulled in a lot of unneeded code leading to major size regression.