### PR TITLE
Flip xhrpost value for Clicky Web Analytics

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -271,7 +271,7 @@ export const ANALYTICS_CONFIG = {
     },
     'transport': {
       'beacon': false,
-      'xhrpost': true,
+      'xhrpost': false,
       'image': true,
     },
   },


### PR DESCRIPTION
The transport.xhrpost value was true and causing problems with analytics
data transmission. Changing it to false puts it in line with most other
analytics vendors and resolves the issue faced.