### PR TITLE
Support AMP4ADS in the webui (validator.ampproject.org)

### DIFF
--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -30,9 +30,43 @@
     <webui-errorlist id="errorListBox"></webui-errorlist>
   </template>
   <script>
+    var minimumValidAmp =
+      '\x3C!--\n' +
+      '     This is the minimum valid AMP HTML document. Just type away\n' +
+      '     here and the AMP Validator will re-check your document on the fly.\n' +
+      '-->\n' +
+      '\x3C!doctype html>\n' +
+      '\x3Chtml ⚡>\n' +
+      '\x3Chead>\n' +
+      '  \x3Cmeta charset="utf-8">\n' +
+      '  \x3Clink rel="canonical" href="self.html" />\n' +
+      '  \x3Cmeta name="viewport" content="width=device-width,minimum-scale=1">\n' +
+      '  \x3Cstyle amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}\x3C/style>\x3Cnoscript>\x3Cstyle amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\x3C/style>\x3C/noscript>\n' +
+      '  \x3Cscript async src="https://cdn.ampproject.org/v0.js">\x3C/script>\n' +
+      '\x3C/head>\n' +
+      '\x3Cbody>Hello, AMP world.\x3C/body>\n' +
+      '\x3C/html>\n';
+
+    var minimumValidAmp4Ads =
+      '\x3C!--\n' +
+      '     This is the minimum valid AMP4ADS document. Just type away\n' +
+      '     here and the AMP Validator will re-check your document on the fly.\n' +
+      '-->\n' +
+      '\x3C!doctype html>\n' +
+      '\x3Chtml ⚡4ads>\n' +
+      '\x3Chead>\n' +
+      '  \x3Cmeta charset="utf-8">\n' +
+      '  \x3Cmeta name="viewport" content="width=device-width,minimum-scale=1">\n' +
+      '  \x3Cstyle amp4ads-boilerplate>body{visibility:hidden}\x3C/style>\n' +
+      '  \x3Cscript async src="https://cdn.ampproject.org/v0.js">\x3C/script>\n' +
+      '\x3C/head>\n' +
+      '\x3Cbody>Hello, AMP4ADS world.\x3C/body>\n' +
+      '\x3C/html>\n';
+
     Polymer({
       is: 'webui-mainpage',
       ready: function() {
+
         // The URL form at the top of the screen.
         var urlForm = this.$.urlForm;
 
@@ -57,88 +91,90 @@
         // When the editor contents change, trigger validation (with a delay)
         // and propagate the validation errors into the editor (as line
         // widgets) and the listbox below the editor as clickable errors.
-        var refreshEditorAndErrors = function(e) {
+        var refreshEditorAndErrors = function() {
+          // Clear the list of errors below the editor, and the inline
+          // messages.
+          listbox.clearErrors();
+          while (lineWidgets.length > 0) {
+            lineWidgets.shift().clear();
+          }
+
+          // Validate - result is of type amp.validator.ValidationResult.
+          // See validator.proto for the provided fields.
+          var validationResult = amp.validator.validateString(
+              editor.getEditorValue(), urlForm.getFormat());
+
+          // Set the status property, which will cause the status bar below
+          // the editor to redisplay.
+          statusBar.status = validationResult.status;
+
+          for (var ii = 0; ii < validationResult.errors.length; ++ii) {
+
+            // Grab the error, and set message and icon as well. Conveniently
+            // the severity maps to 'error' / 'warning' icons in the
+            // Polymer icons (https://elements.polymer-project.org/elements/iron-icons?view=demo:demo/index.html&active=iron-icons).
+            var error = validationResult.errors[ii];
+            error.message = amp.validator.renderErrorMessage(error);
+            error.category = amp.validator.categorizeError(error);
+            error.icon = error.severity.toLowerCase();
+            error.isError = error.severity === 'ERROR';
+            error.isWarning = error.severity === 'WARNING';
+            listbox.addError(error);
+
+            if (listbox.getFilter() !== undefined &&
+                listbox.getFilter() !== error.category) {
+              continue;
+            }
+
+            // Create a dom element for the inline display of errors
+            // inside the editor. TODO(powdercloud): Make this a Polymer
+            // custom element.
+            var div = document.createElement('div');
+            div.setAttribute('class', 'ampproject-message');
+            div.appendChild(document.createTextNode(
+                new Array(error.col).join('\u00A0')));
+            var span = document.createElement('span');
+            span.setAttribute(
+                'class', 'ampproject-' + error.severity.toLowerCase());
+            var icon = document.createElement('iron-icon');
+            icon.setAttribute('icon', error.icon);
+            span.appendChild(icon);
+            div.appendChild(span);
+            div.appendChild(document.createTextNode(' ' + error.message));
+            if (error.specUrl) {
+              div.appendChild(document.createTextNode(' '));
+              var a = document.createElement('a');
+              a.setAttribute('href', error.specUrl);
+              a.setAttribute('target', '_blank');
+              a.appendChild(document.createTextNode('Learn more'));
+              div.appendChild(a);
+              div.appendChild(document.createTextNode('.'));
+            }
+            lineWidgets.push(editor.addLineWidget(error.line - 1, div));
+          }
+          var params = getLocationHashParams();
+          if (params.hasOwnProperty('errno')) {
+            var errno = parseInt(params['errno']);
+            if (errno >= 0 && errno < validationResult.errors.length) {
+              listbox.selectAndFocusError(errno);
+            }
+
+            // We don't want this param to be sticky, e.g. if a user
+            // types into the editor we don't want to go back to this
+            // old error after revalidation.
+            removeParamFromLocationHashParams('errno');
+          }
+        };
+        var refreshEditorAndErrorsWithDelay = function(e) {
           clearTimeout(validationTimeout);
-          validationTimeout = setTimeout(function() {
-
-            // Clear the list of errors below the editor, and the inline
-            // messages.
-            listbox.clearErrors();
-            while (lineWidgets.length > 0) {
-              lineWidgets.shift().clear();
-            }
-
-            // Validate - result is of type amp.validator.ValidationResult.
-            // See validator.proto for the provided fields.
-            var validationResult = amp.validator.validateString(
-                editor.getEditorValue(), urlForm.getFormat());
-
-            // Set the status property, which will cause the status bar below
-            // the editor to redisplay.
-            statusBar.status = validationResult.status;
-
-            for (var ii = 0; ii < validationResult.errors.length; ++ii) {
-
-              // Grab the error, and set message and icon as well. Conveniently
-              // the severity maps to 'error' / 'warning' icons in the
-              // Polymer icons (https://elements.polymer-project.org/elements/iron-icons?view=demo:demo/index.html&active=iron-icons).
-              var error = validationResult.errors[ii];
-              error.message = amp.validator.renderErrorMessage(error);
-              error.category = amp.validator.categorizeError(error);
-              error.icon = error.severity.toLowerCase();
-              error.isError = error.severity === 'ERROR';
-              error.isWarning = error.severity === 'WARNING';
-              listbox.addError(error);
-
-              if (listbox.getFilter() !== undefined &&
-                  listbox.getFilter() !== error.category) {
-                continue;
-              }
-
-              // Create a dom element for the inline display of errors
-              // inside the editor. TODO(powdercloud): Make this a Polymer
-              // custom element.
-              var div = document.createElement('div');
-              div.setAttribute('class', 'ampproject-message');
-              div.appendChild(document.createTextNode(
-                  new Array(error.col).join('\u00A0')));
-              var span = document.createElement('span');
-              span.setAttribute(
-                  'class', 'ampproject-' + error.severity.toLowerCase());
-              var icon = document.createElement('iron-icon');
-              icon.setAttribute('icon', error.icon);
-              span.appendChild(icon);
-              div.appendChild(span);
-              div.appendChild(document.createTextNode(' ' + error.message));
-              if (error.specUrl) {
-                div.appendChild(document.createTextNode(' '));
-                var a = document.createElement('a');
-                a.setAttribute('href', error.specUrl);
-                a.setAttribute('target', '_blank');
-                a.appendChild(document.createTextNode('Learn more'));
-                div.appendChild(a);
-                div.appendChild(document.createTextNode('.'));
-              }
-              lineWidgets.push(editor.addLineWidget(error.line - 1, div));
-            }
-            var params = getLocationHashParams();
-            if (params.hasOwnProperty('errno')) {
-              var errno = parseInt(params['errno']);
-              if (errno >= 0 && errno < validationResult.errors.length) {
-                listbox.selectAndFocusError(errno);
-              }
-
-              // We don't want this param to be sticky, e.g. if a user
-              // types into the editor we don't want to go back to this
-              // old error after revalidation.
-              removeParamFromLocationHashParams('errno');
-            }
-          }, e.detail.validationDelayMs);
+          validationTimeout = setTimeout(
+              refreshEditorAndErrors, e.detail.validationDelayMs);
         };
 
-        editor.addEventListener('amphtml-editor-changes', refreshEditorAndErrors);
+        editor.addEventListener('amphtml-editor-changes',
+                                refreshEditorAndErrorsWithDelay);
         listbox.addEventListener('webui-errorlist-filter-changes',
-                                        refreshEditorAndErrors);
+                                 refreshEditorAndErrors);
 
         // Clicking in the error list at the bottom of the screen moves
         // the editor cursor.
@@ -179,6 +215,26 @@
           }
         });
 
+        urlForm.addEventListener('webui-urlform-format-changes', function(e) {
+          if (e.detail.format === 'AMP4ADS') {
+            var params = getLocationHashParams();
+            params['format'] = 'AMP4ADS';
+            setLocationHashParams(params);
+            if (editor.getEditorValue() === minimumValidAmp) {
+              editor.setEditorValue(minimumValidAmp4Ads);
+            } else {
+              refreshEditorAndErrors();
+            }
+          } else {
+            removeParamFromLocationHashParams('format');
+            if (editor.getEditorValue() === minimumValidAmp4Ads) {
+              editor.setEditorValue(minimumValidAmp);
+            } else {
+              refreshEditorAndErrors();
+            }
+          }
+        });
+
         // Interprets the parameters after the '#' in the URL.
         var params = getLocationHashParams();
         // If #url=<url> was provided, load it, otherwise, start with the
@@ -189,23 +245,12 @@
           if (params.hasOwnProperty('filter') && params['filter']) {
             listbox.setFilter(params['filter']);
           }
+        } else if (params.hasOwnProperty('format') &&
+                   params['format'] === 'AMP4ADS' ) {
+          urlForm.setFormat('AMP4ADS');
+          editor.setEditorValue(minimumValidAmp4Ads);
         } else {
-          var minimumValidAmp =
-            '\x3C!--\n' +
-            '     This is the minimum valid AMP HTML document. Just type away\n' +
-            '     here and the AMP Validator will re-check your document on the fly.\n' +
-            '-->\n' +
-            '\x3C!doctype html>\n' +
-            '\x3Chtml ⚡>\n' +
-            '\x3Chead>\n' +
-            '  \x3Cmeta charset="utf-8">\n' +
-            '  \x3Clink rel="canonical" href="self.html" />\n' +
-            '  \x3Cmeta name="viewport" content="width=device-width,minimum-scale=1">\n' +
-            '  \x3Cstyle amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}\x3C/style>\x3Cnoscript>\x3Cstyle amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\x3C/style>\x3C/noscript>\n' +
-            '  \x3Cscript async src="https://cdn.ampproject.org/v0.js">\x3C/script>\n' +
-            '\x3C/head>\n' +
-            '\x3Cbody>Hello, AMP world.\x3C/body>\n' +
-            '\x3C/html>\n';
+          urlForm.setFormat('AMP');
           editor.setEditorValue(minimumValidAmp);
         }
       }

--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -71,7 +71,7 @@
             // Validate - result is of type amp.validator.ValidationResult.
             // See validator.proto for the provided fields.
             var validationResult = amp.validator.validateString(
-                editor.getEditorValue());
+                editor.getEditorValue(), urlForm.getFormat());
 
             // Set the status property, which will cause the status bar below
             // the editor to redisplay.

--- a/validator/webui/@polymer/webui-urlform/webui-urlform.html
+++ b/validator/webui/@polymer/webui-urlform/webui-urlform.html
@@ -54,7 +54,8 @@
       <paper-material elevation="0">
         <paper-dropdown-menu label="Format" id="formatDropdown">
           <paper-listbox class="dropdown-content" selected="AMP"
-                         id="formatSelector" attr-for-selected="format">
+                         id="formatSelector" attr-for-selected="format"
+                         on-iron-select="formatChange">
             <paper-item format="AMP">AMP</paper-item>
             <paper-item format="AMP4ADS">AMP4ADS</paper-item>
           </paper-listbox>
@@ -74,6 +75,10 @@
           type: Boolean,
           value: false
         }
+      },
+      formatChange: function() {
+        this.fire('webui-urlform-format-changes',
+                  {'format': this.$.formatSelector.selected});
       },
       checkURL: function(e) {
         this.validURL = !this.$.urlToFetch.invalid;
@@ -95,6 +100,9 @@
       },
       getFormat: function() {
         return this.$.formatSelector.selected;
+      },
+      setFormat: function(htmlFormat) {
+        this.$.formatSelector.selected = htmlFormat;
       }
     });
   </script>

--- a/validator/webui/@polymer/webui-urlform/webui-urlform.html
+++ b/validator/webui/@polymer/webui-urlform/webui-urlform.html
@@ -19,6 +19,7 @@
 <link rel="import" href="../paper-input/paper-input.html">
 <link rel="import" href="../paper-material/paper-material.html">
 <link rel="import" href="../paper-toast/paper-toast.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
 <dom-module id="webui-urlform">
   <style scope="webui-urlform">
     .flex-horizontal {
@@ -35,14 +36,30 @@
       min-width: auto;
       right: 0;
     }
+    #formatDropdown {
+      min-width: 120px;
+      max-width: 120px;
+    }
   </style>
   <template>
     <paper-toast id="urlToast" text="Could not fetch the given URL."></paper-toast>
     <div class="container flex-horizontal">
-      <paper-input auto-validate required pattern="[^ \s]+(://.*|\.[a-z]+($|(/.*)))"
-          error-message="Please enter a valid URL" on-focus="checkURL"
-          on-input="checkURL" on-keypress="keyPress" label="URL" id="urlToFetch"
-          class="flexchild"></paper-input>
+      <paper-material elevation="0" class="flexchild">
+        <paper-input
+           auto-validate required pattern="[^ \s]+(://.*|\.[a-z]+($|(/.*)))"
+           error-message="Please enter a valid URL" on-focus="checkURL"
+           on-input="checkURL" on-keypress="keyPress" label="URL" id="urlToFetch">
+        </paper-input>
+      </paper-material>
+      <paper-material elevation="0">
+        <paper-dropdown-menu label="Format" id="formatDropdown">
+          <paper-listbox class="dropdown-content" selected="AMP"
+                         id="formatSelector" attr-for-selected="format">
+            <paper-item format="AMP">AMP</paper-item>
+            <paper-item format="AMP4ADS">AMP4ADS</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </paper-material>
       <paper-material elevation="0">
         <paper-button disabled$="{{!validURL}}" raised
             id="validateButton">Validate</paper-button>
@@ -75,6 +92,9 @@
         this.checkURL();
         this.$.urlToFetch.validate();
         this.$.validateButton.click();
+      },
+      getFormat: function() {
+        return this.$.formatSelector.selected;
       }
     });
   </script>

--- a/validator/webui/build.py
+++ b/validator/webui/build.py
@@ -131,7 +131,10 @@ def CreateWebuiAppengineDist(out_dir):
         else:
           shutil.copytree(entry, os.path.join(tempdir, entry))
     for entry in os.listdir('node_modules'):
-      if entry != '@polymer':
+      if entry == 'web-animations-js':
+        shutil.copytree(os.path.join('node_modules', entry),
+                        os.path.join(tempdir, '@polymer', entry))
+      elif entry != '@polymer':
         shutil.copytree(os.path.join('node_modules', entry),
                         os.path.join(tempdir, entry))
     for entry in os.listdir('node_modules/@polymer'):

--- a/validator/webui/package.json
+++ b/validator/webui/package.json
@@ -34,6 +34,7 @@
     "@polymer/iron-validatable-behavior": "0.0.3",
     "@polymer/paper-behaviors": "0.0.3",
     "@polymer/paper-button": "0.0.3",
+    "@polymer/paper-dropdown-menu": "0.0.3",
     "@polymer/paper-input": "0.0.3",
     "@polymer/paper-item": "0.0.3",
     "@polymer/paper-listbox": "0.0.3",


### PR DESCRIPTION
This adds a format drop down (either AMP or AMP4ADS), and a URL parameter (format). Thus far it requires to use the canary validator.js, which can be configured by visiting https://cdn.ampproject.org/experiments.html and turning on dev-channel.