### PR TITLE
Create amp-border-box-inherit class

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -328,6 +328,20 @@ template {
   box-sizing: border-box;
 }
 
+/**
+ * Authors can add this class to their html tags to provide `border-box` box-sizing
+ * can be easily overriden when you are using a third party component.
+ * https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/
+ */
+.amp-border-box-inherit {
+  box-sizing: border-box;
+}
+.amp-border-box-inherit *,
+.amp-border-box-inherit *:before,
+.amp-border-box-inherit *:after {
+  box-sizing: inherit;
+}
+
 amp-pixel {
   /* Fixed to make position independent of page other elements. */
   position: fixed !important;


### PR DESCRIPTION
So this is on the basis of
https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/

When using .amp-border-box all elements will get `box-sizing: border-box;`
And there would be no way to override it for children in a particular div as we cannot use `*` in custom author css.

I would essentially want to replace the existing `.amp-border-box` but this would be a breaking change for some websites. I didn't find a CHANGELOG so that I can mention this to people who are updating.

This change has a negative performance as mentioned here:
https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#universal-selector
