### PR TITLE
Type check all entry points in a single run.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -364,22 +364,20 @@ function dist() {
 function checkTypes() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
-  buildAlp({
+  // Disabled to improve type check performance, since this provides
+  // little incremental value.
+  /*buildExperiments({
     minify: true,
     checkTypes: true,
     preventRemoveAndMakeDir: true,
-  });
-  buildSw({
-    minify: true,
-    checkTypes: true,
-    preventRemoveAndMakeDir: true,
-  });
-  buildExperiments({
-    minify: true,
-    checkTypes: true,
-    preventRemoveAndMakeDir: true,
-  });
-  var compileSrcs = ['./src/amp-babel.js'];
+  });*/
+  var compileSrcs = [
+    './src/amp-babel.js',
+    './src/amp-shadow.js',
+    './ads/alp/install-alp.js',
+    './src/service-worker/shell.js',
+    './src/service-worker/kill.js',
+  ];
   var extensionSrcs = Object.values(extensions).filter(function(extension) {
     return !extension.noTypeCheck;
   }).map(function(extension) {


### PR DESCRIPTION
- This is much faster and uses much less CPU and RAM (at least 2x faster)
- Trade off is that it can hide some type issues that would be apparent with smaller compilation units, but we already had that problem with extensions.
- Disabled experiment testing for now, because it currently relies on a prebuild step that seems unecessary for type checking purposes and makes it slow.