### PR TITLE
[amp-analytics] Added ability to use variables in selectors.

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -166,8 +166,18 @@ export class AmpAnalytics extends AMP.BaseElement {
           if (!result) {
             return;
           }
-          addListener(this.getWin(), trigger,
-              this.handleEvent_.bind(this, trigger));
+
+          if (trigger['selector']) {
+            // Expand the selector using variable expansion.
+            trigger['selector'] = this.expandTemplate_(trigger['selector'],
+                trigger);
+            addListener(this.getWin(), trigger, this.handleEvent_.bind(this,
+                  trigger));
+
+          } else {
+            addListener(this.getWin(), trigger,
+                this.handleEvent_.bind(this, trigger));
+          }
         }));
       }
     }

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -16,6 +16,7 @@
 
 import {ANALYTICS_CONFIG} from '../vendors';
 import {AmpAnalytics} from '../amp-analytics';
+import {instrumentationServiceFor} from '../instrumentation';
 import {
   installUserNotificationManager,
 } from '../../../amp-user-notification/0.1/amp-user-notification';
@@ -526,6 +527,33 @@ describe('amp-analytics', function() {
           'https://example.com/test1=x&' +
           'test2=http%3A%2F%2Flocalhost%3A9876%2Fcontext.html' +
           '&title=Test%20Title');
+    });
+  });
+
+  it('expands selector with config variable', () => {
+    const ins = instrumentationServiceFor(windowApi);
+    const addListenerSpy = sandbox.spy(ins, 'addListener');
+    const analytics = getAnalyticsTag({
+      requests: {foo: 'https://example.com/bar'},
+      triggers: [{on: 'click', selector: '${foo}', request: 'foo'}],
+      vars: {foo: 'bar'},
+    });
+    return waitForNoSendRequest(analytics).then(() => {
+      expect(addListenerSpy.callCount).to.equal(1);
+      expect(addListenerSpy.args[0][0]['selector']).to.equal('bar');
+    });
+  });
+
+  it('does not expands selector with platform variable', () => {
+    const ins = instrumentationServiceFor(windowApi);
+    const addListenerSpy = sandbox.spy(ins, 'addListener');
+    const analytics = getAnalyticsTag({
+      requests: {foo: 'https://example.com/bar'},
+      triggers: [{on: 'click', selector: '${title}', request: 'foo'}],
+    });
+    return waitForNoSendRequest(analytics).then(() => {
+      expect(addListenerSpy.callCount).to.equal(1);
+      expect(addListenerSpy.args[0][0]['selector']).to.equal('TITLE');
     });
   });
 


### PR DESCRIPTION
This allows remote trigger config to specify a config like this:

Remote config that could be provided by a vendor (like Google Tag Manager or something else). This allows GTM to provide a config that can work across various publishers.
```
{
  on: 'click',
  selector: '${likeButtonSelector}',
  request: 'foo',
}
```

In-page config provided by a publisher like nytimes.com. This way, they can use the remote config from GTM and give any id/class to their like button.
```
{
  vars: { likeButtonSelector: '#myLikeButton' }
}
```

Overall, this will be used like this:

```
<amp-analytics config="https://gtm.com/someconfig.json">
<script type='application/json'>
{
  'vars': { likeButtonSelector: '#myLikeButton' }
}
</script>
</amp-analytics>
```
