### PR TITLE
Emulate readlink -f using Node.js so it works on Mac.

### DIFF
--- a/validator/nodejs/README.md
+++ b/validator/nodejs/README.md
@@ -70,3 +70,7 @@ line 1, col 0: The parent tag of tag 'html ⚡ for top-level html' is '$root', b
 ...
 ```
 As expected, this emits errors because the provided string in the example, `<html>Hello, world.</html>` is not a valid AMP HTML document.
+
+## Release Notes
+### 1.0.10
+* Fixed [#4246: amphtml-validator CLI fails on Mac OS X](https://github.com/ampproject/amphtml/issues/4246).

--- a/validator/nodejs/index.sh
+++ b/validator/nodejs/index.sh
@@ -8,7 +8,9 @@ for CMD in node nodejs; do
   if [ "42" = "$(${CMD} --eval 'console.log("42")' 2>/dev/null)" ]; then
 
     # Compute the absolute path for the directory that index.sh is installed in.
-    DIR="$(dirname $(readlink -f $0))"
+    # Since readlink -f isn't supported on Mac out of the box, we use Node.js
+    # to do the equivalent of $(dirname $(readlink -f $0)).
+    DIR="$($CMD --eval "console.log(require('path').dirname(require('fs').realpathSync(\"$0\")))")"
 
     # If index.js is also in this directory, use it; otherwise we're probably
     # in a bin directory in the NPM directory structure, so we look up the

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphtml-validator",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Validator for AMP HTML (www.ampproject.org)",
   "engines": {
     "node": ">=0.10.25"


### PR DESCRIPTION
I haven't tested this on a Mac (yet); any experience reports are most welcome.
It appears to work fine on Ubuntu.

I hope this addresses https://github.com/ampproject/amphtml/issues/4246.