### PR TITLE
Assert __amp_source_origin when assertHttpsUrl

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -108,6 +108,12 @@ describe('amp-analytics.transport', () => {
     }).to.throw(/https/);
   });
 
+  it('should NOT allow __amp_source_origin', () => {
+    expect(() => {
+      sendRequest(window, 'https://twitter.com?__amp_source_origin=1');
+    }).to.throw(/Source origin is not allowed in/);
+  });
+
   describe('sendRequestUsingIframe', () => {
     const url = 'http://iframe.localhost:9876/test/fixtures/served/iframe.html';
     it('should create and delete an iframe', () => {

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {assertHttpsUrl, parseUrl} from '../../../src/url';
+import {
+  assertHttpsUrl,
+  parseUrl,
+  checkCorsUrl,
+} from '../../../src/url';
 import {dev, user} from '../../../src/log';
 import {loadPromise} from '../../../src/event-helper';
 import {timerFor} from '../../../src/timer';
@@ -30,6 +34,7 @@ const TAG_ = 'amp-analytics.Transport';
  */
 export function sendRequest(win, request, transportOptions) {
   assertHttpsUrl(request);
+  checkCorsUrl(request);
   if (transportOptions['beacon'] &&
       Transport.sendRequestUsingBeacon(win, request)) {
     return;

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -157,7 +157,7 @@ export class AmpForm {
     const inputs = this.form_.elements;
     for (let i = 0; i < inputs.length; i++) {
       user().assert(!inputs[i].name ||
-          inputs[i].name.indexOf(SOURCE_ORIGIN_PARAM) == -1,
+          inputs[i].name != SOURCE_ORIGIN_PARAM,
           'Illegal input name, %s found: %s', SOURCE_ORIGIN_PARAM, inputs[i]);
     }
 

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -60,17 +60,20 @@ export function onDocumentFormSubmit_(e) {
   }
 
   const win = form.ownerDocument.defaultView;
-  const action = form.getAttribute('action');
-  form.__AMP_INIT_ACTION__ = form.__AMP_INIT_ACTION__ || action;
-  user().assert(form.__AMP_INIT_ACTION__,
-      'form action attribute is required: %s', form);
-  assertHttpsUrl(form.__AMP_INIT_ACTION__, form, 'action');
-  user().assert(!startsWith(form.__AMP_INIT_ACTION__, urls.cdn),
+  let action = form.getAttribute('action');
+  if (!form.__AMP_INIT_ACTION__) {
+    form.__AMP_INIT_ACTION__ = action;
+  } else {
+    action = form.__AMP_INIT_ACTION__;
+  }
+  user().assert(action, 'form action attribute is required: %s', form);
+  assertHttpsUrl(action, form, 'action');
+  user().assert(!startsWith(action, urls.cdn),
       'form action should not be on AMP CDN: %s', form);
 
   // Update the form non-xhr action to add `__amp_source_origin` parameter.
   // This allows publishers to understand where the request is coming from.
-  form.setAttribute('action', getCorsUrl(win, form.__AMP_INIT_ACTION__));
+  form.setAttribute('action', getCorsUrl(win, action));
 
   const target = form.getAttribute('target');
   user().assert(target, 'form target attribute is required: %s', form);

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -61,12 +61,13 @@ export function onDocumentFormSubmit_(e) {
 
   const win = form.ownerDocument.defaultView;
   const action = form.getAttribute('action');
-  user().assert(action, 'form action attribute is required: %s', form);
-  assertHttpsUrl(action, form, 'action');
-  user().assert(!startsWith(action, urls.cdn),
+  form.__AMP_INIT_ACTION__ = form.__AMP_INIT_ACTION__ || action;
+  user().assert(form.__AMP_INIT_ACTION__,
+      'form action attribute is required: %s', form);
+  assertHttpsUrl(form.__AMP_INIT_ACTION__, form, 'action');
+  user().assert(!startsWith(form.__AMP_INIT_ACTION__, urls.cdn),
       'form action should not be on AMP CDN: %s', form);
 
-  form.__AMP_INIT_ACTION__ = form.__AMP_INIT_ACTION__ || action;
   // Update the form non-xhr action to add `__amp_source_origin` parameter.
   // This allows publishers to understand where the request is coming from.
   form.setAttribute('action', getCorsUrl(win, form.__AMP_INIT_ACTION__));

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -55,7 +55,7 @@ export function onDocumentFormSubmit_(e) {
   const inputs = form.elements;
   for (let i = 0; i < inputs.length; i++) {
     user().assert(!inputs[i].name ||
-        inputs[i].name.indexOf(SOURCE_ORIGIN_PARAM) == -1,
+        inputs[i].name != SOURCE_ORIGIN_PARAM,
         'Illegal input name, %s found: %s', SOURCE_ORIGIN_PARAM, inputs[i]);
   }
 

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -20,7 +20,7 @@ import {
   isProxyOrigin,
   parseUrl,
   resolveRelativeUrl,
-  SOURCE_ORIGIN_PARAM,
+  checkCorsUrl,
 } from './url';
 import {parseSrcset} from './srcset';
 import {user} from './log';
@@ -287,9 +287,7 @@ function resolveAttrValue(tagName, attrName, attrValue) {
  * @private Visible for testing.
  */
 export function resolveUrlAttr(tagName, attrName, attrValue, windowLocation) {
-  user().assert(attrValue.indexOf(SOURCE_ORIGIN_PARAM) == -1,
-      'Source origin is not allowed in %s', attrValue);
-
+  checkCorsUrl(attrValue);
   const isProxyHost = isProxyOrigin(windowLocation);
   const baseUrl = parseUrl(getSourceUrl(windowLocation));
 

--- a/src/url.js
+++ b/src/url.js
@@ -211,6 +211,8 @@ export function assertHttpsUrl(
     urlString, elementContext, sourceName = 'source') {
   user().assert(urlString != null, '%s %s must be available',
       elementContext, sourceName);
+  user().assert(urlString.indexOf(SOURCE_ORIGIN_PARAM) == -1,
+      'Source origin is not allowed in %s', urlString);
   // (erwinm, #4560): type cast necessary until #4560 is fixed
   const url = parseUrl(/** @type {string} */ (urlString));
   user().assert(

--- a/src/url.js
+++ b/src/url.js
@@ -211,8 +211,6 @@ export function assertHttpsUrl(
     urlString, elementContext, sourceName = 'source') {
   user().assert(urlString != null, '%s %s must be available',
       elementContext, sourceName);
-  user().assert(urlString.indexOf(SOURCE_ORIGIN_PARAM) == -1,
-      'Source origin is not allowed in %s', urlString);
   // (erwinm, #4560): type cast necessary until #4560 is fixed
   const url = parseUrl(/** @type {string} */ (urlString));
   user().assert(
@@ -428,10 +426,19 @@ export function resolveRelativeUrlFallback_(relativeUrlString, baseUrl) {
  * @return {string}
  */
 export function getCorsUrl(win, url) {
+  checkCorsUrl(url);
   const sourceOrigin = getSourceOrigin(win.location.href);
+  return addParamToUrl(url, SOURCE_ORIGIN_PARAM, sourceOrigin);
+}
+
+
+/**
+ * Checks if the url have __amp_source_origin and throws if it does.
+ * @param {string} url
+ */
+export function checkCorsUrl(url) {
   const parsedUrl = parseUrl(url);
   const query = parseQueryString(parsedUrl.search);
   user().assert(!(SOURCE_ORIGIN_PARAM in query),
       'Source origin is not allowed in %s', url);
-  return addParamToUrl(url, SOURCE_ORIGIN_PARAM, sourceOrigin);
 }

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -48,22 +48,29 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
         /form action attribute is required/);
 
     tgt.setAttribute('action', 'http://example.com');
+    tgt.__AMP_INIT_ACTION__ = undefined;
     expect(() => onDocumentFormSubmit_(evt)).to.throw(
         /form action must start with "https:/);
 
     tgt.setAttribute('action', 'https://cdn.ampproject.org');
+    tgt.__AMP_INIT_ACTION__ = undefined;
     expect(() => onDocumentFormSubmit_(evt)).to.throw(
         /form action should not be on AMP CDN/);
 
     tgt.setAttribute('action', 'https://valid.example.com');
+    tgt.__AMP_INIT_ACTION__ = undefined;
     tgt.removeAttribute('target');
     expect(() => onDocumentFormSubmit_(evt)).to.throw(
         /form target attribute is required/);
 
+    tgt.setAttribute('action', 'https://valid.example.com');
+    tgt.__AMP_INIT_ACTION__ = undefined;
     tgt.setAttribute('target', '_self');
     expect(() => onDocumentFormSubmit_(evt)).to.throw(
         /form target=_self is invalid/);
 
+    tgt.setAttribute('action', 'https://valid.example.com');
+    tgt.__AMP_INIT_ACTION__ = undefined;
     tgt.setAttribute('target', '_blank');
     expect(() => onDocumentFormSubmit_(evt)).to.not.throw;
   });

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -257,12 +257,6 @@ describe('assertHttpsUrl', () => {
     }).to.throw(/source must be available/);
     assertHttpsUrl('', referenceElement);
   });
-  it('should NOT allow __amp_source_origin', () => {
-    expect(() => {
-      assertHttpsUrl('https://twitter.com?__amp_source_origin=1',
-          referenceElement);
-    }).to.throw(/Source origin is not allowed in/);
-  });
   it('should allow https', () => {
     assertHttpsUrl('https://twitter.com', referenceElement);
   });

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -257,6 +257,12 @@ describe('assertHttpsUrl', () => {
     }).to.throw(/source must be available/);
     assertHttpsUrl('', referenceElement);
   });
+  it('should NOT allow __amp_source_origin', () => {
+    expect(() => {
+      assertHttpsUrl('https://twitter.com?__amp_source_origin=1',
+          referenceElement);
+    }).to.throw(/Source origin is not allowed in/);
+  });
   it('should allow https', () => {
     assertHttpsUrl('https://twitter.com', referenceElement);
   });


### PR DESCRIPTION
This adds extra protection against user sat `__amp_source_origin`. One case this will protect against is the `amp-analytics` XHR CORS request.

@dvoytenko let me know if we want to drop the assertion from `assertHttpsUrl` and only do it in analytics case?