### PR TITLE
amp-instagram placeholder should not prerender

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -42,7 +42,7 @@ export class AmpImg extends BaseElement {
   /** @override */
   buildCallback() {
     /** @private @const {boolean} */
-    this.isPrerenderAllowed_ = !this.element.hasAttribute('no-prerender');
+    this.isPrerenderAllowed_ = !this.element.hasAttribute('noprerender');
   }
 
   /** @override */

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -40,6 +40,12 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override */
+  buildCallback() {
+    /** @private @const {boolean} */
+    this.isPrerenderAllowed_ = !this.element.hasAttribute('no-prerender');
+  }
+
+  /** @override */
   isLayoutSupported(layout) {
     return isLayoutSizeDefined(layout);
   }
@@ -74,7 +80,7 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return true;
+    return this.isPrerenderAllowed_;
   }
 
   /** @override */

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -180,13 +180,12 @@
       //     ' allow-popups-to-escape-sandbox allow-same-origin');
 
       this.visibilityToggle_ = document.getElementById('visibilityToggle');
-      this.visibilityToggle_.onclick = function() {
-        this.toggleVisibility(this.visibilityState_ != 'visible');
-      }.bind(this);
-      if (visible) {
-        this.updateVisibilityToggle_();
-      }
-
+      this.visibilityToggle_.addEventListener('click', function() {
+        var activeId = this.viewer.getAttribute('data-show-container');
+        if (activeId == this.id) {
+          this.toggleVisibility(this.visibilityState_ != 'visible', true);
+        }
+      }.bind(this));
       this.viewer.classList.add(this.viewportType_);
 
       if (this.viewportType_ == 'natural' && !this.isIos_) {
@@ -268,14 +267,14 @@
     };
 
 
-    Viewer.prototype.toggleVisibility = function(visible) {
+    Viewer.prototype.toggleVisibility = function(visible, updateToggle) {
       log('Viewer ' + this.id + ' visibility -> ', visible);
       this.visibilityState_ = visible ? 'visible' : 'hidden';
       this.sendRequest_('visibilitychange', {
         state: this.visibilityState_,
         prerenderSize: this.prerenderSize
       }, true);
-      if (visible) {
+      if (updateToggle) {
         this.updateVisibilityToggle_();
       }
     };
@@ -514,7 +513,7 @@
       new Viewer(
           'container4',
           '4',
-          'http://localhost:8000/examples/alp.amp.max.html',
+          './alp.amp.max.html',
           false).start();
       addShowContainer('4');
 
@@ -540,7 +539,7 @@
       var viewerEl = document.querySelector('viewer');
       viewerEl.setAttribute('data-show-container', id);
       allViewers.forEach(function(viewer) {
-        viewer.toggleVisibility(viewer.id == id);
+        viewer.toggleVisibility(viewer.id == id, viewer.id == id);
       });
     }
 

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -83,7 +83,7 @@ class AmpInstagram extends AMP.BaseElement {
     const placeholder = this.win.document.createElement('div');
     placeholder.setAttribute('placeholder', '');
     const image = this.win.document.createElement('amp-img');
-    image.setAttribute('no-prerender', '');
+    image.setAttribute('noprerender', '');
     // This will redirect to the image URL. By experimentation this is
     // always the same URL that is actually used inside of the embed.
     image.setAttribute('src', 'https://www.instagram.com/p/' +

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -38,6 +38,7 @@
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
+import {resolveUrlAttr} from '../../../src/sanitizer';
 import {removeElement} from '../../../src/dom';
 import {user} from '../../../src/log';
 
@@ -85,8 +86,10 @@ class AmpInstagram extends AMP.BaseElement {
     const image = this.win.document.createElement('amp-img');
     // This will redirect to the image URL. By experimentation this is
     // always the same URL that is actually used inside of the embed.
-    image.setAttribute('src', 'https://www.instagram.com/p/' +
-        encodeURIComponent(this.shortcode_) + '/media/?size=l');
+    const imgSrc = resolveUrlAttr('amp-img', 'src',
+        'https://www.instagram.com/p/' + encodeURIComponent(this.shortcode_) +
+        '/media/?size=l', this.win.location);
+    image.setAttribute('src', imgSrc);
     image.setAttribute('layout', 'fill');
     image.setAttribute('referrerpolicy', 'origin');
 

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -38,7 +38,6 @@
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {loadPromise} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
-import {resolveUrlAttr} from '../../../src/sanitizer';
 import {removeElement} from '../../../src/dom';
 import {user} from '../../../src/log';
 
@@ -84,12 +83,11 @@ class AmpInstagram extends AMP.BaseElement {
     const placeholder = this.win.document.createElement('div');
     placeholder.setAttribute('placeholder', '');
     const image = this.win.document.createElement('amp-img');
+    image.setAttribute('no-prerender', '');
     // This will redirect to the image URL. By experimentation this is
     // always the same URL that is actually used inside of the embed.
-    const imgSrc = resolveUrlAttr('amp-img', 'src',
-        'https://www.instagram.com/p/' + encodeURIComponent(this.shortcode_) +
-        '/media/?size=l', this.win.location);
-    image.setAttribute('src', imgSrc);
+    image.setAttribute('src', 'https://www.instagram.com/p/' +
+        encodeURIComponent(this.shortcode_) + '/media/?size=l');
     image.setAttribute('layout', 'fill');
     image.setAttribute('referrerpolicy', 'origin');
 

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -63,9 +63,9 @@ describe('amp-instagram', () => {
     });
   });
 
-  it('sets no-prerender on amp-img', () => {
+  it('sets noprerender on amp-img', () => {
     return getIns('fBwFP').then(ins => {
-      expect(ins.querySelector('amp-img').hasAttribute('no-prerender'))
+      expect(ins.querySelector('amp-img').hasAttribute('noprerender'))
           .to.be.true;
     });
   });

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -63,6 +63,13 @@ describe('amp-instagram', () => {
     });
   });
 
+  it('sets no-prerender on amp-img', () => {
+    return getIns('fBwFP').then(ins => {
+      expect(ins.querySelector('amp-img').hasAttribute('no-prerender'))
+          .to.be.true;
+    });
+  });
+
   it('builds a placeholder image without inserting iframe', () => {
     return getIns('fBwFP', true, ins => {
       console.log(ins);

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -248,12 +248,12 @@ describe('amp-img', () => {
 
   });
 
-  it('should respect no-prerender attribute', () => {
+  it('should respect noprerender attribute', () => {
     const el = document.createElement('amp-img');
     el.setAttribute('src', 'test.jpg');
     el.setAttribute('width', 100);
     el.setAttribute('height', 100);
-    el.setAttribute('no-prerender', '');
+    el.setAttribute('noprerender', '');
     const impl = new AmpImg(el);
     impl.buildCallback();
     expect(impl.prerenderAllowed()).to.equal(false);

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -247,4 +247,25 @@ describe('amp-img', () => {
     });
 
   });
+
+  it('should respect no-prerender attribute', () => {
+    const el = document.createElement('amp-img');
+    el.setAttribute('src', 'test.jpg');
+    el.setAttribute('width', 100);
+    el.setAttribute('height', 100);
+    el.setAttribute('no-prerender', '');
+    const impl = new AmpImg(el);
+    impl.buildCallback();
+    expect(impl.prerenderAllowed()).to.equal(false);
+  });
+
+  it('should allow prerender by default', () => {
+    const el = document.createElement('amp-img');
+    el.setAttribute('src', 'test.jpg');
+    el.setAttribute('width', 100);
+    el.setAttribute('height', 100);
+    const impl = new AmpImg(el);
+    impl.buildCallback();
+    expect(impl.prerenderAllowed()).to.equal(true);
+  });
 });


### PR DESCRIPTION
this is temporary until we can hit the image url on the cdn directly without having to go through the www.instagram.com link (which redirects to the cdn url)

at minimum i wish we could use a generic instagram placeholder image like their gray logo or one of their assets (like in https://www.instagram-brand.com/)

cc @rudygalfi @adewale 