### PR TITLE
:nth-child(1n) can be used to emulate *

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -238,10 +238,12 @@ Authors may add custom styles to a document using a single `<style amp-custom>` 
 The following restrictions apply to selectors in author style sheets:
 
 ##### Universal selector
-The universal selector `*` may not be used in author stylesheets. This is because it can have negative performance implications and could be used to circumvent the rules set out in the following paragraph.
+The universal selector `*` may not be used in author stylesheets. This is because it can have negative performance implications and could be used to circumvent the rules set out by the AMP developers.
 
 ##### not selector
 `:not()` may not be used in selectors because it can be used to simulate the universal selector.
+Similary `:nth-child(1n), :nth-child(n)` also should not be used. Though other forms of `:nth-child()` may be used but all forms of `:not()` are forbidden.
+
 
 ##### Pseudo-selectors, pseudo-classes and pseudo-elements
 Pseudo-selectors, pseudo-classes and pseudo-elements are only allowed in selectors that contain tag names and those tag names must not start with `amp-`.


### PR DESCRIPTION
So I was using this in https://github.com/azizhk/spectre-amp/blob/83b4c8f/src/base.less#L9
But I think you guys are open to https://github.com/ampproject/amphtml/pull/3360, so my purpose should get solved.

Please guide what files for validator.
