### PR TITLE
Add Cache SW Kill File

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -330,6 +330,7 @@ var forbiddenTerms = {
     whitelist: [
       // https://docs.google.com/document/d/1tH_sj93Lo8XRpLP0cDSFNrBi1K_jmx_-q1sk_ZW3Nbg/edit#heading=h.ko4gxsan9svq
       'src/service-worker/core.js',
+      'src/service-worker/kill.js',
     ]
   },
   'openDatabase': requiresReviewPrivacy,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -695,6 +695,14 @@ function buildSw(options) {
     minify: opts.minify || argv.minify,
     preventRemoveAndMakeDir: opts.preventRemoveAndMakeDir,
   });
+  // The service-worker kill script that may be loaded by the browser.
+  compileJs('./src/service-worker/', 'kill.js', './dist/', {
+    toName: 'sw-kill.max.js',
+    minifiedName: 'sw-kill.js',
+    watch: opts.watch,
+    minify: opts.minify || argv.minify,
+    preventRemoveAndMakeDir: opts.preventRemoveAndMakeDir,
+  });
   // The script imported by the service-worker. This is the "core".
   opts.noWrapper = true;
   opts.filename = 'core.js';

--- a/src/service-worker/install.js
+++ b/src/service-worker/install.js
@@ -40,7 +40,10 @@ export function installCacheServiceWorker(win) {
     }
     const base = calculateScriptBaseUrl(win.location.pathname,
       getMode().localDev, getMode().test);
-    const url = `${base}/sw.js`;
+    // The kill experiment is really just a configuration that allows us to
+    // quickly kill the cache service worker without cutting a new version.
+    const kill = isExperimentOn(win, `${TAG}-kill`);
+    const url = `${base}/sw${kill ? '-kill' : ''}.js`;
     navigator.serviceWorker.register(url).then(reg => {
       dev().info(TAG, 'ServiceWorker registration successful: ', reg);
     }, err => {

--- a/src/service-worker/kill.js
+++ b/src/service-worker/kill.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../../third_party/babel/custom-babel-helpers';
+
+self.addEventListener('install', function(event) {
+  // Usually when you register a new service worker, it has to wait for a
+  // navigation (refreshing the page) before it really starts. Well, we can't
+  // wait to kill it, so skip the wait.
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', function(event) {
+  // Usually after waiting for a navigation, it has to wait for all other
+  // clients to close before it really starts. Well, we can't wait to kill it,
+  // so tell the others to shove off.
+  const killing = clients.claim().then(() => {
+    // Delete our cache.
+    return caches.delete('cdn-js');
+  }).then(() => {
+    return new Promise((resolve, reject) => {
+      // Delete our database. Stupid IndexedDB doesn't return promises.
+      const request = indexedDB.deleteDatabase('cdn-js');
+      request.onsuccess = resolve;
+      request.onerror = reject;
+    });
+  });
+
+  event.waitUntil(killing);
+});


### PR DESCRIPTION
Allows setting the `cache-service-worker-kill` "experiment" config. When set, the service worker will self destruct, returning us to the dark pre-SW days.

Fixes https://github.com/ampproject/amphtml/issues/4649.