### PR TITLE
Assert no input with name __amp_source_origin in the form

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -150,6 +150,14 @@ export class AmpForm {
     /** @private {?string} */
     this.state_ = null;
 
+    const inputs = this.form_.elements;
+    for (let i = 0; i < inputs.length; i++) {
+      user().assert(!inputs[i].name ||
+          inputs[i].name.indexOf('__amp_source_origin') == -1,
+          'Illegal input name, __amp_source_origin found: %s',
+          inputs[i]);
+    }
+
     this.installSubmitHandler_();
   }
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -16,7 +16,11 @@
 
 import {isExperimentOn} from '../../../src/experiments';
 import {getService} from '../../../src/service';
-import {assertHttpsUrl, addParamsToUrl} from '../../../src/url';
+import {
+  assertHttpsUrl,
+  addParamsToUrl,
+  SOURCE_ORIGIN_PARAM,
+} from '../../../src/url';
 import {user, rethrowAsync} from '../../../src/log';
 import {onDocumentReady} from '../../../src/document-ready';
 import {xhrFor} from '../../../src/xhr';
@@ -153,9 +157,8 @@ export class AmpForm {
     const inputs = this.form_.elements;
     for (let i = 0; i < inputs.length; i++) {
       user().assert(!inputs[i].name ||
-          inputs[i].name.indexOf('__amp_source_origin') == -1,
-          'Illegal input name, __amp_source_origin found: %s',
-          inputs[i]);
+          inputs[i].name.indexOf(SOURCE_ORIGIN_PARAM) == -1,
+          'Illegal input name, %s found: %s', SOURCE_ORIGIN_PARAM, inputs[i]);
     }
 
     this.installSubmitHandler_();

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -107,6 +107,17 @@ describe('amp-form', () => {
     expect(() => new AmpForm(form)).to.not.throw;
   });
 
+  it('should assert none of the inputs named __amp_source_origin', () => {
+    const form = getForm(document, true, false);
+    const illegalInput = document.createElement('input');
+    illegalInput.setAttribute('type', 'hidden');
+    illegalInput.setAttribute('name', '__amp_source_origin');
+    illegalInput.value = 'https://example.com';
+    form.appendChild(illegalInput);
+    expect(() => new AmpForm(form)).to.throw(
+        /Illegal input name, __amp_source_origin found/);
+  });
+
   it('should listen to submit event and inputs blur and input events', () => {
     const form = getForm();
     const nameInput = form.querySelector('input[name=name]');

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -52,6 +52,14 @@ export function onDocumentFormSubmit_(e) {
     return;
   }
 
+  const inputs = form.elements;
+  for (let i = 0; i < inputs.length; i++) {
+    user().assert(!inputs[i].name ||
+        inputs[i].name.indexOf('__amp_source_origin') == -1,
+        'Illegal input name, __amp_source_origin found: %s',
+        inputs[i]);
+  }
+
   const win = form.ownerDocument.defaultView;
   const action = form.getAttribute('action');
   user().assert(action, 'form action attribute is required: %s', form);

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -16,7 +16,7 @@
 
 import {startsWith} from './string';
 import {user} from './log';
-import {assertHttpsUrl, getCorsUrl} from './url';
+import {assertHttpsUrl, getCorsUrl, SOURCE_ORIGIN_PARAM} from './url';
 import {urls} from './config';
 
 
@@ -55,9 +55,8 @@ export function onDocumentFormSubmit_(e) {
   const inputs = form.elements;
   for (let i = 0; i < inputs.length; i++) {
     user().assert(!inputs[i].name ||
-        inputs[i].name.indexOf('__amp_source_origin') == -1,
-        'Illegal input name, __amp_source_origin found: %s',
-        inputs[i]);
+        inputs[i].name.indexOf(SOURCE_ORIGIN_PARAM) == -1,
+        'Illegal input name, %s found: %s', SOURCE_ORIGIN_PARAM, inputs[i]);
   }
 
   const win = form.ownerDocument.defaultView;

--- a/src/url.js
+++ b/src/url.js
@@ -37,8 +37,8 @@ let cache;
 /** @private @const Matches amp_js_* paramters in query string. */
 const AMP_JS_PARAMS_REGEX = /[?&]amp_js[^&]*/;
 
-/** @private @const {string} */
-const SOURCE_ORIGIN_PARAM = '__amp_source_origin';
+/** @const {string} */
+export const SOURCE_ORIGIN_PARAM = '__amp_source_origin';
 
 /**
  * @typedef {({

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -68,6 +68,16 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
     expect(() => onDocumentFormSubmit_(evt)).to.not.throw;
   });
 
+  it('should assert none of the inputs named __amp_source_origin', () => {
+    const illegalInput = document.createElement('input');
+    illegalInput.setAttribute('type', 'hidden');
+    illegalInput.setAttribute('name', '__amp_source_origin');
+    illegalInput.value = 'https://example.com';
+    tgt.appendChild(illegalInput);
+    expect(() => onDocumentFormSubmit_(evt)).to.throw(
+        /Illegal input name, __amp_source_origin found/);
+  });
+
   it('should add __amp_source_origin to action before submit', () => {
     evt.target.setAttribute('action',
         'https://example.com/?__amp_source_origin=12');


### PR DESCRIPTION
Make sure no inputs are named `__amp_source_origin` to make sure no one spoof the runtime-only attribute in their forms.

ITI: #3343 