### PR TITLE
Fixes 2 bugs in ALP parent finding.

### DIFF
--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -226,7 +226,7 @@ export function getA2AAncestor(win) {
     return null;
   }
   const amp = origins[origins.length - 2];
-  if (!ampOrigins.hasOwnProperty(amp)) {
+  if (!ampOrigins[amp] && !ampOrigins.hasOwnProperty(amp)) {
     return null;
   }
   return {
@@ -243,7 +243,7 @@ export function getA2AAncestor(win) {
 function getNthParentWindow(win, distance) {
   let parent = win;
   for (let i = 0; i < distance; i++) {
-    parent = win.parent;
+    parent = parent.parent;
   }
   return parent;
 }

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -36,6 +36,24 @@ describe('alp-handler', () => {
       Image: function() {
         image = this;
       },
+      postMessage: sandbox.stub(),
+      _id: 'base-win',
+    };
+    win.parent = {
+      postMessage: sandbox.stub(),
+      _id: 'p0',
+    };
+    win.parent.parent = {
+      postMessage: sandbox.stub(),
+      _id: 'p1',
+    };
+    win.parent.parent.parent = {
+      postMessage: sandbox.stub(),
+      _id: 'p2',
+    };
+    win.parent.parent.parent.parent = {
+      postMessage: sandbox.stub(),
+      _id: 'p3',
     };
     open = sandbox.stub(win, 'open', () => {
       return {};
@@ -84,18 +102,16 @@ describe('alp-handler', () => {
     expect(event.preventDefault.callCount).to.equal(1);
   }
 
-  function a2aSuccess() {
-    const parent = win.parent = {
-      postMessage: sandbox.stub(),
-    };
-    win.parent.parent = {};
+  function a2aSuccess(ampParent) {
     handleClick(event);
     expect(event.preventDefault.callCount).to.equal(1);
-    expect(parent.postMessage.callCount).to.equal(1);
-    expect(parent.postMessage.lastCall.args[0]).to.equal(
+    expect(ampParent.postMessage.callCount).to.equal(1);
+    expect(ampParent.postMessage.lastCall.args[0]).to.equal(
         'a2a;{"url":"https://cdn.ampproject.org/c/www.example.com/amp.html' +
         '#click=https%3A%2F%2Ftest.com%3Famp%3D1%26adurl%3Dhttps%253A%252F%' +
         '252Fcdn.ampproject.org%252Fc%252Fwww.example.com%252Famp.html"}');
+    expect(ampParent.postMessage.lastCall.args[1]).to.equal(
+        'https://cdn.ampproject.org');
     expect(open.callCount).to.equal(0);
   }
 
@@ -119,7 +135,7 @@ describe('alp-handler', () => {
       'https://cdn.ampproject.org',
       'https://www.google.com',
     ];
-    a2aSuccess();
+    a2aSuccess(win.parent);
   });
 
   it('should perform a2a navigation if appropriate (.de)', () => {
@@ -127,7 +143,37 @@ describe('alp-handler', () => {
       'https://cdn.ampproject.org',
       'https://www.google.de',
     ];
-    a2aSuccess();
+    a2aSuccess(win.parent);
+  });
+
+  it('should perform a2a navigation if appropriate nested: 1', () => {
+    win.location.ancestorOrigins = [
+      'https://3p.ampproject.net',
+      'https://cdn.ampproject.org',
+      'https://www.google.de',
+    ];
+    a2aSuccess(win.parent.parent);
+  });
+
+  it('should perform a2a navigation if appropriate nested: 2', () => {
+    win.location.ancestorOrigins = [
+      'https://some-domain.com',
+      'https://3p.ampproject.net',
+      'https://cdn.ampproject.org',
+      'https://www.google.de',
+    ];
+    a2aSuccess(win.parent.parent.parent);
+  });
+
+  it('should perform a2a navigation if appropriate nested: 3', () => {
+    win.location.ancestorOrigins = [
+      'https://some-domain.com',
+      'https://some-domain.com',
+      'https://3p.ampproject.net',
+      'https://cdn.ampproject.org',
+      'https://www.google.de',
+    ];
+    a2aSuccess(win.parent.parent.parent.parent);
   });
 
   it('should not perform a2a for other origins', () => {


### PR DESCRIPTION
1. Closure Compiler eliminated the `ampOrigins` variable, because it considers `hasOwnProperty` to not actually accessing the object. I think that is a bug.
2. Classic "off by N" error, by failure to properly assign the iteration variable.