### PR TITLE
Only perform URL requesting prefetches when viewer is visible.

### DIFF
--- a/src/base-element.js
+++ b/src/base-element.js
@@ -54,7 +54,8 @@ import {vsyncFor} from './vsync';
  *           ||
  *           || buildCallback
  *           || !getPlaceholder() => createPlaceholderCallback
- *           || preconnectCallback may be called N times after this.
+ *           || preconnectCallback may be called N times after this, but only
+ *           || after the doc becomes visible.
  *           || pauseCallback may be called N times after this.
  *           || resumeCallback may be called N times after this.
  *           ||

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -24,6 +24,7 @@ import {getService} from './service';
 import {parseUrl} from './url';
 import {timer} from './timer';
 import {platformFor} from './platform';
+import {viewerFor} from './viewer';
 
 const ACTIVE_CONNECTION_TIMEOUT_MS = 180 * 1000;
 const PRECONNECT_TIMEOUT_MS = 10 * 1000;
@@ -57,6 +58,9 @@ export class Preconnect {
 
     /** @private {boolean} */
     this.preloadSupported_ = this.isPreloadSupported_();
+
+    /** @private @const {!./service/viewer-impl.Viewer} */
+    this.viewer_ = viewerFor(win);
   }
 
   /**
@@ -96,6 +100,7 @@ export class Preconnect {
     const preconnect = this.document_.createElement('link');
     preconnect.setAttribute('rel', 'preconnect');
     preconnect.setAttribute('href', origin);
+    preconnect.setAttribute('referrerpolicy', 'origin');
     this.head_.appendChild(dns);
     this.head_.appendChild(preconnect);
 
@@ -129,18 +134,21 @@ export class Preconnect {
     const command = this.preloadSupported_ ? 'preload' : 'prefetch';
     this.urls_[url] = true;
     this.url(url, /* opt_alsoConnecting */ true);
-    const prefetch = this.document_.createElement('link');
-    prefetch.setAttribute('rel', command);
-    prefetch.setAttribute('href', url);
-    // Do not set 'as' attribute for now, for 2 reasons
-    // - document value is not yet supported and dropped
-    // - script is blocked due to CSP.
-    // if (opt_preloadAs) {
-    //  prefetch.setAttribute('as', opt_preloadAs);
-    // }
-    this.head_.appendChild(prefetch);
-    // As opposed to preconnect we do not clean this tag up, because there is
-    // no expectation as to it having an immediate effect.
+    this.viewer_.whenFirstVisible().then(() => {
+      const prefetch = this.document_.createElement('link');
+      prefetch.setAttribute('rel', command);
+      prefetch.setAttribute('href', url);
+      prefetch.setAttribute('referrerpolicy', 'origin');
+      // Do not set 'as' attribute for now, for 2 reasons
+      // - document value is not yet supported and dropped
+      // - script is blocked due to CSP.
+      // if (opt_preloadAs) {
+      //  prefetch.setAttribute('as', opt_preloadAs);
+      // }
+      this.head_.appendChild(prefetch);
+      // As opposed to preconnect we do not clean this tag up, because there is
+      // no expectation as to it having an immediate effect.
+    });
   }
 
   isInterestingUrl_(url) {
@@ -185,18 +193,22 @@ export class Preconnect {
     if (!this.platform_.isSafari()) {
       return;
     }
-    // Don't attempt to preconnect for ACTIVE_CONNECTION_TIMEOUT_MS since
-    // we effectively create an active connection.
-    // TODO(@cramforce): Confirm actual http2 timeout in Safari.
-    this.origins_[origin] = timer.now() + ACTIVE_CONNECTION_TIMEOUT_MS;
-    const url = origin +
-        '/amp_preconnect_polyfill_404_or_other_error_expected.' +
-        '_Do_not_worry_about_it?' + Math.random();
-    // We use an XHR without withCredentials(true), so we do not send cookies
-    // to the host and the host cannot set cookies.
-    const xhr = new XMLHttpRequest();
-    xhr.open('HEAD', url, true);
-    xhr.send();
+
+    this.viewer_.whenFirstVisible().then(() => {
+      // Don't attempt to preconnect for ACTIVE_CONNECTION_TIMEOUT_MS since
+      // we effectively create an active connection.
+      // TODO(@cramforce): Confirm actual http2 timeout in Safari.
+      this.origins_[origin] = timer.now() + ACTIVE_CONNECTION_TIMEOUT_MS;
+      const url = origin +
+          '/amp_preconnect_polyfill_404_or_other_error_expected.' +
+          '_Do_not_worry_about_it?' + Math.random();
+      // We use an XHR without withCredentials(true), so we do not send cookies
+      // to the host and the host cannot set cookies.
+      const xhr = new XMLHttpRequest();
+      xhr.open('HEAD', url, true);
+
+      xhr.send();
+    });
   }
 }
 

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -222,14 +222,17 @@ describe('3p-frame', () => {
     const origPreloadSupportValue = preconnect.preloadSupported_;
     preconnect.preloadSupported_ = false;
     prefetchBootstrap(window);
-    const fetches = document.querySelectorAll(
-        'link[rel=prefetch]');
-    expect(fetches).to.have.length(2);
-    expect(fetches[0].href).to.equal(
-        'http://ads.localhost:9876/dist.3p/current/frame.max.html');
-    expect(fetches[1].href).to.equal(
-        'https://3p.ampproject.net/$internalRuntimeVersion$/f.js');
-    preconnect.preloadSupported_ = origPreloadSupportValue;
+    // Wait for visible promise
+    return Promise.resolve().then(() => {
+      const fetches = document.querySelectorAll(
+          'link[rel=prefetch]');
+      expect(fetches).to.have.length(2);
+      expect(fetches[0].href).to.equal(
+          'http://ads.localhost:9876/dist.3p/current/frame.max.html');
+      expect(fetches[1].href).to.equal(
+          'https://3p.ampproject.net/$internalRuntimeVersion$/f.js');
+      preconnect.preloadSupported_ = origPreloadSupportValue;
+    });
   });
 
   it('should make sub domains (unique)', () => {

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -25,6 +25,7 @@ describe('preconnect', () => {
   let preconnect;
   let preloadSupported;
   let isSafari;
+  let visible;
 
   // Factored out to make our linter happy since we don't allow
   // bare javascript URLs.
@@ -43,17 +44,20 @@ describe('preconnect', () => {
           return isSafari;
         });
       }
+      sandbox.stub(preconnect.viewer_, 'whenFirstVisible', () => {
+        return visible;
+      });
       return iframe;
     });
   }
   beforeEach(() => {
+    visible = Promise.resolve();
     isSafari = undefined;
     // Default mock to not support preload - override in cases to test for
     // preload support.
     preloadSupported = false;
     sandbox = sinon.sandbox.create();
     clock = sandbox.useFakeTimers();
-    preconnect = preconnectFor(window);
   });
 
   afterEach(() => {
@@ -76,9 +80,14 @@ describe('preconnect', () => {
           .to.have.length(1);
       expect(iframe.doc.querySelector('link[rel=preconnect]').href)
           .to.equal('https://a.preconnect.com/');
-      expect(iframe.doc.querySelectorAll('link[rel=prefetch]'))
-          .to.have.length(0);
-      expect(open.callCount).to.equal(0);
+      expect(
+          iframe.doc.querySelector('link[rel=preconnect]')
+              .getAttribute('referrerpolicy')).to.equal('origin');
+      return visible.then(() => {
+        expect(iframe.doc.querySelectorAll('link[rel=prefetch]'))
+            .to.have.length(0);
+        expect(open.callCount).to.equal(0);
+      });
     });
   });
 
@@ -100,11 +109,14 @@ describe('preconnect', () => {
           .to.equal('https://s.preconnect.com/');
       expect(iframe.doc.querySelectorAll('link[rel=prefetch]'))
           .to.have.length(0);
-      expect(open.callCount).to.equal(1);
-      expect(send.callCount).to.equal(1);
-      expect(open.args[0][1]).to.include(
-          'https://s.preconnect.com/amp_preconnect_polyfill_404_or' +
-          '_other_error_expected._Do_not_worry_about_it');
+      expect(open.callCount).to.equal(0);
+      return visible.then(() => {
+        expect(open.callCount).to.equal(1);
+        expect(send.callCount).to.equal(1);
+        expect(open.args[0][1]).to.include(
+            'https://s.preconnect.com/amp_preconnect_polyfill_404_or' +
+            '_other_error_expected._Do_not_worry_about_it');
+      });
     });
   });
 
@@ -188,21 +200,27 @@ describe('preconnect', () => {
       preconnect.prefetch('https://a.prefetch.com/foo/bar');
       preconnect.prefetch('https://a.prefetch.com/other');
       preconnect.prefetch(javascriptUrlPrefix + ':alert()');
-      // Also preconnects.
-      expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
-          .to.have.length(1);
-      expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
-          .to.equal('https://a.prefetch.com/');
-      expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
-          .to.have.length(1);
-      expect(iframe.doc.querySelector('link[rel=preconnect]').href)
-          .to.equal('https://a.prefetch.com/');
-      // Actual prefetch
       const fetches = iframe.doc.querySelectorAll(
           'link[rel=prefetch]');
-      expect(fetches).to.have.length(2);
-      expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
-      expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
+      expect(fetches).to.have.length(0);
+      return visible.then(() => {
+        // Also preconnects.
+        expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
+            .to.have.length(1);
+        expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
+            .to.equal('https://a.prefetch.com/');
+        expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
+            .to.have.length(1);
+        expect(iframe.doc.querySelector('link[rel=preconnect]').href)
+            .to.equal('https://a.prefetch.com/');
+        // Actual prefetch
+        const fetches = iframe.doc.querySelectorAll(
+            'link[rel=prefetch]');
+        expect(fetches).to.have.length(2);
+        expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
+        expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
+        expect(fetches[0].getAttribute('referrerpolicy')).to.equal('origin');
+      });
     });
   });
 
@@ -215,21 +233,28 @@ describe('preconnect', () => {
       preconnect.prefetch('https://a.prefetch.com/foo/bar');
       preconnect.prefetch('https://a.prefetch.com/other', 'style');
       preconnect.prefetch(javascriptUrlPrefix + ':alert()');
-      // Also preconnects.
-      expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
-          .to.have.length(1);
-      expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
-          .to.equal('https://a.prefetch.com/');
-      expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
-          .to.have.length(1);
-      expect(iframe.doc.querySelector('link[rel=preconnect]').href)
-          .to.equal('https://a.prefetch.com/');
       // Actual prefetch
       const fetches = iframe.doc.querySelectorAll(
           'link[rel=prefetch],link[rel=preload]');
-      expect(fetches).to.have.length(2);
-      expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
-      expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
+      expect(fetches).to.have.length(0);
+      return visible.then(() => {
+        // Also preconnects.
+        expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
+            .to.have.length(1);
+        expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
+            .to.equal('https://a.prefetch.com/');
+        expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
+            .to.have.length(1);
+        expect(iframe.doc.querySelector('link[rel=preconnect]').href)
+            .to.equal('https://a.prefetch.com/');
+        // Actual prefetch
+        const fetches = iframe.doc.querySelectorAll(
+            'link[rel=prefetch],link[rel=preload]');
+        expect(fetches).to.have.length(2);
+        expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
+        expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
+        expect(fetches[0].getAttribute('referrerpolicy')).to.equal('origin');
+      });
     });
   });
 
@@ -240,26 +265,32 @@ describe('preconnect', () => {
       preconnect.prefetch('https://a.prefetch.com/foo/bar');
       preconnect.prefetch('https://a.prefetch.com/other', 'style');
       preconnect.prefetch(javascriptUrlPrefix + ':alert()');
-      // Also preconnects.
-      expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
-          .to.have.length(1);
-      expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
-          .to.equal('https://a.prefetch.com/');
-      expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
-          .to.have.length(1);
-      expect(iframe.doc.querySelector('link[rel=preconnect]').href)
-          .to.equal('https://a.prefetch.com/');
-
-      const preloads = iframe.doc.querySelectorAll(
-          'link[rel=preload]');
-      expect(preloads).to.have.length(0);
-
-      // Actual prefetch
       const fetches = iframe.doc.querySelectorAll(
           'link[rel=prefetch]');
-      expect(fetches).to.have.length(2);
-      expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
-      expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
+      expect(fetches).to.have.length(0);
+      return visible.then(() => {
+        // Also preconnects.
+        expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
+            .to.have.length(1);
+        expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
+            .to.equal('https://a.prefetch.com/');
+        expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
+            .to.have.length(1);
+        expect(iframe.doc.querySelector('link[rel=preconnect]').href)
+            .to.equal('https://a.prefetch.com/');
+
+        const preloads = iframe.doc.querySelectorAll(
+            'link[rel=preload]');
+        expect(preloads).to.have.length(0);
+
+        // Actual prefetch
+        const fetches = iframe.doc.querySelectorAll(
+            'link[rel=prefetch]');
+        expect(fetches).to.have.length(2);
+        expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
+        expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
+        expect(fetches[0].getAttribute('referrerpolicy')).to.equal('origin');
+      });
     });
   });
 
@@ -270,24 +301,29 @@ describe('preconnect', () => {
       preconnect.prefetch('https://a.prefetch.com/foo/bar');
       preconnect.prefetch('https://a.prefetch.com/other', 'style');
       preconnect.prefetch(javascriptUrlPrefix + ':alert()');
-      // Also preconnects.
-      expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
-          .to.have.length(1);
-      expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
-          .to.equal('https://a.prefetch.com/');
-      expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
-          .to.have.length(1);
-      expect(iframe.doc.querySelector('link[rel=preconnect]').href)
-          .to.equal('https://a.prefetch.com/');
-      // Actual prefetch
       const fetches = iframe.doc.querySelectorAll(
           'link[rel=prefetch]');
       expect(fetches).to.have.length(0);
-      const preloads = iframe.doc.querySelectorAll(
-          'link[rel=preload]');
-      expect(preloads).to.have.length(2);
-      expect(preloads[0].href).to.equal('https://a.prefetch.com/foo/bar');
-      expect(preloads[1].href).to.equal('https://a.prefetch.com/other');
+      return visible.then(() => {
+        // Also preconnects.
+        expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
+            .to.have.length(1);
+        expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
+            .to.equal('https://a.prefetch.com/');
+        expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
+            .to.have.length(1);
+        expect(iframe.doc.querySelector('link[rel=preconnect]').href)
+            .to.equal('https://a.prefetch.com/');
+        // Actual prefetch
+        const fetches = iframe.doc.querySelectorAll(
+            'link[rel=prefetch]');
+        expect(fetches).to.have.length(0);
+        const preloads = iframe.doc.querySelectorAll(
+            'link[rel=preload]');
+        expect(preloads).to.have.length(2);
+        expect(preloads[0].href).to.equal('https://a.prefetch.com/foo/bar');
+        expect(preloads[1].href).to.equal('https://a.prefetch.com/other');
+      });
     });
   });
 });


### PR DESCRIPTION
This makes pre-renders slightly cheaper. Also applies referrer policy on these requests to origin, as they should be independent of the referring page.