### PR TITLE
Fix: renderStart() not defined for ad type that use doubleclick

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -280,7 +280,6 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
     window.context.noContentAvailable = triggerNoContentAvailable;
     window.context.requestResize = triggerResizeRequest;
     window.context.renderStart = triggerRenderStart;
-    window.context.isRenderStartSent = false;
 
     if (data.type === 'facebook' || data.type === 'twitter') {
       // Only make this available to selected embeds until the
@@ -335,10 +334,7 @@ function triggerResizeRequest(width, height) {
 }
 
 function triggerRenderStart() {
-  if (!window.context.isRenderStartSent) {
-    nonSensitiveDataPostMessage('render-start');
-    window.context.isRenderStartSent = true;
-  }
+  nonSensitiveDataPostMessage('render-start');
 }
 
 /**

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -279,15 +279,13 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
     window.context.data = data;
     window.context.noContentAvailable = triggerNoContentAvailable;
     window.context.requestResize = triggerResizeRequest;
+    window.context.renderStart = triggerRenderStart;
+    window.context.isRenderStartSent = false;
 
     if (data.type === 'facebook' || data.type === 'twitter') {
       // Only make this available to selected embeds until the
       // generic solution is available.
       window.context.updateDimensions = triggerDimensions;
-    }
-
-    if (waitForRenderStart.indexOf(data.type) != -1) {
-      window.context.renderStart = triggerRenderStart;
     }
 
     // This only actually works for ads.
@@ -337,7 +335,10 @@ function triggerResizeRequest(width, height) {
 }
 
 function triggerRenderStart() {
-  nonSensitiveDataPostMessage('render-start');
+  if (!window.context.isRenderStartSent) {
+    nonSensitiveDataPostMessage('render-start');
+    window.context.isRenderStartSent = true;
+  }
 }
 
 /**


### PR DESCRIPTION
This is to fix `Uncaught TypeError: global.context.renderStart is not a function`. This involves ad type like openx, rubicon, pulsepoint that import `doubleclick.js`