### PR TITLE
Support for expansion of variables with params in parts of amp-analytics.

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -17,7 +17,7 @@
 import {ANALYTICS_CONFIG} from './vendors';
 import {addListener, instrumentationServiceFor} from './instrumentation';
 import {isJsonScriptTag} from '../../../src/dom';
-import {assertHttpsUrl, appendParamStringToUrl} from '../../../src/url';
+import {assertHttpsUrl, appendEncodedParamStringToUrl} from '../../../src/url';
 import {dev, user} from '../../../src/log';
 import {expandTemplate} from '../../../src/string';
 import {installCidService} from './cid-impl';
@@ -557,7 +557,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     if (request.indexOf('${extraUrlParams}') >= 0) {
       return request.replace('${extraUrlParams}', paramString);
     } else {
-      return appendParamStringToUrl(request, paramString);
+      return appendEncodedParamStringToUrl(request, paramString);
     }
   }
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -515,7 +515,7 @@ export class AmpAnalytics extends AMP.BaseElement {
   }
 
   /**
-   * @param {string} raw The values to URI encode.
+   * @param {string|!Array<string>} raw The values to URI encode.
    * @param {string} unusedName Name of the variable.
    * @return {string} The encoded value.
    * @private
@@ -548,7 +548,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       if (v == null) {
         continue;
       } else {
-        const sv = /** @type {string} */ (this.encodeVars_(v));
+        const sv = this.encodeVars_(v, k);
         s.push(`${encodeURIComponent(k)}=${sv}`);
       }
     }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -499,14 +499,18 @@ export class AmpAnalytics extends AMP.BaseElement {
    * Returns an array containing two values: name and args parsed from the key.
    *
    * @param {string} key The key to be parsed.
-   * @return {Object<string>}
+   * @return {!Object<string>}
    * @private
    */
   getNameArgs_(key) {
     if (!key) {
-      return ['', ''];
+      return {name: '', argList: ''};
     }
     const match = key.match(/([^(]*)(\([^)]*\))?/);
+    if (!match) {
+      user().error(this.getName_(),
+          'Variable with invalid format found: ' + key);
+    }
     return {name: match[1], argList: match[2] || ''};
   }
 
@@ -544,7 +548,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       if (v == null) {
         continue;
       } else {
-        const sv = /** @type {string} */ this.encodeVars_(v);
+        const sv = /** @type {string} */ (this.encodeVars_(v));
         s.push(`${encodeURIComponent(k)}=${sv}`);
       }
     }

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -892,20 +892,29 @@ describe('amp-analytics', function() {
   describe('expandTemplate_', () => {
     const vars = {
       'vars': {'1': '1${2}', '2': '2${3}', '3': '3${4}', '4': '4${1}'}};
+    let analytics;
+
+    beforeEach(() => {
+      analytics = getAnalyticsTag(trivialConfig);
+    });
 
     it('expands nested vars', () => {
-      const analytics = getAnalyticsTag(trivialConfig);
       const actual = analytics.expandTemplate_('${1}', vars);
       expect(actual).to.equal('123%252524%25257B4%25257D');
     });
 
     it('limits the recursion to n', () => {
-      const analytics = getAnalyticsTag(trivialConfig);
       let actual = analytics.expandTemplate_('${1}', vars, {}, 3);
       expect(actual).to.equal('1234%25252524%2525257B1%2525257D');
 
       actual = analytics.expandTemplate_('${1}', vars, {}, 5);
       expect(actual).to.equal('123412%252525252524%25252525257B3%25252525257D');
+    });
+
+    it('works with params', () => {
+      const vars = {'vars': {'fooParam': 'QUERY_PARAM(foo,bar)'}};
+      const actual = analytics.expandTemplate_('${fooParam}', vars);
+      expect(actual).to.equal('QUERY_PARAM(foo,bar)');
     });
   });
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -557,8 +557,8 @@ describe('amp-analytics', function() {
 
   it('expands url-replacements vars', () => {
     const analytics = getAnalyticsTag({
-      'requests': {'pageview':
-        'https://example.com/test1=${var1}&test2=${var2}&title=TITLE'},
+      'requests': {
+        'pageview': 'https://example.com/test1=${var1}&test2=${var2}&title=TITLE'},
       'triggers': [{
         'on': 'visible',
         'request': 'pageview',
@@ -573,6 +573,31 @@ describe('amp-analytics', function() {
           'https://example.com/test1=x&' +
           'test2=http%3A%2F%2Flocalhost%3A9876%2Fcontext.html' +
           '&title=Test%20Title');
+    });
+  });
+
+  it('expands complex vars', () => {
+    const analytics = getAnalyticsTag({
+      'requests': {
+        'pageview': 'https://example.com/test1=${qp_foo}'},
+      'triggers': [{
+        'on': 'visible',
+        'request': 'pageview',
+        'vars': {
+          'qp_foo': '${queryParam(foo)}',
+        },
+      }]});
+    const urlReplacements = urlReplacementsForDoc(analytics.win.document);
+    sandbox.stub(urlReplacements, 'getReplacement_', function(name) {
+      return {sync: param => {
+        return '_' + name.toLowerCase() + '_' + param + '_';
+      }};
+    });
+
+    return waitForSendRequest(analytics).then(() => {
+      expect(sendRequestSpy.calledOnce).to.be.true;
+      expect(sendRequestSpy.args[0][0]).to.equal(
+          'https://example.com/test1=_query_param_foo_');
     });
   });
 
@@ -911,9 +936,15 @@ describe('amp-analytics', function() {
       expect(actual).to.equal('123412%252525252524%25252525257B3%25252525257D');
     });
 
-    it('works with params', () => {
+    it('works with complex params (1)', () => {
       const vars = {'vars': {'fooParam': 'QUERY_PARAM(foo,bar)'}};
       const actual = analytics.expandTemplate_('${fooParam}', vars);
+      expect(actual).to.equal('QUERY_PARAM(foo,bar)');
+    });
+
+    it('works with complex params (2)', () => {
+      const vars = {'vars': {'fooParam': 'QUERY_PARAM'}};
+      const actual = analytics.expandTemplate_('${fooParam(foo,bar)}', vars);
       expect(actual).to.equal('QUERY_PARAM(foo,bar)');
     });
   });

--- a/src/url.js
+++ b/src/url.js
@@ -135,7 +135,7 @@ export function parseUrl(url, opt_nocache) {
  * @param {boolean=} opt_addToFront
  * @return {string}
  */
-function appendParamStringToUrl(url, paramString, opt_addToFront) {
+export function appendParamStringToUrl(url, paramString, opt_addToFront) {
   if (!paramString) {
     return url;
   }

--- a/src/url.js
+++ b/src/url.js
@@ -135,7 +135,8 @@ export function parseUrl(url, opt_nocache) {
  * @param {boolean=} opt_addToFront
  * @return {string}
  */
-export function appendParamStringToUrl(url, paramString, opt_addToFront) {
+export function appendEncodedParamStringToUrl(url, paramString,
+  opt_addToFront) {
   if (!paramString) {
     return url;
   }
@@ -162,7 +163,7 @@ export function appendParamStringToUrl(url, paramString, opt_addToFront) {
  */
 export function addParamToUrl(url, key, value, opt_addToFront) {
   const field = `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
-  return appendParamStringToUrl(url, field, opt_addToFront);
+  return appendEncodedParamStringToUrl(url, field, opt_addToFront);
 }
 
 /**
@@ -173,7 +174,7 @@ export function addParamToUrl(url, key, value, opt_addToFront) {
  * @return {string}
  */
 export function addParamsToUrl(url, params) {
-  return appendParamStringToUrl(url, serializeQueryString(params));
+  return appendEncodedParamStringToUrl(url, serializeQueryString(params));
 }
 
 /**


### PR DESCRIPTION
Specifically, the `vars` and extraUrlParams` section encoded the
variables with params before they could be expanded.

Fixes #4825