### PR TITLE
iOS Embedded AMP Scrolling Service

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -200,13 +200,6 @@ i-amp-sizer {
   content: attr(error-message);
 }
 
-/**
- * Wraps the body's children to make the page scrollable.
- */
-i-amp-container {
-  display: block;
-}
-
 
 /**
  * Helper elements to control scrolling in iOS

--- a/css/amp.css
+++ b/css/amp.css
@@ -201,15 +201,23 @@ i-amp-sizer {
 }
 
 /**
+ * Wraps the body's children to make the page scrollable.
+ */
+i-amp-container {
+  display: block;
+}
+
+
+/**
  * Helper elements to control scrolling in iOS
  */
-#-amp-scrollpos, #-amp-scrollmove, #-amp-endpos {
+#-amp-startpos, #-amp-scrollmove, #-amp-endpos {
   width: 0;
   height: 0;
   visibility: hidden;
 }
 
-#-amp-scrollpos, #-amp-scrollmove {
+#-amp-startpos, #-amp-scrollmove {
   position: absolute;
   top: 0;
   left: 0;

--- a/css/amp.css
+++ b/css/amp.css
@@ -40,6 +40,15 @@ body {
   margin: 0 !important;
 }
 
+body.-amp-scrolling {
+  overflow-y: visible !important;
+  overflow-x: visible !important;
+}
+
+body.-amp-scrolling iframe {
+  pointer-events: none !important;
+}
+
 /** These properties can be overriden by user stylesheets. */
 body {
   /* Text adjust is set to 100% to avoid iOS Safari bugs where the font-size is

--- a/css/amp.css
+++ b/css/amp.css
@@ -201,6 +201,22 @@ i-amp-sizer {
 }
 
 /**
+ * Helper elements to control scrolling in iOS
+ */
+#-amp-scrollpos, #-amp-scrollmove, #-amp-endpos {
+  width: 0;
+  height: 0;
+  visibility: hidden;
+}
+
+#-amp-scrollpos, #-amp-scrollmove {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+
+/**
  * Wraps an element to make the contents scrollable. This is
  * used to wrap iframes which in iOS always behave as if they had the
  * seamless attribute.

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -48,9 +48,8 @@ export class SyntheticScroll {
    * @param {number} scrollTop the body's current scrollTop
    * @param {number} scrollHeight the body's current scrollHeight
    */
-  constructor(scrollEl, scrollTop, scrollHeight) {
-    const doc = scrollEl.ownerDocument;
-    const body = doc.body;
+  constructor(body, scrollTop, scrollHeight) {
+    const doc = body.ownerDocument;
 
     /**
      * @const @private {!Window}
@@ -58,10 +57,9 @@ export class SyntheticScroll {
     this.win_ = doc.defaultView;
 
     /**
-     * We store the style reference directly to speed things up.
-     * @const @private {!CSSStyleDeclaration}
-     **/
-    this.scrollStyle_ = scrollEl.style;
+     * @const @private {!HTMLBodyElement}
+     */
+    this.body_ = body;
 
     /**
      * We track the iframes on the page so we may disable direct interaction
@@ -219,7 +217,7 @@ export class SyntheticScroll {
     body.addEventListener('scroll', this.bodyScroll_.bind(this));
 
     // Promote the scroller to it's own GPU rendering layer.
-    this.scrollStyle_.willChange = 'transform';
+    body.style.willChange = 'transform';
   }
 
   /**
@@ -357,7 +355,7 @@ export class SyntheticScroll {
 
     // "Scroll" by moving the scroller element in the opposite direction of
     // the scroll.
-    this.scrollStyle_.transform = y ? `translate3d(0, ${-y}px, 0)` : '';
+    this.body_.style.transform = y ? `translate3d(0, ${-y}px, 0)` : '';
 
     const fixeds = this.fixedElementStyles_;
     const translation = `translate3d(0, ${y}px, 0)`;
@@ -496,8 +494,7 @@ export class SyntheticScroll {
     // Make the entire body visible so that we may transform its box to scroll.
     // Without this, we'd be scrolling the body but no content would be visible
     // outside the overflow cropping.
-    this.scrollStyle_.overflowY = 'visible';
-    this.scrollStyle_.overflowX = 'visible';
+    this.body_.classList.add('-amp-scrolling');
     // Now that we're entirely visible, we must translate the body into our
     // current scroll position.
     this.scrollTo_(this.scrollTop_, true);
@@ -521,8 +518,7 @@ export class SyntheticScroll {
     // Go back to native scroll mode, so that iframes can cause native
     // scrolling.
     this.scrollTo_(0, true);
-    this.scrollStyle_.overflowY = 'auto';
-    this.scrollStyle_.overflowX = 'hidden';
+    this.body_.classList.remove('-amp-scrolling');
 
     // Suppress this body scrolled event, we expect it.
     // TODO move this into it's own method with setScrollTop's.

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -105,7 +105,7 @@ export class SyntheticScroll {
      * The maximum value that we may scroll the scroller to.
      * @private {number}
      */
-    this.max_ = Math.round(scrollHeight - this.win_./*OK*/innerHeight);
+    this.max_ = Math.round(scrollHeight - this.win_./*REVIEW*/innerHeight);
 
     /**
      * The current scroll offset from the body's own scrollTop. After synthetic
@@ -272,7 +272,7 @@ export class SyntheticScroll {
    */
   getScrollTop() {
     const delta = this.bodyScrolled_ ?
-        -this.scrollMoveEl_./*OK*/getBoundingClientRect().top  :
+        -this.scrollMoveEl_./*REVIEW*/getBoundingClientRect().top  :
         0;
     return this.scrollTop_ + this.offset_ + delta;
   }
@@ -284,10 +284,10 @@ export class SyntheticScroll {
    * @param {number} scrollHeight
    */
   resize(scrollTop, scrollHeight) {
-    var delta = this.scrollMoveEl_./*OK*/getBoundingClientRect().top;
+    var delta = this.scrollMoveEl_./*REVIEW*/getBoundingClientRect().top;
     this.scrollTop_ = scrollTop + delta;
     this.min_ = -this.scrollTop_;
-    this.max_ = Math.round(scrollHeight - this.win_./*OK*/innerHeight) - delta;
+    this.max_ = Math.round(scrollHeight - this.win_./*REVIEW*/innerHeight) - delta;
   }
 
   /**
@@ -420,7 +420,7 @@ export class SyntheticScroll {
       // The doc has scrolled natively, causing our synthetic scroll to be out
       // of sync with the real scrollTop. We must calculate the difference
       // and adjust.
-      const delta = -this.scrollMoveEl_./*OK*/getBoundingClientRect().top;
+      const delta = -this.scrollMoveEl_./*REVIEW*/getBoundingClientRect().top;
       this.scrollTop_ += delta;
       this.min_ -= delta;
       this.max_ -= delta;
@@ -447,7 +447,7 @@ export class SyntheticScroll {
     // Suppress this body scrolled event, we expect it.
     this.bodyScrolled_ = null;
     this.scrollMoveEl_.style.transform = 'translateY(' + this.scrollTop_ + 'px)';
-    this.scrollMoveEl_./*OK*/scrollIntoView(true);
+    this.scrollMoveEl_./*REVIEW*/scrollIntoView(true);
 
     this.setIframeInteractionAllowed_(true);
   }

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Observable} from './observable';
 
 /**
  * The elapsed time cutoff that determines if a user intended to stop the

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -319,7 +319,7 @@ export class SyntheticScroll {
     // the scroll.
     // We remove the transform when there is no offset so that the body may be
     // sync'd with our synthetic scroll position.
-    this.scrollStyle_.style.transform = y ? `translate3d(0, ${-y}px, 0)` : '';
+    this.scrollStyle_.transform = y ? `translate3d(0, ${-y}px, 0)` : '';
 
     // Because the scroller now (usually) has a transform, it is now a
     // "positioned" ancestor.  Thus, fixed elements are fixed based on it and

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -1,0 +1,513 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * The elapsed time cutoff that determines if a user intended to stop the
+ * synthetic scroll momentum.
+ * @const @private {number}
+ */
+const SCROLL_INTENTION_ELAPSED_CUTOFF = (1000 / 60) * 3;
+
+/**
+ * Manages scrolling of embedded AMP document in iOS, since iOS doesn't
+ * natively scroll embedded documents well. This "synthetic" scrolling keeps
+ * track of fixed position elements so that they may be scrolled in unison. It
+ * also keeps track of iframes so that they can be disabled during scrolling
+ * (so they don't start a native scroll during our synthetic scroll).
+ *
+ * This is a substantially modified version of Kinetic Scrolling.
+ */
+export class SyntheticScroll {
+
+  /**
+   * @param {HTMLBodyElement} body
+   * @param {number} scrollTop the body's current scrollTop
+   * @param {number} scrollHeight the body's current scrollHeight
+   */
+  constructor(scrollEl, scrollTop, scrollHeight) {
+    const doc = scrollEl.ownerDocument;
+    const body = doc.body;
+
+    /**
+     * @const @private {!Window}
+     */
+    this.win_ = doc.defaultView;
+
+    /**
+     * We store the style reference directly to speed things up.
+     * @const @private {!CSSStyleDeclaration}
+     **/
+    this.scrollStyle_ = scrollEl.style;
+
+    /**
+     * We track the iframes on the page so we may disable direct interaction
+     * during scrolling. This prevents them from causing native scrolling.
+     * When scrolling is done, they will be re-enabled.
+     * @const @private {!Array<!CSSStyleDeclaration>}
+     **/
+    this.iframeStyles_ = [];
+
+    /**
+     * A list of fixed position elements that we should scroll with the doc.
+     * @const @private {!Array<!CSSStyleDeclaration>}
+     */
+    this.fixedElementStyles_ = [];
+
+    /**
+     * A helper element that records the last position we scrolled to. This
+     * allows us to determine how much the user scrolled natively.
+     * @const @private {Element}
+     */
+    this.scrollMoveEl_ = doc.createElement('div');
+    this.scrollMoveEl_.id = '-amp-scrollmove';
+    body.appendChild(this.scrollMoveEl_);
+
+    /**
+     * The body's current scrollTop position. This is synchronized after every
+     * synthetic scroll and at the start of the synthetic scroll after a native
+     * scroll.
+     * @private {number}
+     */
+    this.scrollTop_ = scrollTop;
+
+    /**
+     * The minimum value that we may scroll the scroller to. This may be less
+     * than zero so we may "overscroll" upwards after synchronizing the body's
+     * scrollTop and our synthetic scroll offset.
+     * @private {number}
+     */
+    this.min_ = -scrollTop;
+
+    /**
+     * The maximum value that we may scroll the scroller to.
+     * @private {number}
+     */
+    this.max_ = Math.round(scrollHeight - this.win_./*OK*/innerHeight);
+
+    /**
+     * The current scroll offset from the body's own scrollTop. After synthetic
+     * scrolling, this value will be added to the scrollTop.
+     * @private {number}
+     */
+    this.offset_ = 0;
+
+    /**
+     * Records the y position of the last touch event, and is used to
+     * determine how much movement happened in the current touch event.
+     * @private {number}
+     */
+    this.reference_ = 0;
+
+    /**
+     * Records the timestamp of the last touch event, and is used to
+     * determine how much time elapsed between now.
+     * @private {number}
+     */
+    this.timestamp_ = 0;
+
+    /**
+     * A calculated velocity that the current scroll gives the doc.
+     * @private {number}
+     */
+    this.velocity_ = 0;
+
+    /**
+     * A total distance between the current offset and where the doc should
+     * end up after accounting for the velocity.
+     * @private {number}
+     */
+    this.amplitude_ = 0;
+
+    /**
+     * The target offset that scroll velocity carries us to.
+     * @private {number}
+     */
+    this.target_ = 0;
+
+    /**
+     * The animation frame id for our synthetic momentum scrolling step
+     * function.
+     * @private {number}
+     */
+    this.autoScrolling_ = 0;
+
+    /**
+     * Used to determine if the user has native scrolled (due to an iframe).
+     * To account for our own scrolling of the body element (synchronizing the
+     * scrollTop and our synthetic scrolling), this value may be null meaning
+     * that this scroll event is expected. If so, it will be set to false after
+     * the expected scroll. Otherwise, it will be true indicating a native
+     * scroll.
+     * @private {boolean|null}
+     */
+    this.bodyScrolled_ = false;
+
+    /**
+     * The synthetic momentum scroll, bound to this context.
+     * @private
+     */
+    this.boundAutoScroll_ = this.autoScroll_.bind(this);
+
+    // We listen on the document level so that, even if the HTML or BODY has
+    // padding, margin, etc, the touch event will still cause scrolling.
+    doc.addEventListener('touchstart', this.touchstart_.bind(this));
+    doc.addEventListener('touchmove', this.touchmove_.bind(this));
+    doc.addEventListener('touchend', this.touchend_.bind(this));
+    // Native scrolling does some weird things. When the user native scrolls
+    // due to an iframe, the only event fired in this doc is a `scroll` on
+    // the body element.
+    body.addEventListener('scroll', this.bodyScroll_.bind(this));
+
+    // Promote the scroller to it's own GPU rendering layer.
+    this.scrollStyle_.willChange = 'transform';
+  }
+
+  /**
+   * Adds a fixed position element to the list we track. When the doc is
+   * scrolled, we will scroll the element in unison.
+   *
+   * @param {!Element} element
+   */
+  addFixedElement(element) {
+    const style = element.style;
+    this.fixedElementStyles_.push(style);
+    style.transform = `translate3d(0, 0, 0)`;
+  }
+
+  /**
+   * Removes the fixed position element from our list.
+   *
+   * @param {!Element} element
+   */
+  removeFixedElement(element) {
+    const style = element.style;
+    const index = this.fixedElementStyles_.indexOf(style);
+
+    if (index > -1) {
+      this.fixedElementStyles_.splice(index, 1);
+      style.transform = '';
+    }
+  }
+
+  /**
+   * Adds an iframe to the list we track. When the doc is scrolled, we will
+   * disable interaction with the element to prevent native scrolling from
+   * kicking in. When scrolling has stopped, we will re-enable.
+   *
+   * @param {!HTMLIFrameElement} iframe
+   */
+  addIframe(iframe) {
+    const style = iframe.style;
+    this.iframeStyles_.push(style);
+
+    // Offset is only present during scrolling, in which case we need to
+    // disable interacting with the iframe.
+    if (this.offset) {
+      style.pointerEvents = 'none';
+    }
+  }
+
+  /**
+   * Removes the iframe from our list.
+   *
+   * @param {!HTMLIFrameElement} iframe
+   */
+  removeIframe(iframe) {
+    const style = iframe.style;
+    const index = this.iframeStyles_.indexOf(style);
+
+    if (index > -1) {
+      this.iframeStyles_.splice(index, 1);
+      style.pointerEvents = '';
+    }
+  }
+
+  /**
+   * Scrolls the document to position ypos.
+   *
+   * @param {number} ypos
+   */
+  setScrollTop(ypos) {
+    this.scrollTo_(ypos);
+    this.scrollStopped_();
+  }
+
+  /**
+   * Calculates the current scrollTop.
+   */
+  getScrollTop() {
+    const delta = this.bodyScrolled_ ?
+        -this.scrollMoveEl_./*OK*/getBoundingClientRect().top  :
+        0;
+    return this.scrollTop_ + this.offset_ + delta;
+  }
+
+  /**
+   * Resize the scroll element. Usually triggered after an orientation change.
+   *
+   * @param {number} scrollTop
+   * @param {number} scrollHeight
+   */
+  resize(scrollTop, scrollHeight) {
+    var delta = this.scrollMoveEl_./*OK*/getBoundingClientRect().top;
+    this.scrollTop_ = scrollTop + delta;
+    this.min_ = -this.scrollTop_;
+    this.max_ = Math.round(scrollHeight - this.win_./*OK*/innerHeight) - delta;
+  }
+
+  /**
+   * Synthetically scrolls the document to position ypos. This does not change
+   * the body's scrollTop.
+   *
+   * @param {number} ypos
+   * @private
+   */
+  scrollTo_(yPos) {
+    const y = Math.min(Math.max(yPos, this.min_), this.max_);
+    if (y === this.offset_) {
+      return false;
+    }
+    this.offset_ = y;
+
+    // "Scroll" by moving the scroller element in the opposite direction of
+    // the scroll.
+    // We remove the transform when there is no offset so that the body may be
+    // sync'd with our synthetic scroll position.
+    this.scrollStyle_.style.transform = y ? `translate3d(0, ${-y}px, 0)` : '';
+
+    // Because the scroller now (usually) has a transform, it is now a
+    // "positioned" ancestor.  Thus, fixed elements are fixed based on it and
+    // will move. So, we need to scroll them in the same direction as the
+    // scroll.  When there is no offset, the scroller will not have a transform
+    // so we don't need additional offsetting.
+    const fixedOffset = y === 0 ? 0 : y + this.scrollTop_;
+    const fixeds = this.fixedElementStyles_;
+    for (let i = 0; i < fixeds.length; i++) {
+      fixeds[i].transform = `translate3d(0, ${fixedOffset}px, 0)`;
+    }
+    return true;
+  }
+
+  /**
+   * Determines the y position of a touch event relative to the screen.
+   *
+   * @param {!TouchEvent} event
+   * @return {number}
+   */
+  eventY_(event) {
+    // Surprisingly, `touchend` does not provide a Touch inside `touches`,
+    // but every `TouchEvent` will provide one inside `changedTouches`.
+    return event.changedTouches[0].screenY;
+  }
+
+  /**
+   * Tracks the velocity of touch movement using a sliding equation.
+   *
+   * @param {number} delta the change in y position since the last velocity
+   *     tracking.
+   */
+  track_(delta) {
+    const now = Date.now();
+    const elapsed = now - this.timestamp_;
+    this.timestamp_ = now;
+
+    // An arbitrary sliding acceleration equation to gain speed based on the
+    // last velocity.
+    // Constants have been pulled out to highlight that they may change.
+    const pixelsPerDelta = 500;
+    const currentWeight = 0.8;
+    const lastWeight = 1 - currentWeight;
+    const v = pixelsPerDelta * delta / (1 + elapsed);
+    this.velocity_ = (currentWeight * v) + (lastWeight * this.velocity_);
+  }
+
+  /**
+   * A step function that simulates momentum using a velocity and total offset
+   * amplitude. We approach the target offset exponentially, backing off as we
+   * get closer.
+   */
+  autoScroll_() {
+    this.autoScrolling_ = 0;
+
+    // We approach the target exponentially, slowing down as we get closer.
+    // Note that duration is arbitrary, it just "feels" right.
+    const duration = 450;
+    const elapsed = Date.now() - this.timestamp_;
+    const delta = this.amplitude_ * Math.exp(-elapsed / duration);
+
+    if (Math.abs(delta) > 0.3) {
+      if (this.scrollTo_(this.target_ - delta)) {
+        this.autoScrolling_ = requestAnimationFrame(this.boundAutoScroll);
+        return;
+      }
+    } else {
+      this.scrollTo_(this.target_);
+    }
+    this.scrollStopped_();
+  }
+
+  /**
+   * Called when the doc first starts scrolling (ie, there is no scroll
+   * synthetic scroll momentum). This will be called if the user natively
+   * scrolls the document, then continues the scroll outside of the iframe.
+   *
+   * @param {TouchEvent} event
+   */
+  scrollStarted_(event) {
+    if (this.bodyScrolled_) {
+      // If the user is still scrolling natively, this will stop it and start
+      // the synthetic scrolling.
+      event.preventDefault();
+      event.stopPropagation();
+
+      // The doc has scrolled natively, causing our synthetic scroll to be out
+      // of sync with the real scrollTop. We must calculate the difference
+      // and adjust.
+      const delta = -this.scrollMoveEl_./*OK*/getBoundingClientRect().top;
+      this.scrollTop_ += delta;
+      this.min_ -= delta;
+      this.max_ -= delta;
+      this.bodyScrolled_ = false;
+    }
+
+    this.setIframeInteractionAllowed_(false);
+  }
+
+  /**
+   * Called when the doc stops scrolling, either because there was not enough
+   * velocity to have synthetic momentum or we are at our target offset from
+   * the momentum.
+   */
+  scrollStopped_() {
+    // To allow native scrolling on iframes, we must adjust the doc's real
+    // scrollTop to match where we syntheticly scrolled (else, the user
+    // wouldn't be able to natively scroll up because Safari thinks
+    // they're "at" the top of the doc).
+    this.scrollTop_ += this.offset_;
+    this.min_ -= offset;
+    this.max_ -= offset;
+    this.scrollTo_(0);
+    // Suppress this body scrolled event, we expect it.
+    this.bodyScrolled_ = null;
+    this.scrollMoveEl_.style.transform = 'translateY(' + this.scrollTop_ + 'px)';
+    this.scrollMoveEl_./*OK*/scrollIntoView(true);
+
+    this.setIframeInteractionAllowed_(true);
+  }
+
+  /**
+   * Enables or disables interaction with iframes.
+   *
+   * @param {boolean} allowed
+   */
+  setIframeInteractionAllowed_(allowed) {
+    const value = allowed ? '' : 'none';
+    const styles = this.iframeStyles_;
+    for (let i = 0; i < styles.length; i++) {
+      styles[i].pointerEvents = value;
+    }
+  }
+
+  /**
+   * A callback bound to the `touchstart` event on the document.
+   *
+   * @param {TouchEvent} event
+   */
+  touchstart_(event) {
+    // We don't allow zooming
+    if (event.touches.length > 1) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (this.autoScrolling_) {
+      cancelAnimationFrame(this.autoScrolling_);
+      this.autoScrolling_ = 0;
+    } else {
+      this.scrollStarted_();
+    }
+
+    this.velocity_ = 0;
+    this.amplitude_ = 0;
+    this.timestamp_ = Date.now();
+    this.reference_ = this.eventY_(event);
+  }
+
+  /**
+   * A callback bound to the `touchmove` event on the document.
+   *
+   * @param {TouchEvent} event
+   */
+  touchmove_(event) {
+    // We don't allow zooming
+    if (event.touches.length > 1) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    const y = this.eventY_(event);
+    const delta = this.reference_ - y;
+    this.track_(delta);
+    this.reference_ = y;
+    this.scrollTo_(this.offset_ + delta);
+
+    event.preventDefault();
+    event.stopPropagation();
+    return false;
+  }
+
+  /**
+   * A callback bound to the `touchend` event on the document.
+   *
+   * @param {TouchEvent} event
+   */
+  touchend_(event) {
+    // We don't allow zooming
+    if (event.touches.length > 1) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    // Only simulate momentum if we think the user meant to have it.  Ie. if
+    // you hang your finger for a few milliseconds, you probably meant to stop
+    // the scrolling entirely.
+    const elapsed = Date.now() - this.timestamp_;
+    if (elapsed < SCROLL_INTENTION_ELAPSED_CUTOFF) {
+      // Determine where we should stop the synthetic momentum.
+      // The multiplier is arbitrary.
+      const multiplier = 1.1;
+      this.amplitude_ = multiplier * this.velocity_;
+      this.target_ = Math.round(this.offset_ + this.amplitude_);
+      this.autoScrolling_ = requestAnimationFrame(this.boundAutoScroll);
+    } else {
+      this.scrollStopped_();
+    }
+  }
+
+  /**
+   * A callback bound to the `scroll` event on the body. This is used to
+   * determine if a native scroll happened.
+   *
+   * @param {TouchEvent} event
+   */
+  bodyScroll_() {
+    this.bodyScrolled_ = this.bodyScrolled_ === null ? false : true;
+  }
+}

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -394,7 +394,9 @@ export class SyntheticScroll {
 
     if (Math.abs(delta) > 0.3) {
       if (this.scrollTo_(this.target_ - delta)) {
-        this.autoScrolling_ = requestAnimationFrame(this.boundAutoScroll);
+        this.autoScrolling_ = this.win_.requestAnimationFrame(
+          this.boundAutoScroll
+        );
         return;
       }
     } else {
@@ -538,7 +540,9 @@ export class SyntheticScroll {
       const multiplier = 1.1;
       this.amplitude_ = multiplier * this.velocity_;
       this.target_ = Math.round(this.offset_ + this.amplitude_);
-      this.autoScrolling_ = requestAnimationFrame(this.boundAutoScroll);
+      this.autoScrolling_ = this.win_.requestAnimationFrame(
+        this.boundAutoScroll
+      );
     } else {
       this.scrollStopped_();
     }

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -386,7 +386,7 @@ export class SyntheticScroll {
   touch_(event, opt_end) {
     let touch;
     if (opt_end) {
-      touch = e.changedTouches[0];
+      touch = event.changedTouches[0];
       //  If this is a single-finger scroll, this will be the finger we are
       //  tracking. If this is a multi-finger scroll, this may be the finger
       //  or it may be one of the other fingers we are not tracking.
@@ -398,7 +398,7 @@ export class SyntheticScroll {
       return;
     }
 
-    const touches = e.touches;
+    const touches = event.touches;
 
     // If we're not tracking a touch yet, just grab the first and track it.
     if (!this.touchId_) {
@@ -457,7 +457,7 @@ export class SyntheticScroll {
       // Only continue autoscrolling if we are not at the bounds of the doc.
       if (this.scrollTo_(this.target_ - delta)) {
         this.autoScrolling_ = this.win_.requestAnimationFrame(
-          this.boundAutoScroll
+          this.boundAutoScroll_
         );
         return;
       }
@@ -574,7 +574,7 @@ export class SyntheticScroll {
   setIframeInteractionAllowed_(allowed) {
     const value = allowed ? '' : 'none';
     const iframes = this.iframeStyles_;
-    for (let i = 0; i < styles.length; i++) {
+    for (let i = 0; i < iframes.length; i++) {
       iframes[i].pointerEvents = value;
     }
   }
@@ -673,7 +673,7 @@ export class SyntheticScroll {
       this.amplitude_ = multiplier * this.velocity_;
       this.target_ = Math.round(this.offset_ + this.amplitude_);
       this.autoScrolling_ = this.win_.requestAnimationFrame(
-        this.boundAutoScroll
+        this.boundAutoScroll_
       );
     } else {
       this.scrollStopped_();

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -332,9 +332,14 @@ export class SyntheticScroll {
       fixeds[i].transform = `translate3d(0, ${fixedOffset}px, 0)`;
     }
 
-    if (y === 0 || scrollEventDelta > SCROLL_EVENT_DELTA) {
+    if (scrollEventDelta > SCROLL_EVENT_DELTA) {
       this.lastScrollEventOffset_ = y;
-      this.scrollObservable_.fire();
+      // The only time we scroll to 0 is when we're synchronizing the scrollTop
+      // and synthetic scroll. In that case, the body's own scroll event will
+      // fire.
+      if (y !== 0) {
+        this.scrollObservable_.fire();
+      }
     }
 
     return true;
@@ -547,5 +552,6 @@ export class SyntheticScroll {
    */
   bodyScroll_() {
     this.bodyScrolled_ = this.bodyScrolled_ === null ? false : true;
+    this.scrollObservable_.fire();
   }
 }

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -99,13 +99,13 @@ export class SyntheticScroll {
      * scrollTop and our synthetic scroll offset.
      * @private {number}
      */
-    this.min_ = -scrollTop;
+    this.minScrollTop_ = -scrollTop;
 
     /**
      * The maximum value that we may scroll the scroller to.
      * @private {number}
      */
-    this.max_ = Math.round(scrollHeight - this.win_./*REVIEW*/innerHeight);
+    this.maxScrollTop_ = Math.round(scrollHeight - this.win_./*REVIEW*/innerHeight);
 
     /**
      * The current scroll offset from the body's own scrollTop. After synthetic
@@ -286,8 +286,8 @@ export class SyntheticScroll {
   resize(scrollTop, scrollHeight) {
     var delta = this.scrollMoveEl_./*REVIEW*/getBoundingClientRect().top;
     this.scrollTop_ = scrollTop + delta;
-    this.min_ = -this.scrollTop_;
-    this.max_ = Math.round(scrollHeight - this.win_./*REVIEW*/innerHeight) - delta;
+    this.minScrollTop_ = -this.scrollTop_;
+    this.maxScrollTop_ = Math.round(scrollHeight - this.win_./*REVIEW*/innerHeight) - delta;
   }
 
   /**
@@ -308,7 +308,7 @@ export class SyntheticScroll {
    * @private
    */
   scrollTo_(yPos) {
-    const y = Math.min(Math.max(yPos, this.min_), this.max_);
+    const y = Math.min(Math.max(yPos, this.minScrollTop_), this.maxScrollTop_);
     if (y === this.offset_) {
       return false;
     }
@@ -422,8 +422,8 @@ export class SyntheticScroll {
       // and adjust.
       const delta = -this.scrollMoveEl_./*REVIEW*/getBoundingClientRect().top;
       this.scrollTop_ += delta;
-      this.min_ -= delta;
-      this.max_ -= delta;
+      this.minScrollTop_ -= delta;
+      this.maxScrollTop_ -= delta;
       this.bodyScrolled_ = false;
     }
 
@@ -441,8 +441,8 @@ export class SyntheticScroll {
     // wouldn't be able to natively scroll up because Safari thinks
     // they're "at" the top of the doc).
     this.scrollTop_ += this.offset_;
-    this.min_ -= offset;
-    this.max_ -= offset;
+    this.minScrollTop_ -= offset;
+    this.maxScrollTop_ -= offset;
     this.scrollTo_(0);
     // Suppress this body scrolled event, we expect it.
     this.bodyScrolled_ = null;

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -482,7 +482,7 @@ export class SyntheticScroll {
       cancelAnimationFrame(this.autoScrolling_);
       this.autoScrolling_ = 0;
     } else {
-      this.scrollStarted_();
+      this.scrollStarted_(event);
     }
 
     this.velocity_ = 0;

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -43,7 +43,7 @@ const SCROLL_EVENT_DELTA = 2.1;
 export class SyntheticScroll {
 
   /**
-   * @param {HTMLBodyElement} body
+   * @param {!HTMLBodyElement} body
    * @param {number} scrollTop the body's current scrollTop
    * @param {number} scrollHeight the body's current scrollHeight
    */
@@ -79,7 +79,7 @@ export class SyntheticScroll {
     /**
      * A helper element that records the last position we scrolled to. This
      * allows us to determine how much the user scrolled natively.
-     * @const @private {Element}
+     * @const @private {!Element}
      */
     this.scrollMoveEl_ = doc.createElement('div');
     this.scrollMoveEl_.id = '-amp-scrollmove';
@@ -410,7 +410,7 @@ export class SyntheticScroll {
    * synthetic scroll momentum). This will be called if the user natively
    * scrolls the document, then continues the scroll outside of the iframe.
    *
-   * @param {TouchEvent} event
+   * @param {!TouchEvent} event
    */
   scrollStarted_(event) {
     if (this.bodyScrolled_) {
@@ -470,7 +470,7 @@ export class SyntheticScroll {
   /**
    * A callback bound to the `touchstart` event on the document.
    *
-   * @param {TouchEvent} event
+   * @param {!TouchEvent} event
    */
   touchstart_(event) {
     // We don't allow zooming
@@ -496,7 +496,7 @@ export class SyntheticScroll {
   /**
    * A callback bound to the `touchmove` event on the document.
    *
-   * @param {TouchEvent} event
+   * @param {!TouchEvent} event
    */
   touchmove_(event) {
     // We don't allow zooming
@@ -520,7 +520,7 @@ export class SyntheticScroll {
   /**
    * A callback bound to the `touchend` event on the document.
    *
-   * @param {TouchEvent} event
+   * @param {!TouchEvent} event
    */
   touchend_(event) {
     // We don't allow zooming
@@ -551,8 +551,6 @@ export class SyntheticScroll {
   /**
    * A callback bound to the `scroll` event on the body. This is used to
    * determine if a native scroll happened.
-   *
-   * @param {TouchEvent} event
    */
   bodyScroll_() {
     this.bodyScrolled_ = this.bodyScrolled_ === null ? false : true;

--- a/src/ios-scroll.js
+++ b/src/ios-scroll.js
@@ -204,6 +204,8 @@ export class SyntheticScroll {
   addFixedElement(element) {
     const style = element.style;
     this.fixedElementStyles_.push(style);
+    // Promote the element to it's own GPU rendering layer. This allows us to
+    // scroll the element in unison with the doc.
     style.transform = `translate3d(0, 0, 0)`;
   }
 

--- a/src/observable.js
+++ b/src/observable.js
@@ -51,11 +51,9 @@ export class Observable {
    * @param {function(TYPE)} handler Observer's instance.
    */
   remove(handler) {
-    for (let i = 0; i < this.handlers_.length; i++) {
-      if (handler == this.handlers_[i]) {
-        this.handlers_.splice(i, 1);
-        break;
-      }
+    const index = this.handlers_.indexOf(handler);
+    if (index > -1) {
+      this.handlers_.splice(index, 1);
     }
   }
 
@@ -64,9 +62,11 @@ export class Observable {
    * @param {TYPE} event
    */
   fire(event) {
-    this.handlers_.forEach(handler => {
+    const handlers = this.handlers_;
+    for (let i = 0; i< handlers.length; i++) {
+      const handler = handlers[i];
       handler(event);
-    });
+    }
   }
 
   /**

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1171,6 +1171,9 @@ export class ViewportBindingNaturalIosScrollEmbed_
 
   /** @override */
   getScrollTop() {
+    if (!this.scroller) {
+      return 0;
+    }
     return this.scroller.getScrollTop();
   }
 
@@ -1196,6 +1199,9 @@ export class ViewportBindingNaturalIosScrollEmbed_
 
   /** @override */
   setScrollTop(scrollTop) {
+    if (!this.scroller) {
+      return;
+    }
     this.scroller.setScrollTop(scrollTop);
   }
 

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -883,39 +883,18 @@ export class ViewportBindingNaturalIosEmbed_ {
     // this is needed.
     this.scrollPosEl_ = this.win.document.createElement('div');
     this.scrollPosEl_.id = '-amp-scrollpos';
-    setStyles(this.scrollPosEl_, {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: 0,
-      height: 0,
-      visibility: 'hidden',
-    });
     documentBody.appendChild(this.scrollPosEl_);
 
     // Insert scrollMove element into DOM. See {@link adjustScrollPos_} for why
     // this is needed.
     this.scrollMoveEl_ = this.win.document.createElement('div');
     this.scrollMoveEl_.id = '-amp-scrollmove';
-    setStyles(this.scrollMoveEl_, {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: 0,
-      height: 0,
-      visibility: 'hidden',
-    });
     documentBody.appendChild(this.scrollMoveEl_);
 
     // Insert endPos element into DOM. See {@link getScrollHeight} for why
     // this is needed.
     this.endPosEl_ = this.win.document.createElement('div');
     this.endPosEl_.id = '-amp-endpos';
-    setStyles(this.endPosEl_, {
-      width: 0,
-      height: 0,
-      visibility: 'hidden',
-    });
     // TODO(dvoytenko): not only it should be at the bottom at setup time,
     // but it must always be at the bottom. Consider using BODY "childList"
     // mutations to track this. For now, however, this is ok since we don't

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1448,11 +1448,11 @@ function createViewport_(window) {
   if (viewer.getViewportType() == 'virtual') {
     binding = new ViewportBindingVirtual_(window, viewer);
   } else if (viewer.getViewportType() == 'natural-ios-embed') {
-    if (isExperimentOn(window, 'amp-ios-scroll')) {
+    // if (isExperimentOn(window, 'amp-ios-scroll')) {
       binding = new ViewportBindingNaturalIosScrollEmbed_(window);
-    } else {
-      binding = new ViewportBindingNaturalIosEmbed_(window);
-    }
+    // } else {
+      // binding = new ViewportBindingNaturalIosEmbed_(window);
+    // }
   } else {
     binding = new ViewportBindingNatural_(window);
   }

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1226,6 +1226,11 @@ export class ViewportBindingNaturalIosScrollEmbed_
       Math.round(rect.height)
     );
   }
+
+  /** @override */
+  updatePaddingTop(paddingTop) {
+    this.win.document.documentElement.style.paddingTop = px(paddingTop);
+  }
 }
 
 

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -814,10 +814,13 @@ export class ViewportBindingNaturalIosEmbed_ {
     this.win = win;
 
     /** @private {?Element} */
-    this.scrollPosEl_ = null;
+    this.startPosEl_ = null;
 
     /** @private {?Element} */
     this.scrollMoveEl_ = null;
+
+    /** @private {?Element} */
+    this.endPosEl_ = null;
 
     /** @private {!{x: number, y: number}} */
     this.pos_ = {x: 0, y: 0};
@@ -879,11 +882,11 @@ export class ViewportBindingNaturalIosEmbed_ {
       bottom: 0,
     });
 
-    // Insert scrollPos element into DOM. See {@link onScrolled_} for why
+    // Insert startPos element into DOM. See {@link onScrolled_} for why
     // this is needed.
-    this.scrollPosEl_ = this.win.document.createElement('div');
-    this.scrollPosEl_.id = '-amp-scrollpos';
-    documentBody.appendChild(this.scrollPosEl_);
+    this.startPosEl_ = this.win.document.createElement('div');
+    this.startPosEl_.id = '-amp-startpos';
+    documentBody.appendChild(this.startPosEl_);
 
     // Insert scrollMove element into DOM. See {@link adjustScrollPos_} for why
     // this is needed.
@@ -980,7 +983,7 @@ export class ViewportBindingNaturalIosEmbed_ {
       return 0;
     }
     return Math.round(this.endPosEl_./*OK*/getBoundingClientRect().top -
-        this.scrollPosEl_./*OK*/getBoundingClientRect().top);
+        this.startPosEl_./*OK*/getBoundingClientRect().top);
   }
 
   /** @override */
@@ -1017,11 +1020,11 @@ export class ViewportBindingNaturalIosEmbed_ {
     // document./*OK*/scrollingElement will point to document.documentElement.
     // This already works correctly in Chrome with "scroll-top-left-interop"
     // flag turned on "chrome://flags/#scroll-top-left-interop".
-    if (!this.scrollPosEl_) {
+    if (!this.startPosEl_) {
       return;
     }
     this.adjustScrollPos_(event);
-    const rect = this.scrollPosEl_./*OK*/getBoundingClientRect();
+    const rect = this.startPosEl_./*OK*/getBoundingClientRect();
     if (this.pos_.x != -rect.left || this.pos_.y != -rect.top) {
       this.pos_.x = -rect.left;
       this.pos_.y = -rect.top;
@@ -1043,14 +1046,14 @@ export class ViewportBindingNaturalIosEmbed_ {
    * @private
    */
   adjustScrollPos_(opt_event) {
-    if (!this.scrollPosEl_ || !this.scrollMoveEl_) {
+    if (!this.startPosEl_ || !this.scrollMoveEl_) {
       return;
     }
 
     // Scroll document into a safe position to avoid scroll freeze on iOS.
     // This means avoiding scrollTop to be minimum (0) or maximum value.
     // This is very sad but very necessary. See #330 for more details.
-    const scrollTop = -this.scrollPosEl_./*OK*/getBoundingClientRect().top;
+    const scrollTop = -this.startPosEl_./*OK*/getBoundingClientRect().top;
     if (scrollTop == 0) {
       this.setScrollPos_(1);
       if (opt_event) {

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1100,9 +1100,6 @@ export class ViewportBindingNaturalIosScrollEmbed_
   constructor(win) {
     super(win);
 
-    // TODO
-    this.onScroll();
-
     this.onResize(() => this.onResized_());
   }
 

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1180,6 +1180,8 @@ export class ViewportBindingNaturalIosScrollEmbed_
       this.getScrollTop_(),
       this.getScrollHeight()
     );
+
+    this.scroller.onScroll(() => this.scrollObservable_.fire());
   }
 
   /**
@@ -1212,11 +1214,6 @@ export class ViewportBindingNaturalIosScrollEmbed_
     return -rect.top;
   }
 
-  /** @override */
-  setScrollTop(scrollTop) {
-    this.scroller.setScrollTop(scrollTop);
-  }
-
   getLayoutRect(el) {
     const rect = el./*OK*/getBoundingClientRect();
     return layoutRectLtwh(
@@ -1225,6 +1222,11 @@ export class ViewportBindingNaturalIosScrollEmbed_
       Math.round(rect.width),
       Math.round(rect.height)
     );
+  }
+
+  /** @override */
+  setScrollTop(scrollTop) {
+    this.scroller.setScrollTop(scrollTop);
   }
 
   /** @override */

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1120,14 +1120,6 @@ export class ViewportBindingNaturalIosScrollEmbed_
     const body = doc.body;
 
     // Setup scrolling styles.
-    // html {
-    //   height: 100% !important;
-    //   -webkit-overflow-scrolling: touch;
-    // }
-    // body {
-    //   height: 100% !important;
-    //   overflow-x: hidden;
-    // }
     setStyles(documentElement, {
       height: '100% !important',
       webkitOverflowScrolling: 'touch',
@@ -1135,29 +1127,11 @@ export class ViewportBindingNaturalIosScrollEmbed_
     setStyles(body, {
       height: '100% !important',
       overflowX: 'hidden',
+      overflowY: 'auto',
+      // Necessary so that absolutely positioned elements remained positioned
+      // relative to the body.
+      position: 'relative',
     });
-
-    let hasContainer = body.children === 1;
-    if (hasContainer) {
-      for (let child = body.firstChild; child; child = child.nextSibling) {
-        // Does this Text Node contain any non-whitespace chars?
-        if (child.nodeType === /* Text */ 3 && /\S/.test(child.data)) {
-          hasContainer = false;
-          break;
-        }
-      }
-    }
-
-    let container;
-    if (hasContainer) {
-      container = body.firstElementChild;
-    } else {
-      container = doc.createElement('i-amp-container');
-      moveChildren(body, container);
-      body.appendChild(container);
-      // TODO Update any `body > X` CSS selectors to `body > i-amp-container > X`.
-    }
-
 
     // Insert startPos element into DOM. See {@link getScrollHeight} for why
     // this is needed.
@@ -1171,9 +1145,8 @@ export class ViewportBindingNaturalIosScrollEmbed_
     this.endPosEl_.id = '-amp-endpos';
     body.appendChild(this.endPosEl_);
 
-    // TODO
     this.scroller = new SyntheticScroll(
-      container,
+      body,
       this.getScrollTop_(),
       this.getScrollHeight()
     );

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1101,9 +1101,9 @@ export class ViewportBindingNaturalIosScrollEmbed_
     super(win);
 
     // TODO
-    this.onResize();
     this.onScroll();
 
+    this.onResize(() => this.onResized_());
   }
 
   /** @override */
@@ -1177,6 +1177,16 @@ export class ViewportBindingNaturalIosScrollEmbed_
     // TODO
     this.scroller = new SyntheticScroll(
       container,
+      this.getScrollTop_(),
+      this.getScrollHeight()
+    );
+  }
+
+  /**
+   * Alerts the synthetic scroller that the viewport has resized
+   */
+  onResized_() {
+    this.scroller.resize(
       this.getScrollTop_(),
       this.getScrollHeight()
     );

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1233,6 +1233,12 @@ export class ViewportBindingNaturalIosScrollEmbed_
   updatePaddingTop(paddingTop) {
     this.win.document.documentElement.style.paddingTop = px(paddingTop);
   }
+
+  /** @override */
+  updateLightboxMode(unusedLightboxMode) {
+    // The layout is always accurate.
+  }
+
 }
 
 

--- a/third_party/kinetic-scrolling/LICENSE.txt
+++ b/third_party/kinetic-scrolling/LICENSE.txt
@@ -1,0 +1,22 @@
+ Copyright (C) 2013 Ariya Hidayat
+ https://github.com/ariya/kinetic/
+
+ Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following
+ conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -96,6 +96,11 @@ const EXPERIMENTS = [
     name: 'AMP Form Extension',
     spec: 'https://github.com/ampproject/amphtml/issues/3343',
   },
+  {
+    id: 'amp-ios-scroll',
+    name: 'AMP iOS Scroll Service',
+    spec: '',
+  },
 ];
 
 


### PR DESCRIPTION
This implements synthetic JS scrolling for embedded AMP docs on iOS. Manual testing still needed, but I need reviewers.

[Rationale](https://docs.google.com/document/d/1aH0eprGeHPYwehxItASXjYwL6XK5cyIodSy_5sQjPn4/edit)

TODO:

- [ ] Find `position: fixed` elements and add them to the scroller
- [ ] Add any `<iframes> ` we create to the scroller
- [ ] Update `body > child` CSS rules to account for the container.
- [ ] Test scrolling on child elements (like carousels)
- [ ] Test viewer doc -> doc swiping
- [ ] Test `IntersectionObserver`