### PR TITLE
Amp slidescroll experiment - Using touch end to load the next slide faster on IOS.

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -27,7 +27,7 @@ const SHOWN_CSS_CLASS = '-amp-slide-item-show';
 const NATIVE_SNAP_TIMEOUT = 35;
 
 /** @const {number} */
-const NATIVE_TOUCH_TIMEOUT = 100;
+const NATIVE_TOUCH_TIMEOUT = 120;
 
 /** @const {number} */
 const CUSTOM_SNAP_TIMEOUT = 100;
@@ -98,8 +98,8 @@ export class AmpSlideScroll extends BaseCarousel {
     /** @private {?number} */
     this.touchEndTimeout_ = null;
 
-    /** @private {?boolean} */
-    this.hasTouchMoved_ = null;
+    /** @private {boolean} */
+    this.hasTouchMoved_ = false;
 
     /**
      * 0 - not in an elastic state.
@@ -112,7 +112,7 @@ export class AmpSlideScroll extends BaseCarousel {
     this.slidesContainer_.addEventListener(
         'scroll', this.scrollHandler_.bind(this));
 
-    if(this.hasNativeSnapPoints_) {
+    if (this.hasNativeSnapPoints_) {
       this.slidesContainer_.addEventListener(
           'touchend', this.touchEndHandler_.bind(this));
 
@@ -123,6 +123,9 @@ export class AmpSlideScroll extends BaseCarousel {
 
   touchMoveHandler_() {
     this.hasTouchMoved_ = true;
+    if (this.touchEndTimeout_) {
+      timer.cancel(this.touchEndTimeout_);
+    }
   }
 
   touchEndHandler_() {
@@ -132,7 +135,7 @@ export class AmpSlideScroll extends BaseCarousel {
       }
       // Timer that detects scroll end and/or end of snap scroll.
       this.touchEndTimeout_ = timer.delay(() => {
-        const currentScrollLeft = this.slidesContainer_./*REVIEW*/scrollLeft;
+        const currentScrollLeft = this.slidesContainer_./*OK*/scrollLeft;
 
         if (this.snappingInProgress_) {
           return;
@@ -141,7 +144,7 @@ export class AmpSlideScroll extends BaseCarousel {
         this.touchEndTimeout_ = null;
       }, NATIVE_TOUCH_TIMEOUT);
     }
-    this.hasTouchMoved_ = null;
+    this.hasTouchMoved_ = false;
   }
 
   /** @override */
@@ -216,7 +219,6 @@ export class AmpSlideScroll extends BaseCarousel {
     }
 
     const currentScrollLeft = this.slidesContainer_./*OK*/scrollLeft;
-    console.log(this.element.id, 'scrolling at ' + currentScrollLeft);
     if (!this.hasNativeSnapPoints_) {
       this.handleCustomElasticScroll_(currentScrollLeft);
     }
@@ -226,7 +228,6 @@ export class AmpSlideScroll extends BaseCarousel {
           this.hasNativeSnapPoints_ ? NATIVE_SNAP_TIMEOUT : CUSTOM_SNAP_TIMEOUT;
       // Timer that detects scroll end and/or end of snap scroll.
       this.scrollTimeout_ = timer.delay(() => {
-        console.log(this.element.id, 'scroll Ended at ' + currentScrollLeft);
 
         if (this.snappingInProgress_) {
           return;

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -15,7 +15,9 @@
  */
 import {Animation} from '../../../src/animation';
 import {BaseCarousel} from './base-carousel';
+import {Gestures} from '../../../src/gesture';
 import {Layout} from '../../../src/layout';
+import {SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {getStyle, setStyle} from '../../../src/style';
 import {numeric} from '../../../src/transition';
 import {timer} from '../../../src/timer';
@@ -108,6 +110,11 @@ export class AmpSlideScroll extends BaseCarousel {
      * @private {number}
      */
     this.elasticScrollState_ = 0;
+
+
+    const gestures =
+        Gestures.get(this.element, /* shouldNotPreventDefault */true);
+    gestures.onGesture(SwipeXRecognizer, () => {});
 
     this.slidesContainer_.addEventListener(
         'scroll', this.scrollHandler_.bind(this));

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -64,12 +64,13 @@ export class Gestures {
    * Creates if not yet created and returns the shared Gestures instance for
    * the specified element.
    * @param {!Element} element
+   * @param {boolean=} shouldPreventDefault
    * @return {!Gestures}
    */
-  static get(element) {
+  static get(element, shouldNotPreventDefault = false) {
     let res = element[PROP_];
     if (!res) {
-      res = new Gestures(element);
+      res = new Gestures(element, shouldNotPreventDefault);
       element[PROP_] = res;
     }
     return res;
@@ -78,7 +79,7 @@ export class Gestures {
   /**
    * @param {!Element} element
    */
-  constructor(element) {
+  constructor(element, shouldNotPreventDefault) {
     /** @private {!Element} */
     this.element_ = element;
 
@@ -96,6 +97,9 @@ export class Gestures {
 
     /** @private {?GestureRecognizer} */
     this.eventing_ = null;
+
+    /** @private {boolean} */
+    this.shouldNotPreventDefault_ = shouldNotPreventDefault;
 
     /**
      * This variable indicates that the eventing has stopped on this
@@ -379,7 +383,9 @@ export class Gestures {
     }
     if (cancelEvent) {
       event.stopPropagation();
-      event.preventDefault();
+      if (!this.shouldNotPreventDefault_) {
+        event.preventDefault();
+      }
     }
     if (this.passAfterEvent_) {
       this.passAfterEvent_ = false;

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -351,4 +351,108 @@ describe('Gestures', () => {
     expect(event.preventDefault.callCount).to.equal(0);
     expect(event.stopPropagation.callCount).to.equal(0);
   });
+
+  describe('Gestures - with shouldNotPreventdefault', () => {
+    let sandbox;
+    let element;
+    let clock;
+    let recognizer;
+    let recognizerMock;
+    let gestures;
+    let eventListeners;
+    let onGesture;
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      clock = sandbox.useFakeTimers();
+
+      eventListeners = {};
+      element = {
+        addEventListener: (eventType, handler) => {
+          eventListeners[eventType] = handler;
+        },
+        ownerDocument: {
+          defaultView: window,
+        },
+      };
+
+      onGesture = sandbox.spy();
+
+      gestures = new Gestures(element, /* shouldNotPreventDefault */true);
+      gestures.onGesture(TestRecognizer, onGesture);
+      expect(gestures.recognizers_.length).to.equal(1);
+      recognizer = gestures.recognizers_[0];
+      recognizerMock = sandbox.mock(recognizer);
+    });
+
+    afterEach(() => {
+      recognizerMock.verify();
+      sandbox.restore();
+    });
+
+    it('should cancel event when eventing', () => {
+      gestures.eventing_ = recognizer;
+      const event = {
+        type: 'touchend',
+        preventDefault: sandbox.spy(),
+        stopPropagation: sandbox.spy(),
+      };
+      eventListeners[event.type](event);
+      expect(event.preventDefault.callCount).to.equal(0);
+      expect(event.stopPropagation.callCount).to.equal(1);
+    });
+
+    it('should cancel event after eventing stopped', () => {
+      gestures.eventing_ = recognizer;
+      gestures.signalEnd_(recognizer);
+      expect(gestures.eventing_).to.equal(null);
+      expect(gestures.wasEventing_).to.equal(true);
+
+      const event = {
+        type: 'touchend',
+        preventDefault: sandbox.spy(),
+        stopPropagation: sandbox.spy(),
+      };
+      eventListeners[event.type](event);
+      expect(event.preventDefault.callCount).to.equal(0);
+      expect(event.stopPropagation.callCount).to.equal(1);
+      expect(gestures.wasEventing_).to.equal(false);
+    });
+
+    it('should cancel event when anyone is ready', () => {
+      gestures.ready_[0] = 1;
+      const event = {
+        type: 'touchend',
+        preventDefault: sandbox.spy(),
+        stopPropagation: sandbox.spy(),
+      };
+      eventListeners[event.type](event);
+      expect(event.preventDefault.callCount).to.equal(0);
+      expect(event.stopPropagation.callCount).to.equal(1);
+    });
+
+    it('should cancel event when anyone is pending', () => {
+      gestures.pending_[0] = 1;
+      let event = {
+        type: 'touchend',
+        preventDefault: sandbox.spy(),
+        stopPropagation: sandbox.spy(),
+      };
+      eventListeners[event.type](event);
+      expect(event.preventDefault.callCount).to.equal(0);
+      expect(event.stopPropagation.callCount).to.equal(1);
+
+      clock.tick(10);
+      event = {
+        type: 'touchend',
+        preventDefault: sandbox.spy(),
+        stopPropagation: sandbox.spy(),
+      };
+      eventListeners[event.type](event);
+      expect(event.preventDefault.callCount).to.equal(0);
+      expect(event.stopPropagation.callCount).to.equal(0);
+    });
+
+  });
+
 });

--- a/test/manual/amp-slidescroll.amp.html
+++ b/test/manual/amp-slidescroll.amp.html
@@ -31,6 +31,7 @@
 </head>
 <body>
   <h1>amp #0</h1>
+  <button onclick="AMP.toggleExperiment('amp-slidescroll');window.location.href=window.location.href;">Toggle Experiment</button>
   <h1>No Loops for you</h1>
   <amp-carousel id="carousel-1" width=400 height=300 type=slides controls>
     <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" layout=fill></amp-img>


### PR DESCRIPTION

**In this PR**

- detect scroll end when touchend is available and use timeout as a backup (this should fix IOS elasticity issue 90% of the times)

**Yet to come**

- Move autoplay to base template.
- Hide scrollbars where possible (and yet allow scrolling)

Part 8 for - #3465