### PR TITLE
Allow A4A ads to fall back to iframe if the ad request fails

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -527,11 +527,10 @@ export class AmpA4A extends AMP.BaseElement {
     return xhrFor(this.win)
         .fetch(adUrl, xhrInit)
         .catch(unusedReason => {
-          // Error so set rendered_ so iframe will not be written on
-          // layoutCallback.
-          // TODO: is this the appropriate action?  Perhaps we should just allow
-          // the ad to be rendered via iframe.
-          this.rendered_ = true;
+          // If an error occurs, let the ad be rendered via iframe after delay.
+          // TODO(taymonbeal): Figure out a more sophisticated test for deciding
+          // whether to retry with an iframe after an ad request failure or just
+          // give up and render the fallback content (or collapse the ad slot).
           return null;
         });
   }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -306,9 +306,9 @@ describe('amp-a4a', () => {
         });
       });
     });
-    it('should run end-to-end in the presence of a validation error', () => {
+    it('should run end-to-end in the presence of an XHR error', () => {
       viewerForMock.onFirstCall().returns(Promise.resolve());
-      xhrMock.onFirstCall().throws(new Error('XHR Error'));
+      xhrMock.onFirstCall().returns(Promise.reject(new Error('XHR Error')));
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = doc.createElement('amp-a4a');
@@ -319,7 +319,7 @@ describe('amp-a4a', () => {
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.instanceof(Promise);
-        return a4a.layoutCallback().catch(reason => {
+        return a4a.layoutCallback().then(() => {
           a4a.vsync_.runScheduledTasks_();
           expect(getAdUrlSpy.calledOnce, 'getAdUrl called exactly once')
               .to.be.true;
@@ -329,14 +329,49 @@ describe('amp-a4a', () => {
           expect(iframe.tagName).to.equal('IFRAME');
           expect(iframe.src.indexOf('https://test.location.org')).to.equal(0);
           expect(iframe.style.visibility).to.equal('');
-          expect(reason).to.not.be.null;
-          expect(reason.message.indexOf('amp-a4a: ')).to.equal(0);
-          const state = JSON.parse(reason.message.substring(
-            reason.message.indexOf('{'),
-            reason.message.lastIndexOf('}') + 1));
-          expect(state).to.deep.equal({
-            m: 'XHR Error', tag: 'AMP-A4A', type: 'adsense', au: 'args',
-          });
+        });
+      });
+    });
+    it('should handle XHR error when resolves before layoutCallback', () => {
+      viewerForMock.onFirstCall().returns(Promise.resolve());
+      xhrMock.onFirstCall().returns(Promise.reject(new Error('XHR Error')));
+      return createAdTestingIframePromise().then(fixture => {
+        const doc = fixture.doc;
+        const a4aElement = doc.createElement('amp-a4a');
+        const a4a = new MockA4AImpl(a4aElement);
+        a4a.onLayoutMeasure();
+        return a4a.adPromise_.then(() => a4a.layoutCallback().then(() => {
+          a4a.vsync_.runScheduledTasks_();
+          // Verify iframe presence and lack of visibility hidden
+          expect(a4aElement.children.length).to.equal(1);
+          const iframe = a4aElement.children[0];
+          expect(iframe.tagName).to.equal('IFRAME');
+          expect(iframe.src.indexOf('https://test.location.org')).to.equal(0);
+          expect(iframe.style.visibility).to.equal('');
+        }));
+      });
+    });
+    it('should handle XHR error when resolves after layoutCallback', () => {
+      viewerForMock.onFirstCall().returns(Promise.resolve());
+      let rejectXhr;
+      xhrMock.onFirstCall().returns(new Promise((unusedResolve, reject) => {
+        rejectXhr = reject;
+      }));
+      return createAdTestingIframePromise().then(fixture => {
+        const doc = fixture.doc;
+        const a4aElement = doc.createElement('amp-a4a');
+        const a4a = new MockA4AImpl(a4aElement);
+        a4a.onLayoutMeasure();
+        const layoutCallbackPromise = a4a.layoutCallback();
+        rejectXhr(new Error('XHR Error'));
+        return layoutCallbackPromise.then(() => {
+          a4a.vsync_.runScheduledTasks_();
+          // Verify iframe presence and lack of visibility hidden
+          expect(a4aElement.children.length).to.equal(1);
+          const iframe = a4aElement.children[0];
+          expect(iframe.tagName).to.equal('IFRAME');
+          expect(iframe.src.indexOf('https://test.location.org')).to.equal(0);
+          expect(iframe.style.visibility).to.equal('');
         });
       });
     });


### PR DESCRIPTION
Since it's currently common for A4A-initiated ad requests to fail (in particular, if the ad server returns a response without proper CORS headers), we will now have A4A render the ad in an iframe after the runtime-imposed delay when this occurs, instead of just giving up. This is a short-term fix; our longer-term plan is to distinguish between "retriable" and "non-retriable" ad request failures, and have A4A fall back to iframe on the former and give up on the latter (rendering the fallback content or collapsing the ad slot, as appropriate). This change also fixes a race condition bug wherein a flag indicating not to render the ad would sometimes be set too late and consequently ignored.