### PR TITLE
Added support for a new trigger `on=hidden`.

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -36,7 +36,7 @@ Container for analytics tags. Positioned far away from top to make sure that doe
     "base": "https://example.com/?domain=${canonicalHost}&path=${canonicalPath}&title=${title}&time=${timestamp}&tz=${timezone}&pid=${pageViewId}&_=${random}",
     "pageview": "${base}&name=${eventName}&type=${eventId}&screenSize=${screenWidth}x${screenHeight}",
     "event": "${base}&name=${eventName}&scrollY=${scrollTop}&scrollX=${scrollLeft}&height=${availableScreenHeight}&width=${availableScreenWidth}&scrollBoundV=${verticalScrollBoundary}&scrollBoundH=${horizontalScrollBoundary}",
-    "visibility": "https://example.com/visibility?a=${maxContinuousTime}&b=${totalVisibleTime}&c=${firstSeenTime}&d=${lastSeenTime}&e=${fistVisibleTime}&f=${lastVisibleTime}&g=${minVisiblePercentage}&h=${maxVisiblePercentage}&i=${elementX}&j=${elementY}&k=${elementWidth}&l=${elementHeight}&m=${totalTime}&n=${loadTimeVisibility}&o=${backgroundedAtStart}&p=${backgrounded}&eventName=${eventName}&subTitle=${subTitle}"
+    "visibility": "https://example.com/visibility?a=${maxContinuousVisibleTime}&b=${totalVisibleTime}&c=${firstSeenTime}&d=${lastSeenTime}&e=${fistVisibleTime}&f=${lastVisibleTime}&g=${minVisiblePercentage}&h=${maxVisiblePercentage}&i=${elementX}&j=${elementY}&k=${elementWidth}&l=${elementHeight}&m=${totalTime}&n=${loadTimeVisibility}&o=${backgroundedAtStart}&p=${backgrounded}&eventName=${eventName}&subTitle=${subTitle}"
   },
   "vars": {
     "title": "Example Request"
@@ -73,6 +73,16 @@ Container for analytics tags. Positioned far away from top to make sure that doe
       "vars": {
         "eventName": "visibility event"
       }
+    },
+    "hidden": {
+      "on": "hidden",
+      "request": "visibility",
+      "visibilitySpec": {
+        "selector": "#anim-id",
+        "visiblePercentageMin": 20,
+        "continuousTimeMax": 5000
+      },
+      "extraUrlParams": { "on": "hidden"}
     },
     "scrollPings": {
       "on": "scroll",

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {dev} from '../../../src/log';
 import {isVisibilitySpecValid} from './visibility-impl';
 import {Observable} from '../../../src/observable';
 import {fromClass} from '../../../src/service';
@@ -57,6 +58,7 @@ export const AnalyticsEventType = {
   CLICK: 'click',
   TIMER: 'timer',
   SCROLL: 'scroll',
+  HIDDEN: 'hidden',
 };
 
 /**
@@ -133,7 +135,8 @@ export class InstrumentationService {
   addListener(config, listener) {
     const eventType = config['on'];
     if (eventType === AnalyticsEventType.VISIBLE) {
-      this.createVisibilityListener_(listener, config);
+      this.createVisibilityListener_(listener, config,
+          AnalyticsEventType.VISIBLE);
     } else if (eventType === AnalyticsEventType.CLICK) {
       if (!config['selector']) {
         user().error(this.TAG_, 'Missing required selector on click trigger');
@@ -162,6 +165,9 @@ export class InstrumentationService {
       if (this.isTimerSpecValid_(config['timerSpec'])) {
         this.createTimerListener_(listener, config['timerSpec']);
       }
+    } else if (eventType === AnalyticsEventType.HIDDEN) {
+      this.createVisibilityListener_(listener, config,
+          AnalyticsEventType.HIDDEN);
     } else {
       let observers = this.customEventObservers_[eventType];
       if (!observers) {
@@ -214,51 +220,49 @@ export class InstrumentationService {
    * @param {!AnalyticsEventListenerDef} The callback to call when the event
    *   occurs.
    * @param {!JSONType} config Configuration for instrumentation.
+   * @param {AnalyticsEventType} visibilityState State for which the callback is triggered.
    * @private
    */
-  createVisibilityListener_(callback, config) {
+  createVisibilityListener_(callback, config, eventType) {
+    dev().assert(eventType == AnalyticsEventType.VISIBLE ||
+        eventType == AnalyticsEventType.HIDDEN,
+        'createVisibilityListener should be called with visible or hidden ' +
+        'eventType');
+    const shouldBeVisible = eventType == AnalyticsEventType.VISIBLE;
     const spec = config['visibilitySpec'];
     if (spec) {
       if (!isVisibilitySpecValid(config)) {
         return;
       }
-      this.runOrSchedule_(() => {
-        visibilityFor(this.win_).then(visibility => {
-          visibility.listenOnce(spec, vars => {
-            if (spec['selector']) {
-              const attr = getDataParamsFromAttributes(
-                this.win_.document.getElementById(spec['selector'].slice(1)),
-                null,
-                VARIABLE_DATA_ATTRIBUTE_KEY
-              );
-              for (const key in attr) {
-                vars[key] = attr[key];
-              }
-            }
-            callback(new AnalyticsEvent(AnalyticsEventType.VISIBLE, vars));
-          });
-        });
-      });
-    } else {
-      this.runOrSchedule_(() => {
-        callback(new AnalyticsEvent(AnalyticsEventType.VISIBLE));
-      });
-    }
-  }
 
-  /**
-   * @param {function()} fn function to run or schedule.
-   * @private
-   */
-  runOrSchedule_(fn) {
-    if (this.viewer_.isVisible()) {
-      fn();
-    } else {
-      this.viewer_.onVisibilityChanged(() => {
-        if (this.viewer_.isVisible()) {
-          fn();
-        }
+      visibilityFor(this.win_).then(visibility => {
+        visibility.listenOnce(spec, vars => {
+          if (spec['selector']) {
+            const attr = getDataParamsFromAttributes(
+              this.win_.document.getElementById(spec['selector'].slice(1)),
+              null,
+              VARIABLE_DATA_ATTRIBUTE_KEY
+            );
+            for (const key in attr) {
+              vars[key] = attr[key];
+            }
+          }
+          callback(new AnalyticsEvent(eventType, vars));
+        }, shouldBeVisible);
       });
+    } else {
+      if (this.viewer_.isVisible() == shouldBeVisible) {
+        callback(new AnalyticsEvent(eventType));
+        config['called'] = true;
+      } else {
+        this.viewer_.onVisibilityChanged(() => {
+          if (!config['called'] &&
+              this.viewer_.isVisible() == shouldBeVisible) {
+            callback(new AnalyticsEvent(eventType));
+            config['called'] = true;
+          }
+        });
+      }
     }
   }
 

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -220,7 +220,7 @@ export class InstrumentationService {
    * @param {!AnalyticsEventListenerDef} The callback to call when the event
    *   occurs.
    * @param {!JSONType} config Configuration for instrumentation.
-   * @param {AnalyticsEventType} visibilityState State for which the callback is triggered.
+   * @param {AnalyticsEventType} eventType Event type for which the callback is triggered.
    * @private
    */
   createVisibilityListener_(callback, config, eventType) {

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -16,6 +16,7 @@
 
 import {InstrumentationService} from '../instrumentation.js';
 import {adopt} from '../../../../src/runtime';
+import {VisibilityState} from '../../../../src/visibility-state';
 import * as sinon from 'sinon';
 
 adopt(window);
@@ -45,6 +46,19 @@ describe('amp-analytics.instrumentation', function() {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  it('works for visible event', () => {
+    const fn = sandbox.stub();
+    ins.addListener({'on': 'visible'}, fn);
+    expect(fn.calledOnce).to.be.true;
+  });
+
+  it('works for hidden event', () => {
+    const fn = sandbox.stub();
+    ins.addListener({'on': 'hidden'}, fn);
+    ins.viewer_.setVisibilityState_(VisibilityState.HIDDEN);
+    expect(fn.calledOnce).to.be.true;
   });
 
   it('always fires click listeners when selector is set to *', () => {

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -329,7 +329,7 @@ The `triggers` attribute describes when an analytics request should be sent. It 
  trigger-configuration. Trigger name can be any string comprised of alphanumeric characters (a-zA-Z0-9). Triggers from a
  configuration with lower precedence are overridden by triggers with the same names from a configuration with higher precedence.
 
-  - `on` (required) The event to listener for. Valid values are `click`, `scroll`, `timer`, and `visible`.
+  - `on` (required) The event to listener for. Valid values are `click`, `scroll`, `timer`, `visible`, and `hidden`.
   - `request` (required) Name of the request to send (as specified in the `requests` section).
   - `vars` An object containing key-value pairs used to override `vars` defined in the top level config, or to specify
     vars unique to this trigger.
@@ -363,10 +363,22 @@ The `triggers` attribute describes when an analytics request should be sent. It 
   ```
 
 #### Page visible trigger (`"on": "visible"`)
-Use this configuration to fire a request when the page becomes visible. The firing of this trigger can be configured using `visibilitySpec`. If multiple properties are specified, they must all be true in order for a request to fire. Configuration properties supported in `visibilitySpec` are:
+Use this configuration to fire a request when the page becomes visible. The firing of this trigger can be configured using `visibilitySpec`.
+
+```javascript
+"triggers": {
+  "defaultPageview": {
+    "on": "visible",
+    "request": "pageview",
+  }
+}
+```
+
+##### Visibility Spec
+Visibility spec is a set of conditions and properties that can be applied to `visible` or `hidden` triggers to change when they fire. If multiple properties are specified, they must all be true in order for a request to fire. Configuration properties supported in `visibilitySpec` are:
   - `selector` This property can be used to specify the element to which all the `visibilitySpec` conditions apply. The selector needs to be an css id that points to an [AMP extended  element](https://github.com/ampproject/amphtml/blob/master/spec/amp-tag-addendum.md#amp-specific-tags).
-  - `continuousTimeMin` and `continuousTimeMax` These properties indicate that a request should be fired when (any part of) an element has been within the viewport for a continuous amount of time that is between the minimum and maximum specified times. The times are expressed in milliseconds. Due to semantic restrictions, `continuousTimeMax` only works when the page is being hidden. Hence `continuousTimeMax` is not yet supported.
-  - `totalTimeMin` and `totalTimeMax` These properties indicate that a request should be fired when (any part of) an element has been within the viewport for a total amount of time that is between the minimum and maximum specified times. The times are expressed in milliseconds. Due to semantic restrictions, `totalTimeMax` only works when the page is being hidden. Hence `totalTimeMax` is not yet supported.
+  - `continuousTimeMin` and `continuousTimeMax` These properties indicate that a request should be fired when (any part of) an element has been within the viewport for a continuous amount of time that is between the minimum and maximum specified times. The times are expressed in milliseconds.
+  - `totalTimeMin` and `totalTimeMax` These properties indicate that a request should be fired when (any part of) an element has been within the viewport for a total amount of time that is between the minimum and maximum specified times. The times are expressed in milliseconds.
   - `visiblePercentageMin` and `visiblePercentageMax` These properties indicate that a request should be fired when the proportion of an element that is visible within the viewport is between the minimum and maximum specified percentages. Percentage values between 0 and 100 are valid. Note that the lower bound (`visiblePercentageMin`) is inclusive while the upper bound (`visiblePercentageMax`) is not. When these properties are defined along with other timing related properties, only the time when these properties are met are counted.
 
 In addition to the conditions above, `visibilitySpec` also enables certain variables which are documented [here](./analytics-vars.md#visibility-variables).
@@ -444,6 +456,18 @@ Use this configuration to fire a request on a regular time interval. Use `timerS
       }
     }
     ```
+
+#### Hidden trigger (`"on": "hidden"`)
+Use this configuration to fire a request when the page becomes is hidden.  The firing of this trigger can be configured using [`visibilitySpec`](#visibility-spec).
+
+```javascript
+"triggers": {
+  "defaultPageview": {
+    "on": "hidden",
+    "request": "pagehide",
+  }
+}
+```
 
 #### Access triggers (`"on": "amp-access-*"`)
 


### PR DESCRIPTION
The new trigger fires when the viewer is hidden. In addition,
visibilitySpec can be used to add additional conditions on when the
trigger fires.

Fixes #2487 #2564