### PR TITLE
Turn on more aggressive compiler optimizations.

### DIFF
--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -129,7 +129,7 @@ function doubleClickWithGpt(global, data, gladeExperiment) {
       });
 
       // Exported for testing.
-      c.slot = slot;
+      global.document.getElementById('c')['slot'] = slot;
       googletag.display('c');
     });
   });

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Node.js global
+var process = {};
+process.env;
+
+// Exposed to ads.
+window.context = {};
+
+// Exposed to custom ad iframes.
+window.draw3p = function() {};
+
+// AMP's globals
+window.AMP_TEST;
+window.AMP_TAG;
+window.AMP_CONFIG;
+window.AMP = {};
+
+// Externed explicitly because we do not export Class shaped names
+// by default.
+window.AMP.BaseElement;
+window.AMP.BaseTemplate;
+
+// Externed explicitly because this private property is read across
+// binaries.
+Element.implementation_ = {};

--- a/build-system/runner/src/org/ampproject/AmpCodingConvention.java
+++ b/build-system/runner/src/org/ampproject/AmpCodingConvention.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ampproject;
+
+import com.google.javascript.jscomp.CodingConvention;
+import com.google.javascript.jscomp.CodingConventions;
+import com.google.javascript.jscomp.ClosureCodingConvention;
+
+
+/**
+ * A coding convention for AMP.
+ */
+public final class AmpCodingConvention extends CodingConventions.Proxy {
+  /** By default, decorate the ClosureCodingConvention. */
+  public AmpCodingConvention() {
+    this(new ClosureCodingConvention());
+  }
+
+  /** Decorates a wrapped CodingConvention. */
+  public AmpCodingConvention(CodingConvention convention) {
+    super(convention);
+  }
+
+  /**
+   * {@inheritDoc}
+   * Because AMP objects can travel between compilation units, we consider
+   * non-private methods exported.
+   * Should we decide to do full-program compilation (for version bound JS
+   * delivery), this could go away there.
+   */
+  @Override public boolean isExported(String name, boolean local) {
+    if (local) {
+      return false;
+    }
+    // ES6 generated module names are not exported.
+    if (name.contains("$")) {
+      return false;
+    }
+    // We do not export class names and similar by default.
+    if (Character.isUpperCase(name.charAt(0))) {
+      return false;
+    }
+    // Starting with _ explicitly exports a name.
+    if (name.startsWith("_")) {
+      return true;
+    }
+    return !name.endsWith("_") && !name.endsWith("ForTesting");
+  }
+}

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -1,10 +1,30 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ampproject;
 
 
 import com.google.common.collect.ImmutableSet;
+import com.google.javascript.jscomp.AbstractCommandLineRunner.FlagUsageException;
 import com.google.javascript.jscomp.CommandLineRunner;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CustomPassExecutionTime;
+import com.google.javascript.jscomp.PropertyRenamingPolicy;
+import com.google.javascript.jscomp.VariableRenamingPolicy;
+
+import java.io.IOException;
 
 
 /**
@@ -27,7 +47,29 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     options.setCollapseProperties(true);
     AmpPass ampPass = new AmpPass(getCompiler(), suffixTypes);
     options.addCustomPass(CustomPassExecutionTime.BEFORE_OPTIMIZATIONS, ampPass);
+    options.setDevirtualizePrototypeMethods(true);
+    options.setExtractPrototypeMemberDeclarations(true);
+    options.setSmartNameRemoval(true);
+    options.optimizeParameters = true;
+    options.optimizeReturns = true;
+    options.optimizeCalls = true;
+    // Have to turn this off because we cannot know whether sub classes
+    // might override a method. In the future this might be doable
+    // with using a more complete extern file instead.
+    options.setRemoveUnusedPrototypeProperties(false);
+    options.setInlineProperties(false);
+    options.setComputeFunctionSideEffects(false);
+    // Waiting for upstream change to stop renaming exported properties.
+    // options.setRenamingPolicy(VariableRenamingPolicy.ALL,
+    //    PropertyRenamingPolicy.ALL_UNQUOTED);
+    // options.setDisambiguatePrivateProperties(true);
     return options;
+  }
+
+  @Override protected void setRunOptions(CompilerOptions options)
+      throws IOException, FlagUsageException {
+    super.setRunOptions(options);
+    options.setCodingConvention(new AmpCodingConvention());
   }
 
   public static void main(String[] args) {

--- a/build-system/runner/src/org/ampproject/AmpPass.java
+++ b/build-system/runner/src/org/ampproject/AmpPass.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ampproject;
 
 import java.util.Set;
@@ -17,7 +32,7 @@ import com.google.javascript.rhino.Node;
  * they are either prefix based and/or operate on the es6 translated code which would mean they
  * operate on a qualifier string name that looks like
  * "module$__$__$__$extensions$amp_test$0_1$log.dev.fine".
- * 
+ *
  * Other custom pass examples found inside closure compiler src:
  * https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PolymerPass.java
  * https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/AngularPass.java

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -176,6 +176,7 @@ function compile(entryModuleFilename, outputDir,
         // Transpile from ES6 to ES5.
         language_in: 'ECMASCRIPT6',
         language_out: 'ECMASCRIPT5',
+        externs: 'build-system/amp.extern.js',
         js_module_root: ['node_modules/', 'build/fake-module/'],
         common_js_entry_module: entryModuleFilename,
         process_common_js_modules: true,

--- a/test/integration/test-amp-ad-doubleclick-with-script.js
+++ b/test/integration/test-amp-ad-doubleclick-with-script.js
@@ -122,8 +122,12 @@ describe('Rendering of one ad with ad script', () => {
       expect(iframe.contentWindow.context.hidden).to.be.false;
       return new Promise(resolve => {
         iframe.contentWindow.addEventListener('amp:visibilitychange', resolve);
-        fixture.win.AMP.viewer.visibilityState_ = 'hidden';
-        fixture.win.AMP.viewer.onVisibilityChange_();
+        fixture.win.AMP.viewer.receiveMessage('visibilitychange', {
+          state: 'hidden',
+        });
+        fixture.win.AMP.viewer.receiveMessage('visibilitychange', {
+          state: 'visible',
+        });
       });
     }).then(() => {
       expect(iframe.getAttribute('width')).to.equal('320');

--- a/test/integration/test-amp-ad-doubleclick.js
+++ b/test/integration/test-amp-ad-doubleclick.js
@@ -121,8 +121,12 @@ describe('Rendering of one ad', () => {
       expect(iframe.contentWindow.context.hidden).to.be.false;
       return new Promise(resolve => {
         iframe.contentWindow.addEventListener('amp:visibilitychange', resolve);
-        fixture.win.AMP.viewer.visibilityState_ = 'hidden';
-        fixture.win.AMP.viewer.onVisibilityChange_();
+        fixture.win.AMP.viewer.receiveMessage('visibilitychange', {
+          state: 'hidden',
+        });
+        fixture.win.AMP.viewer.receiveMessage('visibilitychange', {
+          state: 'visible',
+        });
       });
     }).then(() => {
       expect(iframe.getAttribute('width')).to.equal('320');

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -27,6 +27,17 @@ import * as sinon from 'sinon';
 
 describe('Viewer Visibility State', () => {
 
+  // This test only works with uncompiled JS, because it stubs out
+  // private properties.
+  let origUseCompiledJs;
+  beforeEach(() => {
+    origUseCompiledJs = window.ampTestRuntimeConfig.useCompiledJs;
+    window.ampTestRuntimeConfig.useCompiledJs = false;
+  });
+  afterEach(() => {
+    window.ampTestRuntimeConfig.useCompiledJs = origUseCompiledJs;
+  });
+
   let sandbox;
 
   function noop() {}

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,43 +1,43 @@
       max   |         min   |       gzip   |     brotli   |   file
       ---   |         ---   |        ---   |        ---   |   ---
- 51.96 kB   |     5.65 kB   |    2.26 kB   |    1.94 kB   |   alp.js / alp.max.js
-641.39 kB   |   155.47 kB   |   42.87 kB   |   36.97 kB   |   v0.js / amp.js
-245.97 kB   |    41.78 kB   |   13.13 kB   |   11.69 kB   |   v0/amp-access-0.1.js
- 27.83 kB   |     6.09 kB   |    2.42 kB   |    2.03 kB   |   v0/amp-accordion-0.1.js
-181.83 kB   |       28 kB   |    9.81 kB   |     8.7 kB   |   v0/amp-ad-0.1.js
-256.14 kB   |    60.67 kB   |   20.91 kB   |   18.16 kB   |   v0/amp-analytics-0.1.js
- 90.05 kB   |     9.53 kB   |    3.63 kB   |    3.19 kB   |   v0/amp-anim-0.1.js
- 87.24 kB   |     7.24 kB   |    2.93 kB   |    2.54 kB   |   v0/amp-audio-0.1.js
- 81.74 kB   |     8.36 kB   |    3.18 kB   |    2.74 kB   |   v0/amp-brid-player-0.1.js
-102.43 kB   |      8.1 kB   |     3.1 kB   |    2.67 kB   |   v0/amp-brightcove-0.1.js
-205.93 kB   |    34.81 kB   |    9.96 kB   |    8.84 kB   |   v0/amp-carousel-0.1.js
- 74.33 kB   |     6.99 kB   |     2.8 kB   |     2.4 kB   |   v0/amp-dailymotion-0.1.js
- 89.84 kB   |      5.3 kB   |    2.28 kB   |    1.98 kB   |   v0/amp-dynamic-css-classes-0.1.js
-143.93 kB   |    15.72 kB   |    6.19 kB   |    5.48 kB   |   v0/amp-facebook-0.1.js
- 34.97 kB   |     6.75 kB   |    2.66 kB   |     2.3 kB   |   v0/amp-fit-text-0.1.js
- 98.83 kB   |     9.74 kB   |    3.53 kB   |    3.06 kB   |   v0/amp-font-0.1.js
- 78.79 kB   |     7.45 kB   |    2.83 kB   |    2.44 kB   |   v0/amp-fx-flying-carpet-0.1.js
-139.69 kB   |    15.79 kB   |    5.72 kB   |    5.05 kB   |   v0/amp-iframe-0.1.js
-227.24 kB   |    39.92 kB   |   11.19 kB   |    9.93 kB   |   v0/amp-image-lightbox-0.1.js
- 96.86 kB   |     7.77 kB   |    3.07 kB   |    2.65 kB   |   v0/amp-instagram-0.1.js
- 84.09 kB   |     8.64 kB   |     3.5 kB   |    3.02 kB   |   v0/amp-install-serviceworker-0.1.js
- 81.17 kB   |     7.82 kB   |    3.05 kB   |    2.63 kB   |   v0/amp-jwplayer-0.1.js
-107.76 kB   |      8.8 kB   |    3.41 kB   |    2.96 kB   |   v0/amp-kaltura-player-0.1.js
-139.68 kB   |    15.37 kB   |    4.84 kB   |    4.27 kB   |   v0/amp-lightbox-0.1.js
-108.41 kB   |     9.07 kB   |    3.42 kB   |       3 kB   |   v0/amp-list-0.1.js
-145.44 kB   |    16.63 kB   |    5.29 kB   |    4.69 kB   |   v0/amp-live-list-0.1.js
-144.55 kB   |    40.51 kB   |   14.28 kB   |   12.79 kB   |   v0/amp-mustache-0.1.js
-122.75 kB   |    20.64 kB   |    6.13 kB   |    5.36 kB   |   v0/amp-pinterest-0.1.js
- 73.44 kB   |     6.56 kB   |    2.63 kB   |    2.25 kB   |   v0/amp-reach-player-0.1.js
- 90.01 kB   |    10.97 kB   |    3.87 kB   |    3.36 kB   |   v0/amp-sidebar-0.1.js
-108.67 kB   |    12.78 kB   |    4.56 kB   |    4.03 kB   |   v0/amp-slides-0.1.js
-102.62 kB   |    11.74 kB   |     4.4 kB   |    3.78 kB   |   v0/amp-social-share-0.1.js
- 74.02 kB   |     6.69 kB   |    2.67 kB   |    2.27 kB   |   v0/amp-soundcloud-0.1.js
- 81.99 kB   |     8.54 kB   |    3.16 kB   |    2.72 kB   |   v0/amp-springboard-player-0.1.js
- 85.07 kB   |     7.49 kB   |    2.89 kB   |     2.5 kB   |   v0/amp-sticky-ad-0.1.js
- 144.4 kB   |    15.85 kB   |    6.23 kB   |    5.51 kB   |   v0/amp-twitter-0.1.js
-108.65 kB   |    11.36 kB   |    4.15 kB   |    3.58 kB   |   v0/amp-user-notification-0.1.js
- 73.94 kB   |     6.66 kB   |    2.67 kB   |    2.29 kB   |   v0/amp-vimeo-0.1.js
- 73.48 kB   |     6.52 kB   |    2.63 kB   |    2.26 kB   |   v0/amp-vine-0.1.js
- 111.1 kB   |     9.54 kB   |    3.66 kB   |    3.18 kB   |   v0/amp-youtube-0.1.js
-154.61 kB   |    34.48 kB   |   11.84 kB   |   10.61 kB   |   current-min/f.js / current/integration.js
+ 51.95 kB   |     5.46 kB   |    2.31 kB   |    1.97 kB   |   alp.js / alp.max.js
+641.38 kB   |   144.68 kB   |   42.02 kB   |   36.28 kB   |   v0.js / amp.js
+245.96 kB   |    39.18 kB   |   13.01 kB   |   11.54 kB   |   v0/amp-access-0.1.js
+ 27.83 kB   |     5.88 kB   |    2.42 kB   |    2.01 kB   |   v0/amp-accordion-0.1.js
+181.83 kB   |    26.87 kB   |    9.71 kB   |    8.65 kB   |   v0/amp-ad-0.1.js
+256.14 kB   |    58.08 kB   |    20.7 kB   |   18.01 kB   |   v0/amp-analytics-0.1.js
+ 90.05 kB   |     8.91 kB   |    3.58 kB   |    3.12 kB   |   v0/amp-anim-0.1.js
+ 87.24 kB   |     6.97 kB   |    2.92 kB   |    2.52 kB   |   v0/amp-audio-0.1.js
+ 81.74 kB   |     7.98 kB   |    3.17 kB   |    2.71 kB   |   v0/amp-brid-player-0.1.js
+102.43 kB   |     7.74 kB   |     3.1 kB   |    2.65 kB   |   v0/amp-brightcove-0.1.js
+205.93 kB   |    31.86 kB   |    9.76 kB   |    8.66 kB   |   v0/amp-carousel-0.1.js
+ 74.32 kB   |     6.63 kB   |    2.77 kB   |    2.37 kB   |   v0/amp-dailymotion-0.1.js
+ 89.83 kB   |     5.08 kB   |    2.27 kB   |    1.98 kB   |   v0/amp-dynamic-css-classes-0.1.js
+143.93 kB   |    15.24 kB   |     6.2 kB   |    5.49 kB   |   v0/amp-facebook-0.1.js
+ 34.96 kB   |     6.42 kB   |    2.63 kB   |    2.28 kB   |   v0/amp-fit-text-0.1.js
+ 98.82 kB   |     8.86 kB   |    3.41 kB   |    2.96 kB   |   v0/amp-font-0.1.js
+ 78.79 kB   |     7.16 kB   |    2.85 kB   |    2.43 kB   |   v0/amp-fx-flying-carpet-0.1.js
+139.69 kB   |    14.99 kB   |    5.68 kB   |       5 kB   |   v0/amp-iframe-0.1.js
+227.24 kB   |    36.91 kB   |   10.92 kB   |    9.72 kB   |   v0/amp-image-lightbox-0.1.js
+ 96.86 kB   |     7.43 kB   |    3.05 kB   |    2.62 kB   |   v0/amp-instagram-0.1.js
+ 84.08 kB   |     8.32 kB   |     3.5 kB   |    3.02 kB   |   v0/amp-install-serviceworker-0.1.js
+ 81.17 kB   |     7.44 kB   |    3.04 kB   |    2.62 kB   |   v0/amp-jwplayer-0.1.js
+107.75 kB   |     8.42 kB   |    3.39 kB   |    2.92 kB   |   v0/amp-kaltura-player-0.1.js
+139.68 kB   |    14.06 kB   |    4.75 kB   |    4.21 kB   |   v0/amp-lightbox-0.1.js
+ 108.4 kB   |     8.52 kB   |    3.38 kB   |    2.95 kB   |   v0/amp-list-0.1.js
+145.43 kB   |     14.7 kB   |    5.17 kB   |    4.56 kB   |   v0/amp-live-list-0.1.js
+144.55 kB   |    40.86 kB   |   14.47 kB   |   13.01 kB   |   v0/amp-mustache-0.1.js
+122.74 kB   |    20.41 kB   |    6.16 kB   |    5.38 kB   |   v0/amp-pinterest-0.1.js
+ 73.44 kB   |     6.29 kB   |    2.62 kB   |    2.24 kB   |   v0/amp-reach-player-0.1.js
+ 90.01 kB   |    10.29 kB   |    3.78 kB   |    3.27 kB   |   v0/amp-sidebar-0.1.js
+108.66 kB   |    11.88 kB   |     4.5 kB   |    3.97 kB   |   v0/amp-slides-0.1.js
+102.62 kB   |    11.48 kB   |    4.39 kB   |    3.74 kB   |   v0/amp-social-share-0.1.js
+ 74.02 kB   |     6.42 kB   |    2.66 kB   |    2.26 kB   |   v0/amp-soundcloud-0.1.js
+ 81.98 kB   |     8.15 kB   |    3.15 kB   |    2.71 kB   |   v0/amp-springboard-player-0.1.js
+ 85.06 kB   |     7.04 kB   |    2.88 kB   |    2.47 kB   |   v0/amp-sticky-ad-0.1.js
+ 144.4 kB   |    15.37 kB   |    6.23 kB   |    5.53 kB   |   v0/amp-twitter-0.1.js
+108.65 kB   |     10.7 kB   |    4.09 kB   |    3.52 kB   |   v0/amp-user-notification-0.1.js
+ 73.94 kB   |     6.39 kB   |    2.66 kB   |    2.28 kB   |   v0/amp-vimeo-0.1.js
+ 73.47 kB   |     6.25 kB   |    2.62 kB   |    2.24 kB   |   v0/amp-vine-0.1.js
+111.09 kB   |     8.97 kB   |     3.6 kB   |    3.11 kB   |   v0/amp-youtube-0.1.js
+153.32 kB   |    33.97 kB   |   11.82 kB   |   10.61 kB   |   current-min/f.js / current/integration.js


### PR DESCRIPTION
- allows devirtualization of private methods.
- allows renaming of private properties and methods.
- Aliases `.prototype.` pattern where useful.
- other less important optimizations.

Implements a coding convention for AMP that marks all properties not ending in `_` as exported (so they can travel between co\
mpilation units).

This change by itself has little size impact, but should make our code quite a bit tighter to execute, because many virtual p\
rivate method calls because function calls. Primarily this is a preparation to turn on private property renaming when the ups\
tream change lands in closure compiler.