### PR TITLE
Add option to create an optimized build with readable names.

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -35,7 +35,9 @@ public class AmpCommandLineRunner extends CommandLineRunner {
    * Identifies if the runner only needs to do type checking.
    */
   private boolean typecheck_only = false;
-  
+
+  private boolean pseudo_names = false;
+
   private boolean is_production_env = true;
 
   /**
@@ -72,6 +74,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     options.setRenamingPolicy(VariableRenamingPolicy.ALL,
         PropertyRenamingPolicy.ALL_UNQUOTED);
     options.setDisambiguatePrivateProperties(true);
+    options.setGeneratePseudoNames(pseudo_names);
     return options;
   }
 
@@ -90,23 +93,17 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     return options;
   }
 
-  protected void setTypeCheckOnly(boolean value) {
-    typecheck_only = value;
-  }
-  
-  protected void setProductionFlag(boolean value) {
-    is_production_env = value;
-  }
-
   public static void main(String[] args) {
     AmpCommandLineRunner runner = new AmpCommandLineRunner(args);
 
     // Scan for TYPECHECK_ONLY string which we pass in as a --define
     for (String arg : args) {
       if (arg.contains("--define=TYPECHECK_ONLY=true")) {
-        runner.setTypeCheckOnly(true);
+        runner.typecheck_only = true;
       } else if (arg.contains("--define=FORTESTING=true")) {
-        runner.setProductionFlag(false);
+        runner.is_production_env = false;
+      } else if (arg.contains("--define=PSEUDO_NAMES=true")) {
+        runner.pseudo_names = true;
       }
     }
 

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -227,7 +227,9 @@ function compile(entryModuleFilename, outputDir,
       compilerOptions.compilerFlags.define.push('TYPECHECK_ONLY=true');
       compilerOptions.compilerFlags.jscomp_error = 'checkTypes';
     }
-
+    if (argv.pseudo_names) {
+      compilerOptions.compilerFlags.define.push('PSEUDO_NAMES=true');
+    }
     if (argv.fortesting) {
       compilerOptions.compilerFlags.define.push('FORTESTING=true');
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -775,7 +775,13 @@ gulp.task('build', 'Builds the AMP library', build);
 gulp.task('check-types', 'Check JS types', checkTypes);
 gulp.task('css', 'Recompile css to build directory', compileCss);
 gulp.task('default', 'Same as "watch"', ['watch', 'serve']);
-gulp.task('dist', 'Build production binaries', dist);
+gulp.task('dist', 'Build production binaries', dist, {
+  options: {
+    pseudo_names: 'Compiles with readable names. ' +
+        'Great for profiling and debugging production code.',
+    fortesting: 'Compiles with `getMode().test` set to true',
+  }
+});
 gulp.task('extensions', 'Build AMP Extensions', buildExtensions);
 gulp.task('watch', 'Watches for changes in files, re-build', watch);
 gulp.task('build-experiments', 'Builds experiments.html/js', buildExperiments);


### PR DESCRIPTION
This is great for debugging production issues, but even better for profiling prod code.

`gulp dist --pseudo_names`

![Example names](https://i.imgur.com/TxDZjoT.png)