### PR TITLE
Fix the rendering delay when amp-experiment feature is disabled.

### DIFF
--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -39,7 +39,8 @@ export class AmpExperiment extends AMP.BaseElement {
     if (!this.isExperimentOn_) {
       dev().warn(EXPERIMENT, `Experiment ${EXPERIMENT} disabled`);
       toggle(this.element, false);
-      getService(this.win, 'variant', () => Promise.reject());
+      getService(this.win, 'variant',
+          () => Promise.reject(EXPERIMENT + ' disabled'));
       return;
     }
 

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -39,8 +39,7 @@ export class AmpExperiment extends AMP.BaseElement {
     if (!this.isExperimentOn_) {
       dev().warn(EXPERIMENT, `Experiment ${EXPERIMENT} disabled`);
       toggle(this.element, false);
-      getService(this.win, 'variant',
-          () => Promise.reject(EXPERIMENT + ' disabled'));
+      getService(this.win, 'variant', () => Promise.resolve());
       return;
     }
 

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -39,6 +39,7 @@ export class AmpExperiment extends AMP.BaseElement {
     if (!this.isExperimentOn_) {
       dev().warn(EXPERIMENT, `Experiment ${EXPERIMENT} disabled`);
       toggle(this.element, false);
+      getService(this.win, 'variant', () => Promise.reject());
       return;
     }
 


### PR DESCRIPTION
This is probably also needed in amp-share-tracking.