### PR TITLE
Remove video-id from the amp-youtube extension runtime.

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -62,11 +62,9 @@ class AmpYoutube extends AMP.BaseElement {
     /** @private {number} */
     this.playerState_ = 0;
 
-    // The video-id is supported only for backward compatibility.
     /** @private @const {string} */
     this.videoid_ = user().assert(
-        (this.element.getAttribute('data-videoid') ||
-        this.element.getAttribute('video-id')),
+        this.element.getAttribute('data-videoid'),
         'The data-videoid attribute is required for <amp-youtube> %s',
         this.element);
 

--- a/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii
@@ -46,8 +46,6 @@ tags: {  # amp-youtube
   }
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-youtube.html"
 }
-# amp-youtube either comes with a video-id attribute, or with
-# a data-videoid attribute.
 tags: {  # <amp-youtube>
   tag_name: "AMP-YOUTUBE"
   disallowed_ancestor: "AMP-SIDEBAR"


### PR DESCRIPTION
This attr had been deprecated for a while and has already been removed from the validator.
Some discussion about amp-youtube attrs happeneing in https://github.com/ampproject/amphtml/issues/4367