### PR TITLE
Cache SW: Handle Foreign Fetches

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -376,6 +376,7 @@ function checkTypes() {
     './src/amp-shadow.js',
     './ads/alp/install-alp.js',
     './src/service-worker/shell.js',
+    './src/service-worker/core.js',
     './src/service-worker/kill.js',
   ];
   var extensionSrcs = Object.values(extensions).filter(function(extension) {

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -307,6 +307,7 @@ export function handleFetch(request, maybeClientId) {
 
 self.addEventListener('install', install => {
   install.waitUntil(cachePromise);
+  // Registers the SW for Foreign Fetch events, if they are supported.
   if (install.registerForeignFetch) {
     install.registerForeignFetch({
       scopes: [/** @type {!ServiceWorkerGlobalScope} */(

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -150,7 +150,6 @@ const cachePromise = caches.open('cdn-js').then(result => {
 function fetchAndCache(cache, request, requestFile, requestVersion) {
   // TODO(jridgewell): we should also fetch this requestVersion for all files
   // we know about.
-
   return fetch(request).then(response => {
     // Did we receive a valid response (200 <= status < 300)?
     if (response && response.ok) {
@@ -193,6 +192,8 @@ function fetchAndCache(cache, request, requestFile, requestVersion) {
  * @return {!Promise<string>}
  */
 function getCachedVersion(cache, requestFile) {
+  // TODO(jridgewell): We should make this a bit smarter, so that it selects
+  // the version that has a lot of matches, not just this request file.
   return cache.keys().then(requests => {
     for (let i = 0; i < requests.length; i++) {
       const url = requests[i].url;
@@ -314,10 +315,10 @@ self.addEventListener('foreignfetch', event => {
     return;
   }
 
-  event.respondWith(response.then(response => {
-    // Foreign Fetch requires an { response: !Response } object.
+  event.respondWith(response.then(resp => {
+    // Foreign Fetch requires a { response: !Response } object.
     return {
-      response,
+      response: resp,
       // This allows CORS requests, if one were to come in.
       origin: event.origin,
     };

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -30,13 +30,6 @@ let AmpVersion
  */
 let RtvVersion
 
-/**
- * The SW's current version.
- * @const
- * @type {AmpVersion}
- */
-let VERSION = '$internalRuntimeVersion$';
-
 /** @const */
 const TAG = 'cache-service-worker';
 
@@ -46,19 +39,14 @@ const TAG = 'cache-service-worker';
  * implementation bug.
  * @type {!Array<AmpVersion>}
  */
-const BLACKLIST = (self.AMP_CONFIG &&
-    self.AMP_CONFIG[`${TAG}-blacklist`]) || [];
-
+const BLACKLIST = self.AMP_CONFIG[`${TAG}-blacklist`] || [];
 
 /**
- * Sets the default version for tests.
- *
- * @param {string} version
- * @visibleForTesting
+ * The SW's current version.
+ * @const
+ * @type {RtvVersion}
  */
-export function setVersionForTesting(version) {
-  VERSION = version;
-}
+const VERSION = self.AMP_CONFIG.v;
 
 /**
  * Returns the version of a given versioned JS file.
@@ -70,10 +58,7 @@ export function setVersionForTesting(version) {
 export function rtvVersion(url) {
   // RTVs are 2 digit prefixes followed by the timestamp of the release.
   const matches = /rtv\/(\d{2}\d{13,})/.exec(url);
-  return matches ?
-      matches[1] :
-      // 01 is the prod prefix.
-      `01${VERSION}`;
+  return matches ? matches[1] : VERSION;
 }
 
 /**
@@ -307,7 +292,7 @@ export function handleFetch(request, maybeClientId) {
         // Now, was it because we served an old cached version or because
         // they requested this exact version; If we served an old version,
         // let's get the new one.
-        if (version !== requestVersion && endsWith(requestVersion, VERSION)) {
+        if (version !== requestVersion && requestVersion == VERSION) {
           fetchAndCache(cache, request, requestFile, requestVersion);
         }
 

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -123,9 +123,12 @@ export function isCdnJsFile(url) {
  * @visibleForTesting
  */
 export function isBlacklisted(version) {
-  // Trim the RTV perfix.
-  version = version.substr(2);
-  return BLACKLIST.indexOf(version) > -1;
+  /**
+   * Trim the RTV perfix.
+   * @type {AmpVersion}
+   */
+  const ampVersion = version.substr(2);
+  return BLACKLIST.indexOf(ampVersion) > -1;
 }
 
 /**

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -116,14 +116,14 @@ function isBlacklisted(version) {
  * A mapping from a Client's (unique per tab _and_ refresh) ID to the AMP
  * release version we are serving it.
  *
- * @type {!Object<string, string>}
+ * @type {!Object}
  */
 const clientsMap = Object.create(null);
 
 /**
  * Our cache of CDN JS files.
  *
- * @type {Cache}
+ * @type {!Cache}
  */
 let cache;
 
@@ -210,7 +210,8 @@ self.addEventListener('install', install => {
   install.waitUntil(cachePromise);
   if (install.registerForeignFetch) {
     install.registerForeignFetch({
-      scopes: [self.registration.scope],
+      scopes: [/** @type {!ServiceWorkerGlobalScope} */(
+          self).registration.scope],
       origins: ['*'],
     });
   }
@@ -233,7 +234,7 @@ function handleFetch(request, clientId) {
 
   // We only cache CDN JS files, and we need a clientId to do our magic.
   if (!clientId || !isCdnJsFile(url)) {
-    return;
+    return null;
   }
 
   const requestFile = basename(url);

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -84,9 +84,7 @@ export function rtvVersion(url) {
  * @return {string}
  */
 function basename(url) {
-  const match = /(?!.*?\/)[\w.]+/.exec(url);
-  // Yes, I know there'll always be a match. But Closure!
-  return match ? match[0] : '';
+  return url.substr(url.lastIndexOf('/') + 1);
 }
 
 /**

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -46,7 +46,7 @@ const BLACKLIST = self.AMP_CONFIG[`${TAG}-blacklist`] || [];
  * @const
  * @type {RtvVersion}
  */
-const VERSION = self.AMP_CONFIG.v;
+const BASE_RTV_VERSION = self.AMP_CONFIG.v;
 
 /**
  * Returns the version of a given versioned JS file.
@@ -58,7 +58,7 @@ const VERSION = self.AMP_CONFIG.v;
 export function rtvVersion(url) {
   // RTVs are 2 digit prefixes followed by the timestamp of the release.
   const matches = /rtv\/(\d{2}\d{13,})/.exec(url);
-  return matches ? matches[1] : VERSION;
+  return matches ? matches[1] : BASE_RTV_VERSION;
 }
 
 /**
@@ -295,7 +295,7 @@ export function handleFetch(request, maybeClientId) {
         // Now, was it because we served an old cached version or because
         // they requested this exact version; If we served an old version,
         // let's get the new one.
-        if (version !== requestVersion && requestVersion == VERSION) {
+        if (version !== requestVersion && requestVersion == BASE_RTV_VERSION) {
           fetchAndCache(cache, request, requestFile, requestVersion);
         }
 

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -22,13 +22,13 @@ import {endsWith, startsWith} from '../string';
  * An AMP Release version, not to be confused with an RTV version
  * @typedef {string}
  */
-let AmpVersion
+export let AmpVersion;
 
 /**
  * An RTV version, not to be confused with an AMP Release version.
  * @typedef {string}
  */
-let RtvVersion
+export let RtvVersion;
 
 /** @const */
 const TAG = 'cache-service-worker';

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as sinon from 'sinon';
+
+/**
+ * Cache SW has some side-effects, so we've got to do a little jig to test.
+ */
+const old = window.self;
+const self = window.self = {
+  AMP_CONFIG: {
+    'cache-service-worker-blacklist': ['1313131313131'],
+  },
+  events: {},
+  addEventListener(event, handler) {
+    this.events[event] = handler;
+  },
+  registration: {
+    scope: '/'
+  },
+  cache: {
+    put() {},
+    keys() {},
+    delete() {},
+    match() {},
+  },
+  caches: {
+    open() {
+      return Promise.resolve(this.cache);
+    }
+  }
+};
+// Yes, a require. `import` gets hoisted before user code, and we need to
+// setup our mock self before that.
+const sw = require('../../src/service-worker/core');
+window.self = old;
+
+describe.only('Cache SW', () => {
+  const version = '1234567891234';
+  const rtv = `00${version}`;
+  const url = `https://cdn.ampproject.org/rtv/${rtv}/v0.js`;
+
+  beforeEach(() => {
+    // The version is a 13+ char number, the millisecond timestamp of the date.
+    sw.setVersionForTesting(version);
+  });
+
+  describe('ampVersion', () => {
+    it('matches the RTV version of a url', () => {
+      expect(sw.ampVersion(url)).to.equal(rtv);
+    });
+
+    it('defaults RTV-less url to the current prod rtv', () => {
+      const rtvless = url.replace(/rtv\/\d+\//, '');
+      expect(sw.ampVersion(rtvless)).to.equal(`01${version}`);
+    });
+
+    it('only recognizes prefix and timestamp RTVs', () => {
+      const prefixless = url.replace(rtv, version);
+      expect(sw.ampVersion(prefixless)).to.equal(`01${version}`);
+    });
+  });
+
+  describe('basename', () => {
+    it('matches everything following the last slash of a url', () => {
+      expect(sw.basename(url)).to.equal('v0.js');
+    });
+
+    it('handles god-forsaken urls', () => {
+      expect(sw.basename(`${url}?1`)).to.equal('v0.js');
+      expect(sw.basename(`${url}?1#1`)).to.equal('v0.js');
+      expect(sw.basename(`${url}#1`)).to.equal('v0.js');
+    });
+  });
+
+  describe('urlWithVersion', () => {
+    it('changes RTV version to match version param', () => {
+      expect(sw.urlWithVersion(url, '123')).to.equal(
+        'https://cdn.ampproject.org/rtv/123/v0.js'
+      );
+    });
+
+    it('changes RTV-less url to the RTV equivalent', () => {
+      const rtvless = url.replace(/rtv\/\d+\//, '');
+      expect(sw.urlWithVersion(rtvless, '123')).to.equal(
+        'https://cdn.ampproject.org/rtv/123/v0.js'
+      );
+    });
+  });
+
+  describe('normalizedRequest', () => {
+    const request = new Request(url, {
+      method: 'POST',
+    });
+
+    it('makes a new request to match version', () => {
+      const newRequest = sw.normalizedRequest(request, '123');
+      expect(newRequest.url).to.equal(
+        'https://cdn.ampproject.org/rtv/123/v0.js'
+      );
+      // Ensure `init` is copied over
+      expect(newRequest.method).to.equal('POST');
+    });
+
+    it('makes a new request for versionless RTVs', () => {
+      const rtvless = url.replace(/rtv\/\d+\//, '');
+      const request = new Request(rtvless);
+      const newRequest = sw.normalizedRequest(request, '123');
+      expect(newRequest.url).to.equal(
+        'https://cdn.ampproject.org/rtv/123/v0.js'
+      );
+    });
+
+    it('returns same request if version matches', () => {
+      const newRequest = sw.normalizedRequest(request, rtv);
+      expect(newRequest).to.equal(request);
+    });
+  });
+
+  describe('isCdnJsFile', () => {
+    it('matches for CDN JS files', () => {
+      const rtvless = url.replace(/rtv\/\d+\//, '');
+      expect(sw.isCdnJsFile(url)).to.be.true;
+      expect(sw.isCdnJsFile(rtvless)).to.be.true;
+    });
+
+    it('matches for CDN JS extension files', () => {
+      const url = `https://cdn.ampproject.org/rtv/${rtv}/v0/amp-test.js`;
+      const rtvless = url.replace(/rtv\/\d+\//, '');
+      expect(sw.isCdnJsFile(url)).to.be.true;
+      expect(sw.isCdnJsFile(rtvless)).to.be.true;
+    });
+
+    it('does not match for other CDN RTV files', () => {
+      const url = `https://cdn.ampproject.org/rtv/${rtv}/v0.json`;
+      const rtvless = url.replace(/rtv\/\d+\//, '');
+      expect(sw.isCdnJsFile(url)).to.be.false;
+      expect(sw.isCdnJsFile(rtvless)).to.be.false;
+    });
+
+    it('does not match for other CDN files', () => {
+      const url = `https://cdn.ampproject.org/c/amp/`;
+      expect(sw.isCdnJsFile(url)).to.be.false;
+    });
+
+    it('does not match for non CDN domains', () => {
+      const url = `https://www.malicious.com/rtv/${rtv}/v0.js`;
+      const rtvless = url.replace(/rtv\/\d+\//, '');
+      expect(sw.isCdnJsFile(url)).to.be.false;
+      expect(sw.isCdnJsFile(rtvless)).to.be.false;
+    });
+  });
+
+  describe('isBlacklisted', () => {
+    it('blacklists anything in the blacklist AMP_CONFIG', () => {
+      const blacklisted = self.AMP_CONFIG['cache-service-worker-blacklist'][0];
+      debugger;
+      expect(sw.isBlacklisted(blacklisted)).to.be.true;
+    });
+
+    it('ignores anything in the blacklist AMP_CONFIG', () => {
+      expect(sw.isBlacklisted(version)).to.be.false;
+    });
+  });
+
+  describe('fetchAndCache', () => {
+  });
+
+  describe('getCachedVersion', () => {
+  });
+
+  describe('handleFetch', () => {
+  });
+});

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -60,20 +60,21 @@ const self = window.self = {
     this.events[event] = handler;
   },
   registration: {
-    scope: '/'
+    scope: '/',
   },
   caches: {
     open() {
       return Promise.resolve(cache);
-    }
-  }
+    },
+  },
 };
 // Yes, a require. `import` gets hoisted before user code, and we need to
 // setup our mock self before that.
-const sw = require('../../src/service-worker/core');
+const sw =
+    require('../../src/service-worker/core'); // eslint-disable-line no-undef
 window.self = old;
 
-describe.only('Cache SW', () => {
+describe('Cache SW', () => {
   const rtv = `00${version}`;
   const file = 'v0.js';
   const url = `https://cdn.ampproject.org/rtv/${rtv}/${file}`;
@@ -153,14 +154,11 @@ describe.only('Cache SW', () => {
   });
 
   describe('fetchAndCache', () => {
-    const request = {
-      url: url,
-    };
+    const request = {url};
     const response = {
       ok: true,
       clone() {},
     };
-    let cached;
     let fetch;
     let put;
 
@@ -171,7 +169,7 @@ describe.only('Cache SW', () => {
         // A different file
         [{url: url.replace('v0.js', 'v0/amp-comp.js')}, null]
       );
-      fetch = sandbox.stub(window, 'fetch', req => {
+      fetch = sandbox.stub(window, 'fetch', () => {
         return Promise.resolve(response);
       });
       put = sandbox.spy(cache, 'put');
@@ -235,9 +233,7 @@ describe.only('Cache SW', () => {
   describe('getCachedVersion', () => {
     beforeEach(() => {
       sandbox.stub(cache, 'keys', () => {
-        return Promise.resolve([
-          {url: url},
-        ]);
+        return Promise.resolve([{url}]);
       });
     });
     it('returns cached rtv version, if file is cached', () => {
@@ -261,7 +257,8 @@ describe.only('Cache SW', () => {
     const otherVersion = new Request(url.replace(/(\d+)\/v0.js/, (match, v) => {
       return `00${parseInt(v, 10) - 1}/amp-comp.js`;
     }));
-    const blacklistedRequest = new Request(blacklisted.replace('v0.js', 'amp-comp.js'));
+    const blacklistedRequest = new Request(
+        blacklisted.replace('v0.js', 'amp-comp.js'));
     let clientId = 0;
     let fetch;
 
@@ -339,7 +336,7 @@ describe.only('Cache SW', () => {
           const timer = timerFor(window);
           // First call will resolve after the first.
           const keys = sandbox.stub(cache, 'keys');
-          keys.returns(Promise.resolve([]))
+          keys.returns(Promise.resolve([]));
           keys.onCall(0).returns(timer.promise(100, []));
           return Promise.all([
             sw.handleFetch(request, clientId),
@@ -368,7 +365,7 @@ describe.only('Cache SW', () => {
         it('forces later fetches to use same RTV', () => {
           return sw.handleFetch(compRequest, clientId).then(() => {
             return sw.handleFetch(request, clientId);
-          }).then((resp) => {
+          }).then(resp => {
             expect(sw.rtvVersion(resp.url)).to.equal(sw.rtvVersion(
                 otherVersion.url));
           });
@@ -376,11 +373,12 @@ describe.only('Cache SW', () => {
 
         describe('with blacklisted file', () => {
           beforeEach(() => {
-            cache.cached.splice(1, 1, [blacklistedRequest, responseFromRequest(blacklistedRequest)]);
+            cache.cached.splice(1, 1,
+                [blacklistedRequest, responseFromRequest(blacklistedRequest)]);
           });
 
           it('will cache the blacklisted file', () => {
-            return sw.handleFetch(blacklistedRequest, clientId).then(resp => {
+            return sw.handleFetch(blacklistedRequest, clientId).then(() => {
               expect(fetch).to.not.have.been.called;
             });
           });
@@ -392,10 +390,10 @@ describe.only('Cache SW', () => {
           });
         });
 
-        it('will update cached file if new one is the latest RTV', () => {
+        it('updates cached file if new one is the latest RTV', () => {
           const prodRequest = new Request(prod.replace('v0.js', 'amp-comp.js'));
-          return sw.handleFetch(prodRequest, clientId).then(resp => {
-            return new Promise((resolve) => {
+          return sw.handleFetch(prodRequest, clientId).then(() => {
+            return new Promise(resolve => {
               // Update is out of band with response.
               setTimeout(resolve, 50);
             });
@@ -404,10 +402,11 @@ describe.only('Cache SW', () => {
           });
         });
 
-        it('will not update cached file if new one is not the latest RTV', () => {
-          cache.cached.splice(1, 1, [compRequest, responseFromRequest(compRequest)]);
-          return sw.handleFetch(otherVersion, clientId).then(resp => {
-            return new Promise((resolve) => {
+        it('leaves cached file if new one is not the latest RTV', () => {
+          cache.cached.splice(1, 1,
+              [compRequest, responseFromRequest(compRequest)]);
+          return sw.handleFetch(otherVersion, clientId).then(() => {
+            return new Promise(resolve => {
               // Update is out of band with response.
               setTimeout(resolve, 50);
             });


### PR DESCRIPTION
Implementing based on https://developers.google.com/web/updates/2016/09/foreign-fetch. We still need to enable the Link Header:

```
Link: </sw.js>; rel="serviceworker"
```

/CC @jeffposnick, if you'd be so kind as to review this again.