### PR TITLE
Fill content elements do not need a width or height

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -15,7 +15,7 @@
  */
 
 import {BaseElement} from '../src/base-element';
-import {getLengthNumeral, isLayoutSizeDefined} from '../src/layout';
+import {isLayoutSizeDefined} from '../src/layout';
 import {loadPromise} from '../src/event-helper';
 import {registerElement} from '../src/custom-element';
 import {srcsetFromElement} from '../src/srcset';
@@ -66,9 +66,6 @@ export class AmpImg extends BaseElement {
     }
     this.propagateAttributes(['alt', 'referrerpolicy'], this.img_);
     this.applyFillContent(this.img_, true);
-
-    this.img_.width = getLengthNumeral(this.element.getAttribute('width'));
-    this.img_.height = getLengthNumeral(this.element.getAttribute('height'));
 
     this.element.appendChild(this.img_);
 

--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -16,7 +16,7 @@
 
 import {BaseElement} from '../src/base-element';
 import {assertHttpsUrl} from '../src/url';
-import {getLengthNumeral, isLayoutSizeDefined} from '../src/layout';
+import {isLayoutSizeDefined} from '../src/layout';
 import {loadPromise} from '../src/event-helper';
 import {registerElement} from '../src/custom-element';
 import {getMode} from '../src/mode';
@@ -38,11 +38,6 @@ export function installVideo(win) {
     buildCallback() {
       /** @private @const {!HTMLVideoElement} */
       this.video_ = this.element.ownerDocument.createElement('video');
-      const width = this.element.getAttribute('width');
-      const height = this.element.getAttribute('height');
-
-      this.video_.width = getLengthNumeral(width);
-      this.video_.height = getLengthNumeral(height);
 
       const posterAttr = this.element.getAttribute('poster');
       if (!posterAttr && getMode().development) {

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
+import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
 import {srcsetFromElement} from '../../../src/srcset';
 import * as st from '../../../src/style';
@@ -32,8 +32,6 @@ class AmpAnim extends AMP.BaseElement {
     this.img_ = new Image();
     this.propagateAttributes(['alt'], this.img_);
     this.applyFillContent(this.img_, true);
-    this.img_.width = getLengthNumeral(this.element.getAttribute('width'));
-    this.img_.height = getLengthNumeral(this.element.getAttribute('height'));
 
     // The image is initially hidden if a placeholder is available.
     st.toggle(this.img_, !this.getPlaceholder());

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
+import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
 import {user} from '../../../src/log';
@@ -34,15 +34,6 @@ class AmpBridPlayer extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
-
-    /** @private @const {number} */
-    this.width_ = getLengthNumeral(width);
-
-    /** @private @const {number} */
-    this.height_ = getLengthNumeral(height);
-
     /** @private @const {string} */
     this.partnerID_ = user().assert(
         this.element.getAttribute('data-partner'),
@@ -92,8 +83,6 @@ class AmpBridPlayer extends AMP.BaseElement {
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = src;
     this.applyFillContent(iframe);
-    iframe.width = this.width_;
-    iframe.height = this.height_;
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;
@@ -125,12 +114,10 @@ class AmpBridPlayer extends AMP.BaseElement {
 
     imgPlaceholder.src = 'https://cdn.brid.tv/live/partners/' + encodeURIComponent(partnerID) + '/snapshot/' + encodeURIComponent(feedID) + '.jpg';
     imgPlaceholder.setAttribute('placeholder', '');
-    imgPlaceholder.width = this.width_;
-    imgPlaceholder.height = this.height_;
     imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
-    this.element.appendChild(imgPlaceholder);
     this.applyFillContent(imgPlaceholder);
+    this.element.appendChild(imgPlaceholder);
 
     loadPromise(imgPlaceholder).catch(() => {
       imgPlaceholder.src = 'https://cdn.brid.tv/live/default/defaultSnapshot.png';

--- a/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
@@ -54,8 +54,6 @@ describe('amp-brid-player', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://services.brid.tv/services/iframe/video/13663/264/4144/0/1');
-      expect(iframe.getAttribute('width')).to.equal('640');
-      expect(iframe.getAttribute('height')).to.equal('360');
     });
   });
 

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -40,8 +40,6 @@ class AmpBrightcove extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
     const account = user().assert(
         this.element.getAttribute('data-account'),
         'The data-account attribute is required for <amp-brightcove> %s',
@@ -67,8 +65,6 @@ class AmpBrightcove extends AMP.BaseElement {
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = src;
     this.applyFillContent(iframe);
-    iframe.width = width;
-    iframe.height = height;
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -54,8 +54,6 @@ describe('amp-brightcove', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://players.brightcove.net/906043040001/default_default/index.html?videoId=ref:ampdemo');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -35,8 +35,6 @@ class AmpDailymotion extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
     const videoid = user().assert(
         this.element.getAttribute('data-videoid'),
         'The data-videoid attribute is required for <amp-dailymotion> %s',
@@ -48,8 +46,6 @@ class AmpDailymotion extends AMP.BaseElement {
         videoid) + '?' + this.getQuery_();
 
     this.applyFillContent(iframe);
-    iframe.width = width;
-    iframe.height = height;
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;

--- a/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
@@ -51,8 +51,6 @@ describe('amp-dailymotion', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://www.dailymotion.com/embed/video/x2m8jpp?api=1&html=1&app=amp');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -40,12 +40,8 @@ class AmpFacebook extends AMP.BaseElement {
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
     this.applyFillContent(iframe);
-    const amp = this.element;
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(iframe, 'embed-size', data => {
-      // TODO REVIEW
-      amp.setAttribute('height', data.height);
-      amp.setAttribute('width', data.width);
       this./*OK*/changeHeight(data.height);
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -38,8 +38,7 @@ class AmpFacebook extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const iframe = getIframe(this.element.ownerDocument.defaultView,
-        this.element, 'facebook');
+    const iframe = getIframe(this.win, this.element, 'facebook');
     this.applyFillContent(iframe);
     const amp = this.element;
     // Triggered by context.updateDimensions() inside the iframe.

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -41,11 +41,10 @@ class AmpFacebook extends AMP.BaseElement {
     const iframe = getIframe(this.element.ownerDocument.defaultView,
         this.element, 'facebook');
     this.applyFillContent(iframe);
+    const amp = this.element;
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(iframe, 'embed-size', data => {
-      iframe.height = data.height;
-      iframe.width = data.width;
-      const amp = iframe.parentElement;
+      // TODO REVIEW
       amp.setAttribute('height', data.height);
       amp.setAttribute('width', data.width);
       this./*OK*/changeHeight(data.height);

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -58,8 +58,7 @@ describe('amp-facebook', function() {
       const iframe = ampFB.firstChild;
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
+      expect(iframe.className).to.match(/-amp-fill-content/);
     });
   });
 
@@ -68,8 +67,7 @@ describe('amp-facebook', function() {
       const iframe = ampFB.firstChild;
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
+      expect(iframe.className).to.match(/-amp-fill-content/);
     });
   });
 

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -118,7 +118,7 @@ describe('amp-facebook', function() {
             const impl = ampFB.implementation_;
             impl.changeHeight = newHeight => {
               expect(newHeight).to.equal(666);
-              resolve(iframe);
+              resolve(ampFB);
             };
             iframe.contentWindow.postMessage({
               sentinel: 'amp-test',
@@ -128,8 +128,6 @@ describe('amp-facebook', function() {
               amp3pSentinel: iframe.getAttribute('data-amp-3p-sentinel'),
             }, '*');
           });
-        }).then(iframe => {
-          expect(iframe.height).to.equal('666');
         });
   });
 });

--- a/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
@@ -16,7 +16,7 @@
 
 import {addParamToUrl, assertHttpsUrl} from '../../../src/url';
 import {dev} from '../../../src/log';
-import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
+import {isLayoutSizeDefined} from '../../../src/layout';
 import {isExperimentOn} from '../../../src/experiments';
 import {loadPromise} from '../../../src/event-helper';
 
@@ -38,15 +38,6 @@ class AmpGoogleVrviewImage extends AMP.BaseElement {
       dev().warn(TAG, `TAG ${TAG} disabled`);
       return;
     }
-
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
-
-    /** @private @const {number} */
-    this.width_ = getLengthNumeral(width);
-
-    /** @private @const {number} */
-    this.height_ = getLengthNumeral(height);
 
     /** @private @const {string} */
     this.imageSrc_ = assertHttpsUrl(this.element.getAttribute('src'),
@@ -101,8 +92,6 @@ class AmpGoogleVrviewImage extends AMP.BaseElement {
     this.applyFillContent(iframe);
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
-    iframe.width = this.width_;
-    iframe.height = this.height_;
     iframe.setAttribute('src', this.src_);
     this.element.appendChild(iframe);
 

--- a/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
@@ -64,8 +64,6 @@ describe('amp-google-vrview-image', function() {
       expect(iframe.getAttribute('src')).to.equal(
           'https://storage.googleapis.com/vrview/index.html' +
           '?image=' + encodeURIComponent('https://example.com/image1'));
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 
@@ -81,8 +79,6 @@ describe('amp-google-vrview-image', function() {
           'https://storage.googleapis.com/vrview/index.html' +
           '?image=' + encodeURIComponent('https://example.com/image1') +
           '&is_stereo=true');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -16,7 +16,7 @@
 
 import {IntersectionObserver} from '../../../src/intersection-observer';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
-import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
+import {isLayoutSizeDefined} from '../../../src/layout';
 import {endsWith} from '../../../src/string';
 import {listenFor} from '../../../src/iframe-helper';
 import {loadPromise} from '../../../src/event-helper';
@@ -256,15 +256,11 @@ export class AmpIframe extends AMP.BaseElement {
       }
     }
 
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
     const iframe = this.element.ownerDocument.createElement('iframe');
 
     this.iframe_ = iframe;
 
     this.applyFillContent(iframe);
-    iframe.width = getLengthNumeral(width);
-    iframe.height = getLengthNumeral(height);
     iframe.name = 'amp_iframe' + count++;
 
     if (this.isClickToPlay_) {

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -121,8 +121,6 @@ class AmpInstagram extends AMP.BaseElement {
     iframe.src = 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/embed/?v=4';
     this.applyFillContent(iframe);
-    iframe.width = this.element.getAttribute('width');
-    iframe.height = this.element.getAttribute('height');
     this.element.appendChild(iframe);
     setStyles(iframe, {
       'opacity': 0,

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -52,8 +52,7 @@ describe('amp-instagram', () => {
   function testIframe(iframe) {
     expect(iframe).to.not.be.null;
     expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?v=4');
-    expect(iframe.getAttribute('width')).to.equal('111');
-    expect(iframe.getAttribute('height')).to.equal('222');
+    expect(iframe.className).to.match(/-amp-fill-content/);
     expect(iframe.getAttribute('title')).to.equal('Instagram: Testing');
   }
 

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
+import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
 import {user} from '../../../src/log';
@@ -36,15 +36,6 @@ class AmpJWPlayer extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
-
-    /** @private @const {number} */
-    this.width_ = getLengthNumeral(width);
-
-    /** @private @const {number} */
-    this.height_ = getLengthNumeral(height);
-
     /** @private @const {string} */
     this.contentid_ = user().assert(
       (this.element.getAttribute('data-playlist-id') ||
@@ -76,8 +67,6 @@ class AmpJWPlayer extends AMP.BaseElement {
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = src;
     this.applyFillContent(iframe);
-    iframe.width = this.width_;
-    iframe.height = this.height_;
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;
@@ -105,8 +94,6 @@ class AmpJWPlayer extends AMP.BaseElement {
     imgPlaceholder.src = 'https://content.jwplatform.com/thumbs/' +
         encodeURIComponent(this.contentid_) + '-720.jpg';
     imgPlaceholder.setAttribute('placeholder', '');
-    imgPlaceholder.width = this.width_;
-    imgPlaceholder.height = this.height_;
     imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
     this.applyFillContent(imgPlaceholder);

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -51,8 +51,7 @@ describe('amp-jwplayer', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://content.jwplatform.com/players/Wferorsv-sDZEo0ea.html');
-      expect(iframe.getAttribute('width')).to.equal('320');
-      expect(iframe.getAttribute('height')).to.equal('180');
+      expect(iframe.className).to.match(/-amp-fill-content/);
     });
   });
 

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -42,8 +42,6 @@ class AmpKaltura extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
     const partnerid = user().assert(
         this.element.getAttribute('data-partner'),
         'The data-partner attribute is required for <amp-kaltura-player> %s',
@@ -61,8 +59,6 @@ class AmpKaltura extends AMP.BaseElement {
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = src;
     this.applyFillContent(iframe);
-    iframe.width = width;
-    iframe.height = height;
     this.element.appendChild(iframe);
       /** @private {?Element} */
     this.iframe_ = iframe;
@@ -94,12 +90,10 @@ class AmpKaltura extends AMP.BaseElement {
 
     imgPlaceholder.src = src;
     imgPlaceholder.setAttribute('placeholder', '');
-    imgPlaceholder.width = this.width_;
-    imgPlaceholder.height = this.height_;
     imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
-    this.element.appendChild(imgPlaceholder);
     this.applyFillContent(imgPlaceholder);
+    this.element.appendChild(imgPlaceholder);
 
     loadPromise(imgPlaceholder).then(() => {
       setStyles(imgPlaceholder, {

--- a/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
@@ -53,8 +53,6 @@ describe('amp-kaltura-player', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
                 'https://cdnapisec.kaltura.com/p/1281471/sp/128147100/embedIframeJs/uiconf_id/33502051/partner_id/1281471?iframeembed=true&playerId=kaltura_player_amp&entry_id=1_3ts1ms9c');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 

--- a/extensions/amp-o2-player/0.1/amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/amp-o2-player.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
+import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
 import {user} from '../../../src/log';
 
@@ -32,15 +32,6 @@ class AmpO2Player extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
-
-    /** @private @const {number} */
-    this.width_ = getLengthNumeral(width);
-
-    /** @private @const {number} */
-    this.height_ = getLengthNumeral(height);
-
     /** @private @const {string} */
     this.pid_ = user().assert(
         this.element.getAttribute('data-pid'),
@@ -98,8 +89,6 @@ class AmpO2Player extends AMP.BaseElement {
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = this.src_;
     this.applyFillContent(iframe);
-    iframe.width = this.width_;
-    iframe.height = this.height_;
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;

--- a/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
@@ -53,8 +53,6 @@ describe('amp-o2-player', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://delivery.vidible.tv/htmlembed/pid=123/456.html');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 
@@ -100,8 +98,6 @@ describe('amp-o2-player', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://delivery.vidible.tv/htmlembed/pid=123/456.html?bid=987&vid=789');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 
@@ -116,8 +112,6 @@ describe('amp-o2-player', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://delivery.vidible.tv/htmlembed/pid=123/456.html?m.test=test');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 
@@ -132,8 +126,6 @@ describe('amp-o2-player', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://delivery.dev.vidible.tv/htmlembed/pid=123/456.html');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 });

--- a/extensions/amp-reach-player/0.1/amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/amp-reach-player.js
@@ -31,8 +31,6 @@ class AmpReachPlayer extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
     const embedId = (this.element.getAttribute('data-embed-id') || 'default');
     const iframe = this.element.ownerDocument.createElement('iframe');
 
@@ -40,8 +38,6 @@ class AmpReachPlayer extends AMP.BaseElement {
     iframe.setAttribute('scrolling', 'no');
     iframe.src = 'https://player-cdn.beachfrontmedia.com/playerapi/v1/frame/player/?embed_id=' + encodeURIComponent(embedId);
     this.applyFillContent(iframe);
-    iframe.height = height;
-    iframe.width = width;
     this.element.appendChild(iframe);
     /** @private {!Element} */
     this.iframe_ = iframe;

--- a/extensions/amp-reach-player/0.1/test/test-amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/test/test-amp-reach-player.js
@@ -51,8 +51,6 @@ describe('amp-reach-player', () => {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal('https://player-cdn.beachfrontmedia.com/playerapi/v1/frame/player/?embed_id=default');
-      expect(iframe.getAttribute('width')).to.equal('560');
-      expect(iframe.getAttribute('height')).to.equal('315');
     });
   });
 

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -34,8 +34,6 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
     const mode = user().assert(
         this.element.getAttribute('data-mode'),
         'The data-mode attribute is required for <amp-springboard-player> %s',
@@ -50,11 +48,6 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
         'The data-domain attribute is required for <amp-springboard-player> %s',
         this.element);
 
-    /** @private @const {number} */
-    this.width_ = width;
-    /** @private @const {number} */
-    this.height_ = height;
-    /** @private @const {string} */
     this.mode_ = mode;
     /** @private @const {number} */
     this.contentId_ = contentId;
@@ -90,8 +83,6 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
     	encodeURIComponent(playerId) + '/' + encodeURIComponent(this.domain_) +
     	'/' + encodeURIComponent(items);
     this.applyFillContent(iframe);
-    iframe.width = this.width_;
-    iframe.height = this.height_;
     /** @private {?Element} */
     this.iframe_ = iframe;
     this.element.appendChild(iframe);
@@ -127,12 +118,10 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
         'snapshots/default_snapshot.png';
     }
     imgPlaceholder.setAttribute('placeholder', '');
-    imgPlaceholder.width = this.width_;
-    imgPlaceholder.height = this.height_;
-
-    this.element.appendChild(imgPlaceholder);
-    this.applyFillContent(imgPlaceholder);
     imgPlaceholder.setAttribute('referrerpolicy', 'origin');
+
+    this.applyFillContent(imgPlaceholder);
+    this.element.appendChild(imgPlaceholder);
 
     loadPromise(imgPlaceholder).then(() => {
       setStyles(imgPlaceholder, {

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -48,6 +48,7 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
         'The data-domain attribute is required for <amp-springboard-player> %s',
         this.element);
 
+    /** @private @const {string} */
     this.mode_ = mode;
     /** @private @const {number} */
     this.contentId_ = contentId;

--- a/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
@@ -55,8 +55,6 @@ describe('amp-springboard-player', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal('https://cms.springboardplatform.com/' +
           'embed_iframe/261/video/1578473/test401/test.com/10');
-      expect(iframe.getAttribute('width')).to.equal('480');
-      expect(iframe.getAttribute('height')).to.equal('270');
     });
   });
 

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -49,14 +49,13 @@ class AmpTwitter extends AMP.BaseElement {
     const iframe = getIframe(this.element.ownerDocument.defaultView,
         this.element, 'twitter');
     this.applyFillContent(iframe);
+    const amp = this.element;
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(iframe, 'embed-size', data => {
       // We only get the message if and when there is a tweet to display,
       // so hide the placeholder.
       this.togglePlaceholder(false);
-      iframe.height = data.height;
-      iframe.width = data.width;
-      const amp = iframe.parentElement;
+      // TODO Review
       amp.setAttribute('height', data.height);
       amp.setAttribute('width', data.width);
       this./*OK*/changeHeight(data.height);

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -46,8 +46,7 @@ class AmpTwitter extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const iframe = getIframe(this.element.ownerDocument.defaultView,
-        this.element, 'twitter');
+    const iframe = getIframe(this.win, this.element, 'twitter');
     this.applyFillContent(iframe);
     const amp = this.element;
     // Triggered by context.updateDimensions() inside the iframe.

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -48,15 +48,10 @@ class AmpTwitter extends AMP.BaseElement {
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'twitter');
     this.applyFillContent(iframe);
-    const amp = this.element;
-    // Triggered by context.updateDimensions() inside the iframe.
     listenFor(iframe, 'embed-size', data => {
       // We only get the message if and when there is a tweet to display,
       // so hide the placeholder.
       this.togglePlaceholder(false);
-      // TODO Review
-      amp.setAttribute('height', data.height);
-      amp.setAttribute('width', data.width);
       this./*OK*/changeHeight(data.height);
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -36,8 +36,6 @@ class AmpVimeo extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
     const videoid = user().assert(
         this.element.getAttribute('data-videoid'),
         'The data-videoid attribute is required for <amp-vimeo> %s',
@@ -50,8 +48,6 @@ class AmpVimeo extends AMP.BaseElement {
     iframe.src = 'https://player.vimeo.com/video/' + encodeURIComponent(
         videoid);
     this.applyFillContent(iframe);
-    iframe.width = width;
-    iframe.height = height;
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;

--- a/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
@@ -48,8 +48,6 @@ describe('amp-vimeo', () => {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://player.vimeo.com/video/123');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 

--- a/extensions/amp-vine/0.1/amp-vine.js
+++ b/extensions/amp-vine/0.1/amp-vine.js
@@ -39,8 +39,6 @@ class AmpVine extends AMP.BaseElement {
     const vineid = user().assert(this.element.getAttribute('data-vineid'),
       'The data-vineid attribute is required for <amp-vine> %s',
       this.element);
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
 
     const iframe = this.element.ownerDocument.createElement('iframe');
     iframe.setAttribute('frameborder', '0');
@@ -48,9 +46,6 @@ class AmpVine extends AMP.BaseElement {
       encodeURIComponent(vineid) + '/embed/simple';
 
     this.applyFillContent(iframe);
-
-    iframe.width = width;
-    iframe.height = height;
     this.element.appendChild(iframe);
 
     /** @private {?Element} */

--- a/extensions/amp-vine/0.1/test/test-amp-vine.js
+++ b/extensions/amp-vine/0.1/test/test-amp-vine.js
@@ -46,8 +46,6 @@ describe('amp-vine', () => {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal('https://vine.co/v/MdKjXez002d/embed/simple');
-      expect(iframe.getAttribute('width')).to.equal('400');
-      expect(iframe.getAttribute('height')).to.equal('400');
     });
   });
 

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -17,7 +17,7 @@
 import {getDataParamsFromAttributes} from '../../../src/dom';
 import {loadPromise} from '../../../src/event-helper';
 import {tryParseJson} from '../../../src/json';
-import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
+import {isLayoutSizeDefined} from '../../../src/layout';
 import {user} from '../../../src/log';
 import {setStyles} from '../../../src/style';
 import {addParamsToUrl} from '../../../src/url';
@@ -50,15 +50,6 @@ class AmpYoutube extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const width = this.element.getAttribute('width');
-    const height = this.element.getAttribute('height');
-
-    /** @private @const {number} */
-    this.width_ = getLengthNumeral(width);
-
-    /** @private @const {number} */
-    this.height_ = getLengthNumeral(height);
-
     /** @private {number} */
     this.playerState_ = 0;
 
@@ -94,8 +85,6 @@ class AmpYoutube extends AMP.BaseElement {
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = src;
     this.applyFillContent(iframe);
-    iframe.width = this.width_;
-    iframe.height = this.height_;
     this.element.appendChild(iframe);
 
     /** @private {!Element} */
@@ -193,12 +182,10 @@ class AmpYoutube extends AMP.BaseElement {
     imgPlaceholder.src = 'https://i.ytimg.com/vi/' +
         encodeURIComponent(this.videoid_) + '/sddefault.jpg#404_is_fine';
     imgPlaceholder.setAttribute('placeholder', '');
-    imgPlaceholder.width = this.width_;
-    imgPlaceholder.height = this.height_;
     imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 
-    this.element.appendChild(imgPlaceholder);
     this.applyFillContent(imgPlaceholder);
+    this.element.appendChild(imgPlaceholder);
 
     // Because sddefault.jpg isn't available for all videos, we try to load
     // it and fallback to hqdefault.jpg.

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -75,8 +75,6 @@ describe('amp-youtube', function() {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://www.youtube.com/embed/mGENRKrdoGY?enablejsapi=1');
-      expect(iframe.getAttribute('width')).to.equal('111');
-      expect(iframe.getAttribute('height')).to.equal('222');
     });
   });
 


### PR DESCRIPTION
The `-amp-fill-content` class makes them fill the full size of their
containing element, making the copying useless.

Re: https://github.com/ampproject/amphtml/pull/4420#discussion_r75912313