### PR TITLE
Pass down the parent URL to disable glade in doubleclick test

### DIFF
--- a/test/integration/test-amp-ad-doubleclick.js
+++ b/test/integration/test-amp-ad-doubleclick.js
@@ -27,16 +27,10 @@ describe('Rendering of one ad', () => {
   function replaceUrl(win) {
     // TODO(#2402) Support glade as well.
     const path = '/test/fixtures/doubleclick.html?google_glade=0';
-    try {
-      win.location.hash = 'google_glade=0';
-      win.history.replaceState(null, null, path);
-    } catch (e) {
-      // Browsers are weird. Firefox gets here. We do, however, also in
-      // firefox pass down the parent URL. So we change that, which we
-      // can. We just need to change it back after the test.
-      beforeHref = win.parent.location.href;
-      win.parent.history.replaceState(null, null, path);
-    }
+    // We pass down the parent URL. So we change that, which we
+    // can. We just need to change it back after the test.
+    beforeHref = win.parent.location.href;
+    win.parent.history.replaceState(null, null, path);
   }
 
   beforeEach(() => {


### PR DESCRIPTION
As @cramforce suggested, this is the quickest way to fix the doubleclick integration test. 

Fixes #3001 

cc/ @erwinmombay 