### PR TITLE
Since A4A needs a way to pass an eid, moving holdback to use that met…

### DIFF
--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -163,6 +163,7 @@ function doubleClickWithGlade(global, data, gladeExperiment) {
   }
   if (gladeExperiment === GladeExperiment.GLADE_EXPERIMENT) {
     jsonParameters.gladeExp = '1';
+    jsonParameters.gladeEids = '108809102';
   }
 
   const slot = global.document.querySelector('#c');


### PR DESCRIPTION
…hod as well.

Use both for now (no negative consequences) and remove the old version once transitioned completely.