### PR TITLE
Set Owner on Resource instance

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -86,17 +86,6 @@ export class Resource {
   }
 
   /**
-   * Assigns an owner for the specified element. This means that the resources
-   * within this element will be managed by the owner and not Resources manager.
-   * @param {!Element} element
-   * @param {!AmpElement} owner
-   */
-  static setOwner(element, owner) {
-    dev.assert(owner.contains(element), 'Owner must contain the element');
-    element[OWNER_PROP_] = owner;
-  }
-
-  /**
    * @param {number} id
    * @param {!AmpElement} element
    * @param {!Resources} resources
@@ -203,6 +192,18 @@ export class Resource {
    */
   hasOwner() {
     return !!this.getOwner();
+  }
+
+  /**
+   * Assigns an owner for the specified element. This means that the resources
+   * within this element will be managed by the owner and not Resources manager.
+   * @param {!AmpElement} owner
+   */
+  setOwner(owner) {
+    dev.assert(owner.contains(this.element), 'Owner must contain the element');
+    this.owner_ = owner;
+    // To preserve the ownership when wrapping the element.
+    this.element[OWNER_PROP_] = owner;
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -430,7 +430,9 @@ export class Resources {
    * @package
    */
   setOwner(element, owner) {
-    Resource.setOwner(element, owner);
+    this.discoverResourcesForElement_(element, resource => {
+      resource.setOwner(owner);
+    });
   }
 
   /**


### PR DESCRIPTION
Imagine an amp-element (`A`) is wrapped inside some other element (`B`)
inside a containing `<amp-carousel>`.  If `A` already checked to see if it's
owned, it will have a cached `Resource#owner`. If you then set ownership
of `B` (as `<amp-carousel>` currently does), `A` will only use it's cached
ownership and will never know that is now owned (implicitly) through `B`.
- [ ] Needs tests
