### PR TITLE
Progress toward running the Node.js API on ancient versions of Node.js.

### DIFF
--- a/validator/index_test.js
+++ b/validator/index_test.js
@@ -140,7 +140,7 @@ it('emits text if --format=text is specified on command line', function(done) {
         'feature_tests/minimum_valid_amp.html'
       ],
       {'cwd': 'testdata'},  // Run inside the testdata dir to match paths.
-      (error, stdout, stderr) => {
+      function (error, stdout, stderr) {
         expect(error).toBeDefined();  // At least one file had errors.
         expect(stderr).toBe(severalErrorsOut);
         expect(stdout).toBe('feature_tests/minimum_valid_amp.html: PASS\n');
@@ -158,7 +158,7 @@ it('emits json if --format=json is specified on command line', function(done) {
         'feature_tests/minimum_valid_amp.html'
       ],
       {'cwd': 'testdata'},  // Run inside the testdata dir to match paths.
-      (error, stdout, stderr) => {
+      function (error, stdout, stderr) {
         expect(error).toBeDefined();  // At least one file had errors
         expect(stderr).toBe('');      // entire json results will be on stdout
 

--- a/validator/package.json
+++ b/validator/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Validator for AMP HTML (www.ampproject.org)",
   "engines": {
-    "node": "^4.0.0"
+    "node": "^0.10.25"
   },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
Set the Node.js version to 0.10.25, the Node.js version from Ubuntu Trusty.

I have verified that index.js runs OK with that.
In index_test.js, fix an es6 construct to be old-style. But even with that
it won't pass with 0.10.25.
There's one remaining problem with running on Trusty: The shebang line
wants node, but on Trusty it's 'nodejs'. I will attempt to fix this in a
later revision.