### PR TITLE
Extended experiments URL parser to handle originalHash

### DIFF
--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -126,7 +126,7 @@ describe('a4a_config', () => {
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
         INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
-    expect(rand.called, 'rand called ever').to.be.false;
+    expect(rand, 'rand called ever').to.not.be.called;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
 
@@ -138,7 +138,7 @@ describe('a4a_config', () => {
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
         INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
-    expect(rand.called, 'rand called ever').to.be.false;
+    expect(rand, 'rand called ever').to.not.be.called;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
 
@@ -174,7 +174,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.true;
+      expect(rand, 'rand called at least once').to.be.called;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
 
@@ -186,7 +186,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.true;
+      expect(rand, 'rand called at least once').to.be.called;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
 
@@ -200,7 +200,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.true;
+      expect(rand, 'rand called at least once').to.be.called;
       expect(element.getAttribute('data-experiment-id')).to.equal(
           INTERNAL_BRANCHES.experiment);
     });
@@ -215,7 +215,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.true;
+      expect(rand, 'rand called at least once').to.be.called;
       expect(element.getAttribute('data-experiment-id')).to.equal(
           INTERNAL_BRANCHES.experiment);
     });
@@ -230,7 +230,7 @@ describe('a4a_config', () => {
           expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
               INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
           expect(win.document.cookie).to.be.null;
-          expect(rand.called, 'rand called at least once').to.be.false;
+          expect(rand, 'rand never called').to.not.be.called;
           expect(element.getAttribute('data-experiment-id')).to.equal(
               EXTERNAL_BRANCHES.experiment);
         });
@@ -246,7 +246,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.false;
+      expect(rand, 'rand never called').to.not.be.called;
       expect(element.getAttribute('data-experiment-id')).to.equal(
           EXTERNAL_BRANCHES.control);
     });
@@ -277,7 +277,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.false;
+      expect(rand, 'rand never called').to.not.be.called;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
       // And it shouldn't be in any *other* experiments.
@@ -357,7 +357,7 @@ describe('a4a_config hash param parsing', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.false;
+      expect(rand, 'rand never called').to.not.be.called;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
       // And it shouldn't be in any *other* experiments.

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -271,6 +271,87 @@ describe('a4a_config', () => {
             'element in ', EXTERNAL_BRANCHES[branch]).to.be.false;
       }
     });
+
+    it(`should find param in originalHash when pattern is ${urlBase}`, () => {
+      win.location.search = '?somewhere=over&the=rainbow';
+      win.location.originalHash = '#' + encodeURIComponent(
+          urlBase.substr(1).replace('PARAM', 'a4a:-1'));
+      // Ensure that internal branches aren't attached, even if the PRNG
+      // would normally trigger them.
+      rand.onFirstCall().returns(-1);
+      const element = document.createElement('div');
+      // Should not register as 'A4A enabled', but should still attach the
+      // control experiment ID.
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+      expect(win.document.cookie).to.be.null;
+      expect(rand.called, 'rand called at least once').to.be.false;
+      expect(isInManualExperiment(element), 'element in manual experiment')
+          .to.be.true;
+      // And it shouldn't be in any *other* experiments.
+      for (const branch in EXTERNAL_BRANCHES) {
+        expect(isInExperiment(element, EXTERNAL_BRANCHES[branch]),
+            'element in ', EXTERNAL_BRANCHES[branch]).to.be.false;
+      }
+      for (const branch in EXTERNAL_BRANCHES) {
+        expect(isInExperiment(element, INTERNAL_BRANCHES[branch]),
+            'element in ', EXTERNAL_BRANCHES[branch]).to.be.false;
+      }
+    });
+
+    it(`should find param in hash when !originalHash and pattern=${urlBase}`,
+        () => {
+          win.location.search = '?somewhere=over&the=rainbow';
+          win.location.hash = '#' + encodeURIComponent(
+                  urlBase.substr(1).replace('PARAM', 'a4a:2'));
+          // Ensure that internal branches aren't attached, even if the PRNG
+          // would normally trigger them.
+          rand.onFirstCall().returns(-1);
+          const element = document.createElement('div');
+          expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+              INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+          expect(win.document.cookie).to.be.null;
+          expect(rand.called, 'rand called at least once').to.be.false;
+          expect(element.getAttribute('data-experiment-id')).to.equal(
+              EXTERNAL_BRANCHES.experiment);
+        });
+
+    it(`originalHash should trump hash; pattern=${urlBase}`,
+        () => {
+          win.location.search = '?somewhere=over&the=rainbow';
+          win.location.originalHash = '#' + encodeURIComponent(
+                  urlBase.substr(1).replace('PARAM', 'a4a:2'));
+          win.location.hash = '#' + encodeURIComponent(
+                  urlBase.substr(1).replace('PARAM', 'a4a:-1'));
+          // Ensure that internal branches aren't attached, even if the PRNG
+          // would normally trigger them.
+          rand.onFirstCall().returns(-1);
+          const element = document.createElement('div');
+          expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+              INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+          expect(win.document.cookie).to.be.null;
+          expect(rand.called, 'rand called at least once').to.be.false;
+          expect(element.getAttribute('data-experiment-id')).to.equal(
+              EXTERNAL_BRANCHES.experiment);
+        });
+
+    it(`originalHash should trump search; pattern=${urlBase}`,
+        () => {
+          win.location.search = urlBase.replace('PARAM', 'a4a:-1');
+          win.location.originalHash = '#' + encodeURIComponent(
+                  urlBase.substr(1).replace('PARAM', 'a4a:2'));
+          // Ensure that internal branches aren't attached, even if the PRNG
+          // would normally trigger them.
+          rand.onFirstCall().returns(-1);
+          const element = document.createElement('div');
+          expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+              INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+          expect(win.document.cookie).to.be.null;
+          expect(rand.called, 'rand called at least once').to.be.false;
+          expect(element.getAttribute('data-experiment-id')).to.equal(
+              EXTERNAL_BRANCHES.experiment);
+        });
+
   });
 
 });

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -20,12 +20,14 @@ import {
     isInManualExperiment,
 } from '../traffic-experiments';
 import {resetExperimentToggles_} from '../../../../src/experiments';
+import {Viewer} from '../../../../src/service/viewer-impl';
 import * as sinon from 'sinon';
 
 describe('a4a_config', () => {
   let sandbox;
   let win;
   let rand;
+  let viewer;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -38,6 +40,7 @@ describe('a4a_config', () => {
         href: 'https://cdn.ampproject.org/fnord',
         pathname: '/fnord',
         origin: 'https://cdn.ampproject.org',
+        hash: '',
       },
       document: {
         cookie: null,
@@ -46,7 +49,9 @@ describe('a4a_config', () => {
         subtle: true,
         webkitSubtle: true,
       },
+      navigator: window.navigator,
     };
+    viewer = new Viewer(win);
   });
 
   afterEach(() => {
@@ -68,6 +73,7 @@ describe('a4a_config', () => {
     rand.onFirstCall().returns(-1);  // Force experiment on.
     rand.onSecondCall().returns(0.75);  // Select second branch.
     const element = document.createElement('div');
+    const v = new Viewer(win);
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID,
         EXTERNAL_BRANCHES, INTERNAL_BRANCHES),
            'googleAdsIsA4AEnabled').to.be.true;

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -43,10 +43,7 @@ describe('a4a_config', () => {
   let sandbox;
   let win;
   let rand;
-  let viewer;
   let events;
-  let platform;
-  let docState;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -76,8 +73,8 @@ describe('a4a_config', () => {
       navigator: window.navigator,
     };
     events = {};
-    platform = platformFor(win);
-    docState = documentStateFor(win);
+    platformFor(win);
+    documentStateFor(win);
     installViewerService(win);
   });
 
@@ -303,10 +300,7 @@ describe('a4a_config hash param parsing', () => {
   let sandbox;
   let win;
   let rand;
-  let viewer;
   let events;
-  let platform;
-  let docState;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -337,8 +331,8 @@ describe('a4a_config hash param parsing', () => {
       navigator: window.navigator,
     };
     events = {};
-    platform = platformFor(win);
-    docState = documentStateFor(win);
+    platformFor(win);
+    documentStateFor(win);
   });
   afterEach(() => {
     resetExperimentToggles_();  // Clear saved, page-level experiment state.
@@ -355,7 +349,7 @@ describe('a4a_config hash param parsing', () => {
     it(`should find viewer param when pattern is ${hashBase}`, () => {
       win.location.hash = hashBase.replace('PARAM', 'a4a:-1');
       installViewerService(win);
-      const v = viewerFor(win);
+      viewerFor(win);
       // Ensure that internal branches aren't attached, even if the PRNG
       // would normally trigger them.
       rand.onFirstCall().returns(-1);
@@ -379,22 +373,21 @@ describe('a4a_config hash param parsing', () => {
       }
     });
 
-    it(`hash should trump search; pattern=${hashBase}`,
-        () => {
-          win.location.search = hashBase.replace('PARAM', 'a4a:-1');
-          win.location.hash = hashBase.replace('PARAM', 'a4a:2');
-          installViewerService(win);
-          const v = viewerFor(win);
-          // Ensure that internal branches aren't attached, even if the PRNG
-          // would normally trigger them.
-          rand.onFirstCall().returns(-1);
-          const element = document.createElement('div');
-          expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-              INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
-          expect(win.document.cookie).to.be.null;
-          expect(rand.called, 'rand called at least once').to.be.false;
-          expect(element.getAttribute('data-experiment-id')).to.equal(
-              EXTERNAL_BRANCHES.experiment);
-        });
+    it(`hash should trump search; pattern=${hashBase}`, () => {
+      win.location.search = hashBase.replace('PARAM', 'a4a:-1');
+      win.location.hash = hashBase.replace('PARAM', 'a4a:2');
+      installViewerService(win);
+      viewerFor(win);
+      // Ensure that internal branches aren't attached, even if the PRNG
+      // would normally trigger them.
+      rand.onFirstCall().returns(-1);
+      const element = document.createElement('div');
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+      expect(win.document.cookie).to.be.null;
+      expect(rand.called, 'rand called at least once').to.be.false;
+      expect(element.getAttribute('data-experiment-id')).to.equal(
+          EXTERNAL_BRANCHES.experiment);
+    });
   });
 });

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -22,7 +22,6 @@ import {
 import {resetExperimentToggles_} from '../../../../src/experiments';
 import {installViewerService} from '../../../../src/service/viewer-impl';
 import {resetServiceForTesting} from '../../../../src/service';
-import {viewerFor} from '../../../../src/viewer';
 import {documentStateFor} from '../../../../src/document-state';
 import {platformFor} from '../../../../src/platform';
 import * as sinon from 'sinon';
@@ -349,7 +348,6 @@ describe('a4a_config hash param parsing', () => {
     it(`should find viewer param when pattern is ${hashBase}`, () => {
       win.location.hash = hashBase.replace('PARAM', 'a4a:-1');
       installViewerService(win);
-      viewerFor(win);
       // Ensure that internal branches aren't attached, even if the PRNG
       // would normally trigger them.
       rand.onFirstCall().returns(-1);
@@ -377,7 +375,6 @@ describe('a4a_config hash param parsing', () => {
       win.location.search = hashBase.replace('PARAM', 'a4a:-1');
       win.location.hash = hashBase.replace('PARAM', 'a4a:2');
       installViewerService(win);
-      viewerFor(win);
       // Ensure that internal branches aren't attached, even if the PRNG
       // would normally trigger them.
       rand.onFirstCall().returns(-1);

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -126,7 +126,7 @@ describe('a4a_config', () => {
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
         INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
-    expect(rand, 'rand called ever').to.not.be.called;
+    expect(rand).to.not.be.called;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
 
@@ -138,7 +138,7 @@ describe('a4a_config', () => {
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
         INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
-    expect(rand, 'rand called ever').to.not.be.called;
+    expect(rand).to.not.be.called;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
 
@@ -230,7 +230,7 @@ describe('a4a_config', () => {
           expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
               INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
           expect(win.document.cookie).to.be.null;
-          expect(rand, 'rand never called').to.not.be.called;
+          expect(rand).to.not.be.called;
           expect(element.getAttribute('data-experiment-id')).to.equal(
               EXTERNAL_BRANCHES.experiment);
         });
@@ -246,7 +246,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
-      expect(rand, 'rand never called').to.not.be.called;
+      expect(rand).to.not.be.called;
       expect(element.getAttribute('data-experiment-id')).to.equal(
           EXTERNAL_BRANCHES.control);
     });
@@ -262,7 +262,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.false;
+      expect(rand).to.not.be.called;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
 
@@ -277,7 +277,7 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(rand, 'rand never called').to.not.be.called;
+      expect(rand).to.not.be.called;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
       // And it shouldn't be in any *other* experiments.
@@ -357,7 +357,7 @@ describe('a4a_config hash param parsing', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(rand, 'rand never called').to.not.be.called;
+      expect(rand).to.not.be.called;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
       // And it shouldn't be in any *other* experiments.
@@ -382,7 +382,7 @@ describe('a4a_config hash param parsing', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(rand.called, 'rand called at least once').to.be.false;
+      expect(rand).to.not.be.called;
       expect(element.getAttribute('data-experiment-id')).to.equal(
           EXTERNAL_BRANCHES.experiment);
     });

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -121,7 +121,16 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
  */
 function maybeSetExperimentFromUrl(win, experimentName,
     controlBranchId, treatmentBranchId, manualId) {
-  const expParam = parseQueryString(win.location.search)['exp'];
+  let queryString = win.location.search;
+  // If we're inside the AMP viewer, the hash fragment will have been moved
+  // to the originalHash field.
+  const hash = win.location.originalHash || win.location.hash;
+  if (hash) {
+    // Drop the leading '#' and replace with a
+    // param separator.
+    queryString += '&' + decodeURIComponent(hash.substring(1));
+  }
+  const expParam = parseQueryString(queryString)['exp'];
   if (!expParam) {
     return;
   }

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -26,6 +26,7 @@ import {isGoogleAdsA4AValidEnvironment} from './utils';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
 import {dev} from '../../../src/log';
 import {getMode} from '../../../src/mode';
+import {viewerFor} from '../../../src/viewer';
 import {parseQueryString} from '../../../src/url';
 
 /** @typedef {{string: {branches: !Branches}}} */
@@ -121,16 +122,8 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
  */
 function maybeSetExperimentFromUrl(win, experimentName,
     controlBranchId, treatmentBranchId, manualId) {
-  let queryString = win.location.search;
-  // If we're inside the AMP viewer, the hash fragment will have been moved
-  // to the originalHash field.
-  const hash = win.location.originalHash || win.location.hash;
-  if (hash) {
-    // Drop the leading '#' and replace with a
-    // param separator.
-    queryString += '&' + decodeURIComponent(hash.substring(1));
-  }
-  const expParam = parseQueryString(queryString)['exp'];
+  const expParam = viewerFor(win).getParam('exp') ||
+      parseQueryString(win.location.search)['exp'];
   if (!expParam) {
     return;
   }

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -381,7 +381,6 @@ export class Viewer {
     // instance is constructed, the document is already `visible`.
     this.recheckVisibilityState_();
     this.onVisibilityChange_();
-    dev().fine(TAG_, 'TDRL : viewer init completed; win = ', this.win);
   }
 
   /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -381,6 +381,7 @@ export class Viewer {
     // instance is constructed, the document is already `visible`.
     this.recheckVisibilityState_();
     this.onVisibilityChange_();
+    dev().fine(TAG_, 'TDRL : viewer init completed; win = ', this.win);
   }
 
   /**


### PR DESCRIPTION
When the target page is served via the Google Search page, experiment parameters will be passed in the hash fragment.  In turn, that is translated to `win.location.originalHash` by the AMP viewer.  This change allows the A4A experiments configuration URL parser to find experiment control parameters in the `originalHash` or `hash` fields.