### PR TITLE
[amp-experiment] Exposes isDismissed() method in AmpUserNotification

### DIFF
--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -335,7 +335,7 @@ export class UserNotificationManager {
    * Retrieve a promise associated to an `amp-user-notification` component
    * that is resolved when user agrees to the terms.
    * @param {string} id
-   * @return {!Promise<>}
+   * @return {!Promise<!AmpUserNotification>}
    */
   get(id) {
     this.managerReadyPromise_.then(() => {

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -65,6 +65,14 @@ class NotificationInterface {
    * @return {!Promise}
    */
   show() {}
+
+  /**
+   * Returns whether this notification has been dismissed and the dismissal
+   * has been persisted in storage. Returns false if storage throws error or
+   * 'data-persist-dismissal' is disabled.
+   * @return {!Promise<boolean>}
+   */
+  isDismissed() {}
 }
 
 /**
@@ -263,12 +271,7 @@ export class AmpUserNotification extends AMP.BaseElement {
     return this.dialogPromise_;
   }
 
-  /**
-   * Returns whether this notification has been dismissed and the dismissal
-   * has been persisted in storage. Returns false if storage throws error or
-   * 'data-persist-dismissal' is disabled.
-   * @return {!Promise<boolean>}
-   */
+  /** @override */
   isDismissed() {
     if (!this.persistDismissal_) {
       return Promise.resolve(false);
@@ -334,7 +337,7 @@ export class UserNotificationManager {
    * Retrieve a promise associated to an `amp-user-notification` component
    * that is resolved when user agrees to the terms.
    * @param {string} id
-   * @return {!Promise<!AmpUserNotification>}
+   * @return {!Promise<!NotificationInterface>}
    */
   get(id) {
     this.managerReadyPromise_.then(() => {
@@ -348,7 +351,7 @@ export class UserNotificationManager {
   /**
    * Register an instance of `amp-user-notification`.
    * @param {string} id
-   * @param {!AmpUserNotification} userNotification
+   * @param {!NotificationInterface} userNotification
    * @return {!Promise}
    * @package
    */

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -275,11 +275,10 @@ export class AmpUserNotification extends AMP.BaseElement {
     }
     return this.storagePromise_
         .then(storage => storage.get(this.storageKey_))
-        .catch(reason => {
+        .then(persistedValue => !!persistedValue, reason => {
           dev.error(TAG, 'Failed to read storage', reason);
           return false;
-        })
-        .then(persistedValue => !!persistedValue);
+        });
   }
 
   /**


### PR DESCRIPTION
Also makes the UserNotificationManager.get() to return a promise of AmpUserNotification object.

isDismissed() will later be used by amp-experiment to check if a notification has been dismissed before (consent has been accepted). If not, the experiment will not take effect on the current page view. Experiment should never wait for a consent on the current page view.

