### PR TITLE
Updated format of a4a triggering URL param.

### DIFF
--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -128,28 +128,33 @@ describe('a4a_config', () => {
            'googleAdsIsA4AEnabled').to.be.true;
   });
 
-  ['?PARAM', '?p=blarg&PARAM', '?p=blarg&PARAM&s=987'].forEach(urlBase => {
+  const urlBaseConditions = ['?exp=PARAM',
+    '?p=blarg&exp=PARAM',
+    '?p=blarg&exp=PARAM&s=987',
+    '?p=blarg&exp=zort:123,PARAM,spaz:987&s=987'];
+  urlBaseConditions.forEach(urlBase => {
 
-    it(`should force experiment param from URL when pattern=${urlBase}`, () => {
-      win.location.search = urlBase.replace('PARAM', 'a4a=2');
-      rand.onFirstCall().returns(2);  // Force experiment off.
-      const element = document.createElement('div');
-      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-             'googleAdsIsA4AEnabled').to.be.true;
-      expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.false;
-      expect(element.getAttribute('data-experiment-id')).to.equal(
-          BRANCHES.experiment);
-    });
+    it(`should force experiment param from URL when pattern=${urlBase}`,
+        () => {
+          win.location.search = urlBase.replace('PARAM', 'a4a:2');
+          rand.onFirstCall().returns(2);  // Force experiment off.
+          const element = document.createElement('div');
+          expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
+              'googleAdsIsA4AEnabled').to.be.true;
+          expect(win.document.cookie).to.be.null;
+          expect(rand.called, 'rand called at least once').to.be.false;
+          expect(element.getAttribute('data-experiment-id')).to.equal(
+              BRANCHES.experiment);
+        });
 
     it(`should force control param from URL when pattern=${urlBase}`, () => {
-      win.location.search = urlBase.replace('PARAM', 'a4a=1');
+      win.location.search = urlBase.replace('PARAM', 'a4a:1');
       rand.onFirstCall().returns(2);  // Force experiment off.
       const element = document.createElement('div');
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-             'googleAdsIsA4AEnabled').to.be.false;
+          'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(rand.called, 'rand called at least once').to.be.false;
       expect(element.getAttribute('data-experiment-id')).to.equal(
@@ -157,18 +162,17 @@ describe('a4a_config', () => {
     });
 
     it(`should exclude all experiment IDs when pattern=${urlBase}`, () => {
-      win.location.search = urlBase.replace('PARAM', 'a4a=0');
+      win.location.search = urlBase.replace('PARAM', 'a4a:0');
       rand.onFirstCall().returns(2);  // Force experiment off.
       const element = document.createElement('div');
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-             'googleAdsIsA4AEnabled').to.be.false;
+          'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(rand.called, 'rand called at least once').to.be.false;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
-
   });
 
 });

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {googleAdsIsA4AEnabled} from '../traffic-experiments';
+import {
+  googleAdsIsA4AEnabled,
+  MANUAL_EXPERIMENT_ID,
+} from '../traffic-experiments';
 import {resetExperimentToggles_} from '../../../../src/experiments';
 import * as sinon from 'sinon';
 
@@ -51,37 +54,46 @@ describe('a4a_config', () => {
   });
 
   const EXP_ID = 'EXP_ID';
-  const BRANCHES = {control: 'CONTROL', experiment: 'EXPERIMENT'};
+  const EXTERNAL_BRANCHES = {
+    control: 'EXT_CONTROL',
+    experiment: 'EXT_EXPERIMENT',
+  };
+  const INTERNAL_BRANCHES = {
+    control: 'INT_CONTROL',
+    experiment: 'INT_EXPERIMENT',
+  };
 
   it('should attach expt ID and return true when expt is on', () => {
     rand.onFirstCall().returns(-1);  // Force experiment on.
     rand.onSecondCall().returns(0.75);  // Select second branch.
     const element = document.createElement('div');
-    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
+    expect(googleAdsIsA4AEnabled(win, element, EXP_ID,
+        EXTERNAL_BRANCHES, INTERNAL_BRANCHES),
            'googleAdsIsA4AEnabled').to.be.true;
     expect(win.document.cookie).to.be.null;
     expect(rand.calledTwice, 'rand called twice').to.be.true;
     expect(element.getAttribute('data-experiment-id')).to.equal(
-        BRANCHES.experiment);
+        INTERNAL_BRANCHES.experiment);
   });
 
   it('should attach control ID and return false when control is on', () => {
     rand.onFirstCall().returns(-1);  // Force experiment on.
     rand.onSecondCall().returns(0.25);  // Select first branch.
     const element = document.createElement('div');
-    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
+    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+        INTERNAL_BRANCHES),
            'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(rand.calledTwice, 'rand called twice').to.be.true;
     expect(element.getAttribute('data-experiment-id')).to.equal(
-        BRANCHES.control);
+        INTERNAL_BRANCHES.control);
   });
 
   it('should not attach ID and return false when selected out', () => {
     rand.onFirstCall().returns(2);  // Force experiment off.
     const element = document.createElement('div');
-    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-        'googleAdsIsA4AEnabled').to.be.false;
+    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(rand.calledOnce, 'rand called once').to.be.true;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
@@ -91,8 +103,8 @@ describe('a4a_config', () => {
     win.AMP_MODE.localDev = false;
     win.location.href = 'http://somewhere.over.the.rainbow.org/';
     const element = document.createElement('div');
-    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-           'googleAdsIsA4AEnabled').to.be.false;
+    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(rand.called, 'rand called ever').to.be.false;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
@@ -103,8 +115,8 @@ describe('a4a_config', () => {
     rand.onFirstCall().returns(-1);  // Force experiment on.
     rand.onSecondCall().returns(0.75);  // Select second branch.
     const element = document.createElement('div');
-    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-           'googleAdsIsA4AEnabled').to.be.false;
+    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(rand.called, 'rand called ever').to.be.false;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
@@ -115,8 +127,8 @@ describe('a4a_config', () => {
     rand.onFirstCall().returns(-1);  // Force experiment on.
     rand.onSecondCall().returns(0.75);  // Select second branch.
     const element = document.createElement('div');
-    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-           'googleAdsIsA4AEnabled').to.be.true;
+    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
   });
 
   it('should return true if only crypto.subtle is available', () => {
@@ -124,8 +136,8 @@ describe('a4a_config', () => {
     rand.onFirstCall().returns(-1);  // Force experiment on.
     rand.onSecondCall().returns(0.75);  // Select second branch.
     const element = document.createElement('div');
-    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-           'googleAdsIsA4AEnabled').to.be.true;
+    expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
   });
 
   const urlBaseConditions = ['?exp=PARAM',
@@ -137,41 +149,63 @@ describe('a4a_config', () => {
     it(`should force experiment param from URL when pattern=${urlBase}`,
         () => {
           win.location.search = urlBase.replace('PARAM', 'a4a:2');
-          rand.onFirstCall().returns(2);  // Force experiment off.
+          // Ensure that internal branches aren't attached, even if the PRNG
+          // would normally trigger them.
+          rand.onFirstCall().returns(-1);
           const element = document.createElement('div');
-          expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-              'googleAdsIsA4AEnabled').to.be.true;
+          expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+              INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
           expect(win.document.cookie).to.be.null;
           expect(rand.called, 'rand called at least once').to.be.false;
           expect(element.getAttribute('data-experiment-id')).to.equal(
-              BRANCHES.experiment);
+              EXTERNAL_BRANCHES.experiment);
         });
 
     it(`should force control param from URL when pattern=${urlBase}`, () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:1');
-      rand.onFirstCall().returns(2);  // Force experiment off.
+      // Ensure that internal branches aren't attached, even if the PRNG
+      // would normally trigger them.
+      rand.onFirstCall().returns(-1);
       const element = document.createElement('div');
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
-      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-          'googleAdsIsA4AEnabled').to.be.false;
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(rand.called, 'rand called at least once').to.be.false;
       expect(element.getAttribute('data-experiment-id')).to.equal(
-          BRANCHES.control);
+          EXTERNAL_BRANCHES.control);
     });
 
     it(`should exclude all experiment IDs when pattern=${urlBase}`, () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:0');
-      rand.onFirstCall().returns(2);  // Force experiment off.
+      // Ensure that internal branches aren't attached, even if the PRNG
+      // would normally trigger them.
+      rand.onFirstCall().returns(-1);
       const element = document.createElement('div');
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
-      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, BRANCHES),
-          'googleAdsIsA4AEnabled').to.be.false;
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(rand.called, 'rand called at least once').to.be.false;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
+    });
+
+    it(`should attach manual experiment ID when pattern = ${urlBase}`, () => {
+      win.location.search = urlBase.replace('PARAM', 'a4a:-1');
+      // Ensure that internal branches aren't attached, even if the PRNG
+      // would normally trigger them.
+      rand.onFirstCall().returns(-1);
+      const element = document.createElement('div');
+      // Should not register as 'A4A enabled', but should still attach the
+      // control experiment ID.
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+      expect(win.document.cookie).to.be.null;
+      expect(rand.called, 'rand called at least once').to.be.false;
+      expect(element.getAttribute('data-experiment-id')).to.equal(
+          MANUAL_EXPERIMENT_ID);
     });
   });
 

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -146,6 +146,60 @@ describe('a4a_config', () => {
     '?p=blarg&exp=zort:123,PARAM,spaz:987&s=987'];
   urlBaseConditions.forEach(urlBase => {
 
+    it('should skip url-triggered eid when param is bad', () => {
+      win.location.search = urlBase.replace('PARAM', 'a4a:spaz');
+      // Force random client-side selection off.
+      rand.onFirstCall().returns(2);
+      const element = document.createElement('div');
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+      expect(win.document.cookie).to.be.null;
+      expect(rand.called, 'rand called at least once').to.be.true;
+      expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
+    });
+
+    it('should skip url-triggered eid when param is empty', () => {
+      win.location.search = urlBase.replace('PARAM', 'a4a:');
+      // Force random client-side selection off.
+      rand.onFirstCall().returns(2);
+      const element = document.createElement('div');
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+      expect(win.document.cookie).to.be.null;
+      expect(rand.called, 'rand called at least once').to.be.true;
+      expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
+    });
+
+    it('should fall back to client-side eid when param is bad', () => {
+      win.location.search = urlBase.replace('PARAM', 'a4a:spaz');
+      // Force random client-side selection on.
+      rand.onFirstCall().returns(-1);
+      // Force experiment branch.
+      rand.onSecondCall().returns(0.75);
+      const element = document.createElement('div');
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+      expect(win.document.cookie).to.be.null;
+      expect(rand.called, 'rand called at least once').to.be.true;
+      expect(element.getAttribute('data-experiment-id')).to.equal(
+          INTERNAL_BRANCHES.experiment);
+    });
+
+    it('should fall back to client-side eid when param is empty', () => {
+      win.location.search = urlBase.replace('PARAM', 'a4a:');
+      // Force random client-side selection on.
+      rand.onFirstCall().returns(-1);
+      // Force experiment branch.
+      rand.onSecondCall().returns(0.75);
+      const element = document.createElement('div');
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+      expect(win.document.cookie).to.be.null;
+      expect(rand.called, 'rand called at least once').to.be.true;
+      expect(element.getAttribute('data-experiment-id')).to.equal(
+          INTERNAL_BRANCHES.experiment);
+    });
+
     it(`should force experiment param from URL when pattern=${urlBase}`,
         () => {
           win.location.search = urlBase.replace('PARAM', 'a4a:2');

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -15,8 +15,9 @@
  */
 
 import {
-  googleAdsIsA4AEnabled,
-  MANUAL_EXPERIMENT_ID,
+    googleAdsIsA4AEnabled,
+    isInExperiment,
+    isInManualExperiment,
 } from '../traffic-experiments';
 import {resetExperimentToggles_} from '../../../../src/experiments';
 import * as sinon from 'sinon';
@@ -258,8 +259,17 @@ describe('a4a_config', () => {
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expect(rand.called, 'rand called at least once').to.be.false;
-      expect(element.getAttribute('data-experiment-id')).to.equal(
-          MANUAL_EXPERIMENT_ID);
+      expect(isInManualExperiment(element), 'element in manual experiment')
+          .to.be.true;
+      // And it shouldn't be in any *other* experiments.
+      for (const branch in EXTERNAL_BRANCHES) {
+        expect(isInExperiment(element, EXTERNAL_BRANCHES[branch]),
+            'element in ', EXTERNAL_BRANCHES[branch]).to.be.false;
+      }
+      for (const branch in EXTERNAL_BRANCHES) {
+        expect(isInExperiment(element, INTERNAL_BRANCHES[branch]),
+            'element in ', EXTERNAL_BRANCHES[branch]).to.be.false;
+      }
     });
   });
 

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -344,7 +344,6 @@ describe('all-traffic-experiments-tests', () => {
       expect(containsExperimentId('frob', 'frob')).to.be.true;
     });
     it('should return true for matching query', () => {
-      assert.fail('gnort');
       expect(containsExperimentId('frob,gunk,zort', 'frob')).to.be.true;
       expect(containsExperimentId('frob,gunk,zort', 'gunk')).to.be.true;
       expect(containsExperimentId('frob,gunk,zort', 'zort')).to.be.true;

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -22,7 +22,7 @@ import {
   getPageExperimentBranch,
   mergeExperimentIds,
   isInExperiment,
-  setupPageExperiments,
+  randomlySelectUnsetPageExperiments,
   validateExperimentIds,
 } from '../traffic-experiments';
 import {
@@ -37,7 +37,7 @@ const TAG_ = 'test-amp-ad';
 
 describe('all-traffic-experiments-tests', () => {
 
-  describe('#setupPageExperiments', () => {
+  describe('#randomlySelectUnsetPageExperiments', () => {
     let sandbox;
     let accurateRandomStub;
     let cachedAccuratePrng;
@@ -77,7 +77,7 @@ describe('all-traffic-experiments-tests', () => {
     it('handles empty experiments list', () => {
       // Opt out of experiment.
       sandbox.win.AMP_CONFIG['testExperimentId'] = 0.0;
-      setupPageExperiments(sandbox.win, {});
+      randomlySelectUnsetPageExperiments(sandbox.win, {});
       expect(isExperimentOn(sandbox.win, 'testExperimentId'),
           'experiment is on').to.be.false;
       expect(sandbox.win.pageExperimentBranches).to.be.empty;
@@ -85,7 +85,7 @@ describe('all-traffic-experiments-tests', () => {
     it('handles experiment not diverted path', () => {
       // Opt out of experiment.
       sandbox.win.AMP_CONFIG['testExperimentId'] = 0.0;
-      setupPageExperiments(sandbox.win, testExperimentSet);
+      randomlySelectUnsetPageExperiments(sandbox.win, testExperimentSet);
       expect(isExperimentOn(sandbox.win, 'testExperimentId'),
           'experiment is on').to.be.false;
       expect(getPageExperimentBranch(sandbox.win,
@@ -97,7 +97,7 @@ describe('all-traffic-experiments-tests', () => {
       // return a value < 0.5.
       sandbox.win.AMP_CONFIG['testExperimentId'] = 1.0;
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.3);
-      setupPageExperiments(sandbox.win, testExperimentSet);
+      randomlySelectUnsetPageExperiments(sandbox.win, testExperimentSet);
       expect(isExperimentOn(sandbox.win, 'testExperimentId'),
           'experiment is on').to.be.true;
       expect(getPageExperimentBranch(sandbox.win, 'testExperimentId')).to.equal(
@@ -109,7 +109,7 @@ describe('all-traffic-experiments-tests', () => {
       // return a value > 0.5.
       sandbox.win.AMP_CONFIG['testExperimentId'] = 1.0;
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.6);
-      setupPageExperiments(sandbox.win, testExperimentSet);
+      randomlySelectUnsetPageExperiments(sandbox.win, testExperimentSet);
       expect(isExperimentOn(sandbox.win, 'testExperimentId'),
           'experiment is on').to.be.true;
       expect(getPageExperimentBranch(sandbox.win, 'testExperimentId')).to.equal(
@@ -138,7 +138,7 @@ describe('all-traffic-experiments-tests', () => {
         // expt_3 omitted.
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.6);
-      setupPageExperiments(sandbox.win, experimentInfo);
+      randomlySelectUnsetPageExperiments(sandbox.win, experimentInfo);
       expect(isExperimentOn(sandbox.win, 'expt_0'),
           'expt_0 is on').to.be.true;
       expect(isExperimentOn(sandbox.win, 'expt_1'),
@@ -170,7 +170,7 @@ describe('all-traffic-experiments-tests', () => {
         },
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.7);
-      setupPageExperiments(sandbox.win, experimentInfo);
+      randomlySelectUnsetPageExperiments(sandbox.win, experimentInfo);
       expect(isExperimentOn(sandbox.win, 'expt_0'),
           'expt_0 is on').to.be.true;
       expect(getPageExperimentBranch(sandbox.win, 'expt_0')).to.equal(
@@ -208,7 +208,7 @@ describe('all-traffic-experiments-tests', () => {
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.7);
       RANDOM_NUMBER_GENERATORS.accuratePrng.onSecondCall().returns(0.3);
-      setupPageExperiments(sandbox.win, experimentInfo);
+      randomlySelectUnsetPageExperiments(sandbox.win, experimentInfo);
       expect(isExperimentOn(sandbox.win, 'expt_0'),
           'expt_0 is on').to.be.true;
       expect(isExperimentOn(sandbox.win, 'expt_1'),
@@ -242,9 +242,9 @@ describe('all-traffic-experiments-tests', () => {
       sandbox.win.AMP_CONFIG = {};
       const config = sandbox.win.AMP_CONFIG;
       config['fooExpt'] = 0.0;
-      setupPageExperiments(sandbox.win, exptAInfo);
+      randomlySelectUnsetPageExperiments(sandbox.win, exptAInfo);
       config['fooExpt'] = 1.0;
-      setupPageExperiments(sandbox.win, exptBInfo);
+      randomlySelectUnsetPageExperiments(sandbox.win, exptBInfo);
       // Even though we tried to set up a second time, using a config
       // parameter that should ensure that the experiment was activated, the
       // experiment framework should evaluate each experiment only once per

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -23,12 +23,12 @@ import {
   mergeExperimentIds,
   setupPageExperiments,
   validateExperimentIds,
-} from '../../ads/google/a4a/traffic-experiments';
+} from '../traffic-experiments';
 import {
   isExperimentOn,
   resetExperimentToggles_,
-} from '../../src/experiments';
-import {dev} from '../../src/log';
+} from '../../../../src/experiments';
+import {dev} from '../../../../src/log';
 import * as sinon from 'sinon';
 
 /** @private @const Tag used in dev log messages */

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -21,6 +21,7 @@ import {
   addExperimentIdToElement,
   getPageExperimentBranch,
   mergeExperimentIds,
+  containsExperimentId,
   setupPageExperiments,
   validateExperimentIds,
 } from '../traffic-experiments';
@@ -319,6 +320,34 @@ describe('all-traffic-experiments-tests', () => {
     });
     it('should return empty string for invalid input', () => {
       expect(mergeExperimentIds('frob')).to.equal('');
+    });
+  });
+
+  describe('#containsExperimentIds', () => {
+    it('should return false for empty input string and any query', () => {
+      expect(containsExperimentId('', '')).to.be.false;
+      expect(containsExperimentId('', null)).to.be.false;
+      expect(containsExperimentId('', 'frob')).to.be.false;
+    });
+    it('should return false for null input string and any query', () => {
+      expect(containsExperimentId(null, '')).to.be.false;
+      expect(containsExperimentId(null, null)).to.be.false;
+      expect(containsExperimentId(null, 'frob')).to.be.false;
+    });
+    it('should return false for real data string but mismatching query', () => {
+      expect(containsExperimentId('frob,gunk,zort', 'blub')).to.be.false;
+      expect(containsExperimentId('frob,gunk,zort', 'ort')).to.be.false;
+      expect(containsExperimentId('frob,gunk,zort', 'fro')).to.be.false;
+      expect(containsExperimentId('frob,gunk,zort', 'gunk,zort')).to.be.false;
+    });
+    it('should return true for singleton data and matching query', () => {
+      expect(containsExperimentId('frob', 'frob')).to.be.true;
+    });
+    it('should return true for matching query', () => {
+      assert.fail('gnort');
+      expect(containsExperimentId('frob,gunk,zort', 'frob')).to.be.true;
+      expect(containsExperimentId('frob,gunk,zort', 'gunk')).to.be.true;
+      expect(containsExperimentId('frob,gunk,zort', 'zort')).to.be.true;
     });
   });
 });

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -21,7 +21,7 @@ import {
   addExperimentIdToElement,
   getPageExperimentBranch,
   mergeExperimentIds,
-  containsExperimentId,
+  isInExperiment,
   setupPageExperiments,
   validateExperimentIds,
 } from '../traffic-experiments';
@@ -323,30 +323,39 @@ describe('all-traffic-experiments-tests', () => {
     });
   });
 
-  describe('#containsExperimentIds', () => {
-    it('should return false for empty input string and any query', () => {
-      expect(containsExperimentId('', '')).to.be.false;
-      expect(containsExperimentId('', null)).to.be.false;
-      expect(containsExperimentId('', 'frob')).to.be.false;
+  describe('#isInExperiment', () => {
+    it('should return false for empty element and any query', () => {
+      const element = document.createElement('div');
+      expect(isInExperiment(element, '')).to.be.false;
+      expect(isInExperiment(element, null)).to.be.false;
+      expect(isInExperiment(element, 'frob')).to.be.false;
     });
-    it('should return false for null input string and any query', () => {
-      expect(containsExperimentId(null, '')).to.be.false;
-      expect(containsExperimentId(null, null)).to.be.false;
-      expect(containsExperimentId(null, 'frob')).to.be.false;
+    it('should return false for empty attribute and any query', () => {
+      const element = document.createElement('div');
+      element.setAttribute(EXPERIMENT_ATTRIBUTE, '');
+      expect(isInExperiment(element, '')).to.be.false;
+      expect(isInExperiment(element, null)).to.be.false;
+      expect(isInExperiment(element, 'frob')).to.be.false;
     });
     it('should return false for real data string but mismatching query', () => {
-      expect(containsExperimentId('frob,gunk,zort', 'blub')).to.be.false;
-      expect(containsExperimentId('frob,gunk,zort', 'ort')).to.be.false;
-      expect(containsExperimentId('frob,gunk,zort', 'fro')).to.be.false;
-      expect(containsExperimentId('frob,gunk,zort', 'gunk,zort')).to.be.false;
+      const element = document.createElement('div');
+      element.setAttribute(EXPERIMENT_ATTRIBUTE, 'frob,gunk,zort');
+      expect(isInExperiment(element, 'blub')).to.be.false;
+      expect(isInExperiment(element, 'ort')).to.be.false;
+      expect(isInExperiment(element, 'fro')).to.be.false;
+      expect(isInExperiment(element, 'gunk,zort')).to.be.false;
     });
     it('should return true for singleton data and matching query', () => {
-      expect(containsExperimentId('frob', 'frob')).to.be.true;
+      const element = document.createElement('div');
+      element.setAttribute(EXPERIMENT_ATTRIBUTE, 'frob');
+      expect(isInExperiment(element, 'frob')).to.be.true;
     });
     it('should return true for matching query', () => {
-      expect(containsExperimentId('frob,gunk,zort', 'frob')).to.be.true;
-      expect(containsExperimentId('frob,gunk,zort', 'gunk')).to.be.true;
-      expect(containsExperimentId('frob,gunk,zort', 'zort')).to.be.true;
+      const element = document.createElement('div');
+      element.setAttribute(EXPERIMENT_ATTRIBUTE, 'frob,gunk,zort');
+      expect(isInExperiment(element, 'frob')).to.be.true;
+      expect(isInExperiment(element, 'gunk')).to.be.true;
+      expect(isInExperiment(element, 'zort')).to.be.true;
     });
   });
 });

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -272,6 +272,19 @@ export function parseExperimentIds(idString) {
 }
 
 /**
+ * Checks whether a (possibly empty) experiment ID string (comma-separated)
+ * contains a specific, single ID.
+ *
+ * @param idString  {?string} Comma-separated list of ID strings, per
+ *   #parseExperimentIds.
+ * @param id {?string} Id to look up in the `idString`.
+ * @return {boolean}
+ */
+export function containsExperimentId(idString, id) {
+  return parseExperimentIds(idString).some(x => { return x === id; });
+}
+
+/**
  * Checks that all string experiment IDs in a list are syntactically valid
  * (integer base 10).
  *

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -55,7 +55,7 @@ export function isGoogleAdsA4AValidEnvironment(win) {
   // around that, just say that we're A4A eligible if we're in local dev
   // mode, regardless of origin path.
   return supportsNativeCrypto &&
-      (isProxyOrigin(win.location) || getMode().localDev);
+      (isProxyOrigin(win.location) || getMode().localDev || getMode().test);
 }
 
 /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -25,7 +25,7 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 
 /** @const {!string}  @private */
-const ADSENSE_A4A_EXPERIMENT_ID = 'expAdsenseA4A';
+const ADSENSE_A4A_EXPERIMENT_NAME = 'expAdsenseA4A';
 
 // The following experiment IDs are used by Google-side servers to
 // understand what experiment is running and what mode the A4A code is
@@ -61,7 +61,7 @@ const ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
  */
 export function adsenseIsA4AEnabled(win, element) {
   return googleAdsIsA4AEnabled(
-      win, element, ADSENSE_A4A_EXPERIMENT_ID,
+      win, element, ADSENSE_A4A_EXPERIMENT_NAME,
       ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
       ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES);
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -27,6 +27,21 @@ import {
 /** @const {!string}  @private */
 const ADSENSE_A4A_EXPERIMENT_ID = 'expAdsenseA4A';
 
+// The following experiment IDs are used by Google-side servers to
+// understand what experiment is running and what mode the A4A code is
+// running in.  In this experiment phase, we're testing 8 different
+// configurations, resulting from the Cartesian product of the following:
+//   - Traditional 3p iframe ad rendering (control) vs A4A rendering
+//     (experiment)
+//   - Experiment triggered by an external page, such as the Google Search
+//     page vs. triggered internally in the client code.
+//   - Doubleclick vs Adsense
+// The following two objects contain experiment IDs for the first two
+// categories for Adsense ads.  They are attached to the ad request by
+// ads/google/a4a/traffic-experiments.js#googleAdsIsA4AEnabled when it works
+// out whether a given ad request is in the overall experiment and, if so,
+// which branch it's on.
+
 /** const {!Branches} @private */
 const ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152650',

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -24,13 +24,19 @@ import {
   googleAdsIsA4AEnabled,
 } from '../../../ads/google/a4a/traffic-experiments';
 
-/** @const {string} */
+/** @const {!string}  @private */
 const ADSENSE_A4A_EXPERIMENT_ID = 'expAdsenseA4A';
 
-/** @const {!Branches} */
-const ADSENSE_A4A_EXPERIMENT_BRANCHES = {
+/** const {!Branches} @private */
+const ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES = {
+  control: '117152650',
+  experiment: '117152651',
+};
+
+/** @const {!Branches} @private */
+const ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152630',
-  experiment: '117152632',
+  experiment: '117152633',
 };
 
 /**
@@ -40,5 +46,7 @@ const ADSENSE_A4A_EXPERIMENT_BRANCHES = {
  */
 export function adsenseIsA4AEnabled(win, element) {
   return googleAdsIsA4AEnabled(
-      win, element, ADSENSE_A4A_EXPERIMENT_ID, ADSENSE_A4A_EXPERIMENT_BRANCHES);
+      win, element, ADSENSE_A4A_EXPERIMENT_ID,
+      ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
+      ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES);
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -22,6 +22,11 @@
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {
+    containsExperimentId,
+    MANUAL_EXPERIMENT_ID,
+    EXPERIMENT_ATTRIBUTE,
+} from '../../../ads/google/a4a/traffic-experiments';
+import {
   extractGoogleAdCreativeAndSignature,
   getGoogleAdSlotCounter,
   googleAdUrl,
@@ -63,13 +68,16 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const screen = global.screen;
     const slotRect = this.getIntersectionElementLayoutBox();
     const visibilityState = documentStateFor(global).getVisibilityState();
+    const adTestOn = this.element.getAttribute('data-adtest') ||
+        containsExperimentId(this.element.getAttribute(EXPERIMENT_ATTRIBUTE),
+            MANUAL_EXPERIMENT_ID);
     return googleAdUrl(this, ADSENSE_BASE_URL, startTime, slotNumber, [
       {name: 'client', value: this.element.getAttribute('data-ad-client')},
       {name: 'format', value: `${slotRect.width}x${slotRect.height}`},
       {name: 'w', value: slotRect.width},
       {name: 'h', value: slotRect.height},
       {name: 'iu', value: this.element.getAttribute('data-ad-slot')},
-      {name: 'adtest', value: this.element.getAttribute('data-adtest')},
+      {name: 'adtest', value: adTestOn},
       {
         name: 'bc',
         value: global.SVGElement && global.document.createElementNS ?

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -22,8 +22,7 @@
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {
-    isInExperiment,
-    MANUAL_EXPERIMENT_ID,
+  isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {
   extractGoogleAdCreativeAndSignature,
@@ -68,7 +67,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const slotRect = this.getIntersectionElementLayoutBox();
     const visibilityState = documentStateFor(global).getVisibilityState();
     const adTestOn = this.element.getAttribute('data-adtest') ||
-        isInExperiment(this.element, MANUAL_EXPERIMENT_ID);
+        isInManualExperiment(this.element);
     return googleAdUrl(this, ADSENSE_BASE_URL, startTime, slotNumber, [
       {name: 'client', value: this.element.getAttribute('data-ad-client')},
       {name: 'format', value: `${slotRect.width}x${slotRect.height}`},

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -22,9 +22,8 @@
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {
-    containsExperimentId,
+    isInExperiment,
     MANUAL_EXPERIMENT_ID,
-    EXPERIMENT_ATTRIBUTE,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {
   extractGoogleAdCreativeAndSignature,
@@ -69,8 +68,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const slotRect = this.getIntersectionElementLayoutBox();
     const visibilityState = documentStateFor(global).getVisibilityState();
     const adTestOn = this.element.getAttribute('data-adtest') ||
-        containsExperimentId(this.element.getAttribute(EXPERIMENT_ATTRIBUTE),
-            MANUAL_EXPERIMENT_ID);
+        isInExperiment(this.element, MANUAL_EXPERIMENT_ID);
     return googleAdUrl(this, ADSENSE_BASE_URL, startTime, slotNumber, [
       {name: 'client', value: this.element.getAttribute('data-ad-client')},
       {name: 'format', value: `${slotRect.width}x${slotRect.height}`},

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -22,9 +22,8 @@
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {
-    containsExperimentId,
+    isInExperiment,
     MANUAL_EXPERIMENT_ID,
-    EXPERIMENT_ATTRIBUTE,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {
   extractGoogleAdCreativeAndSignature,
@@ -63,9 +62,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const rawJson = this.element.getAttribute('json');
     const jsonParameters = rawJson ? JSON.parse(rawJson) : {};
     const tfcd = jsonParameters['tfcd'];
-    const adTestOn = containsExperimentId(
-        this.element.getAttribute(EXPERIMENT_ATTRIBUTE),
-        MANUAL_EXPERIMENT_ID);
+    const adTestOn = isInExperiment(this.element, MANUAL_EXPERIMENT_ID);
     return googleAdUrl(this, DOUBLECLICK_BASE_URL, startTime, slotNumber, [
       {name: 'iu', value: this.element.getAttribute('data-slot')},
       {name: 'co', value: jsonParameters['cookieOptOut'] ? '1' : null},
@@ -75,7 +72,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       {name: 'sz', value: `${slotRect.width}x${slotRect.height}`},
       {name: 'tfcd', value: tfcd == undefined ? null : tfcd},
       {name: 'u_sd', value: global.devicePixelRatio},
-      {name: 'adtest', value: adTestOn}
+      {name: 'adtest', value: adTestOn},
     ], [
       {
         name: 'scp',

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -22,6 +22,11 @@
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {
+    containsExperimentId,
+    MANUAL_EXPERIMENT_ID,
+    EXPERIMENT_ATTRIBUTE,
+} from '../../../ads/google/a4a/traffic-experiments';
+import {
   extractGoogleAdCreativeAndSignature,
   getGoogleAdSlotCounter,
   googleAdUrl,
@@ -58,6 +63,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const rawJson = this.element.getAttribute('json');
     const jsonParameters = rawJson ? JSON.parse(rawJson) : {};
     const tfcd = jsonParameters['tfcd'];
+    const adTestOn = containsExperimentId(
+        this.element.getAttribute(EXPERIMENT_ATTRIBUTE),
+        MANUAL_EXPERIMENT_ID);
     return googleAdUrl(this, DOUBLECLICK_BASE_URL, startTime, slotNumber, [
       {name: 'iu', value: this.element.getAttribute('data-slot')},
       {name: 'co', value: jsonParameters['cookieOptOut'] ? '1' : null},
@@ -67,6 +75,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       {name: 'sz', value: `${slotRect.width}x${slotRect.height}`},
       {name: 'tfcd', value: tfcd == undefined ? null : tfcd},
       {name: 'u_sd', value: global.devicePixelRatio},
+      {name: 'adtest', value: adTestOn}
     ], [
       {
         name: 'scp',

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -22,8 +22,7 @@
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {
-    isInExperiment,
-    MANUAL_EXPERIMENT_ID,
+  isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {
   extractGoogleAdCreativeAndSignature,
@@ -62,7 +61,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const rawJson = this.element.getAttribute('json');
     const jsonParameters = rawJson ? JSON.parse(rawJson) : {};
     const tfcd = jsonParameters['tfcd'];
-    const adTestOn = isInExperiment(this.element, MANUAL_EXPERIMENT_ID);
+    const adTestOn = isInManualExperiment(this.element);
     return googleAdUrl(this, DOUBLECLICK_BASE_URL, startTime, slotNumber, [
       {name: 'iu', value: this.element.getAttribute('data-slot')},
       {name: 'co', value: jsonParameters['cookieOptOut'] ? '1' : null},

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -25,7 +25,7 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 
 /** @const {string} */
-const DOUBLECLICK_A4A_EXPERIMENT_ID = 'expDoubleclickA4A';
+const DOUBLECLICK_A4A_EXPERIMENT_NAME = 'expDoubleclickA4A';
 
 // The following experiment IDs are used by Google-side servers to
 // understand what experiment is running and what mode the A4A code is
@@ -63,7 +63,7 @@ export function doubleclickIsA4AEnabled(win, element) {
   // Ensure not within remote.html iframe.
   return !win.document.querySelector('meta[name=amp-3p-iframe-src]') &&
       googleAdsIsA4AEnabled(
-        win, element, DOUBLECLICK_A4A_EXPERIMENT_ID,
+        win, element, DOUBLECLICK_A4A_EXPERIMENT_NAME,
         DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
         DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES);
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -27,6 +27,21 @@ import {
 /** @const {string} */
 const DOUBLECLICK_A4A_EXPERIMENT_ID = 'expDoubleclickA4A';
 
+// The following experiment IDs are used by Google-side servers to
+// understand what experiment is running and what mode the A4A code is
+// running in.  In this experiment phase, we're testing 8 different
+// configurations, resulting from the Cartesian product of the following:
+//   - Traditional 3p iframe ad rendering (control) vs A4A rendering
+//     (experiment)
+//   - Experiment triggered by an external page, such as the Google Search
+//     page vs. triggered internally in the client code.
+//   - Doubleclick vs Adsense
+// The following two objects contain experiment IDs for the first two
+// categories for Doubleclick ads.  They are attached to the ad request by
+// ads/google/a4a/traffic-experiments.js#googleAdsIsA4AEnabled when it works
+// out whether a given ad request is in the overall experiment and, if so,
+// which branch it's on.
+
 /** @const {!Branches} @private */
 const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152660',

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -27,8 +27,14 @@ import {
 /** @const {string} */
 const DOUBLECLICK_A4A_EXPERIMENT_ID = 'expDoubleclickA4A';
 
-/** @const {!Branches} */
-const DOUBLECLICK_A4A_EXPERIMENT_BRANCHES = {
+/** @const {!Branches} @private */
+const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES = {
+  control: '117152660',
+  experiment: '117152661',
+};
+
+/** @const {!Branches} @private */
+const DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152640',
   experiment: '117152641',
 };
@@ -43,5 +49,6 @@ export function doubleclickIsA4AEnabled(win, element) {
   return !win.document.querySelector('meta[name=amp-3p-iframe-src]') &&
       googleAdsIsA4AEnabled(
         win, element, DOUBLECLICK_A4A_EXPERIMENT_ID,
-        DOUBLECLICK_A4A_EXPERIMENT_BRANCHES);
+        DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
+        DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES);
 }


### PR DESCRIPTION
The backend server is changing the format for how URL params will be generated, so this changes the client code to match.

This also moves `test-traffic-experiments.js` from the general `test/functional` dir to `ads/google/a4a/test`, closer to the code that it's actually testing.