### PR TITLE
Workaround for chrome bug breaking amp-font.

### DIFF
--- a/extensions/amp-font/0.1/fontloader.js
+++ b/extensions/amp-font/0.1/fontloader.js
@@ -114,6 +114,10 @@ export class FontLoader {
         } else {
           // Load font with native api if supported.
           this.document_.fonts.load(fontString).then(() => {
+            // Workaround for chrome bug
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=347460
+            return this.document_.fonts.load(fontString);
+          }).then(() => {
             if (this.document_.fonts.check(fontString)) {
               resolve();
             } else {


### PR DESCRIPTION
Chrome bug 347460

Fixes https://github.com/ampproject/amphtml/issues/3411