### PR TITLE
amp-ad local development is broken

### DIFF
--- a/3p/frame.max.html
+++ b/3p/frame.max.html
@@ -2,7 +2,15 @@
 <head>
 <meta charset="utf-8">
 <meta name="robots" content="noindex">
-<script src="./integration.js"></script>
+<script>
+(function() {
+  // skipping try catch on JSON.parse
+  var j = location.hash.substr(1);
+  window.AMP_CONFIG = JSON.parse(j)._context.AMP_CONFIG;
+  var u = window.AMP_CONFIG.thirdPartyFrameHost+'/integration.js';
+  document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
+})();
+</script>
 </head>
 <body style="margin:0">
 <div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">

--- a/3p/remote.html
+++ b/3p/remote.html
@@ -4,10 +4,12 @@
 <meta name="robots" content="noindex">
 <script>
 (function() {
-var v = location.search.substr(1);
-if (!(/^\d+(-canary)?$/.test(v))) return;
-var u = 'https://3p.ampproject.net/'+encodeURIComponent(v)+'/f.js';
-document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
+  var v = location.search.substr(1);
+  if (!(/^\d+(-canary)?$/.test(v))) return;
+  var j = location.hash.substr(1);
+  window.AMP_CONFIG = JSON.parse(j)._context.AMP_CONFIG;
+  var u = window.AMP_CONFIG.thirdPartyFrameHost + encodeURIComponent(v) + '/f.js';
+  document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
 })();
 </script>
 </head>

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -211,7 +211,7 @@ export function randomlySelectUnsetPageExperiments(win, experiments) {
   if (getMode(win).localDev) {
     // In local dev mode, it can be difficult to configure AMP_CONFIG
     // externally.  Default it here if necessary.
-    win.AMP_CONFIG = win.AMP_CONFIG || {};
+    win.AMP_CONFIG = win.AMP_CONFIG || AMP.config.urls;
   }
   for (const experimentName in experiments) {
     // Skip experimentName if it is not a key of experiments object or if it

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -70,6 +70,7 @@ function getFrameAttributes(parentWindow, element, opt_type) {
     locationHref = parentWindow.parent.location.href;
   }
   attributes._context = {
+    AMP_CONFIG: window.AMP_CONFIG || AMP.config.urls,
     referrer: viewer.getUnconfirmedReferrerUrl(),
     canonicalUrl: docInfo.canonicalUrl,
     pageViewId: docInfo.pageViewId,

--- a/src/config.js
+++ b/src/config.js
@@ -27,7 +27,7 @@ export const urls = {
   thirdParty: env.thirdPartyUrl || 'https://3p.ampproject.net',
   thirdPartyFrameHost: env.thirdPartyFrameHost || 'ampproject.net',
   thirdPartyFrameRegex: env.thirdPartyFrameRegex ||
-                        /^d-\d+\.ampproject\.net$/,
+                        '^d-\d+\.ampproject\.net$',
   cdn: env.cdnUrl || 'https://cdn.ampproject.org',
   errorReporting: env.errorReportingUrl ||
                   'https://amp-error-reporting.appspot.com/r',

--- a/test/integration/test-configuration.js
+++ b/test/integration/test-configuration.js
@@ -33,7 +33,7 @@ describe('Configuration', function() {
     const config = fixture.win.AMP_CONFIG = {};
     config.cdnUrl = 'http://foo.bar.com';
     config.thirdPartyUrl = 'http://bar.baz.com';
-    config.thirdPartyFrameRegex = /a-website\.com/;
+    config.thirdPartyFrameRegex = 'a-website\.com';
     config.errorReportingUrl = 'http://error.foo.com';
 
     return fixture.awaitEvent('amp:load:start', 1).then(() => {


### PR DESCRIPTION
Development for `amp-ad` against localhost is broken. Changes to `p3/remote.js` and `p3/frame.max.html` are needed.

[Line 9 in remote.js](https://github.com/ampproject/amphtml/blob/master/3p/remote.html#L9) needed point at my local environment.  Please advise on the appropriate change to gulp build.
```
var u = 'http://localhost:8000/dist.p3/'+encodeURIComponent(v)+'/f.js';
```

Reproduction steps:
1) build the project with `gulp build --version <latest version>` 
2) add an amp-ad integration that does not exist in production
3) add the appropriate html to `./examples/ads.amp.max.html`
4) start the development server with `gulp serve`
5) load `http://localhost:8000/examples/ads.amp.max.html`

It looks like the gulp serve command rewrites production urls when accessing `*.max.html` pages. A rewrite for 3p.ampproject.net is missing so development tries to source amp-ad integrations from prod rather than the local build. I would assume the appropriate fix is somewhere near [this line](https://github.com/ampproject/amphtml/blob/master/build-system/server.js#L130).
