### PR TITLE
bump promise-pjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "heroku-postbuild": "gulp clean && gulp build --fortesting && gulp dist --fortesting"
   },
   "dependencies": {
-    "promise-pjs": "1.0.0",
+    "promise-pjs": "1.1.0",
     "document-register-element": "0.5.4"
   },
   "devDependencies": {


### PR DESCRIPTION
1.1.0 fixes some renaming issues from closure compiler `collapse properties` when constructor function is invoked through `instance.constructor.function`