### PR TITLE
Add Cxense as amp-analytics vendor

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -183,6 +183,18 @@ Container for analytics tags. Positioned far away from top to make sure that doe
 </amp-analytics>
 <!-- End comScore example -->
 
+<!-- Cxense tracking -->
+<amp-analytics type="cxense">
+<script type="application/json">
+{
+  "vars": {
+    "siteId": "1234567890"
+  }
+}
+</script>
+</amp-analytics>
+<!-- End Cxense example -->
+
 <amp-analytics type="googleanalytics" id="googleanalytics">
 <script type="application/json">
 {

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -34,6 +34,11 @@
     "base": "https://sb.scorecardresearch.com/b?",
     "pageview": "https://sb.scorecardresearch.com/b?c1=2&c2=$c2&rn=_random_&c8=_title_&c7=_canonical_url_&c9=_document_referrer_&cs_c7amp=_ampdoc_url_"
   },
+  "cxense": {
+    "host": "https://scomcluster.cxense.com",
+    "base": "https://scomcluster.cxense.com/Repo/rep.gif" ,
+    "pageview": "https://scomcluster.cxense.com/Repo/rep.gif?ver=1&typ=pgv&sid=$siteId&ckp=_client_id_&loc=$documentLocation&rnd=_random_&ref=_document_referrer_&ltm=_timestamp_&wsz=_screen_width_x_screen_height_&bln=_browser_language_&chs=_document_charset_&col=_screen_color_depth_&tzo=_timezone_"
+  },
   "googleanalytics": {
     "host": "https://www.google-analytics.com",
     "basePrefix": "v=1&_v=a0&aip=true&_s=1&dt=_title_&sr=_screen_width_x_screen_height_&_utmht=_timestamp_&jid=&cid=_client_id_&tid=$account&dl=$documentLocation&dr=_document_referrer_&sd=_screen_color_depth_&ul=_browser_language_&de=_document_charset_",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -37,7 +37,7 @@
   "cxense": {
     "host": "https://scomcluster.cxense.com",
     "base": "https://scomcluster.cxense.com/Repo/rep.gif" ,
-    "pageview": "https://scomcluster.cxense.com/Repo/rep.gif?ver=1&typ=pgv&sid=$siteId&ckp=_client_id_&loc=$documentLocation&rnd=_random_&ref=_document_referrer_&ltm=_timestamp_&wsz=_screen_width_x_screen_height_&bln=_browser_language_&chs=_document_charset_&col=_screen_color_depth_&tzo=_timezone_"
+    "pageview": "https://scomcluster.cxense.com/Repo/rep.gif?ver=1&typ=pgv&sid=$siteId&ckp=_client_id_&loc=_source_url_&rnd=_random_&ref=_document_referrer_&ltm=_timestamp_&wsz=_screen_width_x_screen_height_&bln=_browser_language_&chs=_document_charset_&col=_screen_color_depth_&tzo=_timezone_"
   },
   "googleanalytics": {
     "host": "https://www.google-analytics.com",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -307,7 +307,7 @@ export const ANALYTICS_CONFIG = {
       'host': 'https://scomcluster.cxense.com',
       'base': '${host}/Repo/rep.gif',
       'pageview': '${base}?ver=1&typ=pgv&sid=${siteId}&ckp=${clientId(cX_P)}&' +
-          'loc=${documentLocation}&rnd=${random}&ref=${documentReferrer}&' +
+          'loc=${sourceUrl}&rnd=${random}&ref=${documentReferrer}&' +
           'ltm=${timestamp}&wsz=${screenWidth}x${screenHeight}&' +
           'bln=${browserLanguage}&chs=${documentCharset}&' +
           'col=${screenColorDepth}&tzo=${timezone}',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -301,8 +301,6 @@ export const ANALYTICS_CONFIG = {
   },
 
   'cxense': {
-    'vars': {
-    },
     'requests': {
       'host': 'https://scomcluster.cxense.com',
       'base': '${host}/Repo/rep.gif',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -300,6 +300,31 @@ export const ANALYTICS_CONFIG = {
     },
   },
 
+  'cxense': {
+    'vars': {
+    },
+    'requests': {
+      'host': 'https://scomcluster.cxense.com',
+      'base': '${host}/Repo/rep.gif',
+      'pageview': '${base}?ver=1&typ=pgv&sid=${siteId}&ckp=${clientId(cX_P)}&' +
+          'loc=${documentLocation}&rnd=${random}&ref=${documentReferrer}&' +
+          'ltm=${timestamp}&wsz=${screenWidth}x${screenHeight}&' +
+          'bln=${browserLanguage}&chs=${documentCharset}&' +
+          'col=${screenColorDepth}&tzo=${timezone}',
+    },
+    'triggers': {
+      'defaultPageview': {
+        'on': 'visible',
+        'request': 'pageview',
+      },
+    },
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true,
+    },
+  },
+
   'googleanalytics': {
     'vars': {
       'eventValue': '0',

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -125,6 +125,12 @@ Type attribute value: `comscore`
 
 Adds support for comScore Unified Digital Measurement™ pageview analytics. Requires defining *var* `c2` with comScore-provided *c2 id*.
 
+### Cxense
+
+Type attribute value: `cxense`
+
+Adds support for Cxense Insight analytics. Requires defining *var* `siteId` with Cxense-provided *siteId*. More details can be found at [wiki.cxense.com](https://wiki.cxense.com/display/cust/Accelerated+Mobile+Pages+%28AMP%29+integration).
+
 ### Google Analytics
 
 Type attribute value: `googleanalytics`


### PR DESCRIPTION
See #3654 for additional information. This PR adds vendor configuration support for Cxense analytics.
