### PR TITLE
Remove livereload.

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -21,7 +21,6 @@
 var BBPromise = require('bluebird');
 var app = require('connect')();
 var bodyParser = require('body-parser');
-var clr = require('connect-livereload');
 var finalhandler = require('finalhandler');
 var fs = BBPromise.promisifyAll(require('fs'));
 var jsdom = require('jsdom');
@@ -187,8 +186,6 @@ app.use('/max/', function(req, res) {
 app.use('/min/', function(req, res) {
   proxyToAmpProxy(req, res, /* minify */ true);
 });
-
-app.use(clr());
 
 function setAMPAccessControlHeader(res, path) {
   var curUrl = url.parse(path, true);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "chai": "3.5.0",
     "chai-as-promised": "5.2.0",
     "connect": "3.4.1",
-    "connect-livereload": "0.5.4",
     "cssnano": "3.3.2",
     "del": "2.2.0",
     "eslint": "1.10.3",


### PR DESCRIPTION
Its really annoying and confusing and only really helps when working on example HTML files (which is rare) VS. when working on AMP.

Closes #3190