### PR TITLE
Configure the Appengine webui to only serve https.

### DIFF
--- a/validator/webui/app.yaml
+++ b/validator/webui/app.yaml
@@ -5,11 +5,14 @@ api_version: go1
 handlers:
 - url: /fetch
   script: _go_app
+  secure: always
 
 - url: /$
   static_files: index.html
   upload: index.html
+  secure: always
 
 - url: /amp_favicon.png$
   static_files: amp_favicon.png
   upload: amp_favicon\.png$
+  secure: always


### PR DESCRIPTION
If the user visits the http version, a redirect is issued.
The 'secure' option is documented here:
https://cloud.google.com/appengine/docs/python/config/appref#handlers_element