### PR TITLE
Fix circular calls in url.js get origin logic.

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -54,7 +54,11 @@ export function parseUrl(url) {
   };
   // For data URI a.origin is equal to the string 'null' which is not useful.
   // We instead return the actual origin which is the full URL.
-  info.origin = (a.origin && a.origin != 'null') ? a.origin : getOrigin(info);
+  info.origin = (a.origin && a.origin != 'null')
+      ? a.origin
+      : info.protocol == 'data:' || !info.host
+          ? info.href
+          : info.protocol + '//' + info.host;
   user.assert(info.origin, 'Origin must exist');
   // Freeze during testing to avoid accidental mutation.
   cache[url] = (window.AMP_TEST && Object.freeze) ? Object.freeze(info) : info;
@@ -190,25 +194,6 @@ export function parseQueryString(queryString) {
 
 
 /**
- * Don't use this directly, only exported for testing. The value
- * is available via the origin property of the object returned by
- * parseUrl.
- * @param {string|!Location} url
- * @return {string}
- * @visibleForTesting
- */
-export function getOrigin(url) {
-  if (typeof url == 'string') {
-    url = parseUrl(url);
-  }
-  if (url.protocol == 'data:' || !url.host) {
-    return url.href;
-  }
-  return url.protocol + '//' + url.host;
-}
-
-
-/**
  * Returns the URL without fragment. If URL doesn't contain fragment, the same
  * string is returned.
  * @param {string} url
@@ -298,7 +283,7 @@ export function getSourceUrl(url) {
  * @return {string} The source origin of the URL.
  */
 export function getSourceOrigin(url) {
-  return getOrigin(getSourceUrl(url));
+  return parseUrl(getSourceUrl(url)).origin;
 }
 
 /**

--- a/src/url.js
+++ b/src/url.js
@@ -54,12 +54,13 @@ export function parseUrl(url) {
   };
   // For data URI a.origin is equal to the string 'null' which is not useful.
   // We instead return the actual origin which is the full URL.
-  info.origin = (a.origin && a.origin != 'null')
-      ? a.origin
-      : info.protocol == 'data:' || !info.host
-          ? info.href
-          : info.protocol + '//' + info.host;
-  user.assert(info.origin, 'Origin must exist');
+  if (a.origin && a.origin != 'null') {
+    info.origin = a.origin;
+  } else if (info.protocol == 'data:' || !info.host) {
+    info.origin = info.href;
+  } else {
+    info.origin = info.protocol + '//' + info.host;
+  }
   // Freeze during testing to avoid accidental mutation.
   cache[url] = (window.AMP_TEST && Object.freeze) ? Object.freeze(info) : info;
   return info;

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -19,7 +19,6 @@ import {
   addParamsToUrl,
   assertAbsoluteHttpOrHttpsUrl,
   assertHttpsUrl,
-  getOrigin,
   getSourceOrigin,
   getSourceUrl,
   isProxyOrigin,
@@ -30,7 +29,7 @@ import {
   resolveRelativeUrlFallback_,
 } from '../../src/url';
 
-describe('url', () => {
+describe('parseUrl', () => {
 
   const currentPort = location.port;
 
@@ -128,6 +127,15 @@ describe('url', () => {
     });
   });
 
+  it('should parse origin https://twitter.com/path#abc', () => {
+    expect(parseUrl('https://twitter.com/path#abc').origin)
+        .to.equal('https://twitter.com');
+  });
+
+  it('should parse origin data:12345', () => {
+    expect(parseUrl('data:12345').origin)
+        .to.equal('data:12345');
+  });
 });
 
 
@@ -265,22 +273,6 @@ describe('removeFragment', () => {
   });
 });
 
-describe('getOrigin', () => {
-  it('should parse https://twitter.com/path#abc', () => {
-    expect(getOrigin(parseUrl('https://twitter.com/path#abc')))
-        .to.equal('https://twitter.com');
-    expect(parseUrl('https://twitter.com/path#abc').origin)
-        .to.equal('https://twitter.com');
-  });
-
-  it('should parse data:12345', () => {
-    expect(getOrigin(parseUrl('data:12345')))
-        .to.equal('data:12345');
-    expect(parseUrl('data:12345').origin)
-        .to.equal('data:12345');
-  });
-});
-
 describe('addParamToUrl', () => {
   let url;
 
@@ -380,7 +372,7 @@ describe('getSourceOrigin/Url', () => {
   function testOrigin(href, sourceHref) {
     it('should return the source origin/url from ' + href, () => {
       expect(getSourceUrl(href)).to.equal(sourceHref);
-      expect(getSourceOrigin(href)).to.equal(getOrigin(sourceHref));
+      expect(getSourceOrigin(href)).to.equal(parseUrl(sourceHref).origin);
     });
   }
 


### PR DESCRIPTION
In url.js, fix circular calls among parseUrl(), getOrigin(), getSourceUrl() and getSourceOrigin().