### PR TITLE
Server-side access dogfood.

### DIFF
--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -199,7 +199,7 @@ export class AccessService {
       case AccessType.OTHER:
         return new AccessOtherAdapter(this.win, configJson, context);
     }
-    throw dev.createError('Unsuported access type: ', this.type_);
+    throw dev.createError('Unsupported access type: ', this.type_);
   }
 
   /**
@@ -213,6 +213,10 @@ export class AccessService {
     if (type == AccessType.SERVER && !this.isServerEnabled_) {
       user.warn(TAG, 'Experiment "amp-access-server" is not enabled.');
       type = AccessType.CLIENT;
+    }
+    if (type == AccessType.CLIENT && this.isServerEnabled_) {
+      user.info(TAG, 'Forcing access type: SERVER');
+      type = AccessType.SERVER;
     }
     return type;
   }

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -157,6 +157,15 @@ describe('AccessService', () => {
     expect(new AccessService(window).adapter_).to.be
         .instanceOf(AccessServerAdapter);
 
+    // When the 'amp-access-server' experiment is enabled, documents with
+    // access type 'client' are also treated as 'server'.
+    config['type'] = 'client';
+    toggleExperiment(window, 'amp-access-server', true);
+    element.textContent = JSON.stringify(config);
+    expect(new AccessService(window).type_).to.equal('server');
+    expect(new AccessService(window).adapter_).to.be
+        .instanceOf(AccessServerAdapter);
+
     config['type'] = 'other';
     element.textContent = JSON.stringify(config);
     expect(new AccessService(window).type_).to.equal('other');


### PR DESCRIPTION
Forces the SERVER access type on all documents when the amp-access-server
experiment flag is set.