### PR TITLE
Server-side access prototype

### DIFF
--- a/extensions/amp-access/0.1/amp-access-client.js
+++ b/extensions/amp-access/0.1/amp-access-client.js
@@ -66,6 +66,13 @@ export class AccessClientAdapter {
     };
   }
 
+  /**
+   * @return {string}
+   */
+  getAuthorizationUrl() {
+    return this.authorizationUrl_;
+  }
+
   /** @override */
   isAuthorizationEnabled() {
     return true;

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -95,15 +95,16 @@ export class AccessServerAdapter {
     this.serverState_ = stateElement ?
         stateElement.getAttribute('content') : null;
 
-    /** @private @const {boolean} */
-    this.isProxyOrigin_ = isProxyOrigin(this.win.location);
+    const isInExperiment = isExperimentOn(win, TAG);
 
-    const serviceUrlOverride = isExperimentOn(win, TAG) ?
+    /** @private @const {boolean} */
+    this.isProxyOrigin_ = isProxyOrigin(win.location) || isInExperiment;
+
+    const serviceUrlOverride = isInExperiment ?
         this.viewer_.getParam('serverAccessService') : null;
 
     /** @private @const {string} */
-    this.serviceUrl_ = serviceUrlOverride ||
-        removeFragment(this.win.location.href);
+    this.serviceUrl_ = serviceUrlOverride || removeFragment(win.location.href);
   }
 
   /** @override */

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AccessClientAdapter} from './amp-access-client';
+import {isProxyOrigin, removeFragment} from '../../../src/url';
+import {dev} from '../../../src/log';
+import {timer} from '../../../src/timer';
+import {vsyncFor} from '../../../src/vsync';
+import {xhrFor} from '../../../src/xhr';
+
+/** @const {string} */
+const TAG = 'amp-access-server';
+
+/** @const {number} */
+const AUTHORIZATION_TIMEOUT = 3000;
+
+
+/** @implements {AccessTypeAdapterDef} */
+export class AccessServerAdapter {
+
+  /**
+   * @param {!Window} win
+   * @param {!JSONObject} configJson
+   * @param {!AccessTypeAdapterContextDef} context
+   */
+  constructor(win, configJson, context) {
+    /** @const {!Window} */
+    this.win = win;
+
+    /** @const @private {!AccessTypeAdapterContextDef} */
+    this.context_ = context;
+
+    /** @private @const */
+    this.clientAdapter_ = new AccessClientAdapter(win, configJson, context);
+
+    /** @const @private {!Xhr} */
+    this.xhr_ = xhrFor(win);
+
+    /** @const @private {!Timer} */
+    this.timer_ = timer;
+
+    /** @const @private {!Vsync} */
+    this.vsync_ = vsyncFor(win);
+
+    const stateElement = this.win.document.querySelector(
+        'meta[name="i-amp-access-state"]');
+
+    /** @private @const {?string} */
+    this.serverState_ = stateElement ?
+        stateElement.getAttribute('content') : null;
+
+    /** @private @const {boolean} */
+    this.isProxyOrigin_ = isProxyOrigin(this.win.location);
+
+    /** @private @const {string} */
+    this.serviceUrl_ = removeFragment(this.win.location.href);
+  }
+
+  /** @override */
+  getConfig() {
+    return {
+      'client': this.clientAdapter_.getConfig(),
+      'proxy': this.isProxyOrigin_,
+      'serverState': this.serverState_,
+    };
+  }
+
+  /** @override */
+  isAuthorizationEnabled() {
+    return true;
+  }
+
+  /** @override */
+  authorize() {
+    dev.fine(TAG, 'Start authorization with ',
+        this.isProxyOrigin_ ? 'proxy' : 'non-proxy',
+        this.serverState_,
+        this.clientAdapter_.getAuthorizationUrl());
+    if (!this.isProxyOrigin_ || !this.serverState_) {
+      dev.fine(TAG, 'Proceed via client protocol');
+      return this.clientAdapter_.authorize();
+    }
+
+    dev.fine(TAG, 'Proceed via server protocol');
+
+    const varsPromise = this.context_.collectUrlVars(
+        this.clientAdapter_.getAuthorizationUrl(),
+        /* useAuthData */ false);
+    return varsPromise.then(vars => {
+      const requestVars = {};
+      for (const k in vars) {
+        if (vars[k] != null) {
+          requestVars[k] = String(vars[k]);
+        }
+      }
+      const request = {
+        'state': this.serverState_,
+        'vars': requestVars,
+      };
+      dev.fine(TAG, 'Authorization request: ', this.serviceUrl_, request);
+      // Note that `application/x-www-form-urlencoded` is used to avoid
+      // CORS preflight request.
+      return this.timer_.timeoutPromise(
+          AUTHORIZATION_TIMEOUT,
+          this.xhr_.fetchDocument(this.serviceUrl_, {
+            method: 'POST',
+            body: 'request=' + encodeURIComponent(JSON.stringify(request)),
+            credentials: 'include',
+            requireAmpResponseSourceOrigin: true,
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+          }));
+    }).then(response => {
+      dev.fine(TAG, 'Authorization response: ', response);
+      const accessDataString = dev.assert(
+          response.querySelector('script[id="amp-access-data"]'),
+          'No authorization data available').textContent;
+      const accessData = JSON.parse(accessDataString);
+      dev.fine(TAG, '- access data: ', accessData);
+
+      return this.replaceSections_(response).then(() => {
+        return accessData;
+      });
+    });
+  }
+
+  /** @override */
+  pingback() {
+    return this.clientAdapter_.pingback();
+  }
+
+  /**
+   * @param {!Document} doc
+   * @return {!Promise}
+   */
+  replaceSections_(doc) {
+    const sections = doc.querySelectorAll('[i-amp-access-id]');
+    dev.fine(TAG, '- access sections: ', sections);
+    return this.vsync_.mutatePromise(() => {
+      for (let i = 0; i < sections.length; i++) {
+        const section = sections[i];
+        const sectionId = section.getAttribute('i-amp-access-id');
+        const target = this.win.document.querySelector(
+            '[i-amp-access-id=' + sectionId + ']');
+        if (!target) {
+          dev.warn(TAG, 'Section not found: ', sectionId);
+          continue;
+        }
+        target.parentElement.replaceChild(
+            this.win.document.importNode(section, /* deep */ true),
+            target);
+      }
+    });
+  }
+}

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -15,6 +15,7 @@
  */
 
 import {AccessServerAdapter} from '../amp-access-server';
+import {removeFragment} from '../../../../src/url';
 import * as sinon from 'sinon';
 
 describe('AccessServerAdapter', () => {
@@ -159,6 +160,7 @@ describe('AccessServerAdapter', () => {
             }))
             .once();
         const request = {
+          'url': removeFragment(window.location.href),
           'state': 'STATE1',
           'vars': {
             'READER_ID': 'reader1',
@@ -169,8 +171,6 @@ describe('AccessServerAdapter', () => {
             .withExactArgs('http://localhost:8000/af', {
               method: 'POST',
               body: 'request=' + encodeURIComponent(JSON.stringify(request)),
-              credentials: 'include',
-              requireAmpResponseSourceOrigin: true,
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },
@@ -200,6 +200,7 @@ describe('AccessServerAdapter', () => {
             }))
             .once();
         const request = {
+          'url': removeFragment(window.location.href),
           'state': 'STATE1',
           'vars': {
             'READER_ID': 'reader1',
@@ -210,8 +211,6 @@ describe('AccessServerAdapter', () => {
             .withExactArgs('http://localhost:8000/af', {
               method: 'POST',
               body: 'request=' + encodeURIComponent(JSON.stringify(request)),
-              credentials: 'include',
-              requireAmpResponseSourceOrigin: true,
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },
@@ -237,6 +236,7 @@ describe('AccessServerAdapter', () => {
             }))
             .once();
         const request = {
+          'url': removeFragment(window.location.href),
           'state': 'STATE1',
           'vars': {
             'READER_ID': 'reader1',
@@ -247,8 +247,6 @@ describe('AccessServerAdapter', () => {
             .withExactArgs('http://localhost:8000/af', {
               method: 'POST',
               body: 'request=' + encodeURIComponent(JSON.stringify(request)),
-              credentials: 'include',
-              requireAmpResponseSourceOrigin: true,
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -1,0 +1,304 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AccessServerAdapter} from '../amp-access-server';
+import * as sinon from 'sinon';
+
+describe('AccessServerAdapter', () => {
+
+  let sandbox;
+  let clock;
+  let validConfig;
+  let context;
+  let contextMock;
+  let meta;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
+
+    validConfig = {
+      'authorization': 'https://acme.com/a?rid=READER_ID',
+      'pingback': 'https://acme.com/p?rid=READER_ID',
+    };
+
+    meta = document.createElement('meta');
+    meta.setAttribute('name', 'i-amp-access-state');
+    meta.setAttribute('content', 'STATE1');
+    document.head.appendChild(meta);
+
+    context = {
+      buildUrl: () => {},
+      collectUrlVars: () => {},
+    };
+    contextMock = sandbox.mock(context);
+  });
+
+  afterEach(() => {
+    contextMock.verify();
+    sandbox.restore();
+    if (meta.parentNode) {
+      document.head.removeChild(meta);
+    }
+  });
+
+
+  describe('config', () => {
+    it('should load valid config', () => {
+      const adapter = new AccessServerAdapter(window, validConfig, context);
+      expect(adapter.clientAdapter_.authorizationUrl_).to
+          .equal('https://acme.com/a?rid=READER_ID');
+      expect(adapter.clientAdapter_.pingbackUrl_).to
+          .equal('https://acme.com/p?rid=READER_ID');
+      expect(adapter.serverState_).to.equal('STATE1');
+      expect(adapter.isProxyOrigin_).to.be.false;
+    });
+
+    it('should fail if config is invalid', () => {
+      delete validConfig['authorization'];
+      expect(() => {
+        new AccessServerAdapter(window, validConfig, context);
+      }).to.throw(/"authorization" URL must be specified/);
+    });
+
+    it('should tolerate when i-amp-access-state is missing', () => {
+      document.head.removeChild(meta);
+      const adapter = new AccessServerAdapter(window, validConfig, context);
+      expect(adapter.serverState_).to.be.null;
+    });
+  });
+
+  describe('runtime', () => {
+
+    let adapter;
+    let clientAdapter;
+    let clientAdapterMock;
+    let xhrMock;
+    let responseDoc;
+    let targetElement1, targetElement2;
+
+    beforeEach(() => {
+      adapter = new AccessServerAdapter(window, validConfig, context);
+      xhrMock = sandbox.mock(adapter.xhr_);
+
+      clientAdapter = {
+        getAuthorizationUrl: () => validConfig['authorization'],
+        isAuthorizationEnabled: () => true,
+        authorize: () => Promise.resolve({}),
+        pingback: () => Promise.resolve(),
+      };
+      clientAdapterMock = sandbox.mock(clientAdapter);
+      adapter.clientAdapter_ = clientAdapter;
+
+      adapter.isProxyOrigin_ = true;
+
+      responseDoc = document.createElement('div');
+
+      const responseAccessData = document.createElement('script');
+      responseAccessData.setAttribute('type', 'application/json');
+      responseAccessData.setAttribute('id', 'amp-access-data');
+      responseAccessData.textContent = JSON.stringify({'access': 'A'});
+      responseDoc.appendChild(responseAccessData);
+
+      targetElement1 = document.createElement('div');
+      targetElement1.setAttribute('i-amp-access-id', 'a1');
+      document.body.appendChild(targetElement1);
+
+      targetElement2 = document.createElement('div');
+      targetElement2.setAttribute('i-amp-access-id', 'a2');
+      document.body.appendChild(targetElement2);
+    });
+
+    afterEach(() => {
+      clientAdapterMock.verify();
+      xhrMock.verify();
+    });
+
+    describe('authorize', () => {
+
+      it('should fallback to client auth when not on proxy', () => {
+        adapter.isProxyOrigin_ = false;
+        const p = Promise.resolve();
+        clientAdapterMock.expects('authorize').returns(p).once();
+        xhrMock.expects('fetchDocument').never();
+        const result = adapter.authorize();
+        expect(result).to.equal(p);
+      });
+
+      it('should fallback to client auth w/o server state', () => {
+        adapter.serverState_ = null;
+        const p = Promise.resolve();
+        clientAdapterMock.expects('authorize').returns(p).once();
+        xhrMock.expects('fetchDocument').never();
+        const result = adapter.authorize();
+        expect(result).to.equal(p);
+      });
+
+      it('should execute authorize-and-fill', () => {
+        adapter.serviceUrl_ = 'http://localhost:8000/af';
+        contextMock.expects('collectUrlVars')
+            .withExactArgs(
+                'https://acme.com/a?rid=READER_ID',
+                /* useAuthData */ false)
+            .returns(Promise.resolve({
+              'READER_ID': 'reader1',
+              'OTHER': 123,
+            }))
+            .once();
+        const request = {
+          'state': 'STATE1',
+          'vars': {
+            'READER_ID': 'reader1',
+            'OTHER': '123',
+          },
+        };
+        xhrMock.expects('fetchDocument')
+            .withExactArgs('http://localhost:8000/af', {
+              method: 'POST',
+              body: 'request=' + encodeURIComponent(JSON.stringify(request)),
+              credentials: 'include',
+              requireAmpResponseSourceOrigin: true,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+            })
+            .returns(Promise.resolve(responseDoc))
+            .once();
+        const replaceSectionsStub = sandbox.stub(adapter, 'replaceSections_',
+            () => {
+              return Promise.resolve();
+            });
+        return adapter.authorize().then(response => {
+          expect(response).to.exist;
+          expect(response.access).to.equal('A');
+          expect(replaceSectionsStub.callCount).to.equal(1);
+        });
+      });
+
+      it('should fail when XHR fails', () => {
+        adapter.serviceUrl_ = 'http://localhost:8000/af';
+        contextMock.expects('collectUrlVars')
+            .withExactArgs(
+                'https://acme.com/a?rid=READER_ID',
+                /* useAuthData */ false)
+            .returns(Promise.resolve({
+              'READER_ID': 'reader1',
+              'OTHER': 123,
+            }))
+            .once();
+        const request = {
+          'state': 'STATE1',
+          'vars': {
+            'READER_ID': 'reader1',
+            'OTHER': '123',
+          },
+        };
+        xhrMock.expects('fetchDocument')
+            .withExactArgs('http://localhost:8000/af', {
+              method: 'POST',
+              body: 'request=' + encodeURIComponent(JSON.stringify(request)),
+              credentials: 'include',
+              requireAmpResponseSourceOrigin: true,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+            })
+            .returns(Promise.reject('intentional'))
+            .once();
+        return adapter.authorize().then(() => {
+          throw new Error('must never happen');
+        }, error => {
+          expect(error).to.match(/intentional/);
+        });
+      });
+
+      it('should time out XHR fetch', () => {
+        adapter.serviceUrl_ = 'http://localhost:8000/af';
+        contextMock.expects('collectUrlVars')
+            .withExactArgs(
+                'https://acme.com/a?rid=READER_ID',
+                /* useAuthData */ false)
+            .returns(Promise.resolve({
+              'READER_ID': 'reader1',
+              'OTHER': 123,
+            }))
+            .once();
+        const request = {
+          'state': 'STATE1',
+          'vars': {
+            'READER_ID': 'reader1',
+            'OTHER': '123',
+          },
+        };
+        xhrMock.expects('fetchDocument')
+            .withExactArgs('http://localhost:8000/af', {
+              method: 'POST',
+              body: 'request=' + encodeURIComponent(JSON.stringify(request)),
+              credentials: 'include',
+              requireAmpResponseSourceOrigin: true,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+            })
+            .returns(new Promise(() => {}))  // Never resolved.
+            .once();
+        const promise = adapter.authorize();
+        return Promise.resolve().then(() => {
+          clock.tick(3001);
+          return promise;
+        }).then(() => {
+          throw new Error('must never happen');
+        }, error => {
+          expect(error).to.match(/timeout/);
+        });
+      });
+
+      it('should replace sections', () => {
+        const responseElement1 = document.createElement('div');
+        responseElement1.setAttribute('i-amp-access-id', 'a1');
+        responseElement1.textContent = 'a1';
+        responseDoc.appendChild(responseElement1);
+
+        const responseElement2 = document.createElement('div');
+        responseElement2.setAttribute('i-amp-access-id', 'a2');
+        responseElement2.textContent = 'a2';
+        responseDoc.appendChild(responseElement2);
+
+        const unknownResponseElement3 = document.createElement('div');
+        unknownResponseElement3.setAttribute('i-amp-access-id', 'a3');
+        unknownResponseElement3.textContent = 'a3';
+        responseDoc.appendChild(unknownResponseElement3);
+
+        return adapter.replaceSections_(responseDoc).then(() => {
+          expect(document.querySelector('[i-amp-access-id=a1]').textContent)
+              .to.equal('a1');
+          expect(document.querySelector('[i-amp-access-id=a2]').textContent)
+              .to.equal('a2');
+          expect(document.querySelector('[i-amp-access-id=a3]')).to.be.null;
+        });
+      });
+    });
+
+    describe('pingback', () => {
+      it('should always send client pingback', () => {
+        clientAdapterMock.expects('pingback')
+            .returns(Promise.resolve())
+            .once();
+        adapter.pingback();
+      });
+    });
+  });
+});

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -16,11 +16,13 @@
 
 import {AccessClientAdapter} from '../amp-access-client';
 import {AccessOtherAdapter} from '../amp-access-other';
+import {AccessServerAdapter} from '../amp-access-server';
 import {AccessService} from '../amp-access';
 import {Observable} from '../../../../src/observable';
 import {installCidService,} from
     '../../../../extensions/amp-analytics/0.1/cid-impl';
 import {markElementScheduledForTesting} from '../../../../src/custom-element';
+import {toggleExperiment} from '../../../../src/experiments';
 import * as sinon from 'sinon';
 
 describe('AccessService', () => {
@@ -46,6 +48,7 @@ describe('AccessService', () => {
       document.body.removeChild(element);
     }
     sandbox.restore();
+    toggleExperiment(window, 'amp-access-server', false);
   });
 
   it('should disable service when no config', () => {
@@ -134,9 +137,16 @@ describe('AccessService', () => {
 
     config['type'] = 'server';
     element.textContent = JSON.stringify(config);
-    expect(new AccessService(window).type_).to.equal('server');
+    expect(new AccessService(window).type_).to.equal('client');
     expect(new AccessService(window).adapter_).to.be
         .instanceOf(AccessClientAdapter);
+
+    config['type'] = 'server';
+    toggleExperiment(window, 'amp-access-server', true);
+    element.textContent = JSON.stringify(config);
+    expect(new AccessService(window).type_).to.equal('server');
+    expect(new AccessService(window).adapter_).to.be
+        .instanceOf(AccessServerAdapter);
 
     config['type'] = 'other';
     element.textContent = JSON.stringify(config);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -83,6 +83,11 @@ const EXPERIMENTS = [
     name: 'AMP Live List/Blog',
     spec: 'https://github.com/ampproject/amphtml/issues/2762',
   },
+  {
+    id: 'amp-access-server',
+    name: 'AMP Access server side prototype',
+    spec: '',
+  },
 ];
 
 


### PR DESCRIPTION
This PR adds an additional method of access for documents downloaded from CDN. It's completely transparent to client protocol with the only difference that the authorization endpoint is executed via CDN and the initially "hidden" sections are downloaded based on the authorization response.