### PR TITLE
feature(yieldbot): glade cross-origin render frame support

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -52,7 +52,10 @@ export const adPrefetch = {
     'https://cstatic.weborama.fr/js/advertiserv2/adperf_launch_1.0.0_scrambled.js',
     'https://cstatic.weborama.fr/js/advertiserv2/adperf_core_1.0.0_scrambled.js',
   ],
-  yieldbot: 'https://cdn.yldbt.com/js/yieldbot.intent.js',
+  yieldbot: [
+    'https://cdn.yldbt.com/js/yieldbot.intent.amp.js',
+    'https://msg.yldbt.com/js/ybmsg.html',
+  ],
   adstir: 'https://js.ad-stir.com/js/adstir_async.js',
   colombia: 'https://static.clmbtech.com/ad/commons/js/colombia-amp.js',
   eplanning: 'https://us.img.e-planning.net/layers/epl-amp.js',

--- a/ads/yieldbot.js
+++ b/ads/yieldbot.js
@@ -31,7 +31,7 @@ export function yieldbot(global, data) {
 
   global.ybotq = global.ybotq || [];
 
-  loadScript(global, 'https://cdn.yldbt.com/js/yieldbot.intent.js', () => {
+  loadScript(global, 'https://cdn.yldbt.com/js/yieldbot.intent.amp.js', () => {
     global.ybotq.push(() => {
       try {
         const dimensions = [[


### PR DESCRIPTION
Reference AMP specific Yieldbot ad script that has initial support for _`glade.js`_ rendering creative in a cross-origin frame i.e. to account for the deprecation of "`useSameDomainRenderingUntilDeprecated`".