### PR TITLE
Small style cleanups, add docstrings and delete trailing whitespace.

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -124,6 +124,7 @@ def SetupOutDir(out_dir):
 
 
 def InstallNodeDependencies():
+  """Installs the dependencies using npm."""
   logging.info('entering ...')
   # Install the project dependencies specified in package.json into
   # node_modules.
@@ -332,6 +333,12 @@ def RunIndexTest(nodejs_cmd):
 
 
 def CompileValidatorTestMinified(out_dir):
+  """Runs closure compiler for validator_test.js.
+
+  Args:
+    out_dir: directory name of the output directory. Must not have slashes,
+      dots, etc.
+  """
   logging.info('entering ...')
   CompileWithClosure(
       js_files=['htmlparser.js', 'parse-css.js', 'parse-srcset.js',
@@ -344,6 +351,12 @@ def CompileValidatorTestMinified(out_dir):
 
 
 def CompileValidatorLightTestMinified(out_dir):
+  """Runs closure compiler for validator-light_test.js.
+
+  Args:
+    out_dir: directory name of the output directory. Must not have slashes,
+      dots, etc.
+  """
   logging.info('entering ...')
   CompileWithClosure(
       js_files=['htmlparser.js', 'parse-css.js', 'parse-srcset.js',
@@ -357,6 +370,12 @@ def CompileValidatorLightTestMinified(out_dir):
 
 
 def CompileHtmlparserTestMinified(out_dir):
+  """Runs closure compiler for htmlparser_test.js.
+
+  Args:
+    out_dir: directory name of the output directory. Must not have slashes,
+      dots, etc.
+  """
   logging.info('entering ...')
   CompileWithClosure(js_files=['htmlparser.js', 'htmlparser-interface.js',
                                'htmlparser_test.js'],
@@ -366,6 +385,12 @@ def CompileHtmlparserTestMinified(out_dir):
 
 
 def CompileParseCssTestMinified(out_dir):
+  """Runs closure compiler for parse-css_test.js.
+
+  Args:
+    out_dir: directory name of the output directory. Must not have slashes,
+      dots, etc.
+  """
   logging.info('entering ...')
   CompileWithClosure(
       js_files=['parse-css.js', 'tokenize-css.js', 'css-selectors.js',
@@ -377,6 +402,12 @@ def CompileParseCssTestMinified(out_dir):
 
 
 def CompileParseSrcsetTestMinified(out_dir):
+  """Runs closure compiler for parse-srcset_test.js.
+
+  Args:
+    out_dir: directory name of the output directory. Must not have slashes,
+      dots, etc.
+  """
   logging.info('entering ...')
   CompileWithClosure(
       js_files=['parse-srcset.js', 'json-testutil.js', 'parse-srcset_test.js',
@@ -387,7 +418,12 @@ def CompileParseSrcsetTestMinified(out_dir):
 
 
 def GenerateTestRunner(out_dir):
-  """Generates a test runner: a nodejs script that runs our minified tests."""
+  """Generates a test runner: a nodejs script that runs our minified tests.
+
+  Args:
+    out_dir: directory name of the output directory. Must not have slashes,
+      dots, etc.
+  """
   logging.info('entering ...')
   f = open('%s/test_runner' % out_dir, 'w')
   extensions_dir = 'extensions'
@@ -417,12 +453,25 @@ def GenerateTestRunner(out_dir):
 
 
 def RunTests(out_dir, nodejs_cmd):
+  """Runs all the minified tests.
+
+  Args:
+    out_dir: directory name of the output directory. Must not have slashes,
+      dots, etc.
+    nodejs_cmd: the command for calling Node.js
+  """
   logging.info('entering ...')
   subprocess.check_call([nodejs_cmd, '%s/test_runner' % out_dir])
   logging.info('... success')
 
 
 def CreateWebuiAppengineDist(out_dir):
+  """Creates the webui vulcanized directory to deploy to Appengine.
+
+  Args:
+    out_dir: directory name of the output directory. Must not have slashes,
+      dots, etc.
+  """
   logging.info('entering ...')
   try:
     tempdir = tempfile.mkdtemp()

--- a/validator/nodejs/index.sh
+++ b/validator/nodejs/index.sh
@@ -18,7 +18,7 @@ for CMD in node nodejs; do
     else
       MOD="${DIR}/../lib/node_modules/amphtml-validator/index.js"
     fi
-    
+
     exec "$CMD" "$MOD" "$@"
   fi
 done


### PR DESCRIPTION
These came up in our Google internal presubmits.