### PR TITLE
Fix lots of type errors and introduces assertElement.

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -131,3 +131,8 @@ twttr.widgets.createTweet;
 
 var FB;
 FB.init;
+
+// Validator
+var amp;
+amp.validator;
+amp.validator.validateUrlAndLog = function(string, doc, filter) {}

--- a/build-system/runner/src/org/ampproject/AmpCodingConvention.java
+++ b/build-system/runner/src/org/ampproject/AmpCodingConvention.java
@@ -17,6 +17,7 @@
 package org.ampproject;
 
 import com.google.common.collect.ImmutableList;
+import com.google.javascript.jscomp.ClosureCodingConvention.AssertFunctionByTypeName;
 import com.google.javascript.jscomp.CodingConvention;
 import com.google.javascript.jscomp.CodingConvention.AssertionFunctionSpec;
 import com.google.javascript.jscomp.CodingConventions;
@@ -45,9 +46,8 @@ public final class AmpCodingConvention extends CodingConventions.Proxy {
     return ImmutableList.of(
         new AssertionFunctionSpec("user.assert", JSType.TRUTHY),
         new AssertionFunctionSpec("dev.assert", JSType.TRUTHY),
-        new AssertionFunctionSpec("module$src$log.user.assert", JSType.TRUTHY),
-        new AssertionFunctionSpec("module$src$log.dev.assert", JSType.TRUTHY),
-        new AssertionFunctionSpec("Log$$module$src$log.prototype.assert", JSType.TRUTHY)
+        new AssertionFunctionSpec("Log$$module$src$log.prototype.assert", JSType.TRUTHY),
+        new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertElement", "Element")
     );
   }
 

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -101,9 +101,10 @@ export function isLoaded(element) {
  * Returns a promise that will resolve or fail based on the element's 'load'
  * and 'error' events. Optionally this method takes a timeout, which will reject
  * the promise if the resource has not loaded by then.
- * @param {!EventTarget} element
+ * @param {T} element
  * @param {number=} opt_timeout
- * @return {!Promise<!Element>}
+ * @return {!Promise<T>}
+ * @template T
  */
 export function loadPromise(element, opt_timeout) {
   let unlistenLoad;

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -101,7 +101,7 @@ export function isLoaded(element) {
  * Returns a promise that will resolve or fail based on the element's 'load'
  * and 'error' events. Optionally this method takes a timeout, which will reject
  * the promise if the resource has not loaded by then.
- * @param {!Element} element
+ * @param {!EventTarget} element
  * @param {number=} opt_timeout
  * @return {!Promise<!Element>}
  */

--- a/src/json.js
+++ b/src/json.js
@@ -105,7 +105,7 @@ export function getValueForExpr(obj, expr) {
  * Parses the given `json` string without throwing an exception if not valid.
  * Returns `undefined` if parsing fails.
  * Returns the `Object` corresponding to the JSON string when parsing succeeds.
- * @param {string} json JSON string to parse
+ * @param {*} json JSON string to parse
  * @param {function(!Error)=} opt_onFailed Optional function that will be called with
  *     the error if parsing fails.
  * @return {?JSONValueDef|undefined}

--- a/src/log.js
+++ b/src/log.js
@@ -257,16 +257,15 @@ export class Log {
    *
    * @param {*} shouldBeElement
    * @param {string=} opt_message The assertion message
-   * @param {...*} var_args Arguments substituted into %s in the message.
    * @return {!Element} The value of shouldBeTrueish.
    * @template T
    */
   /*eslint "google-camelcase/google-camelcase": 2*/
   assertElement(shouldBeElement, opt_message, var_args) {
     const shouldBeTrueish = shouldBeElement && shouldBeElement.nodeType == 1;
-    return /** @type {!Element} */ (
-        this.assert(shouldBeTrueish, opt_message || 'Element expected',
-            var_args));
+    this.assert(shouldBeTrueish, (opt_message || 'Element expected') + ': %s',
+        shouldBeElement);
+    return /** @type {!Element} */ (shouldBeElement);
   }
 
   /**

--- a/src/log.js
+++ b/src/log.js
@@ -249,7 +249,25 @@ export class Log {
     }
     return shouldBeTrueish;
   }
+
+  /**
+   * Throws an error if the first argument isn't an Element
+   *
+   * Otherwise see `assert` for usage
+   *
+   * @param {*} shouldBeElement
+   * @param {string=} opt_message The assertion message
+   * @param {...*} var_args Arguments substituted into %s in the message.
+   * @return {!Element} The value of shouldBeTrueish.
+   * @template T
+   */
   /*eslint "google-camelcase/google-camelcase": 2*/
+  assertElement(shouldBeElement, opt_message, var_args) {
+    const shouldBeTrueish = shouldBeElement && shouldBeElement.nodeType == 1;
+    return /** @type {!Element} */ (
+        this.assert(shouldBeTrueish, opt_message || 'Element expected',
+            var_args));
+  }
 
   /**
    * Asserts and returns the enum value. If the enum doesn't contain such a value,
@@ -261,6 +279,7 @@ export class Log {
    * @return T
    * @template T
    */
+  /*eslint "google-camelcase/google-camelcase": 2*/
   assertEnumValue(enumObj, s, opt_enumName) {
     for (const k in enumObj) {
       if (enumObj[k] == s) {

--- a/src/log.js
+++ b/src/log.js
@@ -261,7 +261,7 @@ export class Log {
    * @template T
    */
   /*eslint "google-camelcase/google-camelcase": 2*/
-  assertElement(shouldBeElement, opt_message, var_args) {
+  assertElement(shouldBeElement, opt_message) {
     const shouldBeTrueish = shouldBeElement && shouldBeElement.nodeType == 1;
     this.assert(shouldBeTrueish, (opt_message || 'Element expected') + ': %s',
         shouldBeElement);

--- a/src/performance.js
+++ b/src/performance.js
@@ -18,8 +18,9 @@ import {getExistingServiceForWindow} from './service';
 
 /**
  * @param {!Window} window
- * @return {!Performance}
+ * @return {!./service/performance-impl.Performance}
  */
 export function performanceFor(window) {
-  return getExistingServiceForWindow(window, 'performance');
+  return /** @type {!./service/performance-impl.Performance}*/ (
+      getExistingServiceForWindow(window, 'performance'));
 };

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -50,7 +50,7 @@ export class UrlReplacements {
     /** @private {!RegExp|undefined} */
     this.replacementExpr_ = undefined;
 
-    /** @private @const {!Object<string, function(*):*>} */
+    /** @private @const {!Object<string, function(*, *):*>} */
     this.replacements_ = this.win_.Object.create(null);
 
     /** @private @const {function():!Promise<?AccessService>} */
@@ -426,7 +426,7 @@ export class UrlReplacements {
    * @template T
    */
   getAccessValue_(getter, expr) {
-    return this.getAccessService_(this.win_).then(accessService => {
+    return this.getAccessService_().then(accessService => {
       if (!accessService) {
         // Access service is not installed.
         user().error(TAG, 'Access service is not installed to access: ', expr);
@@ -441,8 +441,8 @@ export class UrlReplacements {
    * The data for the timing events is retrieved from performance.timing API.
    * If start and end events are both given, the result is the difference between the two.
    * If only start event is given, the result is the timing value at start event.
-   * @param {string} startEvent
-   * @param {string=} endEvent
+   * @param {*} startEvent
+   * @param {*=} endEvent
    * @return {!Promise<string|undefined>}
    * @private
    */
@@ -472,14 +472,15 @@ export class UrlReplacements {
             : String(metric);
       });
     } else {
-      return Promise.resolve(String(metric));
+      return /** @type {!Promise<(string|undefined)>} */ (
+          Promise.resolve(String(metric)));
     }
   }
 
   /**
    * Returns navigation information from the current browsing context.
    * @param {string} attribute
-   * @return {!Promise<string|undefined>}
+   * @return {!Promise<undefined>|string}
    * @private
    */
   getNavigationData_(attribute) {
@@ -497,7 +498,7 @@ export class UrlReplacements {
    * Sets the value resolver for the variable with the specified name. The
    * value resolver may optionally take an extra parameter.
    * @param {string} varName
-   * @param {function(*):*} resolver
+   * @param {function(*, *):*} resolver
    * @return {!UrlReplacements}
    * @private
    */
@@ -604,7 +605,7 @@ export class UrlReplacements {
   /**
    * Method exists to assist stubbing in tests.
    * @param {string} name
-   * @return {function(*):*}
+   * @return {function(*, *):*}
    */
   getReplacement_(name) {
     return this.replacements_[name];
@@ -620,7 +621,7 @@ export class UrlReplacements {
     if (additionalKeys && additionalKeys.length > 0) {
       const allKeys = Object.keys(this.replacements_);
       additionalKeys.forEach(key => {
-        if (allKeys[key] === undefined) {
+        if (this.replacements_[key] === undefined) {
           allKeys.push(key);
         }
       });

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -246,9 +246,6 @@ export class Viewer {
     // Wait for document to become visible.
     this.docState_.onVisibilityChanged(this.recheckVisibilityState_.bind(this));
 
-    /** @private {function()|undefined} */
-    this.messagingReadyResolver_ = undefined;
-
     /**
      * This promise will resolve when communications channel has been
      * established or timeout in 20 seconds. The timeout is needed to avoid
@@ -296,9 +293,6 @@ export class Viewer {
           this.isTrustedViewerOrigin_(this.win.location.ancestorOrigins[0]));
       trustedViewerPromise = Promise.resolve(trustedViewerResolved);
     } else {
-
-      /** @private {!function(boolean)|undefined} */
-      this.trustedViewerResolver_ = undefined;
       // Wait for comms channel to confirm the origin.
       trustedViewerResolved = undefined;
       trustedViewerPromise = new Promise(resolve => {
@@ -308,9 +302,6 @@ export class Viewer {
 
     /** @const @private {!Promise<boolean>} */
     this.isTrustedViewer_ = trustedViewerPromise;
-
-    /** @private {!function(string)|undefined} */
-    this.viewerOriginResolver_ = undefined;
 
     /** @const @private {!Promise<string>} */
     this.viewerOrigin_ = new Promise(resolve => {

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -119,7 +119,7 @@ export class Viewport {
     /** @private @const {!Observable} */
     this.scrollObservable_ = new Observable();
 
-    /** @private {?HTMLMetaElement|undefined} */
+    /** @private {?Element|undefined} */
     this.viewportMeta_ = undefined;
 
     /** @private {string|undefined} */
@@ -491,7 +491,7 @@ export class Viewport {
   }
 
   /**
-   * @return {?HTMLMetaElement}
+   * @return {?Element}
    * @private
    */
   getViewportMeta_() {
@@ -627,9 +627,7 @@ export class ViewportBindingDef {
    * independent fixed layer.
    * @return {boolean}
    */
-  requiresFixedLayerTransfer() {
-    return false;
-  }
+  requiresFixedLayerTransfer() {}
 
   /**
    * Register a callback for scroll events.
@@ -908,6 +906,9 @@ export class ViewportBindingNaturalIosEmbed_ {
     /** @private {?Element} */
     this.scrollMoveEl_ = null;
 
+    /** @private {?Element} */
+    this.endPosEl_ = null;
+
     /** @private {!{x: number, y: number}} */
     this.pos_ = {x: 0, y: 0};
 
@@ -956,7 +957,7 @@ export class ViewportBindingNaturalIosEmbed_ {
       overflowY: 'auto',
       webkitOverflowScrolling: 'touch',
     });
-    setStyles(documentBody, {
+    setStyles(dev().assertElement(documentBody), {
       overflowX: 'hidden',
       overflowY: 'auto',
       webkitOverflowScrolling: 'touch',
@@ -1185,7 +1186,7 @@ export class ViewportBindingNaturalIosEmbed_ {
  * width=device-width,initial-scale=1,minimum-scale=1
  * ```
  * @param {string} content
- * @return {!Object<string, string>}
+ * @return {!Object<string, (string|undefined)>}
  * @private Visible for testing only.
  */
 export function parseViewportMeta(content) {
@@ -1288,7 +1289,7 @@ function createViewport_(window) {
  * @return {!Viewport}
  */
 export function installViewportService(window) {
-  return getService(window, 'viewport', () => {
+  return /** @type !Viewport} */ (getService(window, 'viewport', () => {
     return createViewport_(window);
-  });
+  }));
 };

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -937,7 +937,8 @@ export class ViewportBindingNaturalIosEmbed_ {
   /** @private */
   setup_() {
     const documentElement = this.win.document.documentElement;
-    const documentBody = this.win.document.body;
+    const documentBody = /** @type {!Element} */ (
+        this.win.document.body);
 
     // Embedded scrolling on iOS is rather complicated. IFrames cannot be sized
     // and be scrollable. Sizing iframe by scrolling height has a big negative
@@ -957,7 +958,7 @@ export class ViewportBindingNaturalIosEmbed_ {
       overflowY: 'auto',
       webkitOverflowScrolling: 'touch',
     });
-    setStyles(dev().assertElement(documentBody), {
+    setStyles(documentBody, {
       overflowX: 'hidden',
       overflowY: 'auto',
       webkitOverflowScrolling: 'touch',

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -129,7 +129,7 @@ export class Vsync {
    */
   run(task, opt_state) {
     this.tasks_.push(task);
-    this.states_.push(opt_state);
+    this.states_.push(opt_state || undefined);
     this.schedule_();
   }
 
@@ -160,9 +160,9 @@ export class Vsync {
    * @return {function(!VsyncStateDef=)}
    */
   createTask(task) {
-    return opt_state => {
+    return /** @type {function(!VsyncStateDef=)} */ (opt_state => {
       this.run(task, opt_state);
-    };
+    });
   }
 
   /**
@@ -259,9 +259,10 @@ export class Vsync {
    * @return {function(!VsyncStateDef=):boolean}
    */
   createAnimTask(contextNode, task) {
-    return opt_state => {
-      return this.runAnim(contextNode, task, opt_state);
-    };
+    return /** @type {function(!VsyncStateDef=):boolean} */ (
+        opt_state => {
+          return this.runAnim(contextNode, task, opt_state);
+        });
   }
 
   /**
@@ -385,7 +386,7 @@ export class Vsync {
  * @return {!Vsync}
  */
 export function installVsyncService(window) {
-  return getService(window, 'vsync', () => {
+  return /** @type {!Vsync} */ (getService(window, 'vsync', () => {
     return new Vsync(window, installViewerService(window));
-  });
+  }));
 };

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -484,7 +484,8 @@ export class FetchResponse {
     user().assert(this.xhr_.responseXML,
         'responseXML should exist. Make sure to return ' +
         'Content-Type: text/html header.');
-    return Promise.resolve(this.xhr_.responseXML);
+    return /** @type {!Promise<!Document>} */ (
+        Promise.resolve(dev().assert(this.xhr_.responseXML)));
   }
 
   /**

--- a/src/share-tracking-service.js
+++ b/src/share-tracking-service.js
@@ -23,6 +23,7 @@ import {getElementServiceIfAvailable} from './element-service';
  * @return {!Promise<?Object<string, string>>}
  */
 export function shareTrackingForOrNull(win) {
-  return getElementServiceIfAvailable(win, 'share-tracking',
-      'amp-share-tracking');
+  return /** @type {!Promise<?Object<string, string>>} */ (
+      getElementServiceIfAvailable(win, 'share-tracking',
+          'amp-share-tracking'));
 }

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -40,12 +40,12 @@ const bodyVisibleSentinel = '__AMP_BODY_VISIBLE';
  *     as the first element in head and all style elements will be positioned
  *     after.
  * @param {string=} opt_ext
- * @return {!HTMLStyleElement}
+ * @return {!Element}
  */
 export function installStyles(doc, cssText, cb, opt_isRuntimeCss, opt_ext) {
   const style = insertStyleElement(
       doc,
-      dev().assert(doc.head),
+      dev().assertElement(doc.head),
       cssText,
       opt_isRuntimeCss || false,
       opt_ext || null);
@@ -72,7 +72,7 @@ export function installStyles(doc, cssText, cb, opt_isRuntimeCss, opt_ext) {
 
 /**
  * Creates the properly configured style element.
- * @param {!Document} doc
+ * @param {?Document} doc
  * @param {!Element|!ShadowRoot} cssRoot
  * @param {string} cssText
  * @param {boolean} isRuntimeCss
@@ -110,7 +110,7 @@ export function insertStyleElement(doc, cssRoot, cssText, isRuntimeCss, ext) {
  */
 export function makeBodyVisible(doc, opt_waitForExtensions) {
   const set = () => {
-    setStyles(dev().assert(doc.body), {
+    setStyles(dev().assertElement(doc.body), {
       opacity: 1,
       visibility: 'visible',
       animation: 'none',

--- a/src/variant-service.js
+++ b/src/variant-service.js
@@ -23,5 +23,6 @@ import {getElementServiceIfAvailable} from './element-service';
  * @return {!Promise<?Object<string, string>>}
  */
 export function variantForOrNull(win) {
-  return getElementServiceIfAvailable(win, 'variant', 'amp-experiment');
+  return /** @type {!Promise<?Object<string, string>>} */ (
+      getElementServiceIfAvailable(win, 'variant', 'amp-experiment'));
 }

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -414,6 +414,25 @@ describe('Logging', () => {
       expect(isUserErrorMessage(error.message)).to.be.false;
       expect(error.message).to.contain('test-other');
     });
+
+    it('should pass for elements', () => {
+      log.assertElement(document.documentElement);
+      const element = document.createElement('element');
+      const ret = log.assertElement(element);
+      expect(ret).to.equal(element);
+    });
+
+    it('should should identify non-elements', () => {
+      expect(() => {
+        log.assertElement(document);
+      }).to.throw(/Element expected: /);
+      expect(() => {
+        log.assertElement(null);
+      }).to.throw(/Element expected: null/);
+      expect(() => {
+        log.assertElement(null, 'custom error');
+      }).to.throw(/custom error: null/);
+    });
   });
 
 


### PR DESCRIPTION
- Gets rid of many specific `Element` types. In practice these aren't helpful, but introduce a lot of casting.
- Might have fixed on actualy bug in url-replacements.js

142 error(s), 6 warning(s), 93.81603250831178% typed