### PR TITLE
basic oewa support

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -268,6 +268,35 @@ Container for analytics tags. Positioned far away from top to make sure that doe
 </amp-analytics>
 <!-- End Mediametrie example -->
 
+<!-- OEWA example -->
+<amp-analytics type="oewa">
+<script type="application/json">
+{
+  "vars": {
+    "s": "offer",
+    "cp": "RedCont/Nachrichten/NachrichtenUeberblick"
+  },
+  "requests": {
+    "url": "https://subdomain.domain.example/amp-analytics-oewa.html"
+  }
+}
+</script>
+</amp-analytics>
+<!-- End OEWA example -->
+
+<!-- OEWADIRECT example -->
+<amp-analytics type="oewadirect">
+<script type="application/json">
+{
+  "vars": {
+    "s": "offer",
+    "cp": "RedCont/Nachrichten/NachrichtenUeberblick"
+  }
+}
+</script>
+</amp-analytics>
+<!-- End OEWADIRECT example -->
+
 <!-- Parsely tracking -->
 <amp-analytics type="parsely">
 <script type="application/json">

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -75,6 +75,12 @@
   "infonline": {
     "pageview": "$url?st=$st&sv=$sv&ap=$ap&co=$co&cp=$cp&host=_canonical_host_&path=_canonical_path_"
   },
+  "oewa": {
+    "pageview": "$url?s=$s&amp=1&cp=$cp&host=_canonical_host_&path=_canonical_path_"
+  },
+  "oewadirect": {
+    "pageview": "https://$s.oewabox.at/j0=,,,r=_canonical_url_;+,amp=1+cp=$cp+ssl=1+hn=_canonical_host_;;;?lt=_page_view_id_&x=_screen_width_x_screen_height_x24&c=_client_id_"
+  },
   "simplereach": {
     "host": "https://edge.simplereach.com",
     "baseParams": "amp=true&pid=$pid&title=_title_&url=_canonical_url_&date=$published_at&authors=$authors&channels=$categories&tags=$tags&referrer=_document_referrer_&page_url=_source_url_&user_id=_client_id_&domain=_canonical_host_",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -377,6 +377,35 @@ export const ANALYTICS_CONFIG = {
     },
   },
 
+  'oewadirect': {
+    'transport': {'beacon': false, 'xhrpost': false, 'image': true},
+    'requests': {
+      'pageview': 'https://${s}.oewabox.at/j0=,,,r=${canonicalUrl};+,amp=1+cp=${cp}+ssl=1+hn=${canonicalHost};;;?lt=${pageViewId}&x=${screenWidth}x${screenHeight}x24&c=CLIENT_ID(oewa)',
+    },
+    'triggers': {
+      'pageview': {
+        'on': 'visible',
+        'request': 'pageview',
+      },
+    },
+  },
+
+  'oewa': {
+    'transport': {'beacon': false, 'xhrpost': false, 'image': true},
+    'requests': {
+      'pageview': '${url}?s=${s}' +
+        '&amp=1' +
+        '&cp=${cp}' +
+        '&host=${canonicalHost}' +
+        '&path=${canonicalPath}',
+    },
+    'triggers': {
+      'pageview': {
+        'on': 'visible',
+        'request': 'pageview',
+      },
+    },
+  },
   'parsely': {
     'requests': {
       'host': 'https://srv.pixel.parsely.com',
@@ -507,7 +536,6 @@ export const ANALYTICS_CONFIG = {
       },
     },
   },
-
   'simplereach': {
     'vars': {
       'pid': '',
@@ -745,5 +773,8 @@ ANALYTICS_CONFIG['infonline']['triggers']['pageview']['iframe' +
 
 ANALYTICS_CONFIG['adobeanalytics_nativeConfig']
   ['triggers']['pageLoad']['iframe' +
+/* TEMPORARY EXCEPTION */ 'Ping'] = true;
+
+ANALYTICS_CONFIG['oewa']['triggers']['pageview']['iframe' +
 /* TEMPORARY EXCEPTION */ 'Ping'] = true;
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -164,6 +164,26 @@ Type attribute value: `mediametrie`
 
 Adds support for Médiamétrie tracking pages. Requires defining *var* `serial`. Vars `level1` to `level4` are optional.
 
+### OEWA
+
+Type attribute value: `oewa`
+
+There is a variation called `oewadirect` wich does not use iframe-ping solution - and has a better client detection, by using AMP CLIENT_ID, this is currently EXPERIMENTAL,
+and as of today (01.07.2015) prohibited by the OEWA - as it does not use `oewa2.js`
+
+Adds support for [OEWA](https://www.oewa.at). Requires a copy of [amp-analytics-oewa.html](http://www.oewa.at/fileadmin/downloads/amp-analytics-oewa.html) on a different subdomain than the including AMP file ([why?](https://github.com/ampproject/amphtml/blob/master/spec/amp-iframe-origin-policy.md)). The file must be served via HTTPS. Example: if your AMP files are hosted on `www.example.com`, then `amp-analytics-oewa.html` needs to be on another subdomain such as `oewa-amp.example.com`.
+
+Additionally, the following variables must be defined:
+
+in vars-section:
+* `s`: offer
+* `cp`: categorypath
+
+in requests-section:
+* `url`: HTTPS location of `amp-analytics-oewa.html`
+
+More details for adding ÖWA, support can be found [here](http://www.oewa.at/basic/implementierung).
+
 ### Parsely
 
 Type attribute value: `parsely`


### PR DESCRIPTION
This one try's to add basic oewa support.
Oewa is a derivation of the infoonline - as it seems.



you need to host a helper-html on a different subdomain (via https)

```
<html>
  <head>
    <script src=https://dispatcher.oewabox.at/oewa.js></script>
  </head>
  <body>
    <script>
      var match,
          pl     = /\+/g,
          search = /([^&=]+)=?([^&]*)/g,
          decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
          query  = window.location.search.substring(1);
      var OEWA = {};
      while (match = search.exec(query)) { OEWA[decode(match[1])] = decode(match[2]); }
      oewa.ns = true;
      oewa.c({}, OEWA, 2);
    </script>
  </body>
</html>
```



call it with:
```
<!-- OEWA example -->
<amp-analytics type="oewa">
<script type="application/json">
{
  "vars": {
    "s": "offer",
    "cp": "RedCont/Nachrichten/NachrichtenUeberblick"
  },
  "requests": {
    "url": "https://subdomain.domain.example/amp-analytics-oewa.html"
  }
}
</script>
</amp-analytics>
<!-- End OEWA example -->
```


i am not a oewa-official - i am trying to get one of them on board too - and let them validate the implementation.

**my only problem is that the `${url}` from the vendors config gets encoded, is there anyway i can disable the encoding on the one variable?**


>log.js:246 Uncaught (in promise) Error: undefined source must start with "https://" or "//" or be relative and served from either https or from localhost. Invalid value: https://https%3A%2F%2Fsecure.krone.at%2Famp_oewa.html?site=ssl-krone&cp=%2F…ulterschluss!_TTIP_bei_uns_so_gut_wie_tot-Leaks_als_Sargnagel-Story-508282​​​(…)