### PR TITLE
Turn on property minification in JS compilation.

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpCodingConvention.java
+++ b/build-system/runner/src/org/ampproject/AmpCodingConvention.java
@@ -60,4 +60,13 @@ public final class AmpCodingConvention extends CodingConventions.Proxy {
     }
     return !name.endsWith("_") && !name.endsWith("ForTesting");
   }
+
+  /**
+   * {@inheritDoc}
+   * We cannot rename properties we treat as exported, because they may travel
+   * between compilation unit.
+   */
+  @Override public boolean blockRenamingForProperty(String name) {
+    return isExported(name, false);
+  }
 }

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.CommandLineRunner;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CustomPassExecutionTime;
+import com.google.javascript.jscomp.PropertyRenamingPolicy;
+import com.google.javascript.jscomp.VariableRenamingPolicy;
 
 import java.io.IOException;
 
@@ -64,10 +66,10 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     options.setRemoveUnusedPrototypeProperties(false);
     options.setInlineProperties(false);
     options.setComputeFunctionSideEffects(false);
-    // Waiting for upstream change to stop renaming exported properties.
-    // options.setRenamingPolicy(VariableRenamingPolicy.ALL,
-    //    PropertyRenamingPolicy.ALL_UNQUOTED);
-    // options.setDisambiguatePrivateProperties(true);
+    // Property renaming. Relies on AmpCodingConvention to be safe.
+    options.setRenamingPolicy(VariableRenamingPolicy.ALL,
+        PropertyRenamingPolicy.ALL_UNQUOTED);
+    options.setDisambiguatePrivateProperties(true);
     return options;
   }
 
@@ -76,7 +78,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     super.setRunOptions(options);
     options.setCodingConvention(new AmpCodingConvention());
   }
-  
+
   /**
    * Create the most basic CompilerOptions instance with type checking turned on.
    */
@@ -85,7 +87,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     options.setCheckTypes(true);
     return options;
   }
-  
+
   protected void setTypeCheckOnly(boolean value) {
     typecheck_only = value;
   }

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,43 +1,43 @@
       max   |         min   |       gzip   |     brotli   |   file
       ---   |         ---   |        ---   |        ---   |   ---
- 54.19 kB   |     5.41 kB   |    2.29 kB   |    1.97 kB   |   alp.js / alp.max.js
-   648 kB   |   145.52 kB   |   42.17 kB   |   36.64 kB   |   v0.js / amp.js
- 246.9 kB   |    38.99 kB   |   12.95 kB   |   11.49 kB   |   v0/amp-access-0.1.js
- 27.83 kB   |     5.84 kB   |    2.41 kB   |    2.01 kB   |   v0/amp-accordion-0.1.js
-183.99 kB   |    26.68 kB   |    9.69 kB   |    8.65 kB   |   v0/amp-ad-0.1.js
-257.98 kB   |    58.23 kB   |   20.67 kB   |   18.02 kB   |   v0/amp-analytics-0.1.js
- 90.05 kB   |     8.82 kB   |    3.56 kB   |     3.1 kB   |   v0/amp-anim-0.1.js
- 87.72 kB   |     6.93 kB   |    2.92 kB   |    2.52 kB   |   v0/amp-audio-0.1.js
- 81.74 kB   |     7.92 kB   |    3.16 kB   |    2.71 kB   |   v0/amp-brid-player-0.1.js
-104.66 kB   |     7.68 kB   |    3.07 kB   |    2.63 kB   |   v0/amp-brightcove-0.1.js
-205.58 kB   |    31.75 kB   |    9.71 kB   |    8.63 kB   |   v0/amp-carousel-0.1.js
- 74.32 kB   |     6.57 kB   |    2.76 kB   |    2.37 kB   |   v0/amp-dailymotion-0.1.js
- 92.07 kB   |     5.06 kB   |    2.27 kB   |    1.97 kB   |   v0/amp-dynamic-css-classes-0.1.js
-144.34 kB   |    15.18 kB   |    6.17 kB   |    5.47 kB   |   v0/amp-facebook-0.1.js
- 34.96 kB   |     6.37 kB   |    2.62 kB   |    2.27 kB   |   v0/amp-fit-text-0.1.js
-101.09 kB   |     8.89 kB   |    3.42 kB   |    2.96 kB   |   v0/amp-font-0.1.js
- 78.79 kB   |     7.12 kB   |    2.83 kB   |    2.42 kB   |   v0/amp-fx-flying-carpet-0.1.js
-141.85 kB   |     14.9 kB   |    5.66 kB   |    4.99 kB   |   v0/amp-iframe-0.1.js
-228.95 kB   |    36.78 kB   |   10.88 kB   |    9.69 kB   |   v0/amp-image-lightbox-0.1.js
- 98.92 kB   |     7.38 kB   |    3.04 kB   |    2.63 kB   |   v0/amp-instagram-0.1.js
- 84.56 kB   |      8.3 kB   |    3.49 kB   |    3.02 kB   |   v0/amp-install-serviceworker-0.1.js
- 81.17 kB   |     7.39 kB   |    3.03 kB   |    2.61 kB   |   v0/amp-jwplayer-0.1.js
-109.98 kB   |     8.37 kB   |     3.4 kB   |    2.93 kB   |   v0/amp-kaltura-player-0.1.js
-139.61 kB   |    14.01 kB   |    4.75 kB   |     4.2 kB   |   v0/amp-lightbox-0.1.js
- 110.7 kB   |     8.52 kB   |     3.4 kB   |    2.97 kB   |   v0/amp-list-0.1.js
-147.67 kB   |    14.62 kB   |    5.14 kB   |    4.54 kB   |   v0/amp-live-list-0.1.js
-145.03 kB   |    40.81 kB   |   14.45 kB   |   13.01 kB   |   v0/amp-mustache-0.1.js
-124.97 kB   |    20.37 kB   |    6.14 kB   |    5.37 kB   |   v0/amp-pinterest-0.1.js
- 73.44 kB   |     6.23 kB   |    2.61 kB   |    2.23 kB   |   v0/amp-reach-player-0.1.js
- 90.01 kB   |    10.27 kB   |    3.78 kB   |    3.27 kB   |   v0/amp-sidebar-0.1.js
-108.38 kB   |    11.82 kB   |    4.49 kB   |    3.96 kB   |   v0/amp-slides-0.1.js
-104.85 kB   |    11.44 kB   |    4.38 kB   |    3.73 kB   |   v0/amp-social-share-0.1.js
- 74.02 kB   |     6.36 kB   |    2.65 kB   |    2.25 kB   |   v0/amp-soundcloud-0.1.js
- 81.98 kB   |      8.1 kB   |    3.15 kB   |     2.7 kB   |   v0/amp-springboard-player-0.1.js
- 85.06 kB   |        7 kB   |    2.87 kB   |    2.46 kB   |   v0/amp-sticky-ad-0.1.js
-144.81 kB   |     15.3 kB   |    6.21 kB   |    5.52 kB   |   v0/amp-twitter-0.1.js
-   111 kB   |    10.68 kB   |    4.09 kB   |    3.52 kB   |   v0/amp-user-notification-0.1.js
- 73.94 kB   |     6.33 kB   |    2.65 kB   |    2.26 kB   |   v0/amp-vimeo-0.1.js
- 73.47 kB   |     6.19 kB   |    2.61 kB   |    2.23 kB   |   v0/amp-vine-0.1.js
-113.33 kB   |     8.91 kB   |    3.59 kB   |     3.1 kB   |   v0/amp-youtube-0.1.js
-154.42 kB   |    33.81 kB   |   11.78 kB   |   10.55 kB   |   current-min/f.js / current/integration.js
+ 54.19 kB   |      5.3 kB   |    2.26 kB   |    1.94 kB   |   alp.js / alp.max.js
+648.29 kB   |   129.32 kB   |   40.33 kB   |   35.12 kB   |   v0.js / amp.js
+ 246.9 kB   |    36.18 kB   |   12.57 kB   |   11.14 kB   |   v0/amp-access-0.1.js
+ 27.83 kB   |     5.69 kB   |    2.36 kB   |    1.97 kB   |   v0/amp-accordion-0.1.js
+184.01 kB   |    25.05 kB   |    9.49 kB   |    8.43 kB   |   v0/amp-ad-0.1.js
+   258 kB   |    54.86 kB   |   20.26 kB   |   17.62 kB   |   v0/amp-analytics-0.1.js
+ 90.05 kB   |     8.38 kB   |    3.47 kB   |    3.03 kB   |   v0/amp-anim-0.1.js
+ 87.72 kB   |     6.72 kB   |    2.87 kB   |    2.47 kB   |   v0/amp-audio-0.1.js
+ 81.74 kB   |     7.62 kB   |    3.08 kB   |    2.64 kB   |   v0/amp-brid-player-0.1.js
+104.66 kB   |     7.43 kB   |    3.01 kB   |    2.58 kB   |   v0/amp-brightcove-0.1.js
+205.66 kB   |    27.32 kB   |     9.2 kB   |    8.15 kB   |   v0/amp-carousel-0.1.js
+ 74.33 kB   |     6.35 kB   |     2.7 kB   |     2.3 kB   |   v0/amp-dailymotion-0.1.js
+ 92.07 kB   |     4.95 kB   |    2.23 kB   |    1.92 kB   |   v0/amp-dynamic-css-classes-0.1.js
+144.36 kB   |    14.81 kB   |    6.09 kB   |    5.41 kB   |   v0/amp-facebook-0.1.js
+ 34.96 kB   |     6.03 kB   |    2.56 kB   |     2.2 kB   |   v0/amp-fit-text-0.1.js
+101.09 kB   |     7.95 kB   |    3.27 kB   |    2.83 kB   |   v0/amp-font-0.1.js
+ 78.79 kB   |     6.91 kB   |    2.77 kB   |    2.36 kB   |   v0/amp-fx-flying-carpet-0.1.js
+141.88 kB   |    13.57 kB   |    5.45 kB   |     4.8 kB   |   v0/amp-iframe-0.1.js
+229.03 kB   |    31.16 kB   |   10.31 kB   |    9.14 kB   |   v0/amp-image-lightbox-0.1.js
+ 98.92 kB   |     7.09 kB   |    2.97 kB   |    2.56 kB   |   v0/amp-instagram-0.1.js
+ 84.56 kB   |     8.04 kB   |    3.42 kB   |    2.95 kB   |   v0/amp-install-serviceworker-0.1.js
+ 81.17 kB   |     7.09 kB   |    2.96 kB   |    2.55 kB   |   v0/amp-jwplayer-0.1.js
+109.98 kB   |     8.14 kB   |    3.34 kB   |    2.88 kB   |   v0/amp-kaltura-player-0.1.js
+139.68 kB   |    11.77 kB   |    4.46 kB   |    3.96 kB   |   v0/amp-lightbox-0.1.js
+ 110.7 kB   |     8.02 kB   |     3.3 kB   |    2.88 kB   |   v0/amp-list-0.1.js
+151.05 kB   |    13.42 kB   |    5.09 kB   |    4.49 kB   |   v0/amp-live-list-0.1.js
+145.02 kB   |    39.52 kB   |   14.27 kB   |   12.78 kB   |   v0/amp-mustache-0.1.js
+124.97 kB   |    20.26 kB   |    6.11 kB   |    5.33 kB   |   v0/amp-pinterest-0.1.js
+ 73.44 kB   |     6.01 kB   |    2.55 kB   |    2.17 kB   |   v0/amp-reach-player-0.1.js
+ 90.01 kB   |     9.56 kB   |    3.61 kB   |    3.13 kB   |   v0/amp-sidebar-0.1.js
+ 108.4 kB   |    11.01 kB   |    4.34 kB   |    3.82 kB   |   v0/amp-slides-0.1.js
+104.86 kB   |    11.27 kB   |    4.33 kB   |    3.69 kB   |   v0/amp-social-share-0.1.js
+ 74.02 kB   |     6.14 kB   |    2.59 kB   |     2.2 kB   |   v0/amp-soundcloud-0.1.js
+ 81.99 kB   |     7.78 kB   |    3.08 kB   |    2.63 kB   |   v0/amp-springboard-player-0.1.js
+ 85.06 kB   |     6.67 kB   |    2.78 kB   |    2.38 kB   |   v0/amp-sticky-ad-0.1.js
+144.83 kB   |    14.93 kB   |    6.13 kB   |    5.44 kB   |   v0/amp-twitter-0.1.js
+110.99 kB   |     9.87 kB   |    3.93 kB   |    3.38 kB   |   v0/amp-user-notification-0.1.js
+ 73.94 kB   |     6.11 kB   |    2.59 kB   |    2.21 kB   |   v0/amp-vimeo-0.1.js
+ 73.47 kB   |     5.97 kB   |    2.55 kB   |    2.17 kB   |   v0/amp-vine-0.1.js
+113.33 kB   |      8.5 kB   |    3.51 kB   |    3.03 kB   |   v0/amp-youtube-0.1.js
+154.79 kB   |    33.84 kB   |   11.78 kB   |   10.56 kB   |   current-min/f.js / current/integration.js


### PR DESCRIPTION
In practice this will rename properties like `this.foo_` and instance methods named as `privateMethod_` (see trailing `_`) to shorter strings like `this.a`.

16KB pre-gzip code size win on `v0.js`. 2KB post-gzip.