### PR TITLE
<amp-video> Propagate controls attribute earlier

### DIFF
--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -52,7 +52,7 @@ export function installVideo(win) {
 
       // Disable video preload in prerender mode.
       this.video_.setAttribute('preload', 'none');
-      this.propagateAttributes(['poster'], this.video_);
+      this.propagateAttributes(['poster', 'controls'], this.video_);
       this.applyFillContent(this.video_, true);
       this.element.appendChild(this.video_);
     }
@@ -68,7 +68,7 @@ export function installVideo(win) {
         assertHttpsUrl(this.element.getAttribute('src'), this.element);
       }
       this.propagateAttributes(
-          ['src', 'controls', 'autoplay', 'muted', 'loop'],
+          ['src', 'autoplay', 'muted', 'loop'],
           this.video_);
 
       if (this.element.hasAttribute('preload')) {

--- a/test/functional/test-amp-video.js
+++ b/test/functional/test-amp-video.js
@@ -137,6 +137,27 @@ describe('amp-video', () => {
     }, sources)).to.be.rejectedWith(/start with/);
   });
 
+  it('should set poster and controls in prerender mode', () => {
+    return getVideo({
+      src: 'video.mp4',
+      width: 160,
+      height: 90,
+      'poster': 'img.png',
+      'controls': '',
+    }, null, function(element) {
+      // Should set appropriate attributes in buildCallback
+      const video = element.querySelector('video');
+      expect(video.getAttribute('poster')).to.equal('img.png');
+      expect(video.getAttribute('controls')).to.exist;
+    }).then(v => {
+      // Same attributes should still be present in layoutCallback.
+      const video = v.querySelector('video');
+      expect(video.tagName).to.equal('VIDEO');
+      expect(video.getAttribute('poster')).to.equal('img.png');
+      expect(video.getAttribute('controls')).to.exist;
+    });
+  });
+
   it('should not set src or preload in prerender mode', () => {
     return getVideo({
       src: 'video.mp4',
@@ -147,14 +168,12 @@ describe('amp-video', () => {
     }, null, function(element) {
       const video = element.querySelector('video');
       expect(video.getAttribute('preload')).to.equal('none');
-      expect(video.getAttribute('poster')).to.equal('img.png');
       expect(video.hasAttribute('src')).to.be.false;
     }).then(v => {
       // Should set appropriate attributes in layoutCallback.
       const video = v.querySelector('video');
       expect(video.tagName).to.equal('VIDEO');
       expect(video.getAttribute('preload')).to.equal('auto');
-      expect(video.getAttribute('poster')).to.equal('img.png');
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/4253 

Propagate controls attribute in prerender phase instead of layout. This fixes an UX issue where when swiping documents in the viewer, videos don't show the controls and look like images until layout is done. 