### PR TITLE
Added support for Linkpulse as a vendor in amp-analytics

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -519,13 +519,13 @@ For complete documentation and additional examples please see: https://marketing
 
 <!-- Linkpulse example - please replace id with your Linkpulse id -->
 <amp-analytics type="linkpulse">
-  <script type="application/json">
-     {
-       "vars": {
-               "id":"aabbcceedd00000000000000"
-        }
-     }
-  </script>
+<script type="application/json">
+{
+  "vars": {
+    "id": "aabbcceedd00000000000000"
+  }
+}
+</script>
 </amp-analytics>
 <!-- End Linkpulse example -->
 

--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -516,6 +516,19 @@ For complete documentation and additional examples please see: https://marketing
 </script>
 </amp-analytics>
 <!-- End Adobe Analytics example -->
+
+<!-- Linkpulse example - please replace id with your Linkpulse id -->
+<amp-analytics type="linkpulse">
+  <script type="application/json">
+     {
+       "vars": {
+               "id":"aabbcceedd00000000000000"
+        }
+     }
+  </script>
+</amp-analytics>
+<!-- End Linkpulse example -->
+
 </div>
 
 <div class="logo"></div>

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -99,5 +99,11 @@
   },
   "mpulse": {
     "onvisible": "https://$beacon_url?h.d=$h.d&h.key=$h.key&h.t=$h.t&h.cr=$h.cr&rt.start=navigation&rt.si=_client_id_&rt.ss=_timestamp_&rt.end=_timestamp_&t_resp=_nav_timing_&t_page=_nav_timing_&t_done=_nav_timing_&nt_nav_type=_nav_type_&nt_red_cnt=_nav_redirect_count_&nt_nav_st=_nav_timing_&nt_red_st=_nav_timing_&nt_red_end=_nav_timing_&nt_fet_st=_nav_timing_&nt_dns_st=_nav_timing_&nt_dns_end=_nav_timing_&nt_con_st=_nav_timing_&nt_ssl_st=_nav_timing_&nt_con_end=_nav_timing_&nt_req_st=_nav_timing_&nt_res_st=_nav_timing_&nt_unload_st=_nav_timing_&nt_unload_end=_nav_timing_&nt_domloading=_nav_timing_&nt_res_end=_nav_timing_&nt_domint=_nav_timing_&nt_domcontloaded_st=_nav_timing_&nt_domcontloaded_end=_nav_timing_&nt_domcomp=_nav_timing_&nt_load_st=_nav_timing_&nt_load_end=_nav_timing_&v=1&http.initiator=amp&u=_source_url_&amp.u=_ampdoc_url_&r2=_document_referrer_&scr.xy=_screen_width_x_screen_height_",
-  }
+  },
+ "linkpulse": {
+    "base": "https://$host",
+    "pageview": "https://$host/p?i=$id&r=_document_referrer_&p=$pageUrl&s=$section&t=$type&c=$channel&mt=_title_&_t=amp&_r=_random_",
+    "pageload": "https://$host/pl?i=$id&ct=_dom_interactive_time_&rt=_page_download_time_&pt=_page_load_time_&p=$pageUrl&c=$channel&t=$type&s=$section&_t=amp&_r=_random_",
+    "ping": "https://$host/u?i=$id&u=_client_id_&p=$pageUrl&uActive=true&isPing=yes&c=$channel&t=$type&s=$section&_t=amp&_r=_random_",
+  },
 }

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -87,6 +87,7 @@ export const ANALYTICS_CONFIG = {
     },
   },
 
+  
   'burt': {
     'vars': {
       'trackingKey': 'ignore',
@@ -670,6 +671,91 @@ export const ANALYTICS_CONFIG = {
       'custom_metric.': 'cmet.',
     },
   },
+
+    'linkpulse': {
+        'vars': {
+            'id'     : '',
+            'pageUrl': 'CANONICAL_URL',
+            'title'  : 'TITLE',
+            'section': '',
+            'channel': 'amp',
+            'type'   : '',
+            'host'   : 'pp.lp4.io',
+            'empty'  : '',
+        },
+        'requests': {
+            'base':'https://${host}',
+            'pageview':'${base}/p?i=${id}'+
+                '&r=${documentReferrer}'+
+                '&p=${pageUrl}'+
+                '&s=${section}'+
+                '&t=${type}'+ 
+                '&c=${channel}'+ 
+                '&mt=${title}'+
+                '&_t=amp'+ 
+                '&_r=${random}',
+           /* 'click': '${base}/c?i=${id}'+
+                '&tp=${sourceUrl}'+
+                '&ps=${empty}'+
+                '&p=${pageUrl}'+
+                '&s=${section}'+ 
+                '&t=${type}'+ 
+                '&c=${channel}'+
+                '&ct=${totalEngagedTime}'+
+                '&_t=amp'+ 
+                '&_r=${random}',*/
+            'pageload':'${base}/pl?i=${id}'+
+                '&ct=${domInteractiveTime}'+
+                '&rt=${pageDownloadTime}'+
+                '&pt=${pageLoadTime}'+
+                '&p=${pageUrl}'+
+                '&c=${channel}'+
+                '&t=${type}'+
+                '&s=${section}'+
+                '&_t=amp'+ 
+                '&_r=${random}',
+            'ping':'${base}/u?i=${id}'+
+                '&u=${clientId(_lp4_u)}'+
+                '&p=${pageUrl}'+
+                '&uActive=true'+
+                '&isPing=yes'+
+                '&c=${channel}'+
+                '&t=${type}'+
+                '&s=${section}'+
+                '&_t=amp'+ 
+                '&_r=${random}'
+        },
+        'triggers': {
+            'pageview': {
+                'on': 'visible',
+                'request': 'pageview',
+            },
+          /*  'click': {
+                'on': 'click',
+                'request': 'click',
+                'selector':'a'
+            },*/
+            'pageload':{
+                'on': 'visible',
+                'request': 'pageload',
+            },
+            'ping':{
+                'on': 'timer',
+                'timerSpec': {
+                    'interval': 30,
+                    'maxTimerLength': 7200
+                    },
+                'request': 'ping'
+                
+            },
+        },
+        'transport': {
+            'beacon':false,
+            'xhrpost':false,
+            'image':true,
+        }
+    },
+
 
 };
 ANALYTICS_CONFIG['infonline']['triggers']['pageview']['iframe' +

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -739,8 +739,6 @@ export const ANALYTICS_CONFIG = {
       'image': true,
     },
   },
-
-
 };
 ANALYTICS_CONFIG['infonline']['triggers']['pageview']['iframe' +
 /* TEMPORARY EXCEPTION */ 'Ping'] = true;

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -87,7 +87,6 @@ export const ANALYTICS_CONFIG = {
     },
   },
 
-  
   'burt': {
     'vars': {
       'trackingKey': 'ignore',
@@ -694,16 +693,6 @@ export const ANALYTICS_CONFIG = {
                 '&mt=${title}'+
                 '&_t=amp'+ 
                 '&_r=${random}',
-           /* 'click': '${base}/c?i=${id}'+
-                '&tp=${sourceUrl}'+
-                '&ps=${empty}'+
-                '&p=${pageUrl}'+
-                '&s=${section}'+ 
-                '&t=${type}'+ 
-                '&c=${channel}'+
-                '&ct=${totalEngagedTime}'+
-                '&_t=amp'+ 
-                '&_r=${random}',*/
             'pageload':'${base}/pl?i=${id}'+
                 '&ct=${domInteractiveTime}'+
                 '&rt=${pageDownloadTime}'+
@@ -730,11 +719,6 @@ export const ANALYTICS_CONFIG = {
                 'on': 'visible',
                 'request': 'pageview',
             },
-          /*  'click': {
-                'on': 'click',
-                'request': 'click',
-                'selector':'a'
-            },*/
             'pageload':{
                 'on': 'visible',
                 'request': 'pageload',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -671,74 +671,74 @@ export const ANALYTICS_CONFIG = {
     },
   },
 
-    'linkpulse': {
-        'vars': {
-            'id'     : '',
-            'pageUrl': 'CANONICAL_URL',
-            'title'  : 'TITLE',
-            'section': '',
-            'channel': 'amp',
-            'type'   : '',
-            'host'   : 'pp.lp4.io',
-            'empty'  : '',
-        },
-        'requests': {
-            'base':'https://${host}',
-            'pageview':'${base}/p?i=${id}'+
-                '&r=${documentReferrer}'+
-                '&p=${pageUrl}'+
-                '&s=${section}'+
-                '&t=${type}'+ 
-                '&c=${channel}'+ 
-                '&mt=${title}'+
-                '&_t=amp'+ 
-                '&_r=${random}',
-            'pageload':'${base}/pl?i=${id}'+
-                '&ct=${domInteractiveTime}'+
-                '&rt=${pageDownloadTime}'+
-                '&pt=${pageLoadTime}'+
-                '&p=${pageUrl}'+
-                '&c=${channel}'+
-                '&t=${type}'+
-                '&s=${section}'+
-                '&_t=amp'+ 
-                '&_r=${random}',
-            'ping':'${base}/u?i=${id}'+
-                '&u=${clientId(_lp4_u)}'+
-                '&p=${pageUrl}'+
-                '&uActive=true'+
-                '&isPing=yes'+
-                '&c=${channel}'+
-                '&t=${type}'+
-                '&s=${section}'+
-                '&_t=amp'+ 
-                '&_r=${random}'
-        },
-        'triggers': {
-            'pageview': {
-                'on': 'visible',
-                'request': 'pageview',
-            },
-            'pageload':{
-                'on': 'visible',
-                'request': 'pageload',
-            },
-            'ping':{
-                'on': 'timer',
-                'timerSpec': {
-                    'interval': 30,
-                    'maxTimerLength': 7200
-                    },
-                'request': 'ping'
-                
-            },
-        },
-        'transport': {
-            'beacon':false,
-            'xhrpost':false,
-            'image':true,
-        }
+  'linkpulse': {
+    'vars': {
+      'id': '',
+      'pageUrl': 'CANONICAL_URL',
+      'title': 'TITLE',
+      'section': '',
+      'channel': 'amp',
+      'type': '',
+      'host': 'pp.lp4.io',
+      'empty': '',
     },
+    'requests': {
+      'base': 'https://${host}',
+      'pageview': '${base}/p?i=${id}' +
+                '&r=${documentReferrer}' +
+                '&p=${pageUrl}' +
+                '&s=${section}' +
+                '&t=${type}' +
+                '&c=${channel}' +
+                '&mt=${title}' +
+                '&_t=amp' +
+                '&_r=${random}',
+      'pageload': '${base}/pl?i=${id}' +
+                '&ct=${domInteractiveTime}' +
+                '&rt=${pageDownloadTime}' +
+                '&pt=${pageLoadTime}' +
+                '&p=${pageUrl}' +
+                '&c=${channel}' +
+                '&t=${type}' +
+                '&s=${section}' +
+                '&_t=amp' +
+                '&_r=${random}',
+      'ping': '${base}/u?i=${id}' +
+                '&u=${clientId(_lp4_u)}' +
+                '&p=${pageUrl}' +
+                '&uActive=true' +
+                '&isPing=yes' +
+                '&c=${channel}' +
+                '&t=${type}' +
+                '&s=${section}' +
+                '&_t=amp' +
+                '&_r=${random}',
+    },
+    'triggers': {
+      'pageview': {
+        'on': 'visible',
+        'request': 'pageview',
+      },
+      'pageload': {
+        'on': 'visible',
+        'request': 'pageload',
+      },
+      'ping': {
+        'on': 'timer',
+        'timerSpec': {
+          'interval': 30,
+          'maxTimerLength': 7200,
+        },
+        'request': 'ping',
+
+      },
+    },
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true,
+    },
+  },
 
 
 };

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -204,7 +204,7 @@ Adds support for Webtrekk. Configuration details can be found at [supportcenter.
 
 Type attribute value: `linkpulse`
 
-Adds support for Linkpulse. Configuration details can be found at [docs.linkpulse.com)(http://docs.linkpulse.com)
+Adds support for Linkpulse. Configuration details can be found at [docs.linkpulse.com](http://docs.linkpulse.com)
 
 
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -146,6 +146,12 @@ Type attribute value: `krux`
 
 Adds support for Krux.  Configuration details can be found at [help.krux.com](https://konsole.zendesk.com/hc/en-us/articles/216596608).
 
+### Linkpulse
+
+Type attribute value: `linkpulse`
+
+Adds support for Linkpulse. Configuration details can be found at [docs.linkpulse.com](http://docs.linkpulse.com)
+
 ### Lotame
 
 Type attribute value: `lotame`
@@ -199,14 +205,6 @@ Adds support for Snowplow Analytics. More details for adding Snowplow Analytics 
 Type attribute value: `webtrekk`
 
 Adds support for Webtrekk. Configuration details can be found at [supportcenter.webtrekk.com](https://supportcenter.webtrekk.com/en/public/amp-analytics.html).
-
-### Linkpulse
-
-Type attribute value: `linkpulse`
-
-Adds support for Linkpulse. Configuration details can be found at [docs.linkpulse.com](http://docs.linkpulse.com)
-
-
 
 ## <a name="attributes"></a>Attributes
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -200,6 +200,14 @@ Type attribute value: `webtrekk`
 
 Adds support for Webtrekk. Configuration details can be found at [supportcenter.webtrekk.com](https://supportcenter.webtrekk.com/en/public/amp-analytics.html).
 
+### Linkpulse
+
+Type attribute value: `linkpulse`
+
+Adds support for Linkpulse. Configuration details can be found at [docs.linkpulse.com)(http://docs.linkpulse.com)
+
+
+
 ## <a name="attributes"></a>Attributes
 
   - `type` See [Analytics vendors](#analytics-vendors)


### PR DESCRIPTION
Initial support for Linkpulse as vendor in amp-analytics.

- Support Page impressions, Page timings and Unique users.

CLA is signed and submitted on behalf for my company.