### PR TITLE
Amp slidescroll experiment - make use of snap points and show a max of 3 slides at a time.

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -96,7 +96,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
   width: 100% !important;
 }
 
-.-amp-slide-item[show] {
+.-amp-slide-item-show {
   display: inline-block !important;
 }
 

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -80,6 +80,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
 .-amp-slides-container {
   height: 100% !important;
   overflow-x: auto !important;
+  overflow-y: hidden !important;
   position: relative;
   white-space: nowrap;
   width: 100% !important;

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -75,24 +75,28 @@ amp-carousel .amp-carousel-button.amp-disabled {
 
 /* Begin SlideScroll */
 .-amp-slidescroll {
-  overflow: hidden;
-  overflow-x: auto;
-  /*VERTICAL ALIGN - http://zerosixthree.se/vertical-align-anything-with-just-3-lines-of-css/#update*/
-  transform-style: preserve-3d;
-  /*END*/
+}
+
+.-amp-slides-container {
+  height: 100% !important;
+  overflow-x: auto !important;
+  position: relative;
   white-space: nowrap;
+  width: 100% !important;
+  scroll-snap-type: mandatory;
   -webkit-overflow-scrolling: touch;
 }
 
 .-amp-slide-item {
+  display: none;
+  height: 100% !important;
   position: relative;
-  top: 50%;
-  /*VERTICAL ALIGN*/
-  transform: translateY(-50%);
-  /*END*/
+  scroll-snap-coordinate: 0 0;
+  width: 100% !important;
 }
 
 .-amp-slide-item[show] {
   display: inline-block !important;
 }
+
 /* End SlideScroll */

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -110,42 +110,46 @@ export class AmpSlideScroll extends BaseCarousel {
   /**
    * Makes the slide corresponding to the given index and the slides surrounding
    *    it available for display.
-   * @param {number} newindex Index of the slide to be displayed.
+   * @param {number} newIndex Index of the slide to be displayed.
    * @private
    */
-  showSlide_(newindex) {
+  showSlide_(newIndex) {
     const noOfSlides = this.noOfSlides_;
-    if (newindex < 0 ||
-        newindex >= this.noOfSlides_ ||
-        this.slideIndex_ == newindex) {
+    if (newIndex < 0 ||
+        newIndex >= this.noOfSlides_ ||
+        this.slideIndex_ == newIndex) {
       return;
     }
     const showIndexArr = [];
-    if (newindex == noOfSlides - 1) {
+    if (newIndex == noOfSlides - 1) {
       // Last slide.
       showIndexArr.push(noOfSlides - 1, noOfSlides - 2);
-    } else if (newindex == 0) {
+    } else if (newIndex == 0) {
       // First slide.
       showIndexArr.push(0, 1);
     } else {
-      showIndexArr.push(newindex - 1, newindex, newindex + 1);
+      showIndexArr.push(newIndex - 1, newIndex, newIndex + 1);
     }
     if (this.slideIndex_ != null) {
       this.updateInViewport(this.slides_[this.slideIndex_], false);
     }
-    this.updateInViewport(this.slides_[newindex], true);
+    this.updateInViewport(this.slides_[newIndex], true);
     showIndexArr.forEach(showIndex => {
       this.slideWrappers_[showIndex].classList.add(SHOWN_CSS_CLASS);
-      this.scheduleLayout(this.slides_[showIndex]);
+      if (showIndex == newIndex) {
+        this.scheduleLayout(this.slides_[showIndex]);
+      } else {
+        this.schedulePreload(this.slides_[showIndex]);
+      }
     });
     // A max of 3 slides are displayed at a time - we show the first slide
     // (which is at scrollLeft 0) when slide 0 is requested - for all other
     // instances we show the second slide (middle slide at
     // scrollLeft = slide's width).
-    const newScrollLeft = (newindex == 0) ? 0 : this.slideWidth_;
+    const newScrollLeft = (newIndex == 0) ? 0 : this.slideWidth_;
     this.slidesContainer_./*REVIEW*/scrollLeft = newScrollLeft;
-    this.slideIndex_ = newindex;
-    this.hideRestOfTheSlides_(newindex);
+    this.slideIndex_ = newIndex;
+    this.hideRestOfTheSlides_(newIndex);
     this.setControlsState();
   }
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -16,6 +16,13 @@
 import {BaseCarousel} from './base-carousel';
 import {Layout} from '../../../src/layout';
 
+/** @const */
+const DIR_FORWARD = 1;
+
+/** @const */
+const DIR_REVERSE = -1;
+
+
 export class AmpSlideScroll extends BaseCarousel {
   /** @override */
   isLayoutSupported(layout) {
@@ -26,21 +33,53 @@ export class AmpSlideScroll extends BaseCarousel {
     /** @private @const {!Window} */
     this.win_ = this.getWin();
 
+    /** @private @const {!boolean} */
+    this.hasNativeSnapPoints_ = (
+        this.element.style.scrollSnapType != undefined ||
+        this.element.style.webkitScrollSnapType != undefined);
     this.element.classList.add('-amp-slidescroll');
 
     /** @private {!Array<!Element>} */
     this.slides_ = this.getRealChildren();
 
+    /** @private {!Element} */
+    this.slidesContainer_ = this.win_.document.createElement('div');
+    this.slidesContainer_.classList.add('-amp-slides-container');
+
+    /** @private {!Array<!Element>} */
+    this.slideWrappers_ = [];
+
+    this.element.appendChild(this.slidesContainer_);
     this.slides_.forEach(slide => {
-      const wrapper = this.win_.document.createElement('div');
-      wrapper.appendChild(slide);
-      wrapper.classList.add('-amp-slide-item');
-      this.element.appendChild(wrapper);
+      this.setAsOwner(slide);
+      const slideWrapper = this.win_.document.createElement('div');
+      slideWrapper.appendChild(slide);
+      slideWrapper.classList.add('-amp-slide-item');
+      this.slidesContainer_.appendChild(slideWrapper);
+      this.slideWrappers_.push(slideWrapper);
     });
+    this.element.appendChild(this.slidesContainer_);
+
+    /** @private {number} */
+    this.noOfSlides_ = this.slides_.length;
+  }
+
+  /** @override */
+  onLayoutMeasure() {
+    /** @private {number} */
+    this.slideWidth_ = this.slidesContainer_./*REVIEW*/offsetWidth;
+
+    /** @private {number} */
+    this.previousScrollLeft_ = this.slidesContainer_./*REVIEW*/scrollLeft;
   }
 
   /** @override */
   layoutCallback() {
+    if (this.slideIndex_ == null) {
+      return this.mutateElement(() => {
+        this.showSlides_(0);
+      }, this.slidesContainer_);
+    }
     return Promise.resolve();
   }
 
@@ -57,9 +96,81 @@ export class AmpSlideScroll extends BaseCarousel {
 
   /** @override */
   hasPrev() {
+    return this.slideIndex_ > 0;
   }
 
   /** @override */
   hasNext() {
+    return this.slideIndex_ < this.slides_.length - 1;
+  }
+
+  /** @override */
+  goCallback(dir, unusedAnimate) {
+    if (this.slideIndex_ != null) {
+      if ((dir == DIR_FORWARD && this.hasNext()) ||
+          (dir == DIR_REVERSE && this.hasPrev())) {
+        this.mutateElement(() => {
+          this.showSlides_(this.slideIndex_ + dir);
+        }, this.slidesContainer_);
+      }
+    }
+  }
+
+  /**
+   * Makes the slide corresponding to the given index and the slides surrounding
+   *    it available for display.
+   * @param {number} newindex Index of the slide to be displayed.
+   * @private
+   */
+  showSlides_(newindex) {
+    const noOfSlides = this.noOfSlides_;
+    if (newindex < 0 ||
+        newindex >= this.noOfSlides_ ||
+        this.slideIndex_ == newindex) {
+      return;
+    }
+    const showIndexArr = [];
+    let newScrollLeft;
+    if (newindex == noOfSlides - 1) {
+      // Last slide.
+      showIndexArr.push(noOfSlides - 1, noOfSlides - 2);
+    } else if (newindex === 0) {
+      // First slide.
+      showIndexArr.push(0, 1);
+      newScrollLeft = 0;
+    } else {
+      showIndexArr.push(newindex - 1, newindex, newindex + 1);
+    }
+
+    if (newScrollLeft == null) {
+      newScrollLeft = this.slideWidth_;
+    }
+    if (this.slideIndex_ != null) {
+      this.updateInViewport(this.slides_[this.slideIndex_], false);
+    }
+    this.updateInViewport(this.slides_[newindex], true);
+    this.slideIndex_ = newindex;
+    showIndexArr.forEach(showIndex => {
+      this.slideWrappers_[showIndex].setAttribute('show', '');
+      this.scheduleLayout(this.slides_[showIndex]);
+    });
+    this.slidesContainer_./*REVIEW*/scrollLeft = newScrollLeft;
+    this.hideRestOfTheSlides_(newindex);
+    this.setControlsState();
+  }
+
+  /**
+   * Given an index, hides rest of the slides that are not needed.
+   * @param {number} index Index of the slide to be displayed.
+   * @private
+   */
+  hideRestOfTheSlides_(index) {
+    for (let i = 0; i < this.noOfSlides_; i++) {
+      if (i != index && i != index - 1 && i != index + 1 &&
+          this.slideWrappers_[i]) {
+        this.slideWrappers_[i].removeAttribute('show');
+        this.schedulePause(this.slides_[i]);
+      }
+    }
   }
 }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -65,7 +65,7 @@ export class AmpSlideScroll extends BaseCarousel {
     this.slideWidth_ = this.getLayoutWidth();
 
     /** @private {number} */
-    this.previousScrollLeft_ = this.slidesContainer_./*REVIEW*/scrollLeft;
+    this.previousScrollLeft_ = this.slidesContainer_./*OK*/scrollLeft;
   }
 
   /** @override */
@@ -147,7 +147,7 @@ export class AmpSlideScroll extends BaseCarousel {
     // instances we show the second slide (middle slide at
     // scrollLeft = slide's width).
     const newScrollLeft = (newIndex == 0) ? 0 : this.slideWidth_;
-    this.slidesContainer_./*REVIEW*/scrollLeft = newScrollLeft;
+    this.slidesContainer_./*OK*/scrollLeft = newScrollLeft;
     this.slideIndex_ = newIndex;
     this.hideRestOfTheSlides_(newIndex);
     this.setControlsState();

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -16,12 +16,6 @@
 import {BaseCarousel} from './base-carousel';
 import {Layout} from '../../../src/layout';
 
-/** @const */
-const DIR_FORWARD = 1;
-
-/** @const */
-const DIR_REVERSE = -1;
-
 
 export class AmpSlideScroll extends BaseCarousel {
   /** @override */
@@ -76,7 +70,7 @@ export class AmpSlideScroll extends BaseCarousel {
   layoutCallback() {
     if (this.slideIndex_ == null) {
       return this.mutateElement(() => {
-        this.showSlides_(0);
+        this.showSlide_(0);
       }, this.slidesContainer_);
     }
     return Promise.resolve();
@@ -106,10 +100,10 @@ export class AmpSlideScroll extends BaseCarousel {
   /** @override */
   goCallback(dir, unusedAnimate) {
     if (this.slideIndex_ != null) {
-      if ((dir == DIR_FORWARD && this.hasNext()) ||
-          (dir == DIR_REVERSE && this.hasPrev())) {
+      if ((dir == 1 && this.hasNext()) ||
+          (dir == -1 && this.hasPrev())) {
         this.mutateElement(() => {
-          this.showSlides_(this.slideIndex_ + dir);
+          this.showSlide_(this.slideIndex_ + dir);
         }, this.slidesContainer_);
       }
     }
@@ -121,7 +115,7 @@ export class AmpSlideScroll extends BaseCarousel {
    * @param {number} newindex Index of the slide to be displayed.
    * @private
    */
-  showSlides_(newindex) {
+  showSlide_(newindex) {
     const noOfSlides = this.noOfSlides_;
     if (newindex < 0 ||
         newindex >= this.noOfSlides_ ||
@@ -166,8 +160,10 @@ export class AmpSlideScroll extends BaseCarousel {
     for (let i = 0; i < this.noOfSlides_; i++) {
       if (i != index && i != index - 1 && i != index + 1 &&
           this.slideWrappers_[i]) {
-        this.slideWrappers_[i].removeAttribute('show');
-        this.schedulePause(this.slides_[i]);
+        if (this.slideWrappers_[i].hasAttribute('show')) {
+          this.slideWrappers_[i].removeAttribute('show');
+          this.schedulePause(this.slides_[i]);
+        }
       }
     }
   }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -49,7 +49,6 @@ export class AmpSlideScroll extends BaseCarousel {
     /** @private {!Array<!Element>} */
     this.slideWrappers_ = [];
 
-    this.element.appendChild(this.slidesContainer_);
     this.slides_.forEach(slide => {
       this.setAsOwner(slide);
       const slideWrapper = this.win_.document.createElement('div');
@@ -130,31 +129,30 @@ export class AmpSlideScroll extends BaseCarousel {
       return;
     }
     const showIndexArr = [];
-    let newScrollLeft;
     if (newindex == noOfSlides - 1) {
       // Last slide.
       showIndexArr.push(noOfSlides - 1, noOfSlides - 2);
     } else if (newindex === 0) {
       // First slide.
       showIndexArr.push(0, 1);
-      newScrollLeft = 0;
     } else {
       showIndexArr.push(newindex - 1, newindex, newindex + 1);
-    }
-
-    if (newScrollLeft == null) {
-      newScrollLeft = this.slideWidth_;
     }
     if (this.slideIndex_ != null) {
       this.updateInViewport(this.slides_[this.slideIndex_], false);
     }
     this.updateInViewport(this.slides_[newindex], true);
-    this.slideIndex_ = newindex;
     showIndexArr.forEach(showIndex => {
       this.slideWrappers_[showIndex].setAttribute('show', '');
       this.scheduleLayout(this.slides_[showIndex]);
     });
+    // A max of 3 slides are displayed at a time - we show the first slide
+    // (which is at scrollLeft 0) when slide 0 is requested - for all other
+    // instances we show the second slide (middle slide at
+    // scrollLeft = slide's width).
+    const newScrollLeft = (newindex === 0) ? 0 : this.slideWidth_;
     this.slidesContainer_./*REVIEW*/scrollLeft = newScrollLeft;
+    this.slideIndex_ = newindex;
     this.hideRestOfTheSlides_(newindex);
     this.setControlsState();
   }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -18,7 +18,7 @@ import {Layout} from '../../../src/layout';
 import {getStyle} from '../../../src/style';
 
 /** @const {string} */
-SHOWN_CSS_CLASS = '-amp-slide-item-show';
+const SHOWN_CSS_CLASS = '-amp-slide-item-show';
 
 export class AmpSlideScroll extends BaseCarousel {
   /** @override */
@@ -71,9 +71,7 @@ export class AmpSlideScroll extends BaseCarousel {
   /** @override */
   layoutCallback() {
     if (this.slideIndex_ == null) {
-      return this.mutateElement(() => {
-        this.showSlide_(0);
-      }, this.slidesContainer_);
+      this.showSlide_(0);
     }
     return Promise.resolve();
   }
@@ -104,9 +102,7 @@ export class AmpSlideScroll extends BaseCarousel {
     if (this.slideIndex_ != null) {
       if ((dir == 1 && this.hasNext()) ||
           (dir == -1 && this.hasPrev())) {
-        this.mutateElement(() => {
-          this.showSlide_(this.slideIndex_ + dir);
-        }, this.slidesContainer_);
+        this.showSlide_(this.slideIndex_ + dir);
       }
     }
   }
@@ -128,7 +124,7 @@ export class AmpSlideScroll extends BaseCarousel {
     if (newindex == noOfSlides - 1) {
       // Last slide.
       showIndexArr.push(noOfSlides - 1, noOfSlides - 2);
-    } else if (newindex === 0) {
+    } else if (newindex == 0) {
       // First slide.
       showIndexArr.push(0, 1);
     } else {
@@ -146,7 +142,7 @@ export class AmpSlideScroll extends BaseCarousel {
     // (which is at scrollLeft 0) when slide 0 is requested - for all other
     // instances we show the second slide (middle slide at
     // scrollLeft = slide's width).
-    const newScrollLeft = (newindex === 0) ? 0 : this.slideWidth_;
+    const newScrollLeft = (newindex == 0) ? 0 : this.slideWidth_;
     this.slidesContainer_./*REVIEW*/scrollLeft = newScrollLeft;
     this.slideIndex_ = newindex;
     this.hideRestOfTheSlides_(newindex);

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -15,7 +15,10 @@
  */
 import {BaseCarousel} from './base-carousel';
 import {Layout} from '../../../src/layout';
+import {getStyle} from '../../../src/style';
 
+/** @const {string} */
+SHOWN_CSS_CLASS = '-amp-slide-item-show';
 
 export class AmpSlideScroll extends BaseCarousel {
   /** @override */
@@ -29,8 +32,7 @@ export class AmpSlideScroll extends BaseCarousel {
 
     /** @private @const {!boolean} */
     this.hasNativeSnapPoints_ = (
-        this.element.style.scrollSnapType != undefined ||
-        this.element.style.webkitScrollSnapType != undefined);
+        getStyle(this.element, 'scrollSnapType') != undefined);
     this.element.classList.add('-amp-slidescroll');
 
     /** @private {!Array<!Element>} */
@@ -60,7 +62,7 @@ export class AmpSlideScroll extends BaseCarousel {
   /** @override */
   onLayoutMeasure() {
     /** @private {number} */
-    this.slideWidth_ = this.slidesContainer_./*REVIEW*/offsetWidth;
+    this.slideWidth_ = this.getLayoutWidth();
 
     /** @private {number} */
     this.previousScrollLeft_ = this.slidesContainer_./*REVIEW*/scrollLeft;
@@ -137,7 +139,7 @@ export class AmpSlideScroll extends BaseCarousel {
     }
     this.updateInViewport(this.slides_[newindex], true);
     showIndexArr.forEach(showIndex => {
-      this.slideWrappers_[showIndex].setAttribute('show', '');
+      this.slideWrappers_[showIndex].classList.add(SHOWN_CSS_CLASS);
       this.scheduleLayout(this.slides_[showIndex]);
     });
     // A max of 3 slides are displayed at a time - we show the first slide
@@ -160,8 +162,8 @@ export class AmpSlideScroll extends BaseCarousel {
     for (let i = 0; i < this.noOfSlides_; i++) {
       if (i != index && i != index - 1 && i != index + 1 &&
           this.slideWrappers_[i]) {
-        if (this.slideWrappers_[i].hasAttribute('show')) {
-          this.slideWrappers_[i].removeAttribute('show');
+        if (this.slideWrappers_[i].classList.contains(SHOWN_CSS_CLASS)) {
+          this.slideWrappers_[i].classList.remove(SHOWN_CSS_CLASS);
           this.schedulePause(this.slides_[i]);
         }
       }

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -13,3 +13,217 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import * as sinon from 'sinon';
+require('../amp-carousel');
+import {createIframePromise} from '../../../../testing/iframe';
+import {toggleExperiment} from '../../../../src/experiments';
+
+describe('SlideScroll', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    toggleExperiment(window, 'amp-slidescroll', true);
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function getAmpSlideScroll() {
+    return createIframePromise().then(iframe => {
+      toggleExperiment(iframe.win, 'amp-slidescroll', true);
+      const imgUrl = 'https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-' +
+          'Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no';
+      const slideScrollHtml =
+        `<amp-carousel type='slides' width=400 height=300 id='c1' controls>
+          <amp-img src='${imgUrl}' width=400 height=300>
+          </amp-img>
+          <amp-img src='${imgUrl}' width=400 height=300>
+          </amp-img>
+          <amp-img src='${imgUrl}' width=400 height=300>
+          </amp-img>
+          <amp-img src='${imgUrl}' width=400 height=300>
+          </amp-img>
+          <amp-img src='${imgUrl}' width=400 height=300>
+          </amp-img>
+        </amp-carousel>
+      `;
+      const dummyDiv = iframe.doc.createElement('div');
+      dummyDiv.innerHTML = slideScrollHtml.trim();
+      const ampSlideScroll = dummyDiv.children[0];
+      return iframe.addElement(ampSlideScroll).then(() => {
+        return Promise.resolve({
+          iframe: iframe,
+          ampSlideScroll: ampSlideScroll,
+        });
+      });
+    });
+  }
+
+  it('should create container and wrappers and show intial slides', () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      expect(
+          ampSlideScroll.getElementsByClassName('-amp-slides-container').length)
+              .to.equal(1);
+      expect(
+          ampSlideScroll.querySelectorAll(
+            '.-amp-slides-container > .-amp-slide-item').length).to.equal(5);
+      const impl = ampSlideScroll.implementation_;
+      expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.true;
+    });
+  });
+
+  it('should show the correct slide', () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      const impl = ampSlideScroll.implementation_;
+      const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
+      const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
+      const hideRestOfTheSlidesSpy = sandbox.spy(impl, 'hideRestOfTheSlides_');
+      const setControlsStateSpy = sandbox.spy(impl, 'setControlsState');
+
+      impl.showSlides_(-1);
+      expect(updateInViewportSpy).to.not.have.been.called;
+      expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
+      expect(setControlsStateSpy).to.not.have.been.called;
+
+
+      impl.showSlides_(5);
+      expect(updateInViewportSpy).to.not.have.been.called;
+      expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
+      expect(setControlsStateSpy).to.not.have.been.called;
+
+      impl.showSlides_(impl.slideIndex_);
+      expect(updateInViewportSpy).to.not.have.been.called;
+      expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
+      expect(setControlsStateSpy).to.not.have.been.called;
+
+
+      impl.showSlides_(1);
+
+      expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.slides_[0], false);
+      expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.slides_[1], true);
+      expect(updateInViewportSpy.callCount).to.equal(2);
+      expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.true;
+      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[0]);
+      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[1]);
+      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[2]);
+      expect(scheduleLayoutSpy.callCount).to.equal(3);
+      expect(impl.slideIndex_).to.equal(1);
+      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(impl.slideWidth_);
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(1);
+      expect(hideRestOfTheSlidesSpy.callCount).to.equal(1);
+      expect(setControlsStateSpy.callCount).to.equal(1);
+
+      impl.showSlides_(0);
+
+      expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.slides_[1], false);
+      expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.slides_[0], true);
+      expect(updateInViewportSpy.callCount).to.equal(4);
+      expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.false;
+      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[0]);
+      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[1]);
+      expect(scheduleLayoutSpy.callCount).to.equal(5);
+      expect(impl.slideIndex_).to.equal(0);
+      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(0);
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(0);
+      expect(hideRestOfTheSlidesSpy.callCount).to.equal(2);
+      expect(setControlsStateSpy.callCount).to.equal(2);
+
+      impl.showSlides_(4);
+
+      expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.slides_[0], false);
+      expect(updateInViewportSpy).to.have.been.calledWith(
+          impl.slides_[4], true);
+      expect(updateInViewportSpy.callCount).to.equal(6);
+      expect(impl.slideWrappers_[3].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[4].hasAttribute('show')).to.be.true;
+      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[3]);
+      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[4]);
+      expect(scheduleLayoutSpy.callCount).to.equal(7);
+      expect(impl.slideIndex_).to.equal(4);
+      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(impl.slideWidth_);
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(4);
+      expect(hideRestOfTheSlidesSpy.callCount).to.equal(3);
+      expect(setControlsStateSpy.callCount).to.equal(3);
+    });
+  });
+
+  it('should hide the unwatned slides slide', () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      const impl = ampSlideScroll.implementation_;
+      const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
+
+      impl.hideRestOfTheSlides_(1);
+
+      expect(impl.slideWrappers_[3].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[4].hasAttribute('show')).to.be.false;
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[3]);
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[4]);
+      expect(schedulePauseSpy.callCount).to.equal(2);
+
+      impl.hideRestOfTheSlides_(0);
+
+      expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[3].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[4].hasAttribute('show')).to.be.false;
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[3]);
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[4]);
+      expect(schedulePauseSpy.callCount).to.equal(5);
+
+      impl.hideRestOfTheSlides_(4);
+
+      expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.false;
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[0]);
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[1]);
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
+      expect(schedulePauseSpy.callCount).to.equal(8);
+    });
+  });
+
+  it('should show/hide the correct controls', () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      const impl = ampSlideScroll.implementation_;
+
+      impl.showSlides_(1);
+      expect(impl.hasNext()).to.be.true;
+      expect(impl.hasPrev()).to.be.true;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+
+      impl.showSlides_(0);
+      expect(impl.hasNext()).to.be.true;
+      expect(impl.hasPrev()).to.be.false;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
+
+      impl.showSlides_(4);
+      expect(impl.hasNext()).to.be.false;
+      expect(impl.hasPrev()).to.be.true;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+    });
+  });
+
+});

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -55,8 +55,8 @@ describe('SlideScroll', () => {
       const ampSlideScroll = dummyDiv.children[0];
       return iframe.addElement(ampSlideScroll).then(() => {
         return Promise.resolve({
-          iframe: iframe,
-          ampSlideScroll: ampSlideScroll,
+          iframe,
+          ampSlideScroll,
         });
       });
     });
@@ -86,27 +86,27 @@ describe('SlideScroll', () => {
       const hideRestOfTheSlidesSpy = sandbox.spy(impl, 'hideRestOfTheSlides_');
       const setControlsStateSpy = sandbox.spy(impl, 'setControlsState');
 
-      impl.showSlides_(-1);
+      impl.showSlide_(-1);
       expect(updateInViewportSpy).to.not.have.been.called;
       expect(scheduleLayoutSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
 
 
-      impl.showSlides_(5);
+      impl.showSlide_(5);
       expect(updateInViewportSpy).to.not.have.been.called;
       expect(scheduleLayoutSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
 
-      impl.showSlides_(impl.slideIndex_);
+      impl.showSlide_(impl.slideIndex_);
       expect(updateInViewportSpy).to.not.have.been.called;
       expect(scheduleLayoutSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
 
 
-      impl.showSlides_(1);
+      impl.showSlide_(1);
 
       expect(updateInViewportSpy).to.have.been.calledWith(
           impl.slides_[0], false);
@@ -126,7 +126,7 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(1);
       expect(setControlsStateSpy.callCount).to.equal(1);
 
-      impl.showSlides_(0);
+      impl.showSlide_(0);
 
       expect(updateInViewportSpy).to.have.been.calledWith(
           impl.slides_[1], false);
@@ -145,7 +145,7 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(2);
       expect(setControlsStateSpy.callCount).to.equal(2);
 
-      impl.showSlides_(4);
+      impl.showSlide_(4);
 
       expect(updateInViewportSpy).to.have.been.calledWith(
           impl.slides_[0], false);
@@ -170,34 +170,36 @@ describe('SlideScroll', () => {
       const ampSlideScroll = obj.ampSlideScroll;
       const impl = ampSlideScroll.implementation_;
       const schedulePauseSpy = sandbox.spy(impl, 'schedulePause');
+      const hideRestOfTheSlidesSpy = sandbox.spy(impl, 'hideRestOfTheSlides_');
 
-      impl.hideRestOfTheSlides_(1);
+      impl.showSlide_(1);
 
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(1);
       expect(impl.slideWrappers_[3].hasAttribute('show')).to.be.false;
       expect(impl.slideWrappers_[4].hasAttribute('show')).to.be.false;
-      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[3]);
-      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[4]);
-      expect(schedulePauseSpy.callCount).to.equal(2);
+      expect(schedulePauseSpy).to.not.have.been.called;
+      expect(schedulePauseSpy.callCount).to.equal(0);
 
-      impl.hideRestOfTheSlides_(0);
+      impl.showSlide_(0);
+
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(0);
 
       expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.false;
       expect(impl.slideWrappers_[3].hasAttribute('show')).to.be.false;
       expect(impl.slideWrappers_[4].hasAttribute('show')).to.be.false;
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
-      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[3]);
-      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[4]);
-      expect(schedulePauseSpy.callCount).to.equal(5);
+      expect(schedulePauseSpy.callCount).to.equal(1);
 
-      impl.hideRestOfTheSlides_(4);
+      impl.showSlide_(4);
+
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(4);
 
       expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.false;
       expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.false;
       expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.false;
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[0]);
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[1]);
-      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
-      expect(schedulePauseSpy.callCount).to.equal(8);
+      expect(schedulePauseSpy.callCount).to.equal(3);
     });
   });
 
@@ -206,19 +208,19 @@ describe('SlideScroll', () => {
       const ampSlideScroll = obj.ampSlideScroll;
       const impl = ampSlideScroll.implementation_;
 
-      impl.showSlides_(1);
+      impl.showSlide_(1);
       expect(impl.hasNext()).to.be.true;
       expect(impl.hasPrev()).to.be.true;
       expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
       expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
 
-      impl.showSlides_(0);
+      impl.showSlide_(0);
       expect(impl.hasNext()).to.be.true;
       expect(impl.hasPrev()).to.be.false;
       expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
       expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
 
-      impl.showSlides_(4);
+      impl.showSlide_(4);
       expect(impl.hasNext()).to.be.false;
       expect(impl.hasPrev()).to.be.true;
       expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -36,23 +36,21 @@ describe('SlideScroll', () => {
       toggleExperiment(iframe.win, 'amp-slidescroll', true);
       const imgUrl = 'https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-' +
           'Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no';
-      const slideScrollHtml =
-        `<amp-carousel type='slides' width=400 height=300 id='c1' controls>
-          <amp-img src='${imgUrl}' width=400 height=300>
-          </amp-img>
-          <amp-img src='${imgUrl}' width=400 height=300>
-          </amp-img>
-          <amp-img src='${imgUrl}' width=400 height=300>
-          </amp-img>
-          <amp-img src='${imgUrl}' width=400 height=300>
-          </amp-img>
-          <amp-img src='${imgUrl}' width=400 height=300>
-          </amp-img>
-        </amp-carousel>
-      `;
+      const slideScrollHtml = "<amp-carousel type='slides'></amp-carousel>";
       const dummyDiv = iframe.doc.createElement('div');
       dummyDiv.innerHTML = slideScrollHtml.trim();
       const ampSlideScroll = dummyDiv.children[0];
+      ampSlideScroll.setAttribute('width', '400');
+      ampSlideScroll.setAttribute('height', '300');
+      ampSlideScroll.setAttribute('controls', '');
+
+      for (let i = 0; i < 5; i++) {
+        const img = document.createElement('amp-img');
+        ampSlideScroll.setAttribute('src', imgUrl);
+        ampSlideScroll.setAttribute('width', '400');
+        ampSlideScroll.setAttribute('height', '300');
+        ampSlideScroll.appendChild(img);
+      }
       return iframe.addElement(ampSlideScroll).then(() => {
         return Promise.resolve({
           iframe,
@@ -72,8 +70,10 @@ describe('SlideScroll', () => {
           ampSlideScroll.querySelectorAll(
             '.-amp-slides-container > .-amp-slide-item').length).to.equal(5);
       const impl = ampSlideScroll.implementation_;
-      expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.true;
-      expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[0].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
+      expect(impl.slideWrappers_[1].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
     });
   });
 
@@ -113,9 +113,12 @@ describe('SlideScroll', () => {
       expect(updateInViewportSpy).to.have.been.calledWith(
           impl.slides_[1], true);
       expect(updateInViewportSpy.callCount).to.equal(2);
-      expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.true;
-      expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.true;
-      expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[0].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
+      expect(impl.slideWrappers_[1].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
+      expect(impl.slideWrappers_[2].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[0]);
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[1]);
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[2]);
@@ -133,9 +136,12 @@ describe('SlideScroll', () => {
       expect(updateInViewportSpy).to.have.been.calledWith(
           impl.slides_[0], true);
       expect(updateInViewportSpy.callCount).to.equal(4);
-      expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.true;
-      expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.true;
-      expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[0].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
+      expect(impl.slideWrappers_[1].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
+      expect(impl.slideWrappers_[2].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[0]);
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[1]);
       expect(scheduleLayoutSpy.callCount).to.equal(5);
@@ -152,8 +158,10 @@ describe('SlideScroll', () => {
       expect(updateInViewportSpy).to.have.been.calledWith(
           impl.slides_[4], true);
       expect(updateInViewportSpy.callCount).to.equal(6);
-      expect(impl.slideWrappers_[3].hasAttribute('show')).to.be.true;
-      expect(impl.slideWrappers_[4].hasAttribute('show')).to.be.true;
+      expect(impl.slideWrappers_[3].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
+      expect(impl.slideWrappers_[4].classList.contains('-amp-slide-item-show'))
+          .to.be.true;
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[3]);
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[4]);
       expect(scheduleLayoutSpy.callCount).to.equal(7);
@@ -175,8 +183,10 @@ describe('SlideScroll', () => {
       impl.showSlide_(1);
 
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(1);
-      expect(impl.slideWrappers_[3].hasAttribute('show')).to.be.false;
-      expect(impl.slideWrappers_[4].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[3].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
+      expect(impl.slideWrappers_[4].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
       expect(schedulePauseSpy).to.not.have.been.called;
       expect(schedulePauseSpy.callCount).to.equal(0);
 
@@ -184,9 +194,12 @@ describe('SlideScroll', () => {
 
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(0);
 
-      expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.false;
-      expect(impl.slideWrappers_[3].hasAttribute('show')).to.be.false;
-      expect(impl.slideWrappers_[4].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[2].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
+      expect(impl.slideWrappers_[3].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
+      expect(impl.slideWrappers_[4].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
       expect(schedulePauseSpy.callCount).to.equal(1);
 
@@ -194,9 +207,12 @@ describe('SlideScroll', () => {
 
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(4);
 
-      expect(impl.slideWrappers_[0].hasAttribute('show')).to.be.false;
-      expect(impl.slideWrappers_[1].hasAttribute('show')).to.be.false;
-      expect(impl.slideWrappers_[2].hasAttribute('show')).to.be.false;
+      expect(impl.slideWrappers_[0].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
+      expect(impl.slideWrappers_[1].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
+      expect(impl.slideWrappers_[2].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[0]);
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[1]);
       expect(schedulePauseSpy.callCount).to.equal(3);

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -83,12 +83,14 @@ describe('SlideScroll', () => {
       const impl = ampSlideScroll.implementation_;
       const updateInViewportSpy = sandbox.spy(impl, 'updateInViewport');
       const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
+      const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
       const hideRestOfTheSlidesSpy = sandbox.spy(impl, 'hideRestOfTheSlides_');
       const setControlsStateSpy = sandbox.spy(impl, 'setControlsState');
 
       impl.showSlide_(-1);
       expect(updateInViewportSpy).to.not.have.been.called;
       expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(schedulePreloadSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
 
@@ -96,12 +98,14 @@ describe('SlideScroll', () => {
       impl.showSlide_(5);
       expect(updateInViewportSpy).to.not.have.been.called;
       expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(schedulePreloadSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
 
       impl.showSlide_(impl.slideIndex_);
       expect(updateInViewportSpy).to.not.have.been.called;
       expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(schedulePreloadSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
 
@@ -119,10 +123,11 @@ describe('SlideScroll', () => {
           .to.be.true;
       expect(impl.slideWrappers_[2].classList.contains('-amp-slide-item-show'))
           .to.be.true;
-      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[0]);
+      expect(schedulePreloadSpy).to.have.been.calledWith(impl.slides_[0]);
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[1]);
-      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[2]);
-      expect(scheduleLayoutSpy.callCount).to.equal(3);
+      expect(schedulePreloadSpy).to.have.been.calledWith(impl.slides_[2]);
+      expect(scheduleLayoutSpy.callCount).to.equal(1);
+      expect(schedulePreloadSpy.callCount).to.equal(2);
       expect(impl.slideIndex_).to.equal(1);
       expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(impl.slideWidth_);
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(1);
@@ -143,8 +148,9 @@ describe('SlideScroll', () => {
       expect(impl.slideWrappers_[2].classList.contains('-amp-slide-item-show'))
           .to.be.false;
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[0]);
-      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[1]);
-      expect(scheduleLayoutSpy.callCount).to.equal(5);
+      expect(schedulePreloadSpy).to.have.been.calledWith(impl.slides_[1]);
+      expect(scheduleLayoutSpy.callCount).to.equal(2);
+      expect(schedulePreloadSpy.callCount).to.equal(3);
       expect(impl.slideIndex_).to.equal(0);
       expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(0);
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(0);
@@ -162,9 +168,10 @@ describe('SlideScroll', () => {
           .to.be.true;
       expect(impl.slideWrappers_[4].classList.contains('-amp-slide-item-show'))
           .to.be.true;
-      expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[3]);
+      expect(schedulePreloadSpy).to.have.been.calledWith(impl.slides_[3]);
       expect(scheduleLayoutSpy).to.have.been.calledWith(impl.slides_[4]);
-      expect(scheduleLayoutSpy.callCount).to.equal(7);
+      expect(scheduleLayoutSpy.callCount).to.equal(3);
+      expect(schedulePreloadSpy.callCount).to.equal(4);
       expect(impl.slideIndex_).to.equal(4);
       expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(impl.slideWidth_);
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(4);

--- a/test/manual/amp-slidescroll.amp.html
+++ b/test/manual/amp-slidescroll.amp.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="../../dist/v0/amp-carousel-0.1.max.js"></script>
+  <script async custom-element="amp-anim" src="../../dist/v0/amp-anim-0.1.max.js"></script>
+  <style amp-custom>
+  /* AMP.CSS */
+  html, body {
+    overflow-x: hidden !important;
+    height: auto !important;
+  }
+
+  /**
+   * Margin:0 is currently needed for iOS viewer embeds.
+   * See:
+   * https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md
+   * and {@link ViewportBindingNaturalIosEmbed_} for more info.
+   */
+  body {
+    margin: 0 !important;
+  }
+  /* END AMP.CSS */
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="../../dist/amp.js"></script>
+</head>
+<body>
+  <h1>amp #0</h1>
+  <amp-carousel id="carousel-3" width=400 height=300 type=slides controls>
+    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" layout=fill></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=400 height=300></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=400 height=300></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" layout=fill></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=400 height=300></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=400 height=300></amp-img>
+  </amp-carousel>
+</body>
+</html>


### PR DESCRIPTION
Implement a scrollable carousel

**In this PR**
- Use snap-points in css.
- Show only 3 slides at a time.
- Make the nav buttons functional.
- update viewport when slides change.
- schedule and pause layout as needed.
- unit tests for all of the above.

Part 2 for  - #3465

**Yet to come** 
- listening to scroll.
- updating slide index on scroll.
- polyfilling snap-points when not available.