### PR TITLE
renderOutsideViewport() was ignoring the x-axis

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -439,6 +439,11 @@ export class Resource {
     const multipler = Math.max(renders, 0);
     let scrollPenalty = 1;
     let distance;
+    // If outside of viewport's x-axis, element is not in viewport.
+    if (viewportBox.right < layoutBox.left ||
+        viewportBox.left > layoutBox.right ) {
+      return false;
+    }
     if (viewportBox.bottom < layoutBox.top) {
       // Element is below viewport
       distance = layoutBox.top - viewportBox.bottom;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -441,7 +441,7 @@ export class Resource {
     let distance;
     // If outside of viewport's x-axis, element is not in viewport.
     if (viewportBox.right < layoutBox.left ||
-        viewportBox.left > layoutBox.right ) {
+        viewportBox.left > layoutBox.right) {
       return false;
     }
     if (viewportBox.bottom < layoutBox.top) {

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -1077,5 +1077,85 @@ describe('Resource renderOutsideViewport', () => {
         expect(resource.renderOutsideViewport()).to.equal(false);
       });
     });
+
+    describe('when element is on the left of viewport', () => {
+      beforeEach(() => {
+        resource.layoutBox_ = layoutRectLtwh(-200, 0, 100, 100);
+      });
+
+      it('should disallow rendering', () => {
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      it('should disallow rendering when scrolling towards on y-axis', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      it('should disallow rendering when scrolling away on y-axis', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+    });
+
+    describe('when element is on the right of viewport', () => {
+      beforeEach(() => {
+        resource.layoutBox_ = layoutRectLtwh(200, 0, 100, 100);
+      });
+
+      it('should disallow rendering', () => {
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      it('should disallow rendering when scrolling towards on y-axis', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      it('should disallow rendering when scrolling away on y-axis', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+    });
+
+    describe('when element is fully in viewport', () => {
+      beforeEach(() => {
+        resource.layoutBox_ = layoutRectLtwh(0, 0, 100, 100);
+      });
+
+      it('should allow rendering', () => {
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should allow rendering when scrolling towards', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should allow rendering when scrolling away', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+    });
+
+    describe('when element is partially in viewport', () => {
+      beforeEach(() => {
+        resource.layoutBox_ = layoutRectLtwh(-50, -50, 100, 100);
+      });
+
+      it('should allow rendering', () => {
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should allow rendering when scrolling towards', () => {
+        resources.lastVelocity_ = -2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      it('should allow rendering when scrolling away', () => {
+        resources.lastVelocity_ = 2;
+        expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+    });
   });
 });


### PR DESCRIPTION
`renderOutsideViewport()` was ignoring the x-axis before declaring something is already in viewport.

See https://github.com/ampproject/amphtml/issues/4080 for details