### PR TITLE
Validator webui: For /fetch, use an x-www-form-urlencoded form.

### DIFF
--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -467,9 +467,10 @@
                   editor.setEditorValue(JSON.parse(xmlHttp.responseText).Contents);
                 }
               };
-              xmlHttp.open('POST', '/fetch?url=' + encodeURIComponent(urlToFetch), true);
+              xmlHttp.open('POST', '/fetch', true);
               xmlHttp.setRequestHeader('X-Requested-By', 'validator webui');
-              xmlHttp.send();
+              xmlHttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+              xmlHttp.send('url=' + encodeURIComponent(urlToFetch));
             }
           });
 


### PR DESCRIPTION
This avoids putting the url into the querystring.
Instead it's in the form submission.
Interestingly, the Go version of the code can already handle this.