### PR TITLE
Hiding scrollbar for carousel

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -88,7 +88,6 @@ amp-carousel .amp-carousel-button.amp-disabled {
   top: 0;
   width: 100% !important;
   scroll-snap-type: mandatory !important;
-  -webkit-overflow-scrolling: touch !important;
   /**
    * Hide the scrollbar by tucking it under some padding
    * which gets cut off as it overflows the parent.
@@ -97,6 +96,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
    */
   padding-bottom: 20px !important;
   box-sizing: content-box !important;
+  -webkit-overflow-scrolling: touch !important;
 }
 
 .-amp-slides-container.-amp-no-scroll {

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -88,7 +88,6 @@ amp-carousel .amp-carousel-button.amp-disabled {
   top: 0;
   width: 100% !important;
   scroll-snap-type: mandatory !important;
-  -ms-overflow-style: none;
   -webkit-overflow-scrolling: touch !important;
   /**
    * Hide the scrollbar by tucking it under some padding

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -90,15 +90,11 @@ amp-carousel .amp-carousel-button.amp-disabled {
   scroll-snap-type: mandatory !important;
   -ms-overflow-style: none;
   -webkit-overflow-scrolling: touch !important;
-}
-
-.-amp-slides-container::-webkit-scrollbar {
   /**
-   * Height not set to 0 because of safari bug.
-   * https://bugs.webkit.org/show_bug.cgi?id=160622
+   * Hide the scrollbar by tucking it under some padding
+   * which gets cut off as it overflows the parent.
    */
-   height: 0.1px;
-   background-color: transparent;
+  padding-bottom: 20px !important;
 }
 
 .-amp-slides-container.-amp-no-scroll {

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -91,6 +91,9 @@ amp-carousel .amp-carousel-button.amp-disabled {
   /**
    * Hide the scrollbar by tucking it under some padding
    * which gets cut off as it overflows the parent.
+   * The exact size of the padding does not matter as long as it is
+   * larger than the height of the scrollbar. 20px is large enough to cover
+   * both desktop and mobile scrolbar sizes in different browsers.
    * This relies on content box-sizing, although that's the default
    * we still ensure it does not get overwritten.
    */

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -93,8 +93,11 @@ amp-carousel .amp-carousel-button.amp-disabled {
   /**
    * Hide the scrollbar by tucking it under some padding
    * which gets cut off as it overflows the parent.
+   * This relies on content box-sizing, although that's the default
+   * we still ensure it does not get overwritten.
    */
   padding-bottom: 20px !important;
+  box-sizing: content-box !important;
 }
 
 .-amp-slides-container.-amp-no-scroll {


### PR DESCRIPTION
Hiding the scrollbar for carousel by tucking it under some padding which gets cut-off as the padding overflows the fixed-height parent. The exact size of the padding doesn't matter as long as it is larger than scrollbars; 20px should be plenty.

@sriramkrish85 This _may_ do it. Seems to work on Safari/iOS and Chrome. Generic enough that I think should be fine in Edge and FF too. I haven't fully tested it with different configuration of carousel though.

Test Link here: https://goo.gl/Wpxbik (Experiment is auto-enabled for that test)