### PR TITLE
add expected AMP_CONFIG fields to extern

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -33,8 +33,14 @@ window.draw3p;
 window.AMP_TEST;
 window.AMP_TEST_IFRAME;
 window.AMP_TAG;
-window.AMP_CONFIG;
+window.AMP_CONFIG = {};
 window.AMP = {};
+
+window.AMP_CONFIG.thirdPartyUrl;
+window.AMP_CONFIG.thirdPartyFrameHost;
+window.AMP_CONFIG.thirdPartyFrameRegex;
+window.AMP_CONFIG.cdnUrl;
+window.AMP_CONFIG.errorReportingUrl;
 
 // Should have been defined in the closure compiler's extern file for
 // IntersectionObserverEntry, but appears to have been omitted.

--- a/src/config.js
+++ b/src/config.js
@@ -19,16 +19,17 @@
  * use the src/config.js module for various constants. We can use the
  * AMP_CONFIG global to translate user-defined configurations to this
  * module.
- * @type {Object}
+ * @type {!Object<string, string>}
  */
 const env = self.AMP_CONFIG || {};
 
+/** @type {!Object<string, string>} */
 export const urls = {
-  thirdParty: env.thirdPartyUrl || 'https://3p.ampproject.net',
-  thirdPartyFrameHost: env.thirdPartyFrameHost || 'ampproject.net',
-  thirdPartyFrameRegex: env.thirdPartyFrameRegex ||
-                        /^d-\d+\.ampproject\.net$/,
-  cdn: env.cdnUrl || 'https://cdn.ampproject.org',
-  errorReporting: env.errorReportingUrl ||
-                  'https://amp-error-reporting.appspot.com/r',
+  thirdParty: env['thirdPartyUrl'] || 'https://3p.ampproject.net',
+  thirdPartyFrameHost: env['thirdPartyFrameHost'] || 'ampproject.net',
+  thirdPartyFrameRegex: env['thirdPartyFrameRegex'] ||
+      /^d-\d+\.ampproject\.net$/,
+  cdn: env['cdnUrl'] || 'https://cdn.ampproject.org',
+  errorReporting: env['errorReportingUrl'] ||
+      'https://amp-error-reporting.appspot.com/r',
 };


### PR DESCRIPTION
this is so that closure doesn't optimize the names