### PR TITLE
Optimize service retrieval for inlineability.

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -70,7 +70,7 @@ export function isGoogleAdsA4AValidEnvironment(win) {
  */
 export function googleAdUrl(
     a4a, baseUrl, startTime, slotNumber, queryParams, unboundedQueryParams) {
-  const referrerPromise = viewerFor(a4a.getWin()).getReferrerUrl();
+  const referrerPromise = viewerFor(a4a.win).getReferrerUrl();
   return getAdCid(a4a).then(clientId => referrerPromise.then(referrer =>
       buildAdUrl(
           a4a, baseUrl, startTime, slotNumber, queryParams,
@@ -124,7 +124,7 @@ export function extractGoogleAdCreativeAndSignature(
 function buildAdUrl(
     a4a, baseUrl, startTime, slotNumber, queryParams, unboundedQueryParams,
     clientId, referrer) {
-  const global = a4a.getWin();
+  const global = a4a.win;
   const documentInfo = documentInfoFor(global);
   if (!global.gaGlobal) {
     // Read by GPT for GA/GPT integration.

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -36,6 +36,9 @@ var privateServiceFactory = 'This service should only be installed in ' +
 var shouldNeverBeUsed =
     'Usage of this API is not allowed - only for internal purposes.';
 
+var backwardCompat = 'This method must not be called. It is only retained ' +
+    'for backward compatibility during rollout.';
+
 // Terms that must not appear in our source files.
 var forbiddenTerms = {
   'DO NOT SUBMIT': '',
@@ -412,6 +415,11 @@ var forbiddenTerms = {
     message: 'Use dom.openWindowDialog',
     whitelist: [
       'src/dom.js',
+    ],
+  },
+  '\\.getWin\\(': {
+    message: backwardCompat,
+    whitelist: [
     ],
   },
 };

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -52,7 +52,7 @@ export function installPixel(win) {
       // resource consumption.
       toggle(this.element, false);
       const src = this.element.getAttribute('src');
-      return urlReplacementsFor(this.getWin()).expand(this.assertSource(src))
+      return urlReplacementsFor(this.win).expand(this.assertSource(src))
           .then(src => {
             const image = new Image();
             image.src = src;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -179,7 +179,7 @@ export class AmpA4A extends AMP.BaseElement {
     // buildCallback promise chain.
     // If another ad is currently loading we only load ads that are currently
     // in viewport.
-    const allowRender = allowRenderOutsideViewport(this.element, this.getWin());
+    const allowRender = allowRenderOutsideViewport(this.element, this.win);
     if (allowRender !== true) {
       return allowRender;
     }
@@ -242,7 +242,7 @@ export class AmpA4A extends AMP.BaseElement {
       return;
     }
     this.layoutMeasureExecuted_ = true;
-    user.assert(!isPositionFixed(this.element, this.getWin()),
+    user.assert(!isPositionFixed(this.element, this.win),
         '<%s> is not allowed to be placed in elements with ' +
         'position:fixed: %s', this.element.tagName, this.element);
     // OnLayoutMeasure can be called when page is in prerender so delay until
@@ -259,7 +259,7 @@ export class AmpA4A extends AMP.BaseElement {
     // promise chain due to cancel from unlayout, the promise will be rejected.
     this.promiseId_++;
     const promiseId = this.promiseId_;
-    this.adPromise_ = viewerFor(this.getWin()).whenFirstVisible()
+    this.adPromise_ = viewerFor(this.win).whenFirstVisible()
       .then(() => {
         if (promiseId != this.promiseId_) {
           return Promise.reject(cancellation());
@@ -338,7 +338,7 @@ export class AmpA4A extends AMP.BaseElement {
     // creatives which rendered via the buildCallback promise chain.  Ensure
     // slot counts towards 3p loading count until we know that the creative is
     // valid AMP.
-    this.timerId_ = incrementLoadingAds(this.getWin());
+    this.timerId_ = incrementLoadingAds(this.win);
     return this.adPromise_.then(rendered => {
       if (!rendered) {
         // Was not AMP creative so wrap in cross domain iframe.  layoutCallback
@@ -448,7 +448,7 @@ export class AmpA4A extends AMP.BaseElement {
       // TODO(kjwright):  Add requireAmpResponseSourceOrigin once supported
       // server-side
     };
-    return xhrFor(this.getWin())
+    return xhrFor(this.win)
         .fetch(adUrl, xhrInit)
         .catch(unusedReason => {
           // Error so set rendered_ so iframe will not be written on
@@ -504,7 +504,7 @@ export class AmpA4A extends AMP.BaseElement {
     // 3p throttling count was incremented.  We want to "release" the throttle
     // immediately since we now know we are not a 3p ad.
     if (this.timerId_) {
-      decrementLoadingAds(this.timerId_, this.getWin());
+      decrementLoadingAds(this.timerId_, this.win);
     }
     // AMP documents are required to be UTF-8
     return utf8FromArrayBuffer(bytes).then(creative => {
@@ -555,9 +555,9 @@ export class AmpA4A extends AMP.BaseElement {
             // host document is a short-term fix.  Ultimately, AMP will provide
             // a better mechanism for this, and this code will have to be
             // updated to coordinate with their approach.
-            const style = this.getWin().document.querySelector(
+            const style = this.win.document.querySelector(
                 'style[amp-runtime]') ||
-                this.getWin().document.createElement('style');
+                this.win.document.createElement('style');
             shadowRoot.appendChild(style.cloneNode(true));
             // End TODO.
             shadowRoot./*OK*/innerHTML += (cssBlock + bodyBlock);
@@ -595,7 +595,7 @@ export class AmpA4A extends AMP.BaseElement {
     // TODO: remove call to getCorsUrl and instead have fetch API return
     // modified url.
     iframe.setAttribute(
-      'src', xhrFor(this.getWin()).getCorsUrl(this.getWin(), this.adUrl_));
+      'src', xhrFor(this.win).getCorsUrl(this.win, this.adUrl_));
     this.vsync_.mutate(() => {
       // TODO(keithwrightbos): noContentCallback?
       this.apiHandler_ = new AmpAdApiHandler(this, this.element);
@@ -782,7 +782,8 @@ export class AmpA4A extends AMP.BaseElement {
     if (!metaData.customElementExtensions) {
       return;
     }
-    const extensions = extensionsFor(this.getWin());
+    const win = this.win;
+    const extensions = extensionsFor(win);
     metaData.forEach(extensionId => {
       extensions.loadExtension(extensionId);
     });

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -32,7 +32,7 @@ class AmpAccordion extends AMP.BaseElement {
     this.sections_ = this.getRealChildren();
 
     /** @const @private {!Window} */
-    this.win_ = this.getWin();
+    this.win_ = this.win;
 
     /** @const @private {string} */
     this.id_ = this.getSessionStorageKey_();

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -53,13 +53,13 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   isValidElement() {
-    return isGoogleAdsA4AValidEnvironment(this.getWin()) && this.isInAmpAdTag();
+    return isGoogleAdsA4AValidEnvironment(this.win) && this.isInAmpAdTag();
   }
 
   /** @override */
   getAdUrl() {
     const startTime = timer.now();
-    const global = this.getWin();
+    const global = this.win;
     const slotNumber = getGoogleAdSlotCounter(global).nextSlotNumber();
     const screen = global.screen;
     const slotRect = this.getIntersectionElementLayoutBox();
@@ -106,7 +106,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       return null;
     }
     const ctypesReMatch = /[?&]force_a4a_ctypes=([^&]+)/.exec(
-        this.getWin().location.search);
+        this.win.location.search);
     // If the RE passes, then length is necessarily > 1.
     if (ctypesReMatch) {
       return ctypesReMatch[1];

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -44,7 +44,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   isValidElement() {
-    return isGoogleAdsA4AValidEnvironment(this.getWin()) &&
+    return isGoogleAdsA4AValidEnvironment(this.win) &&
         this.isInAmpAdTag() &&
         !document.querySelector('meta[name=amp-3p-iframe-src]');
   }
@@ -52,7 +52,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /** @override */
   getAdUrl() {
     const startTime = timer.now();
-    const global = this.getWin();
+    const global = this.win;
     const slotNumber = getGoogleAdSlotCounter(global).nextSlotNumber();
     const slotRect = this.getIntersectionElementLayoutBox();
     const rawJson = this.element.getAttribute('json');

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -139,7 +139,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   }
 
   renderOutsideViewport() {
-    const allowRender = allowRenderOutsideViewport(this.element, this.getWin());
+    const allowRender = allowRenderOutsideViewport(this.element, this.win);
     if (allowRender !== true) {
       return allowRender;
     }
@@ -189,7 +189,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     /** @private @const {function()} */
     this.boundNoContentHandler_ = () => this.noContentHandler_();
 
-    setupA2AListener(this.getWin());
+    setupA2AListener(this.win);
   }
 
   /**
@@ -198,7 +198,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // We always need the bootstrap.
-    preloadBootstrap(this.getWin());
+    preloadBootstrap(this.win);
     const type = this.element.getAttribute('type');
     const prefetch = adPrefetch[type];
     const preconnect = adPreconnect[type];
@@ -229,7 +229,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    * @override
    */
   onLayoutMeasure() {
-    this.isInFixedContainer_ = isPositionFixed(this.element, this.getWin());
+    this.isInFixedContainer_ = isPositionFixed(this.element, this.win);
     // We remeasured this tag, let's also remeasure the iframe. Should be
     // free now and it might have changed.
     this.measureIframeLayoutBox_();
@@ -267,7 +267,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       user.assert(!this.isInFixedContainer_,
           '<amp-ad> is not allowed to be placed in elements with ' +
           'position:fixed: %s', this.element);
-      incrementLoadingAds(this.getWin());
+      incrementLoadingAds(this.win);
       return getAdCid(this).then(cid => {
         if (cid) {
           this.element.setAttribute('ampcid', cid);

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -56,7 +56,7 @@ export class AmpAdApiHandler {
     this.unlisteners_ = [];
 
     /** @private @const */
-    this.viewer_ = viewerFor(this.baseInstance_.getWin());
+    this.viewer_ = viewerFor(this.baseInstance_.win);
   }
 
   /**

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -65,7 +65,7 @@ export class AmpAd extends AMP.BaseElement {
     }
     // TODO(tdrl): Check amp-ad registry to see if they have this already.
     if (!a4aRegistry[type] ||
-        !a4aRegistry[type](this.getWin(), this.element)) {
+        !a4aRegistry[type](this.win, this.element)) {
       // Network either has not provided any A4A implementation or the
       // implementation exists, but has explicitly chosen not to handle this
       // tag as A4A.  Fall back to the 3p implementation.
@@ -74,7 +74,7 @@ export class AmpAd extends AMP.BaseElement {
     // TODO(dvoytenko): Reimplement a4a via `upgradeCallback`. It will look
     // as following:
     /*
-      const extensions = extensionsFor(this.getWin());
+      const extensions = extensionsFor(this.win);
       return extensions.loadElementClass(extensionTag).then(ctor => {
         return new ctor(this.element);
       });
@@ -100,7 +100,7 @@ export class AmpAd extends AMP.BaseElement {
     // that the loader can handle the case.
     const extensionTag = networkImplementationTag(type);
     const newChild = this.element.ownerDocument.createElement(extensionTag);
-    extensionsFor(this.getWin()).loadExtension(extensionTag);
+    extensionsFor(this.win).loadExtension(extensionTag);
     copyAttributes(this.element, newChild);
     this.element.appendChild(newChild);
   }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -84,7 +84,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     this.consentPromise_ = Promise.resolve();
 
     if (this.consentNotificationId_ != null) {
-      this.consentPromise_ = userNotificationManagerFor(this.getWin())
+      this.consentPromise_ = userNotificationManagerFor(this.win)
           .then(service => service.get(this.consentNotificationId_));
     }
   }
@@ -170,11 +170,11 @@ export class AmpAnalytics extends AMP.BaseElement {
             // Expand the selector using variable expansion.
             trigger['selector'] = this.expandTemplate_(trigger['selector'],
                 trigger);
-            addListener(this.getWin(), trigger, this.handleEvent_.bind(this,
+            addListener(this.win, trigger, this.handleEvent_.bind(this,
                   trigger));
 
           } else {
-            addListener(this.getWin(), trigger,
+            addListener(this.win, trigger,
                 this.handleEvent_.bind(this, trigger));
           }
         }));
@@ -239,10 +239,11 @@ export class AmpAnalytics extends AMP.BaseElement {
     if (this.element.hasAttribute('data-credentials')) {
       fetchConfig.credentials = this.element.getAttribute('data-credentials');
     }
-    return urlReplacementsFor(this.getWin()).expand(remoteConfigUrl)
+    const win = this.win;
+    return urlReplacementsFor(win).expand(remoteConfigUrl)
         .then(expandedUrl => {
           remoteConfigUrl = expandedUrl;
-          return xhrFor(this.getWin()).fetchJson(remoteConfigUrl, fetchConfig);
+          return xhrFor(win).fetchJson(remoteConfigUrl, fetchConfig);
         })
         .then(jsonValue => {
           this.remoteConfig_ = jsonValue;
@@ -319,7 +320,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     }
 
     const props = this.config_['optout'].split('.');
-    let k = this.getWin();
+    let k = this.win;
     for (let i = 0; i < props.length; i++) {
       if (!k) {
         return false;
@@ -393,7 +394,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     request = this.expandTemplate_(request, trigger, event);
 
     // For consistency with amp-pixel we also expand any url replacements.
-    return urlReplacementsFor(this.getWin()).expand(request).then(request => {
+    return urlReplacementsFor(this.win).expand(request).then(request => {
       this.sendRequest_(request, trigger);
       return request;
     });
@@ -418,8 +419,8 @@ export class AmpAnalytics extends AMP.BaseElement {
     const threshold = parseFloat(spec['threshold']); // Threshold can be NaN.
     if (threshold >= 0 && threshold <= 100) {
       const key = this.expandTemplate_(spec['sampleOn'], trigger);
-      const keyPromise = urlReplacementsFor(this.getWin()).expand(key);
-      const cryptoPromise = cryptoFor(this.getWin());
+      const keyPromise = urlReplacementsFor(this.win).expand(key);
+      const cryptoPromise = cryptoFor(this.win);
       return Promise.all([keyPromise, cryptoPromise])
           .then(results => results[1].uniform(results[0]))
           .then(digest => digest * 100 < spec['threshold']);
@@ -488,9 +489,9 @@ export class AmpAnalytics extends AMP.BaseElement {
     if (trigger['iframePing']) {
       user.assert(trigger['on'] == 'visible',
           'iframePing is only available on page view requests.');
-      sendRequestUsingIframe(this.getWin(), request);
+      sendRequestUsingIframe(this.win, request);
     } else {
-      sendRequest(this.getWin(), request, this.config_['transport'] || {});
+      sendRequest(this.win, request, this.config_['transport'] || {});
     }
   }
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -168,7 +168,7 @@ describe('amp-analytics', function() {
             analytics.createdCallback();
             analytics.buildCallback();
             const urlReplacements = installUrlReplacementsService(
-                analytics.getWin());
+                analytics.win);
             sandbox.stub(urlReplacements, 'getReplacement_', function(name) {
               expect(this.replacements_).to.have.property(name);
               return '_' + name.toLowerCase() + '_';
@@ -738,7 +738,7 @@ describe('amp-analytics', function() {
       const analytics = getAnalyticsTag(config);
 
       const urlReplacements = installUrlReplacementsService(
-                analytics.getWin());
+                analytics.win);
       sandbox.stub(urlReplacements, 'getReplacement_').returns(0);
       sandbox.stub(crypto, 'uniform')
           .withArgs('0').returns(Promise.resolve(0.005));

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -37,7 +37,7 @@ export class AmpSlideScroll extends BaseCarousel {
   /** @override */
   buildCarousel() {
     /** @private @const {!Window} */
-    this.win_ = this.getWin();
+    this.win_ = this.win;
 
     /** @const @private {!Vsync} */
     this.vsync_ = this.getVsync();

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -34,7 +34,7 @@ export class AmpExperiment extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.isExperimentOn_ = isExperimentOn(this.getWin(), EXPERIMENT);
+    this.isExperimentOn_ = isExperimentOn(this.win, EXPERIMENT);
     if (!this.isExperimentOn_) {
       dev.warn(EXPERIMENT, `Experiment ${EXPERIMENT} disabled`);
       toggle(this.element, false);
@@ -45,7 +45,7 @@ export class AmpExperiment extends AMP.BaseElement {
     const results = Object.create(null);
     const variants = Object.keys(config).map(experimentName => {
       return allocateVariant(
-          this.getWin(), experimentName, config[experimentName])
+          this.win, experimentName, config[experimentName])
               .then(variantName => {
                 results[experimentName] = variantName;
               });
@@ -56,7 +56,7 @@ export class AmpExperiment extends AMP.BaseElement {
         .then(() => results)
         .then(this.addToBody_.bind(this));
 
-    getService(this.getWin(), 'variant', () => this.experimentVariants_);
+    getService(this.win, 'variant', () => this.experimentVariants_);
   }
 
   getConfig_() {
@@ -80,7 +80,7 @@ export class AmpExperiment extends AMP.BaseElement {
    * @private
    */
   addToBody_(experiments) {
-    const doc = this.getWin().document;
+    const doc = this.win.document;
     return waitForBodyPromise(doc).then(() => {
       for (const name in experiments) {
         if (experiments[name]) {

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -28,7 +28,7 @@ class AmpFacebook extends AMP.BaseElement {
     // Hosts the facebook SDK.
     this.preconnect.preload(
         'https://connect.facebook.net/en_US/sdk.js', 'script');
-    preloadBootstrap(this.getWin());
+    preloadBootstrap(this.win);
   }
 
   /** @override */

--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -101,11 +101,11 @@ export class AmpFont extends AMP.BaseElement {
     this.fontVariant_ =
         this.element.getAttribute('font-variant') || DEFAULT_VARIANT_;
     /** @private @const {!Document} */
-    this.document_ = this.getWin().document;
+    this.document_ = this.win.document;
     /** @private @const {!Element} */
     this.documentElement_ = this.document_.documentElement;
     /** @private @const {!FontLoader} */
-    this.fontLoader_ = new FontLoader(this.getWin());
+    this.fontLoader_ = new FontLoader(this.win);
     this.startLoad_();
   }
 

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -32,7 +32,7 @@ class AmpFlyingCarpet extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.isExperimentOn_ = isExperimentOn(this.getWin(), EXPERIMENT);
+    this.isExperimentOn_ = isExperimentOn(this.win, EXPERIMENT);
     if (!this.isExperimentOn_) {
       dev.warn(EXPERIMENT, `Experiment ${EXPERIMENT} disabled`);
       toggle(this.element, false);

--- a/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
@@ -33,7 +33,7 @@ class AmpGoogleVrviewImage extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     /** @const @private {boolean} */
-    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    this.isExperimentOn_ = isExperimentOn(this.win, TAG);
     if (!this.isExperimentOn_) {
       dev.warn(TAG, `TAG ${TAG} disabled`);
       return;
@@ -87,7 +87,7 @@ class AmpGoogleVrviewImage extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    this.isExperimentOn_ = isExperimentOn(this.win, TAG);
     if (!this.isExperimentOn_) {
       dev.warn(TAG, `TAG ${TAG} disabled`);
       return Promise.resolve();

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -273,7 +273,7 @@ export class AmpIframe extends AMP.BaseElement {
         // Prevent this iframe from ever being recreated.
         this.iframeSrc = null;
 
-        timerFor(this.getWin()).promise(trackingIframeTimeout).then(() => {
+        timerFor(this.win).promise(trackingIframeTimeout).then(() => {
           removeElement(iframe);
           this.element.setAttribute('amp-removed', '');
           this.iframe_ = null;
@@ -296,7 +296,7 @@ export class AmpIframe extends AMP.BaseElement {
       // container. To avoid this problem, we set the `overflow:auto` property
       // 1s later via `amp-active` class.
       if (this.container_ != this.element) {
-        timerFor(this.getWin()).delay(() => {
+        timerFor(this.win).delay(() => {
           this.deferMutate(() => {
             this.container_.classList.add('amp-active');
           });

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -717,7 +717,7 @@ class AmpImageLightbox extends AMP.BaseElement {
 
     /**  @private {function(this:AmpImageLightbox, Event)}*/
     this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
-    this.getWin().document.documentElement.addEventListener(
+    this.win.document.documentElement.addEventListener(
         'keydown', this.boundCloseOnEscape_);
 
     // Prepare to enter in lightbox
@@ -768,7 +768,7 @@ class AmpImageLightbox extends AMP.BaseElement {
     if (this.historyId_ != -1) {
       this.getHistory_().pop(this.historyId_);
     }
-    this.getWin().document.documentElement.removeEventListener(
+    this.win.document.documentElement.removeEventListener(
         'keydown', this.boundCloseOnEscape_);
     this.boundCloseOnEscape_ = null;
   }

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -80,9 +80,9 @@ class AmpInstagram extends AMP.BaseElement {
 
   /** @override */
   createPlaceholderCallback() {
-    const placeholder = this.getWin().document.createElement('div');
+    const placeholder = this.win.document.createElement('div');
     placeholder.setAttribute('placeholder', '');
-    const image = this.getWin().document.createElement('amp-img');
+    const image = this.win.document.createElement('amp-img');
     // This will redirect to the image URL. By experimentation this is
     // always the same URL that is actually used inside of the embed.
     image.setAttribute('src', 'https://www.instagram.com/p/' +

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -32,7 +32,7 @@ const TAG = 'amp-install-serviceworker';
 class AmpInstallServiceWorker extends AMP.BaseElement {
   /** @override */
   buildCallback() {
-    const win = this.getWin();
+    const win = this.win;
     if (!('serviceWorker' in win.navigator)) {
       return;
     }
@@ -63,7 +63,7 @@ class AmpInstallServiceWorker extends AMP.BaseElement {
     }
 
     if (parseUrl(win.location.href).origin == parseUrl(src).origin) {
-      install(this.getWin(), src);
+      install(this.win, src);
     } else {
       user.error(TAG,
           'Did not install ServiceWorker because it does not ' +
@@ -73,7 +73,7 @@ class AmpInstallServiceWorker extends AMP.BaseElement {
 
   /** @private */
   scheduleIframeLoad_() {
-    viewerFor(this.getWin()).whenFirstVisible().then(() => {
+    viewerFor(this.win).whenFirstVisible().then(() => {
       // If the user is longer than 20 seconds on this page, load
       // the external iframe to install the ServiceWorker. The wait is
       // introduced to avoid installing SWs for content that the user
@@ -88,7 +88,7 @@ class AmpInstallServiceWorker extends AMP.BaseElement {
   insertIframe_() {
     // If we are no longer visible, we will not do a SW registration on this
     // page view.
-    if (!viewerFor(this.getWin()).isVisible()) {
+    if (!viewerFor(this.win).isVisible()) {
       return;
     }
     this.insertedIframe_ = true;

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -43,20 +43,18 @@ describe('amp-install-serviceworker', () => {
     let calledSrc;
     const p = new Promise(() => {});
     implementation.win = {
-      return {
-        location: {
-          href: 'https://example.com/some/path',
-        },
-        navigator: {
-          serviceWorker: {
-            register: src => {
-              expect(calledSrc).to.be.undefined;
-              calledSrc = src;
-              return p;
-            },
+      location: {
+        href: 'https://example.com/some/path',
+      },
+      navigator: {
+        serviceWorker: {
+          register: src => {
+            expect(calledSrc).to.be.undefined;
+            calledSrc = src;
+            return p;
           },
         },
-      };
+      },
     };
     implementation.buildCallback();
     expect(calledSrc).to.equal('https://example.com/sw.js');
@@ -86,18 +84,16 @@ describe('amp-install-serviceworker', () => {
     install.setAttribute('src', 'https://other-origin.com/sw.js');
     const p = new Promise(() => {});
     implementation.win = {
-      return {
-        location: {
-          href: 'https://example.com/some/path',
-        },
-        navigator: {
-          serviceWorker: {
-            register: () => {
-              return p;
-            },
+      location: {
+        href: 'https://example.com/some/path',
+      },
+      navigator: {
+        serviceWorker: {
+          register: () => {
+            return p;
           },
         },
-      };
+      },
     };
     implementation.buildCallback();
     expect(install.children).to.have.length(0);
@@ -111,19 +107,17 @@ describe('amp-install-serviceworker', () => {
     let calledSrc;
     const p = new Promise(() => {});
     implementation.win = {
-      return {
-        location: {
-          href: 'https://cdn.ampproject.org/some/path',
-        },
-        navigator: {
-          serviceWorker: {
-            register: src => {
-              calledSrc = src;
-              return p;
-            },
+      location: {
+        href: 'https://cdn.ampproject.org/some/path',
+      },
+      navigator: {
+        serviceWorker: {
+          register: src => {
+            calledSrc = src;
+            return p;
           },
         },
-      };
+      },
     };
     implementation.buildCallback();
     expect(calledSrc).to.undefined;

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -66,13 +66,11 @@ describe('amp-install-serviceworker', () => {
     expect(implementation).to.be.defined;
     install.setAttribute('src', 'https://example.com/sw.js');
     implementation.win = {
-      return {
-        location: {
-          href: 'https://example.com/some/path',
-        },
-        navigator: {
-        },
-      };
+      location: {
+        href: 'https://example.com/some/path',
+      },
+      navigator: {
+      },
     };
     implementation.buildCallback();
   });

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -42,7 +42,7 @@ describe('amp-install-serviceworker', () => {
     install.setAttribute('src', 'https://example.com/sw.js');
     let calledSrc;
     const p = new Promise(() => {});
-    implementation.getWin = () => {
+    implementation.win = {
       return {
         location: {
           href: 'https://example.com/some/path',
@@ -67,7 +67,7 @@ describe('amp-install-serviceworker', () => {
     const implementation = install.implementation_;
     expect(implementation).to.be.defined;
     install.setAttribute('src', 'https://example.com/sw.js');
-    implementation.getWin = () => {
+    implementation.win = {
       return {
         location: {
           href: 'https://example.com/some/path',
@@ -85,7 +85,7 @@ describe('amp-install-serviceworker', () => {
     expect(implementation).to.be.defined;
     install.setAttribute('src', 'https://other-origin.com/sw.js');
     const p = new Promise(() => {});
-    implementation.getWin = () => {
+    implementation.win = {
       return {
         location: {
           href: 'https://example.com/some/path',
@@ -110,7 +110,7 @@ describe('amp-install-serviceworker', () => {
     install.setAttribute('src', 'https://cdn.ampproject.org/sw.js');
     let calledSrc;
     const p = new Promise(() => {});
-    implementation.getWin = () => {
+    implementation.win = {
       return {
         location: {
           href: 'https://cdn.ampproject.org/some/path',
@@ -158,7 +158,7 @@ describe('amp-install-serviceworker', () => {
           },
         },
       };
-      implementation.getWin = () => win;
+      implementation.win = win;
       documentInfo = {
         canonicalUrl: 'https://www.example.com/path',
         sourceUrl: 'https://source.example.com/path',

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -70,7 +70,7 @@ class AmpLightbox extends AMP.BaseElement {
   activate() {
     /**  @private {function(this:AmpLightbox, Event)}*/
     this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
-    this.getWin().document.documentElement.addEventListener(
+    this.win.document.documentElement.addEventListener(
         'keydown', this.boundCloseOnEscape_);
     this.getViewport().enterLightboxMode();
 
@@ -79,7 +79,7 @@ class AmpLightbox extends AMP.BaseElement {
       this.element.style.opacity = 0;
       // TODO(dvoytenko): use new animations support instead.
       this.element.style.transition = 'opacity 0.1s ease-in';
-      vsyncFor(this.getWin()).mutate(() => {
+      vsyncFor(this.win).mutate(() => {
         this.element.style.opacity = '';
       });
     }).then(() => {
@@ -109,7 +109,7 @@ class AmpLightbox extends AMP.BaseElement {
     if (this.historyId_ != -1) {
       this.getHistory_().pop(this.historyId_);
     }
-    this.getWin().document.documentElement.removeEventListener(
+    this.win.document.documentElement.removeEventListener(
         'keydown', this.boundCloseOnEscape_);
     this.boundCloseOnEscape_ = null;
     this.schedulePause(this.container_);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -36,7 +36,7 @@ export class AmpList extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     /** @const {!Element} */
-    this.container_ = this.getWin().document.createElement('div');
+    this.container_ = this.win.document.createElement('div');
     this.applyFillContent(this.container_, true);
     this.element.appendChild(this.container_);
     if (!this.element.hasAttribute('role')) {
@@ -44,7 +44,7 @@ export class AmpList extends AMP.BaseElement {
     }
 
     /** @private @const {!UrlReplacements} */
-    this.urlReplacements_ = urlReplacementsFor(this.getWin());
+    this.urlReplacements_ = urlReplacementsFor(this.win);
   }
 
   /** @override */
@@ -58,13 +58,13 @@ export class AmpList extends AMP.BaseElement {
           if (opts.credentials) {
             opts.requireAmpResponseSourceOrigin = true;
           }
-          return xhrFor(this.getWin()).fetchJson(src, opts);
+          return xhrFor(this.win).fetchJson(src, opts);
         }).then(data => {
           user.assert(typeof data == 'object' && Array.isArray(data['items']),
               'Response must be {items: []} object %s %s',
               this.element, data);
           const items = data['items'];
-          return templatesFor(this.getWin()).findAndRenderTemplateArray(
+          return templatesFor(this.win).findAndRenderTemplateArray(
               this.element, items).then(this.rendered_.bind(this));
         });
   }

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -113,7 +113,7 @@ export class AmpLiveList extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     /** @const {!Window} */
-    this.win = this.getWin();
+    this.win = this.win;
 
     /** @private @const {boolean} */
     this.isExperimentOn_ = isExperimentOn(this.win, TAG);

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -112,9 +112,6 @@ export class AmpLiveList extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    /** @const {!Window} */
-    this.win = this.win;
-
     /** @private @const {boolean} */
     this.isExperimentOn_ = isExperimentOn(this.win, TAG);
 

--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -41,7 +41,7 @@ export class AmpMustache extends AMP.BaseTemplate {
   render(data) {
     const html = mustacheRender(this.template_, data);
     const sanitized = sanitizeHtml(html);
-    const root = this.getWin().document.createElement('div');
+    const root = this.win.document.createElement('div');
     root./*OK*/innerHTML = sanitized;
     return this.unwrap(root);
   }

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -25,7 +25,7 @@ class AmpShareTracking extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.isExperimentOn_ = isExperimentOn(this.getWin(), TAG);
+    this.isExperimentOn_ = isExperimentOn(this.win, TAG);
     if (!this.isExperimentOn_) {
       dev.warn(TAG, `TAG ${TAG} disabled`);
       return;

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -37,7 +37,7 @@ export class AmpSidebar extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     /** @private @const {!Window} */
-    this.win_ = this.getWin();
+    this.win_ = this.win;
 
     /** @private @const {!Document} */
     this.document_ = this.win_.document;

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -52,7 +52,7 @@ class AmpSocialShare extends AMP.BaseElement {
     /** @private {string} */
     this.href_ = null;
     const hrefWithVars = addParamsToUrl(this.shareEndpoint_, this.params_);
-    const urlReplacements = urlReplacementsFor(this.getWin());
+    const urlReplacements = urlReplacementsFor(this.win);
     urlReplacements.expand(hrefWithVars).then(href => {
       this.href_ = href;
     });
@@ -68,7 +68,7 @@ class AmpSocialShare extends AMP.BaseElement {
       return;
     }
     const windowFeatures = 'resizable,scrollbars,width=640,height=480';
-    openWindowDialog(this.getWin(), this.href_, '_blank', windowFeatures);
+    openWindowDialog(this.win, this.href_, '_blank', windowFeatures);
   }
 
 };

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -158,8 +158,8 @@ describe('amp-social-share', () => {
   it('opens share window in _blank', () => {
     return getShare('twitter').then(el => {
       el.implementation_.handleClick_();
-      expect(el.implementation_.getWin().open.called).to.be.true;
-      expect(el.implementation_.getWin().open.calledWith(
+      expect(el.implementation_.win.open.called).to.be.true;
+      expect(el.implementation_.win.open.calledWith(
         'https://twitter.com/intent/tweet?text=doc%20title&' +
           'url=https%3A%2F%2Fcanonicalexample.com%2F',
           '_blank', 'resizable,scrollbars,width=640,height=480'

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -146,7 +146,7 @@ class AmpStickyAd extends AMP.BaseElement {
    * @private
    */
   addCloseButton_() {
-    const closeButton = this.getWin().document.createElement('button');
+    const closeButton = this.win.document.createElement('button');
     closeButton.classList.add('amp-sticky-ad-close-button');
     closeButton.setAttribute('aria-label',
         this.element.getAttribute('data-close-button-aria-label') || 'Close');

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -31,7 +31,7 @@ class AmpTwitter extends AMP.BaseElement {
     // Hosts the script that renders tweets.
     this.preconnect.preload(
         'https://platform.twitter.com/widgets.js', 'script');
-    preloadBootstrap(this.getWin());
+    preloadBootstrap(this.win);
   }
 
   /** @override */

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -90,7 +90,7 @@ export class AmpUserNotification extends AMP.BaseElement {
   createdCallback() {
 
     /** @private @const {!Window} */
-    this.win_ = this.getWin();
+    this.win_ = this.win;
 
     /** @private @const {!UrlReplacements} */
     this.urlReplacements_ = urlReplacementsFor(this.win_);

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -106,7 +106,7 @@ class AmpYoutube extends AMP.BaseElement {
       this.playerReadyResolver_ = resolve;
     });
 
-    this.getWin().addEventListener(
+    this.win.addEventListener(
         'message', event => this.handleYoutubeMessages_(event));
 
     return loadPromise(iframe)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -502,6 +502,23 @@ var activeBundleOperationCount = 0;
  */
 function compileJs(srcDir, srcFilename, destDir, options) {
   options = options || {};
+  if (options.minify) {
+    function minify() {
+      console.log('Minifying ' + srcFilename);
+      closureCompile(srcDir + srcFilename, destDir, options.minifiedName,
+          options)
+          .then(function() {
+            fs.writeFileSync(destDir + '/version.txt', internalRuntimeVersion);
+            if (options.latestName) {
+              fs.copySync(
+                  destDir + '/' + options.minifiedName,
+                  destDir + '/' + options.latestName);
+            }
+          });
+    }
+    minify();
+    return;
+  }
   var bundler = browserify(srcDir + srcFilename, {debug: true})
       .transform(babel, { loose: argv.strictBabelTransform ? undefined : 'all' });
   if (options.watch) {
@@ -555,49 +572,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     });
   }
 
-  function minify() {
-    console.log('Minifying ' + srcFilename);
-    closureCompile(srcDir + srcFilename, destDir, options.minifiedName,
-        options)
-        .then(function() {
-          fs.writeFileSync(destDir + '/version.txt', internalRuntimeVersion);
-          if (options.latestName) {
-            fs.copySync(
-                destDir + '/' + options.minifiedName,
-                destDir + '/' + options.latestName);
-          }
-        });
-  }
-
-  /*
-  Pre closure compiler minification. Add this back, should we have problems
-  with closure.
-  function minify() {
-    console.log('Minifying ' + srcFilename);
-    bundler.bundle()
-      .on('error', function(err) { console.error(err); this.emit('end'); })
-      .pipe(lazybuild())
-      .pipe($$.uglify({
-        preserveComments: 'some'
-      }))
-      .pipe($$.rename(options.minifiedName))
-      .pipe(lazywrite())
-      .on('end', function() {
-        fs.writeFileSync(destDir + '/version.txt', internalRuntimeVersion);
-        if (options.latestName) {
-          fs.copySync(
-              destDir + '/' + options.minifiedName,
-              destDir + '/' + options.latestName);
-        }
-      });
-  }
-  */
-
-  if (options.minify) {
-    minify();
-  } else {
-    rebundle();
-  }
+  rebundle();
 }
 
 /**

--- a/src/action.js
+++ b/src/action.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getServiceForDoc} from './service';
+import {getExistingServiceForDoc} from './service';
 
 
 /**
@@ -22,5 +22,5 @@ import {getServiceForDoc} from './service';
  * @return {!Action}
  */
 export function actionServiceForDoc(nodeOrDoc) {
-  return getServiceForDoc(nodeOrDoc, 'action');
+  return getExistingServiceForDoc(nodeOrDoc, 'action');
 }

--- a/src/ad-cid.js
+++ b/src/ad-cid.js
@@ -33,13 +33,13 @@ export function getAdCid(adElement) {
   if (!(scope || consentId)) {
     return Promise.resolve();
   }
-  return cidForOrNull(adElement.getWin()).then(cidService => {
+  return cidForOrNull(adElement.win).then(cidService => {
     if (!cidService) {
       return;
     }
     let consent = Promise.resolve();
     if (consentId) {
-      consent = userNotificationManagerFor(adElement.getWin()).then(service => {
+      consent = userNotificationManagerFor(adElement.win).then(service => {
         return service.get(consentId);
       });
       if (!scope && consentId) {

--- a/src/ampdoc.js
+++ b/src/ampdoc.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 /**
  * Returns the global instance of the `AmpDocService` service that can be
@@ -25,5 +25,5 @@ import {getService} from './service';
  */
 export function ampdocFor(window) {
   return /** @type {!./service/ampdoc-impl.AmpDocService} */ (
-      getService(window, 'ampdoc'));
+      getExistingServiceForWindow(window, 'ampdoc'));
 }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -139,7 +139,7 @@ export class BaseElement {
     this.inViewport_ = false;
 
     /** @public @const {!Window}  */
-    this.win = baseElement.element.ownerDocument.defaultView;
+    this.win = element.ownerDocument.defaultView;
 
     /** @private {!Object<string, function(!./service/action-impl.ActionInvocation)>} */
     this.actionMap_ = this.win.Object.create(null);

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -138,14 +138,17 @@ export class BaseElement {
     /** @package {boolean} */
     this.inViewport_ = false;
 
+    /** @public @const {!Window}  */
+    this.win = baseElement.element.ownerDocument.defaultView;
+
     /** @private {!Object<string, function(!./service/action-impl.ActionInvocation)>} */
-    this.actionMap_ = this.getWin().Object.create(null);
+    this.actionMap_ = this.win.Object.create(null);
 
     /** @protected {!./preconnect.Preconnect} */
-    this.preconnect = preconnectFor(this.getWin());
+    this.preconnect = preconnectFor(this.win);
 
     /** @private {!./service/resources-impl.Resources}  */
-    this.resources_ = resourcesFor(this.getWin());
+    this.resources_ = resourcesFor(this.win);
   }
 
   /**
@@ -163,14 +166,9 @@ export class BaseElement {
     return this.layout_;
   }
 
-  /** @protected @return {!Window} */
-  getWin() {
-    return this.element.ownerDocument.defaultView;
-  }
-
   /** @protected @return {!./service/vsync-impl.Vsync} */
   getVsync() {
-    return vsyncFor(this.getWin());
+    return vsyncFor(this.win);
   }
 
   /**
@@ -570,7 +568,7 @@ export class BaseElement {
    * @return {!./service/viewport-impl.Viewport}
    */
   getViewport() {
-    return viewportFor(this.getWin());
+    return viewportFor(this.win);
   }
 
  /**
@@ -709,7 +707,7 @@ export class BaseElement {
    * TODO(dvoytenko, #3406): Remove as deprecated.
    */
   requestFullOverlay() {
-    viewerFor(this.getWin()).requestFullOverlay();
+    viewerFor(this.win).requestFullOverlay();
   }
 
   /**
@@ -719,7 +717,7 @@ export class BaseElement {
    * TODO(dvoytenko, #3406): Remove as deprecated.
    */
   cancelFullOverlay() {
-    viewerFor(this.getWin()).cancelFullOverlay();
+    viewerFor(this.win).cancelFullOverlay();
   }
 
   /**

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -166,6 +166,14 @@ export class BaseElement {
     return this.layout_;
   }
 
+  /**
+   * DO NOT CALL. Retained for backward compat during rollout.
+   * @protected @return {!Window}
+   */
+  getWin() {
+    return this.win;
+  }
+
   /** @protected @return {!./service/vsync-impl.Vsync} */
   getVsync() {
     return vsyncFor(this.win);

--- a/src/element-stub.js
+++ b/src/element-stub.js
@@ -32,7 +32,7 @@ export class ElementStub extends BaseElement {
     const name = element.tagName.toLowerCase();
     if (!loadingChecked[name]) {
       loadingChecked[name] = true;
-      extensionsFor(this.getWin()).loadExtension(name);
+      extensionsFor(this.win).loadExtension(name);
     }
     stubbedElements.push(this);
   }

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 
 /**
@@ -23,5 +23,5 @@ import {getService} from './service';
  */
 export function extensionsFor(window) {
   return /** @type {!./service/extensions-impl.Extensions} */ (
-      getService(window, 'extensions'));
+      getExistingServiceForWindow(window, 'extensions'));
 };

--- a/src/history.js
+++ b/src/history.js
@@ -15,7 +15,7 @@
  */
 
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 
 /**
@@ -24,5 +24,5 @@ import {getService} from './service';
  * @return {!History}
  */
 export function historyFor(window) {
-  return getService(window, 'history');
+  return getExistingServiceForWindow(window, 'history');
 };

--- a/src/performance.js
+++ b/src/performance.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 /**
  * @param {!Window} window
  * @return {!Performance}
  */
 export function performanceFor(window) {
-  return getService(window, 'performance');
+  return getExistingServiceForWindow(window, 'performance');
 };

--- a/src/resources.js
+++ b/src/resources.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 /**
  * @param {!Window} window
@@ -22,5 +22,5 @@ import {getService} from './service';
  */
 export function resourcesFor(window) {
   return /** @type {!./service/resources-impl.Resources} */ (
-      getService(window, 'resources'));
+      getExistingServiceForWindow(window, 'resources'));
 };

--- a/src/service.js
+++ b/src/service.js
@@ -36,14 +36,10 @@ let ServiceHolderDef;
  * Returns a service with the given id. Assumes that it has been constructed
  * already.
  * @param {!Window} win
+ * @param {string} id
  * @return {!Object} The service.
  */
 export function getExistingServiceForWindow(win, id) {
-  if (getMode().localDev) {
-    dev.assert(
-       win.services && win.services[id] && win.services[id].obj,
-        'Window service does not exist %s', id);
-  }
   return win.services[id].obj;
 }
 
@@ -51,16 +47,10 @@ export function getExistingServiceForWindow(win, id) {
  * Returns a service with the given id. Assumes that it has been constructed
  * already.
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+ * @param {string} id
  * @return {!Object} The service.
  */
 export function getExistingServiceForDoc(nodeOrDoc, id) {
-  if (getMode().localDev) {
-    const holder = getAmpdocServiceHolder(nodeOrDoc);
-    dev.assert(
-       holder.services && holder.services[id] &&
-       holder.services[id].obj,
-        'AmpDoc service does not exist %s', id);
-  }
   return getAmpdocServiceHolder(nodeOrDoc).services[id].obj;
 }
 
@@ -205,7 +195,7 @@ function getAmpdoc(nodeOrDoc) {
  */
 function getAmpdocServiceHolder(nodeOrDoc) {
   const ampdoc = getAmpdoc(nodeOrDoc);
-  return ampdoc.isSingleDoc() ? ampdoc.getWin() : ampdoc;
+  return ampdoc.isSingleDoc() ? ampdoc.win : ampdoc;
 }
 
 /**

--- a/src/service.js
+++ b/src/service.js
@@ -17,7 +17,6 @@
 // Requires polyfills in immediate side effect.
 import './polyfills';
 import {dev} from './log';
-import {getMode} from './mode';
 
 /**
  * Holds info about a service.

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -97,7 +97,7 @@ export class ActionService {
     this.globalMethodHandlers_ = {};
 
     /** @private {!./vsync-impl.Vsync} */
-    this.vsync_ = vsyncFor(ampdoc.getWin());
+    this.vsync_ = vsyncFor(ampdoc.win);
 
     // Add core events.
     this.addEvent('tap');

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -127,6 +127,14 @@ export class AmpDoc {
   }
 
   /**
+   * DO NOT CALL. Retained for backward compat during rollout.
+   * @return {!Window}
+   */
+  getWin() {
+    return dev.assert(null, 'not implemented');
+  }
+
+  /**
    * Locates an element with the specified ID within the ampdoc. In the
    * shadow-doc mode, when multiple documents could be present, this method
    * localizes search only to the DOM subtree specific to this ampdoc.
@@ -153,6 +161,11 @@ export class AmpDocSingle extends AmpDoc {
     super();
     /** @public @const {!Window} */
     this.win = win;
+  }
+
+  /** @override */
+  getWin() {
+    return this.win;
   }
 
   /** @override */
@@ -183,6 +196,11 @@ export class AmpDocShadow extends AmpDoc {
     this.win = win;
     /** @private @const {!ShadowRoot} */
     this.shadowRoot_ = shadowRoot;
+  }
+
+  /** @override */
+  getWin() {
+    return this.win;
   }
 
   /** @override */

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -116,13 +116,6 @@ export class AmpDoc {
   }
 
   /**
-   * @return {!Window}
-   */
-  getWin() {
-    return dev.assert(null, 'not implemented');
-  }
-
-  /**
    * Returns the root node for this ampdoc. It will either be a `Document` for
    * the single-doc runtime mode, or a `ShadowRoot` for shadow-doc mode. This
    * node can be used, among other things, to add ampdoc-wide event listeners.
@@ -158,18 +151,13 @@ export class AmpDocSingle extends AmpDoc {
    */
   constructor(win) {
     super();
-    /** @private @const {!Window} */
+    /** @public @const {!Window} */
     this.win = win;
   }
 
   /** @override */
   isSingleDoc() {
     return true;
-  }
-
-  /** @override */
-  getWin() {
-    return this.win;
   }
 
   /** @override */
@@ -200,11 +188,6 @@ export class AmpDocShadow extends AmpDoc {
   /** @override */
   isSingleDoc() {
     return false;
-  }
-
-  /** @override */
-  getWin() {
-    return this.win;
   }
 
   /** @override */

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -34,7 +34,7 @@ export class StandardActions {
     this.actions_ = installActionServiceForDoc(ampdoc);
 
     /** @const @private {!./resources-impl.Resources} */
-    this.resources_ = installResourcesService(ampdoc.getWin());
+    this.resources_ = installResourcesService(ampdoc.win);
 
     this.actions_.addGlobalMethodHandler('hide', this.handleHide.bind(this));
   }

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -49,7 +49,7 @@ export class BaseTemplate {
     this.element = element;
 
     /** @public @const */
-    this.win = this.element.ownerDocument.defaultView;
+    this.win = element.ownerDocument.defaultView;
 
     this.compileCallback();
   }

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -48,12 +48,10 @@ export class BaseTemplate {
     /** @public @const */
     this.element = element;
 
-    this.compileCallback();
-  }
+    /** @public @const */
+    this.win = this.element.ownerDocument.defaultView;
 
-  /** @protected @return {!Window} */
-  getWin() {
-    return this.element.ownerDocument.defaultView;
+    this.compileCallback();
   }
 
   /**

--- a/src/template.js
+++ b/src/template.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 
 /**
@@ -23,5 +23,5 @@ import {getService} from './service';
  */
 export function templatesFor(window) {
   return /** @type {!./service/template-impl.Templates} */ (
-      getService(window, 'templates'));
+      getExistingServiceForWindow(window, 'templates'));
 };

--- a/src/url-replacements.js
+++ b/src/url-replacements.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 
 /**
@@ -23,5 +23,5 @@ import {getService} from './service';
  */
 export function urlReplacementsFor(window) {
   return /** @type {!./service/url-replacements-impl.UrlReplacements} */ (
-      getService(window, 'url-replace'));
+      getExistingServiceForWindow(window, 'url-replace'));
 };

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 
 /**
@@ -23,5 +23,5 @@ import {getService} from './service';
  */
 export function viewerFor(window) {
   return /** @type {!./service/viewer-impl.Viewer} */ (
-      getService(window, 'viewer'));
+      getExistingServiceForWindow(window, 'viewer'));
 };

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 /**
  * @param {!Window} window
@@ -22,5 +22,5 @@ import {getService} from './service';
  */
 export function viewportFor(window) {
   return /** @type {!./service/viewport-impl.Viewport} */ (
-      getService(window, 'viewport'));
+      getExistingServiceForWindow(window, 'viewport'));
 };

--- a/src/vsync.js
+++ b/src/vsync.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 
 /**
@@ -23,5 +23,5 @@ import {getService} from './service';
  */
 export function vsyncFor(window) {
   return /** @type {!./service/vsync-impl.Vsync} */ (
-      getService(window, 'vsync'));
+      getExistingServiceForWindow(window, 'vsync'));
 };

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getService} from './service';
+import {getExistingServiceForWindow} from './service';
 
 
 /**
@@ -22,5 +22,6 @@ import {getService} from './service';
  * @return {!./service/xhr-impl.Xhr}
  */
 export function xhrFor(window) {
-  return /** @type {!./service/xhr-impl.Xhr} */ (getService(window, 'xhr'));
+  return /** @type {!./service/xhr-impl.Xhr} */ (
+      getExistingServiceForWindow(window, 'xhr'));
 };

--- a/test/functional/test-ampdoc.js
+++ b/test/functional/test-ampdoc.js
@@ -133,7 +133,7 @@ describe('AmpDocSingle', () => {
   });
 
   it('should return window', () => {
-    expect(ampdoc.getWin()).to.equal(window);
+    expect(ampdoc.win).to.equal(window);
   });
 
   it('should return document as root', () => {
@@ -170,7 +170,7 @@ describe('AmpDocShadow', () => {
     if (!ampdoc) {
       return;
     }
-    expect(ampdoc.getWin()).to.equal(window);
+    expect(ampdoc.win).to.equal(window);
     expect(ampdoc.isSingleDoc()).to.be.false;
   });
 

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -27,7 +27,7 @@ import {
 import * as sinon from 'sinon';
 
 
-describe('service', () => {
+describe.only('service', () => {
 
   let sandbox;
 

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -148,7 +148,7 @@ describe('service', () => {
       });
       ampdoc = {
         isSingleDoc: () => false,
-        getWin: () => windowApi,
+        win: windowApi,
       };
       ampdocMock = sandbox.mock(ampdoc);
       const ampdocServiceApi = {getAmpDoc: () => ampdoc};

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -16,6 +16,8 @@
 
 import {
   fromClass,
+  getExistingServiceForWindow,
+  getExistingServiceForDoc,
   getService,
   getServicePromise,
   getServiceForDoc,
@@ -95,6 +97,19 @@ describe('service', () => {
       expect(factory.callCount).to.equal(1);
     });
 
+    it('should return the service when it exists', () => {
+      const c1 = getService(window, 'c', factory);
+      const c2 = getExistingServiceForWindow(window, 'c');
+      expect(c1).to.equal(c2);
+    });
+
+    it('should throw before creation', () => {
+      getService(window, 'another service to avoid NPE', () => {});
+      expect(() => {
+        getExistingServiceForWindow(window, 'c');
+      }).to.throw(/Window service does not exist c/);
+    });
+
     it('should fail without factory on initial setup', () => {
       expect(() => {
         getService(window, 'not-present');
@@ -160,7 +175,9 @@ describe('service', () => {
 
       const b1 = getServiceForDoc(node, 'b', factory);
       const b2 = getServiceForDoc(node, 'b', factory);
+      const b3 = getExistingServiceForDoc(node, 'b');
       expect(b1).to.equal(b2);
+      expect(b1).to.equal(b3);
       expect(b1).to.not.equal(a1);
       expect(factory.callCount).to.equal(2);
       expect(factory.args[1][0]).to.equal(ampdoc);
@@ -173,7 +190,9 @@ describe('service', () => {
 
       const a1 = getServiceForDoc(ampdoc, 'a', factory);
       const a2 = getServiceForDoc(ampdoc, 'a', factory);
+      const a3 = getExistingServiceForDoc(ampdoc, 'a', factory);
       expect(a1).to.equal(a2);
+      expect(a1).to.equal(a3);
       expect(a1).to.equal(1);
       expect(factory.callCount).to.equal(1);
       expect(factory.args[0][0]).to.equal(ampdoc);

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -27,7 +27,7 @@ import {
 import * as sinon from 'sinon';
 
 
-describe.only('service', () => {
+describe('service', () => {
 
   let sandbox;
 
@@ -107,7 +107,7 @@ describe.only('service', () => {
       getService(window, 'another service to avoid NPE', () => {});
       expect(() => {
         getExistingServiceForWindow(window, 'c');
-      }).to.throw(/Window service does not exist c/);
+      }).to.throw();
     });
 
     it('should fail without factory on initial setup', () => {
@@ -146,13 +146,14 @@ describe.only('service', () => {
       factory = sandbox.spy(() => {
         return ++count;
       });
+      windowApi = {};
       ampdoc = {
         isSingleDoc: () => false,
         win: windowApi,
       };
       ampdocMock = sandbox.mock(ampdoc);
       const ampdocServiceApi = {getAmpDoc: () => ampdoc};
-      windowApi = {};
+
       getService(windowApi, 'ampdoc', () => ampdocServiceApi);
       node = {nodeType: 1, ownerDocument: {defaultView: windowApi}};
       resetServiceForTesting(windowApi, 'a');

--- a/test/functional/test-template.js
+++ b/test/functional/test-template.js
@@ -280,9 +280,15 @@ describe('Template', () => {
 
 describe('BaseTemplate', () => {
 
+  let templateElement;
+
+  beforeEach(() => {
+    templateElement = document.createElement('div');
+  });
+
   it('should require render override', () => {
     expect(() => {
-      new BaseTemplate().render();
+      new BaseTemplate(templateElement).render();
     }).to.throw(/Not implemented/);
   });
 
@@ -290,7 +296,7 @@ describe('BaseTemplate', () => {
     const root = document.createElement('div');
     const element1 = document.createElement('div');
     root.appendChild(element1);
-    expect(new BaseTemplate().unwrap(root)).to.equal(element1);
+    expect(new BaseTemplate(templateElement).unwrap(root)).to.equal(element1);
   });
 
   it('should unwrap with empty/whitespace text', () => {
@@ -299,20 +305,20 @@ describe('BaseTemplate', () => {
     root.appendChild(document.createTextNode('   '));
     root.appendChild(element1);
     root.appendChild(document.createTextNode(' \n\t  '));
-    expect(new BaseTemplate().unwrap(root)).to.equal(element1);
+    expect(new BaseTemplate(templateElement).unwrap(root)).to.equal(element1);
   });
 
   it('should NOT unwrap multiple elements', () => {
     const root = document.createElement('div');
     root.appendChild(document.createElement('div'));
     root.appendChild(document.createElement('div'));
-    expect(new BaseTemplate().unwrap(root)).to.equal(root);
+    expect(new BaseTemplate(templateElement).unwrap(root)).to.equal(root);
   });
 
   it('should NOT unwrap with non-empty/whitespace text', () => {
     const root = document.createElement('div');
     root.appendChild(document.createTextNode('a'));
     root.appendChild(document.createElement('div'));
-    expect(new BaseTemplate().unwrap(root)).to.equal(root);
+    expect(new BaseTemplate(templateElement).unwrap(root)).to.equal(root);
   });
 });

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,52 +1,52 @@
       max   |         min   |       gzip   |   file
       ---   |         ---   |        ---   |   ---
  58.37 kB   |     5.47 kB   |    2.36 kB   |   alp.js / alp.max.js
-696.08 kB   |   131.36 kB   |   41.38 kB   |   shadow-v0.js / amp-shadow.js
-727.87 kB   |   137.15 kB   |   43.33 kB   |   v0.js / amp.js
-280.24 kB   |     6.89 kB   |    3.04 kB   |   v0/amp-a4a-0.1.js
-248.79 kB   |    34.46 kB   |   12.07 kB   |   v0/amp-access-0.1.js
- 45.41 kB   |     6.13 kB   |    2.48 kB   |   v0/amp-accordion-0.1.js
-254.34 kB   |    31.06 kB   |   11.45 kB   |   v0/amp-ad-0.1.js
-303.18 kB   |     32.5 kB   |      12 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-298.69 kB   |    31.23 kB   |   11.62 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-270.33 kB   |    58.09 kB   |   21.09 kB   |   v0/amp-analytics-0.1.js
- 99.78 kB   |     8.25 kB   |    3.44 kB   |   v0/amp-anim-0.1.js
- 98.36 kB   |     6.71 kB   |    2.89 kB   |   v0/amp-audio-0.1.js
- 91.67 kB   |     7.61 kB   |     3.1 kB   |   v0/amp-brid-player-0.1.js
-116.71 kB   |     7.42 kB   |    3.03 kB   |   v0/amp-brightcove-0.1.js
-225.92 kB   |    32.02 kB   |   10.41 kB   |   v0/amp-carousel-0.1.js
-  84.2 kB   |      6.3 kB   |     2.7 kB   |   v0/amp-dailymotion-0.1.js
- 99.49 kB   |     4.73 kB   |    2.13 kB   |   v0/amp-dynamic-css-classes-0.1.js
-116.77 kB   |     8.65 kB   |    3.58 kB   |   v0/amp-experiment-0.1.js
-159.34 kB   |    15.15 kB   |    6.21 kB   |   v0/amp-facebook-0.1.js
+696.55 kB   |   131.19 kB   |   41.36 kB   |   shadow-v0.js / amp-shadow.js
+728.37 kB   |      137 kB   |    43.3 kB   |   v0.js / amp.js
+281.11 kB   |     6.89 kB   |    3.04 kB   |   v0/amp-a4a-0.1.js
+249.82 kB   |    34.55 kB   |   12.08 kB   |   v0/amp-access-0.1.js
+  45.4 kB   |     6.13 kB   |    2.48 kB   |   v0/amp-accordion-0.1.js
+ 255.2 kB   |    31.06 kB   |   11.44 kB   |   v0/amp-ad-0.1.js
+304.02 kB   |    32.46 kB   |   12.01 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+299.54 kB   |    31.19 kB   |   11.62 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+271.25 kB   |    58.12 kB   |   21.11 kB   |   v0/amp-analytics-0.1.js
+100.66 kB   |     8.25 kB   |    3.44 kB   |   v0/amp-anim-0.1.js
+ 99.24 kB   |     6.71 kB   |    2.89 kB   |   v0/amp-audio-0.1.js
+ 92.55 kB   |     7.61 kB   |     3.1 kB   |   v0/amp-brid-player-0.1.js
+117.59 kB   |     7.42 kB   |    3.02 kB   |   v0/amp-brightcove-0.1.js
+226.81 kB   |    31.95 kB   |   10.39 kB   |   v0/amp-carousel-0.1.js
+ 85.08 kB   |      6.3 kB   |     2.7 kB   |   v0/amp-dailymotion-0.1.js
+ 100.4 kB   |     4.78 kB   |    2.13 kB   |   v0/amp-dynamic-css-classes-0.1.js
+117.62 kB   |     8.63 kB   |    3.57 kB   |   v0/amp-experiment-0.1.js
+160.25 kB   |    15.13 kB   |    6.21 kB   |   v0/amp-facebook-0.1.js
  35.27 kB   |     5.71 kB   |    2.44 kB   |   v0/amp-fit-text-0.1.js
-107.89 kB   |     7.76 kB   |    3.19 kB   |   v0/amp-font-0.1.js
- 147.7 kB   |    12.43 kB   |    4.97 kB   |   v0/amp-form-0.1.js
- 97.04 kB   |     7.88 kB   |    3.18 kB   |   v0/amp-fx-flying-carpet-0.1.js
-109.56 kB   |     8.22 kB   |     3.4 kB   |   v0/amp-google-vrview-image-0.1.js
-155.31 kB   |    14.26 kB   |    5.73 kB   |   v0/amp-iframe-0.1.js
-236.64 kB   |    31.21 kB   |    10.3 kB   |   v0/amp-image-lightbox-0.1.js
-110.47 kB   |     7.18 kB   |    3.02 kB   |   v0/amp-instagram-0.1.js
- 90.75 kB   |     7.92 kB   |    3.38 kB   |   v0/amp-install-serviceworker-0.1.js
-  91.1 kB   |     7.08 kB   |    2.98 kB   |   v0/amp-jwplayer-0.1.js
- 122.1 kB   |     8.17 kB   |    3.36 kB   |   v0/amp-kaltura-player-0.1.js
-145.12 kB   |    11.66 kB   |    4.41 kB   |   v0/amp-lightbox-0.1.js
- 91.78 kB   |     5.73 kB   |    2.52 kB   |   v0/amp-list-0.1.js
- 159.5 kB   |    13.16 kB   |    5.02 kB   |   v0/amp-live-list-0.1.js
-146.23 kB   |    39.62 kB   |   14.24 kB   |   v0/amp-mustache-0.1.js
- 84.32 kB   |     6.47 kB   |    2.75 kB   |   v0/amp-o2-player-0.1.js
-132.33 kB   |    20.08 kB   |    6.03 kB   |   v0/amp-pinterest-0.1.js
- 83.31 kB   |     5.96 kB   |    2.55 kB   |   v0/amp-reach-player-0.1.js
- 79.38 kB   |     5.44 kB   |     2.3 kB   |   v0/amp-share-tracking-0.1.js
- 96.49 kB   |     9.86 kB   |    3.72 kB   |   v0/amp-sidebar-0.1.js
-114.07 kB   |    10.77 kB   |    4.26 kB   |   v0/amp-slides-0.1.js
-112.26 kB   |    11.02 kB   |    4.24 kB   |   v0/amp-social-share-0.1.js
- 83.89 kB   |     6.08 kB   |    2.59 kB   |   v0/amp-soundcloud-0.1.js
- 91.93 kB   |     7.78 kB   |    3.09 kB   |   v0/amp-springboard-player-0.1.js
-107.78 kB   |     7.91 kB   |    3.22 kB   |   v0/amp-sticky-ad-0.1.js
-159.76 kB   |    15.23 kB   |    6.25 kB   |   v0/amp-twitter-0.1.js
-119.15 kB   |     9.98 kB   |    3.95 kB   |   v0/amp-user-notification-0.1.js
- 83.81 kB   |     6.05 kB   |    2.59 kB   |   v0/amp-vimeo-0.1.js
- 83.34 kB   |     5.91 kB   |    2.55 kB   |   v0/amp-vine-0.1.js
-128.96 kB   |     8.62 kB   |    3.59 kB   |   v0/amp-youtube-0.1.js
+108.77 kB   |     7.66 kB   |    3.15 kB   |   v0/amp-font-0.1.js
+148.65 kB   |    12.46 kB   |    4.97 kB   |   v0/amp-form-0.1.js
+ 97.92 kB   |     7.87 kB   |    3.17 kB   |   v0/amp-fx-flying-carpet-0.1.js
+110.43 kB   |     8.21 kB   |     3.4 kB   |   v0/amp-google-vrview-image-0.1.js
+156.18 kB   |    14.25 kB   |    5.73 kB   |   v0/amp-iframe-0.1.js
+237.54 kB   |    31.13 kB   |   10.26 kB   |   v0/amp-image-lightbox-0.1.js
+111.34 kB   |     7.17 kB   |    3.02 kB   |   v0/amp-instagram-0.1.js
+ 91.63 kB   |     7.91 kB   |    3.38 kB   |   v0/amp-install-serviceworker-0.1.js
+ 91.98 kB   |     7.08 kB   |    2.98 kB   |   v0/amp-jwplayer-0.1.js
+122.98 kB   |     8.17 kB   |    3.36 kB   |   v0/amp-kaltura-player-0.1.js
+146.01 kB   |    11.57 kB   |    4.37 kB   |   v0/amp-lightbox-0.1.js
+ 92.69 kB   |     5.55 kB   |    2.44 kB   |   v0/amp-list-0.1.js
+160.43 kB   |    13.08 kB   |    4.98 kB   |   v0/amp-live-list-0.1.js
+146.23 kB   |    39.61 kB   |   14.24 kB   |   v0/amp-mustache-0.1.js
+  85.2 kB   |     6.47 kB   |    2.75 kB   |   v0/amp-o2-player-0.1.js
+133.23 kB   |    19.92 kB   |    5.97 kB   |   v0/amp-pinterest-0.1.js
+ 84.19 kB   |     5.96 kB   |    2.55 kB   |   v0/amp-reach-player-0.1.js
+ 80.26 kB   |     5.44 kB   |     2.3 kB   |   v0/amp-share-tracking-0.1.js
+ 97.39 kB   |     9.82 kB   |     3.7 kB   |   v0/amp-sidebar-0.1.js
+114.97 kB   |    10.73 kB   |    4.25 kB   |   v0/amp-slides-0.1.js
+113.15 kB   |    10.82 kB   |    4.16 kB   |   v0/amp-social-share-0.1.js
+ 84.77 kB   |     6.08 kB   |    2.59 kB   |   v0/amp-soundcloud-0.1.js
+ 92.81 kB   |     7.78 kB   |    3.09 kB   |   v0/amp-springboard-player-0.1.js
+108.65 kB   |     7.91 kB   |    3.21 kB   |   v0/amp-sticky-ad-0.1.js
+160.67 kB   |    15.25 kB   |    6.25 kB   |   v0/amp-twitter-0.1.js
+120.08 kB   |     9.94 kB   |    3.92 kB   |   v0/amp-user-notification-0.1.js
+ 84.69 kB   |     6.05 kB   |    2.59 kB   |   v0/amp-vimeo-0.1.js
+ 84.22 kB   |     5.91 kB   |    2.55 kB   |   v0/amp-vine-0.1.js
+129.84 kB   |     8.62 kB   |    3.58 kB   |   v0/amp-youtube-0.1.js
 173.15 kB   |    38.29 kB   |   13.37 kB   |   current-min/f.js / current/integration.js


### PR DESCRIPTION
Functions such as `viewportFor(win)` can now be inlined as `win.services.viewport.obj`.

Changes the method `getWin()` to use a property access in all places

- Main trade off is that caching the window will break when a DOM node moves windows. That should never happen, though :)
- Closure Compiler knows that property access is side effect free (we promised it), so it can more aggressively inline.
- This should actually be a major speed up in itself, as it avoid 2 trips into C++ per window lookup.

Great idea @erwinmombay, @dvoytenko 