### PR TITLE
getLengthNumeral() function: check input param null and return undefined

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -211,10 +211,8 @@ export function getLengthUnits(length) {
  * @return {number|undefined}
  */
 export function getLengthNumeral(length) {
-  if (!length) {
-    return undefined;
-  }
-  return parseFloat(length);
+  const res = parseFloat(length);
+  return isNaN(res) ? undefined : res;
 }
 
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -208,9 +208,12 @@ export function getLengthUnits(length) {
 /**
  * Returns the numeric value of a CSS length value.
  * @param {!LengthDef|string} length
- * @return {number}
+ * @return {number|undefined}
  */
 export function getLengthNumeral(length) {
+  if (!length) {
+    return undefined;
+  }
   return parseFloat(length);
 }
 

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -86,6 +86,7 @@ describe('Layout', () => {
     expect(getLengthNumeral('10.1vmin')).to.equal(10.1);
 
     expect(getLengthNumeral(null)).to.equal(undefined);
+    expect(getLengthNumeral('auto')).to.equal(undefined);
   });
 
   it('assertLength', () => {

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -84,6 +84,8 @@ describe('Layout', () => {
     expect(getLengthNumeral('10.1px')).to.equal(10.1);
     expect(getLengthNumeral('10.1em')).to.equal(10.1);
     expect(getLengthNumeral('10.1vmin')).to.equal(10.1);
+
+    expect(getLengthNumeral(null)).to.equal(undefined);
   });
 
   it('assertLength', () => {


### PR DESCRIPTION
fix #3953