### PR TITLE
amp-font: fix font loading promise resolved(safari)

### DIFF
--- a/extensions/amp-font/0.1/fontloader.js
+++ b/extensions/amp-font/0.1/fontloader.js
@@ -217,7 +217,7 @@ export class FontLoader {
     const customFontElement = this.customFontElement_ =
         this.document_.createElement('div');
     style.setStyles(customFontElement, {
-      fontFamily: this.fontConfig_.family,
+      fontFamily: this.fontConfig_.family + ' ,san-serif, serif',
       margin: 0,
       padding: 0,
       whiteSpace: 'nowrap',

--- a/extensions/amp-font/0.1/fontloader.js
+++ b/extensions/amp-font/0.1/fontloader.js
@@ -217,7 +217,7 @@ export class FontLoader {
     const customFontElement = this.customFontElement_ =
         this.document_.createElement('div');
     style.setStyles(customFontElement, {
-      fontFamily: this.fontConfig_.family + ' ,san-serif, serif',
+      fontFamily: this.fontConfig_.family + ',' + DEFAULT_FONTS_.join(','),
       margin: 0,
       padding: 0,
       whiteSpace: 'nowrap',

--- a/extensions/amp-font/0.1/fontloader.js
+++ b/extensions/amp-font/0.1/fontloader.js
@@ -217,7 +217,7 @@ export class FontLoader {
     const customFontElement = this.customFontElement_ =
         this.document_.createElement('div');
     style.setStyles(customFontElement, {
-      fontFamily: this.fontConfig_.family + ',' + DEFAULT_FONTS_.join(','),
+      fontFamily: this.fontConfig_.family + ',' + DEFAULT_FONTS_.join(),
       margin: 0,
       padding: 0,
       whiteSpace: 'nowrap',

--- a/test/manual/unavailable-font.amp.html
+++ b/test/manual/unavailable-font.amp.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Font example</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+   <style amp-custom>
+    @font-face {
+      font-family: 'Font Does Not exist';
+      font-style: normal;
+      font-weight: 400;
+      src: url(fonts/FontDoesNotExist.ttf) format('truetype');
+    }
+
+    .unavailable-font-loaded .unavailable-font {
+      font-family: 'Font Does Not exist', serif, sans-serif;
+    }
+
+    .unavailable-font-missing .unavailable-font,
+        .another-unavailable-font-missing .another-unavailable-font  {
+          color: red;
+    }
+
+  </style>
+  <script async custom-element="amp-font" src="../../dist/v0/amp-font-0.1.max.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="../../dist/amp.js"></script>
+
+</head>
+<body class="comic-amp-font-loading comic-amp-bold-font-loading">
+
+   <amp-font layout="nodisplay"
+      font-family="Font Does Not Exist"
+      timeout="1000"
+      on-error-remove-class="unavailable-font-loading"
+      on-error-add-class="unavailable-font-missing"
+      on-load-remove-class="unavailable-font-loading"
+      on-load-add-class="unavailable-font-loaded">
+  </amp-font>
+
+  <p class="unavailable-font">
+    Font doesn't exist test text, should turn red after 1sec
+  </p>
+
+</body>
+</html>


### PR DESCRIPTION
#4168
This is cause by a racing condition of failing to load font resource and first measurement of the font div height. 
By providing two standard font as default to font-family should solve this.