### PR TITLE
fix for safari tech preview not shadowing unprefixed prop assignment to prefixed

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -133,7 +133,7 @@ export function makeBodyVisible(doc, opt_waitForExtensions) {
       animation: 'none',
     });
 
-    // TODO(erwinm): Remove this when safari technology preview has merged
+    // TODO(erwinm, #4097): Remove this when safari technology preview has merged
     // the fix for https://github.com/ampproject/amphtml/issues/4047
     // https://bugs.webkit.org/show_bug.cgi?id=159791 which is in r202950.
     if (platform.isSafari()) {

--- a/src/styles.js
+++ b/src/styles.js
@@ -16,6 +16,7 @@
 
 import {setStyles} from './style';
 import {waitForBody} from './dom';
+import {platform} from './platform';
 import {waitForExtensions} from './render-delaying-extensions';
 import {dev} from './log';
 
@@ -131,6 +132,17 @@ export function makeBodyVisible(doc, opt_waitForExtensions) {
       visibility: 'visible',
       animation: 'none',
     });
+
+    // TODO(erwinm): Remove this when safari technology preview has merged
+    // the fix for https://github.com/ampproject/amphtml/issues/4047
+    // https://bugs.webkit.org/show_bug.cgi?id=159791 which is in r202950.
+    if (platform.isSafari()) {
+      if (doc.body.style['webkitAnimation'] !== undefined) {
+        doc.body.style['webkitAnimation'] = 'none';
+      } else if (doc.body.style['WebkitAnimation'] !== undefined) {
+        doc.body.style['WebkitAnimation'] = 'none';
+      }
+    }
   };
   waitForBody(doc, () => {
     const extensionsPromise = opt_waitForExtensions ?


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/4047

will create cleanup issue and refer to it in comments before this is merged.