### PR TITLE
Add __amp_source_origin to amp-form non-xhr action and update example.

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -79,7 +79,28 @@ app.use('/api/echo/post', function(req, res) {
   res.end(JSON.stringify(req.body, null, 2));
 });
 
+const ORIGIN_REGEX = new RegExp("http://localhost:8000|" +
+    "https?://.+\.herokuapp\.com:8000");
+const SOURCE_ORIGIN_REGEX = new RegExp("http://localhost:8000|" +
+    "https?://.+\.herokuapp\.com:8000/");
+
 app.use('/form/html/post', function(req, res) {
+  if(!ORIGIN_REGEX.test(req.headers.origin)) {
+    res.statusCode = 500;
+    res.end(JSON.stringify({
+      message: 'Origin header is invalid.'
+    }));
+    return;
+  }
+
+  if(!SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)) {
+    res.statusCode = 500;
+    res.end(JSON.stringify({
+      message: '__amp_source_origin parameter is invalid.'
+    }));
+    return;
+  }
+
   var form = new formidable.IncomingForm();
   form.parse(req, function(err, fields) {
     res.setHeader('Content-Type', 'text/html');
@@ -99,6 +120,22 @@ app.use('/form/html/post', function(req, res) {
 });
 
 app.use('/form/echo-json/post', function(req, res) {
+  if(!ORIGIN_REGEX.test(req.headers.origin)) {
+    res.statusCode = 500;
+    res.end(JSON.stringify({
+      message: 'Origin header is invalid.'
+    }));
+    return;
+  }
+
+  if(!SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)) {
+    res.statusCode = 500;
+    res.end(JSON.stringify({
+      message: '__amp_source_origin parameter is invalid.'
+    }));
+    return;
+  }
+
   var form = new formidable.IncomingForm();
   form.parse(req, function(err, fields) {
     res.setHeader('Content-Type', 'application/json');

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -79,13 +79,13 @@ app.use('/api/echo/post', function(req, res) {
   res.end(JSON.stringify(req.body, null, 2));
 });
 
-const ORIGIN_REGEX = new RegExp("http://localhost:8000|" +
-    "https?://.+\.herokuapp\.com:8000");
-const SOURCE_ORIGIN_REGEX = new RegExp("http://localhost:8000|" +
-    "https?://.+\.herokuapp\.com:8000/");
+const ORIGIN_REGEX = new RegExp('^http://localhost:8000|' +
+    '^https?://.+\.herokuapp\.com:8000');
+const SOURCE_ORIGIN_REGEX = new RegExp('^http://localhost:8000|' +
+    '^https?://.+\.herokuapp\.com:8000/');
 
 app.use('/form/html/post', function(req, res) {
-  if(!ORIGIN_REGEX.test(req.headers.origin)) {
+  if (!ORIGIN_REGEX.test(req.headers.origin)) {
     res.statusCode = 500;
     res.end(JSON.stringify({
       message: 'Origin header is invalid.'
@@ -93,7 +93,7 @@ app.use('/form/html/post', function(req, res) {
     return;
   }
 
-  if(!SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)) {
+  if (!SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)) {
     res.statusCode = 500;
     res.end(JSON.stringify({
       message: '__amp_source_origin parameter is invalid.'
@@ -120,7 +120,7 @@ app.use('/form/html/post', function(req, res) {
 });
 
 app.use('/form/echo-json/post', function(req, res) {
-  if(!ORIGIN_REGEX.test(req.headers.origin)) {
+  if (!ORIGIN_REGEX.test(req.headers.origin)) {
     res.statusCode = 500;
     res.end(JSON.stringify({
       message: 'Origin header is invalid.'
@@ -128,7 +128,7 @@ app.use('/form/echo-json/post', function(req, res) {
     return;
   }
 
-  if(!SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)) {
+  if (!SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)) {
     res.statusCode = 500;
     res.end(JSON.stringify({
       message: '__amp_source_origin parameter is invalid.'
@@ -147,7 +147,7 @@ app.use('/form/echo-json/post', function(req, res) {
     res.setHeader('Access-Control-Expose-Headers',
         'AMP-Access-Control-Allow-Source-Origin')
     res.setHeader('AMP-Access-Control-Allow-Source-Origin',
-        req.protocol + '://' + req.headers.host);
+        req.query.__amp_source_origin);
     res.end(JSON.stringify(fields));
   });
 });

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -142,6 +142,10 @@ app.use('/form/echo-json/post', function(req, res) {
     if (fields['email'] == 'already@subscribed.com') {
       res.statusCode = 500;
     }
+    res.setHeader('Access-Control-Allow-Origin',
+        req.protocol + '://' + req.headers.host);
+    res.setHeader('Access-Control-Expose-Headers',
+        'AMP-Access-Control-Allow-Source-Origin')
     res.setHeader('AMP-Access-Control-Allow-Source-Origin',
         req.protocol + '://' + req.headers.host);
     res.end(JSON.stringify(fields));

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -79,8 +79,21 @@ app.use('/api/echo/post', function(req, res) {
   res.end(JSON.stringify(req.body, null, 2));
 });
 
+/**
+ * In practice this would be *.ampproject.org and the publishers
+ * origin. Please see AMP CORS docs for more details:
+ *    https://goo.gl/F6uCAY
+ * @type {RegExp}
+ */
 const ORIGIN_REGEX = new RegExp('^http://localhost:8000|' +
     '^https?://.+\.herokuapp\.com:8000');
+
+/**
+ * In practice this would be the publishers origin.
+ * Please see AMP CORS docs for more details:
+ *    https://goo.gl/F6uCAY
+ * @type {RegExp}
+ */
 const SOURCE_ORIGIN_REGEX = new RegExp('^http://localhost:8000|' +
     '^https?://.+\.herokuapp\.com:8000/');
 
@@ -143,7 +156,7 @@ app.use('/form/echo-json/post', function(req, res) {
       res.statusCode = 500;
     }
     res.setHeader('Access-Control-Allow-Origin',
-        req.protocol + '://' + req.headers.host);
+        req.headers.origin);
     res.setHeader('Access-Control-Expose-Headers',
         'AMP-Access-Control-Allow-Source-Origin')
     res.setHeader('AMP-Access-Control-Allow-Source-Origin',

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -16,7 +16,7 @@
 
 import {isExperimentOn} from '../../../src/experiments';
 import {getService} from '../../../src/service';
-import {assertHttpsUrl, getCorsUrl} from '../../../src/url';
+import {assertHttpsUrl} from '../../../src/url';
 import {user, rethrowAsync} from '../../../src/log';
 import {onDocumentReady} from '../../../src/document-ready';
 import {xhrFor} from '../../../src/xhr';
@@ -145,16 +145,6 @@ export class AmpForm {
 
     /** @private {?string} */
     this.state_ = null;
-
-    // Update the form non-xhr action to add `__amp_source_origin` parameter.
-    // This allows publishers to understand where the request is coming from.
-    const action = this.form_.getAttribute('action');
-    user().assert(action, 'form action is required: %s',
-        this.form_);
-    assertHttpsUrl(action, this.form_, 'action');
-    user().assert(!startsWith(action, urls.cdn),
-        'form action should not be on cdn.ampproject.org: %s', this.form_);
-    this.form_.setAttribute('action', getCorsUrl(this.win_, action));
 
     this.installSubmitHandler_();
   }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -16,11 +16,10 @@
 
 import {isExperimentOn} from '../../../src/experiments';
 import {getService} from '../../../src/service';
-import {assertHttpsUrl} from '../../../src/url';
+import {assertHttpsUrl, getCorsUrl} from '../../../src/url';
 import {user, rethrowAsync} from '../../../src/log';
 import {onDocumentReady} from '../../../src/document-ready';
 import {xhrFor} from '../../../src/xhr';
-import {getCorsUrl} from '../../../src/service/xhr-impl';
 import {toArray} from '../../../src/types';
 import {startsWith} from '../../../src/string';
 import {templatesFor} from '../../../src/template';

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -20,6 +20,7 @@ import {assertHttpsUrl} from '../../../src/url';
 import {user, rethrowAsync} from '../../../src/log';
 import {onDocumentReady} from '../../../src/document-ready';
 import {xhrFor} from '../../../src/xhr';
+import {getCorsUrl} from '../../../src/service/xhr-impl';
 import {toArray} from '../../../src/types';
 import {startsWith} from '../../../src/string';
 import {templatesFor} from '../../../src/template';
@@ -145,6 +146,16 @@ export class AmpForm {
 
     /** @private {?string} */
     this.state_ = null;
+
+    // Update the form non-xhr action to add `__amp_source_origin` parameter.
+    // This allows publishers to understand where the request is coming from.
+    const action = this.form_.getAttribute('action');
+    user().assert(action, 'form action is required: %s',
+        this.form_);
+    assertHttpsUrl(action, this.form_, 'action');
+    user().assert(!startsWith(action, urls.cdn),
+        'form action should not be on cdn.ampproject.org: %s', this.form_);
+    this.form_.setAttribute('action', getCorsUrl(this.win_, action));
 
     this.installSubmitHandler_();
   }

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -95,24 +95,6 @@ describe('amp-form', () => {
     expect(() => new AmpForm(form)).to.not.throw;
   });
 
-  it('should assert valid action and append __amp_source_origin to it', () => {
-    const form = getForm();
-    form.removeAttribute('action');
-    expect(() => new AmpForm(form)).to.throw(
-        /form action is required/);
-    form.setAttribute('action', 'http://example.com');
-    expect(() => new AmpForm(form)).to.throw(
-        /form action must start with/);
-    form.setAttribute('action', 'https://cdn.ampproject.org/example.com');
-    expect(() => new AmpForm(form)).to.throw(
-        /form action should not be on cdn\.ampproject\.org/);
-    form.setAttribute('action', 'https://example.com');
-    expect(() => new AmpForm(form)).to.not.throw;
-    new AmpForm(form);
-    expect(form.getAttribute('action')).to.contain(
-        '__amp_source_origin=http%3A%2F%2Flocalhost%3A9876');
-  });
-
   it('should assert valid action-xhr when provided', () => {
     const form = getForm();
     form.setAttribute('action-xhr', 'http://example.com');

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -58,6 +58,7 @@ describe('amp-form', () => {
     nameInput.setAttribute('value', 'John Miller');
     form.appendChild(nameInput);
     form.setAttribute('action-xhr', 'https://example.com');
+    form.setAttribute('action', 'https://example.com');
 
     if (button1) {
       const submitBtn = doc.createElement('input');
@@ -92,6 +93,24 @@ describe('amp-form', () => {
         /form requires at least one <input type=submit>/);
     form = getForm(document, true, false);
     expect(() => new AmpForm(form)).to.not.throw;
+  });
+
+  it('should assert valid action and append __amp_source_origin to it', () => {
+    const form = getForm();
+    form.removeAttribute('action');
+    expect(() => new AmpForm(form)).to.throw(
+        /form action is required/);
+    form.setAttribute('action', 'http://example.com');
+    expect(() => new AmpForm(form)).to.throw(
+        /form action must start with/);
+    form.setAttribute('action', 'https://cdn.ampproject.org/example.com');
+    expect(() => new AmpForm(form)).to.throw(
+        /form action should not be on cdn\.ampproject\.org/);
+    form.setAttribute('action', 'https://example.com');
+    expect(() => new AmpForm(form)).to.not.throw;
+    new AmpForm(form);
+    expect(form.getAttribute('action')).to.contain(
+        '__amp_source_origin=http%3A%2F%2Flocalhost%3A9876');
   });
 
   it('should assert valid action-xhr when provided', () => {

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -60,9 +60,7 @@ export function onDocumentFormSubmit_(e) {
       'form action should not be on AMP CDN: %s', form);
   // Update the form non-xhr action to add `__amp_source_origin` parameter.
   // This allows publishers to understand where the request is coming from.
-  if (action.indexOf('__amp_source_origin=') == -1) {
-    form.setAttribute('action', getCorsUrl(win, action));
-  }
+  form.setAttribute('action', getCorsUrl(win, action, /*override*/ true));
 
   const target = form.getAttribute('target');
   user().assert(target, 'form target attribute is required: %s', form);

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -53,7 +53,7 @@ export function onDocumentFormSubmit_(e) {
   }
 
   const win = form.ownerDocument.defaultView;
-  let action = form.getAttribute('action');
+  const action = form.getAttribute('action');
   user().assert(action, 'form action attribute is required: %s', form);
   assertHttpsUrl(action, form, 'action');
   user().assert(!startsWith(action, urls.cdn),

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -51,8 +51,8 @@ export function onDocumentFormSubmit_(e) {
   if (!form || form.tagName != 'FORM') {
     return;
   }
-  const win = form.ownerDocument.defaultView;
 
+  const win = form.ownerDocument.defaultView;
   const action = form.getAttribute('action');
   user().assert(action, 'form action attribute is required: %s', form);
   assertHttpsUrl(action, form, 'action');

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -16,7 +16,7 @@
 
 import {startsWith} from './string';
 import {user} from './log';
-import {assertHttpsUrl} from './url';
+import {assertHttpsUrl, getCorsUrl} from './url';
 import {urls} from './config';
 
 
@@ -51,12 +51,18 @@ export function onDocumentFormSubmit_(e) {
   if (!form || form.tagName != 'FORM') {
     return;
   }
+  const win = form.ownerDocument.defaultView;
 
   const action = form.getAttribute('action');
   user().assert(action, 'form action attribute is required: %s', form);
   assertHttpsUrl(action, form, 'action');
   user().assert(!startsWith(action, urls.cdn),
       'form action should not be on AMP CDN: %s', form);
+  // Update the form non-xhr action to add `__amp_source_origin` parameter.
+  // This allows publishers to understand where the request is coming from.
+  if (action.indexOf('__amp_source_origin=') == -1) {
+    form.setAttribute('action', getCorsUrl(win, action));
+  }
 
   const target = form.getAttribute('target');
   user().assert(target, 'form target attribute is required: %s', form);

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -53,14 +53,16 @@ export function onDocumentFormSubmit_(e) {
   }
 
   const win = form.ownerDocument.defaultView;
-  const action = form.getAttribute('action');
+  let action = form.getAttribute('action');
   user().assert(action, 'form action attribute is required: %s', form);
   assertHttpsUrl(action, form, 'action');
   user().assert(!startsWith(action, urls.cdn),
       'form action should not be on AMP CDN: %s', form);
+
+  form.__AMP_INIT_ACTION__ = form.__AMP_INIT_ACTION__ || action;
   // Update the form non-xhr action to add `__amp_source_origin` parameter.
   // This allows publishers to understand where the request is coming from.
-  form.setAttribute('action', getCorsUrl(win, action, /*override*/ true));
+  form.setAttribute('action', getCorsUrl(win, form.__AMP_INIT_ACTION__));
 
   const target = form.getAttribute('target');
   user().assert(target, 'form target attribute is required: %s', form);

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -17,10 +17,8 @@
 import {dev, user} from '../log';
 import {fromClass} from '../service';
 import {
-  addParamToUrl,
   getSourceOrigin,
-  parseQueryString,
-  parseUrl,
+  getCorsUrl,
 } from '../url';
 import {isArray, isObject, isFormData} from '../types';
 
@@ -53,9 +51,6 @@ const allowedFetchTypes_ = {
   text: 2,
   arraybuffer: 3,
 };
-
-/** @private @const {string} */
-const SOURCE_ORIGIN_PARAM = '__amp_source_origin';
 
 /** @private @const {string} */
 const ALLOW_SOURCE_ORIGIN_HEADER = 'AMP-Access-Control-Allow-Source-Origin';
@@ -528,22 +523,6 @@ class FetchResponseHeaders {
   get(name) {
     return this.xhr_.getResponseHeader(name);
   }
-}
-
-
-/**
- * Add "__amp_source_origin" query parameter to the URL.
- * @param {!Window} win
- * @param {string} url
- * @return {string}
- */
-export function getCorsUrl(win, url) {
-  const sourceOrigin = getSourceOrigin(win.location.href);
-  const parsedUrl = parseUrl(url);
-  const query = parseQueryString(parsedUrl.search);
-  user().assert(!(SOURCE_ORIGIN_PARAM in query),
-      'Source origin is not allowed in %s', url);
-  return addParamToUrl(url, SOURCE_ORIGIN_PARAM, sourceOrigin);
 }
 
 

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -248,12 +248,7 @@ export class Xhr {
    * @return {string}
    */
   getCorsUrl(win, url) {
-    const sourceOrigin = getSourceOrigin(win.location.href);
-    const parsedUrl = parseUrl(url);
-    const query = parseQueryString(parsedUrl.search);
-    user().assert(!(SOURCE_ORIGIN_PARAM in query),
-        'Source origin is not allowed in %s', url);
-    return addParamToUrl(url, SOURCE_ORIGIN_PARAM, sourceOrigin);
+    return getCorsUrl(win, url);
   }
 
 }
@@ -533,6 +528,22 @@ class FetchResponseHeaders {
   get(name) {
     return this.xhr_.getResponseHeader(name);
   }
+}
+
+
+/**
+ * Add "__amp_source_origin" query parameter to the URL.
+ * @param {!Window} win
+ * @param {string} url
+ * @return {string}
+ */
+export function getCorsUrl(win, url) {
+  const sourceOrigin = getSourceOrigin(win.location.href);
+  const parsedUrl = parseUrl(url);
+  const query = parseQueryString(parsedUrl.search);
+  user().assert(!(SOURCE_ORIGIN_PARAM in query),
+      'Source origin is not allowed in %s', url);
+  return addParamToUrl(url, SOURCE_ORIGIN_PARAM, sourceOrigin);
 }
 
 

--- a/src/url.js
+++ b/src/url.js
@@ -36,6 +36,9 @@ let cache;
 /** @private @const Matches amp_js_* paramters in query string. */
 const AMP_JS_PARAMS_REGEX = /[?&]amp_js[^&]*/;
 
+/** @private @const {string} */
+const SOURCE_ORIGIN_PARAM = '__amp_source_origin';
+
 /**
  * @typedef {({
  *   href: string,
@@ -405,4 +408,20 @@ export function resolveRelativeUrlFallback_(relativeUrlString, baseUrl) {
           basePath.slice(0, basePath.length - 1).join('/') :
           '') +
       '/' + relativeUrlString;
+}
+
+
+/**
+ * Add "__amp_source_origin" query parameter to the URL.
+ * @param {!Window} win
+ * @param {string} url
+ * @return {string}
+ */
+export function getCorsUrl(win, url) {
+  const sourceOrigin = getSourceOrigin(win.location.href);
+  const parsedUrl = parseUrl(url);
+  const query = parseQueryString(parsedUrl.search);
+  user().assert(!(SOURCE_ORIGIN_PARAM in query),
+      'Source origin is not allowed in %s', url);
+  return addParamToUrl(url, SOURCE_ORIGIN_PARAM, sourceOrigin);
 }

--- a/src/url.js
+++ b/src/url.js
@@ -415,13 +415,19 @@ export function resolveRelativeUrlFallback_(relativeUrlString, baseUrl) {
  * Add "__amp_source_origin" query parameter to the URL.
  * @param {!Window} win
  * @param {string} url
+ * @param {boolean=} override
  * @return {string}
  */
-export function getCorsUrl(win, url) {
+export function getCorsUrl(win, url, override = false) {
   const sourceOrigin = getSourceOrigin(win.location.href);
-  const parsedUrl = parseUrl(url);
-  const query = parseQueryString(parsedUrl.search);
-  user().assert(!(SOURCE_ORIGIN_PARAM in query),
+  const pUrl = parseUrl(url);
+  const query = parseQueryString(pUrl.search);
+  user().assert(override || !(SOURCE_ORIGIN_PARAM in query),
       'Source origin is not allowed in %s', url);
+  if (override) {
+    query[SOURCE_ORIGIN_PARAM] = sourceOrigin;
+    const baseUrl = `${pUrl.protocol}//${pUrl.host}${pUrl.pathname}`;
+    return `${addParamsToUrl(baseUrl, query)}${pUrl.hash}`;
+  }
   return addParamToUrl(url, SOURCE_ORIGIN_PARAM, sourceOrigin);
 }

--- a/src/url.js
+++ b/src/url.js
@@ -415,19 +415,13 @@ export function resolveRelativeUrlFallback_(relativeUrlString, baseUrl) {
  * Add "__amp_source_origin" query parameter to the URL.
  * @param {!Window} win
  * @param {string} url
- * @param {boolean=} override
  * @return {string}
  */
-export function getCorsUrl(win, url, override = false) {
+export function getCorsUrl(win, url) {
   const sourceOrigin = getSourceOrigin(win.location.href);
-  const pUrl = parseUrl(url);
-  const query = parseQueryString(pUrl.search);
-  user().assert(override || !(SOURCE_ORIGIN_PARAM in query),
+  const parsedUrl = parseUrl(url);
+  const query = parseQueryString(parsedUrl.search);
+  user().assert(!(SOURCE_ORIGIN_PARAM in query),
       'Source origin is not allowed in %s', url);
-  if (override) {
-    query[SOURCE_ORIGIN_PARAM] = sourceOrigin;
-    const baseUrl = `${pUrl.protocol}//${pUrl.host}${pUrl.pathname}`;
-    return `${addParamsToUrl(baseUrl, query)}${pUrl.hash}`;
-  }
   return addParamToUrl(url, SOURCE_ORIGIN_PARAM, sourceOrigin);
 }

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -68,6 +68,16 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
     expect(() => onDocumentFormSubmit_(evt)).to.not.throw;
   });
 
+  it('should add __amp_source_origin to action before submit', () => {
+    expect(evt.target.getAttribute('action')).to.not.contain(
+        '__amp_source_origin');
+    onDocumentFormSubmit_(evt);
+    expect(evt.target.getAttribute('action')).to.contain(
+        '__amp_source_origin');
+    expect(() => onDocumentFormSubmit_(evt)).to.not.throw(
+        /Source origin is not allowed in/);
+  });
+
   it('should do nothing if already prevented', () => {
     evt.defaultPrevented = true;
     onDocumentFormSubmit_(evt);

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -69,15 +69,21 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
   });
 
   it('should add __amp_source_origin to action before submit', () => {
-    expect(evt.target.getAttribute('action')).to.not.contain(
-        '__amp_source_origin');
+    evt.target.setAttribute('action',
+        'https://example.com/?__amp_source_origin=12');
+    expect(() => onDocumentFormSubmit_(evt))
+        .to.throw(/Source origin is not allowed in/);
+
+    evt.target.__AMP_INIT_ACTION__ = null;
+    evt.target.setAttribute('action', 'https://example.com/');
     onDocumentFormSubmit_(evt);
     expect(evt.target.getAttribute('action')).to.contain(
         '__amp_source_origin');
     expect(() => onDocumentFormSubmit_(evt)).to.not.throw(
         /Source origin is not allowed in/);
 
-    // Should override __amp_source_origin on every submit.
+    // Should not throw on any subsequent submits and use initial
+    // value of action.
     evt.target.setAttribute('action',
         'https://www.example.com/?a=1&__amp_source_origin=example1.com&b=2');
     onDocumentFormSubmit_(evt);

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -76,6 +76,13 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
         '__amp_source_origin');
     expect(() => onDocumentFormSubmit_(evt)).to.not.throw(
         /Source origin is not allowed in/);
+
+    // Should override __amp_source_origin on every submit.
+    evt.target.setAttribute('action',
+        'https://www.example.com/?a=1&__amp_source_origin=example1.com&b=2');
+    onDocumentFormSubmit_(evt);
+    expect(evt.target.getAttribute('action')).to.contain(
+        '__amp_source_origin=http%3A%2F%2Flocalhost%3A9876');
   });
 
   it('should do nothing if already prevented', () => {

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -28,6 +28,7 @@ import {
   resolveRelativeUrl,
   resolveRelativeUrlFallback_,
   serializeQueryString,
+  getCorsUrl,
 } from '../../src/url';
 
 describe('parseUrl', () => {
@@ -555,4 +556,20 @@ describe('resolveRelativeUrl', () => {
       'file?f=0#h',
       parseUrl('http://base.org/bfile?bf=0#bh'),
       'http://base.org/file?f=0#h');
+});
+
+
+describe('getCorsUrl', () => {
+  it('should error if __amp_source_origin is set', () => {
+    expect(() => getCorsUrl(window, 'http://example.com?__amp_source_origin'))
+        .to.throw(/Source origin is not allowed in/);
+    expect(() => getCorsUrl(window, 'http://example.com?name=hello'))
+        .to.not.throw;
+  });
+
+  it('should set __amp_source_origin as a url param', () => {
+    expect(getCorsUrl(window, 'http://example.com?name=hello'))
+        .to.equal('http://example.com?name=hello&' +
+            '__amp_source_origin=http%3A%2F%2Flocalhost%3A9876');
+  });
 });

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -572,12 +572,4 @@ describe('getCorsUrl', () => {
         .to.equal('http://example.com/?name=hello&' +
             '__amp_source_origin=http%3A%2F%2Flocalhost%3A9876');
   });
-
-  it('should override __amp_source_origin if already set', () => {
-    expect(getCorsUrl(window,
-        'http://example.com?a=1&__amp_source_origin=example1.com&b=2', true))
-            .to.equal(
-                'http://example.com/?a=1&' +
-                '__amp_source_origin=http%3A%2F%2Flocalhost%3A9876&b=2');
-  });
 });

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -561,15 +561,23 @@ describe('resolveRelativeUrl', () => {
 
 describe('getCorsUrl', () => {
   it('should error if __amp_source_origin is set', () => {
-    expect(() => getCorsUrl(window, 'http://example.com?__amp_source_origin'))
+    expect(() => getCorsUrl(window, 'http://example.com/?__amp_source_origin'))
         .to.throw(/Source origin is not allowed in/);
-    expect(() => getCorsUrl(window, 'http://example.com?name=hello'))
+    expect(() => getCorsUrl(window, 'http://example.com/?name=hello'))
         .to.not.throw;
   });
 
   it('should set __amp_source_origin as a url param', () => {
-    expect(getCorsUrl(window, 'http://example.com?name=hello'))
-        .to.equal('http://example.com?name=hello&' +
+    expect(getCorsUrl(window, 'http://example.com/?name=hello'))
+        .to.equal('http://example.com/?name=hello&' +
             '__amp_source_origin=http%3A%2F%2Flocalhost%3A9876');
+  });
+
+  it('should override __amp_source_origin if already set', () => {
+    expect(getCorsUrl(window,
+        'http://example.com?a=1&__amp_source_origin=example1.com&b=2', true))
+            .to.equal(
+                'http://example.com/?a=1&' +
+                '__amp_source_origin=http%3A%2F%2Flocalhost%3A9876&b=2');
   });
 });


### PR DESCRIPTION
Follow up to #4485 and part of security review for `amp-form`.

ITI: #3343
