### PR TITLE
Added annotation to identify events as from AMP page

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -43,7 +43,7 @@
   "cxense": {
     "host": "https://scomcluster.cxense.com",
     "base": "https://scomcluster.cxense.com/Repo/rep.gif" ,
-    "pageview": "https://scomcluster.cxense.com/Repo/rep.gif?ver=1&typ=pgv&sid=$siteId&ckp=_client_id_&loc=_source_url_&rnd=_random_&ref=_document_referrer_&ltm=_timestamp_&wsz=_screen_width_x_screen_height_&bln=_browser_language_&chs=_document_charset_&col=_screen_color_depth_&tzo=_timezone_"
+    "pageview": "https://scomcluster.cxense.com/Repo/rep.gif?ver=1&typ=pgv&sid=$siteId&ckp=_client_id_&loc=_source_url_&rnd=_random_&ref=_document_referrer_&ltm=_timestamp_&wsz=_screen_width_x_screen_height_&bln=_browser_language_&chs=_document_charset_&col=_screen_color_depth_&tzo=_timezone_&cp_cx_channel=amp"
   },
   "googleanalytics": {
     "host": "https://www.google-analytics.com",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -342,7 +342,7 @@ export const ANALYTICS_CONFIG = {
           'loc=${sourceUrl}&rnd=${random}&ref=${documentReferrer}&' +
           'ltm=${timestamp}&wsz=${screenWidth}x${screenHeight}&' +
           'bln=${browserLanguage}&chs=${documentCharset}&' +
-          'col=${screenColorDepth}&tzo=${timezone}',
+          'col=${screenColorDepth}&tzo=${timezone}&cp_cx_channel=amp',
     },
     'triggers': {
       'defaultPageview': {


### PR DESCRIPTION
See issue #5077 for additional information. This PR adds event attributes to indicate that this analytics event originated from an AMP page.

