### PR TITLE
Basic CSRF protection for validator web ui

### DIFF
--- a/validator/index.js
+++ b/validator/index.js
@@ -376,6 +376,11 @@ function serve(port, validatorScript) {
         // internet. It presents the results as JSON.
         //
         if (request.url.startsWith('/fetch?')) {
+          if (request.headers['x-requested-by'] !== 'validator webui') {
+            response.writeHead(400, {'Content-Type': 'text/plain'});
+            response.end('Bad request.');
+            return;
+          }
           const parsedUrl = url.parse(request.url, true);
           const urlToFetch = parsedUrl['query']['url'];
           if (!urlToFetch.startsWith('https://') &&

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -468,6 +468,7 @@
                 }
               };
               xmlHttp.open("GET", "/fetch?url=" + encodeURIComponent(urlToFetch), true);
+              xmlHttp.setRequestHeader('X-Requested-By', 'validator webui');
               xmlHttp.send();
             }
           });

--- a/validator/webui/serve.go
+++ b/validator/webui/serve.go
@@ -39,6 +39,10 @@ func init() {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("X-Requested-By") != "validator webui" {
+		http.Error(w, "Bad request.", http.StatusBadRequest)
+		return
+	}
 	param := r.FormValue("url")
 	u, err := url.Parse(param)
 	if param == "" || err != nil || (u.Scheme != "http" && u.Scheme != "https") {


### PR DESCRIPTION
Implement the scheme described in http://security.stackexchange.com/questions/23371/csrf-protection-with-custom-headers-and-without-validating-token/23373 for basic CSRF protection.