### PR TITLE
Don't include closure compiler polyfills in secondary binaries.

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -198,6 +198,8 @@ function compile(entryModuleFilenames, outputDir,
         // Transpile from ES6 to ES5.
         language_in: 'ECMASCRIPT6',
         language_out: 'ECMASCRIPT5',
+        rewrite_polyfills: !!(
+            options.includePolyfills || options.includeBasicPolyfills),
         externs: externs,
         js_module_root: [
           'node_modules/',

--- a/build-system/tasks/size.js
+++ b/build-system/tasks/size.js
@@ -211,6 +211,7 @@ function sizeTask() {
   gulp.src([
       'dist/**/*.js',
       '!dist/**/*-latest.js',
+      '!dist/**/check-types.js',
       'dist.3p/{current,current-min}/**/*.js',
     ])
     .pipe(sizer())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -158,6 +158,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     minify: shouldMinify,
     preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
     externs: ['ads/ads.extern.js',],
+    includeBasicPolyfills: true,
   });
 
   // For compilation with babel we start with the amp-babel entry point,

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,17 +1,17 @@
       max   |         min   |         gzip   |   file
       ---   |         ---   |          ---   |   ---
   70.5 kB   |     5.62 kB   |      2.45 kB   |   alp.js / alp.max.js
-774.03 kB   |   143.97 kB   |     45.46 kB   |   shadow-v0.js / amp-shadow.js
+774.03 kB   |   143.97 kB   |     45.45 kB   |   shadow-v0.js / amp-shadow.js
     428 B   |       278 B   |   sw-kill.js
     537 B   |       382 B   |        sw.js
-808.67 kB   |   145.55 kB   |     46.01 kB   |   v0.js / amp.js
-500.95 kB   |    46.37 kB   |     16.58 kB   |   v0/amp-a4a-0.1.js
+808.67 kB   |   145.55 kB   |        46 kB   |   v0.js / amp.js
+500.95 kB   |     2.07 kB   |      1.27 kB   |   v0/amp-a4a-0.1.js
 298.16 kB   |     40.4 kB   |     13.61 kB   |   v0/amp-access-0.1.js
  54.95 kB   |      6.3 kB   |      2.51 kB   |   v0/amp-accordion-0.1.js
-455.61 kB   |    73.51 kB   |     24.72 kB   |   v0/amp-ad-0.1.js
-542.36 kB   |    75.33 kB   |     26.32 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-535.73 kB   |    73.71 kB   |     25.83 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-503.85 kB   |    68.16 kB   |     23.86 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+455.61 kB   |    33.55 kB   |     12.26 kB   |   v0/amp-ad-0.1.js
+542.36 kB   |    35.29 kB   |     13.31 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+535.73 kB   |    33.67 kB   |      12.8 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+503.85 kB   |    27.35 kB   |     10.49 kB   |   v0/amp-ad-network-fake-impl-0.1.js
 291.51 kB   |    61.04 kB   |      22.1 kB   |   v0/amp-analytics-0.1.js
  106.9 kB   |     8.23 kB   |      3.42 kB   |   v0/amp-anim-0.1.js
 126.14 kB   |     9.34 kB   |      3.76 kB   |   v0/amp-apester-media-0.1.js
@@ -19,35 +19,35 @@
 108.76 kB   |     6.83 kB   |       2.9 kB   |   v0/amp-audio-0.1.js
  97.93 kB   |     7.56 kB   |      3.04 kB   |   v0/amp-brid-player-0.1.js
 129.64 kB   |     7.28 kB   |      2.96 kB   |   v0/amp-brightcove-0.1.js
-249.83 kB   |    35.92 kB   |     11.07 kB   |   v0/amp-carousel-0.1.js
+249.83 kB   |    35.92 kB   |     11.06 kB   |   v0/amp-carousel-0.1.js
  90.66 kB   |     6.31 kB   |      2.68 kB   |   v0/amp-dailymotion-0.1.js
 112.64 kB   |     2.14 kB   |      1.05 kB   |   v0/amp-dynamic-css-classes-0.1.js
 127.91 kB   |     8.17 kB   |      3.41 kB   |   v0/amp-experiment-0.1.js
 155.73 kB   |    15.37 kB   |      6.21 kB   |   v0/amp-facebook-0.1.js
  41.89 kB   |     3.07 kB   |      1.35 kB   |   v0/amp-fit-text-0.1.js
 114.93 kB   |     7.92 kB   |      3.23 kB   |   v0/amp-font-0.1.js
-170.86 kB   |    13.93 kB   |      5.48 kB   |   v0/amp-form-0.1.js
+170.86 kB   |    13.93 kB   |      5.47 kB   |   v0/amp-form-0.1.js
  40.31 kB   |     4.33 kB   |       1.9 kB   |   v0/amp-fresh-0.1.js
  51.95 kB   |     7.08 kB   |      2.88 kB   |   v0/amp-fx-flying-carpet-0.1.js
  90.14 kB   |     6.07 kB   |      2.56 kB   |   v0/amp-gfycat-0.1.js
 119.05 kB   |     8.28 kB   |      3.42 kB   |   v0/amp-google-vrview-image-0.1.js
  174.2 kB   |     15.1 kB   |      6.03 kB   |   v0/amp-iframe-0.1.js
-245.79 kB   |    31.51 kB   |     10.35 kB   |   v0/amp-image-lightbox-0.1.js
+245.79 kB   |    31.51 kB   |     10.34 kB   |   v0/amp-image-lightbox-0.1.js
 117.46 kB   |     7.24 kB   |      3.02 kB   |   v0/amp-instagram-0.1.js
 101.15 kB   |     8.39 kB   |      3.56 kB   |   v0/amp-install-serviceworker-0.1.js
- 97.35 kB   |     7.03 kB   |      2.94 kB   |   v0/amp-jwplayer-0.1.js
+ 97.35 kB   |     7.03 kB   |      2.93 kB   |   v0/amp-jwplayer-0.1.js
 135.01 kB   |     8.11 kB   |      3.32 kB   |   v0/amp-kaltura-player-0.1.js
 152.82 kB   |    11.86 kB   |      4.45 kB   |   v0/amp-lightbox-0.1.js
 146.43 kB   |    13.62 kB   |      4.79 kB   |   v0/amp-lightbox-viewer-0.1.js
 101.96 kB   |      5.8 kB   |       2.5 kB   |   v0/amp-list-0.1.js
 164.76 kB   |    12.77 kB   |      4.83 kB   |   v0/amp-live-list-0.1.js
-155.67 kB   |    40.22 kB   |      14.4 kB   |   v0/amp-mustache-0.1.js
+155.67 kB   |    40.22 kB   |     14.39 kB   |   v0/amp-mustache-0.1.js
  91.18 kB   |      6.7 kB   |      2.72 kB   |   v0/amp-o2-player-0.1.js
 145.74 kB   |    20.25 kB   |      6.05 kB   |   v0/amp-pinterest-0.1.js
  90.36 kB   |     5.97 kB   |      2.53 kB   |   v0/amp-reach-player-0.1.js
    100 kB   |     5.83 kB   |      2.52 kB   |   v0/amp-share-tracking-0.1.js
 104.43 kB   |    10.04 kB   |      3.77 kB   |   v0/amp-sidebar-0.1.js
-   118 kB   |     9.81 kB   |      3.93 kB   |   v0/amp-slides-0.1.js
+   118 kB   |     9.81 kB   |      3.92 kB   |   v0/amp-slides-0.1.js
 130.86 kB   |    13.51 kB   |      5.11 kB   |   v0/amp-social-share-0.1.js
  90.79 kB   |     6.29 kB   |      2.63 kB   |   v0/amp-soundcloud-0.1.js
  98.25 kB   |     7.76 kB   |      3.04 kB   |   v0/amp-springboard-player-0.1.js

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,62 +1,61 @@
-      max   |         min   |        gzip   |   file
-      ---   |         ---   |         ---   |   ---
- 69.93 kB   |     5.52 kB   |     2.43 kB   |   alp.js / alp.max.js
-770.91 kB   |   143.88 kB   |    45.43 kB   |   shadow-v0.js / amp-shadow.js
-   5.8 kB   |       428 B   |       278 B   |   sw-kill.js / sw-kill.max.js
- 293.9 kB   |     1.95 kB   |       972 B   |   sw.js / sw.max.js
-805.44 kB   |   145.45 kB   |    45.94 kB   |   v0.js / amp.js
- 333.2 kB   |     3.48 kB   |     1.85 kB   |   v0/amp-a4a-0.1.js
-297.33 kB   |    41.75 kB   |    14.09 kB   |   v0/amp-access-0.1.js
- 54.23 kB   |      6.3 kB   |     2.53 kB   |   v0/amp-accordion-0.1.js
-289.06 kB   |    34.89 kB   |    12.74 kB   |   v0/amp-ad-0.1.js
-375.63 kB   |    36.63 kB   |    13.79 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-369.01 kB   |    35.01 kB   |    13.29 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-336.07 kB   |    28.69 kB   |    10.99 kB   |   v0/amp-ad-network-fake-impl-0.1.js
-290.88 kB   |    62.68 kB   |    22.68 kB   |   v0/amp-analytics-0.1.js
-106.32 kB   |     8.13 kB   |      3.4 kB   |   v0/amp-anim-0.1.js
-125.42 kB   |     9.24 kB   |     3.74 kB   |   v0/amp-apester-media-0.1.js
-163.13 kB   |    16.96 kB   |     6.48 kB   |   v0/amp-app-banner-0.1.js
-108.18 kB   |     6.83 kB   |     2.92 kB   |   v0/amp-audio-0.1.js
- 97.93 kB   |     7.46 kB   |     3.02 kB   |   v0/amp-brid-player-0.1.js
-128.93 kB   |     7.28 kB   |     2.98 kB   |   v0/amp-brightcove-0.1.js
-249.02 kB   |    36.47 kB   |    11.33 kB   |   v0/amp-carousel-0.1.js
- 90.67 kB   |     6.21 kB   |     2.66 kB   |   v0/amp-dailymotion-0.1.js
-112.07 kB   |     2.25 kB   |     1.09 kB   |   v0/amp-dynamic-css-classes-0.1.js
-127.12 kB   |     9.49 kB   |     3.89 kB   |   v0/amp-experiment-0.1.js
-154.88 kB   |    15.38 kB   |     6.23 kB   |   v0/amp-facebook-0.1.js
- 41.16 kB   |     3.07 kB   |     1.35 kB   |   v0/amp-fit-text-0.1.js
-114.35 kB   |     7.82 kB   |     3.21 kB   |   v0/amp-font-0.1.js
-170.27 kB   |    15.39 kB   |     5.99 kB   |   v0/amp-form-0.1.js
- 40.32 kB   |     4.23 kB   |     1.87 kB   |   v0/amp-fresh-0.1.js
- 51.22 kB   |     6.98 kB   |     2.85 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 90.15 kB   |     5.96 kB   |     2.55 kB   |   v0/amp-gfycat-0.1.js
-119.05 kB   |     8.28 kB   |     3.45 kB   |   v0/amp-google-vrview-image-0.1.js
-173.22 kB   |    15.11 kB   |     6.05 kB   |   v0/amp-iframe-0.1.js
-244.88 kB   |    32.02 kB   |    10.59 kB   |   v0/amp-image-lightbox-0.1.js
- 116.7 kB   |     7.11 kB   |     2.99 kB   |   v0/amp-instagram-0.1.js
-101.16 kB   |     8.39 kB   |     3.58 kB   |   v0/amp-install-serviceworker-0.1.js
- 97.36 kB   |     6.92 kB   |     2.91 kB   |   v0/amp-jwplayer-0.1.js
- 134.3 kB   |     8.11 kB   |     3.34 kB   |   v0/amp-kaltura-player-0.1.js
-152.24 kB   |    12.41 kB   |     4.72 kB   |   v0/amp-lightbox-0.1.js
- 145.7 kB   |    13.52 kB   |     4.78 kB   |   v0/amp-lightbox-viewer-0.1.js
-101.96 kB   |      5.8 kB   |     2.52 kB   |   v0/amp-list-0.1.js
-164.05 kB   |     14.1 kB   |     5.34 kB   |   v0/amp-live-list-0.1.js
-155.09 kB   |    40.22 kB   |    14.42 kB   |   v0/amp-mustache-0.1.js
- 91.19 kB   |      6.6 kB   |     2.71 kB   |   v0/amp-o2-player-0.1.js
-145.02 kB   |    20.25 kB   |     6.07 kB   |   v0/amp-pinterest-0.1.js
- 89.78 kB   |     5.87 kB   |     2.51 kB   |   v0/amp-reach-player-0.1.js
-100.01 kB   |     5.72 kB   |      2.5 kB   |   v0/amp-share-tracking-0.1.js
- 103.6 kB   |     9.93 kB   |     3.75 kB   |   v0/amp-sidebar-0.1.js
-117.42 kB   |      9.7 kB   |      3.9 kB   |   v0/amp-slides-0.1.js
-130.12 kB   |    14.15 kB   |     5.39 kB   |   v0/amp-social-share-0.1.js
- 90.79 kB   |     6.19 kB   |     2.61 kB   |   v0/amp-soundcloud-0.1.js
- 98.25 kB   |     7.66 kB   |     3.03 kB   |   v0/amp-springboard-player-0.1.js
-114.27 kB   |     7.95 kB   |     3.22 kB   |   v0/amp-sticky-ad-0.1.js
-155.24 kB   |     15.5 kB   |     6.27 kB   |   v0/amp-twitter-0.1.js
-131.78 kB   |    10.31 kB   |     4.04 kB   |   v0/amp-user-notification-0.1.js
- 90.21 kB   |     5.96 kB   |     2.55 kB   |   v0/amp-vimeo-0.1.js
- 89.81 kB   |     5.83 kB   |     2.51 kB   |   v0/amp-vine-0.1.js
-642.69 kB   |   514.19 kB   |   168.52 kB   |   v0/amp-viz-vega-0.1.js
-141.17 kB   |     8.61 kB   |     3.57 kB   |   v0/amp-youtube-0.1.js
- 12.87 kB   |     3.58 kB   |     1.58 kB   |   v0/cache-service-worker-0.1.js
-206.18 kB   |    45.83 kB   |    15.97 kB   |   current-min/f.js / current/integration.js
+      max   |         min   |         gzip   |   file
+      ---   |         ---   |          ---   |   ---
+  70.5 kB   |     5.62 kB   |      2.45 kB   |   alp.js / alp.max.js
+774.03 kB   |   143.97 kB   |     45.46 kB   |   shadow-v0.js / amp-shadow.js
+    428 B   |       278 B   |   sw-kill.js
+    537 B   |       382 B   |        sw.js
+808.67 kB   |   145.55 kB   |     46.01 kB   |   v0.js / amp.js
+500.95 kB   |    46.37 kB   |     16.58 kB   |   v0/amp-a4a-0.1.js
+298.16 kB   |     40.4 kB   |     13.61 kB   |   v0/amp-access-0.1.js
+ 54.95 kB   |      6.3 kB   |      2.51 kB   |   v0/amp-accordion-0.1.js
+455.61 kB   |    73.51 kB   |     24.72 kB   |   v0/amp-ad-0.1.js
+542.36 kB   |    75.33 kB   |     26.32 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+535.73 kB   |    73.71 kB   |     25.83 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+503.85 kB   |    68.16 kB   |     23.86 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+291.51 kB   |    61.04 kB   |      22.1 kB   |   v0/amp-analytics-0.1.js
+ 106.9 kB   |     8.23 kB   |      3.42 kB   |   v0/amp-anim-0.1.js
+126.14 kB   |     9.34 kB   |      3.76 kB   |   v0/amp-apester-media-0.1.js
+163.93 kB   |     16.3 kB   |      6.17 kB   |   v0/amp-app-banner-0.1.js
+108.76 kB   |     6.83 kB   |       2.9 kB   |   v0/amp-audio-0.1.js
+ 97.93 kB   |     7.56 kB   |      3.04 kB   |   v0/amp-brid-player-0.1.js
+129.64 kB   |     7.28 kB   |      2.96 kB   |   v0/amp-brightcove-0.1.js
+249.83 kB   |    35.92 kB   |     11.07 kB   |   v0/amp-carousel-0.1.js
+ 90.66 kB   |     6.31 kB   |      2.68 kB   |   v0/amp-dailymotion-0.1.js
+112.64 kB   |     2.14 kB   |      1.05 kB   |   v0/amp-dynamic-css-classes-0.1.js
+127.91 kB   |     8.17 kB   |      3.41 kB   |   v0/amp-experiment-0.1.js
+155.73 kB   |    15.37 kB   |      6.21 kB   |   v0/amp-facebook-0.1.js
+ 41.89 kB   |     3.07 kB   |      1.35 kB   |   v0/amp-fit-text-0.1.js
+114.93 kB   |     7.92 kB   |      3.23 kB   |   v0/amp-font-0.1.js
+170.86 kB   |    13.93 kB   |      5.48 kB   |   v0/amp-form-0.1.js
+ 40.31 kB   |     4.33 kB   |       1.9 kB   |   v0/amp-fresh-0.1.js
+ 51.95 kB   |     7.08 kB   |      2.88 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 90.14 kB   |     6.07 kB   |      2.56 kB   |   v0/amp-gfycat-0.1.js
+119.05 kB   |     8.28 kB   |      3.42 kB   |   v0/amp-google-vrview-image-0.1.js
+ 174.2 kB   |     15.1 kB   |      6.03 kB   |   v0/amp-iframe-0.1.js
+245.79 kB   |    31.51 kB   |     10.35 kB   |   v0/amp-image-lightbox-0.1.js
+117.46 kB   |     7.24 kB   |      3.02 kB   |   v0/amp-instagram-0.1.js
+101.15 kB   |     8.39 kB   |      3.56 kB   |   v0/amp-install-serviceworker-0.1.js
+ 97.35 kB   |     7.03 kB   |      2.94 kB   |   v0/amp-jwplayer-0.1.js
+135.01 kB   |     8.11 kB   |      3.32 kB   |   v0/amp-kaltura-player-0.1.js
+152.82 kB   |    11.86 kB   |      4.45 kB   |   v0/amp-lightbox-0.1.js
+146.43 kB   |    13.62 kB   |      4.79 kB   |   v0/amp-lightbox-viewer-0.1.js
+101.96 kB   |      5.8 kB   |       2.5 kB   |   v0/amp-list-0.1.js
+164.76 kB   |    12.77 kB   |      4.83 kB   |   v0/amp-live-list-0.1.js
+155.67 kB   |    40.22 kB   |      14.4 kB   |   v0/amp-mustache-0.1.js
+ 91.18 kB   |      6.7 kB   |      2.72 kB   |   v0/amp-o2-player-0.1.js
+145.74 kB   |    20.25 kB   |      6.05 kB   |   v0/amp-pinterest-0.1.js
+ 90.36 kB   |     5.97 kB   |      2.53 kB   |   v0/amp-reach-player-0.1.js
+   100 kB   |     5.83 kB   |      2.52 kB   |   v0/amp-share-tracking-0.1.js
+104.43 kB   |    10.04 kB   |      3.77 kB   |   v0/amp-sidebar-0.1.js
+   118 kB   |     9.81 kB   |      3.93 kB   |   v0/amp-slides-0.1.js
+130.86 kB   |    13.51 kB   |      5.11 kB   |   v0/amp-social-share-0.1.js
+ 90.79 kB   |     6.29 kB   |      2.63 kB   |   v0/amp-soundcloud-0.1.js
+ 98.25 kB   |     7.76 kB   |      3.04 kB   |   v0/amp-springboard-player-0.1.js
+   115 kB   |     8.05 kB   |      3.24 kB   |   v0/amp-sticky-ad-0.1.js
+156.09 kB   |    15.49 kB   |      6.24 kB   |   v0/amp-twitter-0.1.js
+132.42 kB   |    10.31 kB   |      4.02 kB   |   v0/amp-user-notification-0.1.js
+  90.2 kB   |     6.07 kB   |      2.57 kB   |   v0/amp-vimeo-0.1.js
+  89.8 kB   |     5.93 kB   |      2.53 kB   |   v0/amp-vine-0.1.js
+643.43 kB   |   514.19 kB   |    168.51 kB   |   v0/amp-viz-vega-0.1.js
+ 142.2 kB   |     8.64 kB   |      3.56 kB   |   v0/amp-youtube-0.1.js
+207.07 kB   |    45.93 kB   |     15.98 kB   |   current-min/f.js / current/integration.js


### PR DESCRIPTION
Small code size wins across the board.

fixes https://github.com/ampproject/amphtml/issues/4933