### PR TITLE
[WIP] Ad Feature: Show default fallback when no ad is available to serve

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -25,6 +25,7 @@ import {user} from '../../../src/log';
 import {getIframe} from '../../../src/3p-frame';
 import {setupA2AListener} from './a2a-listener';
 import {AmpAdApiHandler} from './amp-ad-api-handler';
+import {setStyles} from '../../../src/style';
 
 /** @const These tags are allowed to have fixed positioning */
 const POSITION_FIXED_TAG_WHITELIST = {
@@ -311,7 +312,11 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (!this.fallback_) {
       this.attemptChangeHeight(0).then(() => {
         this./*OK*/collapse();
-      }, () => {});
+      }, () => {
+        this.deferMutate(() => {
+          this.addDefaultFallback();
+        })
+      });
     }
     this.deferMutate(() => {
       if (!this.iframe_) {
@@ -351,5 +356,21 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.apiHandler_ = null;
     }
     return true;
+  }
+
+  addDefaultFallback() {
+    if (this.placeholder_) {
+      this.togglePlaceholder(false);
+    }
+    const defaultFallback = this.win.document.createElement('div');
+    setStyles(defaultFallback, {
+      position: 'absolute',
+      top: '0',
+      bottom: '0',
+      left: '0',
+      right: '0',
+      background: '#D3D3D3',
+    });
+    this.element.appendChild(defaultFallback);
   }
 }

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -304,36 +304,17 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    * @private
    */
   noContentHandler_() {
-    // If iframe is null nothing to do.
+    // If iframe is null nothing to do
     if (!this.iframe_) {
       return;
     }
-    // If a fallback does not exist attempt to collapse the ad.
-    if (!this.fallback_) {
-      this.attemptChangeHeight(0).then(() => {
-        this./*OK*/collapse();
-      }, () => {
-        this.deferMutate(() => {
-          this.addDefaultFallback();
-        })
-      });
-    }
-    this.deferMutate(() => {
-      if (!this.iframe_) {
-        return;
-      }
-      if (this.fallback_) {
-        // Hide placeholder when falling back.
-        if (this.placeholder_) {
-          this.togglePlaceholder(false);
-        }
-        this.toggleFallback(true);
-      }
-      // Remove the iframe only if it is not the master.
-      if (this.iframe_.name.indexOf('_master') == -1) {
-        removeElement(this.iframe_);
-        this.iframe_ = null;
-      }
+
+    //Attempt to collapse the ad first
+    this.attemptChangeHeight(0).then(() => {
+      this./*OK*/collapse();
+    }, () => {
+      // Attempt to apply fallback
+      this.applyFallback_();
     });
   }
 
@@ -358,19 +339,35 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     return true;
   }
 
-  addDefaultFallback() {
-    if (this.placeholder_) {
-      this.togglePlaceholder(false);
-    }
-    const defaultFallback = this.win.document.createElement('div');
-    setStyles(defaultFallback, {
-      position: 'absolute',
-      top: '0',
-      bottom: '0',
-      left: '0',
-      right: '0',
-      background: '#D3D3D3',
+  /* Method that will apply fallback after collapse fail */
+  applyFallback_() {
+    this.deferMutate(() => {
+      if (!this.iframe_) {
+        return;
+      }
+      if (this.placeholder_) {
+        this.togglePlaceholder(false);
+      }
+      if (this.fallback_) {
+        this.toggleFallback(true);
+      } else {
+        // create our own fallback
+        const defaultFallback = this.win.document.createElement('div');
+        setStyles(defaultFallback, {
+          position: 'absolute',
+          top: '0',
+          bottom: '0',
+          left: '0',
+          right: '0',
+          background: '#D3D3D3',
+        });
+        this.element.appendChild(defaultFallback);
+      }
+      // Remove the iframe only if it is not the master.
+      if (this.iframe_.name.indexOf('_master') == -1) {
+        removeElement(this.iframe_);
+        this.iframe_ = null;
+      }
     });
-    this.element.appendChild(defaultFallback);
   }
 }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -258,7 +258,7 @@ function tests(name) {
     });
 
     describe('has no-content', () => {
-      it('should display fallback', () => {
+      it('should attemptChangeHeight to 0', () => {
         return getAd({
           width: 300,
           height: 250,
@@ -274,21 +274,6 @@ function tests(name) {
               ad.implementation_, 'deferMutate', function(callback) {
                 callback();
               });
-          expect(ad).to.not.have.class('amp-notsupported');
-          ad.implementation_.noContentHandler_();
-          expect(ad).to.have.class('amp-notsupported');
-        });
-      });
-
-      it('should attemptChangeHeight to 0 when there is no fallback', () => {
-        return getAd({
-          width: 300,
-          height: 750,
-          type: '_ping_',
-          src: 'testsrc',
-        }, 'https://schema.org', ad => {
-          return ad;
-        }).then(ad => {
           const attemptChangeHeight = sandbox.stub(ad.implementation_,
               'attemptChangeHeight',
               function() {
@@ -300,6 +285,32 @@ function tests(name) {
           ad.implementation_.noContentHandler_();
           expect(attemptChangeHeight).to.have.been.called;
           expect(attemptChangeHeight.firstCall.args[0]).to.equal(0);
+        });
+      });
+
+      it('should display fallback when attemptChangeHeight to 0 fails', () => {
+        return getAd({
+          width: 300,
+          height: 250,
+          type: '_ping_',
+          src: 'testsrc',
+        }, 'https://schema.org', ad => {
+          const fallback = document.createElement('div');
+          fallback.setAttribute('fallback', '');
+          ad.appendChild(fallback);
+          return ad;
+        }).then(ad => {
+          sandbox.stub(ad.implementation_, 'attemptChangeHeight',
+              () => {
+                return Promise.reject(new Error('forTesting'));
+              });
+          sandbox.stub(
+              ad.implementation_, 'deferMutate', function(callback) {
+                callback();
+                expect(ad).to.have.class('amp-notsupported');
+              });
+          expect(ad).to.not.have.class('amp-notsupported');
+          ad.implementation_.noContentHandler_();
         });
       });
 
@@ -383,9 +394,12 @@ function tests(name) {
           sandbox.stub(
               ad.implementation_, 'deferMutate', function(callback) {
                 callback();
+                expect(ad.implementation_.iframe_).to.be.null;
               });
+          sandbox.stub(ad.implementation_, 'attemptChangeHeight', function() {
+            return Promise.reject();
+          });
           ad.implementation_.noContentHandler_();
-          expect(ad.implementation_.iframe_).to.be.null;
         });
       });
 

--- a/test/manual/fallback.html
+++ b/test/manual/fallback.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+
+    amp-ad iframe {
+      margin: 30px;
+      padding: 30px;
+      border: 10px solid red;
+    }
+
+    #fill-div {
+      width: 300px;
+      height: 700px;
+      background-color: red;
+    }
+
+   /* amp-ad {
+      border: 2px solid green;
+    }*/
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="../../dist/amp.js"></script>
+  <script async custom-element="amp-ad" src="../../dist/v0/amp-ad-0.1.max.js"></script>
+</head>
+<body>
+  <div id="fill-div">
+    Testing Div
+  </div>
+  <h2>Doubleclick no ad with placeholder and no fallback</h2>
+  <amp-ad width=300 height=200
+      type="doubleclick"
+      data-slot="/4119129/doesnt-exist"
+      >
+     <div class="adv-placeholder" placeholder>
+       <amp-anim width=16 height=16 src="//www.repstatic.it/cless-mobile/main/amp/2016-v1//img/loader.gif">
+           <amp-img placeholder width=16 height=16 src="//www.repstatic.it/cless-mobile/main/amp/2016-v1//img/loader.gif">
+         </amp-img>
+       </amp-anim>
+     </div>
+       <a href="http://www.repubblica.it/sport/2016/02/09/news/app_rep-133068373/">
+         <amp-img placeholder width=300 height=100 src="//www.repstatic.it/cless-mobile/main/amp/2016-v1/img/adv-300-100.jpg">
+       </a>
+     </div> -->
+  </amp-ad>
+  <div id="fill-div">
+    Testing Div
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Implement #3817 

With #4015 in, I am able to add default fallback after `attemptChangeHeight` fails.
My initial implement is to add one grey div to `amp-ad` when there's no user provided fallback. 

@jridgewell @lannka @jasti PTAL, and let me know how would you like the default fallback to be?
