### PR TITLE
Escape < and > in amp-video doc.

### DIFF
--- a/builtins/amp-video.md
+++ b/builtins/amp-video.md
@@ -63,7 +63,7 @@ For example:
 
 **src**
 
-Required if no <source> children are present. Must be HTTPS.
+Required if no &lt;source&gt; children are present. Must be HTTPS.
 
 **poster**
 


### PR DESCRIPTION
This is to address the validation issue when docs pulls from here to push on ampproject.org.
See https://github.com/ampproject/docs/issues/110