### PR TITLE
Introduces an iframe fixture for postMessage related tests.

### DIFF
--- a/test/fixtures/served/iframe-stub.html
+++ b/test/fixtures/served/iframe-stub.html
@@ -21,7 +21,10 @@
   // 'testStubEcho'.
   window.addEventListener('message', event => {
     if (event.source == window.parent && !event.data.testStubEcho) {
-      const data = Object.assign(event.data, {testStubEcho: true});
+      const data = {
+        testStubEcho: true,
+        receivedMessage: event.data,
+      };
       window.parent.postMessage(data, '*');
       console.log('echoed message to parent window: ' + JSON.stringify(data));
     }

--- a/test/fixtures/served/iframe-stub.html
+++ b/test/fixtures/served/iframe-stub.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body onhashchange="postMessageToParent()" style="background-color:red">
+<script>
+
+  /**
+   * Reads JSON format message data from the URL fragment, and then post it to
+   * parent window.
+   */
+  function postMessageToParent() {
+    if (location.hash.length > 1) {
+      const data = JSON.parse(decodeURIComponent(location.hash.substr(1)));
+      window.parent.postMessage(data, '*');
+      console.log('posted message to parent window: ' + JSON.stringify(data));
+    }
+  }
+
+  postMessageToParent();
+
+  // Echo back a message received from parent window with a marker field
+  // 'testStubEcho'.
+  window.addEventListener('message', event => {
+    if (event.source == window.parent && !event.data.testStubEcho) {
+      const data = Object.assign(event.data, {testStubEcho: true});
+      window.parent.postMessage(data, '*');
+      console.log('echoed message to parent window: ' + JSON.stringify(data));
+    }
+  });
+</script>
+</body>
+</html>

--- a/test/functional/test-iframe-stub.js
+++ b/test/functional/test-iframe-stub.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createIframeWithMessageStub,
+  expectPostMessage,
+} from '../../testing/iframe';
+
+describe('test-iframe-createIframeWithMessageStub', () => {
+
+  const data1 = {
+    foo: 'bar',
+    test: true,
+  };
+
+  const data2 = {
+    num: 5,
+  };
+
+  let iframe;
+
+  beforeEach(() => {
+    return createIframeWithMessageStub(window).then(newIframe => {
+      iframe = newIframe;
+    });
+  });
+
+  it('should get message from fragment and post back to parent window', () => {
+    iframe.postMessageToParent(data1);
+    expectPostMessage(iframe.contentWindow, window, data1)
+        .then(receivedMessage => {
+          expect(receivedMessage).to.jsonEqual(data1);
+        })
+        .then(() => {
+          iframe.postMessageToParent(data2);
+          return expectPostMessage(iframe.contentWindow, window, data2);
+        })
+        .then(receivedMessage => {
+          expect(receivedMessage).to.jsonEqual(data2);
+        });
+  });
+
+  it('should echo back message to parent window', () => {
+    iframe.contentWindow.postMessage(data1, '*');
+    return iframe.expectMessageFromParent(data1).then(() => {
+      iframe.contentWindow.postMessage(data2, '*');
+    }).then(() => {
+      iframe.expectMessageFromParent(data2);
+    });
+  });
+});

--- a/test/functional/test-iframe-stub.js
+++ b/test/functional/test-iframe-stub.js
@@ -40,7 +40,7 @@ describe('test-iframe-createIframeWithMessageStub', () => {
 
   it('should get message from fragment and post back to parent window', () => {
     iframe.postMessageToParent(data1);
-    expectPostMessage(iframe.contentWindow, window, data1)
+    return expectPostMessage(iframe.contentWindow, window, data1)
         .then(receivedMessage => {
           expect(receivedMessage).to.jsonEqual(data1);
         })

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -261,7 +261,7 @@ export function createServedIframe(src) {
   });
 }
 
-const IFRAME_SRC =
+const IFRAME_STUB_URL =
     '//ads.localhost:9876/test/fixtures/served/iframe-stub.html#';
 
 /**
@@ -279,14 +279,14 @@ const IFRAME_SRC =
  */
 export function createIframeWithMessageStub(win) {
   const element = win.document.createElement('iframe');
-  element.src = IFRAME_SRC;
+  element.src = IFRAME_STUB_URL;
   win.document.body.appendChild(element);
 
   /**
    * Instructs the iframe to send a message to parent window.
    */
   element.postMessageToParent = msg => {
-    element.src = IFRAME_SRC + encodeURIComponent(JSON.stringify(msg));
+    element.src = IFRAME_STUB_URL + encodeURIComponent(JSON.stringify(msg));
   };
 
   /**

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -297,12 +297,11 @@ export function createIframeWithMessageStub(win) {
     return new Promise(resolve => {
       const listener = event => {
         if (event.source == element.contentWindow
-            && event.data.testStubEcho) {
-          delete event.data.testStubEcho;
-          if (JSON.stringify(msg) == JSON.stringify(event.data)) {
-            win.removeEventListener('message', listener);
-            resolve(event.data);
-          }
+            && event.data.testStubEcho
+            && JSON.stringify(msg)
+                == JSON.stringify(event.data.receivedMessage)) {
+          win.removeEventListener('message', listener);
+          resolve(msg);
         }
       };
       win.addEventListener('message', listener);

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -261,6 +261,83 @@ export function createServedIframe(src) {
   });
 }
 
+const IFRAME_SRC =
+    '//ads.localhost:9876/test/fixtures/served/iframe-stub.html#';
+
+/**
+ * Creates an iframe fixture in the given window that can be used for
+ * window.postMessage related tests.
+ *
+ * It provides functions like:
+ * - instruct the iframe to post a message to the parent window
+ * - verify the iframe has received a message from the parent window
+ *
+ * See /test/fixtures/served/iframe-stub.html for implementation.
+ *
+ * @param win {!Window}
+ * @returns {!Promise<!HTMLIFrameElement>}
+ */
+export function createIframeWithMessageStub(win) {
+  const element = win.document.createElement('iframe');
+  element.src = IFRAME_SRC;
+  win.document.body.appendChild(element);
+
+  /**
+   * Instructs the iframe to send a message to parent window.
+   */
+  element.postMessageToParent = msg => {
+    element.src = IFRAME_SRC + encodeURIComponent(JSON.stringify(msg));
+  };
+
+  /**
+   * Returns a Promise that resolves when the iframe acknowledged the reception
+   * of the specified message.
+   */
+  element.expectMessageFromParent = msg => {
+    return new Promise(resolve => {
+      const listener = event => {
+        if (event.source == element.contentWindow
+            && event.data.testStubEcho) {
+          delete event.data.testStubEcho;
+          if (JSON.stringify(msg) == JSON.stringify(event.data)) {
+            win.removeEventListener('message', listener);
+            resolve(event.data);
+          }
+        }
+      };
+      win.addEventListener('message', listener);
+    });
+  };
+
+  return new Promise(resolve => {
+    element.onload = () => {
+      resolve(element);
+    };
+  });
+}
+
+/**
+ * Returns a Promise that resolves when a post message is observed from the
+ * given source window to target window.
+ *
+ * @param sourceWin {!Window}
+ * @param targetwin {!Window}
+ * @param msg {!Object}
+ * @returns {!Promise<!Object>}
+ */
+export function expectPostMessage(sourceWin, targetwin, msg) {
+  return new Promise(resolve => {
+    const listener = event => {
+      if (event.source == sourceWin
+          && JSON.stringify(msg) == JSON.stringify(event.data)) {
+        targetwin.removeEventListener('message', listener);
+        resolve(event.data);
+      }
+    };
+    targetwin.addEventListener('message', listener);
+  });
+}
+
 /**
  * Returns a promise for when the condition becomes true.
  * @param {string} description


### PR DESCRIPTION
A proof of concept test is also added.

The fixture can be used in the unit test for `amp-ad-api-handler`.