### PR TITLE
Fixing swipe in slidescroll carousel sometimes causing viewer document swipes in iOS

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -15,9 +15,7 @@
  */
 import {Animation} from '../../../src/animation';
 import {BaseSlides} from './base-slides';
-import {Gestures} from '../../../src/gesture';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {getStyle, setStyle} from '../../../src/style';
 import {numeric} from '../../../src/transition';
 import {timerFor} from '../../../src/timer';

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -107,10 +107,7 @@ export class AmpSlideScroll extends BaseSlides {
      */
     this.elasticScrollState_ = 0;
 
-
-    const gestures =
-        Gestures.get(this.element, /* shouldNotPreventDefault */true);
-    gestures.onGesture(SwipeXRecognizer, () => {});
+    this.cancelTouchEvents_();
 
     this.slidesContainer_.addEventListener(
         'scroll', this.scrollHandler_.bind(this));
@@ -478,5 +475,20 @@ export class AmpSlideScroll extends BaseSlides {
     return Animation.animate(this.slidesContainer_, pos => {
       this.slidesContainer_./*OK*/scrollLeft = interpolate(pos);
     }, 80, 'ease-out').thenAlways();
+  }
+
+  /**
+   * Cancels the touchmove events for the element so that viewer does not
+   * consider the swipes in the carousel as swipes for changing AMP documents.
+   * @private
+   */
+  cancelTouchEvents_() {
+    // TODO(aghassemi): https://github.com/ampproject/amphtml/issues/4742
+    // prevents us from using SwipeXRecognizer with an empty handler to
+    // cancel the events. This work around is not great and temporary until
+    // #4742 is fixed.
+    this.element.addEventListener('touchmove', evt => {
+      evt.stopPropagation();
+    });
   }
 }


### PR DESCRIPTION
This is a work-around. Please see https://github.com/ampproject/amphtml/issues/4742 for the related bug. 

@ericfs depending on how much we can do for #4742, we might also need to change how the viewer decides whether bunch of touchmove events are a horizontal swipe or not (ideally same formula as AMP's gesture recognizer)