### PR TITLE
Ads: Use new numeric #renderOutsideViewport API

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -59,17 +59,9 @@ export function installAd(win) {
 
       // Ad opts into lazier loading strategy where we only load ads that are
       // at closer than 1.25 viewports away.
-      // TODO(jridgewell): Can this be moved to the new number based
-      // renderOutsideViewport?
       if (this.element.getAttribute('data-loading-strategy') ==
           'prefer-viewability-over-views') {
-        const box = this.getIntersectionElementLayoutBox();
-        const viewportBox = this.getViewport().getRect();
-        const distanceFromViewport = box.top - viewportBox.bottom;
-        if (distanceFromViewport <= 1.25 * (viewportBox.height)) {
-          return true;
-        }
-        return false;
+        return 1.25;
       }
 
       // Otherwise the ad is good to go.

--- a/test/functional/test-amp-ad.js
+++ b/test/functional/test-amp-ad.js
@@ -434,35 +434,17 @@ function tests(name, installer) {
 
       it('should prefer-viewability-over-views', () => {
         let clock;
-        const elementBox = {
-          top: 4000,
-        };
-        const viewportRect = {
-          height: 1000,
-          bottom: 1000,
-        };
         return getGoodAd(ad => {
-          ad.resources_.add(ad.element);
-          sandbox.stub(ad, 'getIntersectionElementLayoutBox', () => {
-            return elementBox;
-          });
-          sandbox.stub(ad.getViewport(), 'getRect', () => {
-            return viewportRect;
-          });
+          expect(ad.renderOutsideViewport()).not.to.be.false;
         }, () => {
           clock = sandbox.useFakeTimers();
         }, 'prefer-viewability-over-views').then(ad => {
-          clock.tick(10000);
           // False because we just rendered one.
           expect(ad.renderOutsideViewport()).to.be.false;
-          viewportRect.bottom = '2749';
+          clock.tick(900);
           expect(ad.renderOutsideViewport()).to.be.false;
-          // 125% of viewport away
-          viewportRect.bottom = '2750';
-          expect(ad.renderOutsideViewport()).to.be.true;
-          // We currently render above viewport.
-          viewportRect.bottom = '6000';
-          expect(ad.renderOutsideViewport()).to.be.true;
+          clock.tick(100);
+          expect(ad.renderOutsideViewport()).to.equal(1.25);
         });
       });
     });


### PR DESCRIPTION
This changes the way ads determine if they can render outside the viewport by using the builtin numeric API.

The old code does not consider scroll direction, or whether the ad is above the current viewport or wayyy above the viewport. The new code will de-prioritize the ad if the user is scrolling away.