### PR TITLE
Friendly frames embeds

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -517,6 +517,7 @@ var forbiddenTermsSrcInclusive = {
     message: bannedTermsHelpString,
     whitelist: [
       'src/element-stub.js',
+      'src/friendly-iframe-embed.js',
       'src/runtime.js',
       'src/service/extensions-impl.js',
       'src/service/lightbox-manager-discovery.js',
@@ -546,6 +547,7 @@ var forbiddenTermsSrcInclusive = {
     whitelist: [
       'src/base-element.js',
       'src/event-helper.js',
+      'src/friendly-iframe-embed.js',
       'src/service/performance-impl.js',
       'src/service/url-replacements-impl.js',
       'extensions/amp-ad/0.1/amp-ad-api-handler.js',

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -145,10 +145,7 @@ export function stubElements(win) {
     // If amp-ad and amp-embed haven't been registered, manually register them
     // with ElementStub, in case the script to the element is not included.
     if (!knownElements['amp-ad'] && !knownElements['amp-embed']) {
-      win.ampExtendedElements['amp-ad'] = true;
-      registerElement(win, 'amp-ad', ElementStub);
-      win.ampExtendedElements['amp-embed'] = true;
-      registerElement(win, 'amp-embed', ElementStub);
+      stubLegacyElements(win);
     }
   }
   const list = win.document.querySelectorAll('[custom-element]');
@@ -167,6 +164,16 @@ export function stubElements(win) {
 }
 
 /**
+ * @param {!Window} win
+ */
+function stubLegacyElements(win) {
+  win.ampExtendedElements['amp-ad'] = true;
+  registerElement(win, 'amp-ad', ElementStub);
+  win.ampExtendedElements['amp-embed'] = true;
+  registerElement(win, 'amp-embed', ElementStub);
+}
+
+/**
  * Stub element if not yet known.
  * @param {!Window} win
  * @param {string} name
@@ -180,6 +187,22 @@ export function stubElementIfNotKnown(win, name) {
   }
   win.ampExtendedElements[name] = true;
   registerElement(win, name, ElementStub);
+}
+
+/**
+ * Copies the specified element to child window (friendly iframe). This way
+ * all implementations of the AMP elements are shared between all friendly
+ * frames.
+ * @param {!Window} childWin
+ * @param {string} name
+ */
+export function copyElementToChildWindow(childWin, name) {
+  if (!childWin.ampExtendedElements) {
+    childWin.ampExtendedElements = {};
+    stubLegacyElements(childWin);
+  }
+  childWin.ampExtendedElements[name] = true;
+  registerElement(childWin, name, knownElements[name] || ElementStub);
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -18,6 +18,16 @@ import {dev} from './log';
 import {cssEscape} from '../third_party/css-escape/css-escape';
 import {toArray} from './types';
 
+const HTML_ESCAPE_CHARS = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+  '`': '&#x60;',
+};
+const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
+
 
 /**
  * Waits until the child element is constructed. Once the child is found, the
@@ -543,4 +553,40 @@ export function escapeCssSelectorIdent(win, ident) {
   }
   // Polyfill.
   return cssEscape(ident);
+}
+
+
+/**
+ * Returns a frame element if available.
+ * @param {!Window} win
+ * @return {?HTMLIFrameElement}
+ */
+export function getFrameElement(win) {
+  try {
+    return /** @type {?HTMLIFrameElement} */ (win.frameElement);
+  } catch (e) {
+    // Ignore the error.
+    return null;
+  }
+}
+
+
+/**
+ * Escapes `<`, `>` and other HTML charcaters with their escaped forms.
+ * @param {string} text
+ * @return {string}
+ */
+export function escapeHtml(text) {
+  if (!text) {
+    return text;
+  }
+  return text.replace(HTML_ESCAPE_REGEX, escapeHtmlChar);
+}
+
+/**
+ * @param {string} c
+ * @return string
+ */
+function escapeHtmlChar(c) {
+  return HTML_ESCAPE_CHARS[c];
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -557,21 +557,6 @@ export function escapeCssSelectorIdent(win, ident) {
 
 
 /**
- * Returns a frame element if available.
- * @param {!Window} win
- * @return {?HTMLIFrameElement}
- */
-export function getFrameElement(win) {
-  try {
-    return /** @type {?HTMLIFrameElement} */ (win.frameElement);
-  } catch (e) {
-    // Ignore the error.
-    return null;
-  }
-}
-
-
-/**
  * Escapes `<`, `>` and other HTML charcaters with their escaped forms.
  * @param {string} text
  * @return {string}

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -1,0 +1,223 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {escapeHtml} from './dom';
+import {extensionsFor} from './extensions';
+import {getTopWindow} from './service';
+import {loadPromise} from './event-helper';
+import {resourcesForDoc} from './resources';
+
+
+/**
+ * Parameters used to create the new "friendly iframe" embed.
+ * - html: The complete content of an AMP embed, which is itself an AMP
+ *   document. Can include whatever is normally allowed in an AMP document,
+ *   except for AMP `<script>` declarations. Those should be passed as an
+ *   array of `extensionIds`.
+ * - extensionsIds: An optional array of AMP extension IDs used in this embed.
+ * - fonts: An optional array of fonts used in this embed.
+ *
+ * @typedef {{
+ *   url: string,
+ *   html: string,
+ *   extensionIds: (?Array<string>|undefined),
+ *   fonts: (?Array<string>|undefined),
+ * }}
+ */
+export let FriendlyIframeSpec;
+
+
+/**
+ * @type {boolean|undefined}
+ * @visiblefortesting
+ */
+let srcdocSupported;
+
+/**
+ * @param {boolean|undefined} val
+ * @visiblefortesting
+ */
+export function setSrcdocSupportedForTesting(val) {
+  srcdocSupported = val;
+}
+
+/**
+ * Returns `true` if the Friendly Iframes are supported.
+ * @return {boolean}
+ */
+function isSrcdocSupported() {
+  if (srcdocSupported === undefined) {
+    srcdocSupported = 'srcdoc' in HTMLIFrameElement.prototype;
+  }
+  return srcdocSupported;
+}
+
+
+/**
+ * Creates the requested "friendly iframe" embed. Returns the promise that
+ * will be resolved as soon as the embed is available. The actual
+ * initialization of the embed will start as soon as the `iframe` is added
+ * to the DOM.
+ * @param {!HTMLIFrameElement} iframe
+ * @param {!Element} container
+ * @param {!FriendlyIframeSpec} spec
+ * @return {!Promise<FriendlyIframeEmbed>}
+ */
+export function installFriendlyIframeEmbed(iframe, container, spec) {
+  const win = getTopWindow(iframe.ownerDocument.defaultView);
+  const extensions = extensionsFor(win);
+
+  iframe.style.visibility = 'hidden';
+  iframe.setAttribute('referrerpolicy', 'unsafe-url');
+
+  // Pre-load extensions.
+  if (spec.extensionIds) {
+    spec.extensionIds.forEach(
+        extensionId => extensions.loadExtension(extensionId));
+  }
+
+  const html = mergeHtml(spec);
+
+  // Receive the signal when iframe is ready: it's document is formed.
+  iframe.onload = () => {
+    // Chrome does not reflect the iframe readystate.
+    iframe.readyState = 'complete';
+  };
+  let readyPromise;
+  if (isSrcdocSupported()) {
+    iframe.srcdoc = html;
+    // TODO(dvoytenko): Look for a way to get a faster call from here.
+    // Experiments show that the iframe's "load" event is consistently 50-100ms
+    // later than the contentWindow actually available.
+    readyPromise = loadPromise(iframe);
+    container.appendChild(iframe);
+  } else {
+    iframe.src = 'about:blank';
+    container.appendChild(iframe);
+    const childDoc = iframe.contentWindow.document;
+    childDoc.open();
+    childDoc.write(html);
+    childDoc.close();
+    // Window is created synchornously in this case.
+    readyPromise = Promise.resolve();
+  }
+  return readyPromise.then(() => {
+    // Add extensions.
+    extensionsFor(win).installExtensionsInChildWindow(
+        iframe.contentWindow, spec.extensionIds || []);
+    // Ready to be shown.
+    iframe.style.visibility = '';
+    return new FriendlyIframeEmbed(iframe, spec);
+  });
+}
+
+
+/**
+ * Merges base and fonts into html document.
+ * @param {!FriendlyIframeSpec} spec
+ */
+function mergeHtml(spec) {
+  const originalHtml = spec.html;
+  const originalHtmlUp = originalHtml.toUpperCase();
+
+  // Find the insertion point.
+  let ip = originalHtmlUp.indexOf('<HEAD');
+  if (ip != -1) {
+    ip = originalHtmlUp.indexOf('>', ip + 1) + 1;
+  }
+  if (ip == -1) {
+    ip = originalHtmlUp.indexOf('<BODY');
+  }
+  if (ip == -1) {
+    ip = originalHtmlUp.indexOf('<HTML');
+    if (ip != -1) {
+      ip = originalHtmlUp.indexOf('>', ip + 1) + 1;
+    }
+  }
+
+  const result = [];
+
+  // Preambule.
+  if (ip > 0) {
+    result.push(originalHtml.substring(0, ip));
+  }
+
+  // Add <BASE> tag.
+  result.push(`<base href="${escapeHtml(spec.url)}">`);
+
+  // Load fonts.
+  if (spec.fonts) {
+    spec.fonts.forEach(font => {
+      result.push(
+          `<link href="${escapeHtml(font)}" rel="stylesheet" type="text/css">`);
+    });
+  }
+
+  // Postambule.
+  if (ip > 0) {
+    result.push(originalHtml.substring(ip));
+  } else {
+    result.push(originalHtml);
+  }
+
+  return result.join('');
+}
+
+
+/**
+ * Exposes `mergeHtml` for testing purposes.
+ * @param {!FriendlyIframeSpec} spec
+ * @visibleForTesting
+ */
+export function mergeHtmlForTesting(spec) {
+  return mergeHtml(spec);
+}
+
+
+/**
+ * A "friendly iframe" embed. This is the iframe that's fully accessible to
+ * the AMP runtime. It's similar to Shadow DOM in many respects, but it also
+ * provides iframe/viewport measurements and enables the use of `vh`, `vw` and
+ * `@media` CSS.
+ *
+ * The friendly iframe is managed by the top-level AMP Runtime. When it's
+ * destroyed, the `destroy` method must be called to free up the shared
+ * resources.
+ */
+export class FriendlyIframeEmbed {
+
+  /**
+   * @param {!HTMLIFrameElement} iframe
+   * @param {!FriendlyIframeSpec} spec
+   */
+  constructor(iframe, spec) {
+    /** @const {!HTMLIFrameElement} */
+    this.iframe = iframe;
+
+    /** @const {!Window} */
+    this.win = iframe.contentWindow;
+
+    /** @const {!FriendlyIframeSpec} */
+    this.spec = spec;
+  }
+
+  /**
+   * Ensures that all resources from this iframe have been released.
+   */
+  destroy() {
+    resourcesForDoc(this.iframe).removeForChildWindow(this.win);
+  }
+}

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -116,7 +116,7 @@ export function installFriendlyIframeEmbed(iframe, container, spec) {
   }
   return readyPromise.then(() => {
     // Add extensions.
-    extensionsFor(win).installExtensionsInChildWindow(
+    extensions.installExtensionsInChildWindow(
         iframe.contentWindow, spec.extensionIds || []);
     // Ready to be shown.
     iframe.style.visibility = '';

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -20,6 +20,7 @@ import {
   addDocFactoryToExtension,
   addElementToExtension,
   addShadowRootFactoryToExtension,
+  installBuiltinElements,
   installExtensionsInShadowDoc,
   installExtensionsService,
   registerExtension,
@@ -39,8 +40,6 @@ import {installActionServiceForDoc} from './service/action-impl';
 import {installGlobalSubmitListener} from './document-submit';
 import {extensionsFor} from './extensions';
 import {installHistoryService} from './service/history-impl';
-import {installImg} from '../builtins/amp-img';
-import {installPixel} from '../builtins/amp-pixel';
 import {installPlatformService} from './service/platform-impl';
 import {installResourcesServiceForDoc} from './service/resources-impl';
 import {
@@ -54,7 +53,6 @@ import {installStyles} from './style-installer';
 import {installTimerService} from './service/timer-impl';
 import {installTemplatesService} from './service/template-impl';
 import {installUrlReplacementsService} from './service/url-replacements-impl';
-import {installVideo} from '../builtins/amp-video';
 import {installVideoManagerForDoc} from './service/video-manager-impl';
 import {installViewerService} from './service/viewer-impl';
 import {installViewportService} from './service/viewport-impl';
@@ -120,9 +118,7 @@ export function installAmpdocServices(ampdoc) {
  * @param {!Window} global Global scope to adopt.
  */
 export function installBuiltins(global) {
-  installImg(global);
-  installPixel(global);
-  installVideo(global);
+  installBuiltinElements(global);
 }
 
 
@@ -338,7 +334,7 @@ export function adoptShadowMode(global) {
  */
 function prepareAndRegisterElement(global, extensions,
     name, implementationClass, opt_css) {
-  addElementToExtension(extensions, name, implementationClass);
+  addElementToExtension(extensions, name, implementationClass, opt_css);
   if (opt_css) {
     installStyles(global.document, opt_css, () => {
       registerElementClass(global, name, implementationClass, opt_css);
@@ -359,7 +355,7 @@ function prepareAndRegisterElement(global, extensions,
  */
 function prepareAndRegisterElementShadowMode(global, extensions,
     name, implementationClass, opt_css) {
-  addElementToExtension(extensions, name, implementationClass);
+  addElementToExtension(extensions, name, implementationClass, opt_css);
   registerElementClass(global, name, implementationClass, opt_css);
   if (opt_css) {
     addShadowRootFactoryToExtension(extensions, shadowRoot => {

--- a/src/service.js
+++ b/src/service.js
@@ -39,6 +39,7 @@ let ServiceHolderDef;
  * @return {!Object} The service.
  */
 export function getExistingServiceForWindow(win, id) {
+  win = getTopWindow(win);
   const exists = win.services && win.services[id] && win.services[id].obj;
   return dev().assert(exists, `${id} service not found. Make sure it is ` +
       `installed.`);
@@ -75,6 +76,7 @@ export function getExistingServiceForDoc(nodeOrDoc, id) {
  * @return {T}
  */
 export function getService(win, id, opt_factory) {
+  win = getTopWindow(win);
   return getServiceInternal(win, win, id,
       opt_factory ? opt_factory : undefined);
 }
@@ -89,6 +91,7 @@ export function getService(win, id, opt_factory) {
  * @template T
  */
 export function fromClass(win, id, constructor) {
+  win = getTopWindow(win);
   return getServiceInternal(win, win, id, undefined, constructor);
 }
 
@@ -181,6 +184,35 @@ export function getServicePromiseOrNullForDoc(nodeOrDoc, id) {
   return getServicePromiseOrNullInternal(
       getAmpdocServiceHolder(nodeOrDoc),
       id);
+}
+
+/**
+ * Set the parent and top windows on a child window (friendly iframe).
+ * @param {!Window} win
+ * @param {!Window} parentWin
+ */
+export function setParentWindow(win, parentWin) {
+  win.__AMP_PARENT = parentWin;
+  win.__AMP_TOP = getTopWindow(parentWin);
+}
+
+/**
+ * Returns the parent window for a child window (friendly iframe).
+ * @param {!Window} win
+ * @return {!Window}
+ */
+export function getParentWindow(win) {
+  return win.__AMP_PARENT || win;
+}
+
+/**
+ * Returns the top window where AMP Runtime is installed for a child window
+ * (friendly iframe).
+ * @param {!Window} win
+ * @return {!Window}
+ */
+export function getTopWindow(win) {
+  return win.__AMP_TOP || win;
 }
 
 /**

--- a/src/service.js
+++ b/src/service.js
@@ -216,6 +216,24 @@ export function getTopWindow(win) {
 }
 
 /**
+ * Returns the parent "friendly" iframe if the node belongs to a child window.
+ * @param {!Node} node
+ * @param {!Window} topWin
+ * @return {?HTMLIFrameElement}
+ */
+export function getParentWindowFrameElement(node, topWin) {
+  const childWin = (node.ownerDocument || node).defaultView;
+  if (childWin && childWin != topWin && getTopWindow(childWin) == topWin) {
+    try {
+      return /** @type {?HTMLIFrameElement} */ (childWin.frameElement);
+    } catch (e) {
+      // Ignore the error.
+    }
+  }
+  return null;
+}
+
+/**
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @return {!./service/ampdoc-impl.AmpDoc}
  */

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {closestNode} from '../dom';
+import {closestNode, getFrameElement} from '../dom';
 import {dev} from '../log';
-import {getService} from '../service';
+import {getService, getTopWindow} from '../service';
 import {isShadowRoot} from '../types';
 import {isDocumentReady, whenDocumentReady} from '../document-ready';
 import {waitForBodyPromise} from '../dom';
@@ -120,6 +120,17 @@ export class AmpDocService {
         }
       }
 
+      // Traverse the boundary of a friendly iframe.
+      const win = (n.ownerDocument || n).defaultView;
+      if (win && win != this.win && getTopWindow(win) == this.win) {
+        const frameElement = getFrameElement(win);
+        if (frameElement) {
+          n = frameElement;
+          continue;
+        }
+      }
+
+      // Shadow doc.
       // TODO(dvoytenko): Replace with `getRootNode()` API when it's available.
       const shadowRoot = closestNode(n, n => isShadowRoot(n));
       if (!shadowRoot) {

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import {closestNode, getFrameElement} from '../dom';
+import {closestNode} from '../dom';
 import {dev} from '../log';
-import {getService, getTopWindow} from '../service';
+import {
+  getParentWindowFrameElement,
+  getService,
+} from '../service';
 import {isShadowRoot} from '../types';
 import {isDocumentReady, whenDocumentReady} from '../document-ready';
 import {waitForBodyPromise} from '../dom';
@@ -121,13 +124,10 @@ export class AmpDocService {
       }
 
       // Traverse the boundary of a friendly iframe.
-      const win = (n.ownerDocument || n).defaultView;
-      if (win && win != this.win && getTopWindow(win) == this.win) {
-        const frameElement = getFrameElement(win);
-        if (frameElement) {
-          n = frameElement;
-          continue;
-        }
+      const frameElement = getParentWindowFrameElement(n, this.win);
+      if (frameElement) {
+        n = frameElement;
+        continue;
       }
 
       // Shadow doc.

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -115,6 +115,9 @@ export class Resource {
     /** @export @const {string} */
     this.debugid = element.tagName.toLowerCase() + '#' + id;
 
+    /** @const {!Window} */
+    this.hostWin = element.ownerDocument.defaultView;
+
     /** @private {!./resources-impl.Resources} */
     this.resources_ = resources;
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -414,6 +414,14 @@ export class Resources {
     if (!resource) {
       return;
     }
+    this.removeResource_(resource);
+  }
+
+  /**
+   * @param {!Resource} resource
+   * @private
+   */
+  removeResource_(resource) {
     const index = this.resources_.indexOf(resource);
     if (index != -1) {
       this.resources_.splice(index, 1);
@@ -421,6 +429,15 @@ export class Resources {
     resource.pauseOnRemove();
     this.cleanupTasks_(resource, /* opt_removePending */ true);
     dev().fine(TAG_, 'element removed:', resource.debugid);
+  }
+
+  /**
+   * Removes all resources belonging to the specified child window.
+   * @param {!Window} childWin
+   */
+  removeForChildWindow(childWin) {
+    const toRemove = this.resources_.filter(r => r.hostWin == childWin);
+    toRemove.forEach(r => this.removeResource_(r));
   }
 
   /**

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -19,8 +19,10 @@ import {FixedLayer} from './fixed-layer';
 import {Observable} from '../observable';
 import {checkAndFix as checkAndFixIosScrollfreezeBug,} from
     './ios-scrollfreeze-bug';
-import {getFrameElement, waitForBody} from '../dom';
-import {getService, getTopWindow} from '../service';
+import {
+  getParentWindowFrameElement,
+  getService,
+} from '../service';
 import {layoutRectLtwh} from '../layout-rect';
 import {dev} from '../log';
 import {numeric} from '../transition';
@@ -31,6 +33,7 @@ import {timerFor} from '../timer';
 import {installVsyncService} from './vsync-impl';
 import {installViewerService} from './viewer-impl';
 import {isExperimentOn} from '../experiments';
+import {waitForBody} from '../dom';
 
 
 const TAG_ = 'Viewport';
@@ -290,18 +293,15 @@ export class Viewport {
     const scrollTop = this.getScrollTop();
 
     // Go up the window hierarchy through friendly iframes.
-    const win = (el.ownerDocument || el).defaultView;
-    if (win && win != this.win_ && getTopWindow(win) == this.win_) {
-      const frameElement = getFrameElement(win);
-      if (frameElement) {
-        const b = this.binding_.getLayoutRect(el, 0, 0);
-        const c = this.binding_.getLayoutRect(
-            frameElement, scrollLeft, scrollTop);
-        return layoutRectLtwh(Math.round(b.left + c.left),
-            Math.round(b.top + c.top),
-            Math.round(b.width),
-            Math.round(b.height));
-      }
+    const frameElement = getParentWindowFrameElement(el, this.win_);
+    if (frameElement) {
+      const b = this.binding_.getLayoutRect(el, 0, 0);
+      const c = this.binding_.getLayoutRect(
+          frameElement, scrollLeft, scrollTop);
+      return layoutRectLtwh(Math.round(b.left + c.left),
+          Math.round(b.top + c.top),
+          Math.round(b.width),
+          Math.round(b.height));
     }
 
     return this.binding_.getLayoutRect(el, scrollLeft, scrollTop);

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -713,4 +713,65 @@ describe('DOM', () => {
       expect(dom.escapeCssSelectorIdent({}, 'a b')).to.equal('a\\ b');
     });
   });
+
+  describe('getFrameElement', () => {
+
+    let iframe;
+
+    beforeEach(() => {
+      iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      const html = '<div id="one"></div>';
+      if ('srcdoc' in iframe) {
+        iframe.srcdoc = html;
+      } else {
+        iframe.src = 'about:blank';
+        const childDoc = iframe.contentWindow.document;
+        childDoc.open();
+        childDoc.write(html);
+        childDoc.close();
+      }
+      return new Promise(resolve => {
+        const interval = setInterval(() => {
+          if (iframe.contentWindow) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 4);
+      });
+    });
+
+    afterEach(() => {
+      dom.removeElement(iframe);
+    });
+
+    it('should return frameElement', () => {
+      expect(dom.getFrameElement(iframe.contentWindow)).to.equal(iframe);
+    });
+
+    it('should survive exceptions', () => {
+      const childWin = {};
+      Object.defineProperties(childWin, {
+        frameElement: {
+          get: () => {throw new Error('intentional');},
+        },
+      });
+      expect(dom.getFrameElement(childWin)).to.equal(null);
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('should tolerate empty string', () => {
+      expect(dom.escapeHtml('')).to.equal('');
+    });
+
+    it('should ignore non-escapes', () => {
+      expect(dom.escapeHtml('abc')).to.equal('abc');
+    });
+
+    it('should subsctitute escapes', () => {
+      expect(dom.escapeHtml('a<b>&c"d\'e\`f')).to.equal(
+          'a&lt;b&gt;&amp;c&quot;d&#x27;e&#x60;f');
+    });
+  });
 });

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -714,52 +714,6 @@ describe('DOM', () => {
     });
   });
 
-  describe('getFrameElement', () => {
-
-    let iframe;
-
-    beforeEach(() => {
-      iframe = document.createElement('iframe');
-      document.body.appendChild(iframe);
-      const html = '<div id="one"></div>';
-      if ('srcdoc' in iframe) {
-        iframe.srcdoc = html;
-      } else {
-        iframe.src = 'about:blank';
-        const childDoc = iframe.contentWindow.document;
-        childDoc.open();
-        childDoc.write(html);
-        childDoc.close();
-      }
-      return new Promise(resolve => {
-        const interval = setInterval(() => {
-          if (iframe.contentWindow) {
-            clearInterval(interval);
-            resolve();
-          }
-        }, 4);
-      });
-    });
-
-    afterEach(() => {
-      dom.removeElement(iframe);
-    });
-
-    it('should return frameElement', () => {
-      expect(dom.getFrameElement(iframe.contentWindow)).to.equal(iframe);
-    });
-
-    it('should survive exceptions', () => {
-      const childWin = {};
-      Object.defineProperties(childWin, {
-        frameElement: {
-          get: () => {throw new Error('intentional');},
-        },
-      });
-      expect(dom.getFrameElement(childWin)).to.equal(null);
-    });
-  });
-
   describe('escapeHtml', () => {
     it('should tolerate empty string', () => {
       expect(dom.escapeHtml('')).to.equal('');

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -1,0 +1,244 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  installFriendlyIframeEmbed,
+  mergeHtmlForTesting,
+  setSrcdocSupportedForTesting,
+} from '../../src/friendly-iframe-embed';
+import {extensionsFor} from '../../src/extensions';
+import {loadPromise} from '../../src/event-helper';
+import {resourcesForDoc} from '../../src/resources';
+import * as sinon from 'sinon';
+
+
+describe('friendly-iframe-embed', () => {
+
+  let sandbox;
+  let iframe;
+  let extensionsMock;
+  let resourcesMock;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    const extensions = extensionsFor(window);
+    const resources = resourcesForDoc(window.document);
+    extensionsMock = sandbox.mock(extensions);
+    resourcesMock = sandbox.mock(resources);
+
+    iframe = document.createElement('iframe');
+  });
+
+  afterEach(() => {
+    if (iframe.parentElement) {
+      iframe.parentElement.removeChild(iframe);
+    }
+    extensionsMock.verify();
+    resourcesMock.verify();
+    setSrcdocSupportedForTesting(undefined);
+    sandbox.restore();
+  });
+
+  it('should follow main install steps', () => {
+
+    // Resources are not involved.
+    extensionsMock.expects('loadExtension').never();
+    resourcesMock.expects('add').never();
+
+    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
+      url: 'https://acme.org/url1',
+      html: '<a href="/url2"></a>',
+    });
+
+    // Attributes set.
+    expect(iframe.style.visibility).to.equal('hidden');
+    expect(iframe.getAttribute('referrerpolicy')).to.equal('unsafe-url');
+
+    // Iframe has been appended to DOM.
+    expect(iframe.parentElement).to.equal(document.body);
+
+    return embedPromise.then(embed => {
+      expect(embed.win).to.be.ok;
+      expect(embed.win).to.equal(iframe.contentWindow);
+      expect(embed.iframe).to.equal(iframe);
+      expect(embed.spec.url).to.equal('https://acme.org/url1');
+
+      // Iframe is made visible again.
+      expect(iframe.style.visibility).to.equal('');
+
+      // BASE element has been inserted.
+      expect(embed.win.document.querySelector('base').href)
+          .to.equal('https://acme.org/url1');
+      expect(embed.win.document.querySelector('a').href)
+          .to.equal('https://acme.org/url2');
+
+      return loadPromise(iframe);
+    }).then(() => {
+      // Iframe is marked as complete.
+      expect(iframe.readyState).to.equal('complete');
+    });
+  });
+
+  it('should write doc if srcdoc is not available', () => {
+    setSrcdocSupportedForTesting(false);
+
+    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
+      url: 'https://acme.org/url1',
+      html: '<a href="/url2"></a>',
+    });
+
+    return embedPromise.then(embed => {
+      expect(embed.iframe.src).to.equal('about:blank');
+      expect(!!embed.iframe.srcdoc).to.be.false;
+
+      expect(embed.win).to.be.ok;
+      expect(embed.win).to.equal(iframe.contentWindow);
+      expect(embed.iframe).to.equal(iframe);
+
+      expect(embed.win.document.querySelector('base')).to.exist;
+      expect(embed.win.document.querySelector('a')).to.exist;
+    });
+  });
+
+  it('should install extensions', () => {
+
+    // Extensions preloading have been requested.
+    extensionsMock.expects('loadExtension')
+        .withExactArgs('amp-test')
+        .returns(Promise.resolve())
+        .once();
+
+    // Extensions are installed.
+    let installExtWin;
+    extensionsMock.expects('installExtensionsInChildWindow')
+        .withExactArgs(sinon.match(arg => {
+          installExtWin = arg;
+          return true;
+        }), ['amp-test'])
+        .once();
+
+    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
+      url: 'https://acme.org/url1',
+      html: '<amp-test></amp-test>',
+      extensionIds: ['amp-test'],
+    });
+    return embedPromise.then(embed => {
+      expect(installExtWin).to.equal(embed.win);
+    });
+  });
+
+  it('should uninstall all resources', () => {
+    extensionsMock.expects('loadExtension').atLeast(1);
+    extensionsMock.expects('installExtensionsInChildWindow').atLeast(1);
+    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
+      url: 'https://acme.org/url1',
+      html: '<amp-test></amp-test>',
+      extensionIds: ['amp-test'],
+    });
+    return embedPromise.then(embed => {
+      resourcesMock.expects('removeForChildWindow')
+          .withExactArgs(embed.win)
+          .once();
+      embed.destroy();
+    });
+  });
+
+  describe('mergeHtml', () => {
+    let spec;
+
+    beforeEach(() => {
+      spec = {
+        url: 'https://acme.org/embed1',
+        html: '<a></a>',
+      };
+    });
+
+    it('should install base', () => {
+      const html = mergeHtmlForTesting(spec);
+      expect(html.indexOf('<base href="https://acme.org/embed1">')).to.equal(0);
+    });
+
+    it('should install fonts', () => {
+      const FONT1 = 'https://acme.org/font1';
+      const FONT2 = 'https://acme.org/font2';
+      spec.fonts = [FONT1, FONT2];
+      const html = mergeHtmlForTesting(spec);
+      const templ = '<link href="FONT" rel="stylesheet" type="text/css">';
+      expect(html.indexOf(templ.replace('FONT', FONT1))).to.be.greaterThan(0);
+      expect(html.indexOf(templ.replace('FONT', FONT2))).to.be.greaterThan(0);
+    });
+
+    it('should escape urls', () => {
+      spec.url = 'https://acme.org/embed<1';
+      spec.fonts = ['https://acme.org/font<1'];
+      const html = mergeHtmlForTesting(spec);
+      expect(html.indexOf('<base href="https://acme.org/embed&lt;1">'))
+          .to.greaterThan(-1);
+      expect(html.indexOf('<link href="https://acme.org/font&lt;1"'))
+          .to.greaterThan(-1);
+    });
+
+    it('should pre-pend to html', () => {
+      const html = mergeHtmlForTesting(spec);
+      expect(html).to.equal('<base href="https://acme.org/embed1"><a></a>');
+    });
+
+    it('should insert into head', () => {
+      spec.html = '<html><head>head</head><body>body';
+      const html = mergeHtmlForTesting(spec);
+      expect(html).to.equal(
+          '<html><head>'
+          + '<base href="https://acme.org/embed1">'
+          + 'head</head><body>body');
+    });
+
+    it('should insert into head w/o html', () => {
+      spec.html = '<head>head</head><body>body';
+      const html = mergeHtmlForTesting(spec);
+      expect(html).to.equal(
+          '<head>'
+          + '<base href="https://acme.org/embed1">'
+          + 'head</head><body>body');
+    });
+
+    it('should insert before body', () => {
+      spec.html = '<html><body>body';
+      const html = mergeHtmlForTesting(spec);
+      expect(html).to.equal(
+          '<html>'
+          + '<base href="https://acme.org/embed1">'
+          + '<body>body');
+    });
+
+    it('should insert before body w/o html', () => {
+      spec.html = '<body>body';
+      const html = mergeHtmlForTesting(spec);
+      expect(html).to.equal(
+          '<base href="https://acme.org/embed1">'
+          + '<body>body');
+    });
+
+    it('should insert after html', () => {
+      spec.html = '<html>content';
+      const html = mergeHtmlForTesting(spec);
+      expect(html).to.equal(
+          '<html>'
+          + '<base href="https://acme.org/embed1">'
+          + 'content');
+    });
+  });
+});

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -34,6 +34,7 @@ describe('Resource', () => {
     sandbox = sinon.sandbox.create();
 
     element = {
+      ownerDocument: {defaultView: window},
       tagName: 'AMP-AD',
       style: {},
       isBuilt: () => false,
@@ -717,6 +718,7 @@ describe('Resource renderOutsideViewport', () => {
     sandbox = sinon.sandbox.create();
 
     element = {
+      ownerDocument: {defaultView: window},
       tagName: 'AMP-AD',
       isBuilt: () => false,
       isUpgraded: () => false,

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -286,6 +286,7 @@ describe('Resources pause/resume/unlayout scheduling', () => {
 
   function createElement() {
     return {
+      ownerDocument: {defaultView: window},
       tagName: 'amp-test',
       isBuilt() {
         return true;
@@ -467,6 +468,7 @@ describe('Resources schedulePreload', () => {
 
   function createElement() {
     return {
+      ownerDocument: {defaultView: window},
       tagName: 'amp-test',
       isBuilt() {
         return true;
@@ -592,6 +594,7 @@ describe('Resources discoverWork', () => {
 
   function createElement(rect) {
     return {
+      ownerDocument: {defaultView: window},
       tagName: 'amp-test',
       isBuilt: () => {
         return true;
@@ -854,6 +857,7 @@ describe('Resources changeSize', () => {
 
   function createElement(rect) {
     return {
+      ownerDocument: {defaultView: window},
       tagName: 'amp-test',
       isBuilt: () => {
         return true;
@@ -1208,6 +1212,7 @@ describe('Resources mutateElement and collapse', () => {
 
   function createElement(rect, isAmp) {
     return {
+      ownerDocument: {defaultView: window},
       tagName: isAmp ? 'amp-test' : 'div',
       classList: {
         contains: className => isAmp && className == '-amp-element',
@@ -1415,6 +1420,7 @@ describe('Resources.add', () => {
 
   function createElement() {
     const element = {
+      ownerDocument: {defaultView: window},
       tagName: 'amp-test',
       isBuilt() {
         return true;

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -321,6 +321,7 @@ describe('runtime', () => {
       expect(ext.elements['amp-ext']).exist;
       expect(ext.elements['amp-ext'].implementationClass)
           .to.equal(win.AMP.BaseElement);
+      expect(ext.elements['amp-ext'].css).to.equal('a{}');
 
       expect(installStylesStub.callCount).to.equal(1);
       expect(installStylesStub.calledWithExactly(
@@ -464,6 +465,7 @@ describe('runtime', () => {
       expect(ext.elements['amp-ext']).exist;
       expect(ext.elements['amp-ext'].implementationClass)
           .to.equal(win.AMP.BaseElement);
+      expect(ext.elements['amp-ext'].css).to.equal('a{}');
 
       // Register is called immediately as well.
       expect(registerStub.calledWithExactly(win, 'amp-ext', AMP.BaseElement))

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -23,6 +23,7 @@ import {
   getServiceForDoc,
   getServicePromiseForDoc,
   resetServiceForTesting,
+  setParentWindow,
 } from '../../src/service';
 import * as sinon from 'sinon';
 
@@ -129,6 +130,22 @@ describe('service', () => {
           expect(factory.callCount).to.equal(0);
         });
       });
+    });
+
+    it('should resolve service for a child window', () => {
+      const c = getService(window, 'c', factory);
+
+      // A child.
+      const child = {};
+      setParentWindow(child, window);
+      expect(getService(child, 'c', factory)).to.equal(c);
+      expect(getExistingServiceForWindow(child, 'c')).to.equal(c);
+
+      // A grandchild.
+      const grandchild = {};
+      setParentWindow(grandchild, child);
+      expect(getService(grandchild, 'c', factory)).to.equal(c);
+      expect(getExistingServiceForWindow(grandchild, 'c')).to.equal(c);
     });
   });
 
@@ -249,6 +266,27 @@ describe('service', () => {
           expect(factory.callCount).to.equal(0);
         });
       });
+    });
+
+    it('should resolve service for a child window', () => {
+      ampdocMock.expects('isSingleDoc').returns(true).atLeast(1);
+      const c = getServiceForDoc(node, 'c', factory);
+
+      // A child.
+      const childWin = {};
+      const childWinNode =
+          {nodeType: 1, ownerDocument: {defaultView: childWin}};
+      setParentWindow(childWin, windowApi);
+      expect(getServiceForDoc(childWinNode, 'c', factory)).to.equal(c);
+      expect(getExistingServiceForDoc(childWinNode, 'c')).to.equal(c);
+
+      // A grandchild.
+      const grandchildWin = {};
+      const grandChildWinNode =
+          {nodeType: 1, ownerDocument: {defaultView: grandchildWin}};
+      setParentWindow(grandchildWin, childWin);
+      expect(getServiceForDoc(grandChildWinNode, 'c', factory)).to.equal(c);
+      expect(getExistingServiceForDoc(grandChildWinNode, 'c')).to.equal(c);
     });
   });
 });


### PR DESCRIPTION
Partial for #4915.

This outlines major changes for "friendly frames" support. It also contains a manual test setup to demonstrate the use of the API. Let's discuss before tests. Some important points:

1. Boundary traversal rules: who and when is allowed traversal
2. Analytics will have to have some major changes to support friendly frames (although it'd have to have the same for shadow DOM as well)
3. Things like UrlReplacements are still very unclear. Specifically we probably shouldn't allow a blanket access to parent document's URL vars - some scoping is necessary. Likewise, shadow DOM has the same issues most likely.
