### PR TITLE
Only run Travis on code changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ addons:
     - protobuf-compiler
     - python-protobuf
 before_install:
+  - |
+      git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(examples|spec))/' || {
+        echo "Only docs were updated, stopping build process."
+        exit
+      }
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
This prevents the Travis run when only markdown files are changed, or
only examples/spec files are changed. Aka, only run Travis on code
changes.

Inspiration https://github.com/facebook/react/pull/2000.