### PR TITLE
Creative API: page visibility

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -277,6 +277,8 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
     draw3p(window, data, opt_configCallback);
     updateVisibilityState(window);
     nonSensitiveDataPostMessage('render-start');
+    // Subscribe to page visibility updates.
+    nonSensitiveDataPostMessage('send-embed-state');
   } catch (e) {
     if (!window.context.mode.test) {
       lightweightErrorReport(e);

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -79,7 +79,6 @@ export class AmpAdApiHandler {
     this.embedStateApi_ = new SubscriptionApi(
         this.iframe_, 'send-embed-state', is3p,
         () => this.sendEmbedInfo_(this.baseInstance_.isInViewport()));
-    this.embedStateApi_.init();
     // Triggered by context.noContentAvailable() inside the ad iframe.
     listenForOnce(this.iframe_, 'no-content', () => {
       if (this.noContentCallback_) {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -441,5 +441,43 @@ function tests(name) {
         });
       });
     });
+
+    describe('embed-state API', () => {
+      it('should support subscription via send-embed-state', () => {
+        const iframeSrc = 'http://ads.localhost:' + location.port +
+            '/base/test/fixtures/served/iframe.html';
+        return getAd({
+          width: 100,
+          height: 100,
+          type: '_ping_',
+          src: 'testsrc',
+        }, 'https://schema.org').then(element => {
+          return new Promise((resolve, unusedReject) => {
+            const impl = element.implementation_;
+            impl.layoutCallback();
+            impl.apiHandler_.sendEmbedInfo_ = () => {
+              resolve(impl);
+            };
+            impl.iframe_.onload = function() {
+              impl.iframe_.contentWindow.postMessage({
+                sentinel: 'amp-test',
+                type: 'subscribeToEmbedState',
+                is3p: true,
+                amp3pSentinel:
+                    impl.iframe_.getAttribute('data-amp-3p-sentinel'),
+              }, '*');
+            };
+            impl.iframe_.src = iframeSrc;
+            // Precondition check.
+            expect(impl.apiHandler_.embedStateApi_.clientWindows_.length)
+                  .to.equal(0);
+          });
+        }).then(impl => {
+          // Check that we have a new subscription.
+          expect(impl.apiHandler_.embedStateApi_.clientWindows_.length)
+              .to.equal(1);
+        });
+      });
+    });
   };
 }

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -402,12 +402,15 @@ export class SubscriptionApi {
     this.is3p_ = is3p;
     this.requestCallback_ = requestCallback;
     this.clientWindows_ = [];
+
+    this.init_();
   }
 
   /**
    * Start listening for messages.
+   * @private
    */
-  init() {
+  init_() {
     listenFor(
         this.iframe_, this.type_, (data, source, origin) => {
           // This message might be from any window within the iframe, we need

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -397,28 +397,32 @@ export class SubscriptionApi {
    *     invoked whenever a new window subscribes.
    */
   constructor(iframe, type, is3p, requestCallback) {
+    /** @private {!Element} */
     this.iframe_ = iframe;
-    this.type_ = type;
+    /** @private {boolean} */
     this.is3p_ = is3p;
-    this.requestCallback_ = requestCallback;
+    /** @private {!Array<{win: !Window, origin: string}>} */
     this.clientWindows_ = [];
 
-    this.init_();
+    this.init_(type, requestCallback);
   }
 
   /**
    * Start listening for messages.
+   * @param {string} type Type of the subscription message.
+   * @param {function(!Object, !Window, string)} requestCallback Callback
+   *     invoked whenever a new window subscribes.
    * @private
    */
-  init_() {
+  init_(type, requestCallback) {
     listenFor(
-        this.iframe_, this.type_, (data, source, origin) => {
+        this.iframe_, type, (data, source, origin) => {
           // This message might be from any window within the iframe, we need
           // to keep track of which windows want to be sent updates.
           if (!this.clientWindows_.some(entry => entry.win == source)) {
             this.clientWindows_.push({win: source, origin});
           }
-          this.requestCallback_(data, source, origin);
+          requestCallback(data, source, origin);
         }, this.is3p_,
         // For 3P frames we also allow nested frames within them to subscribe..
         this.is3p_ /* opt_includingNestedWindows */);

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -17,7 +17,7 @@
 import {Observable} from './observable';
 import {dev} from './log';
 import {layoutRectLtwh, rectIntersection, moveLayoutRect} from './layout-rect';
-import {listenFor, postMessageToWindows} from './iframe-helper';
+import {SubscriptionApi} from './iframe-helper';
 import {timer} from './timer';
 
 /**
@@ -95,12 +95,6 @@ export class IntersectionObserver extends Observable {
     super();
     /** @private @const */
     this.baseElement_ = baseElement;
-    /** @private {?Element} */
-    this.iframe_ = iframe;
-    /** @private {!Array<{win: !Window, origin: string}>} */
-    this.clientWindows_ = [];
-    /** @private {boolean} */
-    this.is3p_ = opt_is3p || false;
     /** @private {boolean} */
     this.shouldSendIntersectionChanges_ = false;
     /** @private {boolean} */
@@ -115,27 +109,25 @@ export class IntersectionObserver extends Observable {
     /** @private @const {function()} */
     this.boundFlush_ = this.flush_.bind(this);
 
+    /**
+     * An object which handles tracking subscribers to the
+     * intersection updates for this element.
+     * Triggered by context.observeIntersection(…) inside the ad/iframe
+     * or by directly posting a send-intersections message.
+     * @private {!SubscriptionApi}
+     */
+    this.postMessageApi_ = new SubscriptionApi(
+        iframe, 'send-intersections', opt_is3p || false,
+        // Each time someone subscribes we make sure that they
+        // get an update.
+        () => this.startSendingIntersectionChanges_());
+
     this.init_();
   }
 
   init_() {
-    // Triggered by context.observeIntersection(…) inside the ad/iframe.
-    // We use listen instead of listenOnce, because a single ad/iframe might
-    // have multiple parties wanting to receive viewability data.
-    // The second time this is called, it doesn't do much but it
-    // guarantees that the receiver gets an initial intersection change
-    // record.
-    listenFor(this.iframe_, 'send-intersections', (data, source, origin) => {
-      // This message might be from any window within the iframe, we need
-      // to keep track of which windows want to be sent updates.
-      if (!this.clientWindows_.some(entry => entry.win == source)) {
-        this.clientWindows_.push({win: source, origin});
-      }
-      this.startSendingIntersectionChanges_();
-    }, this.is3p_,
-    // For 3P frames we also allow nested frames within them to listen to
-    // the intersection changes.
-    this.is3p_ /* opt_includingNestedWindows */);
+    // Start listening to messages.
+    this.postMessageApi_.init();
 
     this.add(() => {
       this.sendElementIntersection_();
@@ -223,13 +215,8 @@ export class IntersectionObserver extends Observable {
     if (!this.pendingChanges_.length) {
       return;
     }
-    // Note that we multicast the update to all interested windows.
-    postMessageToWindows(
-        this.iframe_,
-        this.clientWindows_,
-        'intersection',
-        {changes: this.pendingChanges_},
-        this.is3p_);
+    // Note that SubscribeApi multicasts the update to all interested windows.
+    this.postMessageApi_.send('intersection', {changes: this.pendingChanges_});
     this.pendingChanges_.length = 0;
   }
 }

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -126,9 +126,6 @@ export class IntersectionObserver extends Observable {
   }
 
   init_() {
-    // Start listening to messages.
-    this.postMessageApi_.init();
-
     this.add(() => {
       this.sendElementIntersection_();
     });

--- a/test/fixtures/served/iframe.html
+++ b/test/fixtures/served/iframe.html
@@ -14,6 +14,12 @@ window.addEventListener('message', function(event) {
         height: event.data.height,
         width: event.data.width,
       }, '*');
+    } else if (event.data.type == 'subscribeToEmbedState') {
+      var sentinel = event.data.is3p ? event.data.amp3pSentinel : 'amp';
+      parent./*OK*/postMessage({
+        sentinel: sentinel,
+        type: 'send-embed-state',
+      }, '*');
     }
   }
 });

--- a/test/fixtures/served/iframe.html
+++ b/test/fixtures/served/iframe.html
@@ -8,18 +8,20 @@ window.addEventListener('message', function(event) {
   if (event.data && event.data.sentinel == 'amp-test') {
     if (event.data.type == 'requestHeight') {
       var sentinel = event.data.is3p ? event.data.amp3pSentinel : 'amp';
-      parent./*OK*/postMessage({
-        sentinel: sentinel,
-        type: 'embed-size',
-        height: event.data.height,
-        width: event.data.width,
-      }, '*');
+      parent./*OK*/postMessage(
+          {
+            sentinel: sentinel,
+            type: 'embed-size',
+            height: event.data.height,
+            width: event.data.width,
+          }, '*');
     } else if (event.data.type == 'subscribeToEmbedState') {
       var sentinel = event.data.is3p ? event.data.amp3pSentinel : 'amp';
-      parent./*OK*/postMessage({
-        sentinel: sentinel,
-        type: 'send-embed-state',
-      }, '*');
+      parent./*OK*/postMessage(
+          {
+            sentinel: sentinel,
+            type: 'send-embed-state',
+          }, '*');
     }
   }
 });

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -239,7 +239,8 @@ describe('IntersectionObserver', () => {
       messages.push(JSON.parse(JSON.stringify(message)));
     });
     clock.tick(33);
-    ioInstance.clientWindows_ = [{win: testIframe.contentWindow, origin: '*'}];
+    ioInstance.postMessageApi_.clientWindows_ =
+        [{win: testIframe.contentWindow, origin: '*'}];
     ioInstance.startSendingIntersectionChanges_();
     expect(getIntersectionChangeEntrySpy.callCount).to.equal(1);
     expect(messages).to.have.length(1);
@@ -256,7 +257,8 @@ describe('IntersectionObserver', () => {
       // Copy because arg is modified in place.
       messages.push(JSON.parse(JSON.stringify(message)));
     });
-    ioInstance.clientWindows_ = [{win: testIframe.contentWindow, origin: '*'}];
+    ioInstance.postMessageApi_.clientWindows_ =
+        [{win: testIframe.contentWindow, origin: '*'}];
     ioInstance.startSendingIntersectionChanges_();
     expect(getIntersectionChangeEntrySpy.callCount).to.equal(1);
     expect(messages).to.have.length(1);


### PR DESCRIPTION
Adds support for subscribing to embed-state messages (which contain page visibility information) from nested ad iframes (as done previosuly for IntersectionObserver). A new message is added, send-embed-state, used to subscribe to the updates. 

The code for handling subscription is refactored out of IntersectionObserver and into a reusable class in iframe-helper.js . I also added a test for subscription to embed-state updates as there did not seem to be any at the moment.

This is the next change in the implementation of #3019, apologies for the delay.