### PR TITLE
Type check first extension (amp-youtube)

### DIFF
--- a/build-system/amp.extension.extern.js
+++ b/build-system/amp.extension.extern.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var AMP;
+window.AMP;
+// Externed explicitly because we do not export Class shaped names
+// by default.
+/**
+ * This uses the internal name of the type, because there appears to be no
+ * other way to reference an ES6 type from an extern that is defined in
+ * the app.
+ * @constructor
+ * @extends {BaseElement$$module$src$base_element}
+ */
+AMP.BaseElement = class {};
+
+/*
+     \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  /  _____|
+ \   \/    \/   / /  ^  \    |  |_)  |    |   \|  | |  | |   \|  | |  |  __
+  \            / /  /_\  \   |      /     |  . `  | |  | |  . `  | |  | |_ |
+   \    /\    / /  _____  \  |  |\  \----.|  |\   | |  | |  |\   | |  |__| |
+    \__/  \__/ /__/     \__\ | _| `._____||__| \__| |__| |__| \__|  \______|
+
+  Any private property for BaseElement should be declared in
+  build-system/amp.extern.js, this is so closure compiler doesn't rename
+  the private properties of BaseElement since if it did there is a
+  possibility that the private property's new symbol in the core compilation
+  unit would collide with a renamed private property in the inheriting class
+  in extensions.
+ */
+var SomeBaseElementLikeClass;
+SomeBaseElementLikeClass.prototype.layout_;
+
+/** @type {number} */
+SomeBaseElementLikeClass.prototype.layoutWidth_;
+
+/** @type {boolean} */
+SomeBaseElementLikeClass.prototype.inViewport_;
+
+SomeBaseElementLikeClass.prototype.actionMap_;
+
+AMP.BaseTemplate;

--- a/build-system/amp.extension.extern.js
+++ b/build-system/amp.extension.extern.js
@@ -25,7 +25,10 @@ window.AMP;
  * @constructor
  * @extends {BaseElement$$module$src$base_element}
  */
-AMP.BaseElement = class {};
+AMP.BaseElement = class {
+  /** @param {!AmpElement} element */
+  constructor(element) {}
+};
 
 /*
      \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  /  _____|

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -46,39 +46,6 @@ window.AMP_CONFIG.errorReportingUrl;
 // IntersectionObserverEntry, but appears to have been omitted.
 IntersectionObserverEntry.prototype.rootBounds;
 
-// Externed explicitly because we do not export Class shaped names
-// by default.
-/**
- * @constructor
- */
-window.AMP.BaseElement = function(element) {};
-
-/*
-     \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  /  _____|
- \   \/    \/   / /  ^  \    |  |_)  |    |   \|  | |  | |   \|  | |  |  __
-  \            / /  /_\  \   |      /     |  . `  | |  | |  . `  | |  | |_ |
-   \    /\    / /  _____  \  |  |\  \----.|  |\   | |  | |  |\   | |  |__| |
-    \__/  \__/ /__/     \__\ | _| `._____||__| \__| |__| |__| \__|  \______|
-
-  Any private property for BaseElement should be declared in
-  build-system/amp.extern.js, this is so closure compiler doesn't rename
-  the private properties of BaseElement since if it did there is a
-  possibility that the private property's new symbol in the core compilation
-  unit would collide with a renamed private property in the inheriting class
-  in extensions.
- */
-window.AMP.BaseElement.prototype.layout_;
-
-/** @type {number} */
-window.AMP.BaseElement.prototype.layoutWidth_;
-
-/** @type {boolean} */
-window.AMP.BaseElement.prototype.inViewport_;
-
-window.AMP.BaseElement.prototype.actionMap_;
-
-window.AMP.BaseTemplate;
-
 // Externed explicitly because this private property is read across
 // binaries.
 Element.implementation_ = {};

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -72,13 +72,20 @@ function cleanupBuildDir() {
 }
 exports.cleanupBuildDir = cleanupBuildDir;
 
-function compile(entryModuleFilename, outputDir,
+function compile(entryModuleFilenames, outputDir,
     outputFilename, options) {
   return new Promise(function(resolve, reject) {
+    var entryModuleFilename;
+    if (entryModuleFilenames instanceof Array) {
+      entryModuleFilename = entryModuleFilenames[0];
+    } else {
+      entryModuleFilename = entryModuleFilenames;
+      entryModuleFilenames = [entryModuleFilename];
+    }
     const checkTypes = options.checkTypes || argv.typecheck_only;
     var intermediateFilename = 'build/cc/' +
         entryModuleFilename.replace(/\//g, '_').replace(/^\./, '');
-    console./*OK*/log('Starting closure compiler for', entryModuleFilename);
+    console./*OK*/log('Starting closure compiler for', entryModuleFilenames);
 
     // If undefined/null or false then we're ok executing the deletions
     // and mkdir.
@@ -197,7 +204,7 @@ function compile(entryModuleFilename, outputDir,
           'build/patched-module/',
           'build/fake-module/',
         ],
-        entry_point: entryModuleFilename,
+        entry_point: entryModuleFilenames,
         process_common_js_modules: true,
         // This strips all files from the input set that aren't explicitly
         // required.

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -29,8 +29,9 @@ const YT_PLAYER_STATE_PLAYING = 1;
 
 class AmpYoutube extends AMP.BaseElement {
 
-  constructor() {
-    super();
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
     /** @private {number} */
     this.playerState_ = 0;
 

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -18,7 +18,7 @@ import {getDataParamsFromAttributes} from '../../../src/dom';
 import {loadPromise} from '../../../src/event-helper';
 import {tryParseJson} from '../../../src/json';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {user} from '../../../src/log';
+import {dev, user} from '../../../src/log';
 import {setStyles} from '../../../src/style';
 import {addParamsToUrl} from '../../../src/url';
 import {timerFor} from '../../../src/timer';
@@ -29,13 +29,34 @@ const YT_PLAYER_STATE_PLAYING = 1;
 
 class AmpYoutube extends AMP.BaseElement {
 
-  /** @override */
-  preconnectCallback(onLayout) {
-    this.preconnect.url('https://www.youtube.com', onLayout);
+  constructor() {
+    super();
+    /** @private {number} */
+    this.playerState_ = 0;
+
+    /** @private {?string}  */
+    this.videoid_ = null;
+
+    /** @private {?Element} */
+    this.iframe_ = null;
+
+    /** @private {?Promise} */
+    this.playerReadyPromise_ = null;
+
+    /** @private {?Function} */
+    this.playerReadyResolver_ = null;
+  }
+
+  /**
+   * @param {boolean=} opt_onLayout
+   * @override
+   */
+  preconnectCallback(opt_onLayout) {
+    this.preconnect.url('https://www.youtube.com', opt_onLayout);
     // Host that YT uses to serve JS needed by player.
-    this.preconnect.url('https://s.ytimg.com', onLayout);
+    this.preconnect.url('https://s.ytimg.com', opt_onLayout);
     // Load high resolution placeholder images for videos in prerender mode.
-    this.preconnect.url('https://i.ytimg.com', onLayout);
+    this.preconnect.url('https://i.ytimg.com', opt_onLayout);
   }
 
   /** @override */
@@ -50,10 +71,6 @@ class AmpYoutube extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    /** @private {number} */
-    this.playerState_ = 0;
-
-    /** @private @const {string} */
     this.videoid_ = user().assert(
         this.element.getAttribute('data-videoid'),
         'The data-videoid attribute is required for <amp-youtube> %s',
@@ -69,8 +86,8 @@ class AmpYoutube extends AMP.BaseElement {
     // See
     // https://developers.google.com/youtube/iframe_api_reference
     const iframe = this.element.ownerDocument.createElement('iframe');
-
-    let src = `https://www.youtube.com/embed/${encodeURIComponent(this.videoid_)}?enablejsapi=1`;
+    dev().assert(this.videoid_);
+    let src = `https://www.youtube.com/embed/${encodeURIComponent(this.videoid_ || '')}?enablejsapi=1`;
 
     const params = getDataParamsFromAttributes(this.element);
     if ('autoplay' in params) {
@@ -85,12 +102,9 @@ class AmpYoutube extends AMP.BaseElement {
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
 
-    /** @private {!Element} */
     this.iframe_ = iframe;
 
-    /** @private @const {!Promise} */
     this.playerReadyPromise_ = new Promise(resolve => {
-      /** @private @const {function()} */
       this.playerReadyResolver_ = resolve;
     });
 
@@ -164,7 +178,8 @@ class AmpYoutube extends AMP.BaseElement {
   /** @private */
   buildImagePlaceholder_() {
     const imgPlaceholder = this.element.ownerDocument.createElement('img');
-    const videoid = this.videoid_;
+    dev().assert(this.videoid_);
+    const videoid = this.videoid_ || '';
 
     setStyles(imgPlaceholder, {
       // Cover matches YouTube Player styling.
@@ -178,7 +193,7 @@ class AmpYoutube extends AMP.BaseElement {
     // load the needed size or even better match YTPlayer logic for loading
     // player thumbnails for different screen sizes for a cache win!
     imgPlaceholder.src = 'https://i.ytimg.com/vi/' +
-        encodeURIComponent(this.videoid_) + '/sddefault.jpg#404_is_fine';
+        encodeURIComponent(videoid) + '/sddefault.jpg#404_is_fine';
     imgPlaceholder.setAttribute('placeholder', '');
     imgPlaceholder.setAttribute('referrerpolicy', 'origin');
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -354,8 +354,15 @@ function checkTypes() {
     checkTypes: true,
     preventRemoveAndMakeDir: true,
   });
-  compile(false, true, /* opt_preventRemoveAndMakeDir*/ true,
-      /* check types */ true);
+  //compile(false, true, /* opt_preventRemoveAndMakeDir*/ true,
+  //    /* check types */ true);
+  closureCompile([
+    './src/amp-babel.js',
+    './extensions/amp-youtube/0.1/amp-youtube.js',
+  ],  './dist', 'check-types.js', {
+    checkTypes: true,
+    externs: ['build-system/amp.extension.extern.js',],
+  });
 }
 
 /**

--- a/src/dom.js
+++ b/src/dom.js
@@ -414,7 +414,7 @@ export function childElementsByTag(parent, tagName) {
  * Returns element data-param- attributes as url parameters key-value pairs.
  * e.g. data-param-some-attr=value -> {someAttr: value}.
  * @param {!Element} element
- * @param {function(string):string} opt_computeParamNameFunc to compute the parameter
+ * @param {function(string):string=} opt_computeParamNameFunc to compute the parameter
  *    name, get passed the camel-case parameter name.
  * @param {string=} opt_paramPattern Regex pattern to match data attributes.
  * @return {!Object<string, string>}


### PR DESCRIPTION
- Compiles together with main binary. While this may overlook some problems, it avoid unknown type warnings.
- Adds a dedicated extern for `AMP.BaseElement`. This is needed to get the inheritance hierarchy correct and not get unknown type warnings for other compilation units.