### PR TITLE
Add additional CSS test to validator.

### DIFF
--- a/validator/testdata/feature_tests/css_errors.html
+++ b/validator/testdata/feature_tests/css_errors.html
@@ -26,6 +26,12 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <style amp-custom>
+    a {
+        two: 2;
+        b {
+            three: 3;
+        }
+    }
     url("an unterminated string)
     A trailing backslash \
     url(foo"bar)

--- a/validator/testdata/feature_tests/css_errors.out
+++ b/validator/testdata/feature_tests/css_errors.out
@@ -1,5 +1,7 @@
 FAIL
-feature_tests/css_errors.html:29:8 CSS syntax error in tag 'style amp-custom' - unterminated string. [AUTHOR_STYLESHEET_PROBLEM]
-feature_tests/css_errors.html:30:25 CSS syntax error in tag 'style amp-custom' - stray trailing backslash. [AUTHOR_STYLESHEET_PROBLEM]
-feature_tests/css_errors.html:31:4 CSS syntax error in tag 'style amp-custom' - bad url. [AUTHOR_STYLESHEET_PROBLEM]
-feature_tests/css_errors.html:29:4 CSS syntax error in tag 'style amp-custom' - end of stylesheet encountered in prelude of a qualified rule. [AUTHOR_STYLESHEET_PROBLEM]
+feature_tests/css_errors.html:35:8 CSS syntax error in tag 'style amp-custom' - unterminated string. [AUTHOR_STYLESHEET_PROBLEM]
+feature_tests/css_errors.html:36:25 CSS syntax error in tag 'style amp-custom' - stray trailing backslash. [AUTHOR_STYLESHEET_PROBLEM]
+feature_tests/css_errors.html:37:4 CSS syntax error in tag 'style amp-custom' - bad url. [AUTHOR_STYLESHEET_PROBLEM]
+feature_tests/css_errors.html:31:8 CSS syntax error in tag 'style amp-custom' - incomplete declaration. [AUTHOR_STYLESHEET_PROBLEM]
+feature_tests/css_errors.html:33:8 CSS syntax error in tag 'style amp-custom' - invalid declaration. [AUTHOR_STYLESHEET_PROBLEM]
+feature_tests/css_errors.html:35:4 CSS syntax error in tag 'style amp-custom' - end of stylesheet encountered in prelude of a qualified rule. [AUTHOR_STYLESHEET_PROBLEM]


### PR DESCRIPTION
This change works on both Goggle Cache and JS validator.  It is breaking CloudFlare validator so adding as test case. 