### PR TITLE
Flying Carpets: Set Container Width

### DIFF
--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.css
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.css
@@ -44,8 +44,6 @@ amp-fx-flying-carpet > .-amp-fx-flying-carpet-clip {
 amp-fx-flying-carpet > .-amp-fx-flying-carpet-clip > .-amp-fx-flying-carpet-container {
   position: fixed !important;
   top: 0 !important;
-  left: 0 !important;
-  width: 100% !important;
   /*
    * Included to force slow webkit browsers (Android) into rendering the
    * container using the GPU.

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -18,6 +18,7 @@ import {CSS} from '../../../build/amp-fx-flying-carpet-0.1.css';
 import {Layout} from '../../../src/layout';
 import {isExperimentOn} from '../../../src/experiments';
 import {dev, user} from '../../../src/log';
+import {setStyle} from '../../../src/style';
 
 /** @const */
 const EXPERIMENT = 'amp-fx-flying-carpet';
@@ -43,20 +44,36 @@ class AmpFlyingCarpet extends AMP.BaseElement {
       return;
     }
 
+    /** @const @private {!Vsync} */
+    this.vsync_ = this.getVsync();
+
     const children = this.getRealChildNodes();
     const doc = this.element.ownerDocument;
 
+    /**
+     * A cached reference to the container, used to set its width to match
+     * the flying carpet's.
+     * @private @const
+     */
+    this.container_ = doc.createElement('div');
+
     const clip = doc.createElement('div');
     clip.setAttribute('class', '-amp-fx-flying-carpet-clip');
-    const container = doc.createElement('div');
-    container.setAttribute('class', '-amp-fx-flying-carpet-container');
+    this.container_.setAttribute('class', '-amp-fx-flying-carpet-container');
 
     for (let i = 0; i < children.length; i++) {
-      container.appendChild(children[i]);
+      this.container_.appendChild(children[i]);
     }
-    clip.appendChild(container);
+    clip.appendChild(this.container_);
 
     this.element.appendChild(clip);
+  }
+
+  onLayoutMeasure() {
+    const width = this.getLayoutWidth();
+    this.vsync_.mutate(() => {
+      setStyle(this.container_, 'width', width, 'px');
+    });
   }
 
   assertPosition() {

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -98,6 +98,26 @@ describe('amp-fx-flying-carpet', () => {
     });
   });
 
+  it('should sync width of fixed container', () => {
+    return getAmpFlyingCarpet().then(flyingCarpet => {
+      const impl = flyingCarpet.implementation_;
+      const container = flyingCarpet.firstChild.firstChild;
+      let width = 10;
+
+      impl.vsync_.mutate = function(callback) {
+        callback();
+      };
+      impl.getLayoutWidth = () => width;
+
+      impl.onLayoutMeasure();
+      expect(container.style.width).to.equal(width + 'px');
+
+      width++;
+      impl.onLayoutMeasure();
+      expect(container.style.width).to.equal(width + 'px');
+    });
+  });
+
   it('should not render in the first viewport', () => {
     return getAmpFlyingCarpet(null, '99vh').then(() => {
       throw new Error('should never reach this');


### PR DESCRIPTION
Synchronizes the container width with the actual width of the `<amp-fx-flying-carpet>`.

Fixes https://github.com/ampproject/amphtml/issues/3542.