### PR TITLE
Excludes iframe fixtures from being embedded into the Karma test runner page.

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -20,7 +20,13 @@ var karmaConf = path.resolve('karma.conf.js');
 
 var commonTestPaths = [
   'test/_init_tests.js',
-  'test/fixtures/**/*.html',
+  'test/fixtures/*.html',
+  {
+    pattern: 'test/fixtures/served/*.html',
+    included: false,
+    nocache: false,
+    watched: true,
+  },
   {
     pattern: 'dist/**/*.js',
     included: false,


### PR DESCRIPTION
Those fixtures are supposed to be loaded in iframes (that's why they're under `/fixtures/served`). They add message listener to window and post messages to parent window. Loading them in the Karma test runner page would interfere the running tests and cause confusion during debugging.

For example the fixture [iframe-intersection.html](https://github.com/ampproject/amphtml/blob/de055f64b014f46baa1ee6d213d46400fc0bee66/test/fixtures/served/iframe-intersection.html#L30) periodically post message.
