### PR TITLE
Fix missing sinon imports.

### DIFF
--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -18,6 +18,7 @@ import {AmpAudio} from '../amp-audio';
 import {adopt} from '../../../../src/runtime';
 import {naturalDimensions_} from '../../../../src/layout';
 import {createIframePromise} from '../../../../testing/iframe';
+import * as sinon from 'sinon';
 require('../amp-audio');
 
 adopt(window);

--- a/extensions/amp-carousel/0.1/test/test-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-carousel.js
@@ -39,6 +39,7 @@ describe('Carousel gestures', () => {
   });
 
   afterEach(() => {
+    sandbox.restore();
     document.body.removeChild(element);
   });
 

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -448,7 +448,6 @@ describe('amp-iframe', () => {
   });
 
   it('should listen for embed-ready event', () => {
-    sinon.sandbox.create();
     const activateIframeSpy_ =
         sandbox.spy(AmpIframe.prototype, 'activateIframe_');
     return getAmpIframe({

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -20,6 +20,7 @@ import {createIframePromise} from '../../../../testing/iframe';
 import {platform} from '../../../../src/platform';
 import {timer} from '../../../../src/timer';
 import {toggleExperiment} from '../../../../src/experiments';
+import * as sinon from 'sinon';
 require('../amp-sidebar');
 
 adopt(window);

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -184,3 +184,5 @@ chai.Assertion.addMethod('jsonEqual', function(compare) {
     b
   );
 });
+
+delete sinon;

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -19,6 +19,7 @@ import '../third_party/babel/custom-babel-helpers';
 import '../src/polyfills';
 import {removeElement} from '../src/dom';
 import {adopt} from '../src/runtime';
+import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -185,4 +185,4 @@ chai.Assertion.addMethod('jsonEqual', function(compare) {
   );
 });
 
-delete sinon;
+delete window.sinon;

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -185,4 +185,4 @@ chai.Assertion.addMethod('jsonEqual', function(compare) {
   );
 });
 
-delete window.sinon;
+sinon = null;

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -19,7 +19,6 @@ import '../third_party/babel/custom-babel-helpers';
 import '../src/polyfills';
 import {removeElement} from '../src/dom';
 import {adopt} from '../src/runtime';
-import * as sinon from 'sinon';
 
 adopt(window);
 
@@ -185,4 +184,3 @@ chai.Assertion.addMethod('jsonEqual', function(compare) {
     b
   );
 });
-

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -29,6 +29,7 @@ import {resetServiceForTesting} from '../../src/service';
 import {setModeForTesting} from '../../src/mode';
 import {validateData} from '../../src/3p';
 import {viewerFor} from '../../src/viewer';
+import * as sinon from 'sinon';
 
 describe('3p-frame', () => {
 

--- a/test/functional/test-amp-video.js
+++ b/test/functional/test-amp-video.js
@@ -16,6 +16,7 @@
 
 import {createIframePromise} from '../../testing/iframe';
 import {installVideo} from '../../builtins/amp-video';
+import * as sinon from 'sinon';
 
 describe('amp-video', () => {
 

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -15,6 +15,7 @@
  */
 
 import {BaseElement} from '../../src/base-element';
+import * as sinon from 'sinon';
 
 
 describe('BaseElement', () => {

--- a/test/functional/test-curve.js
+++ b/test/functional/test-curve.js
@@ -15,6 +15,7 @@
  */
 
 import {Curves, bezierCurve, getCurve} from '../../src/curve';
+import * as sinon from 'sinon';
 
 describe('Curve', () => {
 

--- a/test/functional/test-finite-state-machine.js
+++ b/test/functional/test-finite-state-machine.js
@@ -15,6 +15,7 @@
  */
 
 import {FiniteStateMachine} from '../../src/finite-state-machine';
+import * as sinon from 'sinon';
 
 describe('Finite State Machine', () => {
 

--- a/test/functional/test-observable.js
+++ b/test/functional/test-observable.js
@@ -15,6 +15,7 @@
  */
 
 import {Observable} from '../../src/observable';
+import * as sinon from 'sinon';
 
 describe('Observable', () => {
 

--- a/test/functional/test-pass.js
+++ b/test/functional/test-pass.js
@@ -16,6 +16,7 @@
 
 import {Pass} from '../../src/pass';
 import {timer} from '../../src/timer';
+import * as sinon from 'sinon';
 
 describe('Pass', () => {
 

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -15,6 +15,7 @@
  */
 
 import * as st from '../../src/style';
+import * as sinon from 'sinon';
 
 describe('Style', () => {
 

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -15,6 +15,7 @@
  */
 
 import {Timer} from '../../src/timer';
+import * as sinon from 'sinon';
 
 describe('Timer', () => {
 

--- a/test/functional/test-transition.js
+++ b/test/functional/test-transition.js
@@ -15,6 +15,7 @@
  */
 
 import * as tr from '../../src/transition';
+import * as sinon from 'sinon';
 
 describe('Transition', () => {
 

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -23,6 +23,7 @@ import {createAmpElementProto} from '../../src/custom-element';
 import {viewerFor} from '../../src/viewer';
 import {resourcesFor} from '../../src/resources';
 import {VisibilityState} from '../../src/service/viewer-impl';
+import * as sinon from 'sinon';
 
 describe('Viewer Visibility State', () => {
 


### PR DESCRIPTION
Missing imports caused tests to fail sometimes, I've observed failures in `test-3p-frame` because of the missing `sinon` imports where it would fail with an ambiguous error of `.apply on undefined`. 

```log
Chrome 50.0.2661 (Mac OS X 10.11.4) 3p-frame "before each" hook for "add attributes" FAILED
	TypeError: Cannot read property 'apply' of undefined
	    at Object.useFakeTimers (/Users/mkhatib/amphtml/node_modules/karma-sinon-chai/node_modules/sinon/lib/sinon/sandbox.js:60:49)
	    at Context.<anonymous> (/var/folders/7w/bvjck7ls7f58m040x_qvph4w002y5_/T/04cec7eade73edf4e00348343b3bb3f1.browserify:60490:21 <- /Users/mkhatib/amphtml/test/functional/test-3p-frame.js:40:20)
```

After investigating that error was happening inside sinon sandbox library file where it tries to apply `useFakeTimer` method. Adding the proper import in the test file fixed this issue.