### PR TITLE
Optimize functions that showed up in profile.

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -22,6 +22,7 @@ import {ElementStub, stubbedElements} from './element-stub';
 import {createLoaderElement} from '../src/loader';
 import {dev, rethrowAsync, user} from './log';
 import {getIntersectionChangeEntry} from '../src/intersection-observer';
+import {getMode} from './mode';
 import {parseSizeList} from './size-list';
 import {reportError} from './error';
 import {resourcesFor} from './resources';
@@ -668,11 +669,19 @@ export function createAmpElementProto(win, name, opt_implementationClass) {
 
 
   /**
+   * Dispatches a custom event.
+   *
+   * NOTE: This is currently only active for tests.
+   * Do not rely on this mechanism for production code.
+   *
    * @param {string} name
    * @param {!Object=} opt_data Event data.
    * @final @this {!Element}
    */
   ElementProto.dispatchCustomEvent = function(name, opt_data) {
+    if (!getMode().test) {
+      return;
+    }
     const data = opt_data || {};
     // Constructors of events need to come from the correct window. Sigh.
     const win = this.ownerDocument.defaultView;

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -142,8 +142,12 @@ export function toggleExperiment(win, experimentId, opt_on,
  * @return {!Array<string>}
  */
 function getExperimentIds(win) {
+  if (win._experimentCookie) {
+    return win._experimentCookie;
+  }
   const experimentCookie = getCookie(win, COOKIE_NAME);
-  return experimentCookie ? experimentCookie.split(/\s*,\s*/g) : [];
+  return win._experimentCookie = (
+      experimentCookie ? experimentCookie.split(/\s*,\s*/g) : []);
 }
 
 
@@ -153,6 +157,7 @@ function getExperimentIds(win) {
  * @param {!Array<string>} experimentIds
  */
 function saveExperimentIds(win, experimentIds) {
+  win._experimentCookie = null;
   setCookie(win, COOKIE_NAME, experimentIds.join(','),
       timer.now() + COOKIE_EXPIRATION_INTERVAL);
 }

--- a/src/log.js
+++ b/src/log.js
@@ -70,7 +70,7 @@ export class Log {
      * the tests runs because only the former is relayed to the console.
      * @const {!Window}
      */
-    this.win = win.AMP_TEST_IFRAME ? win.parent : win;
+    this.win = (getMode().test && win.AMP_TEST_IFRAME) ? win.parent : win;
 
     /** @private @const {function(!./mode.ModeDef):!LogLevel} */
     this.levelFunc_ = levelFunc;
@@ -98,7 +98,7 @@ export class Log {
     }
 
     // Logging is enabled for tests directly.
-    if (this.win.ENABLE_LOG) {
+    if (getMode().test && this.win.ENABLE_LOG) {
       return LogLevel.FINE;
     }
 

--- a/src/mode.js
+++ b/src/mode.js
@@ -95,7 +95,7 @@ function getMode_() {
     filter: developmentQuery['filter'],
     /* global process: false */
     minified: process.env.NODE_ENV == 'production',
-    test: !!(window.AMP_TEST),
+    test: !!(window.AMP_TEST || window.__karma__),
     log: developmentQuery['log'],
     version: fullVersion,
   };

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -50,8 +50,17 @@ export class UrlReplacements {
     this.replacements_ = this.win_.Object.create(null);
 
     /** @private @const {function():!Promise<?AccessService>} */
-    this.getAccessService_ = accessServiceForOrNull.bind(null);
+    this.getAccessService_ = accessServiceForOrNull;
 
+    /** @private {boolean} */
+    this.initialized_ = false;
+  }
+
+  /**
+   * Lazily initialize the default replacements.
+   */
+  initialize_() {
+    this.initialized_ = true;
     // Returns a random value for cache busters.
     this.set_('RANDOM', () => {
       return Math.random();
@@ -158,7 +167,7 @@ export class UrlReplacements {
           return service.get(opt_userNotificationId);
         });
       }
-      return cidFor(win).then(cid => {
+      return cidFor(this.win_).then(cid => {
         return cid.get({
           scope,
           createCookieIfNotPresent: true,
@@ -449,6 +458,9 @@ export class UrlReplacements {
    * @private
    */
   expand_(url, opt_bindings, opt_collectVars) {
+    if (!this.initialized_) {
+      this.initialize_();
+    }
     const expr = this.getExpr_(opt_bindings);
     let replacementPromise;
     const encodeValue = val => {
@@ -520,6 +532,7 @@ export class UrlReplacements {
   }
 
   /**
+   * Method exists to assist stubbing in tests.
    * @param {string} name
    * @return {function(*):*}
    */

--- a/src/url.js
+++ b/src/url.js
@@ -75,6 +75,7 @@ export function parseUrl(url) {
     pathname: a.pathname,
     search: a.search,
     hash: a.hash,
+    origin: null,  // Set below.
   };
 
   // Some IE11 specific polyfills.

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -86,6 +86,7 @@ describe('Logging', () => {
     });
 
     it('should be enabled when forced for tests', () => {
+      mode.test = true;
       win.ENABLE_LOG = true;
       expect(new Log(win, RETURNS_OFF).level_).to.equal(LogLevel.FINE);
     });


### PR DESCRIPTION
- no longer dispatch custom events in prod that we only use for tests.
- cache parsed experiment cookie.
- optimize log class to short circuit more conditionals in prod.
- do not allocate a promise per service unless required.
- lazily initialize URL replacement functions.
- never change the shape of the URL object.