### PR TITLE
A4A shadow styling fix.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -545,11 +545,15 @@ export class AmpA4A extends AMP.BaseElement {
             // Finally, add body and re-formatted CSS styling to the shadow root.
             const shadowRoot =
                 this.element.shadowRoot || this.element.createShadowRoot();
-            const forTesting = this.getWin();
+            // TODO(dvoytenko, tdrl): Cloning the amp-runtime style from the
+            // host document is a short-term fix.  Ultimately, AMP will provide
+            // a better mechanism for this, and this code will have to be
+            // updated to coordinate with their approach.
             const style = this.getWin().document.querySelector(
                 'style[amp-runtime]') ||
                 this.getWin().document.createElement('style');
             shadowRoot.appendChild(style.cloneNode(true));
+            // End TODO.
             shadowRoot./*OK*/innerHTML += (cssBlock + bodyBlock);
             this.rendered_ = true;
             this.onAmpCreativeShadowDomRender();

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -545,8 +545,10 @@ export class AmpA4A extends AMP.BaseElement {
             // Finally, add body and re-formatted CSS styling to the shadow root.
             const shadowRoot =
                 this.element.shadowRoot || this.element.createShadowRoot();
+            const forTesting = this.getWin();
             const style = this.getWin().document.querySelector(
-                'style[amp-runtime]');
+                'style[amp-runtime]') ||
+                this.getWin().document.createElement('style');
             shadowRoot.appendChild(style.cloneNode(true));
             shadowRoot./*OK*/innerHTML += (cssBlock + bodyBlock);
             this.rendered_ = true;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -545,6 +545,9 @@ export class AmpA4A extends AMP.BaseElement {
             // Finally, add body and re-formatted CSS styling to the shadow root.
             const shadowRoot =
                 this.element.shadowRoot || this.element.createShadowRoot();
+	    const style = this.getWin().document.querySelector(
+		'style[amp-runtime]');
+	    shadowRoot.appendChild(style.cloneNode());
             shadowRoot./*OK*/innerHTML += (cssBlock + bodyBlock);
             this.rendered_ = true;
             this.onAmpCreativeShadowDomRender();

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -547,7 +547,7 @@ export class AmpA4A extends AMP.BaseElement {
                 this.element.shadowRoot || this.element.createShadowRoot();
 	    const style = this.getWin().document.querySelector(
 		'style[amp-runtime]');
-	    shadowRoot.appendChild(style.cloneNode());
+	    shadowRoot.appendChild(style.cloneNode(true));
             shadowRoot./*OK*/innerHTML += (cssBlock + bodyBlock);
             this.rendered_ = true;
             this.onAmpCreativeShadowDomRender();

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -545,9 +545,9 @@ export class AmpA4A extends AMP.BaseElement {
             // Finally, add body and re-formatted CSS styling to the shadow root.
             const shadowRoot =
                 this.element.shadowRoot || this.element.createShadowRoot();
-	    const style = this.getWin().document.querySelector(
-		'style[amp-runtime]');
-	    shadowRoot.appendChild(style.cloneNode(true));
+            const style = this.getWin().document.querySelector(
+                'style[amp-runtime]');
+            shadowRoot.appendChild(style.cloneNode(true));
             shadowRoot./*OK*/innerHTML += (cssBlock + bodyBlock);
             this.rendered_ = true;
             this.onAmpCreativeShadowDomRender();

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -47,6 +47,33 @@ class MockA4AImpl extends AmpA4A {
   supportsAmpCreativeRender() { return true; }
 }
 
+
+/**
+ * Create a promise for an iframe that has a super-minimal mock AMP environment
+ * in it.
+ *
+ * @return {!Promise<{
+ *   win: !Window,
+ *   doc: !Document,
+ *   iframe: !Element,
+ *   addElement: function(!Element):!Promise
+ * }>
+ */
+function createAdTestingIframePromise() {
+  return createIframePromise().then(fixture => {
+    const doc = fixture.doc;
+    // TODO(a4a-cam@): This is necessary in the short term, until A4A is
+    // smarter about host document styling.  The issue is that it needs to
+    // inherit the AMP runtime style element in order for shadow DOM-enclosed
+    // elements to behave properly.  So we have to set up a minimal one here.
+    const ampStyle = doc.createElement('style');
+    ampStyle.setAttribute('amp-runtime', 'scratch-fortesting');
+    doc.head.appendChild(ampStyle);
+    return fixture;
+  });
+}
+
+
 describe('amp-a4a', () => {
   let sandbox;
   let xhrMock;
@@ -89,7 +116,7 @@ describe('amp-a4a', () => {
         method: 'GET',
         credentials: 'include',
       }).onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = doc.createElement('amp-a4a');
         a4aElement.setAttribute('width', 200);
@@ -99,6 +126,7 @@ describe('amp-a4a', () => {
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
         const extractCreativeAndSignatureSpy = sandbox.spy(
           a4a, 'extractCreativeAndSignature');
+        doc.body.appendChild(a4aElement);
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.instanceof(Promise);
         return a4a.adPromise_.then(() => {
@@ -124,7 +152,7 @@ describe('amp-a4a', () => {
     it('should run end-to-end w/o shadow DOM support', () => {
       viewerForMock.onFirstCall().returns(Promise.resolve());
       xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = doc.createElement('amp-a4a');
         a4aElement.setAttribute('width', 200);
@@ -156,7 +184,7 @@ describe('amp-a4a', () => {
     it('must not be position:fixed', () => {
       viewerForMock.onFirstCall().returns(Promise.resolve());
       xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = doc.createElement('amp-a4a');
         a4aElement.setAttribute('width', 200);
@@ -174,7 +202,7 @@ describe('amp-a4a', () => {
     it('#onLayoutMeasure #layoutCallback not valid AMP', () => {
       viewerForMock.onFirstCall().returns(Promise.resolve());
       xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = doc.createElement('amp-a4a');
         a4aElement.setAttribute('width', 200);
@@ -214,7 +242,7 @@ describe('amp-a4a', () => {
 
   describe('#preconnectCallback', () => {
     it('validate adsense', () => {
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = doc.createElement('amp-a4a');
         a4aElement.setAttribute('type', 'adsense');
@@ -302,7 +330,7 @@ describe('amp-a4a', () => {
           baseTestDoc.slice(splicePoint));
     }
     it('should not render AMP natively', () => {
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = doc.createElement('amp-a4a');
         const a4a = new AmpA4A(a4aElement);
@@ -318,7 +346,7 @@ describe('amp-a4a', () => {
       });
     });
     it('should render AMP natively', () => {
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = doc.createElement('amp-a4a');
         const a4a = new AmpA4A(a4aElement);
@@ -331,11 +359,13 @@ describe('amp-a4a', () => {
           expect(a4aElement.shadowRoot).to.not.be.null;
           expect(rendered).to.be.true;
           const root = a4aElement.shadowRoot;
-          expect(root.children[0].tagName).to.equal('STYLE');
-          expect(root.children[0].innerHTML).to
-            .equal('p { background: green }');
-          expect(root.children[1].tagName).to.equal('AMP-AD-BODY');
-          expect(root.children[1].innerHTML).to.equal('<p>some text</p>');
+          const styles = root.querySelectorAll('style');
+          expect(Array.prototype.some.call(styles,
+              s => { return s.innerHTML == 'p { background: green }' }),
+              'Some style is "background: green"').to.be.true;
+          const adBody = root.querySelector('amp-ad-body');
+          expect(adBody).to.be.ok;
+          expect(adBody.innerHTML).to.equal('<p>some text</p>');
         });
       });
     });
@@ -394,7 +424,7 @@ describe('amp-a4a', () => {
 
   describe('#relocateFonts_', () => {
     it('should be a no-op when there are no style sheets', () => {
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const metaData = {};
         const a4a = new AmpA4A(doc.createElement('amp-a4a'));
@@ -408,7 +438,7 @@ describe('amp-a4a', () => {
     });
 
     it('should create head tags with attributes', () => {
-      return createIframePromise().then(fixture => {
+      return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const metaData = {
           customStylesheets: [
@@ -453,7 +483,7 @@ describe('amp-a4a', () => {
 
     describe('#unlayoutCallback', () => {
       it('verify state reset', () => {
-        return createIframePromise().then(fixture => {
+        return createAdTestingIframePromise().then(fixture => {
           const doc = fixture.doc;
           const a4aElement = doc.createElement('amp-a4a');
           a4aElement.setAttribute('width', 200);
@@ -486,7 +516,7 @@ describe('amp-a4a', () => {
         });
       });
       it('verify cancelled promise', () => {
-        return createIframePromise().then(fixture => {
+        return createAdTestingIframePromise().then(fixture => {
           let whenFirstVisibleResolve = null;
           viewerForMock.returns(new Promise(resolve => {
             whenFirstVisibleResolve = resolve;
@@ -515,7 +545,7 @@ describe('amp-a4a', () => {
         });
       });
       it('verify unhandled error', () => {
-        return createIframePromise().then(fixture => {
+        return createAdTestingIframePromise().then(fixture => {
           viewerForMock.returns(Promise.resolve());
           let rejectResolve = null;
           const sendXhrRequestMock =


### PR DESCRIPTION
A4A was not setting AMP styling within the shadow DOM for legitimate AMP ads rendered there.  As a consequence, the elements were inferring 0 sizing and never rendering.  This adds styling by copying from the document head.  This is a short-term fix, as we work out how to handle it more cleanly.