### PR TITLE
Use translate instead of visibility in viewer example

### DIFF
--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -84,11 +84,11 @@
       right: 0;
       bottom: 0;
       overflow-x: hidden;
-      visibility: hidden;
+      transform: translateX(-100%);
     }
 
     viewer[data-show-container="1"] #container1 {
-      visibility: visible;
+      transform: translateX(0);
     }
 
     viewer[data-show-container="1"] #show-container1-anchor {
@@ -96,7 +96,7 @@
     }
 
     viewer[data-show-container="2"] #container2 {
-      visibility: visible;
+      transform: translateX(0);
     }
 
     viewer[data-show-container="2"] #show-container2-anchor {
@@ -104,7 +104,7 @@
     }
 
     viewer[data-show-container="3"] #container3 {
-      visibility: visible;
+      transform: translateX(0);
     }
 
     viewer[data-show-container="3"] #show-container3-anchor {
@@ -112,7 +112,7 @@
     }
 
     viewer[data-show-container="4"] #container4 {
-      visibility: visible;
+      transform: translateX(0);
     }
 
     viewer[data-show-container="4"] #show-container4-anchor {

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -84,11 +84,13 @@
       right: 0;
       bottom: 0;
       overflow-x: hidden;
+      visibility: hidden;
       transform: translateX(-100%);
     }
 
     viewer[data-show-container="1"] #container1 {
-      transform: translateX(0);
+      visibility: visible;
+      transform: none;
     }
 
     viewer[data-show-container="1"] #show-container1-anchor {
@@ -96,7 +98,8 @@
     }
 
     viewer[data-show-container="2"] #container2 {
-      transform: translateX(0);
+      visibility: visible;
+      transform: none;
     }
 
     viewer[data-show-container="2"] #show-container2-anchor {
@@ -104,7 +107,8 @@
     }
 
     viewer[data-show-container="3"] #container3 {
-      transform: translateX(0);
+      visibility: visible;
+      transform: none;
     }
 
     viewer[data-show-container="3"] #show-container3-anchor {
@@ -112,7 +116,8 @@
     }
 
     viewer[data-show-container="4"] #container4 {
-      transform: translateX(0);
+      visibility: visible;
+      transform: none;
     }
 
     viewer[data-show-container="4"] #show-container4-anchor {


### PR DESCRIPTION
This fixes an unknown issue when opening the viewer example on an iOS device. Visibility doesn't work and hence viewer example is scrambled and unusable. 

Viewer using visibility viewed on an iOS device:
http://amp-mk-1.herokuapp.com/examples.build/viewer.html
![Viewer using visibility viewed on an iOS device](https://cloud.githubusercontent.com/assets/2647/16671238/3f7f55da-4453-11e6-9c61-bf865cfc6a8b.png)


Viewer using translate(-100%) viewed on an iOS device:
http://amp-mk-3.herokuapp.com/examples.build/viewer.html
![image](https://cloud.githubusercontent.com/assets/2647/16671563/e152ed58-4454-11e6-8cc0-f3271b6f55f4.png)

