### PR TITLE
Fix: amp-ad clean up intersectionObserver timeout 

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -510,6 +510,7 @@ var forbiddenTermsSrcInclusive = {
   '\\.scrollTo\\(': bannedTermsHelpString,
   '\\.webkitConvertPointFromNodeToPage\\(': bannedTermsHelpString,
   '\\.webkitConvertPointFromPageToNode\\(': bannedTermsHelpString,
+  '\\.scheduleUnlayout\\(': bannedTermsHelpString,
   'loadExtension': {
     message: bannedTermsHelpString,
     whitelist: [
@@ -535,14 +536,6 @@ var forbiddenTermsSrcInclusive = {
         'error.cancellation() may be applicable.',
     whitelist: [
       'extensions/amp-access/0.1/access-expr-impl.js',
-    ],
-  },
-  'scheduleUnlayout': {
-    message: bannedTermsHelpString,
-    whitelist: [
-      'src/service/resources-impl.js',
-      'src/base-element.js',
-      'extensions/amp-sticky-ad/0.1/amp-sticky-ad.js',
     ],
   },
 };

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -536,7 +536,15 @@ var forbiddenTermsSrcInclusive = {
     whitelist: [
       'extensions/amp-access/0.1/access-expr-impl.js',
     ],
-  }
+  },
+  'scheduleUnlayout': {
+    message: bannedTermsHelpString,
+    whitelist: [
+      'src/service/resources-impl.js',
+      'src/base-element.js',
+      'extensions/amp-sticky-ad/0.1/amp-sticky-ad.js',
+    ],
+  },
 };
 
 // Terms that must appear in a source file.

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -162,7 +162,7 @@ class AmpStickyAd extends AMP.BaseElement {
   onCloseButtonClick_() {
     this.vsync_.mutate(() => {
       this.visible_ = false;
-      this.scheduleUnlayout(this.ad_);
+      this./*OK*/scheduleUnlayout(this.ad_);
       removeElement(this.element);
       this.viewport_.updatePaddingBottom(0);
     });

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -162,6 +162,7 @@ class AmpStickyAd extends AMP.BaseElement {
   onCloseButtonClick_() {
     this.vsync_.mutate(() => {
       this.visible_ = false;
+      this.scheduleUnlayout(this.ad_);
       removeElement(this.element);
       this.viewport_.updatePaddingBottom(0);
     });

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -631,7 +631,7 @@ export class BaseElement {
    * @protected
    */
   scheduleUnlayout(elements) {
-    this.resources_.scheduleUnlayout(this.element, elements);
+    this.resources_./*OK*/scheduleUnlayout(this.element, elements);
   }
 
   /**

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -130,6 +130,18 @@ export class IntersectionObserver extends Observable {
       this.sendElementIntersection_();
     });
   }
+
+  /**
+   * Check if we need to unlisten when moving out of viewport,
+   * unlisten and reset unlistenViewportChanges_.
+   * @private
+   */
+  unlistenOnOutViewport_() {
+    if (this.unlistenViewportChanges_) {
+      this.unlistenViewportChanges_();
+      this.unlistenViewportChanges_ = null;
+    }
+  }
   /**
    * Called via postMessage from the child iframe when the ad/iframe starts
    * observing its position in the viewport.
@@ -173,9 +185,8 @@ export class IntersectionObserver extends Observable {
         unlistenScroll();
         unlistenChanged();
       };
-    } else if (this.unlistenViewportChanges_) {
-      this.unlistenViewportChanges_();
-      this.unlistenViewportChanges_ = null;
+    } else {
+      this.unlistenOnOutViewport_();
     }
   }
 
@@ -208,6 +219,7 @@ export class IntersectionObserver extends Observable {
    * @private
    */
   flush_() {
+    // TODO(zhouyx): One potential place to check if element is still in doc.
     this.flushTimeout_ = 0;
     if (!this.pendingChanges_.length) {
       return;
@@ -223,9 +235,6 @@ export class IntersectionObserver extends Observable {
   destroy() {
     timer.cancel(this.flushTimeout_);
     this.flushTimeout_ = 0;
-    if (this.unlistenViewportChanges_) {
-      this.unlistenViewportChanges_();
-      this.unlistenViewportChanges_ = null;
-    }
+    this.unlistenOnOutViewport_();
   }
 }

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -16,6 +16,7 @@
 
 import {Observable} from './observable';
 import {dev} from './log';
+import {documentContains} from './dom';
 import {layoutRectLtwh, rectIntersection, moveLayoutRect} from './layout-rect';
 import {SubscriptionApi} from './iframe-helper';
 import {timer} from './timer';
@@ -208,6 +209,10 @@ export class IntersectionObserver extends Observable {
    * @private
    */
   flush_() {
+    if (!this.isElementInDoc_()) {
+      return;
+    }
+
     this.flushTimeout_ = 0;
     if (!this.pendingChanges_.length) {
       return;
@@ -218,10 +223,18 @@ export class IntersectionObserver extends Observable {
   }
 
   /**
-   * Provice a function to clear timeout before set this intersection to null.
+   * Provide a function to clear timeout before set this intersection to null.
    */
   destroy() {
     timer.cancel(this.flushTimeout_);
     this.flushTimeout_ = 0;
+  }
+
+  /**
+   * Provide a method to check the element is not removed from DOM.
+   */
+  isElementInDoc_() {
+    return documentContains(
+        this.baseElement_.win.document, this.baseElement_.element);
   }
 }

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -16,7 +16,6 @@
 
 import {Observable} from './observable';
 import {dev} from './log';
-import {documentContains} from './dom';
 import {layoutRectLtwh, rectIntersection, moveLayoutRect} from './layout-rect';
 import {SubscriptionApi} from './iframe-helper';
 import {timer} from './timer';
@@ -209,10 +208,6 @@ export class IntersectionObserver extends Observable {
    * @private
    */
   flush_() {
-    if (!this.isElementInDoc_()) {
-      return;
-    }
-
     this.flushTimeout_ = 0;
     if (!this.pendingChanges_.length) {
       return;
@@ -228,13 +223,9 @@ export class IntersectionObserver extends Observable {
   destroy() {
     timer.cancel(this.flushTimeout_);
     this.flushTimeout_ = 0;
-  }
-
-  /**
-   * Provide a method to check the element is not removed from DOM.
-   */
-  isElementInDoc_() {
-    return documentContains(
-        this.baseElement_.win.document, this.baseElement_.element);
+    if (this.unlistenViewportChanges_) {
+      this.unlistenViewportChanges_();
+      this.unlistenViewportChanges_ = null;
+    }
   }
 }

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -330,6 +330,7 @@ describe('IntersectionObserver', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
     insert(testIframe);
+    ioInstance.onViewportCallback(true);
     sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
       // Copy because arg is modified in place.
       messages.push(JSON.parse(JSON.stringify(message)));
@@ -343,5 +344,6 @@ describe('IntersectionObserver', () => {
     ioInstance.destroy();
     clock.tick(50);
     expect(messages).to.have.length(1);
+    expect(ioInstance.unlistenViewportChanges_).to.be.null;
   });
 });

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -222,6 +222,9 @@ describe('IntersectionObserver', () => {
 
   it('should not send intersection', () => {
     const ioInstance = new IntersectionObserver(element, testIframe);
+    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
+      return true;
+    });
     insert(testIframe);
     const postMessageSpy = sinon/*OK*/.spy(testIframe.contentWindow,
         'postMessage');
@@ -233,6 +236,9 @@ describe('IntersectionObserver', () => {
   it('should send intersection', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
+    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
+      return true;
+    });
     insert(testIframe);
     sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
       // Copy because arg is modified in place.
@@ -252,6 +258,9 @@ describe('IntersectionObserver', () => {
   it('should send more intersections', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
+    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
+      return true;
+    });
     insert(testIframe);
     sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
       // Copy because arg is modified in place.
@@ -318,6 +327,9 @@ describe('IntersectionObserver', () => {
   it('should go into in-viewport state for initially visible element', () => {
     element.isInViewport = () => true;
     const ioInstance = new IntersectionObserver(element, testIframe);
+    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
+      return true;
+    });
     insert(testIframe);
     ioInstance.startSendingIntersectionChanges_();
     expect(getIntersectionChangeEntrySpy.callCount).to.equal(2);
@@ -329,6 +341,9 @@ describe('IntersectionObserver', () => {
   it('should not send intersection after destroy is called', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
+    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
+      return true;
+    });
     insert(testIframe);
     sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
       // Copy because arg is modified in place.

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -222,9 +222,6 @@ describe('IntersectionObserver', () => {
 
   it('should not send intersection', () => {
     const ioInstance = new IntersectionObserver(element, testIframe);
-    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
-      return true;
-    });
     insert(testIframe);
     const postMessageSpy = sinon/*OK*/.spy(testIframe.contentWindow,
         'postMessage');
@@ -236,9 +233,6 @@ describe('IntersectionObserver', () => {
   it('should send intersection', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
-    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
-      return true;
-    });
     insert(testIframe);
     sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
       // Copy because arg is modified in place.
@@ -258,9 +252,6 @@ describe('IntersectionObserver', () => {
   it('should send more intersections', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
-    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
-      return true;
-    });
     insert(testIframe);
     sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
       // Copy because arg is modified in place.
@@ -327,9 +318,6 @@ describe('IntersectionObserver', () => {
   it('should go into in-viewport state for initially visible element', () => {
     element.isInViewport = () => true;
     const ioInstance = new IntersectionObserver(element, testIframe);
-    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
-      return true;
-    });
     insert(testIframe);
     ioInstance.startSendingIntersectionChanges_();
     expect(getIntersectionChangeEntrySpy.callCount).to.equal(2);
@@ -341,9 +329,6 @@ describe('IntersectionObserver', () => {
   it('should not send intersection after destroy is called', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
-    sandbox.stub(ioInstance, 'isElementInDoc_', function() {
-      return true;
-    });
     insert(testIframe);
     sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
       // Copy because arg is modified in place.


### PR DESCRIPTION
Add presubmit check for `scheduleUnlayout` function
`scheduleUnlayout` for ad when user close sticky-ad
Check element inside document before in intersectionObserver `flush_` function, fix tests.