### PR TITLE
-Add alt attribute for instagram img container

### DIFF
--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -115,7 +115,8 @@ class AmpInstagram extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowtransparency', 'true');
     //Add title to the iframe for better accessibility.
-    iframe.setAttribute('title', 'Instagram: ' + this.element.getAttribute('alt'));
+    iframe.setAttribute('title', 'Instagram: ' + 
+        this.element.getAttribute('alt'));
     iframe.src = 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/embed/?v=4';
     this.applyFillContent(iframe);

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -115,7 +115,7 @@ class AmpInstagram extends AMP.BaseElement {
     this.iframe_ = iframe;
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowtransparency', 'true');
-    //title frame for a11y
+    //Add title to the iframe for better accessibility.
     iframe.setAttribute('title', 'Instagram: ' + this.element.getAttribute('alt'));
     iframe.src = 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/embed/?v=4';

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -89,7 +89,6 @@ class AmpInstagram extends AMP.BaseElement {
         encodeURIComponent(this.shortcode_) + '/media/?size=l');
     image.setAttribute('layout', 'fill');
 
-    //Push alt to underlying amp-img component
     this.propagateAttributes(['alt'], image);
 
     // This makes the non-iframe image appear in the exact same spot

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -115,7 +115,7 @@ class AmpInstagram extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowtransparency', 'true');
     //Add title to the iframe for better accessibility.
-    iframe.setAttribute('title', 'Instagram: ' + 
+    iframe.setAttribute('title', 'Instagram: ' +
         this.element.getAttribute('alt'));
     iframe.src = 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/embed/?v=4';

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -24,6 +24,7 @@
  * <code>
  * <amp-instagram
  *   data-shortcode="fBwFP"
+ *   alt="Fastest page in the west."
  *   width="320"
  *   height="392"
  *   layout="responsive">
@@ -87,6 +88,10 @@ class AmpInstagram extends AMP.BaseElement {
     image.setAttribute('src', 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/media/?size=l');
     image.setAttribute('layout', 'fill');
+
+    //Push alt to underlying amp-img component
+    this.propagateAttributes(['alt'], image);
+
     // This makes the non-iframe image appear in the exact same spot
     // where it will be inside of the iframe.
     setStyles(image, {
@@ -110,6 +115,8 @@ class AmpInstagram extends AMP.BaseElement {
     this.iframe_ = iframe;
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowtransparency', 'true');
+    //title frame for a11y
+    iframe.setAttribute('title', 'Instagram: ' + this.element.getAttribute('alt'));
     iframe.src = 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/embed/?v=4';
     this.applyFillContent(iframe);

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -32,7 +32,7 @@ describe('amp-instagram', () => {
       ins.setAttribute('data-shortcode', shortcode);
       ins.setAttribute('width', '111');
       ins.setAttribute('height', '222');
-      ins.setAttribute('alt', 'Testing')
+      ins.setAttribute('alt', 'Testing');
       if (opt_responsive) {
         ins.setAttribute('layout', 'responsive');
       }
@@ -53,7 +53,7 @@ describe('amp-instagram', () => {
     expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?v=4');
     expect(iframe.getAttribute('width')).to.equal('111');
     expect(iframe.getAttribute('height')).to.equal('222');
-    expect(iframe.getAttribute('title')).to.equal('Instagram: Testing')
+    expect(iframe.getAttribute('title')).to.equal('Instagram: Testing');
   }
 
   it('renders', () => {

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -32,6 +32,7 @@ describe('amp-instagram', () => {
       ins.setAttribute('data-shortcode', shortcode);
       ins.setAttribute('width', '111');
       ins.setAttribute('height', '222');
+      ins.setAttribute('alt', 'Testing')
       if (opt_responsive) {
         ins.setAttribute('layout', 'responsive');
       }
@@ -44,6 +45,7 @@ describe('amp-instagram', () => {
     expect(image.getAttribute('src')).to.equal(
         'https://www.instagram.com/p/fBwFP/media/?size=l');
     expect(image.getAttribute('layout')).to.equal('fill');
+    expect(image.getAttribute('alt')).to.equal('Testing');
   }
 
   function testIframe(iframe) {
@@ -51,6 +53,7 @@ describe('amp-instagram', () => {
     expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?v=4');
     expect(iframe.getAttribute('width')).to.equal('111');
     expect(iframe.getAttribute('height')).to.equal('222');
+    expect(iframe.getAttribute('title')).to.equal('Instagram: Testing')
   }
 
   it('renders', () => {

--- a/test/manual/amp-instagram.amp.html
+++ b/test/manual/amp-instagram.amp.html
@@ -26,7 +26,7 @@
   <h1>amp #0</h1>
   <amp-instagram
     data-shortcode="fBwFP"
-    alt="Guy computing on a couch."
+    alt="Malte Ubl computing on a couch."
     width="320"
     height="392"
     layout="responsive">

--- a/test/manual/amp-instagram.amp.html
+++ b/test/manual/amp-instagram.amp.html
@@ -26,6 +26,7 @@
   <h1>amp #0</h1>
   <amp-instagram
     data-shortcode="fBwFP"
+    alt="Guy computing on a couch."
     width="320"
     height="392"
     layout="responsive">


### PR DESCRIPTION
This PR addresses a couple of accessibility issues that exist with the amp-instagram component.

Namely:
1) rendered  tag that houses the Instagram image does not have option for an alt attribute to make image screen reader friendly.
2) iframe pulled in from Instagram does not have a title attribute which helps screen reader users differentiate frames.

Issue #3503 details the amp-instagram component use in markup and rendered output.

*Commit log*
-Add title attribute for instagram iframe
-Update instagram tests to include alt and title attribute checks