### PR TITLE
Make more URLs configurable: frame, remote, and login done

### DIFF
--- a/3p/frame.max.html
+++ b/3p/frame.max.html
@@ -2,7 +2,26 @@
 <head>
 <meta charset="utf-8">
 <meta name="robots" content="noindex">
-<script src="./integration.js"></script>
+<script>
+(function() {
+var c = window.AMP_CONFIG = window.AMP_CONFIG || {};
+var context;
+try {
+  context = JSON.parse(location.hash.substring(
+    location.hash.indexOf('{'),
+    location.hash.lastIndexOf('}') + 1
+  ))._context;
+}
+catch (e) { context = { AMP_CONFIG: {} }; }
+for (var key in context.AMP_CONFIG)
+  if (c[key] === undefined) c[key] = context.AMP_CONFIG[key]
+var v = context.mode.version;
+var u = context.mode.localDev || context.mode.test
+  ? './integration.js'
+  : c.thirdPartyUrl+'/'+encodeURIComponent(v)+'/f.js';
+document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
+})();
+</script>
 </head>
 <body style="margin:0">
 <div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -476,7 +476,7 @@ export function validateAllowedTypes(window, type, allowedTypes) {
   if (window.location.hostname == thirdPartyHost) {
     return;
   }
-  if (urls.thirdPartyFrameRegex.test(window.location.hostname)) {
+  if (new RegExp(urls.thirdPartyFrameRegex).test(window.location.hostname)) {
     return;
   }
   if (window.location.hostname == 'ads.localhost') {

--- a/3p/remote.html
+++ b/3p/remote.html
@@ -4,9 +4,22 @@
 <meta name="robots" content="noindex">
 <script>
 (function() {
-var v = location.search.substr(1);
 if (!(/^\d+(-canary)?$/.test(v))) return;
-var u = 'https://3p.ampproject.net/'+encodeURIComponent(v)+'/f.js';
+var c = window.AMP_CONFIG = window.AMP_CONFIG || {};
+var context;
+try {
+  context = JSON.parse(location.hash.substring(
+    location.hash.indexOf('{'),
+    location.hash.lastIndexOf('}') + 1
+  ))._context;
+}
+catch (e) { context = { AMP_CONFIG: {} }; }
+for (var key in context.AMP_CONFIG)
+  if (c[key] === undefined) c[key] = context.AMP_CONFIG[key]
+var v = context.mode.version;
+var u = context.mode.localDev || context.mode.test
+  ? './integration.js'
+  : c.thirdPartyUrl+'/'+encodeURIComponent(v)+'/f.js';
 document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
 })();
 </script>

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -143,7 +143,6 @@
   <script src="./viewer-integr-messaging.js"></script>
 
   <script>
-
     var SENTINEL = '__AMP__';
 
     var allViewers = [];

--- a/extensions/amp-access/0.1/amp-login-done.html
+++ b/extensions/amp-access/0.1/amp-login-done.html
@@ -5,7 +5,25 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
   <meta name="robots" content="noindex">
   <title>AMP Login Complete</title>
-  <script async src="../../../dist/v0/amp-login-done-0.1.max.js"></script>
+  <script>
+  (function() {
+    var c = window.AMP_CONFIG = window.AMP_CONFIG || {};
+    var context;
+    try {
+      context = JSON.parse(location.hash.substring(
+        location.hash.indexOf('{'),
+        location.hash.lastIndexOf('}') + 1
+      ))._context;
+    }
+    catch (e) { context = { AMP_CONFIG: {} }; }
+    for (var key in context.AMP_CONFIG)
+      if (c[key] === undefined) c[key] = context.AMP_CONFIG[key]
+    var u = context.testOrLocalDev
+      ? '../../../dist/v0/amp-login-done-0.1.max.js'
+      : c.cdnUrl+'/v0/amp-login-done-0.1.js';
+    document.write('<script async'+' src="'+encodeURI(u)+'"><'+'/script>');
+  })();
+  </script>
   <style>
     body {
       margin: 0;

--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -284,7 +284,21 @@ class WebLoginDialog {
     } else {
       returnUrl = `${urls.cdn}/v0/amp-login-done-0.1.html`;
     }
-    return returnUrl + '?url=' + encodeURIComponent(currentUrl);
+    return returnUrl + '?url=' + encodeURIComponent(currentUrl)
+        + this.getReturnUrlHash_();
+  }
+
+  /**
+   * @return {string}
+   * @private
+   */
+  getReturnUrlHash_() {
+    const context = {
+      AMP_CONFIG: this.win.AMP_CONFIG || {},
+      testOrLocalDev: getMode().localDev || getMode().test,
+    };
+
+    return `#${JSON.stringify({_context: context})}`;
   }
 }
 

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -279,7 +279,7 @@ describe('WebLoginDialog', () => {
   it('should have correct window.open params', () => {
     windowMock.expects('open')
         .withExactArgs(
-            'http://acme.com/login?return=' + RETURN_URL_ESC,
+            sinon.match('http://acme.com/login?return=' + RETURN_URL_ESC),
             '_blank',
             'height=450,width=700,left=150,top=275' +
             ',resizable=yes,scrollbars=yes')
@@ -306,7 +306,7 @@ describe('WebLoginDialog', () => {
   it('should have correct URL with other parameters', () => {
     windowMock.expects('open')
         .withExactArgs(
-            'http://acme.com/login?a=1&return=' + RETURN_URL_ESC,
+            sinon.match('http://acme.com/login?a=1&return=' + RETURN_URL_ESC),
             '_blank',
             'height=450,width=700,left=150,top=275' +
             ',resizable=yes,scrollbars=yes')
@@ -326,7 +326,7 @@ describe('WebLoginDialog', () => {
   it('should substitute return URL', () => {
     windowMock.expects('open')
         .withExactArgs(
-            'http://acme.com/login?a=1&ret1=' + RETURN_URL_ESC,
+            sinon.match('http://acme.com/login?a=1&ret1=' + RETURN_URL_ESC),
             '_blank',
             'height=450,width=700,left=150,top=275' +
             ',resizable=yes,scrollbars=yes')
@@ -348,10 +348,10 @@ describe('WebLoginDialog', () => {
     viewer.getResolvedViewerUrl = () => 'http://acme.com/viewer1';
     windowMock.expects('open')
         .withArgs(
-            'http://acme.com/login?a=1&ret1=' +
+            sinon.match('http://acme.com/login?a=1&ret1=' +
             encodeURIComponent('http://localhost:8000/extensions' +
                 '/amp-access/0.1/amp-login-done.html?url=' +
-                encodeURIComponent('http://acme.com/viewer1')))
+                encodeURIComponent('http://acme.com/viewer1'))))
         .returns(dialog)
         .once();
     const promise = openLoginDialog(windowApi,
@@ -398,7 +398,7 @@ describe('WebLoginDialog', () => {
           return urlPromise;
         })
         .then(() => {
-          expect(dialogUrl).to.be.equal(
+          expect(dialogUrl).to.have.string(
             'http://acme.com/login?a=1&return=' + RETURN_URL_ESC);
           succeed();
           return promise;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -363,7 +363,6 @@ function thirdPartyBootstrap(watch, shouldMinify) {
   }
   $$.util.log('Processing ' + input);
   var html = fs.readFileSync(input, 'utf8');
-  var min = html;
   // By default we use an absolute URL, that is independent of the
   // actual frame host for the JS inside the frame.
   var jsPrefix = 'https://3p.ampproject.net/' + internalRuntimeVersion;
@@ -372,10 +371,7 @@ function thirdPartyBootstrap(watch, shouldMinify) {
   if (argv.fortesting) {
     jsPrefix = '.';
   }
-  // Convert default relative URL to absolute min URL.
-  min = min.replace(/\.\/integration\.js/g, jsPrefix + '/f.js');
   gulp.src(input)
-      .pipe($$.file('frame.html', min))
       .pipe(gulp.dest('dist.3p/' + internalRuntimeVersion))
       .on('end', function() {
         var aliasToLatestBuild = 'dist.3p/current';
@@ -626,15 +622,12 @@ function buildLoginDoneVersion(version, options) {
   // Build HTML.
   $$.util.log('Processing ' + htmlPath);
   var html = fs.readFileSync(htmlPath, 'utf8');
-  var minHtml = html.replace(
-      '../../../dist/v0/amp-login-done-' + version + '.max.js',
-      'https://cdn.ampproject.org/v0/amp-login-done-' + version + '.js');
 
   mkdirSync('dist');
   mkdirSync('dist/v0');
 
   fs.writeFileSync('dist/v0/amp-login-done-' + version + '.html',
-      minHtml);
+      html);
 
   // Build JS.
   var js = fs.readFileSync(jsPath, 'utf8');

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -74,6 +74,7 @@ function getFrameAttributes(parentWindow, element, opt_type) {
     locationHref = parentWindow.parent.location.href;
   }
   attributes._context = {
+    AMP_CONFIG: parentWindow.AMP_CONFIG || {},
     referrer: viewer.getUnconfirmedReferrerUrl(),
     canonicalUrl: docInfo.canonicalUrl,
     pageViewId: docInfo.pageViewId,

--- a/src/config.js
+++ b/src/config.js
@@ -28,7 +28,7 @@ export const urls = {
   thirdParty: env['thirdPartyUrl'] || 'https://3p.ampproject.net',
   thirdPartyFrameHost: env['thirdPartyFrameHost'] || 'ampproject.net',
   thirdPartyFrameRegex: env['thirdPartyFrameRegex'] ||
-      /^d-\d+\.ampproject\.net$/,
+      '^d-\\d+\.ampproject\\.net$',
   cdn: env['cdnUrl'] || 'https://cdn.ampproject.org',
   errorReporting: env['errorReportingUrl'] ||
       'https://amp-error-reporting.appspot.com/r',

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -124,32 +124,65 @@ describe('3p-frame', () => {
     const width = window.innerWidth;
     const height = window.innerHeight;
     const amp3pSentinel = iframe.getAttribute('data-amp-3p-sentinel');
-    const fragment =
-        '{"testAttr":"value","ping":"pong","width":50,"height":100,' +
-        '"type":"_ping_"' +
-        ',"_context":{"referrer":"http://acme.org/",' +
-        '"canonicalUrl":"https://foo.bar/baz",' +
-        '"pageViewId":"' + docInfo.pageViewId + '","clientId":"cidValue",' +
-        '"location":{"href":"' + locationHref + '"},"tagName":"MY-ELEMENT",' +
-        '"mode":{"localDev":true,"development":false,"minified":false,' +
-        '"test":false,"version":"$internalRuntimeVersion$"}' +
-        ',"hidden":false' +
-        ',"startTime":1234567888' +
-        ',"amp3pSentinel":"' + amp3pSentinel + '"' +
-        ',"initialIntersection":{"time":1234567888,' +
-        '"rootBounds":{"left":0,"top":0,"width":' + width + ',"height":' +
-        height + ',"bottom":' + height + ',"right":' + width +
-        ',"x":0,"y":0},"boundingClientRect":' +
-        '{"width":100,"height":200},"intersectionRect":{' +
-        '"left":0,"top":0,"width":0,"height":0,"bottom":0,' +
-        '"right":0,"x":0,"y":0}}}}';
+    const fragment = {
+      testAttr: 'value',
+      ping: 'pong',
+      width: 50,
+      height: 100,
+      type: '_ping_',
+      _context: {
+        AMP_CONFIG: {},
+        referrer: 'http://acme.org/',
+        canonicalUrl: 'https://foo.bar/baz',
+        pageViewId: docInfo.pageViewId,
+        clientId: 'cidValue',
+        location: {href: locationHref},
+        tagName: 'MY-ELEMENT',
+        mode: {
+          localDev: true,
+          development: false,
+          minified: false,
+          test: false,
+          version: '$internalRuntimeVersion$',
+        },
+        hidden: false,
+        startTime: 1234567888,
+        amp3pSentinel,
+        initialIntersection: {
+          time: 1234567888,
+          rootBounds: {
+            left: 0,
+            top: 0,
+            width,
+            height,
+            bottom: height,
+            right: width,
+            x: 0,
+            y: 0,
+          },
+          boundingClientRect: {width: 100, height: 200},
+          intersectionRect: {
+            width: 0,
+            height: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            x: 0,
+            y: 0,
+          },
+        },
+      },
+    };
+
+
     const srcParts = src.split('#');
     expect(srcParts[0]).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
-    expect(JSON.parse(srcParts[1])).to.deep.equal(JSON.parse(fragment));
+    expect(JSON.parse(srcParts[1])).to.deep.equal(fragment);
 
     // Switch to same origin for inner tests.
-    iframe.src = '/dist.3p/current/frame.max.html#' + fragment;
+    iframe.src = '/dist.3p/current/frame.max.html#' + JSON.stringify(fragment);
 
     document.body.appendChild(iframe);
     return loadPromise(iframe).then(() => {

--- a/test/integration/test-configuration.js
+++ b/test/integration/test-configuration.js
@@ -33,7 +33,7 @@ describe('Configuration', function() {
     const config = fixture.win.AMP_CONFIG = {};
     config.cdnUrl = 'http://foo.bar.com';
     config.thirdPartyUrl = 'http://bar.baz.com';
-    config.thirdPartyFrameRegex = /a-website\.com/;
+    config.thirdPartyFrameRegex = '/a-website\.com/';
     config.errorReportingUrl = 'http://error.foo.com';
 
     return fixture.awaitEvent('amp:load:start', 1).then(() => {


### PR DESCRIPTION
This is a rebased version of this is PR: Make more URLs configurable: frame, remote, and login done #4542

Which includes @erwinmombay AMP_CONFIG add expected AMP_CONFIG fields to extern 

https://github.com/ampproject/amphtml/commit/cea864561a0d5c8322d4922724f41975eac798ba