### PR TITLE
Add a .user-valid and .user-invalid to inputs, fieldsets and forms

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -11,20 +11,32 @@
     <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
     <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
     <style amp-custom>
-        input:invalid {
+        input.user-invalid {
             background-color: #dc4e41;
+        }
+
+        input.user-valid {
+            background-color: #4CAF50;
+        }
+
+        fieldset.user-invalid {
+            border: 3px solid #dc4e41;
+        }
+
+        fieldset.user-valid {
+            border: 3px solid #4CAF50;
         }
 
         form .form-message {
             display: none;
         }
 
-        form:invalid .invalid-message {
+        form.user-invalid .invalid-message {
             display: block;
             color: #dc4e41;
         }
 
-        form:valid .valid-message {
+        form.user-valid .valid-message {
             display: block;
             color: #4CAF50;
         }
@@ -73,10 +85,10 @@
         <input type="submit" value="Subscribe">
     </fieldset>
 
-    <div class="invalid-message">
+    <div class="form-message invalid-message">
         There are some input that needs fixing. Please fix them.
     </div>
-    <div class="valid-message">
+    <div class="form-message valid-message">
         Everything looks good, you can submit now!
     </div>
 </form>

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -59,7 +59,7 @@ const UserValidityState = {
 let validationBubble;
 
 
-/** @const {boolean} */
+/** @type {boolean|undefined} */
 let reportValiditySupported;
 
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -78,7 +78,7 @@ export function setReportValiditySupported(isSupported) {
  */
 function isReportValiditySupported() {
   if (reportValiditySupported === undefined) {
-    reportValiditySupported = element.reportValidity;
+    reportValiditySupported = !!document.createElement('form').reportValidity;
   }
   return reportValiditySupported;
 }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -24,9 +24,9 @@ import {toArray} from '../../../src/types';
 import {startsWith} from '../../../src/string';
 import {templatesFor} from '../../../src/template';
 import {
-    removeElement,
-    childElementByAttr,
-    ancestorElementsByTag,
+  removeElement,
+  childElementByAttr,
+  ancestorElementsByTag,
 } from '../../../src/dom';
 import {installStyles} from '../../../src/styles';
 import {CSS} from '../../../build/amp-form-0.1.css';
@@ -74,11 +74,12 @@ export function setReportValiditySupported(isSupported) {
 
 /**
  * Returns whether reportValidity API is supported.
+ * @param {!Document} doc
  * @return {boolean}
  */
-function isReportValiditySupported() {
+function isReportValiditySupported(doc) {
   if (reportValiditySupported === undefined) {
-    reportValiditySupported = !!document.createElement('form').reportValidity;
+    reportValiditySupported = !!doc.createElement('form').reportValidity;
   }
   return reportValiditySupported;
 }
@@ -317,7 +318,7 @@ function onInvalidInputBlur_(event) {
  * @param {!HTMLInputElement} input
  */
 function reportInputValidity(input) {
-  if (isReportValiditySupported()) {
+  if (isReportValiditySupported(input.ownerDocument)) {
     input.reportValidity();
   } else {
     input./*OK*/focus();
@@ -424,7 +425,7 @@ function checkUserValidity(element, propagate = false) {
  */
 export function onInputInteraction_(e) {
   const input = e.target;
-  checkUserValidity(input, /** propagate */ true);
+  checkUserValidity(input, /* propagate */ true);
 }
 
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -378,6 +378,9 @@ function getUserValidityStateFor(element) {
  * sense approach for when to apply these classes. As the specs gets clearer, we should
  * strive to match it as much as possible.
  *
+ * TODO(#4317): Follow up on ancestor propagation behavior and understand the future
+ *              specs for the :user-valid/:user-inavlid.
+ *
  * @param {!HTMLInputElement|!HTMLFormElement|!HTMLFieldSetElement} element
  * @param {boolean=} propagate Whether to propagate the user validity to ancestors.
  * @returns {boolean} Whether the element is valid or not.

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -16,10 +16,10 @@
 
 import {createIframePromise} from '../../../../testing/iframe';
 import {
-    AmpForm,
-    installAmpForm,
-    setReportValiditySupported,
-    onInputInteraction_,
+  AmpForm,
+  installAmpForm,
+  setReportValiditySupported,
+  onInputInteraction_,
 } from '../amp-form';
 import * as sinon from 'sinon';
 import {timer} from '../../../../src/timer';
@@ -546,15 +546,17 @@ describe('amp-form', () => {
         emailInput.setAttribute('type', 'email');
         emailInput.setAttribute('required', '');
         fieldset.appendChild(emailInput);
+        const usernameInput = document.createElement('input');
+        usernameInput.setAttribute('name', 'nickname');
+        usernameInput.setAttribute('required', '');
+        fieldset.appendChild(usernameInput);
         form.appendChild(fieldset);
         sandbox.spy(form, 'checkValidity');
         sandbox.spy(emailInput, 'checkValidity');
         sandbox.spy(fieldset, 'checkValidity');
         sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
-        const event = {target: emailInput};
-        onInputInteraction_(event);
-
+        onInputInteraction_({target: emailInput});
         expect(form.checkValidity.called).to.be.true;
         expect(emailInput.checkValidity.called).to.be.true;
         expect(fieldset.checkValidity.called).to.be.true;
@@ -562,10 +564,47 @@ describe('amp-form', () => {
         expect(emailInput.className).to.contain('user-invalid');
         expect(fieldset.className).to.contain('user-invalid');
 
+        // No interaction happened with usernameInput, so no user-class should
+        // be added at this point.
+        expect(usernameInput.className).to.not.contain('user-invalid');
+        expect(usernameInput.className).to.not.contain('user-valid');
+
+
         emailInput.value = 'cool@bea.ns';
-        onInputInteraction_(event);
-        expect(form.className).to.contain('user-valid');
+        onInputInteraction_({target: emailInput});
         expect(emailInput.className).to.contain('user-valid');
+        expect(form.className).to.contain('user-invalid');
+        expect(fieldset.className).to.contain('user-invalid');
+
+        // Still no interaction.
+        expect(usernameInput.className).to.not.contain('user-invalid');
+        expect(usernameInput.className).to.not.contain('user-valid');
+
+        // Both inputs back to invalid.
+        emailInput.value = 'invalid-value';
+        onInputInteraction_({target: emailInput});
+        expect(emailInput.className).to.contain('user-invalid');
+        expect(form.className).to.contain('user-invalid');
+        expect(fieldset.className).to.contain('user-invalid');
+
+        // Still no interaction.
+        expect(usernameInput.className).to.not.contain('user-invalid');
+        expect(usernameInput.className).to.not.contain('user-valid');
+
+        // Only email input is invalid now.
+        usernameInput.value = 'coolbeans';
+        onInputInteraction_({target: usernameInput});
+        expect(emailInput.className).to.contain('user-invalid');
+        expect(form.className).to.contain('user-invalid');
+        expect(usernameInput.className).to.contain('user-valid');
+        expect(fieldset.className).to.contain('user-invalid');
+
+        // Both input are finally valid.
+        emailInput.value = 'cool@bea.ns';
+        onInputInteraction_({target: emailInput});
+        expect(emailInput.className).to.contain('user-valid');
+        expect(usernameInput.className).to.contain('user-valid');
+        expect(form.className).to.contain('user-valid');
         expect(fieldset.className).to.contain('user-valid');
       });
     });

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -551,7 +551,7 @@ describe('amp-form', () => {
         sandbox.spy(fieldset, 'checkValidity');
         sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
-        const event = { target: emailInput };
+        const event = {target: emailInput};
         onInputInteraction_(event);
 
         expect(form.checkValidity.called).to.be.true;
@@ -586,7 +586,7 @@ describe('amp-form', () => {
         sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
         emailInput.value = 'cool@bea.ns';
-        const event = { target: emailInput };
+        const event = {target: emailInput};
         onInputInteraction_(event);
 
         expect(emailInput.checkValidity.called).to.be.true;

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -15,7 +15,12 @@
  */
 
 import {createIframePromise} from '../../../../testing/iframe';
-import {AmpForm, installAmpForm} from '../amp-form';
+import {
+    AmpForm,
+    installAmpForm,
+    setReportValiditySupported,
+    onInputInteraction_,
+} from '../amp-form';
 import * as sinon from 'sinon';
 import {timer} from '../../../../src/timer';
 import '../../../amp-mustache/0.1/amp-mustache';
@@ -100,13 +105,25 @@ describe('amp-form', () => {
     expect(() => new AmpForm(form)).to.not.throw;
   });
 
-  it('should listen to submit event', () => {
+  it('should listen to submit event and inputs blur and input events', () => {
     const form = getForm();
+    const nameInput = form.querySelector('input[name=name]');
+    nameInput.addEventListener = sandbox.spy();
+    const emailInput = document.createElement('input');
+    emailInput.addEventListener = sandbox.spy();
+    form.addEventListener = sandbox.spy();
+    emailInput.setAttribute('type', 'email');
+    form.appendChild(emailInput);
     form.addEventListener = sandbox.spy();
     form.setAttribute('action-xhr', 'https://example.com');
     new AmpForm(form);
     expect(form.addEventListener.called).to.be.true;
     expect(form.addEventListener.calledWith('submit')).to.be.true;
+    expect(nameInput.addEventListener.calledWith('blur')).to.be.true;
+    expect(nameInput.addEventListener.calledWith('input')).to.be.true;
+    expect(emailInput.addEventListener.calledWith('blur')).to.be.true;
+    expect(emailInput.addEventListener.calledWith('input')).to.be.true;
+    expect(form.className).to.contain('-amp-form');
   });
 
   it('should do nothing if already submitted', () => {
@@ -127,22 +144,45 @@ describe('amp-form', () => {
   });
 
   it('should respect novalidate on a form', () => {
+    setReportValiditySupported(true);
     const form = getForm();
     form.setAttribute('novalidate', '');
+    const emailInput = document.createElement('input');
+    emailInput.setAttribute('name', 'email');
+    emailInput.setAttribute('type', 'email');
+    emailInput.setAttribute('required', '');
+    form.appendChild(emailInput);
     const ampForm = new AmpForm(form);
     const event = {
       stopImmediatePropagation: sandbox.spy(),
       target: form,
       preventDefault: sandbox.spy(),
     };
+    ampForm.vsync_ = {
+      run: (task, state) => {
+        if (task.measure) {
+          task.measure(state);
+        }
+        if (task.mutate) {
+          task.mutate(state);
+        }
+      },
+    };
     sandbox.spy(form, 'checkValidity');
+    sandbox.spy(emailInput, 'reportValidity');
     ampForm.xhrAction_ = null;
     ampForm.handleSubmit_(event);
+    // Check validity should always be called regardless of novalidate.
+    expect(form.checkValidity.called).to.be.true;
+
+    // However reporting validity shouldn't happen when novalidate.
+    expect(emailInput.reportValidity.called).to.be.false;
     expect(event.preventDefault.called).to.be.false;
-    expect(form.checkValidity.called).to.be.false;
+    expect(form.hasAttribute('amp-novalidate')).to.be.true;
   });
 
   it('should check validity and report when invalid', () => {
+    setReportValiditySupported(false);
     return getAmpForm().then(ampForm => {
       const form = ampForm.form_;
       const emailInput = document.createElement('input');
@@ -456,4 +496,107 @@ describe('amp-form', () => {
       });
     });
   });
+
+  describe('User Validity', () => {
+    it('should manage valid/invalid on input/fieldset/form on submit', () => {
+      setReportValiditySupported(false);
+      return getAmpForm(true).then(ampForm => {
+        const form = ampForm.form_;
+        const fieldset = document.createElement('fieldset');
+        const emailInput = document.createElement('input');
+        emailInput.setAttribute('name', 'email');
+        emailInput.setAttribute('type', 'email');
+        emailInput.setAttribute('required', '');
+        fieldset.appendChild(emailInput);
+        form.appendChild(fieldset);
+        sandbox.spy(form, 'checkValidity');
+        sandbox.spy(emailInput, 'checkValidity');
+        sandbox.spy(fieldset, 'checkValidity');
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
+
+        const event = {
+          target: ampForm.form_,
+          preventDefault: sandbox.spy(),
+        };
+        ampForm.handleSubmit_(event);
+
+        expect(form.checkValidity.called).to.be.true;
+        expect(emailInput.checkValidity.called).to.be.true;
+        expect(fieldset.checkValidity.called).to.be.true;
+        expect(form.className).to.contain('user-invalid');
+        expect(emailInput.className).to.contain('user-invalid');
+        expect(fieldset.className).to.contain('user-invalid');
+
+        emailInput.value = 'cool@bea.ns';
+        ampForm.handleSubmit_(event);
+        expect(form.className).to.contain('user-valid');
+        expect(emailInput.className).to.contain('user-valid');
+        expect(fieldset.className).to.contain('user-valid');
+      });
+    });
+
+    it('should manage valid/invalid on input user interaction', () => {
+      setReportValiditySupported(false);
+      return getAmpForm(true).then(ampForm => {
+        const form = ampForm.form_;
+        const fieldset = document.createElement('fieldset');
+        const emailInput = document.createElement('input');
+        emailInput.setAttribute('name', 'email');
+        emailInput.setAttribute('type', 'email');
+        emailInput.setAttribute('required', '');
+        fieldset.appendChild(emailInput);
+        form.appendChild(fieldset);
+        sandbox.spy(form, 'checkValidity');
+        sandbox.spy(emailInput, 'checkValidity');
+        sandbox.spy(fieldset, 'checkValidity');
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
+
+        const event = { target: emailInput };
+        onInputInteraction_(event);
+
+        expect(form.checkValidity.called).to.be.true;
+        expect(emailInput.checkValidity.called).to.be.true;
+        expect(fieldset.checkValidity.called).to.be.true;
+        expect(form.className).to.contain('user-invalid');
+        expect(emailInput.className).to.contain('user-invalid');
+        expect(fieldset.className).to.contain('user-invalid');
+
+        emailInput.value = 'cool@bea.ns';
+        onInputInteraction_(event);
+        expect(form.className).to.contain('user-valid');
+        expect(emailInput.className).to.contain('user-valid');
+        expect(fieldset.className).to.contain('user-valid');
+      });
+    });
+
+    it('should propagates user-valid only when going from invalid', () => {
+      setReportValiditySupported(false);
+      return getAmpForm(true).then(ampForm => {
+        const form = ampForm.form_;
+        const fieldset = document.createElement('fieldset');
+        const emailInput = document.createElement('input');
+        emailInput.setAttribute('name', 'email');
+        emailInput.setAttribute('type', 'email');
+        emailInput.setAttribute('required', '');
+        fieldset.appendChild(emailInput);
+        form.appendChild(fieldset);
+        sandbox.spy(form, 'checkValidity');
+        sandbox.spy(emailInput, 'checkValidity');
+        sandbox.spy(fieldset, 'checkValidity');
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
+
+        emailInput.value = 'cool@bea.ns';
+        const event = { target: emailInput };
+        onInputInteraction_(event);
+
+        expect(emailInput.checkValidity.called).to.be.true;
+        expect(form.checkValidity.called).to.be.false;
+        expect(fieldset.checkValidity.called).to.be.false;
+        expect(emailInput.className).to.contain('user-valid');
+        expect(form.className).to.not.contain('user-valid');
+        expect(fieldset.className).to.not.contain('user-valid');
+      });
+    });
+  });
+
 });

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -353,7 +353,7 @@ describe('amp-form', () => {
       expect(form.className).to.not.contain('amp-form-submit-error');
       expect(form.className).to.not.contain('amp-form-submit-success');
       fetchJsonResolver();
-      return timer.promise(20).then(() => {
+      return timer.promise(0).then(() => {
         expect(ampForm.state_).to.equal('submit-success');
         expect(form.className).to.not.contain('amp-form-submitting');
         expect(form.className).to.not.contain('amp-form-submit-error');
@@ -516,6 +516,7 @@ describe('amp-form', () => {
 
         const event = {
           target: ampForm.form_,
+          stopImmediatePropagation: sandbox.spy(),
           preventDefault: sandbox.spy(),
         };
         ampForm.handleSubmit_(event);

--- a/extensions/amp-form/0.1/test/test-validation-bubble.js
+++ b/extensions/amp-form/0.1/test/test-validation-bubble.js
@@ -62,7 +62,7 @@ describe('validation-bubble', () => {
       bubble.show(targetEl, 'Hello World');
       expect(bubbleEl).to.not.be.null;
       expect(bubbleEl.textContent).to.equal('Hello World');
-      expect(bubbleEl.style.display).to.equal('');
+      expect(bubbleEl.style.display).to.equal('block');
       expect(bubbleEl.style.top).to.equal('290px');
       expect(bubbleEl.style.left).to.equal('500px');
 

--- a/extensions/amp-form/0.1/validation-bubble.js
+++ b/extensions/amp-form/0.1/validation-bubble.js
@@ -105,7 +105,7 @@ function measureTargetElement(state) {
 function showBubbleElement(state) {
   state.bubbleElement.textContent = state.message;
   setStyles(state.bubbleElement, {
-    display: '',
+    display: 'block',
     top: `${state.targetRect.top - 10}px`,
     left: `${state.targetRect.left + state.targetRect.width / 2}px`,
   });

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -68,7 +68,7 @@ export function onDocumentFormSubmit_(e) {
   const isAmpFormMarked = form.classList.contains('-amp-form');
   let shouldValidate;
   if (isAmpFormMarked) {
-    shouldValidate = !form.hasAttribute('-amp-novalidate');
+    shouldValidate = !form.hasAttribute('amp-novalidate');
   } else {
     shouldValidate = !form.hasAttribute('novalidate');
   }

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -62,7 +62,16 @@ export function onDocumentFormSubmit_(e) {
   user.assert(target, 'form target attribute is required: %s', form);
   user.assert(target == '_blank' || target == '_top',
       'form target=%s is invalid can only be _blank or _top: %s', target, form);
-  const shouldValidate = !form.hasAttribute('novalidate');
+
+  // amp-form extension will add novalidate to all forms to manually trigger
+  // validation. In that case `novalidate` doesn't have the same meaning.
+  const isAmpFormMarked = form.classList.contains('-amp-form');
+  let shouldValidate;
+  if (isAmpFormMarked) {
+    shouldValidate = !form.hasAttribute('-amp-novalidate');
+  } else {
+    shouldValidate = !form.hasAttribute('novalidate');
+  }
 
   // Safari does not trigger validation check on submission, hence we
   // trigger it manually. In other browsers this would never execute since

--- a/src/dom.js
+++ b/src/dom.js
@@ -438,16 +438,16 @@ export function hasNextNodeInDocumentOrder(element) {
 
 
 /**
- * Finds all ancestor elements that satisfies the callback.
+ * Finds all ancestor elements that satisfies predicate.
  * @param {!Element} child
- * @param {function(!Element):boolean} callback
+ * @param {function(!Element):boolean} predicate
  * @return {!Array<!Element>}
  */
-export function ancestorElements(child, callback) {
+export function ancestorElements(child, predicate) {
   const ancestors = [];
   for (let ancestor = child.parentElement; ancestor;
        ancestor = ancestor.parentElement) {
-    if (callback(ancestor)) {
+    if (predicate(ancestor)) {
       ancestors.push(ancestor);
     }
   }
@@ -459,12 +459,12 @@ export function ancestorElements(child, callback) {
  * Finds all ancestor elements that has the specified tag name.
  * @param {!Element} child
  * @param {string} attr
- * @return {!Array.<!Element>}
+ * @return {!Array<!Element>}
  */
 export function ancestorElementsByTag(child, tagName) {
-  const upperTagName = tagName.toUpperCase();
+  tagName = tagName.toUpperCase();
   return ancestorElements(child, el => {
-    return el.tagName == upperTagName;
+    return el.tagName == tagName;
   });
 }
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -438,6 +438,38 @@ export function hasNextNodeInDocumentOrder(element) {
 
 
 /**
+ * Finds all ancestor elements that satisfies the callback.
+ * @param {!Element} child
+ * @param {function(!Element):boolean} callback
+ * @return {!Array<!Element>}
+ */
+export function ancestorElements(child, callback) {
+  const ancestors = [];
+  for (let ancestor = child.parentElement; ancestor;
+       ancestor = ancestor.parentElement) {
+    if (callback(ancestor)) {
+      ancestors.push(ancestor);
+    }
+  }
+  return ancestors;
+}
+
+
+/**
+ * Finds all ancestor elements that has the specified tag name.
+ * @param {!Element} child
+ * @param {string} attr
+ * @return {!Array.<!Element>}
+ */
+export function ancestorElementsByTag(child, tagName) {
+  const upperTagName = tagName.toUpperCase();
+  return ancestorElements(child, el => {
+    return el.tagName == upperTagName;
+  });
+}
+
+
+/**
  * This method wraps around window's open method. It first tries to execute
  * `open` call with the provided target and if it fails, it retries the call
  * with the `_top` target. This is necessary given that in some embedding

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -318,6 +318,35 @@ describe('DOM', () => {
     expect(dom.lastChildElementByAttr(parent, 'on-child')).to.be.null;
   });
 
+  it('ancestorElements should find all matches', () => {
+    const parent = document.createElement('parent');
+    const element1 = document.createElement('element1');
+    parent.appendChild(element1);
+    const element2 = document.createElement('element2');
+    element1.appendChild(element2);
+    expect(dom.ancestorElements(element2, () => true).length).to.equal(2);
+    expect(dom.ancestorElements(element2, e => e.tagName == 'ELEMENT1').length)
+        .to.equal(1);
+    expect(dom.ancestorElements(element1, e => e.tagName == 'PARENT').length)
+        .to.equal(1);
+    expect(dom.ancestorElements(parent, e => e.tagName == 'ELEMENT3').length)
+        .to.be.equal(0);
+  });
+
+  it('ancestorElementsByTag should find all matches', () => {
+    const parent = document.createElement('parent');
+    const element1 = document.createElement('element1');
+    parent.appendChild(element1);
+    const element2 = document.createElement('element2');
+    element1.appendChild(element2);
+    expect(dom.ancestorElementsByTag(element2, 'ELEMENT1').length)
+        .to.equal(1);
+    expect(dom.ancestorElementsByTag(element1, 'PARENT').length)
+        .to.equal(1);
+    expect(dom.ancestorElementsByTag(element2, 'ELEMENT3').length)
+        .to.be.equal(0);
+  });
+
   describe('contains', () => {
     let connectedElement;
     let connectedChild;


### PR DESCRIPTION
This would allow publishers to better handling and direct users attention when the fields they're interacting with become valid/invalid. As opposed to the `:valid` and `:invalid` pseudo classes which get applied on the document load.

See [:user-invalid spec](https://drafts.csswg.org/selectors-4/#user-pseudos) and [:-moz-ui-invalid](https://developer.mozilla.org/en-US/docs/Web/CSS/%3A-moz-ui-invalid) - I don't try to match Mozilla prefixed. Instead I apply these classes when user interacts with the inputs.

- [x] Add tests
- [x] Open an issue to track polyfilling fieldset.checkValidity - #3898.

ITI: #3343 

[Play around with the demo here](https://amp-mk-1.herokuapp.com/examples.build/forms.amp.max.html) to see how this works. I over-did the styling to showcase the different hooks at each level. Note that you might have to wait 2 minutes for the heroku instance to start.