### PR TITLE
Apply property shorthand syntax following ECMAScript 6 format

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,7 @@
       "objectsInObjects": false,
       "arraysInObjects": false
     }],
+    "object-shorthand": [2, "properties"],
     "prefer-const": 2,
     "quotes": [2, "single", "avoid-escape"],
     "radix": 2,

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -276,17 +276,11 @@ function triggerNoContentAvailable() {
 }
 
 function triggerDimensions(width, height) {
-  nonSensitiveDataPostMessage('embed-size', {
-    width: width,
-    height: height,
-  });
+  nonSensitiveDataPostMessage('embed-size', {width, height});
 }
 
 function triggerResizeRequest(width, height) {
-  nonSensitiveDataPostMessage('embed-size', {
-    width: width,
-    height: height,
-  });
+  nonSensitiveDataPostMessage('embed-size', {width, height});
 }
 
 /**

--- a/3p/messaging.js
+++ b/3p/messaging.js
@@ -45,7 +45,7 @@ const listeners = [];
  */
 export function listenParent(win, type, callback) {
   const listener = {
-    type: type,
+    type,
     cb: callback,
   };
   listeners.push(listener);

--- a/ads/teads.js
+++ b/ads/teads.js
@@ -26,7 +26,7 @@ export function teads(global, data) {
     allowed_data: ['pid', 'tag'],
     mandatory_data: ['pid'],
     mandatory_tag_data: ['tta', 'ttp'],
-    data: data,
+    data,
   };
 
   validateDataExists(data, global._teads_amp.mandatory_data);

--- a/build-system/tasks/make-golden.js
+++ b/build-system/tasks/make-golden.js
@@ -199,7 +199,7 @@ function diffScreenshot_(file, dir, host, verbose, cb) {
         .pipe(gulp.dest(diffFile + '.json'))
         .on('error', function(error) {
           util.log(util.colors.red('Screenshot diff failed: ', file, error));
-          cb({error: error});
+          cb({error});
         })
         .on('end', function(res) {
           var contents = fs.readFileSync(diffFile + '.json', 'utf8');

--- a/examples/viewer-integr-messaging.js
+++ b/examples/viewer-integr-messaging.js
@@ -60,7 +60,7 @@ ViewerMessaging.prototype.sendRequest = function(eventType, payload,
   var requestId = ++this.requestIdCounter_;
   if (awaitResponse) {
     var promise = new Promise(function(resolve, reject) {
-      this.waitingForResponse_[requestId] = {resolve: resolve, reject: reject};
+      this.waitingForResponse_[requestId] = {resolve, reject};
     }.bind(this));
     this.sendMessage_(this.requestSentinel_, requestId, eventType, payload,
         true);

--- a/examples/viewer-integr-messaging.js
+++ b/examples/viewer-integr-messaging.js
@@ -140,10 +140,10 @@ ViewerMessaging.prototype.onResponse_ = function(message) {
 ViewerMessaging.prototype.sendMessage_ = function(sentinel, requestId,
       eventType, payload, awaitResponse) {
   var message = {
-    sentinel: sentinel,
-    requestId: requestId,
+    sentinel,
+    requestId,
     type: eventType,
-    payload: payload,
+    payload,
     rsvp: awaitResponse
   };
   this.target_./*OK*/postMessage(message, this.targetOrigin_);

--- a/extensions/amp-access/0.1/access-expr-impl.js
+++ b/extensions/amp-access/0.1/access-expr-impl.js
@@ -245,7 +245,7 @@ parse: function parse(input) {
                     token: this.terminals_[symbol] || symbol,
                     line: lexer.yylineno,
                     loc: yyloc,
-                    expected: expected
+                    expected,
                 });
             }
         if (action[0] instanceof Array && action.length > 1) {

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -813,7 +813,7 @@ export class AccessService {
           this.buildUrl_(this.loginConfig_[k], /* useAuthData */ true)
               .then(url => {
                 this.loginUrlMap_[k] = url;
-                return {type: k, url: url};
+                return {type: k, url};
               }));
     }
     return Promise.all(promises);

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -1155,7 +1155,7 @@ describe('AccessService login', () => {
         .withExactArgs('')
         .once();
     const event = {preventDefault: sandbox.spy()};
-    service.handleAction_({method: 'login', event: event});
+    service.handleAction_({method: 'login', event});
     expect(event.preventDefault.callCount).to.equal(1);
   });
 
@@ -1164,7 +1164,7 @@ describe('AccessService login', () => {
         .withExactArgs('other')
         .once();
     const event = {preventDefault: sandbox.spy()};
-    service.handleAction_({method: 'login-other', event: event});
+    service.handleAction_({method: 'login-other', event});
     expect(event.preventDefault.callCount).to.equal(1);
   });
 

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -46,10 +46,7 @@ describe('amp-accordion', () => {
         }
       }
       return iframe.addElement(ampAccordion).then(() => {
-        return Promise.resolve({
-          iframe: iframe,
-          ampAccordion: ampAccordion,
-        });
+        return Promise.resolve({iframe, ampAccordion});
       });
     });
   }

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -347,7 +347,7 @@ class AmpAd extends AMP.BaseElement {
       postMessage(
           this.iframe_,
           'embed-size-denied',
-          {requestedHeight: requestedHeight, requestedWidth: requestedWidth},
+          {requestedHeight, requestedWidth},
           targetOrigin,
           /* opt_is3P */ true);
     }

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -333,7 +333,7 @@ class AmpAd extends AMP.BaseElement {
       const targetOrigin =
           this.iframe_.src ? parseUrl(this.iframe_.src).origin : '*';
       postMessage(this.iframe_, 'embed-state', {
-        inViewport: inViewport,
+        inViewport,
         pageHidden: !this.viewer_.isVisible(),
       }, targetOrigin, /* opt_is3P */ true);
     }

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -257,7 +257,7 @@ export class Activity {
     setTimeout(this.boundStopIgnore_, timeToWait);
 
     this.activityHistory_.push({
-      type: type,
+      type,
       time: secondKey,
     });
   }

--- a/extensions/amp-analytics/0.1/storage-impl.js
+++ b/extensions/amp-analytics/0.1/storage-impl.js
@@ -333,17 +333,14 @@ export class ViewerStorageBinding {
 
   /** @override */
   loadBlob(origin) {
-    return this.viewer_.sendMessage('loadStore', {
-      'origin': origin,
-    }, true).then(response => response['blob']);
+    return this.viewer_.sendMessage('loadStore', {origin}, true).then(
+      response => response['blob']
+    );
   }
 
   /** @override */
   saveBlob(origin, blob) {
-    return this.viewer_.sendMessage('saveStore', {
-      'origin': origin,
-      'blob': blob,
-    }, true);
+    return this.viewer_.sendMessage('saveStore', {origin, blob}, true);
   }
 }
 

--- a/extensions/amp-carousel/0.1/slides.js
+++ b/extensions/amp-carousel/0.1/slides.js
@@ -345,11 +345,11 @@ export class AmpSlides extends BaseCarousel {
       maxDelta = 1;
     }
     this.swipeState_ = {
-      containerWidth: containerWidth,
-      prevTr: prevTr,
-      nextTr: nextTr,
-      prevIndex: prevIndex,
-      nextIndex: nextIndex,
+      containerWidth,
+      prevTr,
+      nextTr,
+      prevIndex,
+      nextIndex,
       min: minDelta,
       max: maxDelta,
       pos: 0,

--- a/extensions/amp-carousel/0.1/test/test-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slides.js
@@ -210,8 +210,8 @@ describe('Slides functional', () => {
         pos: 0,
         min: 0,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.onSwipe_({deltaX: -32});
       expect(slides.swipeState_.pos).to.equal(0.1);
@@ -233,8 +233,8 @@ describe('Slides functional', () => {
         pos: 0,
         min: -1,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.onSwipe_({deltaX: 32});
       expect(slides.swipeState_.pos).to.equal(-0.1);
@@ -256,8 +256,8 @@ describe('Slides functional', () => {
         pos: 0,
         min: 0,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.onSwipe_({deltaX: 32});
       expect(slides.swipeState_.pos).to.equal(0);
@@ -295,8 +295,8 @@ describe('Slides functional', () => {
         pos: 0.55,
         min: 0,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.swipeState_ = s;
       const promise = slides.onSwipeEnd_({velocityX: 0});
@@ -328,8 +328,8 @@ describe('Slides functional', () => {
         pos: -0.6,
         min: 0,
         max: 0,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.swipeState_ = s;
       const promise = slides.onSwipeEnd_({velocityX: 0});
@@ -356,8 +356,8 @@ describe('Slides functional', () => {
         pos: -0.6,
         min: -1,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.swipeState_ = s;
       const promise = slides.onSwipeEnd_({velocityX: 0});
@@ -382,8 +382,8 @@ describe('Slides functional', () => {
         pos: 0.6,
         min: 0,
         max: 0,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.swipeState_ = s;
       const promise = slides.onSwipeEnd_({velocityX: 0});
@@ -406,8 +406,8 @@ describe('Slides functional', () => {
         pos: 0.6,
         min: -1,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.swipeState_ = s;
       const promise = slides.onSwipeEnd_({velocityX: 0});
@@ -432,8 +432,8 @@ describe('Slides functional', () => {
         pos: 0.45,
         min: 0,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.swipeState_ = s;
       const promise = slides.onSwipeEnd_({velocityX: -0.5});
@@ -463,8 +463,8 @@ describe('Slides functional', () => {
         pos: 0.45,
         min: 0,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.swipeState_ = s;
       const promise = slides.onSwipeEnd_({velocityX: 0});
@@ -494,8 +494,8 @@ describe('Slides functional', () => {
         pos: 0.45,
         min: 0,
         max: 1,
-        prevTr: prevTr,
-        nextTr: nextTr,
+        prevTr,
+        nextTr,
       };
       slides.swipeState_ = s;
       const promise = slides.onSwipeEnd_({velocityX: 0.5});

--- a/extensions/amp-dynamic-css-classes/0.1/test/test-runtime-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/test/test-runtime-classes.js
@@ -36,12 +36,12 @@ describe('dynamic classes are inserted at runtime', () => {
     };
     body = {
       tagName: 'BODY',
-      classList: classList,
+      classList,
     };
     mockWin = {
       document: {
         referrer: 'http://localhost/',
-        body: body,
+        body,
       },
       navigator: {
         userAgent: '',

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -348,11 +348,7 @@ describe('amp-iframe', () => {
       impl.layoutCallback();
       const p = new Promise((resolve, unusedReject) => {
         impl.updateSize_ = (newHeight, newWidth) => {
-          resolve({
-            amp: amp,
-            newHeight: newHeight,
-            newWidth: newWidth,
-          });
+          resolve({amp, newHeight, newWidth});
         };
       });
       amp.iframe.contentWindow.postMessage({
@@ -382,10 +378,7 @@ describe('amp-iframe', () => {
       impl.layoutCallback();
       const p = new Promise((resolve, unusedReject) => {
         impl.updateSize_ = (newHeight, unusedNewWidth) => {
-          resolve({
-            amp: amp,
-            newHeight: newHeight,
-          });
+          resolve({amp, newHeight});
         };
       });
       amp.iframe.contentWindow.postMessage({

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -118,10 +118,9 @@ describe('amp-image-lightbox component', () => {
       impl.unlistenViewport_ = viewportOnChangedUnsubscribed;
       const enterLightboxMode = sandbox.spy();
       const leaveLightboxMode = sandbox.spy();
-      impl.getViewport = () => {return {
-        enterLightboxMode: enterLightboxMode,
-        leaveLightboxMode: leaveLightboxMode,
-      };};
+      impl.getViewport = () => {
+        return {enterLightboxMode, leaveLightboxMode};
+      };
       const historyPop = sandbox.spy();
       impl.getHistory_ = () => {
         return {pop: historyPop};

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -82,8 +82,8 @@ describe('amp-image-lightbox component', () => {
       const leaveLightboxMode = sandbox.spy();
       impl.getViewport = () => {return {
         onChanged: viewportOnChanged,
-        enterLightboxMode: enterLightboxMode,
-        leaveLightboxMode: leaveLightboxMode,
+        enterLightboxMode,
+        leaveLightboxMode,
       };};
       const historyPush = sandbox.spy();
       impl.getHistory_ = () => {
@@ -151,8 +151,8 @@ describe('amp-image-lightbox component', () => {
       const leaveLightboxMode = sandbox.spy();
       impl.getViewport = () => {return {
         onChanged: viewportOnChanged,
-        enterLightboxMode: enterLightboxMode,
-        leaveLightboxMode: leaveLightboxMode,
+        enterLightboxMode,
+        leaveLightboxMode,
       };};
       const historyPush = sandbox.spy();
       impl.getHistory_ = () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -65,7 +65,7 @@ describe('amp-list component', () => {
     const newHeight = 127;
     const itemElement = document.createElement('div');
     itemElement.style.height = newHeight + 'px';
-    const xhrPromise = Promise.resolve({items: items});
+    const xhrPromise = Promise.resolve({items});
     const renderPromise = Promise.resolve([itemElement]);
     let measureFunc;
     xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
@@ -94,7 +94,7 @@ describe('amp-list component', () => {
       {title: 'Title1'},
     ];
     const itemElement = document.createElement('div');
-    const xhrPromise = Promise.resolve({items: items});
+    const xhrPromise = Promise.resolve({items});
     const renderPromise = Promise.resolve([itemElement]);
     xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
         sinon.match(opts => opts.credentials === undefined))
@@ -117,7 +117,7 @@ describe('amp-list component', () => {
     element.setAttribute('role', 'list1');
     const itemElement = document.createElement('div');
     itemElement.setAttribute('role', 'listitem1');
-    const xhrPromise = Promise.resolve({items: items});
+    const xhrPromise = Promise.resolve({items});
     const renderPromise = Promise.resolve([itemElement]);
     xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
         sinon.match(opts => opts.credentials === undefined))
@@ -135,7 +135,7 @@ describe('amp-list component', () => {
 
   it('should request credentials', () => {
     const items = [];
-    const xhrPromise = Promise.resolve({items: items});
+    const xhrPromise = Promise.resolve({items});
     element.setAttribute('credentials', 'include');
     xhrMock.expects('fetchJson').withExactArgs('https://data.com/list.json',
         sinon.match(opts => {

--- a/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
@@ -26,7 +26,7 @@
         return new Promise(function(resolve) {
           const div = document.createElement('div');
           resolve({
-            div: div,
+            div,
             addElement: function(element) {
               div.appendChild(element);
               return new Timer(window).promise(16).then(() => {

--- a/extensions/amp-pinterest/0.1/util.js
+++ b/extensions/amp-pinterest/0.1/util.js
@@ -89,10 +89,4 @@ function set(el, attr, value) {
   }
 };
 
-export const Util = {
-  filter: filter,
-  guid: guid,
-  log: log,
-  make: make,
-  set: set,
-};
+export const Util = {filter, guid, log, make, set};

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -44,10 +44,7 @@ describe('amp-sidebar', () => {
       ampSidebar.setAttribute('id', 'sidebar1');
       ampSidebar.setAttribute('layout', 'nodisplay');
       return iframe.addElement(ampSidebar).then(() => {
-        return Promise.resolve({
-          iframe: iframe,
-          ampSidebar: ampSidebar,
-        });
+        return Promise.resolve({iframe, ampSidebar});
       });
     });
   }

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -400,10 +400,7 @@ export class UserNotificationManager {
       resolve = r;
     });
 
-    return this.deferRegistry_[id] = {
-      promise: promise,
-      resolve: resolve,
-    };
+    return this.deferRegistry_[id] = {promise, resolve};
   }
 }
 

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -158,7 +158,7 @@ export class AmpUserNotification extends AMP.BaseElement {
     return this.urlReplacements_.expand(showIfHref).then(href => {
       return addParamsToUrl(href, {
         elementId: this.elementId_,
-        ampUserId: ampUserId,
+        ampUserId,
       });
     });
   }

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -81,7 +81,7 @@ function getFrameAttributes(parentWindow, element, opt_type) {
         timer.now(),
         viewportFor(parentWindow).getRect(),
         element.getLayoutBox()),
-    startTime: startTime,
+    startTime,
   };
   const adSrc = element.getAttribute('src');
   if (adSrc) {

--- a/src/animation.js
+++ b/src/animation.js
@@ -93,8 +93,12 @@ export class Animation {
    * @return {!Animation}
    */
   add(delay, transition, duration, opt_curve) {
-    this.segments_.push({delay: delay, func: transition, duration: duration,
-        curve: getCurve(opt_curve)});
+    this.segments_.push({
+      delay,
+      func: transition,
+      duration,
+      curve: getCurve(opt_curve),
+    });
     return this;
   }
 

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -355,8 +355,8 @@ class SwipeRecognizer extends GestureRecognizer {
     }
 
     this.signalEmit({
-      first: first,
-      last: last,
+      first,
+      last,
       time: this.lastTime_,
       deltaX: this.horiz_ ? this.lastX_ - this.startX_ : 0,
       deltaY: this.vert_ ? this.lastY_ - this.startY_ : 0,
@@ -585,8 +585,8 @@ export class TapzoomRecognizer extends GestureRecognizer {
     this.prevTime_ = this.lastTime_;
 
     this.signalEmit({
-      first: first,
-      last: last,
+      first,
+      last,
       centerClientX: this.startX_,
       centerClientY: this.startY_,
       deltaX: this.lastX_ - this.startX_,
@@ -782,8 +782,8 @@ export class PinchRecognizer extends GestureRecognizer {
     const lastSq = this.sqDist_(this.lastX1_, this.lastX2_,
         this.lastY1_, this.lastY2_);
     this.signalEmit({
-      first: first,
-      last: last,
+      first,
+      last,
       time: this.lastTime_,
       centerClientX: this.centerClientX_,
       centerClientY: this.centerClientY_,

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -91,7 +91,7 @@ function getOrCreateListenForEvents(parentWin, iframe, opt_is3P) {
   if (!windowEvents) {
     windowEvents = {
       frame: iframe,
-      origin: origin,
+      origin,
       events: Object.create(null),
     };
     listenSentinel.push(windowEvents);

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -129,7 +129,7 @@ export class IntersectionObserver extends Observable {
       // This message might be from any window within the iframe, we need
       // to keep track of which windows want to be sent updates.
       if (!this.clientWindows_.some(entry => entry.win == source)) {
-        this.clientWindows_.push({win: source, origin: origin});
+        this.clientWindows_.push({win: source, origin});
       }
       this.startSendingIntersectionChanges_();
     }, this.is3p_,

--- a/src/layout-rect.js
+++ b/src/layout-rect.js
@@ -42,10 +42,10 @@ let LayoutRectDef;
  */
 export function layoutRectLtwh(left, top, width, height) {
   return {
-    left: left,
-    top: top,
-    width: width,
-    height: height,
+    left,
+    top,
+    width,
+    height,
     bottom: top + height,
     right: left + width,
   };

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -67,8 +67,8 @@ export function adopt(global) {
     const register = function() {
       registerExtendedElement(global, name, implementationClass);
       elementsForTesting.push({
-        name: name,
-        implementationClass: implementationClass,
+        name,
+        implementationClass,
         css: opt_css,
       });
       // Resolve this extension's Service Promise.

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -216,8 +216,8 @@ export function sanitizeFormattingHtml(html) {
           return null;
         }
         return {
-          'tagName': tagName,
-          'attribs': [],
+          tagName,
+          attribs: [],
         };
       }
   );

--- a/src/service.js
+++ b/src/service.js
@@ -98,7 +98,7 @@ export function getServicePromise(win, id) {
   services[id] = {
     obj: null,
     promise: p,
-    resolve: resolve,
+    resolve,
   };
 
   return p;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -281,7 +281,7 @@ export class ActionService {
     while (n) {
       actionInfo = this.matchActionInfo_(n, actionEventType);
       if (actionInfo) {
-        return {node: n, actionInfo: actionInfo};
+        return {node: n, actionInfo};
       }
       n = n.parentElement;
     }
@@ -394,9 +394,9 @@ export function parseActionMap(s, context) {
       }
 
       const action = {
-        event: event,
-        target: target,
-        method: method,
+        event,
+        target,
+        method,
         args: (args && window.AMP_TEST && Object.freeze) ?
             Object.freeze(args) : args,
         str: s,
@@ -551,7 +551,7 @@ class ParserTokenizer {
       const s = this.str_.substring(newIndex, end);
       const value = hasFraction ? parseFloat(s) : parseInt(s, 10);
       newIndex = end - 1;
-      return {type: TokenType.LITERAL, value: value, index: newIndex};
+      return {type: TokenType.LITERAL, value, index: newIndex};
     }
 
     // Different separators.
@@ -573,7 +573,7 @@ class ParserTokenizer {
       }
       const value = this.str_.substring(newIndex + 1, end);
       newIndex = end;
-      return {type: TokenType.LITERAL, value: value, index: newIndex};
+      return {type: TokenType.LITERAL, value, index: newIndex};
     }
 
     // A key
@@ -587,7 +587,7 @@ class ParserTokenizer {
     const value = convertValues && (s == 'true' || s == 'false') ?
         s == 'true' : s;
     newIndex = end - 1;
-    return {type: TokenType.LITERAL, value: value, index: newIndex};
+    return {type: TokenType.LITERAL, value, index: newIndex};
   }
 }
 

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -289,7 +289,7 @@ export class FixedLayer {
           state[fe.id] = {
             fixed: isFixed,
             transferrable: isTransferrable,
-            top: top,
+            top,
             zIndex: styles.getPropertyValue('z-index'),
           };
         });
@@ -350,7 +350,7 @@ export class FixedLayer {
       element[DECLARED_FIXED_PROP] = true;
       fe = {
         id: fixedId,
-        element: element,
+        element,
         selectors: [selector],
       };
       this.fixedElements_.push(fe);

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -150,7 +150,7 @@ export class History {
       reject = aReject;
     });
 
-    this.queue_.push({callback: callback, resolve: resolve, reject: reject});
+    this.queue_.push({callback, resolve, reject});
     if (this.queue_.length == 1) {
       this.deque_();
     }
@@ -473,11 +473,7 @@ export class HistoryBindingNatural_ {
           resolve = aResolve;
           reject = aReject;
         }));
-    this.waitingState_ = {
-      promise: promise,
-      resolve: resolve,
-      reject: reject,
-    };
+    this.waitingState_ = {promise, resolve, reject};
     return promise;
   }
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -215,9 +215,9 @@ export class Performance {
 
     if (this.viewer_ && this.viewer_.isPerformanceTrackingOn()) {
       this.viewer_.tick({
-        'label': label,
-        'from': opt_from,
-        'value': opt_value,
+        label,
+        from: opt_from,
+        value: opt_value,
       });
     } else {
       this.queueTick_(label, opt_from, opt_value);
@@ -277,9 +277,9 @@ export class Performance {
     }
 
     this.events_.push({
-      'label': label,
-      'from': opt_from,
-      'value': opt_value,
+      label,
+      from: opt_from,
+      value: opt_value,
     });
   }
 
@@ -340,7 +340,7 @@ export class Performance {
   prerenderComplete_(value) {
     if (this.viewer_) {
       this.viewer_.prerenderComplete({
-        'value': value,
+        value,
       });
     }
   }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1258,10 +1258,10 @@ export class Resources {
       request.callback = opt_callback;
     } else {
       this.requestsChangeSize_.push(/** {!ChangeSizeRequestDef} */{
-        resource: resource,
-        newHeight: newHeight,
-        newWidth: newWidth,
-        force: force,
+        resource,
+        newHeight,
+        newWidth,
+        force,
         callback: opt_callback,
       });
     }
@@ -1358,10 +1358,10 @@ export class Resources {
 
     const task = {
       id: taskId,
-      resource: resource,
+      resource,
       priority: Math.max(resource.getPriority(), parentPriority) +
           priorityOffset,
-      callback: callback,
+      callback,
       scheduleTime: timer.now(),
       startTime: 0,
       promise: null,

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -159,7 +159,7 @@ class UrlReplacements {
       }
       return cidFor(win).then(cid => {
         return cid.get({
-          scope: scope,
+          scope,
           createCookieIfNotPresent: true,
         }, consent);
       });

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -763,7 +763,7 @@ export class Viewer {
    */
   postDocumentResized(width, height) {
     this.sendMessageUnreliable_(
-        'documentResized', {width: width, height: height}, false);
+        'documentResized', {width, height}, false);
   }
 
   /**
@@ -791,7 +791,7 @@ export class Viewer {
    */
   postPushHistory(stackIndex) {
     return this.sendMessageUnreliable_(
-        'pushHistory', {stackIndex: stackIndex}, true);
+        'pushHistory', {stackIndex}, true);
   }
 
   /**
@@ -801,7 +801,7 @@ export class Viewer {
    */
   postPopHistory(stackIndex) {
     return this.sendMessageUnreliable_(
-        'popHistory', {stackIndex: stackIndex}, true);
+        'popHistory', {stackIndex}, true);
   }
 
   /**
@@ -995,7 +995,7 @@ export class Viewer {
     if (found) {
       found.data = data;
     } else {
-      this.messageQueue_.push({eventType: eventType, data: data});
+      this.messageQueue_.push({eventType, data});
     }
     if (awaitResponse) {
       // TODO(dvoytenko): This is somewhat questionable. What do we return

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -750,8 +750,8 @@ export class Viewer {
    */
   postDocumentReady(width, height) {
     this.sendMessageUnreliable_('documentLoaded', {
-      width: width,
-      height: height,
+      width,
+      height,
       title: this.win.document.title,
     }, false);
   }

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -476,12 +476,12 @@ export class Viewport {
         'bottom=', (scrollTop + size.height),
         'velocity=', velocity);
     this.changeObservable_.fire({
-      relayoutAll: relayoutAll,
+      relayoutAll,
       top: scrollTop,
       left: scrollLeft,
       width: size.width,
       height: size.height,
-      velocity: velocity,
+      velocity,
     });
   }
 

--- a/src/srcset.js
+++ b/src/srcset.js
@@ -83,14 +83,14 @@ export function parseSrcset(s, opt_element) {
     const url = parts[0];
     if (parts.length == 1 || parts.length == 2 && !parts[1]) {
       // If no "w" or "x" specified, we assume it's "1x".
-      sources.push({url: url, width: undefined, dpr: 1});
+      sources.push({url, width: undefined, dpr: 1});
     } else {
       const spec = parts[1].toLowerCase();
       const lastChar = spec.substring(spec.length - 1);
       if (lastChar == 'w') {
-        sources.push({url: url, width: parseFloat(spec), dpr: undefined});
+        sources.push({url, width: parseFloat(spec), dpr: undefined});
       } else if (lastChar == 'x') {
-        sources.push({url: url, width: undefined, dpr: parseFloat(spec)});
+        sources.push({url, width: undefined, dpr: parseFloat(spec)});
       }
     }
   }

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -239,7 +239,7 @@ describe('3p-frame', () => {
 
   it('should make sub domains (crypto)', () => {
     const fakeWin = {
-      document: document,
+      document,
       crypto: {
         getRandomValues: function(arg) {
           arg[0] = 123;
@@ -252,7 +252,7 @@ describe('3p-frame', () => {
 
   it('should make sub domains (fallback)', () => {
     const fakeWin = {
-      document: document,
+      document,
       Math: {
         random: function() {
           return 0.567;

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -233,10 +233,7 @@ describe('3p-frame', () => {
   });
 
   it('should make sub domains (Math)', () => {
-    const fakeWin = {
-      document: document,
-      Math: Math,
-    };
+    const fakeWin = {document, Math};
     expect(getSubDomain(fakeWin)).to.match(/^d-\d+$/);
   });
 

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -203,19 +203,19 @@ describe('3p', () => {
     const slave0 = {
       context: {
         isMaster: false,
-        master: master,
+        master,
       },
     };
     const slave1 = {
       context: {
         isMaster: false,
-        master: master,
+        master,
       },
     };
     const slave2 = {
       context: {
         isMaster: false,
-        master: master,
+        master,
       },
     };
     let done;

--- a/test/functional/test-cookies.js
+++ b/test/functional/test-cookies.js
@@ -76,7 +76,7 @@ describe('getCookie', () => {
           return cookie;
         },
       };
-      setCookie({document: doc, location: {hostname: hostname}},
+      setCookie({document: doc, location: {hostname}},
           'c&1', 'v&1', 1447383159853, {
             highestAvailableDomain: true,
           });

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1471,7 +1471,7 @@ describe('CustomElement Overflow Element', () => {
         Object: {
           create: proto => Object.create(proto),
         },
-        HTMLElement: HTMLElement,
+        HTMLElement,
         setInterval: callback => {
           intervalCallback = callback;
         },

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -153,7 +153,7 @@ describe('FixedLayer', () => {
     const attrs = {};
     const children = [];
     const elem = {
-      id: id,
+      id,
       autoOffsetTop: 17,
       toString: () => {
         return id;
@@ -227,7 +227,7 @@ describe('FixedLayer', () => {
       type: 1,
       selectorText: selector,
       style: {position: 'fixed'},
-      elements: elements,
+      elements,
     };
     if (allRules[selector]) {
       throw new Error('dup selector');
@@ -241,7 +241,7 @@ describe('FixedLayer', () => {
       type: 1,
       selectorText: selector,
       style: {},
-      elements: elements,
+      elements,
     };
     if (allRules[selector]) {
       throw new Error('dup selector');

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -153,7 +153,7 @@ describe('3p integration.js', () => {
         location: {
           originValidated: true,
         },
-        data: data,
+        data,
       },
     };
     let called = false;
@@ -176,7 +176,7 @@ describe('3p integration.js', () => {
         location: {
           originValidated: true,
         },
-        data: data,
+        data,
       },
     };
     let called = false;
@@ -208,7 +208,7 @@ describe('3p integration.js', () => {
     const win = {
       context: {
         location: {},
-        data: data,
+        data,
       },
     };
     expect(() => {
@@ -225,7 +225,7 @@ describe('3p integration.js', () => {
         location: {
           originValidated: true,
         },
-        data: data,
+        data,
         tagName: 'AMP-EMBED',
       },
     };

--- a/test/functional/test-json.js
+++ b/test/functional/test-json.js
@@ -60,7 +60,7 @@ describe('json', () => {
 
     it('should shortcircuit if a parent in chain is not an object', () => {
       const child = {str: 'A'};
-      const obj = {child: child, nonobj: 'B'};
+      const obj = {child, nonobj: 'B'};
       expect(getValueForExpr(obj, 'child.str')).to.equal('A');
       expect(getValueForExpr(obj, 'nonobj')).to.equal('B');
       expect(getValueForExpr(obj, 'nonobj.str')).to.be.undefined;

--- a/test/functional/test-json.js
+++ b/test/functional/test-json.js
@@ -30,7 +30,7 @@ describe('json', () => {
 
     it('should return a nested value', () => {
       const child = {str: 'A', num: 1, bool: true, val: null};
-      const obj = {child: child};
+      const obj = {child};
       expect(getValueForExpr(obj, 'child')).to.deep.equal(child);
       expect(getValueForExpr(obj, 'child.str')).to.equal('A');
       expect(getValueForExpr(obj, 'child.num')).to.equal(1);
@@ -41,7 +41,7 @@ describe('json', () => {
 
     it('should return a nested value without proto', () => {
       const child = {str: 'A', num: 1, bool: true, val: null};
-      const obj = recreateNonProtoObject({child: child});
+      const obj = recreateNonProtoObject({child});
       expect(getValueForExpr(obj, 'child')).to.deep.equal(child);
       expect(getValueForExpr(obj, 'child.str')).to.equal('A');
       expect(getValueForExpr(obj, 'child.num')).to.equal(1);
@@ -52,7 +52,7 @@ describe('json', () => {
 
     it('should shortcircuit if a parent in chain missing', () => {
       const child = {str: 'A'};
-      const obj = {child: child};
+      const obj = {child};
       expect(getValueForExpr(obj, 'child.str')).to.equal('A');
       expect(getValueForExpr(obj, 'unknown.str')).to.be.undefined;
       expect(getValueForExpr(obj, 'unknown.chain.str')).to.be.undefined;

--- a/test/functional/test-mustache.js
+++ b/test/functional/test-mustache.js
@@ -44,7 +44,7 @@ describe('Mustache', () => {
   it('should only expand own properties', () => {
     const parent = {value: 'bc'};
     const child = Object.create(parent);
-    const container = {parent: parent, child: child};
+    const container = {parent, child};
     expect(mustache.render('a{{value}}', parent)).to.equal('abc');
     expect(mustache.render('a{{value}}', child)).to.equal('a');
     expect(mustache.render('a{{parent.value}}', container)).to.equal('abc');

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -39,8 +39,8 @@ describe('runtime', () => {
       navigator: {},
       setTimeout: () => {},
       location: parseUrl('https://acme.com/document1'),
-      Object: Object,
-      HTMLElement: HTMLElement,
+      Object,
+      HTMLElement,
     };
     errorStub = sandbox.stub(dev, 'error');
   });
@@ -172,4 +172,3 @@ describe('runtime', () => {
     });
   });
 });
-

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -83,7 +83,7 @@ describe('UrlReplacements', () => {
         loadObservable.add(callback);
       },
       complete: false,
-      Object: Object,
+      Object,
       performance: {
         timing: {
           navigationStart: 100,

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -458,7 +458,7 @@ describe('Viewer', () => {
 
     const delivered = [];
     viewer.setMessageDeliverer((eventType, data) => {
-      delivered.push({eventType: eventType, data: data});
+      delivered.push({eventType, data});
     }, 'https://acme.com');
 
     expect(viewer.messageQueue_.length).to.equal(0);
@@ -510,7 +510,7 @@ describe('Viewer', () => {
     it('should post broadcast event', () => {
       const delivered = [];
       viewer.setMessageDeliverer((eventType, data) => {
-        delivered.push({eventType: eventType, data: data});
+        delivered.push({eventType, data});
       }, 'https://acme.com');
       viewer.broadcast({type: 'type1'});
       expect(viewer.messageQueue_.length).to.equal(0);

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -730,7 +730,7 @@ describe('ViewportBindingNaturalIosEmbed', () => {
       },
       createElement: tagName => {
         return {
-          tagName: tagName,
+          tagName,
           id: '',
           style: {},
           scrollIntoView: sandbox.spy(),

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -563,9 +563,7 @@ describe('ViewportBindingNatural', () => {
     documentElement = {
       style: {},
     };
-    windowApi.document = {
-      documentElement: documentElement,
-    };
+    windowApi.document = {documentElement};
     windowMock = sandbox.mock(windowApi);
     binding = new ViewportBindingNatural_(windowApi);
   });

--- a/validator/validator-light_test.js
+++ b/validator/validator-light_test.js
@@ -77,7 +77,7 @@ function findHtmlFilesRelativeToTestdata() {
       }
     } else {
       for (const subdir of readdir(root)) {
-        testSubdirs.push({root: root, subdir: subdir});
+        testSubdirs.push({root, subdir});
       }
     }
   }

--- a/validator/validator_test.js
+++ b/validator/validator_test.js
@@ -77,7 +77,7 @@ function findHtmlFilesRelativeToTestdata() {
       }
     } else {
       for (const subdir of readdir(root)) {
-        testSubdirs.push({root: root, subdir: subdir});
+        testSubdirs.push({root, subdir});
       }
     }
   }


### PR DESCRIPTION
#3504

From [previous PR](https://github.com/ampproject/amphtml/pull/3421#discussion-diff-65625388)
It might be better to apply [property shorthand syntax](http://es6-features.org/#PropertyShorthand) according to ES6 format throughout the code base for consistency.

For example, converting
```javascript
obj = { x: x, y: y };
```
to
```javascript
obj = { x, y };
```

However, if that's the convention we want, I find it not that intuitive when it comes to cases like the following:
```javascript
this.changeObservable_.fire({
  relayoutAll: relayoutAll,
  top: scrollTop,
  left: scrollLeft,
  width: size.width,
  height: size.height,
  velocity: velocity,
});
```
if I change the above block to
```javascript
this.changeObservable_.fire({
  relayoutAll,
  top: scrollTop,
  left: scrollLeft,
  width: size.width,
  height: size.height,
  velocity,
});
```
I think it introduced un-intuitiveness here.

What do you think about it? @cramforce @dvoytenko @mkhatib 