### PR TITLE
Make dev-env setup instructions more Windows-aware

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -42,33 +42,33 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 
 ### Build & Test
 
-| Command                       | Description                                                           |
-| ----------------------------- | --------------------------------------------------------------------- |
-| **`gulp`***                   | Runs "watch" and "serve". Use this for standard local dev.            |
-| `gulp dist`*                  | Builds production binaries.                                           |
-| `gulp dist --fortesting`*     | Indicates the production binaries are used for local testing. Without this ads, tweets and similar use cases are expected to break locally when using minified sources.|
-| `gulp lint`                   | Validates against Google Closure Linter.                              |
-| `gulp lint --watch`           | Watches for changes in files, Validates against Google Closure Linter.|
-| `gulp lint --fix`             | Fixes simple lint warnings/errors automatically.                      |
-| `gulp build`*                 | Builds the AMP library.                                               |
-| `gulp build --css-only`*      | Builds only the embedded css into js files for the AMP library.       |
-| `gulp clean`                  | Removes build output.                                                 |
-| `gulp css`                    | Recompile css to build directory.                                     |
-| `gulp extensions`             | Build AMP Extensions.                                                 |
-| `gulp watch`*                 | Watches for changes in files, re-build.                               |
-| `gulp test`*                  | Runs tests in Chrome.                                                 |
-| `gulp test --verbose`*        | Runs tests in Chrome with logging enabled.                            |
-| `gulp test --nobuild`         | Runs tests without re-build.                                          |
-| `gulp test --watch`*          | Watches for changes in files, runs corresponding test(s) in Chrome.   |
-| `gulp test --watch --verbose`*| Same as "watch" with logging enabled.                                 |
-| `gulp test --saucelabs`*      | Runs test on saucelabs (requires [setup](#saucelabs)).                |
-| `gulp test --safari`*         | Runs tests in Safari.                                                 |
-| `gulp test --firefox`*        | Runs tests in Firefox.                                                |
-| `gulp test --files=<test-files-path-glob>`*        | Runs specific test files.                                                |
-| `gulp serve`                  | Serves content in repo root dir over http://localhost:8000/. Examples live in http://localhost:8000/examples/          |
-| `npm run ava`* | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava). |
+| Command                                                                 | Description                                                           |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| **`gulp`**<sup>[[1]](#footnote-1)</sup>                                 | Runs "watch" and "serve". Use this for standard local dev.            |
+| `gulp dist`<sup>[[1]](#footnote-1)</sup>                                | Builds production binaries.                                           |
+| `gulp dist --fortesting`<sup>[[1]](#footnote-1)</sup>                   | Indicates the production binaries are used for local testing. Without this ads, tweets and similar use cases are expected to break locally when using minified sources. |
+| `gulp lint`                                                             | Validates against Google Closure Linter.                              |
+| `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
+| `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
+| `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
+| `gulp build --css-only`<sup>[[1]](#footnote-1)</sup>                    | Builds only the embedded css into js files for the AMP library.       |
+| `gulp clean`                                                            | Removes build output.                                                 |
+| `gulp css`                                                              | Recompile css to build directory.                                     |
+| `gulp extensions`                                                       | Build AMP Extensions.                                                 |
+| `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
+| `gulp test`<sup>[[1]](#footnote-1)</sup>                                | Runs tests in Chrome.                                                 |
+| `gulp test --verbose`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Chrome with logging enabled.                            |
+| `gulp test --nobuild`                                                   | Runs tests without re-build.                                          |
+| `gulp test --watch`<sup>[[1]](#footnote-1)</sup>                        | Watches for changes in files, runs corresponding test(s) in Chrome.   |
+| `gulp test --watch --verbose`*                                          | Same as "watch" with logging enabled.                                 |
+| `gulp test --saucelabs`<sup>[[1]](#footnote-1)</sup>                    | Runs test on saucelabs (requires [setup](#saucelabs)).                |
+| `gulp test --safari`<sup>[[1]](#footnote-1)</sup>                       | Runs tests in Safari.                                                 |
+| `gulp test --firefox`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Firefox.                                                |
+| `gulp test --files=<test-files-path-glob>`<sup>[[1]](#footnote-1)</sup> | Runs specific test files.                                             |
+| `gulp serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Examples live in http://localhost:8000/examples/ |
+| `npm run ava`<sup>[[1]](#footnote-1)</sup>                              | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava). |
 
-\* On Windows, this command must be run as administrator.
+<a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.
 
 #### Saucelabs
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -34,8 +34,8 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 
 1. Install [NodeJS](https://nodejs.org).
 2. In the repo directory, run `npm i` command to install the required npm packages.
-3. run `sudo npm i -g gulp` command to install gulp in your local bin folder ('/usr/local/bin/' on Mac).
-4. `edit /etc/hosts` and map `ads.localhost` and `iframe.localhost` to `127.0.0.1`.
+3. Run `npm i -g gulp` command to install gulp system-wide (on Mac or Linux you may need to prefix this with `sudo`, depending on how Node was installed).
+4. Edit your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows) and map `ads.localhost` and `iframe.localhost` to `127.0.0.1`.
 <pre>
   127.0.0.1               ads.localhost iframe.localhost
 </pre>
@@ -44,30 +44,31 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 
 | Command                       | Description                                                           |
 | ----------------------------- | --------------------------------------------------------------------- |
-| **`gulp`**                    | Runs "watch" and "serve". Use this for standard local dev.            |
-| `gulp dist`                   | Builds production binaries.                                           |
-| `gulp dist --fortesting`      | Indicates the production binaries are used for local testing. Without this ads, tweets and similar use cases are expected to break locally when using minified sources.|
+| **`gulp`***                   | Runs "watch" and "serve". Use this for standard local dev.            |
+| `gulp dist`*                  | Builds production binaries.                                           |
+| `gulp dist --fortesting`*     | Indicates the production binaries are used for local testing. Without this ads, tweets and similar use cases are expected to break locally when using minified sources.|
 | `gulp lint`                   | Validates against Google Closure Linter.                              |
 | `gulp lint --watch`           | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`             | Fixes simple lint warnings/errors automatically.                      |
-| `gulp build`                  | Builds the AMP library.                                               |
-| `gulp build` --css-only       | Builds only the embedded css into js files for the AMP library.       |
+| `gulp build`*                 | Builds the AMP library.                                               |
+| `gulp build --css-only`*      | Builds only the embedded css into js files for the AMP library.       |
 | `gulp clean`                  | Removes build output.                                                 |
 | `gulp css`                    | Recompile css to build directory.                                     |
 | `gulp extensions`             | Build AMP Extensions.                                                 |
-| `gulp watch`                  | Watches for changes in files, re-build.                               |
-| `gulp test`                   | Runs tests in Chrome.                                                 |
-| `gulp test --verbose`         | Runs tests in Chrome with logging enabled.                            |
+| `gulp watch`*                 | Watches for changes in files, re-build.                               |
+| `gulp test`*                  | Runs tests in Chrome.                                                 |
+| `gulp test --verbose`*        | Runs tests in Chrome with logging enabled.                            |
 | `gulp test --nobuild`         | Runs tests without re-build.                                          |
-| `gulp test --watch`           | Watches for changes in files, runs corresponding test(s) in Chrome.   |
-| `gulp test --watch --verbose` | Same as "watch" with logging enabled.                                 |
-| `gulp test --saucelabs`       | Runs test on saucelabs (requires [setup](#saucelabs)).                |
-| `gulp test --safari`          | Runs tests in Safari.                                                 |
-| `gulp test --firefox`         | Runs tests in Firefox.                                                |
-| `gulp test --files=<test-files-path-glob>`         | Runs specific test files.                                                |
+| `gulp test --watch`*          | Watches for changes in files, runs corresponding test(s) in Chrome.   |
+| `gulp test --watch --verbose`*| Same as "watch" with logging enabled.                                 |
+| `gulp test --saucelabs`*      | Runs test on saucelabs (requires [setup](#saucelabs)).                |
+| `gulp test --safari`*         | Runs tests in Safari.                                                 |
+| `gulp test --firefox`*        | Runs tests in Firefox.                                                |
+| `gulp test --files=<test-files-path-glob>`*        | Runs specific test files.                                                |
 | `gulp serve`                  | Serves content in repo root dir over http://localhost:8000/. Examples live in http://localhost:8000/examples/          |
-| `npm run ava` | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava). |
+| `npm run ava`* | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava). |
 
+\* On Windows, this command must be run as administrator.
 
 #### Saucelabs
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -60,7 +60,7 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 | `gulp test --verbose`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Chrome with logging enabled.                            |
 | `gulp test --nobuild`                                                   | Runs tests without re-build.                                          |
 | `gulp test --watch`<sup>[[1]](#footnote-1)</sup>                        | Watches for changes in files, runs corresponding test(s) in Chrome.   |
-| `gulp test --watch --verbose`*                                          | Same as "watch" with logging enabled.                                 |
+| `gulp test --watch --verbose`<sup>[[1]](#footnote-1)</sup>              | Same as "watch" with logging enabled.                                 |
 | `gulp test --saucelabs`<sup>[[1]](#footnote-1)</sup>                    | Runs test on saucelabs (requires [setup](#saucelabs)).                |
 | `gulp test --safari`<sup>[[1]](#footnote-1)</sup>                       | Runs tests in Safari.                                                 |
 | `gulp test --firefox`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Firefox.                                                |


### PR DESCRIPTION
I recently assisted a confused Windows developer on Slack who was having a hard time getting his environment set up. This demonstrated to me that the existing setup instructions assume a Unix environment and aren't very friendly to Windows users. Here's an attempt at fixing this.