### PR TITLE
Allowing schedule(pause/resume/unlayout) to go deep into the subtree.

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1004,7 +1004,7 @@ function createBaseAmpElementProto(win) {
    * Requests the element to unload any expensive resources when the element
    * goes into non-visible state. The scope is up to the actual component.
    *
-   * Calling this method on unbuilt ot unupgraded element has no effect.
+   * Calling this method on unbuilt or unupgraded element has no effect.
    *
    * @return {boolean}
    * @package @final @this {!Element}

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1431,7 +1431,7 @@ export class Resources {
    * Finds resources within the parent resource's shallow or deep subtree.
    * @param {!Resource} parentResource
    * @param {!Array<!Element>} elements
-   * @param {!boolean} deepSubtree Whether the parent resource's shallow or deep
+   * @param {boolean} deepSubtree Whether the parent resource's shallow or deep
    * subtree is searched for resources.
    * @param {function(!Resource)} callback
    */

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -465,7 +465,7 @@ export class Resources {
 
   /**
    * Invokes `unload` on the elements' resource which in turn will invoke
-   * the `documentBecameInactive` callback on the custom element.
+   * the `pauseCallback` callback on the custom element.
    * Resources that call `schedulePause` must also call `scheduleResume`.
    * @param {!Element} parentElement
    * @param {!Element|!Array<!Element>} subElements
@@ -474,7 +474,8 @@ export class Resources {
     const parentResource = Resource.forElement(parentElement);
     subElements = elements_(subElements);
 
-    this.discoverResourcesForArray_(parentResource, subElements, resource => {
+    this.discoverResourcesForArray_(parentResource, subElements,
+    /* deepSubtree */ true, resource => {
       resource.pause();
     });
   }
@@ -490,7 +491,8 @@ export class Resources {
     const parentResource = Resource.forElement(parentElement);
     subElements = elements_(subElements);
 
-    this.discoverResourcesForArray_(parentResource, subElements, resource => {
+    this.discoverResourcesForArray_(parentResource, subElements,
+    /* deepSubtree */ true, resource => {
       resource.resume();
     });
   }
@@ -506,7 +508,8 @@ export class Resources {
     const parentResource = Resource.forElement(parentElement);
     subElements = elements_(subElements);
 
-    this.discoverResourcesForArray_(parentResource, subElements, resource => {
+    this.discoverResourcesForArray_(parentResource, subElements,
+    /* deepSubtree */ true, resource => {
       resource.unlayout();
     });
   }
@@ -1353,7 +1356,8 @@ export class Resources {
    */
   scheduleLayoutOrPreloadForSubresources_(parentResource, layout, subElements) {
     const resources = [];
-    this.discoverResourcesForArray_(parentResource, subElements, resource => {
+    this.discoverResourcesForArray_(parentResource, subElements,
+    /* deepSubtree */ false, resource => {
       if (resource.getState() != ResourceState.NOT_BUILT) {
         resources.push(resource);
       }
@@ -1417,21 +1421,24 @@ export class Resources {
   updateInViewportForSubresources_(parentResource, subElements,
       inLocalViewport) {
     const inViewport = parentResource.isInViewport() && inLocalViewport;
-    this.discoverResourcesForArray_(parentResource, subElements, resource => {
+    this.discoverResourcesForArray_(parentResource, subElements,
+    /* deepSubtree */ false, resource => {
       resource.setInViewport(inViewport);
     });
   }
 
   /**
-   * Finds resources within the parent resource's shallow subtree.
+   * Finds resources within the parent resource's shallow or deep subtree.
    * @param {!Resource} parentResource
    * @param {!Array<!Element>} elements
+   * @param {!boolean} deepSubtree Whether the parent resource's shallow or deep
+   * subtree is searched for resources.
    * @param {function(!Resource)} callback
    */
-  discoverResourcesForArray_(parentResource, elements, callback) {
+  discoverResourcesForArray_(parentResource, elements, deepSubtree, callback) {
     elements.forEach(element => {
       dev().assert(parentResource.element.contains(element));
-      this.discoverResourcesForElement_(element, callback);
+      this.discoverResourcesForElement_(element, deepSubtree, callback);
     });
   }
 
@@ -1439,14 +1446,26 @@ export class Resources {
    * @param {!Element} element
    * @param {function(!Resource)} callback
    */
-  discoverResourcesForElement_(element, callback) {
+  discoverResourcesForElement_(element, deepSubtree, callback) {
+    if (deepSubtree) {
+      if (element.classList.contains('-amp-element')) {
+        callback(Resource.forElement(element));
+      }
+      const ampElements = element.getElementsByClassName('-amp-element');
+      for (let i = 0; i < ampElements.length; i++) {
+        callback(Resource.forElement(ampElements[i]));
+      }
+      return;
+    }
+
     // Breadth-first search.
     if (element.classList.contains('-amp-element')) {
       callback(Resource.forElement(element));
       // Also schedule amp-element that is a placeholder for the element.
       const placeholder = element.getPlaceholder();
       if (placeholder) {
-        this.discoverResourcesForElement_(placeholder, callback);
+        this.discoverResourcesForElement_(placeholder, /* deepSubtree */ false,
+            callback);
       }
     } else {
       const ampElements = element.getElementsByClassName('-amp-element');

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -282,6 +282,8 @@ describe('Resources pause/resume/unlayout scheduling', () => {
   let child0;
   let child1;
   let child2;
+  let grandChild;
+  let grandGrandChild;
 
   function createElement() {
     return {
@@ -439,6 +441,7 @@ describe('Resources pause/resume/unlayout scheduling', () => {
 
       resources.scheduleResume(parent, children);
       expect(stub1.calledOnce).to.be.true;
+      expect(stub2.calledOnce).to.be.true;
       expect(stub3.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
Fixes #4503 

Currently when an element is scheduled for pause/resume/unlayout, only its direct amp children are called. The issue is that if an amp-element lives inside another amp-element, it will not get the scheduled events ( root cause of #4503 where there is an `amp-youtube` inside an `amp-carousel` inside an `amp-lightbox` ).

With this PR, we allow pause/resume/unlayout to go to _all_ descendants and not just the shallow subtree.
