### PR TITLE
Use window-wide URL cache.

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -24,7 +24,7 @@ const a = window.document.createElement('a');
 // We cached all parsed URLs. As of now there are no use cases
 // of AMP docs that would ever parse an actual large number of URLs,
 // but we often parse the same one over and over again.
-const cache = Object.create(null);
+const cache = window.UrlCache || (window.UrlCache = Object.create(null));
 
 /** @private @const Matches amp_js_* paramters in query string. */
 const AMP_JS_PARAMS_REGEX = /[?&]amp_js[^&]*/;


### PR DESCRIPTION
Otherwise each compilation unit (because we don't have a URL service) creates their own cache.

Also helps with #3986, although the main benefit here is performance.