### PR TITLE
Add parseUrl() polyfill for IE11.

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -57,6 +57,10 @@ export function parseUrl(url) {
     return fromCache;
   }
   a.href = url;
+  // IE11 doesn't provide full URL components when parsing relative URLs.
+  // Assigning to itself again does the trick.
+  a.href = a.href;
+
   const info = {
     href: a.href,
     protocol: a.protocol,
@@ -67,6 +71,21 @@ export function parseUrl(url) {
     search: a.search,
     hash: a.hash,
   };
+
+  // Some IE11 specific polyfills.
+  // 1) IE11 strips out the leading '/' in the pathname.
+  if (info.pathname === '' || info.pathname[0] !== '/') {
+    info.pathname = '/' + info.pathname;
+  }
+
+  // 2) For URLs with implicit ports, IE11 parses to default ports while
+  // other browsers leave the port field empty.
+  if ((info.protocol == 'http:' && info.port == 80)
+      || (info.protocol == 'https:' && info.port == 443)) {
+    info.port = '';
+    info.host = info.hostname;
+  }
+
   // For data URI a.origin is equal to the string 'null' which is not useful.
   // We instead return the actual origin which is the full URL.
   if (a.origin && a.origin != 'null') {

--- a/src/url.js
+++ b/src/url.js
@@ -59,7 +59,9 @@ export function parseUrl(url) {
   a.href = url;
   // IE11 doesn't provide full URL components when parsing relative URLs.
   // Assigning to itself again does the trick.
-  a.href = a.href;
+  if (!a.protocol) {
+    a.href = a.href;
+  }
 
   const info = {
     href: a.href,

--- a/src/url.js
+++ b/src/url.js
@@ -59,6 +59,8 @@ export function parseUrl(url) {
   a.href = url;
   // IE11 doesn't provide full URL components when parsing relative URLs.
   // Assigning to itself again does the trick.
+  // TODO(lannka, #3449): Remove all the polyfills once we don't support IE11
+  // and it passes tests in all browsers.
   if (!a.protocol) {
     a.href = a.href;
   }

--- a/src/url.js
+++ b/src/url.js
@@ -74,7 +74,7 @@ export function parseUrl(url) {
 
   // Some IE11 specific polyfills.
   // 1) IE11 strips out the leading '/' in the pathname.
-  if (info.pathname === '' || info.pathname[0] !== '/') {
+  if (info.pathname[0] !== '/') {
     info.pathname = '/' + info.pathname;
   }
 

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -74,6 +74,32 @@ describe('parseUrl', () => {
       origin: 'https://foo.com:123',
     });
   });
+  it('should omit HTTP default port', () => {
+    compareParse('http://foo.com:80/abc?123#foo', {
+      href: 'http://foo.com/abc?123#foo',
+      protocol: 'http:',
+      host: 'foo.com',
+      hostname: 'foo.com',
+      port: '',
+      pathname: '/abc',
+      search: '?123',
+      hash: '#foo',
+      origin: 'http://foo.com',
+    });
+  });
+  it('should omit HTTPS default port', () => {
+    compareParse('https://foo.com:443/abc?123#foo', {
+      href: 'https://foo.com/abc?123#foo',
+      protocol: 'https:',
+      host: 'foo.com',
+      hostname: 'foo.com',
+      port: '',
+      pathname: '/abc',
+      search: '?123',
+      hash: '#foo',
+      origin: 'https://foo.com',
+    });
+  });
   it('should support http', () => {
     compareParse('http://foo.com:123/abc?123#foo', {
       href: 'http://foo.com:123/abc?123#foo',
@@ -126,7 +152,6 @@ describe('parseUrl', () => {
       origin: 'http://foo.com:123',
     });
   });
-
   it('should parse origin https://twitter.com/path#abc', () => {
     expect(parseUrl('https://twitter.com/path#abc').origin)
         .to.equal('https://twitter.com');


### PR DESCRIPTION
It fixes most of the tests in test-url.js under IE11. (Tested via Saucelabs).

Fixes #3449 