### PR TITLE
Validator NodeJS / cmd line update - Handle two more errors that can happen

### DIFF
--- a/validator/index_test.js
+++ b/validator/index_test.js
@@ -107,5 +107,20 @@ it('rejects a specific file that is known to have errors', (done) => {
       });
 });
 
+it('handles syntax errors in validator file', (done) => {
+  // Note: This points the library at a file that's not even Javascript.
+  ampValidator.getInstance(/*validatorJs*/ 'dist/validator.protoascii')
+      .then((instance) => {
+        fail('We should not get here since this is not a good validator.');
+        done();
+      })
+      .catch((error) => {
+        expect(error.message)
+            .toBe(
+                'Could not instantiate validator.js - Unexpected token ILLEGAL');
+        done();
+      });
+});
+
 jasmine.onComplete(function(passed) { process.exit(passed ? 0 : 1); });
 jasmine.execute();


### PR DESCRIPTION
Handle two more errors that can happen
- DNS resolution errors.
- Syntax errors in the validator.js script, e.g. when
  something is specified that's not a validator.js file.

Also I think for the command line it looks smoother
to log the error message rather than the object, so I switched
it to that.

Example session with this change:
$ ./index.js --validator_js https://www.google.com/ https://www.google.com/
Could not instantiate validator.js - Unexpected token <
$ ./index.js --validator_js https://www.google.com/ https://www.google.colm/
Unable to fetch https://www.google.colm/ - getaddrinfo ENOTFOUND www.google.colm www.google.colm:443
$ ./index.js https://www.google.com/
... this prints a whole bunch of validation errors as expected ...