### PR TITLE
[WIP] [DO NOT SUBMIT] Shadow root scoping

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -50,6 +50,17 @@ app.use('/examples', function(req, res, next) {
   next();
 });
 
+/* XXX: can only do this after updating relative URL resolution.
+app.use('/examples/pwa.html', function(req, res, next) {
+  res.setHeader('Content-Type', 'text/html');
+  res.statusCode = 200;
+  fs.readFileAsync(process.cwd() +
+      '/examples/pwa.html').then((file) => {
+        res.end(file);
+      });
+});
+*/
+
 app.use('/api/show', function(req, res) {
   res.setHeader('Content-Type', 'application/json');
   res.end(JSON.stringify({

--- a/examples/pwa.html
+++ b/examples/pwa.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PWA</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto">
+  <style>
+    body {
+      margin: 0;
+      font-family: Roboto, Arial;
+    }
+
+    header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 56px;
+      background: rgba(0, 0, 0, 0.9);
+      color: #eee;
+      display: flex;
+      align-content: center;
+      align-items: center;
+      justify-content: center;
+      font-size: 18px;
+    }
+
+    .container {
+      min-height: 100vh;
+      background: #eee;
+      overflow: hidden;
+    }
+
+    .stream {
+      margin: 64px 8px;
+    }
+
+    .card {
+      background: #fff;
+      box-shadow: 0 1px 4px 0 rgba(0,0,0,0.14);
+      padding: 8px;
+      margin: 8px 0;
+    }
+
+    .card a {
+      text-decoration: none;
+    }
+
+    .card h4 {
+      margin: 8px 0;
+      font-size: 16px;
+      color: rgba(0,0,0,0.95);
+    }
+
+    .card .detail {
+      margin: 8px 0;
+      font-size: 14px;
+      color: rgba(0,0,0,0.87);
+    }
+  </style>
+
+  <script src="./pwa.js"></script>
+</head>
+<body>
+  <header>
+    PWA Chronicles
+  </header>
+  <div class="container">
+    <section id="stream" class="stream">
+      <article class="card">
+        <a href="#/examples.build/article.amp.max.html">
+          <h4>Lorem Ipsum</h4>
+          <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
+        </a>
+      </article>
+      <article class="card">
+        <a href="#/examples.build/youtube.amp.max.html">
+          <h4>YouTube video</h4>
+          <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
+        </a>
+      </article>
+    </section>
+
+    <div id="doc-container" class="doc-container">
+      Document will appear here
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/pwa.js
+++ b/examples/pwa.js
@@ -120,6 +120,8 @@ class AmpViewer {
     this.stylesheets_ = [];
     /** @private @const {!Array<!Element>} */
     this.scripts_ = [];
+    /** @private @const {...} */
+    this.viewer_ = null;
   }
 
   /**
@@ -146,7 +148,10 @@ class AmpViewer {
     log('Shadow root:', this.shadowRoot_);
 
     this.ampReadyPromise_.then(AMP => {
-      AMP.attachShadowRoot(this.shadowRoot_);
+      const amp = AMP.attachShadowRoot(this.shadowRoot_);
+      this.viewer_ = amp.viewer;
+      this.viewer_.setMessageDeliverer(this.onMessage_.bind(this),
+          'http://localhost:8000');
     });
 
     // Head
@@ -259,6 +264,12 @@ class AmpViewer {
    */
   resolveUrl_(relativeUrlString) {
     return new URL(relativeUrlString, this.baseUrl_).toString();
+  }
+
+  /**
+   */
+  onMessage_(type, data, rsvp) {
+    log('receieved message:', type, data, rsvp);
   }
 }
 

--- a/examples/pwa.js
+++ b/examples/pwa.js
@@ -1,0 +1,310 @@
+'use strict';
+
+var shell;
+
+window.onload = () => {
+  shell = new Shell(window);
+};
+
+
+function log(args) {
+  var var_args = Array.prototype.slice.call(arguments, 0);
+  var_args.unshift('[SHELL]');
+  console/*OK*/.log.apply(console, var_args);
+}
+
+
+class Shell {
+
+  constructor(win) {
+    /** @private @const {!Window} */
+    this.win = win;
+
+    /** @private @const {!AmpViewer} */
+    this.ampViewer_ = new AmpViewer(win,
+        win.document.getElementById('doc-container'));
+
+    /** @private {string} */
+    this.currentPage_ = stripHashMarker(win.location.hash);
+
+    win.addEventListener('popstate', this.handlePopState_.bind(this));
+
+    log('STARTED');
+
+    if (this.currentPage_) {
+      this.navigateTo(this.currentPage_);
+    }
+  }
+
+  /**
+   */
+  handlePopState_() {
+    const newPage = stripHashMarker(this.win.location.hash);
+    log('Pop state: ', newPage, this.currentPage_);
+    if (newPage != this.currentPage_) {
+      this.navigateTo(newPage);
+    }
+  }
+
+  /**
+   * @param {string} path
+   * @return {!Promise}
+   */
+  navigateTo(path) {
+    log('Navigate to: ', path);
+    this.currentPage_ = path;
+
+    // Update URL.
+    const newHash = '#' + path;
+    const push = !this.currentPage_ && !!path;
+    if (newHash != this.win.location.hash) {
+      if (push) {
+        this.win.history.pushState(null, '', newHash);
+      } else {
+        this.win.history.replaceState(null, '', newHash);
+      }
+    }
+
+    if (!path) {
+      log('Back to shell');
+      this.ampViewer_.clear();
+      return Promise.resolve();
+    }
+
+    // Fetch.
+    const url = this.resolveUrl_(path);
+    log('Fetch and render doc:', path, url);
+    return fetchDocument(url).then(doc => {
+      log('Fetch complete: ', doc);
+      this.ampViewer_.show(doc, url);
+    });
+  }
+
+  /**
+   * @param {string} url
+   * @return {string}
+   */
+  resolveUrl_(url) {
+    if (!this.a_) {
+      this.a_ = this.win.document.createElement('a');
+    }
+    this.a_.href = url;
+    return this.a_.href;
+  }
+}
+
+
+class AmpViewer {
+
+  constructor(win, container) {
+    /** @private @const {!Window} */
+    this.win = win;
+    /** @private @const {!Element} */
+    this.container = container;
+
+    win.AMP_SHADOW = true;
+    this.ampReadyPromise_ = new Promise(resolve => {
+      (window.AMP = window.AMP || []).push(resolve);
+    });
+    this.ampReadyPromise_.then(AMP => {
+      log('AMP LOADED:', AMP);
+    });
+
+    /** @private @const {string} */
+    this.baseUrl_ = null;
+    /** @private @const {?Element} */
+    this.host_ = null;
+    /** @private @const {?ShadowRoot} */
+    this.shadowRoot_ = null;
+    /** @private @const {!Array<string>} */
+    this.stylesheets_ = [];
+    /** @private @const {!Array<!Element>} */
+    this.scripts_ = [];
+  }
+
+  /**
+   */
+  clear() {
+    this.container.textContent = '';
+  }
+
+  /**
+   * @param {!Document} doc
+   * @param {string} url
+   */
+  show(doc, url) {
+    log('Show document:', doc, url);
+    this.container.textContent = '';
+
+    this.baseUrl_ = url;
+
+    this.host_ = this.win.document.createElement('div');
+    this.host_.classList.add('amp-doc-host');
+    this.container.appendChild(this.host_);
+
+    this.shadowRoot_ = this.host_.createShadowRoot();
+    log('Shadow root:', this.shadowRoot_);
+
+    this.ampReadyPromise_.then(AMP => {
+      AMP.attachShadowRoot(this.shadowRoot_);
+    });
+
+    // Head
+    log('head:', doc.head);
+    for (let n = doc.head.firstElementChild; n; n = n.nextElementSibling) {
+      const tagName = n.tagName;
+      const isMeta = tagName == 'META';
+      const isLink = tagName == 'LINK';
+      const name = n.getAttribute('name');
+      const rel = n.getAttribute('rel');
+      if (n.tagName == 'TITLE') {
+        this.title_ = n.textContent;
+        log('- title: ', this.title_);
+      } else if (isMeta && n.hasAttribute('charset')) {
+        // Ignore.
+      } else if (isMeta && name == 'viewport') {
+        // Ignore.
+      } else if (isLink && rel == 'canonical') {
+        this.canonicalUrl_ = n.getAttribute('href');
+        log('- canonical: ', this.canonicalUrl_);
+      } else if (isLink && rel == 'stylesheet') {
+        this.stylesheets_.push(n.getAttribute('href'));
+        log('- stylesheet: ', this.stylesheets_[this.stylesheets_.length - 1]);
+      } else if (n.tagName == 'STYLE') {
+        if (n.hasAttribute('amp-boilerplate')) {
+          // Ignore.
+          log('- ignored embedded style: ', n);
+        } else {
+          log('- embedded style: ', n);
+          this.shadowRoot_.appendChild(this.win.document.importNode(n, true));
+        }
+      } else if (n.tagName == 'SCRIPT') {
+        if (n.hasAttribute('src')) {
+          log('- src script: ', n);
+          this.scripts_.push(n);
+        } else {
+          log('- non-src script: ', n);
+          this.shadowRoot_.appendChild(this.win.document.importNode(n, true));
+        }
+      } else if (n.tagName == 'NOSCRIPT') {
+        // Ignore.
+      } else {
+        log('- UNKNOWN head element:', n);
+      }
+    }
+
+    this.mergeHead_();
+
+    // Body
+    this.shadowRoot_.appendChild(this.win.document.importNode(doc.body, true));
+  }
+
+  mergeHead_() {
+    const doc = this.win.document;
+
+    // Title.
+    doc.title = this.title_ || '';
+    log('SET title: ', doc.title);
+
+    // Stylesheets.
+    this.stylesheets_.forEach(stylesheet => {
+      const href = this.resolveUrl_(stylesheet);
+      const exists = doc.querySelector('link[href="' + href + '"]');
+      if (exists) {
+        log('- stylesheet already exists: ', href);
+      } else {
+        const el = doc.createElement('link');
+        el.setAttribute('rel', 'stylesheet');
+        el.setAttribute('type', 'text/css');
+        el.setAttribute('href', href);
+        doc.head.appendChild(el);
+        log('- stylesheet added: ', href, el);
+      }
+    });
+
+    // Scripts.
+    this.scripts_.forEach(script => {
+      // XXX: stub elements, reg templates
+      const customElement = script.getAttribute('custom-element');
+      const customTemplate = script.getAttribute('custom-template');
+      const src = this.resolveUrl_(script.getAttribute('src'));
+      log('script: ', customElement, customTemplate, script.getAttribute('src'), src);
+      const existsExpr =
+          customElement ? '[custom-element="' + customElement + '"]' :
+          customTemplate ? '[custom-template="' + customTemplate + '"]' :
+          // TODO: version control!
+          '[src="' + src + '"]';
+      const exists = doc.querySelector('script' + existsExpr);
+      if (exists) {
+        log('- script already exists: ', customElement, customTemplate, src);
+      } else {
+        const el = doc.createElement('script');
+        el.setAttribute('async', '');
+        el.setAttribute('src', src);
+        if (customElement) {
+          el.setAttribute('custom-element', customElement);
+        }
+        if (customTemplate) {
+          el.setAttribute('custom-template', customTemplate);
+        }
+        doc.head.appendChild(el);
+        log('- script added: ', src, el);
+      }
+    });
+  }
+
+  /**
+   * @param {string} url
+   * @return {string}
+   */
+  resolveUrl_(relativeUrlString) {
+    return new URL(relativeUrlString, this.baseUrl_).toString();
+  }
+}
+
+
+/**
+ */
+function stripHashMarker(s) {
+  if (s && s.substr(0, 1) == '#') {
+    s = s.substr(1);
+  }
+  return s;
+}
+
+/**
+ * @param {string} url
+ * @return {!Promise<!Document>}
+ */
+function fetchDocument(url) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'document';
+    xhr.setRequestHeader('Accept', 'text/html');
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState < /* STATUS_RECEIVED */ 2) {
+        return;
+      }
+      if (xhr.status < 100 || xhr.status > 599) {
+        xhr.onreadystatechange = null;
+        reject(new Error(`Unknown HTTP status ${xhr.status}`));
+        return;
+      }
+      if (xhr.readyState == /* COMPLETE */ 4) {
+        if (xhr.responseXML) {
+          resolve(xhr.responseXML);
+        } else {
+          reject(new Error(`No xhr.responseXML`));
+        }
+      }
+    };
+    xhr.onerror = () => {
+      reject(new Error('Network failure'));
+    };
+    xhr.onabort = () => {
+      reject(new Error('Request aborted'));
+    };
+    xhr.send();
+  });
+}

--- a/src/amp-core-service.js
+++ b/src/amp-core-service.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import {installActionService} from './service/action-impl';
+import {installActionService, installActionServiceForShadowRoot} from './service/action-impl';
 import {installFramerateService} from './service/framerate-impl';
 import {installHistoryService} from './service/history-impl';
-import {installResourcesService} from './service/resources-impl';
+import {installResourcesService, installResourcesServiceForShadowRoot} from './service/resources-impl';
 import {installStandardActions} from './service/standard-actions-impl';
-import {installUrlReplacementsService} from './service/url-replacements-impl';
-import {installViewerService} from './service/viewer-impl';
-import {installViewportService} from './service/viewport-impl';
+import {installUrlReplacementsService, installUrlReplacementsServiceForShadowRoot} from './service/url-replacements-impl';
+import {installViewerService, installViewerServiceForShadowRoot} from './service/viewer-impl';
+import {installViewportService, installViewportServiceForShadowRoot} from './service/viewport-impl';
 import {installVsyncService} from './service/vsync-impl';
 import {installXhrService} from './service/xhr-impl';
 
@@ -32,14 +32,37 @@ import {installXhrService} from './service/xhr-impl';
  * @param {!Window} window
  */
 export function installCoreServices(window) {
-  installViewerService(window);
-  installViewportService(window);
-  installHistoryService(window);
-  installVsyncService(window);
-  installActionService(window);
-  installResourcesService(window);
-  installStandardActions(window);
-  installFramerateService(window);
-  installUrlReplacementsService(window);
-  installXhrService(window);
+  // XXX
+  if (!window.AMP_SHADOW) {
+    installViewerService(window);     // DOC
+  }
+  installVsyncService(window);      // SUPER
+  if (!window.AMP_SHADOW) {
+    installViewportService(window);   // DOC
+  }
+  installHistoryService(window);    // SUPER
+  if (!window.AMP_SHADOW) {
+    installActionService(window);     // DOC
+    installResourcesService(window);  // DOC
+    installStandardActions(window);   // DOC
+  }
+  installFramerateService(window);  // SUPER?
+  if (!window.AMP_SHADOW) {
+    installUrlReplacementsService(window);  // DOC
+  }
+  installXhrService(window);        // SUPER
+}
+
+
+/**
+ * @param {!Window} window
+ * @param {!ShadowRoot} shadowRoot
+ */
+export function installCoreServicesShadowRoot(window, shadowRoot) {
+  installViewerServiceForShadowRoot(window, shadowRoot);     // DOC
+  installViewportServiceForShadowRoot(window, shadowRoot);   // DOC
+  installActionServiceForShadowRoot(window, shadowRoot);     // DOC
+  installResourcesServiceForShadowRoot(window, shadowRoot);  // DOC
+  //installStandardActions(window);   // DOC  // XXX
+  installUrlReplacementsServiceForShadowRoot(window, shadowRoot);  // DOC
 }

--- a/src/amp.js
+++ b/src/amp.js
@@ -33,51 +33,71 @@ import {maybeValidate} from './validator-integration';
 import {maybeTrackImpression} from './impression';
 import {isExperimentOn} from './experiments';
 
+function install() {
+  // XXX
+  installCoreServices(window);    // MIXED
+  // We need the core services (viewer/resources) to start instrumenting
+  if (!window.AMP_SHADOW) {
+    perf.coreServicesAvailable();   // DOC
+    maybeTrackImpression(window);   // DOC
+  }
+  templatesFor(window);           // SUPER
+
+  installImg(window);             // SUPER
+  installPixel(window);           // SUPER
+  installVideo(window);           // SUPER
+
+  adopt(window);                  // ????
+  stubElements(window);           // SUPER    XXX: add more stubs (inject via runtime?)
+
+  if (!window.AMP_SHADOW) {
+    installPullToRefreshBlocker(window);    // SUPER   NEEDED?
+    installGlobalClickListener(window);     // SUPER   NEEDED?
+    if (isExperimentOn(window, 'form-submit')) {
+      installGlobalSubmitListener(window);    // SUPER   NEEDED?
+    }
+  }
+}
+
 // We must under all circumstances call makeBodyVisible.
 // It is much better to have AMP tags not rendered than having
 // a completely blank page.
 try {
+  console.log('AMP: init AMP:', window.AMP_SHADOW);
   // Should happen first.
   installErrorReporting(window);  // Also calls makeBodyVisible on errors.
   const perf = installPerformanceService(window);
 
   perf.tick('is');
-  installStyles(document, cssText, () => {
-    try {
-      installCoreServices(window);
-      // We need the core services (viewer/resources) to start instrumenting
-      perf.coreServicesAvailable();
-      maybeTrackImpression(window);
-      templatesFor(window);
+  if (!window.AMP_SHADOW) {
+    installStyles(document, cssText, () => {
+      try {
+        install();
 
-      installImg(window);
-      installPixel(window);
-      installVideo(window);
-
-      adopt(window);
-      stubElements(window);
-
-      installPullToRefreshBlocker(window);
-      installGlobalClickListener(window);
-      if (isExperimentOn(window, 'form-submit')) {
-        installGlobalSubmitListener(window);
+        maybeValidate(window);
+        if (!window.AMP_SHADOW) {
+          makeBodyVisible(document, /* waitForExtensions */ true);    // DOC
+        }
+      } catch (e) {
+        if (!window.AMP_SHADOW) {
+          makeBodyVisible(document);
+        }
+        throw e;
+      } finally {
+        perf.tick('e_is');
+        // TODO(erwinm): move invocation of the `flush` method when we have the
+        // new ticks in place to batch the ticks properly.
+        perf.flush();
       }
-
-      maybeValidate(window);
-      makeBodyVisible(document, /* waitForExtensions */ true);
-    } catch (e) {
-      makeBodyVisible(document);
-      throw e;
-    } finally {
-      perf.tick('e_is');
-      // TODO(erwinm): move invocation of the `flush` method when we have the
-      // new ticks in place to batch the ticks properly.
-      perf.flush();
-    }
-  }, /* opt_isRuntimeCss */ true, /* opt_ext */ 'amp-runtime');
+    }, /* opt_isRuntimeCss */ true, /* opt_ext */ 'amp-runtime');
+  } else {
+    install();
+  }
 } catch (e) {
   // In case of an error call this.
-  makeBodyVisible(document);
+  if (!window.AMP_SHADOW) {
+    makeBodyVisible(document);
+  }
   throw e;
 }
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -16,9 +16,7 @@
 
 import {Layout} from './layout';
 import {preconnectFor} from './preconnect';
-import {resourcesFor} from './resources';
 import {viewerFor} from './viewer';
-import {viewportFor} from './viewport';
 import {vsyncFor} from './vsync';
 
 
@@ -135,9 +133,6 @@ export class BaseElement {
 
     /** @protected {!Preconnect} */
     this.preconnect = preconnectFor(this.getWin());
-
-    /** @private {!Resources}  */
-    this.resources_ = resourcesFor(this.getWin());
   }
 
   /**
@@ -158,6 +153,11 @@ export class BaseElement {
   /** @protected @return {!Window} */
   getWin() {
     return this.element.ownerDocument.defaultView;
+  }
+
+  /** @protected @return {!Resources} */
+  getResources() {
+    return this.element.getResources();
   }
 
   /** @protected @return {!Vsync} */
@@ -280,7 +280,7 @@ export class BaseElement {
    * @param {!Element} element
    */
   setAsOwner(element) {
-    this.resources_.setOwner(element, this.element);
+    this.getResources().setOwner(element, this.element);
   }
 
   /**
@@ -444,7 +444,7 @@ export class BaseElement {
    * @return {number}
    */
   getMaxDpr() {
-    return this.resources_.getMaxDpr();
+    return this.getResources().getMaxDpr();
   }
 
   /**
@@ -452,7 +452,7 @@ export class BaseElement {
    * @return {number}
    */
   getDpr() {
-    return this.resources_.getDpr();
+    return this.getResources().getDpr();
   }
 
   /**
@@ -563,7 +563,7 @@ export class BaseElement {
    * @return {!Viewport}
    */
   getViewport() {
-    return viewportFor(this.getWin());
+    return this.element.getViewport();
   }
 
  /**
@@ -571,7 +571,7 @@ export class BaseElement {
   * @return {!LayoutRect}
   */
   getIntersectionElementLayoutBox() {
-    return this.resources_.getResourceForElement(this.element).getLayoutBox();
+    return this.getResources().getResourceForElement(this.element).getLayoutBox();
   }
 
   /**
@@ -582,7 +582,7 @@ export class BaseElement {
    * @protected
    */
   scheduleLayout(elements) {
-    this.resources_.scheduleLayout(this.element, elements);
+    this.getResources().scheduleLayout(this.element, elements);
   }
 
   /**
@@ -590,7 +590,7 @@ export class BaseElement {
    * @protected
    */
   schedulePause(elements) {
-    this.resources_.schedulePause(this.element, elements);
+    this.getResources().schedulePause(this.element, elements);
   }
 
   /**
@@ -602,7 +602,7 @@ export class BaseElement {
    * @protected
    */
   schedulePreload(elements) {
-    this.resources_.schedulePreload(this.element, elements);
+    this.getResources().schedulePreload(this.element, elements);
   }
 
   /**
@@ -614,7 +614,7 @@ export class BaseElement {
    * @protected
    */
   updateInViewport(elements, inLocalViewport) {
-    this.resources_.updateInViewport(this.element, elements, inLocalViewport);
+    this.getResources().updateInViewport(this.element, elements, inLocalViewport);
   }
 
   /**
@@ -627,7 +627,7 @@ export class BaseElement {
    * @protected
    */
   changeHeight(newHeight, opt_callback) {
-    this.resources_./*OK*/changeSize(
+    this.getResources()./*OK*/changeSize(
         this.element, newHeight, /* newWidth */ undefined, opt_callback);
   }
 
@@ -645,7 +645,7 @@ export class BaseElement {
    * @protected
    */
   attemptChangeHeight(newHeight, opt_callback) {
-    this.resources_.attemptChangeSize(
+    this.getResources().attemptChangeSize(
         this.element, newHeight, /* newWidth */ undefined, opt_callback);
   }
 
@@ -664,7 +664,7 @@ export class BaseElement {
   * @protected
   */
  attemptChangeSize(newHeight, newWidth, opt_callback) {
-   this.resources_.attemptChangeSize(
+   this.getResources().attemptChangeSize(
        this.element, newHeight, newWidth, opt_callback);
  }
 
@@ -683,7 +683,7 @@ export class BaseElement {
   * @return {!Promise}
   */
   mutateElement(mutator, opt_element) {
-    return this.resources_.mutateElement(opt_element || this.element, mutator);
+    return this.getResources().mutateElement(opt_element || this.element, mutator);
   }
 
   /**
@@ -692,7 +692,7 @@ export class BaseElement {
    * @param {!Function} callback
    */
   deferMutate(callback) {
-    this.resources_.deferMutate(this.element, callback);
+    this.getResources().deferMutate(this.element, callback);
   }
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -26,6 +26,7 @@ import {parseSizeList} from './size-list';
 import {reportError} from './error';
 import {resourcesFor} from './resources';
 import {timer} from './timer';
+import {viewportFor} from './viewport';
 import {vsyncFor} from './vsync';
 import * as dom from './dom';
 
@@ -316,9 +317,6 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
     this.readyState = 'loading';
     this.everAttached = false;
 
-    /** @private @const {!Resources}  */
-    this.resources_ = resourcesFor(win);
-
     /** @private {!Layout} */
     this.layout_ = Layout.NODISPLAY;
 
@@ -381,6 +379,16 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
      * @private {boolean|undefined}
      */
     this.isInTemplate_ = undefined;
+  };
+
+  /** @return {!Resources} */
+  ElementProto.getResources = function() {
+    return dev.assert(this.resources_);
+  };
+
+  /** @return {!Viewport} */
+  ElementProto.getViewport = function() {
+    return dev.assert(this.viewport_);
   };
 
   /** @private @this {!Element} */
@@ -639,13 +647,44 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
     }
     if (!this.everAttached) {
       this.everAttached = true;
+
+      const win = this.ownerDocument.defaultView;
+      /** @private @const {?Resources}  */
+      this.resources_ = !win.AMP_SHADOW ? resourcesFor(win) : null;
+      /** @private @const {?Viewport}  */
+      this.viewport_ = !win.AMP_SHADOW ? viewportFor(win) : null;
+      if (!this.resources_) {
+        /** @private @const {?ShadowRoot}  */
+        this.shadowRoot_ = null;
+        for (let n = this.parentNode; n; n = n.parentNode) {
+          if (n instanceof ShadowRoot) {
+            this.shadowRoot_ = n;
+            break;
+          }
+        }
+        dev.assert(this.shadowRoot_, 'Shadow root not available');
+        /** @private @const {?Promise}  */
+        this.shadowRootAttached_ = awaitShadowRoot(this.shadowRoot_).then(() => {
+          console.log('AMP: shadow root resolved!!!');
+          this.resources_ = resourcesFor(this.shadowRoot_.AMP);
+          this.viewport_ = viewportFor(this.shadowRoot_.AMP);
+          console.log('- resources: ', this.resources_);
+        });
+      }
+
       try {
         this.firstAttachedCallback_();
       } catch (e) {
         reportError(e, this);
       }
     }
-    this.resources_.add(this);
+    if (this.resources_ != null) {
+      this.resources_.add(this);
+    } else {
+      this.shadowRootAttached_.then(() => {
+        this.resources_.add(this);
+      });
+    }
   };
 
   /**
@@ -1288,4 +1327,27 @@ export function resetScheduledElementForTesting(win, elementName) {
  */
 export function getElementClassForTesting(elementName) {
   return knownElements[elementName] || null;
+}
+
+/**
+ * @param {!ShadowRoot} shadowRoot
+ * @return {!Promise}
+ */
+export function awaitShadowRoot(shadowRoot) {
+  let promise = shadowRoot['__AMP_READY_PROMISE'];
+  if (!promise) {
+    promise = new Promise(resolve => {
+      shadowRoot['__AMP_READY_PROMISE_RESOLVE'] = resolve;
+    });
+    shadowRoot['__AMP_READY_PROMISE'] = promise;
+  }
+  return promise;
+}
+
+/**
+ */
+export function attachShadowRoot(win, shadowRoot) {
+  const promise = awaitShadowRoot(shadowRoot);
+  const resolve = shadowRoot['__AMP_READY_PROMISE_RESOLVE'];
+  resolve();
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -207,4 +207,8 @@ export function prepareAndAttachShadowRoot(global, shadowRoot) {
   // XXX: discover all other extensions and install their CSS
   installCoreServicesShadowRoot(global, shadowRoot);
   attachShadowRoot(global, shadowRoot);
+
+  shadowRoot.AMP.viewer = viewerFor(shadowRoot.AMP);
+
+  return shadowRoot.AMP;
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -16,13 +16,14 @@
 
 import {BaseElement} from './base-element';
 import {BaseTemplate, registerExtendedTemplate} from './template';
+import {cssText} from '../build/css';
 import {dev} from './log';
 import {getMode} from './mode';
 import {getService} from './service';
-import {installStyles} from './styles';
-import {installCoreServices} from './amp-core-service';
+import {installStyles, installStylesForShadowRoot} from './styles';
+import {installCoreServices, installCoreServicesShadowRoot} from './amp-core-service';
 import {isExperimentOn, toggleExperiment} from './experiments';
-import {registerElement} from './custom-element';
+import {registerElement, attachShadowRoot} from './custom-element';
 import {registerExtendedElement} from './extended-element';
 import {resourcesFor} from './resources';
 import {viewerFor} from './viewer';
@@ -100,16 +101,18 @@ export function adopt(global) {
   };
 
   installCoreServices(global);
-  const viewer = viewerFor(global);
+  if (!global.AMP_SHADOW) {
+    const viewer = viewerFor(global);
 
-  /** @const */
-  global.AMP.viewer = viewer;
+    /** @const */
+    global.AMP.viewer = viewer;
 
-  if (getMode().development) {
-    /** @const */
-    global.AMP.toggleRuntime = viewer.toggleRuntime.bind(viewer);
-    /** @const */
-    global.AMP.resources = resourcesFor(global);
+    if (getMode().development) {
+      /** @const */
+      global.AMP.toggleRuntime = viewer.toggleRuntime.bind(viewer);
+      /** @const */
+      global.AMP.resources = resourcesFor(global);
+    }
   }
 
   // Experiments.
@@ -118,13 +121,19 @@ export function adopt(global) {
   /** @const */
   global.AMP.toggleExperiment = toggleExperiment.bind(null, global);
 
-  const viewport = viewportFor(global);
+  if (!global.AMP_SHADOW) {
+    const viewport = viewportFor(global);
 
-  /** @const */
-  global.AMP.viewport = {};
-  global.AMP.viewport.getScrollLeft = viewport.getScrollLeft.bind(viewport);
-  global.AMP.viewport.getScrollWidth = viewport.getScrollWidth.bind(viewport);
-  global.AMP.viewport.getWidth = viewport.getWidth.bind(viewport);
+    /** @const */
+    global.AMP.viewport = {};
+    global.AMP.viewport.getScrollLeft = viewport.getScrollLeft.bind(viewport);
+    global.AMP.viewport.getScrollWidth = viewport.getScrollWidth.bind(viewport);
+    global.AMP.viewport.getWidth = viewport.getWidth.bind(viewport);
+  }
+
+  if (global.AMP_SHADOW) {
+    global.AMP.attachShadowRoot = prepareAndAttachShadowRoot.bind(null, global);
+  }
 
   /**
    * Registers a new custom element.
@@ -185,4 +194,17 @@ export function registerForUnitTest(win) {
       registerElement(win, element.name, element.implementationClass);
     }
   }
+}
+
+
+/**
+ */
+export function prepareAndAttachShadowRoot(global, shadowRoot) {
+  console.log('AMP: Attach shadow root: ', shadowRoot);
+  shadowRoot.AMP = {};
+  installStylesForShadowRoot(shadowRoot, cssText, () => {},
+      /* opt_isRuntimeCss */ true, /* opt_ext */ 'amp-runtime');
+  // XXX: discover all other extensions and install their CSS
+  installCoreServicesShadowRoot(global, shadowRoot);
+  attachShadowRoot(global, shadowRoot);
 }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -86,10 +86,14 @@ export class ActionService {
 
   /**
    * @param {!Window} win
+   * @param {!EventTarget} root
    */
-  constructor(win) {
+  constructor(win, root) {
     /** @const {!Window} */
     this.win = win;
+
+    /** @const {!EventTarget} */
+    this.root = root;
 
     /** @const @private {!Object<string, function(!ActionInvocation)>} */
     this.globalMethodHandlers_ = {};
@@ -110,7 +114,7 @@ export class ActionService {
     if (name == 'tap') {
       // TODO(dvoytenko): if needed, also configure touch-based tap, e.g. for
       // fast-click.
-      this.win.document.addEventListener('click', event => {
+      this.root.addEventListener('click', event => {
         if (!event.defaultPrevented) {
           this.trigger(event.target, 'tap', event);
         }
@@ -199,7 +203,7 @@ export class ActionService {
       return;
     }
 
-    const target = this.win.document.getElementById(action.actionInfo.target);
+    const target = this.root.getElementById(action.actionInfo.target);
     if (!target) {
       this.actionInfoError_('target not found', action.actionInfo, target);
       return;
@@ -607,6 +611,17 @@ function isNum(c) {
  */
 export function installActionService(win) {
   return getService(win, 'action', () => {
-    return new ActionService(win);
+    return new ActionService(win, win.document);
+  });
+};
+
+/**
+ * @param {!Window} win
+ * @param {!ShadowRoot} shadowRoot
+ * @return {!ActionService}
+ */
+export function installActionServiceForShadowRoot(win, shadowRoot) {
+  return getService(shadowRoot.AMP, 'action', () => {
+    return new ActionService(win, shadowRoot);
   });
 };

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -29,9 +29,9 @@ import {dev} from '../log';
 import {reportError} from '../error';
 import {timer} from '../timer';
 import {installFramerateService} from './framerate-impl';
-import {installViewerService} from './viewer-impl';
-import {installViewportService} from './viewport-impl';
-import {installVsyncService} from './vsync-impl';
+import {viewerFor} from '../viewer';
+import {viewportFor} from '../viewport';
+import {vsyncFor} from '../vsync';
 import {platformFor} from '../platform';
 import {FiniteStateMachine} from '../finite-state-machine';
 import {isArray} from '../types';
@@ -53,12 +53,12 @@ const FOCUS_HISTORY_TIMEOUT_ = 1000 * 60;  // 1min
 const FOUR_FRAME_DELAY_ = 70;
 
 export class Resources {
-  constructor(window) {
+  constructor(window, viewer, viewport) {
     /** @const {!Window} */
     this.win = window;
 
     /** @const @private {!Viewer} */
-    this.viewer_ = installViewerService(window);
+    this.viewer_ = viewer;
 
     /** @const @private {!Platform} */
     this.platform_ = platformFor(window);
@@ -149,10 +149,10 @@ export class Resources {
     this.scrollHeight_ = 0;
 
     /** @private @const {!Viewport} */
-    this.viewport_ = installViewportService(this.win);
+    this.viewport_ = viewport;
 
     /** @private @const {!Vsync} */
-    this.vsync_ = installVsyncService(this.win);
+    this.vsync_ = vsyncFor(this.win);
 
     /** @private @const {!FocusHistory} */
     this.activeHistory_ = new FocusHistory(this.win, FOCUS_HISTORY_TIMEOUT_);
@@ -2397,6 +2397,27 @@ let SizeDef;
  */
 export function installResourcesService(win) {
   return getService(win, 'resources', () => {
-    return new Resources(win);
+    return new Resources(
+        win,
+        viewerFor(win),
+        viewportFor(win)
+        );
+  });
+};
+
+/**
+ * @param {!Window} win
+ * @param {!ShadowRoot} shadowRoot
+ * @return {!Resources}
+ */
+export function installResourcesServiceForShadowRoot(win, shadowRoot) {
+  console.log('AMP: installResourcesServiceForShadowRoot');
+  return getService(shadowRoot.AMP, 'resources', () => {
+    // XXX: redo
+    return new Resources(
+        win,
+        viewerFor(shadowRoot.AMP),
+        viewportFor(shadowRoot.AMP)
+        );
   });
 };

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -574,3 +574,15 @@ export function installUrlReplacementsService(window) {
     return new UrlReplacements(window);
   });
 };
+
+/**
+ * @param {!Window} window
+ * @param {!ShadowRoot} shadowRoot
+ * @return {!UrlReplacements}
+ */
+export function installUrlReplacementsServiceForShadowRoot(window, shadowRoot) {
+  return getService(shadowRoot.AMP, 'url-replace', () => {
+    // XXX: redo
+    return new UrlReplacements(window);
+  });
+};

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -1072,3 +1072,16 @@ export function installViewerService(window) {
     return new Viewer(window);
   });
 };
+
+/**
+ * @param {!Window} window
+ * @param {!ShadowRoot} shadowRoot
+ * @return {!Viewer}
+ */
+export function installViewerServiceForShadowRoot(window, shadowRoot) {
+  console.log('AMP: installViewerServiceForShadowRoot', window, shadowRoot);
+  return getService(shadowRoot.AMP, 'viewer', () => {
+    // XXX: update
+    return new Viewer(window);
+  });
+};

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -23,8 +23,8 @@ import {onDocumentReady} from '../document-ready';
 import {platform} from '../platform';
 import {px, setStyle, setStyles} from '../style';
 import {timer} from '../timer';
-import {installVsyncService} from './vsync-impl';
-import {installViewerService} from './viewer-impl';
+import {vsyncFor} from '../vsync';
+import {installViewerService, installViewerServiceForShadowRoot} from './viewer-impl';
 
 
 const TAG_ = 'Viewport';
@@ -95,7 +95,7 @@ export class Viewport {
     this.scrollMeasureTime_ = 0;
 
     /** @private {Vsync} */
-    this.vsync_ = installVsyncService(win);
+    this.vsync_ = vsyncFor(win);
 
     /** @private {boolean} */
     this.scrollTracking_ = false;
@@ -1303,11 +1303,11 @@ export function updateViewportMetaString(currentValue, updateParams) {
 
 /**
  * @param {!Window} window
+ * @param {!Viewer} viewer
  * @return {!Viewport}
  * @private
  */
-function createViewport_(window) {
-  const viewer = installViewerService(window);
+function createViewport_(window, viewer) {
   let binding;
   if (viewer.getViewportType() == 'virtual') {
     binding = new ViewportBindingVirtual_(window, viewer);
@@ -1326,6 +1326,20 @@ function createViewport_(window) {
  */
 export function installViewportService(window) {
   return getService(window, 'viewport', () => {
-    return createViewport_(window);
+    return createViewport_(window, installViewerService(window));
+  });
+};
+
+
+/**
+ * @param {!Window} window
+ * @param {!ShadowRoot} shadowRoot
+ * @return {!Viewport}
+ */
+export function installViewportServiceForShadowRoot(window, shadowRoot) {
+  console.log('AMP: installViewportServiceForShadowRoot');
+  return getService(shadowRoot.AMP, 'viewport', () => {
+    // XXX: redo
+    return createViewport_(window, installViewerServiceForShadowRoot(window, shadowRoot));
   });
 };

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -111,6 +111,7 @@ export class Vsync {
 
     // When the document changes visibility, vsync has to reschedule the queue
     // processing.
+    // XXX: remove dependency on Viewer
     this.viewer_.onVisibilityChanged(() => {
       if (this.scheduled_) {
         this.forceSchedule_();

--- a/src/styles.js
+++ b/src/styles.js
@@ -82,6 +82,23 @@ export function installStyles(doc, cssText, cb, opt_isRuntimeCss, opt_ext) {
 }
 
 /**
+ */
+export function installStylesForShadowRoot(shadowRoot, cssText, cb, opt_isRuntimeCss, opt_ext) {
+  const style = shadowRoot.ownerDocument.createElement('style');
+  style.textContent = cssText;
+  let afterElement = null;
+  // Make sure that we place style tags after the main runtime CSS. Otherwise
+  // the order is random.
+  if (opt_isRuntimeCss) {
+    style.setAttribute('amp-runtime', '');
+  } else {
+    style.setAttribute('amp-extension', opt_ext || '');
+    afterElement = shadowRoot.querySelector('style[amp-runtime]');
+  }
+  insertAfterOrAtStart(shadowRoot, style, afterElement);
+}
+
+/**
  * Sets the document's body opacity to 1.
  * If the body is not yet available (because our script was loaded
  * synchronously), polls until it is.

--- a/test/functional/test-platform.js
+++ b/test/functional/test-platform.js
@@ -47,6 +47,12 @@ describe('Platform', () => {
     expect(platform.isWebKit()).to.equal(isWebKit);
   }
 
+  it('should tolerate empty or null', () => {
+    testUserAgent(null);
+    testUserAgent('');
+    testUserAgent(' ');
+  });
+
   it('iPhone 6 Plus', () => {
     isIos = true;
     isSafari = true;


### PR DESCRIPTION
This is about 50% working hackery. Important points:

1. Scope: window or ampdoc. Any AMP service falls into one of these two scopes and has to be thus split in our codebase. Examples: vsync is window-scoped, while viewport is ampdoc scoped.
2. We may want to impose harsher window/document globals restrictions.
3. Bunch of work needed to re-install AMP in a new shadow root. E.g. all extensions need to keep their CSS and apply it again in the shadow root, etc. For now, I only reapply main `amp.css` to demonstrate what needs to be done.
4. Similarly, lots of stubbing complications since we can no longer rely on `</head>` == all extensions are now. We had this problem before and so this might be a good time to try to solve it.
5. The hardest part so far: URL resolution. Since the URLs are likely to be sub-path'd, we need to resolve `src`, `href`, etc against the document's URL, not shell's. For instance, AMP doc URL is `/doc1.amp.html` and shell URL is `/shell/doc1.amp.html` have different dir base. There's a way, of course, to ensure that the general URL structure remains the same between the two and thus this becomes a non-issue, e.g. `/doc1.amp.html` -> `/doc1.shell.html`.
