### PR TITLE
Introduce gulp test --nobuild flag to skip re-build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ script:
   # the css files into js files.
   - gulp dep-check
   # Unit tests with Travis' default chromium
-  - gulp test --compiled --fortesting
+  - gulp test --nobuild --compiled --fortesting
   # Integration tests with all saucelabs browsers
-  - gulp test --saucelabs --integration --compiled --fortesting
+  - gulp test --nobuild --saucelabs --integration --compiled --fortesting
   # All unit tests with an old chrome (best we can do right now to pass tests
   # and not start relying on new features).
   # Disabled because it regressed. Better to run the other saucelabs tests.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -57,6 +57,7 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 | `gulp watch`                  | Watches for changes in files, re-build.                               |
 | `gulp test`                   | Runs tests in Chrome.                                                 |
 | `gulp test --verbose`         | Runs tests in Chrome with logging enabled.                            |
+| `gulp test --nobuild`         | Runs tests without re-build.                                          |
 | `gulp test --watch`           | Watches for changes in files, runs corresponding test(s) in Chrome.   |
 | `gulp test --watch --verbose` | Same as "watch" with logging enabled.                                 |
 | `gulp test --saucelabs`       | Runs test on saucelabs (requires [setup](#saucelabs)).                |

--- a/build-system/tasks/test.js
+++ b/build-system/tasks/test.js
@@ -51,17 +51,10 @@ function getConfig() {
   return extend(obj, karmaConfig.default);
 }
 
-var prerequisites = ['build'];
-if (process.env.TRAVIS) {
-  // No need to do this because we are guaranteed to have done
-  // it.
-  prerequisites = [];
-}
-
 /**
  * Run tests.
  */
-gulp.task('test', 'Runs tests', prerequisites, function(done) {
+gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
   if (argv.saucelabs && process.env.MAIN_REPO &&
       // Sauce Labs does not work on Pull Requests directly.
       // The @ampsauce bot builds these.


### PR DESCRIPTION
A time saver when debugging flaky tests.