### PR TITLE
Allow binding to specific hostname or IP, default to localhost

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gulp serve
+web: gulp serve --host=0.0.0.0

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -20,6 +20,7 @@ var util = require('gulp-util');
 var webserver = require('gulp-webserver');
 var app = require('../server').app;
 
+var host = argv.host || 'localhost';
 var port = argv.port || process.env.PORT || 8000;
 var useHttps = argv.https != undefined;
 
@@ -30,7 +31,7 @@ function serve() {
   var server = gulp.src(process.cwd())
       .pipe(webserver({
         port,
-        host: '0.0.0.0',
+        host,
         directoryListing: true,
         https: useHttps,
         middleware: [app]
@@ -48,6 +49,7 @@ gulp.task(
     serve,
     {
       options: {
+        'host': '  Hostname or IP address to bind to (default: localhost)',
         'port': '  Specifies alternative port (default: 8000)',
         'https': '  Use HTTPS server (default: false)'
       }
@@ -55,5 +57,5 @@ gulp.task(
 );
 
 function getHost() {
-  return (useHttps ? 'https' : 'http') + '://localhost:' + port;
+  return (useHttps ? 'https' : 'http') + '://' + host + ':' + port;
 }


### PR DESCRIPTION
This change allows users running the development server through gulp to override which hostname or IP address on their machine it should bind to, by supplying a `--host` command line flag. By default, it now binds to localhost, as users usually do not intend for their development server to be accessible to everyone who has network connectivity to their machine. Binding to all available addresses is still possible with `--host=0.0.0.0`.