### PR TITLE
Allow ads to declare loading distance

### DIFF
--- a/builtins/amp-ad.js
+++ b/builtins/amp-ad.js
@@ -57,15 +57,25 @@ export function installAd(win) {
         return false;
       }
 
+      // Legacy code from #2425, deprecated by the loading distance attribute.
       // Ad opts into lazier loading strategy where we only load ads that are
       // at closer than 1.25 viewports away.
-      if (this.element.getAttribute('data-loading-strategy') ==
-          'prefer-viewability-over-views') {
+      const loadingStrategy = this.element.getAttribute('data-loading-strategy');
+      if (loadingStrategy == 'prefer-viewability-over-views') {
         return 1.25;
       }
 
+      // Ad opts into lazier loading strategy where we only load ads that are
+      // at closer than `distance` viewports away.
+      const loadingDistance = parseFloat(
+          this.element.getAttribute('data-loading-distance')
+      );
+      if (!isNaN(loadingDistance)) {
+        return loadingDistance;
+      }
+
       // Otherwise the ad is good to go.
-      return super.renderOutsideViewport();
+      return true;
     }
 
     /** @override */

--- a/test/functional/test-amp-ad.js
+++ b/test/functional/test-amp-ad.js
@@ -397,7 +397,7 @@ function tests(name, installer) {
     });
 
     describe('renderOutsideViewport', () => {
-      function getGoodAd(cb, layoutCb, opt_loadingStrategy) {
+      function getGoodAd(cb, layoutCb, opt_attrs) {
         const attributes = {
           width: 300,
           height: 250,
@@ -409,8 +409,9 @@ function tests(name, installer) {
           // Test precedence
           'data-width': '6666',
         };
-        if (opt_loadingStrategy) {
-          attributes['data-loading-strategy'] = opt_loadingStrategy;
+        opt_attrs = opt_attrs || null;
+        for (var prop in opt_attrs) {
+          attributes[prop] = opt_attrs[prop];
         }
         return getAd(attributes, 'https://schema.org', element => {
           cb(element.implementation_);
@@ -421,7 +422,7 @@ function tests(name, installer) {
       it('should not return false after scrolling, then false for 1s', () => {
         let clock;
         return getGoodAd(ad => {
-          expect(ad.renderOutsideViewport()).not.to.be.false;
+          expect(ad.renderOutsideViewport()).to.be.true;
         }, () => {
           clock = sandbox.useFakeTimers();
         }).then(ad => {
@@ -430,23 +431,45 @@ function tests(name, installer) {
           clock.tick(900);
           expect(ad.renderOutsideViewport()).to.be.false;
           clock.tick(100);
-          expect(ad.renderOutsideViewport()).not.to.be.false;
+          expect(ad.renderOutsideViewport()).to.be.true;
         });
       });
 
       it('should prefer-viewability-over-views', () => {
         let clock;
         return getGoodAd(ad => {
-          expect(ad.renderOutsideViewport()).not.to.be.false;
+          expect(ad.renderOutsideViewport()).to.be.true;
         }, () => {
           clock = sandbox.useFakeTimers();
-        }, 'prefer-viewability-over-views').then(ad => {
+        }, {
+            'data-loading-strategy': 'prefer-viewability-over-views',
+            // Included to verify loading-strategy is prioritized.
+            'data-loading-distance': '2',
+        }).then(ad => {
           // False because we just rendered one.
           expect(ad.renderOutsideViewport()).to.be.false;
           clock.tick(900);
           expect(ad.renderOutsideViewport()).to.be.false;
           clock.tick(100);
           expect(ad.renderOutsideViewport()).to.equal(1.25);
+        });
+      });
+
+      it('should load inside loading-distance', () => {
+        let clock;
+        return getGoodAd(ad => {
+          expect(ad.renderOutsideViewport()).to.be.true;
+        }, () => {
+          clock = sandbox.useFakeTimers();
+        }, {
+            'data-loading-distance': '2',
+        }).then(ad => {
+          // False because we just rendered one.
+          expect(ad.renderOutsideViewport()).to.be.false;
+          clock.tick(900);
+          expect(ad.renderOutsideViewport()).to.be.false;
+          clock.tick(100);
+          expect(ad.renderOutsideViewport()).to.equal(2);
         });
       });
     });


### PR DESCRIPTION
Allows ads to declare they would like to render inside
`loading-distance` viewports, which will increase their viewability at
the expense of total "views".

https://github.com/ampproject/amphtml/pull/2693 had the unintended
consequence of forcing all ads to load only when they're close to the
viewport. This reverts that change, so ads will render however far
outside the viewport they are. Instead, ads may opt into a custom
distance (or the now-legacy `prefer-viewability-over-views`);

Closes #2565
