### PR TITLE
Avoid 1-2 closure allocations per service retrieval.

### DIFF
--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -19,7 +19,7 @@
  * has performed on the page.
  */
 
-import {getService} from '../../../src/service';
+import {fromClass} from '../../../src/service';
 import {viewerFor} from '../../../src/viewer';
 import {viewportFor} from '../../../src/viewport';
 import {listen} from '../../../src/event-helper';
@@ -308,7 +308,5 @@ export class Activity {
  * @return {!Activity}
  */
 export function installActivityService(win) {
-  return getService(win, 'activity', () => {
-    return new Activity(win);
-  });
+  return fromClass(win, 'activity', Activity);
 };

--- a/extensions/amp-analytics/0.1/cid-impl.js
+++ b/extensions/amp-analytics/0.1/cid-impl.js
@@ -23,7 +23,7 @@
  */
 
 import {getCookie, setCookie} from '../../../src/cookies';
-import {getService} from '../../../src/service';
+import {fromClass} from '../../../src/service';
 import {
   getSourceOrigin,
   isProxyOrigin,
@@ -374,7 +374,5 @@ function getEntropy(win) {
  * @return {!Cid}
  */
 export function installCidService(window) {
-  return getService(window, 'cid', () => {
-    return new Cid(window);
-  });
+  return fromClass(window, 'cid', Cid);
 }

--- a/extensions/amp-analytics/0.1/crypto-impl.js
+++ b/extensions/amp-analytics/0.1/crypto-impl.js
@@ -15,7 +15,7 @@
  */
 
 import * as lib from '../../../third_party/closure-library/sha384-generated';
-import {getService} from '../../../src/service';
+import {fromClass} from '../../../src/service';
 import {dev} from '../../../src/log';
 
 /** @const {string} */
@@ -114,7 +114,5 @@ function str2ab(str) {
 }
 
 export function installCryptoService(win) {
-  return getService(win, 'crypto', () => {
-    return new Crypto(win);
-  });
+  return fromClass(win, 'crypto', Crypto);
 }

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -16,7 +16,7 @@
 
 import {isVisibilitySpecValid} from './visibility-impl';
 import {Observable} from '../../../src/observable';
-import {getService} from '../../../src/service';
+import {fromClass} from '../../../src/service';
 import {timer} from '../../../src/timer';
 import {user} from '../../../src/log';
 import {viewerFor} from '../../../src/viewer';
@@ -465,7 +465,6 @@ export class InstrumentationService {
  * @return {!InstrumentationService}
  */
 export function instrumentationServiceFor(window) {
-  return getService(window, 'amp-analytics-instrumentation', () => {
-    return new InstrumentationService(window);
-  });
+  return fromClass(window, 'amp-analytics-instrumentation',
+      InstrumentationService);
 }

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {dev} from '../../../src/log';
-import {getService} from '../../../src/service';
+import {fromClass} from '../../../src/service';
 import {rectIntersection} from '../../../src/layout-rect';
 import {resourcesFor} from '../../../src/resources';
 import {timer} from '../../../src/timer';
@@ -481,7 +481,5 @@ export class Visibility {
  * @return {!Visibility}
  */
 export function installVisibilityService(win) {
-  return getService(win, 'visibility', () => {
-    return new Visibility(win);
-  });
+  return fromClass(win, 'visibility', Visibility);
 };

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -17,7 +17,7 @@
 import {Poller} from './poller';
 import {addParamToUrl} from '../../../src/url';
 import {getMode} from '../../../src/mode';
-import {getService} from '../../../src/service';
+import {fromClass} from '../../../src/service';
 import {user} from '../../../src/log';
 import {viewerFor} from '../../../src/viewer';
 import {whenDocumentReady} from '../../../src/document-ready';
@@ -219,7 +219,5 @@ export class LiveListManager {
  * @return {!LiveListManager}
  */
 export function installLiveListManager(win) {
-  return getService(win, 'liveListManager', () => {
-    return new LiveListManager(win);
-  });
+  return fromClass(win, 'liveListManager', LiveListManager);
 }

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -17,7 +17,7 @@
 import {CSS} from '../../../build/amp-user-notification-0.1.css';
 import {assertHttpsUrl, addParamsToUrl} from '../../../src/url';
 import {cidFor} from '../../../src/cid';
-import {getService} from '../../../src/service';
+import {fromClass} from '../../../src/service';
 import {dev, user, rethrowAsync} from '../../../src/log';
 import {storageFor} from '../../../src/storage';
 import {urlReplacementsFor} from '../../../src/url-replacements';
@@ -399,9 +399,8 @@ export class UserNotificationManager {
  * @private
  */
 function getUserNotificationManager_(window) {
-  return getService(window, 'userNotificationManager', () => {
-    return new UserNotificationManager(window);
-  });
+  return fromClass(window, 'userNotificationManager',
+      UserNotificationManager);
 }
 
 /**

--- a/src/document-click.js
+++ b/src/document-click.js
@@ -15,7 +15,7 @@
  */
 
 import {closestByTag} from './dom';
-import {getService} from './service';
+import {fromClass} from './service';
 import {dev} from './log';
 import {historyFor} from './history';
 import {openWindowDialog} from './dom';
@@ -43,9 +43,7 @@ export function uninstallGlobalClickListener(window) {
  * @param {!Window} window
  */
 function clickHandlerFor(window) {
-  return getService(window, 'clickhandler', () => {
-    return new ClickHandler(window);
-  });
+  return fromClass(window, 'clickhandler', ClickHandler);
 }
 
 /**

--- a/src/document-state.js
+++ b/src/document-state.js
@@ -15,7 +15,7 @@
  */
 
 import {Observable} from './observable';
-import {getService} from './service';
+import {fromClass} from './service';
 import {getVendorJsPropertyName} from './style';
 
 
@@ -120,7 +120,5 @@ export class DocumentState {
  * @return {!DocumentState}
  */
 export function documentStateFor(window) {
-  return getService(window, 'documentState', () => {
-    return new DocumentState(window);
-  });
+  return fromClass(window, 'documentState', DocumentState);
 };

--- a/src/input.js
+++ b/src/input.js
@@ -15,7 +15,7 @@
  */
 
 import {Observable} from './observable';
-import {getService} from './service';
+import {fromClass} from './service';
 import {dev} from './log';
 import {listenOnce, listenOncePromise} from './event-helper';
 
@@ -238,7 +238,5 @@ export class Input {
  * @return {!Input}
  */
 export function inputFor(window) {
-  return getService(window, 'input', () => {
-    return new Input(window);
-  });
+  return fromClass(window, 'input', Input);
 };

--- a/src/platform.js
+++ b/src/platform.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {fromClass} from './service';
 
 
 /**
@@ -137,9 +137,7 @@ export class Platform {
  * @return {!Platform}
  */
 export function platformFor(window) {
-  return getService(window, 'platform', () => {
-    return new Platform(window);
-  });
+  return fromClass(window, 'platform', Platform);
 };
 
 export const platform = platformFor(window);

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -20,7 +20,7 @@
  */
 
 
-import {getService} from './service';
+import {fromClass} from './service';
 import {parseUrl} from './url';
 import {timer} from './timer';
 import {platformFor} from './platform';
@@ -237,7 +237,5 @@ export class Preconnect {
  * @return {!Preconnect}
  */
 export function preconnectFor(window) {
-  return getService(window, 'preconnect', () => {
-    return new Preconnect(window);
-  });
+  return fromClass(window, 'preconnect', Preconnect);
 };

--- a/src/service.js
+++ b/src/service.js
@@ -46,8 +46,21 @@ let ServiceHolderDef;
  * @return {*}
  */
 export function getService(win, id, opt_factory) {
-  return getServiceInternal(win, id,
-      opt_factory ? () => opt_factory(win) : undefined);
+  return getServiceInternal(win, win, id,
+      opt_factory ? opt_factory : undefined);
+}
+
+/**
+ * Returns a service and registers it given a class to be used as
+ * implementation.
+ * @param {!Window} win
+ * @param {string} id of the service.
+ * @param {function(new:T, !Window)} constructor
+ * @return {T}
+ * @template T
+ */
+export function fromClass(win, id, constructor) {
+  return getServiceInternal(win, win, id, undefined, constructor);
 }
 
 /**
@@ -90,8 +103,28 @@ export function getServiceForDoc(nodeOrDoc, id, opt_factory) {
   const ampdoc = getAmpdoc(nodeOrDoc);
   return getServiceInternal(
       ampdoc.isSingleDoc() ? ampdoc.getWin() : ampdoc,
+      ampdoc,
       id,
-      opt_factory ? () => opt_factory(ampdoc) : undefined);
+      opt_factory);
+}
+
+/**
+ * Returns a service and registers it given a class to be used as
+ * implementation.
+ * @param {!Node|!./service/ampdoc-impl.AmpDoc} win
+ * @param {string} id of the service.
+ * @param {function(new:T, !./service/ampdoc-impl.AmpDoc)} constructor
+ * @return {T}
+ * @template T
+ */
+export function fromClassForDoc(nodeOrDoc, id, constructor) {
+  const ampdoc = getAmpdoc(nodeOrDoc);
+  return getServiceInternal(
+      ampdoc.isSingleDoc() ? ampdoc.getWin() : ampdoc,
+      ampdoc,
+      id,
+      undefined,
+      constructor);
 }
 
 /**
@@ -147,14 +180,18 @@ function getAmpdocService(win) {
 }
 
 /**
- * @param {!Object} holder
+ * @param {!Object} holder Object holding the service instance.
+ * @param {!Object} context Win or AmpDoc.
  * @param {string} id of the service.
- * @param {function():!Object=} opt_factory Should create the service
+ * @param {!Function=} opt_factory Should create the service
  *     if it does not exist yet. If the factory is not given, it is an error
- *     if the service does not exist yet.
+ *     if the service does not exist yet. Called with context.
+ * @param {!Function} opt_constructor Constructor function to new the service.
+ *     Called with context.
  * @return {*}
  */
-function getServiceInternal(holder, id, opt_factory) {
+function getServiceInternal(holder, context, id, opt_factory,
+    opt_constructor) {
   const services = getServices(holder);
   let s = services[id];
   if (!s) {
@@ -166,8 +203,11 @@ function getServiceInternal(holder, id, opt_factory) {
   }
 
   if (!s.obj) {
-    dev.assert(opt_factory, 'Factory not given and service missing %s', id);
-    s.obj = opt_factory();
+    dev.assert(opt_factory || opt_constructor,
+        'Factory or class not given and service missing %s', id);
+    s.obj = opt_constructor
+        ? new opt_constructor(context)
+        : opt_factory(context);
     // The service may have been requested already, in which case we have a
     // pending promise we need to fulfill.
     if (s.resolve) {

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {dev, user} from '../log';
-import {getServiceForDoc} from '../service';
+import {fromClassForDoc} from '../service';
 import {getMode} from '../mode';
 import {timer} from '../timer';
 import {vsyncFor} from '../vsync';
@@ -613,7 +613,5 @@ function isNum(c) {
  * @return {!ActionService}
  */
 export function installActionServiceForDoc(ampdoc) {
-  return getServiceForDoc(ampdoc, 'action', ampdoc => {
-    return new ActionService(ampdoc);
-  });
+  return fromClassForDoc(ampdoc, 'action', ActionService);
 };

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -16,7 +16,7 @@
 
 import {documentInfoFor} from '../document-info';
 import {onDocumentReady} from '../document-ready';
-import {getService} from '../service';
+import {fromClass} from '../service';
 import {loadPromise} from '../event-helper';
 import {resourcesFor} from '../resources';
 import {timer} from '../timer';
@@ -374,7 +374,5 @@ export class Performance {
  * @return {!Performance}
  */
 export function installPerformanceService(window) {
-  return getService(window, 'performance', () => {
-    return new Performance(window);
-  });
+  return fromClass(window, 'performance', Performance);
 };

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -24,7 +24,7 @@ import {checkAndFix as ieMediaCheckAndFix} from './ie-media-bug';
 import {closest, hasNextNodeInDocumentOrder, waitForBody} from '../dom';
 import {onDocumentReady} from '../document-ready';
 import {expandLayoutRect} from '../layout-rect';
-import {getService} from '../service';
+import {fromClass} from '../service';
 import {inputFor} from '../input';
 import {installViewerService} from './viewer-impl';
 import {installViewportService} from './viewport-impl';
@@ -1551,7 +1551,5 @@ let SizeDef;
  * @return {!Resources}
  */
 export function installResourcesService(win) {
-  return getService(win, 'resources', () => {
-    return new Resources(win);
-  });
+  return fromClass(win, 'resources', Resources);
 };

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getServiceForDoc} from '../service';
+import {fromClassForDoc} from '../service';
 import {installActionServiceForDoc} from './action-impl';
 import {installResourcesService} from './resources-impl';
 import {toggle} from '../style';
@@ -62,8 +62,6 @@ export class StandardActions {
  * @return {!StandardActions}
  */
 export function installStandardActionsForDoc(ampdoc) {
-  return /** @type {!StandardActions} */ (
-      getServiceForDoc(ampdoc, 'standard-actions', ampdoc => {
-        return new StandardActions(ampdoc);
-      }));
+  return fromClassForDoc(
+      ampdoc, 'standard-actions', StandardActions);
 };

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {childElementByTag} from '../dom';
-import {getService} from '../service';
+import {fromClass} from '../service';
 import {user} from '../log';
 
 
@@ -349,7 +349,5 @@ export function registerExtendedTemplate(win, type, templateClass) {
  * @return {!Templates}
  */
 export function installTemplatesService(window) {
-  return getService(window, 'templates', () => {
-    return new Templates(window);
-  });
+  return fromClass(window, 'templates', Templates);
 };

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -19,7 +19,7 @@ import {cidFor} from '../cid';
 import {variantForOrNull} from '../variant-service';
 import {dev, user, rethrowAsync} from '../log';
 import {documentInfoFor} from '../document-info';
-import {getService} from '../service';
+import {fromClass} from '../service';
 import {loadPromise} from '../event-helper';
 import {getSourceUrl, parseUrl, removeFragment, parseQueryString} from '../url';
 import {viewerFor} from '../viewer';
@@ -605,7 +605,5 @@ export class UrlReplacements {
  * @return {!UrlReplacements}
  */
 export function installUrlReplacementsService(window) {
-  return getService(window, 'url-replace', () => {
-    return new UrlReplacements(window);
-  });
+  return fromClass(window, 'url-replace', UrlReplacements);
 };

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -17,7 +17,7 @@
 import {Observable} from '../observable';
 import {documentStateFor} from '../document-state';
 import {getMode} from '../mode';
-import {getService} from '../service';
+import {fromClass} from '../service';
 import {dev} from '../log';
 import {parseQueryString, parseUrl, removeFragment} from '../url';
 import {platform} from '../platform';
@@ -1051,7 +1051,5 @@ export let ViewerHistoryPoppedEventDef;
  * @return {!Viewer}
  */
 export function installViewerService(window) {
-  return getService(window, 'viewer', () => {
-    return new Viewer(window);
-  });
+  return fromClass(window, 'viewer', Viewer);
 };

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {dev, user} from '../log';
-import {getService} from '../service';
+import {fromClass} from '../service';
 import {
   addParamToUrl,
   getSourceOrigin,
@@ -535,7 +535,5 @@ class FetchResponseHeaders {
  * @return {!Xhr}
  */
 export function installXhrService(window) {
-  return getService(window, 'xhr', () => {
-    return new Xhr(window);
-  });
+  return fromClass(window, 'xhr', Xhr);
 };

--- a/src/timer.js
+++ b/src/timer.js
@@ -18,7 +18,7 @@
 import './polyfills';
 
 import {user} from './log';
-import {getService} from './service';
+import {fromClass} from './service';
 
 /**
  * Helper with all things Timer.
@@ -165,9 +165,7 @@ export class Timer {
  * @return {!Timer}
  */
 export function timerFor(window) {
-  return /** @type {!Timer} */ (getService(window, 'timer', () => {
-    return new Timer(window);
-  }));
+  return fromClass(window, 'timer', Timer);
 };
 
 

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -15,6 +15,7 @@
  */
 
 import {
+  fromClass,
   getService,
   getServicePromise,
   getServiceForDoc,
@@ -38,6 +39,7 @@ describe('service', () => {
 
   describe('window singletons', () => {
 
+    let Class;
     let count;
     let factory;
 
@@ -46,6 +48,11 @@ describe('service', () => {
       factory = sandbox.spy(() => {
         return ++count;
       });
+      Class = class {
+        constructor() {
+          this.count = ++count;
+        }
+      };
       resetServiceForTesting(window, 'a');
       resetServiceForTesting(window, 'b');
       resetServiceForTesting(window, 'c');
@@ -68,6 +75,19 @@ describe('service', () => {
       expect(factory.args[1][0]).to.equal(window);
     });
 
+    it('should make instances from class', () => {
+
+      const a1 = fromClass(window, 'a', Class);
+      const a2 = fromClass(window, 'a', Class);
+      expect(a1).to.equal(a2);
+      expect(a1.count).to.equal(1);
+
+      const b1 = fromClass(window, 'b', Class);
+      const b2 = fromClass(window, 'b', Class);
+      expect(b1).to.equal(b2);
+      expect(b1).to.not.equal(a1);
+    });
+
     it('should work without a factory', () => {
       const c1 = getService(window, 'c', factory);
       const c2 = getService(window, 'c');
@@ -78,7 +98,7 @@ describe('service', () => {
     it('should fail without factory on initial setup', () => {
       expect(() => {
         getService(window, 'not-present');
-      }).to.throw(/Factory not given and service missing not-present/);
+      }).to.throw(/not given and service missing not-present/);
     });
 
     it('should provide a promise that resolves when registered', () => {
@@ -193,7 +213,7 @@ describe('service', () => {
     it('should fail without factory on initial setup', () => {
       expect(() => {
         getServiceForDoc(node, 'not-present');
-      }).to.throw(/Factory not given and service missing not-present/);
+      }).to.throw(/not given and service missing not-present/);
     });
 
     it('should provide a promise that resolves when registered', () => {


### PR DESCRIPTION
1. No longer wraps factories in another closure.
2. Supports just passing in the constructor, instead of a factory function.

Also passes the context (Window or AmpDoc) to the factory. This will allow further optimizations for services like `documentInfo` that do use a custom factory.

Affects #3986