### PR TITLE
Don't allow src attribute on amp-youtube.

### DIFF
--- a/extensions/amp-youtube/0.1/test/validator-amp-youtube.out
+++ b/extensions/amp-youtube/0.1/test/validator-amp-youtube.out
@@ -1,7 +1,7 @@
 FAIL
 amp-youtube/0.1/test/validator-amp-youtube.html:32:2 The attribute 'video-id' in tag 'amp-youtube' is deprecated - use 'data-videoid' instead. (see https://www.ampproject.org/docs/reference/extended/amp-youtube.html) [DEPRECATION]
 amp-youtube/0.1/test/validator-amp-youtube.html:35:2 The attribute 'video-id' in tag 'amp-youtube' is deprecated - use 'data-videoid' instead. (see https://www.ampproject.org/docs/reference/extended/amp-youtube.html) [DEPRECATION]
-amp-youtube/0.1/test/validator-amp-youtube.html:44:2 The tag 'amp-youtube' is missing a mandatory attribute - pick one of ['src', 'data-videoid']. (see https://www.ampproject.org/docs/reference/extended/amp-youtube.html) [AMP_TAG_PROBLEM]
+amp-youtube/0.1/test/validator-amp-youtube.html:44:2 The tag 'amp-youtube' is missing a mandatory attribute - pick one of ['data-videoid', 'video-id' (deprecated)]. (see https://www.ampproject.org/docs/reference/extended/amp-youtube.html) [AMP_TAG_PROBLEM]
 amp-youtube/0.1/test/validator-amp-youtube.html:46:2 The implied layout 'CONTAINER' is not supported by tag 'amp-youtube'. (see https://www.ampproject.org/docs/reference/extended/amp-youtube.html) [AMP_LAYOUT_PROBLEM]
 amp-youtube/0.1/test/validator-amp-youtube.html:49:2 The attribute 'video-id' in tag 'amp-youtube' is deprecated - use 'data-videoid' instead. (see https://www.ampproject.org/docs/reference/extended/amp-youtube.html) [DEPRECATION]
-amp-youtube/0.1/test/validator-amp-youtube.html:49:2 Mutually exclusive attributes encountered in tag 'amp-youtube' - pick one of ['src', 'data-videoid']. (see https://www.ampproject.org/docs/reference/extended/amp-youtube.html) [AMP_TAG_PROBLEM]
+amp-youtube/0.1/test/validator-amp-youtube.html:49:2 Mutually exclusive attributes encountered in tag 'amp-youtube' - pick one of ['data-videoid', 'video-id' (deprecated)]. (see https://www.ampproject.org/docs/reference/extended/amp-youtube.html) [AMP_TAG_PROBLEM]

--- a/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii
@@ -54,20 +54,11 @@ tags: {  # <amp-youtube>
   also_requires_tag: "amp-youtube extension .js script"
   attrs: {
     name: "data-videoid"
-    mandatory_oneof: "['src', 'data-videoid']"
-  }
-  attrs: {
-    name: "src"
-    mandatory_oneof: "['src', 'data-videoid']"
-    value_url: {
-      allowed_protocol: "http"  # runtime will rewrite URL to https in this case
-      allowed_protocol: "https"
-      allow_relative: true
-    }
+    mandatory_oneof: "['data-videoid', 'video-id' (deprecated)]"
   }
   attrs: {
     name: "video-id"
-    mandatory_oneof: "['src', 'data-videoid']"
+    mandatory_oneof: "['data-videoid', 'video-id' (deprecated)]"
     deprecation: "data-videoid"
     deprecation_url: "https://www.ampproject.org/docs/reference/extended/amp-youtube.html"
   }


### PR DESCRIPTION
It doesn't work and no doc in our 10k sample uses it.

Should improve potential confusion around the issues pointed out a little bit https://github.com/ampproject/amphtml/issues/4367.