### PR TITLE
Optimize preconnect and rename `prefetch` to `preload`.

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -16,7 +16,7 @@
 
 import {removeElement} from '../../../src/dom';
 import {getAdCid} from '../../../src/ad-cid';
-import {prefetchBootstrap} from '../../../src/3p-frame';
+import {preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
 import {adPrefetch, adPreconnect} from '../../../ads/_config';
@@ -202,15 +202,15 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // We always need the bootstrap.
-    prefetchBootstrap(this.getWin());
+    preloadBootstrap(this.getWin());
     const type = this.element.getAttribute('type');
     const prefetch = adPrefetch[type];
     const preconnect = adPreconnect[type];
     if (typeof prefetch == 'string') {
-      this.preconnect.prefetch(prefetch, 'script');
+      this.preconnect.preload(prefetch, 'script');
     } else if (prefetch) {
       prefetch.forEach(p => {
-        this.preconnect.prefetch(p, 'script');
+        this.preconnect.preload(p, 'script');
       });
     }
     if (typeof preconnect == 'string') {

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -15,7 +15,7 @@
  */
 
 
-import {getIframe, prefetchBootstrap} from '../../../src/3p-frame';
+import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
@@ -26,9 +26,9 @@ class AmpFacebook extends AMP.BaseElement {
   preconnectCallback(onLayout) {
     this.preconnect.url('https://facebook.com', onLayout);
     // Hosts the facebook SDK.
-    this.preconnect.prefetch(
+    this.preconnect.preload(
         'https://connect.facebook.net/en_US/sdk.js', 'script');
-    prefetchBootstrap(this.getWin());
+    preloadBootstrap(this.getWin());
   }
 
   /** @override */

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -15,7 +15,7 @@
  */
 
 
-import {getIframe, prefetchBootstrap} from '../../../src/3p-frame';
+import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {loadPromise} from '../../../src/event-helper';
@@ -29,9 +29,9 @@ class AmpTwitter extends AMP.BaseElement {
     // All images
     this.preconnect.url('https://pbs.twimg.com', onLayout);
     // Hosts the script that renders tweets.
-    this.preconnect.prefetch(
+    this.preconnect.preload(
         'https://platform.twitter.com/widgets.js', 'script');
-    prefetchBootstrap(this.getWin());
+    preloadBootstrap(this.getWin());
   }
 
   /** @override */
@@ -46,7 +46,6 @@ class AmpTwitter extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    // TODO(malteubl): Preconnect to twitter.
     const iframe = getIframe(this.element.ownerDocument.defaultView,
         this.element, 'twitter');
     this.applyFillContent(iframe);

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -165,17 +165,17 @@ export function addDataAndJsonAttributes_(element, attributes) {
 }
 
 /**
- * Prefetches URLs related to the bootstrap iframe.
+ * Preloads URLs related to the bootstrap iframe.
  * @param {!Window} parentWindow
  * @return {string}
  */
-export function prefetchBootstrap(window) {
+export function preloadBootstrap(window) {
   const url = getBootstrapBaseUrl(window);
   const preconnect = preconnectFor(window);
-  preconnect.prefetch(url, 'document');
+  preconnect.preload(url, 'document');
   // While the URL may point to a custom domain, this URL will always be
   // fetched by it.
-  preconnect.prefetch(
+  preconnect.preload(
       'https://3p.ampproject.net/$internalRuntimeVersion$/f.js', 'script');
 }
 

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -19,12 +19,11 @@ import {
   getIframe,
   getBootstrapBaseUrl,
   getSubDomain,
-  prefetchBootstrap,
+  preloadBootstrap,
   resetCountForTesting,
 } from '../../src/3p-frame';
 import {documentInfoFor} from '../../src/document-info';
 import {loadPromise} from '../../src/event-helper';
-import {preconnectFor} from '../../src/preconnect';
 import {resetServiceForTesting} from '../../src/service';
 import {setModeForTesting} from '../../src/mode';
 import {validateData} from '../../3p/3p';
@@ -220,20 +219,16 @@ describe('3p-frame', () => {
 
   it('should prefetch bootstrap frame and JS', () => {
     setModeForTesting({localDev: true});
-    const preconnect = preconnectFor(window);
-    const origPreloadSupportValue = preconnect.preloadSupported_;
-    preconnect.preloadSupported_ = false;
-    prefetchBootstrap(window);
+    preloadBootstrap(window);
     // Wait for visible promise
     return Promise.resolve().then(() => {
       const fetches = document.querySelectorAll(
-          'link[rel=prefetch]');
+          'link[rel=prefetch],link[rel=preload]');
       expect(fetches).to.have.length(2);
       expect(fetches[0].href).to.equal(
           'http://ads.localhost:9876/dist.3p/current/frame.max.html');
       expect(fetches[1].href).to.equal(
           'https://3p.ampproject.net/$internalRuntimeVersion$/f.js');
-      preconnect.preloadSupported_ = origPreloadSupportValue;
     });
   });
 


### PR DESCRIPTION
The optimization is to no longer create the `dns-prefetch` link tag if we know that the browser support preconnect (which also resolves DNS, of course).

Renamed the `prefetch` method to `preload` because that is the preferred implementation in browsers that support it.