### PR TITLE
Refactoring: Turn private custom element methods into functions.

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -640,9 +640,6 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
         }
         this.implementation_.layout_ = this.layout_;
         this.implementation_.firstAttachedCallback();
-      } catch (e) {
-        reportError(e, this);
-      } finally {
         if (!isUpgraded(this)) {
           // amp:attached is dispatched from the ElementStub class when it replayed
           // the firstAttachedCallback call.
@@ -650,6 +647,8 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
         } else {
           this.dispatchCustomEvent('amp:attached');
         }
+      } catch (e) {
+        reportError(e, this);
       }
     }
     this.resources_.add(this);
@@ -1249,8 +1248,8 @@ function assertNotTemplate(element) {
 };
 
 /**
+ * @param {!Element} element
  * @return {!./service/vsync-impl.Vsync}
- * param {!Element} element
  */
 function getVsync(element) {
   return vsyncFor(element.ownerDocument.defaultView);
@@ -1258,8 +1257,8 @@ function getVsync(element) {
 
 /**
  * Whether the element has been upgraded yet.
+ * @param {!Element} element
  * @return {boolean}
- * @final @this {!Element}
  */
 function isUpgraded(element) {
   return !(element.implementation_ instanceof ElementStub);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -383,18 +383,13 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
     this.isInTemplate_ = undefined;
   };
 
-  /** @private @this {!Element} */
-  ElementProto.assertNotTemplate_ = function() {
-    dev.assert(!this.isInTemplate_, 'Must never be called in template');
-  };
-
   /**
    * Whether the element has been upgraded yet.
    * @return {boolean}
    * @final @this {!Element}
    */
   ElementProto.isUpgraded = function() {
-    return !(this.implementation_ instanceof ElementStub);
+    return isUpgraded(this);
   };
 
   /**
@@ -442,7 +437,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @return {number} @this {!Element}
    */
   ElementProto.getPriority = function() {
-    dev.assert(this.isUpgraded(), 'Cannot get priority of unupgraded element');
+    dev.assert(isUpgraded(this), 'Cannot get priority of unupgraded element');
     return this.implementation_.getPriority();
   };
 
@@ -455,11 +450,11 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @final @this {!Element}
    */
   ElementProto.build = function() {
-    this.assertNotTemplate_();
+    assertNotTemplate(this);
     if (this.isBuilt()) {
       return;
     }
-    dev.assert(this.isUpgraded(), 'Cannot build unupgraded element');
+    dev.assert(isUpgraded(this), 'Cannot build unupgraded element');
     try {
       this.implementation_.buildCallback();
       this.preconnect(/* onLayout */ false);
@@ -510,14 +505,6 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
   };
 
   /**
-   * @return {!./service/vsync-impl.Vsync}
-   * @private @this {!Element}
-   */
-  ElementProto.getVsync_ = function() {
-    return vsyncFor(this.ownerDocument.defaultView);
-  };
-
-  /**
    * Whether the custom element declares that it has to be fixed.
    * @return {boolean}
    * @private @this {!Element}
@@ -534,7 +521,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    */
   ElementProto.updateLayoutBox = function(layoutBox) {
     this.layoutWidth_ = layoutBox.width;
-    if (this.isUpgraded()) {
+    if (isUpgraded(this)) {
       this.implementation_.layoutWidth_ = this.layoutWidth_;
     }
     // TODO(malteubl): Forward for stubbed elements.
@@ -548,7 +535,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
           layoutBox.top >= 0) {
         // Few top elements will also be pre-initialized with a loading
         // element.
-        this.getVsync_().mutate(() => {
+        getVsync(this).mutate(() => {
           this.prepareLoading_();
         });
       }
@@ -568,7 +555,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @package @this {!Element}
    */
   ElementProto.applySizesAndMediaQuery = function() {
-    this.assertNotTemplate_();
+    assertNotTemplate(this);
 
     // Media query.
     if (this.mediaQuery_ === undefined) {
@@ -641,10 +628,28 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
     }
     if (!this.everAttached) {
       this.everAttached = true;
+      if (!isUpgraded(this)) {
+        this.classList.add('amp-unresolved');
+        this.classList.add('-amp-unresolved');
+      }
       try {
-        this.firstAttachedCallback_();
+        this.layout_ = applyLayout_(this);
+        if (this.layout_ != Layout.NODISPLAY &&
+            !this.implementation_.isLayoutSupported(this.layout_)) {
+          throw new Error('Layout not supported for: ' + this.layout_);
+        }
+        this.implementation_.layout_ = this.layout_;
+        this.implementation_.firstAttachedCallback();
       } catch (e) {
         reportError(e, this);
+      } finally {
+        if (!isUpgraded(this)) {
+          // amp:attached is dispatched from the ElementStub class when it replayed
+          // the firstAttachedCallback call.
+          this.dispatchCustomEvent('amp:stubbed');
+        } else {
+          this.dispatchCustomEvent('amp:attached');
+        }
       }
     }
     this.resources_.add(this);
@@ -662,35 +667,6 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
     this.implementation_.detachedCallback();
   };
 
-  /**
-   * Called when the element is attached to the DOM for the first time.
-   * @private @final @this {!Element}
-   */
-  ElementProto.firstAttachedCallback_ = function() {
-    if (!this.isUpgraded()) {
-      this.classList.add('amp-unresolved');
-      this.classList.add('-amp-unresolved');
-    }
-    try {
-      this.layout_ = applyLayout_(this);
-      if (this.layout_ != Layout.NODISPLAY &&
-          !this.implementation_.isLayoutSupported(this.layout_)) {
-        throw new Error('Layout not supported for: ' + this.layout_);
-      }
-      this.implementation_.layout_ = this.layout_;
-      this.implementation_.firstAttachedCallback();
-    } catch (e) {
-      reportError(e, this);
-      throw e;
-    }
-    if (!this.isUpgraded()) {
-      // amp:attached is dispatched from the ElementStub class when it replayed
-      // the firstAttachedCallback call.
-      this.dispatchCustomEvent('amp:stubbed');
-    } else {
-      this.dispatchCustomEvent('amp:attached');
-    }
-  };
 
   /**
    * @param {string} name
@@ -782,8 +758,8 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @package @final @this {!Element}
    */
   ElementProto.layoutCallback = function() {
-    this.assertNotTemplate_();
-    dev.assert(this.isUpgraded() && this.isBuilt(),
+    assertNotTemplate(this);
+    dev.assert(isUpgraded(this) && this.isBuilt(),
         'Must be upgraded and built to receive viewport events');
     this.dispatchCustomEvent('amp:load:start');
     const promise = this.implementation_.layoutCallback();
@@ -812,7 +788,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @final @package @this {!Element}
    */
   ElementProto.viewportCallback = function(inViewport) {
-    this.assertNotTemplate_();
+    assertNotTemplate(this);
     this.isInViewport_ = inViewport;
     if (this.layoutCount_ == 0) {
       if (!inViewport) {
@@ -827,7 +803,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
         }, 100);
       }
     }
-    if (this.isUpgraded() && this.isBuilt()) {
+    if (isUpgraded(this) && this.isBuilt()) {
       this.updateInViewport_(inViewport);
     }
   };
@@ -849,8 +825,8 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @package @final @this {!Element}
    */
   ElementProto.pauseCallback = function() {
-    this.assertNotTemplate_();
-    if (!this.isBuilt() || !this.isUpgraded()) {
+    assertNotTemplate(this);
+    if (!this.isBuilt() || !isUpgraded(this)) {
       return;
     }
     this.implementation_.pauseCallback();
@@ -864,8 +840,8 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @package @final @this {!Element}
    */
   ElementProto.resumeCallback = function() {
-    this.assertNotTemplate_();
-    if (!this.isBuilt() || !this.isUpgraded()) {
+    assertNotTemplate(this);
+    if (!this.isBuilt() || !isUpgraded(this)) {
       return;
     }
     this.implementation_.resumeCallback();
@@ -881,8 +857,8 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @package @final @this {!Element}
    */
   ElementProto.unlayoutCallback = function() {
-    this.assertNotTemplate_();
-    if (!this.isBuilt() || !this.isUpgraded()) {
+    assertNotTemplate(this);
+    if (!this.isBuilt() || !isUpgraded(this)) {
       return false;
     }
     const isReLayoutNeeded = this.implementation_.unlayoutCallback();
@@ -913,7 +889,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @final @this {!Element}
    */
   ElementProto.enqueAction = function(invocation) {
-    this.assertNotTemplate_();
+    assertNotTemplate(this);
     if (!this.isBuilt()) {
       dev.assert(this.actionQueue_).push(invocation);
     } else {
@@ -994,42 +970,17 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @package @final @this {!Element}
    */
   ElementProto.togglePlaceholder = function(show) {
-    this.assertNotTemplate_();
+    assertNotTemplate(this);
     if (show) {
-      this.showLastPlaceholder_();
+      const placeholder = this.getPlaceholder();
+      if (placeholder) {
+        placeholder.classList.remove('amp-hidden');
+      }
     } else {
-      this.hideAllPlaceholders_();
-    }
-  };
-
-  /**
-   * Returns an optional placeholder element for this custom element.
-   * @return {!Array.<!Element>}
-   * @private @this {!Element}
-   */
-  ElementProto.getAllPlaceholders_ = function() {
-    return dom.childElementsByAttr(this, 'placeholder');
-  };
-
-  /**
-   * Hides all placeholders in an element.
-   * @private @this {!Element}
-   */
-  ElementProto.hideAllPlaceholders_ = function() {
-    const placeholders = this.getAllPlaceholders_();
-    for (let i = 0; i < placeholders.length; i++) {
-      placeholders[i].classList.add('amp-hidden');
-    }
-  };
-
-  /**
-   * Shows the last placeholder in an element.
-   * @private @this {!Element}
-   */
-  ElementProto.showLastPlaceholder_ = function() {
-    const placeholder = this.getPlaceholder();
-    if (placeholder) {
-      placeholder.classList.remove('amp-hidden');
+      const placeholders = dom.childElementsByAttr(this, 'placeholder');
+      for (let i = 0; i < placeholders.length; i++) {
+        placeholders[i].classList.add('amp-hidden');
+      }
     }
   };
 
@@ -1049,7 +1000,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @package @final @this {!Element}
    */
   ElementProto.toggleFallback = function(state) {
-    this.assertNotTemplate_();
+    assertNotTemplate(this);
     // This implementation is notably less efficient then placeholder toggling.
     // The reasons for this are: (a) "not supported" is the state of the whole
     // element, (b) some realyout is expected and (c) fallback condition would
@@ -1118,7 +1069,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
    * @private @final @this {!Element}
    */
   ElementProto.toggleLoading_ = function(state, opt_cleanup) {
-    this.assertNotTemplate_();
+    assertNotTemplate(this);
     this.loadingState_ = state;
     if (!state && !this.loadingContainer_) {
       return;
@@ -1130,7 +1081,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
       return;
     }
 
-    this.getVsync_().mutate(() => {
+    getVsync(this).mutate(() => {
       let state = this.loadingState_;
       // Repeat "loading enabled" check because it could have changed while
       // waiting for vsync.
@@ -1201,7 +1152,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
         this.overflowElement_.onclick = () => {
           this.resources_./*OK*/changeSize(
               this, requestedHeight, requestedWidth);
-          this.getVsync_().mutate(() => {
+          getVsync(this).mutate(() => {
             this.overflowCallback(
                 /* overflown */ false, requestedHeight, requestedWidth);
           });
@@ -1291,3 +1242,25 @@ export function resetScheduledElementForTesting(win, elementName) {
 export function getElementClassForTesting(elementName) {
   return knownElements[elementName] || null;
 }
+
+/** @param {!Element} element */
+function assertNotTemplate(element) {
+  dev.assert(!element.isInTemplate_, 'Must never be called in template');
+};
+
+/**
+ * @return {!./service/vsync-impl.Vsync}
+ * param {!Element} element
+ */
+function getVsync(element) {
+  return vsyncFor(element.ownerDocument.defaultView);
+};
+
+/**
+ * Whether the element has been upgraded yet.
+ * @return {boolean}
+ * @final @this {!Element}
+ */
+function isUpgraded(element) {
+  return !(element.implementation_ instanceof ElementStub);
+};


### PR DESCRIPTION
And inline a few methods.

The calls on the element are slow and cannot be optimized because the compiler doesn't touch the extern objects.