### PR TITLE
Make A4A handle XHR (and other) errors gracefully

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -306,6 +306,40 @@ describe('amp-a4a', () => {
         });
       });
     });
+    it('should run end-to-end in the presence of a validation error', () => {
+      viewerForMock.onFirstCall().returns(Promise.resolve());
+      xhrMock.onFirstCall().throws(new Error('XHR Error'));
+      return createAdTestingIframePromise().then(fixture => {
+        const doc = fixture.doc;
+        const a4aElement = doc.createElement('amp-a4a');
+        a4aElement.setAttribute('width', 200);
+        a4aElement.setAttribute('height', 50);
+        a4aElement.setAttribute('type', 'adsense');
+        const a4a = new MockA4AImpl(a4aElement);
+        const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+        a4a.onLayoutMeasure();
+        expect(a4a.adPromise_).to.be.instanceof(Promise);
+        return a4a.layoutCallback().catch(reason => {
+          a4a.vsync_.runScheduledTasks_();
+          expect(getAdUrlSpy.calledOnce, 'getAdUrl called exactly once')
+              .to.be.true;
+          // Verify iframe presence and lack of visibility hidden
+          expect(a4aElement.children.length).to.equal(1);
+          const iframe = a4aElement.children[0];
+          expect(iframe.tagName).to.equal('IFRAME');
+          expect(iframe.src.indexOf('https://test.location.org')).to.equal(0);
+          expect(iframe.style.visibility).to.equal('');
+          expect(reason).to.not.be.null;
+          expect(reason.message.indexOf('amp-a4a: ')).to.equal(0);
+          const state = JSON.parse(reason.message.substring(
+            reason.message.indexOf('{'),
+            reason.message.lastIndexOf('}') + 1));
+          expect(state).to.deep.equal({
+            m: 'XHR Error', tag: 'AMP-A4A', type: 'adsense', au: 'args',
+          });
+        });
+      });
+    });
     // TODO(tdrl): Go through case analysis in amp-a4a.js#onLayoutMeasure and
     // add one test for each case / ensure that all cases are covered.
   });
@@ -624,40 +658,6 @@ describe('amp-a4a', () => {
             expect(getAdUrlSpy.called, 'getAdUrl never called')
                 .to.be.false;
             expect(reason).to.deep.equal(cancellation());
-          });
-        });
-      });
-      it('verify unhandled error', () => {
-        return createAdTestingIframePromise().then(fixture => {
-          viewerForMock.returns(Promise.resolve());
-          let rejectResolve = null;
-          const sendXhrRequestMock =
-              sandbox.stub(MockA4AImpl.prototype, 'sendXhrRequest_');
-          sendXhrRequestMock.returns(new Promise((resolve, reject) => {
-            rejectResolve = reject;
-          }));
-          const doc = fixture.doc;
-          const a4aElement = doc.createElement('amp-a4a');
-          a4aElement.setAttribute('width', 200);
-          a4aElement.setAttribute('height', 50);
-          a4aElement.setAttribute('type', 'adsense');
-          const a4a = new MockA4AImpl(a4aElement);
-          const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-          a4a.onLayoutMeasure();
-          rejectResolve(new Error('some error'));
-          return a4a.adPromise_.then(() => {
-            assert.fail('should have thrown error');
-          }).catch(reason => {
-            expect(getAdUrlSpy.called, 'getAdUrl called once')
-                .to.be.true;
-            expect(reason).to.not.be.null;
-            expect(reason.message.indexOf('amp-a4a: ')).to.equal(0);
-            const state = JSON.parse(reason.message.substring(
-              reason.message.indexOf('{'),
-              reason.message.lastIndexOf('}') + 1));
-            expect(state).to.deep.equal({
-              m: 'some error', tag: 'AMP-A4A', type: 'adsense', au: 'args',
-            });
           });
         });
       });


### PR DESCRIPTION
With A4A, if there is any sort of error validating the creative, go ahead and render it in an iframe, and report the error (by bubbling up to the unhandled error handler).