### PR TITLE
Polyfill reportValidation calls and bubble UI for webkit.

### DIFF
--- a/extensions/amp-form/0.1/amp-form.css
+++ b/extensions/amp-form/0.1/amp-form.css
@@ -16,30 +16,30 @@
 
 form.amp-form-submit-success [submit-success],
 form.amp-form-submit-error [submit-error] {
-    display: block;
+  display: block;
 }
 
 
 .-amp-validation-bubble {
-    background-color: white;
-    box-shadow: 0 5px 15px 0 rgba(0, 0, 0, .5);
-    max-width: 200px;
-    position: absolute;
-    top: -999px;
-    left: -999px;
-    box-sizing: border-box;
-    padding: 10px;
-    border-radius: 5px;
+  transform: translate(-50%, -100%);
+  background-color: white;
+  box-shadow: 0 5px 15px 0 rgba(0, 0, 0, .5);
+  max-width: 200px;
+  position: absolute;
+  display: none;
+  box-sizing: border-box;
+  padding: 10px;
+  border-radius: 5px;
 }
 
 .-amp-validation-bubble:after {
-    content: ' ';
-    position: absolute;
-    bottom: -8px;
-    left: 30px;
-    width: 0;
-    height: 0;
-    border-left: 8px solid transparent;
-    border-right: 8px solid transparent;
-    border-top: 8px solid #fff;
+  content: ' ';
+  position: absolute;
+  bottom: -8px;
+  left: 30px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid #fff;
 }

--- a/extensions/amp-form/0.1/amp-form.css
+++ b/extensions/amp-form/0.1/amp-form.css
@@ -18,3 +18,28 @@ form.amp-form-submit-success [submit-success],
 form.amp-form-submit-error [submit-error] {
     display: block;
 }
+
+
+.-amp-validation-bubble {
+    background-color: white;
+    box-shadow: 0 5px 15px 0 rgba(0, 0, 0, .5);
+    max-width: 200px;
+    position: absolute;
+    top: -999px;
+    left: -999px;
+    box-sizing: border-box;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.-amp-validation-bubble:after {
+    content: ' ';
+    position: absolute;
+    bottom: -8px;
+    left: 30px;
+    width: 0;
+    height: 0;
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 8px solid #fff;
+}

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -206,7 +206,7 @@ function reportValidity(state) {
  * @param {!HTMLFormElement} form
  */
 function reportFormValidity(form) {
-  const inputs = toArray(form.querySelectorAll('input,select,textarea'));
+  const inputs = form.querySelectorAll('input,select,textarea');
   for (let i = 0; i < inputs.length; i++) {
     if (!inputs[i].checkValidity()) {
       reportInputValidity(inputs[i]);

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -111,6 +111,7 @@ export class AmpForm {
     if (shouldValidate &&
         this.form_.checkValidity && !this.form_.checkValidity()) {
       e.preventDefault();
+      // TODO(#3776): Use .mutate method when it supports passing state.
       this.vsync_.run({
         measure: undefined,
         mutate: reportValidity,

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -111,7 +111,10 @@ export class AmpForm {
     if (shouldValidate &&
         this.form_.checkValidity && !this.form_.checkValidity()) {
       e.preventDefault();
-      this.vsync_.run({mutate: reportValidity}, {form: this.form_});
+      this.vsync_.run({
+        measure: undefined,
+        mutate: reportValidity
+      }, {form: this.form_});
       return;
     }
 
@@ -188,14 +191,18 @@ export class AmpForm {
 }
 
 
+/**
+ * Reports validity of the form passed through state object.
+ * @param {!Object} state
+ */
 function reportValidity(state) {
   reportFormValidity(state.form);
 }
 
+
 /**
  * Reports validity for the first invalid input - if any.
  * @param {!HTMLFormElement} form
- * @private
  */
 function reportFormValidity(form) {
   const inputs = toArray(form.querySelectorAll('input,select,textarea'));
@@ -211,11 +218,11 @@ function reportFormValidity(form) {
 /**
  * Revalidates the currently focused input after a change.
  * @param {!KeyboardEvent} event
- * @private
  */
 function onInvalidInputKeyUp_(event) {
-  validationBubble.hide();
-  if (!event.target.checkValidity()) {
+  if (event.target.checkValidity()) {
+    validationBubble.hide();
+  } else {
     validationBubble.show(event.target, event.target.validationMessage);
   }
 }
@@ -224,7 +231,6 @@ function onInvalidInputKeyUp_(event) {
 /**
  * Hides validation bubble and removes listeners on the invalid input.
  * @param {!Event} event
- * @private
  */
 function onInvalidInputBlur_(event) {
   validationBubble.hide();
@@ -236,7 +242,6 @@ function onInvalidInputBlur_(event) {
 /**
  * Focuses and reports the invalid message of the input in a message bubble.
  * @param {!HTMLInputElement} input
- * @private
  */
 function reportInputValidity(input) {
   input./*OK*/focus();
@@ -256,7 +261,6 @@ function reportInputValidity(input) {
 /**
  * Installs submission handler on all forms in the document.
  * @param {!Window} win
- * @private
  */
 function installSubmissionHandlers(win) {
   onDocumentReady(win.document, () => {
@@ -269,7 +273,6 @@ function installSubmissionHandlers(win) {
 
 /**
  * @param {!Window} win
- * @private
  */
 function installAmpForm(win) {
   return getService(win, 'amp-form', () => {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -274,12 +274,13 @@ function installSubmissionHandlers(win) {
 
 /**
  * @param {!Window} win
+ * @private visible for testing.
  */
-function installAmpForm(win) {
+export function installAmpForm(win) {
   return getService(win, 'amp-form', () => {
     if (isExperimentOn(win, TAG)) {
       installStyles(win.document, CSS, () => {
-        validationBubble = new ValidationBubble(window);
+        validationBubble = new ValidationBubble(win);
         installSubmissionHandlers(win);
       });
     }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -113,7 +113,7 @@ export class AmpForm {
       e.preventDefault();
       this.vsync_.run({
         measure: undefined,
-        mutate: reportValidity
+        mutate: reportValidity,
       }, {form: this.form_});
       return;
     }

--- a/extensions/amp-form/0.1/test/test-validation-bubble.js
+++ b/extensions/amp-form/0.1/test/test-validation-bubble.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as sinon from 'sinon';
+import {ValidationBubble} from '../validation-bubble';
+import {createIframePromise} from '../../../../testing/iframe';
+
+describe('validation-bubble', () => {
+
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should append a dom element to the document', () => {
+    return createIframePromise().then(iframe => {
+      new ValidationBubble(iframe.win);
+      expect(iframe.doc.querySelector('.-amp-validation-bubble'))
+          .to.not.be.null;
+    });
+  });
+
+  it('should show and hide bubble', () => {
+    return createIframePromise().then(iframe => {
+      const targetEl = iframe.doc.createElement('div');
+      targetEl.textContent = 'I am the target!';
+      targetEl.style.position = 'absolute';
+      targetEl.style.top = '300px';
+      targetEl.style.left = '400px';
+      targetEl.style.width = '200px';
+      iframe.doc.body.appendChild(targetEl);
+
+      const bubble = new ValidationBubble(iframe.win);
+      bubble.vsync_ = {
+        run: (task, state) => {
+          if (task.measure) {
+            task.measure(state);
+          }
+          if (task.mutate) {
+            task.mutate(state);
+          }
+        },
+      };
+      const bubbleEl = iframe.doc.querySelector('.-amp-validation-bubble');
+      bubble.show(targetEl, 'Hello World');
+      expect(bubbleEl).to.not.be.null;
+      expect(bubbleEl.textContent).to.equal('Hello World');
+      expect(bubbleEl.style.display).to.equal('');
+      expect(bubbleEl.style.top).to.equal('290px');
+      expect(bubbleEl.style.left).to.equal('500px');
+
+      bubble.hide();
+      expect(bubbleEl.style.display).to.equal('none');
+    });
+  });
+});

--- a/extensions/amp-form/0.1/validation-bubble.js
+++ b/extensions/amp-form/0.1/validation-bubble.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {vsyncFor} from '../../../src/vsync';
+import {viewportFor} from '../../../src/viewport';
+import {setStyles} from '../../../src/style';
+
+const EDGE = '-99999px';
+
+export class ValidationBubble {
+
+  /**
+   * Creates a bubble component to display messages in.
+   * @param {!Window} win
+   */
+  constructor(win) {
+
+    /** @private @const {!Viewport} */
+    this.viewport_ = viewportFor(win);
+
+    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync_ = vsyncFor(win);
+
+    /** @private @const {!HTMLDivElement} */
+    this.bubbleElement_ = win.document.createElement('div');
+    this.bubbleElement_.classList.add('-amp-validation-bubble');
+    win.document.body.appendChild(this.bubbleElement_);
+  }
+
+  /**
+   * Hides the bubble off screen.
+   */
+  hide() {
+    this.vsync_.mutate(() => {
+      setStyles(this.bubbleElement_, {
+        top: EDGE,
+        left: EDGE,
+      });
+    });
+  }
+
+  /**
+   * Shows the bubble targeted to an element with the passed message.
+   * @param {!HTMLElement} targetElement
+   * @param {string} message
+   */
+  show(targetElement, message) {
+    this.bubbleElement_.textContent = message;
+
+    let targetRect;
+    let bubbleRect;
+    this.vsync_.run({
+      measure: () => {
+        targetRect = this.viewport_.getLayoutRect(targetElement);
+        bubbleRect = this.viewport_.getLayoutRect(this.bubbleElement_);
+      },
+      mutate: () => {
+        setStyles(this.bubbleElement_, {
+          top: `${this.computeTop_(bubbleRect, targetRect)}px`,
+          left: `${this.computeLeft_(bubbleRect, targetRect)}px`,
+        });
+      },
+    });
+  }
+
+  /**
+   * Computes the left position of the bubble.
+   * @param {!../../../src/layout-rect.LayoutRectDef} bubbleRect
+   * @param {!../../../src/layout-rect.LayoutRectDef} targetRect
+   * @return {number}
+   * @private
+   */
+  computeLeft_(bubbleRect, targetRect) {
+    return (targetRect.left -
+        // Center the bubble relative to the target element.
+        (bubbleRect.width - targetRect.width) / 2);
+  }
+
+  /**
+   * Computes the left position of the bubble.
+   * @param {!../../../src/layout-rect.LayoutRectDef} bubbleRect
+   * @param {!../../../src/layout-rect.LayoutRectDef} targetRect
+   * @return {number}
+   * @private
+   */
+  computeTop_(bubbleRect, targetRect) {
+    return (targetRect.top -
+        // Move the bubble the height of the bubble box.
+        bubbleRect.height -
+        // Account for the bubble caret and some margin from the input field.
+        10);
+  }
+}

--- a/extensions/amp-form/0.1/validation-bubble.js
+++ b/extensions/amp-form/0.1/validation-bubble.js
@@ -42,6 +42,7 @@ export class ValidationBubble {
    * Hides the bubble off screen.
    */
   hide() {
+    // TODO(#3776): Use .mutate method when it supports passing state.
     this.vsync_.run({
       measure: undefined,
       mutate: hideBubble,
@@ -100,7 +101,7 @@ function measureTargetElement(state) {
 function showBubbleElement(state) {
   state.bubbleElement.textContent = state.message;
   setStyles(state.bubbleElement, {
-    display: 'initial',
+    display: '',
     top: `${state.targetRect.top - 10}px`,
     left: `${state.targetRect.left + state.targetRect.width / 2}px`,
   });

--- a/extensions/amp-form/0.1/validation-bubble.js
+++ b/extensions/amp-form/0.1/validation-bubble.js
@@ -18,6 +18,9 @@ import {vsyncFor} from '../../../src/vsync';
 import {viewportFor} from '../../../src/viewport';
 import {setStyles} from '../../../src/style';
 
+/** @type {string} */
+const OBJ_PROP = '__BUBBLE_OBJ';
+
 export class ValidationBubble {
 
   /**
@@ -35,6 +38,7 @@ export class ValidationBubble {
     /** @private @const {!HTMLDivElement} */
     this.bubbleElement_ = win.document.createElement('div');
     this.bubbleElement_.classList.add('-amp-validation-bubble');
+    this.bubbleElement_[OBJ_PROP] = this;
     win.document.body.appendChild(this.bubbleElement_);
   }
 

--- a/extensions/amp-form/0.1/validation-bubble.js
+++ b/extensions/amp-form/0.1/validation-bubble.js
@@ -43,6 +43,7 @@ export class ValidationBubble {
    */
   hide() {
     this.vsync_.run({
+      measure: undefined,
       mutate: hideBubble,
     }, {
       bubbleElement: this.bubbleElement_,


### PR DESCRIPTION
Test this out on any webkit-based browser at [the demo here](https://amp-mk-1.herokuapp.com/examples.build/forms.amp.max.html).

This polyfill the bubble UI for validation reporting in webkit browsers. This matches browsers implementation of one invalid bubble at a time, focusing the invalid input, hide bubble on blur and continuous revalidation as the user types in an active invalid reported input.

- [x] Figure out why the example is working on Safari Desktop and iOS simulator but not on real iOS - This was due to the demo page being served on http instead of https.
- [x] Add and fix tests

ITI: #3343 