### PR TITLE
Make URLs configurable from AMP_CONFIG

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -24,6 +24,7 @@
 
 import './polyfills';
 import {installEmbedStateListener} from './environment';
+import {urls} from '../src/config';
 import {a9} from '../ads/a9';
 import {adblade, industrybrains} from '../ads/adblade';
 import {adition} from '../ads/adition';
@@ -421,11 +422,13 @@ export function validateParentOrigin(window, parentLocation) {
  * @visiblefortesting
  */
 export function validateAllowedTypes(window, type, allowedTypes) {
+  const thirdPartyHost = parseUrl(urls.thirdParty).hostname;
+
   // Everything allowed in default iframe.
-  if (window.location.hostname == '3p.ampproject.net') {
+  if (window.location.hostname == thirdPartyHost) {
     return;
   }
-  if (/^d-\d+\.ampproject\.net$/.test(window.location.hostname)) {
+  if (urls.thirdPartyFrameRegex.test(window.location.hostname)) {
     return;
   }
   if (window.location.hostname == 'ads.localhost') {
@@ -453,7 +456,8 @@ export function validateAllowedEmbeddingOrigins(window, allowedHostnames) {
   // nothing.
   const ancestor = ancestors ? ancestors[0] : window.document.referrer;
   let hostname = parseUrl(ancestor).hostname;
-  const onDefault = hostname == 'cdn.ampproject.org';
+  const cdnHostname = parseUrl(urls.cdn).hostname;
+  const onDefault = hostname == cdnHostname;
   if (onDefault) {
     // If we are on the cache domain, parse the source hostname from
     // the referrer. The referrer is used because it should be
@@ -527,7 +531,7 @@ export function isTagNameAllowed(type, tagName) {
  * @param {!Error} e
  */
 function lightweightErrorReport(e) {
-  new Image().src = 'https://amp-error-reporting.appspot.com/r' +
+  new Image().src = urls.errorReporting +
       '?3p=1&v=' + encodeURIComponent('$internalRuntimeVersion$') +
       '&m=' + encodeURIComponent(e.message) +
       '&r=' + encodeURIComponent(document.referrer);

--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -19,13 +19,14 @@ import {
   parseQueryString,
 } from '../../src/url';
 import {closest, openWindowDialog} from '../../src/dom';
+import {urls} from '../../src/config';
 
 
 /**
  * Origins that are trusted to serve valid AMP documents.
  */
 const ampOrigins = {
-  'https://cdn.ampproject.org': true,
+  [urls.cdn]: true,
   'http://localhost:8000': true,
 };
 
@@ -86,7 +87,7 @@ export function handleClick(e) {
   const win = link.a.ownerDocument.defaultView;
   const ancestors = win.location.ancestorOrigins;
   if (ancestors && ancestors[ancestors.length - 1] == 'http://localhost:8000') {
-    destination = destination.replace('https://cdn.ampproject.org/c/',
+    destination = destination.replace(`${urls.cdn}/c/`,
         'http://localhost:8000/max/');
   }
 
@@ -129,7 +130,7 @@ function getEventualUrl(a) {
   if (!eventualUrl) {
     return;
   }
-  if (!eventualUrl.indexOf('https://cdn.ampproject.org/c/') == 0) {
+  if (!eventualUrl.indexOf(`${urls.cdn}/c/`) == 0) {
     return;
   }
   return eventualUrl;
@@ -163,13 +164,13 @@ export function warmupStatic(win) {
   // Preconnect using an image, because that works on all browsers.
   // The image has a 1 minute cache time to avoid duplicate
   // preconnects.
-  new win.Image().src = 'https://cdn.ampproject.org/preconnect.gif';
+  new win.Image().src = `${urls.cdn}/preconnect.gif`;
   // Preload the primary AMP JS that is render blocking.
   const linkRel = /*OK*/document.createElement('link');
   linkRel.rel = 'preload';
   linkRel.setAttribute('as', 'script');
   linkRel.href =
-      'https://cdn.ampproject.org/rtv/01$internalRuntimeVersion$/v0.js';
+      `${urls.cdn}/rtv/01$internalRuntimeVersion$/v0.js`;
   getHeadOrFallback(win.document).appendChild(linkRel);
 }
 

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -61,6 +61,7 @@ exports.rules = [
       '3p/**->src/types.js',
       '3p/**->src/string.js',
       '3p/**->src/url.js',
+      '3p/**->src/config.js',
     ],
   },
   {

--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -20,6 +20,7 @@ import {dev, user} from '../../../src/log';
 import {openWindowDialog} from '../../../src/dom';
 import {parseUrl} from '../../../src/url';
 import {viewerFor} from '../../../src/viewer';
+import {urls} from '../../../src/config';
 
 /** @const */
 const TAG = 'amp-access-login';
@@ -281,7 +282,7 @@ class WebLoginDialog {
       returnUrl = loc.protocol + '//' + loc.host +
           '/extensions/amp-access/0.1/amp-login-done.html';
     } else {
-      returnUrl = 'https://cdn.ampproject.org/v0/amp-login-done-0.1.html';
+      returnUrl = `${urls.cdn}/v0/amp-login-done-0.1.html`;
     }
     return returnUrl + '?url=' + encodeURIComponent(currentUrl);
   }

--- a/extensions/amp-ad/0.1/a2a-listener.js
+++ b/extensions/amp-ad/0.1/a2a-listener.js
@@ -17,6 +17,7 @@ import {closestByTag} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
 import {user} from '../../../src/log';
 import {viewerFor} from '../../../src/viewer';
+import {urls} from '../../../src/config';
 
 
 /**
@@ -75,7 +76,7 @@ export function handleMessageEvent(win, event) {
   user.assert(closestByTag(activeElement, 'amp-ad'),
       'A2A request from non-ad frame %s %s', nav.url, origin);
   // We only allow AMP shaped URLs.
-  user.assert(nav.url.indexOf('https://cdn.ampproject.org/') == 0,
+  user.assert(nav.url.indexOf(urls.cdn) == 0,
       'Invalid ad A2A URL %s %s', nav.url, origin);
   viewerFor(win).navigateTo(nav.url, 'ad-' + origin);
 }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -29,6 +29,7 @@ import {CSS} from '../../../build/amp-form-0.1.css';
 import {ValidationBubble} from './validation-bubble';
 import {vsyncFor} from '../../../src/vsync';
 import {actionServiceForDoc} from '../../../src/action';
+import {urls} from '../../../src/config';
 
 /** @type {string} */
 const TAG = 'amp-form';
@@ -78,7 +79,7 @@ export class AmpForm {
     this.xhrAction_ = this.form_.getAttribute('action-xhr');
     if (this.xhrAction_) {
       assertHttpsUrl(this.xhrAction_, this.form_, 'action-xhr');
-      user.assert(!startsWith(this.xhrAction_, 'https://cdn.ampproject.org'),
+      user.assert(!startsWith(this.xhrAction_, urls.cdn),
           'form action-xhr should not be on cdn.ampproject.org: %s',
           this.form_);
     }

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -23,6 +23,7 @@ import {parseUrl} from '../../../src/url';
 import {removeElement} from '../../../src/dom';
 import {timerFor} from '../../../src/timer';
 import {user} from '../../../src/log';
+import {urls} from '../../../src/config';
 
 /** @const {string} */
 const TAG_ = 'amp-iframe';
@@ -61,7 +62,7 @@ export class AmpIframe extends AMP.BaseElement {
         'if allow-same-origin is set. See https://github.com/ampproject/' +
         'amphtml/blob/master/spec/amp-iframe-origin-policy.md for details.',
         this.element);
-    user.assert(!(endsWith(url.hostname, '.ampproject.net') ||
+    user.assert(!(endsWith(url.hostname, `.${urls.thirdPartyFrameHost}`) ||
         endsWith(url.hostname, '.ampproject.org')),
         'amp-iframe does not allow embedding of frames from ' +
         'ampproject.*: %s', src);

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -27,6 +27,7 @@ import {timer} from './timer';
 import {user} from './log';
 import {viewportFor} from './viewport';
 import {viewerFor} from './viewer';
+import {urls} from './config';
 
 
 /** @type {!Object<string,number>} Number of 3p frames on the for that type. */
@@ -176,7 +177,7 @@ export function preloadBootstrap(window) {
   // While the URL may point to a custom domain, this URL will always be
   // fetched by it.
   preconnect.preload(
-      'https://3p.ampproject.net/$internalRuntimeVersion$/f.js', 'script');
+      `${urls.thirdParty}/$internalRuntimeVersion$/f.js`, 'script');
 }
 
 /**
@@ -215,7 +216,7 @@ function getDefaultBootstrapBaseUrl(parentWindow) {
         '.html';
   }
   return 'https://' + getSubDomain(parentWindow) +
-      '.ampproject.net/$internalRuntimeVersion$/frame.html';
+      `.${urls.thirdPartyFrameHost}/$internalRuntimeVersion$/frame.html`;
 }
 
 /**

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Allows for runtime configuration. Internally, the runtime should
+ * use the src/config.js module for various constants. We can use the
+ * AMP_CONFIG global to translate user-defined configurations to this
+ * module.
+ * @type {Object}
+ */
+const env = window.AMP_CONFIG || {};
+
+export const urls = {
+  thirdParty: env.thirdPartyUrl || 'https://3p.ampproject.net',
+  thirdPartyFrameHost: env.thirdPartyFrameHost || 'ampproject.net',
+  thirdPartyFrameRegex: env.thirdPartyFrameRegex ||
+                        /^d-\d+\.ampproject\.net$/,
+  cdn: env.cdnUrl || 'https://cdn.ampproject.org',
+  errorReporting: env.errorReportingUrl ||
+                  'https://amp-error-reporting.appspot.com/r',
+};

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -17,6 +17,7 @@
 import {startsWith} from './string';
 import {user} from './log';
 import {assertHttpsUrl} from './url';
+import {urls} from './config';
 
 
 /** @const {string} */
@@ -54,8 +55,8 @@ export function onDocumentFormSubmit_(e) {
   const action = form.getAttribute('action');
   user.assert(action, 'form action attribute is required: %s', form);
   assertHttpsUrl(action, form, 'action');
-  user.assert(!startsWith(action, 'https://cdn.ampproject.org'),
-      'form action should not be on cdn.ampproject.org: %s', form);
+  user.assert(!startsWith(action, urls.cdn),
+      'form action should not be on AMP CDN: %s', form);
 
   const target = form.getAttribute('target');
   user.assert(target, 'form target attribute is required: %s', form);

--- a/src/error.js
+++ b/src/error.js
@@ -19,6 +19,7 @@ import {getMode} from './mode';
 import {exponentialBackoff} from './exponential-backoff';
 import {USER_ERROR_SENTINEL, isUserErrorMessage} from './log';
 import {makeBodyVisible} from './styles';
+import {urls} from './config';
 
 const globalExponentialBackoff = exponentialBackoff(1.5);
 
@@ -144,7 +145,7 @@ export function getErrorReportUrl(message, filename, line, col, error) {
   // ../tools/errortracker
   // It stores error reports via https://cloud.google.com/error-reporting/
   // for analyzing production issues.
-  let url = 'https://amp-error-reporting.appspot.com/r' +
+  let url = urls.errorReporting +
       '?v=' + encodeURIComponent('$internalRuntimeVersion$') +
       '&m=' + encodeURIComponent(message.replace(USER_ERROR_SENTINEL, '')) +
       '&a=' + (isUserErrorMessage(message) ? 1 : 0);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -52,6 +52,7 @@ import {setStyle} from './style';
 import {viewerFor} from './viewer';
 import {viewportFor} from './viewport';
 import {waitForBody} from './dom';
+import * as config from './config';
 
 
 /** @const @private {string} */
@@ -138,6 +139,9 @@ function adoptShared(global, opts, callback) {
   global.AMP = {
     win: global,
   };
+
+  /** @const */
+  global.AMP.config = config;
 
   /** @const */
   global.AMP.BaseElement = BaseElement;

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -23,6 +23,7 @@ import {
 } from './url';
 import {parseSrcset} from './srcset';
 import {user} from './log';
+import {urls} from './config';
 
 
 /** @private @const {string} */
@@ -337,7 +338,7 @@ function resolveImageUrlAttr(attrValue, baseUrl, isProxyHost) {
   }
 
   // Rewrite as a proxy URL.
-  return 'https://cdn.ampproject.org/i/' +
+  return `${urls.cdn}/i/` +
       (src.protocol == 'https:' ? 's/' : '') +
       encodeURIComponent(src.host) +
       src.pathname + (src.search || '') + (src.hash || '');

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {urls} from '../config';
 import {dev, rethrowAsync} from '../log';
 import {getMode} from '../mode';
 
@@ -413,10 +414,9 @@ export function calculateExtensionScriptUrl(path, extensionId, isTest,
     }
     return `https://cdn.ampproject.org/v0/${extensionId}-0.1.js`;
   }
-  const domain = 'https://cdn.ampproject.org/';
   const folderPath = getMode().version == '$internalRuntimeVersion$' ?
       '' : `rtv/${getMode().version}/`;
-  return `${domain}${folderPath}v0/${extensionId}-0.1.js`;
+  return `${urls.cdn}/${folderPath}v0/${extensionId}-0.1.js`;
 }
 
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -24,7 +24,7 @@ import {platform} from '../platform';
 import {timer} from '../timer';
 import {reportError} from '../error';
 import {VisibilityState} from '../visibility-state';
-
+import {urls} from '../config';
 
 const TAG_ = 'Viewer';
 const SENTINEL_ = '__AMP__';
@@ -432,7 +432,7 @@ export class Viewer {
    *     requested the navigation.
    */
   navigateTo(url, requestedBy) {
-    dev.assert(url.indexOf('https://cdn.ampproject.org/') == 0,
+    dev.assert(url.indexOf(urls.cdn) == 0,
         'Invalid A2A URL %s %s', url, requestedBy);
     if (this.hasCapability('a2a')) {
       this.sendMessage('a2a', {

--- a/src/url.js
+++ b/src/url.js
@@ -17,6 +17,7 @@
 import {endsWith} from './string';
 import {user} from './log';
 import {getMode} from './mode';
+import {urls} from './config';
 
 // Cached a-tag to avoid memory allocation during URL parsing.
 const a = window.document.createElement('a');
@@ -261,7 +262,7 @@ export function isProxyOrigin(url) {
   const path = url.pathname.split('/');
   const prefix = path[1];
   // List of well known proxy hosts. New proxies must be added here.
-  return (url.origin == 'https://cdn.ampproject.org' ||
+  return (url.origin == urls.cdn ||
       (url.origin.indexOf('http://localhost:') == 0 &&
        (prefix == 'c' || prefix == 'v')));
 }

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -15,7 +15,7 @@
  */
 
 import {getMode} from './mode';
-
+import {urls} from './config';
 
 /**
  * Triggers validation for the current document if there is a script in the
@@ -35,7 +35,7 @@ export function maybeValidate(win) {
   const s = win.document.createElement('script');
   // TODO(@cramforce): Introduce a switch to locally built version for local
   // development.
-  s.src = 'https://cdn.ampproject.org/v0/validator.js';
+  s.src = `${urls.cdn}/v0/validator.js`;
   s.onload = () => {
     win.document.head.removeChild(s);
     /* global amp: false */

--- a/test/fixtures/configuration.html
+++ b/test/fixtures/configuration.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="/base/dist/amp.js"></script>
+</head>
+<body>
+  <p>
+    <amp-img id="img0" src="/base/examples/img/sample.jpg" width=527 height=193 layout="responsive"></amp-img>
+  </p>
+</body>
+</html>

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -53,7 +53,7 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
 
     tgt.setAttribute('action', 'https://cdn.ampproject.org');
     expect(() => onDocumentFormSubmit_(evt)).to.throw(
-        /form action should not be on cdn\.ampproject\.org/);
+        /form action should not be on AMP CDN/);
 
     tgt.setAttribute('action', 'https://valid.example.com');
     tgt.removeAttribute('target');

--- a/test/integration/test-configuration.js
+++ b/test/integration/test-configuration.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createFixtureIframe} from '../../testing/iframe.js';
+
+describe('Configuration', function() {
+  this.timeout(5000);
+
+  let fixture;
+  beforeEach(() => {
+    return createFixtureIframe('test/fixtures/configuration.html', 500)
+    .then(f => {
+      fixture = f;
+    });
+  });
+
+  it('urls should be configurable', () => {
+    expect(fixture.win.AMP_CONFIG).to.equal(undefined);
+
+    const config = fixture.win.AMP_CONFIG = {};
+    config.cdnUrl = 'http://foo.bar.com';
+    config.thirdPartyUrl = 'http://bar.baz.com';
+    config.thirdPartyFrameRegex = /a-website\.com/;
+    config.errorReportingUrl = 'http://error.foo.com';
+
+    return fixture.awaitEvent('amp:load:start', 1).then(() => {
+      expect(fixture.win.AMP.config.urls.cdn).to.equal(config.cdnUrl);
+      expect(fixture.win.AMP.config.urls.thirdParty)
+      .to.equal(config.thirdPartyUrl);
+      expect(fixture.win.AMP.config.urls.thirdPartyFrameRegex)
+      .to.equal(config.thirdPartyFrameRegex);
+      expect(fixture.win.AMP.config.urls.errorReporting)
+      .to.equal(config.errorReportingUrl);
+    });
+  });
+});


### PR DESCRIPTION
Closes #3934

I'll need a little guidance on how to add tests (if it merits additional tests at all). I tried to add as little code as possible (where some situations it would have been safer to use something like `path.join(...)`, but that hadn't been implemented, the user will just have to be wary about trailing slashes in their custom URLs).

I was a little unsure on naming conventions. Like, do you guys prefer `CONFIGURATION_THAT_YELLS` or `configurationThatSings`? I just went ahead and rolled with changing everything how I thought it should be and ran `npm test` after each change.

There's a ton of places that are still hard-coded because they can't access the run-time configuration (build system, docs, etc.). Would definitely be possible in the future to configure this at a higher-level (first  at the project/env level), and then pass through the build system (which applies to examples/docs/testserver), which then informs the run-time. We can do that as needed :)