### PR TITLE
format -> htmlFormat / html-format, since for the command line tool

### DIFF
--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -102,7 +102,7 @@
           // Validate - result is of type amp.validator.ValidationResult.
           // See validator.proto for the provided fields.
           var validationResult = amp.validator.validateString(
-              editor.getEditorValue(), urlForm.getFormat());
+              editor.getEditorValue(), urlForm.getHtmlFormat());
 
           // Set the status property, which will cause the status bar below
           // the editor to redisplay.
@@ -215,10 +215,10 @@
           }
         });
 
-        urlForm.addEventListener('webui-urlform-format-changes', function(e) {
-          if (e.detail.format === 'AMP4ADS') {
+        urlForm.addEventListener('webui-urlform-html-format-changes', function(e) {
+          if (e.detail.htmlFormat === 'AMP4ADS') {
             var params = getLocationHashParams();
-            params['format'] = 'AMP4ADS';
+            params['htmlFormat'] = 'AMP4ADS';
             setLocationHashParams(params);
             if (editor.getEditorValue() === minimumValidAmp) {
               editor.setEditorValue(minimumValidAmp4Ads);
@@ -226,7 +226,7 @@
               refreshEditorAndErrors();
             }
           } else {
-            removeParamFromLocationHashParams('format');
+            removeParamFromLocationHashParams('htmlFormat');
             if (editor.getEditorValue() === minimumValidAmp4Ads) {
               editor.setEditorValue(minimumValidAmp);
             } else {
@@ -245,12 +245,12 @@
           if (params.hasOwnProperty('filter') && params['filter']) {
             listbox.setFilter(params['filter']);
           }
-        } else if (params.hasOwnProperty('format') &&
-                   params['format'] === 'AMP4ADS' ) {
-          urlForm.setFormat('AMP4ADS');
+        } else if (params.hasOwnProperty('htmlFormat') &&
+                   params['htmlFormat'] === 'AMP4ADS' ) {
+          urlForm.setHtmlFormat('AMP4ADS');
           editor.setEditorValue(minimumValidAmp4Ads);
         } else {
-          urlForm.setFormat('AMP');
+          urlForm.setHtmlFormat('AMP');
           editor.setEditorValue(minimumValidAmp);
         }
       }

--- a/validator/webui/@polymer/webui-urlform/webui-urlform.html
+++ b/validator/webui/@polymer/webui-urlform/webui-urlform.html
@@ -36,7 +36,7 @@
       min-width: auto;
       right: 0;
     }
-    #formatDropdown {
+    #htmlFormatDropdown {
       min-width: 120px;
       max-width: 120px;
     }
@@ -52,12 +52,12 @@
         </paper-input>
       </paper-material>
       <paper-material elevation="0">
-        <paper-dropdown-menu label="Format" id="formatDropdown">
+        <paper-dropdown-menu label="HTML Format" id="htmlFormatDropdown">
           <paper-listbox class="dropdown-content" selected="AMP"
-                         id="formatSelector" attr-for-selected="format"
-                         on-iron-select="formatChange">
-            <paper-item format="AMP">AMP</paper-item>
-            <paper-item format="AMP4ADS">AMP4ADS</paper-item>
+                         id="htmlFormatSelector" attr-for-selected="htmlFormat"
+                         on-iron-select="htmlFormatChange">
+            <paper-item htmlFormat="AMP">AMP</paper-item>
+            <paper-item htmlFormat="AMP4ADS">AMP4ADS</paper-item>
           </paper-listbox>
         </paper-dropdown-menu>
       </paper-material>
@@ -76,9 +76,9 @@
           value: false
         }
       },
-      formatChange: function() {
-        this.fire('webui-urlform-format-changes',
-                  {'format': this.$.formatSelector.selected});
+      htmlFormatChange: function() {
+        this.fire('webui-urlform-html-format-changes',
+                  {'htmlFormat': this.$.htmlFormatSelector.selected});
       },
       checkURL: function(e) {
         this.validURL = !this.$.urlToFetch.invalid;
@@ -98,11 +98,11 @@
         this.$.urlToFetch.validate();
         this.$.validateButton.click();
       },
-      getFormat: function() {
-        return this.$.formatSelector.selected;
+      getHtmlFormat: function() {
+        return this.$.htmlFormatSelector.selected;
       },
-      setFormat: function(htmlFormat) {
-        this.$.formatSelector.selected = htmlFormat;
+      setHtmlFormat: function(htmlFormat) {
+        this.$.htmlFormatSelector.selected = htmlFormat;
       }
     });
   </script>


### PR DESCRIPTION
format is used for the output format of the tool. So I figure renaming
this for consistency makes the world slightly less confusing and it's
still easy to do now.