### PR TITLE
force sticky-ad margin-bottom to be 0

### DIFF
--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -23,6 +23,7 @@ amp-sticky-ad {
   z-index: 2;
   /* TODO(zhouyx, #3250): discuss on what the max-height should be? */
   max-height: 100px !important;
+  margin-bottom: 0 !important;
   box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0.5);
 }

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -24,6 +24,10 @@ amp-sticky-ad {
   /* TODO(zhouyx, #3250): discuss on what the max-height should be? */
   max-height: 100px !important;
   margin-bottom: 0 !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
   box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0.5);
 }
@@ -47,6 +51,10 @@ amp-sticky-ad {
 }
 
 .-amp-sticky-ad-layout > amp-ad {
+  margin-bottom: 0 !important;
+  margin-top: 0 !important;
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
   display: block;
 }
 


### PR DESCRIPTION
if user add margin to sticky-ad, it will add gap between sticky-ad and bottom of the page. need to  add `margin-bottom: 0 !important` to force it to be at the bottom of the page?