### PR TITLE
When fetching pages for the validator webui, set the user agent to what I see on my Nexus 5X phone with Chrome. 

### DIFF
--- a/validator/webui/serve-standalone.go
+++ b/validator/webui/serve-standalone.go
@@ -129,7 +129,17 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		var netClient = &http.Client{
 			Timeout: time.Second * 20,
 		}
-		resp, err := netClient.Get(param)
+		req, err := http.NewRequest("GET", param, nil)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Bad gateway (%v)", err.Error()),
+				http.StatusBadGateway)
+			return
+		}
+		req.Header.Add("User-Agent",
+			"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MTC19V) "+
+				"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile "+
+				"Safari/537.36 (compatible; validator.ampproject.org)")
+		resp, err := netClient.Do(req)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Bad gateway (%v)", err.Error()),
 				http.StatusBadGateway)

--- a/validator/webui/serve.go
+++ b/validator/webui/serve.go
@@ -52,7 +52,17 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx := appengine.NewContext(r)
 	client := urlfetch.Client(ctx)
-	resp, err := client.Get(u.String())
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Bad gateway (%v)", err.Error()),
+			http.StatusBadGateway)
+		return
+	}
+	req.Header.Add("User-Agent",
+		"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MTC19V) "+
+			"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile "+
+			"Safari/537.36 (compatible; validator.ampproject.org)")
+	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Bad gateway (%v)", err.Error()),
 			http.StatusBadGateway)


### PR DESCRIPTION
This should avoid getting a desktop page. In practice it should also be similar to what Google
indexing uses. It should reduce confusion around sites that behave differently based on the user agent:
https://groups.google.com/forum/#!topic/amphtml-discuss/NqzESU2_YNY

Note that the resulting user agent for validator.ampproject.org includes
an AppEngine string as well. E.g. with the dev server it reads:

Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; validator.ampproject.org) AppEngine-Google; (+http://code.google.com/appengine; appid: dev~None)