### PR TITLE
Makes ads/_config.js contain full list of ad networks

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -36,6 +36,8 @@
  * }
  */
 export const adConfig = {
+  _ping_: {},
+
   fakead3p: {
     renderStartImplemented: true,
   },
@@ -56,9 +58,17 @@ export const adConfig = {
     ],
   },
 
+  adform: {},
+
   adgeneration: {
     prefetch: 'https://i.socdm.com/sdk/js/adg-script-loader.js',
   },
+
+  adition: {},
+
+  adman: {},
+
+  adreactor: {},
 
   adsense: {
     prefetch: 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js',
@@ -70,6 +80,8 @@ export const adConfig = {
     prefetch: 'https://static.adsnative.com/static/js/render.v1.js',
     preconnect: 'https://api.adsnative.com',
   },
+
+  adspirit: {},
 
   adstir: {
     prefetch: 'https://js.ad-stir.com/js/adstir_async.js',
@@ -118,9 +130,13 @@ export const adConfig = {
     preconnect: 'https://ad.caprofitx.adtdp.com',
   },
 
+  chargeads: {},
+
   colombia: {
     prefetch: 'https://static.clmbtech.com/ad/commons/js/colombia-amp.js',
   },
+
+  contentad: {},
 
   criteo: {
     prefetch: 'https://static.criteo.net/js/ld/publishertag.js',
@@ -156,6 +172,8 @@ export const adConfig = {
     ],
   },
 
+  flite: {},
+
   genieessp: {
     prefetch: 'https://js.gsspcln.jp/l/amp.js',
   },
@@ -169,6 +187,8 @@ export const adConfig = {
     preconnect: 'https://spad.i-mobile.co.jp',
   },
 
+  improvedigital: {},
+
   industrybrains: {
     prefetch: 'https://web.industrybrains.com/js/ads/async/show.js',
     preconnect: [
@@ -181,6 +201,8 @@ export const adConfig = {
     prefetch: 'https://cf.cdn.inmobi.com/ad/inmobi.secure.js',
     renderStartImplemented: true,
   },
+
+  kargo: {},
 
   mads: {
     prefetch: 'https://eu2.madsone.com/js/tags.js',
@@ -230,6 +252,8 @@ export const adConfig = {
     ],
   },
 
+  openadstream: {},
+
   openx: {
     prefetch: 'https://www.googletagservices.com/tag/js/gpt.js',
     preconnect: [
@@ -238,6 +262,8 @@ export const adConfig = {
       'https://tpc.googlesyndication.com',
     ],
   },
+
+  plista: {},
 
   pubmatic: {
     prefetch: 'https://ads.pubmatic.com/AdServer/js/amp.js',
@@ -261,6 +287,10 @@ export const adConfig = {
     ],
   },
 
+  rubicon: {},
+
+  sharethrough: {},
+
   smartadserver: {
     prefetch: 'https://ec-ns.sascdn.com/diff/js/amp.v0.js',
     preconnect: 'https://static.sascdn.com',
@@ -281,6 +311,8 @@ export const adConfig = {
     prefetch: 'https://ap.lijit.com/www/sovrn_amp/sovrn_ads.js',
   },
 
+  taboola: {},
+
   teads: {
     prefetch: 'https://cdn.teads.tv/media/format/v3/teads-format.min.js',
     preconnect: [
@@ -290,12 +322,18 @@ export const adConfig = {
     ],
   },
 
+  triplelift: {},
+
+  webediads: {},
+
   'weborama-display': {
     prefetch: [
       'https://cstatic.weborama.fr/js/advertiserv2/adperf_launch_1.0.0_scrambled.js',
       'https://cstatic.weborama.fr/js/advertiserv2/adperf_core_1.0.0_scrambled.js',
     ],
   },
+
+  widespace: {},
 
   yahoojp: {
     prefetch: [
@@ -324,4 +362,6 @@ export const adConfig = {
   yieldone: {
     prefetch: 'https://img.ak.impact-ad.jp/ic/pone/commonjs/yone-amp.js',
   },
+
+  zergnet: {},
 };

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -67,7 +67,10 @@ function getAdTypes() {
     weborama: ['weborama-display'],
   };
 
-  const adTypes = [];
+  // Start with Google ad types
+  const adTypes = ['adsense', 'doubleclick'];
+
+  // Add all other ad types
   const files = fs.readdirSync('./ads/');
   for (var i = 0; i < files.length; i++) {
     if (path.extname(files[i]) == '.js'

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -57,16 +57,33 @@ function getConfig() {
   return extend(obj, karmaConfig.default);
 }
 
-function getAdExtensions() {
-  const adNetworks = [];
+function getAdTypes() {
+  const namingExceptions = {
+    // We recommend 3P ad networks use the same string for filename and type.
+    // Write exceptions here in alphabetic order.
+    // filename: [type1, type2, ... ]
+    adblade: ['adblade', 'industrybrains'],
+    mantis: ['mantis-display', 'mantis-recommend'],
+    weborama: ['weborama-display'],
+  };
+
+  const adTypes = [];
   const files = fs.readdirSync('./ads/');
   for (var i = 0; i < files.length; i++) {
     if (path.extname(files[i]) == '.js'
         && files[i][0] != '_' && files[i] != 'ads.extern.js') {
-      adNetworks.push(path.basename(files[i], '.js'));
+      const adType = path.basename(files[i], '.js');
+      const expanded = namingExceptions[adType];
+      if (expanded) {
+        for (var j = 0; j < expanded.length; j++) {
+          adTypes.push(expanded[j]);
+        }
+      } else {
+        adTypes.push(adType);
+      }
     }
   }
-  return adNetworks;
+  return adTypes;
 }
 
 /**
@@ -108,7 +125,7 @@ gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
   c.client.amp = {
     useCompiledJs: !!argv.compiled,
     saucelabs: !!argv.saucelabs,
-    adExtensions: getAdExtensions(),
+    adTypes: getAdTypes(),
   };
 
   if (argv.grep) {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -237,9 +237,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(unusedOnLayout) {
-    const config = adConfig[this.element.getAttribute('type')];
-    // TODO(lannka): config should be never null in real.
-    const preconnect = config ? config.preconnect : null;
+    const preconnect = adConfig[this.element.getAttribute('type')].preconnect;
     // NOTE(keithwrightbos): using onLayout to indicate if preconnect should be
     // given preferential treatment.  Currently this would be false when
     // relevant (i.e. want to preconnect on or before onLayoutMeasure) which

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -94,9 +94,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     this.boundNoContentHandler_ = () => this.noContentHandler_();
 
     const adType = this.element.getAttribute('type');
-    // TODO(lannka): this should be never null in real.
-    /** {?Object} */
+    /** {!Object} */
     this.config = adConfig[adType];
+    user().assert(this.config, `Type "${adType}" is not supported in amp-ad`);
 
     setupA2AListener(this.win);
 
@@ -111,19 +111,17 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   preconnectCallback(onLayout) {
     // We always need the bootstrap.
     preloadBootstrap(this.win);
-    const prefetch = this.config ? this.config.prefetch : null;
-    const preconnect = this.config ? this.config.preconnect : null;
-    if (typeof prefetch == 'string') {
-      this.preconnect.preload(prefetch, 'script');
-    } else if (prefetch) {
-      prefetch.forEach(p => {
+    if (typeof this.config.prefetch == 'string') {
+      this.preconnect.preload(this.config.prefetch, 'script');
+    } else if (this.config.prefetch) {
+      this.config.prefetch.forEach(p => {
         this.preconnect.preload(p, 'script');
       });
     }
-    if (typeof preconnect == 'string') {
-      this.preconnect.url(preconnect, onLayout);
-    } else if (preconnect) {
-      preconnect.forEach(p => {
+    if (typeof this.config.preconnect == 'string') {
+      this.preconnect.url(this.config.preconnect, onLayout);
+    } else if (this.config.preconnect) {
+      this.config.preconnect.forEach(p => {
         this.preconnect.url(p, onLayout);
       });
     }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -175,7 +175,7 @@ function tests(name) {
       return expect(getAd({
         width: 300,
         height: 250,
-      }, null)).to.be.rejectedWith(/type/);
+      })).to.be.rejectedWith(/type/);
     });
 
     it('should reject unknown type', () => {
@@ -183,7 +183,7 @@ function tests(name) {
         width: 300,
         height: 250,
         type: 'unknownType',
-      }, null)).to.be.rejectedWith(/unknownType/);
+      })).to.be.rejectedWith(/unknownType/);
     });
 
     it('must not be position:fixed', () => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -167,6 +167,14 @@ function tests(name) {
       }, null)).to.be.rejectedWith(/type/);
     });
 
+    it('should reject unknown type', () => {
+      return expect(getAd({
+        width: 300,
+        height: 250,
+        type: 'unknownType',
+      }, null)).to.be.rejectedWith(/unknownType/);
+    });
+
     it('must not be position:fixed', () => {
       return expect(getAd({
         width: 300,

--- a/test/functional/test-ad-cid.js
+++ b/test/functional/test-ad-cid.js
@@ -46,6 +46,7 @@ function tests(name) {
   return () => {
     describe('cid-ad support', () => {
       const cidScope = 'cid-in-ads-test';
+      const config = adConfig['_ping_'];
       let sandbox;
 
       beforeEach(() => {
@@ -54,7 +55,6 @@ function tests(name) {
 
       afterEach(() => {
         sandbox.restore();
-        delete adConfig['_ping_'];
         setCookie(window, cidScope, '', Date.now() - 5000);
       });
 
@@ -73,7 +73,7 @@ function tests(name) {
         });
 
         it('provides cid to ad', () => {
-          adConfig['_ping_'] = {clientIdScope: cidScope};
+          config.clientIdScope = cidScope;
 
           const s = installCidService(window);
           sandbox.stub(s, 'get', scope => {
@@ -86,7 +86,7 @@ function tests(name) {
         });
 
         it('times out', () => {
-          adConfig['_ping_'] = {clientIdScope: cidScope};
+          config.clientIdScope = cidScope;
           const s = installCidService(window);
           sandbox.stub(s, 'get', scope => {
             expect(scope).to.equal(cidScope);
@@ -106,7 +106,7 @@ function tests(name) {
       });
 
       it('provides cid to ad', () => {
-        adConfig['_ping_'] = {clientIdScope: cidScope};
+        config.clientIdScope = cidScope;
         return getAd({
           width: 300,
           height: 250,
@@ -125,7 +125,7 @@ function tests(name) {
       });
 
       it('proceeds on failed CID', () => {
-        adConfig['_ping_'] = {clientIdScope: cidScope};
+        config.clientIdScope = cidScope;
         return getAd({
           width: 300,
           height: 250,
@@ -144,7 +144,7 @@ function tests(name) {
       });
 
       it('waits for consent', () => {
-        adConfig['_ping_'] = {clientIdScope: cidScope};
+        config.clientIdScope = cidScope;
         return getAd({
           width: 300,
           height: 250,
@@ -173,6 +173,7 @@ function tests(name) {
       });
 
       it('waits for consent w/o cidScope', () => {
+        config.clientIdScope = null;
         return getAd({
           width: 300,
           height: 250,
@@ -201,6 +202,7 @@ function tests(name) {
       });
 
       it('provide null if notification and cid is not provided', () => {
+        config.clientIdScope = null;
         let uidSpy = null;
         return getAd({
           width: 300,
@@ -227,7 +229,7 @@ function tests(name) {
       });
 
       it('provides null if cid service not available', () => {
-        adConfig['_ping_'] = {clientIdScope: cidScope};
+        config.clientIdScope = cidScope;
         return getAd({
           width: 300,
           height: 250,

--- a/test/functional/test-ads-config.js
+++ b/test/functional/test-ads-config.js
@@ -44,6 +44,8 @@ describe('test-ads-config', () => {
     // Google's ad networks.
     expect(adConfig).to.include.key('adsense');
     expect(adConfig).to.include.key('doubleclick');
+
+    expect(adConfig).to.include.key('_ping_');
   });
 
   it('should sort adConfig in alphabetic order', () => {

--- a/test/functional/test-ads-config.js
+++ b/test/functional/test-ads-config.js
@@ -22,11 +22,6 @@ describe('test-ads-config', () => {
     window.ampTestRuntimeConfig.adTypes.forEach(adType => {
       expect(adConfig, `Missing config for [${adType}]`).to.contain.key(adType);
     });
-
-    // Google ad networks and fake ad networks
-    ['adsense', 'doubleclick', '_ping_'].forEach(adType => {
-      expect(adConfig, `Missing config for [${adType}]`).to.contain.key(adType);
-    });
   });
 
   it('should sort adConfig in alphabetic order', () => {

--- a/test/functional/test-ads-config.js
+++ b/test/functional/test-ads-config.js
@@ -19,33 +19,14 @@ import {adConfig} from '../../ads/_config';
 describe('test-ads-config', () => {
 
   it('should have all ad networks configured', () => {
-    // Get all ad extensions from test env.
-    const extensions = window.ampTestRuntimeConfig.adExtensions;
-    const namingExceptions = {
-      // We recommend 3P ad networks use the same string for filename and ID.
-      // Write exceptions here in alpabetic order.
-      // filename: [ID1, ID2, ... ]
-      adblade: ['adblade', 'industrybrains'],
-      mantis: ['mantis-display', 'mantis-recommend'],
-      weborama: ['weborama-display'],
-    };
+    window.ampTestRuntimeConfig.adTypes.forEach(adType => {
+      expect(adConfig, `Missing config for [${adType}]`).to.contain.key(adType);
+    });
 
-    for (let i = 0; i < extensions.length; i++) {
-      const expanded = namingExceptions[extensions[i]];
-      if (expanded) {
-        for (let j = 0; j < expanded.length; j++) {
-          expect(adConfig).to.include.key(expanded[j]);
-        }
-      } else {
-        expect(adConfig).to.include.key(extensions[i]);
-      }
-    }
-
-    // Google's ad networks.
-    expect(adConfig).to.include.key('adsense');
-    expect(adConfig).to.include.key('doubleclick');
-
-    expect(adConfig).to.include.key('_ping_');
+    // Google ad networks and fake ad networks
+    ['adsense', 'doubleclick', '_ping_'].forEach(adType => {
+      expect(adConfig, `Missing config for [${adType}]`).to.contain.key(adType);
+    });
   });
 
   it('should sort adConfig in alphabetic order', () => {

--- a/test/functional/test-ads-config.js
+++ b/test/functional/test-ads-config.js
@@ -18,6 +18,34 @@ import {adConfig} from '../../ads/_config';
 
 describe('test-ads-config', () => {
 
+  it('should have all ad networks configured', () => {
+    // Get all ad extensions from test env.
+    const extensions = window.ampTestRuntimeConfig.adExtensions;
+    const namingExceptions = {
+      // We recommend 3P ad networks use the same string for filename and ID.
+      // Write exceptions here in alpabetic order.
+      // filename: [ID1, ID2, ... ]
+      adblade: ['adblade', 'industrybrains'],
+      mantis: ['mantis-display', 'mantis-recommend'],
+      weborama: ['weborama-display'],
+    };
+
+    for (let i = 0; i < extensions.length; i++) {
+      const expanded = namingExceptions[extensions[i]];
+      if (expanded) {
+        for (let j = 0; j < expanded.length; j++) {
+          expect(adConfig).to.include.key(expanded[j]);
+        }
+      } else {
+        expect(adConfig).to.include.key(extensions[i]);
+      }
+    }
+
+    // Google's ad networks.
+    expect(adConfig).to.include.key('adsense');
+    expect(adConfig).to.include.key('doubleclick');
+  });
+
   it('should sort adConfig in alphabetic order', () => {
     delete adConfig.fakead3p;
     const keys = Object.keys(adConfig);

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -35,6 +35,10 @@ describe('3p integration.js', () => {
 
   it('should register integrations', () => {
     window.ampTestRuntimeConfig.adTypes.forEach(adType => {
+      // TODO: remove this once we register fakead3p as normal networks.
+      if (adType == 'fakead3p') {
+        return;
+      }
       expect(registrations, `Missing registration for [${adType}]`)
           .to.contain.key(adType);
     });

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -34,36 +34,16 @@ describe('3p integration.js', () => {
   });
 
   it('should register integrations', () => {
-    // Get all ad extensions from test env.
-    const extensions = window.ampTestRuntimeConfig.adExtensions;
-    const namingExceptions = {
-      // We recommend 3P ad networks use the same string for filename and ID.
-      // Write exceptions here in alpabetic order.
-      // filename: [ID1, ID2, ... ]
-      adblade: ['adblade', 'industrybrains'],
-      mantis: ['mantis-display', 'mantis-recommend'],
-      weborama: ['weborama-display'],
-    };
+    window.ampTestRuntimeConfig.adTypes.forEach(adType => {
+      expect(registrations, `Missing registration for [${adType}]`)
+          .to.contain.key(adType);
+    });
 
-    for (let i = 0; i < extensions.length; i++) {
-      const expanded = namingExceptions[extensions[i]];
-      if (expanded) {
-        for (let j = 0; j < expanded.length; j++) {
-          expect(registrations).to.include.key(expanded[j]);
-        }
-      } else {
-        if (extensions[i] == 'fakead3p') {
-          continue;
-        }
-        expect(registrations).to.include.key(extensions[i]);
-      }
-    }
-
-    // Google's ad networks.
-    expect(registrations).to.include.key('adsense');
-    expect(registrations).to.include.key('doubleclick');
-
-    expect(registrations).to.include.key('_ping_');
+    // Google ad networks and fake ad networks
+    ['adsense', 'doubleclick', '_ping_'].forEach(adType => {
+      expect(registrations, `Missing registration for [${adType}]`)
+          .to.contain.key(adType);
+    });
   });
 
   it('should not throw validateParentOrigin without ancestorOrigins', () => {

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -38,12 +38,6 @@ describe('3p integration.js', () => {
       expect(registrations, `Missing registration for [${adType}]`)
           .to.contain.key(adType);
     });
-
-    // Google ad networks and fake ad networks
-    ['adsense', 'doubleclick', '_ping_'].forEach(adType => {
-      expect(registrations, `Missing registration for [${adType}]`)
-          .to.contain.key(adType);
-    });
   });
 
   it('should not throw validateParentOrigin without ancestorOrigins', () => {


### PR DESCRIPTION
Added test to enforce it.
Benefits:

- Force all ad network to take a look at the config file to see if they can take advantage of features like preconnect and render-start API.
- So we can print user error if publisher has mis-used an unknown `type` in `amp-ad`.
- Simplifies code a little bit (avoid null check in multiple places).

This is a follow up work to #5068