### PR TITLE
Add Zucks to amp-ad support 

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -94,6 +94,7 @@ import {yieldbot} from '../ads/yieldbot';
 import {yieldmo} from '../ads/yieldmo';
 import {yieldone} from '../ads/yieldone';
 import {zergnet} from '../ads/zergnet';
+import {zucks} from '../ads/zucks';
 
 
 /**
@@ -171,6 +172,7 @@ register('yieldbot', yieldbot);
 register('yieldmo', yieldmo);
 register('zergnet', zergnet);
 register('yieldone', yieldone);
+register('zucks', zucks);
 
 register('_ping_', function(win, data) {
   win.document.getElementById('c').textContent = data.ping;

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -214,6 +214,13 @@ export const adPreconnect = {
     'https://www.zergnet.com',
     'https://zergnet.com',
   ],
+  zucks: [
+    'https://j.zucks.net.zimg.jp',
+    'https://sh.zucks.net',
+    'https://zucks.co.jp',
+    'https://k.zucks.net',
+    'https://static.zucks.net.zimg.jp',
+  ],
 };
 
 /**

--- a/ads/zucks.js
+++ b/ads/zucks.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {loadScript, validateSrcPrefix} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function zucks(global, data) {
+  const src = data.src;
+  validateSrcPrefix('https://j.zucks.net.zimg.jp/', src);
+  loadScript(global, src);
+}

--- a/ads/zucks.md
+++ b/ads/zucks.md
@@ -1,0 +1,33 @@
+<!---
+Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Zucks
+
+## Example
+
+```html
+<amp-ad width="320" height="50"
+    type="zucks"
+    src="https://j.zucks.net.zimg.jp/j?f={id}">
+</amp-ad>
+```
+
+## Configuration
+
+For more information, please [contact Zucks](https://zucks.co.jp/contact/).
+
+Supported parameters:
+- src

--- a/builtins/amp-ad.md
+++ b/builtins/amp-ad.md
@@ -125,6 +125,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [Yieldmo](../ads/yieldmo.md)
 - [YahooJP](../ads/yahoojp.md)
 - [yieldone](../ads/yieldone.md)
+- [zucks](../ads/zucks.md)
 
 ## Styling
 

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -107,6 +107,7 @@
     <a href="#yieldone">yield One</a> |
     <a href="#yieldmo">Yieldmo</a> |
     <a href="#zergnet">ZergNet</a> |
+    <a href="#zucks">Zucks</a> |
   </nav>
 
   <div class="fixed">
@@ -715,6 +716,13 @@
       type="zergnet"
       data-zergid="42658">
   </amp-embed>
+
+  <h2 id="zucks">Zucks</h2>
+  <amp-ad width="300" height="250"
+      type="zucks"
+      src="https://j.zucks.net.zimg.jp/j?f=10286">
+  </amp-ad>
+
 </amp-ad>
 </body>
 </html>

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -117,6 +117,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [Yieldbot](../../ads/yieldbot.md)
 - [Yieldmo](../../ads/yieldmo.md)
 - [YahooJP](../../ads/yahoojp.md)
+- [Zucks](../../ads/zucks.md)
 
 ## Styling
 


### PR DESCRIPTION
#4677 
Add Zucks to amp-ad support

Our corporate Contributor License Agreement was avoided =(
Can you take a look at it ?
Corporation Name: Zucks, Inc.