### PR TITLE
Remove Resources#updateScrollHeight_

### DIFF
--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -298,16 +298,6 @@
     };
 
 
-    Viewer.prototype.documentHeight_ = function(documentHeight) {
-      log('AMP document height:', documentHeight);
-      if (this.viewportType_ == 'virtual') {
-        this.iframe.style.height = Math.max(documentHeight,
-            this.container./*OK*/offsetHeight) + 'px';
-      }
-      return Promise.resolve();
-    };
-
-
     Viewer.prototype.onScroll_ = function() {
       this.sendRequest_('viewport', {
         scrollTop: this.container./*OK*/scrollTop
@@ -397,9 +387,6 @@
     Viewer.prototype.processRequest_ = function(type, data, awaitResponse) {
       if (type == 'documentLoaded') {
         return this.documentReady_();
-      }
-      if (type == 'documentResized') {
-        return this.documentHeight_(data.height);
       }
       if (type == 'requestFullOverlay') {
         return this.requestFullOverlay_();

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -316,19 +316,6 @@ export class Resources {
     });
   }
 
-  /** @private */
-  updateScrollHeight_() {
-    if (!this.win.document.body) {
-      return;
-    }
-    const scrollHeight = this.win.document.body./*OK*/scrollHeight;
-    if (scrollHeight != this./*OK*/scrollHeight_) {
-      this./*OK*/scrollHeight_ = scrollHeight;
-      this.viewer_.postDocumentResized(this.viewport_.getSize().width,
-          scrollHeight);
-    }
-  }
-
   /**
    * Returns the maximum DPR available on this device.
    * @return {number}
@@ -1469,7 +1456,6 @@ export class Resources {
         if (this.visible_) {
           dev.fine(TAG_, 'next pass:', delay);
           this.schedulePass(delay);
-          this.updateScrollHeight_();
         } else {
           dev.fine(TAG_, 'document is not visible: no scheduling');
         }

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -757,16 +757,6 @@ export class Viewer {
   }
 
   /**
-   * Triggers "documentResized" event for the viewer.
-   * @param {number} width
-   * @param {number} height
-   */
-  postDocumentResized(width, height) {
-    this.sendMessageUnreliable_(
-        'documentResized', {width, height}, false);
-  }
-
-  /**
    * Requests full overlay mode from the viewer. Returns a promise that yields
    * when the viewer has switched to full overlay mode.
    * @return {!Promise}

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -424,14 +424,6 @@ describe('Viewer', () => {
     expect(m.data.title).to.equal('Awesome doc');
   });
 
-  it('should post documentResized event', () => {
-    viewer.postDocumentResized(13, 14);
-    const m = viewer.messageQueue_[0];
-    expect(m.eventType).to.equal('documentResized');
-    expect(m.data.width).to.equal(13);
-    expect(m.data.height).to.equal(14);
-  });
-
   it('should post request/cancelFullOverlay event', () => {
     viewer.requestFullOverlay();
     viewer.cancelFullOverlay();
@@ -441,20 +433,17 @@ describe('Viewer', () => {
 
   it('should queue non-dupe events', () => {
     viewer.postDocumentReady(11, 12);
-    viewer.postDocumentResized(13, 14);
-    viewer.postDocumentResized(15, 16);
-    expect(viewer.messageQueue_.length).to.equal(2);
-    expect(viewer.messageQueue_[0].eventType).to.equal('documentLoaded');
-    const m = viewer.messageQueue_[1];
-    expect(m.eventType).to.equal('documentResized');
-    expect(m.data.width).to.equal(15);
-    expect(m.data.height).to.equal(16);
+    viewer.postDocumentReady(13, 14);
+    expect(viewer.messageQueue_.length).to.equal(1);
+    const m = viewer.messageQueue_[0];
+    expect(m.eventType).to.equal('documentLoaded');
+    expect(m.data.width).to.equal(13);
+    expect(m.data.height).to.equal(14);
   });
 
   it('should dequeue events when deliverer set', () => {
     viewer.postDocumentReady(11, 12);
-    viewer.postDocumentResized(13, 14);
-    expect(viewer.messageQueue_.length).to.equal(2);
+    expect(viewer.messageQueue_.length).to.equal(1);
 
     const delivered = [];
     viewer.setMessageDeliverer((eventType, data) => {
@@ -462,11 +451,9 @@ describe('Viewer', () => {
     }, 'https://acme.com');
 
     expect(viewer.messageQueue_.length).to.equal(0);
-    expect(delivered.length).to.equal(2);
+    expect(delivered.length).to.equal(1);
     expect(delivered[0].eventType).to.equal('documentLoaded');
     expect(delivered[0].data.width).to.equal(11);
-    expect(delivered[1].eventType).to.equal('documentResized');
-    expect(delivered[1].data.width).to.equal(13);
   });
 
   describe('Messaging not embedded', () => {


### PR DESCRIPTION
We will no longer check during passes if the document height has changed.

Fixes #3515.