### PR TITLE
Allow links to Facebook Messenger

### DIFF
--- a/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
+++ b/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
@@ -64,7 +64,7 @@ tags: {  # <amp-social-share>
       allowed_protocol: "mailto"
       # Whitelisting additional commonly observed third party
       # protocols which should be safe
-      allower_protocol: "fb-messenger"
+      allowed_protocol: "fb-messenger"
       allowed_protocol: "snapchat"
       allowed_protocol: "sms"
       allowed_protocol: "tel"

--- a/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
+++ b/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
@@ -64,6 +64,7 @@ tags: {  # <amp-social-share>
       allowed_protocol: "mailto"
       # Whitelisting additional commonly observed third party
       # protocols which should be safe
+      allower_protocol: "fb-messenger"
       allowed_protocol: "snapchat"
       allowed_protocol: "sms"
       allowed_protocol: "tel"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -707,7 +707,6 @@ attr_lists: {
       allowed_protocol: "ftp"
       # Whitelisting additional commonly observed third party
       # protocols which should be safe
-      allowed_protocol: "fb-messenger"
       allowed_protocol: "sms"
       allowed_protocol: "tel"
       allowed_protocol: "viber"
@@ -803,7 +802,6 @@ tags: {
       allowed_protocol: "mailto"
       # Whitelisting additional commonly observed third party
       # protocols which should be safe
-      allowed_protocol: "fb-messenger"
       allowed_protocol: "sms"
       allowed_protocol: "tel"
       allowed_protocol: "viber"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -707,6 +707,7 @@ attr_lists: {
       allowed_protocol: "ftp"
       # Whitelisting additional commonly observed third party
       # protocols which should be safe
+      allowed_protocol: "fb-messenger"
       allowed_protocol: "sms"
       allowed_protocol: "tel"
       allowed_protocol: "viber"
@@ -802,6 +803,7 @@ tags: {
       allowed_protocol: "mailto"
       # Whitelisting additional commonly observed third party
       # protocols which should be safe
+      allowed_protocol: "fb-messenger"
       allowed_protocol: "sms"
       allowed_protocol: "tel"
       allowed_protocol: "viber"


### PR DESCRIPTION
Because `amp-share` is still experimental I'd like to allow links using the `fb-messenger` protocol so that it can be used as a share element.