### PR TITLE
<slidescroll>: Schedule pause for surrounding slides

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -420,6 +420,7 @@ export class AmpSlideScroll extends BaseSlides {
         this.scheduleLayout(this.slides_[showIndex]);
         this.scheduleResume(this.slides_[showIndex]);
       } else {
+        this.schedulePause(this.slides_[showIndex]);
         this.schedulePreload(this.slides_[showIndex]);
       }
     });

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -420,7 +420,6 @@ export class AmpSlideScroll extends BaseSlides {
         this.scheduleLayout(this.slides_[showIndex]);
         this.scheduleResume(this.slides_[showIndex]);
       } else {
-        this.schedulePause(this.slides_[showIndex]);
         this.schedulePreload(this.slides_[showIndex]);
       }
     });
@@ -448,12 +447,18 @@ export class AmpSlideScroll extends BaseSlides {
   hideRestOfTheSlides_(indexArr) {
     const noOfSlides_ = this.noOfSlides_;
     for (let i = 0; i < noOfSlides_; i++) {
-      if (indexArr.indexOf(i) == -1 &&
-          this.slideWrappers_[i].classList.contains(SHOWN_CSS_CLASS)) {
+      if (!this.slideWrappers_[i].classList.contains(SHOWN_CSS_CLASS)) {
+        continue;
+      }
+      // Hide if not shown anymore
+      if (indexArr.indexOf(i) == -1) {
         if (this.shouldLoop) {
           setStyle(this.slideWrappers_[i], 'order', '');
         }
         this.slideWrappers_[i].classList.remove(SHOWN_CSS_CLASS);
+      }
+      // Pause if not the current slide
+      if (this.slideIndex_ != i) {
         this.schedulePause(this.slides_[i]);
       }
     }

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -241,8 +241,9 @@ describe('SlideScroll', () => {
           .to.be.false;
       expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS))
           .to.be.false;
-      expect(schedulePauseSpy).to.not.have.been.called;
-      expect(schedulePauseSpy.callCount).to.equal(0);
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[0]);
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
+      expect(schedulePauseSpy.callCount).to.equal(2);
 
       impl.showSlide_(0);
 
@@ -257,8 +258,9 @@ describe('SlideScroll', () => {
           .to.be.false;
       expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS))
           .to.be.false;
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[1]);
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
-      expect(schedulePauseSpy.callCount).to.equal(1);
+      expect(schedulePauseSpy.callCount).to.equal(4);
 
       impl.showSlide_(4);
 
@@ -276,7 +278,8 @@ describe('SlideScroll', () => {
           .to.be.true;
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[0]);
       expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[1]);
-      expect(schedulePauseSpy.callCount).to.equal(3);
+      expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[3]);
+      expect(schedulePauseSpy.callCount).to.equal(7);
     });
   });
 
@@ -633,7 +636,9 @@ describe('SlideScroll', () => {
         expect(impl.slideWrappers_[4].style.order).to.equal('');
 
         expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[4]);
-        expect(schedulePauseSpy.callCount).to.equal(1);
+        expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[0]);
+        expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
+        expect(schedulePauseSpy.callCount).to.equal(3);
 
         impl.showSlide_(0);
 
@@ -655,7 +660,9 @@ describe('SlideScroll', () => {
         expect(impl.slideWrappers_[3].style.order).to.equal('');
         expect(impl.slideWrappers_[4].style.order).to.equal('1');
         expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[2]);
-        expect(schedulePauseSpy.callCount).to.equal(2);
+        expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[4]);
+        expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[1]);
+        expect(schedulePauseSpy.callCount).to.equal(6);
 
         impl.showSlide_(4);
 
@@ -676,9 +683,10 @@ describe('SlideScroll', () => {
         expect(impl.slideWrappers_[2].style.order).to.equal('');
         expect(impl.slideWrappers_[3].style.order).to.equal('1');
         expect(impl.slideWrappers_[4].style.order).to.equal('2');
-        expect(schedulePauseSpy).to.not.have.been.calledWith(impl.slides_[0]);
+        expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[3]);
+        expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[0]);
         expect(schedulePauseSpy).to.have.been.calledWith(impl.slides_[1]);
-        expect(schedulePauseSpy.callCount).to.equal(3);
+        expect(schedulePauseSpy.callCount).to.equal(9);
       });
     });
 


### PR DESCRIPTION
Fixe a bug where videos were not pausing after +/- 1 slide navigation (they were pausing after +/- 2 slide navigations however).

Issue was that slidescroll keeps 3 slides ready to be displayed at all times, but was not pausing the surrounding slides of the currently displaying one.