### PR TITLE
Remove experimental tag for ads data-loading-strategy

### DIFF
--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -148,7 +148,7 @@ Optional attribute to pass configuration to the ad as an arbitrarily complex JSO
 
 Optional attribute. If provided will require confirming the [amp-user-notification](../amp-user-notification/amp-user-notification.md) with the given HTML-id until the "AMP client id" for the user (similar to a cookie) is passed to the ad. The means ad rendering is delayed until the user confirmed the notification.
 
-### Experimental: data-loading-strategy
+### data-loading-strategy
 
 Supported value: `prefer-viewability-over-views`. Instructs AMP to load ads in a way that prefers a high degree of viewability, while sometimes loading too late to generate a view.
 


### PR DESCRIPTION
I think we've been advertising this as experimental for a while. Keep getting partner questions as to why this is experimental. Time to remove? @lannka 