### PR TITLE
Gracefully handle an error during CID generation.

### DIFF
--- a/src/ad-cid.js
+++ b/src/ad-cid.js
@@ -17,6 +17,7 @@
 import {cidForOrNull} from './cid';
 import {clientIdScope} from '../ads/_config';
 import {userNotificationManagerFor} from './user-notification';
+import {dev} from '../src/log';
 
 
 /**
@@ -45,6 +46,10 @@ export function getAdCid(adElement) {
         return consent;
       }
     }
-    return cidService.get(scope, consent);
+    return cidService.get(scope, consent).catch(error => {
+      // Not getting a CID is not fatal.
+      dev.error('ad-cid', error);
+      return undefined;
+    });
   });
 }

--- a/test/functional/test-ad-cid.js
+++ b/test/functional/test-ad-cid.js
@@ -74,6 +74,24 @@ function tests(name) {
         });
       });
 
+      it('proceeds on failed CID', () => {
+        clientIdScope['with_cid'] = cidScope;
+        return getAd({
+          width: 300,
+          height: 250,
+          type: 'with_cid',
+          src: 'testsrc',
+        }, 'https://schema.org', function(ad) {
+          const win = ad.ownerDocument.defaultView;
+          const service = installCidService(win);
+          sandbox.stub(service, 'get',
+              () => Promise.reject(new Error('nope')));
+          return ad;
+        }).then(ad => {
+          expect(ad.getAttribute('ampcid')).to.be.null;
+        });
+      });
+
       it('waits for consent', () => {
         clientIdScope['with_cid'] = cidScope;
         return getAd({


### PR DESCRIPTION
Ads should work fine, when the CID cannot be provided.