### PR TITLE
add dummy vars for define flags warning suppression

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -106,6 +106,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
         runner.pseudo_names = true;
       }
     }
+    
 
     if (runner.shouldRunCompiler()) {
       runner.run();

--- a/build-system/runner/src/org/ampproject/AmpPass.java
+++ b/build-system/runner/src/org/ampproject/AmpPass.java
@@ -85,7 +85,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
   private boolean isFunctionInvokeAndPropAccess(Node n, String fnQualifiedName, Set<String> props) {
     // mode.getMode().localDev
     // mode [property] ->
-    //   getMode [call] 
+    //   getMode [call]
     //   ${property} [string]
     if (!n.isGetProp()) {
       return false;

--- a/src/amp.js
+++ b/src/amp.js
@@ -36,6 +36,15 @@ import {cssText} from '../build/css';
 import {maybeValidate} from './validator-integration';
 import {maybeTrackImpression} from './impression';
 
+/** @define @const {boolean} */
+const TYPECHECK_ONLY = false;
+
+/** @define @const {boolean} */
+const FORTESTING = false;
+
+/** @define @const {boolean} */
+const PSEUDO_NAMES = false;
+
 // We must under all circumstances call makeBodyVisible.
 // It is much better to have AMP tags not rendered than having
 // a completely blank page.


### PR DESCRIPTION
supress the warnings we get during compilation for the custom flags we pass to our `AmpCommandLineRunner` class