### PR TITLE
Use performance.mark API to expose our perf timings to browser.

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -243,6 +243,13 @@ export class Performance {
     } else {
       this.queueTick_(label, opt_from, opt_value);
     }
+    // Add browser performance timeline entries for simple ticks.
+    // These are for example exposed in WPT.
+    if (this.win.performance
+        && this.win.performance.mark
+        && arguments.length == 1) {
+      this.win.performance.mark(label);
+    }
   }
 
   /**


### PR DESCRIPTION
See https://w3c.github.io/user-timing/#dom-performance-mark