### PR TITLE
Make Log DCEable.

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -29,7 +29,7 @@ import {computeInMasterFrame, nextTick, register, run} from './3p';
 import {urls} from '../src/config';
 import {endsWith} from '../src/string';
 import {parseUrl, getSourceUrl} from '../src/url';
-import {user} from '../src/log';
+import {initLogConstructor, user} from '../src/log';
 
 // 3P - please keep in alphabetic order
 import {facebook} from './facebook';
@@ -99,6 +99,7 @@ import {yieldmo} from '../ads/yieldmo';
 import {yieldone} from '../ads/yieldone';
 import {zergnet} from '../ads/zergnet';
 
+initLogConstructor();
 
 /**
  * Whether the embed type may be used with amp-embed tag.

--- a/ads/alp/install-alp.js
+++ b/ads/alp/install-alp.js
@@ -19,6 +19,8 @@
 import '../../third_party/babel/custom-babel-helpers';
 
 import {installAlpClickHandler, warmupStatic} from './handler';
+import {initLogConstructor} from '../../src/log';
 
+initLogConstructor();
 installAlpClickHandler(window);
 warmupStatic(window);

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -225,8 +225,20 @@ var forbiddenTerms = {
       'src/service/xhr-impl.js',
     ],
   },
+  'initLogConstructor': {
+    message: 'Should only be called from JS binary entry files.',
+    whitelist: [
+      '3p/integration.js',
+      'ads/alp/install-alp.js',
+      'dist.3p/current/integration.js',
+      'extensions/amp-access/0.1/amp-login-done.js',
+      'src/runtime.js',
+      'src/log.js',
+      'tools/experiments/experiments.js',
+    ],
+  },
   'sendMessage': {
-    message: privateServiceFactory,
+    message: 'Usages must be reviewed.',
     whitelist: [
       'src/service/viewer-impl.js',
       'extensions/amp-analytics/0.1/storage-impl.js',

--- a/extensions/amp-access/0.1/amp-login-done.js
+++ b/extensions/amp-access/0.1/amp-login-done.js
@@ -22,7 +22,10 @@
 import '../../../third_party/babel/custom-babel-helpers';
 import '../../../src/polyfills';
 import {LoginDoneDialog} from './amp-login-done-dialog';
+import {initLogConstructor} from '../../../src/log';
 import {onDocumentReady} from '../../../src/document-ready';
+
+initLogConstructor();
 
 onDocumentReady(document, () => {
   new LoginDoneDialog(window).start();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -348,6 +348,9 @@ function dist() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   compile(false, true, true);
+  // NOTE:
+  // When adding a line here, consider whether you need to include polyfills
+  // and whether you need to init logging (initLogConstructor).
   buildAlp({minify: true, watch: false, preventRemoveAndMakeDir: true});
   buildSw({minify: true, watch: false, preventRemoveAndMakeDir: true});
   buildExtensions({minify: true, preventRemoveAndMakeDir: true});

--- a/src/log.js
+++ b/src/log.js
@@ -390,7 +390,7 @@ export function rethrowAsync(var_args) {
  * on Log and closure literally can't even.
  * @type {{user: ?Log, dev: ?Log}}
  */
-let logs = window.log = (window.log || {
+const logs = self.log = (self.log || {
   user: null,
   dev: null,
 });

--- a/src/log.js
+++ b/src/log.js
@@ -386,11 +386,33 @@ export function rethrowAsync(var_args) {
 
 
 /**
- * A cached user log. We do not use a Service since the service module depends
+ * Cache for logs. We do not use a Service since the service module depends
  * on Log and closure literally can't even.
- * @type {Log}
+ * @type {{user: ?Log, dev: ?Log}}
  */
-let userLog;
+let logs = window.log = (window.log || {
+  user: null,
+  dev: null,
+});
+
+
+/**
+ * Eventually holds a constructor for Log objects. Lazily initialized, so we
+ * can avoid ever referencing the real constructor except in JS binaries
+ * that actually want to include the implementation.
+ * @typedef {?Function}
+ */
+let logConstructor = null;
+
+
+export function initLogConstructor() {
+  logConstructor = Log;
+}
+
+export function resetLogConstructorForTesting() {
+  logConstructor = null;
+}
+
 
 /**
  * Publisher level log.
@@ -403,10 +425,13 @@ let userLog;
  * @return {!Log}
  */
 export function user() {
-  if (userLog) {
-    return userLog;
+  if (logs.user) {
+    return logs.user;
   }
-  return userLog = new Log(self, mode => {
+  if (!logConstructor) {
+    throw new Error('failed to call initLogConstructor');
+  }
+  return logs.user = new logConstructor(self, mode => {
     const logNum = parseInt(mode.log, 10);
     if (mode.development || logNum >= 1) {
       return LogLevel.FINE;
@@ -415,13 +440,6 @@ export function user() {
   }, USER_ERROR_SENTINEL);
 }
 
-
-/**
- * A cached dev log. We do not use a Service since the service module depends
- * on Log and closure literally can't even.
- * @type {Log}
- */
-let devLog;
 
 /**
  * AMP development log. Calls to `devLog().assert` and `dev.fine` are stripped in
@@ -434,10 +452,13 @@ let devLog;
  * @return {!Log}
  */
 export function dev() {
-  if (devLog) {
-    return devLog;
+  if (logs.dev) {
+    return logs.dev;
   }
-  return devLog = new Log(self, mode => {
+  if (!logConstructor) {
+    throw new Error('failed to call initLogConstructor');
+  }
+  return logs.dev = new logConstructor(self, mode => {
     const logNum = parseInt(mode.log, 10);
     if (logNum >= 3) {
       return LogLevel.FINE;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -58,6 +58,7 @@ import {installViewportService} from './service/viewport-impl';
 import {installVsyncService} from './service/vsync-impl';
 import {installXhrService} from './service/xhr-impl';
 import {isExperimentOn, toggleExperiment} from './experiments';
+import {initLogConstructor} from './log';
 import {platformFor} from './platform';
 import {registerElement} from './custom-element';
 import {registerExtendedElement} from './extended-element';
@@ -68,6 +69,7 @@ import {viewportFor} from './viewport';
 import {waitForBody} from './dom';
 import * as config from './config';
 
+initLogConstructor();
 
 /** @const @private {string} */
 const TAG = 'runtime';

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -30,6 +30,10 @@ import {
   createIframePromise,
   doNotLoadExternalResourcesInTest,
 } from '../../testing/iframe';
+import {
+  initLogConstructor,
+  resetLogConstructorForTesting,
+} from '../../src/log';
 import * as cust from '../../src/custom-element';
 import * as sinon from 'sinon';
 
@@ -446,6 +450,16 @@ describe('Extensions', () => {
   });
 
   describe('get correct script source', () => {
+
+    beforeEach(() => {
+      // These functions must not rely on log for cases in SW.
+      resetLogConstructorForTesting();
+    });
+
+    afterEach(() => {
+      initLogConstructor();
+    });
+
     it('with local mode for testing with compiled js', () => {
       const script = calculateExtensionScriptUrl({
         pathname: 'examples/ads.amp.html',

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,5 +1,6 @@
       max   |         min   |         gzip   |   file
       ---   |         ---   |          ---   |   ---
+<<<<<<< 06eec1122bc9f0e560bd2a3934d168d3c9436367
   70.5 kB   |     5.62 kB   |      2.45 kB   |   alp.js / alp.max.js
 775.57 kB   |   144.02 kB   |     45.47 kB   |   shadow-v0.js / amp-shadow.js
     428 B   |       278 B   |   sw-kill.js
@@ -59,3 +60,64 @@
 643.44 kB   |   514.19 kB   |    168.51 kB   |   v0/amp-viz-vega-0.1.js
 132.57 kB   |     7.06 kB   |      2.99 kB   |   v0/amp-youtube-0.1.js
 206.75 kB   |    45.93 kB   |     15.98 kB   |   current-min/f.js / current/integration.js
+=======
+    71 kB   |     5.77 kB   |      2.52 kB   |   alp.js / alp.max.js
+774.41 kB   |   144.17 kB   |     45.51 kB   |   shadow-v0.js / amp-shadow.js
+    428 B   |       278 B   |   sw-kill.js
+    581 B   |       405 B   |        sw.js
+809.05 kB   |   145.75 kB   |     46.04 kB   |   v0.js / amp.js
+335.04 kB   |     2.12 kB   |      1.29 kB   |   v0/amp-a4a-0.1.js
+298.58 kB   |    38.22 kB   |     12.88 kB   |   v0/amp-access-0.1.js
+ 55.36 kB   |     3.45 kB   |      1.41 kB   |   v0/amp-accordion-0.1.js
+290.76 kB   |    31.46 kB   |     11.54 kB   |   v0/amp-ad-0.1.js
+377.48 kB   |    32.41 kB   |     12.29 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+370.86 kB   |    30.79 kB   |     11.79 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+337.91 kB   |    24.48 kB   |      9.43 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+291.92 kB   |    58.15 kB   |     21.08 kB   |   v0/amp-analytics-0.1.js
+107.46 kB   |      5.4 kB   |      2.36 kB   |   v0/amp-anim-0.1.js
+126.56 kB   |     6.49 kB   |      2.72 kB   |   v0/amp-apester-media-0.1.js
+164.34 kB   |    13.61 kB   |      5.25 kB   |   v0/amp-app-banner-0.1.js
+109.47 kB   |     4.03 kB   |      1.81 kB   |   v0/amp-audio-0.1.js
+ 99.07 kB   |      4.8 kB   |      1.98 kB   |   v0/amp-brid-player-0.1.js
+130.13 kB   |     4.45 kB   |      1.91 kB   |   v0/amp-brightcove-0.1.js
+250.25 kB   |    33.02 kB   |     10.04 kB   |   v0/amp-carousel-0.1.js
+ 91.81 kB   |     3.51 kB   |      1.59 kB   |   v0/amp-dailymotion-0.1.js
+113.05 kB   |     2.19 kB   |      1.06 kB   |   v0/amp-dynamic-css-classes-0.1.js
+128.32 kB   |      5.3 kB   |      2.34 kB   |   v0/amp-experiment-0.1.js
+156.36 kB   |    13.28 kB   |       5.5 kB   |   v0/amp-facebook-0.1.js
+  42.3 kB   |     3.11 kB   |      1.38 kB   |   v0/amp-fit-text-0.1.js
+115.34 kB   |     5.12 kB   |      2.15 kB   |   v0/amp-font-0.1.js
+171.28 kB   |    11.27 kB   |      4.53 kB   |   v0/amp-form-0.1.js
+ 41.45 kB   |     1.48 kB   |        813 B   |   v0/amp-fresh-0.1.js
+ 52.36 kB   |     4.22 kB   |      1.81 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 91.29 kB   |      3.3 kB   |      1.48 kB   |   v0/amp-gfycat-0.1.js
+120.19 kB   |      5.5 kB   |      2.37 kB   |   v0/amp-google-vrview-image-0.1.js
+174.61 kB   |    12.23 kB   |      4.97 kB   |   v0/amp-iframe-0.1.js
+246.21 kB   |    28.61 kB   |      9.28 kB   |   v0/amp-image-lightbox-0.1.js
+117.88 kB   |     4.41 kB   |      1.96 kB   |   v0/amp-instagram-0.1.js
+ 102.2 kB   |     6.25 kB   |      2.81 kB   |   v0/amp-install-serviceworker-0.1.js
+  98.5 kB   |     4.26 kB   |      1.87 kB   |   v0/amp-jwplayer-0.1.js
+135.43 kB   |     5.35 kB   |      2.27 kB   |   v0/amp-kaltura-player-0.1.js
+153.45 kB   |     9.01 kB   |      3.38 kB   |   v0/amp-lightbox-0.1.js
+146.84 kB   |    10.79 kB   |       3.8 kB   |   v0/amp-lightbox-viewer-0.1.js
+103.09 kB   |     2.96 kB   |      1.39 kB   |   v0/amp-list-0.1.js
+165.18 kB   |     9.93 kB   |      3.81 kB   |   v0/amp-live-list-0.1.js
+156.08 kB   |    37.37 kB   |     13.39 kB   |   v0/amp-mustache-0.1.js
+ 92.33 kB   |     3.94 kB   |      1.64 kB   |   v0/amp-o2-player-0.1.js
+146.16 kB   |    17.44 kB   |      4.97 kB   |   v0/amp-pinterest-0.1.js
+ 90.92 kB   |     3.17 kB   |      1.42 kB   |   v0/amp-reach-player-0.1.js
+101.15 kB   |     2.99 kB   |      1.45 kB   |   v0/amp-share-tracking-0.1.js
+104.85 kB   |      7.2 kB   |      2.69 kB   |   v0/amp-sidebar-0.1.js
+118.65 kB   |     7.01 kB   |      2.86 kB   |   v0/amp-slides-0.1.js
+131.28 kB   |    10.66 kB   |      4.01 kB   |   v0/amp-social-share-0.1.js
+ 91.93 kB   |     3.49 kB   |      1.54 kB   |   v0/amp-soundcloud-0.1.js
+ 99.39 kB   |        5 kB   |      1.98 kB   |   v0/amp-springboard-player-0.1.js
+115.42 kB   |     5.22 kB   |      2.15 kB   |   v0/amp-sticky-ad-0.1.js
+156.77 kB   |     13.4 kB   |      5.54 kB   |   v0/amp-twitter-0.1.js
+132.84 kB   |     7.63 kB   |      3.03 kB   |   v0/amp-user-notification-0.1.js
+ 91.35 kB   |     3.27 kB   |      1.48 kB   |   v0/amp-vimeo-0.1.js
+ 90.95 kB   |     3.13 kB   |      1.43 kB   |   v0/amp-vine-0.1.js
+643.85 kB   |   511.36 kB   |    167.47 kB   |   v0/amp-viz-vega-0.1.js
+142.61 kB   |     5.88 kB   |      2.53 kB   |   v0/amp-youtube-0.1.js
+207.19 kB   |    46.09 kB   |     16.04 kB   |   current-min/f.js / current/integration.js
+>>>>>>> Make Log DCEable.

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,123 +1,61 @@
       max   |         min   |         gzip   |   file
       ---   |         ---   |          ---   |   ---
-<<<<<<< 06eec1122bc9f0e560bd2a3934d168d3c9436367
-  70.5 kB   |     5.62 kB   |      2.45 kB   |   alp.js / alp.max.js
-775.57 kB   |   144.02 kB   |     45.47 kB   |   shadow-v0.js / amp-shadow.js
-    428 B   |       278 B   |   sw-kill.js
-    537 B   |       382 B   |        sw.js
-810.21 kB   |    145.6 kB   |     46.02 kB   |   v0.js / amp.js
-330.34 kB   |     2.07 kB   |      1.27 kB   |   v0/amp-a4a-0.1.js
-293.95 kB   |    39.46 kB   |     13.32 kB   |   v0/amp-access-0.1.js
- 54.95 kB   |      6.3 kB   |      2.52 kB   |   v0/amp-accordion-0.1.js
-286.07 kB   |    32.68 kB   |     11.99 kB   |   v0/amp-ad-0.1.js
-372.78 kB   |    34.41 kB   |     13.05 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-366.16 kB   |    32.77 kB   |     12.53 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-333.21 kB   |    26.32 kB   |     10.18 kB   |   v0/amp-ad-network-fake-impl-0.1.js
- 287.3 kB   |    60.15 kB   |     21.85 kB   |   v0/amp-analytics-0.1.js
- 48.96 kB   |     6.57 kB   |       2.8 kB   |   v0/amp-anim-0.1.js
- 115.5 kB   |     7.68 kB   |      3.14 kB   |   v0/amp-apester-media-0.1.js
-159.72 kB   |     15.4 kB   |      5.88 kB   |   v0/amp-app-banner-0.1.js
- 50.96 kB   |     5.18 kB   |      2.28 kB   |   v0/amp-audio-0.1.js
- 40.73 kB   |     5.95 kB   |      2.43 kB   |   v0/amp-brid-player-0.1.js
- 71.62 kB   |     5.63 kB   |      2.33 kB   |   v0/amp-brightcove-0.1.js
-245.62 kB   |     34.9 kB   |     10.73 kB   |   v0/amp-carousel-0.1.js
- 33.44 kB   |     4.66 kB   |      2.06 kB   |   v0/amp-dailymotion-0.1.js
-112.64 kB   |     2.14 kB   |      1.05 kB   |   v0/amp-dynamic-css-classes-0.1.js
-127.92 kB   |     8.17 kB   |      3.41 kB   |   v0/amp-experiment-0.1.js
-146.37 kB   |    13.88 kB   |      5.72 kB   |   v0/amp-facebook-0.1.js
- 41.89 kB   |     3.07 kB   |      1.35 kB   |   v0/amp-fit-text-0.1.js
-110.72 kB   |     6.87 kB   |      2.89 kB   |   v0/amp-font-0.1.js
-166.66 kB   |    13.93 kB   |      5.48 kB   |   v0/amp-form-0.1.js
- 41.05 kB   |     4.33 kB   |       1.9 kB   |   v0/amp-fresh-0.1.js
- 51.95 kB   |     7.08 kB   |      2.88 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 32.81 kB   |      4.4 kB   |      1.93 kB   |   v0/amp-gfycat-0.1.js
- 61.68 kB   |     6.62 kB   |      2.81 kB   |   v0/amp-google-vrview-image-0.1.js
-164.57 kB   |    13.51 kB   |      5.49 kB   |   v0/amp-iframe-0.1.js
-241.58 kB   |    29.86 kB   |       9.8 kB   |   v0/amp-image-lightbox-0.1.js
- 59.47 kB   |     5.59 kB   |       2.4 kB   |   v0/amp-instagram-0.1.js
- 97.58 kB   |     7.48 kB   |      3.25 kB   |   v0/amp-install-serviceworker-0.1.js
- 39.99 kB   |     5.39 kB   |      2.31 kB   |   v0/amp-jwplayer-0.1.js
- 77.06 kB   |     6.48 kB   |       2.7 kB   |   v0/amp-kaltura-player-0.1.js
-148.83 kB   |     7.82 kB   |      2.95 kB   |   v0/amp-lightbox-0.1.js
-142.22 kB   |     12.7 kB   |       4.5 kB   |   v0/amp-lightbox-viewer-0.1.js
-102.69 kB   |      5.8 kB   |       2.5 kB   |   v0/amp-list-0.1.js
-160.93 kB   |    11.99 kB   |      4.58 kB   |   v0/amp-live-list-0.1.js
-155.67 kB   |    40.22 kB   |      14.4 kB   |   v0/amp-mustache-0.1.js
- 33.83 kB   |     5.04 kB   |       2.1 kB   |   v0/amp-o2-player-0.1.js
-145.75 kB   |    20.25 kB   |      6.05 kB   |   v0/amp-pinterest-0.1.js
- 32.54 kB   |     1.35 kB   |        685 B   |   v0/amp-reach-player-0.1.js
-100.74 kB   |     5.83 kB   |      2.52 kB   |   v0/amp-share-tracking-0.1.js
-100.23 kB   |      6.2 kB   |      2.32 kB   |   v0/amp-sidebar-0.1.js
-118.24 kB   |     9.81 kB   |      3.93 kB   |   v0/amp-slides-0.1.js
-130.87 kB   |    13.51 kB   |      5.11 kB   |   v0/amp-social-share-0.1.js
- 33.56 kB   |     4.64 kB   |         2 kB   |   v0/amp-soundcloud-0.1.js
- 41.02 kB   |     6.14 kB   |      2.43 kB   |   v0/amp-springboard-player-0.1.js
-110.79 kB   |     7.06 kB   |      2.89 kB   |   v0/amp-sticky-ad-0.1.js
-146.73 kB   |       14 kB   |      5.75 kB   |   v0/amp-twitter-0.1.js
-132.43 kB   |    10.31 kB   |      4.03 kB   |   v0/amp-user-notification-0.1.js
- 32.85 kB   |     4.41 kB   |      1.94 kB   |   v0/amp-vimeo-0.1.js
- 32.45 kB   |     4.28 kB   |       1.9 kB   |   v0/amp-vine-0.1.js
-643.44 kB   |   514.19 kB   |    168.51 kB   |   v0/amp-viz-vega-0.1.js
-132.57 kB   |     7.06 kB   |      2.99 kB   |   v0/amp-youtube-0.1.js
-206.75 kB   |    45.93 kB   |     15.98 kB   |   current-min/f.js / current/integration.js
-=======
-    71 kB   |     5.77 kB   |      2.52 kB   |   alp.js / alp.max.js
-774.41 kB   |   144.17 kB   |     45.51 kB   |   shadow-v0.js / amp-shadow.js
+  71.2 kB   |     5.77 kB   |      2.51 kB   |   alp.js / alp.max.js
+ 776.2 kB   |   144.25 kB   |     45.54 kB   |   shadow-v0.js / amp-shadow.js
     428 B   |       278 B   |   sw-kill.js
     581 B   |       405 B   |        sw.js
-809.05 kB   |   145.75 kB   |     46.04 kB   |   v0.js / amp.js
-335.04 kB   |     2.12 kB   |      1.29 kB   |   v0/amp-a4a-0.1.js
-298.58 kB   |    38.22 kB   |     12.88 kB   |   v0/amp-access-0.1.js
- 55.36 kB   |     3.45 kB   |      1.41 kB   |   v0/amp-accordion-0.1.js
-290.76 kB   |    31.46 kB   |     11.54 kB   |   v0/amp-ad-0.1.js
-377.48 kB   |    32.41 kB   |     12.29 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-370.86 kB   |    30.79 kB   |     11.79 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-337.91 kB   |    24.48 kB   |      9.43 kB   |   v0/amp-ad-network-fake-impl-0.1.js
-291.92 kB   |    58.15 kB   |     21.08 kB   |   v0/amp-analytics-0.1.js
-107.46 kB   |      5.4 kB   |      2.36 kB   |   v0/amp-anim-0.1.js
-126.56 kB   |     6.49 kB   |      2.72 kB   |   v0/amp-apester-media-0.1.js
-164.34 kB   |    13.61 kB   |      5.25 kB   |   v0/amp-app-banner-0.1.js
-109.47 kB   |     4.03 kB   |      1.81 kB   |   v0/amp-audio-0.1.js
- 99.07 kB   |      4.8 kB   |      1.98 kB   |   v0/amp-brid-player-0.1.js
-130.13 kB   |     4.45 kB   |      1.91 kB   |   v0/amp-brightcove-0.1.js
-250.25 kB   |    33.02 kB   |     10.04 kB   |   v0/amp-carousel-0.1.js
- 91.81 kB   |     3.51 kB   |      1.59 kB   |   v0/amp-dailymotion-0.1.js
-113.05 kB   |     2.19 kB   |      1.06 kB   |   v0/amp-dynamic-css-classes-0.1.js
-128.32 kB   |      5.3 kB   |      2.34 kB   |   v0/amp-experiment-0.1.js
-156.36 kB   |    13.28 kB   |       5.5 kB   |   v0/amp-facebook-0.1.js
-  42.3 kB   |     3.11 kB   |      1.38 kB   |   v0/amp-fit-text-0.1.js
-115.34 kB   |     5.12 kB   |      2.15 kB   |   v0/amp-font-0.1.js
-171.28 kB   |    11.27 kB   |      4.53 kB   |   v0/amp-form-0.1.js
- 41.45 kB   |     1.48 kB   |        813 B   |   v0/amp-fresh-0.1.js
- 52.36 kB   |     4.22 kB   |      1.81 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 91.29 kB   |      3.3 kB   |      1.48 kB   |   v0/amp-gfycat-0.1.js
-120.19 kB   |      5.5 kB   |      2.37 kB   |   v0/amp-google-vrview-image-0.1.js
-174.61 kB   |    12.23 kB   |      4.97 kB   |   v0/amp-iframe-0.1.js
-246.21 kB   |    28.61 kB   |      9.28 kB   |   v0/amp-image-lightbox-0.1.js
-117.88 kB   |     4.41 kB   |      1.96 kB   |   v0/amp-instagram-0.1.js
- 102.2 kB   |     6.25 kB   |      2.81 kB   |   v0/amp-install-serviceworker-0.1.js
-  98.5 kB   |     4.26 kB   |      1.87 kB   |   v0/amp-jwplayer-0.1.js
-135.43 kB   |     5.35 kB   |      2.27 kB   |   v0/amp-kaltura-player-0.1.js
-153.45 kB   |     9.01 kB   |      3.38 kB   |   v0/amp-lightbox-0.1.js
-146.84 kB   |    10.79 kB   |       3.8 kB   |   v0/amp-lightbox-viewer-0.1.js
-103.09 kB   |     2.96 kB   |      1.39 kB   |   v0/amp-list-0.1.js
-165.18 kB   |     9.93 kB   |      3.81 kB   |   v0/amp-live-list-0.1.js
-156.08 kB   |    37.37 kB   |     13.39 kB   |   v0/amp-mustache-0.1.js
- 92.33 kB   |     3.94 kB   |      1.64 kB   |   v0/amp-o2-player-0.1.js
-146.16 kB   |    17.44 kB   |      4.97 kB   |   v0/amp-pinterest-0.1.js
- 90.92 kB   |     3.17 kB   |      1.42 kB   |   v0/amp-reach-player-0.1.js
-101.15 kB   |     2.99 kB   |      1.45 kB   |   v0/amp-share-tracking-0.1.js
-104.85 kB   |      7.2 kB   |      2.69 kB   |   v0/amp-sidebar-0.1.js
-118.65 kB   |     7.01 kB   |      2.86 kB   |   v0/amp-slides-0.1.js
-131.28 kB   |    10.66 kB   |      4.01 kB   |   v0/amp-social-share-0.1.js
- 91.93 kB   |     3.49 kB   |      1.54 kB   |   v0/amp-soundcloud-0.1.js
- 99.39 kB   |        5 kB   |      1.98 kB   |   v0/amp-springboard-player-0.1.js
-115.42 kB   |     5.22 kB   |      2.15 kB   |   v0/amp-sticky-ad-0.1.js
-156.77 kB   |     13.4 kB   |      5.54 kB   |   v0/amp-twitter-0.1.js
-132.84 kB   |     7.63 kB   |      3.03 kB   |   v0/amp-user-notification-0.1.js
- 91.35 kB   |     3.27 kB   |      1.48 kB   |   v0/amp-vimeo-0.1.js
- 90.95 kB   |     3.13 kB   |      1.43 kB   |   v0/amp-vine-0.1.js
-643.85 kB   |   511.36 kB   |    167.47 kB   |   v0/amp-viz-vega-0.1.js
-142.61 kB   |     5.88 kB   |      2.53 kB   |   v0/amp-youtube-0.1.js
-207.19 kB   |    46.09 kB   |     16.04 kB   |   current-min/f.js / current/integration.js
->>>>>>> Make Log DCEable.
+810.84 kB   |   145.83 kB   |     46.08 kB   |   v0.js / amp.js
+330.95 kB   |     2.12 kB   |      1.29 kB   |   v0/amp-a4a-0.1.js
+294.56 kB   |    37.27 kB   |     12.58 kB   |   v0/amp-access-0.1.js
+ 55.56 kB   |     3.45 kB   |      1.41 kB   |   v0/amp-accordion-0.1.js
+286.67 kB   |    30.59 kB   |     11.27 kB   |   v0/amp-ad-0.1.js
+373.39 kB   |    31.52 kB   |     12.05 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+366.77 kB   |     29.9 kB   |     11.54 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+333.82 kB   |    23.45 kB   |      9.12 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+287.91 kB   |    57.26 kB   |     20.82 kB   |   v0/amp-analytics-0.1.js
+ 49.56 kB   |     3.74 kB   |      1.72 kB   |   v0/amp-anim-0.1.js
+116.11 kB   |     4.83 kB   |      2.08 kB   |   v0/amp-apester-media-0.1.js
+160.33 kB   |    12.71 kB   |      4.95 kB   |   v0/amp-app-banner-0.1.js
+ 51.57 kB   |     2.34 kB   |      1.16 kB   |   v0/amp-audio-0.1.js
+ 41.34 kB   |     3.15 kB   |      1.33 kB   |   v0/amp-brid-player-0.1.js
+ 72.23 kB   |     2.79 kB   |      1.25 kB   |   v0/amp-brightcove-0.1.js
+246.23 kB   |    31.98 kB   |      9.72 kB   |   v0/amp-carousel-0.1.js
+ 34.04 kB   |     1.81 kB   |        920 B   |   v0/amp-dailymotion-0.1.js
+113.25 kB   |     2.18 kB   |      1.07 kB   |   v0/amp-dynamic-css-classes-0.1.js
+128.53 kB   |      5.3 kB   |      2.34 kB   |   v0/amp-experiment-0.1.js
+146.98 kB   |    11.79 kB   |         5 kB   |   v0/amp-facebook-0.1.js
+  42.5 kB   |     3.11 kB   |      1.38 kB   |   v0/amp-fit-text-0.1.js
+111.33 kB   |     4.03 kB   |       1.8 kB   |   v0/amp-font-0.1.js
+167.27 kB   |    11.26 kB   |      4.53 kB   |   v0/amp-form-0.1.js
+ 41.65 kB   |     1.48 kB   |        816 B   |   v0/amp-fresh-0.1.js
+ 52.56 kB   |     4.22 kB   |      1.81 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 33.41 kB   |     1.55 kB   |        790 B   |   v0/amp-gfycat-0.1.js
+ 62.29 kB   |      3.8 kB   |      1.73 kB   |   v0/amp-google-vrview-image-0.1.js
+165.18 kB   |    10.63 kB   |      4.42 kB   |   v0/amp-iframe-0.1.js
+242.19 kB   |    26.96 kB   |      8.72 kB   |   v0/amp-image-lightbox-0.1.js
+ 60.08 kB   |     2.75 kB   |      1.29 kB   |   v0/amp-instagram-0.1.js
+  98.2 kB   |      5.3 kB   |      2.48 kB   |   v0/amp-install-serviceworker-0.1.js
+  40.6 kB   |     2.58 kB   |      1.21 kB   |   v0/amp-jwplayer-0.1.js
+ 77.66 kB   |     3.68 kB   |      1.61 kB   |   v0/amp-kaltura-player-0.1.js
+149.44 kB   |     7.86 kB   |      2.97 kB   |   v0/amp-lightbox-0.1.js
+142.83 kB   |     9.87 kB   |      3.48 kB   |   v0/amp-lightbox-viewer-0.1.js
+103.29 kB   |     2.96 kB   |      1.39 kB   |   v0/amp-list-0.1.js
+161.54 kB   |     9.14 kB   |      3.54 kB   |   v0/amp-live-list-0.1.js
+156.28 kB   |    37.36 kB   |     13.39 kB   |   v0/amp-mustache-0.1.js
+ 34.44 kB   |     2.24 kB   |        972 B   |   v0/amp-o2-player-0.1.js
+146.35 kB   |    17.43 kB   |      4.97 kB   |   v0/amp-pinterest-0.1.js
+ 33.15 kB   |     1.39 kB   |        704 B   |   v0/amp-reach-player-0.1.js
+101.35 kB   |     2.99 kB   |      1.45 kB   |   v0/amp-share-tracking-0.1.js
+100.84 kB   |     6.24 kB   |      2.34 kB   |   v0/amp-sidebar-0.1.js
+118.85 kB   |        7 kB   |      2.86 kB   |   v0/amp-slides-0.1.js
+131.47 kB   |    10.66 kB   |      4.01 kB   |   v0/amp-social-share-0.1.js
+ 34.17 kB   |     1.79 kB   |        870 B   |   v0/amp-soundcloud-0.1.js
+ 41.62 kB   |     3.33 kB   |      1.32 kB   |   v0/amp-springboard-player-0.1.js
+111.41 kB   |     4.22 kB   |      1.76 kB   |   v0/amp-sticky-ad-0.1.js
+147.34 kB   |    11.91 kB   |      5.04 kB   |   v0/amp-twitter-0.1.js
+133.04 kB   |     7.63 kB   |      3.03 kB   |   v0/amp-user-notification-0.1.js
+ 33.46 kB   |     1.56 kB   |        803 B   |   v0/amp-vimeo-0.1.js
+ 33.06 kB   |     1.43 kB   |        759 B   |   v0/amp-vine-0.1.js
+644.05 kB   |   511.35 kB   |    167.47 kB   |   v0/amp-viz-vega-0.1.js
+133.17 kB   |     4.26 kB   |      1.94 kB   |   v0/amp-youtube-0.1.js
+      0 B   |    46.09 kB   |     16.04 kB   |   current-min/f.js / current/integration.js

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -16,7 +16,7 @@
 
 import '../../third_party/babel/custom-babel-helpers';
 import '../../src/polyfills';
-import {dev} from '../../src/log';
+import {dev, initLogConstructor} from '../../src/log';
 import {getCookie, setCookie} from '../../src/cookies';
 import {getMode} from '../../src/mode';
 import {isExperimentOn, toggleExperiment} from '../../src/experiments';
@@ -24,6 +24,8 @@ import {listenOnce} from '../../src/event-helper';
 import {onDocumentReady} from '../../src/document-ready';
 //TODO(@cramforce): For type. Replace with forward declaration.
 import '../../src/service/timer-impl';
+
+initLogConstructor();
 
 const COOKIE_MAX_AGE_DAYS = 180;  // 6 month
 


### PR DESCRIPTION
- Makes it so that `user()` and `dev()` do not directly reference the log constuctor. Hence binaries that do not directly initialize it, will not include the class itself.
- A bit sad that one now has to be super careful to initialize the constructor in binaries that want it.
- Also ensures (by caching instances in window instead of a module global) that there is only one instance per window.

Nice code size wins across the board.