### PR TITLE
Validator Updates while watching IO

### DIFF
--- a/validator/htmlparser.js
+++ b/validator/htmlparser.js
@@ -627,7 +627,9 @@ amp.htmlparser.HtmlParser.INSIDE_TAG_TOKEN_ = new RegExp(
         '|\'[^\']*\'' +
         // The positive lookahead is used to make sure that in
         // <foo bar= baz=boo>, the value for bar is blank, not "baz=boo".
-        '|(?=[a-z][a-z-]*\\s*=)' +
+        // Note that <foo bar=baz=boo zik=zak>, the value for bar is
+        // "baz=boo" and the value for zip is "zak".
+        '|(?=[a-z][a-z-]*\\s+=)' +
         // An unquoted value that is not an attribute name.
         // We know it is not an attribute name because the previous
         // zero-width match would've eliminated that possibility.

--- a/validator/testdata/feature_tests/parser.html
+++ b/validator/testdata/feature_tests/parser.html
@@ -22,7 +22,7 @@
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html" />
-  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <meta name="viewport" content=width=device-width,minimum-scale=1>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 133
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 217
+spec_file_revision: 218
 
 # Validator extensions.
 # =====================
@@ -265,6 +265,7 @@ tags: {
       properties: { name: "initial-scale" }
       properties: { name: "minimum-scale" mandatory: true value_double: 1.0 }
       properties: { name: "maximum-scale" }
+      properties: { name: "shrink-to-fit" }
       properties: { name: "user-scalable" }
     }
   }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,12 +20,12 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii) are always released together.
-min_validator_revision_required: 133
+min_validator_revision_required: 135
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 218
+spec_file_revision: 219
 
 # Validator extensions.
 # =====================


### PR DESCRIPTION
Release Notes:
- Allow shrink-to-fit for `<meta name="viewport"...>`
- Support unqouted attribute values that have assignments within (htmlparser.js).