### PR TITLE
Change waitForBody to use one MutationObserver for N calls

### DIFF
--- a/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import {documentStateFor} from '../../../src/document-state';
 import {getService} from '../../../src/service';
 import {parseUrl} from '../../../src/url';
 import {viewerFor} from '../../../src/viewer';
 import {vsyncFor} from '../../../src/vsync';
-import {waitForBody} from '../../../src/dom';
 
 /**
  * Strips everything but the domain from referrer string.
@@ -92,7 +92,8 @@ function normalizedReferrers(win) {
  * @param {!Array<string>} classes
  */
 function addDynamicCssClasses(win, classes) {
-  waitForBody(win.document, () => {
+  const docState = documentStateFor(win);
+  docState.onBodyAvailable(() => {
     const body = win.document.body;
     const classList = body.classList;
 

--- a/extensions/amp-dynamic-css-classes/0.1/test/test-runtime-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/test/test-runtime-classes.js
@@ -53,6 +53,7 @@ describe('dynamic classes are inserted at runtime', () => {
         href: 'https://cdn.ampproject.org/v/www.origin.com/foo/?f=0',
       },
     };
+    mockWin.document.defaultView = mockWin;
   });
 
   function setup(embeded, userAgent, referrer) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -21,6 +21,7 @@ import {Layout, getLayoutClass, getLengthNumeral, getLengthUnits,
 import {ElementStub, stubbedElements} from './element-stub';
 import {createLoaderElement} from '../src/loader';
 import {dev, rethrowAsync, user} from './log';
+import {documentStateFor} from './document-state';
 import {getIntersectionChangeEntry} from '../src/intersection-observer';
 import {getMode} from './mode';
 import {parseSizeList} from './size-list';
@@ -162,7 +163,8 @@ export function stubElements(win) {
   }
   // Repeat stubbing when HEAD is complete.
   if (!win.document.body) {
-    dom.waitForBody(win.document, () => stubElements(win));
+    const docState = documentStateFor(win);
+    docState.onBodyAvailable(() => stubElements(win));
   }
 }
 

--- a/src/document-state.js
+++ b/src/document-state.js
@@ -17,6 +17,7 @@
 import {Observable} from './observable';
 import {fromClass} from './service';
 import {getVendorJsPropertyName} from './style';
+import {waitForChild} from './dom';
 
 
 /**
@@ -130,25 +131,8 @@ export class DocumentState {
     }
     if (!this.bodyAvailableObservable_) {
       this.bodyAvailableObservable_ = new Observable();
-
-      // Listen for body to be created, then call onBodyAvailable_.
-      const win = this.win;
-      if (win.MutationObserver) {
-        const observer = new win.MutationObserver(() => {
-          if (doc.body) {
-            observer.disconnect();
-            this.onBodyAvailable_();
-          }
-        });
-        observer.observe(doc.documentElement, {childList: true});
-      } else {
-        const interval = win.setInterval(() => {
-          if (doc.body) {
-            win.clearInterval(interval);
-            this.onBodyAvailable_();
-          }
-        }, /* milliseconds */ 5);
-      }
+      waitForChild(doc.documentElement, () => !!doc.body,
+          this.onBodyAvailable_.bind(this));
     }
     return this.bodyAvailableObservable_.add(handler);
   }

--- a/src/document-state.js
+++ b/src/document-state.js
@@ -67,7 +67,7 @@ export class DocumentState {
           this.boundOnVisibilityChanged_);
     }
 
-    /** @private @const {!Observable|null} */
+    /** @private @const {?Observable} */
     this.bodyAvailableObservable_ = null;
   }
 
@@ -118,8 +118,10 @@ export class DocumentState {
   }
 
   /**
+   * If body is already available, callback is called synchronously and null
+   * is returned.
    * @param {function()} handler
-   * @return {!UnlistenDef|null}
+   * @return {?UnlistenDef}
    */
   onBodyAvailable(handler) {
     const doc = this.document_;
@@ -129,9 +131,8 @@ export class DocumentState {
     }
     if (!this.bodyAvailableObservable_) {
       this.bodyAvailableObservable_ = new Observable();
-      waitForChild(doc.documentElement,
-                   () => !!doc.body,
-                   this.onBodyAvailable_.bind(this));
+      waitForChild(doc.documentElement, () => !!doc.body,
+          this.onBodyAvailable_.bind(this));
     }
     return this.bodyAvailableObservable_.add(handler);
   }

--- a/src/document-state.js
+++ b/src/document-state.js
@@ -123,7 +123,7 @@ export class DocumentState {
    */
   onBodyAvailable(handler) {
     const doc = this.document_;
-    if (!!doc.body) {
+    if (doc.body) {
       handler();
       return null;
     }
@@ -139,6 +139,7 @@ export class DocumentState {
   /** @private */
   onBodyAvailable_() {
     this.bodyAvailableObservable_.fire();
+    this.bodyAvailableObservable_.removeAll();
     this.bodyAvailableObservable_ = null;
   }
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -53,10 +53,10 @@ export function waitForChild(parent, checkFunc, callback) {
 
 /**
  * Waits for document's body to be available.
+ * Will be deprecated soon; use {@link AmpDoc#whenBodyAvailable} or
+ * @{link DocumentState#onBodyAvailable} instead.
  * @param {!Document} doc
  * @param {function()} callback
- * @deprecated Use {@link AmpDoc#whenBodyAvailable} or
- *    @{link DocumentState#onBodyAvailable} instead.
  */
 export function waitForBody(doc, callback) {
   waitForChild(doc.documentElement, () => !!doc.body, callback);

--- a/src/dom.js
+++ b/src/dom.js
@@ -16,7 +16,6 @@
 
 import {dev} from './log';
 import {cssEscape} from '../third_party/css-escape/css-escape';
-import {documentStateFor} from './document-state';
 import {toArray} from './types';
 
 
@@ -56,10 +55,11 @@ export function waitForChild(parent, checkFunc, callback) {
  * Waits for document's body to be available.
  * @param {!Document} doc
  * @param {function()} callback
+ * @deprecated Use {@link AmpDoc#whenBodyAvailable} or
+ *    @{link DocumentState#onBodyAvailable} instead.
  */
 export function waitForBody(doc, callback) {
-  const docState = documentStateFor(doc.defaultView);
-  docState.onBodyAvailable(callback);
+  waitForChild(doc.documentElement, () => !!doc.body, callback);
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -58,8 +58,14 @@ export function waitForChild(parent, checkFunc, callback) {
  * @param {function()} callback
  */
 export function waitForBody(doc, callback) {
-  const docState = documentStateFor(doc.defaultView);
-  docState.onBodyAvailable(callback);
+  // Prefer DocumentState.onBodyAvailable() to minimize creation of
+  // MutationObserver by waitForChild().
+  if (doc.defaultView) {
+    const docState = documentStateFor(doc.defaultView);
+    docState.onBodyAvailable(callback);
+  } else {
+    waitForChild(doc.documentElement, () => !!doc.body, callback);
+  }
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -16,6 +16,7 @@
 
 import {dev} from './log';
 import {cssEscape} from '../third_party/css-escape/css-escape';
+import {documentStateFor} from './document-state';
 import {toArray} from './types';
 
 
@@ -57,7 +58,8 @@ export function waitForChild(parent, checkFunc, callback) {
  * @param {function()} callback
  */
 export function waitForBody(doc, callback) {
-  waitForChild(doc.documentElement, () => !!doc.body, callback);
+  const docState = documentStateFor(doc.defaultView);
+  docState.onBodyAvailable(callback);
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -58,14 +58,8 @@ export function waitForChild(parent, checkFunc, callback) {
  * @param {function()} callback
  */
 export function waitForBody(doc, callback) {
-  // Prefer DocumentState.onBodyAvailable() to minimize creation of
-  // MutationObserver by waitForChild().
-  if (doc.defaultView) {
-    const docState = documentStateFor(doc.defaultView);
-    docState.onBodyAvailable(callback);
-  } else {
-    waitForChild(doc.documentElement, () => !!doc.body, callback);
-  }
+  const docState = documentStateFor(doc.defaultView);
+  docState.onBodyAvailable(callback);
 }
 
 

--- a/src/observable.js
+++ b/src/observable.js
@@ -52,6 +52,13 @@ export class Observable {
   }
 
   /**
+   * Removes all observers.
+   */
+  removeAll() {
+    this.handlers_.length = 0;
+  }
+
+  /**
    * Fires an event. All observers are called.
    * @param {TYPE=} opt_event
    */

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -15,11 +15,11 @@
  */
 
 import {dev} from './log';
+import {documentStateFor} from './document-state';
 import {performanceFor} from './performance';
 import {platformFor} from './platform';
 import {setStyles} from './style';
-import {waitForBody} from './dom';
-import {waitForServices} from './render-delaying-services';
+import {waitForExtensions} from './render-delaying-extensions';
 
 
 const bodyVisibleSentinel = '__AMP_BODY_VISIBLE';
@@ -127,7 +127,9 @@ export function makeBodyVisible(doc, opt_waitForServices) {
       }
     }
   };
-  waitForBody(doc, () => {
+  const win = doc.defaultView;
+  const docState = documentStateFor(win);
+  docState.onBodyAvailable(() => {
     if (doc.defaultView[bodyVisibleSentinel]) {
       return;
     }

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -130,14 +130,14 @@ export function makeBodyVisible(doc, opt_waitForServices) {
   const win = doc.defaultView;
   const docState = documentStateFor(win);
   docState.onBodyAvailable(() => {
-    if (doc.defaultView[bodyVisibleSentinel]) {
+    if (win[bodyVisibleSentinel]) {
       return;
     }
-    doc.defaultView[bodyVisibleSentinel] = true;
+    win[bodyVisibleSentinel] = true;
     if (opt_waitForServices) {
-      waitForServices(doc.defaultView).then(set, set).then(() => {
+      waitForServices(win).then(set, set).then(() => {
         try {
-          const perf = performanceFor(doc.defaultView);
+          const perf = performanceFor(win);
           perf.tick('mbv');
           perf.flush();
         } catch (e) {}

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -19,7 +19,7 @@ import {documentStateFor} from './document-state';
 import {performanceFor} from './performance';
 import {platformFor} from './platform';
 import {setStyles} from './style';
-import {waitForExtensions} from './render-delaying-extensions';
+import {waitForServices} from './render-delaying-services';
 
 
 const bodyVisibleSentinel = '__AMP_BODY_VISIBLE';

--- a/test/functional/test-document-state.js
+++ b/test/functional/test-document-state.js
@@ -15,6 +15,7 @@
  */
 
 import {DocumentState} from '../../src/document-state';
+import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 
 
@@ -42,10 +43,7 @@ describe('DocumentState', () => {
         }
       },
     };
-    windowApi = {
-      document: testDoc,
-      setInterval: () => {}, // No-op for testing.
-    };
+    windowApi = {document: testDoc};
     docState = new DocumentState(windowApi);
   });
 
@@ -113,6 +111,7 @@ describe('DocumentState', () => {
 
   it('should fire body availability change', () => {
     const callback = sandbox.spy();
+    sandbox.stub(dom, 'waitForChild');
 
     expect(testDoc.body).to.equal(undefined);
 

--- a/test/functional/test-document-state.js
+++ b/test/functional/test-document-state.js
@@ -15,7 +15,6 @@
  */
 
 import {DocumentState} from '../../src/document-state';
-import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 
 
@@ -43,7 +42,10 @@ describe('DocumentState', () => {
         }
       },
     };
-    windowApi = {document: testDoc};
+    windowApi = {
+      document: testDoc,
+      setInterval: () => {}, // No-op for testing.
+    };
     docState = new DocumentState(windowApi);
   });
 
@@ -111,7 +113,6 @@ describe('DocumentState', () => {
 
   it('should fire body availability change', () => {
     const callback = sandbox.spy();
-    sandbox.stub(dom, 'waitForChild');
 
     expect(testDoc.body).to.equal(undefined);
 

--- a/test/functional/test-document-state.js
+++ b/test/functional/test-document-state.js
@@ -15,6 +15,7 @@
  */
 
 import {DocumentState} from '../../src/document-state';
+import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 
 
@@ -106,5 +107,25 @@ describe('DocumentState', () => {
     expect(docState.isHidden()).to.equal(true);
     expect(docState.getVisibilityState()).to.equal('invisible');
     expect(callback.callCount).to.equal(1);
+  });
+
+  it('should fire body availability change', () => {
+    const callback = sandbox.spy();
+    const stub = sandbox.stub(dom, 'waitForChild');
+
+    expect(testDoc.body).to.equal(undefined);
+
+    const first = docState.onBodyAvailable(callback);
+    expect(first).to.not.equal(null);
+    expect(callback.callCount).to.equal(0);
+
+    testDoc.body = {};
+    docState.onBodyAvailable_();
+
+    expect(callback.callCount).to.equal(1);
+
+    const second = docState.onBodyAvailable(callback);
+    expect(second).to.equal(null);
+    expect(callback.callCount).to.equal(2);
   });
 });

--- a/test/functional/test-document-state.js
+++ b/test/functional/test-document-state.js
@@ -111,7 +111,7 @@ describe('DocumentState', () => {
 
   it('should fire body availability change', () => {
     const callback = sandbox.spy();
-    const stub = sandbox.stub(dom, 'waitForChild');
+    sandbox.stub(dom, 'waitForChild');
 
     expect(testDoc.body).to.equal(undefined);
 

--- a/test/functional/test-observable.js
+++ b/test/functional/test-observable.js
@@ -60,6 +60,13 @@ describe('Observable', () => {
     observable.fire('C');
     expect(observer1Called).to.equal(1);
     expect(observer2Called).to.equal(2);
+
+    observable.add(observer1);
+    observable.add(observer2);
+    observable.removeAll();
+    observable.fire('D');
+    expect(observer1Called).to.equal(1);
+    expect(observer2Called).to.equal(2);
   });
 
 });


### PR DESCRIPTION
Fixes #4040. Instead of instantiating N MutationObservers for N calls to waitForBody, instantiate one and use an Observable in DocumentState to store the event handlers.

Seems to offer a modest performance improvement for large N. Tested rough approach on desktop Chrome:
N = 10000, 127.7 vs 5.2 ms (25x faster)
N = 1000, 4.14 vs 0.37 ms (11x faster)
N = 100, 0.52 vs 0.25 ms (2x faster)
N = 10, 0.26 vs 0.27 ms (0x faster)

[mutationObserverTest.html.zip](https://github.com/ampproject/amphtml/files/443033/mutationObserverTest.html.zip)