### PR TITLE
Make our compilation O(extensions) instead of O(extensions**2)

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -118,13 +118,23 @@ function compile(entryModuleFilenames, outputDir,
             internalRuntimeVersion + '/';
     }
     const srcs = [
-      '3p/**/*.js',
-      'ads/**/*.js',
-      'extensions/**/*.js',
-      'build/**/*.js',
-      '!build/cc/**',
-      '!build/polyfills.js',
-      '!build/polyfills/**/*.js',
+      '3p/3p.js',
+      // Ads config files.
+      'ads/_*.js',
+      'ads/alp/**/*.js',
+      'ads/google/**/*.js',
+      // Files under build/. Should be sparse.
+      'build/css.js',
+      'build/*.css.js',
+      'build/fake-module/**/*.js',
+      'build/patched-module/**/*.js',
+      'build/experiments/**/*.js',
+      // Strange access/login related files.
+      'build/all/v0/*.js',
+      // A4A has these cross extension deps.
+      'extensions/**/*-config.js',
+      'extensions/amp-ad/**/*.js',
+      'extensions/amp-a4a/**/*.js',
       'src/**/*.js',
       '!third_party/babel/custom-babel-helpers.js',
       // Exclude since it's not part of the runtime/extension binaries.
@@ -140,7 +150,7 @@ function compile(entryModuleFilenames, outputDir,
       'node_modules/promise-pjs/promise.js',
       'build/patched-module/document-register-element/build/' +
           'document-register-element.max.js',
-      'node_modules/core-js/modules/**.js',
+      //'node_modules/core-js/modules/**.js',
       // Not sure what these files are, but they seem to duplicate code
       // one level below and confuse the compiler.
       '!node_modules/core-js/modules/library/**.js',
@@ -149,6 +159,21 @@ function compile(entryModuleFilenames, outputDir,
       '!**/test-*.js',
       '!**/*.extern.js',
     ];
+    // Add needed path for extensions.
+    // Instead of globbing all extensions, this will only add the actual
+    // extension path for much quicker build times.
+    entryModuleFilenames.forEach(function(filename) {
+      if (!filename.startsWith('extensions/')) {
+        return;
+      }
+      var path = filename.replace(/\/[^/]+\.js$/, '/**/*.js');
+      srcs.push(path);
+    });
+    if (options.include3pDirectories) {
+      srcs.push(
+        '3p/**/*.js',
+        'ads/**/*.js')
+    }
     // Many files include the polyfills, but we only want to deliver them
     // once. Since all files automatically wait for the main binary to load
     // this works fine.
@@ -259,6 +284,7 @@ function compile(entryModuleFilenames, outputDir,
     var stream = gulp.src(srcs)
         .pipe(closureCompiler(compilerOptions))
         .on('error', function(err) {
+          console./*OK*/error('Error compiling', entryModuleFilenames);
           console./*OK*/error(err.message);
           process.exit(1);
         });

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -163,7 +163,7 @@ function compile(entryModuleFilenames, outputDir,
     // Instead of globbing all extensions, this will only add the actual
     // extension path for much quicker build times.
     entryModuleFilenames.forEach(function(filename) {
-      if (!filename.indexOf('extensions/') == -1) {
+      if (filename.indexOf('extensions/') == -1) {
         return;
       }
       var path = filename.replace(/\/[^/]+\.js$/, '/**/*.js');

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -163,7 +163,7 @@ function compile(entryModuleFilenames, outputDir,
     // Instead of globbing all extensions, this will only add the actual
     // extension path for much quicker build times.
     entryModuleFilenames.forEach(function(filename) {
-      if (!filename.startsWith('extensions/')) {
+      if (!filename.indexOf('extensions/') == -1) {
         return;
       }
       var path = filename.replace(/\/[^/]+\.js$/, '/**/*.js');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -159,6 +159,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
     externs: ['ads/ads.extern.js',],
     includeBasicPolyfills: true,
+    include3pDirectories: true,
   });
 
   // For compilation with babel we start with the amp-babel entry point,


### PR DESCRIPTION
Closure compiler parses all files in the glob for module ids and dependencies only to drop 99% on a typical compilation.

This change make extensions only glob themselves and not other extensions and additonally makes the glob area sparser (e.g. only `integration.js` globs the 3p code like it should be).

Significant additional work can be done to further reduce the files included in a given compilation, but this should be a good first step.