### PR TITLE
Carousel propagating events to its owned children

### DIFF
--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -28,6 +28,9 @@ export class BaseCarousel extends AMP.BaseElement {
     /** @const @private {boolean} */
     this.showControls_ = this.element.hasAttribute('controls');
 
+    /** @const @private {Array<!Element>} */
+    this.realChildren_ = this.getRealChildren();
+
     if (this.showControls_) {
       this.element.classList.add('-amp-carousel-has-controls');
     }
@@ -150,7 +153,18 @@ export class BaseCarousel extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
+    this.scheduleUnlayout(this.realChildren_);
     return true;
+  }
+
+  /** @override */
+  pauseCallback() {
+    this.schedulePause(this.realChildren_);
+  }
+
+  /** @override */
+  resumeCallback() {
+    this.scheduleResume(this.realChildren_);
   }
 
   /**

--- a/extensions/amp-carousel/0.1/test/test-base-slide.js
+++ b/extensions/amp-carousel/0.1/test/test-base-slide.js
@@ -114,6 +114,11 @@ describe('BaseSlides', () => {
     }
 
     /** @override */
+    getRealChildren() {
+      return [];
+    }
+
+    /** @override */
     goCallback() {
       goCallbackSpy();
     }

--- a/extensions/amp-carousel/0.1/test/test-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-carousel.js
@@ -169,6 +169,7 @@ describe('Carousel layout scheduling and viewport updates', () => {
   let sandbox;
   let element;
   let cell0, cell1, cell2;
+  let children;
   let carousel;
 
   function setupElements() {
@@ -186,7 +187,8 @@ describe('Carousel layout scheduling and viewport updates', () => {
     cell1.style.width = '300px';
     cell2.classList.add('cell2');
     cell2.style.width = '300px';
-    element.getRealChildren = () => [cell0, cell1, cell2];
+    children = [cell0, cell1, cell2];
+    element.getRealChildren = () => children;
     return element;
   }
 
@@ -222,6 +224,8 @@ describe('Carousel layout scheduling and viewport updates', () => {
     carousel.scheduleLayout = sandbox.spy();
     carousel.updateInViewport = sandbox.spy();
     carousel.schedulePause = sandbox.spy();
+    carousel.scheduleResume = sandbox.spy();
+    carousel.scheduleUnlayout = sandbox.spy();
     carousel.schedulePreload = sandbox.spy();
   });
   afterEach(() => {
@@ -236,6 +240,17 @@ describe('Carousel layout scheduling and viewport updates', () => {
             carousel.doLayout_)).to.be.true;
     expect(carousel.updateInViewport_.calledWith(320, 0)).to.be.true;
     expect(carousel.doLayout_.calledWith(320)).to.be.true;
+  });
+
+  it('should propagate pause/resume/unlayout to its owned children', () => {
+    carousel.pauseCallback();
+    expect(carousel.schedulePause.calledWith(children)).to.be.true;
+
+    carousel.resumeCallback();
+    expect(carousel.scheduleResume.calledWith(children)).to.be.true;
+
+    carousel.unlayoutCallback();
+    expect(carousel.scheduleUnlayout.calledWith(children)).to.be.true;
   });
 
 });


### PR DESCRIPTION
Fixes #4503

A less intrusive fix for #4503 than PR #4535 (which will be abandoned after this is merged).

Since carousel can have `<amp-whatever>` children and is the owner for them, it needs manage its children for `pause`, `resume` and `unlayout` life cycle events in addition to just doing it for `layout`. For those events, we simply propagate the event to the children.