### PR TITLE
Stop encoding the selector config.

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -170,7 +170,7 @@ export class AmpAnalytics extends AMP.BaseElement {
           if (trigger['selector']) {
             // Expand the selector using variable expansion.
             trigger['selector'] = this.expandTemplate_(trigger['selector'],
-                trigger);
+                trigger, undefined, undefined, false);
             addListener(this.win, trigger, this.handleEvent_.bind(this,
                   trigger));
 
@@ -435,11 +435,14 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @param {!Object} event Object with details about the event.
    * @param {number} opt_iterations Number of recursive expansions to perform.
    *    Defaults to 2 substitutions.
+   * @param {boolean=} opt_encode Used to determine if the vars should be
+   *    encoded or not. Defaults to true.
    * @return {string} The expanded string.
    * @private
    */
-  expandTemplate_(template, trigger, event, opt_iterations) {
+  expandTemplate_(template, trigger, event, opt_iterations, opt_encode) {
     opt_iterations = opt_iterations === undefined ? 2 : opt_iterations;
+    opt_encode = opt_encode === undefined ? true : opt_encode;
     if (opt_iterations < 0) {
       user.error('Maximum depth reached while expanding variables. Please ' +
           'ensure that the variables are not recursive.');
@@ -455,11 +458,12 @@ export class AmpAnalytics extends AMP.BaseElement {
       const argList = match[2] || '';
       let raw = (event && event['vars'] && event['vars'][name]) ||
           (trigger['vars'] && trigger['vars'][name]) ||
-          (this.config_['vars'] && this.config_['vars'][name]);
+          (this.config_['vars'] && this.config_['vars'][name]) ||
+          '';
       if (typeof raw == 'string') {
         raw = this.expandTemplate_(raw, trigger, event, opt_iterations - 1);
       }
-      const val = this.encodeVars_(raw != null ? raw : '', name);
+      const val = opt_encode ? this.encodeVars_(raw, name) : raw;
       return val + argList;
     });
   }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -170,7 +170,8 @@ export class AmpAnalytics extends AMP.BaseElement {
           if (trigger['selector']) {
             // Expand the selector using variable expansion.
             trigger['selector'] = this.expandTemplate_(trigger['selector'],
-                trigger, undefined, undefined, false);
+                trigger, /* arg*/ undefined, /* arg */ undefined,
+                /* arg*/ false);
             addListener(this.win, trigger, this.handleEvent_.bind(this,
                   trigger));
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -551,6 +551,29 @@ describe('amp-analytics', function() {
     });
   });
 
+  function selectorExpansionTest(selector) {
+    it('expand selector value: ' + selector, () => {
+      const ins = instrumentationServiceFor(windowApi);
+      const addListenerSpy = sandbox.spy(ins, 'addListener');
+      const analytics = getAnalyticsTag({
+        requests: {foo: 'https://example.com/bar'},
+        triggers: [{on: 'click', selector: '${foo}, ${bar}', request: 'foo'}],
+        vars: {foo: selector, bar: '123'},
+      });
+      return waitForNoSendRequest(analytics).then(() => {
+        expect(addListenerSpy.callCount).to.equal(1);
+        expect(addListenerSpy.args[0][0]['selector']).to
+            .equal(selector + ', 123');
+      });
+    });
+  }
+
+  ['.clazz', 'a, div', 'a .foo', 'a #foo', 'a > div', 'div + p', 'div ~ ul',
+    '[target=_blank]', '[title~=flower]', '[lang|=en]', 'a[href^="https"]',
+    'a[href$=".pdf"]', 'a[href="w3schools"]', 'a:active', 'p::after',
+    'p:first-child', 'p:lang(it)', ':not(p)', 'p:nth-child(2)']
+        .map(selectorExpansionTest);
+
   it('does not expands selector with platform variable', () => {
     const ins = instrumentationServiceFor(windowApi);
     const addListenerSpy = sandbox.spy(ins, 'addListener');

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -388,17 +388,17 @@ In addition to the conditions above, `visibilitySpec` also enables certain varia
 
 #### Click trigger (`"on": "click"`)
 Use this configuration to fire a request when a specified element is clicked. Use `selector` to control which elements will cause this request to fire:
-  - `selector` A CSS selector used to refine which elements should be tracked. Use value `*` to track all elements.  The value of `selector` can include variables that are defined in inline or remote config. The variables will be expanded to determine the elements to be tracked.
+  - `selector` A CSS selector used to refine which elements should be tracked. Use value `*` to track all elements. The value of `selector` can include variables that are defined in inline or remote config. The variables will be expanded to determine the elements to be tracked.
 
     ```javascript
     "vars": {
-      "id1": "socialButtonId",
-      "id2": "shareButtonClass"
+      "id1": "#socialButtonId",
+      "id2": ".shareButtonClass"
     },
     "triggers": {
       "anchorClicks": {
         "on": "click",
-        "selector": "a, #${id1}, .${id2}",
+        "selector": "a, ${id1}, ${id2}",
         "request": "event",
         "vars": {
           "eventId": 128


### PR DESCRIPTION
Encoding messes up with many types of selector values. Since the values
are not sent over wire, encoding is not necessary in the first place.

fixes #4055