### PR TITLE
Several improvements to error reporting

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -333,7 +333,6 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
         reportRenderedEntityIdentifier;
     window.context.computeInMasterFrame = computeInMasterFrame;
     delete data._context;
-
     manageWin(window);
     installEmbedStateListener();
     draw3p(window, data, opt_configCallback);
@@ -342,8 +341,9 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
     nonSensitiveDataPostMessage('send-embed-state');
     nonSensitiveDataPostMessage('bootstrap-loaded');
   } catch (e) {
-    if (!window.context.mode.test) {
-      lightweightErrorReport(e);
+    const c = window.context || {mode: {test: false}};
+    if (!c.mode.test) {
+      lightweightErrorReport(e, c.canary);
       throw e;
     }
   }
@@ -580,10 +580,13 @@ export function isTagNameAllowed(type, tagName) {
  * too many deps for this small JS binary.
  *
  * @param {!Error} e
+ * @param {boolean} isCanary
  */
-function lightweightErrorReport(e) {
+function lightweightErrorReport(e, isCanary) {
   new Image().src = urls.errorReporting +
       '?3p=1&v=' + encodeURIComponent('$internalRuntimeVersion$') +
       '&m=' + encodeURIComponent(e.message) +
-      '&r=' + encodeURIComponent(document.referrer);
+      '&ca=' + (isCanary ? 1 : 0) +
+      '&r=' + encodeURIComponent(document.referrer) +
+      '&s=' + encodeURIComponent(e.stack || '');
 }

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -431,7 +431,12 @@ var forbidden3pTerms = {
   // usage in babel's external helpers that is in a code path that we do
   // not use.
   '\\.then\\((?!callNext)': ThreePTermsMessage,
-  'Math\\.sign' : ThreePTermsMessage,
+  'Math\\.sign': ThreePTermsMessage,
+  'Object\\.assign': {
+    message: ThreePTermsMessage,
+    // See https://github.com/ampproject/amphtml/issues/4877
+    whitelist: ['ads/openx.js'],
+  },
 };
 
 var bannedTermsHelpString = 'Please review viewport.js for a helper method ' +

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -81,6 +81,7 @@ function getFrameAttributes(parentWindow, element, opt_type) {
     },
     tagName: element.tagName,
     mode: getModeObject(),
+    canary: !!(parentWindow.AMP_CONFIG && parentWindow.AMP_CONFIG.canary),
     hidden: !viewer.isVisible(),
     amp3pSentinel: generateSentinel(parentWindow),
     initialIntersection: element.getIntersectionChangeEntry(),

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -144,6 +144,9 @@ beforeEach(beforeTest);
 
 function beforeTest() {
   window.AMP_MODE = null;
+  window.AMP_CONFIG = {
+    canary: 'testSentinel',
+  };
   window.AMP_TEST = true;
   window.ampExtendedElements = {};
   const ampdocService = installDocService(window, true);

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -156,6 +156,7 @@ describe('3p-frame', () => {
         '"location":{"href":"' + locationHref + '"},"tagName":"MY-ELEMENT",' +
         '"mode":{"localDev":true,"development":false,"minified":false,' +
         '"test":false,"version":"$internalRuntimeVersion$"}' +
+        ',"canary":true' +
         ',"hidden":false' +
         ',"startTime":1234567888' +
         ',"amp3pSentinel":"' + amp3pSentinel + '"' +

--- a/tools/errortracker/app.yaml
+++ b/tools/errortracker/app.yaml
@@ -1,5 +1,5 @@
 application: amp-error-reporting
-version: 8
+version: 9
 runtime: go
 api_version: go1
 


### PR DESCRIPTION
- thread through canary state into 3p iframe and report it.
- change throttling of error reporting by another factor of 10 for general traffic.

Unrelated: Forbid usage of Object.assign in 3p code as this showed up in error reports.