### PR TITLE
Put the Github and Chrome extension links in the upper right

### DIFF
--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -285,9 +285,11 @@
       paper-toolbar {
         --paper-toolbar-background: #fbfafb;
         --paper-toolbar-color: #0379C4;
-        --paper-toolbar: { font-family: Roboto, verdana, arial, sans-serif; }
+        --paper-toolbar: { font-family: Roboto, verdana, arial, sans-serif; };
+        --width: 100%
       }
-      .ampproject {
+      .ampproject-left {
+        @apply(--layout-flex);
         color: #0379C4;
         padding: 15px 10px 15px 50px;
         margin: 10px 0;
@@ -299,18 +301,35 @@
         background-size: 40px 40px;
         background-position: center left;
       }
-      .ampproject a:link { color: #0379C4; text-decoration: none; }
-      .ampproject a:visited { color: #0379C4; text-decoration: none; }
-      .ampproject a:hover { color: #0379C4; text-decoration: none; }
-      .ampproject a:active { color: #0379C4; text-decoration: none; }
+      .ampproject-right {
+        color: #0379C4;
+        margin: 10px 0;
+      }
+      .ampproject-link a:link { color: #0379C4; text-decoration: none; }
+      .ampproject-link a:visited { color: #0379C4; text-decoration: none; }
+      .ampproject-link a:hover { color: #0379C4; text-decoration: none; }
+      .ampproject-link a:active { color: #0379C4; text-decoration: none; }
+
+      .flex-horizontal {
+        @apply(--layout-horizontal);
+        @apply(--layout-center);
+        margin-bottom: 10px;
+      }
+      .flexchild {
+      }
     </style>
     <template>
-      <paper-toolbar>
-        <div class="ampproject">
+      <paper-toolbar "container flex-horizontal">
+        <div class="ampproject-left ampproject-link">
           <a href="https://www.ampproject.org/"
-             target="_blank">Accelerated Mobile Pages Project</a> -
+             target="_blank">Accelerated Mobile Pages Project</a>
+        </div>
+        <div class="ampproject-right ampproject-link">
           <a href="https://github.com/ampproject/amphtml/blob/master/validator/README.md"
-             target="_blank">Validator</a>
+             target="_blank">GITHUB</a>
+          &nbsp;&nbsp;&nbsp;
+          <a href="https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc"
+             target="_blank">CHROME EXTENSION</a>
         </div>
       </paper-toolbar>
     </template>

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -305,11 +305,16 @@
         color: #0379C4;
         margin: 10px 0;
       }
-      .ampproject-link a:link { color: #0379C4; text-decoration: none; }
-      .ampproject-link a:visited { color: #0379C4; text-decoration: none; }
-      .ampproject-link a:hover { color: #0379C4; text-decoration: none; }
-      .ampproject-link a:active { color: #0379C4; text-decoration: none; }
-
+      .ampproject-link a:link,
+      .ampproject-link a:visited,
+      .ampproject-link a:hover,
+      .ampproject-link a:active {
+        color: #0379C4;
+        text-decoration: none;
+        font-size: 14px;
+        font-weight: 300;
+        letter-spacing: 0.04em;
+      }
       .flex-horizontal {
         @apply(--layout-horizontal);
         @apply(--layout-center);

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -319,7 +319,7 @@
       }
     </style>
     <template>
-      <paper-toolbar "container flex-horizontal">
+      <paper-toolbar>
         <div class="ampproject-left ampproject-link">
           <a href="https://www.ampproject.org/"
              target="_blank">Accelerated Mobile Pages Project</a>


### PR DESCRIPTION
Also make them upper case, much like the entries on www.ampproject.org.

PS: Now I'm starting to think I want the example buttons replaced
with links like these as well (it'd reclaim space for showing the
html source), but one thing at a time is probably best. :-)