### PR TITLE
Only allocate a single primary custom element prototype per window.

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -22,6 +22,7 @@ import {ElementStub, stubbedElements} from './element-stub';
 import {createLoaderElement} from '../src/loader';
 import {dev, rethrowAsync, user} from './log';
 import {getIntersectionChangeEntry} from '../src/intersection-observer';
+import {getMode} from './mode';
 import {parseSizeList} from './size-list';
 import {reportError} from './error';
 import {resourcesFor} from './resources';
@@ -280,7 +281,6 @@ class AmpElement {
   // TODO(dvoytenko): Add all exposed methods.
 }
 
-
 /**
  * Creates a new custom element class prototype.
  *
@@ -293,10 +293,34 @@ class AmpElement {
  * @return {!Object} Prototype of element.
  */
 export function createAmpElementProto(win, name, opt_implementationClass) {
+  const ElementProto = win.Object.create(createBaseAmpElementProto(win));
+  ElementProto.name = name;
+  if (getMode().test && opt_implementationClass) {
+    ElementProto.implementationClassForTesting = opt_implementationClass;
+  }
+  return ElementProto;
+}
+
+/**
+ * Creates a new custom element class prototype.
+ *
+ * The prototype is cached per window and meant to be sub classed for a
+ * concrete object.
+ *
+ * @param {!Window} win The window in which to register the elements.
+ * @return {!Object} Prototype of element.
+ */
+function createBaseAmpElementProto(win) {
+
+  if (win.BaseCustomElementProto) {
+    return win.BaseCustomElementProto;
+  }
+
   /**
    * @lends {AmpElement.prototype}
    */
   const ElementProto = win.Object.create(win.HTMLElement.prototype);
+  win.BaseCustomElementProto = ElementProto;
 
   /**
    * Called when elements is created. Sets instance vars since there is no
@@ -317,7 +341,7 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
     this.everAttached = false;
 
     /** @private @const {!./service/resources-impl.Resources}  */
-    this.resources_ = resourcesFor(win);
+    this.resources_ = resourcesFor(this.ownerDocument.defaultView);
 
     /** @private {!Layout} */
     this.layout_ = Layout.NODISPLAY;
@@ -363,7 +387,10 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
     this.overflowElement_ = undefined;
 
     // `opt_implementationClass` is only used for tests.
-    const Ctor = opt_implementationClass || knownElements[name];
+    let Ctor = knownElements[this.name];
+    if (getMode().test && this.implementationClassForTesting) {
+      Ctor = this.implementationClassForTesting;
+    }
 
     /** @private {!./base-element.BaseElement} */
     this.implementation_ = new Ctor(this);

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -23,6 +23,8 @@ import {platform} from '../src/platform';
 import {setModeForTesting} from '../src/mode';
 import {setDefaultBootstrapBaseUrlForTesting} from '../src/3p-frame';
 
+// Needs to be called before the custom elements are first made.
+beforeTest();
 adopt(window);
 
 // Make amp section in karma config readable by tests.
@@ -110,10 +112,12 @@ sinon.sandbox.create = function(config) {
   return sandbox;
 };
 
-beforeEach(() => {
+beforeEach(beforeTest);
+
+function beforeTest() {
   setModeForTesting(null);
   window.AMP_TEST = true;
-});
+}
 
 // Global cleanup of tags added during tests. Cool to add more
 // to selector.


### PR DESCRIPTION
- This may save a lot of memory.
- But it makes the prototype chain of our custom elements deeper.