### PR TITLE
Amp slidescroll experiment - Animate navigation buttons

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -227,19 +227,19 @@ export class AmpSlideScroll extends BaseCarousel {
   /**
    * Animate and snap to the correct slide for a given scrollLeft.
    * @param {number} currentScrollLeft scrollLeft value of the slides container.
-   * @param {number=} optForceDir if a valid direction is given force it to
+   * @param {number=} opt_forceDir if a valid direction is given force it to
    *    move 1 slide in that direction.
    * @return {!Promise}
    */
-  customSnap_(currentScrollLeft, optForceDir) {
+  customSnap_(currentScrollLeft, opt_forceDir) {
     this.snappingInProgress_ = true;
     const newIndex = this.getNextSlideIndex_(currentScrollLeft);
     let toScrollLeft;
     let diff = newIndex - this.slideIndex_;
     const hasPrev = this.hasPrev();
 
-    if (diff == 0 && (optForceDir == 1 || optForceDir == -1)) {
-      diff = optForceDir;
+    if (diff == 0 && (opt_forceDir == 1 || opt_forceDir == -1)) {
+      diff = opt_forceDir;
     }
 
     if (diff == 0) {

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -142,17 +142,25 @@ export class AmpSlideScroll extends BaseCarousel {
   }
 
   /** @override */
-  goCallback(dir, unusedAnimate) {
+  goCallback(dir, animate) {
     if (this.slideIndex_ != null) {
-      if ((dir == 1 && this.hasNext()) ||
-          (dir == -1 && this.hasPrev())) {
+      const hasNext = this.hasNext();
+      const hasPrev = this.hasPrev();
+      if ((dir == 1 && hasNext) ||
+          (dir == -1 && hasPrev)) {
         let newIndex = this.slideIndex_ + dir;
         if (newIndex == -1) {
           newIndex = this.noOfSlides_ - 1;
         } else if (newIndex >= this.noOfSlides_) {
           newIndex = 0;
         }
-        this.showSlide_(newIndex);
+        if (animate) {
+          const currentScrollLeft =
+              (dir == 1 && !hasPrev) ? 0 : this.slideWidth_;
+          this.customSnap_(currentScrollLeft, dir);
+        } else {
+          this.showSlide_(newIndex);
+        }
       }
     }
   }
@@ -219,14 +227,20 @@ export class AmpSlideScroll extends BaseCarousel {
   /**
    * Animate and snap to the correct slide for a given scrollLeft.
    * @param {number} currentScrollLeft scrollLeft value of the slides container.
+   * @param {number=} optForceDir if a valid direction is given force it to
+   *    move 1 slide in that direction.
    * @return {!Promise}
    */
-  customSnap_(currentScrollLeft) {
+  customSnap_(currentScrollLeft, optForceDir) {
     this.snappingInProgress_ = true;
     const newIndex = this.getNextSlideIndex_(currentScrollLeft);
     let toScrollLeft;
-    const diff = newIndex - this.slideIndex_;
+    let diff = newIndex - this.slideIndex_;
     const hasPrev = this.hasPrev();
+
+    if (diff == 0 && (optForceDir == 1 || optForceDir == -1)) {
+      diff = optForceDir;
+    }
 
     if (diff == 0) {
       // Snap and stay.

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -98,6 +98,26 @@ describe('SlideScroll', () => {
     });
   });
 
+  it('should go to the correct slide on button click', () => {
+    return getAmpSlideScroll().then(obj => {
+      const ampSlideScroll = obj.ampSlideScroll;
+      const impl = ampSlideScroll.implementation_;
+      const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+      impl.slideWidth_ = 400;
+
+      impl.goCallback(1);
+      expect(showSlideSpy).to.have.been.calledWith(1);
+      expect(showSlideSpy.callCount).to.equal(1);
+
+      impl.goCallback(-1);
+      expect(showSlideSpy).to.have.been.calledWith(0);
+      expect(showSlideSpy.callCount).to.equal(2);
+
+      impl.goCallback(0);
+      expect(showSlideSpy.callCount).to.equal(2);
+    });
+  });
+
   it('should show the correct slide', () => {
     return getAmpSlideScroll().then(obj => {
       const ampSlideScroll = obj.ampSlideScroll;
@@ -415,6 +435,27 @@ describe('SlideScroll', () => {
       impl.customSnap_(200);
       expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
       impl.customSnap_(400);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+
+      impl.showSlide_(0);
+
+      impl.customSnap_(0, -1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+      impl.customSnap_(0, 1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
+
+      impl.showSlide_(3);
+
+      impl.customSnap_(400, -1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
+      impl.customSnap_(400, 1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
+
+      impl.showSlide_(4);
+
+      impl.customSnap_(400, -1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
+      impl.customSnap_(400, 1);
       expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
     });
   });
@@ -778,6 +819,32 @@ describe('SlideScroll', () => {
         expect(animateScrollLeftSpy).to.have.been.calledWith(600, 800);
         impl.customSnap_(800);
         expect(animateScrollLeftSpy).to.have.been.calledWith(800, 800);
+
+        impl.customSnap_(400, -1);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
+        impl.customSnap_(400, 1);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 800);
+      });
+    });
+
+    it('should go to the correct slide on button click', () => {
+      return getAmpSlideScroll(true).then(obj => {
+        const ampSlideScroll = obj.ampSlideScroll;
+        const impl = ampSlideScroll.implementation_;
+        const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+        impl.slideWidth_ = 400;
+
+        impl.goCallback(-1);
+        expect(showSlideSpy).to.have.been.calledWith(4);
+        expect(showSlideSpy.callCount).to.equal(1);
+
+        impl.goCallback(1);
+        expect(showSlideSpy).to.have.been.calledWith(0);
+        expect(showSlideSpy.callCount).to.equal(2);
+
+        impl.goCallback(1);
+        expect(showSlideSpy).to.have.been.calledWith(1);
+        expect(showSlideSpy.callCount).to.equal(3);
       });
     });
   });


### PR DESCRIPTION
**In this PR**

- Animate prev and next button scrolling

**Yet to come**

- detect scroll end when touchend is available and use timeout as a backup (this should fix IOS elasticity issue 90% of the times)
- Move autoplay to base template.
- try tweak the timeout.
- Hide scrollbars where possible (and yet allow scrolling)

Part 7 for - #3465