### PR TITLE
Disable option to activate autoplay with YT.

### DIFF
--- a/examples/youtube.amp.html
+++ b/examples/youtube.amp.html
@@ -17,7 +17,7 @@
     <amp-youtube
             data-videoid="mGENRKrdoGY"
             layout="responsive"
-            data-param-autoplay=1
+            data-param-controls=1
             width="480" height="270">
         <amp-img placeholder width="480" height="270" layout="responsive" src="https://i.ytimg.com/vi/mGENRKrdoGY/hqdefault.jpg"></amp-img>
     </amp-youtube>

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -86,7 +86,7 @@ class AmpYoutube extends AMP.BaseElement {
       delete params['autoplay'];
       user.warn('Autoplay is currently not support with amp-youtube.');
     }
-    src = addParamsToUrl(src, getDataParamsFromAttributes(this.element));
+    src = addParamsToUrl(src, params);
 
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -81,6 +81,11 @@ class AmpYoutube extends AMP.BaseElement {
 
     let src = `https://www.youtube.com/embed/${encodeURIComponent(this.videoid_)}?enablejsapi=1`;
 
+    const params = getDataParamsFromAttributes(this.element);
+    if ('autoplay' in params) {
+      delete params['autoplay'];
+      user.warn('Autoplay is currently not support with amp-youtube.');
+    }
     src = addParamsToUrl(src, getDataParamsFromAttributes(this.element));
 
     iframe.setAttribute('frameborder', '0');

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -210,8 +210,9 @@ describe('amp-youtube', function() {
       'data-param-my-param': 'hello world',
     }).then(yt => {
       const iframe = yt.querySelector('iframe');
-      expect(iframe.src).to.contain('autoplay=1');
       expect(iframe.src).to.contain('myParam=hello%20world');
+      // autoplay is temporarily black listed.
+      expect(iframe.src).to.not.contain('autoplay=1');
     });
   });
 });

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -68,6 +68,8 @@ Keys and values will be URI encoded. Keys will be camel cased.
 
 See [Youtube Embedded Player Parameters](https://developers.google.com/youtube/player_parameters) for more parameter options for youtube.
 
+Because of limitations in mobile browsers, the `autoplay` param is currently not supported. Follow [this issue](https://github.com/ampproject/amphtml/issues/3799) for updates on autoplay support in AMP.
+
 ## Validation
 
 See [amp-youtube rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii) in the AMP validator specification.

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -60,11 +60,11 @@ E.g. in https://www.youtube.com/watch?v=Z1q71gFeRqM Z1q71gFeRqM is the video id.
 
 **data-param-***
 
-All `data-param-*` attributes will be added as query parameter to the youtube iframe src. This may be used to pass custom values through to youtube plugins, such as autoplay.
+All `data-param-*` attributes will be added as query parameter to the youtube iframe src. This may be used to pass custom values through to youtube plugins, such as whether to show controls.
 
 Keys and values will be URI encoded. Keys will be camel cased.
 
-- `data-param-autoplay=1` becomes `&autoplay=1`
+- `data-param-controls=1` becomes `&controls=1`
 
 See [Youtube Embedded Player Parameters](https://developers.google.com/youtube/player_parameters) for more parameter options for youtube.
 


### PR DESCRIPTION
While autoplay is landing in mobile browsers (for now it is still blocked in Safari and Chrome), we deactivate this for now to ensure the experience if good when it becomes available. Autoplay support will be added back later this year with support for features like

- no autoplay off screen
- mute by default
- only autoplay a single video per page