### PR TITLE
Experiment: Only send amp-access auth request after doc becomes visible.

### DIFF
--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -393,7 +393,12 @@ export class AccessService {
     }
 
     this.toggleTopClass_('amp-access-loading', true);
-    const responsePromise = this.adapter_.authorize().catch(error => {
+    const startPromise = isExperimentOn(this.win, 'no-auth-in-prerender')
+        ? this.viewer_.whenFirstVisible()
+        : Promise.resolve();
+    const responsePromise = startPromise.then(() => {
+      return this.adapter_.authorize();
+    }).catch(error => {
       this.analyticsEvent_('access-authorization-failed');
       if (this.authorizationFallbackResponse_ && !opt_disableFallback) {
         // Use fallback.

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -96,6 +96,11 @@ const EXPERIMENTS = [
     name: 'AMP Form Extension',
     spec: 'https://github.com/ampproject/amphtml/issues/3343',
   },
+  {
+    id: 'no-auth-in-prerender',
+    name: 'Delay amp-access auth request until doc becomes visible.',
+    spec: '',
+  },
 ];
 
 


### PR DESCRIPTION
This is a pure experiment. We want to see what the effects are on UX in the real world.