### PR TITLE
https://schema.org/ingredients was superseded by recipeIngredient

### DIFF
--- a/examples/metadata-examples/recipe-json-ld.amp.html
+++ b/examples/metadata-examples/recipe-json-ld.amp.html
@@ -93,7 +93,7 @@
           "calories": "250 cal",
           "fatContent": "12 g"
         },
-        "ingredients": [
+        "recipeIngredient": [
           "apples",
           "White sugar"
         ],


### PR DESCRIPTION
BTW, @danbri, where can the discussion for this be found? Intuitively, `ingredients` makes more sense, since we're talking about an array, than `recipeIngredient`, which designates one ingredient, yet its value is an array (when [expressed](https://schema.org/recipeIngredient) in JSON+LD; in RDFa or Microdata it's naturally a single value).

Also, should SDTT warn about superseded properties?