### PR TITLE
Fix travis skip matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
     - python-protobuf
 before_install:
   - |
-      git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(examples|spec))/' || {
+      [ -z "$(git diff --name-only $TRAVIS_COMMIT_RANGE)" ] || git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.(md|txt)$)|(^(examples|spec))/' || {
         echo "Only docs were updated, stopping build process."
         exit
       }


### PR DESCRIPTION
Canary cuts are hard checkouts, meaning they have no previous commit to
compare against. Because there's no comparison, the diff check would
return an empty string. Because the empty string passes the "not
anything that's not a doc change" check, it would skip Travis.