### PR TITLE
Do not execute pass callbacks if their window went away.

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -110,13 +110,6 @@ export function incrementLoadingAds(win) {
  * anyway.
  */
 export function isPositionFixed(el, win) {
-  // TODO(@cramforce): Figure out why test comes here with the window
-  // removed. This is somehow related to the resource framework running
-  // on a timer that is not bound to the lifetime of the iframe.
-  // See https://github.com/ampproject/amphtml/issues/3709
-  if (!win) {
-    return false;
-  }
   let hasFixedAncestor = false;
   do {
     if (POSITION_FIXED_TAG_WHITELIST[el.tagName]) {

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -105,7 +105,8 @@ export class Gestures {
     this.wasEventing_ = false;
 
     /** @private {!Pass} */
-    this.pass_ = new Pass(this.doPass_.bind(this));
+    this.pass_ = new Pass(element.ownerDocument.defaultView,
+        this.doPass_.bind(this));
 
     /** @private {!Observable} */
     this.pointerDownObservable_ = new Observable();

--- a/src/pass.js
+++ b/src/pass.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {timer} from './timer';
+import {timerFor} from './timer';
 
 
 /**
@@ -26,11 +26,14 @@ export class Pass {
 
   /**
    * Creates a new Pass instance.
+   * @param {!Window} win
    * @param {function()} handler Handler to be executed when pass is triggered.
    * @param {number=} opt_defaultDelay Default delay to be used when schedule
    *   is called without one.
    */
-  constructor(handler, opt_defaultDelay) {
+  constructor(win, handler, opt_defaultDelay) {
+    this.timer_ = timerFor(win);
+
     /** @private @const {function()} */
     this.handler_ = handler;
 
@@ -79,13 +82,13 @@ export class Pass {
       delay = 10;
     }
 
-    const nextTime = timer.now() + delay;
+    const nextTime = this.timer_.now() + delay;
     // Schedule anew if nothing is scheduled currently or if the new time is
     // sooner then previously requested.
     if (!this.isPending() || nextTime - this.nextTime_ < -10) {
       this.cancel();
       this.nextTime_ = nextTime;
-      this.scheduled_ = timer.delay(this.boundPass_, delay);
+      this.scheduled_ = this.timer_.delay(this.boundPass_, delay);
 
       return true;
     }
@@ -106,7 +109,7 @@ export class Pass {
    */
   cancel() {
     if (this.isPending()) {
-      timer.cancel(this.scheduled_);
+      this.timer_.cancel(this.scheduled_);
       this.scheduled_ = -1;
     }
   }

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -322,7 +322,7 @@ export class HistoryBindingNatural_ {
     history.pushState = this.historyPushState_.bind(this);
     history.replaceState = this.historyReplaceState_.bind(this);
 
-    const eventPass = new Pass(this.onHistoryEvent_.bind(this), 50);
+    const eventPass = new Pass(this.win, this.onHistoryEvent_.bind(this), 50);
     this.popstateHandler_ = e => {
       dev.fine(TAG_, 'popstate event: ' + this.win.history.length + ', ' +
           JSON.stringify(e.state));

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -118,7 +118,7 @@ export class Resources {
     this.lastVelocity_ = 0;
 
     /** @const {!Pass} */
-    this.pass_ = new Pass(() => this.doPass_());
+    this.pass_ = new Pass(this.win, () => this.doPass_());
 
     /** @const {!TaskQueue} */
     this.exec_ = new TaskQueue();

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -108,7 +108,7 @@ export class Vsync {
     this.boundRunScheduledTasks_ = this.runScheduledTasks_.bind(this);
 
     /** @const {!Pass} */
-    this.pass_ = new Pass(this.boundRunScheduledTasks_, FRAME_TIME);
+    this.pass_ = new Pass(this.win, this.boundRunScheduledTasks_, FRAME_TIME);
 
     // When the document changes visibility, vsync has to reschedule the queue
     // processing.

--- a/src/timer.js
+++ b/src/timer.js
@@ -18,6 +18,7 @@
 import './polyfills';
 
 import {user} from './log';
+import {getService} from './service';
 
 /**
  * Helper with all things Timer.
@@ -159,5 +160,15 @@ export class Timer {
   }
 }
 
+/**
+ * @param {!Window} window
+ * @return {!Timer}
+ */
+export function timerFor(window) {
+  return /** @type {!Timer} */ (getService(window, 'timer', () => {
+    return new Timer(window);
+  }));
+};
 
-export const timer = new Timer(window);
+
+export const timer = timerFor(window);

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -33,6 +33,9 @@ describe('TapRecognizer', () => {
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
+      ownerDocument: {
+        defaultView: window,
+      },
     };
 
     gestures = new Gestures(element);
@@ -122,6 +125,9 @@ describe('DoubletapRecognizer', () => {
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
+      ownerDocument: {
+        defaultView: window,
+      },
     };
 
     gestures = new Gestures(element);
@@ -227,6 +233,9 @@ describe('SwipeXYRecognizer', () => {
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
+      ownerDocument: {
+        defaultView: window,
+      },
     };
 
     gestures = new Gestures(element);
@@ -411,6 +420,9 @@ describe('TapzoomRecognizer', () => {
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
+      ownerDocument: {
+        defaultView: window,
+      },
     };
 
     gestures = new Gestures(element);
@@ -589,6 +601,9 @@ describe('PinchRecognizer', () => {
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
+      ownerDocument: {
+        defaultView: window,
+      },
     };
 
     gestures = new Gestures(element);

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -50,6 +50,9 @@ describe('Gestures', () => {
       addEventListener: (eventType, handler) => {
         eventListeners[eventType] = handler;
       },
+      ownerDocument: {
+        defaultView: window,
+      },
     };
 
     onGesture = sandbox.spy();

--- a/test/functional/test-pass.js
+++ b/test/functional/test-pass.js
@@ -29,7 +29,7 @@ describe('Pass', () => {
     sandbox = sinon.sandbox.create();
     timerMock = sandbox.mock(timer);
     handlerCalled = 0;
-    pass = new Pass(() => {
+    pass = new Pass(window, () => {
       handlerCalled++;
     });
   });
@@ -94,7 +94,7 @@ describe('Pass', () => {
   });
 
   it('should have a min delay for recursive schedule', () => {
-    pass = new Pass(() => {
+    pass = new Pass(window, () => {
       expect(pass.running_).to.equal(true);
       if (handlerCalled++ == 0) {
         pass.schedule();


### PR DESCRIPTION
This could happen in tests if multiple windows had different lifetime. Also turns timer into a service but does not yet fix all callsites.

Fixes #3709 but all the other timer usages could lead to similar issues.