### PR TITLE
Validator web ui: Move the ampproject-toolbar into its own .html file.

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -424,8 +424,9 @@ def CreateWebuiAppengineDist(out_dir):
     shutil.copytree('webui', os.path.join(tempdir, 'webui'))
     os.symlink(os.path.abspath('node_modules/codemirror'),
                os.path.join(tempdir, 'webui/codemirror'))
-    os.symlink(os.path.abspath('node_modules/@polymer'),
-               os.path.join(tempdir, 'webui/@polymer'))
+    for d in os.listdir('node_modules/@polymer'):
+      os.symlink(os.path.abspath(os.path.join('node_modules/@polymer', d)),
+                 os.path.join(tempdir, 'webui/@polymer', d))
     os.symlink(os.path.abspath('node_modules/webcomponents-lite'),
                os.path.join(tempdir, 'webui/webcomponents-lite'))
     vulcanized_index_html = subprocess.check_output([

--- a/validator/index.js
+++ b/validator/index.js
@@ -303,19 +303,14 @@ exports.getInstance = getInstance;
 
 /**
  * Maps from file extension to a mime-type.
- * @param {!string} extension
- * @returns {!string}
+ * @type {!Object<string, string>}
  */
-function extToMime(extension) {
-  if (extension === '.html') {
-    return 'text/html';
-  } else if (extension === '.js') {
-    return 'text/javascript';
-  } else if (extension === '.css') {
-    return 'text/css';
-  }
-  return 'text/plain';
-}
+const extToMime = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.png': 'image/png'
+};
 
 /**
  * Serves a web UI for validation.
@@ -361,35 +356,24 @@ function serve(port, validatorScript) {
             response.end(validatorScriptContents);
             return;
           }
-          //
-          // Handle '/amp_favicon.png'
-          //
-          if (request.url === '/amp_favicon.png') {
-            const contents = fs.readFileSync(
-                path.join(__dirname, 'webui/amp_favicon.png'), 'binary');
-            response.writeHead(200, {'Content-Type': 'image/png'});
-            response.end(contents, 'binary');
-            return;
-          }
-          // Look up any other resources relative to node_modules.
+          // Look up any other resources relative to node_modules or webui.
           const relative_path = request.url.substr(1);  // Strip leading '/'.
-          const node_modules_path =
-              path.join(__dirname, 'node_modules', relative_path);
+          for (root of ['node_modules', 'webui']) {
+            const abs_path = path.join(__dirname, root, relative_path);
 
-          // Only serve .js .html .css below node_modules.
-          if (path.resolve(node_modules_path)
-                  .startsWith(path.resolve(__dirname)) &&
-              ['.js', '.html',
-               '.css'].indexOf(path.extname(node_modules_path)) !== -1) {
-            try {
-              const contents = fs.readFileSync(node_modules_path, 'utf-8');
-              response.writeHead(
-                  200,
-                  {'Content-Type': extToMime(path.extname(node_modules_path))});
-              response.end(contents);
-              return;
-            } catch (error) {
-              // Fall through for 404 below.
+            // Only serve files with known mime type and only if they're below
+            // the directory that this module is located in.
+            if (path.resolve(abs_path).startsWith(path.resolve(__dirname)) &&
+                extToMime.hasOwnProperty(path.extname(abs_path))) {
+              try {
+                const contents = fs.readFileSync(abs_path, 'binary');
+                response.writeHead(
+                    200, {'Content-Type': extToMime[path.extname(abs_path)]});
+                response.end(contents, 'binary');
+                return;
+              } catch (error) {
+                // May fall through for 404 below.
+              }
             }
           }
           response.writeHead(404, {'Content-Type': 'text/plain'});

--- a/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
+++ b/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
@@ -1,0 +1,82 @@
+<!--
+  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!-- Toolbar displayed at the top of the page. This doesn't do much but has a
+     lot of styling, so we isolate it to keep the source for other parts of
+     the page easier to read. -->
+<link rel="import" href="../paper-toolbar/paper-toolbar.html">
+<link rel="import" href="../polymer/polymer.html">
+<dom-module id="ampproject-toolbar">
+  <style scope="ampproject-toolbar">
+    paper-toolbar {
+      --paper-toolbar-background: #fbfafb;
+      --paper-toolbar-color: #0379C4;
+      --paper-toolbar: { font-family: Roboto, verdana, arial, sans-serif; };
+      --width: 100%
+    }
+    .ampproject-left {
+      @apply(--layout-flex);
+      color: #0379C4;
+      padding: 15px 10px 15px 50px;
+      margin: 10px 0;
+      width: auto;
+      text-transform: none;
+      white-space: nowrap;
+      background-image: url('data:image/svg+xml;utf-8,<svg width=\22 14px\22  height=\22 14px\22  viewBox=\22 0 0 14 14\22  version=\22 1.1\22  xmlns=\22 http://www.w3.org/2000/svg\22  xmlns:xlink=\22 http://www.w3.org/1999/xlink\22 ><title>AMP Logo</title><g id=\22 Page-1\22  stroke=\22 none\22  stroke-width=\22 1\22  fill=\22 none\22  fill-rule=\22 evenodd\22 ><g id=\22 AMP-Logo\22  fill=\22 #0379C4\22 ><path d=\22 M8.657817,0.216062 L7.647297,5.589962 L10.085327,5.589962 C10.188787,5.589962 10.256477,5.698322 10.211117,5.791282 L6.230217,13.958532 C6.480467,13.985622 6.734567,13.999972 6.992097,13.999972 C10.853717,13.999972 13.984117,10.869572 13.984117,7.007952 C13.984117,3.720402 11.715067,0.963312 8.657817,0.216062\22  id=\22 Fill-4\22 ></path><path d=\22 M6.425398,8.529948 L3.987158,8.529948 C3.883698,8.529948 3.815938,8.421588 3.861298,8.328628 L7.885808,0.072478 C7.591808,0.034958 7.292138,0.015708 6.987848,0.015848 C3.168228,0.018088 0.028028,3.136308 0.000168,6.955858 C-0.024192,10.303328 2.304078,13.111168 5.429718,13.824608 L6.425398,8.529948 Z\22  id=\22 Fill-1\22 ></path></g></g></svg>');
+      background-repeat: no-repeat;
+      background-size: 40px 40px;
+      background-position: center left;
+    }
+    .ampproject-right {
+      color: #0379C4;
+      margin: 10px 0;
+    }
+    .ampproject-link a:link,
+    .ampproject-link a:visited,
+    .ampproject-link a:hover,
+    .ampproject-link a:active {
+      color: #0379C4;
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 300;
+      letter-spacing: 0.04em;
+    }
+    .flex-horizontal {
+      @apply(--layout-horizontal);
+      @apply(--layout-center);
+      margin-bottom: 10px;
+    }
+  </style>
+  <template>
+    <paper-toolbar>
+      <div class="ampproject-left ampproject-link">
+        <a href="https://www.ampproject.org/"
+           target="_blank">Accelerated Mobile Pages Project</a>
+      </div>
+      <div class="ampproject-right ampproject-link">
+        <a href="https://github.com/ampproject/amphtml/blob/master/validator/README.md"
+           target="_blank">GITHUB</a>
+        &nbsp;&nbsp;&nbsp;
+        <a href="https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc"
+           target="_blank">CHROME EXTENSION</a>
+      </div>
+    </paper-toolbar>
+  </template>
+  <script>
+    Polymer({
+    is: 'ampproject-toolbar'
+    });
+  </script>
+</dom-module>

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -33,8 +33,8 @@
   <link rel="import" href="@polymer/paper-listbox/paper-listbox.html">
   <link rel="import" href="@polymer/paper-material/paper-material.html">
   <link rel="import" href="@polymer/paper-styles/demo-pages.html">
-  <link rel="import" href="@polymer/paper-toolbar/paper-toolbar.html">
   <link rel="import" href="@polymer/polymer/polymer.html">
+  <link rel="import" href="@polymer/ampproject-toolbar/ampproject-toolbar.html">
   <link rel="stylesheet" href="codemirror/lib/codemirror.css">
   <script src="codemirror/lib/codemirror.js"></script>
   <script src="codemirror/addon/selection/selection-pointer.js"></script>
@@ -273,74 +273,6 @@
           this.$.urlToFetch.validate();
           this.$.validateButton.click();
         }
-      });
-    </script>
-  </dom-module>
-
-  <!-- Toolbar displayed at the top of the page. This doesn't do much but has a
-       lot of styling, so we isolate it to keep the source for other parts of
-       the page easier to read. -->
-  <dom-module id="ampproject-toolbar">
-    <style scope="ampproject-toolbar">
-      paper-toolbar {
-        --paper-toolbar-background: #fbfafb;
-        --paper-toolbar-color: #0379C4;
-        --paper-toolbar: { font-family: Roboto, verdana, arial, sans-serif; };
-        --width: 100%
-      }
-      .ampproject-left {
-        @apply(--layout-flex);
-        color: #0379C4;
-        padding: 15px 10px 15px 50px;
-        margin: 10px 0;
-        width: auto;
-        text-transform: none;
-        white-space: nowrap;
-        background-image: url('data:image/svg+xml;utf-8,<svg width=\22 14px\22  height=\22 14px\22  viewBox=\22 0 0 14 14\22  version=\22 1.1\22  xmlns=\22 http://www.w3.org/2000/svg\22  xmlns:xlink=\22 http://www.w3.org/1999/xlink\22 ><title>AMP Logo</title><g id=\22 Page-1\22  stroke=\22 none\22  stroke-width=\22 1\22  fill=\22 none\22  fill-rule=\22 evenodd\22 ><g id=\22 AMP-Logo\22  fill=\22 #0379C4\22 ><path d=\22 M8.657817,0.216062 L7.647297,5.589962 L10.085327,5.589962 C10.188787,5.589962 10.256477,5.698322 10.211117,5.791282 L6.230217,13.958532 C6.480467,13.985622 6.734567,13.999972 6.992097,13.999972 C10.853717,13.999972 13.984117,10.869572 13.984117,7.007952 C13.984117,3.720402 11.715067,0.963312 8.657817,0.216062\22  id=\22 Fill-4\22 ></path><path d=\22 M6.425398,8.529948 L3.987158,8.529948 C3.883698,8.529948 3.815938,8.421588 3.861298,8.328628 L7.885808,0.072478 C7.591808,0.034958 7.292138,0.015708 6.987848,0.015848 C3.168228,0.018088 0.028028,3.136308 0.000168,6.955858 C-0.024192,10.303328 2.304078,13.111168 5.429718,13.824608 L6.425398,8.529948 Z\22  id=\22 Fill-1\22 ></path></g></g></svg>');
-        background-repeat: no-repeat;
-        background-size: 40px 40px;
-        background-position: center left;
-      }
-      .ampproject-right {
-        color: #0379C4;
-        margin: 10px 0;
-      }
-      .ampproject-link a:link,
-      .ampproject-link a:visited,
-      .ampproject-link a:hover,
-      .ampproject-link a:active {
-        color: #0379C4;
-        text-decoration: none;
-        font-size: 14px;
-        font-weight: 300;
-        letter-spacing: 0.04em;
-      }
-      .flex-horizontal {
-        @apply(--layout-horizontal);
-        @apply(--layout-center);
-        margin-bottom: 10px;
-      }
-      .flexchild {
-      }
-    </style>
-    <template>
-      <paper-toolbar>
-        <div class="ampproject-left ampproject-link">
-          <a href="https://www.ampproject.org/"
-             target="_blank">Accelerated Mobile Pages Project</a>
-        </div>
-        <div class="ampproject-right ampproject-link">
-          <a href="https://github.com/ampproject/amphtml/blob/master/validator/README.md"
-             target="_blank">GITHUB</a>
-          &nbsp;&nbsp;&nbsp;
-          <a href="https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc"
-             target="_blank">CHROME EXTENSION</a>
-        </div>
-      </paper-toolbar>
-    </template>
-    <script>
-      Polymer({
-        is: 'ampproject-toolbar'
       });
     </script>
   </dom-module>


### PR DESCRIPTION
Fix up and slightly simplify index.js to make this work.
build.py now needs to link the @polymer directories into the copied
webui/@polymer dir.