### PR TITLE
getMode DCE

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -39,6 +39,9 @@ var shouldNeverBeUsed =
 var backwardCompat = 'This method must not be called. It is only retained ' +
     'for backward compatibility during rollout.';
 
+var realiasGetMode = 'Do not re-alias getMode or its return so it can be ' +
+    'DCE\'d. Use explicitly like "getMode().localDev" instead.';
+
 // Terms that must not appear in our source files.
 var forbiddenTerms = {
   'DO NOT SUBMIT': '',
@@ -68,11 +71,23 @@ var forbiddenTerms = {
   },
   // Match `getMode` that is not followed by a "()." and is assigned
   // as a variable.
-  '(?:var|let|const).*?getMode(?!\\(\\)\\.)': {
-    message: 'Do not re-alias getMode or its return so it can be DCE\'d.' +
-        ' Use explicitly like "getMode().localDev" instead.',
+  '\\bgetMode\\([^)]*\\)(?!\\.)': {
+    message: realiasGetMode,
     whitelist: [
-      'dist.3p/current/integration.js'
+      'src/mode.js',
+      'dist.3p/current/integration.js',
+    ]
+  },
+  'import[^}]*\\bgetMode as': {
+    message: realiasGetMode,
+  },
+  '\\bgetModeObject\\(': {
+    message: realiasGetMode,
+    whitelist: [
+      'src/mode-object.js',
+      'src/3p-frame.js',
+      'src/log.js',
+      'dist.3p/current/integration.js',
     ]
   },
   '(?:var|let|const) +IS_DEV +=': {

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -20,6 +20,7 @@ import {getService} from './service';
 import {documentInfoFor} from './document-info';
 import {tryParseJson} from './json';
 import {getMode} from './mode';
+import {getModeObject} from './mode-object';
 import {getIntersectionChangeEntry} from './intersection-observer';
 import {preconnectFor} from './preconnect';
 import {dashToCamelCase} from './string';
@@ -78,7 +79,7 @@ function getFrameAttributes(parentWindow, element, opt_type) {
       href: locationHref,
     },
     tagName: element.tagName,
-    mode: getMode(),
+    mode: getModeObject(),
     hidden: !viewer.isVisible(),
     startTime,
     amp3pSentinel: generateSentinel(parentWindow),

--- a/src/log.js
+++ b/src/log.js
@@ -15,6 +15,7 @@
  */
 
 import {getMode} from './mode';
+import {getModeObject} from './mode-object';
 
 
 /** @const Time when this JS loaded.  */
@@ -108,7 +109,7 @@ export class Log {
     }
 
     // Delegate to the specific resolver.
-    return this.levelFunc_(getMode());
+    return this.levelFunc_(getModeObject());
   }
 
   /**

--- a/src/mode-object.js
+++ b/src/mode-object.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getMode} from './mode';
+
+/**
+ * Provides info about the current app. This return value may be cached and
+ * passed around as it will always be DCE'd.
+ * @param {?Window=} opt_win
+ * @return {!./mode.ModeDef}
+ */
+export function getModeObject(opt_win) {
+  return {
+    localDev: getMode(opt_win).localDev,
+    development: getMode(opt_win).development,
+    filter: getMode(opt_win).filter,
+    minified: getMode(opt_win).minified,
+    test: getMode(opt_win).test,
+    log: getMode(opt_win).log,
+    version: getMode(opt_win).version,
+  };
+}


### PR DESCRIPTION
It’d be great if we could move `getModeObject` into `mode.js`, but then
I’d have to learn Java to update the DCE code. @erwinmombay?