### PR TITLE
Clean amp-iframe test to not use pollForLayout

### DIFF
--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -23,10 +23,8 @@ import {
 import {adopt} from '../../../../src/runtime';
 import {
   createIframePromise,
-  pollForLayout,
   poll,
 } from '../../../../testing/iframe';
-import {loadPromise} from '../../../../src/event-helper';
 import {viewportFor} from '../../../../src/viewport';
 import * as sinon from 'sinon';
 
@@ -93,32 +91,30 @@ describe('amp-iframe', () => {
         img.setAttribute('placeholder', '');
         i.appendChild(img);
       }
-      iframe.doc.body.appendChild(i);
+
       viewport.setScrollTop(parseInt(top, 10));
+
       if (opt_onAppend) {
-        opt_onAppend(iframe.doc);
+        opt_onAppend(iframe);
       }
-      // Wait an event loop for the iframe to be created.
-      return pollForLayout(iframe.win, 1).then(() => {
-        const created = i.querySelector('iframe');
+
+      return iframe.addElement(i).then(ampIframe => {
+        const created = ampIframe.querySelector('iframe');
         if (created) {
-          // Wait for the iframe to load
-          return loadPromise(created).then(() => {
-            // Wait a bit more for postMessage to get through.
-            return timer.promise(0).then(() => {
-              return {
-                container: i,
-                iframe: created,
-                scrollWrapper: i.querySelector('i-amp-scroll-container'),
-              };
-            });
+          // Wait a bit more for postMessage to get through.
+          return timer.promise(0).then(() => {
+            return {
+              container: ampIframe,
+              iframe: created,
+              scrollWrapper: ampIframe.querySelector('i-amp-scroll-container'),
+            };
           });
         }
         // No iframe was created.
         return {
-          container: i,
+          container: ampIframe,
           iframe: null,
-          error: i.textContent,
+          error: ampIframe.textContent,
         };
       });
     });
@@ -199,9 +195,11 @@ describe('amp-iframe', () => {
       sandbox: 'allow-scripts',
       width: 100,
       height: 100,
-    }, '599px', '1000px').then(amp => {
-      expect(amp.iframe).to.be.null;
-    }).catch(() => {});
+    }, '599px', '1000px').then(() => {
+      throw new Error('must never happen');
+    }, error => {
+      expect(error.message).to.match(/position/);
+    });
   });
 
   it('should respect translations', () => {
@@ -210,9 +208,11 @@ describe('amp-iframe', () => {
       sandbox: 'allow-scripts',
       width: 100,
       height: 100,
-    }, '650px', '1000px', '-100px').then(amp => {
-      expect(amp.iframe).to.be.null;
-    }).catch(() => {});
+    }, '650px', '1000px', '-100px').then(() => {
+      throw new Error('must never happen');
+    }, error => {
+      expect(error.message).to.match(/position/);
+    });
   });
 
   it('should render if further than 75% viewport away from top', () => {
@@ -374,7 +374,6 @@ describe('amp-iframe', () => {
       resizable: '',
     }).then(amp => {
       const impl = amp.container.implementation_;
-      impl.layoutCallback();
       const p = new Promise((resolve, unusedReject) => {
         impl.updateSize_ = (height, width) => {
           resolve({amp, height, width});
@@ -478,48 +477,47 @@ describe('amp-iframe', () => {
     const attributes = {
       src: clickableIframeSrc,
       sandbox: 'allow-scripts allow-same-origin',
-      width: 10,
-      height: 10,
+      width: 5,
+      height: 5,
       poster: 'https://i.ytimg.com/vi/cMcCTVAFBWM/hqdefault.jpg',
     };
     let nonTracking;
-    return getAmpIframe(attributes, null, null, null, doc => {
-      function addFrame() {
-        const i = doc.createElement('amp-iframe');
-        for (const key in attributes) {
-          i.setAttribute(key, attributes[key]);
-        }
-        i.style.height = '10px';
-        i.style.width = '10px';
-        i.style.display = 'block';
+    return getAmpIframe(attributes, null, null, null, iframe => {
+      function addFrame(testIframe, width, height) {
+        const i = testIframe.doc.createElement('amp-iframe');
+        i.setAttribute('src', clickableIframeSrc);
+        i.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+        i.setAttribute('width', width);
+        i.setAttribute('height', height);
         i.style.position = 'absolute';
         i.style.top = '600px';
-        doc.body.appendChild(i);
-        return i;
+        return testIframe.addElement(i);
       }
-
-      addFrame();
-      nonTracking = addFrame();
-      nonTracking.style.width = '100px';
-      nonTracking.style.height = '100px';
+      addFrame(iframe, 10, 10);
+      nonTracking = addFrame(iframe, 100, 100);
     }).then(iframe => {
       const impl = iframe.container.implementation_;
       const doc = impl.element.ownerDocument;
       expect(impl.looksLikeTrackingIframe_()).to.be.true;
       const iframes = doc.querySelectorAll('amp-iframe');
+      // appended amp-iframe 10x10
       expect(iframes[0].implementation_
           .looksLikeTrackingIframe_()).to.be.true;
+      // appended amp-iframe 100x100
       expect(iframes[1].implementation_
-          .looksLikeTrackingIframe_()).to.be.true;
-      expect(iframes[2].implementation_
           .looksLikeTrackingIframe_()).to.be.false;
+      // amp-iframe 5x5
+      expect(iframes[2].implementation_
+          .looksLikeTrackingIframe_()).to.be.true;
       expect(doc.querySelectorAll('iframe,[amp-removed]')).to.have.length(2);
       return poll('iframe removal', () => {
         return doc.querySelectorAll('[amp-removed]').length == 1;
       }).then(() => {
         expect(doc.querySelectorAll('iframe')).to.have.length(1);
-        expect(nonTracking.implementation_.iframe_)
-            .to.equal(doc.querySelector('iframe'));
+        nonTracking.then(ampIframe => {
+          expect(ampIframe.implementation_.iframe_)
+              .to.equal(doc.querySelector('iframe'));
+        });
       });
     });
   });


### PR DESCRIPTION
When I'm writing test for amp-iframe, `pollForLayout` [[code](https://github.com/ampproject/amphtml/blob/master/testing/iframe.js#L309)] sometimes fails and `amp-iframe.layoutCallback` is never called in the test.
I don't know why we use `pollForLayout` and `loadPromise` in the amp-iframe test, so I tried to clean it up. I used `addElement` instead of `appendChild` when adding the amp-iframe to the test frame. Not sure whether this is a correct change.