### PR TITLE
Handle data-adtest and data-tag-origin as amp-ad type=adsense parameters

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -21,7 +21,7 @@ import {checkData} from '../../src/3p';
  * @param {!Object} data
  */
 export function adsense(global, data) {
-  checkData(data, ['adClient', 'adSlot', 'adHost']);
+  checkData(data, ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin']);
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.
     global.gaGlobal = {
@@ -40,6 +40,12 @@ export function adsense(global, data) {
   }
   if (data['adHost']) {
     i.setAttribute('data-ad-host', data['adHost']);
+  }
+  if (data['adtest']) {
+    i.setAttribute('data-adtest', data['adtest']);
+  }
+  if (data['tagOrigin']) {
+    i.setAttribute('data-tag-origin', data['tagOrigin']);
   }
   i.setAttribute('data-page-url', global.context.canonicalUrl);
   i.setAttribute('class', 'adsbygoogle');

--- a/ads/google/adsense.md
+++ b/ads/google/adsense.md
@@ -35,3 +35,5 @@ Supported parameters:
 - data-ad-client
 - data-ad-slot
 - data-ad-host
+- data-adtest
+- data-tag-origin


### PR DESCRIPTION
Handle a couple more options to adsense ads.