### PR TITLE
Clean up AmpSlides tests

### DIFF
--- a/extensions/amp-carousel/0.1/test/test-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slides.js
@@ -913,33 +913,4 @@ describe('empty Slides functional', () => {
       slides.buildCallback();
     }).to.throw(/should have at least 1 slide/);
   });
-
-  it('should not throw an error on layoutCallback', () => {
-    expect(() => {
-      slides.buildCallback();
-    }).to.throw(/should have at least 1 slide/);
-  });
-
-  it('should not throw an error on viewportCallback', () => {
-    expect(() => {
-      slides.buildCallback();
-    }).to.throw(/should have at least 1 slide/);
-  });
-
-  it('should not throw an error on goCallback', () => {
-    expect(() => {
-      slides.buildCallback();
-    }).to.throw(/should have at least 1 slide/);
-    expect(() => {
-      slides.goCallback();
-    }).to.not.throw();
-  });
-
-  it('should not have any controls', () => {
-    expect(() => {
-      slides.buildCallback();
-    }).to.throw(/should have at least 1 slide/);
-    expect(slides.hasNext()).to.be.false;
-    expect(slides.hasPrev()).to.be.false;
-  });
 });

--- a/extensions/amp-carousel/0.1/test/test-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slides.js
@@ -913,4 +913,12 @@ describe('empty Slides functional', () => {
       slides.buildCallback();
     }).to.throw(/should have at least 1 slide/);
   });
+
+  it('should not have any controls', () => {
+    expect(() => {
+      slides.buildCallback();
+    }).to.throw(/should have at least 1 slide/);
+    expect(slides.hasNext()).to.be.false;
+    expect(slides.hasPrev()).to.be.false;
+  });
 });


### PR DESCRIPTION
Follow up of https://github.com/ampproject/amphtml/pull/5033
When there are zero slides, the `buildCallback` already throws using `user.assert`, so no extra functions in the workflow will be called. Therefore, no need to test them.