### PR TITLE
Nested flying carpet hack fix

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -163,7 +163,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
     setupA2AListener(this.win);
 
-    /** @private {string|undefined} */
+    /** @private {?Element|undefined} */
     this.container_ = undefined;
   }
 
@@ -208,7 +208,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (this.container_ === undefined) {
       this.container_ = getAdContainer(this.element);
       if (this.container_) {
-        this.element.setAttribute('amp-container-element', this.container_);
+        this.element.setAttribute('amp-container-element',
+            this.container_.tagName);
       }
     }
     // We remeasured this tag, let's also remeasure the iframe. Should be

--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -52,17 +52,18 @@ export function isAdPositionAllowed(el, win) {
 }
 
 /**
+ * Returns the blessed container element, if the ad is contained by one.
+ * This is called during layout measure.
  * @param {!Element} el
  * @param {!Window} win
- * @return {?string} a string that contains container of the ad.
- * This is called during layout measure.
+ * @return {?Element}
  */
 export function getAdContainer(el) {
-  while (el && el.tagName != 'BODY') {
+  do {
     el = el.parentNode;
     if (POSITION_FIXED_TAG_WHITELIST[el.tagName]) {
-      return el.tagName;
+      return el;
     }
-  }
+  } while (el && el.tagName != 'BODY')
   return null;
 }

--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -18,29 +18,42 @@
  * Tags that are allowed to have fixed positioning
  * @const {!Object<string, boolean>}
  */
-const POSITION_FIXED_TAG_WHITELIST = {
+const CONTAINERS = {
   'AMP-FX-FLYING-CARPET': true,
   'AMP-LIGHTBOX': true,
   'AMP-STICKY-AD': true,
 };
 
 /**
+ * Determines if an element is fixed-positioned.
+ * OK to use, because it's only called from onLayoutMeasure
+ * @param {!Element} el
+ * @param {!Window} win
+ * @return {boolean}
+ */
+function isPositionFixed(el, win) {
+  return win./*OK*/getComputedStyle(el).position == 'fixed';
+}
+
+/**
  * @param {!Element} el
  * @param {!Window} win
  * @return {boolean} whether the element position is allowed. If the element
- * belongs to POSITION_FIXED_TAG_WHITELIST, it is allowed to be position fixed.
+ * belongs to CONTAINERS, it is allowed to be position fixed.
  * If the element has a position fixed ancestor, it is not allowed.
  * This should only be called when a layout on the page was just forced
  * anyway.
  */
 export function isAdPositionAllowed(el, win) {
   let hasFixedAncestor = false;
+  let containers = 0;
   do {
-    if (POSITION_FIXED_TAG_WHITELIST[el.tagName]) {
-      return true;
-    }
-    if (win/*because only called from onLayoutMeasure */
-        ./*OK*/getComputedStyle(el).position == 'fixed') {
+    if (CONTAINERS[el.tagName]) {
+      // The containers must not themselves be contained in a fixed-position
+      // element. Continue the search.
+      containers++;
+      hasFixedAncestor = false;
+    } else if (isPositionFixed(el, win)) {
       // Because certain blessed elements may contain a position fixed
       // container (which contain an ad), we continue to search the
       // ancestry tree.
@@ -48,7 +61,7 @@ export function isAdPositionAllowed(el, win) {
     }
     el = el.parentNode;
   } while (el && el.tagName != 'BODY');
-  return !hasFixedAncestor;
+  return !hasFixedAncestor && containers <= 1;
 }
 
 /**
@@ -61,7 +74,7 @@ export function isAdPositionAllowed(el, win) {
 export function getAdContainer(el) {
   do {
     el = el.parentNode;
-    if (POSITION_FIXED_TAG_WHITELIST[el.tagName]) {
+    if (CONTAINERS[el.tagName]) {
       return el;
     }
   } while (el && el.tagName != 'BODY')

--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -77,6 +77,6 @@ export function getAdContainer(el) {
     if (CONTAINERS[el.tagName]) {
       return el;
     }
-  } while (el && el.tagName != 'BODY')
+  } while (el && el.tagName != 'BODY');
   return null;
 }


### PR DESCRIPTION
There’s a clever hack where you can put a flying-carpet inside a
fixed-position element, make it 100% size, and you have a full-page ad
interstitial. Good thing flying-carpets are experimental.