### PR TITLE
Amp slidescroll experiment - Handling Custom Snapping

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -87,12 +87,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
   white-space: nowrap !important;
   width: 100% !important;
   scroll-snap-type: mandatory !important;
-  -ms-overflow-style: none;
   -webkit-overflow-scrolling: touch !important;
-}
-
-.-amp-slides-container::-webkit-scrollbar {
-  display: none;
 }
 
 .-amp-slides-container.no-scroll {

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -90,7 +90,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
   -webkit-overflow-scrolling: touch !important;
 }
 
-.-amp-slides-container.no-scroll {
+.-amp-slides-container.-amp-no-scroll {
   overflow-x: hidden !important;
 }
 

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -87,12 +87,18 @@ amp-carousel .amp-carousel-button.amp-disabled {
   white-space: nowrap !important;
   width: 100% !important;
   scroll-snap-type: mandatory !important;
+  -ms-overflow-style: none;
   -webkit-overflow-scrolling: touch !important;
+}
+
+.-amp-slides-container::-webkit-scrollbar {
+  display: none;
 }
 
 .-amp-slides-container.no-scroll {
   overflow-x: hidden !important;
 }
+
 
 .-amp-slide-item {
   align-items: center !important;

--- a/extensions/amp-carousel/0.1/amp-carousel.js
+++ b/extensions/amp-carousel/0.1/amp-carousel.js
@@ -27,7 +27,7 @@ class CarouselSelector {
         element.getAttribute('type') == 'slides') {
       const slideScrollExpt =
           isExperimentOn(element.ownerDocument.defaultView, 'amp-slidescroll');
-      if (slideScrollExpt || true) {
+      if (slideScrollExpt) {
         return new AmpSlideScroll(element);
       }
       return new AmpSlides(element);

--- a/extensions/amp-carousel/0.1/amp-carousel.js
+++ b/extensions/amp-carousel/0.1/amp-carousel.js
@@ -27,7 +27,7 @@ class CarouselSelector {
         element.getAttribute('type') == 'slides') {
       const slideScrollExpt =
           isExperimentOn(element.ownerDocument.defaultView, 'amp-slidescroll');
-      if (slideScrollExpt) {
+      if (slideScrollExpt || true) {
         return new AmpSlideScroll(element);
       }
       return new AmpSlides(element);

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -23,10 +23,10 @@ import {timer} from '../../../src/timer';
 /** @const {string} */
 const SHOWN_CSS_CLASS = '-amp-slide-item-show';
 
-/** @const {string} */
+/** @const {number} */
 const NATIVE_SNAP_TIMEOUT = 40;
 
-/** @const {string} */
+/** @const {number} */
 const CUSTOM_SNAP_TIMEOUT = 100;
 
 export class AmpSlideScroll extends BaseCarousel {
@@ -89,10 +89,10 @@ export class AmpSlideScroll extends BaseCarousel {
     /** @private @const {boolean} */
     this.snappingInProgress_ = false;
 
-    /** @private {?number}*/
+    /** @private {?number} */
     this.scrollTimeout_ = null;
 
-    /** @private {number}*/
+    /** @private {number} */
     // 0 - not in an elastic state.
     // -1 - elastic scrolling (back) to the left of scrollLeft 0.
     // 1 - elastic scrolling (fwd) to the right of the max scrollLeft possible.
@@ -123,6 +123,9 @@ export class AmpSlideScroll extends BaseCarousel {
   viewportCallback(inViewport) {
     if (inViewport) {
       this.hintControls();
+    }
+    if (inViewport == false) {
+      this.updateInViewport(this.slides_[this.slideIndex_], inViewport);
     }
   }
 
@@ -214,7 +217,7 @@ export class AmpSlideScroll extends BaseCarousel {
   /**
    * Animate and snap to the correct slide for a given scrollLeft.
    * @param {number} currentScrollLeft scrollLeft value of the slides container.
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   customSnap_(currentScrollLeft) {
     this.snappingInProgress_ = true;
@@ -243,7 +246,7 @@ export class AmpSlideScroll extends BaseCarousel {
    * Gets the slideIndex of the potential next slide based on the
    *    current scrollLeft.
    * @param {number} currentScrollLeft scrollLeft value of the slides container.
-   * @returns {number} a number representing the next slide index.
+   * @return {number} a number representing the next slide index.
    */
   getNextSlideIndex_(currentScrollLeft) {
     // This can be only 0, 1 or 2, since only a max of 3 slides are shown at
@@ -378,7 +381,7 @@ export class AmpSlideScroll extends BaseCarousel {
    * Animate scrollLeft of the container.
    * @param {number} fromScrollLeft.
    * @param {number} toScrollLeft.
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   animateScrollLeft_(fromScrollLeft, toScrollLeft) {
     if (fromScrollLeft == toScrollLeft) {

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -13,13 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Animation} from '../../../src/animation';
 import {BaseCarousel} from './base-carousel';
 import {Layout} from '../../../src/layout';
 import {getStyle, setStyle} from '../../../src/style';
+import {numeric} from '../../../src/transition';
 import {timer} from '../../../src/timer';
 
 /** @const {string} */
 const SHOWN_CSS_CLASS = '-amp-slide-item-show';
+
+/** @const {string} */
+const NATIVE_SNAP_TIMEOUT = 40;
+
+/** @const {string} */
+const CUSTOM_SNAP_TIMEOUT = 100;
 
 export class AmpSlideScroll extends BaseCarousel {
   /** @override */
@@ -148,11 +156,12 @@ export class AmpSlideScroll extends BaseCarousel {
       timer.cancel(this.scrollTimeout_);
     }
     const currentScrollLeft = this.slidesContainer_./*OK*/scrollLeft;
-    if (currentScrollLeft != this.previousScrollLeft_ &&
-        !this.hasNativeSnapPoints_) {
-      // TODO(sriramkrish85): Handle custom scroll here.
+    if (!this.hasNativeSnapPoints_) {
+      this.handleCustomElasticScroll_(currentScrollLeft);
     }
 
+    const timeout =
+        this.hasNativeSnapPoints_ ? NATIVE_SNAP_TIMEOUT : CUSTOM_SNAP_TIMEOUT;
     // Timer that detects scroll end and/or end of snap scroll.
     this.scrollTimeout_ = timer.delay(() => {
       if (this.snappingInProgress_) {
@@ -160,18 +169,73 @@ export class AmpSlideScroll extends BaseCarousel {
       }
       if (this.hasNativeSnapPoints_) {
         this.updateOnScroll_(currentScrollLeft);
+      } else {
+        this.customSnap_(currentScrollLeft);
       }
-    }, 100);
+    }, timeout);
     this.previousScrollLeft_ = currentScrollLeft;
   }
 
-
   /**
-   * Updates to the right state of the new index on scroll.
+   * Handles custom elastic scroll (snap points polyfill).
    * @param {number} currentScrollLeft scrollLeft value of the slides container.
    */
-  updateOnScroll_(currentScrollLeft) {
+  handleCustomElasticScroll_(currentScrollLeft) {
+    const scrollWidth = this.slidesContainer_./*REVIEW*/scrollWidth;
+    if (this.isElasticScrollingBack_ && currentScrollLeft >= 0) {
+      // Elastic Scroll is reversing direction take control.
+      this.customSnap_(currentScrollLeft).then(() => {
+        this.isElasticScrollingBack_ = false;
+      });
+    } else if (this.isElasticScrollFwd_ &&
+          (currentScrollLeft + this.slideWidth_) <= scrollWidth) {
+      // Elastic Scroll is reversing direction take control.
+      this.customSnap_(currentScrollLeft).then(() => {
+        this.isElasticScrollFwd_ = false;
+      });
+    } else if (currentScrollLeft < 0) {
+      // Direction = -1.
+      this.isElasticScrollingBack_ = true;
+    } else if ((currentScrollLeft + this.slideWidth_) >= scrollWidth) {
+      // Direction = +1.
+      this.isElasticScrollFwd_ = true;
+    }
+  }
+
+  /**
+   * Animate and snap to the correct slide for a given scrollLeft.
+   * @param {number} currentScrollLeft scrollLeft value of the slides container.
+   * @returns {!Promise}
+   */
+  customSnap_(currentScrollLeft) {
     this.snappingInProgress_ = true;
+    const newIndex = this.getNextSlideIndex_(currentScrollLeft);
+    let toScrollLeft;
+    const diff = newIndex - this.slideIndex_;
+
+    if (diff == 0) {
+      // Snap and stay.
+      toScrollLeft = this.hasPrev() ? this.slideWidth_ : 0;
+    } else if (diff == 1 || diff == -1 * (this.noOfSlides_ - 1)) {
+      // Move fwd.
+      toScrollLeft = this.hasPrev() ? this.slideWidth_ * 2 : this.slideWidth_;
+    } else if (diff == -1 || diff == this.noOfSlides_ - 1) {
+      // Move backward.
+      toScrollLeft = 0;
+    }
+
+    return this.animateScrollLeft_(currentScrollLeft, toScrollLeft).then(() => {
+      this.updateOnScroll_(toScrollLeft);
+    });
+  }
+
+  /**
+   * Gets the slideIndex of the potential next slide based on the
+   *    current scrollLeft.
+   * @param {number} currentScrollLeft scrollLeft value of the slides container.
+   * @returns {number} a number representing the next slide index.
+   */
+  getNextSlideIndex_(currentScrollLeft) {
     // This can be only 0, 1 or 2, since only a max of 3 slides are shown at
     // a time.
     const scrolledSlideIndex = Math.round(currentScrollLeft / this.slideWidth_);
@@ -201,6 +265,16 @@ export class AmpSlideScroll extends BaseCarousel {
       newIndex = (newIndex < 0) ? 0 :
           (newIndex >= this.noOfSlides_) ? this.noOfSlides_ - 1 : newIndex;
     }
+    return newIndex;
+  }
+
+  /**
+   * Updates to the right state of the new index on scroll.
+   * @param {number} currentScrollLeft scrollLeft value of the slides container.
+   */
+  updateOnScroll_(currentScrollLeft) {
+    this.snappingInProgress_ = true;
+    const newIndex = this.getNextSlideIndex_(currentScrollLeft);
     this.vsync_.mutate(() => {
       // Make the container non scrollable to stop scroll events.
       this.slidesContainer_.classList.add('no-scroll');
@@ -288,5 +362,21 @@ export class AmpSlideScroll extends BaseCarousel {
         this.schedulePause(this.slides_[i]);
       }
     }
+  }
+
+  /**
+   * Animate scrollLeft of the container.
+   * @param {number} fromScrollLeft.
+   * @param {number} toScrollLeft.
+   * @returns {!Promise}
+   */
+  animateScrollLeft_(fromScrollLeft, toScrollLeft) {
+    if (fromScrollLeft == toScrollLeft) {
+      return Promise.resolve();
+    }
+    const interpolate = numeric(fromScrollLeft, toScrollLeft);
+    return Animation.animate(this.slidesContainer_, pos => {
+      this.slidesContainer_./*REVIEW*/scrollLeft = interpolate(pos);
+    }, 80, 'ease-in-out').thenAlways();
   }
 }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -292,12 +292,12 @@ export class AmpSlideScroll extends BaseCarousel {
     const newIndex = this.getNextSlideIndex_(currentScrollLeft);
     this.vsync_.mutate(() => {
       // Make the container non scrollable to stop scroll events.
-      this.slidesContainer_.classList.add('no-scroll');
+      this.slidesContainer_.classList.add('-amp-no-scroll');
       // Scroll to new slide and update scrollLeft to the correct slide.
       this.showSlide_(newIndex);
       this.vsync_.mutate(() => {
         // Make the container scrollable again to enable user swiping.
-        this.slidesContainer_.classList.remove('no-scroll');
+        this.slidesContainer_.classList.remove('-amp-no-scroll');
         this.snappingInProgress_ = false;
       });
     });

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -92,10 +92,12 @@ export class AmpSlideScroll extends BaseCarousel {
     /** @private {?number} */
     this.scrollTimeout_ = null;
 
-    /** @private {number} */
-    // 0 - not in an elastic state.
-    // -1 - elastic scrolling (back) to the left of scrollLeft 0.
-    // 1 - elastic scrolling (fwd) to the right of the max scrollLeft possible.
+    /**
+     * 0 - not in an elastic state.
+     * -1 - elastic scrolling (back) to the left of scrollLeft 0.
+     * 1 - elastic scrolling (fwd) to the right of the max scrollLeft possible.
+     * @private {number}
+     */
     this.elasticScrollState_ = 0;
 
     this.slidesContainer_.addEventListener(
@@ -124,7 +126,7 @@ export class AmpSlideScroll extends BaseCarousel {
     if (inViewport) {
       this.hintControls();
     }
-    if (inViewport == false) {
+    if (this.slideIndex_ != null) {
       this.updateInViewport(this.slides_[this.slideIndex_], inViewport);
     }
   }
@@ -190,7 +192,7 @@ export class AmpSlideScroll extends BaseCarousel {
    * @param {number} currentScrollLeft scrollLeft value of the slides container.
    */
   handleCustomElasticScroll_(currentScrollLeft) {
-    const scrollWidth = this.slidesContainer_./*REVIEW*/scrollWidth;
+    const scrollWidth = this.slidesContainer_./*OK*/scrollWidth;
     if (this.elasticScrollState_ == -1 &&
         currentScrollLeft >= this.previousScrollLeft_) {
       // Elastic Scroll is reversing direction take control.
@@ -224,14 +226,14 @@ export class AmpSlideScroll extends BaseCarousel {
     const newIndex = this.getNextSlideIndex_(currentScrollLeft);
     let toScrollLeft;
     const diff = newIndex - this.slideIndex_;
-    const hasPrev_ = this.hasPrev();
+    const hasPrev = this.hasPrev();
 
     if (diff == 0) {
       // Snap and stay.
-      toScrollLeft = hasPrev_ ? this.slideWidth_ : 0;
+      toScrollLeft = hasPrev ? this.slideWidth_ : 0;
     } else if (diff == 1 || diff == -1 * (this.noOfSlides_ - 1)) {
       // Move fwd.
-      toScrollLeft = hasPrev_ ? this.slideWidth_ * 2 : this.slideWidth_;
+      toScrollLeft = hasPrev ? this.slideWidth_ * 2 : this.slideWidth_;
     } else if (diff == -1 || diff == this.noOfSlides_ - 1) {
       // Move backward.
       toScrollLeft = 0;
@@ -256,15 +258,15 @@ export class AmpSlideScroll extends BaseCarousel {
     // shown slide.
     let updateValue = 0;
 
-    const hasPrev_ = this.hasPrev();
-    const hasNext_ = this.hasNext();
+    const hasPrev = this.hasPrev();
+    const hasNext = this.hasNext();
 
-    if (hasPrev_ && hasNext_) {
+    if (hasPrev && hasNext) {
       updateValue = scrolledSlideIndex - 1;
-    } else if (hasNext_) {
+    } else if (hasNext) {
       // Has next and does not have a prev. (slideIndex 0)
       updateValue = scrolledSlideIndex;
-    } else if (hasPrev_) {
+    } else if (hasPrev) {
       // Has prev and no next slide (last slide)
       updateValue = scrolledSlideIndex - 1;
     }
@@ -389,7 +391,7 @@ export class AmpSlideScroll extends BaseCarousel {
     }
     const interpolate = numeric(fromScrollLeft, toScrollLeft);
     return Animation.animate(this.slidesContainer_, pos => {
-      this.slidesContainer_./*REVIEW*/scrollLeft = interpolate(pos);
+      this.slidesContainer_./*OK*/scrollLeft = interpolate(pos);
     }, 80, 'ease-in-out').thenAlways();
   }
 }

--- a/extensions/amp-carousel/0.1/test/test-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slides.js
@@ -773,12 +773,11 @@ describe('Slides functional', () => {
       slides.updateInViewport = sandbox.spy();
       slides.schedulePause = sandbox.spy();
       slides.schedulePreload = sandbox.spy();
-
-      Animation.animate = () => {
+      sandbox.stub(Animation, 'animate', () => {
         return {
           thenAlways: cb => cb(),
         };
-      };
+      });
     });
     afterEach(() => {
       sandbox.restore();
@@ -819,6 +818,11 @@ describe('Slides functional', () => {
       slides.updateInViewport = sandbox.spy();
       slides.schedulePause = sandbox.spy();
       slides.schedulePreload = sandbox.spy();
+      sandbox.stub(Animation, 'animate', () => {
+        return {
+          thenAlways: cb => cb(),
+        };
+      });
     });
     afterEach(() => {
       sandbox.restore();

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -19,7 +19,7 @@ import '../amp-carousel';
 import {createIframePromise} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';
 
-describe('SlideScroll', () => {
+describe.only('SlideScroll', () => {
   const SHOW_CLASS = '-amp-slide-item-show';
   let sandbox;
 
@@ -343,6 +343,83 @@ describe('SlideScroll', () => {
     });
   });
 
+  it('should get the correct next slide index for a scrollLeft' , () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      const impl = ampSlideScroll.implementation_;
+      impl.slideWidth_ = 400;
+
+      // Already at slide 0;
+      expect(impl.getNextSlideIndex_(0)).to.equal(0);
+      expect(impl.getNextSlideIndex_(100)).to.equal(0);
+      expect(impl.getNextSlideIndex_(200)).to.equal(1);
+      expect(impl.getNextSlideIndex_(400)).to.equal(1);
+
+      impl.showSlide_(3);
+
+      expect(impl.getNextSlideIndex_(0)).to.equal(2);
+      expect(impl.getNextSlideIndex_(100)).to.equal(2);
+      expect(impl.getNextSlideIndex_(200)).to.equal(3);
+      expect(impl.getNextSlideIndex_(400)).to.equal(3);
+      expect(impl.getNextSlideIndex_(500)).to.equal(3);
+      expect(impl.getNextSlideIndex_(600)).to.equal(4);
+      expect(impl.getNextSlideIndex_(800)).to.equal(4);
+
+      impl.showSlide_(4);
+      expect(impl.getNextSlideIndex_(0)).to.equal(3);
+      expect(impl.getNextSlideIndex_(100)).to.equal(3);
+      expect(impl.getNextSlideIndex_(200)).to.equal(4);
+      expect(impl.getNextSlideIndex_(400)).to.equal(4);
+    });
+  });
+
+  it('should custom snap to the correct slide', () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      const impl = ampSlideScroll.implementation_;
+      const animateScrollLeftSpy = sandbox.spy(impl, 'animateScrollLeft_');
+      impl.slideWidth_ = 400;
+
+      impl.customSnap_(0);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+      impl.customSnap_(100);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
+      impl.customSnap_(200);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
+      impl.customSnap_(400);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+
+      impl.showSlide_(3);
+
+      impl.customSnap_(0);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+      impl.customSnap_(100);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
+      impl.customSnap_(200);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
+      impl.customSnap_(400);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+      impl.customSnap_(500);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(500, 400);
+      impl.customSnap_(600);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(600, 800);
+      impl.customSnap_(800);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(800, 800);
+
+      impl.showSlide_(4);
+
+      impl.customSnap_(0);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+      impl.customSnap_(100);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
+      impl.customSnap_(200);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
+      impl.customSnap_(400);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+
+    });
+  });
+
   describe('Looping', () => {
     beforeEach(() => {
       toggleExperiment(window, 'amp-slidescroll', true);
@@ -611,6 +688,68 @@ describe('SlideScroll', () => {
         impl.updateOnScroll_(1);
         expect(showSlideSpy).to.be.calledWith(4);
         expect(impl.slideIndex_).to.equal(4);
+      });
+    });
+
+    it('should get the correct next slide index for a scrollLeft' , () => {
+      return getAmpSlideScroll(true).then(obj => {
+        const ampSlideScroll = obj.ampSlideScroll;
+        const impl = ampSlideScroll.implementation_;
+
+        //Slide width = 400
+        impl.slideWidth_ = 400;
+        // Already at slide 0;
+
+        expect(impl.getNextSlideIndex_(0)).to.equal(4);
+        expect(impl.getNextSlideIndex_(100)).to.equal(4);
+        expect(impl.getNextSlideIndex_(200)).to.equal(0);
+        expect(impl.getNextSlideIndex_(400)).to.equal(0);
+        expect(impl.getNextSlideIndex_(500)).to.equal(0);
+        expect(impl.getNextSlideIndex_(600)).to.equal(1);
+        expect(impl.getNextSlideIndex_(800)).to.equal(1)
+
+        impl.showSlide_(3);
+
+        expect(impl.getNextSlideIndex_(0)).to.equal(2);
+        expect(impl.getNextSlideIndex_(100)).to.equal(2);
+        expect(impl.getNextSlideIndex_(200)).to.equal(3);
+        expect(impl.getNextSlideIndex_(400)).to.equal(3);
+        expect(impl.getNextSlideIndex_(500)).to.equal(3);
+        expect(impl.getNextSlideIndex_(600)).to.equal(4);
+        expect(impl.getNextSlideIndex_(800)).to.equal(4);
+
+        impl.showSlide_(4);
+        expect(impl.getNextSlideIndex_(0)).to.equal(3);
+        expect(impl.getNextSlideIndex_(100)).to.equal(3);
+        expect(impl.getNextSlideIndex_(200)).to.equal(4);
+        expect(impl.getNextSlideIndex_(400)).to.equal(4);
+        expect(impl.getNextSlideIndex_(500)).to.equal(4);
+        expect(impl.getNextSlideIndex_(600)).to.equal(0);
+        expect(impl.getNextSlideIndex_(800)).to.equal(0)
+      });
+    });
+
+    it('should custom snap to the correct slide', () => {
+      return getAmpSlideScroll(true).then(obj => {
+        const ampSlideScroll = obj.ampSlideScroll;
+        const impl = ampSlideScroll.implementation_;
+        const animateScrollLeftSpy = sandbox.spy(impl, 'animateScrollLeft_');
+        impl.slideWidth_ = 400;
+
+        impl.customSnap_(0);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+        impl.customSnap_(100);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
+        impl.customSnap_(200);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
+        impl.customSnap_(400);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+        impl.customSnap_(500);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(500, 400);
+        impl.customSnap_(600);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(600, 800);
+        impl.customSnap_(800);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(800, 800);
       });
     });
   });

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -19,7 +19,7 @@ import '../amp-carousel';
 import {createIframePromise} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';
 
-describe.only('SlideScroll', () => {
+describe('SlideScroll', () => {
   const SHOW_CLASS = '-amp-slide-item-show';
   let sandbox;
 
@@ -416,7 +416,35 @@ describe.only('SlideScroll', () => {
       expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
       impl.customSnap_(400);
       expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+    });
+  });
 
+  it('should handle custom elastic scroll', () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      const impl = ampSlideScroll.implementation_;
+      const customSnapSpy = sandbox.stub(impl, 'customSnap_', () => {
+        return {
+          then: cb => {
+            cb();
+          },
+        };
+      });
+      impl.slideWidth_ = 400;
+
+      impl.handleCustomElasticScroll_(-10);
+      expect(impl.elasticScrollState_).to.equal(-1);
+      impl.previousScrollLeft_ = -10;
+      impl.handleCustomElasticScroll_(-5);
+      expect(customSnapSpy).to.have.been.calledWith(-5);
+
+      impl.previousScrollLeft_ = null;
+
+      impl.handleCustomElasticScroll_(410);
+      expect(impl.elasticScrollState_).to.equal(1);
+      impl.previousScrollLeft_ = 410;
+      impl.handleCustomElasticScroll_(405);
+      expect(customSnapSpy).to.have.been.calledWith(405);
     });
   });
 
@@ -706,7 +734,7 @@ describe.only('SlideScroll', () => {
         expect(impl.getNextSlideIndex_(400)).to.equal(0);
         expect(impl.getNextSlideIndex_(500)).to.equal(0);
         expect(impl.getNextSlideIndex_(600)).to.equal(1);
-        expect(impl.getNextSlideIndex_(800)).to.equal(1)
+        expect(impl.getNextSlideIndex_(800)).to.equal(1);
 
         impl.showSlide_(3);
 
@@ -725,7 +753,7 @@ describe.only('SlideScroll', () => {
         expect(impl.getNextSlideIndex_(400)).to.equal(4);
         expect(impl.getNextSlideIndex_(500)).to.equal(4);
         expect(impl.getNextSlideIndex_(600)).to.equal(0);
-        expect(impl.getNextSlideIndex_(800)).to.equal(0)
+        expect(impl.getNextSlideIndex_(800)).to.equal(0);
       });
     });
 


### PR DESCRIPTION
**In this PR**

- Custom Snap implementation  (when native snap is not available.)
- Fix test-slides to not overwrite the Animation object globally.

**Yet to come**

- Animate prev and next button scrolling
- detect scroll end when touchend is available and use timeout as a backup (this should fix IOS elasticity issue 90% of the times)
- try tweak the timeout.
- Hide scrollbars where possible (and yet allow scrolling)

Demo: 

https://ampskrish.herokuapp.com/test/manual/amp-slidescroll.amp.html
(Remember to `AMP.toggleExperiment('amp-slidescroll);` before testing.)

Part 5 for - #3465