### PR TITLE
Pass scrollHeight and scrollWidth to documentLoaded event

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -686,9 +686,8 @@ export class Resources {
 
     if (this.documentReady_ && this.firstPassAfterDocumentReady_) {
       this.firstPassAfterDocumentReady_ = false;
-      this.viewer_.postDocumentReady(this.viewport_.getSize().width,
-        this.win.document.body./*OK*/scrollHeight);
-      this.updateScrollHeight_();
+      this.viewer_.postDocumentReady(this.viewport_.getScrollWidth(),
+        this.viewport_.getScrollHeight());
     }
 
     const viewportSize = this.viewport_.getSize();


### PR DESCRIPTION
It made no sense to pass the viewport’s `width` and the document’s
`scrollHeight`. We should either pass the viewport’s `width` and `height`, or
the document’s `scrollWidth` and `scrollHeight`.

Since you can determine the viewport’s size from the viewer’s iframe, I
chose to send the `scrollWidth` and `scrollHeight`.