### PR TITLE
Make CID generation depend on whenFirstVisible promise.

### DIFF
--- a/extensions/amp-analytics/0.1/cid-impl.js
+++ b/extensions/amp-analytics/0.1/cid-impl.js
@@ -121,6 +121,8 @@ class Cid {
         'The client id name must only use the characters ' +
         '[a-zA-Z0-9-_]+\nInstead found: %s', getCidStruct.scope);
     return consent.then(() => {
+      return viewerFor(this.win).whenFirstVisible();
+    }).then(() => {
       return getExternalCid(this, getCidStruct,
           opt_persistenceConsent || consent);
     });


### PR DESCRIPTION
This is just a defense-in-depth, so that when callers happen to ask before this time, we will not provide the value.