### PR TITLE
make window config template prefixing be explicit

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -86,7 +86,8 @@ function compile(entryModuleFilename, outputDir,
     var unneededFiles = [
       'build/fake-module/third_party/babel/custom-babel-helpers.js',
     ];
-    var wrapper = windowConfig.getTemplate() +
+    var wrapper = (options.includeWindowConfig ?
+        windowConfig.getTemplate() : '') +
         '(function(){var process={env:{NODE_ENV:"production"}};' +
         '%output%})();';
     if (options.wrapper) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -681,6 +681,7 @@ function buildAlp(options) {
     toName: 'alp.max.js',
     watch: options.watch,
     minify: options.minify || argv.minify,
+    includeWindowConfig: true,
     includePolyfills: true,
     minifiedName: 'alp.js',
     preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,


### PR DESCRIPTION
only alp.js and v0.js should have the global window.AMP_CONFIG object embedded in the file