### PR TITLE
Fix Iframe #postMessage Error

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -208,8 +208,12 @@ export class AmpAdApiHandler {
    * @param {string} origin
    * @private
    */
-  sendEmbedSizeResponse_(
-      success, requestedWidth, requestedHeight, source, origin) {
+  sendEmbedSizeResponse_(success, requestedWidth, requestedHeight, source,
+      origin) {
+    // The iframe may have been removed by the time we resize.
+    if (!this.iframe_) {
+      return;
+    }
     postMessageToWindows(
         this.iframe_,
         [{win: source, origin}],

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -141,9 +141,9 @@ export class AmpAdApiHandler {
       this.iframe_.style.visibility = 'hidden';
     }
 
-    this.viewer_.onVisibilityChanged(() => {
+    this.unlisteners_.push(this.viewer_.onVisibilityChanged(() => {
       this.sendEmbedInfo_(this.baseInstance_.isInViewport());
-    });
+    }));
 
     this.element_.appendChild(this.iframe_);
     return loadPromise(this.iframe_).then(() => {

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -47,6 +47,7 @@ export class AmpAdApiHandler {
     /** @private {?IntersectionObserver} */
     this.intersectionObserver_ = null;
 
+    /** @private {SubscriptionApi} */
     this.embedStateApi_ = null;
 
     /** @private {boolean} */
@@ -169,16 +170,16 @@ export class AmpAdApiHandler {
 
   /** @override  */
   unlayoutCallback() {
-    this.unlisteners_.forEach(unlistener => unlistener());
-    this.unlisteners_ = [];
     if (this.iframe_) {
+      this.unlisteners_.forEach(unlistener => unlistener());
+      this.unlisteners_.length = 0;
+      this.embedStateApi_.destroy();
+      this.embedStateApi_ = null;
+      this.intersectionObserver_.destroy();
+      this.intersectionObserver_ = null;
       removeElement(this.iframe_);
       this.iframe_ = null;
     }
-    // IntersectionObserver's listeners were cleaned up by
-    // setInViewport(false) before #unlayoutCallback
-    this.intersectionObserver_.destroy();
-    this.intersectionObserver_ = null;
   }
 
   /**

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -16,6 +16,7 @@
 
 import {dev} from './log';
 import {parseUrl} from './url';
+import {filterSplice} from './utils/array';
 
 /**
  * Sentinel used to force unlistening after a iframe is detached.
@@ -443,6 +444,8 @@ export class SubscriptionApi {
    * @param {!Object} data Message payload.
    */
   send(type, data) {
+    // Remove clients that have been removed from the DOM.
+    filterSplice(this.clientWindows_, client => !!client.win.parent);
     postMessageToWindows(
         this.iframe_,
         this.clientWindows_,

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -407,33 +407,22 @@ export class SubscriptionApi {
    *     invoked whenever a new window subscribes.
    */
   constructor(iframe, type, is3p, requestCallback) {
-    /** @private {!Element} */
+    /** @private @const {!Element} */
     this.iframe_ = iframe;
-    /** @private {boolean} */
+    /** @private @const {boolean} */
     this.is3p_ = is3p;
-    /** @private {!Array<{win: !Window, origin: string}>} */
+    /** @private @const {!Array<{win: !Window, origin: string}>} */
     this.clientWindows_ = [];
 
-    this.init_(type, requestCallback);
-  }
-
-  /**
-   * Start listening for messages.
-   * @param {string} type Type of the subscription message.
-   * @param {function(!Object, !Window, string)} requestCallback Callback
-   *     invoked whenever a new window subscribes.
-   * @private
-   */
-  init_(type, requestCallback) {
-    listenFor(
-        this.iframe_, type, (data, source, origin) => {
-          // This message might be from any window within the iframe, we need
-          // to keep track of which windows want to be sent updates.
-          if (!this.clientWindows_.some(entry => entry.win == source)) {
-            this.clientWindows_.push({win: source, origin});
-          }
-          requestCallback(data, source, origin);
-        }, this.is3p_,
+    /** @private @const {!UnlistenDef} */
+    this.unlisten_ = listenFor(this.iframe_, type, (data, source, origin) => {
+      // This message might be from any window within the iframe, we need
+      // to keep track of which windows want to be sent updates.
+      if (!this.clientWindows_.some(entry => entry.win == source)) {
+        this.clientWindows_.push({win: source, origin});
+      }
+      requestCallback(data, source, origin);
+    }, this.is3p_,
         // For 3P frames we also allow nested frames within them to subscribe..
         this.is3p_ /* opt_includingNestedWindows */);
   }
@@ -452,5 +441,10 @@ export class SubscriptionApi {
         type,
         data,
         this.is3p_);
+  }
+
+  destroy() {
+    this.unlisten_();
+    this.clientWindows_.length = 0;
   }
 }

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -236,7 +236,7 @@ export class IntersectionObserver extends Observable {
    */
   destroy() {
     this.timer_.cancel(this.flushTimeout_);
-    this.flushTimeout_ = 0;
     this.unlistenOnOutViewport_();
+    this.postMessageApi_.destroy();
   }
 }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -32,6 +32,7 @@ import {installVsyncService} from './vsync-impl';
 import {isArray} from '../types';
 import {dev} from '../log';
 import {reportError} from '../error';
+import {filterSplice} from '../utils/array';
 
 
 const TAG_ = 'Resources';
@@ -414,7 +415,7 @@ export class Resources {
     if (!resource) {
       return;
     }
-    const index = resource ? this.resources_.indexOf(resource) : -1;
+    const index = this.resources_.indexOf(resource);
     if (index != -1) {
       this.resources_.splice(index, 1);
     }
@@ -1579,8 +1580,9 @@ export class Resources {
       this.exec_.purge(task => {
         return task.resource == resource;
       });
-      this.requestsChangeSize_ = this.requestsChangeSize_.filter(
-          request => request.resource != resource);
+      filterSplice(this.requestsChangeSize_, request => {
+        return request.resource == resource
+      });
     }
 
     if (resource.getState() == ResourceState.NOT_BUILT && opt_removePending &&

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1581,7 +1581,7 @@ export class Resources {
         return task.resource == resource;
       });
       filterSplice(this.requestsChangeSize_, request => {
-        return request.resource == resource
+        return request.resource != resource;
       });
     }
 

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * A bit like Array#filter, but removes elements that filter true from the
+ * A bit like Array#filter, but removes elements that filter false from the
  * array. Returns the filtered items.
  *
  * @param {!Array<T>} array
@@ -27,7 +27,7 @@ export function filterSplice(array, filter) {
   const splice = [];
   for (let i = 0; i < array.length; i++) {
     const item = array[i];
-    if (filter(item, i, array)) {
+    if (!filter(item, i, array)) {
       splice.push(item);
       array.splice(i, 1);
       i--;

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A bit like Array#filter, but removes elements that filter true from the
+ * array. Returns the filtered items.
+ *
+ * @param {!Array<T>} array
+ * @param {function(T, number, !Array<T>):boolean} filter
+ * @return {!Array<T>}
+ * @template T
+ */
+export function filterSplice(array, filter) {
+  const splice = [];
+  for (let i = 0; i < array.length; i++) {
+    const item = array[i];
+    if (filter(item, i, array)) {
+      splice.push(item);
+      array.splice(i, 1);
+      i--;
+    }
+  }
+  return splice;
+}

--- a/test/functional/utils/test-array.js
+++ b/test/functional/utils/test-array.js
@@ -26,16 +26,22 @@ describe('filterSplice', function() {
 
   it('should splice elements that filter true', () => {
     filterSplice(array, i => i > 2);
-    expect(array).to.deep.equal([1, 2]);
+    expect(array).to.deep.equal([3, 4, 5]);
   });
 
   it('should return filtered elements', () => {
     const filtered = filterSplice(array, i => i > 2);
-    expect(filtered).to.deep.equal([3, 4, 5]);
+    expect(filtered).to.deep.equal([1, 2]);
   });
 
-  it('handle consecutive removals', () => {
+  it('handles no removals', () => {
     const filtered = filterSplice(array, () => true);
+    expect(array).to.deep.equal([1, 2, 3, 4, 5]);
+    expect(filtered).to.deep.equal([]);
+  });
+
+  it('handles consecutive removals', () => {
+    const filtered = filterSplice(array, () => false);
     expect(array).to.deep.equal([]);
     expect(filtered).to.deep.equal([1, 2, 3, 4, 5]);
   });

--- a/test/functional/utils/test-array.js
+++ b/test/functional/utils/test-array.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  filterSplice,
+} from '../../../src/utils/array';
+
+describe('filterSplice', function() {
+  let array;
+  beforeEach(() => {
+    array = [1, 2, 3, 4, 5];
+  });
+
+  it('should splice elements that filter true', () => {
+    filterSplice(array, i => i > 2);
+    expect(array).to.deep.equal([1, 2]);
+  });
+
+  it('should return filtered elements', () => {
+    const filtered = filterSplice(array, i => i > 2);
+    expect(filtered).to.deep.equal([3, 4, 5]);
+  });
+
+  it('handle consecutive removals', () => {
+    const filtered = filterSplice(array, () => true);
+    expect(array).to.deep.equal([]);
+    expect(filtered).to.deep.equal([1, 2, 3, 4, 5]);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/4034.

Never post to an iframe that is no longer active. We had three cases:

1. When the iframe requests a resize, but is removed before the resize completes. In that case, we'd cue up a promise to eventually send a `embed-size-X` message but send it to a non-existent iframe window.
2. When a ad's sub-iframes subscribe to the `embed-state` message, but the sub-iframe (or parent) is later removed.
3. When an ad's or iframe's sub-iframes subscribe to the `intersection` message, but the sub-iframe is removed.