### PR TITLE
Fixes viewer swipe not pausing videos on subsequent plays

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1523,8 +1523,8 @@ export class Resources {
     vsm.addTransition(hidden, inactive, unload);
     vsm.addTransition(hidden, paused, pause);
 
-    vsm.addTransition(inactive, visible, doPass);
-    vsm.addTransition(inactive, hidden, doPass);
+    vsm.addTransition(inactive, visible, resume);
+    vsm.addTransition(inactive, hidden, resume);
     vsm.addTransition(inactive, inactive, noop);
     vsm.addTransition(inactive, paused, doPass);
 

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -329,7 +329,7 @@ describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
         });
       });
 
-      it('does not call callbacks when going to HIDDEN', () => {
+      it('calls resumeCallback when going to HIDDEN', () => {
         viewer.setVisibilityState_(VisibilityState.VISIBLE);
         changeVisibility('hidden');
         return waitForNextPass().then(() => {

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -319,13 +319,13 @@ describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
         }).then(setupSpys);
       });
 
-      it('calls layout when going to VISIBLE', () => {
+      it('calls layout and resume when going to VISIBLE', () => {
         viewer.setVisibilityState_(VisibilityState.VISIBLE);
         return waitForNextPass().then(() => {
           expect(layoutCallback).to.have.been.called;
           expect(unlayoutCallback).not.to.have.been.called;
           expect(pauseCallback).not.to.have.been.called;
-          expect(resumeCallback).not.to.have.been.called;
+          expect(resumeCallback).to.have.been.called;
         });
       });
 
@@ -336,7 +336,7 @@ describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
           expect(layoutCallback).not.to.have.been.called;
           expect(unlayoutCallback).not.to.have.been.called;
           expect(pauseCallback).not.to.have.been.called;
-          expect(resumeCallback).not.to.have.been.called;
+          expect(resumeCallback).to.have.been.called;
         });
       });
 

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -329,7 +329,7 @@ describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
         });
       });
 
-      it('calls resumeCallback when going to HIDDEN', () => {
+      it('calls resume when going to HIDDEN', () => {
         viewer.setVisibilityState_(VisibilityState.VISIBLE);
         changeVisibility('hidden');
         return waitForNextPass().then(() => {


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/4363
This was caught by error logging @jridgewell suggested we add to https://github.com/ampproject/amphtml/pull/4137 :clap: 

So in the VSM, going from `visible || hidden` to `inactive` calls `unload` which itself also calls `pause` on all resources. The issue is coming back from `invisible` to those states, does not call `resume` which means all components stay paused (`paused_ == true`) which is not correct.

This PR causes `inactive` to `visible || hidden` state change to call resume in addition to doing a pass.