### PR TITLE
Allow filtering the validator errors by category.

### DIFF
--- a/src/mode.js
+++ b/src/mode.js
@@ -19,6 +19,7 @@
  * @typedef {{
  *   localDev: boolean,
  *   development: boolean,
+ *   filter: (string|undefined)
  *   minified: boolean,
  *   test: boolean,
  *   log: (string|undefined),
@@ -88,6 +89,9 @@ function getMode_() {
     localDev: isLocalDev,
     // Triggers validation
     development: developmentQuery['development'] == '1' || window.AMP_DEV_MODE,
+    // Allows filtering validation errors by error category. For the
+    // available categories, see ErrorCategory in validator/validator.proto.
+    filter: developmentQuery['filter'],
     minified: process.env.NODE_ENV == 'production',
     test: window.AMP_TEST,
     log: developmentQuery['log'],

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -31,13 +31,14 @@ export function maybeValidate(win) {
   if (filename.indexOf('about:') == 0) {  // Should only happen in tests.
     return;
   }
+
   const s = win.document.createElement('script');
   // TODO(@cramforce): Introduce a switch to locally built version for local
   // development.
   s.src = 'https://cdn.ampproject.org/v0/validator.js';
   s.onload = () => {
     win.document.head.removeChild(s);
-    amp.validator.validateUrlAndLog(filename, win.document);
+    amp.validator.validateUrlAndLog(filename, win.document, getMode().filter);
   };
   win.document.head.appendChild(s);
 }


### PR DESCRIPTION
E.g., when &filter=AUTHOR_STYLESHEET_PROBLEM is appended
to a URL, the validator will only display those errors
classified as AUTHOR_STYLESHEET_PROBLEM.