### PR TITLE
Fix styling for iframes on iOS

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -101,8 +101,8 @@ i-amp-sizer {
 
 .-amp-fill-content {
   display: block;
-  min-width: 100%;     /* These lines are a work around to this issue in iOS: */
-  max-width: 100%;     /* https://bugs.webkit.org/show_bug.cgi?id=155198         */
+  width: 1px;          /* These lines are a work around to this issue in iOS: */
+  min-width: 100%;     /* https://bugs.webkit.org/show_bug.cgi?id=155198      */
   height: 100%;
   margin: auto;
 }


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/4540. I opted to just update `.-amp-fill-content`, since these styles were specifically added to fix this case (but didn't fully).