### PR TITLE
RFC: Add --files to allow running specific test files.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -62,6 +62,7 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 | `gulp test --saucelabs`       | Runs test on saucelabs (requires [setup](#saucelabs)).                |
 | `gulp test --safari`          | Runs tests in Safari.                                                 |
 | `gulp test --firefox`         | Runs tests in Firefox.                                                |
+| `gulp test --files=<test-files-path-glob>`         | Runs specific test files.                                                |
 | `gulp serve`                  | Serves content in repo root dir over http://localhost:8000/. Examples live in http://localhost:8000/examples.build/          |
 
 

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -117,6 +117,7 @@ var karma = {
 
 /** @const  */
 module.exports = {
+  commonTestPaths: commonTestPaths,
   testPaths: testPaths,
   integrationTestPaths: integrationTestPaths,
   karma: karma,

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -86,7 +86,13 @@ gulp.task('test', 'Runs tests', prerequisites, function(done) {
     c.client.captureConsole = true;
   }
 
-  if (argv.integration) {
+  if (argv.files) {
+    const files = [];
+    const passedPaths = Array.isArray(argv.files) ? argv.files : [argv.files];
+    config.commonTestPaths.forEach(file => files.push(file));
+    passedPaths.forEach(file => files.push(file));
+    c.files = files;
+  } else if (argv.integration) {
     c.files = config.integrationTestPaths;
   } else {
     c.files = config.testPaths;
@@ -115,5 +121,6 @@ gulp.task('test', 'Runs tests', prerequisites, function(done) {
         'binaries for execution',
     'oldchrome': 'Runs test with an old chrome. Saucelabs only.',
     'grep': 'Runs tests that match the pattern',
+    'files': 'Runs tests for specific files',
   }
 });

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -87,11 +87,7 @@ gulp.task('test', 'Runs tests', prerequisites, function(done) {
   }
 
   if (argv.files) {
-    const files = [];
-    const passedPaths = Array.isArray(argv.files) ? argv.files : [argv.files];
-    config.commonTestPaths.forEach(file => files.push(file));
-    passedPaths.forEach(file => files.push(file));
-    c.files = files;
+    c.files = [].concat(config.commonTestPaths, argv.files);
   } else if (argv.integration) {
     c.files = config.integrationTestPaths;
   } else {


### PR DESCRIPTION
Following are test runs for `test-amp-iframe.js` with the following command:


| Test | Single Run | Subsequent Watched Runs |
| ----- | --------------- | --------- |
| gulp test (describe.only - current flow)<br>gulp test | 59s | ~8s |
| gulp test (--files - build all extensions)<br>gulp test --files=extensions/amp-iframe/0.1/test/*.js | 36s | ~6s |
| gulp test (--files build only extensions being tested - this change)<br>gulp test --files=extensions/amp-iframe/0.1/test/*.js | *18s* | *~4s* |

Even with no speed wins this also allows us to run tests that are in multiple files or multiple `describe` blocks in the same file - currently not possible, one would have to keep doing `.only` on multiple describe blocks. Speed wins also gonna keep accumulate as we add more and more extensions.

In general this hopefully could be very useful during development where one is just incrementally adding tests and testing functionality in general.

I general this can even be faster with more optimization to what needs to be built or compiled. For example, as far as I can tell one wouldn't need to run `compile` in `build` step for running the unit tests, though not entirely sure (for example, the `test-amp-iframe` runs in 12s instead of 18s if `compile` is dropped). One can also probably skip building examples during running these kind of tests (though the saves from examples might be insignificant - ~1s - another ~1s for dropping `buildAlp` when not needed).

I think more importantly, this get rid of a lot of `.only` usage and forgetting it in source code to only realize the test failed after travis has ran `presubmit` - some usage still probably useful to run a single `describe` or `it` blocks.

cc/ @cramforce @dvoytenko @jridgewell @sriramkrish85 @erwinmombay 