### PR TITLE
Add references to layout docs; fixes #173

### DIFF
--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -40,7 +40,7 @@ limitations under the License.
 The runtime may choose to delay or prioritize resource loading based on the viewport position, system resources, connection bandwidth, or other factors. The `amp-img` components allows the runtime to effectively manage image resources this way.
 
 `amp-img` components, like all externally fetched AMP resources, must be given an
-explicit size (as in width / height) in advance, so that the aspect ratio can be known without fetching the image. Actual layout behavior is determined by the layout attribute.
+explicit size (as in width / height) in advance, so that the aspect ratio can be known without fetching the image. Actual layout behavior is determined by the layout attribute. For details on layouts, see [AMP HTML Layout System](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md) and [Supported Layouts](https://www.ampproject.org/docs/guides/responsive/control_layout.html).
 
 If the resource requested by the `amp-img` component fails to load, the space will be blank unless a [`fallback`](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#fallback) child is provided. A fallback is only executed on the initial layout and subsequent src changes after the fact (through resize + srcset for example) will not have a fallback for performance implications.
 


### PR DESCRIPTION
Added references to HTML layout spec and Supported Layouts per issue #173.
Updated ampproject/docs in https://github.com/ampproject/docs/pull/184