### PR TITLE
sticky-ad IOS scrolling issue fix

### DIFF
--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -144,12 +144,9 @@
       background-color: #f4f4f4;
     }
 
-    .amp-sticky-ad-loaded {
-      background-color: rgba(255,255,255,1);
-    }
   </style>
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
-  <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-0.1.js"></script>
+  <script async custom-element="amp-sticky-ad" src="https://zhouyx.herokuapp.com/dist/v0/amp-sticky-ad-0.1.max.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -146,7 +146,7 @@
 
   </style>
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
-  <script async custom-element="amp-sticky-ad" src="https://zhouyx.herokuapp.com/dist/v0/amp-sticky-ad-0.1.max.js"></script>
+  <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -146,7 +146,7 @@
 
   </style>
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
-  <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-0.1.js"></script>
+  <script async custom-element="amp-sticky-ad" src="https://zhouyx.herokuapp.com/dist/v0/amp-sticky-ad-0.1.max.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -160,7 +160,7 @@
     </div>
   </header>
   <main role="main">
-  <amp-sticky-ad layout="nodisplay">
+  <amp-sticky-ad layout="container">
     <amp-ad width="320"
       height="50"
       type="imobile"

--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -159,7 +159,7 @@
     </div>
   </header>
   <main role="main">
-  <amp-sticky-ad layout="container">
+  <amp-sticky-ad layout="nodisplay">
     <amp-ad width="320"
       height="50"
       type="imobile"

--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -150,7 +150,6 @@
   </style>
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
   <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-0.1.js"></script>
-  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -24,8 +24,7 @@ amp-sticky-ad {
   /* TODO(zhouyx, #3250): discuss on what the max-height should be? */
   max-height: 100px !important;
   box-sizing: border-box;
-  /*background-color: rgba(255,255,255,0.5);*/
-  background-color: red;
+  background-color: rgba(255,255,255,0.5);
 }
 
 .-amp-sticky-ad-layout {
@@ -47,8 +46,6 @@ amp-sticky-ad {
 }
 
 .-amp-sticky-ad-layout > amp-ad {
-  /* need a background-color other than default to prevent blink */
-  /*background-color: rgba(255,255,255,0);*/
   display: block;
 }
 

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -24,17 +24,22 @@ amp-sticky-ad {
   /* TODO(zhouyx, #3250): discuss on what the max-height should be? */
   max-height: 100px !important;
   box-sizing: border-box;
-  background-color: rgba(255,255,255,0.5);
+  /*background-color: rgba(255,255,255,0.5);*/
+  background-color: red;
 }
 
 .-amp-sticky-ad-layout {
   display: flex;
-  visibility: hidden;
+  visibility: hidden !important;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   overflow: visible !important;
   transform: translateZ(0) !important;
+}
+
+.-amp-sticky-ad-visible {
+  visibility: visible !important;
 }
 
 .amp-sticky-ad-loaded {
@@ -43,7 +48,7 @@ amp-sticky-ad {
 
 .-amp-sticky-ad-layout > amp-ad {
   /* need a background-color other than default to prevent blink */
-  background-color: rgba(255,255,255,0);
+  /*background-color: rgba(255,255,255,0);*/
   display: block;
 }
 

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -15,6 +15,7 @@
  */
 
 amp-sticky-ad {
+  visibility: hidden;
   position: fixed !important;
   text-align:center;
   bottom: 0 !important;

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -24,11 +24,12 @@ amp-sticky-ad {
   /* TODO(zhouyx, #3250): discuss on what the max-height should be? */
   max-height: 100px !important;
   box-sizing: border-box;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(255,255,255,0.5);
 }
 
 .-amp-sticky-ad-layout {
   display: flex;
+  visibility: hidden;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -42,7 +43,7 @@ amp-sticky-ad {
 
 .-amp-sticky-ad-layout > amp-ad {
   /* need a background-color other than default to prevent blink */
-  /*background-color: rgba(255, 255, 255, 0);*/
+  background-color: rgba(255,255,255,0);
   display: block;
 }
 
@@ -51,13 +52,12 @@ amp-sticky-ad {
   display: block;
   height: 32px;
   width: 32px;
-  background-color: #fff;
+  background-color: rgba(255,255,255,0.6);
   color: grey;
   font-size: 26px;
   line-height: 26px;
   vertical-align: middle;
   padding: 0;
-  opacity: 0.5;
   top: -32px;
   right: 0;
 }

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -24,16 +24,16 @@ amp-sticky-ad {
   /* TODO(zhouyx, #3250): discuss on what the max-height should be? */
   max-height: 100px !important;
   box-sizing: border-box;
-  background-color: rgba(255,255,255,0.5);
+  background-color: rgba(0, 0, 0, 0.5);
 }
 
 .-amp-sticky-ad-layout {
-  display: flex !important;
-  visibility: hidden;
+  display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   overflow: visible !important;
+  transform: translateZ(0) !important;
 }
 
 .amp-sticky-ad-loaded {
@@ -41,6 +41,8 @@ amp-sticky-ad {
 }
 
 .-amp-sticky-ad-layout > amp-ad {
+  /* need a background-color other than default to prevent blink */
+  /*background-color: rgba(255, 255, 255, 0);*/
   display: block;
 }
 

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -15,6 +15,7 @@
  */
 
 amp-sticky-ad {
+  visibility: hidden !important;
   position: fixed !important;
   text-align:center;
   bottom: 0 !important;
@@ -27,8 +28,11 @@ amp-sticky-ad {
   background-color: rgba(255,255,255,0.5);
 }
 
+amp-sticky-ad.visible {
+  visibility: visible !important;
+}
+
 .-amp-sticky-ad-layout {
-  visibility: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -15,7 +15,6 @@
  */
 
 amp-sticky-ad {
-  visibility: hidden;
   position: fixed !important;
   text-align:center;
   bottom: 0 !important;
@@ -29,6 +28,7 @@ amp-sticky-ad {
 }
 
 .-amp-sticky-ad-layout {
+  visibility: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -15,7 +15,6 @@
  */
 
 amp-sticky-ad {
-  visibility: hidden !important;
   position: fixed !important;
   text-align:center;
   bottom: 0 !important;
@@ -28,12 +27,9 @@ amp-sticky-ad {
   background-color: rgba(255,255,255,0.5);
 }
 
-amp-sticky-ad.visible {
-  visibility: visible !important;
-}
-
 .-amp-sticky-ad-layout {
-  display: flex;
+  display: flex !important;
+  visibility: hidden;
   flex-direction: column;
   align-items: center;
   justify-content: center;

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -35,12 +35,12 @@ class AmpStickyAd extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     /** @const @private {boolean} */
-    // this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
-    // if (!this.isExperimentOn_) {
-    //   dev.warn(TAG, `TAG ${TAG} disabled`);
-    //   return;
-    // }
-    // toggle(this.element, true);
+    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    if (!this.isExperimentOn_) {
+      dev.warn(TAG, `TAG ${TAG} disabled`);
+      return;
+    }
+    toggle(this.element, true);
     this.element.classList.add('-amp-sticky-ad-layout');
     const children = this.getRealChildren();
     user.assert((children.length == 1 && children[0].tagName == 'AMP-AD'),
@@ -70,10 +70,10 @@ class AmpStickyAd extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     // this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
-    // if (!this.isExperimentOn_) {
-    //   dev.warn(TAG, `TAG ${TAG} disabled`);
-    //   return Promise.resolve();
-    // }
+    if (!this.isExperimentOn_) {
+      dev.warn(TAG, `TAG ${TAG} disabled`);
+      return Promise.resolve();
+    }
     // Reschedule layout for ad if layout sticky-ad again.
     if (this.visible_) {
       this.updateInViewport(this.ad_, true);
@@ -123,9 +123,9 @@ class AmpStickyAd extends AMP.BaseElement {
       this.removeOnScrollListener_();
       this.deferMutate(() => {
         this.visible_ = true;
-        // setStyles(this.element, {
-        //   'visibility': 'visible',
-        // });
+        setStyles(this.element, {
+          'visibility': 'visible',
+        });
         toggle(this.element, true);
         this.viewport_.addToFixedLayer(this.element);
         this.updateInViewport(this.ad_, true);

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -19,7 +19,6 @@ import {Layout} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 import {removeElement} from '../../../src/dom';
-import {setStyles} from '../../../src/style';
 import {timer} from '../../../src/timer';
 import {toggle} from '../../../src/style';
 
@@ -35,11 +34,11 @@ class AmpStickyAd extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     /** @const @private {boolean} */
-    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
-    if (!this.isExperimentOn_) {
-      dev.warn(TAG, `TAG ${TAG} disabled`);
-      return;
-    }
+    // this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    // if (!this.isExperimentOn_) {
+    //   dev.warn(TAG, `TAG ${TAG} disabled`);
+    //   return;
+    // }
     toggle(this.element, true);
     this.element.classList.add('-amp-sticky-ad-layout');
     const children = this.getRealChildren();
@@ -70,10 +69,10 @@ class AmpStickyAd extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     // this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
-    if (!this.isExperimentOn_) {
-      dev.warn(TAG, `TAG ${TAG} disabled`);
-      return Promise.resolve();
-    }
+    // if (!this.isExperimentOn_) {
+    //   dev.warn(TAG, `TAG ${TAG} disabled`);
+    //   return Promise.resolve();
+    // }
     // Reschedule layout for ad if layout sticky-ad again.
     if (this.visible_) {
       this.updateInViewport(this.ad_, true);
@@ -123,10 +122,7 @@ class AmpStickyAd extends AMP.BaseElement {
       this.removeOnScrollListener_();
       this.deferMutate(() => {
         this.visible_ = true;
-        setStyles(this.element, {
-          'visibility': 'visible',
-        });
-        toggle(this.element, true);
+        this.element.classList.add('-amp-sticky-ad-visible');
         this.viewport_.addToFixedLayer(this.element);
         this.updateInViewport(this.ad_, true);
         this.scheduleLayout(this.ad_);

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -19,9 +19,9 @@ import {Layout} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 import {removeElement} from '../../../src/dom';
+import {setStyles} from '../../../src/style';
 import {timer} from '../../../src/timer';
 import {toggle} from '../../../src/style';
-import {setStyles} from '../../../src/style';
 
 /** @const */
 const TAG = 'amp-sticky-ad';
@@ -29,7 +29,7 @@ const TAG = 'amp-sticky-ad';
 class AmpStickyAd extends AMP.BaseElement {
   /** @override */
   isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
+    return layout == Layout.CONTAINER;
   }
 
   /** @override */
@@ -108,7 +108,6 @@ class AmpStickyAd extends AMP.BaseElement {
     if (scrollTop > viewportHeight) {
       this.removeOnScrollListener_();
       this.deferMutate(() => {
-        //toggle(this.element, true);
         setStyles(this.element, {
           'visibility': 'visible',
         })

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -28,7 +28,7 @@ const TAG = 'amp-sticky-ad';
 class AmpStickyAd extends AMP.BaseElement {
   /** @override */
   isLayoutSupported(layout) {
-    return layout == Layout.CONTAINER;
+    return layout == Layout.NODISPLAY;
   }
 
   /** @override */
@@ -122,7 +122,9 @@ class AmpStickyAd extends AMP.BaseElement {
       this.removeOnScrollListener_();
       this.deferMutate(() => {
         this.visible_ = true;
-        this.element.classList.add('visible');
+        setStyles(this.element, {
+          'visibility': 'visible',
+        });
         this.viewport_.addToFixedLayer(this.element);
         this.updateInViewport(this.ad_, true);
         this.scheduleLayout(this.ad_);

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -34,11 +34,11 @@ class AmpStickyAd extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     /** @const @private {boolean} */
-    // this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
-    // if (!this.isExperimentOn_) {
-    //   dev.warn(TAG, `TAG ${TAG} disabled`);
-    //   return;
-    // }
+    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    if (!this.isExperimentOn_) {
+      dev.warn(TAG, `TAG ${TAG} disabled`);
+      return;
+    }
     toggle(this.element, true);
     this.element.classList.add('-amp-sticky-ad-layout');
     const children = this.getRealChildren();
@@ -68,11 +68,11 @@ class AmpStickyAd extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    // this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
-    // if (!this.isExperimentOn_) {
-    //   dev.warn(TAG, `TAG ${TAG} disabled`);
-    //   return Promise.resolve();
-    // }
+    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    if (!this.isExperimentOn_) {
+      dev.warn(TAG, `TAG ${TAG} disabled`);
+      return Promise.resolve();
+    }
     // Reschedule layout for ad if layout sticky-ad again.
     if (this.visible_) {
       this.updateInViewport(this.ad_, true);

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -21,6 +21,7 @@ import {isExperimentOn} from '../../../src/experiments';
 import {removeElement} from '../../../src/dom';
 import {timer} from '../../../src/timer';
 import {toggle} from '../../../src/style';
+import {setStyles} from '../../../src/style';
 
 /** @const */
 const TAG = 'amp-sticky-ad';
@@ -107,7 +108,10 @@ class AmpStickyAd extends AMP.BaseElement {
     if (scrollTop > viewportHeight) {
       this.removeOnScrollListener_();
       this.deferMutate(() => {
-        toggle(this.element, true);
+        //toggle(this.element, true);
+        setStyles(this.element, {
+          'visibility': 'visible',
+        })
         this.viewport_.addToFixedLayer(this.element);
         this.scheduleLayout(this.ad_);
         // Add border-bottom to the body to compensate space that was taken

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -21,6 +21,7 @@ import {isExperimentOn} from '../../../src/experiments';
 import {removeElement} from '../../../src/dom';
 import {setStyles} from '../../../src/style';
 import {timer} from '../../../src/timer';
+import {toggle} from '../../../src/style';
 
 /** @const */
 const TAG = 'amp-sticky-ad';
@@ -34,12 +35,12 @@ class AmpStickyAd extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     /** @const @private {boolean} */
-    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
-    if (!this.isExperimentOn_) {
-      dev.warn(TAG, `TAG ${TAG} disabled`);
-      return;
-    }
-
+    // this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    // if (!this.isExperimentOn_) {
+    //   dev.warn(TAG, `TAG ${TAG} disabled`);
+    //   return;
+    // }
+    // toggle(this.element, true);
     this.element.classList.add('-amp-sticky-ad-layout');
     const children = this.getRealChildren();
     user.assert((children.length == 1 && children[0].tagName == 'AMP-AD'),
@@ -68,11 +69,11 @@ class AmpStickyAd extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
-    if (!this.isExperimentOn_) {
-      dev.warn(TAG, `TAG ${TAG} disabled`);
-      return Promise.resolve();
-    }
+    // this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    // if (!this.isExperimentOn_) {
+    //   dev.warn(TAG, `TAG ${TAG} disabled`);
+    //   return Promise.resolve();
+    // }
     // Reschedule layout for ad if layout sticky-ad again.
     if (this.visible_) {
       this.updateInViewport(this.ad_, true);
@@ -122,9 +123,10 @@ class AmpStickyAd extends AMP.BaseElement {
       this.removeOnScrollListener_();
       this.deferMutate(() => {
         this.visible_ = true;
-        setStyles(this.element, {
-          'visibility': 'visible',
-        });
+        // setStyles(this.element, {
+        //   'visibility': 'visible',
+        // });
+        toggle(this.element, true);
         this.viewport_.addToFixedLayer(this.element);
         this.updateInViewport(this.ad_, true);
         this.scheduleLayout(this.ad_);

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -47,12 +47,16 @@ class AmpStickyAd extends AMP.BaseElement {
 
     /** @const @private {!Element} */
     this.ad_ = children[0];
+    this.setAsOwner(this.ad_);
 
     /** @private @const {!Viewport} */
     this.viewport_ = this.getViewport();
 
     /** @const @private {!Vsync} */
     this.vsync_ = this.getVsync();
+
+    /** @const @private {boolean} */
+    this.visible_ = false;
 
     /**
      * On viewport scroll, check requirements for amp-stick-ad to display.
@@ -69,7 +73,17 @@ class AmpStickyAd extends AMP.BaseElement {
       dev.warn(TAG, `TAG ${TAG} disabled`);
       return Promise.resolve();
     }
+    // Reschedule layout for ad if layout sticky-ad again.
+    if (this.visible_) {
+      this.updateInViewport(this.ad_, true);
+      this.scheduleLayout(this.ad_);
+    }
     return Promise.resolve();
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    return true;
   }
 
   /** @override */
@@ -107,10 +121,10 @@ class AmpStickyAd extends AMP.BaseElement {
     if (scrollTop > viewportHeight) {
       this.removeOnScrollListener_();
       this.deferMutate(() => {
-        setStyles(this.element, {
-          'visibility': 'visible',
-        });
+        this.visible_ = true;
+        this.element.classList.add('visible');
         this.viewport_.addToFixedLayer(this.element);
+        this.updateInViewport(this.ad_, true);
         this.scheduleLayout(this.ad_);
         // Add border-bottom to the body to compensate space that was taken
         // by sticky ad, so no content would be blocked by sticky ad unit.

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -21,7 +21,6 @@ import {isExperimentOn} from '../../../src/experiments';
 import {removeElement} from '../../../src/dom';
 import {setStyles} from '../../../src/style';
 import {timer} from '../../../src/timer';
-import {toggle} from '../../../src/style';
 
 /** @const */
 const TAG = 'amp-sticky-ad';
@@ -110,7 +109,7 @@ class AmpStickyAd extends AMP.BaseElement {
       this.deferMutate(() => {
         setStyles(this.element, {
           'visibility': 'visible',
-        })
+        });
         this.viewport_.addToFixedLayer(this.element);
         this.scheduleLayout(this.ad_);
         // Add border-bottom to the body to compensate space that was taken


### PR DESCRIPTION
fix the issue that `amp-sticky-ad` disappear before it shows `amp-ad`.
But ad still only displays after scrolling is fully stopped.
#3599 
