### PR TITLE
Make share-tracking extension to get incoming/outcoming fragments

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -115,6 +115,13 @@ app.use('/form/echo-json/post', function(req, res) {
   });
 });
 
+app.use('/share-tracking/get-outgoing-fragment', function(req, res) {
+  res.setHeader('Content-Type', 'application/json');
+  res.json({
+    outgoingFragment: '54321'
+  });
+});
+
 // Fetches an AMP document from the AMP proxy and replaces JS
 // URLs, so that they point to localhost.
 function proxyToAmpProxy(req, res, minify) {

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -116,7 +116,6 @@ app.use('/form/echo-json/post', function(req, res) {
 });
 
 app.use('/share-tracking/get-outgoing-fragment', function(req, res) {
-  res.setHeader('Content-Type', 'application/json');
   res.json({
     outgoingFragment: '54321'
   });

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -117,7 +117,7 @@ app.use('/form/echo-json/post', function(req, res) {
 
 app.use('/share-tracking/get-outgoing-fragment', function(req, res) {
   res.json({
-    outgoingFragment: '54321'
+    fragment: '54321'
   });
 });
 

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -116,6 +116,8 @@ app.use('/form/echo-json/post', function(req, res) {
 });
 
 app.use('/share-tracking/get-outgoing-fragment', function(req, res) {
+  res.setHeader('AMP-Access-Control-Allow-Source-Origin',
+      req.protocol + '://' + req.headers.host);
   res.json({
     fragment: '54321'
   });

--- a/css/amp.css
+++ b/css/amp.css
@@ -403,3 +403,10 @@ form [submit-error] {
 amp-live-list > [update] {
   display: none;
 }
+
+/**
+ * Display none elements
+ */
+amp-experiment, amp-share-tracking {
+  display: none;
+}

--- a/examples/share-tracking-with-url.amp.html
+++ b/examples/share-tracking-with-url.amp.html
@@ -14,8 +14,5 @@
   <amp-share-tracking data-href='http://localhost:8000/share-tracking/get-outgoing-fragment'>
   </amp-share-tracking>
 
-  <amp-share-tracking>
-  </amp-share-tracking>
-
 </body>
 </html>

--- a/examples/share-tracking-without-url.amp.html
+++ b/examples/share-tracking-without-url.amp.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Share tracking examples</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0/amp-share-tracking-0.1.js"></script>
+</head>
+<body>
+  <amp-share-tracking>
+  </amp-share-tracking>
+
+</body>
+</html>

--- a/examples/share-tracking.amp.html
+++ b/examples/share-tracking.amp.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Share tracking examples</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0/amp-share-tracking-0.1.js"></script>
+</head>
+<body>
+  <amp-share-tracking data-href='http://localhost:8000/share-tracking/get-outgoing-fragment'>
+  </amp-share-tracking>
+
+  <amp-share-tracking>
+  </amp-share-tracking>
+
+</body>
+</html>

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -15,31 +15,165 @@
  */
 
 import {isExperimentOn} from '../../../src/experiments';
-import {getService} from '../../../src/service';
+import {fromClass} from '../../../src/service';
+import {xhrFor} from '../../../src/xhr';
+import {viewerFor} from '../../../src/viewer';
 import {dev} from '../../../src/log';
 
 /** @private @const {string} */
 const TAG = 'amp-share-tracking';
 
-class AmpShareTracking extends AMP.BaseElement {
+/**
+ * @export
+ * @typedef {{
+ *   outgoingFragment: string
+ * }}
+ */
+let ShareTrackingPostResponseDef;
+
+export class AmpShareTracking extends AMP.BaseElement {
+  /**
+    * @return {boolean}
+    * @private
+    */
+  isExperimentOn_() {
+    return isExperimentOn(this.getWin(), TAG);
+  }
 
   /** @override */
-  buildCallback() {
-    this.isExperimentOn_ = isExperimentOn(this.win, TAG);
-    if (!this.isExperimentOn_) {
+  isLayoutSupported(unusedLayout) {
+    return true;
+  }
+
+  /** @override */
+  createdCallback() {
+    if (!this.isExperimentOn_()) {
       dev.warn(TAG, `TAG ${TAG} disabled`);
       return;
     }
+
+    /** @private @const {!Window} */
+    this.win_ = this.getWin();
+
+    /** @private @const {!ShareTrackingService} */
+    this.shareTrackingService_ = getShareTrackingService_(this.win_);
+  }
+
+  /** @override */
+  buildCallback() {
+    if (!this.isExperimentOn_()) {
+      dev.warn(TAG, `TAG ${TAG} disabled`);
+      return;
+    }
+
+    this.vendorHref = this.element.getAttribute('data-href');
+    dev.fine(TAG, 'vendorHref: ', this.vendorHref);
+
+    return Promise.all([
+      this.shareTrackingService_.getIncomingFragment(),
+      this.shareTrackingService_.getOutgoingFragment(this.vendorHref)]).then(
+        results => {
+          this.incomingFragment = results[0];
+          this.outgoingFragment = results[1];
+          dev.fine(TAG, 'get incoming fragment: ' + this.incomingFragment);
+          dev.fine(TAG, 'get outgoing fragment: ' + this.outgoingFragment);
+        });
   }
 }
 
 /**
- * ShareTrackingService processes the incoming and outcoming url fragment
+ * ShareTrackingService processes the incoming and outgoing url fragment
  */
 export class ShareTrackingService {
   constructor(window) {
-    this.win = window;
+    this.win_ = window;
   }
+
+  /**
+   * Get the incoming share-tracking fragment from the url
+   * @return {!Promise<string>}
+   */
+  getIncomingFragment() {
+    // remove the #
+    const hash = this.win_.location.hash.substr(1);
+
+    // when the url contains the share-tracking identifier directly
+    if (hash.indexOf('.') == 0) {
+      const endIndex = hash.indexOf('&');
+      if (endIndex != -1) {
+        return Promise.resolve(hash.substr(1, (endIndex - 1)));
+      } else {
+        return Promise.resolve(hash.substr(1));
+      }
+    }
+
+    // get the share-tracking identifier from the viewer
+    return viewerFor(this.win_).getShareTrackingIncomingFragment();
+  }
+
+  /**
+   * Get an outgoing share-tracking fragment
+   * @return {!Promise<string>}
+   */
+  getOutgoingFragment(vendorUrl) {
+    if (vendorUrl) {
+      return this.getOutgoingFragmentFromVendor(vendorUrl).then(
+        response => {
+          if (!response.outgoingFragment) {
+            dev.warn(TAG, 'The response from [' + vendorUrl +
+                '] does not have an outgoingFragment value. ' +
+                'Generating outgoing fragment using random generator.');
+            return this.getOutgoingFragmentRandomly();
+          } else {
+            return Promise.resolve(response.outgoingFragment);
+          }
+        }
+      );
+    } else {
+      return this.getOutgoingFragmentRandomly();
+    }
+  }
+
+  /**
+   * Get an outgoing share-tracking fragment from vendor
+   * by issueing a post request to the url the vendor provided
+   * @return {!Promise<!ShareTrackingPostResponseDef>}
+   */
+  getOutgoingFragmentFromVendor(vendorUrl) {
+    const postReq = {
+      method: 'POST',
+      credentials: 'include',
+      body: {},
+    };
+    return xhrFor(this.win_).fetchJson(vendorUrl, postReq);
+  }
+
+  /**
+   * Get a random outgoing share-tracking fragment
+   * @return {!Promise<string>}
+   */
+  getOutgoingFragmentRandomly() {
+    const randomFragment = this.getRandomFragment();
+    return Promise.resolve(randomFragment);
+  }
+
+  /**
+   * Get a random fragment
+   * @return {!string}
+   */
+  getRandomFragment() {
+    // TODO(yuxichen): generate random fragment
+    return 'rAmDoM';
+  }
+}
+
+/**
+ * @param {!Window} window
+ * @return {!ShareTrackingService}
+ * @private
+ */
+function getShareTrackingService_(window) {
+  return fromClass(window, 'shareTrackingService', ShareTrackingService);
 }
 
 /**
@@ -47,9 +181,7 @@ export class ShareTrackingService {
  * @return {!ShareTrackingService}
  */
 export function installShareTrackingService(window) {
-  return getService(window, 'shareTrackingService', () => {
-    return new ShareTrackingService(window);
-  });
+  return getShareTrackingService_(window);
 }
 
 installShareTrackingService(AMP.win);

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -75,7 +75,7 @@ export class AmpShareTracking extends AMP.BaseElement {
 
   /**
    * Get an outgoing share-tracking fragment
-   * @return {!Promise<string|undefined>}
+   * @return {!Promise<string>}
    * @private
    */
   getOutgoingFragment_() {
@@ -89,7 +89,7 @@ export class AmpShareTracking extends AMP.BaseElement {
    * Get an outgoing share-tracking fragment from vendor
    * by issueing a post request to the url the vendor provided
    * @param {string} vendorUrl
-   * @return {!Promise<string|undefined>}
+   * @return {!Promise<string>}
    * @private
    */
   getOutgoingFragmentFromVendor_(vendorUrl) {
@@ -105,8 +105,10 @@ export class AmpShareTracking extends AMP.BaseElement {
       }
       user.error(TAG, 'The response from [' + vendorUrl + '] does not ' +
           'have a fragment value.');
+      return '';
     }).catch(error => {
       user.error(TAG, 'The request to share-tracking endpoint failed:' + error);
+      return '';
     });
   }
 

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -106,7 +106,7 @@ export class AmpShareTracking extends AMP.BaseElement {
       user.error(TAG, 'The response from [' + vendorUrl + '] does not ' +
           'have a fragment value.');
       return '';
-    }).catch(error => {
+    }, error => {
       user.error(TAG, 'The request to share-tracking endpoint failed:' + error);
       return '';
     });

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -108,10 +108,9 @@ export class AmpShareTracking extends AMP.BaseElement {
     return xhrFor(this.win).fetchJson(vendorUrl, postReq).then(response => {
       if (response.fragment) {
         return response.fragment;
-      } else {
-        user.error(TAG, 'The response from [' + vendorUrl + '] does not ' +
-            'have an outgoingFragment value. The outgoing fragment is empty.');
       }
+      user.error(TAG, 'The response from [' + vendorUrl + '] does not ' +
+          'have an outgoingFragment value.');
     }).catch(error => {
       user.error(TAG, error);
     });

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -23,6 +23,9 @@ import {dev, user} from '../../../src/log';
 /** @private @const {string} */
 const TAG = 'amp-share-tracking';
 
+/**
+ * @visibleForTesting
+ */
 export class AmpShareTracking extends AMP.BaseElement {
   /**
     * @return {boolean}
@@ -60,20 +63,13 @@ export class AmpShareTracking extends AMP.BaseElement {
 
   /**
    * Get the incoming share-tracking fragment from the viewer
-   * @return {!Promise<string|undefined>}
+   * @return {!Promise<string>}
    * @private
    */
   getIncomingFragment_() {
     return viewerFor(this.win).getFragment().then(fragment => {
-      if (!fragment || fragment.indexOf('.') != 0) {
-        return;
-      }
-      const endIndex = fragment.indexOf('&');
-      if (endIndex != -1) {
-        return fragment.substr(1, (endIndex - 1));
-      } else {
-        return fragment.substr(1);
-      }
+      const match = fragment.match(/\.([^&]*)/);
+      return match && match[1];
     });
   }
 

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -69,7 +69,7 @@ export class AmpShareTracking extends AMP.BaseElement {
   getIncomingFragment_() {
     return viewerFor(this.win).getFragment().then(fragment => {
       const match = fragment.match(/\.([^&]*)/);
-      return match && match[1];
+      return match ? match[1] : '';
     });
   }
 

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -36,8 +36,7 @@ describe('amp-share-tracking', () => {
     sandbox.restore();
   });
 
-  function getAmpShareTracking(optVendorUrl, optStubGetIncomingFragment,
-        optStubGetOutgoingFragment) {
+  function getAmpShareTracking(optVendorUrl) {
     return createIframePromise().then(iframe => {
       toggleExperiment(iframe.win, 'amp-share-tracking', true);
       const el = iframe.doc.createElement('amp-share-tracking');
@@ -45,145 +44,113 @@ describe('amp-share-tracking', () => {
         el.setAttribute('data-href', optVendorUrl);
       }
       const ampShareTracking = new AmpShareTracking(el);
-      if (optStubGetIncomingFragment) {
-        sandbox.stub(ampShareTracking, 'getIncomingFragment_',
-            () => optStubGetIncomingFragment);
-      }
-      if (optStubGetOutgoingFragment) {
-        sandbox.stub(ampShareTracking, 'getOutgoingFragment_',
-            () => optStubGetOutgoingFragment);
-      }
       return ampShareTracking;
     });
   }
 
-  it('should get vendor url from data-href', () => {
-    return getAmpShareTracking(
-      /*vendorUrl*/'http://foo.bar',
-      /*stubGetIncomingFragment*/Promise.resolve(),
-      /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(() => {
-          expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
-        });
-      });
-  });
-
   it('should get incoming fragment starting with dot', () => {
     viewerForMock.onFirstCall().returns(Promise.resolve('.12345'));
-    return getAmpShareTracking(
-      /*vendorUrl*/undefined,
-      /*stubGetIncomingFragment*/undefined,
-      /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(fragments => {
-          expect(fragments.incomingFragment).to.equal('12345');
-          expect(fragments.outgoingFragment).to.be.undefined;
-        });
+    const mockJsonResponse = {fragment: '54321'};
+    xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      ampShareTracking.buildCallback();
+      expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.incomingFragment).to.equal('12345');
       });
+    });
   });
 
   it('should get incoming fragment starting with dot and ignore ' +
       'other parameters', () => {
     viewerForMock.onFirstCall().returns(Promise.resolve('.12345&key=value'));
-    return getAmpShareTracking(
-      /*vendorUrl*/undefined,
-      /*stubGetIncomingFragment*/undefined,
-      /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(fragments => {
-          expect(fragments.incomingFragment).to.equal('12345');
-          expect(fragments.outgoingFragment).to.be.undefined;
-        });
+    const mockJsonResponse = {fragment: '54321'};
+    xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      ampShareTracking.buildCallback();
+      expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.incomingFragment).to.equal('12345');
       });
+    });
   });
 
   it('should ignore incoming fragment if it is empty', () => {
     viewerForMock.onFirstCall().returns(Promise.resolve());
-    return getAmpShareTracking(
-      /*vendorUrl*/undefined,
-      /*stubGetIncomingFragment*/undefined,
-      /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(fragments => {
-          expect(fragments.incomingFragment).to.be.undefined;
-          expect(fragments.outgoingFragment).to.be.undefined;
-        });
+    const mockJsonResponse = {fragment: '54321'};
+    xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      ampShareTracking.buildCallback();
+      expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.incomingFragment).to.be.undefined;
       });
+    });
   });
 
   it('should ignore incoming fragment if it does not start with dot', () => {
     viewerForMock.onFirstCall().returns(Promise.resolve('12345'));
-    return getAmpShareTracking(
-      /*vendorUrl*/undefined,
-      /*stubGetIncomingFragment*/undefined,
-      /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(fragments => {
-          expect(fragments.incomingFragment).to.be.undefined;
-          expect(fragments.outgoingFragment).to.be.undefined;
-        });
+    const mockJsonResponse = {fragment: '54321'};
+    xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      ampShareTracking.buildCallback();
+      expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.incomingFragment).to.be.undefined;
       });
+    });
   });
 
   it('should get outgoing fragment randomly if no vendor url ' +
       'is provided', () => {
-    return getAmpShareTracking(
-      /*vendorUrl*/undefined,
-      /*stubGetIncomingFragment*/Promise.resolve(),
-      /*stubGetOutgoingFragment*/undefined).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(fragments => {
-          expect(fragments.incomingFragment).to.be.undefined;
-          expect(fragments.outgoingFragment).to.equal('rAmDoM');
-        });
+    viewerForMock.onFirstCall().returns(Promise.resolve('.12345'));
+    return getAmpShareTracking().then(ampShareTracking => {
+      ampShareTracking.buildCallback();
+      expect(ampShareTracking.vendorHref_).to.be.null;
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.outgoingFragment).to.equal('rAmDoM');
       });
+    });
   });
 
   it('should get outgoing fragment from vendor if vendor url is provided ' +
       'and the response format is correct', () => {
+    viewerForMock.onFirstCall().returns(Promise.resolve('.12345'));
     const mockJsonResponse = {fragment: '54321'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
-    return getAmpShareTracking(
-      /*vendorUrl*/'http://foo.bar',
-      /*stubGetIncomingFragment*/Promise.resolve(),
-      /*stubGetOutgoingFragment*/undefined).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(fragments => {
-          expect(fragments.incomingFragment).to.be.undefined;
-          expect(fragments.outgoingFragment).to.equal('54321');
-        });
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      ampShareTracking.buildCallback();
+      expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.outgoingFragment).to.equal('54321');
       });
+    });
   });
 
   it('should get empty outgoing fragment if vendor url is provided ' +
       'but the response format is NOT correct', () => {
+    viewerForMock.onFirstCall().returns(Promise.resolve('.12345'));
     const mockJsonResponse = {foo: 'bar'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
-    return getAmpShareTracking(
-      /*vendorUrl*/'http://foo.bar',
-      /*stubGetIncomingFragment*/Promise.resolve(),
-      /*stubGetOutgoingFragment*/undefined).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(fragments => {
-          expect(fragments.incomingFragment).to.be.undefined;
-          expect(fragments.outgoingFragment).to.be.undefined;
-        });
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      ampShareTracking.buildCallback();
+      expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.outgoingFragment).to.be.undefined;
       });
+    });
   });
 
   it('should get empty outgoing fragment if vendor url is provided ' +
-      'but the endpoint does not exist', () => {
+      'but the xhr fails', () => {
+    viewerForMock.onFirstCall().returns(Promise.resolve('.12345'));
     xhrMock.onFirstCall().returns(Promise.reject('404'));
-    return getAmpShareTracking(
-      /*vendorUrl*/'http://foo.bar',
-      /*stubGetIncomingFragment*/Promise.resolve(),
-      /*stubGetOutgoingFragment*/undefined).then(ampShareTracking => {
-        ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments_.then(fragments => {
-          expect(fragments.incomingFragment).to.be.undefined;
-          expect(fragments.outgoingFragment).to.be.undefined;
-        });
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      ampShareTracking.buildCallback();
+      expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.outgoingFragment).to.be.undefined;
       });
+    });
   });
 });

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -21,7 +21,7 @@ import {Xhr} from '../../../../src/service/xhr-impl';
 import {toggleExperiment} from '../../../../src/experiments';
 import * as sinon from 'sinon';
 
-describe.only('amp-share-tracking', () => {
+describe('amp-share-tracking', () => {
   let sandbox;
   let viewerForMock;
   let xhrMock;
@@ -142,7 +142,7 @@ describe.only('amp-share-tracking', () => {
 
   it('should get outgoing fragment from vendor if vendor url is provided ' +
       'and the response format is correct', () => {
-    const mockJsonResponse = {outgoingFragment: '54321'};
+    const mockJsonResponse = {fragment: '54321'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
     return getAmpShareTracking(
       /*vendorUrl*/'http://foo.bar',
@@ -156,7 +156,7 @@ describe.only('amp-share-tracking', () => {
       });
   });
 
-  it('should get outgoing fragment randomly if vendor url is provided ' +
+  it('should get empty outgoing fragment if vendor url is provided ' +
       'but the response format is NOT correct', () => {
     const mockJsonResponse = {foo: 'bar'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
@@ -167,7 +167,22 @@ describe.only('amp-share-tracking', () => {
         ampShareTracking.buildCallback();
         return ampShareTracking.shareTrackingFragments_.then(fragments => {
           expect(fragments.incomingFragment).to.be.undefined;
-          expect(fragments.outgoingFragment).to.equal('rAmDoM');
+          expect(fragments.outgoingFragment).to.be.undefined;
+        });
+      });
+  });
+
+  it('should get empty outgoing fragment if vendor url is provided ' +
+      'but the endpoint does not exist', () => {
+    xhrMock.onFirstCall().returns(Promise.reject('404'));
+    return getAmpShareTracking(
+      /*vendorUrl*/'http://foo.bar',
+      /*stubGetIncomingFragment*/Promise.resolve(),
+      /*stubGetOutgoingFragment*/undefined).then(ampShareTracking => {
+        ampShareTracking.buildCallback();
+        return ampShareTracking.shareTrackingFragments_.then(fragments => {
+          expect(fragments.incomingFragment).to.be.undefined;
+          expect(fragments.outgoingFragment).to.be.undefined;
         });
       });
   });

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -81,7 +81,7 @@ describe('amp-share-tracking', () => {
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
-        expect(fragments.incomingFragment).to.be.null;
+        expect(fragments.incomingFragment).to.equal('');
       });
     });
   });
@@ -93,7 +93,7 @@ describe('amp-share-tracking', () => {
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
-        expect(fragments.incomingFragment).to.be.null;
+        expect(fragments.incomingFragment).to.equal('');
       });
     });
   });

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -44,6 +44,7 @@ describe('amp-share-tracking', () => {
         el.setAttribute('data-href', optVendorUrl);
       }
       const ampShareTracking = new AmpShareTracking(el);
+      ampShareTracking.buildCallback();
       return ampShareTracking;
     });
   }
@@ -53,7 +54,6 @@ describe('amp-share-tracking', () => {
     const mockJsonResponse = {fragment: '54321'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
-      ampShareTracking.buildCallback();
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
         expect(fragments.incomingFragment).to.equal('12345');
@@ -67,7 +67,6 @@ describe('amp-share-tracking', () => {
     const mockJsonResponse = {fragment: '54321'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
-      ampShareTracking.buildCallback();
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
         expect(fragments.incomingFragment).to.equal('12345');
@@ -80,7 +79,6 @@ describe('amp-share-tracking', () => {
     const mockJsonResponse = {fragment: '54321'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
-      ampShareTracking.buildCallback();
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
         expect(fragments.incomingFragment).to.be.undefined;
@@ -93,7 +91,6 @@ describe('amp-share-tracking', () => {
     const mockJsonResponse = {fragment: '54321'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
-      ampShareTracking.buildCallback();
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
         expect(fragments.incomingFragment).to.be.undefined;
@@ -105,7 +102,6 @@ describe('amp-share-tracking', () => {
       'is provided', () => {
     viewerForMock.onFirstCall().returns(Promise.resolve('.12345'));
     return getAmpShareTracking().then(ampShareTracking => {
-      ampShareTracking.buildCallback();
       expect(ampShareTracking.vendorHref_).to.be.null;
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
         expect(fragments.outgoingFragment).to.equal('rAmDoM');
@@ -119,7 +115,6 @@ describe('amp-share-tracking', () => {
     const mockJsonResponse = {fragment: '54321'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
-      ampShareTracking.buildCallback();
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
         expect(fragments.outgoingFragment).to.equal('54321');
@@ -133,10 +128,28 @@ describe('amp-share-tracking', () => {
     const mockJsonResponse = {foo: 'bar'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
-      ampShareTracking.buildCallback();
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
         expect(fragments.outgoingFragment).to.be.undefined;
+      });
+    });
+  });
+
+  it('should call fetchJson with correct request when getting outgoing' +
+      'fragment', () => {
+    viewerForMock.onFirstCall().returns(Promise.resolve('.12345'));
+    const mockJsonResponse = {fragment: '54321'};
+    xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
+      const xhrCall = xhrMock.getCall(0);
+      expect(xhrCall.args[0]).to.equal('http://foo.bar');
+      const config = xhrCall.args[1];
+      expect(config.method).to.equal('POST');
+      expect(config.credentials).to.equal('include');
+      expect(config.requireAmpResponseSourceOrigin).to.be.true;
+      return ampShareTracking.shareTrackingFragments_.then(fragments => {
+        expect(fragments.outgoingFragment).to.equal('54321');
       });
     });
   });
@@ -146,7 +159,6 @@ describe('amp-share-tracking', () => {
     viewerForMock.onFirstCall().returns(Promise.resolve('.12345'));
     xhrMock.onFirstCall().returns(Promise.reject('404'));
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
-      ampShareTracking.buildCallback();
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
         expect(fragments.outgoingFragment).to.be.undefined;

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS-IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createIframePromise} from '../../../../testing/iframe';
+import {
+  AmpShareTracking,
+  ShareTrackingService,
+} from '../amp-share-tracking';
+import {Viewer} from '../../../../src/service/viewer-impl';
+import {Xhr} from '../../../../src/service/xhr-impl';
+import {toggleExperiment} from '../../../../src/experiments';
+import * as sinon from 'sinon';
+
+describe('amp-share-tracking', () => {
+  let sandbox;
+  let shareTrackingService;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    shareTrackingService = {
+      getIncomingFragment: () => Promise.resolve('inFragment'),
+      getOutgoingFragment: () => Promise.resolve('outFragment'),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function getAmpShareTracking(optVendorUrl) {
+    return createIframePromise().then(iframe => {
+      toggleExperiment(iframe.win, 'amp-share-tracking', true);
+      const el = iframe.doc.createElement('amp-share-tracking');
+      if (optVendorUrl) {
+        el.setAttribute('data-href', optVendorUrl);
+      }
+      const ampShareTracking = new AmpShareTracking(el);
+      ampShareTracking.createdCallback();
+      ampShareTracking.shareTrackingService_ = shareTrackingService;
+      return ampShareTracking;
+    });
+  }
+
+  it('should get vendor url from data-href', () => {
+    return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
+      ampShareTracking.buildCallback().then(() => {
+        expect(ampShareTracking.vendorHref).to.equal('http://foo.bar');
+      });
+    });
+  });
+
+  it('should get incoming/outging fragment from service', () => {
+    return getAmpShareTracking().then(ampShareTracking => {
+      ampShareTracking.buildCallback().then(() => {
+        expect(ampShareTracking.incomingFragment).to.equal('inFragment');
+        expect(ampShareTracking.outgoingFragment).to.equal('outFragment');
+        expect(ampShareTracking.vendorHref).to.be.null;
+      });
+    });
+  });
+
+  describe('ShareTrackingService', () => {
+    let service;
+    let viewerForMock;
+    let xhrMock;
+
+    beforeEach(() => {
+      service = new ShareTrackingService(window);
+      viewerForMock = sandbox.stub(Viewer.prototype,
+          'getShareTrackingIncomingFragment');
+      xhrMock = sandbox.stub(Xhr.prototype, 'fetchJson');
+    });
+
+    it('should get incoming fragment starting with dot', () => {
+      service.win_.location.hash = '.12345';
+      service.getIncomingFragment().then(str => {
+        expect(str).to.equal('12345');
+      });
+    });
+
+    it('should get incoming fragment starting with dot ' +
+        'and ignore any parameters', () => {
+      service.win_.location.hash = '.12345&key=value';
+      service.getIncomingFragment().then(str => {
+        expect(str).to.equal('12345');
+      });
+    });
+
+    it('should get incoming fragment from the viewer ' +
+        'if fragment is empty', () => {
+      service.win_.location.hash = '';
+      viewerForMock.onFirstCall().returns(Promise.resolve('12345'));
+      service.getIncomingFragment().then(str => {
+        expect(str).to.equal('12345');
+      });
+    });
+
+    it('should get incoming fragment from the viewer ' +
+        'if no fragment starting with dot is provided', () => {
+      service.win_.location.hash = '54321';
+      viewerForMock.onFirstCall().returns(Promise.resolve('12345'));
+      service.getIncomingFragment().then(str => {
+        expect(str).to.equal('12345');
+      });
+    });
+
+    it('should get outgoing fragment randomly if no vendor url ' +
+        'is provided', () => {
+      service.getRandomFragment = () => 'rAmDoM';
+      return service.getOutgoingFragment().then(str => {
+        expect(str).to.equal('rAmDoM');
+      });
+    });
+
+    it('should get outgoing fragment from vendor if vendor url is provided ' +
+        'and the response format is correct', () => {
+      const mockJsonResponse = {outgoingFragment: '54321'};
+      xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
+      return service.getOutgoingFragment('http://foo.bar').then(str => {
+        expect(str).to.equal('54321');
+      });
+    });
+
+    it('should get outgoing fragment randomly if vendor url is provided ' +
+        'but the response format is NOT correct', () => {
+      const mockJsonResponse = {foo: 'bar'};
+      service.getRandomFragment = () => 'rAmDoM';
+      xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
+      return service.getOutgoingFragment('http://foo.bar').then(str => {
+        expect(str).to.equal('rAmDoM');
+      });
+    });
+  });
+
+});

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -130,7 +130,7 @@ describe('amp-share-tracking', () => {
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
-        expect(fragments.outgoingFragment).to.be.undefined;
+        expect(fragments.outgoingFragment).to.equal('');
       });
     });
   });
@@ -161,7 +161,7 @@ describe('amp-share-tracking', () => {
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
-        expect(fragments.outgoingFragment).to.be.undefined;
+        expect(fragments.outgoingFragment).to.equal('');
       });
     });
   });

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -21,7 +21,7 @@ import {Xhr} from '../../../../src/service/xhr-impl';
 import {toggleExperiment} from '../../../../src/experiments';
 import * as sinon from 'sinon';
 
-describe('amp-share-tracking', () => {
+describe.only('amp-share-tracking', () => {
   let sandbox;
   let viewerForMock;
   let xhrMock;
@@ -46,11 +46,11 @@ describe('amp-share-tracking', () => {
       }
       const ampShareTracking = new AmpShareTracking(el);
       if (optStubGetIncomingFragment) {
-        sandbox.stub(ampShareTracking, 'getIncomingFragment',
+        sandbox.stub(ampShareTracking, 'getIncomingFragment_',
             () => optStubGetIncomingFragment);
       }
       if (optStubGetOutgoingFragment) {
-        sandbox.stub(ampShareTracking, 'getOutgoingFragment',
+        sandbox.stub(ampShareTracking, 'getOutgoingFragment_',
             () => optStubGetOutgoingFragment);
       }
       return ampShareTracking;
@@ -63,8 +63,8 @@ describe('amp-share-tracking', () => {
       /*stubGetIncomingFragment*/Promise.resolve(),
       /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
         ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments.then(() => {
-          expect(ampShareTracking.vendorHref).to.equal('http://foo.bar');
+        return ampShareTracking.shareTrackingFragments_.then(() => {
+          expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
         });
       });
   });
@@ -76,7 +76,7 @@ describe('amp-share-tracking', () => {
       /*stubGetIncomingFragment*/undefined,
       /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
         ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments.then(fragments => {
+        return ampShareTracking.shareTrackingFragments_.then(fragments => {
           expect(fragments.incomingFragment).to.equal('12345');
           expect(fragments.outgoingFragment).to.be.undefined;
         });
@@ -91,7 +91,7 @@ describe('amp-share-tracking', () => {
       /*stubGetIncomingFragment*/undefined,
       /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
         ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments.then(fragments => {
+        return ampShareTracking.shareTrackingFragments_.then(fragments => {
           expect(fragments.incomingFragment).to.equal('12345');
           expect(fragments.outgoingFragment).to.be.undefined;
         });
@@ -105,7 +105,7 @@ describe('amp-share-tracking', () => {
       /*stubGetIncomingFragment*/undefined,
       /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
         ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments.then(fragments => {
+        return ampShareTracking.shareTrackingFragments_.then(fragments => {
           expect(fragments.incomingFragment).to.be.undefined;
           expect(fragments.outgoingFragment).to.be.undefined;
         });
@@ -119,7 +119,7 @@ describe('amp-share-tracking', () => {
       /*stubGetIncomingFragment*/undefined,
       /*stubGetOutgoingFragment*/Promise.resolve()).then(ampShareTracking => {
         ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments.then(fragments => {
+        return ampShareTracking.shareTrackingFragments_.then(fragments => {
           expect(fragments.incomingFragment).to.be.undefined;
           expect(fragments.outgoingFragment).to.be.undefined;
         });
@@ -133,7 +133,7 @@ describe('amp-share-tracking', () => {
       /*stubGetIncomingFragment*/Promise.resolve(),
       /*stubGetOutgoingFragment*/undefined).then(ampShareTracking => {
         ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments.then(fragments => {
+        return ampShareTracking.shareTrackingFragments_.then(fragments => {
           expect(fragments.incomingFragment).to.be.undefined;
           expect(fragments.outgoingFragment).to.equal('rAmDoM');
         });
@@ -149,7 +149,7 @@ describe('amp-share-tracking', () => {
       /*stubGetIncomingFragment*/Promise.resolve(),
       /*stubGetOutgoingFragment*/undefined).then(ampShareTracking => {
         ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments.then(fragments => {
+        return ampShareTracking.shareTrackingFragments_.then(fragments => {
           expect(fragments.incomingFragment).to.be.undefined;
           expect(fragments.outgoingFragment).to.equal('54321');
         });
@@ -165,7 +165,7 @@ describe('amp-share-tracking', () => {
       /*stubGetIncomingFragment*/Promise.resolve(),
       /*stubGetOutgoingFragment*/undefined).then(ampShareTracking => {
         ampShareTracking.buildCallback();
-        return ampShareTracking.shareTrackingFragments.then(fragments => {
+        return ampShareTracking.shareTrackingFragments_.then(fragments => {
           expect(fragments.incomingFragment).to.be.undefined;
           expect(fragments.outgoingFragment).to.equal('rAmDoM');
         });

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -75,13 +75,13 @@ describe('amp-share-tracking', () => {
   });
 
   it('should ignore incoming fragment if it is empty', () => {
-    viewerForMock.onFirstCall().returns(Promise.resolve());
+    viewerForMock.onFirstCall().returns(Promise.resolve(''));
     const mockJsonResponse = {fragment: '54321'};
     xhrMock.onFirstCall().returns(Promise.resolve(mockJsonResponse));
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
-        expect(fragments.incomingFragment).to.be.undefined;
+        expect(fragments.incomingFragment).to.be.null;
       });
     });
   });
@@ -93,7 +93,7 @@ describe('amp-share-tracking', () => {
     return getAmpShareTracking('http://foo.bar').then(ampShareTracking => {
       expect(ampShareTracking.vendorHref_).to.equal('http://foo.bar');
       return ampShareTracking.shareTrackingFragments_.then(fragments => {
-        expect(fragments.incomingFragment).to.be.undefined;
+        expect(fragments.incomingFragment).to.be.null;
       });
     });
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -401,7 +401,8 @@ function buildExamples(watch) {
   buildExample('released.amp.html');
   buildExample('social-share.amp.html');
   buildExample('twitter.amp.html');
-  buildExample('share-tracking.amp.html');
+  buildExample('share-tracking-with-url.amp.html');
+  buildExample('share-tracking-without-url.amp.html');
   buildExample('soundcloud.amp.html');
   buildExample('springboard-player.amp.html');
   buildExample('sticky.ads.amp.html');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -401,6 +401,7 @@ function buildExamples(watch) {
   buildExample('released.amp.html');
   buildExample('social-share.amp.html');
   buildExample('twitter.amp.html');
+  buildExample('share-tracking.amp.html');
   buildExample('soundcloud.amp.html');
   buildExample('springboard-player.amp.html');
   buildExample('sticky.ads.amp.html');

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -802,7 +802,8 @@ export class Viewer {
   }
 
   /**
-   * Get the fragment from the url or the viewer
+   * Get the fragment from the url or the viewer.
+   * Strip leading '#' in the fragment
    * @return {!Promise<string>}
    */
   getFragment() {

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -804,20 +804,21 @@ export class Viewer {
   /**
    * Get the fragment from the url or the viewer.
    * Strip leading '#' in the fragment
-   * @return {!Promise<string|undefined>}
+   * @return {!Promise<string>}
    */
   getFragment() {
     if (!this.isEmbedded_) {
       let hash = this.win.location.hash;
-      if (hash.indexOf('#') == 0) {
-        hash = hash.substr(1);
-      }
+      /* Strip leading '#' */
+      hash = hash.substr(1);
       return Promise.resolve(hash);
     }
     if (!this.hasCapability('fragment')) {
-      return Promise.resolve();
+      return Promise.resolve('');
     }
-    return this.sendMessageUnreliable_('fragment', undefined, true);
+    return this.sendMessageUnreliable_('fragment', undefined, true).then(
+      hash => hash || ''
+    );
   }
 
   /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -804,7 +804,7 @@ export class Viewer {
   /**
    * Get the fragment from the url or the viewer.
    * Strip leading '#' in the fragment
-   * @return {!Promise<string>}
+   * @return {!Promise<string|undefined>}
    */
   getFragment() {
     if (!this.isEmbedded_) {

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -221,6 +221,10 @@ export class Viewer {
     this.performanceTracking_ = this.params_['csi'] === '1';
     dev.fine(TAG_, '- performanceTracking:', this.performanceTracking_);
 
+    this.shareTrackingIncomingFragment_ = this.params_['share-tracking'];
+    dev.fine(TAG_, '- shareTrackingIncomingFragment:',
+        this.shareTrackingIncomingFragment_);
+
     /**
      * Whether the AMP document is embedded in a viewer, such as an iframe or
      * a web view.
@@ -799,6 +803,18 @@ export class Viewer {
       }
       return this.sendMessage('cid', undefined, true);
     });
+  }
+
+  /**
+   * Retrieves the share-tracking identifier from the viewer
+   * @return {!Promise<string>}
+   */
+  getShareTrackingIncomingFragment() {
+    if (this.shareTrackingIncomingFragment_) {
+      return Promise.resolve(this.shareTrackingIncomingFragment_);
+    }
+    return this.sendMessageUnreliable_(
+        'shareTrackingIncomingFragment', undefined, true);
   }
 
   /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -221,10 +221,6 @@ export class Viewer {
     this.performanceTracking_ = this.params_['csi'] === '1';
     dev.fine(TAG_, '- performanceTracking:', this.performanceTracking_);
 
-    this.shareTrackingIncomingFragment_ = this.params_['share-tracking'];
-    dev.fine(TAG_, '- shareTrackingIncomingFragment:',
-        this.shareTrackingIncomingFragment_);
-
     /**
      * Whether the AMP document is embedded in a viewer, such as an iframe or
      * a web view.
@@ -806,15 +802,21 @@ export class Viewer {
   }
 
   /**
-   * Retrieves the share-tracking identifier from the viewer
+   * Get the fragment from the url or the viewer
    * @return {!Promise<string>}
    */
-  getShareTrackingIncomingFragment() {
-    if (this.shareTrackingIncomingFragment_) {
-      return Promise.resolve(this.shareTrackingIncomingFragment_);
+  getFragment() {
+    if (!this.isEmbedded_) {
+      let hash = this.win.location.hash;
+      if (hash.indexOf('#') == 0) {
+        hash = hash.substr(1);
+      }
+      return Promise.resolve(hash);
     }
-    return this.sendMessageUnreliable_(
-        'shareTrackingIncomingFragment', undefined, true);
+    if (!this.hasCapability('fragment')) {
+      return Promise.resolve();
+    }
+    return this.sendMessageUnreliable_('fragment', undefined, true);
   }
 
   /**

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -204,24 +204,40 @@ describe('Viewer', () => {
     expect(viewer.isPerformanceTrackingOn()).to.be.false;
   });
 
-  it('should configure shareTrackingIncomingFragment from url', () => {
-    windowApi.location.hash = '#share-tracking=12345';
+  it('should get fragment from the url in non-embedded mode', () => {
+    windowApi.parent = windowApi;
+    windowApi.location.hash = '#foo';
     const viewer = new Viewer(windowApi);
-    return viewer.getShareTrackingIncomingFragment().then(fragment => {
-      expect(fragment).to.be.equal('12345');
+    return viewer.getFragment().then(fragment => {
+      expect(fragment).to.be.equal('foo');
     });
   });
 
-  it('should configure shareTrackingIncomingFragment from viewer ' +
-      'if it is not provided in url', () => {
-    windowApi.location.hash = '';
+  it('should get fragment from the viewer in embedded mode' +
+      'if the viewer has capability of getting fragment', () => {
+    windowApi.parent = {};
+    windowApi.location.hash = '#foo&cap=fragment';
     const viewer = new Viewer(windowApi);
     sandbox.stub(viewer, 'sendMessageUnreliable_', name => {
-      expect(name).to.equal('shareTrackingIncomingFragment');
+      expect(name).to.equal('fragment');
       return Promise.resolve('from-viewer');
     });
-    return viewer.getShareTrackingIncomingFragment().then(fragment => {
+    return viewer.getFragment().then(fragment => {
       expect(fragment).to.be.equal('from-viewer');
+    });
+  });
+
+  it('should NOT get fragment from the viewer in embedded mode' +
+      'if the viewer does NOT has capability of getting fragment', () => {
+    windowApi.parent = {};
+    windowApi.location.hash = '#foo';
+    const viewer = new Viewer(windowApi);
+    sandbox.stub(viewer, 'sendMessageUnreliable_', name => {
+      expect(name).to.equal('fragment');
+      return Promise.resolve('from-viewer');
+    });
+    return viewer.getFragment().then(fragment => {
+      expect(fragment).to.be.undefined;
     });
   });
 

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -228,7 +228,7 @@ describe('Viewer', () => {
   });
 
   it('should NOT get fragment from the viewer in embedded mode' +
-      'if the viewer does NOT has capability of getting fragment', () => {
+      'if the viewer does NOT have capability of getting fragment', () => {
     windowApi.parent = {};
     windowApi.location.hash = '#foo';
     const viewer = new Viewer(windowApi);
@@ -237,7 +237,21 @@ describe('Viewer', () => {
       return Promise.resolve('from-viewer');
     });
     return viewer.getFragment().then(fragment => {
-      expect(fragment).to.be.undefined;
+      expect(fragment).to.equal('');
+    });
+  });
+
+  it('should NOT get fragment from the viewer in embedded mode' +
+      'if the viewer does NOT return a fragment', () => {
+    windowApi.parent = {};
+    windowApi.location.hash = '#foo';
+    const viewer = new Viewer(windowApi);
+    sandbox.stub(viewer, 'sendMessageUnreliable_', name => {
+      expect(name).to.equal('fragment');
+      return Promise.resolve();
+    });
+    return viewer.getFragment().then(fragment => {
+      expect(fragment).to.equal('');
     });
   });
 

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -204,6 +204,27 @@ describe('Viewer', () => {
     expect(viewer.isPerformanceTrackingOn()).to.be.false;
   });
 
+  it('should configure shareTrackingIncomingFragment from url', () => {
+    windowApi.location.hash = '#share-tracking=12345';
+    const viewer = new Viewer(windowApi);
+    return viewer.getShareTrackingIncomingFragment().then(fragment => {
+      expect(fragment).to.be.equal('12345');
+    });
+  });
+
+  it('should configure shareTrackingIncomingFragment from viewer ' +
+      'if it is not provided in url', () => {
+    windowApi.location.hash = '';
+    const viewer = new Viewer(windowApi);
+    sandbox.stub(viewer, 'sendMessageUnreliable_', name => {
+      expect(name).to.equal('shareTrackingIncomingFragment');
+      return Promise.resolve('from-viewer');
+    });
+    return viewer.getShareTrackingIncomingFragment().then(fragment => {
+      expect(fragment).to.be.equal('from-viewer');
+    });
+  });
+
   it('should configure correctly for iOS embedding', () => {
     windowApi.name = '__AMP__viewportType=natural';
     windowApi.parent = {};


### PR DESCRIPTION
#3135 
* `AmpShareTracking` will get incoming and outgoing share tracking identifier
* Get incoming fragment: from url hash directly or ask viewer to get it
* Get outgoing fragment: from url endpoint provided by vendor or generate randomly