### PR TITLE
Validator Roll Up

### DIFF
--- a/validator/htmlparser.js
+++ b/validator/htmlparser.js
@@ -236,7 +236,6 @@ class TagNameStack {
         case TagRegion.PRE_HEAD:
         case TagRegion.PRE_BODY:
           this.startTag('BODY', []);
-          console.error(text.charCodeAt(0));
           break;
         case TagRegion.IN_HEAD:
           this.endTag('HEAD');

--- a/validator/htmlparser_test.js
+++ b/validator/htmlparser_test.js
@@ -65,7 +65,8 @@ describe('HtmlParser', () => {
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, 'hello world');
     expect(handler.log).toEqual([
-      'startDoc()', 'pcdata("hello world")', 'endDoc()'
+      'startDoc()', 'startTag(BODY,[])', 'pcdata("hello world")',
+      'endTag(BODY)', 'endDoc()'
     ]);
   });
 

--- a/validator/testdata/feature_tests/link_meta_values.html
+++ b/validator/testdata/feature_tests/link_meta_values.html
@@ -46,5 +46,8 @@
 </head>
 <body>
 Hello, world.
+
+  <a href="http://example.com/" rel="canonical">OK</a>
+
 </body>
 </html>

--- a/validator/testdata/feature_tests/text_begins_body.html
+++ b/validator/testdata/feature_tests/text_begins_body.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This document is correct except for the "text" string located in the head
+  section.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  text
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+Hello, world.
+</body>
+</html>

--- a/validator/testdata/feature_tests/text_begins_body.out
+++ b/validator/testdata/feature_tests/text_begins_body.out
@@ -1,0 +1,8 @@
+FAIL
+feature_tests/text_begins_body.html:28:2 The attribute 'amp-boilerplate' may not appear in tag 'style amp-custom'. (see https://www.ampproject.org/docs/reference/spec.html#stylesheets) [DISALLOWED_HTML]
+feature_tests/text_begins_body.html:28:2 The parent tag of tag 'style amp-custom' is 'body', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec.html#stylesheets) [DISALLOWED_HTML]
+feature_tests/text_begins_body.html:29:2 The tag 'script' is disallowed except in specific forms. [CUSTOM_JAVASCRIPT_DISALLOWED]
+feature_tests/text_begins_body.html:34:7 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec.html#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/text_begins_body.html:34:7 The mandatory tag 'noscript enclosure for boilerplate' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/text_begins_body.html:34:7 The tag 'head > style[amp-boilerplate]' is missing or incorrect, but required by 'noscript > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]
+feature_tests/text_begins_body.html:34:7 The mandatory tag 'head > style[amp-boilerplate]' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 143
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 235
+spec_file_revision: 236
 
 # Validator extensions.
 # =====================
@@ -2065,13 +2065,13 @@ tags: {
 # 4.10.16 The fieldset element
 tags: {
   tag_name: "FIELDSET"
-  mandatory_ancestor: "FORM"
-  also_requires_tag: "amp-form extension .js script"
   attrs: { name: "disabled" }
   attrs: { name: "form" }
   attrs: { name: "name" }
-  # TODO: update with ampproject.org url when available
-  spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-form/amp-form.md"
+}
+# 4.10.17 The legend element
+tags: {
+  tag_name: "LEGEND"
 }
 
 # 4.11 Scripting

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 143
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 236
+spec_file_revision: 237
 
 # Validator extensions.
 # =====================
@@ -823,7 +823,6 @@ tags: {
     # TODO(gregable): This could be improved such that the error message would
     # report which value in a list is the one causing problems.
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated.
-        "canonical|"  # Only allowed for link tags, specific req's for AMP.
         "components|"
         "dns-prefetch|"
         "import|"

--- a/validator/validator.js
+++ b/validator/validator.js
@@ -207,7 +207,7 @@ class ChildTagMatcher {
     this.numChildTagsSeen_++;  // Increment this first to allow early exit.
     if (childTags.childTagNameOneof.length > 0) {
       const names = childTags.childTagNameOneof;
-      if (names.indexOf(tagName) == -1) {
+      if (names.indexOf(tagName) === -1) {
         if (amp.validator.GENERATE_DETAILED_ERRORS) {
           const allowedNames = '[\'' + names.join('\', \'') + '\']';
           context.addError(
@@ -215,8 +215,10 @@ class ChildTagMatcher {
               amp.validator.ValidationError.Code.DISALLOWED_CHILD_TAG_NAME,
               context.getDocLocator(),
               /* params */
-              [tagName.toLowerCase(), getTagSpecName(this.parentSpec_),
-               allowedNames.toLowerCase()],
+              [
+                tagName.toLowerCase(), getTagSpecName(this.parentSpec_),
+                allowedNames.toLowerCase()
+              ],
               this.parentSpec_.specUrl, result);
         } else {
           result.status = amp.validator.ValidationResult.Status.FAIL;
@@ -225,7 +227,7 @@ class ChildTagMatcher {
       }
     }
     if (childTags.firstChildTagNameOneof.length > 0 &&
-        (this.numChildTagsSeen_ - 1) == 0) {
+        (this.numChildTagsSeen_ - 1) === 0) {
       const names = childTags.firstChildTagNameOneof;
       if (names.indexOf(tagName) == -1) {
         if (amp.validator.GENERATE_DETAILED_ERRORS) {
@@ -236,8 +238,10 @@ class ChildTagMatcher {
                   .DISALLOWED_FIRST_CHILD_TAG_NAME,
               context.getDocLocator(),
               /* params */
-              [tagName.toLowerCase(), getTagSpecName(this.parentSpec_),
-               allowedNames.toLowerCase()],
+              [
+                tagName.toLowerCase(), getTagSpecName(this.parentSpec_),
+                allowedNames.toLowerCase()
+              ],
               this.parentSpec_.specUrl, result);
         } else {
           result.status = amp.validator.ValidationResult.Status.FAIL;
@@ -559,13 +563,13 @@ class CdataMatcher {
      * @private
      */
     this.cdataRegex_ = null;
-    if (tagSpec.cdata && tagSpec.cdata.cdataRegex) {
+    if (tagSpec.cdata !== null && tagSpec.cdata.cdataRegex !== null) {
       this.cdataRegex_ = new RegExp('^(' + tagSpec.cdata.cdataRegex + ')$');
     }
 
     /** @type {string} */
     var blacklistedCdataRegexStr = '';
-    if (tagSpec.cdata) {
+    if (tagSpec.cdata !== null) {
       for (const blacklist of tagSpec.cdata.blacklistedCdataRegex) {
         blacklistedCdataRegexStr += blacklist + '|';
       }
@@ -895,7 +899,8 @@ class Context {
   setCdataMatcher(matcher) {
     if (amp.validator.GENERATE_DETAILED_ERRORS && matcher !== null) {
       // We store away the position from when the matcher was created
-      // so we can use it to generate error messages relating to the opening tag.
+      // so we can use it to generate error messages relating to the opening
+      // tag.
       matcher.setLineCol(
           new LineCol(this.docLocator_.getLine(), this.docLocator_.getCol()));
     }
@@ -908,8 +913,8 @@ class Context {
   /** @param {?ChildTagMatcher} matcher */
   setChildTagMatcher(matcher) {
     if (amp.validator.GENERATE_DETAILED_ERRORS && matcher !== null) {
-        matcher.setLineCol(
-            new LineCol(this.docLocator_.getLine(), this.docLocator_.getCol()));
+      matcher.setLineCol(
+          new LineCol(this.docLocator_.getLine(), this.docLocator_.getCol()));
     }
     this.tagStack_.setChildTagMatcher(matcher);
   }
@@ -1011,7 +1016,7 @@ class ParsedUrlSpec {
       return;
     }
     const scheme = urlComponents[goog.uri.utils.ComponentIndex.SCHEME];
-    if (scheme &&
+    if (scheme !== undefined && scheme.length > 0 &&
         !this.allowedProtocols_.hasOwnProperty(scheme.toLowerCase())) {
       if (amp.validator.GENERATE_DETAILED_ERRORS) {
         adapter.invalidUrlProtocol(
@@ -1021,7 +1026,8 @@ class ParsedUrlSpec {
       }
       return;
     }
-    if (!this.spec_.allowRelative && (scheme === undefined)) {
+    if (!this.spec_.allowRelative &&
+        (scheme === undefined || scheme.length == 0)) {
       if (amp.validator.GENERATE_DETAILED_ERRORS) {
         adapter.disallowedRelativeUrl(context, url, tagSpec, result);
       } else {
@@ -1030,7 +1036,7 @@ class ParsedUrlSpec {
       return;
     }
     const domain = urlComponents[goog.uri.utils.ComponentIndex.DOMAIN];
-    if (domain &&
+    if (domain !== undefined && domain.length > 0 &&
         this.disallowedDomains_.hasOwnProperty(domain.toLowerCase())) {
       if (amp.validator.GENERATE_DETAILED_ERRORS) {
         adapter.disallowedDomain(
@@ -1231,7 +1237,7 @@ class ParsedAttrTriggerSpec {
      */
     this.spec_ = attrSpec.trigger;
 
-    goog.asserts.assert(attrSpec.name != null);
+    goog.asserts.assert(attrSpec.name !== null);
     /**
      * @type {string} attrName
      * @private
@@ -1244,7 +1250,7 @@ class ParsedAttrTriggerSpec {
      */
     this.ifValueRegex_ = null;
 
-    if (this.spec_ && this.spec_.ifValueRegex) {
+    if (this.spec_ !== null && this.spec_.ifValueRegex !== null) {
       this.ifValueRegex_ = new RegExp('^(' + this.spec_.ifValueRegex + ')$');
     }
   }
@@ -1299,7 +1305,7 @@ class ParsedAttrSpec {
      * @private
      */
     this.triggerSpec_ = null;
-    if (this.spec_.trigger) {
+    if (this.spec_.trigger !== null) {
       this.triggerSpec_ = new ParsedAttrTriggerSpec(this.spec_);
     }
     /**
@@ -1333,7 +1339,7 @@ class ParsedAttrSpec {
      * @private
      */
     this.valueRegex_ = null;
-    if (this.spec_ && this.spec_.valueRegex) {
+    if (this.spec_ !== null && this.spec_.valueRegex !== null) {
       this.valueRegex_ = new RegExp('^(' + this.spec_.valueRegex + ')$');
     }
 
@@ -1342,7 +1348,7 @@ class ParsedAttrSpec {
      * @private
      */
     this.valueRegexCasei_ = null;
-    if (this.spec_ && this.spec_.valueRegexCasei) {
+    if (this.spec_ !== null && this.spec_.valueRegexCasei !== null) {
       this.valueRegexCasei_ =
           new RegExp('^(' + this.spec_.valueRegexCasei + ')$', 'i');
     }
@@ -1352,7 +1358,7 @@ class ParsedAttrSpec {
      * @private
      */
     this.blacklistedValueRegex_ = null;
-    if (this.spec_ && this.spec_.blacklistedValueRegex) {
+    if (this.spec_ !== null && this.spec_.blacklistedValueRegex !== null) {
       this.blacklistedValueRegex_ =
           new RegExp(this.spec_.blacklistedValueRegex, 'i');
     }
@@ -1483,11 +1489,11 @@ class ParsedAttrSpec {
   validateAttrValueUrl(context, attrName, attrValue, tagSpec, result) {
     /** @type {!Array<string>} */
     let maybeUris = [];
-    if (attrName != 'srcset') {
+    if (attrName !== 'srcset') {
       maybeUris.push(goog.string.trim(attrValue));
     } else {
       let srcset = goog.string.trim(attrValue);
-      if (srcset == '') {
+      if (srcset === '') {
         if (amp.validator.GENERATE_DETAILED_ERRORS) {
           context.addError(
               amp.validator.ValidationError.Severity.ERROR,
@@ -1585,7 +1591,7 @@ class ParsedAttrSpec {
       }
       const propertySpec = this.valuePropertyByName_[name];
       if (propertySpec.value !== null) {
-        if (propertySpec.value != value.toLowerCase()) {
+        if (propertySpec.value !== value.toLowerCase()) {
           if (amp.validator.GENERATE_DETAILED_ERRORS) {
             context.addError(
                 amp.validator.ValidationError.Severity.ERROR,
@@ -1600,7 +1606,7 @@ class ParsedAttrSpec {
           }
         }
       } else if (propertySpec.valueDouble !== null) {
-        if (parseFloat(value) != propertySpec.valueDouble) {
+        if (parseFloat(value) !== propertySpec.valueDouble) {
           if (amp.validator.GENERATE_DETAILED_ERRORS) {
             context.addError(
                 amp.validator.ValidationError.Severity.ERROR,
@@ -1692,10 +1698,10 @@ class ParsedAttrLists {
     // (1) layout attrs.
     if (tagSpec.ampLayout !== null) {
       const layoutSpecs = this.attrListsByName['$AMP_LAYOUT_ATTRS'];
-      if (layoutSpecs) {
+      if (layoutSpecs !== undefined) {
         for (const spec of layoutSpecs) {
           const name = spec.getSpec().name;
-          goog.asserts.assert(name != null);
+          goog.asserts.assert(name !== null);
           if (!namesSeen.hasOwnProperty(name)) {
             namesSeen[name] = 0;
             attrs.push(spec);
@@ -1706,7 +1712,7 @@ class ParsedAttrLists {
     // (2) attributes specified within |tagSpec|.
     for (const spec of tagSpec.attrs) {
       const name = spec.name;
-      goog.asserts.assert(name != null);
+      goog.asserts.assert(name !== null);
       if (!namesSeen.hasOwnProperty(name)) {
         namesSeen[name] = 0;
         attrs.push(new ParsedAttrSpec(spec, this.nextId++));
@@ -1718,7 +1724,7 @@ class ParsedAttrLists {
       goog.asserts.assert(specs !== undefined);
       for (const spec of specs) {
         const name = spec.getSpec().name;
-        goog.asserts.assert(name != null);
+        goog.asserts.assert(name !== null);
         if (!namesSeen.hasOwnProperty(name)) {
           namesSeen[name] = 0;
           attrs.push(spec);
@@ -1727,12 +1733,12 @@ class ParsedAttrLists {
     }
     // (4) attributes specified in the global_attr list.
     const globalSpecs = this.attrListsByName['$GLOBAL_ATTRS'];
-    if (!globalSpecs) {
+    if (globalSpecs === undefined) {
       return attrs;
     }
     for (const spec of globalSpecs) {
       const name = spec.getSpec().name;
-      goog.asserts.assert(name != null);
+      goog.asserts.assert(name !== null);
       if (!namesSeen.hasOwnProperty(name)) {
         namesSeen[name] = 0;
         attrs.push(spec);
@@ -1910,7 +1916,6 @@ function CalculateLayout(inputLayout, width, height, sizesAttr, heightsAttr) {
  */
 function shouldRecordTagspecValidated(tag, tagSpecNamesToTrack) {
   return tag.mandatory || tag.unique ||
-      getTagSpecName(tag) != null &&
       tagSpecNamesToTrack.hasOwnProperty(getTagSpecName(tag));
 }
 
@@ -2025,7 +2030,7 @@ class ParsedTagSpec {
       for (const altName of altNames) {
         this.attrsByName_[altName] = parsedAttrSpec;
       }
-      if (parsedAttrSpec.getSpec().dispatchKey) {
+      if (parsedAttrSpec.getSpec().dispatchKey !== null) {
         this.dispatchKeyAttrSpec_ = parsedAttrSpec;
       }
       if (parsedAttrSpec.getSpec().implicit) {
@@ -2143,7 +2148,7 @@ class ParsedTagSpec {
    * @param {!amp.validator.ValidationResult} result
    */
   validateLayout(context, attrsByKey, result) {
-    goog.asserts.assert(this.spec_.ampLayout != null);
+    goog.asserts.assert(this.spec_.ampLayout !== null);
 
     const layoutAttr = attrsByKey['layout'];
     const widthAttr = attrsByKey['width'];
@@ -2376,7 +2381,7 @@ class ParsedTagSpec {
     // At this point, it's an error either way, but we try to give a
     // more specific error in the case of Mustache template characters.
     if (amp.validator.GENERATE_DETAILED_ERRORS) {
-      if (attrName.indexOf('{{') != -1) {
+      if (attrName.indexOf('{{') !== -1) {
         context.addError(
             amp.validator.ValidationError.Severity.ERROR,
             amp.validator.ValidationError.Code.TEMPLATE_IN_ATTR_NAME,
@@ -2682,8 +2687,11 @@ class ParsedTagSpec {
                 amp.validator.ValidationError.Severity.ERROR,
                 amp.validator.ValidationError.Code.MANDATORY_TAG_ANCESTOR,
                 context.getDocLocator(),
-                /* params */[this.spec_.tagName.toLowerCase(),
-                             mandatoryAncestor.toLowerCase()],
+                /* params */
+                [
+                  this.spec_.tagName.toLowerCase(),
+                  mandatoryAncestor.toLowerCase()
+                ],
                 this.spec_.specUrl, validationResult);
           }
         } else {
@@ -2699,8 +2707,11 @@ class ParsedTagSpec {
               amp.validator.ValidationError.Severity.ERROR,
               amp.validator.ValidationError.Code.DISALLOWED_TAG_ANCESTOR,
               context.getDocLocator(),
-              /* params */[this.spec_.tagName.toLowerCase(),
-                           disallowedAncestor.toLowerCase()],
+              /* params */
+              [
+                this.spec_.tagName.toLowerCase(),
+                disallowedAncestor.toLowerCase()
+              ],
               this.spec_.specUrl, validationResult);
         } else {
           validationResult.status = amp.validator.ValidationResult.Status.FAIL;
@@ -2784,7 +2795,7 @@ class TagSpecDispatch {
 
     // Special case for foo=foo. We consider this a match for a dispatch key of
     // foo="" or just <tag foo>.
-    if (attrName == attrValue)
+    if (attrName === attrValue)
       return this.matchingDispatchKey(attrName, '', mandatoryParent);
 
     return -1;
@@ -2955,7 +2966,7 @@ function specificity(code) {
 amp.validator.maxSpecificity = function(validationResult) {
   let max = 0;
   for (const error of validationResult.errors) {
-    goog.asserts.assert(error.code != null);
+    goog.asserts.assert(error.code !== null);
     const thisSpecificity = specificity(error.code);
     max = Math.max(thisSpecificity, max);
   }
@@ -3015,7 +3026,7 @@ class ParsedValidatorRules {
     for (let i = 0; i < rules.tags.length; ++i) {
       const tag = rules.tags[i];
       if (amp.validator.GENERATE_DETAILED_ERRORS)
-        goog.asserts.assert(rules.templateSpecUrl != null);
+        goog.asserts.assert(rules.templateSpecUrl !== null);
       const parsedTagSpec = new ParsedTagSpec(
           rules.templateSpecUrl, parsedAttrLists, tagspecIdsByTagSpecName,
           shouldRecordTagspecValidated(tag, tagSpecNamesToTrack), tag, i);
@@ -3092,7 +3103,9 @@ class ParsedValidatorRules {
         let attrValue = encounteredAttrs[i + 1];
         // Our html parser repeats the key as the value if there is no value. We
         // replace the value with an empty string instead in this case.
-        if (attrName === attrValue) attrValue = '';
+        if (attrName === attrValue) {
+          attrValue = '';
+        }
         attrName = attrName.toLowerCase();
 
         const maybeTagSpecId = tagSpecDispatch.matchingDispatchKey(
@@ -3164,7 +3177,7 @@ class ParsedValidatorRules {
         return;
       }
       // If this is the first attempt, always use it.
-      if (resultForBestAttempt.errors.length == 0) {
+      if (resultForBestAttempt.errors.length === 0) {
         resultForBestAttempt.copyFrom(resultForAttempt);
         return;
       }
@@ -3229,8 +3242,7 @@ class ParsedValidatorRules {
     }
     // (Re)set the cdata matcher to the expectations that this tag
     // brings with it.
-    if (spec.cdata !== null)
-      context.setCdataMatcher(new CdataMatcher(spec));
+    if (spec.cdata !== null) context.setCdataMatcher(new CdataMatcher(spec));
     if (spec.childTags !== null)
       context.setChildTagMatcher(new ChildTagMatcher(spec));
   }

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -279,11 +279,14 @@ def PrintObject(descriptor, msg, this_id, out):
       out.PushIndent(2)
     if field_desc.type == descriptor.FieldDescriptor.TYPE_MESSAGE:
       if field_desc.label == descriptor.FieldDescriptor.LABEL_REPEATED:
+        elements = []
         for val in field_val:
           field_id = next_id
           next_id = PrintObject(descriptor, val, field_id, out)
-          out.Line('o_%d.%s.push(o_%d);' %
-                   (this_id, UnderscoreToCamelCase(field_desc.name), field_id))
+          elements.append('o_%d' % field_id)
+        out.Line('o_%d.%s = [%s];' %
+                 (this_id, UnderscoreToCamelCase(field_desc.name),
+                  ','.join(elements)))
       else:
         field_id = next_id
         next_id = PrintObject(descriptor, field_val, field_id, out)

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -109,7 +109,7 @@ def FieldTypeFor(descriptor, field_desc):
   if field_desc.label == descriptor.FieldDescriptor.LABEL_REPEATED:
     return '!Array<!%s>' % element_type
   else:
-    return element_type
+    return '?%s' % element_type
 
 
 def NonRepeatedValueToString(descriptor, field_desc, value):
@@ -169,6 +169,9 @@ SKIP_FIELDS_FOR_LIGHT = ['error_formats', 'spec_url', 'validator_revision',
                          'min_validator_revision_required', 'deprecation_url',
                          'errors']
 SKIP_CLASSES_FOR_LIGHT = ['amp.validator.ValidationError']
+EXPORTED_CLASSES = ['amp.validator.ValidationResult',
+                    'amp.validator.ValidationError']
+CONSTRUCTOR_ARG_FIELDS = ['name', 'tag_name']
 
 
 def PrintClassFor(descriptor, msg_desc, out):
@@ -189,28 +192,42 @@ def PrintClassFor(descriptor, msg_desc, out):
   if msg_desc.full_name in SKIP_CLASSES_FOR_LIGHT:
     out.Line('if (amp.validator.GENERATE_DETAILED_ERRORS) {')
     out.PushIndent(2)
+  constructor_arg_fields = []
+  constructor_arg_field_names = {}
+  for field in msg_desc.fields:
+    if field.name in CONSTRUCTOR_ARG_FIELDS:
+      constructor_arg_fields.append(field)
+      constructor_arg_field_names[field.name] = 1
   out.Line('/**')
+  for field in constructor_arg_fields:
+    out.Line(' * @param {%s} %s' % (FieldTypeFor(descriptor, field),
+                                    UnderscoreToCamelCase(field.name)))
   out.Line(' * @constructor')
-  is_exported = msg_desc.name in ['ValidationResult', 'ValidationError']
+  out.Line(' * @struct')
   export_or_empty = ''
-  if is_exported:
+  if msg_desc.full_name in EXPORTED_CLASSES:
     out.Line(' * @export')
     export_or_empty = ' @export'
   out.Line(' */')
-  out.Line('%s = function() {' % msg_desc.full_name)
+  out.Line('%s = function(%s) {' % (
+      msg_desc.full_name,
+      ','.join([UnderscoreToCamelCase(f.name)
+                for f in constructor_arg_fields])))
   out.PushIndent(2)
   for field in msg_desc.fields:
     if field.name in SKIP_FIELDS_FOR_LIGHT:
       out.Line('if (amp.validator.GENERATE_DETAILED_ERRORS) {')
       out.PushIndent(2)
-    if field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
-      out.Line('/**%s @type {%s} */' % (export_or_empty,
-                                        FieldTypeFor(descriptor, field)))
-      out.Line('this.%s = [];' % UnderscoreToCamelCase(field.name))
-    else:
-      out.Line('/**%s @type {?%s} */' % (export_or_empty,
-                                         FieldTypeFor(descriptor, field)))
-      out.Line('this.%s = null;' % UnderscoreToCamelCase(field.name))
+    out.Line('/**%s @type {%s} */' % (export_or_empty,
+                                      FieldTypeFor(descriptor, field)))
+    assigned_value = 'null'
+    if field.name in constructor_arg_field_names:
+      # field.name is also the parameter name.
+      assigned_value = UnderscoreToCamelCase(field.name)
+    elif field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
+      assigned_value = '[]'
+    out.Line('this.%s = %s;' % (UnderscoreToCamelCase(field.name),
+                                assigned_value))
     if field.name in SKIP_FIELDS_FOR_LIGHT:
       out.PopIndent()
       out.Line('}')
@@ -271,12 +288,9 @@ def PrintObject(descriptor, msg, this_id, out):
   Returns:
     The next object id, that is, next variable available for creating objects.
   """
-  out.Line('var o_%d = new %s();' % (this_id, msg.DESCRIPTOR.full_name))
   next_id = this_id + 1
+  field_names_and_assigned_values = []
   for (field_desc, field_val) in msg.ListFields():
-    if field_desc.name in SKIP_FIELDS_FOR_LIGHT:
-      out.Line('if (amp.validator.GENERATE_DETAILED_ERRORS) {')
-      out.PushIndent(2)
     if field_desc.type == descriptor.FieldDescriptor.TYPE_MESSAGE:
       if field_desc.label == descriptor.FieldDescriptor.LABEL_REPEATED:
         elements = []
@@ -284,21 +298,31 @@ def PrintObject(descriptor, msg, this_id, out):
           field_id = next_id
           next_id = PrintObject(descriptor, val, field_id, out)
           elements.append('o_%d' % field_id)
-        out.Line('o_%d.%s = [%s];' %
-                 (this_id, UnderscoreToCamelCase(field_desc.name),
-                  ','.join(elements)))
+        field_names_and_assigned_values.append(
+            (field_desc.name, '[%s]' % ','.join(elements)))
       else:
         field_id = next_id
         next_id = PrintObject(descriptor, field_val, field_id, out)
-        out.Line('o_%d.%s = o_%d;' %
-                 (this_id, UnderscoreToCamelCase(field_desc.name), field_id))
+        field_names_and_assigned_values.append(
+            (field_desc.name, 'o_%d' % field_id))
     else:
-      out.Line('o_%d.%s = %s;' %
-               (this_id, UnderscoreToCamelCase(field_desc.name),
-                ValueToString(descriptor, field_desc, field_val)))
-    if field_desc.name in SKIP_FIELDS_FOR_LIGHT:
-      out.PopIndent()
-      out.Line('}')
+      field_names_and_assigned_values.append(
+          (field_desc.name, ValueToString(descriptor, field_desc, field_val)))
+  constructor_arg_values = []
+  for (name, value) in field_names_and_assigned_values:
+    if name in CONSTRUCTOR_ARG_FIELDS:
+      constructor_arg_values.append(value)
+  out.Line('var o_%d = new %s(%s);' % (
+      this_id, msg.DESCRIPTOR.full_name, ','.join(constructor_arg_values)))
+  for (name, value) in field_names_and_assigned_values:
+    if name not in CONSTRUCTOR_ARG_FIELDS:
+      if name in SKIP_FIELDS_FOR_LIGHT:
+        out.Line('if (amp.validator.GENERATE_DETAILED_ERRORS) {')
+        out.PushIndent(2)
+      out.Line('o_%d.%s = %s;' % (this_id, UnderscoreToCamelCase(name), value))
+      if name in SKIP_FIELDS_FOR_LIGHT:
+        out.PopIndent()
+        out.Line('}')
   return next_id
 
 

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -242,8 +242,10 @@ def PrintEnumFor(enum_desc, out):
   out.Line(' * @export')
   out.Line(' */')
   out.Line('%s = {' % enum_desc.full_name)
-  out.Line(',\n'.join(["  %s: '%s'" % (v.name, v.name) for v in enum_desc.values
-                      ]))
+  out.PushIndent(2)
+  for v in enum_desc.values:
+    out.Line("%s: '%s'," % (v.name, v.name))
+  out.PopIndent()
   out.Line('};')
   if enum_desc.full_name in SKIP_ENUMS_FOR_LIGHT:
     out.PopIndent()


### PR DESCRIPTION
- Allow fieldset and legend elements. #2025
- Re-allow `<a rel=canonical>`. #596 
- Text nodes now open the `<body>` tag in html parser, more closely matching browser behavior.
