### PR TITLE
amp-pixel: remove useless width assignment

### DIFF
--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -42,9 +42,6 @@ export function installPixel(win) {
 
     /** @override */
     buildCallback() {
-      // Remove user defined size. Pixels should always be the default size.
-      this.element.style.width = '';
-      this.element.style.height = '';
       // Consider the element invisible.
       this.element.setAttribute('aria-hidden', 'true');
     }
@@ -59,10 +56,6 @@ export function installPixel(win) {
           .then(src => {
             const image = new Image();
             image.src = src;
-            image.width = 1;
-            image.height = 1;
-            // Make it take zero space
-            this.element.style.width = 0;
             this.element.appendChild(image);
           });
     }


### PR DESCRIPTION
We've already `display: none`'d the element with `toggle(this.element, false)`.