### PR TITLE
<amp-video>: Add playsinline attribute for iOS

### DIFF
--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -45,6 +45,9 @@ export function installVideo(win) {
             'No "poster" attribute has been provided for amp-video.');
       }
 
+      // Enable inline play for iOS.
+      this.video_.setAttribute('playsinline', '');
+      this.video_.setAttribute('webkit-playsinline', '');
       // Disable video preload in prerender mode.
       this.video_.setAttribute('preload', 'none');
       this.propagateAttributes(['poster', 'controls'], this.video_);

--- a/test/functional/test-amp-video.js
+++ b/test/functional/test-amp-video.js
@@ -149,6 +149,8 @@ describe('amp-video', () => {
       const video = element.querySelector('video');
       expect(video.getAttribute('poster')).to.equal('img.png');
       expect(video.getAttribute('controls')).to.exist;
+      expect(video.getAttribute('playsinline')).to.exist;
+      expect(video.getAttribute('webkit-playsinline')).to.exist;
     }).then(v => {
       // Same attributes should still be present in layoutCallback.
       const video = v.querySelector('video');


### PR DESCRIPTION
iOS 10 will support inline play if attribute `playsinline` is present. 

Adding both prefixed and standard `playsinline` attribute to `<amp-video>`.