### PR TITLE
No longer set as attribute in preload requests.

### DIFF
--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -132,9 +132,12 @@ export class Preconnect {
     const prefetch = this.document_.createElement('link');
     prefetch.setAttribute('rel', command);
     prefetch.setAttribute('href', url);
-    if (opt_preloadAs) {
-      prefetch.setAttribute('as', opt_preloadAs);
-    }
+    // Do not set 'as' attribute for now, for 2 reasons
+    // - document value is not yet supported and dropped
+    // - script is blocked due to CSP.
+    // if (opt_preloadAs) {
+    //  prefetch.setAttribute('as', opt_preloadAs);
+    // }
     this.head_.appendChild(prefetch);
     // As opposed to preconnect we do not clean this tag up, because there is
     // no expectation as to it having an immediate effect.

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -220,10 +220,8 @@ describe('3p-frame', () => {
     expect(fetches).to.have.length(2);
     expect(fetches[0].href).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
-    expect(fetches[0].getAttribute('as')).to.equal('document');
     expect(fetches[1].href).to.equal(
         'https://3p.ampproject.net/$internalRuntimeVersion$/f.js');
-    expect(fetches[1].getAttribute('as')).to.equal('script');
     preconnect.preloadSupported_ = origPreloadSupportValue;
   });
 

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -229,9 +229,7 @@ describe('preconnect', () => {
           'link[rel=prefetch],link[rel=preload]');
       expect(fetches).to.have.length(2);
       expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
-      expect(fetches[0].getAttribute('as')).to.equal('script');
       expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
-      expect(fetches[1].getAttribute('as')).to.equal('style');
     });
   });
 
@@ -261,9 +259,7 @@ describe('preconnect', () => {
           'link[rel=prefetch]');
       expect(fetches).to.have.length(2);
       expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
-      expect(fetches[0].getAttribute('as')).to.equal('script');
       expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
-      expect(fetches[1].getAttribute('as')).to.equal('style');
     });
   });
 
@@ -291,9 +287,7 @@ describe('preconnect', () => {
           'link[rel=preload]');
       expect(preloads).to.have.length(2);
       expect(preloads[0].href).to.equal('https://a.prefetch.com/foo/bar');
-      expect(preloads[0].getAttribute('as')).to.equal('script');
       expect(preloads[1].href).to.equal('https://a.prefetch.com/other');
-      expect(preloads[1].getAttribute('as')).to.equal('style');
     });
   });
 });


### PR DESCRIPTION
The feature is currently essentially broken because:

- document requests are ignored
- script requests are silently ignored, because they violate the CSP