### PR TITLE
Fix for video not pausing on subsequent plays when inside lightbox, sidebar or carousel.

### DIFF
--- a/extensions/amp-carousel/0.1/carousel.js
+++ b/extensions/amp-carousel/0.1/carousel.js
@@ -155,6 +155,7 @@ export class AmpCarousel extends BaseCarousel {
   doLayout_(pos) {
     this.withinWindow_(pos, cell => {
       this.scheduleLayout(cell);
+      this.scheduleResume(cell);
     });
   }
 

--- a/extensions/amp-carousel/0.1/slides.js
+++ b/extensions/amp-carousel/0.1/slides.js
@@ -247,6 +247,7 @@ export class AmpSlides extends BaseCarousel {
     this.updateInViewport(oldSlide, false);
     this.updateInViewport(newSlide, true);
     this.scheduleLayout(newSlide);
+    this.scheduleResume(newSlide);
     this.setControlsState();
     this.schedulePause(oldSlide);
   }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -354,6 +354,7 @@ export class AmpSlideScroll extends BaseCarousel {
       this.slideWrappers_[showIndex].classList.add(SHOWN_CSS_CLASS);
       if (showIndex == newIndex) {
         this.scheduleLayout(this.slides_[showIndex]);
+        this.scheduleResume(this.slides_[showIndex]);
       } else {
         this.schedulePreload(this.slides_[showIndex]);
       }

--- a/extensions/amp-carousel/0.1/test/test-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slides.js
@@ -772,6 +772,7 @@ describe('Slides functional', () => {
       slides.scheduleLayout = sandbox.spy();
       slides.updateInViewport = sandbox.spy();
       slides.schedulePause = sandbox.spy();
+      slides.scheduleResume = sandbox.spy();
       slides.schedulePreload = sandbox.spy();
       sandbox.stub(Animation, 'animate', () => {
         return {
@@ -817,6 +818,7 @@ describe('Slides functional', () => {
       slides.scheduleLayout = sandbox.spy();
       slides.updateInViewport = sandbox.spy();
       slides.schedulePause = sandbox.spy();
+      slides.scheduleResume = sandbox.spy();
       slides.schedulePreload = sandbox.spy();
       sandbox.stub(Animation, 'animate', () => {
         return {
@@ -862,6 +864,19 @@ describe('Slides functional', () => {
       expect(slide2.style.visibility).to.be.equal('hidden');
       expect(slides.scheduleLayout.calledWith(slide0)).to.be.true;
       expect(slides.schedulePreload.calledWith(slide2)).to.be.true;
+    });
+
+    it('should pause hidden slides and resume visible ones', () => {
+      expect(slides.schedulePause.callCount).to.equal(0);
+      expect(slides.scheduleResume.callCount).to.equal(0);
+
+      slides.goCallback(1, /*animate*/ true);
+      expect(slides.schedulePause.withArgs(slide0).callCount).to.equal(1);
+      expect(slides.scheduleResume.withArgs(slide1).callCount).to.equal(1);
+
+      slides.goCallback(-1, /*animate*/ false);
+      expect(slides.schedulePause.withArgs(slide1).callCount).to.equal(1);
+      expect(slides.scheduleResume.withArgs(slide0).callCount).to.equal(1);
     });
   });
 });

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -59,6 +59,9 @@ class AmpLightbox extends AMP.BaseElement {
 
     /** @private {number} */
     this.historyId_ = -1;
+
+    /** @private {boolean} */
+    this.active_ = false;
   }
 
   /** @override */
@@ -68,6 +71,9 @@ class AmpLightbox extends AMP.BaseElement {
 
   /** @override */
   activate() {
+    if (this.active_) {
+      return;
+    }
     /**  @private {function(this:AmpLightbox, Event)}*/
     this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
     this.getWin().document.documentElement.addEventListener(
@@ -91,6 +97,8 @@ class AmpLightbox extends AMP.BaseElement {
     this.getHistory_().push(this.close.bind(this)).then(historyId => {
       this.historyId_ = historyId;
     });
+
+    this.active_ = true;
   }
 
   /**
@@ -105,6 +113,9 @@ class AmpLightbox extends AMP.BaseElement {
   }
 
   close() {
+    if (!this.active_) {
+      return;
+    }
     this.getViewport().leaveLightboxMode();
     this.element.style.display = 'none';
     if (this.historyId_ != -1) {
@@ -114,6 +125,7 @@ class AmpLightbox extends AMP.BaseElement {
         'keydown', this.boundCloseOnEscape_);
     this.boundCloseOnEscape_ = null;
     this.schedulePause(this.container_);
+    this.active_ = false;
   }
 
   getHistory_() {

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -85,6 +85,7 @@ class AmpLightbox extends AMP.BaseElement {
     }).then(() => {
       this.updateInViewport(this.container_, true);
       this.scheduleLayout(this.container_);
+      this.scheduleResume(this.container_);
     });
 
     this.getHistory_().push(this.close.bind(this)).then(historyId => {

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -145,7 +145,9 @@ export class AmpSidebar extends AMP.BaseElement {
         this.element.setAttribute('open', '');
         this.element.setAttribute('aria-hidden', 'false');
         timer.delay(() => {
-          this.scheduleLayout(this.getRealChildren());
+          const children = this.getRealChildren();
+          this.scheduleLayout(children);
+          this.scheduleResume(children);
         }, ANIMATION_TIMEOUT);
       });
     });

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -236,6 +236,8 @@ describe('amp-sidebar', () => {
     return getAmpSidebar().then(obj => {
       const sidebarElement = obj.ampSidebar;
       const impl = sidebarElement.implementation_;
+      impl.schedulePause = sandbox.spy();
+      impl.scheduleResume = sandbox.spy();
       impl.vsync_ = {
         mutate: function(callback) {
           callback();
@@ -245,10 +247,24 @@ describe('amp-sidebar', () => {
         callback();
       });
       expect(impl.isOpen_()).to.be.false;
+      expect(impl.schedulePause.callCount).to.equal(0);
+      expect(impl.scheduleResume.callCount).to.equal(0);
       impl.toggle_();
       expect(impl.isOpen_()).to.be.true;
+      expect(impl.schedulePause.callCount).to.equal(0);
+      expect(impl.scheduleResume.callCount).to.equal(1);
       impl.toggle_();
       expect(impl.isOpen_()).to.be.false;
+      expect(impl.schedulePause.callCount).to.equal(1);
+      expect(impl.scheduleResume.callCount).to.equal(1);
+      impl.toggle_();
+      expect(impl.isOpen_()).to.be.true;
+      expect(impl.schedulePause.callCount).to.equal(1);
+      expect(impl.scheduleResume.callCount).to.equal(2);
+      impl.toggle_();
+      expect(impl.isOpen_()).to.be.false;
+      expect(impl.schedulePause.callCount).to.equal(2);
+      expect(impl.scheduleResume.callCount).to.equal(2);
     });
   });
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -601,6 +601,14 @@ export class BaseElement {
   }
 
   /**
+   * @param {!Element|!Array<!Element>} elements
+   * @protected
+   */
+  scheduleResume(elements) {
+    this.resources_.scheduleResume(this.element, elements);
+  }
+  
+  /**
    * Schedule the preload request for the children element or elements
    * specified. Resource manager will perform the actual preload based on the
    * priority of this element and its children.

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -607,7 +607,7 @@ export class BaseElement {
   scheduleResume(elements) {
     this.resources_.scheduleResume(this.element, elements);
   }
-  
+
   /**
    * Schedule the preload request for the children element or elements
    * specified. Resource manager will perform the actual preload based on the

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -631,7 +631,7 @@ export class Resource {
   pause() {
     if (this.state_ == ResourceState.NOT_BUILT || this.paused_) {
       if (this.paused_) {
-        dev.warn(TAG, 'pause() called on an already paused resource:',
+        dev.error(TAG, 'pause() called on an already paused resource:',
           this.debugid);
       }
       return;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -630,6 +630,10 @@ export class Resource {
    */
   pause() {
     if (this.state_ == ResourceState.NOT_BUILT || this.paused_) {
+      if (this.paused_) {
+        dev.warn(TAG, 'pause() called on an already paused resource:',
+          this.debugid);
+      }
       return;
     }
     this.paused_ = true;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -453,6 +453,7 @@ export class Resources {
   /**
    * Invokes `unload` on the elements' resource which in turn will invoke
    * the `documentBecameInactive` callback on the custom element.
+   * Resources that call `schedulePause` must also call `scheduleResume`.
    * @param {!Element} parentElement
    * @param {!Element|!Array<!Element>} subElements
    */
@@ -462,6 +463,22 @@ export class Resources {
 
     this.discoverResourcesForArray_(parentResource, subElements, resource => {
       resource.pause();
+    });
+  }
+
+  /**
+   * Invokes `resume` on the elements' resource which in turn will invoke
+   * `resumeCallback` only on paused custom elements.
+   * Resources that call `schedulePause` must also call `scheduleResume`.
+   * @param {!Element} parentElement
+   * @param {!Element|!Array<!Element>} subElements
+   */
+  scheduleResume(parentElement, subElements) {
+    const parentResource = Resource.forElement(parentElement);
+    subElements = elements_(subElements);
+
+    this.discoverResourcesForArray_(parentResource, subElements, resource => {
+      resource.resume();
     });
   }
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -409,7 +409,7 @@ describe('Resources pause/resume scheduling', () => {
       }).to.not.throw();
     });
 
-    it('should call resumeCallback on puased custom elements', () => {
+    it('should call resumeCallback on paused custom elements', () => {
       const stub1 = sandbox.stub(child1, 'resumeCallback');
 
       resources.scheduleResume(parent, children);

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -360,6 +360,7 @@ describe('Resources pause/resume scheduling', () => {
     it('should be ok with non amp children', () => {
       expect(() => {
         resources.schedulePause(parent, children);
+        resources.schedulePause(parent, child0);
       }).to.not.throw();
     });
 
@@ -404,6 +405,7 @@ describe('Resources pause/resume scheduling', () => {
     it('should be ok with non amp children', () => {
       expect(() => {
         resources.scheduleResume(parent, children);
+        resources.scheduleResume(parent, child0);
       }).to.not.throw();
     });
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -273,7 +273,7 @@ describe('Resources', () => {
   });
 });
 
-describe('Resources schedulePause', () => {
+describe('Resources pause/resume scheduling', () => {
 
   let sandbox;
   let resources;
@@ -306,6 +306,8 @@ describe('Resources schedulePause', () => {
       getPlaceholder() {
       },
       pauseCallback() {
+      },
+      resumeCallback() {
       },
       unlayoutCallback() {
         return false;
@@ -342,45 +344,84 @@ describe('Resources schedulePause', () => {
     sandbox.restore();
   });
 
-  it('should not throw with a single element', () => {
-    expect(() => {
-      resources.schedulePause(parent, child1);
-    }).to.not.throw();
-  });
+  describe('schedulePause', () => {
+    it('should not throw with a single element', () => {
+      expect(() => {
+        resources.schedulePause(parent, child1);
+      }).to.not.throw();
+    });
 
-  it('should not throw with an array of elements', () => {
-    expect(() => {
-      resources.schedulePause(parent, [child1, child2]);
-    }).to.not.throw();
-  });
+    it('should not throw with an array of elements', () => {
+      expect(() => {
+        resources.schedulePause(parent, [child1, child2]);
+      }).to.not.throw();
+    });
 
-  it('should be ok with non amp children', () => {
-    expect(() => {
+    it('should be ok with non amp children', () => {
+      expect(() => {
+        resources.schedulePause(parent, children);
+      }).to.not.throw();
+    });
+
+    it('should call pauseCallback on custom element', () => {
+      const stub1 = sandbox.stub(child1, 'pauseCallback');
+      const stub2 = sandbox.stub(child2, 'pauseCallback');
+
       resources.schedulePause(parent, children);
-    }).to.not.throw();
+      expect(stub1.calledOnce).to.be.true;
+      expect(stub2.calledOnce).to.be.true;
+    });
+
+    it('should call unlayoutCallback when unlayoutOnPause', () => {
+      const stub1 = sandbox.stub(child1, 'unlayoutCallback');
+      const stub2 = sandbox.stub(child2, 'unlayoutCallback');
+      sandbox.stub(child1, 'unlayoutOnPause').returns(true);
+
+      resources.schedulePause(parent, children);
+      expect(stub1.calledOnce).to.be.true;
+      expect(stub2.calledOnce).to.be.false;
+    });
   });
 
-  it('should call pauseCallback on custom element', () => {
-    const stub1 = sandbox.stub(child1, 'pauseCallback');
-    const stub2 = sandbox.stub(child2, 'pauseCallback');
+  describe('scheduleResume', () => {
+    beforeEach(() => {
+      // Pause one child.
+      resources.schedulePause(parent, child1);
+    });
 
-    resources.schedulePause(parent, children);
-    expect(stub1.calledOnce).to.be.true;
-    expect(stub2.calledOnce).to.be.true;
+    it('should not throw with a single element', () => {
+      expect(() => {
+        resources.scheduleResume(parent, child1);
+      }).to.not.throw();
+    });
+
+    it('should not throw with an array of elements', () => {
+      expect(() => {
+        resources.scheduleResume(parent, [child1, child2]);
+      }).to.not.throw();
+    });
+
+    it('should be ok with non amp children', () => {
+      expect(() => {
+        resources.scheduleResume(parent, children);
+      }).to.not.throw();
+    });
+
+    it('should call resumeCallback on puased custom elements', () => {
+      const stub1 = sandbox.stub(child1, 'resumeCallback');
+
+      resources.scheduleResume(parent, children);
+      expect(stub1.calledOnce).to.be.true;
+    });
+
+    it('should not call resumeCallback on non-paused custom elements', () => {
+      const stub2 = sandbox.stub(child2, 'resumeCallback');
+
+      resources.scheduleResume(parent, children);
+      expect(stub2.calledOnce).to.be.false;
+    });
   });
-
-  it('should call unlayoutCallback when unlayoutOnPause', () => {
-    const stub1 = sandbox.stub(child1, 'unlayoutCallback');
-    const stub2 = sandbox.stub(child2, 'unlayoutCallback');
-    sandbox.stub(child1, 'unlayoutOnPause').returns(true);
-
-    resources.schedulePause(parent, children);
-    expect(stub1.calledOnce).to.be.true;
-    expect(stub2.calledOnce).to.be.false;
-  });
-
 });
-
 
 describe('Resources schedulePreload', () => {
 

--- a/test/manual/amp-sidebar.amp.html
+++ b/test/manual/amp-sidebar.amp.html
@@ -240,6 +240,9 @@
         </ul>
       </section>
     </amp-accordion>
+    <amp-youtube layout="responsive" data-videoid="lBTCB7yLs8Y"
+      width="480" height="270">
+    </amp-youtube>
     <amp-list width="396" height="80" layout=fixed
       src="/test/manual/amp-list-data.json?RANDOM">
       <template type="amp-mustache">


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/3169 

This PR introduces a `scheduleResume` that components that do manual calls to `schedulePause` must call when appropriate. (e.g. lightbox `close()` calls `schedulePause` and lightbox `open()` calls `scheduleResume`). `scheduleResume` won't do anything for component's that are not paused already. Without a subsequent call to `scheduleResume` after a `schedulePause`, the component will be locked in a permanent paused mode. (The root cause of this issue)