### PR TITLE
Stop adding originValidated attribute to 3p window.context.location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ npm-debug.log
 .tm_properties
 .settings
 build-system/runner/TESTS-TestSuites.xml
-.vscode/
+
 /test/manual/amp-ad.adtech.html

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ npm-debug.log
 .tm_properties
 .settings
 build-system/runner/TESTS-TestSuites.xml
-
+.vscode/
 /test/manual/amp-ad.adtech.html

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -220,8 +220,6 @@ export const waitForRenderStart = [
  */
 export function draw3p(win, data, configCallback) {
   const type = data.type;
-  user().assert(win.context.location.originValidated != null,
-      'Origin should have been validated');
 
   user().assert(isTagNameAllowed(data.type, win.context.tagName),
       'Embed type %s not allowed with tag %s', data.type, win.context.tagName);
@@ -445,8 +443,7 @@ function reportRenderedEntityIdentifier(entityId) {
 /**
  * Throws if the current frame's parent origin is not equal to
  * the claimed origin.
- * For browsers that don't support ancestorOrigins it adds
- * `originValidated = false` to the location object.
+ * Only check for browsers that support ancestorOrigins
  * @param {!Window} window
  * @param {!Location} parentLocation
  * @visibleForTesting
@@ -456,14 +453,11 @@ export function validateParentOrigin(window, parentLocation) {
   // Currently only webkit and blink based browsers support
   // ancestorOrigins. In that case we proceed but mark the origin
   // as non-validated.
-  if (!ancestors || !ancestors.length) {
-    parentLocation.originValidated = false;
-    return;
-  }
-  user().assert(ancestors[0] == parentLocation.origin,
+  if (ancestors && ancestors.length) {
+    user().assert(ancestors[0] == parentLocation.origin,
       'Parent origin mismatch: %s, %s',
       ancestors[0], parentLocation.origin);
-  parentLocation.originValidated = true;
+  }
 }
 
 /**

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -453,11 +453,12 @@ export function validateParentOrigin(window, parentLocation) {
   // Currently only webkit and blink based browsers support
   // ancestorOrigins. In that case we proceed but mark the origin
   // as non-validated.
-  if (ancestors && ancestors.length) {
-    user().assert(ancestors[0] == parentLocation.origin,
+  if (!ancestors || !ancestors.length) {
+    return;
+  }
+  user().assert(ancestors[0] == parentLocation.origin,
       'Parent origin mismatch: %s, %s',
       ancestors[0], parentLocation.origin);
-  }
 }
 
 /**

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -157,11 +157,6 @@ describe('3p-frame', () => {
       expect(win.context.canonicalUrl).to.equal('https://foo.bar/baz');
       expect(win.context.location.href).to.equal(locationHref);
       expect(win.context.location.origin).to.equal('http://localhost:9876');
-      if (location.ancestorOrigins) {
-        expect(win.context.location.originValidated).to.be.true;
-      } else {
-        expect(win.context.location.originValidated).to.be.false;
-      }
       expect(win.context.pageViewId).to.equal(docInfo.pageViewId);
       expect(win.context.referrer).to.equal('http://acme.org/');
       expect(win.context.data.testAttr).to.equal('value');

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -66,12 +66,11 @@ describe('3p integration.js', () => {
     expect(registrations).to.include.key('_ping_');
   });
 
-  it('should validateParentOrigin without ancestorOrigins', () => {
+  it('should not throw validateParentOrigin without ancestorOrigins', () => {
     let parent = {};
     validateParentOrigin({
       location: {},
     }, parent);
-    expect(parent.originValidated).to.be.false;
 
     parent = {};
     validateParentOrigin({
@@ -79,7 +78,6 @@ describe('3p integration.js', () => {
         ancestorOrigins: [],
       },
     }, parent);
-    expect(parent.originValidated).to.be.false;
   });
 
   it('should validateParentOrigin with correct ancestorOrigins', () => {
@@ -91,8 +89,6 @@ describe('3p integration.js', () => {
         ancestorOrigins: ['abc', 'xyz'],
       },
     }, parent);
-
-    expect(parent.originValidated).to.be.true;
   });
 
   it('should throw in validateParentOrigin with incorrect ancestorOrigins',
@@ -200,21 +196,6 @@ describe('3p integration.js', () => {
     expect(called).to.be.false;
     finish();
     expect(called).to.be.true;
-  });
-
-  it('should throw if origin was never validated', () => {
-    const data = {
-      type: 'testAction',
-    };
-    const win = {
-      context: {
-        location: {},
-        data,
-      },
-    };
-    expect(() => {
-      draw3p(win, data);
-    }).to.throw(/Origin should have been validated/);
   });
 
   it('should throw if origin was never validated', () => {


### PR DESCRIPTION
This is to solve #4702. It  remove the  `Location.originValidated` value which is a duplicate of `Location.ancestorOrigins`.  The change help us to prevent changing cached object and solves the modification to freezed object issue. 
Also I think it's a better approach than #4766, as we don't need to clone the Location object.