### PR TITLE
Add Zucks to amp-ad support

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -101,6 +101,7 @@ import {yieldbot} from '../ads/yieldbot';
 import {yieldmo} from '../ads/yieldmo';
 import {yieldone} from '../ads/yieldone';
 import {zergnet} from '../ads/zergnet';
+import {zucks} from '../ads/zucks';
 
 initLogConstructor();
 
@@ -191,6 +192,7 @@ register('yieldbot', yieldbot);
 register('yieldmo', yieldmo);
 register('zergnet', zergnet);
 register('yieldone', yieldone);
+register('zucks', zucks);
 
 // For backward compat, we always allow these types without the iframe
 // opting in.

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -366,4 +366,13 @@ export const adConfig = {
   },
 
   zergnet: {},
+
+  zucks: {
+    preconnect: [
+      'https://j.zucks.net.zimg.jp',
+      'https://sh.zucks.net',
+      'https://k.zucks.net',
+      'https://static.zucks.net.zimg.jp',
+    ],
+  },
 };

--- a/ads/zucks.js
+++ b/ads/zucks.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {validateData, writeScript} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function zucks(global, data) {
+  validateData(data, ['frameId']);
+  writeScript(global, `https://j.zucks.net.zimg.jp/j?f=${data['frameId']}`);
+}

--- a/ads/zucks.md
+++ b/ads/zucks.md
@@ -1,0 +1,33 @@
+<!---
+Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Zucks
+
+## Example
+
+```html
+<amp-ad width="320" height="50"
+      type="zucks"
+      data-frame-id="{FRAME-ID}">
+</amp-ad>
+```
+
+## Configuration
+
+For more information, please [contact Zucks](https://zucks.co.jp/contact/).
+
+Supported parameters:
+- data-frame-id

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -137,6 +137,7 @@
     <a href="#yieldone">Yield One</a> |
     <a href="#yieldmo">Yieldmo</a> |
     <a href="#zergnet">ZergNet</a> |
+    <a href="#zucks">Zucks</a> |
   </nav>
 
   <div class="fixed">
@@ -895,6 +896,15 @@
     <div placeholder></div>
     <div fallback></div>
   </amp-embed>
+
+  <h2 id="zucks">Zucks</h2>
+  <amp-ad width="320" height="50"
+      type="zucks"
+      data-frame-id="_bda46cf5ac">
+     <div placeholder></div>
+     <div fallback></div>
+   </amp-ad>
+
 </amp-ad>
 </body>
 </html>

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -141,6 +141,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [Yieldbot](../../ads/yieldbot.md)
 - [Yieldmo](../../ads/yieldmo.md)
 - [Yieldone](../../ads/yieldone.md)
+- [Zucks](../../ads/zucks.md)
 
 ## Supported embed types
 


### PR DESCRIPTION
Hi, as stated in https://github.com/ampproject/amphtml/issues/4677 we want to add Zucks Ad Network into the supported ad network for amp-ad.

We have signed Google Corporate CLA.

Corporation name: Zucks, Inc

Thank you very much !