### PR TITLE
Set inViewport before scheduling layout

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -603,9 +603,10 @@ export class Resources {
   /**
    * Schedules the work pass at the latest with the specified delay.
    * @param {number=} opt_delay
+   * @return {boolean}
    */
   schedulePass(opt_delay) {
-    this.pass_.schedule(opt_delay);
+    return this.pass_.schedule(opt_delay);
   }
 
   /**
@@ -931,7 +932,23 @@ export class Resources {
       ? expandLayoutRect(viewportRect, 0.25, 0.25)
       : viewportRect;
 
-    // Phase 3: Schedule elements for layout within a reasonable distance from
+    // Phase 3: Trigger "viewport enter/exit" events.
+    for (let i = 0; i < this.resources_.length; i++) {
+      const r = this.resources_[i];
+      if (r.hasOwner()) {
+        continue;
+      }
+      // Note that when the document is not visible, neither are any of its
+      // elements to reduce CPU cycles.
+      // TODO(dvoytenko, #3434): Reimplement the use of `isFixed` with
+      // layers. This is currently a short-term fix to the problem that
+      // the fixed elements get incorrect top coord.
+      const shouldBeInViewport = (this.visible_ && r.isDisplayed() &&
+          (r.isFixed() || r.overlaps(visibleRect)));
+      r.setInViewport(shouldBeInViewport);
+    }
+
+    // Phase 4: Schedule elements for layout within a reasonable distance from
     // current viewport.
     if (loadRect) {
       for (let i = 0; i < this.resources_.length; i++) {
@@ -946,22 +963,6 @@ export class Resources {
           this.scheduleLayoutOrPreload_(r, /* layout */ true);
         }
       }
-    }
-
-    // Phase 4: Trigger "viewport enter/exit" events.
-    for (let i = 0; i < this.resources_.length; i++) {
-      const r = this.resources_[i];
-      if (r.hasOwner()) {
-        continue;
-      }
-      // Note that when the document is not visible, neither are any of its
-      // elements to reduce CPU cycles.
-      // TODO(dvoytenko, #3434): Reimplement the use of `isFixed` with
-      // layers. This is currently a short-term fix to the problem that
-      // the fixed elements get incorrect top coord.
-      const shouldBeInViewport = (this.visible_ && r.isDisplayed() &&
-          (r.isFixed() || r.overlaps(visibleRect)));
-      r.setInViewport(shouldBeInViewport);
     }
 
     // Phase 5: Idle layout: layout more if we are otherwise not doing much.
@@ -1410,8 +1411,11 @@ export class Resources {
           delay = Math.min(delay, MUTATE_DEFER_DELAY_);
         }
         if (this.visible_) {
-          dev.fine(TAG_, 'next pass:', delay);
-          this.schedulePass(delay);
+          if (this.schedulePass(delay)) {
+            dev.fine(TAG_, 'next pass:', delay);
+          } else {
+            dev.fine(TAG_, 'pass already scheduled');
+          }
         } else {
           dev.fine(TAG_, 'document is not visible: no scheduling');
         }


### PR DESCRIPTION
Fixes #3911.

Now the scrolled-into-view `<amp-instagram>` will be scheduled to layout in the first pass after scrolling into view (~10ms, which is just execution time, no idle waiting).