### PR TITLE
Set `referrerpolicy=origin` on auto generated placeholders.

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -51,7 +51,7 @@ export class AmpImg extends BaseElement {
     if (this.element.id) {
       this.img_.setAttribute('amp-img-id', this.element.id);
     }
-    this.propagateAttributes(['alt'], this.img_);
+    this.propagateAttributes(['alt', 'referrerpolicy'], this.img_);
     this.applyFillContent(this.img_, true);
 
     this.img_.width = getLengthNumeral(this.element.getAttribute('width'));

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -127,6 +127,7 @@ class AmpBridPlayer extends AMP.BaseElement {
     imgPlaceholder.setAttribute('placeholder', '');
     imgPlaceholder.width = this.width_;
     imgPlaceholder.height = this.height_;
+    imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
     this.element.appendChild(imgPlaceholder);
     this.applyFillContent(imgPlaceholder);

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -88,6 +88,7 @@ class AmpInstagram extends AMP.BaseElement {
     image.setAttribute('src', 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/media/?size=l');
     image.setAttribute('layout', 'fill');
+    image.setAttribute('referrerpolicy', 'origin');
 
     this.propagateAttributes(['alt'], image);
 

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -46,6 +46,7 @@ describe('amp-instagram', () => {
         'https://www.instagram.com/p/fBwFP/media/?size=l');
     expect(image.getAttribute('layout')).to.equal('fill');
     expect(image.getAttribute('alt')).to.equal('Testing');
+    expect(image.getAttribute('referrerpolicy')).to.equal('origin');
   }
 
   function testIframe(iframe) {

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -107,6 +107,7 @@ class AmpJWPlayer extends AMP.BaseElement {
     imgPlaceholder.setAttribute('placeholder', '');
     imgPlaceholder.width = this.width_;
     imgPlaceholder.height = this.height_;
+    imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
     this.applyFillContent(imgPlaceholder);
 

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -96,6 +96,7 @@ class AmpKaltura extends AMP.BaseElement {
     imgPlaceholder.setAttribute('placeholder', '');
     imgPlaceholder.width = this.width_;
     imgPlaceholder.height = this.height_;
+    imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
     this.element.appendChild(imgPlaceholder);
     this.applyFillContent(imgPlaceholder);

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -132,6 +132,7 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
 
     this.element.appendChild(imgPlaceholder);
     this.applyFillContent(imgPlaceholder);
+    imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
     loadPromise(imgPlaceholder).then(() => {
       setStyles(imgPlaceholder, {

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -194,6 +194,7 @@ class AmpYoutube extends AMP.BaseElement {
     imgPlaceholder.setAttribute('placeholder', '');
     imgPlaceholder.width = this.width_;
     imgPlaceholder.height = this.height_;
+    imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
     this.element.appendChild(imgPlaceholder);
     this.applyFillContent(imgPlaceholder);

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -102,6 +102,7 @@ describe('amp-youtube', function() {
       expect(imgPlaceholder.className).to.not.match(/amp-hidden/);
       expect(imgPlaceholder.src).to.be.equal(
           'https://i.ytimg.com/vi/mGENRKrdoGY/sddefault.jpg#404_is_fine');
+      expect(imgPlaceholder.getAttribute('referrerpolicy')).to.equal('origin');
     }).then(yt => {
       const iframe = yt.querySelector('iframe');
       expect(iframe).to.not.be.null;
@@ -119,12 +120,14 @@ describe('amp-youtube', function() {
       const imgPlaceholder = yt.querySelector('img[placeholder]');
       expect(imgPlaceholder).to.not.be.null;
       expect(imgPlaceholder.className).to.not.match(/amp-hidden/);
+      expect(imgPlaceholder.getAttribute('referrerpolicy')).to.equal('origin');
     }).then(yt => {
       const iframe = yt.querySelector('iframe');
       expect(iframe).to.not.be.null;
 
       const imgPlaceholder = yt.querySelector('img[placeholder]');
       expect(imgPlaceholder.className).to.match(/amp-hidden/);
+      expect(imgPlaceholder.getAttribute('referrerpolicy')).to.equal('origin');
 
       expect(imgPlaceholder.src).to.equal(
           'https://i.ytimg.com/vi/mGENRKrdoGY/sddefault.jpg#404_is_fine');

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -49,6 +49,23 @@ describe('amp-img', () => {
     });
   }
 
+  it('should load an img with more attributes', () => {
+    return getImg({
+      src: '/base/examples/img/sample.jpg',
+      width: 300,
+      height: 200,
+      alt: 'An image',
+      referrerpolicy: 'origin',
+    }).then(ampImg => {
+      const img = ampImg.querySelector('img');
+      expect(img.tagName).to.equal('IMG');
+      expect(img.getAttribute('src')).to.equal('/base/examples/img/sample.jpg');
+      expect(ampImg.implementation_.getPriority()).to.equal(0);
+      expect(img.getAttribute('alt')).to.equal('An image');
+      expect(img.getAttribute('referrerpolicy')).to.equal('origin');
+    });
+  });
+
   it('should load an img', () => {
     return getImg({
       src: '/base/examples/img/sample.jpg',
@@ -71,6 +88,7 @@ describe('amp-img', () => {
       const img = ampImg.querySelector('img');
       expect(img.tagName).to.equal('IMG');
       expect(img.getAttribute('src')).to.equal('/base/examples/img/sample.jpg');
+      expect(img.hasAttribute('referrerpolicy')).to.be.false;
     });
   });
 


### PR DESCRIPTION
This seems appropriate, because we load these directly from the hosting servers instead of going through the AMP Cache.