### PR TITLE
Added support for extraUrlParams in trigger blocks and URL vars.

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -55,6 +55,9 @@ Container for analytics tags. Positioned far away from top to make sure that doe
       "vars": {
         "eventName": "page-loaded",
         "eventId": "42"
+      },
+      "extraUrlParams": {
+        "param1": "Another value"
       }
     },
     "visibility": {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -16,8 +16,7 @@
 
 import {ANALYTICS_CONFIG} from './vendors';
 import {addListener, instrumentationServiceFor} from './instrumentation';
-import {assertHttpsUrl, addParamsToUrl, appendParamStringToUrl,} from
-    '../../../src/url';
+import {assertHttpsUrl, addParamsToUrl} from '../../../src/url';
 import {dev, user} from '../../../src/log';
 import {expandTemplate} from '../../../src/string';
 import {installCidService} from './cid-impl';
@@ -364,14 +363,11 @@ export class AmpAnalytics extends AMP.BaseElement {
       const params = {};
       Object.assign(params, this.config_['extraUrlParams'],
           trigger['extraUrlParams']);
-      const extraUrlParams = addParamsToUrl('', params).substr(1);
-      if (extraUrlParams) {
-        const newRequest = request.replace('${extraUrlParams}', extraUrlParams);
-        if (newRequest == request) {
-          request = appendParamStringToUrl(request, extraUrlParams);
-        } else {
-          request = newRequest;
-        }
+      if (request.indexOf('${extraUrlParams}') >= 0) {
+        const extraUrlParams = addParamsToUrl('', params).substr(1);
+        request = request.replace('${extraUrlParams}', extraUrlParams);
+      } else {
+        request = addParamsToUrl(request, params);
       }
     }
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -172,8 +172,8 @@ export class AmpAnalytics extends AMP.BaseElement {
   /**
    * Replace the names of keys in params object with the values in replace map.
    *
-   * @param {Object<string, string>} params The params that need to be renamed.
-   * @param {Object<string, string>} replaceMap A map of pattern and replacement
+   * @param {!Object<string, string>} params The params that need to be renamed.
+   * @param {!Object<string, string>} replaceMap A map of pattern and replacement
    *    value.
    * @private
    */
@@ -186,9 +186,8 @@ export class AmpAnalytics extends AMP.BaseElement {
       for (const replaceMapKey in replaceMap) {
         if (++count > MAX_REPLACES) {
           user.error(this.getName_(),
-            'More than ' + MAX_REPLACES.toString() +
-            ' extraUrlParamsReplaceMap rules aren\'t allowed; Skipping the rest'
-          );
+              'More than ' + MAX_REPLACES + ' extraUrlParamsReplaceMap rules ' +
+              'aren\'t allowed; Skipping the rest');
           break;
         }
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -592,6 +592,14 @@ describe('amp-analytics', function() {
       };
     });
 
+    function verifyRequest() {
+      expect(sendRequestSpy.args[0][0]).to.have.string('v0=0');
+      expect(sendRequestSpy.args[0][0]).to.have.string('v1=1');
+      expect(sendRequestSpy.args[0][0]).to.not.have.string('s.evar1');
+      expect(sendRequestSpy.args[0][0]).to.not.have.string('s.evar0');
+      expect(sendRequestSpy.args[0][0]).to.have.string('foofoo=baz');
+    }
+
     it('are sent', () => {
       const analytics = getAnalyticsTag(config, {'config': 'config1'});
       return waitForSendRequest(analytics).then(() => {
@@ -604,11 +612,7 @@ describe('amp-analytics', function() {
       config.extraUrlParamsReplaceMap = {'s.evar': 'v'};
       const analytics = getAnalyticsTag(config , {'config': 'config1'});
       return waitForSendRequest(analytics).then(() => {
-        expect(sendRequestSpy.args[0][0]).to.have.string('v0=0');
-        expect(sendRequestSpy.args[0][0]).to.have.string('v1=1');
-        expect(sendRequestSpy.args[0][0]).to.not.have.string('s.evar1');
-        expect(sendRequestSpy.args[0][0]).to.not.have.string('s.evar0');
-        expect(sendRequestSpy.args[0][0]).to.have.string('foofoo=baz');
+        verifyRequest();
       });
     });
 
@@ -617,8 +621,9 @@ describe('amp-analytics', function() {
       config.extraUrlParamsReplaceMap = {'s.evar': 'v'};
       const analytics = getAnalyticsTag(config, {'config': 'config1'});
       return waitForSendRequest(analytics).then(() => {
-        expect(sendRequestSpy.args[0][0]).to.equal(
-            'https://example.com/helloworld?a=b&foofoo=baz&v0=0&v1=1&c=d&v=e');
+        verifyRequest();
+        expect(sendRequestSpy.args[0][0]).to.have.string('c=d');
+        expect(sendRequestSpy.args[0][0]).to.have.string('v=e');
       });
     });
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -581,36 +581,54 @@ describe('amp-analytics', function() {
     });
   });
 
-  it('sends extraUrlParams', () => {
-    const analytics = getAnalyticsTag({
-      'vars': {'host': 'example.com', 'path': 'helloworld'},
-      'extraUrlParams': {'s.evar0': '0', 's.evar1': '1', 'foofoo': 'baz'},
-      'requests': {'foo': 'https://${host}/${path}?a=b'},
-      'triggers': [{'on': 'visible', 'request': 'foo'}],
-    }, {
-      'config': 'config1',
+  describe('extraUrlParams', () => {
+    let config;
+    beforeEach(() => {
+      config = {
+        vars: {host: 'example.com', path: 'helloworld'},
+        extraUrlParams: {'s.evar0': '0', 's.evar1': '1', 'foofoo': 'baz'},
+        requests: {foo: 'https://${host}/${path}?a=b'},
+        triggers: {trig: {'on': 'visible', 'request': 'foo'}},
+      };
     });
-    return waitForSendRequest(analytics).then(() => {
-      expect(sendRequestSpy.args[0][0]).to.equal(
-          'https://example.com/helloworld?a=b&s.evar0=0&s.evar1=1&foofoo=baz');
-    });
-  });
 
-  it('handles extraUrlParamsReplaceMap', () => {
-    const analytics = getAnalyticsTag({
-      'extraUrlParams': {'s.evar0': '0', 's.evar1': '1', 'foofoo': 'baz'},
-      'extraUrlParamsReplaceMap': {'s.evar': 'v'},
-      'requests': {'foo': 'https://example.com/${title}'},
-      'triggers': [{'on': 'visible', 'request': 'foo'}],
-    }, {
-      'config': 'config1',
+    it('are sent', () => {
+      const analytics = getAnalyticsTag(config, {'config': 'config1'});
+      return waitForSendRequest(analytics).then(() => {
+        expect(sendRequestSpy.args[0][0]).to.equal(
+            'https://example.com/helloworld?a=b&s.evar0=0&s.evar1=1&foofoo=baz');
+      });
     });
-    return waitForSendRequest(analytics).then(() => {
-      expect(sendRequestSpy.args[0][0]).to.have.string('v0=0');
-      expect(sendRequestSpy.args[0][0]).to.have.string('v1=1');
-      expect(sendRequestSpy.args[0][0]).to.not.have.string('s.evar1');
-      expect(sendRequestSpy.args[0][0]).to.not.have.string('s.evar0');
-      expect(sendRequestSpy.args[0][0]).to.have.string('foofoo=baz');
+
+    it('are renamed by extraUrlParamsReplaceMap', () => {
+      config.extraUrlParamsReplaceMap = {'s.evar': 'v'};
+      const analytics = getAnalyticsTag(config , {'config': 'config1'});
+      return waitForSendRequest(analytics).then(() => {
+        expect(sendRequestSpy.args[0][0]).to.have.string('v0=0');
+        expect(sendRequestSpy.args[0][0]).to.have.string('v1=1');
+        expect(sendRequestSpy.args[0][0]).to.not.have.string('s.evar1');
+        expect(sendRequestSpy.args[0][0]).to.not.have.string('s.evar0');
+        expect(sendRequestSpy.args[0][0]).to.have.string('foofoo=baz');
+      });
+    });
+
+    it('are supported at trigger level', () => {
+      config.triggers.trig.extraUrlParams = {c: 'd', 's.evar': 'e'};
+      config.extraUrlParamsReplaceMap = {'s.evar': 'v'};
+      const analytics = getAnalyticsTag(config, {'config': 'config1'});
+      return waitForSendRequest(analytics).then(() => {
+        expect(sendRequestSpy.args[0][0]).to.equal(
+            'https://example.com/helloworld?a=b&foofoo=baz&v0=0&v1=1&c=d&v=e');
+      });
+    });
+
+    it('are supported as a var in URL', () => {
+      config.requests.foo = 'https://${host}/${path}?${extraUrlParams}&a=b';
+      const analytics = getAnalyticsTag(config, {'config': 'config1'});
+      return waitForSendRequest(analytics).then(() => {
+        expect(sendRequestSpy.args[0][0]).to.equal(
+            'https://example.com/helloworld?s.evar0=0&s.evar1=1&foofoo=baz&a=b');
+      });
     });
   });
 

--- a/extensions/amp-analytics/analytics-vars.md
+++ b/extensions/amp-analytics/analytics-vars.md
@@ -315,6 +315,14 @@ Example usage: `${clientId(foo)}`
 
 Example value: `U6XEpUs3yaeQyR2DKATQH1pTZ6kg140fvuLbtl5nynbUWtIodJxP5TEIYBic4qcV`
 
+### extraUrlParams
+
+Provides all the params defined in extraUrlParams block of the config as a variable. If this variable is used, the parameters are not appended to the end of the URL.
+
+Example usage: `${extraUrlParams}`
+
+Example value: 'foo=bar&baz=something'
+
 ### pageViewId
 
 Provides a string that is intended to be random and likely to be unique per URL, user and day.

--- a/src/url.js
+++ b/src/url.js
@@ -69,7 +69,7 @@ export function parseUrl(url) {
  * @param {boolean=} opt_addToFront
  * @return {string}
  */
-export function appendParamStringToUrl(url, paramString, opt_addToFront) {
+function appendParamStringToUrl(url, paramString, opt_addToFront) {
   if (!paramString) {
     return url;
   }

--- a/src/url.js
+++ b/src/url.js
@@ -69,7 +69,7 @@ export function parseUrl(url) {
  * @param {boolean=} opt_addToFront
  * @return {string}
  */
-function appendParamStringToUrl(url, paramString, opt_addToFront) {
+export function appendParamStringToUrl(url, paramString, opt_addToFront) {
   if (!paramString) {
     return url;
   }


### PR DESCRIPTION
- params in trigger block override the ones at top level config. #2422
- If the extraUrlParams variable is used in request URL, it is replaces
  with extra params and the params are not appended to the url. #2423

/cc @rudygalfi 