### PR TITLE
Make AMP robust when it is loaded into sandbox or data URI.

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -27,7 +27,14 @@
  * @return {?string}
  */
 export function getCookie(win, name) {
-  const cookieString = win.document.cookie;
+  let cookieString;
+  try {
+    cookieString = win.document.cookie;
+  } catch (ignore) {
+    // Act as if no cookie is available. Exceptions can be thrown when
+    // AMP docs are opened on origins that do not allow setting
+    // cookies such as null origins.
+  }
   if (!cookieString) {
     return null;
   }
@@ -91,9 +98,16 @@ function trySetCookie(win, name, value, expirationTime, domain) {
     value = 'delete';
     expirationTime = 0;
   }
-  win.document.cookie = encodeURIComponent(name) + '=' +
+  const cookie = encodeURIComponent(name) + '=' +
       encodeURIComponent(value) +
       '; path=/' +
       (domain ? '; domain=' + domain : '') +
       '; expires=' + new Date(expirationTime).toUTCString();
+  try {
+    win.document.cookie = cookie;
+  } catch (ignore) {
+    // Do not throw if setting the cookie failed Exceptions can be thrown
+    // when AMP docs are opened on origins that do not allow setting
+    // cookies such as null origins.
+  };
 }


### PR DESCRIPTION
In that case setting or reading a cookie may throw an exception.
See e.g. http://output.jsbin.com/tihozejapi/quiet

Affects #2952