### PR TITLE
Remove broken AppNexus examples.

### DIFF
--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -59,7 +59,7 @@
     <a href="#adtech" class="broken">AdTech</a> |
     <a href="#aduptech">Ad Up Technology</a> |
     <a href="#amoad" class="broken">AmoAd</a> |
-    <a href="#appnexus" class="broken">App Nexus</a> |
+    <a href="#appnexus">App Nexus</a> |
     <a href="#chargeads">Chargeads</a> |
     <a href="#colombia" class="broken">Colombia ad</a> |
     <a href="#criteo" class="broken">Criteo</a> |
@@ -195,20 +195,7 @@
       data-sid="62056d310111552c951d19c06bfa71e16e615e39493eceff667912488bc576a6">
   </amp-ad>
 
-  <h2 id="appnexus" class="broken">AppNexus single ad with tagid (placement id)</h2>
-  <amp-ad width=300 height=250
-      type="appnexus"
-      data-tagid="6063968">
-  </amp-ad>
-
-  <h2 class="broken">AppNexus single ad with member and code</h2>
-  <amp-ad width=300 height=250
-      type="appnexus"
-      data-member="958"
-      data-code="inv_code_test">
-  </amp-ad>
-
-  <h2>AppNexus with JSON based configuration multi ad</h2>
+  <h2 id="appnexus">AppNexus with JSON based configuration multi ad</h2>
   <amp-ad width=300 height=250
       type="appnexus"
       data-target="apn_ad_1"


### PR DESCRIPTION
They were removed in #3638 to fix #3589, but brought back by #4202 
Remove again.