### PR TITLE
Reduce memory allocations in frequently called code.

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -899,7 +899,7 @@ export class Resources {
 
     // Phase 2: Remeasure if there were any relayouts. Unfortunately, currently
     // there's no way to optimize this. All reads happen here.
-    const toUnload = [];
+    let toUnload;
     if (relayoutCount > 0 || remeasureCount > 0 ||
             relayoutAll || relayoutTop != -1) {
       for (let i = 0; i < this.resources_.length; i++) {
@@ -914,6 +914,9 @@ export class Resources {
           const wasDisplayed = r.isDisplayed();
           r.measure();
           if (wasDisplayed && !r.isDisplayed()) {
+            if (!toUnload) {
+              toUnload = [];
+            }
             toUnload.push(r);
           }
         }
@@ -921,7 +924,7 @@ export class Resources {
     }
 
     // Unload all in one cycle.
-    if (toUnload.length > 0) {
+    if (toUnload) {
       this.vsync_.mutate(() => {
         toUnload.forEach(r => {
           r.unload();

--- a/test/functional/test-event-helper.js
+++ b/test/functional/test-event-helper.js
@@ -26,9 +26,10 @@ import * as sinon from 'sinon';
 
 describe('EventHelper', () => {
 
-  function getEvent(name) {
+  function getEvent(name, target) {
     const event = document.createEvent('Event');
     event.initEvent(name, true, true);
+    event.testTarget = target;
     return event;
   }
 
@@ -76,7 +77,7 @@ describe('EventHelper', () => {
   });
 
   it('listen', () => {
-    const event = getEvent('load');
+    const event = getEvent('load', element);
     let c = 0;
     const handler = e => {
       c++;
@@ -101,7 +102,7 @@ describe('EventHelper', () => {
   });
 
   it('listenOnce', () => {
-    const event = getEvent('load');
+    const event = getEvent('load', element);
     let c = 0;
     const handler = e => {
       c++;
@@ -122,7 +123,7 @@ describe('EventHelper', () => {
   });
 
   it('listenOnce - cancel', () => {
-    const event = getEvent('load');
+    const event = getEvent('load', element);
     let c = 0;
     const handler = e => {
       c++;
@@ -142,7 +143,7 @@ describe('EventHelper', () => {
   });
 
   it('listenOncePromise - load event', () => {
-    const event = getEvent('load');
+    const event = getEvent('load', element);
     const promise = listenOncePromise(element, 'load').then(result => {
       expect(result).to.equal(event);
     });
@@ -151,7 +152,7 @@ describe('EventHelper', () => {
   });
 
   it('listenOncePromise - with time limit', () => {
-    const event = getEvent('load');
+    const event = getEvent('load', element);
     const promise = expect(listenOncePromise(element, 'load', false, 100))
       .to.eventually.become(event);
     clock.tick(99);
@@ -196,7 +197,7 @@ describe('EventHelper', () => {
     const promise = loadPromise(element).then(result => {
       expect(result).to.equal(element);
     });
-    loadObservable.fire(getEvent('load'));
+    loadObservable.fire(getEvent('load', element));
     return promise;
   });
 
@@ -208,7 +209,7 @@ describe('EventHelper', () => {
     }, reason => {
       expect(reason.message).to.include('Failed HTTP request for');
     });
-    errorObservable.fire(getEvent('error'));
+    errorObservable.fire(getEvent('error', element));
     return promise;
   });
 

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -294,7 +294,9 @@ describe('UrlReplacements', () => {
     const urlReplacements = installUrlReplacementsService(win);
     const validMetric = urlReplacements.expand('?sh=PAGE_LOAD_TIME&s');
     urlReplacements.win_.performance.timing.loadEventStart = 109;
-    loadObservable.fire(document.createEvent('Event')); // Mimics load event.
+    loadObservable.fire({
+      target: win,
+    }); // Mimics load event.
     return validMetric.then(res => {
       expect(res).to.match(/sh=9&s/);
     });


### PR DESCRIPTION
- Don't allocate rarely needed unload array during work discovery.
- Allocate 5 fewer closures per `loadPromise`.
- Also avoid most further work for `loadPromise`s that are already loaded.

Affects #3986