### PR TITLE
Update random generation of share tracking fragment

### DIFF
--- a/extensions/amp-analytics/0.1/cid-impl.js
+++ b/extensions/amp-analytics/0.1/cid-impl.js
@@ -29,6 +29,7 @@ import {
   isProxyOrigin,
   parseUrl,
 } from '../../../src/url';
+import {getCryptoRandomBytesArray} from '../../../src/utils/bytes';
 import {viewerFor} from '../../../src/viewer';
 import {cryptoFor} from '../../../src/crypto';
 import {user} from '../../../src/log';
@@ -372,13 +373,12 @@ function shouldUpdateStoredTime(storedCidInfo) {
  * @return {!Uint8Array|string} Entropy.
  */
 function getEntropy(win) {
-  // Widely available in browsers we support:
-  // http://caniuse.com/#search=getRandomValues
-  if (win.crypto && win.crypto.getRandomValues) {
-    const uint8array = new Uint8Array(16);  // 128 bit
-    win.crypto.getRandomValues(uint8array);
+  // Use win.crypto.getRandomValues to get 128 bits of random value
+  const uint8array = getCryptoRandomBytesArray(win, 16); // 128 bit
+  if (uint8array) {
     return uint8array;
   }
+
   // Support for legacy browsers.
   return String(win.location.href + Date.now() +
       win.Math.random() + win.screen.width + win.screen.height);

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -153,7 +153,7 @@ export class AmpShareTracking extends AMP.BaseElement {
       bytes = new Uint8Array(SHARE_TRACKING_NUMBER_OF_BYTES);
       let random = Math.random();
       for (let i = 0; i < SHARE_TRACKING_NUMBER_OF_BYTES; i++) {
-        random <<= 8;
+        random *= 256;
         bytes[i] = Math.floor(random);
         random -= bytes[i];
       }

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -20,11 +20,14 @@ import {viewerFor} from '../../../src/viewer';
 import {getService} from '../../../src/service';
 import {Layout} from '../../../src/layout';
 import {base64UrlEncodeFromBytes} from '../../../src/utils/base64';
-import {getRandomBytesArray} from '../../../src/utils/bytes';
+import {getCryptoRandomBytesArray} from '../../../src/utils/bytes';
 import {dev, user} from '../../../src/log';
 
 /** @private @const {string} */
 const TAG = 'amp-share-tracking';
+
+/** @private @const {number} */
+const SHARE_TRACKING_NUMBER_OF_BYTES = 6;
 
 /**
  * @visibleForTesting
@@ -93,7 +96,7 @@ export class AmpShareTracking extends AMP.BaseElement {
     if (this.vendorHref_) {
       return this.getOutgoingFragmentFromVendor_(this.vendorHref_);
     }
-    return this.getRandomBase64_();
+    return this.getShareTrackingRandomBase64_();
   }
 
   /**
@@ -128,8 +131,34 @@ export class AmpShareTracking extends AMP.BaseElement {
    * @return {!Promise<string>}
    * @private
    */
-  getRandomBase64_() {
-    return Promise.resolve(base64UrlEncodeFromBytes(getRandomBytesArray(6)));
+  getShareTrackingRandomBase64_() {
+    return Promise.resolve(base64UrlEncodeFromBytes(
+        this.getShareTrackingRandomBytes_()));
+  }
+
+  /**
+   * Get a random bytes array that has 48 bits (6 bytes).
+   * Use win.crypto.getRandomValues if it is available.
+   * Otherwise, use Math.random as fallback.
+   * @return {!Promise<string>}
+   * @private
+   */
+  getShareTrackingRandomBytes_() {
+    // Use win.crypto.getRandomValues to get 48 bits of random value
+    let bytes = getCryptoRandomBytesArray(this.win,
+        SHARE_TRACKING_NUMBER_OF_BYTES); // 48 bit
+
+    // Support for legacy browsers
+    if (!bytes) {
+      bytes = new Uint8Array(SHARE_TRACKING_NUMBER_OF_BYTES);
+      let random = Math.random();
+      for (let i = 0; i < SHARE_TRACKING_NUMBER_OF_BYTES; i++) {
+        random <<= 8;
+        bytes[i] = Math.floor(random);
+        random -= bytes[i];
+      }
+    }
+    return bytes;
   }
 }
 

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -96,7 +96,8 @@ export class AmpShareTracking extends AMP.BaseElement {
     if (this.vendorHref_) {
       return this.getOutgoingFragmentFromVendor_(this.vendorHref_);
     }
-    return this.getShareTrackingRandomBase64_();
+    return Promise.resolve(base64UrlEncodeFromBytes(
+        this.getShareTrackingRandomBytes_()));
   }
 
   /**
@@ -124,16 +125,6 @@ export class AmpShareTracking extends AMP.BaseElement {
       user().error(TAG, 'The request to share-tracking endpoint failed:' + err);
       return '';
     });
-  }
-
-  /**
-   * Get a random base64url string using 48 bits (6 bytes) random number
-   * @return {!Promise<string>}
-   * @private
-   */
-  getShareTrackingRandomBase64_() {
-    return Promise.resolve(base64UrlEncodeFromBytes(
-        this.getShareTrackingRandomBytes_()));
   }
 
   /**

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -109,7 +109,7 @@ describe('amp-share-tracking', () => {
     viewerForMock.onFirstCall().returns(Promise.resolve(''));
     return getAmpShareTracking().then(ampShareTracking => {
       return shareTrackingForOrNull(ampShareTracking.win).then(fragments => {
-        expect(fragments.outgoingFragment).to.equal('AAAAAAAA');
+        expect(fragments.outgoingFragment).to.equal('HHHHHHHH');
       });
     });
   });

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -104,12 +104,12 @@ describe('amp-share-tracking', () => {
 
   it('should get outgoing fragment randomly if no vendor url ' +
       'is provided and fallback to Math.random generation', () => {
-    sandbox.stub(Math, 'random').returns(0.1111111111111111);
+    sandbox.stub(Math, 'random').returns(0.123456789123456789);
     randomBytesMock.onFirstCall().returns(null);
     viewerForMock.onFirstCall().returns(Promise.resolve(''));
     return getAmpShareTracking().then(ampShareTracking => {
       return shareTrackingForOrNull(ampShareTracking.win).then(fragments => {
-        expect(fragments.outgoingFragment).to.equal('HHHHHHHH');
+        expect(fragments.outgoingFragment).to.equal('H5rdN8Eh');
       });
     });
   });

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -21,17 +21,19 @@ import {Xhr} from '../../../../src/service/xhr-impl';
 import {shareTrackingForOrNull} from '../../../../src/share-tracking-service';
 import {toggleExperiment} from '../../../../src/experiments';
 import * as sinon from 'sinon';
+import * as bytes from '../../../../src/utils/bytes';
 
 describe('amp-share-tracking', () => {
   let sandbox;
   let viewerForMock;
   let xhrMock;
+  let randomBytesMock;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     viewerForMock = sandbox.stub(Viewer.prototype, 'getFragment');
     xhrMock = sandbox.stub(Xhr.prototype, 'fetchJson');
-    sandbox.stub(Math, 'random').returns(0.1111111111111111234);
+    randomBytesMock = sandbox.stub(bytes, 'getCryptoRandomBytesArray');
   });
 
   afterEach(() => {
@@ -89,11 +91,25 @@ describe('amp-share-tracking', () => {
   });
 
   it('should get outgoing fragment randomly if no vendor url ' +
-      'is provided', () => {
+      'is provided and win.crypto is availble', () => {
+    viewerForMock.onFirstCall().returns(Promise.resolve(''));
+    randomBytesMock.onFirstCall().returns(new Uint8Array([1, 2, 3, 4, 5, 6]));
+    return getAmpShareTracking().then(ampShareTracking => {
+      return shareTrackingForOrNull(ampShareTracking.win).then(fragments => {
+        // the base64url of byte array [1, 2, 3, 4, 5, 6]
+        expect(fragments.outgoingFragment).to.equal('AQIDBAUG');
+      });
+    });
+  });
+
+  it('should get outgoing fragment randomly if no vendor url ' +
+      'is provided and fallback to Math.random generation', () => {
+    sandbox.stub(Math, 'random').returns(0.1111111111111111);
+    randomBytesMock.onFirstCall().returns(null);
     viewerForMock.onFirstCall().returns(Promise.resolve(''));
     return getAmpShareTracking().then(ampShareTracking => {
       return shareTrackingForOrNull(ampShareTracking.win).then(fragments => {
-        expect(fragments.outgoingFragment).to.equal('HHHHHHHH');
+        expect(fragments.outgoingFragment).to.equal('AAAAAAAA');
       });
     });
   });

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -49,12 +49,13 @@ export function bytesToString(bytes) {
  * @return {?Uint8Array}
  */
 export function getCryptoRandomBytesArray(win, length) {
+  if (!win.crypto || !win.crypto.getRandomValues) {
+    return null;
+  }
+
   // Widely available in browsers we support:
   // http://caniuse.com/#search=getRandomValues
-  if (win.crypto && win.crypto.getRandomValues) {
-    const uint8array = new Uint8Array(length);
-    win.crypto.getRandomValues(uint8array);
-    return uint8array;
-  }
-  return null;
+  const uint8array = new Uint8Array(length);
+  win.crypto.getRandomValues(uint8array);
+  return uint8array;
 }

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -43,17 +43,18 @@ export function bytesToString(bytes) {
 };
 
 /**
- * Generate a random bytes array with specific length
+ * Generate a random bytes array with specific length using
+ * win.crypto.getRandomValues. Return null if it is not available.
  * @param {!number} length
- * @return {!Uint8Array}
+ * @return {?Uint8Array}
  */
-export function getRandomBytesArray(length) {
-  let random = Math.random();
-  const bytes = new Uint8Array(length);
-  for (let i = 0; i < length; i++) {
-    random *= 256;
-    bytes[i] = Math.floor(random);
-    random -= bytes[i];
+export function getCryptoRandomBytesArray(win, length) {
+  // Widely available in browsers we support:
+  // http://caniuse.com/#search=getRandomValues
+  if (win.crypto && win.crypto.getRandomValues) {
+    const uint8array = new Uint8Array(length);
+    win.crypto.getRandomValues(uint8array);
+    return uint8array;
   }
-  return bytes;
+  return null;
 }

--- a/test/functional/utils/test-bytes.js
+++ b/test/functional/utils/test-bytes.js
@@ -17,10 +17,24 @@
 import {
   stringToBytes,
   bytesToString,
-  getRandomBytesArray,
+  getCryptoRandomBytesArray,
 } from '../../../src/utils/bytes';
 
 describe('stringToBytes', function() {
+  let fakeWin;
+
+  beforeEach(() => {
+    fakeWin = {
+      crypto: {
+        getRandomValues: array => {
+          for (let i = 0; i < array.length; i++) {
+            array[i] = i + 1;
+          }
+        },
+      },
+    };
+  });
+
   it('should map a sample string appropriately', () => {
     const bytes = stringToBytes('abÿ');
     expect(bytes.length).to.equal(3);
@@ -40,17 +54,20 @@ describe('stringToBytes', function() {
     expect(str).to.equal('foo');
   });
 
-  it('should generate random bytes array', () => {
-    Math.random = () => 0.1111111111111111;
-    expect(getRandomBytesArray(1)).to.deep.equal(new Uint8Array([28]));
-    expect(getRandomBytesArray(2)).to.deep.equal(new Uint8Array([28, 113]));
-    expect(getRandomBytesArray(3)).to.deep
-        .equal(new Uint8Array([28, 113, 199]));
-    expect(getRandomBytesArray(4)).to.deep
-        .equal(new Uint8Array([28, 113, 199, 28]));
-    expect(getRandomBytesArray(5)).to.deep
-        .equal(new Uint8Array([28, 113, 199, 28, 113]));
-    expect(getRandomBytesArray(6)).to.deep
-        .equal(new Uint8Array([28, 113, 199, 28, 113, 199]));
+  it('should generate random bytes array when win.crypto is availble', () => {
+    expect(getCryptoRandomBytesArray(fakeWin, 1)).to.deep
+      .equal(new Uint8Array([1]));
+    expect(getCryptoRandomBytesArray(fakeWin, 2)).to.deep
+      .equal(new Uint8Array([1, 2]));
+    expect(getCryptoRandomBytesArray(fakeWin, 3)).to.deep
+      .equal(new Uint8Array([1, 2, 3]));
+  });
+
+  it('should not generate random bytes array when win.crypto is' +
+      'not availble', () => {
+    fakeWin.crypto = undefined;
+    expect(getCryptoRandomBytesArray(fakeWin, 1)).to.be.null;
+    expect(getCryptoRandomBytesArray(fakeWin, 2)).to.be.null;
+    expect(getCryptoRandomBytesArray(fakeWin, 3)).to.be.null;
   });
 });

--- a/test/functional/utils/test-bytes.js
+++ b/test/functional/utils/test-bytes.js
@@ -63,11 +63,9 @@ describe('stringToBytes', function() {
       .equal(new Uint8Array([1, 2, 3]));
   });
 
-  it('should not generate random bytes array when win.crypto is' +
-      'not availble', () => {
+  it('should return null when trying to generate random bytes array if ' +
+      'win.crypto is not availble', () => {
     fakeWin.crypto = undefined;
     expect(getCryptoRandomBytesArray(fakeWin, 1)).to.be.null;
-    expect(getCryptoRandomBytesArray(fakeWin, 2)).to.be.null;
-    expect(getCryptoRandomBytesArray(fakeWin, 3)).to.be.null;
   });
 });


### PR DESCRIPTION
In the share tracking fragment generation logic, we decided to use the win.crypto.getRandomValues (which has enough entropy) by default if available, otherwise, fall back to use Math.random once only in the share tracking code(Math.random has limited precision and it's enough for random share tracking generation).