### PR TITLE
Fix js error that occurs when a extraUrlParams var has array value.

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -404,7 +404,9 @@ export class AmpAnalytics extends AMP.BaseElement {
       Object.assign(params, this.config_['extraUrlParams'],
           trigger['extraUrlParams']);
       for (const k in params) {
-        params[k] = this.expandTemplate_(params[k], trigger, event);
+        if (typeof params[k] == 'string') {
+          params[k] = this.expandTemplate_(params[k], trigger, event);
+        }
       }
       if (request.indexOf('${extraUrlParams}') >= 0) {
         const extraUrlParams = addParamsToUrl('', params).substr(1);

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -714,6 +714,15 @@ describe('amp-analytics', function() {
             '&foofoo=baz&a=b');
       });
     });
+
+    it('work when the value is an array', () => {
+      config.extraUrlParams = {'foo': ['0']};
+      const analytics = getAnalyticsTag(config);
+      return waitForSendRequest(analytics).then(() => {
+        expect(sendRequestSpy.args[0][0]).to.equal(
+            'https://example.com/helloworld?a=b&foo=0');
+      });
+    });
   });
 
   it('fetches and merges remote config', () => {


### PR DESCRIPTION
This regression was introduced in #4576.