### PR TITLE
Update the Appengine deployment for validator webui.

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -21,6 +21,7 @@ import logging
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 
@@ -381,6 +382,31 @@ def RunTests(out_dir, nodejs_cmd):
   logging.info('... success')
 
 
+def CreateWebuiAppengineDist(out_dir):
+  logging.info('entering ...')
+  webui_out = os.path.join(out_dir, 'webui_appengine')
+  shutil.copytree('webui', webui_out)
+  shutil.copytree('node_modules/codemirror',
+                  os.path.join(webui_out, 'codemirror'),
+                  symlinks=False,
+                  ignore=lambda d, files: [
+                      f for f in files
+                      if not os.path.isdir(os.path.join(d, f)) and
+                      os.path.splitext(f)[1] not in ['.css', '.js']])
+  shutil.copytree('node_modules/@polymer',
+                  os.path.join(webui_out, 'polymer'),
+                  symlinks=False,
+                  ignore=lambda d, files: [
+                      f for f in files
+                      if not os.path.isdir(os.path.join(d, f)) and
+                      os.path.splitext(f)[1] != '.html'])
+  webcomponents_out = os.path.join(out_dir, 'webcomponents-lite')
+  os.mkdir(webcomponents_out)
+  shutil.copyfile('node_modules/webcomponents-lite/webcomponents-lite.js',
+                  os.path.join(webcomponents_out, 'webcomponents-lite.js'))
+  logging.info('... success')
+
+
 def Main():
   """The main method, which executes all build steps and runs the tests."""
   logging.basicConfig(format='[[%(filename)s %(funcName)s]] - %(message)s',
@@ -402,6 +428,7 @@ def Main():
   CompileParseSrcsetTestMinified(out_dir='dist')
   GenerateTestRunner(out_dir='dist')
   RunTests(out_dir='dist', nodejs_cmd=nodejs_cmd)
+  CreateWebuiAppengineDist(out_dir='dist')
 
 
 if __name__ == '__main__':

--- a/validator/webui/app.yaml
+++ b/validator/webui/app.yaml
@@ -1,3 +1,4 @@
+version: 1
 runtime: go
 api_version: go1
 
@@ -10,13 +11,13 @@ handlers:
   upload: index.html
 
 - url: /cm/(.*\.(js|css))$
-  static_files: ../node_modules/codemirror/\1
-  upload: ../node_modules/codemirror/.*\.(js|css)$
+  static_files: codemirror/\1
+  upload: codemirror/.*\.(js|css)$
 
 - url: /pm/(.*\.html)$
-  static_files: ../node_modules/@polymer/\1
-  upload: ../node_modules/@polymer/.*\.html$
+  static_files: polymer/\1
+  upload: polymer/.*\.html$
 
 - url: /webcomponents-lite.js$
-  static_files: ../node_modules/webcomponents-lite/webcomponents-lite.js
-  upload: ../node_modules/webcomponents-lite/webcomponents-lite\.js$
+  static_files: webcomponents-lite/webcomponents-lite.js
+  upload: webcomponents-lite/webcomponents-lite\.js$

--- a/validator/webui/serve.go
+++ b/validator/webui/serve.go
@@ -17,7 +17,8 @@
 // To use this:
 // (1) Install the App Engine SDK for Go from
 //     https://cloud.google.com/appengine/downloads#Google_App_Engine_SDK_for_Go
-// (2) Type 'goapp serve webui' from the validator directory
+// (2) Run build.py.
+// (2) Type 'goapp serve .' in the dist/webui_appengine directory.
 // (3) Point your web browser at http://localhost:8080/
 
 package webui


### PR DESCRIPTION
@honeybadgerdontcare This is your change (thanks!) plus a small/simple/fast step to "build" in build.py.
As for including or not including some App ID, one can specify this on the command line
(--application) so it's not necessary to include this in app.yml, I think (https://cloud.google.com/appengine/docs/go/tools/appcfg-arguments).
