### PR TITLE
no items ref point on update should be a no op instead of an error

### DIFF
--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -228,7 +228,9 @@ export class AmpLiveList extends AMP.BaseElement {
   /** @override */
   update(updatedElement) {
     const container = this.getItemsSlot_(updatedElement);
-    user().assert(container, 'amp-live-list must have an `items` slot');
+    if (!container) {
+      return this.updateTime_;
+    }
     this.validateLiveListItems_(container);
     const mutateItems = this.getUpdates_(container);
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -270,21 +270,11 @@ describe('amp-live-list', () => {
       expect(stub.callCount).to.equal(1);
     });
 
-    it('asserts that an items slot was provided on update', () => {
+    it('no items slot on update should be a no op update', () => {
       const update = document.createElement('div');
-      const updateLiveListItems = document.createElement('div');
-      update.appendChild(updateLiveListItems);
-      updateLiveListItems.appendChild(document.createElement('div'));
-
       expect(() => {
         liveList.update(update);
-      }).to.throw(/amp-live-list must have an `items` slot/);
-
-      updateLiveListItems.setAttribute('items', '');
-
-      expect(() => {
-        liveList.update(update);
-      }).to.not.throw(/amp-live-list must have an `items` slot/);
+      }).to.not.throw();
     });
 
     it('discovers children to insert when they have newly discovered ' +


### PR DESCRIPTION
this makes it a bit more forgiving on the server side filtering requirements

cc @ericlindley-g 