### PR TITLE
Call viewportCallback in a task queue

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -2063,7 +2063,16 @@ export class Resource {
     }
     dev.fine(TAG_, 'inViewport:', this.debugid, inViewport);
     this.isInViewport_ = inViewport;
-    this.element.viewportCallback(inViewport);
+    if (this.viewportCallbackPromise_) {
+      return;
+    }
+    this.viewportCallbackPromise_ = Promise.resolve();
+    this.resources_.schedule_(this, 'viewportCallback', -1, this.getPriority(), () => {
+      const promise = this.viewportCallbackPromise_;
+      this.viewportCallbackPromise_ = null;
+      this.element.viewportCallback(this.isInViewport_);
+      return promise;
+    });
   }
 
   /**


### PR DESCRIPTION
This is just a prototype to start the conversation.

In investigating why my iOS scroller performs so badly, I've found the [`Resource#setInViewport`](https://github.com/ampproject/amphtml/blob/master/src/service/resources-impl.js#L2060-L2067) to be a real resource hog because it calls `#viewportCallback` (I'm looking at you, Carousels). It's [called](https://github.com/ampproject/amphtml/blob/master/src/service/resources-impl.js#L1018) synchronously [in a loop](https://github.com/ampproject/amphtml/blob/master/src/service/resources-impl.js#L1005-L1019) when trying to "discover work" in `Resources`.

But that had me thinking. The other intensive callbacks execute in the "work" phase (not the discover phase). The work phase limits itself to doing as much as it can in 16ms chunks. What if we called `viewportCallback` in the "work" phase, too.

It seems to [work well](https://amp-jridgewell.herokuapp.com/examples.build/everything.amp.max.html#log=4), and it dramatically improves scroll performance.
