### PR TITLE
Fix xhr.assertSuccess promise

### DIFF
--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -366,8 +366,9 @@ export function assertSuccess(response) {
       } else {
         reject(err);
       }
+    } else {
+      resolve(response);
     }
-    resolve(response);
   });
 }
 

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -358,7 +358,7 @@ export function assertSuccess(response) {
         response.json().then(json => {
           err.responseJson = json;
           reject(err);
-        }).catch(() => {
+        }, () => {
           // Ignore a failed json parsing and just throw the error without
           // setting responseJson.
           reject(err);

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -268,15 +268,13 @@ describe('XHR', function() {
               });
         });
 
-        it('should not return a resolved indented promise', () => {
+        it('should not resolve after rejecting promise', () => {
           mockXhr.status = 500;
           mockXhr.responseText = '{"a": "hello"}';
           mockXhr.headers['Content-Type'] = 'application/json';
           mockXhr.getResponseHeader = () => 'application/json';
-          const promise = assertSuccess(
-              createResponseInstance('{"a": 2}', mockXhr));
-          promise.should.be.rejected;
-          return promise;
+          return assertSuccess(createResponseInstance('{"a": 2}', mockXhr))
+              .should.not.be.fulfilled;
         });
       });
 


### PR DESCRIPTION
The else part is obvious. What might not be obvious is the test change. @dvoytenko I dropped (changed actually) the test of the previous return a resolved promise issue inside the constructor of the promise, this doesn't actually to have the effect that we thought it would. Tried it with a snippet like the following:

```javascript
function myfunc() { 
  return new Promise((resolve, reject)  => {
    return Promise.resolve();
  });
}

myfunc().then(() => console.log('I will never be resolved so I will not log...'));
```

I am not sure if I am still missing the issue with the previous return statement - if I am can you write a small snippet (like the above) that could show the problem? Probably will help me understand it better.