### PR TITLE
Inline installation of chrome extension when webui is on ampproject.org

### DIFF
--- a/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
+++ b/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
@@ -71,13 +71,23 @@
            target="_blank">GITHUB</a>
         &nbsp;&nbsp;&nbsp;
         <a href="https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc"
-           target="_blank">CHROME EXTENSION</a>
+           id="install-extension" onclick="return false;" target="_blank">CHROME EXTENSION</a>
       </div>
     </paper-toolbar>
   </template>
   <script>
     Polymer({
-    is: 'ampproject-toolbar'
+      is: 'ampproject-toolbar',
+      listeners: {
+        'install-extension.tap': 'installExtension'
+      },
+      installExtension: function(e) {
+        if (document.domain.endsWith('ampproject.org')) {
+          chrome.webstore.install('https://chrome.google.com/webstore/detail/nmoffdblmcmgeicmolmhobpoocbbmknc');
+        } else {
+          window.open('https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc', '_blank');
+        }
+      }
     });
   </script>
 </dom-module>

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -23,6 +23,7 @@
   <link rel="import" href="@polymer/paper-styles/demo-pages.html">
   <link rel="import" href="@polymer/webui-mainpage/webui-mainpage.html">
   <link rel="import" href="@polymer/polymer/polymer.html">
+  <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/nmoffdblmcmgeicmolmhobpoocbbmknc">
   <script src="webui.js"></script>
   <script src="https://cdn.ampproject.org/v0/validator.js"></script>
   <style is="custom-style">


### PR DESCRIPTION
Per https://developer.chrome.com/webstore/inline_installation#verified-site, can only inline an extension that is on a verified site for the extension, which would be ampproject.org.