### PR TITLE
IntersectionObserver: Intersect with Owner element

### DIFF
--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -85,10 +85,7 @@ function getFrameAttributes(parentWindow, element, opt_type) {
     mode: getModeObject(),
     hidden: !viewer.isVisible(),
     amp3pSentinel: generateSentinel(parentWindow),
-    initialIntersection: getIntersectionChangeEntry(
-        Date.now(),
-        viewportFor(parentWindow).getRect(),
-        element.getLayoutBox()),
+    initialIntersection: element.getIntersectionChangeEntry(),
     startTime,
   };
   const adSrc = element.getAttribute('src');

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -21,12 +21,10 @@ import {documentInfoForDoc} from './document-info';
 import {tryParseJson} from './json';
 import {getMode} from './mode';
 import {getModeObject} from './mode-object';
-import {getIntersectionChangeEntry} from './intersection-observer';
 import {preconnectFor} from './preconnect';
 import {dashToCamelCase} from './string';
 import {parseUrl, assertHttpsUrl} from './url';
 import {user} from './log';
-import {viewportFor} from './viewport';
 import {viewerFor} from './viewer';
 import {urls} from './config';
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -874,11 +874,10 @@ function createBaseAmpElementProto(win) {
   */
   ElementProto.getIntersectionChangeEntry = function() {
     const box = this.implementation_.getIntersectionElementLayoutBox();
-    const rootBounds = this.implementation_.getViewport().getRect();
-    return getIntersectionChangeEntry(
-        Date.now(),
-        rootBounds,
-        box);
+    const owner = this.resources_.getResourceForElement(this).getOwner();
+    const viewportBox = this.implementation_.getViewport().getRect();
+    const ownerBox = owner && owner.getLayoutBox();
+    return getIntersectionChangeEntry(box, ownerBox, viewportBox);
   };
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -876,6 +876,7 @@ function createBaseAmpElementProto(win) {
     const box = this.implementation_.getIntersectionElementLayoutBox();
     const owner = this.resources_.getResourceForElement(this).getOwner();
     const viewportBox = this.implementation_.getViewport().getRect();
+    // TODO(jridgewell, #4826): We may need to make this recursive.
     const ownerBox = owner && owner.getLayoutBox();
     return getIntersectionChangeEntry(box, ownerBox, viewportBox);
   };

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -15,7 +15,7 @@
  */
 
 import {dev} from './log';
-import {layoutRectLtwh, rectIntersection, moveLayoutRect} from './layout-rect';
+import {layoutRectLtwh, rectIntersection} from './layout-rect';
 import {SubscriptionApi} from './iframe-helper';
 import {timerFor} from './timer';
 

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Observable} from './observable';
 import {dev} from './log';
 import {layoutRectLtwh, rectIntersection, moveLayoutRect} from './layout-rect';
 import {SubscriptionApi} from './iframe-helper';
@@ -84,15 +83,14 @@ export function getIntersectionChangeEntry(
  * Note: The IntersectionObserver would not send any data over to the iframe if
  * it had not requested the intersection data already via a postMessage.
  */
-export class IntersectionObserver extends Observable {
+export class IntersectionObserver {
   /**
    * @param {!BaseElement} element.
-   * @param {!Element} iframe Iframe element which requested the intersection
-   *    data.
+   * @param {!HTMLIFrameElement} iframe Iframe element which requested the
+   *     intersection data.
    * @param {?boolean} opt_is3p Set to `true` when the iframe is 3'rd party.
    */
   constructor(baseElement, iframe, opt_is3p) {
-    super();
     /** @private @const */
     this.baseElement_ = baseElement;
     /** @private @const {!Timer} */
@@ -123,14 +121,10 @@ export class IntersectionObserver extends Observable {
         // Each time someone subscribes we make sure that they
         // get an update.
         () => this.startSendingIntersectionChanges_());
-
-    this.init_();
   }
 
-  init_() {
-    this.add(() => {
-      this.sendElementIntersection_();
-    });
+  fire() {
+    this.sendElementIntersection_();
   }
 
   /**

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -81,22 +81,20 @@ export function getIntersectionChangeEntry(element, owner, viewport) {
       'Negative dimensions in ad.');
   // Building an IntersectionObserverEntry.
 
-  let boundingClientRect = element;
+  let intersectionRect = element;
   if (owner) {
-    boundingClientRect = rectIntersection(owner, boundingClientRect) ||
+    intersectionRect = rectIntersection(owner, intersectionRect) ||
+        // No intersection.
         layoutRectLtwh(0, 0, 0, 0);
   }
-  boundingClientRect = moveLayoutRect(boundingClientRect, -viewport.left,
-      -viewport.top);
-
-  const intersectionRect = rectIntersection(viewport, boundingClientRect) ||
+  intersectionRect = rectIntersection(viewport, intersectionRect) ||
       // No intersection.
       layoutRectLtwh(0, 0, 0, 0);
 
   return {
     time: Date.now(),
     rootBounds: DomRectFromLayoutRect(viewport),
-    boundingClientRect: DomRectFromLayoutRect(boundingClientRect),
+    boundingClientRect: DomRectFromLayoutRect(element),
     intersectionRect: DomRectFromLayoutRect(intersectionRect),
     intersectionRatio: intersectionRatio(intersectionRect, element),
   };

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -98,7 +98,7 @@ export function getIntersectionChangeEntry(element, owner, viewport) {
     rootBounds: DomRectFromLayoutRect(viewport),
     boundingClientRect: DomRectFromLayoutRect(boundingClientRect),
     intersectionRect: DomRectFromLayoutRect(intersectionRect),
-    intersectionRatio: intersectionRatio(boundingClientRect, element),
+    intersectionRatio: intersectionRatio(intersectionRect, element),
   };
 }
 

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -78,7 +78,7 @@ function intersectionRatio(smaller, larger) {
  */
 export function getIntersectionChangeEntry(element, owner, viewport) {
   dev().assert(element.width >= 0 && element.height >= 0,
-      'Negative dimensions in ad.');
+      'Negative dimensions in element.');
   // Building an IntersectionObserverEntry.
 
   let intersectionRect = element;

--- a/src/layout-rect.js
+++ b/src/layout-rect.js
@@ -59,14 +59,7 @@ export function layoutRectLtwh(left, top, width, height) {
  * @return {!LayoutRectDef}
  */
 export function layoutRectFromDomRect(rect) {
-  return {
-    left: rect.left,
-    top: rect.top,
-    width: rect.width,
-    height: rect.height,
-    bottom: rect.top + rect.height,
-    right: rect.left + rect.width,
-  };
+  return layoutRectLtwh(rect.left, rect.top, rect.width, rect.height);
 }
 
 

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -107,29 +107,29 @@ describe('3p-frame', () => {
     div.getIntersectionChangeEntry = function() {
       return {
         time: 1234567888,
-        rootBounds:{
-          left:0,
-          top:0,
-          width:width,
-          height:height,
-          bottom:height,
-          right:width,
-          x:0,
-          y:0,
+        rootBounds: {
+          left: 0,
+          top: 0,
+          width,
+          height,
+          bottom: height,
+          right: width,
+          x: 0,
+          y: 0,
         },
-        boundingClientRect:{
-          width:100,
-          height:200,
+        boundingClientRect: {
+          width: 100,
+          height: 200,
         },
-        intersectionRect:{
-          left:0,
-          top:0,
-          width:0,
-          height:0,
-          bottom:0,
-          right:0,
-          x:0,
-          y:0,
+        intersectionRect: {
+          left: 0,
+          top: 0,
+          width: 0,
+          height: 0,
+          bottom: 0,
+          right: 0,
+          x: 0,
+          y: 0,
         },
       };
     };
@@ -303,14 +303,14 @@ describe('3p-frame', () => {
     div.setAttribute('type', '_ping_');
     div.getIntersectionChangeEntry = function() {
       return {
-        left:0,
-        top:0,
-        width:0,
-        height:0,
-        bottom:0,
-        right:0,
-        x:0,
-        y:0,
+        left: 0,
+        top: 0,
+        width: 0,
+        height: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
       };
     };
 

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -102,10 +102,35 @@ describe('3p-frame', () => {
     div.setAttribute('height', '100');
     div.setAttribute('ampcid', 'cidValue');
 
-    div.getLayoutBox = function() {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    div.getIntersectionChangeEntry = function() {
       return {
-        width: 100,
-        height: 200,
+        time: 1234567888,
+        rootBounds:{
+          left:0,
+          top:0,
+          width:width,
+          height:height,
+          bottom:height,
+          right:width,
+          x:0,
+          y:0,
+        },
+        boundingClientRect:{
+          width:100,
+          height:200,
+        },
+        intersectionRect:{
+          left:0,
+          top:0,
+          width:0,
+          height:0,
+          bottom:0,
+          right:0,
+          x:0,
+          y:0,
+        },
       };
     };
 
@@ -121,8 +146,6 @@ describe('3p-frame', () => {
     expect(locationHref).to.not.be.empty;
     const docInfo = documentInfoForDoc(window.document);
     expect(docInfo.pageViewId).to.not.be.empty;
-    const width = window.innerWidth;
-    const height = window.innerHeight;
     const amp3pSentinel = iframe.getAttribute('data-amp-3p-sentinel');
     const fragment =
         '{"testAttr":"value","ping":"pong","width":50,"height":100,' +
@@ -278,10 +301,16 @@ describe('3p-frame', () => {
 
     const div = document.createElement('div');
     div.setAttribute('type', '_ping_');
-    div.getLayoutBox = function() {
+    div.getIntersectionChangeEntry = function() {
       return {
-        width: 100,
-        height: 200,
+        left:0,
+        top:0,
+        width:0,
+        height:0,
+        bottom:0,
+        right:0,
+        x:0,
+        y:0,
       };
     };
 

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -269,6 +269,7 @@ describe('CustomElement', () => {
 
   it('Element - getIntersectionChangeEntry', () => {
     const element = new ElementClass();
+    element.attachedCallback();
     element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
     element.getIntersectionChangeEntry();
     expect(testElementGetInsersectionElementLayoutBox.callCount).to.equal(1);

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -24,7 +24,7 @@ import {layoutRectLtwh} from '../../src/layout-rect';
 import * as sinon from 'sinon';
 
 
-describe('getIntersectionChangeEntry', () => {
+describe.only('getIntersectionChangeEntry', () => {
   let sandbox;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -76,6 +76,47 @@ describe('getIntersectionChangeEntry', () => {
     expect(change.intersectionRatio).to.be.closeTo(0.1666666, .0001);
   });
 
+  it('intersects on the edge', () => {
+    const rootBounds = layoutRectLtwh(0, 100, 100, 100);
+    const layoutBox = layoutRectLtwh(50, 200, 150, 200);
+    const change = getIntersectionChangeEntry(layoutBox, null, rootBounds);
+
+    expect(change).to.be.object;
+    expect(change.time).to.equal(Date.now());
+
+    expect(change.rootBounds).to.deep.equal({
+      'left': 0,
+      'top': 100,
+      'width': 100,
+      'height': 100,
+      'bottom': 200,
+      'right': 100,
+      'x': 0,
+      'y': 100,
+    });
+    expect(change.boundingClientRect).to.deep.equal({
+      'left': 50,
+      'top': 200,
+      'width': 150,
+      'height': 200,
+      'bottom': 400,
+      'right': 200,
+      'x': 50,
+      'y': 200,
+    });
+    expect(change.intersectionRect).to.deep.equal({
+      'left': 50,
+      'top': 200,
+      'width': 50,
+      'height': 0,
+      'bottom': 200,
+      'right': 100,
+      'x': 50,
+      'y': 200,
+    });
+    expect(change.intersectionRatio).to.equal(0);
+  });
+
   it('intersect correctly 2', () => {
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const layoutBox = layoutRectLtwh(50, 199, 150, 200);
@@ -111,11 +152,12 @@ describe('getIntersectionChangeEntry', () => {
     expect(change.intersectionRect.width).to.equal(0);
   });
 
-  it.only('intersects with an owner element', () => {
+  it('intersects with an owner element', () => {
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const ownerBounds = layoutRectLtwh(40, 110, 20, 20);
     const layoutBox = layoutRectLtwh(50, 50, 150, 200);
-    const change = getIntersectionChangeEntry(layoutBox, ownerBounds, rootBounds);
+    const change = getIntersectionChangeEntry(layoutBox, ownerBounds,
+        rootBounds);
 
     expect(change).to.be.object;
     expect(change.time).to.equal(Date.now());
@@ -151,6 +193,92 @@ describe('getIntersectionChangeEntry', () => {
       'y': 110,
     });
     expect(change.intersectionRatio).to.be.closeTo(0.0066666, .0001);
+  });
+
+  it('does not intersect with an elements out of viewport', () => {
+    const rootBounds = layoutRectLtwh(0, 100, 100, 100);
+    const ownerBounds = layoutRectLtwh(0, 200, 100, 100);
+    const layoutBox = layoutRectLtwh(50, 225, 100, 100);
+    const change = getIntersectionChangeEntry(layoutBox, ownerBounds,
+        rootBounds);
+
+    expect(change).to.be.object;
+    expect(change.time).to.equal(Date.now());
+
+    expect(change.rootBounds).to.deep.equal({
+      'left': 0,
+      'top': 100,
+      'width': 100,
+      'height': 100,
+      'bottom': 200,
+      'right': 100,
+      'x': 0,
+      'y': 100,
+    });
+    expect(change.boundingClientRect).to.deep.equal({
+      'left': 50,
+      'top': 225,
+      'width': 100,
+      'height': 100,
+      'bottom': 325,
+      'right': 150,
+      'x': 50,
+      'y': 225,
+    });
+    expect(change.intersectionRect).to.deep.equal({
+      'left': 0,
+      'top': 0,
+      'width': 0,
+      'height': 0,
+      'bottom': 0,
+      'right': 0,
+      'x': 0,
+      'y': 0,
+    });
+    expect(change.intersectionRatio).to.equal(0);
+  });
+
+  it('does not intersect with an element out of viewport', () => {
+    const rootBounds = layoutRectLtwh(0, 100, 100, 100);
+    const ownerBounds = layoutRectLtwh(0, 100, 100, 100);
+    const layoutBox = layoutRectLtwh(50, 225, 100, 100);
+    const change = getIntersectionChangeEntry(layoutBox, ownerBounds,
+        rootBounds);
+
+    expect(change).to.be.object;
+    expect(change.time).to.equal(Date.now());
+
+    expect(change.rootBounds).to.deep.equal({
+      'left': 0,
+      'top': 100,
+      'width': 100,
+      'height': 100,
+      'bottom': 200,
+      'right': 100,
+      'x': 0,
+      'y': 100,
+    });
+    expect(change.boundingClientRect).to.deep.equal({
+      'left': 50,
+      'top': 225,
+      'width': 100,
+      'height': 100,
+      'bottom': 325,
+      'right': 150,
+      'x': 50,
+      'y': 225,
+    });
+    expect(change.intersectionRect).to.deep.equal({
+      'left': 0,
+      'top': 0,
+      'width': 0,
+      'height': 0,
+      'bottom': 0,
+      'right': 0,
+      'x': 0,
+      'y': 0,
+    });
+    expect(change.intersectionRatio).to.equal(0);
   });
 });
 

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -44,21 +44,27 @@ describe('getIntersectionChangeEntry', () => {
     expect(change).to.be.object;
     expect(change.time).to.equal(Date.now());
 
-    expect(change.rootBounds).to.equal(rootBounds);
-    expect(change.rootBounds.x).to.equal(0);
-    expect(change.rootBounds.y).to.equal(100);
-    expect(change.boundingClientRect).to.jsonEqual({
+    expect(change.rootBounds).to.deep.equal({
+      'left': 0,
+      'top': 100,
+      'width': 100,
+      'height': 100,
+      'bottom': 200,
+      'right': 100,
+      'x': 0,
+      'y': 100,
+    });
+    expect(change.boundingClientRect).to.deep.equal({
       'left': 50,
-      'top': -50,
+      'top': 50,
       'width': 150,
       'height': 200,
-      'bottom': 150,
+      'bottom': 250,
       'right': 200,
       'x': 50,
-      'y': -50,
+      'y': 50,
     });
-    expect(change.intersectionRect.height).to.equal(100);
-    expect(change.intersectionRect).to.jsonEqual({
+    expect(change.intersectionRect).to.deep.equal({
       'left': 50,
       'top': 100,
       'width': 50,
@@ -68,6 +74,7 @@ describe('getIntersectionChangeEntry', () => {
       'x': 50,
       'y': 100,
     });
+    expect(change.intersectionRatio).to.be.closeTo(0.1666666, .0001);
   });
 
   it('intersect correctly 2', () => {
@@ -75,8 +82,7 @@ describe('getIntersectionChangeEntry', () => {
     const layoutBox = layoutRectLtwh(50, 199, 150, 200);
     const change = getIntersectionChangeEntry(layoutBox, null, rootBounds);
 
-    expect(change.intersectionRect.height).to.equal(1);
-    expect(change.intersectionRect).to.jsonEqual({
+    expect(change.intersectionRect).to.deep.equal({
       'left': 50,
       'top': 199,
       'width': 50,

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -25,6 +25,16 @@ import * as sinon from 'sinon';
 
 
 describe('getIntersectionChangeEntry', () => {
+  let sandbox;
+  let clock;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   it('intersect correctly base', () => {
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
@@ -32,7 +42,7 @@ describe('getIntersectionChangeEntry', () => {
     const change = getIntersectionChangeEntry(layoutBox, rootBounds);
 
     expect(change).to.be.object;
-    expect(change.time).to.equal(123);
+    expect(change.time).to.equal(Date.now());
 
     expect(change.rootBounds).to.equal(rootBounds);
     expect(change.rootBounds.x).to.equal(0);
@@ -64,7 +74,6 @@ describe('getIntersectionChangeEntry', () => {
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const layoutBox = layoutRectLtwh(50, 199, 150, 200);
     const change = getIntersectionChangeEntry(layoutBox, rootBounds);
-    expect(change.time).to.equal(111);
 
     expect(change.intersectionRect.height).to.equal(1);
     expect(change.intersectionRect).to.jsonEqual({

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -26,10 +26,9 @@ import * as sinon from 'sinon';
 
 describe('getIntersectionChangeEntry', () => {
   let sandbox;
-  let clock;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    clock = sandbox.useFakeTimers();
+    sandbox.useFakeTimers();
   });
 
   afterEach(() => {

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -110,6 +110,48 @@ describe('getIntersectionChangeEntry', () => {
     expect(change.intersectionRect.height).to.equal(0);
     expect(change.intersectionRect.width).to.equal(0);
   });
+
+  it.only('intersects with an owner element', () => {
+    const rootBounds = layoutRectLtwh(0, 100, 100, 100);
+    const ownerBounds = layoutRectLtwh(40, 110, 20, 20);
+    const layoutBox = layoutRectLtwh(50, 50, 150, 200);
+    const change = getIntersectionChangeEntry(layoutBox, ownerBounds, rootBounds);
+
+    expect(change).to.be.object;
+    expect(change.time).to.equal(Date.now());
+
+    expect(change.rootBounds).to.deep.equal({
+      'left': 0,
+      'top': 100,
+      'width': 100,
+      'height': 100,
+      'bottom': 200,
+      'right': 100,
+      'x': 0,
+      'y': 100,
+    });
+    expect(change.boundingClientRect).to.deep.equal({
+      'left': 50,
+      'top': 50,
+      'width': 150,
+      'height': 200,
+      'bottom': 250,
+      'right': 200,
+      'x': 50,
+      'y': 50,
+    });
+    expect(change.intersectionRect).to.deep.equal({
+      'left': 50,
+      'top': 110,
+      'width': 10,
+      'height': 20,
+      'bottom': 130,
+      'right': 60,
+      'x': 50,
+      'y': 110,
+    });
+    expect(change.intersectionRatio).to.be.closeTo(0.0066666, .0001);
+  });
 });
 
 

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -24,7 +24,7 @@ import {layoutRectLtwh} from '../../src/layout-rect';
 import * as sinon from 'sinon';
 
 
-describe.only('getIntersectionChangeEntry', () => {
+describe('getIntersectionChangeEntry', () => {
   let sandbox;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -39,7 +39,7 @@ describe('getIntersectionChangeEntry', () => {
   it('intersect correctly base', () => {
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const layoutBox = layoutRectLtwh(50, 50, 150, 200);
-    const change = getIntersectionChangeEntry(layoutBox, rootBounds);
+    const change = getIntersectionChangeEntry(layoutBox, null, rootBounds);
 
     expect(change).to.be.object;
     expect(change.time).to.equal(Date.now());
@@ -73,7 +73,7 @@ describe('getIntersectionChangeEntry', () => {
   it('intersect correctly 2', () => {
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const layoutBox = layoutRectLtwh(50, 199, 150, 200);
-    const change = getIntersectionChangeEntry(layoutBox, rootBounds);
+    const change = getIntersectionChangeEntry(layoutBox, null, rootBounds);
 
     expect(change.intersectionRect.height).to.equal(1);
     expect(change.intersectionRect).to.jsonEqual({
@@ -91,7 +91,7 @@ describe('getIntersectionChangeEntry', () => {
   it('intersect correctly 3', () => {
     const rootBounds = layoutRectLtwh(198, 299, 100, 100);
     const layoutBox = layoutRectLtwh(50, 100, 150, 200);
-    const change = getIntersectionChangeEntry(layoutBox, rootBounds);
+    const change = getIntersectionChangeEntry(layoutBox, null, rootBounds);
 
     expect(change.intersectionRect.height).to.equal(1);
     expect(change.intersectionRect.width).to.equal(2);
@@ -100,7 +100,7 @@ describe('getIntersectionChangeEntry', () => {
   it('intersect correctly 3', () => {
     const rootBounds = layoutRectLtwh(202, 299, 100, 100);
     const layoutBox = layoutRectLtwh(50, 100, 150, 200);
-    const change = getIntersectionChangeEntry(layoutBox, rootBounds);
+    const change = getIntersectionChangeEntry(layoutBox, null, rootBounds);
 
     expect(change.intersectionRect.height).to.equal(0);
     expect(change.intersectionRect.width).to.equal(0);
@@ -216,7 +216,7 @@ describe('IntersectionObserver', () => {
         getIntersectionChangeEntrySpy();
         const rootBounds = layoutRectLtwh(198, 299, 100, 100);
         const layoutBox = layoutRectLtwh(50, 100, 150, 200);
-        return getIntersectionChangeEntry(layoutBox, rootBounds);
+        return getIntersectionChangeEntry(layoutBox, null, rootBounds);
       },
     };
     element.isInViewport = () => false;

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -30,7 +30,7 @@ describe('getIntersectionChangeEntry', () => {
     const time = 123;
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const layoutBox = layoutRectLtwh(50, 50, 150, 200);
-    const change = getIntersectionChangeEntry(time, rootBounds, layoutBox);
+    const change = getIntersectionChangeEntry(layoutBox, rootBounds);
 
     expect(change).to.be.object;
     expect(change.time).to.equal(123);
@@ -65,7 +65,7 @@ describe('getIntersectionChangeEntry', () => {
     const time = 111;
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const layoutBox = layoutRectLtwh(50, 199, 150, 200);
-    const change = getIntersectionChangeEntry(time, rootBounds, layoutBox);
+    const change = getIntersectionChangeEntry(layoutBox, rootBounds);
     expect(change.time).to.equal(111);
 
     expect(change.intersectionRect.height).to.equal(1);
@@ -84,7 +84,7 @@ describe('getIntersectionChangeEntry', () => {
   it('intersect correctly 3', () => {
     const rootBounds = layoutRectLtwh(198, 299, 100, 100);
     const layoutBox = layoutRectLtwh(50, 100, 150, 200);
-    const change = getIntersectionChangeEntry(111, rootBounds, layoutBox);
+    const change = getIntersectionChangeEntry(layoutBox, rootBounds);
 
     expect(change.intersectionRect.height).to.equal(1);
     expect(change.intersectionRect.width).to.equal(2);
@@ -93,7 +93,7 @@ describe('getIntersectionChangeEntry', () => {
   it('intersect correctly 3', () => {
     const rootBounds = layoutRectLtwh(202, 299, 100, 100);
     const layoutBox = layoutRectLtwh(50, 100, 150, 200);
-    const change = getIntersectionChangeEntry(111, rootBounds, layoutBox);
+    const change = getIntersectionChangeEntry(layoutBox, rootBounds);
 
     expect(change.intersectionRect.height).to.equal(0);
     expect(change.intersectionRect.width).to.equal(0);
@@ -209,8 +209,7 @@ describe('IntersectionObserver', () => {
         getIntersectionChangeEntrySpy();
         const rootBounds = layoutRectLtwh(198, 299, 100, 100);
         const layoutBox = layoutRectLtwh(50, 100, 150, 200);
-        return getIntersectionChangeEntry(Date.now(),
-            rootBounds, layoutBox);
+        return getIntersectionChangeEntry(layoutBox, rootBounds);
       },
     };
     element.isInViewport = () => false;

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -27,7 +27,6 @@ import * as sinon from 'sinon';
 describe('getIntersectionChangeEntry', () => {
 
   it('intersect correctly base', () => {
-    const time = 123;
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const layoutBox = layoutRectLtwh(50, 50, 150, 200);
     const change = getIntersectionChangeEntry(layoutBox, rootBounds);
@@ -62,7 +61,6 @@ describe('getIntersectionChangeEntry', () => {
   });
 
   it('intersect correctly 2', () => {
-    const time = 111;
     const rootBounds = layoutRectLtwh(0, 100, 100, 100);
     const layoutBox = layoutRectLtwh(50, 199, 150, 200);
     const change = getIntersectionChangeEntry(layoutBox, rootBounds);


### PR DESCRIPTION
When an element has an Owner, give the intersection accounting for the owner and viewport. Essentially, every Owner element defines it's own coordinate system so this just calculates the intersection based on that.

Fixes https://github.com/ampproject/amphtml/issues/4048.