### PR TITLE
Introduce timeouts for CID retrieval.

### DIFF
--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -19,6 +19,7 @@ import {dev} from '../../src/log';
 import {platformFor} from '../../src/platform';
 import {installPerformanceService} from '../../src/service/performance-impl';
 import {resetServiceForTesting} from '../../src/service';
+import {timerFor} from '../../src/timer';
 import * as sinon from 'sinon';
 
 
@@ -517,8 +518,10 @@ describe('Viewer', () => {
     });
     let trustedViewer;
     let persistedCidData;
+    let shouldTimeout;
 
     beforeEach(() => {
+      shouldTimeout = false;
       clock.tick(100);
       trustedViewer = true;
       persistedCidData = cidData;
@@ -528,6 +531,9 @@ describe('Viewer', () => {
         if (message != 'cid') {
           return Promise.reject();
         }
+        if (shouldTimeout) {
+          return timerFor(window).promise(15000);
+        }
         if (payload) {
           persistedCidData = payload;
         }
@@ -536,22 +542,43 @@ describe('Viewer', () => {
     });
 
     it('should return CID', () => {
-      expect(viewer.baseCid()).to.eventually.equal(cidData);
+      const p = expect(viewer.baseCid()).to.eventually.equal(cidData);
+      p.then(() => {
+        // This should not trigger a timeout.
+        clock.tick(100000);
+      });
+      return p;
     });
 
     it('should not request cid for untrusted viewer', () => {
       trustedViewer = false;
-      expect(viewer.baseCid()).to.eventually.be.undefined;
+      return expect(viewer.baseCid()).to.eventually.be.undefined;
     });
 
     it('should convert CID returned by legacy API to new format', () => {
       persistedCidData = 'cid-123';
-      expect(viewer.baseCid()).to.eventually.equal(cidData);
+      return expect(viewer.baseCid()).to.eventually.equal(cidData);
     });
 
     it('should send message to store cid', () => {
       const newCidData = JSON.stringify({time: 101, cid: 'cid-456'});
-      expect(viewer.baseCid(newCidData)).to.eventually.equal(newCidData);
+      return expect(viewer.baseCid(newCidData))
+          .to.eventually.equal(newCidData);
+    });
+
+    it('should time out', () => {
+      shouldTimeout = true;
+      const p = expect(viewer.baseCid()).to.eventually.be.undefined;
+      Promise.resolve().then(() => {
+        clock.tick(9999);
+        Promise.resolve().then(() => {
+          clock.tick(1);
+        });
+      });
+      return p.then(() => {
+        // Ticked 100 at start.
+        expect(Date.now()).to.equal(10100);
+      });
     });
   });
 


### PR DESCRIPTION
- Wait a maximum of 10 seconds for a "trusted viewer" to supply a CID. Given the nature of CID it seems better to proceed with a local value if it takes very long. We need to monitor whether this gets hit a lot in practice. We currently wait 20 seconds to establish the connection alone.
- Wait a maximum of 1 seconds for getting a CID for use in ads. Ads typically do not rely on them and it seems better to just run without one instead of waiting a sustained amount of time.

Fixes #4836