### PR TITLE
Only create the img element for an amp-img during layout.

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -35,7 +35,10 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override */
-  buildCallback() {
+  initialize_() {
+    if (this.img_) {
+      return;
+    }
     /** @private {boolean} */
     this.allowImgLoadFallback_ = true;
 
@@ -75,6 +78,7 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   layoutCallback() {
+    this.initialize_();
     let promise = this.updateImageSrc_();
 
     // We only allow to fallback on error on the initial layoutCallback

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -395,7 +395,7 @@ function tests(name) {
     });
 
     describe('renderOutsideViewport', () => {
-      function getGoodAd(cb, layoutCb, opt_loadingStrategy) {
+      function getGoodAd(cb, opt_loadingStrategy) {
         const attributes = {
           width: 300,
           height: 250,
@@ -410,15 +410,13 @@ function tests(name) {
         return getAd(attributes, 'https://schema.org', element => {
           cb(element.implementation_);
           return element;
-        }, layoutCb);
+        });
       }
 
       it('should not return false after scrolling, then false for 1s', () => {
-        let clock;
+        const clock = sandbox.useFakeTimers();
         return getGoodAd(ad => {
           expect(ad.renderOutsideViewport()).not.to.be.false;
-        }, () => {
-          clock = sandbox.useFakeTimers();
         }).then(ad => {
           // False because we just rendered one.
           expect(ad.renderOutsideViewport()).to.be.false;
@@ -430,11 +428,9 @@ function tests(name) {
       });
 
       it('should prefer-viewability-over-views', () => {
-        let clock;
+        const clock = sandbox.useFakeTimers();
         return getGoodAd(ad => {
           expect(ad.renderOutsideViewport()).not.to.be.false;
-        }, () => {
-          clock = sandbox.useFakeTimers();
         }, 'prefer-viewability-over-views').then(ad => {
           // False because we just rendered one.
           expect(ad.renderOutsideViewport()).to.be.false;

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -53,6 +53,8 @@ describe('SlideScroll', () => {
         ampSlideScroll.setAttribute('src', imgUrl);
         ampSlideScroll.setAttribute('width', '400');
         ampSlideScroll.setAttribute('height', '300');
+        // See https://github.com/ampproject/amphtml/issues/3989
+        ampSlideScroll.style.display = 'inline';
         ampSlideScroll.appendChild(img);
       }
       return iframe.addElement(ampSlideScroll).then(() => {

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -172,7 +172,6 @@ describe('amp-img', () => {
       loadStub.returns(Promise.resolve());
       impl.buildCallback();
 
-      expect(impl.img_).to.not.have.class('-amp-ghost');
       expect(toggleElSpy.callCount).to.equal(0);
 
       return impl.layoutCallback().catch(() => {

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -17,6 +17,7 @@
 
 import {Timer} from '../src/timer';
 import {installRuntimeServices, registerForUnitTest} from '../src/runtime';
+import {cssText} from '../build/css';
 
 let iframeCount = 0;
 
@@ -187,6 +188,7 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
     let iframe = document.createElement('iframe');
     iframe.name = 'test_' + iframeCount++;
     iframe.srcdoc = '<!doctype><html><head>' +
+        '<style>.-amp-element {display: block;}</style>' +
         '<body style="margin:0"><div id=parent></div>';
     iframe.onload = function() {
       // Flag as being a test window.


### PR DESCRIPTION
This significantly reduces the work during pre-render for the most popular element.

Fixes a bunch of tests that cannot deal with elements actually having dimensions, which so far was not the case in unit tests unless elements had inherent dimensions.

Affects #3986 