### PR TITLE
Build elements only when they are ready - @mkhatib

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -435,31 +435,19 @@ export function createAmpElementProto(win, name, implementationClass) {
    * Requests or requires the element to be built. The build is done by
    * invoking {@link BaseElement.buildCallback} method.
    *
-   * If the "force" argument is "false", the element will first check if
-   * implementation is ready to build by calling
-   * {@link BaseElement.isReadyToBuild} method. If this method returns "true"
-   * the build proceeds, otherwise no build is done.
-   *
-   * If the "force" argument is "true", the element performs build regardless
-   * of what {@link BaseElement.isReadyToBuild} would return.
-   *
    * Returned value indicates whether or not build has been performed.
    *
    * This method can only be called on a upgraded element.
    *
-   * @param {boolean} force Whether or not force the build.
    * @return {boolean}
    * @final @this {!Element}
    */
-  ElementProto.build = function(force) {
+  ElementProto.build = function() {
     this.assertNotTemplate_();
     if (this.isBuilt()) {
       return true;
     }
     dev.assert(this.isUpgraded(), 'Cannot build unupgraded element');
-    if (!force) {
-      return false;
-    }
     try {
       this.implementation_.buildCallback();
       this.preconnect(/* onLayout */ false);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -435,17 +435,14 @@ export function createAmpElementProto(win, name, implementationClass) {
    * Requests or requires the element to be built. The build is done by
    * invoking {@link BaseElement.buildCallback} method.
    *
-   * Returned value indicates whether or not build has been performed.
-   *
    * This method can only be called on a upgraded element.
    *
-   * @return {boolean}
    * @final @this {!Element}
    */
   ElementProto.build = function() {
     this.assertNotTemplate_();
     if (this.isBuilt()) {
-      return true;
+      return;
     }
     dev.assert(this.isUpgraded(), 'Cannot build unupgraded element');
     try {
@@ -476,7 +473,6 @@ export function createAmpElementProto(win, name, implementationClass) {
         this.appendChild(placeholder);
       }
     }
-    return true;
   };
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -457,7 +457,7 @@ export function createAmpElementProto(win, name, implementationClass) {
       return true;
     }
     dev.assert(this.isUpgraded(), 'Cannot build unupgraded element');
-    if (!force && !this.implementation_.isReadyToBuild()) {
+    if (!force) {
       return false;
     }
     try {

--- a/src/dom.js
+++ b/src/dom.js
@@ -383,3 +383,19 @@ export function getDataParamsFromAttributes(element, opt_computeParamNameFunc) {
   }
   return params;
 }
+
+
+/**
+ * Whether the element has been already fully parsed by the browser.
+ * @param {!Element} element
+ * @return {boolean}
+ */
+export function isElementFullyParsed(element) {
+  let currentElement = element;
+  do {
+    if (currentElement.nextSibling) {
+      return true;
+    }
+  } while (currentElement = element.parentNode);
+  return false;
+}

--- a/src/dom.js
+++ b/src/dom.js
@@ -386,11 +386,14 @@ export function getDataParamsFromAttributes(element, opt_computeParamNameFunc) {
 
 
 /**
- * Whether the element has been already fully parsed by the browser.
+ * Whether the element have a next node in the document order.
+ * This means either:
+ *  a. The element itself has a nextSibling.
+ *  b. Any of the element ancestors has a nextSibling.
  * @param {!Element} element
  * @return {boolean}
  */
-export function isElementFullyParsed(element) {
+export function hasNextNodeInDocumentOrder(element) {
   let currentElement = element;
   do {
     if (currentElement.nextSibling) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -430,7 +430,7 @@ export class Resources {
     if (index != -1) {
       this.resources_.splice(index, 1);
     }
-    this.cleanupTasks_(resource, /** removePending */ true);
+    this.cleanupTasks_(resource, /* opt_removePending */ true);
     dev.fine(TAG_, 'element removed:', resource.debugid);
   }
 
@@ -1519,7 +1519,8 @@ export class Resources {
           request => request.resource != resource);
     }
 
-    if (resource.getState() == ResourceState_.NOT_BUILT && opt_removePending) {
+    if (resource.getState() == ResourceState_.NOT_BUILT && opt_removePending &&
+        this.pendingBuildResources_) {
       const pendingIndex = this.pendingBuildResources_.indexOf(resource);
       if (pendingIndex != -1) {
         this.pendingBuildResources_.splice(pendingIndex, 1);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -138,7 +138,7 @@ export class Resources {
     /** @private {!Array<!Function>} */
     this.deferredMutates_ = [];
 
-    /** @private {?Array<!Element>} */
+    /** @private {?Array<!Resource>} */
     this.pendingBuildResources_ = [];
 
     /** @private {number} */
@@ -430,6 +430,7 @@ export class Resources {
     if (index != -1) {
       this.resources_.splice(index, 1);
     }
+    this.cleanupTasks_(resource, /** removePending */ true);
     dev.fine(TAG_, 'element removed:', resource.debugid);
   }
 
@@ -1498,9 +1499,10 @@ export class Resources {
   /**
    * Cleanup task queues from tasks for elements that has been unloaded.
    * @param resource
+   * @param opt_removePending Whether to remove from pending build resources.
    * @private
    */
-  cleanupTasks_(resource) {
+  cleanupTasks_(resource, opt_removePending) {
     if (resource.getState() == ResourceState_.NOT_LAID_OUT) {
       // If the layout promise for this resource has not resolved yet, remove
       // it from the task queues to make sure this resource can be rescheduled
@@ -1515,6 +1517,13 @@ export class Resources {
       });
       this.requestsChangeSize_ = this.requestsChangeSize_.filter(
           request => request.resource != resource);
+    }
+
+    if (resource.getState() == ResourceState_.NOT_BUILT && opt_removePending) {
+      const pendingIndex = this.pendingBuildResources_.indexOf(resource);
+      if (pendingIndex != -1) {
+        this.pendingBuildResources_.splice(pendingIndex, 1);
+      }
     }
   }
 }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -394,8 +394,8 @@ export class Resources {
         this.schedulePass();
       } else {
         this.pendingBuildResources_.push(element);
+        this.buildReadyResources_();
       }
-      this.buildReadyResources_();
     }
 
     dev.fine(TAG_, 'element added:', resource.debugid);

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -458,15 +458,15 @@ describe('DOM', () => {
     });
   });
 
-  describe.only('isElementFullyParsed', () => {
+  describe('hasNextNodeInDocumentOrder', () => {
     it('should return true when the element has a nextSibling', () => {
       const element = document.createElement('div');
       const parent = document.createElement('div');
       const sibling = document.createElement('div');
-      expect(dom.isElementFullyParsed(element)).to.be.false;
+      expect(dom.hasNextNodeInDocumentOrder(element)).to.be.false;
       parent.appendChild(element);
       parent.appendChild(sibling);
-      expect(dom.isElementFullyParsed(element)).to.be.true;
+      expect(dom.hasNextNodeInDocumentOrder(element)).to.be.true;
     });
 
     it('should return true when element ancestor has nextSibling', () => {
@@ -474,11 +474,11 @@ describe('DOM', () => {
       const parent = document.createElement('div');
       const uncle = document.createElement('div');
       const ancestor = document.createElement('div');
-      expect(dom.isElementFullyParsed(element)).to.be.false;
+      expect(dom.hasNextNodeInDocumentOrder(element)).to.be.false;
       ancestor.appendChild(parent);
       ancestor.appendChild(uncle);
       parent.appendChild(element);
-      expect(dom.isElementFullyParsed(element)).to.be.true;
+      expect(dom.hasNextNodeInDocumentOrder(element)).to.be.true;
     });
   });
 });

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -457,4 +457,28 @@ describe('DOM', () => {
       expect(params.attr1).to.be.undefined;
     });
   });
+
+  describe.only('isElementFullyParsed', () => {
+    it('should return true when the element has a nextSibling', () => {
+      const element = document.createElement('div');
+      const parent = document.createElement('div');
+      const sibling = document.createElement('div');
+      expect(dom.isElementFullyParsed(element)).to.be.false;
+      parent.appendChild(element);
+      parent.appendChild(sibling);
+      expect(dom.isElementFullyParsed(element)).to.be.true;
+    });
+
+    it('should return true when element ancestor has nextSibling', () => {
+      const element = document.createElement('div');
+      const parent = document.createElement('div');
+      const uncle = document.createElement('div');
+      const ancestor = document.createElement('div');
+      expect(dom.isElementFullyParsed(element)).to.be.false;
+      ancestor.appendChild(parent);
+      ancestor.appendChild(uncle);
+      parent.appendChild(element);
+      expect(dom.isElementFullyParsed(element)).to.be.true;
+    });
+  });
 });

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -659,6 +659,9 @@ describe('Resources discoverWork', () => {
   });
 
   it('should eject stale tasks when element unloaded', () => {
+    const pendingResource = createResource(5, layoutRectLtwh(0, 0, 0, 0));
+    pendingResource.state_ = ResourceState_.NOT_BUILT;
+    resources.pendingBuildResources_ = [pendingResource];
     resources.visible_ = true;
     // Don't resolve layout - immulating DOM being removed and load
     // promise not resolving.
@@ -679,6 +682,7 @@ describe('Resources discoverWork', () => {
     expect(resources.queue_.getSize()).to.equal(2);
     expect(resources.queue_.tasks_[0].resource).to.equal(resource1);
     expect(resources.queue_.tasks_[1].resource).to.equal(resource2);
+    expect(resources.pendingBuildResources_.length).to.equal(1);
 
     resources.work_();
     expect(resources.exec_.getSize()).to.equal(2);
@@ -699,8 +703,13 @@ describe('Resources discoverWork', () => {
 
     // Removes them even from scheduling queue.
     resource2.unload();
-    resources.cleanupTasks_(resource2);
+    resources.cleanupTasks_(resource2, /*opt_removePending*/true);
     expect(resources.queue_.getSize()).to.equal(0);
+    expect(resources.pendingBuildResources_.length).to.equal(1);
+
+    const pendingElement = {'__AMP__RESOURCE': pendingResource};
+    resources.remove(pendingElement);
+    expect(resources.pendingBuildResources_.length).to.equal(0);
   });
 
 });

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -703,7 +703,7 @@ describe('Resources discoverWork', () => {
 
     // Removes them even from scheduling queue.
     resource2.unload();
-    resources.cleanupTasks_(resource2, /*opt_removePending*/true);
+    resources.cleanupTasks_(resource2, /* opt_removePending */ true);
     expect(resources.queue_.getSize()).to.equal(0);
     expect(resources.pendingBuildResources_.length).to.equal(1);
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -2600,5 +2600,5 @@ describe('Resources.add', () => {
       expect(parent.build.called).to.be.true;
       expect(resources.pendingBuildResources_.length).to.be.equal(0);
     });
-  })
+  });
 });


### PR DESCRIPTION
So, this only checks if the element has its `nextSibling` and does not traverse the parent tree. Waiting on reply on #3081 to understand why do we need to traverse the parents.

If this looks good, I can start adding tests as well!

Fixes #3081 