### PR TITLE
Remove the no longer used gladeExp param.

### DIFF
--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -314,7 +314,6 @@ function doubleClickWithGlade(global, data, gladeExperiment) {
     jsonParameters.targeting = data.targeting;
   }
   if (gladeExperiment === GladeExperiment.GLADE_EXPERIMENT) {
-    jsonParameters.gladeExp = '1';
     jsonParameters.gladeEids = '108809102';
   }
   const expIds = data['experimentId'];


### PR DESCRIPTION
This functionality is now captured by gladeEids.