### PR TITLE
Reset border-top for iOS in lightbox mode

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -719,9 +719,7 @@ class AmpImageLightbox extends AMP.BaseElement {
         'keydown', this.boundCloseOnEscape_);
 
     // Prepare to enter in lightbox
-    this.requestFullOverlay();
-    this.getViewport().disableTouchZoom();
-    this.getViewport().hideFixedLayer();
+    this.getViewport().enterLightboxMode();
 
     this.enter_();
 
@@ -764,9 +762,7 @@ class AmpImageLightbox extends AMP.BaseElement {
       this.unlistenViewport_ = null;
     }
 
-    this.cancelFullOverlay();
-    this.getViewport().showFixedLayer();
-    this.getViewport().restoreOriginalTouchZoom();
+    this.getViewport().leaveLightboxMode();
     if (this.historyId_ != -1) {
       this.getHistory_().pop(this.historyId_);
     }

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -77,17 +77,13 @@ describe('amp-image-lightbox component', () => {
   it('should activate all steps', () => {
     return getImageLightbox().then(lightbox => {
       const impl = lightbox.implementation_;
-      const requestFullOverlay = sandbox.spy();
-      impl.requestFullOverlay = requestFullOverlay;
       const viewportOnChanged = sandbox.spy();
-      const disableTouchZoom = sandbox.spy();
-      const hideFixedLayer = sandbox.spy();
-      const showFixedLayer = sandbox.spy();
+      const enterLightboxMode = sandbox.spy();
+      const leaveLightboxMode = sandbox.spy();
       impl.getViewport = () => {return {
         onChanged: viewportOnChanged,
-        disableTouchZoom: disableTouchZoom,
-        hideFixedLayer: hideFixedLayer,
-        showFixedLayer: showFixedLayer,
+        enterLightboxMode: enterLightboxMode,
+        leaveLightboxMode: leaveLightboxMode,
       };};
       const historyPush = sandbox.spy();
       impl.getHistory_ = () => {
@@ -103,15 +99,13 @@ describe('amp-image-lightbox component', () => {
       ampImage.setAttribute('src', 'data:');
       impl.activate({source: ampImage});
 
-      expect(requestFullOverlay.callCount).to.equal(1);
       expect(viewportOnChanged.callCount).to.equal(1);
       expect(impl.unlistenViewport_).to.not.equal(null);
       expect(historyPush.callCount).to.equal(1);
       expect(enter.callCount).to.equal(1);
       expect(impl.sourceElement_).to.equal(ampImage);
-      expect(disableTouchZoom.callCount).to.equal(1);
-      expect(hideFixedLayer.callCount).to.equal(1);
-      expect(showFixedLayer.callCount).to.equal(0);
+      expect(enterLightboxMode.callCount).to.equal(1);
+      expect(leaveLightboxMode.callCount).to.equal(0);
     });
   });
 
@@ -120,17 +114,13 @@ describe('amp-image-lightbox component', () => {
       const impl = lightbox.implementation_;
       impl.active_ = true;
       impl.historyId_ = 11;
-      const cancelFullOverlay = sandbox.spy();
-      impl.cancelFullOverlay = cancelFullOverlay;
       const viewportOnChangedUnsubscribed = sandbox.spy();
       impl.unlistenViewport_ = viewportOnChangedUnsubscribed;
-      const restoreOriginalTouchZoom = sandbox.spy();
-      const hideFixedLayer = sandbox.spy();
-      const showFixedLayer = sandbox.spy();
+      const enterLightboxMode = sandbox.spy();
+      const leaveLightboxMode = sandbox.spy();
       impl.getViewport = () => {return {
-        restoreOriginalTouchZoom: restoreOriginalTouchZoom,
-        hideFixedLayer: hideFixedLayer,
-        showFixedLayer: showFixedLayer,
+        enterLightboxMode: enterLightboxMode,
+        leaveLightboxMode: leaveLightboxMode,
       };};
       const historyPop = sandbox.spy();
       impl.getHistory_ = () => {
@@ -147,11 +137,9 @@ describe('amp-image-lightbox component', () => {
       expect(exit.callCount).to.equal(1);
       expect(viewportOnChangedUnsubscribed.callCount).to.equal(1);
       expect(impl.unlistenViewport_).to.equal(null);
-      expect(cancelFullOverlay.callCount).to.equal(1);
-      expect(restoreOriginalTouchZoom.callCount).to.equal(1);
+      expect(leaveLightboxMode.callCount).to.equal(1);
+      expect(enterLightboxMode.callCount).to.equal(0);
       expect(historyPop.callCount).to.equal(1);
-      expect(showFixedLayer.callCount).to.equal(1);
-      expect(hideFixedLayer.callCount).to.equal(0);
     });
   });
 
@@ -160,14 +148,12 @@ describe('amp-image-lightbox component', () => {
       const impl = lightbox.implementation_;
       const setupCloseSpy = sandbox.spy(impl, 'close');
       const viewportOnChanged = sandbox.spy();
-      const disableTouchZoom = sandbox.spy();
-      const restoreOriginalTouchZoom = sandbox.spy();
+      const enterLightboxMode = sandbox.spy();
+      const leaveLightboxMode = sandbox.spy();
       impl.getViewport = () => {return {
         onChanged: viewportOnChanged,
-        disableTouchZoom: disableTouchZoom,
-        restoreOriginalTouchZoom: restoreOriginalTouchZoom,
-        hideFixedLayer: () => {},
-        showFixedLayer: () => {},
+        enterLightboxMode: enterLightboxMode,
+        leaveLightboxMode: leaveLightboxMode,
       };};
       const historyPush = sandbox.spy();
       impl.getHistory_ = () => {

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -78,9 +78,7 @@ class AmpLightbox extends AMP.BaseElement {
     this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
     this.getWin().document.documentElement.addEventListener(
         'keydown', this.boundCloseOnEscape_);
-    this.requestFullOverlay();
-    this.getViewport().resetTouchZoom();
-    this.getViewport().hideFixedLayer();
+    this.getViewport().enterLightboxMode();
 
     this.mutateElement(() => {
       this.element.style.display = '';
@@ -112,8 +110,7 @@ class AmpLightbox extends AMP.BaseElement {
   }
 
   close() {
-    this.cancelFullOverlay();
-    this.getViewport().showFixedLayer();
+    this.getViewport().leaveLightboxMode();
     this.element.style.display = 'none';
     if (this.historyId_ != -1) {
       this.getHistory_().pop(this.historyId_);

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -688,6 +688,8 @@ export class BaseElement {
   /**
    * Requests full overlay mode from the viewer.
    * @protected
+   * @deprecated Use `Viewport.enterLightboxMode`.
+   * TODO(dvoytenko, #3406): Remove as deprecated.
    */
   requestFullOverlay() {
     viewerFor(this.getWin()).requestFullOverlay();
@@ -696,6 +698,8 @@ export class BaseElement {
   /**
    * Requests to cancel full overlay mode from the viewer.
    * @protected
+   * @deprecated Use `Viewport.leaveLightboxMode`.
+   * TODO(dvoytenko, #3406): Remove as deprecated.
    */
   cancelFullOverlay() {
     viewerFor(this.getWin()).cancelFullOverlay();

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -290,6 +290,26 @@ export class Viewport {
   }
 
   /**
+   * Instruct the viewport to enter lightbox mode.
+   */
+  enterLightboxMode() {
+    this.viewer_.requestFullOverlay();
+    this.disableTouchZoom();
+    this.hideFixedLayer();
+    this.vsync_.mutate(() => this.binding_.updateLightboxMode(true));
+  }
+
+  /**
+   * Instruct the viewport to enter lightbox mode.
+   */
+  leaveLightboxMode() {
+    this.viewer_.cancelFullOverlay();
+    this.showFixedLayer();
+    this.restoreOriginalTouchZoom();
+    this.vsync_.mutate(() => this.binding_.updateLightboxMode(false));
+  }
+
+  /**
    * Resets touch zoom to initial scale of 1.
    */
   resetTouchZoom() {
@@ -548,6 +568,13 @@ class ViewportBindingDef {
   updatePaddingTop(unusedPaddingTop) {}
 
   /**
+   * Updates the viewport whether it's currently in the lightbox or a normal
+   * mode.
+   * @param {boolean} unusedLightboxMode
+   */
+  updateLightboxMode(unusedLightboxMode) {}
+
+  /**
    * Returns the size of the viewport.
    * @return {!{width: number, height: number}}
    */
@@ -658,6 +685,11 @@ export class ViewportBindingNatural_ {
   /** @override */
   updatePaddingTop(paddingTop) {
     this.win.document.documentElement.style.paddingTop = px(paddingTop);
+  }
+
+  /** @override */
+  updateLightboxMode(unusedLightboxMode) {
+    // The layout is always accurate.
   }
 
   /** @override */
@@ -887,6 +919,16 @@ export class ViewportBindingNaturalIosEmbed_ {
   }
 
   /** @override */
+  updateLightboxMode(lightboxMode) {
+    // This code will no longer be needed with the newer iOS viewport
+    // implementation.
+    onDocumentReady(this.win.document, () => {
+      this.win.document.body.style.borderTopStyle =
+          lightboxMode ? 'none' : 'solid';
+    });
+  }
+
+  /** @override */
   cleanup_() {
     // TODO(dvoytenko): remove listeners
   }
@@ -1088,6 +1130,11 @@ export class ViewportBindingVirtual_ {
   /** @override */
   updatePaddingTop(paddingTop) {
     this.win.document.documentElement.style.paddingTop = px(paddingTop);
+  }
+
+  /** @override */
+  updateLightboxMode(unusedLightboxMode) {
+    // The layout is always accurate.
   }
 
   /** @override */


### PR DESCRIPTION
Closes #3340.

This is  a temporary fix until the iOS viewport implementation is replaced.
