### PR TITLE
Exploration to fix memory leaks in tests.

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -404,6 +404,9 @@ export class Resources {
   remove(element) {
     const resource = this.getResourceForElement(element);
     const index = resource ? this.resources_.indexOf(resource) : -1;
+    if (resource) {
+      resource.element[RESOURCE_PROP_] = null;
+    }
     if (index != -1) {
       this.resources_.splice(index, 1);
     }

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -76,7 +76,7 @@ sinon.sandbox.create = function(config) {
 // Global cleanup of tags added during tests. Cool to add more
 // to selector.
 afterEach(() => {
-  const cleanup = document.querySelectorAll('link,meta');
+  const cleanup = document.querySelectorAll('link,meta,iframe');
   for (let i = 0; i < cleanup.length; i++) {
     try {
       const element = cleanup[i];

--- a/test/functional/test-3p-environment.js
+++ b/test/functional/test-3p-environment.js
@@ -35,6 +35,10 @@ describe('3p environment', () => {
     });
   });
 
+  afterEach(() => {
+    testWin = null;
+  });
+
   it('should instrument a window', () => {
     expect(testWin.setTimeout).to.match(/native/);
     manageWin(testWin);

--- a/test/functional/test-3p-messaging.js
+++ b/test/functional/test-3p-messaging.js
@@ -36,6 +36,10 @@ describe('3p messaging', () => {
     });
   });
 
+  afterEach(() => {
+    testWin = null;
+  });
+
   it('should receive messages', () => {
     let progress = '';
     listenParent(testWin, 'test', function(d) {

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -19,7 +19,7 @@ import {BaseElement} from '../../src/base-element';
 import {installImg, AmpImg} from '../../builtins/amp-img';
 import * as sinon from 'sinon';
 
-describe('amp-img', () => {
+describe('amp-img unit', () => {
   let sandbox;
 
   beforeEach(() => {


### PR DESCRIPTION
Inspired by @mkhatib I spent a totally unreasonable amount of time last night trying to figure out how we are leaking windows in our unit tests.

For now I'd just like to document what I've found:

- We should obviously start removing iframes after tests run. That is obvious and was only removed due to issues with Safari. Even if we only do this outside of Safari it would still be better.
- Most tests are just fine. Because of that, only the above change is well worth it. We do have **166** leaks out of about 2000 tests, though. More precisely we leak that many `Resources` objects. It appears we only (after my changes here) leak 13 `Windows` (and 73 Window proxies if I read the heap dump correctly).
- When the `console` is open we leak 100s of objects, because the console keeps them alive. We will need to change our logger to stringify all objects, because this is unacceptable. The alternative would be to turn off logging during full test runs. CC @dvoytenko 
- I found one leak in integration tests in `iframe.js` that would leak the window used by the last test that was run. Respectively this only leaks a single window ever, so it is not the cause of the more widespread leaks. Fixed.
- Tests that use a pattern like `let testWin; beforeEach(() => { testWin = getWin() })` leak the window. In particular, they leak the last window created for a given describe block. I audited a subset of tests to add an `afterEach` to fix the leak. This fixes a few links, but doesn't get us close to 0.
- I suspect, but haven't actually proven, that there are more subtle variants of this involving detached DOM nodes leaking their `ownerDocument.defaultView`.
- To reduce the severity of the above I added 2 defense in depth mechanisms. The helpers in `iframe.js` resolve a promise with an object pointing to the windows and elements created for a fixture/canvas iframe. I added an `onunload` event handler to the created iframe, so that, then it is removed from the DOM, it destroys the references in the resolved object. That way when you only leak the handle to the window, as opposed to the window, then there is no leak.