### PR TITLE
Roll back A4A experiment to 1% of canary.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -2,6 +2,6 @@
   "canary": true,
   "no-auth-in-prerender": 1,
   "amp-sticky-ad": 1,
-  "expAdsenseA4A": 0.05,
-  "expDoubleclickA4A": 0.05
+  "expAdsenseA4A": 0.01,
+  "expDoubleclickA4A": 0.01
 }


### PR DESCRIPTION
We have found a couple of bugs in A4A.  The biggest is being addressed in #4579 , but there's at least one other related to control experiment IDs not being handled properly.

While we're sorting that out, we'd like to roll the experiment back to a lower fraction.