### PR TITLE
Allow passing optional window into getMode

### DIFF
--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -16,7 +16,6 @@
 
 import {googleAdsIsA4AEnabled} from '../traffic-experiments';
 import {resetExperimentToggles_} from '../../../../src/experiments';
-import {setModeForTesting} from '../../../../src/mode';
 import * as sinon from 'sinon';
 
 describe('a4a_config', () => {
@@ -27,8 +26,10 @@ describe('a4a_config', () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     rand = sandbox.stub(Math, 'random');
-    setModeForTesting({localDev: true});
     win = {
+      AMP_MODE: {
+        localDev: true,
+      },
       location: {
         href: 'https://cdn.ampproject.org/fnord',
         pathname: '/fnord',
@@ -46,7 +47,6 @@ describe('a4a_config', () => {
 
   afterEach(() => {
     resetExperimentToggles_();  // Clear saved, page-level experiment state.
-    setModeForTesting(null);
     sandbox.restore();
   });
 
@@ -88,7 +88,7 @@ describe('a4a_config', () => {
   });
 
   it('should return false when not on CDN or local dev', () => {
-    setModeForTesting({localDev: false});
+    win.AMP_MODE.localDev = false;
     win.location.href = 'http://somewhere.over.the.rainbow.org/';
     const element = document.createElement('div');
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -170,7 +170,7 @@ function selectRandomProperty(obj) {
  */
 export function setupPageExperiments(win, experiments) {
   win.pageExperimentBranches = win.pageExperimentBranches || {};
-  if (getMode().localDev) {
+  if (getMode(win).localDev) {
     // In local dev mode, it can be difficult to configure AMP_CONFIG
     // externally.  Default it here if necessary.
     win.AMP_CONFIG = win.AMP_CONFIG || {};
@@ -182,7 +182,7 @@ export function setupPageExperiments(win, experiments) {
         win.pageExperimentBranches.hasOwnProperty(experimentId)) {
       continue;
     }
-    if (getMode().localDev) {
+    if (getMode(win).localDev) {
       win.AMP_CONFIG[experimentId] = win.AMP_CONFIG[experimentId] || 0.0;
     }
     // If we're in the experiment, but we haven't already forced a specific

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -190,6 +190,48 @@ public class AmpPassTest extends Es6CompilerTestCase {
             "})()"));
   }
 
+  public void testGetModeWinTestPropertyReplacement() throws Exception {
+    test(
+        LINE_JOINER.join(
+             "(function() {",
+             "function getMode() { return { test: true } }",
+             "var win = {};",
+             "var $mode = { getMode: getMode };",
+             "  if ($mode.getMode(win).test) {",
+             "    console.log('hello world');",
+             "  }",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "function getMode() { return { test: true }; }",
+             "var $mode = { getMode: getMode };",
+             "  if (false) {",
+             "    console.log('hello world');",
+             "  }",
+            "})()"));
+  }
+
+  public void testGetModeWinMinifiedPropertyReplacement() throws Exception {
+    test(
+        LINE_JOINER.join(
+             "(function() {",
+             "function getMode() { return { minified: false } }",
+             "var win = {};",
+             "var $mode = { getMode: getMode };",
+             "  if ($mode.getMode(win).minified) {",
+             "    console.log('hello world');",
+             "  }",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "function getMode() { return { minified: false }; }",
+             "var $mode = { getMode: getMode };",
+             "  if (true) {",
+             "    console.log('hello world');",
+             "  }",
+            "})()"));
+  }
+
   public void testGetModePreserve() throws Exception {
     test(
         LINE_JOINER.join(

--- a/src/mode.js
+++ b/src/mode.js
@@ -43,13 +43,14 @@ let fullVersion = '';
 
 /**
  * Provides info about the current app.
+ * @param {!Window=} win
  * @return {!ModeDef}
  */
-export function getMode() {
+export function getMode(opt_win) {
   if (mode) {
     return mode;
   }
-  return mode = getMode_();
+  return mode = getMode_(opt_win || window);
 }
 
 /**
@@ -62,19 +63,22 @@ export function setModeForTesting(m) {
 
 /**
  * Provides info about the current app.
+ * @param {!Window} win
  * @return {!ModeDef}
  */
-function getMode_() {
-  if (window.context && window.context.mode) {
-    return window.context.mode;
+function getMode_(win) {
+  // For 3p integration code
+  if (win.context && win.context.mode) {
+    return win.context.mode;
   }
+
   const isLocalDev = !!(location.hostname == 'localhost' ||
-      (location.ancestorOrigins && location.ancestorOrigins[0] &&
+      ((location.ancestorOrigins && location.ancestorOrigins[0] &&
           location.ancestorOrigins[0].indexOf('http://localhost:') == 0)) &&
       // Filter out localhost running against a prod script.
       // Because all allowed scripts are ours, we know that these can only
       // occur during local dev.
-      !!document.querySelector('script[src*="/dist/"],script[src*="/base/"]');
+      !!document.querySelector('script[src*="/dist/"],script[src*="/base/"]'));
 
   const developmentQuery = parseQueryString_(
       // location.originalHash is set by the viewer when it removes the fragment
@@ -82,20 +86,20 @@ function getMode_() {
       location.originalHash || location.hash);
 
   if (!fullVersion) {
-    fullVersion = getFullVersion_(window, isLocalDev);
+    fullVersion = getFullVersion_(win, isLocalDev);
   }
 
   return {
     localDev: isLocalDev,
     // Triggers validation
     development: !!(developmentQuery['development'] == '1' ||
-        window.AMP_DEV_MODE),
+        win.AMP_DEV_MODE),
     // Allows filtering validation errors by error category. For the
     // available categories, see ErrorCategory in validator/validator.proto.
     filter: developmentQuery['filter'],
     /* global process: false */
     minified: process.env.NODE_ENV == 'production',
-    test: !!(window.AMP_TEST || window.__karma__),
+    test: !!(win.AMP_TEST || win.__karma__),
     log: developmentQuery['log'],
     version: fullVersion,
   };

--- a/src/mode.js
+++ b/src/mode.js
@@ -39,6 +39,12 @@ const version = '$internalRuntimeVersion$';
 let fullVersion = '';
 
 /**
+ * A #querySelector query to see if we have any scripts with development paths.
+ * @type {string}
+ */
+const developmentScriptQuery = 'script[src*="/dist/"],script[src*="/base/"]';
+
+/**
  * Provides info about the current app.
  * @param {?Window=} opt_win
  * @return {!ModeDef}
@@ -68,8 +74,7 @@ function getMode_(win) {
       // Filter out localhost running against a prod script.
       // Because all allowed scripts are ours, we know that these can only
       // occur during local dev.
-      !!(!document ||
-        document.querySelector('script[src*="/dist/"],script[src*="/base/"]'));
+      (!win.document || !!win.document.querySelector(developmentScriptQuery));
 
   const developmentQuery = parseQueryString_(
       // location.originalHash is set by the viewer when it removes the fragment

--- a/src/mode.js
+++ b/src/mode.js
@@ -40,7 +40,7 @@ let fullVersion = '';
 
 /**
  * Provides info about the current app.
- * @param {!Window=} win
+ * @param {?Window=} win
  * @return {!ModeDef}
  */
 export function getMode(opt_win) {

--- a/src/mode.js
+++ b/src/mode.js
@@ -28,9 +28,6 @@
  */
 export let ModeDef;
 
-/** @typedef {?ModeDef} */
-let mode = null;
-
 /** @typedef {string} */
 const version = '$internalRuntimeVersion$';
 
@@ -47,18 +44,11 @@ let fullVersion = '';
  * @return {!ModeDef}
  */
 export function getMode(opt_win) {
-  if (mode) {
-    return mode;
+  const win = opt_win || window;
+  if (win.AMP_MODE) {
+    return win.AMP_MODE;
   }
-  return mode = getMode_(opt_win || window);
-}
-
-/**
- * Set mode in a test. Pass null in afterEach function to reset.
- * @param {?ModeDef} m
- */
-export function setModeForTesting(m) {
-  mode = m;
+  return win.AMP_MODE = getMode_(win);
 }
 
 /**

--- a/src/mode.js
+++ b/src/mode.js
@@ -40,7 +40,7 @@ let fullVersion = '';
 
 /**
  * Provides info about the current app.
- * @param {?Window=} win
+ * @param {?Window=} opt_win
  * @return {!ModeDef}
  */
 export function getMode(opt_win) {

--- a/src/mode.js
+++ b/src/mode.js
@@ -64,11 +64,12 @@ function getMode_(win) {
 
   const isLocalDev = !!(location.hostname == 'localhost' ||
       (location.ancestorOrigins && location.ancestorOrigins[0] &&
-          location.ancestorOrigins[0].indexOf('http://localhost:') == 0)) &&
+        location.ancestorOrigins[0].indexOf('http://localhost:') == 0)) &&
       // Filter out localhost running against a prod script.
       // Because all allowed scripts are ours, we know that these can only
       // occur during local dev.
-      (!document || !!document.querySelector('script[src*="/dist/"],script[src*="/base/"]'));
+      !!(!document ||
+        document.querySelector('script[src*="/dist/"],script[src*="/base/"]'));
 
   const developmentQuery = parseQueryString_(
       // location.originalHash is set by the viewer when it removes the fragment

--- a/src/mode.js
+++ b/src/mode.js
@@ -63,12 +63,12 @@ function getMode_(win) {
   }
 
   const isLocalDev = !!(location.hostname == 'localhost' ||
-      ((location.ancestorOrigins && location.ancestorOrigins[0] &&
+      (location.ancestorOrigins && location.ancestorOrigins[0] &&
           location.ancestorOrigins[0].indexOf('http://localhost:') == 0)) &&
       // Filter out localhost running against a prod script.
       // Because all allowed scripts are ours, we know that these can only
       // occur during local dev.
-      !!document.querySelector('script[src*="/dist/"],script[src*="/base/"]'));
+      (!document || !!document.querySelector('script[src*="/dist/"],script[src*="/base/"]'));
 
   const developmentQuery = parseQueryString_(
       // location.originalHash is set by the viewer when it removes the fragment

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -208,7 +208,7 @@ export class Viewer {
     // realistic iOS environment.
     if (platform.isIos() &&
             this.viewportType_ != ViewportType.NATURAL_IOS_EMBED &&
-            (getMode().localDev || getMode().development)) {
+            (getMode(win).localDev || getMode(win).development)) {
       this.viewportType_ = ViewportType.NATURAL_IOS_EMBED;
     }
     dev.fine(TAG_, '- viewportType:', this.viewportType_);

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -21,7 +21,6 @@ import {removeElement} from '../src/dom';
 import {adopt} from '../src/runtime';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {platform} from '../src/platform';
-import {setModeForTesting} from '../src/mode';
 import {setDefaultBootstrapBaseUrlForTesting} from '../src/3p-frame';
 
 // Needs to be called before the custom elements are first made.
@@ -138,7 +137,7 @@ sinon.sandbox.create = function(config) {
 beforeEach(beforeTest);
 
 function beforeTest() {
-  setModeForTesting(null);
+  window.AMP_MODE = null;
   window.AMP_TEST = true;
   installDocService(window, true);
 }

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -190,7 +190,7 @@ describe('3p-frame', () => {
   });
 
   it('should pick the right bootstrap unique url (prod)', () => {
-    window.AMP_MODE = null;;
+    window.AMP_MODE = {};
     expect(getBootstrapBaseUrl(window)).to.match(
         /^https:\/\/d-\d+\.ampproject\.net\/\$\internal\w+\$\/frame\.html$/);
   });
@@ -270,7 +270,7 @@ describe('3p-frame', () => {
     viewerMock.expects('getUnconfirmedReferrerUrl')
         .returns('http://acme.org/').twice();
 
-    window.AMP_MODE = null;
+    window.AMP_MODE = {};
     const link = document.createElement('link');
     link.setAttribute('rel', 'canonical');
     link.setAttribute('href', 'https://foo.bar/baz');

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -25,7 +25,6 @@ import {
 import {documentInfoFor} from '../../src/document-info';
 import {loadPromise} from '../../src/event-helper';
 import {resetServiceForTesting} from '../../src/service';
-import {setModeForTesting} from '../../src/mode';
 import {validateData} from '../../3p/3p';
 import {viewerFor} from '../../src/viewer';
 import * as sinon from 'sinon';
@@ -44,7 +43,6 @@ describe('3p-frame', () => {
     sandbox.restore();
     resetServiceForTesting(window, 'bootstrapBaseUrl');
     resetCountForTesting();
-    setModeForTesting(null);
     const m = document.querySelector(
         '[name="amp-3p-iframe-src"]');
     if (m) {
@@ -83,13 +81,13 @@ describe('3p-frame', () => {
   });
 
   it('should create an iframe', () => {
-    setModeForTesting({
+    window.AMP_MODE = {
       localDev: true,
       development: false,
       minified: false,
       test: false,
       version: '$internalRuntimeVersion$',
-    });
+    };
 
     clock.tick(1234567888);
     const link = document.createElement('link');
@@ -180,19 +178,19 @@ describe('3p-frame', () => {
 
 
   it('should pick the right bootstrap url for local-dev mode', () => {
-    setModeForTesting({localDev: true});
+    window.AMP_MODE = {localDev: true};
     expect(getBootstrapBaseUrl(window)).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
   });
 
   it('should pick the right bootstrap url for testing mode', () => {
-    setModeForTesting({test: true});
+    window.AMP_MODE = {test: true};
     expect(getBootstrapBaseUrl(window)).to.equal(
         'http://ads.localhost:9876/base/dist.3p/current/frame.max.html');
   });
 
   it('should pick the right bootstrap unique url (prod)', () => {
-    setModeForTesting({});
+    window.AMP_MODE = null;;
     expect(getBootstrapBaseUrl(window)).to.match(
         /^https:\/\/d-\d+\.ampproject\.net\/\$\internal\w+\$\/frame\.html$/);
   });
@@ -218,7 +216,7 @@ describe('3p-frame', () => {
   });
 
   it('should prefetch bootstrap frame and JS', () => {
-    setModeForTesting({localDev: true});
+    window.AMP_MODE = {localDev: true};
     preloadBootstrap(window);
     // Wait for visible promise
     return Promise.resolve().then(() => {
@@ -272,7 +270,7 @@ describe('3p-frame', () => {
     viewerMock.expects('getUnconfirmedReferrerUrl')
         .returns('http://acme.org/').twice();
 
-    setModeForTesting({});
+    window.AMP_MODE = null;
     const link = document.createElement('link');
     link.setAttribute('rel', 'canonical');
     link.setAttribute('href', 'https://foo.bar/baz');

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -15,7 +15,6 @@
  */
 
 import {getErrorReportUrl, cancellation} from '../../src/error';
-import {setModeForTesting} from '../../src/mode';
 import {parseUrl, parseQueryString} from '../../src/url';
 import {user} from '../../src/log';
 import * as sinon from 'sinon';
@@ -35,7 +34,6 @@ describe('reportErrorToServer', () => {
   afterEach(() => {
     window.onerror = onError;
     sandbox.restore();
-    setModeForTesting(null);
     window.viewerState = undefined;
   });
 

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -29,7 +29,7 @@ import {
   createIframePromise,
   doNotLoadExternalResourcesInTest,
 } from '../../testing/iframe';
-import {setModeForTesting, getMode} from '../../src/mode';
+import {getMode} from '../../src/mode';
 import * as sinon from 'sinon';
 
 
@@ -369,7 +369,7 @@ describe('Extensions', () => {
 
   describe('get correct script source', () => {
     it('with local mode for testing with compiled js', () => {
-      setModeForTesting({localDev: true});
+      window.AMP_MODE = {localDev: true};
       expect(getMode().localDev).to.be.true;
       const script = calculateExtensionScriptUrl('examples.build/ads.amp.html',
           'amp-ad', true, true);
@@ -377,7 +377,7 @@ describe('Extensions', () => {
     });
 
     it('with local mode for testing without compiled js', () => {
-      setModeForTesting({localDev: true});
+      window.AMP_MODE = {localDev: true};
       expect(getMode().localDev).to.be.true;
       const script = calculateExtensionScriptUrl('examples.build/ads.amp.html',
         'amp-ad', true, false);
@@ -385,7 +385,7 @@ describe('Extensions', () => {
     });
 
     it('with local mode normal pathname', () => {
-      setModeForTesting({localDev: true});
+      window.AMP_MODE = {localDev: true};
       expect(getMode().localDev).to.be.true;
       const script = calculateExtensionScriptUrl('examples.build/ads.amp.html',
           'amp-ad');
@@ -393,7 +393,7 @@ describe('Extensions', () => {
     });
 
     it('with local mode min pathname', () => {
-      setModeForTesting({localDev: true});
+      window.AMP_MODE = {localDev: true};
       expect(getMode().localDev).to.be.true;
       const script = calculateExtensionScriptUrl(
           'examples.build/ads.amp.min.html', 'amp-ad');
@@ -401,7 +401,7 @@ describe('Extensions', () => {
     });
 
     it('with local mode max pathname', () => {
-      setModeForTesting({localDev: true});
+      window.AMP_MODE = {localDev: true};
       expect(getMode().localDev).to.be.true;
       const script = calculateExtensionScriptUrl(
           'examples.build/ads.amp.max.html', 'amp-ad');
@@ -410,7 +410,7 @@ describe('Extensions', () => {
     });
 
     it('with remote mode', () => {
-      setModeForTesting({localDev: false, version: 123});
+      window.AMP_MODE = {localDev: false, version: 123};
       expect(getMode().localDev).to.be.false;
       expect(getMode().version).to.equal(123);
       const script = calculateExtensionScriptUrl('', 'amp-ad');

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -23,7 +23,6 @@ import {
   rethrowAsync,
   user,
 } from '../../src/log';
-import {setModeForTesting} from '../../src/mode';
 import * as sinon from 'sinon';
 
 describe('Logging', () => {
@@ -44,7 +43,7 @@ describe('Logging', () => {
     sandbox = sinon.sandbox.create();
 
     mode = {};
-    setModeForTesting(mode);
+    window.AMP_MODE = mode;
 
     logSpy = sandbox.spy();
     timeoutSpy = sandbox.spy();
@@ -57,7 +56,6 @@ describe('Logging', () => {
   });
 
   afterEach(() => {
-    setModeForTesting(null);
     sandbox.restore();
     sandbox = null;
   });

--- a/test/functional/test-traffic-experiments.js
+++ b/test/functional/test-traffic-experiments.js
@@ -59,6 +59,7 @@ describe('all-traffic-experiments-tests', () => {
         },
         document: {
           cookie: null,
+          querySelector: () => {},
         },
       };
       accurateRandomStub = sandbox.stub().returns(-1);

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -17,7 +17,6 @@
 import {Viewer} from '../../src/service/viewer-impl';
 import {dev} from '../../src/log';
 import {platform} from '../../src/platform';
-import {setModeForTesting} from '../../src/mode';
 import * as sinon from 'sinon';
 
 
@@ -218,12 +217,11 @@ describe('Viewer', () => {
     windowApi.name = '__AMP__viewportType=natural';
     windowApi.parent = windowApi;
     sandbox.mock(platform).expects('isIos').returns(true).atLeast(1);
-    setModeForTesting({
+    windowApi.AMP_MODE = {
       localDev: false,
       development: false,
-    });
+    };
     const viewportType = new Viewer(windowApi).getViewportType();
-    setModeForTesting(null);
     expect(viewportType).to.equal('natural');
   });
 


### PR DESCRIPTION
Separated from https://github.com/ampproject/amphtml/pull/4037 on @dvoytenko's [suggestion](https://github.com/ampproject/amphtml/pull/4037#discussion_r70680148).

Allows the `win` context to be (optionally) passed into `getMode`. This important for use in ServiceWorkers since they do not have a `window` variable.