### PR TITLE
Fix the usage of SubtleCrypto API on old Chrome (37, 38, 39).

### DIFF
--- a/extensions/amp-analytics/0.1/crypto-impl.js
+++ b/extensions/amp-analytics/0.1/crypto-impl.js
@@ -39,7 +39,7 @@ export class Crypto {
   sha384(input) {
     if (this.subtle_) {
       try {
-        return this.subtle_.digest('SHA-384',
+        return this.subtle_.digest({name: 'SHA-384'},
                 input instanceof Uint8Array ? input : str2ab(input))
             // [].slice.call(Unit8Array) is a shim for Array.from(Unit8Array)
             .then(buffer => [].slice.call(new Uint8Array(buffer)),

--- a/extensions/amp-analytics/0.1/test/test-crypto-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-crypto-impl.js
@@ -82,7 +82,7 @@ describe('crypto-impl', () => {
 
   function isModernChrome() {
     const platform = new Platform(window);
-    return platform.isChrome() && platform.getMajorVersion() >= 45;
+    return platform.isChrome() && platform.getMajorVersion() >= 37;
   }
 
   beforeEach(() => {


### PR DESCRIPTION
Fixes #4354