### PR TITLE
Use webcomponents.js instead of webcomponents-lite.

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -427,8 +427,8 @@ def CreateWebuiAppengineDist(out_dir):
     for d in os.listdir('node_modules/@polymer'):
       os.symlink(os.path.abspath(os.path.join('node_modules/@polymer', d)),
                  os.path.join(tempdir, 'webui/@polymer', d))
-    os.symlink(os.path.abspath('node_modules/webcomponents-lite'),
-               os.path.join(tempdir, 'webui/webcomponents-lite'))
+    os.symlink(os.path.abspath('node_modules/webcomponents.js'),
+               os.path.join(tempdir, 'webui/webcomponents.js'))
     vulcanized_index_html = subprocess.check_output([
         'node_modules/vulcanize/bin/vulcanize',
         '--inline-scripts', '--inline-css',

--- a/validator/package.json
+++ b/validator/package.json
@@ -45,8 +45,8 @@
     "@polymer/polymer": "1.2.5-npm-test.2",
     "codemirror": "5.15.2",
     "commander": "2.9.0",
-    "webcomponents-lite": "0.6.0",
-    "promise" : "7.1.1"
+    "promise": "7.1.1",
+    "webcomponents.js": "^0.7.22"
   },
   "devDependencies": {
     "google-closure-compiler": "20160517.1.0",

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -19,7 +19,7 @@
   <title>The AMP Validator</title>
   <meta charset="utf-8"/>
   <link rel="shortcut icon" href="/amp_favicon.png">
-  <script src="webcomponents-lite/webcomponents-lite.js"></script>
+  <script src="webcomponents.js/webcomponents.min.js"></script>
   <link rel="import" href="@polymer/paper-styles/demo-pages.html">
   <link rel="import" href="@polymer/webui-mainpage/webui-mainpage.html">
   <link rel="import" href="@polymer/polymer/polymer.html">


### PR DESCRIPTION
This way we get a polyfill for the shadow dom which makes the validator webui work with Firefox and
Safari.