### PR TITLE
Update docs for amp-video autoplay attribute

### DIFF
--- a/builtins/amp-video.md
+++ b/builtins/amp-video.md
@@ -72,9 +72,7 @@ default the first frame is displayed.
 
 **autoplay**
 
-The `autoplay` attribute allows the author to specify when - if ever - the animated image will autoplay.
-
-The presence of the attribute alone implies that the animated image will always autoplay. The author may specify values to limit when the animations will autoplay. Allowable values are `desktop`, `tablet`, or `mobile`, with multiple values separated by a space. The runtime makes a best-guess approximation to the device type to apply this value.
+If present, the video will automatically start playback once rendered (if autoplay is supported by the browser).
 
 **controls**
 


### PR DESCRIPTION
The browser-type values for the `autoplay` attribute are not supported and instead the attribute behaves more like its XHTML counterpart.

Fixes #3715