### PR TITLE
Introduce "group" setting to experiment config

### DIFF
--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -18,7 +18,7 @@ import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 import {toggle} from '../../../src/style';
 import {waitForBodyPromise} from '../../../src/dom';
-import {allocateVariant, assertName} from './variant';
+import {allocateVariant} from './variant';
 import {getService} from '../../../src/service';
 
 /** @const */
@@ -44,16 +44,11 @@ export class AmpExperiment extends AMP.BaseElement {
     const config = this.getConfig_();
     const results = Object.create(null);
     const variants = Object.keys(config).map(experimentName => {
-      assertName(experimentName);
-      const experimentConfig = config[experimentName];
-      // If no 'grouping' is specified, fallback to experiment name.
-      if (!experimentConfig.grouping) {
-        experimentConfig.grouping = experimentName;
-      }
-      return allocateVariant(this.getWin(), experimentConfig)
-          .then(variantName => {
-            results[experimentName] = variantName;
-          });
+      return allocateVariant(
+          this.getWin(), experimentName, config[experimentName])
+              .then(variantName => {
+                results[experimentName] = variantName;
+              });
     });
 
     /** @private @const {!Promise<!Object<string, ?string>>} */

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -18,7 +18,7 @@ import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 import {toggle} from '../../../src/style';
 import {waitForBodyPromise} from '../../../src/dom';
-import {allocateVariant} from './variant';
+import {allocateVariant, assertName} from './variant';
 import {getService} from '../../../src/service';
 
 /** @const */
@@ -44,7 +44,13 @@ export class AmpExperiment extends AMP.BaseElement {
     const config = this.getConfig_();
     const results = Object.create(null);
     const variants = Object.keys(config).map(experimentName => {
-      return allocateVariant(this.getWin(), config[experimentName])
+      assertName(experimentName);
+      const experimentConfig = config[experimentName];
+      // If no 'grouping' is specified, fallback to experiment name.
+      if (!experimentConfig.grouping) {
+        experimentConfig.grouping = experimentName;
+      }
+      return allocateVariant(this.getWin(), experimentConfig)
           .then(variantName => {
             results[experimentName] = variantName;
           });

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -122,33 +122,15 @@ describe('amp-experiment', () => {
     }).to.throw();
   });
 
-  it('should throw if there is invalid experiment name', () => {
-    const badConfig = {
-      'invalid_name!': {
-        variants: {
-          'variant-a': 50,
-          'variant-b': 50,
-        },
-      },
-    };
-    expect(() => {
-      addConfigElement('script', 'application/json', JSON.stringify(badConfig));
-      experiment.buildCallback();
-    }).to.throw();
-  });
-
   it('should add attributes to body element for the allocated variants', () => {
     addConfigElement('script');
     const stub = sandbox.stub(variant, 'allocateVariant');
-    stub.withArgs(
-        win, config['experiment-1']).returns(Promise.resolve('variant-a'));
-    stub.withArgs(
-        win, config['experiment-2']).returns(Promise.resolve('variant-d'));
-    // experiment-3 doesn't have grouping specified, fallback to experiment name
-    const experiment3config =
-        Object.assign(config['experiment-3'], {grouping: 'experiment-3'});
-    stub.withArgs(
-        win, experiment3config).returns(Promise.resolve(null));
+    stub.withArgs(win, 'experiment-1', config['experiment-1'])
+        .returns(Promise.resolve('variant-a'));
+    stub.withArgs(win, 'experiment-2', config['experiment-2'])
+        .returns(Promise.resolve('variant-d'));
+    stub.withArgs(win, 'experiment-3', config['experiment-3'])
+        .returns(Promise.resolve(null));
 
     experiment.buildCallback();
     return variantForOrNull(win).then(variants => {

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -25,14 +25,12 @@ describe('amp-experiment', () => {
 
   const config = {
     'experiment-1': {
-      grouping: 'xyz',
       variants: {
         'variant-a': 50,
         'variant-b': 50,
       },
     },
     'experiment-2': {
-      grouping: 'xyz',
       variants: {
         'variant-c': 50,
         'variant-d': 50,

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -25,12 +25,14 @@ describe('amp-experiment', () => {
 
   const config = {
     'experiment-1': {
+      grouping: 'xyz',
       variants: {
         'variant-a': 50,
         'variant-b': 50,
       },
     },
     'experiment-2': {
+      grouping: 'xyz',
       variants: {
         'variant-c': 50,
         'variant-d': 50,
@@ -120,6 +122,21 @@ describe('amp-experiment', () => {
     }).to.throw();
   });
 
+  it('should throw if there is invalid experiment name', () => {
+    const badConfig = {
+      'invalid_name!': {
+        variants: {
+          'variant-a': 50,
+          'variant-b': 50,
+        },
+      },
+    };
+    expect(() => {
+      addConfigElement('script', 'application/json', JSON.stringify(badConfig));
+      experiment.buildCallback();
+    }).to.throw();
+  });
+
   it('should add attributes to body element for the allocated variants', () => {
     addConfigElement('script');
     const stub = sandbox.stub(variant, 'allocateVariant');
@@ -127,8 +144,11 @@ describe('amp-experiment', () => {
         win, config['experiment-1']).returns(Promise.resolve('variant-a'));
     stub.withArgs(
         win, config['experiment-2']).returns(Promise.resolve('variant-d'));
+    // experiment-3 doesn't have grouping specified, fallback to experiment name
+    const experiment3config =
+        Object.assign(config['experiment-3'], {grouping: 'experiment-3'});
     stub.withArgs(
-        win, config['experiment-3']).returns(Promise.resolve(null));
+        win, experiment3config).returns(Promise.resolve(null));
 
     experiment.buildCallback();
     return variantForOrNull(win).then(variants => {

--- a/extensions/amp-experiment/0.1/test/test-variant.js
+++ b/extensions/amp-experiment/0.1/test/test-variant.js
@@ -69,7 +69,7 @@ describe('allocateVariant', () => {
           'invalid_char_%_in_name': 1,
         },
       });
-    }).to.throw(/Invalid variant name/);
+    }).to.throw(/Invalid name/);
 
     expect(() => {
       allocateVariant(fakeWin, {
@@ -103,6 +103,15 @@ describe('allocateVariant', () => {
         },
       });
     }).to.throw(/Invalid percentage/);
+
+    expect(() => {
+      allocateVariant(fakeWin, {
+        grouping: 'invalid_name!',
+        variants: {
+          'variant_1': 50,
+        },
+      });
+    }).to.throw(/Invalid name/);
   });
 
   it('should work around float rounding error', () => {
@@ -155,8 +164,9 @@ describe('allocateVariant', () => {
       scope: 'amp-experiment',
       createCookieIfNotPresent: true,
     }).returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('123abc').returns(Promise.resolve(0.4));
+    uniformStub.withArgs('xyz:123abc').returns(Promise.resolve(0.4));
     return expect(allocateVariant(fakeWin, {
+      grouping: 'xyz',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
@@ -169,9 +179,10 @@ describe('allocateVariant', () => {
       scope: 'custom-scope',
       createCookieIfNotPresent: true,
     }).returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('123abc').returns(Promise.resolve(0.4));
+    uniformStub.withArgs('xyz:123abc').returns(Promise.resolve(0.4));
     return expect(allocateVariant(fakeWin, {
       cidScope: 'custom-scope',
+      grouping: 'xyz',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
@@ -191,9 +202,10 @@ describe('allocateVariant', () => {
       scope: 'amp-experiment',
       createCookieIfNotPresent: true,
     }).returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('123abc').returns(Promise.resolve(0.4));
+    uniformStub.withArgs('xyz:123abc').returns(Promise.resolve(0.4));
     return expect(allocateVariant(fakeWin, {
       consentNotificationId: 'notif-1',
+      grouping: 'xyz',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
@@ -207,6 +219,7 @@ describe('allocateVariant', () => {
 
     return expect(allocateVariant(fakeWin, {
       consentNotificationId: 'notif-1',
+      grouping: 'xyz',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
@@ -226,6 +239,7 @@ describe('allocateVariant', () => {
     uniformStub.returns(Promise.resolve(0.4));
     return expect(allocateVariant(fakeWin, {
       consentNotificationId: 'notif-1',
+      grouping: 'xyz',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,

--- a/extensions/amp-experiment/0.1/test/test-variant.js
+++ b/extensions/amp-experiment/0.1/test/test-variant.js
@@ -48,23 +48,23 @@ describe('allocateVariant', () => {
 
   it('should throw for invalid config', () => {
     expect(() => {
-      allocateVariant(fakeWin, null);
+      allocateVariant(fakeWin, 'name', null);
     }).to.throw();
 
     expect(() => {
-      allocateVariant(fakeWin, undefined);
+      allocateVariant(fakeWin, 'name', undefined);
     }).to.throw();
 
     expect(() => {
-      allocateVariant(fakeWin, {});
+      allocateVariant(fakeWin, 'name', {});
     }).to.throw(/Missing experiment variants config/);
 
     expect(() => {
-      allocateVariant(fakeWin, {variants: {}});
+      allocateVariant(fakeWin, 'name', {variants: {}});
     }).to.throw(/Missing experiment variants config/);
 
     expect(() => {
-      allocateVariant(fakeWin, {
+      allocateVariant(fakeWin, 'name', {
         variants: {
           'invalid_char_%_in_name': 1,
         },
@@ -72,7 +72,7 @@ describe('allocateVariant', () => {
     }).to.throw(/Invalid name/);
 
     expect(() => {
-      allocateVariant(fakeWin, {
+      allocateVariant(fakeWin, 'name', {
         variants: {
           'variant_1': 50,
           'variant_2': 51,
@@ -81,7 +81,7 @@ describe('allocateVariant', () => {
     }).to.throw(/Total percentage is bigger than 100/);
 
     expect(() => {
-      allocateVariant(fakeWin, {
+      allocateVariant(fakeWin, 'name', {
         variants: {
           'negative_percentage': -1,
         },
@@ -89,7 +89,7 @@ describe('allocateVariant', () => {
     }).to.throw(/Invalid percentage/);
 
     expect(() => {
-      allocateVariant(fakeWin, {
+      allocateVariant(fakeWin, 'name', {
         variants: {
           'too_big_percentage': 101,
         },
@@ -97,7 +97,7 @@ describe('allocateVariant', () => {
     }).to.throw(/Invalid percentage/);
 
     expect(() => {
-      allocateVariant(fakeWin, {
+      allocateVariant(fakeWin, 'name', {
         variants: {
           'non_number_percentage': '50',
         },
@@ -105,8 +105,16 @@ describe('allocateVariant', () => {
     }).to.throw(/Invalid percentage/);
 
     expect(() => {
-      allocateVariant(fakeWin, {
-        grouping: 'invalid_name!',
+      allocateVariant(fakeWin, 'invalid_name!', {
+        variants: {
+          'variant_1': 50,
+        },
+      });
+    }).to.throw(/Invalid name/);
+
+    expect(() => {
+      allocateVariant(fakeWin, 'name', {
+        group: 'invalid_group_name!',
         variants: {
           'variant_1': 50,
         },
@@ -116,7 +124,7 @@ describe('allocateVariant', () => {
 
   it('should work around float rounding error', () => {
     expect(() => {
-      allocateVariant(fakeWin, {
+      allocateVariant(fakeWin, 'name', {
         variants: {
           'a': 50.1,
           'b': 40.3,
@@ -129,7 +137,7 @@ describe('allocateVariant', () => {
   });
 
   it('should work in non-sticky mode', () => {
-    return expect(allocateVariant(fakeWin, {
+    return expect(allocateVariant(fakeWin, 'name', {
       sticky: false,
       variants: {
         '-Variant_1': 56.1,
@@ -139,7 +147,7 @@ describe('allocateVariant', () => {
   });
 
   it('should allocate variant in name order', () => {
-    return expect(allocateVariant(fakeWin, {
+    return expect(allocateVariant(fakeWin, 'name', {
       sticky: false,
       variants: {
         '-Variant_2': 50,
@@ -149,7 +157,7 @@ describe('allocateVariant', () => {
   });
 
   it('can have no variant allocated if variants don\'t add up to 100', () => {
-    return expect(allocateVariant(fakeWin, {
+    return expect(allocateVariant(fakeWin, 'name', {
       sticky: false,
       variants: {
         '-Variant_1': 2.1,
@@ -164,9 +172,8 @@ describe('allocateVariant', () => {
       scope: 'amp-experiment',
       createCookieIfNotPresent: true,
     }).returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('xyz:123abc').returns(Promise.resolve(0.4));
-    return expect(allocateVariant(fakeWin, {
-      grouping: 'xyz',
+    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+    return expect(allocateVariant(fakeWin, 'name', {
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
@@ -179,10 +186,24 @@ describe('allocateVariant', () => {
       scope: 'custom-scope',
       createCookieIfNotPresent: true,
     }).returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('xyz:123abc').returns(Promise.resolve(0.4));
-    return expect(allocateVariant(fakeWin, {
+    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+    return expect(allocateVariant(fakeWin, 'name', {
       cidScope: 'custom-scope',
-      grouping: 'xyz',
+      variants: {
+        '-Variant_1': 50,
+        '-Variant_2': 50,
+      },
+    })).to.eventually.equal('-Variant_1');
+  });
+
+  it('should work in sticky mode with custom group', () => {
+    getCidStub.withArgs({
+      scope: 'amp-experiment',
+      createCookieIfNotPresent: true,
+    }).returns(Promise.resolve('123abc'));
+    uniformStub.withArgs('custom-group:123abc').returns(Promise.resolve(0.4));
+    return expect(allocateVariant(fakeWin, 'name', {
+      group: 'custom-group',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
@@ -202,10 +223,9 @@ describe('allocateVariant', () => {
       scope: 'amp-experiment',
       createCookieIfNotPresent: true,
     }).returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('xyz:123abc').returns(Promise.resolve(0.4));
-    return expect(allocateVariant(fakeWin, {
+    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+    return expect(allocateVariant(fakeWin, 'name', {
       consentNotificationId: 'notif-1',
-      grouping: 'xyz',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
@@ -217,9 +237,8 @@ describe('allocateVariant', () => {
     getNotificationStub.withArgs('notif-1')
         .returns(Promise.resolve(null));
 
-    return expect(allocateVariant(fakeWin, {
+    return expect(allocateVariant(fakeWin, 'name', {
       consentNotificationId: 'notif-1',
-      grouping: 'xyz',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
@@ -237,9 +256,8 @@ describe('allocateVariant', () => {
 
     getCidStub.returns(Promise.resolve('123abc'));
     uniformStub.returns(Promise.resolve(0.4));
-    return expect(allocateVariant(fakeWin, {
+    return expect(allocateVariant(fakeWin, 'name', {
       consentNotificationId: 'notif-1',
-      grouping: 'xyz',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -83,9 +83,7 @@ function validateConfig(config) {
   const variants = config.variants;
   user.assert(isObject(variants) && Object.keys(variants).length > 0,
     'Missing experiment variants config.');
-  if (config.sticky !== false) {
-    assertName(config.grouping);
-  }
+  assertName(config.grouping);
   let totalPercentage = 0;
   for (const variantName in variants) {
     if (variants.hasOwnProperty(variantName)) {

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -22,19 +22,16 @@ import {cryptoFor} from '../../../src/crypto';
 
 const nameValidator = /^[\w-]+$/;
 
-export function assertName(name) {
-  user.assert(nameValidator.test(name),
-      `Invalid name ${name}: %s. Allowed chars are [a-zA-Z0-9-_].`);
-}
-
 /**
  * Allocates the current page view to an experiment variant based on the given
  * experiment config.
  * @param {!Window} win
+ * @param {string} experimentName
  * @param {!Object} config
  * @return {!Promise<?string>}
  */
-export function allocateVariant(win, config) {
+export function allocateVariant(win, experimentName, config) {
+  assertName(experimentName);
   validateConfig(config);
 
   const sticky = config.sticky !== false;
@@ -56,7 +53,8 @@ export function allocateVariant(win, config) {
     if (!hasConsent) {
       return null;
     }
-    return getBucketTicket(win, config.grouping, sticky ? cidScope : null)
+    const group = config.group || experimentName;
+    return getBucketTicket(win, group, sticky ? cidScope : null)
         .then(ticket => {
           let upperBound = 0;
 
@@ -83,7 +81,7 @@ function validateConfig(config) {
   const variants = config.variants;
   user.assert(isObject(variants) && Object.keys(variants).length > 0,
     'Missing experiment variants config.');
-  assertName(config.grouping);
+  assertName(config.group);
   let totalPercentage = 0;
   for (const variantName in variants) {
     if (variants.hasOwnProperty(variantName)) {
@@ -105,11 +103,11 @@ function validateConfig(config) {
  * is hashed from the CID of the given scope (opt_cidScope). If the
  * scope is not provided, a random number is used.
  * @param {!Window} win
- * @param {string} grouping
+ * @param {string} group
  * @param {string=} opt_cidScope
  * @return {!Promise<!number>} a float number in the range of [0, 100)
  */
-function getBucketTicket(win, grouping, opt_cidScope) {
+function getBucketTicket(win, group, opt_cidScope) {
   if (!opt_cidScope) {
     return Promise.resolve(win.Math.random() * 100);
   }
@@ -119,6 +117,11 @@ function getBucketTicket(win, grouping, opt_cidScope) {
         Promise.resolve()));
 
   return Promise.all([cidPromise, cryptoFor(win)])
-      .then(results => results[1].uniform(grouping + ':' + results[0]))
+      .then(results => results[1].uniform(group + ':' + results[0]))
       .then(hash => hash * 100);
+}
+
+function assertName(name) {
+  user.assert(nameValidator.test(name),
+      `Invalid name ${name}: %s. Allowed chars are [a-zA-Z0-9-_].`);
 }

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -81,7 +81,9 @@ function validateConfig(config) {
   const variants = config.variants;
   user.assert(isObject(variants) && Object.keys(variants).length > 0,
     'Missing experiment variants config.');
-  assertName(config.group);
+  if (config.group) {
+    assertName(config.group);
+  }
   let totalPercentage = 0;
   for (const variantName in variants) {
     if (variants.hasOwnProperty(variantName)) {


### PR DESCRIPTION
It acts as a seed for the CID hashing. `group` is optional, experiment name is used if not specified.