### PR TITLE
IntersectionObserver: Translate element coords into viewport coords

### DIFF
--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -81,24 +81,24 @@ export function getIntersectionChangeEntry(element, owner, viewport) {
       'Negative dimensions in element.');
   // Building an IntersectionObserverEntry.
 
+  let intersectionRect = element;
+  if (owner) {
+    intersectionRect = rectIntersection(owner, element) ||
+        // No intersection.
+        layoutRectLtwh(0, 0, 0, 0);
+  }
+  intersectionRect = rectIntersection(viewport, intersectionRect) ||
+      // No intersection.
+      layoutRectLtwh(0, 0, 0, 0);
+
   // The element is relative to (0, 0), while the viewport moves. So, we must
   // adjust.
   const boundingClientRect = moveLayoutRect(element, -viewport.left,
       -viewport.top);
-
-  let intersectionRect = boundingClientRect;
-  if (owner) {
-    const ownerRect = moveLayoutRect(owner, -viewport.left, -viewport.top);
-    intersectionRect = rectIntersection(ownerRect, boundingClientRect) ||
-        // No intersection.
-        layoutRectLtwh(0, 0, 0, 0);
-  }
-
-  // Now, a normal IntersectionObserver reports the viewport as (x,y) (0, 0).
+  intersectionRect = moveLayoutRect(intersectionRect, -viewport.left,
+      -viewport.top);
+  // Now, move the viewport to (0, 0)
   const rootBounds = moveLayoutRect(viewport, -viewport.left, -viewport.top);
-  intersectionRect = rectIntersection(rootBounds, intersectionRect) ||
-      // No intersection.
-      layoutRectLtwh(0, 0, 0, 0);
 
   return /** @type {!IntersectionObserverEntry} */ ({
     time: Date.now(),

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -93,6 +93,7 @@ export function getIntersectionChangeEntry(element, owner, viewport) {
 
   // The element is relative to (0, 0), while the viewport moves. So, we must
   // adjust.
+  // TODO(jridgewell, #5149): Fixed position elements must be recalculated.
   const boundingClientRect = moveLayoutRect(element, -viewport.left,
       -viewport.top);
   intersectionRect = moveLayoutRect(intersectionRect, -viewport.left,

--- a/src/layout-rect.js
+++ b/src/layout-rect.js
@@ -124,7 +124,8 @@ export function expandLayoutRect(rect, dw, dh) {
  * @return {!LayoutRectDef}
  */
 export function moveLayoutRect(rect, dx, dy) {
-  if (dx == 0 && dy == 0) {
+  if ((dx == 0 && dy == 0) ||
+      (rect.width == 0 && rect.height == 0)) {
     return rect;
   }
   return layoutRectLtwh(rect.left + dx, rect.top + dy,

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -45,33 +45,33 @@ describe('getIntersectionChangeEntry', () => {
 
     expect(change.rootBounds).to.deep.equal({
       'left': 0,
-      'top': 100,
+      'top': 0,
       'width': 100,
       'height': 100,
-      'bottom': 200,
+      'bottom': 100,
       'right': 100,
       'x': 0,
-      'y': 100,
+      'y': 0,
     });
     expect(change.boundingClientRect).to.deep.equal({
       'left': 50,
-      'top': 50,
+      'top': -50,
       'width': 150,
       'height': 200,
-      'bottom': 250,
+      'bottom': 150,
       'right': 200,
       'x': 50,
-      'y': 50,
+      'y': -50,
     });
     expect(change.intersectionRect).to.deep.equal({
       'left': 50,
-      'top': 100,
+      'top': 0,
       'width': 50,
       'height': 100,
-      'bottom': 200,
+      'bottom': 100,
       'right': 100,
       'x': 50,
-      'y': 100,
+      'y': 0,
     });
     expect(change.intersectionRatio).to.be.closeTo(0.1666666, .0001);
   });
@@ -86,33 +86,33 @@ describe('getIntersectionChangeEntry', () => {
 
     expect(change.rootBounds).to.deep.equal({
       'left': 0,
-      'top': 100,
+      'top': 0,
       'width': 100,
       'height': 100,
-      'bottom': 200,
+      'bottom': 100,
       'right': 100,
       'x': 0,
-      'y': 100,
+      'y': 0,
     });
     expect(change.boundingClientRect).to.deep.equal({
       'left': 50,
-      'top': 200,
+      'top': 100,
       'width': 150,
       'height': 200,
-      'bottom': 400,
+      'bottom': 300,
       'right': 200,
       'x': 50,
-      'y': 200,
+      'y': 100,
     });
     expect(change.intersectionRect).to.deep.equal({
       'left': 50,
-      'top': 200,
+      'top': 100,
       'width': 50,
       'height': 0,
-      'bottom': 200,
+      'bottom': 100,
       'right': 100,
       'x': 50,
-      'y': 200,
+      'y': 100,
     });
     expect(change.intersectionRatio).to.equal(0);
   });
@@ -124,13 +124,13 @@ describe('getIntersectionChangeEntry', () => {
 
     expect(change.intersectionRect).to.deep.equal({
       'left': 50,
-      'top': 199,
+      'top': 99,
       'width': 50,
       'height': 1,
-      'bottom': 200,
+      'bottom': 100,
       'right': 100,
       'x': 50,
-      'y': 199,
+      'y': 99,
     });
   });
 
@@ -164,33 +164,33 @@ describe('getIntersectionChangeEntry', () => {
 
     expect(change.rootBounds).to.deep.equal({
       'left': 0,
-      'top': 100,
+      'top': 0,
       'width': 100,
       'height': 100,
-      'bottom': 200,
+      'bottom': 100,
       'right': 100,
       'x': 0,
-      'y': 100,
+      'y': 0,
     });
     expect(change.boundingClientRect).to.deep.equal({
       'left': 50,
-      'top': 50,
+      'top': -50,
       'width': 150,
       'height': 200,
-      'bottom': 250,
+      'bottom': 150,
       'right': 200,
       'x': 50,
-      'y': 50,
+      'y': -50,
     });
     expect(change.intersectionRect).to.deep.equal({
       'left': 50,
-      'top': 110,
+      'top': 10,
       'width': 10,
       'height': 20,
-      'bottom': 130,
+      'bottom': 30,
       'right': 60,
       'x': 50,
-      'y': 110,
+      'y': 10,
     });
     expect(change.intersectionRatio).to.be.closeTo(0.0066666, .0001);
   });
@@ -207,23 +207,23 @@ describe('getIntersectionChangeEntry', () => {
 
     expect(change.rootBounds).to.deep.equal({
       'left': 0,
-      'top': 100,
+      'top': 0,
       'width': 100,
       'height': 100,
-      'bottom': 200,
+      'bottom': 100,
       'right': 100,
       'x': 0,
-      'y': 100,
+      'y': 0,
     });
     expect(change.boundingClientRect).to.deep.equal({
       'left': 50,
-      'top': 225,
+      'top': 125,
       'width': 100,
       'height': 100,
-      'bottom': 325,
+      'bottom': 225,
       'right': 150,
       'x': 50,
-      'y': 225,
+      'y': 125,
     });
     expect(change.intersectionRect).to.deep.equal({
       'left': 0,
@@ -250,23 +250,23 @@ describe('getIntersectionChangeEntry', () => {
 
     expect(change.rootBounds).to.deep.equal({
       'left': 0,
-      'top': 100,
+      'top': 0,
       'width': 100,
       'height': 100,
-      'bottom': 200,
+      'bottom': 100,
       'right': 100,
       'x': 0,
-      'y': 100,
+      'y': 0,
     });
     expect(change.boundingClientRect).to.deep.equal({
       'left': 50,
-      'top': 225,
+      'top': 125,
       'width': 100,
       'height': 100,
-      'bottom': 325,
+      'bottom': 225,
       'right': 150,
       'x': 50,
-      'y': 225,
+      'y': 125,
     });
     expect(change.intersectionRect).to.deep.equal({
       'left': 0,


### PR DESCRIPTION
I made a mistake in Fixes a mistake in #4826. The “viewport” we report
moves with the scroll position, while a real IntersectionObserver does
not. And, our elements didn’t move with the scroll position, while the
real one did.

So, this translates elements into their position relative to scroll,
and removes the scroll relative position from viewport.

Fixes #5090.
/cc @jasti