### PR TITLE
Match resizing behavior of iframe inside amp-ad and amp-iframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 build-system/runner/TESTS-TestSuites.xml
 .vscode/
 /test/manual/amp-ad.adtech.html
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,5 @@ npm-debug.log
 .tm_properties
 .settings
 build-system/runner/TESTS-TestSuites.xml
-.vscode/
+
 /test/manual/amp-ad.adtech.html
-.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ npm-debug.log
 .tm_properties
 .settings
 build-system/runner/TESTS-TestSuites.xml
-
+.vscode/
 /test/manual/amp-ad.adtech.html

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -95,20 +95,7 @@ export class AmpAdApiHandler {
     // Install iframe resize API.
     this.unlisteners_.push(listenFor(this.iframe_, 'embed-size',
         (data, source, origin) => {
-          let newHeight, newWidth;
-          if (data.width !== undefined) {
-            newWidth = Math.max(this.element_./*OK*/offsetWidth +
-                data.width - this.iframe_./*OK*/offsetWidth, data.width);
-            this.iframe_.width = newWidth;
-          }
-          if (data.height !== undefined) {
-            newHeight = Math.max(this.element_./*OK*/offsetHeight +
-                data.height - this.iframe_./*OK*/offsetHeight, data.height);
-            this.iframe_.height = newHeight;
-          }
-          if (newHeight !== undefined || newWidth !== undefined) {
-            this.updateSize_(newHeight, newWidth, source, origin);
-          }
+          this.updateSize_(data.height, data.width, source, origin);
         }, this.is3p_, this.is3p_));
 
     // Install API that listen to ad response
@@ -192,11 +179,23 @@ export class AmpAdApiHandler {
    * @private
    */
   updateSize_(height, width, source, origin) {
-    this.baseInstance_.attemptChangeSize(height, width).then(() => {
-      this.sendEmbedSizeResponse_(
-        true /* success */, width, height, source, origin);
-    }, () => this.sendEmbedSizeResponse_(
-        false /* success */, width, height, source, origin));
+    let newHeight, newWidth;
+    if (height !== undefined) {
+      newHeight = Math.max(this.element_./*OK*/offsetHeight +
+          height - this.iframe_./*OK*/offsetHeight, height);
+    }
+    if (width !== undefined) {
+      newWidth = Math.max(this.element_./*OK*/offsetWidth +
+          width - this.iframe_./*OK*/offsetWidth, width);
+    }
+
+    if (newHeight !== undefined || newWidth !== undefined) {
+      this.baseInstance_.attemptChangeSize(newHeight, newWidth).then(() => {
+        this.sendEmbedSizeResponse_(
+          true /* success */, newWidth, newHeight, source, origin);
+      }, () => this.sendEmbedSizeResponse_(
+          false /* success */, newWidth, newHeight, source, origin));
+    }
   }
 
   /**

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -179,10 +179,8 @@ export class AmpAdApiHandler {
    * @private
    */
   updateSize_(height, width, source, origin) {
-    // Calculate new width and new height based on the requested size.
-    // This is to get correct size if padding exists.
-    // If padding > 0,  new size will be requested size plus padding.
-    // If padding <= 0, new size will be requested size.
+    // Calculate new width and height of the container to include the padding.
+    // If padding is negative, just use the requested width and height directly.
     let newHeight, newWidth;
     if (height !== undefined) {
       newHeight = Math.max(this.element_./*OK*/offsetHeight +

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -179,6 +179,10 @@ export class AmpAdApiHandler {
    * @private
    */
   updateSize_(height, width, source, origin) {
+    // Calculate new width and new height based on the requested size.
+    // This is to get correct size if padding exists.
+    // If padding > 0,  new size will be requested size plus padding.
+    // If padding <= 0, new size will be requested size.
     let newHeight, newWidth;
     if (height !== undefined) {
       newHeight = Math.max(this.element_./*OK*/offsetHeight +

--- a/extensions/amp-ad/0.1/test/test-amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-api-handler.js
@@ -191,10 +191,7 @@ describe('amp-ad-api-handler', () => {
         requestedHeight: 217,
         type: 'embed-size-denied',
         sentinel: 'amp3ptest' + testIndex,
-      })).then(() => {
-        expect(iframe.height).to.equal('217');
-        expect(iframe.width).to.equal('114');
-      });
+      }));
     });
 
     it('should be able to use embed-size API, change size succeed', () => {
@@ -212,15 +209,10 @@ describe('amp-ad-api-handler', () => {
         requestedHeight: 217,
         type: 'embed-size-changed',
         sentinel: 'amp3ptest' + testIndex,
-      })).then(() => {
-        expect(iframe.height).to.equal('217');
-        expect(iframe.width).to.equal('114');
-      });
+      }));
     });
 
     it('should be able to use embed-size API to resize height only', () => {
-      iframe.height = 11;
-      iframe.width = 22;
       sandbox.stub(adImpl, 'attemptChangeSize', () => {
         return Promise.resolve();
       });
@@ -234,10 +226,7 @@ describe('amp-ad-api-handler', () => {
         requestedHeight: 217,
         type: 'embed-size-changed',
         sentinel: 'amp3ptest' + testIndex,
-      })).then(() => {
-        expect(iframe.height).to.equal('217');
-        expect(iframe.width).to.equal('22');
-      });
+      }));
     });
   });
 });

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -409,6 +409,10 @@ export class AmpIframe extends AMP.BaseElement {
       return;
     }
 
+    // Calculate new width and new height based on the requested size.
+    // This is to get correct size if padding exists.
+    // If padding > 0,  new size will be requested size plus padding.
+    // If padding <= 0, new size will be requested size.
     let newHeight, newWidth;
     if (height !== undefined) {
       newHeight = Math.max(

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -409,10 +409,8 @@ export class AmpIframe extends AMP.BaseElement {
       return;
     }
 
-    // Calculate new width and new height based on the requested size.
-    // This is to get correct size if padding exists.
-    // If padding > 0,  new size will be requested size plus padding.
-    // If padding <= 0, new size will be requested size.
+    // Calculate new width and height of the container to include the padding.
+    // If padding is negative, just use the requested width and height directly.
     let newHeight, newWidth;
     if (height !== undefined) {
       newHeight = Math.max(


### PR DESCRIPTION
The iframe inside `amp-ad` and iframe inside `amp-iframe` should behave the same during resizing. In `amp-iframe` we only try to change size for parent container (`amp-iframe` itself), and child iframe will always fill the size of its parent. 
With this PR, I try to do the same thing for `amp-ad` and its child iframe. 

checked we never set `iframe_.widht/iframe_.height` elsewhere, also tested ads pages manually.