### PR TITLE
Validator index.js (Node.js API and command line tool): --format=color|text|json

### DIFF
--- a/validator/index.js
+++ b/validator/index.js
@@ -153,61 +153,61 @@ function ValidationResult() {
  * @constructor
  */
 function ValidationError() {
-    /**
-     * The severity of the error - possible values are 'UNKNOWN_SEVERITY',
-     * 'ERROR', and 'WARNING'.
-     */
-    this.severity = 'UNKNOWN_SEVERITY';
-    /**
-     * The line number at which the error was seen (1 is the first line).
-     */
-    this.line = 1;
-    /**
-     * The column number at which the error was seen (0 is the first column).
-     */
-    this.col = 0;
-    /**
-     * A human-readable error message for the validation error.
-     * If you find yourself trying to write a parser against this string
-     * to scrape out some detail, consider looking at the code and params
-     * fields below.
-     * @type {!string}
-     */
-    this.message = '';
-    /**
-     * The spec URL is often added by the validator to provide additional
-     * context for the error. In a user interface this would be shown
-     * as a "Learn more" link.
-     * @type {!string}
-     */
-    this.specUrl = null;
-    /**
-     * Categorizes error messages into higher-level groups. This makes it
-     * easier to create error statistics across a site and give advice based
-     * on the most common problems for a set of pages.
-     * See the ErrorCategory.Code enum in validator.proto for possible values.
-     * @type {!string}
-     */
-    this.category = 'UNKNOWN';
-    /**
-     * This field is only useful when scripting against the validator,
-     * it should not be displayed in a user interface as it adds nothing
-     * for humans to read over the message field (see above).
-     * Possible values are the codes listed in ValidationError.Code - see
-     * validator.proto. Examples: 'UNKNOWN_CODE', 'MANDATORY_TAG_MISSING',
-     * 'TAG_REQUIRED_BY_MISSING'. For each of these codes there is a
-     * format string in validator-main.protoascii (look for error_formats),
-     * which is used to assemble the message from the strings in params.
-     * @type {!string}
-     */
-    this.code = 'UNKNOWN_CODE';
-    /**
-     * This field is only useful when scripting against the validator,
-     * it should not be displayed in a user interface as it adds nothing
-     * for humans to read over the message field (see above).
-     * @type {!Array<!string>}
-     */
-    this.params = [];
+  /**
+   * The severity of the error - possible values are 'UNKNOWN_SEVERITY',
+   * 'ERROR', and 'WARNING'.
+   */
+  this.severity = 'UNKNOWN_SEVERITY';
+  /**
+   * The line number at which the error was seen (1 is the first line).
+   */
+  this.line = 1;
+  /**
+   * The column number at which the error was seen (0 is the first column).
+   */
+  this.col = 0;
+  /**
+   * A human-readable error message for the validation error.
+   * If you find yourself trying to write a parser against this string
+   * to scrape out some detail, consider looking at the code and params
+   * fields below.
+   * @type {!string}
+   */
+  this.message = '';
+  /**
+   * The spec URL is often added by the validator to provide additional
+   * context for the error. In a user interface this would be shown
+   * as a "Learn more" link.
+   * @type {!string}
+   */
+  this.specUrl = null;
+  /**
+   * Categorizes error messages into higher-level groups. This makes it
+   * easier to create error statistics across a site and give advice based
+   * on the most common problems for a set of pages.
+   * See the ErrorCategory.Code enum in validator.proto for possible values.
+   * @type {!string}
+   */
+  this.category = 'UNKNOWN';
+  /**
+   * This field is only useful when scripting against the validator,
+   * it should not be displayed in a user interface as it adds nothing
+   * for humans to read over the message field (see above).
+   * Possible values are the codes listed in ValidationError.Code - see
+   * validator.proto. Examples: 'UNKNOWN_CODE', 'MANDATORY_TAG_MISSING',
+   * 'TAG_REQUIRED_BY_MISSING'. For each of these codes there is a
+   * format string in validator-main.protoascii (look for error_formats),
+   * which is used to assemble the message from the strings in params.
+   * @type {!string}
+   */
+  this.code = 'UNKNOWN_CODE';
+  /**
+   * This field is only useful when scripting against the validator,
+   * it should not be displayed in a user interface as it adds nothing
+   * for humans to read over the message field (see above).
+   * @type {!Array<!string>}
+   */
+  this.params = [];
 }
 
 /**
@@ -220,22 +220,22 @@ function ValidationError() {
  * @constructor
  */
 function Validator(scriptContents) {
-    // The 'sandbox' is a Javascript object (dictionary) which holds
-    // the results of evaluating the validatorJs / scriptContents, so
-    // basically, it holds functions, prototypes, etc. As a
-    // side-effect of evaluating, the VM will compile this code and
-    // it's worth holding onto it. Hence, this validate function is
-    // reached via 2 codepaths - either the sandbox came from the
-    // cache, precompiledByValidatorJs - or we just varructed it
-    // after downloading and evaluating the script. The API is fancier
-    // here, vm.Script / vm.createContext / vm.runInContext and all
-    // that, but it's quite similar to a Javascript eval.
-    this.sandbox = vm.createContext();
-    try {
-      new vm.Script(scriptContents).runInContext(this.sandbox);
-    } catch (error) {
-      throw new Error('Could not instantiate validator.js - ' + error.message);
-    }
+  // The 'sandbox' is a Javascript object (dictionary) which holds
+  // the results of evaluating the validatorJs / scriptContents, so
+  // basically, it holds functions, prototypes, etc. As a
+  // side-effect of evaluating, the VM will compile this code and
+  // it's worth holding onto it. Hence, this validate function is
+  // reached via 2 codepaths - either the sandbox came from the
+  // cache, precompiledByValidatorJs - or we just varructed it
+  // after downloading and evaluating the script. The API is fancier
+  // here, vm.Script / vm.createContext / vm.runInContext and all
+  // that, but it's quite similar to a Javascript eval.
+  this.sandbox = vm.createContext();
+  try {
+    new vm.Script(scriptContents).runInContext(this.sandbox);
+  } catch (error) {
+    throw new Error('Could not instantiate validator.js - ' + error.message);
+  }
 }
 
 /**
@@ -243,25 +243,26 @@ function Validator(scriptContents) {
  * @returns {!ValidationResult}
  * @export
  */
-Validator.prototype.validateString = function(inputString) {
-    var internalResult = this.sandbox.amp.validator.validateString(inputString);
-    var result = new ValidationResult();
-    result.status = internalResult.status;
-    for (var ii = 0; ii < internalResult.errors.length; ii++) {
-      var internalError = internalResult.errors[ii];
-      var error = new ValidationError();
-      error.severity = internalError.severity;
-      error.line = internalError.line;
-      error.col = internalError.col;
-      error.message =
-          this.sandbox.amp.validator.renderErrorMessage(internalError);
-      error.specUrl = internalError.specUrl;
-      error.code = internalError.code;
-      error.params = internalError.params;
-      error.category = this.sandbox.amp.validator.categorizeError(internalError);
-      result.errors.push(error);
-    }
-    return result;
+Validator.prototype.validateString =
+    function(inputString) {
+  var internalResult = this.sandbox.amp.validator.validateString(inputString);
+  var result = new ValidationResult();
+  result.status = internalResult.status;
+  for (var ii = 0; ii < internalResult.errors.length; ii++) {
+    var internalError = internalResult.errors[ii];
+    var error = new ValidationError();
+    error.severity = internalError.severity;
+    error.line = internalError.line;
+    error.col = internalError.col;
+    error.message =
+        this.sandbox.amp.validator.renderErrorMessage(internalError);
+    error.specUrl = internalError.specUrl;
+    error.code = internalError.code;
+    error.params = internalError.params;
+    error.category = this.sandbox.amp.validator.categorizeError(internalError);
+    result.errors.push(error);
+  }
+  return result;
 }
 
 /**

--- a/validator/index.js
+++ b/validator/index.js
@@ -153,61 +153,61 @@ function ValidationResult() {
  * @constructor
  */
 function ValidationError() {
-  /**
-   * The severity of the error - possible values are 'UNKNOWN_SEVERITY',
-   * 'ERROR', and 'WARNING'.
-   */
-  this.severity = 'UNKNOWN_SEVERITY';
-  /**
-   * The line number at which the error was seen (1 is the first line).
-   */
-  this.line = 1;
-  /**
-   * The column number at which the error was seen (0 is the first column).
-   */
-  this.col = 0;
-  /**
-   * A human-readable error message for the validation error.
-   * If you find yourself trying to write a parser against this string
-   * to scrape out some detail, consider looking at the code and params
-   * fields below.
-   * @type {!string}
-   */
-  this.message = '';
-  /**
-   * The spec URL is often added by the validator to provide additional
-   * context for the error. In a user interface this would be shown
-   * as a "Learn more" link.
-   * @type {!string}
-   */
-  this.specUrl = null;
-  /**
-   * Categorizes error messages into higher-level groups. This makes it
-   * easier to create error statistics across a site and give advice based
-   * on the most common problems for a set of pages.
-   * See the ErrorCategory.Code enum in validator.proto for possible values.
-   * @type {!string}
-   */
-  this.category = 'UNKNOWN';
-  /**
-   * This field is only useful when scripting against the validator,
-   * it should not be displayed in a user interface as it adds nothing
-   * for humans to read over the message field (see above).
-   * Possible values are the codes listed in ValidationError.Code - see
-   * validator.proto. Examples: 'UNKNOWN_CODE', 'MANDATORY_TAG_MISSING',
-   * 'TAG_REQUIRED_BY_MISSING'. For each of these codes there is a
-   * format string in validator-main.protoascii (look for error_formats),
-   * which is used to assemble the message from the strings in params.
-   * @type {!string}
-   */
-  this.code = 'UNKNOWN_CODE';
-  /**
-   * This field is only useful when scripting against the validator,
-   * it should not be displayed in a user interface as it adds nothing
-   * for humans to read over the message field (see above).
-   * @type {!Array<!string>}
-   */
-  this.params = [];
+    /**
+     * The severity of the error - possible values are 'UNKNOWN_SEVERITY',
+     * 'ERROR', and 'WARNING'.
+     */
+    this.severity = 'UNKNOWN_SEVERITY';
+    /**
+     * The line number at which the error was seen (1 is the first line).
+     */
+    this.line = 1;
+    /**
+     * The column number at which the error was seen (0 is the first column).
+     */
+    this.col = 0;
+    /**
+     * A human-readable error message for the validation error.
+     * If you find yourself trying to write a parser against this string
+     * to scrape out some detail, consider looking at the code and params
+     * fields below.
+     * @type {!string}
+     */
+    this.message = '';
+    /**
+     * The spec URL is often added by the validator to provide additional
+     * context for the error. In a user interface this would be shown
+     * as a "Learn more" link.
+     * @type {!string}
+     */
+    this.specUrl = null;
+    /**
+     * Categorizes error messages into higher-level groups. This makes it
+     * easier to create error statistics across a site and give advice based
+     * on the most common problems for a set of pages.
+     * See the ErrorCategory.Code enum in validator.proto for possible values.
+     * @type {!string}
+     */
+    this.category = 'UNKNOWN';
+    /**
+     * This field is only useful when scripting against the validator,
+     * it should not be displayed in a user interface as it adds nothing
+     * for humans to read over the message field (see above).
+     * Possible values are the codes listed in ValidationError.Code - see
+     * validator.proto. Examples: 'UNKNOWN_CODE', 'MANDATORY_TAG_MISSING',
+     * 'TAG_REQUIRED_BY_MISSING'. For each of these codes there is a
+     * format string in validator-main.protoascii (look for error_formats),
+     * which is used to assemble the message from the strings in params.
+     * @type {!string}
+     */
+    this.code = 'UNKNOWN_CODE';
+    /**
+     * This field is only useful when scripting against the validator,
+     * it should not be displayed in a user interface as it adds nothing
+     * for humans to read over the message field (see above).
+     * @type {!Array<!string>}
+     */
+    this.params = [];
 }
 
 /**
@@ -220,22 +220,22 @@ function ValidationError() {
  * @constructor
  */
 function Validator(scriptContents) {
-  // The 'sandbox' is a Javascript object (dictionary) which holds
-  // the results of evaluating the validatorJs / scriptContents, so
-  // basically, it holds functions, prototypes, etc. As a
-  // side-effect of evaluating, the VM will compile this code and
-  // it's worth holding onto it. Hence, this validate function is
-  // reached via 2 codepaths - either the sandbox came from the
-  // cache, precompiledByValidatorJs - or we just varructed it
-  // after downloading and evaluating the script. The API is fancier
-  // here, vm.Script / vm.createContext / vm.runInContext and all
-  // that, but it's quite similar to a Javascript eval.
-  this.sandbox = vm.createContext();
-  try {
-    new vm.Script(scriptContents).runInContext(this.sandbox);
-  } catch (error) {
-    throw new Error('Could not instantiate validator.js - ' + error.message);
-  }
+    // The 'sandbox' is a Javascript object (dictionary) which holds
+    // the results of evaluating the validatorJs / scriptContents, so
+    // basically, it holds functions, prototypes, etc. As a
+    // side-effect of evaluating, the VM will compile this code and
+    // it's worth holding onto it. Hence, this validate function is
+    // reached via 2 codepaths - either the sandbox came from the
+    // cache, precompiledByValidatorJs - or we just varructed it
+    // after downloading and evaluating the script. The API is fancier
+    // here, vm.Script / vm.createContext / vm.runInContext and all
+    // that, but it's quite similar to a Javascript eval.
+    this.sandbox = vm.createContext();
+    try {
+      new vm.Script(scriptContents).runInContext(this.sandbox);
+    } catch (error) {
+      throw new Error('Could not instantiate validator.js - ' + error.message);
+    }
 }
 
 /**
@@ -243,26 +243,25 @@ function Validator(scriptContents) {
  * @returns {!ValidationResult}
  * @export
  */
-Validator.prototype.validateString =
-    function(inputString) {
-  var internalResult = this.sandbox.amp.validator.validateString(inputString);
-  var result = new ValidationResult();
-  result.status = internalResult.status;
-  for (var ii = 0; ii < internalResult.errors.length; ii++) {
-    var internalError = internalResult.errors[ii];
-    var error = new ValidationError();
-    error.severity = internalError.severity;
-    error.line = internalError.line;
-    error.col = internalError.col;
-    error.message =
-        this.sandbox.amp.validator.renderErrorMessage(internalError);
-    error.specUrl = internalError.specUrl;
-    error.code = internalError.code;
-    error.params = internalError.params;
-    error.category = this.sandbox.amp.validator.categorizeError(internalError);
-    result.errors.push(error);
-  }
-  return result;
+Validator.prototype.validateString = function(inputString) {
+    var internalResult = this.sandbox.amp.validator.validateString(inputString);
+    var result = new ValidationResult();
+    result.status = internalResult.status;
+    for (var ii = 0; ii < internalResult.errors.length; ii++) {
+      var internalError = internalResult.errors[ii];
+      var error = new ValidationError();
+      error.severity = internalError.severity;
+      error.line = internalError.line;
+      error.col = internalError.col;
+      error.message =
+          this.sandbox.amp.validator.renderErrorMessage(internalError);
+      error.specUrl = internalError.specUrl;
+      error.code = internalError.code;
+      error.params = internalError.params;
+      error.category = this.sandbox.amp.validator.categorizeError(internalError);
+      result.errors.push(error);
+    }
+    return result;
 }
 
 /**

--- a/validator/index.js
+++ b/validator/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var Promise = require('promise');
+var colors = require('colors');
 var fs = require('fs');
 var http = require('http');
 var https = require('https');
@@ -152,61 +153,61 @@ function ValidationResult() {
  * @constructor
  */
 function ValidationError() {
-    /**
-     * The severity of the error - possible values are 'UNKNOWN_SEVERITY',
-     * 'ERROR', and 'WARNING'.
-     */
-    this.severity = 'UNKNOWN_SEVERITY';
-    /**
-     * The line number at which the error was seen (1 is the first line).
-     */
-    this.line = 1;
-    /**
-     * The column number at which the error was seen (0 is the first column).
-     */
-    this.col = 0;
-    /**
-     * A human-readable error message for the validation error.
-     * If you find yourself trying to write a parser against this string
-     * to scrape out some detail, consider looking at the code and params
-     * fields below.
-     * @type {!string}
-     */
-    this.message = '';
-    /**
-     * The spec URL is often added by the validator to provide additional
-     * context for the error. In a user interface this would be shown
-     * as a "Learn more" link.
-     * @type {!string}
-     */
-    this.specUrl = null;
-    /**
-     * Categorizes error messages into higher-level groups. This makes it
-     * easier to create error statistics across a site and give advice based
-     * on the most common problems for a set of pages.
-     * See the ErrorCategory.Code enum in validator.proto for possible values.
-     * @type {!string}
-     */
-    this.category = 'UNKNOWN';
-    /**
-     * This field is only useful when scripting against the validator,
-     * it should not be displayed in a user interface as it adds nothing
-     * for humans to read over the message field (see above).
-     * Possible values are the codes listed in ValidationError.Code - see
-     * validator.proto. Examples: 'UNKNOWN_CODE', 'MANDATORY_TAG_MISSING',
-     * 'TAG_REQUIRED_BY_MISSING'. For each of these codes there is a
-     * format string in validator-main.protoascii (look for error_formats),
-     * which is used to assemble the message from the strings in params.
-     * @type {!string}
-     */
-    this.code = 'UNKNOWN_CODE';
-    /**
-     * This field is only useful when scripting against the validator,
-     * it should not be displayed in a user interface as it adds nothing
-     * for humans to read over the message field (see above).
-     * @type {!Array<!string>}
-     */
-    this.params = [];
+  /**
+   * The severity of the error - possible values are 'UNKNOWN_SEVERITY',
+   * 'ERROR', and 'WARNING'.
+   */
+  this.severity = 'UNKNOWN_SEVERITY';
+  /**
+   * The line number at which the error was seen (1 is the first line).
+   */
+  this.line = 1;
+  /**
+   * The column number at which the error was seen (0 is the first column).
+   */
+  this.col = 0;
+  /**
+   * A human-readable error message for the validation error.
+   * If you find yourself trying to write a parser against this string
+   * to scrape out some detail, consider looking at the code and params
+   * fields below.
+   * @type {!string}
+   */
+  this.message = '';
+  /**
+   * The spec URL is often added by the validator to provide additional
+   * context for the error. In a user interface this would be shown
+   * as a "Learn more" link.
+   * @type {!string}
+   */
+  this.specUrl = null;
+  /**
+   * Categorizes error messages into higher-level groups. This makes it
+   * easier to create error statistics across a site and give advice based
+   * on the most common problems for a set of pages.
+   * See the ErrorCategory.Code enum in validator.proto for possible values.
+   * @type {!string}
+   */
+  this.category = 'UNKNOWN';
+  /**
+   * This field is only useful when scripting against the validator,
+   * it should not be displayed in a user interface as it adds nothing
+   * for humans to read over the message field (see above).
+   * Possible values are the codes listed in ValidationError.Code - see
+   * validator.proto. Examples: 'UNKNOWN_CODE', 'MANDATORY_TAG_MISSING',
+   * 'TAG_REQUIRED_BY_MISSING'. For each of these codes there is a
+   * format string in validator-main.protoascii (look for error_formats),
+   * which is used to assemble the message from the strings in params.
+   * @type {!string}
+   */
+  this.code = 'UNKNOWN_CODE';
+  /**
+   * This field is only useful when scripting against the validator,
+   * it should not be displayed in a user interface as it adds nothing
+   * for humans to read over the message field (see above).
+   * @type {!Array<!string>}
+   */
+  this.params = [];
 }
 
 /**
@@ -219,51 +220,50 @@ function ValidationError() {
  * @constructor
  */
 function Validator(scriptContents) {
-    // The 'sandbox' is a Javascript object (dictionary) which holds
-    // the results of evaluating the validatorJs / scriptContents, so
-    // basically, it holds functions, prototypes, etc. As a
-    // side-effect of evaluating, the VM will compile this code and
-    // it's worth holding onto it. Hence, this validate function is
-    // reached via 2 codepaths - either the sandbox came from the
-    // cache, precompiledByValidatorJs - or we just varructed it
-    // after downloading and evaluating the script. The API is fancier
-    // here, vm.Script / vm.createContext / vm.runInContext and all
-    // that, but it's quite similar to a Javascript eval.
-    this.sandbox = vm.createContext();
-    try {
-      new vm.Script(scriptContents).runInContext(this.sandbox);
-    } catch (error) {
-      throw new Error('Could not instantiate validator.js - ' + error.message);
-    }
+  // The 'sandbox' is a Javascript object (dictionary) which holds
+  // the results of evaluating the validatorJs / scriptContents, so
+  // basically, it holds functions, prototypes, etc. As a
+  // side-effect of evaluating, the VM will compile this code and
+  // it's worth holding onto it. Hence, this validate function is
+  // reached via 2 codepaths - either the sandbox came from the
+  // cache, precompiledByValidatorJs - or we just varructed it
+  // after downloading and evaluating the script. The API is fancier
+  // here, vm.Script / vm.createContext / vm.runInContext and all
+  // that, but it's quite similar to a Javascript eval.
+  this.sandbox = vm.createContext();
+  try {
+    new vm.Script(scriptContents).runInContext(this.sandbox);
+  } catch (error) {
+    throw new Error('Could not instantiate validator.js - ' + error.message);
   }
+}
 
-  /**
-   * @param {!string} inputString
-   * @returns {!ValidationResult}
-   * @export
-   */
-Validator.prototype.validateString = function(inputString) {
-    var internalResult =
-        this.sandbox.amp.validator.validateString(inputString);
-    var result = new ValidationResult();
-    result.status = internalResult.status;
-    for (var ii = 0; ii < internalResult.errors.length; ii++) {
-      var internalError = internalResult.errors[ii];
-      var error = new ValidationError();
-      error.severity = internalError.severity;
-      error.line = internalError.line;
-      error.col = internalError.col;
-      error.message =
-          this.sandbox.amp.validator.renderErrorMessage(internalError);
-      error.specUrl = internalError.specUrl;
-      error.code = internalError.code;
-      error.params = internalError.params;
-      error.category =
-          this.sandbox.amp.validator.categorizeError(internalError);
-      result.errors.push(error);
-    }
-    return result;
+/**
+ * @param {!string} inputString
+ * @returns {!ValidationResult}
+ * @export
+ */
+Validator.prototype.validateString =
+    function(inputString) {
+  var internalResult = this.sandbox.amp.validator.validateString(inputString);
+  var result = new ValidationResult();
+  result.status = internalResult.status;
+  for (var ii = 0; ii < internalResult.errors.length; ii++) {
+    var internalError = internalResult.errors[ii];
+    var error = new ValidationError();
+    error.severity = internalError.severity;
+    error.line = internalError.line;
+    error.col = internalError.col;
+    error.message =
+        this.sandbox.amp.validator.renderErrorMessage(internalError);
+    error.specUrl = internalError.specUrl;
+    error.code = internalError.code;
+    error.params = internalError.params;
+    error.category = this.sandbox.amp.validator.categorizeError(internalError);
+    result.errors.push(error);
   }
+  return result;
+}
 
 /**
  * A global static map used by the getInstance function to avoid loading
@@ -307,15 +307,21 @@ exports.getInstance = getInstance;
  * and console.error as is appropriate.
  * @param {!string} filename
  * @param {!ValidationResult} validationResult
+ * @param {boolean} color
  */
-function logValidationResult(filename, validationResult) {
+function logValidationResult(filename, validationResult, color) {
   if (validationResult.status === 'PASS') {
-    console.log(filename + ': PASS');
+    console.log(filename + ': ' + (color ? colors.green('PASS') : 'PASS'));
   }
   for (var ii = 0; ii < validationResult.errors.length; ii++) {
     var error = validationResult.errors[ii];
-    var msg =
-        filename + ':' + error.line + ':' + error.col + ' ' + error.message;
+    var msg = filename + ':' + error.line + ':' + error.col + ' ';
+    if (color) {
+      msg += (error.severity === 'ERROR' ? colors.red : colors.magenta)(
+          error.message);
+    } else {
+      msg += error.message
+    }
     if (error.specUrl) {
       msg += ' (see ' + error.specUrl + ')';
     }
@@ -333,63 +339,76 @@ function logValidationResult(filename, validationResult) {
 function main() {
   program.version('0.1.0')
       .usage(
-          '<fileOrUrlOrMinus...>\n\n' +
-          '  By default, validates the files or urls provided as arguments.\n' +
-          '  If "-" is specified, reads from stdin instead.\n' +
-          '  Note the --validator_js option for selecting the Validator to\n' +
-          '  run.')
+          '[options] <fileOrUrlOrMinus...>\n\n' +
+          '  Validates the files or urls provided as arguments. If "-" is ' +
+          '  specified, reads from stdin instead.')
       .option(
-          '--validator_js <fileOrUrl>', 'The Validator Javascript. \n' +
-              '  Latest published version by default, or \n' +
-              '  dist/validator_minified.js (built with build.py) \n' +
+          '--validator_js <fileOrUrl>', 'The Validator Javascript.\n' +
+              '  Latest published version by default, or\n' +
+              '  dist/validator_minified.js (built with build.py)\n' +
               '  for development.',
-          'https://cdn.ampproject.org/v0/validator.js');
-
-  program.command('* <fileOrUrlOrMinus...>')
-      .description('Validates list of files or urls (default).')
-      .action(function(fileOrUrlOrMinus) {
-        if (fileOrUrlOrMinus.length === 0) {
-          program.outputHelp();
-          process.exit(1);
-        }
-        for (var ii = 0; ii < fileOrUrlOrMinus.length; ii++) {
-          var item = fileOrUrlOrMinus[ii];
-          var input;
-          if (item === '-') {
-            input = readFromStdin();
-          } else if (isHttpOrHttpsUrl(item)) {
-            input = readFromUrl(item);
-          } else {
-            input = readFromFile(item);
-          }
-          input
-              .then(function(data) {
-                getInstance(program.validator_js)
-                    .then(function(validator) {
-                      var validationResult = validator.validateString(data);
-                      logValidationResult(item, validationResult);
-                      if (validationResult.status !== 'PASS') {
-                        process.exitCode = 1;
-                      }
-                    })
-                    .catch(function(error) {
-                      console.error(error.message);
-                      process.exitCode = 1;
-                    });
-
-              })
-              .catch(function(error) {
-                console.error(error.message);
-                process.exitCode = 1;
-              });
-        }
-      });
-
-  program.parse(process.argv);
-  if (program.args === 0) {
+          'https://cdn.ampproject.org/v0/validator.js')
+      .option(
+          '--format <color|text|json>', 'How to format the output.\n' +
+              '  "color" displays errors/warnings/success in\n' +
+              '          red/orange/green.\n' +
+              '  "text"  avoids color (e.g., useful in terminals not\n' +
+              '          supporting color).\n' +
+              '  "json"  emits json corresponding to the ValidationResult\n' +
+              '          message in validator.proto.',
+          'color')
+      .parse(process.argv);
+  if (program.args.length === 0) {
     program.outputHelp();
     process.exit(1);
   }
+  var inputs = [];
+  for (var ii = 0; ii < program.args.length; ii++) {
+    var item = program.args[ii];
+    if (item === '-') {
+      inputs.push(readFromStdin());
+    } else if (isHttpOrHttpsUrl(item)) {
+      inputs.push(readFromUrl(item));
+    } else {
+      inputs.push(readFromFile(item));
+    }
+  }
+  getInstance(program.validator_js)
+      .then(function(validator) {
+        Promise.all(inputs)
+            .then(function(resolvedInputs) {
+              var jsonOut = {};
+              for (var ii = 0; ii < resolvedInputs.length; ii++) {
+                var validationResult =
+                    validator.validateString(resolvedInputs[ii]);
+                if (program.format === 'json') {
+                  jsonOut[program.args[ii]] = validationResult;
+                } else {
+                  logValidationResult(
+                      program.args[ii], validationResult,
+                      program.format === 'color' ? true : false);
+                }
+                if (validationResult.status !== 'PASS') {
+                  process.exitCode = 1;
+                }
+              }
+              if (program.format === 'json') {
+                console.log(JSON.stringify(jsonOut))
+              }
+            })
+            .catch(function(error) {
+              console.error(
+                  program.format == 'color' ? colors.red(error.message) :
+                                              error.message);
+              process.exitCode = 1;
+            });
+      })
+      .catch(function(error) {
+        console.error(
+            program.format == 'color' ? colors.red(error.message) :
+                                        error.message);
+        process.exitCode = 1;
+      });
 }
 
 if (require.main === module) {

--- a/validator/index_test.js
+++ b/validator/index_test.js
@@ -22,6 +22,7 @@ global.assert = require('assert');
 var fs = require('fs');
 global.path = require('path');
 
+var execFile = require('child_process').execFile;
 var JasmineRunner = require('jasmine');
 var jasmine = new JasmineRunner();
 
@@ -122,6 +123,59 @@ it('handles syntax errors in validator file', function(done) {
         done();
       });
 });
+
+it('emits text if --format=text is specified on command line', function(done) {
+  var severalErrorsOut =
+      fs.readFileSync('testdata/feature_tests/several_errors.out', 'utf-8')
+          .split('\n')
+          .splice(1)  // trim 1st line
+          .join('\n')
+          .replace(/ \[[A-Z_]+\]/g, '');  // trim error categories
+  execFile(
+      process.execPath,
+      [
+        '../index.js', '--format=text',
+        '--validator_js=../dist/validator_minified.js',
+        'feature_tests/several_errors.html',
+        'feature_tests/minimum_valid_amp.html'
+      ],
+      {'cwd': 'testdata'},  // Run inside the testdata dir to match paths.
+      (error, stdout, stderr) => {
+        expect(error).toBeDefined();  // At least one file had errors.
+        expect(stderr).toBe(severalErrorsOut);
+        expect(stdout).toBe('feature_tests/minimum_valid_amp.html: PASS\n');
+        done();
+      });
+}, 5000);
+
+it('emits json if --format=json is specified on command line', function(done) {
+  execFile(
+      process.execPath,
+      [
+        '../index.js', '--format=json',
+        '--validator_js=../dist/validator_minified.js',
+        'feature_tests/several_errors.html',
+        'feature_tests/minimum_valid_amp.html'
+      ],
+      {'cwd': 'testdata'},  // Run inside the testdata dir to match paths.
+      (error, stdout, stderr) => {
+        expect(error).toBeDefined();  // At least one file had errors
+        expect(stderr).toBe('');      // entire json results will be on stdout
+
+        // We inspect the parsed JSON but not very deep, to keep this test
+        // relatively robust. We don't want it to churn if the validator
+        // changes its outputs slightly.
+        var parsedJson = JSON.parse(stdout);
+        expect(parsedJson['feature_tests/minimum_valid_amp.html'])
+            .toBeDefined();
+        expect(parsedJson['feature_tests/several_errors.html']).toBeDefined();
+        expect(parsedJson['feature_tests/minimum_valid_amp.html'].status)
+            .toBe('PASS');
+        expect(parsedJson['feature_tests/several_errors.html'].status)
+            .toBe('FAIL');
+        done();
+      });
+}, 5000);
 
 jasmine.onComplete(function(passed) { process.exit(passed ? 0 : 1); });
 jasmine.execute();

--- a/validator/package.json
+++ b/validator/package.json
@@ -15,6 +15,7 @@
     "amp-validator": "index.js"
   },
   "dependencies": {
+    "colors": "1.1.2",
     "commander": "2.9.0",
     "promise" : "7.1.1"
   },


### PR DESCRIPTION
Add --format option to command line tool, supporting --format=color, ￼…
--format=text, and --format=json. In color format, errors are red,
warnings are magenta, SUCCESS is green. In json format, a json
dictionary is emitted to stdout which maps from the input file name
to the ValidationResult object.