### PR TITLE
A2A navigation for ALP

### DIFF
--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -21,6 +21,14 @@ import {
 import {closest, openWindowDialog} from '../../src/dom';
 
 
+/**
+ * Origins that are trusted to serve valid AMP documents.
+ */
+const ampOrigins = {
+  'https://cdn.ampproject.org': true,
+  'http://localhost:8000': true,
+};
+
 
 /**
  * Install a click listener that transforms navigation to the AMP cache
@@ -59,6 +67,9 @@ export function handleClick(e) {
 
   const link = getLinkInfo(e);
   if (!link || !link.eventualUrl) {
+    return;
+  }
+  if (e.isTrusted === false) {
     return;
   }
 
@@ -133,6 +144,13 @@ function getEventualUrl(a) {
  */
 function navigateTo(win, a, url) {
   const target = (a.target || '_top').toLowerCase();
+  const a2aAncestor = getA2AAncestor(win);
+  if (a2aAncestor) {
+    a2aAncestor.win./*OK*/postMessage('a2a;' + JSON.stringify({
+      url,
+    }), a2aAncestor.origin);
+    return;
+  }
   openWindowDialog(win, url, target);
 }
 
@@ -180,4 +198,52 @@ export function warmupDynamic(e) {
  */
 function getHeadOrFallback(doc) {
   return doc.head || doc.documentElement;
+}
+
+/**
+ * Returns info about an ancestor that can perform A2A navigations
+ * or null if none is present.
+ * @param {!Window} win
+ * @return {?{
+ *   win: !Window,
+ *   origin: string,
+ * }}
+ */
+export function getA2AAncestor(win) {
+  if (!win.location.ancestorOrigins) {
+    return null;
+  }
+  const origins = win.location.ancestorOrigins;
+  // We expect top, amp cache, ad (can be nested).
+  if (origins.length < 2) {
+    return null;
+  }
+  const top = origins[origins.length - 1];
+  // Not a security property. We just check whether the
+  // viewer might support A2A. More domains can be added to whitelist
+  // as needed.
+  if (top.indexOf('.google.') == -1) {
+    return null;
+  }
+  const amp = origins[origins.length - 2];
+  if (!ampOrigins.hasOwnProperty(amp)) {
+    return null;
+  }
+  return {
+    win: getNthParentWindow(win, origins.length - 1),
+    origin: amp,
+  };
+}
+
+/**
+ * Returns the Nth parent of the given window.
+ * @param {!Window} win
+ * @param {number} distance frames above us.
+ */
+function getNthParentWindow(win, distance) {
+  let parent = win;
+  for (let i = 0; i < distance; i++) {
+    parent = win.parent;
+  }
+  return parent;
 }

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -244,7 +244,7 @@ var forbiddenTerms = {
       'src/experiments.js',
     ]
   },
-  'isTrusted': {
+  'isTrustedViewer': {
     message: requiresReviewPrivacy,
     whitelist: [
       'src/service/viewer-impl.js',

--- a/examples/alp.amp.html
+++ b/examples/alp.amp.html
@@ -8,10 +8,11 @@
   <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>
 </head>
 <body>
   <h2>ALP</h2>
-
+  <button onclick="document.querySelector('amp-ad iframe').src='http://ads.localhost:8000/examples.build/alp/creative.html'">Make first ad local</button>
   <h3>target=_blank</h3>
   <amp-ad
       width=300

--- a/examples/alp/creative.html
+++ b/examples/alp/creative.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<script async src="/dist/alp.max.js"></script>
+<a href="https://adclick.g.doubleclick.net/pcs/click?xai=AKAOjsvenF_MgYsNxq34Qfcf11Jd3Zj-oGnwq9lNtBfk9Z2OIzcOmdBC6Cxo7z_LTDnXUY2OFU7j9RnVxKPCrnyzZPVCm9qBV8gJB_wUo1YWioB1HoNy5tNkGQnmFngnbR4B8TxGIZSgGFIV3xxTN6WeeWSyu6PkyXHzh5JZip1ZaaEYDbA0jt1zdZD7i-q-vloPQDg7xuC-juobHJqhuIzuyIIC7vd06Smzmec&sai=AMfl-YRM4s_tsvh3KxxzqTxeECl7XFF7ZYUAMz5fyi7tXN-bw8govNKz0k5be4H7lu_q9r3eqQanLvNxzg&sig=Cg0ArKJSzE_IUhqd-hBcEAE&urlfix=1&adurl=https://cdn.ampproject.org/c/s/www.buzzfeed.com/amphtml/stephaniemcneal/you-can-use-this-website-to-make-president-obama-say-whateve" target=_top><img src="http://placehold.it/300x250"></a>

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -111,6 +111,14 @@
       text-decoration: underline;
     }
 
+    viewer[data-show-container="4"] #container4 {
+      visibility: visible;
+    }
+
+    viewer[data-show-container="4"] #show-container4-anchor {
+      text-decoration: underline;
+    }
+
     viewer.natural container {
       overflow-y: hidden;
     }
@@ -191,6 +199,7 @@
         prerenderSize: this.prerenderSize_,
         viewerorigin: parseUrl(window.location.href).origin,
         csi: this.csi_,
+        cap: 'foo,a2a',
       };
       log('Params:' + JSON.stringify(params));
 
@@ -405,8 +414,13 @@
       }
       if (type == 'sendCsi') {
         log('[CSI] sendCsi.');
+        return;
       }
       if (type == 'scroll') {
+        return;
+      }
+      if (type == 'a2a') {
+        log('a2a navigation', data);
         return;
       }
       return Promise.reject('request not supported: ' + type);
@@ -483,6 +497,13 @@
           false).start();
       addShowContainer('3');
 
+      new Viewer(
+          'container4',
+          '4',
+          'http://localhost:8000/examples.build/alp.amp.max.html',
+          false).start();
+      addShowContainer('4');
+
       showContainer('1');
     }
 
@@ -512,6 +533,7 @@
       <a class="show-container-anchor" id="show-container1-anchor">One</a>
       <a class="show-container-anchor" id="show-container2-anchor">Two</a>
       <a class="show-container-anchor" id="show-container3-anchor">Three</a>
+      <a class="show-container-anchor" id="show-container4-anchor">ALP</a>
       <a>|</a>
       <a id="visibilityToggle">Visible</a>
     </header>
@@ -526,6 +548,11 @@
       </div>
     </container>
     <container id="container3">
+      <div class="wait">
+        Please wait, the AMP doc will appear here...
+      </div>
+    </container>
+    <container id="container4">
       <div class="wait">
         Please wait, the AMP doc will appear here...
       </div>

--- a/extensions/amp-ad/0.1/a2a-listener.js
+++ b/extensions/amp-ad/0.1/a2a-listener.js
@@ -1,0 +1,81 @@
+/* Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {closestByTag} from '../../../src/dom';
+import {isExperimentOn} from '../../../src/experiments';
+import {user} from '../../../src/log';
+import {viewerFor} from '../../../src/viewer';
+
+
+/**
+ * Sets up a special document wide listener that relays requests
+ * from ad iframes to the viewer to perform A2A navigations.
+ * Requests are denied if the requests come from iframes that
+ * do not currently have focus.
+ * @param {!Window} win
+ */
+export function setupA2AListener(win) {
+  if (win.a2alistener) {
+    return;
+  }
+  win.a2alistener = true;
+  if (!isExperimentOn(win, 'alp')) {
+    return;
+  }
+  win.addEventListener('message', handleMessageEvent.bind(null, win));
+}
+
+/**
+ * Handles a potential a2a message.
+ * @param {!Window} win
+ * @param {!Event} event
+ * @visibleForTesting
+ */
+export function handleMessageEvent(win, event) {
+  const data = event.data;
+  // Only handle messages starting with the magic string.
+  if (typeof data != 'string' || data.indexOf('a2a;') != 0) {
+    return;
+  }
+  const origin = event.origin;
+  const nav = JSON.parse(data.substr(/* 'a2a;'.length */ 4));
+  const source = event.source;
+  const activeElement = win.document.activeElement;
+  // Check that the active element is an iframe.
+  user.assert(activeElement.tagName == 'IFRAME',
+      'A2A request with invalid active element %s %s %s',
+      activeElement, nav.url, origin);
+  let found = false;
+  let sourceParent = source;
+  const activeWindow = activeElement.contentWindow;
+  while (sourceParent != win.top) {
+    if (sourceParent == activeWindow) {
+      found = true;
+      break;
+    }
+    sourceParent = sourceParent.parent;
+  }
+  // Check that the active iframe contains the iframe that sent us
+  // the message.
+  user.assert(found,
+      'A2A request from invalid source win %s %s', nav.url, origin);
+  // Check that the iframe is contained in an ad.
+  user.assert(closestByTag(activeElement, 'amp-ad'),
+      'A2A request from non-ad frame %s %s', nav.url, origin);
+  // We only allow AMP shaped URLs.
+  user.assert(nav.url.indexOf('https://cdn.ampproject.org/') == 0,
+      'Invalid ad A2A URL %s %s', nav.url, origin);
+  viewerFor(win).navigateTo(nav.url, 'ad-' + origin);
+}

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -26,6 +26,8 @@ import {timer} from '../../../src/timer';
 import {user} from '../../../src/log';
 import {viewerFor} from '../../../src/viewer';
 import {removeElement} from '../../../src/dom';
+import {setupA2AListener} from './a2a-listener';
+
 
 
 /** @const These tags are allowed to have fixed positioning */
@@ -90,6 +92,7 @@ class AmpAd extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    const win = this.getWin();
     /** @private {?Element} */
     this.iframe_ = null;
 
@@ -122,7 +125,8 @@ class AmpAd extends AMP.BaseElement {
     /**
      * @private @const
      */
-    this.viewer_ = viewerFor(this.getWin());
+    this.viewer_ = viewerFor(win);
+    setupA2AListener(win);
   }
 
   /**

--- a/extensions/amp-ad/0.1/test/test-a2a-listener.js
+++ b/extensions/amp-ad/0.1/test/test-a2a-listener.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {handleMessageEvent} from '../a2a-listener';
+import * as sinon from 'sinon';
+
+describe('amp-ad a2a listener', function() {
+  let sandbox;
+  let event;
+  let win;
+  let findClosestAd;
+  let navigateTo;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    const source = {};
+    findClosestAd = true;
+    event = {
+      type: 'message',
+      origin: 'https://foo.com',
+      source,
+      data: 'a2a;' + JSON.stringify({
+        url: 'https://cdn.ampproject.org/c/test',
+      }),
+    };
+    navigateTo = sandbox.stub();
+    win = {
+      document: {
+        activeElement: {
+          tagName: 'IFRAME',
+          contentWindow: source,
+          closest: tagName => {
+            return findClosestAd && tagName == 'amp-ad';
+          },
+        },
+      },
+      services: {
+        viewer: {
+          obj: {
+            navigateTo,
+          },
+        },
+      },
+    };
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function expectNavigation() {
+    expect(navigateTo.callCount).to.equal(1);
+    expect(navigateTo.lastCall.args[0]).to.equal(
+        'https://cdn.ampproject.org/c/test');
+    expect(navigateTo.lastCall.args[1]).to.equal(
+        'ad-https://foo.com');
+  }
+
+  it('should ignore other messages', () => {
+    event.data = {};
+    handleMessageEvent(win, event);
+    event.data = '{}';
+    handleMessageEvent(win, event);
+    expect(navigateTo.callCount).to.equal(0);
+  });
+
+  it('should initiate navigation', () => {
+    handleMessageEvent(win, event);
+    expectNavigation();
+  });
+
+  it('should initiate navigation (nested frames)', () => {
+    const source = win.document.activeElement.contentWindow;
+    const parent = win.document.activeElement.contentWindow = {};
+    source.parent = parent;
+    handleMessageEvent(win, event);
+    expectNavigation();
+  });
+
+  it('should fail for invalid active element', () => {
+    win.document.activeElement.tagName = 'INPUT';
+    expect(() => {
+      handleMessageEvent(win, event);
+    }).to.throw(/A2A request with invalid active element/);
+  });
+
+  it('should fail for invalid url', () => {
+    event.data = 'a2a;' + JSON.stringify({
+      url: 'https://test.com/c/test',
+    });
+    expect(() => {
+      handleMessageEvent(win, event);
+    }).to.throw(/Invalid ad A2A URL/);
+  });
+
+  it('should fail for invalid url', () => {
+    findClosestAd = false;
+    expect(() => {
+      handleMessageEvent(win, event);
+    }).to.throw(/A2A request from non-ad frame/);
+  });
+});

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -90,7 +90,9 @@ function tests(name) {
         expect(preconnects[preconnects.length - 1].href).to.equal(
             'https://testsrc/');
         // Make sure we run tests without CID available by default.
-        expect(ad.ownerDocument.defaultView.services.cid).to.be.undefined;
+        const win = ad.ownerDocument.defaultView;
+        expect(win.services.cid).to.be.undefined;
+        expect(win.a2alistener).to.be.true;
       });
     });
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -407,6 +407,43 @@ export class Viewer {
   }
 
   /**
+   * Viewers can communicate their "capabilities" and this method allows
+   * checking them.
+   * @param {string} name Of the capability.
+   * @return {boolean}
+   */
+  hasCapability(name) {
+    const capabilities = this.params_['cap'];
+    if (!capabilities) {
+      return false;
+    }
+    // TODO(@cramforce): Consider caching the split.
+    return capabilities.split(',').indexOf(name) != -1;
+  }
+
+  /**
+   * Requests A2A navigation to the given destination. If the viewer does
+   * not support this operation, will navigate the top level window
+   * to the destination.
+   * The URL is assumed to be in AMP Cache format already.
+   * @param {string} url An AMP article URL.
+   * @param {string} requestedBy Informational string about the entity that
+   *     requested the navigation.
+   */
+  navigateTo(url, requestedBy) {
+    dev.assert(url.indexOf('https://cdn.ampproject.org/') == 0,
+        'Invalid A2A URL %s %s', url, requestedBy);
+    if (this.hasCapability('a2a')) {
+      this.sendMessage('a2a', {
+        url,
+        requestedBy,
+      }, /* awaitResponse */ false);
+    } else {
+      this.win.top.location.href = url;
+    }
+  }
+
+  /**
    * Whether the document is embedded in a iframe.
    * @return {boolean}
    */

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -101,6 +101,15 @@ describe('Viewer', () => {
     expect(viewer.getParam('other')).to.equal('something');
   });
 
+  it('should expose viewer capabilities', () => {
+    windowApi.name = '__AMP__viewportType=natural';
+    windowApi.location.hash = '#paddingTop=17&cap=foo,bar';
+    const viewer = new Viewer(windowApi);
+    expect(viewer.hasCapability('foo')).to.be.true;
+    expect(viewer.hasCapability('bar')).to.be.true;
+    expect(viewer.hasCapability('other')).to.be.false;
+  });
+
   it('should not clear fragment in non-embedded mode', () => {
     windowApi.parent = windowApi;
     windowApi.location.href = 'http://www.example.com#test=1';
@@ -108,6 +117,7 @@ describe('Viewer', () => {
     const viewer = new Viewer(windowApi);
     expect(windowApi.history.replaceState.callCount).to.equal(0);
     expect(viewer.getParam('test')).to.equal('1');
+    expect(viewer.hasCapability('foo')).to.be.false;
   });
 
   it('should clear fragment in embedded mode', () => {
@@ -1014,6 +1024,45 @@ describe('Viewer', () => {
       });
       clock.tick(1010);
       return result;
+    });
+  });
+
+  describe('navigateTo', () => {
+    const ampUrl = 'https://cdn.ampproject.org/test/123';
+    it('should initiate a2a navigation', () => {
+      windowApi.location.hash = '#cap=a2a';
+      windowApi.top = {
+        location: {},
+      };
+      const viewer = new Viewer(windowApi);
+      const send = sandbox.stub(viewer, 'sendMessage');
+      viewer.navigateTo(ampUrl, 'abc123');
+      expect(send.lastCall.args[0]).to.equal('a2a');
+      expect(send.lastCall.args[1]).to.jsonEqual({
+        url: ampUrl,
+        requestedBy: 'abc123',
+      });
+      expect(windowApi.top.location.href).to.be.undefined;
+    });
+
+    it('should fail for non-amp url', () => {
+      windowApi.location.hash = '#cap=a2a';
+      const viewer = new Viewer(windowApi);
+      sandbox.stub(viewer, 'sendMessage');
+      expect(() => {
+        viewer.navigateTo('http://www.test.com', 'abc123');
+      }).to.throw(/Invalid A2A URL/);
+    });
+
+    it('should perform fallback navigation', () => {
+      windowApi.top = {
+        location: {},
+      };
+      const viewer = new Viewer(windowApi);
+      const send = sandbox.stub(viewer, 'sendMessage');
+      viewer.navigateTo(ampUrl, 'abc123');
+      expect(send.callCount).to.equal(0);
+      expect(windowApi.top.location.href).to.equal(ampUrl);
     });
   });
 });


### PR DESCRIPTION
A2A navigation is our acronym for page navigation by sending a request to the viewer to navigate to another AMP page while remaining inside of the viewer.

Some curious aspects of this PR

- Tries to infer from the creative (deeply nested in ad iframes) that the top frame might support a2a. This is to avoid senseless requests that cannot be fullfilled.
- Introduces the concept of capabilities, where viewers can communicate what features they support. This will be crucial in the future as we have a set of viewers, not all of which support all features.
- Not all viewers actually have such a top frame (E.g. Google's iOS native viewer). This is a TODO.
- The creative does prefetching of the destination page, but this may be the wrong URL for some viewers. Another TODO.

Related to #2934