### PR TITLE
Better error repoting for loadPromise fail

### DIFF
--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -142,7 +142,11 @@ function getTarget(event) {
 function failedToLoad(event) {
   // Report failed loads as user errors so that they automatically go
   // into the "document error" bucket.
-  throw user().createError('Failed HTTP request for %s.', event.target);
+  let target = event.target;
+  if (target && target.src) {
+    target = target.src;
+  }
+  throw user().createError('Failed to load:', target);
 }
 
 /**

--- a/test/functional/test-event-helper.js
+++ b/test/functional/test-event-helper.js
@@ -207,7 +207,7 @@ describe('EventHelper', () => {
     }).then(() => {
       throw new Error('Should not be reached.');
     }, reason => {
-      expect(reason.message).to.include('Failed HTTP request for');
+      expect(reason.message).to.include('Failed to load');
     });
     errorObservable.fire(getEvent('error', element));
     return promise;


### PR DESCRIPTION
we have lots of `
Error: Failed HTTP request for %s. [object HTMLImageElement]` in the log.

`createError` does not support interpolation so `%s` was useless. Also `[object HTMLImageElement]` is not very helpful.

Changing to use `src` instead of the object when available, now we get:

`Error: Failed to load: https://cdn.ampproject.org/i/example.com/logo.jpg​​​`