### PR TITLE
Missing width/height quotes in example

### DIFF
--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -54,7 +54,7 @@ One or zero immediate child nodes can have the `fallback` attribute. If present,
 
 For example:
 ```html
-<amp-audio width=400 height=300 src="https://yourhost.com/audios/myaudio.mp3">
+<amp-audio width="400" height="300" src="https://yourhost.com/audios/myaudio.mp3">
   <div fallback>
     <p>Your browser doesn’t support HTML5 audio</p>
   </div>


### PR DESCRIPTION
When I pasted this `<amp-audio>` html example into a post to test it, it would output as raw html. 

Realized that the quotes were missing in the example. That seemed to fix it.