### PR TITLE
eliminate dev().assert() and dev().fine() calls from src/log.js module

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpPass.java
+++ b/build-system/runner/src/org/ampproject/AmpPass.java
@@ -64,10 +64,13 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
   }
 
   @Override public void visit(NodeTraversal t, Node n, Node parent) {
+    if (isCallRemovable(n)) {
+      Node call = n.getGrandparent();
+      maybeEliminateCallExceptFirstParam(call, call.getParent());
     // Remove `dev.assert` calls and preserve first argument if any.
-    if (isNameStripType(n, ImmutableSet.of( "dev.assert"))) {
+    } else if (isNameStripType(n, ImmutableSet.of( "dev.assert"))) {
       maybeEliminateCallExceptFirstParam(n, parent);
-    // Remove any `stripTypes` passed in outright like `dev.warn`.
+    // Remove any `stripTypes` passed in outright like `dev.fine`.
     } else if (isNameStripType(n, stripTypeSuffixes)) {
       removeExpression(n, parent);
     // Remove any `getMode().localDev` and `getMode().test` calls and replace it with `false`.
@@ -81,6 +84,28 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
     } else if (isProd) {
       maybeReplaceRValueInVar(n, assignmentReplacements);
     }
+  }
+  
+  private boolean isCallRemovable(Node n) {
+    // Looks for a label named "assert" or "fine" then traverses up
+    // looking for a "Call". This more or less looks for
+    // module$src$log.dev().assert(); or module$src$log.dev().fine();
+    if (n != null && n.isString() &&
+        // Refactor to read this in from passed in from command line runner instead
+        (n.getString() == "assert" || n.getString() == "fine")) {
+      Node call = n.getGrandparent();
+      if (call == null || !call.isCall()) {
+        return false;
+      }
+      // Look for a module named src/log.js and a `dev` export that is called.
+      Node siblingcall = n.getParent().getFirstChild();
+      if (siblingcall.isCall()) {
+        Node getprop = siblingcall.getFirstChild();
+        return getprop != null && getprop.isGetProp() &&
+            getprop.matchesQualifiedName("module$src$log.dev");
+      }
+    }
+    return false;
   }
 
   private void maybeReplaceRValueInVar(Node n, Map<String, Node> map) {
@@ -154,7 +179,7 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
       return false;
     }
     Node getprop = n.getFirstChild();
-    if (getprop == null) {
+    if (getprop == null || !getprop.isGetProp()) {
       return false;
     }
     return qualifiedNameEndsWithStripType(getprop, suffixes);
@@ -170,21 +195,20 @@ class AmpPass extends AbstractPostOrderCallback implements HotSwapCompilerPass {
     compiler.reportCodeChange();
   }
 
-  private void maybeEliminateCallExceptFirstParam(Node n, Node p) {
-    Node call = n.getFirstChild();
-    if (call == null) {
+  private void maybeEliminateCallExceptFirstParam(Node call, Node p) {
+    Node getprop = call.getFirstChild();
+    if (getprop == null) {
       return;
     }
 
-    Node firstArg = call.getNext();
+    Node firstArg = getprop.getNext();
     if (firstArg == null) {
-      p.removeChild(n);
-      compiler.reportCodeChange();
+      removeExpression(call, p);
       return;
     }
 
     firstArg.detachFromParent();
-    p.replaceChild(n, firstArg);
+    p.replaceChild(call, firstArg);
     compiler.reportCodeChange();
   }
 

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -32,7 +32,7 @@ public class AmpPassTest extends Es6CompilerTestCase {
     return 1;
   }
 
-  public void testDevFineRemoval() throws Exception {
+  public void testDevFineRemovalDeprecated() throws Exception {
     test(
         LINE_JOINER.join(
              "(function() {",
@@ -59,6 +59,34 @@ public class AmpPassTest extends Es6CompilerTestCase {
             "})()"));
   }
 
+  public void testDevFineRemoval() throws Exception {
+    test(
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { fine: function() {}} } };",
+             "  module$src$log.dev().fine('hello world');",
+             "  console.log('this is preserved');",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { fine: function() {}} } };",
+             "  'hello world';",
+             "  console.log('this is preserved');",
+            "})()"));
+    test(
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { fine: function() {}} } };",
+             "  module$src$log.dev().fine();",
+             "  console.log('this is preserved');",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { fine: function() {}} } };",
+             "  console.log('this is preserved');",
+            "})()"));
+  }
+
   public void testDevErrorPreserve() throws Exception {
     test(
         LINE_JOINER.join(
@@ -75,7 +103,7 @@ public class AmpPassTest extends Es6CompilerTestCase {
             "})()"));
   }
 
-  public void testDevAssertExpressionRemoval() throws Exception {
+  public void testDevAssertExpressionRemovalDeprecated() throws Exception {
     test(
         LINE_JOINER.join(
              "(function() {",
@@ -104,7 +132,36 @@ public class AmpPassTest extends Es6CompilerTestCase {
             "})()"));
   }
 
-  public void testDevAssertPreserveFirstArg() throws Exception {
+  public void testDevAssertExpressionRemoval() throws Exception {
+    test(
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  module$src$log.dev().assert('hello world');",
+             "  console.log('this is preserved');",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  \"hello world\";",
+             "  console.log('this is preserved');",
+            "})()"));
+    test(
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  var someValue = module$src$log.dev().assert();",
+             "  console.log('this is preserved', someValue);",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  var someValue;",
+             "  console.log('this is preserved', someValue);",
+            "})()"));
+  }
+
+  public void testDevAssertPreserveFirstArgDeprecated() throws Exception {
     test(
         LINE_JOINER.join(
              "(function() {",
@@ -120,7 +177,23 @@ public class AmpPassTest extends Es6CompilerTestCase {
             "})()"));
   }
 
-  public void testShouldPreserveNoneCalls() throws Exception {
+  public void testDevAssertPreserveFirstArg() throws Exception {
+    test(
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  var someValue = module$src$log.dev().assert(true, 'This is an error');",
+             "  console.log('this is preserved', someValue);",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  var someValue = true;",
+             "  console.log('this is preserved', someValue);",
+            "})()"));
+  }
+
+  public void testShouldPreserveNoneCallsDeprecated() throws Exception {
     test(
         // Does reliasing
         LINE_JOINER.join(
@@ -133,6 +206,23 @@ public class AmpPassTest extends Es6CompilerTestCase {
              "(function() {",
              "  var log = { dev: { assert: function() {} } };",
              "  var someValue = log.dev.assert;",
+             "  console.log('this is preserved', someValue);",
+            "})()"));
+  }
+
+  public void testShouldPreserveNoneCalls() throws Exception {
+    test(
+        // Does reliasing
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  var someValue = module$src$log.dev().assert;",
+             "  console.log('this is preserved', someValue);",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  var someValue = module$src$log.dev().assert;",
              "  console.log('this is preserved', someValue);",
             "})()"));
   }


### PR DESCRIPTION
This is in preparation for the changes @jridgewell is doing for us to tree shake the log module better. (remove side effects from a simple module import)