### PR TITLE
In build.py, vulcanize the appengine validator webui app

### DIFF
--- a/validator/package.json
+++ b/validator/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "google-closure-compiler": "20151015.0.0",
     "google-closure-library": "20151015.0.0",
-    "jasmine": "2.3.2"
+    "jasmine": "2.3.2",
+    "vulcanize": "1.14.8"
   }
 }

--- a/validator/webui/app.yaml
+++ b/validator/webui/app.yaml
@@ -10,18 +10,6 @@ handlers:
   static_files: index.html
   upload: index.html
 
-- url: /cm/(.*\.(js|css))$
-  static_files: codemirror/\1
-  upload: codemirror/.*\.(js|css)$
-
-- url: /pm/(.*\.html)$
-  static_files: polymer/\1
-  upload: polymer/.*\.html$
-
-- url: /webcomponents-lite.js$
-  static_files: webcomponents-lite.js
-  upload: webcomponents-lite\.js$
-
 - url: /amp_favicon.png$
   static_files: amp_favicon.png
   upload: amp_favicon\.png$

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -18,29 +18,30 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
   <title>The AMP Validator</title>
   <meta charset="utf-8"/>
+
   <link rel="shortcut icon" href="/amp_favicon.png">
-  <script src="webcomponents-lite.js"></script>
-  <link rel="import" href="/pm/iron-collapse/iron-collapse.html">
-  <link rel="import" href="/pm/iron-flex-layout/iron-flex-layout.html">
-  <link rel="import" href="/pm/iron-icon/iron-icon.html">
-  <link rel="import" href="/pm/iron-icons/communication-icons.html">
-  <link rel="import" href="/pm/iron-icons/iron-icons.html">
-  <link rel="import" href="/pm/iron-resizable-behavior/iron-resizable-behavior.html">
-  <link rel="import" href="/pm/paper-button/paper-button.html">
-  <link rel="import" href="/pm/paper-input/paper-input.html">
-  <link rel="import" href="/pm/paper-item/paper-item.html">
-  <link rel="import" href="/pm/paper-listbox/paper-listbox.html">
-  <link rel="import" href="/pm/paper-material/paper-material.html">
-  <link rel="import" href="/pm/paper-styles/demo-pages.html">
-  <link rel="import" href="/pm/paper-toolbar/paper-toolbar.html">
-  <link rel="import" href="/pm/polymer/polymer.html">
-  <link rel="stylesheet" href="/cm/lib/codemirror.css">
-  <script src="/cm/lib/codemirror.js"></script>
-  <script src="/cm/addon/selection/selection-pointer.js"></script>
-  <script src="/cm/mode/css/css.js"></script>
-  <script src="/cm/mode/htmlmixed/htmlmixed.js"></script>
-  <script src="/cm/mode/javascript/javascript.js"></script>
-  <script src="/cm/mode/xml/xml.js"></script>
+  <script src="webcomponents-lite/webcomponents-lite.js"></script>
+  <link rel="import" href="@polymer/iron-collapse/iron-collapse.html">
+  <link rel="import" href="@polymer/iron-flex-layout/iron-flex-layout.html">
+  <link rel="import" href="@polymer/iron-icon/iron-icon.html">
+  <link rel="import" href="@polymer/iron-icons/communication-icons.html">
+  <link rel="import" href="@polymer/iron-icons/iron-icons.html">
+  <link rel="import" href="@polymer/iron-resizable-behavior/iron-resizable-behavior.html">
+  <link rel="import" href="@polymer/paper-button/paper-button.html">
+  <link rel="import" href="@polymer/paper-input/paper-input.html">
+  <link rel="import" href="@polymer/paper-item/paper-item.html">
+  <link rel="import" href="@polymer/paper-listbox/paper-listbox.html">
+  <link rel="import" href="@polymer/paper-material/paper-material.html">
+  <link rel="import" href="@polymer/paper-styles/demo-pages.html">
+  <link rel="import" href="@polymer/paper-toolbar/paper-toolbar.html">
+  <link rel="import" href="@polymer/polymer/polymer.html">
+  <link rel="stylesheet" href="codemirror/lib/codemirror.css">
+  <script src="codemirror/lib/codemirror.js"></script>
+  <script src="codemirror/addon/selection/selection-pointer.js"></script>
+  <script src="codemirror/mode/css/css.js"></script>
+  <script src="codemirror/mode/htmlmixed/htmlmixed.js"></script>
+  <script src="codemirror/mode/javascript/javascript.js"></script>
+  <script src="codemirror/mode/xml/xml.js"></script>
   <script src="https://cdn.ampproject.org/v0/validator.js"></script>
   <style is="custom-style">
     paper-item {


### PR DESCRIPTION
This inlines the javascript / css / html except for validator.js itself,
reducing the number of requests and improving initial load time.
To make this work, I tweaked validator/webui/index.html some and
made build.py create a little temporary root with symlinks. This means
I need to also adjust the webui command for index.js - but luckily
the new version is simpler: it just looks up most resources relative
to node_modules. Also, this simplifies app.yaml.