### PR TITLE
Run index_test.js with ancient crufty nodejs version

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -24,11 +24,8 @@ add `#development=1` to your URL and look for the validation messages in the
 Javascript console. See also
 [our documentation over at ampproject.org](https://www.ampproject.org/docs/guides/validate.html).
 
-For the additional choices listed below, install Node.js version 4.X on your
-system (tested with v4.4.2). E.g.,
-[by downloading](https://nodejs.org/en/download/) or
-[by using a package manager](https://nodejs.org/en/download/package-manager/) or
-[by using NVM](https://github.com/creationix/nvm).
+For the additional choices listed below, install Node.js and npm on your system,
+then run `npm install` in this directory.
 
 ## Using the command-line tool (Beta!)
 
@@ -84,8 +81,9 @@ ampValidator.getInstance((instance) => {
 
 ## Building a Custom Validator
 
-This is only useful for development - e.g. when making changes to validator.js,
-and it's rough aroung the edges. Below are instructions for Linux Ubuntu 14.
+The following is only useful for development - e.g. when making changes to
+validator.js, and it's rough aroung the edges. Below are instructions for Linux
+Ubuntu 14.
 
 Install these packages using apt-get:
 
@@ -95,7 +93,10 @@ Install these packages using apt-get:
 * python-protobuf
 * python2.7
 
-In addition, install Node.js version 4.X on your system (tested with v4.4.2). E.g.,
+Though we've ported `index.js` (the above commands) to Node.js versions
+as ancient as v0.10.25, we develop the validator with a more recent version
+of Node.js. So, in addition to the above,
+install Node.js version 4.X on your system (tested with v4.4.2). E.g.,
   [by downloading](https://nodejs.org/en/download/) or
   [by using a package manager](https://nodejs.org/en/download/package-manager/) or
   [by using NVM](https://github.com/creationix/nvm).

--- a/validator/README.md
+++ b/validator/README.md
@@ -24,8 +24,11 @@ add `#development=1` to your URL and look for the validation messages in the
 Javascript console. See also
 [our documentation over at ampproject.org](https://www.ampproject.org/docs/guides/validate.html).
 
-For the additional choices listed below, install Node.js and npm on your system,
-then run `npm install` in this directory.
+For the additional choices listed below, install Node.js version 4.X on your
+system (tested with v4.4.2). E.g.,
+[by downloading](https://nodejs.org/en/download/) or
+[by using a package manager](https://nodejs.org/en/download/package-manager/) or
+[by using NVM](https://github.com/creationix/nvm).
 
 ## Using the command-line tool (Beta!)
 
@@ -81,9 +84,8 @@ ampValidator.getInstance((instance) => {
 
 ## Building a Custom Validator
 
-The following is only useful for development - e.g. when making changes to
-validator.js, and it's rough aroung the edges. Below are instructions for Linux
-Ubuntu 14.
+This is only useful for development - e.g. when making changes to validator.js,
+and it's rough aroung the edges. Below are instructions for Linux Ubuntu 14.
 
 Install these packages using apt-get:
 
@@ -93,10 +95,7 @@ Install these packages using apt-get:
 * python-protobuf
 * python2.7
 
-Though we've ported `index.js` (the above commands) to Node.js versions
-as ancient as v0.10.25, we develop the validator with a more recent version
-of Node.js. So, in addition to the above,
-install Node.js version 4.X on your system (tested with v4.4.2). E.g.,
+In addition, install Node.js version 4.X on your system (tested with v4.4.2). E.g.,
   [by downloading](https://nodejs.org/en/download/) or
   [by using a package manager](https://nodejs.org/en/download/package-manager/) or
   [by using NVM](https://github.com/creationix/nvm).

--- a/validator/index.js
+++ b/validator/index.js
@@ -16,9 +16,6 @@
  * limitations under the license.
  */
 
-// When modifying this file, make sure it runs with at least Node.js
-// v0.10.25 and v4.4.2. v0.10.25 is the default version for Ubuntu 14.04 LTS.
-
 'use strict';
 
 var Promise = require('promise');

--- a/validator/index_test.js
+++ b/validator/index_test.js
@@ -16,81 +16,85 @@
  * limitations under the license.
  */
 
+// When modifying this file, make sure it runs with at least Node.js
+// v0.10.25 and v4.4.2. v0.10.25 is the default version for Ubuntu 14.04 LTS.
+
 'use strict';
 
 global.assert = require('assert');
-const fs = require('fs');
+var fs = require('fs');
 global.path = require('path');
 
-const JasmineRunner = require('jasmine');
-const jasmine = new JasmineRunner();
+var JasmineRunner = require('jasmine');
+var jasmine = new JasmineRunner();
 
-const ampValidator = require('./index.js');
+var ampValidator = require('./index.js');
 
-it('deployed validator rejects the empty file', (done) => {
+it('deployed validator rejects the empty file', function(done) {
   // Note: This will fetch and use the validator from
   // 'https://cdn.ampproject.org/v0/validator.js', since only one argument
   // is supplied to validateString.
   ampValidator.getInstance()
-      .then((instance) => {
-        const validationResult = instance.validateString('');
+      .then(function(instance) {
+        var validationResult = instance.validateString('');
         expect(validationResult.status).toBe('FAIL');
         done();
       })
-      .catch((error) => {
+      .catch(function(error) {
         fail(error);
         done();
       });
 });
 
-it('validator_minified.js was built (run build.py if this fails)', () => {
+it('validator_minified.js was built (run build.py if this fails)', function() {
   expect(fs.statSync('dist/validator_minified.js').isFile()).toBe(true);
 });
 
-it('built validator rejects the empty file', (done) => {
+it('built validator rejects the empty file', function(done) {
   // Note: This will use the validator that was built with build.py.
   ampValidator.getInstance(/*validatorJs*/ 'dist/validator_minified.js')
-      .then((instance) => {
-        const validationResult = instance.validateString('');
+      .then(function(instance) {
+        var validationResult = instance.validateString('');
         expect(validationResult.status).toBe('FAIL');
         done();
       })
-      .catch((error) => {
+      .catch(function(error) {
         fail(error);
         done();
       });
 });
 
-it('accepts the minimum valid AMP file', (done) => {
+it('accepts the minimum valid AMP file', function(done) {
   // Note: This will use the validator that was built with build.py.
-  const mini =
+  var mini =
       fs.readFileSync('testdata/feature_tests/minimum_valid_amp.html', 'utf-8');
   ampValidator.getInstance(/*validatorJs*/ 'dist/validator_minified.js')
-      .then((instance) => {
-        const validationResult = instance.validateString('');
+      .then(function(instance) {
+        var validationResult = instance.validateString('');
         expect(validationResult.status).toBe('FAIL');
         done();
       })
-      .catch((error) => {
+      .catch(function(error) {
         fail(error);
         done();
       });
 });
 
-it('rejects a specific file that is known to have errors', (done) => {
+it('rejects a specific file that is known to have errors', function(done) {
   // Note: This will use the validator that was built with build.py.
-  const severalErrorsHtml =
+  var severalErrorsHtml =
       fs.readFileSync('testdata/feature_tests/several_errors.html', 'utf-8');
-  const severalErrorsOut =
+  var severalErrorsOut =
       fs.readFileSync('testdata/feature_tests/several_errors.out', 'utf-8');
   ampValidator.getInstance(/*validatorJs*/ 'dist/validator_minified.js')
-      .then((instance) => {
-        const validationResult = instance.validateString(severalErrorsHtml);
+      .then(function(instance) {
+        var validationResult = instance.validateString(severalErrorsHtml);
         expect(validationResult.status).toBe('FAIL');
         // Here, we assemble the output from the validationResult that was
         // computed by the validator and compare it with the golden file.
-        let out = 'FAIL\n';
-        for (const error of validationResult.errors) {
+        var out = 'FAIL\n';
+        for (var ii = 0; ii < validationResult.errors.length; ii++) {
+          var error = validationResult.errors[ii];
           out += 'feature_tests/several_errors.html';
           out += ':' + error.line + ':' + error.col + ' ' + error.message;
           if (error.specUrl) {
@@ -101,20 +105,20 @@ it('rejects a specific file that is known to have errors', (done) => {
         expect(out).toBe(severalErrorsOut);
         done();
       })
-      .catch((error) => {
+      .catch(function(error) {
         fail(error);
         done();
       });
 });
 
-it('handles syntax errors in validator file', (done) => {
+it('handles syntax errors in validator file', function(done) {
   // Note: This points the library at a file that's not even Javascript.
   ampValidator.getInstance(/*validatorJs*/ 'dist/validator.protoascii')
-      .then((instance) => {
+      .then(function(instance) {
         fail('We should not get here since this is not a good validator.');
         done();
       })
-      .catch((error) => {
+      .catch(function(error) {
         expect(error.message)
             .toBe(
                 'Could not instantiate validator.js - Unexpected token ILLEGAL');

--- a/validator/index_test.js
+++ b/validator/index_test.js
@@ -16,9 +16,6 @@
  * limitations under the license.
  */
 
-// When modifying this file, make sure it runs with at least Node.js
-// v0.10.25 and v4.4.2. v0.10.25 is the default version for Ubuntu 14.04 LTS.
-
 'use strict';
 
 global.assert = require('assert');

--- a/validator/package.json
+++ b/validator/package.json
@@ -41,7 +41,8 @@
     "@polymer/polymer": "1.2.5-npm-test.2",
     "codemirror": "5.15.2",
     "commander": "2.9.0",
-    "webcomponents-lite": "0.6.0"
+    "webcomponents-lite": "0.6.0",
+    "promise" : "7.1.1"
   },
   "devDependencies": {
     "google-closure-compiler": "20160517.1.0",


### PR DESCRIPTION
Ported index.js and index_test.js to v0.10.25, the Node.js version that runs on Ubuntu 14.04 LTS. Unfortunately it doesn't look like the npm package works with this old Node.js version, perhaps due to the use of the at-polymer libraries. But if I use a recent version of Node.js to install the dependencies I can then switch my Node.js version to this ancient version and index_test.js still passes. So I guess we're half-way there, sort of.