### PR TITLE
Apply the filter to the editor contents.

### DIFF
--- a/validator/webui/@polymer/webui-errorlist/webui-errorlist.html
+++ b/validator/webui/@polymer/webui-errorlist/webui-errorlist.html
@@ -113,7 +113,9 @@
         this.filter = undefined;
         this.$.listboxErrors.render();
         removeParamFromLocationHashParams('filter');
+        this.fire('webui-errorlist-filter-changes', {'validationDelayMs': 0});
       },
+      getFilter: function() { return this.filter; },
       filterErrors: function(error) {
         // If no filter set, return all errors.
         if (this.filter === undefined) {
@@ -125,7 +127,20 @@
         }
       },
       handleSelect: function(e) {
-        var error = this.errors[this.selectedError];
+        // This.selectedError refers to the index into the filtered array,
+        // but this.errors is not filtered.
+        var filteredErrors;
+        if (this.filter === undefined) {
+          filteredErrors = this.errors;
+        } else {
+          filteredErrors = [];
+          for (var ii = 0; ii < this.errors.length; ii++) {
+            if (this.filter === this.errors[ii].category) {
+              filteredErrors.push(this.errors[ii]);
+            }
+          }
+        }
+        var error = filteredErrors[this.selectedError];
         if (!error) {
           return;
         }

--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -57,7 +57,7 @@
         // When the editor contents change, trigger validation (with a delay)
         // and propagate the validation errors into the editor (as line
         // widgets) and the listbox below the editor as clickable errors.
-        editor.addEventListener('amphtml-editor-changes', function(e) {
+        var refreshEditorAndErrors = function(e) {
           clearTimeout(validationTimeout);
           validationTimeout = setTimeout(function() {
 
@@ -89,6 +89,11 @@
               error.isError = error.severity === 'ERROR';
               error.isWarning = error.severity === 'WARNING';
               listbox.addError(error);
+
+              if (listbox.getFilter() !== undefined &&
+                  listbox.getFilter() !== error.category) {
+                continue;
+              }
 
               // Create a dom element for the inline display of errors
               // inside the editor. TODO(powdercloud): Make this a Polymer
@@ -129,7 +134,11 @@
               removeParamFromLocationHashParams('errno');
             }
           }, e.detail.validationDelayMs);
-        });
+        };
+
+        editor.addEventListener('amphtml-editor-changes', refreshEditorAndErrors);
+        listbox.addEventListener('webui-errorlist-filter-changes',
+                                        refreshEditorAndErrors);
 
         // Clicking in the error list at the bottom of the screen moves
         // the editor cursor.


### PR DESCRIPTION
webui-mainpage.html grabs the filter from the listbox and applies it.
The listbox fires filter changes, and we treat those like an editor refresh.
The errorlist is patched up so that when the selected error is sent
  in an event, the filter is applied.