### PR TITLE
Apply a default object-fit:contain for replaced content in carousel and expose a new amp-carousel-slide class

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -20,7 +20,7 @@ amp-carousel {
 /**
  * `amp-carousel-slide` class is added to every item in the carousel to
  * allow page authors to target items for user-defined styling.
- * Every `<amp-carousel>'s` immediate children is considered an item in
+ * Every `<amp-carousel>'s` immediate child is considered a slide in
  * the carousel.
  */
 amp-carousel-slide {

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -17,6 +17,21 @@
 amp-carousel {
 }
 
+/**
+ * `amp-carousel-slide` class is added to every item in the carousel to
+ * allow page authors to target items for user-defined styling.
+ * Every component’s immediate children is considered an item in the carousel.
+ */
+amp-carousel-slide {
+}
+
+.amp-carousel-slide .-amp-replaced-content {
+  /*
+   * Apply contain object-fit to all replaced content to avoid distorted ratios.
+   */
+  object-fit: contain;
+}
+
 .amp-carousel-button {
   position: absolute;
   box-sizing: border-box;

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -26,7 +26,7 @@ amp-carousel {
 amp-carousel-slide {
 }
 
-.amp-carousel-slide .-amp-replaced-content {
+.amp-carousel-slide > .-amp-replaced-content {
   /*
    * Apply contain object-fit to all replaced content to avoid distorted ratios.
    */

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -20,7 +20,8 @@ amp-carousel {
 /**
  * `amp-carousel-slide` class is added to every item in the carousel to
  * allow page authors to target items for user-defined styling.
- * Every component’s immediate children is considered an item in the carousel.
+ * Every `<amp-carousel>'s` immediate children is considered an item in
+ * the carousel.
  */
 amp-carousel-slide {
 }

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -54,6 +54,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
     this.cells_.forEach(cell => {
       this.setAsOwner(cell);
+      cell.classList.add('amp-carousel-slide');
       cell.style.display = 'inline-block';
       if (cell != this.cells_[0]) {
         // TODO(dvoytenko): this has to be customizable

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -79,6 +79,7 @@ export class AmpSlideScroll extends BaseSlides {
     this.slides_.forEach(slide => {
       this.setAsOwner(slide);
       const slideWrapper = this.win_.document.createElement('div');
+      slide.classList.add('amp-carousel-slide');
       slideWrapper.appendChild(slide);
       slideWrapper.classList.add('-amp-slide-item');
       this.slidesContainer_.appendChild(slideWrapper);

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -66,7 +66,7 @@ describe('SlideScroll', () => {
     });
   }
 
-  it('should create container and wrappers and show intial slides', () => {
+  it('should create container and wrappers and show initial slides', () => {
     return getAmpSlideScroll().then(obj => {
       const ampSlideScroll = obj.ampSlideScroll;
       expect(
@@ -75,6 +75,9 @@ describe('SlideScroll', () => {
       expect(
           ampSlideScroll.querySelectorAll(
             '.-amp-slides-container > .-amp-slide-item').length).to.equal(5);
+      expect(
+          ampSlideScroll.getElementsByClassName('amp-carousel-slide').length)
+              .to.equal(5);
       const impl = ampSlideScroll.implementation_;
       expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS))
           .to.be.true;

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -90,6 +90,7 @@ The value of `delay` must be a number of milliseconds, e.g. `delay=5000`.
 
 ## Styling
 - You may use the `amp-carousel` element selector to style it freely.
+- You may use the `.amp-carousel-slide` class selector to target carousel items.
 - `.amp-carousel-button` by default uses an inlined SVG as the background-image of the buttons.
 You may override this with your own SVG or image like so:
 


### PR DESCRIPTION
Applying `object-fit: contain` for replaced content inside carousel is the default behaviour of WP plugin and also makes sense in general to avoid distorted ratios. 

Fixes #4811

This PR:
- Adds a new public  `amp-carousel-slide` class to every carousel item so authors can target items using it rather than doing direct child selectors on `amp-carousel` which is easy to break when we shuffle the DOM structure. 
- Changes the default behavius of replaced content inside carousel to be `object-fit: contain;`

/cc @sriramkrish85 @zhouyx @ericlindley-g 