### PR TITLE
Allow alt attribute on `<amp-instagram>` tag.

### DIFF
--- a/extensions/amp-instagram/0.1/validator-amp-instagram.protoascii
+++ b/extensions/amp-instagram/0.1/validator-amp-instagram.protoascii
@@ -51,6 +51,7 @@ tags: {  # <amp-instagram>
   disallowed_ancestor: "head"
   disallowed_ancestor: "amp-sidebar"
   also_requires_tag: "amp-instagram extension .js script"
+  attrs: { name: "alt" }
   attrs: {
     name: "data-shortcode"
     mandatory_oneof: "['data-shortcode', 'src']"


### PR DESCRIPTION
See Issue #3520 

Fixes #3549 