### PR TITLE
Adjust SauceLab timeout to fix the Safari "Disconnected" failures on SauceLab

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -109,9 +109,10 @@ var karma = {
       },
       captureConsole: false,
     },
-    captureTimeout: 120000,
-    browserDisconnectTimeout: 120000,
-    browserNoActivityTimeout: 120000,
+    browserDisconnectTimeout: 10000,
+    browserDisconnectTolerance: 1,
+    browserNoActivityTimeout: 4 * 60 * 1000,
+    captureTimeout: 4 * 60 * 1000,
   }
 };
 


### PR DESCRIPTION
The new numbers are from this [article](https://support.saucelabs.com/customer/en/portal/articles/2440724-karma-disconnected-tests-particularly-with-safari).

Addresses #3622 