### PR TITLE
AMP Slidescroll : Replace inline-block with flex + Work around for scroll snap webkit bug

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -78,30 +78,30 @@ amp-carousel .amp-carousel-button.amp-disabled {
 }
 
 .-amp-slides-container {
-  align-items: center;
   display: flex;
   height: 100% !important;
   overflow-x: auto !important;
   overflow-y: hidden !important;
   position: relative;
-  text-align: center;
   white-space: nowrap;
   width: 100% !important;
-  scroll-snap-type: mandatory;
-  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: mandatory !important;
+  -webkit-overflow-scrolling: touch !important;
 }
 
 .-amp-slide-item {
   display: none;
-  flex: 1 0 100% !important;
+  flex: 0 0 100% !important;
   height: 100% !important;
-  position: relative;
+  position: relative !important;
   scroll-snap-coordinate: 0 0 !important;
   width: 100% !important;
 }
 
 .-amp-slide-item-show {
-  display: block !important;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
 }
 
 .-amp-carousel-start-marker,
@@ -111,7 +111,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
   width: 1px !important;
   background-color: transparent !important;
   scroll-snap-coordinate: 0 0 !important;
-  flex: 1 0 1px !important;
+  flex: 0 0 1px !important;
 }
 
 .-amp-carousel-start-marker {

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -78,10 +78,13 @@ amp-carousel .amp-carousel-button.amp-disabled {
 }
 
 .-amp-slides-container {
+  align-items: center;
+  display: flex;
   height: 100% !important;
   overflow-x: auto !important;
   overflow-y: hidden !important;
   position: relative;
+  text-align: center;
   white-space: nowrap;
   width: 100% !important;
   scroll-snap-type: mandatory;
@@ -90,6 +93,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
 
 .-amp-slide-item {
   display: none;
+  flex: 1 0 100% !important;
   height: 100% !important;
   position: relative;
   scroll-snap-coordinate: 0 0;
@@ -97,7 +101,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
 }
 
 .-amp-slide-item-show {
-  display: inline-block !important;
+  display: block !important;
 }
 
 /* End SlideScroll */

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -96,12 +96,32 @@ amp-carousel .amp-carousel-button.amp-disabled {
   flex: 1 0 100% !important;
   height: 100% !important;
   position: relative;
-  scroll-snap-coordinate: 0 0;
+  scroll-snap-coordinate: 0 0 !important;
   width: 100% !important;
 }
 
 .-amp-slide-item-show {
   display: block !important;
+}
+
+.-amp-carousel-start-marker,
+.-amp-carousel-end-marker {
+  display: block !important;
+  height: 100% !important;
+  width: 1px !important;
+  background-color: transparent !important;
+  scroll-snap-coordinate: 0 0 !important;
+  flex: 1 0 1px !important;
+}
+
+.-amp-carousel-start-marker {
+  order: -1 !important;
+  margin-left: -1px !important;
+}
+
+.-amp-carousel-end-marker {
+  order: 100000000 !important;
+  margin-right: -1px !important;
 }
 
 /* End SlideScroll */

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -20,6 +20,9 @@ import {getStyle} from '../../../src/style';
 /** @const {string} */
 const SHOWN_CSS_CLASS = '-amp-slide-item-show';
 
+/** @const {string} */
+const SHOWN_CSS_CLASS = '-amp-slide-item-show';
+
 export class AmpSlideScroll extends BaseCarousel {
   /** @override */
   isLayoutSupported(layout) {
@@ -42,6 +45,13 @@ export class AmpSlideScroll extends BaseCarousel {
     this.slidesContainer_ = this.win_.document.createElement('div');
     this.slidesContainer_.classList.add('-amp-slides-container');
 
+    // workaround - https://bugs.webkit.org/show_bug.cgi?id=158821
+    if (this.hasNativeSnapPoints_) {
+      const dummy = this.win_.document.createElement('div');
+      dummy.classList.add('-amp-carousel-start-marker');
+      this.slidesContainer_.appendChild(dummy);
+    }
+
     /** @private {!Array<!Element>} */
     this.slideWrappers_ = [];
 
@@ -53,6 +63,14 @@ export class AmpSlideScroll extends BaseCarousel {
       this.slidesContainer_.appendChild(slideWrapper);
       this.slideWrappers_.push(slideWrapper);
     });
+
+    // workaround - https://bugs.webkit.org/show_bug.cgi?id=158821
+    if (this.hasNativeSnapPoints_) {
+      const dummy = this.win_.document.createElement('div');
+      dummy.classList.add('-amp-carousel-end-marker');
+      this.slidesContainer_.appendChild(dummy);
+    }
+
     this.element.appendChild(this.slidesContainer_);
 
     /** @private {number} */

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -42,11 +42,15 @@ export class AmpSlideScroll extends BaseCarousel {
     this.slidesContainer_ = this.win_.document.createElement('div');
     this.slidesContainer_.classList.add('-amp-slides-container');
 
-    // workaround - https://bugs.webkit.org/show_bug.cgi?id=158821
+    // Workaround - https://bugs.webkit.org/show_bug.cgi?id=158821
     if (this.hasNativeSnapPoints_) {
-      const dummy = this.win_.document.createElement('div');
-      dummy.classList.add('-amp-carousel-start-marker');
-      this.slidesContainer_.appendChild(dummy);
+      const start = this.win_.document.createElement('div');
+      start.classList.add('-amp-carousel-start-marker');
+      this.slidesContainer_.appendChild(start);
+
+      const end = this.win_.document.createElement('div');
+      end.classList.add('-amp-carousel-end-marker');
+      this.slidesContainer_.appendChild(end);
     }
 
     /** @private {!Array<!Element>} */
@@ -60,13 +64,6 @@ export class AmpSlideScroll extends BaseCarousel {
       this.slidesContainer_.appendChild(slideWrapper);
       this.slideWrappers_.push(slideWrapper);
     });
-
-    // workaround - https://bugs.webkit.org/show_bug.cgi?id=158821
-    if (this.hasNativeSnapPoints_) {
-      const dummy = this.win_.document.createElement('div');
-      dummy.classList.add('-amp-carousel-end-marker');
-      this.slidesContainer_.appendChild(dummy);
-    }
 
     this.element.appendChild(this.slidesContainer_);
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -20,9 +20,6 @@ import {getStyle} from '../../../src/style';
 /** @const {string} */
 const SHOWN_CSS_CLASS = '-amp-slide-item-show';
 
-/** @const {string} */
-const SHOWN_CSS_CLASS = '-amp-slide-item-show';
-
 export class AmpSlideScroll extends BaseCarousel {
   /** @override */
   isLayoutSupported(layout) {

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -77,6 +77,23 @@ describe('SlideScroll', () => {
     });
   });
 
+  it('should create start/end markers when scroll-snap is available', () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      const impl = ampSlideScroll.implementation_;
+      ampSlideScroll.style['scrollSnapType'] = '';
+      ampSlideScroll.style['webkitScrollSnapType'] = '';
+      ampSlideScroll.style['msScrollSnapType'] = '';
+      impl.buildCarousel();
+      expect(
+          ampSlideScroll.getElementsByClassName(
+              '-amp-carousel-start-marker').length).to.equal(1);
+      expect(
+          ampSlideScroll.getElementsByClassName(
+              '-amp-carousel-end-marker').length).to.equal(1);
+    });
+  });
+
   it('should show the correct slide', () => {
     return getAmpSlideScroll().then(obj => {
       const ampSlideScroll = obj.ampSlideScroll;
@@ -186,16 +203,6 @@ describe('SlideScroll', () => {
       const hideRestOfTheSlidesSpy = sandbox.spy(impl, 'hideRestOfTheSlides_');
 
       impl.showSlide_(1);
-
-      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(1);
-      expect(impl.slideWrappers_[3].classList.contains('-amp-slide-item-show'))
-          .to.be.false;
-      expect(impl.slideWrappers_[4].classList.contains('-amp-slide-item-show'))
-          .to.be.false;
-      expect(schedulePauseSpy).to.not.have.been.called;
-      expect(schedulePauseSpy.callCount).to.equal(0);
-
-      impl.showSlide_(0);
 
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(1);
       expect(impl.slideWrappers_[3].classList.contains('-amp-slide-item-show'))

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -94,7 +94,6 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
 
-
       impl.showSlide_(5);
       expect(updateInViewportSpy).to.not.have.been.called;
       expect(scheduleLayoutSpy).to.not.have.been.called;
@@ -111,7 +110,6 @@ describe('SlideScroll', () => {
 
 
       impl.showSlide_(1);
-
       expect(updateInViewportSpy).to.have.been.calledWith(
           impl.slides_[0], false);
       expect(updateInViewportSpy).to.have.been.calledWith(
@@ -188,6 +186,16 @@ describe('SlideScroll', () => {
       const hideRestOfTheSlidesSpy = sandbox.spy(impl, 'hideRestOfTheSlides_');
 
       impl.showSlide_(1);
+
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(1);
+      expect(impl.slideWrappers_[3].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
+      expect(impl.slideWrappers_[4].classList.contains('-amp-slide-item-show'))
+          .to.be.false;
+      expect(schedulePauseSpy).to.not.have.been.called;
+      expect(schedulePauseSpy.callCount).to.equal(0);
+
+      impl.showSlide_(0);
 
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith(1);
       expect(impl.slideWrappers_[3].classList.contains('-amp-slide-item-show'))

--- a/test/manual/amp-slidescroll.amp.html
+++ b/test/manual/amp-slidescroll.amp.html
@@ -33,7 +33,7 @@
   <h1>amp #0</h1>
   <amp-carousel id="carousel-3" width=400 height=300 type=slides controls>
     <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" layout=fill></amp-img>
-    <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=400 height=300></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=100 height=70></amp-img>
     <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=400 height=300></amp-img>
     <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" layout=fill></amp-img>
     <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=400 height=300></amp-img>


### PR DESCRIPTION
**In this PR**
- AMP Slidescroll : Replace inline-block with flex
- Workaround for https://bugs.webkit.org/show_bug.cgi?id=158821

**Yet to come**

- Support for loops 
- Scroll Support for snap-points
- Polyfill snapping