### PR TITLE
fixSmallTypoIn3pCompanyName

### DIFF
--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -58,7 +58,7 @@
     <a href="#adstir">AdStir</a> |
     <a href="#adtech" class="broken">AdTech</a> |
     <a href="#aduptech">Ad Up Technology</a> |
-    <a href="#amoad" class="broken">AmoAd</a> |
+    <a href="#amoad" class="broken">AMoAd</a> |
     <a href="#appnexus">App Nexus</a> |
     <a href="#chargeads">Chargeads</a> |
     <a href="#colombia" class="broken">Colombia ad</a> |


### PR DESCRIPTION
I found a trivial typo of our company name.
Could you merge this? thanks.

Amoad -> AMoAd