### PR TITLE
Expose loadPromise as method on BaseElement

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -529,6 +529,17 @@ var forbiddenTermsSrcInclusive = {
       'extensions/amp-access/0.1/access-expr-impl.js',
     ],
   },
+  '[^.]loadPromise': {
+    message: 'Most users should use BaseElement…loadPromise.',
+    whitelist: [
+      'src/base-element.js',
+      'src/event-helper.js',
+      'src/service/performance-impl.js',
+      'src/service/url-replacements-impl.js',
+      'extensions/amp-ad/0.1/amp-ad-api-handler.js',
+      'extensions/amp-analytics/0.1/transport.js',
+    ]
+  },
 };
 
 // Terms that must appear in a source file.

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -25,8 +25,6 @@ export class AmpImg extends BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-    /** @private @const {function(!Element, number=): !Promise<!Element>} */
-    this.loadPromise_ = this.loadPromise;
 
     /** @private {boolean} */
     this.allowImgLoadFallback_ = true;
@@ -119,7 +117,7 @@ export class AmpImg extends BaseElement {
 
     this.img_.setAttribute('src', src);
 
-    return this.loadPromise_(this.img_).then(() => {
+    return this.loadPromise(this.img_).then(() => {
       // Clean up the fallback if the src has changed.
       if (!this.allowImgLoadFallback_ &&
           this.img_.classList.contains('-amp-ghost')) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -16,7 +16,6 @@
 
 import {BaseElement} from '../src/base-element';
 import {isLayoutSizeDefined} from '../src/layout';
-import {loadPromise} from '../src/event-helper';
 import {registerElement} from '../src/custom-element';
 import {srcsetFromElement} from '../src/srcset';
 
@@ -27,7 +26,7 @@ export class AmpImg extends BaseElement {
   constructor(element) {
     super(element);
     /** @private @const {function(!Element, number=): !Promise<!Element>} */
-    this.loadPromise_ = loadPromise;
+    this.loadPromise_ = this.loadPromise;
 
     /** @private {boolean} */
     this.allowImgLoadFallback_ = true;

--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -17,7 +17,6 @@
 import {BaseElement} from '../src/base-element';
 import {assertHttpsUrl} from '../src/url';
 import {isLayoutSizeDefined} from '../src/layout';
-import {loadPromise} from '../src/event-helper';
 import {registerElement} from '../src/custom-element';
 import {getMode} from '../src/mode';
 import {dev} from '../src/log';
@@ -89,7 +88,7 @@ export function installVideo(win) {
         this.video_.appendChild(child);
       });
 
-      return loadPromise(this.video_);
+      return this.loadPromise(this.video_);
     }
 
     /** @override */

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -20,7 +20,6 @@ import {preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {isAdPositionAllowed, getAdContainer,}
     from '../../../src/ad-helper';
-import {loadPromise} from '../../../src/event-helper';
 import {adPrefetch, adPreconnect} from '../../../ads/_config';
 import {timerFor} from '../../../src/timer';
 import {user} from '../../../src/log';
@@ -261,7 +260,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         return this.apiHandler_.startUp(this.iframe_, true);
       });
     }
-    return loadPromise(this.iframe_);
+    return this.loadPromise(this.iframe_);
   }
 
   /** @override  */

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {srcsetFromElement} from '../../../src/srcset';
 import * as st from '../../../src/style';
 
@@ -97,7 +96,7 @@ class AmpAnim extends AMP.BaseElement {
       return Promise.resolve();
     }
     this.img_.setAttribute('src', src);
-    this.loadPromise_ = loadPromise(this.img_)
+    this.loadPromise_ = this.loadPromise(this.img_)
         .catch(error => {
           if (!this.img_.getAttribute('src')) {
             return;

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -17,7 +17,6 @@
 
 import {CSS} from '../../../build/amp-apester-media-0.1.css';
 import {user, dev} from '../../../src/log';
-import {loadPromise} from '../../../src/event-helper';
 import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
 import {isExperimentOn} from '../../../src/experiments';
 import {removeElement} from '../../../src/dom';
@@ -195,7 +194,7 @@ class AmpApesterMedia extends AMP.BaseElement {
           this.iframe_ = iframe;
           this.element.appendChild(overflow);
           this.element.appendChild(iframe);
-          return this.iframePromise_ = loadPromise(iframe).then(() => {
+          return this.iframePromise_ = this.loadPromise(iframe).then(() => {
             vsyncFor(this.win).runPromise({mutate}, state);
             return media;
           });

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -16,7 +16,6 @@
 
 import {Layout} from '../../../src/layout';
 import {assertHttpsUrl} from '../../../src/url';
-import {loadPromise} from '../../../src/event-helper';
 import {dev} from '../../../src/log';
 
 /**
@@ -65,7 +64,7 @@ export class AmpAudio extends AMP.BaseElement {
     });
     this.element.appendChild(audio);
     this.audio_ = audio;
-    return loadPromise(audio);
+    return this.loadPromise(audio);
   }
 
   /** @override */

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
 import {user} from '../../../src/log';
 
@@ -100,7 +99,7 @@ class AmpBridPlayer extends AMP.BaseElement {
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */
@@ -133,9 +132,9 @@ class AmpBridPlayer extends AMP.BaseElement {
     this.applyFillContent(imgPlaceholder);
     this.element.appendChild(imgPlaceholder);
 
-    loadPromise(imgPlaceholder).catch(() => {
+    this.loadPromise(imgPlaceholder).catch(() => {
       imgPlaceholder.src = 'https://cdn.brid.tv/live/default/defaultSnapshot.png';
-      return loadPromise(imgPlaceholder);
+      return this.loadPromise(imgPlaceholder);
     }).then(() => {
       setStyles(imgPlaceholder, {
         'visibility': '',

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {addParamsToUrl} from '../../../src/url';
 import {getDataParamsFromAttributes, removeElement} from '../../../src/dom';
 import {user} from '../../../src/log';
@@ -75,7 +74,7 @@ class AmpBrightcove extends AMP.BaseElement {
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @private */

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {user} from '../../../src/log';
 
 
@@ -59,7 +58,7 @@ class AmpDailymotion extends AMP.BaseElement {
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @private */

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -18,7 +18,6 @@
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 
 
 class AmpFacebook extends AMP.BaseElement {
@@ -49,7 +48,7 @@ class AmpFacebook extends AMP.BaseElement {
       this./*OK*/changeHeight(data.height);
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 };
 

--- a/extensions/amp-gfycat/0.1/amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/amp-gfycat.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {user} from '../../../src/log';
 
 class AmpGfycat extends AMP.BaseElement {
@@ -69,7 +68,7 @@ class AmpGfycat extends AMP.BaseElement {
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
 
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */

--- a/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
@@ -18,7 +18,6 @@ import {addParamToUrl, assertHttpsUrl} from '../../../src/url';
 import {dev} from '../../../src/log';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {isExperimentOn} from '../../../src/experiments';
-import {loadPromise} from '../../../src/event-helper';
 
 /** @const */
 const TAG = 'amp-google-vrview-image';
@@ -98,7 +97,7 @@ class AmpGoogleVrviewImage extends AMP.BaseElement {
     /** @private {!Element} */
     this.iframe_ = iframe;
 
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 }
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -19,7 +19,6 @@ import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {endsWith} from '../../../src/string';
 import {listenFor} from '../../../src/iframe-helper';
-import {loadPromise} from '../../../src/event-helper';
 import {parseUrl} from '../../../src/url';
 import {removeElement} from '../../../src/dom';
 import {timerFor} from '../../../src/timer';
@@ -306,7 +305,7 @@ export class AmpIframe extends AMP.BaseElement {
 
     this.container_.appendChild(iframe);
 
-    return loadPromise(iframe).then(() => {
+    return this.loadPromise(iframe).then(() => {
       // On iOS the iframe at times fails to render inside the `overflow:auto`
       // container. To avoid this problem, we set the `overflow:auto` property
       // 1s later via `amp-active` class.

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -27,7 +27,7 @@ import {Layout} from '../../../src/layout';
 import {bezierCurve} from '../../../src/curve';
 import {continueMotion} from '../../../src/motion';
 import {historyFor} from '../../../src/history';
-import {isLoaded, loadPromise} from '../../../src/event-helper';
+import {isLoaded} from '../../../src/event-helper';
 import {
   layoutRectFromDomRect,
   layoutRectLtwh,
@@ -289,7 +289,7 @@ export class ImageViewer {
     // and then naturally upgrade to a higher quality image.
     return timerFor(this.win).promise(1).then(() => {
       this.image_.setAttribute('src', src);
-      return loadPromise(this.image_);
+      return this.loadPromise(this.image_);
     });
   }
 

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -36,7 +36,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
 import {removeElement} from '../../../src/dom';
 import {user} from '../../../src/log';
@@ -133,7 +132,7 @@ class AmpInstagram extends AMP.BaseElement {
     setStyles(iframe, {
       'opacity': 0,
     });
-    return this.iframePromise_ = loadPromise(iframe).then(() => {
+    return this.iframePromise_ = this.loadPromise(iframe).then(() => {
       this.getVsync().mutate(() => {
         setStyles(iframe, {
           'opacity': 1,

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
 import {user} from '../../../src/log';
 
@@ -70,7 +69,7 @@ class AmpJWPlayer extends AMP.BaseElement {
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */
@@ -100,7 +99,7 @@ class AmpJWPlayer extends AMP.BaseElement {
 
     // Not every media item has a thumbnail image.  If no image is found,
     // don't add the placeholder to the DOM.
-    loadPromise(imgPlaceholder).then(() => {
+    this.loadPromise(imgPlaceholder).then(() => {
       this.element.appendChild(imgPlaceholder);
     }).catch(() => {
       // If the thumbnail image isn't available, we can safely ignore this

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {addParamsToUrl} from '../../../src/url';
 import {getDataParamsFromAttributes} from '../../../src/dom';
 import {setStyles} from '../../../src/style';
@@ -72,7 +71,7 @@ class AmpKaltura extends AMP.BaseElement {
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @private */
@@ -105,7 +104,7 @@ class AmpKaltura extends AMP.BaseElement {
     this.applyFillContent(imgPlaceholder);
     this.element.appendChild(imgPlaceholder);
 
-    loadPromise(imgPlaceholder).then(() => {
+    this.loadPromise(imgPlaceholder).then(() => {
       setStyles(imgPlaceholder, {
         'visibility': '',
       });

--- a/extensions/amp-o2-player/0.1/amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/amp-o2-player.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {user} from '../../../src/log';
 
 class AmpO2Player extends AMP.BaseElement {
@@ -92,7 +91,7 @@ class AmpO2Player extends AMP.BaseElement {
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */

--- a/extensions/amp-reach-player/0.1/amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/amp-reach-player.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 
 class AmpReachPlayer extends AMP.BaseElement {
 
@@ -51,7 +50,7 @@ class AmpReachPlayer extends AMP.BaseElement {
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */

--- a/extensions/amp-soundcloud/0.1/amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/amp-soundcloud.js
@@ -29,7 +29,6 @@
  */
 
 import {Layout} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {user} from '../../../src/log';
 
 
@@ -94,7 +93,7 @@ class AmpSoundcloud extends AMP.BaseElement {
 
     this.iframe_ = iframe;
 
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
 import {user} from '../../../src/log';
 
@@ -101,7 +100,7 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
     this.applyFillContent(iframe);
     this.iframe_ = iframe;
     this.element.appendChild(iframe);
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */
@@ -138,7 +137,7 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
     this.applyFillContent(imgPlaceholder);
     this.element.appendChild(imgPlaceholder);
 
-    loadPromise(imgPlaceholder).then(() => {
+    this.loadPromise(imgPlaceholder).then(() => {
       setStyles(imgPlaceholder, {
         'visibility': '',
       });

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -18,7 +18,6 @@
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor} from '../../../src/iframe-helper';
-import {loadPromise} from '../../../src/event-helper';
 
 
 class AmpTwitter extends AMP.BaseElement {
@@ -58,7 +57,7 @@ class AmpTwitter extends AMP.BaseElement {
       this./*OK*/changeHeight(data.height);
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 };
 

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -15,7 +15,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {user} from '../../../src/log';
 
 class AmpVimeo extends AMP.BaseElement {
@@ -51,7 +50,7 @@ class AmpVimeo extends AMP.BaseElement {
     this.element.appendChild(iframe);
     /** @private {?Element} */
     this.iframe_ = iframe;
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */

--- a/extensions/amp-vine/0.1/amp-vine.js
+++ b/extensions/amp-vine/0.1/amp-vine.js
@@ -16,7 +16,6 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {loadPromise} from '../../../src/event-helper';
 import {user} from '../../../src/log';
 
 class AmpVine extends AMP.BaseElement {
@@ -51,7 +50,7 @@ class AmpVine extends AMP.BaseElement {
     /** @private {?Element} */
     this.iframe_ = iframe;
 
-    return loadPromise(iframe);
+    return this.loadPromise(iframe);
   }
 
   /** @override */

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -15,7 +15,6 @@
  */
 
 import {getDataParamsFromAttributes} from '../../../src/dom';
-import {loadPromise} from '../../../src/event-helper';
 import {tryParseJson} from '../../../src/json';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
@@ -112,7 +111,7 @@ class AmpYoutube extends AMP.BaseElement {
     this.win.addEventListener(
         'message', event => this.handleYoutubeMessages_(event));
 
-    return loadPromise(iframe)
+    return this.loadPromise(iframe)
         .then(() => {
           // Make sure the YT player is ready for this. For some reason YT player
           // would send couple of messages but then stop. Waiting for a bit before
@@ -203,7 +202,7 @@ class AmpYoutube extends AMP.BaseElement {
 
     // Because sddefault.jpg isn't available for all videos, we try to load
     // it and fallback to hqdefault.jpg.
-    loadPromise(imgPlaceholder).then(() => {
+    this.loadPromise(imgPlaceholder).then(() => {
       // A pretty ugly hack since onerror won't fire on YouTube image 404.
       // This might be due to the fact that YouTube returns data to the request
       // even when the status is 404. YouTube returns a placeholder image that
@@ -215,7 +214,7 @@ class AmpYoutube extends AMP.BaseElement {
     }).catch(() => {
       imgPlaceholder.src = 'https://i.ytimg.com/vi/' +
           encodeURIComponent(videoid) + '/hqdefault.jpg';
-      return loadPromise(imgPlaceholder);
+      return this.loadPromise(imgPlaceholder);
     }).then(() => {
       setStyles(imgPlaceholder, {
         'visibility': '',

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -15,6 +15,7 @@
  */
 
 import {Layout} from './layout';
+import {loadPromise} from './event-helper';
 import {preconnectFor} from './preconnect';
 import {viewerFor} from './viewer';
 import {viewportFor} from './viewport';
@@ -415,6 +416,20 @@ export class BaseElement {
    * @param {!./service/action-impl.ActionInvocation} unusedInvocation
    */
   activate(unusedInvocation) {
+  }
+
+  /**
+   * Returns a promise that will resolve or fail based on the element's 'load'
+   * and 'error' events. Optionally this method takes a timeout, which will reject
+   * the promise if the resource has not loaded by then.
+   * @param {T} element
+   * @param {number=} opt_timeout
+   * @return {!Promise<T>}
+   * @template T
+   * @final
+   */
+  loadPromise(element, opt_timeout) {
+    return loadPromise(element, opt_timeout);
   }
 
   /**

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -120,7 +120,7 @@ describe('amp-img', () => {
     });
 
     it('should not display fallback if loading succeeds', () => {
-      sandbox.stub(impl, 'loadPromise_').returns(Promise.resolve());
+      sandbox.stub(impl, 'loadPromise').returns(Promise.resolve());
       const errorSpy = sandbox.spy(impl, 'onImgLoadingError_');
       const toggleSpy = sandbox.spy(impl, 'toggleFallback');
       impl.buildCallback();
@@ -137,7 +137,7 @@ describe('amp-img', () => {
     });
 
     it('should display fallback if loading fails', () => {
-      sandbox.stub(impl, 'loadPromise_').returns(Promise.reject());
+      sandbox.stub(impl, 'loadPromise').returns(Promise.reject());
       const errorSpy = sandbox.spy(impl, 'onImgLoadingError_');
       const toggleSpy = sandbox.spy(impl, 'toggleFallback');
       impl.buildCallback();
@@ -154,7 +154,7 @@ describe('amp-img', () => {
     });
 
     it('should fallback only once', () => {
-      const loadStub = sandbox.stub(impl, 'loadPromise_');
+      const loadStub = sandbox.stub(impl, 'loadPromise');
       loadStub
           .onCall(0).returns(Promise.reject())
           .onCall(1).returns(Promise.resolve());
@@ -187,7 +187,7 @@ describe('amp-img', () => {
     });
 
     it('should remove the fallback if src is successfully updated', () => {
-      const loadStub = sandbox.stub(impl, 'loadPromise_');
+      const loadStub = sandbox.stub(impl, 'loadPromise');
       loadStub.onCall(0).returns(Promise.reject());
       loadStub.returns(Promise.resolve());
       impl.buildCallback();
@@ -208,7 +208,7 @@ describe('amp-img', () => {
     });
 
     it('should not remove the fallback if src is not updated', () => {
-      const loadStub = sandbox.stub(impl, 'loadPromise_');
+      const loadStub = sandbox.stub(impl, 'loadPromise');
       loadStub.onCall(0).returns(Promise.reject());
       loadStub.returns(Promise.resolve());
       impl.buildCallback();
@@ -228,7 +228,7 @@ describe('amp-img', () => {
 
     it('should not remove the fallback if src is updated but ' +
        'fails fetching', () => {
-      const loadStub = sandbox.stub(impl, 'loadPromise_');
+      const loadStub = sandbox.stub(impl, 'loadPromise');
       loadStub.returns(Promise.reject());
       impl.buildCallback();
 

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,121 +1,61 @@
       max   |         min   |         gzip   |   file
       ---   |         ---   |          ---   |   ---
   70.5 kB   |     5.62 kB   |      2.45 kB   |   alp.js / alp.max.js
-<<<<<<< 17c4b9b48629dd837a174e161ec2a96bfadcc723
-775.32 kB   |      144 kB   |     45.45 kB   |   shadow-v0.js / amp-shadow.js
+775.57 kB   |   144.02 kB   |     45.47 kB   |   shadow-v0.js / amp-shadow.js
     428 B   |       278 B   |   sw-kill.js
     537 B   |       382 B   |        sw.js
-809.96 kB   |   145.58 kB   |     46.03 kB   |   v0.js / amp.js
-330.42 kB   |     2.07 kB   |      1.27 kB   |   v0/amp-a4a-0.1.js
+810.21 kB   |    145.6 kB   |     46.02 kB   |   v0.js / amp.js
+330.34 kB   |     2.07 kB   |      1.27 kB   |   v0/amp-a4a-0.1.js
 293.95 kB   |    39.46 kB   |     13.32 kB   |   v0/amp-access-0.1.js
- 54.95 kB   |      6.3 kB   |      2.51 kB   |   v0/amp-accordion-0.1.js
-286.14 kB   |    32.67 kB   |     11.99 kB   |   v0/amp-ad-0.1.js
-372.86 kB   |    34.41 kB   |     13.06 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-366.23 kB   |    32.77 kB   |     12.53 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-333.29 kB   |    26.32 kB   |     10.18 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+ 54.95 kB   |      6.3 kB   |      2.52 kB   |   v0/amp-accordion-0.1.js
+286.07 kB   |    32.68 kB   |     11.99 kB   |   v0/amp-ad-0.1.js
+372.78 kB   |    34.41 kB   |     13.05 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+366.16 kB   |    32.77 kB   |     12.53 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+333.21 kB   |    26.32 kB   |     10.18 kB   |   v0/amp-ad-network-fake-impl-0.1.js
  287.3 kB   |    60.15 kB   |     21.85 kB   |   v0/amp-analytics-0.1.js
-102.84 kB   |     7.24 kB   |      3.08 kB   |   v0/amp-anim-0.1.js
-121.94 kB   |     8.29 kB   |      3.39 kB   |   v0/amp-apester-media-0.1.js
+ 48.96 kB   |     6.57 kB   |       2.8 kB   |   v0/amp-anim-0.1.js
+ 115.5 kB   |     7.68 kB   |      3.14 kB   |   v0/amp-apester-media-0.1.js
 159.72 kB   |     15.4 kB   |      5.88 kB   |   v0/amp-app-banner-0.1.js
-104.84 kB   |     5.84 kB   |      2.56 kB   |   v0/amp-audio-0.1.js
- 94.45 kB   |     6.57 kB   |       2.7 kB   |   v0/amp-brid-player-0.1.js
-125.51 kB   |     6.29 kB   |      2.62 kB   |   v0/amp-brightcove-0.1.js
-245.62 kB   |     34.9 kB   |     10.74 kB   |   v0/amp-carousel-0.1.js
- 87.19 kB   |     5.32 kB   |      2.34 kB   |   v0/amp-dailymotion-0.1.js
+ 50.96 kB   |     5.18 kB   |      2.28 kB   |   v0/amp-audio-0.1.js
+ 40.73 kB   |     5.95 kB   |      2.43 kB   |   v0/amp-brid-player-0.1.js
+ 71.62 kB   |     5.63 kB   |      2.33 kB   |   v0/amp-brightcove-0.1.js
+245.62 kB   |     34.9 kB   |     10.73 kB   |   v0/amp-carousel-0.1.js
+ 33.44 kB   |     4.66 kB   |      2.06 kB   |   v0/amp-dailymotion-0.1.js
 112.64 kB   |     2.14 kB   |      1.05 kB   |   v0/amp-dynamic-css-classes-0.1.js
 127.92 kB   |     8.17 kB   |      3.41 kB   |   v0/amp-experiment-0.1.js
-151.74 kB   |    14.49 kB   |      5.93 kB   |   v0/amp-facebook-0.1.js
+146.37 kB   |    13.88 kB   |      5.72 kB   |   v0/amp-facebook-0.1.js
  41.89 kB   |     3.07 kB   |      1.35 kB   |   v0/amp-fit-text-0.1.js
 110.72 kB   |     6.87 kB   |      2.89 kB   |   v0/amp-font-0.1.js
 166.66 kB   |    13.93 kB   |      5.48 kB   |   v0/amp-form-0.1.js
  41.05 kB   |     4.33 kB   |       1.9 kB   |   v0/amp-fresh-0.1.js
  51.95 kB   |     7.08 kB   |      2.88 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 86.67 kB   |     5.08 kB   |      2.22 kB   |   v0/amp-gfycat-0.1.js
-115.56 kB   |     7.28 kB   |      3.08 kB   |   v0/amp-google-vrview-image-0.1.js
-169.99 kB   |    14.11 kB   |      5.71 kB   |   v0/amp-iframe-0.1.js
-241.59 kB   |    30.45 kB   |     10.01 kB   |   v0/amp-image-lightbox-0.1.js
-113.26 kB   |     6.25 kB   |      2.68 kB   |   v0/amp-instagram-0.1.js
+ 32.81 kB   |      4.4 kB   |      1.93 kB   |   v0/amp-gfycat-0.1.js
+ 61.68 kB   |     6.62 kB   |      2.81 kB   |   v0/amp-google-vrview-image-0.1.js
+164.57 kB   |    13.51 kB   |      5.49 kB   |   v0/amp-iframe-0.1.js
+241.58 kB   |    29.86 kB   |       9.8 kB   |   v0/amp-image-lightbox-0.1.js
+ 59.47 kB   |     5.59 kB   |       2.4 kB   |   v0/amp-instagram-0.1.js
  97.58 kB   |     7.48 kB   |      3.25 kB   |   v0/amp-install-serviceworker-0.1.js
- 93.88 kB   |     6.04 kB   |      2.59 kB   |   v0/amp-jwplayer-0.1.js
-130.81 kB   |     7.12 kB   |      2.99 kB   |   v0/amp-kaltura-player-0.1.js
+ 39.99 kB   |     5.39 kB   |      2.31 kB   |   v0/amp-jwplayer-0.1.js
+ 77.06 kB   |     6.48 kB   |       2.7 kB   |   v0/amp-kaltura-player-0.1.js
 148.83 kB   |     7.82 kB   |      2.95 kB   |   v0/amp-lightbox-0.1.js
 142.22 kB   |     12.7 kB   |       4.5 kB   |   v0/amp-lightbox-viewer-0.1.js
 102.69 kB   |      5.8 kB   |       2.5 kB   |   v0/amp-list-0.1.js
-160.56 kB   |     11.9 kB   |      4.55 kB   |   v0/amp-live-list-0.1.js
-155.67 kB   |    40.22 kB   |     14.39 kB   |   v0/amp-mustache-0.1.js
- 87.71 kB   |     5.71 kB   |      2.38 kB   |   v0/amp-o2-player-0.1.js
-145.75 kB   |    20.25 kB   |      6.05 kB   |   v0/amp-pinterest-0.1.js
-  86.3 kB   |     4.98 kB   |      2.18 kB   |   v0/amp-reach-player-0.1.js
-100.74 kB   |     5.83 kB   |      2.52 kB   |   v0/amp-share-tracking-0.1.js
-100.23 kB   |      6.2 kB   |      2.32 kB   |   v0/amp-sidebar-0.1.js
-118.24 kB   |     9.81 kB   |      3.92 kB   |   v0/amp-slides-0.1.js
-130.87 kB   |    13.51 kB   |      5.11 kB   |   v0/amp-social-share-0.1.js
- 87.31 kB   |      5.3 kB   |      2.29 kB   |   v0/amp-soundcloud-0.1.js
- 94.77 kB   |     6.77 kB   |      2.71 kB   |   v0/amp-springboard-player-0.1.js
-110.79 kB   |     7.06 kB   |      2.89 kB   |   v0/amp-sticky-ad-0.1.js
-152.15 kB   |    14.61 kB   |      5.97 kB   |   v0/amp-twitter-0.1.js
-132.43 kB   |    10.31 kB   |      4.02 kB   |   v0/amp-user-notification-0.1.js
- 86.73 kB   |     5.07 kB   |      2.23 kB   |   v0/amp-vimeo-0.1.js
- 86.33 kB   |     4.94 kB   |      2.19 kB   |   v0/amp-vine-0.1.js
-643.44 kB   |   514.19 kB   |    168.51 kB   |   v0/amp-viz-vega-0.1.js
-137.99 kB   |     7.65 kB   |      3.23 kB   |   v0/amp-youtube-0.1.js
-=======
-774.35 kB   |   144.01 kB   |     45.47 kB   |   shadow-v0.js / amp-shadow.js
-    428 B   |       278 B   |   sw-kill.js
-    537 B   |       382 B   |        sw.js
-808.99 kB   |   145.59 kB   |     46.02 kB   |   v0.js / amp.js
-334.53 kB   |     2.07 kB   |      1.27 kB   |   v0/amp-a4a-0.1.js
-298.17 kB   |    40.41 kB   |     13.62 kB   |   v0/amp-access-0.1.js
- 54.95 kB   |      6.3 kB   |      2.51 kB   |   v0/amp-accordion-0.1.js
-290.25 kB   |    33.56 kB   |     12.26 kB   |   v0/amp-ad-0.1.js
-376.97 kB   |    35.29 kB   |     13.31 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-370.34 kB   |    33.67 kB   |      12.8 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
- 337.4 kB   |    27.35 kB   |     10.49 kB   |   v0/amp-ad-network-fake-impl-0.1.js
-291.51 kB   |    61.04 kB   |      22.1 kB   |   v0/amp-analytics-0.1.js
- 48.96 kB   |     6.57 kB   |       2.8 kB   |   v0/amp-anim-0.1.js
- 115.5 kB   |     7.68 kB   |      3.13 kB   |   v0/amp-apester-media-0.1.js
-163.93 kB   |     16.3 kB   |      6.17 kB   |   v0/amp-app-banner-0.1.js
- 50.96 kB   |     5.18 kB   |      2.28 kB   |   v0/amp-audio-0.1.js
- 40.58 kB   |     5.93 kB   |      2.43 kB   |   v0/amp-brid-player-0.1.js
- 71.62 kB   |     5.63 kB   |      2.33 kB   |   v0/amp-brightcove-0.1.js
-249.84 kB   |    35.92 kB   |     11.07 kB   |   v0/amp-carousel-0.1.js
- 33.31 kB   |     4.66 kB   |      2.05 kB   |   v0/amp-dailymotion-0.1.js
-112.64 kB   |     2.14 kB   |      1.05 kB   |   v0/amp-dynamic-css-classes-0.1.js
-127.92 kB   |     8.17 kB   |      3.41 kB   |   v0/amp-experiment-0.1.js
-150.52 kB   |    14.74 kB   |         6 kB   |   v0/amp-facebook-0.1.js
- 41.89 kB   |     3.07 kB   |      1.35 kB   |   v0/amp-fit-text-0.1.js
-114.94 kB   |     7.92 kB   |      3.23 kB   |   v0/amp-font-0.1.js
-170.87 kB   |    13.93 kB   |      5.47 kB   |   v0/amp-form-0.1.js
- 41.05 kB   |     4.33 kB   |       1.9 kB   |   v0/amp-fresh-0.1.js
- 51.95 kB   |     7.08 kB   |      2.88 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 32.79 kB   |     4.41 kB   |      1.94 kB   |   v0/amp-gfycat-0.1.js
- 61.68 kB   |     6.62 kB   |      2.81 kB   |   v0/amp-google-vrview-image-0.1.js
-168.77 kB   |     14.5 kB   |      5.81 kB   |   v0/amp-iframe-0.1.js
-245.79 kB   |    30.93 kB   |     10.14 kB   |   v0/amp-image-lightbox-0.1.js
- 59.37 kB   |     5.59 kB   |       2.4 kB   |   v0/amp-instagram-0.1.js
- 101.8 kB   |     8.39 kB   |      3.56 kB   |   v0/amp-install-serviceworker-0.1.js
- 39.99 kB   |     5.39 kB   |      2.31 kB   |   v0/amp-jwplayer-0.1.js
- 76.91 kB   |     6.47 kB   |       2.7 kB   |   v0/amp-kaltura-player-0.1.js
-153.04 kB   |    11.86 kB   |      4.45 kB   |   v0/amp-lightbox-0.1.js
-146.44 kB   |    13.62 kB   |      4.79 kB   |   v0/amp-lightbox-viewer-0.1.js
-102.69 kB   |      5.8 kB   |       2.5 kB   |   v0/amp-list-0.1.js
-164.77 kB   |    12.77 kB   |      4.83 kB   |   v0/amp-live-list-0.1.js
+160.93 kB   |    11.99 kB   |      4.58 kB   |   v0/amp-live-list-0.1.js
 155.67 kB   |    40.22 kB   |      14.4 kB   |   v0/amp-mustache-0.1.js
  33.83 kB   |     5.04 kB   |       2.1 kB   |   v0/amp-o2-player-0.1.js
 145.75 kB   |    20.25 kB   |      6.05 kB   |   v0/amp-pinterest-0.1.js
- 32.42 kB   |     1.34 kB   |        684 B   |   v0/amp-reach-player-0.1.js
+ 32.54 kB   |     1.35 kB   |        685 B   |   v0/amp-reach-player-0.1.js
 100.74 kB   |     5.83 kB   |      2.52 kB   |   v0/amp-share-tracking-0.1.js
-104.44 kB   |    10.04 kB   |      3.77 kB   |   v0/amp-sidebar-0.1.js
+100.23 kB   |      6.2 kB   |      2.32 kB   |   v0/amp-sidebar-0.1.js
 118.24 kB   |     9.81 kB   |      3.93 kB   |   v0/amp-slides-0.1.js
 130.87 kB   |    13.51 kB   |      5.11 kB   |   v0/amp-social-share-0.1.js
- 33.44 kB   |     4.64 kB   |         2 kB   |   v0/amp-soundcloud-0.1.js
- 40.88 kB   |     6.12 kB   |      2.42 kB   |   v0/amp-springboard-player-0.1.js
-115.01 kB   |     8.05 kB   |      3.24 kB   |   v0/amp-sticky-ad-0.1.js
-150.93 kB   |    14.86 kB   |      6.04 kB   |   v0/amp-twitter-0.1.js
-132.43 kB   |    10.31 kB   |      4.02 kB   |   v0/amp-user-notification-0.1.js
+ 33.56 kB   |     4.64 kB   |         2 kB   |   v0/amp-soundcloud-0.1.js
+ 41.02 kB   |     6.14 kB   |      2.43 kB   |   v0/amp-springboard-player-0.1.js
+110.79 kB   |     7.06 kB   |      2.89 kB   |   v0/amp-sticky-ad-0.1.js
+146.73 kB   |       14 kB   |      5.75 kB   |   v0/amp-twitter-0.1.js
+132.43 kB   |    10.31 kB   |      4.03 kB   |   v0/amp-user-notification-0.1.js
  32.85 kB   |     4.41 kB   |      1.94 kB   |   v0/amp-vimeo-0.1.js
  32.45 kB   |     4.28 kB   |       1.9 kB   |   v0/amp-vine-0.1.js
 643.44 kB   |   514.19 kB   |    168.51 kB   |   v0/amp-viz-vega-0.1.js
-136.78 kB   |     8.04 kB   |      3.35 kB   |   v0/amp-youtube-0.1.js
->>>>>>> Expose loadPromise as method on BaseElement
+132.57 kB   |     7.06 kB   |      2.99 kB   |   v0/amp-youtube-0.1.js
 206.75 kB   |    45.93 kB   |     15.98 kB   |   current-min/f.js / current/integration.js

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,6 +1,7 @@
       max   |         min   |         gzip   |   file
       ---   |         ---   |          ---   |   ---
   70.5 kB   |     5.62 kB   |      2.45 kB   |   alp.js / alp.max.js
+<<<<<<< 17c4b9b48629dd837a174e161ec2a96bfadcc723
 775.32 kB   |      144 kB   |     45.45 kB   |   shadow-v0.js / amp-shadow.js
     428 B   |       278 B   |   sw-kill.js
     537 B   |       382 B   |        sw.js
@@ -58,4 +59,63 @@
  86.33 kB   |     4.94 kB   |      2.19 kB   |   v0/amp-vine-0.1.js
 643.44 kB   |   514.19 kB   |    168.51 kB   |   v0/amp-viz-vega-0.1.js
 137.99 kB   |     7.65 kB   |      3.23 kB   |   v0/amp-youtube-0.1.js
+=======
+774.35 kB   |   144.01 kB   |     45.47 kB   |   shadow-v0.js / amp-shadow.js
+    428 B   |       278 B   |   sw-kill.js
+    537 B   |       382 B   |        sw.js
+808.99 kB   |   145.59 kB   |     46.02 kB   |   v0.js / amp.js
+334.53 kB   |     2.07 kB   |      1.27 kB   |   v0/amp-a4a-0.1.js
+298.17 kB   |    40.41 kB   |     13.62 kB   |   v0/amp-access-0.1.js
+ 54.95 kB   |      6.3 kB   |      2.51 kB   |   v0/amp-accordion-0.1.js
+290.25 kB   |    33.56 kB   |     12.26 kB   |   v0/amp-ad-0.1.js
+376.97 kB   |    35.29 kB   |     13.31 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+370.34 kB   |    33.67 kB   |      12.8 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+ 337.4 kB   |    27.35 kB   |     10.49 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+291.51 kB   |    61.04 kB   |      22.1 kB   |   v0/amp-analytics-0.1.js
+ 48.96 kB   |     6.57 kB   |       2.8 kB   |   v0/amp-anim-0.1.js
+ 115.5 kB   |     7.68 kB   |      3.13 kB   |   v0/amp-apester-media-0.1.js
+163.93 kB   |     16.3 kB   |      6.17 kB   |   v0/amp-app-banner-0.1.js
+ 50.96 kB   |     5.18 kB   |      2.28 kB   |   v0/amp-audio-0.1.js
+ 40.58 kB   |     5.93 kB   |      2.43 kB   |   v0/amp-brid-player-0.1.js
+ 71.62 kB   |     5.63 kB   |      2.33 kB   |   v0/amp-brightcove-0.1.js
+249.84 kB   |    35.92 kB   |     11.07 kB   |   v0/amp-carousel-0.1.js
+ 33.31 kB   |     4.66 kB   |      2.05 kB   |   v0/amp-dailymotion-0.1.js
+112.64 kB   |     2.14 kB   |      1.05 kB   |   v0/amp-dynamic-css-classes-0.1.js
+127.92 kB   |     8.17 kB   |      3.41 kB   |   v0/amp-experiment-0.1.js
+150.52 kB   |    14.74 kB   |         6 kB   |   v0/amp-facebook-0.1.js
+ 41.89 kB   |     3.07 kB   |      1.35 kB   |   v0/amp-fit-text-0.1.js
+114.94 kB   |     7.92 kB   |      3.23 kB   |   v0/amp-font-0.1.js
+170.87 kB   |    13.93 kB   |      5.47 kB   |   v0/amp-form-0.1.js
+ 41.05 kB   |     4.33 kB   |       1.9 kB   |   v0/amp-fresh-0.1.js
+ 51.95 kB   |     7.08 kB   |      2.88 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 32.79 kB   |     4.41 kB   |      1.94 kB   |   v0/amp-gfycat-0.1.js
+ 61.68 kB   |     6.62 kB   |      2.81 kB   |   v0/amp-google-vrview-image-0.1.js
+168.77 kB   |     14.5 kB   |      5.81 kB   |   v0/amp-iframe-0.1.js
+245.79 kB   |    30.93 kB   |     10.14 kB   |   v0/amp-image-lightbox-0.1.js
+ 59.37 kB   |     5.59 kB   |       2.4 kB   |   v0/amp-instagram-0.1.js
+ 101.8 kB   |     8.39 kB   |      3.56 kB   |   v0/amp-install-serviceworker-0.1.js
+ 39.99 kB   |     5.39 kB   |      2.31 kB   |   v0/amp-jwplayer-0.1.js
+ 76.91 kB   |     6.47 kB   |       2.7 kB   |   v0/amp-kaltura-player-0.1.js
+153.04 kB   |    11.86 kB   |      4.45 kB   |   v0/amp-lightbox-0.1.js
+146.44 kB   |    13.62 kB   |      4.79 kB   |   v0/amp-lightbox-viewer-0.1.js
+102.69 kB   |      5.8 kB   |       2.5 kB   |   v0/amp-list-0.1.js
+164.77 kB   |    12.77 kB   |      4.83 kB   |   v0/amp-live-list-0.1.js
+155.67 kB   |    40.22 kB   |      14.4 kB   |   v0/amp-mustache-0.1.js
+ 33.83 kB   |     5.04 kB   |       2.1 kB   |   v0/amp-o2-player-0.1.js
+145.75 kB   |    20.25 kB   |      6.05 kB   |   v0/amp-pinterest-0.1.js
+ 32.42 kB   |     1.34 kB   |        684 B   |   v0/amp-reach-player-0.1.js
+100.74 kB   |     5.83 kB   |      2.52 kB   |   v0/amp-share-tracking-0.1.js
+104.44 kB   |    10.04 kB   |      3.77 kB   |   v0/amp-sidebar-0.1.js
+118.24 kB   |     9.81 kB   |      3.93 kB   |   v0/amp-slides-0.1.js
+130.87 kB   |    13.51 kB   |      5.11 kB   |   v0/amp-social-share-0.1.js
+ 33.44 kB   |     4.64 kB   |         2 kB   |   v0/amp-soundcloud-0.1.js
+ 40.88 kB   |     6.12 kB   |      2.42 kB   |   v0/amp-springboard-player-0.1.js
+115.01 kB   |     8.05 kB   |      3.24 kB   |   v0/amp-sticky-ad-0.1.js
+150.93 kB   |    14.86 kB   |      6.04 kB   |   v0/amp-twitter-0.1.js
+132.43 kB   |    10.31 kB   |      4.02 kB   |   v0/amp-user-notification-0.1.js
+ 32.85 kB   |     4.41 kB   |      1.94 kB   |   v0/amp-vimeo-0.1.js
+ 32.45 kB   |     4.28 kB   |       1.9 kB   |   v0/amp-vine-0.1.js
+643.44 kB   |   514.19 kB   |    168.51 kB   |   v0/amp-viz-vega-0.1.js
+136.78 kB   |     8.04 kB   |      3.35 kB   |   v0/amp-youtube-0.1.js
+>>>>>>> Expose loadPromise as method on BaseElement
 206.75 kB   |    45.93 kB   |     15.98 kB   |   current-min/f.js / current/integration.js


### PR DESCRIPTION
…instead of importing the module. Almost all extensions use it and it is often their only substatial import.

Significant code size wins across the board.