### PR TITLE
Make sure that the update ref point is hidden on load

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -278,13 +278,14 @@ function getLiveBlogItem() {
 }
 
 // Will match live-blog max/min/none
-app.use('/examples.build/live-blog.amp.max.html', function(req, res, next) {
-  if ('amp_latest_update_time' in req.query) {
-    res.setHeader('Content-Type', 'text/html');
-    res.end(getLiveBlogItem());
-    return;
-  }
-  next();
+app.use('/examples.build/live-blog(-non-floating-button)?.amp.(min.|max.)?html',
+  function(req, res, next) {
+    if ('amp_latest_update_time' in req.query) {
+      res.setHeader('Content-Type', 'text/html');
+      res.end(getLiveBlogItem());
+      return;
+    }
+    next();
 });
 
 // Proxy with unminified JS.

--- a/css/amp.css
+++ b/css/amp.css
@@ -395,3 +395,11 @@ form [submit-success],
 form [submit-error] {
   display: none;
 }
+
+/**
+ * Hide the update reference point of amp-live-list by default. This is
+ * reset by the `amp-live-list > .amp-active[update]` selector.
+ */
+amp-live-list > [update] {
+  display: none;
+}

--- a/examples/live-blog-non-floating-button.amp.html
+++ b/examples/live-blog-non-floating-button.amp.html
@@ -129,31 +129,6 @@
       background: yellow;
     }
 
-    #live-list-update-button {
-      position: fixed;
-      top: 10px;
-      left: 50%;
-      transform: translateX(-50%);
-    }
-
-    .button {
-      border: none;
-      border-radius: 2px;
-
-      color: #fafafa;
-      height: 26px;
-      min-width: 32px;
-      padding: 0 16px;
-      margin: 0 16px;
-      text-transform: uppercase;
-      letter-spacing: 0;
-      cursor: pointer;
-      vertical-align: middle;
-      line-height: 26px;
-      text-align: center;
-      background: #3f51b5;
-    }
-
     .amp-live-list-item {
       border: 1px solid #dcdcdc;
       border-width: 1px 0 0;
@@ -162,6 +137,40 @@
     .social-box {
       text-align: right;
       margin: 10px 0;
+    }
+
+    .update-panel {
+      background-color: #f4f4f4;
+      border: 1px #dcdcdc solid;
+      height: 40px;
+      cursor: pointer;
+    }
+
+    .update-panel:hover {
+      background-color: #dcdcdc;
+    }
+
+    #live-blog-1 > .update-panel.amp-active {
+      display: flex;
+      overflow-y: hidden;
+      height: 100px;
+      max-height: 150px;
+      transition-property: height;
+      transition-duration: .5s;
+      transition-timing-function: ease-in;
+      align-items: center;
+      justify-content: center;
+    }
+
+    #live-blog-1 > .update-panel.amp-hidden {
+      max-height: 0;
+      overflow: hidden;
+      /*
+        We need this so that animation is triggered since by default the
+        update button is `display: none`
+       */
+      display: flex;
+      border-width: 0;
     }
 
     amp-live-list > [update] {
@@ -198,8 +207,10 @@
             data-poll-interval="15000"
             data-max-items-per-page="5"
             id="live-blog-1">
-            <button id="live-list-update-button" update class="button"
-                on="tap:live-blog-1.update">You have updates</button>
+            <div id="live-list-update-button" update class="update-panel"
+              on="tap:live-blog-1.update">
+              <a href="#">You have updates</a>
+            </div>
             <div items>
               <div id="live-blog-item-1" data-sort-time="1466669033418">
                 <h3 class="headline">

--- a/extensions/amp-live-list/0.1/amp-live-list.css
+++ b/extensions/amp-live-list/0.1/amp-live-list.css
@@ -22,14 +22,14 @@ amp-live-list > [update] {
   z-index: 1000 !important;
 }
 
+/* Reset the `display: none` set in amp.css */
+amp-live-list > .amp-active[update] {
+  display: block;
+}
+
 amp-live-list > [items] > [data-tombstone] {
   display: none;
 }
-
-amp-live-list > .amp-hidden[update] {
-  display: none;
-}
-
 
 .amp-live-list-item {
 }

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -192,7 +192,8 @@ export class AmpLiveList extends AMP.BaseElement {
      */
     this.curNumOfLiveItems_ = 0;
 
-    this.updateSlot_.classList.add('amp-hidden');
+    // Make sure we hide the button
+    this.toggleUpdateButton_(false);
     this.eachChildElement_(this.itemsSlot_, item => {
       item.classList.add(classes.ITEM);
     });
@@ -235,7 +236,7 @@ export class AmpLiveList extends AMP.BaseElement {
     // top of the component.
     if (this.pendingItemsInsert_.length > 0) {
       this.deferMutate(() => {
-        this.updateSlot_.classList.remove('amp-hidden');
+        this.toggleUpdateButton_(true);
       });
     } else if (this.pendingItemsReplace_.length > 0 ||
         this.pendingItemsTombstone_.length > 0) {
@@ -283,7 +284,7 @@ export class AmpLiveList extends AMP.BaseElement {
       }
 
       // Always hide update slot after mutation operation.
-      this.updateSlot_.classList.add('amp-hidden');
+      this.toggleUpdateButton_(false);
 
       // Insert and tombstone operations must happen first before we measure
       // number of items to delete down to `data-max-items-per-page`.
@@ -297,6 +298,18 @@ export class AmpLiveList extends AMP.BaseElement {
       });
     }
     return promise;
+  }
+
+  /**
+   * Sets the `amp-hidden` and `amp-active` classes on the `update` reference
+   * point.
+   *
+   * @param {boolean} visible
+   * @private
+   */
+  toggleUpdateButton_(visible) {
+    this.updateSlot_.classList.toggle('amp-hidden', !visible);
+    this.updateSlot_.classList.toggle('amp-active', visible);
   }
 
   /**

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -69,7 +69,8 @@ export class LiveListManager {
       if (getMode().localDev && (this.win.location.pathname == '/examples' +
             '.build/live-list-update.amp.max.html' ||
             this.win.location.pathname == '/examples.build/live-blog.amp' +
-            '.max.html')) {
+            '.max.html' || this.win.location.pathname == '/examples.build/' +
+            'live-blog-non-floating-button.amp.max.html')) {
         this.interval_ = 5000;
       }
 

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -256,6 +256,20 @@ If present the entry is assumed to be deleted.
 
 ## Styling
 
+On very slow connections the javascript and styles of the component
+might arrive later than when the body is unhidden (the amp-boilerplate
+style timesout) so we highly recommend adding the following styles below
+in your own `amp-custom` styles.
+
+```css
+amp-live-list > [update] {
+  display: none;
+}
+```
+
+When we apply the `amp-active` class to the update reference point it will set
+`display: block`.
+
 An `amp-live-list-item` class is added to all the children of the `items`
 reference point.
 
@@ -287,8 +301,9 @@ amp-live-list > [items] > [data-tombstone] {
 }
 ```
 
-An `.amp-hidden` class is added to the `update` reference point, and you can
-hook into this class to add transitions. (see Examples below)
+An `.amp-hidden` and `.amp-active` class is added to the `update`
+reference point, and you can hook into this class to add transitions.
+(see Examples below)
 
 ## Examples
 
@@ -302,6 +317,10 @@ the lowest one.
 ```html
 
 <style amp-custom>
+  amp-live-list > [update] {
+    display: none;
+  }
+
   #fixed-button {
     position: fixed;
     top: 10px;
@@ -309,11 +328,11 @@ the lowest one.
     transform: translateX(-50%)
   }
 
-  .slide {
+  .slide.amp-active {
     overflow-y: hidden;
     height: 100px;
     max-height: 150px;
-    transition-property: all;
+    transition-property: height;
     transition-duration: .2s;
     transition-timing-function: ease-in;
     background: #3f51b5;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -358,6 +358,7 @@ function buildExamples(watch) {
   buildExample('carousel.amp.html');
   buildExample('csp.amp.html');
   buildExample('layout-flex-item.amp.html');
+  buildExample('live-blog-non-floating-button.amp.html');
   buildExample('live-blog.amp.html');
   buildExample('live-list-update.amp.html');
   buildExample('live-list.amp.html');


### PR DESCRIPTION
This can be an issue on super slow connections where the amp-boilerplate has timed out and shown the body and the update button is floating (for fixed position buttons) but not clickable (has no actual update)