### PR TITLE
Added hasLoadedOnce() method on resource.

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -66,7 +66,7 @@ describe('amp-analytics.visibility', () => {
           getLayoutBox: () => {},
           element: {getIntersectionChangeEntry: getIntersectionStub},
           getId: getIdStub,
-          isLayoutPending: () => false});
+          hasLoadedOnce: () => true});
   });
 
   afterEach(() => {

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -322,8 +322,8 @@ export class Visibility {
 
     for (let r = this.resources_.length - 1; r >= 0; r--) {
       const res = this.resources_[r];
-      if (res.isLayoutPending()) {
-        loadedPromises.push(res.loaded());
+      if (!res.hasLoadedOnce()) {
+        loadedPromises.push(res.loadedOnce());
         continue;
       }
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -196,7 +196,7 @@ export class Performance {
     return this.whenReadyToRetrieveResources_().then(() => {
       return Promise.all(this.resources_.getResourcesInViewport().map(r => {
         // We're ok with the layout failing and still reporting.
-        return r.loaded().catch(function() {});
+        return r.loadedOnce().catch(function() {});
       }));
     });
   }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -154,10 +154,15 @@ export class Resource {
     */
     this.pendingChangeSize_ = undefined;
 
+    /** @private {boolean} */
+    this.loadedOnce_ = false;
+
     /** @private @const {!Promise} */
     this.loadPromise_ = new Promise(resolve => {
       /** @const  */
       this.loadPromiseResolve_ = resolve;
+    }).then(() => {
+      this.loadedOnce_ = true;
     });
 
     /** @private {boolean} */
@@ -573,11 +578,20 @@ export class Resource {
 
   /**
    * Returns a promise that is resolved when this resource is laid out
-   * for the first time and the resource was loaded.
+   * for the first time and the resource was loaded. Note that the resource
+   * could be unloaded subsequently. This method returns resolved promise for
+   * sunch unloaded elements.
    * @return {!Promise}
    */
-  loaded() {
+  loadedOnce() {
     return this.loadPromise_;
+  }
+
+  /**
+   * @return {boolean} true if the resource has been loaded at least once.
+   */
+  hasLoadedOnce() {
+    return this.loadedOnce_;
   }
 
   /**

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -437,7 +437,7 @@ describe('Resource', () => {
 
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
-    const loaded = resource.loaded();
+    const loaded = resource.loadedOnce();
     const promise = resource.startLayout(true);
     expect(resource.layoutPromise_).to.not.equal(null);
     expect(resource.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);


### PR DESCRIPTION
Started using the new method instead of isLayoutPending because
layoutPending returns true when an element has unloaded after being
loaded.

Fixes #4792