### PR TITLE
refactor ad-cid test

### DIFF
--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -18,6 +18,7 @@ import {AmpAd3PImpl} from '../amp-ad-3p-impl';
 import {createAdPromise} from '../../../../testing/ad-iframe';
 import {createIframePromise} from '../../../../testing/iframe';
 import {createElementWithAttributes} from '../../../../src/dom';
+import * as adCid from '../../../../src/ad-cid';
 import '../../../amp-sticky-ad/0.1/amp-sticky-ad';
 import * as sinon from 'sinon';
 import * as lolex from 'lolex';
@@ -227,6 +228,28 @@ function tests(name) {
         ad.implementation_.unlayoutCallback();
         const newLayout = ad.implementation_.layoutCallback();
         expect(newLayout).to.not.equal(secondLayout);
+      });
+    });
+
+    describe('get CID', () => {
+      it('should propagete CID to ad iframe', () => {
+        sandbox.stub(adCid, 'getAdCid', () => {
+          return Promise.resolve('sentinel123');
+        });
+        return getAd().then(ad => {
+          const src = ad.firstChild.getAttribute('src');
+          expect(src).to.contain('"clientId":"sentinel123"');
+        });
+      });
+
+      it('should proceed w/o CID', () => {
+        sandbox.stub(adCid, 'getAdCid', () => {
+          return Promise.resolve(undefined);
+        });
+        return getAd().then(ad => {
+          const src = ad.firstChild.getAttribute('src');
+          expect(src).to.contain('"clientId":null');
+        });
       });
     });
 

--- a/test/functional/test-ad-cid.js
+++ b/test/functional/test-ad-cid.js
@@ -15,7 +15,7 @@
  */
 
 import {adConfig} from '../../ads/_config';
-import {createAdPromise} from '../../testing/ad-iframe';
+import {createIframePromise} from '../../testing/iframe';
 import {installCidService} from '../../extensions/amp-analytics/0.1/cid-impl';
 import {
   installUserNotificationManager,
@@ -25,224 +25,136 @@ import {setCookie} from '../../src/cookies';
 import {timerFor} from '../../src/timer';
 import * as sinon from 'sinon';
 
+describe('ad-cid', () => {
+  const cidScope = 'cid-in-ads-test';
+  const config = adConfig['_ping_'];
+  let sandbox;
 
-// TODO: I'm not sure if this is fully kosher.  This test asks, 'does the
-// CID get written to the element properly?'  When amp-ad is actually a delegate
-// to either amp-a4a or amp-ad-3p-impl, the CID gets written only to the
-// 3p-impl child Element.  Changing the test in this way checks that the CID
-// appears on the 3p-impl child, rather than the (delegating) parent.  That
-// should (?) be enough to ensure that it's propagated forward to the ad in the
-// 3p iframe.
-// describe('ad-cid-embed', tests('amp-embed'));
-describe('ad-cid', tests('amp-ad'));
+  let cidService;
+  let uidService;
+  let clock;
+  let element;
+  let adElement;
 
-function tests(name) {
-  function getAd(attributes, canonical, opt_handleElement,
-                 opt_beforeLayoutCallback) {
-    return createAdPromise(name, attributes, canonical,
-                           opt_handleElement, opt_beforeLayoutCallback);
-  }
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
+    cidService = installCidService(window);
+    uidService = installUserNotificationManager(window);
+    element = document.createElement('amp-ad');
+    element.setAttribute('type', '_ping_');
+    adElement = {
+      element,
+      win: window,
+    };
+  });
 
-  return () => {
-    describe('cid-ad support', () => {
-      const cidScope = 'cid-in-ads-test';
-      const config = adConfig['_ping_'];
-      let sandbox;
+  afterEach(() => {
+    sandbox.restore();
+    setCookie(window, cidScope, '', Date.now() - 5000);
+  });
 
-      beforeEach(() => {
-        sandbox = sinon.sandbox.create();
-      });
+  it('should get correct cid', () => {
+    config.clientIdScope = cidScope;
 
-      afterEach(() => {
-        sandbox.restore();
-        setCookie(window, cidScope, '', Date.now() - 5000);
-      });
+    sandbox.stub(cidService, 'get', scope => {
+      expect(scope).to.equal(cidScope);
+      return Promise.resolve('test123');
+    });
+    return getAdCid(adElement).then(cid => {
+      expect(cid).to.equal('test123');
+    });
+  });
 
-      describe('unit test', () => {
-        let clock;
-        let element;
-        let adElement;
-        beforeEach(() => {
-          clock = sandbox.useFakeTimers();
-          element = document.createElement('amp-ad');
-          element.setAttribute('type', '_ping_');
-          adElement = {
-            element,
-            win: window,
-          };
-        });
+  it('should return on timeout', () => {
+    config.clientIdScope = cidScope;
+    sandbox.stub(cidService, 'get', scope => {
+      expect(scope).to.equal(cidScope);
+      return timerFor(window).promise(2000);
+    });
+    const p = getAdCid(adElement).then(cid => {
+      expect(cid).to.be.undefined;
+      expect(Date.now()).to.equal(1000);
+    });
+    clock.tick(999);
+    // Let promises resolve before ticking 1 more ms.
+    Promise.resolve().then(() => {
+      clock.tick(1);
+    });
+    return p;
+  });
 
-        it('provides cid to ad', () => {
-          config.clientIdScope = cidScope;
+  it('should return undefined on failed CID', () => {
+    config.clientIdScope = cidScope;
+    sandbox.stub(cidService, 'get', () => {
+      return Promise.reject(new Error('nope'));
+    });
+    return getAdCid(adElement).then(cid => {
+      expect(cid).to.be.undefined;
+    });
+  });
 
-          const s = installCidService(window);
-          sandbox.stub(s, 'get', scope => {
-            expect(scope).to.equal(cidScope);
-            return Promise.resolve('test123');
-          });
-          return getAdCid(adElement).then(cid => {
-            expect(cid).to.equal('test123');
-          });
-        });
-
-        it('times out', () => {
-          config.clientIdScope = cidScope;
-          const s = installCidService(window);
-          sandbox.stub(s, 'get', scope => {
-            expect(scope).to.equal(cidScope);
-            return timerFor(window).promise(2000);
-          });
-          const p = getAdCid(adElement).then(cid => {
-            expect(cid).to.be.undefined;
-            expect(Date.now()).to.equal(1000);
-          });
-          clock.tick(999);
-          // Let promises resolve before ticking 1 more ms.
-          Promise.resolve().then(() => {
-            clock.tick(1);
-          });
-          return p;
-        });
-      });
-
-      it('provides cid to ad', () => {
-        config.clientIdScope = cidScope;
-        return getAd({
-          width: 300,
-          height: 250,
-          type: '_ping_',
-          src: 'testsrc',
-        }, 'https://schema.org', function(ad) {
-          const win = ad.ownerDocument.defaultView;
-          setCookie(window, cidScope, 'sentinel123',
-              Date.now() + 5000);
-          installCidService(win);
-          return ad;
-        }).then(ad => {
-          const src = ad.firstChild.getAttribute('src');
-          expect(src).to.contain('"clientId":"sentinel123"');
-        });
-      });
-
-      it('proceeds on failed CID', () => {
-        config.clientIdScope = cidScope;
-        return getAd({
-          width: 300,
-          height: 250,
-          type: '_ping_',
-          src: 'testsrc',
-        }, 'https://schema.org', function(ad) {
-          const win = ad.ownerDocument.defaultView;
-          const service = installCidService(win);
-          sandbox.stub(service, 'get',
-              () => Promise.reject(new Error('nope')));
-          return ad;
-        }).then(ad => {
-          const src = ad.firstChild.getAttribute('src');
-          expect(src).to.contain('"clientId":null');
-        });
-      });
-
-      it('waits for consent', () => {
-        config.clientIdScope = cidScope;
-        return getAd({
-          width: 300,
-          height: 250,
-          type: '_ping_',
-          src: 'testsrc',
-          'data-consent-notification-id': 'uid',
-        }, 'https://schema.org', function(ad) {
-          const win = ad.ownerDocument.defaultView;
-          const cidService = installCidService(win);
-          const uidService = installUserNotificationManager(win);
-          sandbox.stub(uidService, 'get', id => {
-            expect(id).to.equal('uid');
-            return Promise.resolve('consent');
-          });
-          sandbox.stub(cidService, 'get', (scope, consent) => {
-            expect(scope).to.equal(cidScope);
-            return consent.then(val => {
-              return val + '-cid';
-            });
-          });
-          return ad;
-        }).then(ad => {
-          const src = ad.firstChild.getAttribute('src');
-          expect(src).to.contain('"clientId":"consent-cid"');
-        });
-      });
-
-      it('waits for consent w/o cidScope', () => {
-        config.clientIdScope = null;
-        return getAd({
-          width: 300,
-          height: 250,
-          type: '_ping_',
-          src: 'testsrc',
-          'data-consent-notification-id': 'uid',
-        }, 'https://schema.org', function(ad) {
-          const win = ad.ownerDocument.defaultView;
-          const cidService = installCidService(win);
-          const uidService = installUserNotificationManager(win);
-          sandbox.stub(uidService, 'get', id => {
-            expect(id).to.equal('uid');
-            return Promise.resolve('consent');
-          });
-          sandbox.stub(cidService, 'get', (scope, consent) => {
-            expect(scope).to.equal(cidScope);
-            return consent.then(val => {
-              return val + '-cid';
-            });
-          });
-          return ad;
-        }).then(ad => {
-          const src = ad.firstChild.getAttribute('src');
-          expect(src).to.contain('"clientId":"consent"');
-        });
-      });
-
-      it('provide null if notification and cid is not provided', () => {
-        config.clientIdScope = null;
-        let uidSpy = null;
-        return getAd({
-          width: 300,
-          height: 250,
-          type: '_ping_',
-          src: 'testsrc',
-        }, 'https://schema.org', function(ad) {
-          const win = ad.ownerDocument.defaultView;
-          const cidService = installCidService(win);
-          const uidService = installUserNotificationManager(win);
-          uidSpy = sandbox.spy(uidService, 'get');
-          sandbox.stub(cidService, 'get', (scope, consent) => {
-            expect(scope).to.equal(cidScope);
-            return consent.then(val => {
-              return val + '-cid';
-            });
-          });
-          return ad;
-        }).then(ad => {
-          expect(uidSpy.callCount).to.equal(0);
-          const src = ad.firstChild.getAttribute('src');
-          expect(src).to.contain('"clientId":null');
-        });
-      });
-
-      it('provides null if cid service not available', () => {
-        config.clientIdScope = cidScope;
-        return getAd({
-          width: 300,
-          height: 250,
-          type: '_ping_',
-          src: 'testsrc',
-        }, 'https://schema.org', function(ad) {
-          setCookie(window, cidScope, 'XXX', Date.now() + 5000);
-          return ad;
-        }).then(ad => {
-          const src = ad.firstChild.getAttribute('src');
-          expect(src).to.contain('"clientId":null');
-        });
+  it('should wait for consent w/ cidScope', () => {
+    config.clientIdScope = cidScope;
+    adElement.element.setAttribute('data-consent-notification-id', 'uid');
+    sandbox.stub(uidService, 'get', id => {
+      expect(id).to.equal('uid');
+      return Promise.resolve('consent');
+    });
+    sandbox.stub(cidService, 'get', (scope, consent) => {
+      expect(scope).to.equal(cidScope);
+      return consent.then(val => {
+        console.log('val is', val);
+        return val + '-cid';
       });
     });
-  };
-}
+    return getAdCid(adElement).then(cid => {
+      expect(cid).to.equal('consent-cid');
+    });
+  });
+
+  it('should wait for consent w/0 cidScope', () => {
+    config.clientIdScope = null;
+    adElement.element.setAttribute('data-consent-notification-id', 'uid');
+    sandbox.stub(uidService, 'get', id => {
+      expect(id).to.equal('uid');
+      return Promise.resolve('consent');
+    });
+    sandbox.stub(cidService, 'get', (scope, consent) => {
+      expect(scope).to.equal(cidScope);
+      return consent.then(val => {
+        return val + '-cid';
+      });
+    });
+    return getAdCid(adElement).then(cid => {
+      expect(cid).to.equal('consent');
+    });
+  });
+
+  it('should return undefined if notification and cid is not provided',
+      () => {
+        config.clientIdScope = null;
+        sandbox.stub(cidService, 'get', (scope, consent) => {
+          expect(scope).to.equal(cidScope);
+          return consent.then(val => {
+            return val + '-cid';
+          });
+        });
+        const uidSpy = sandbox.spy(uidService, 'get');
+        return getAdCid(adElement).then(cid => {
+          expect(uidSpy).to.not.be.called;
+          expect(cid).to.be.undefined;
+        });
+      });
+
+  it('should return null if cid service not available', () => {
+    config.clientIdScope = cidScope;
+    return createIframePromise(true /* runtimeOff */).then(iframe => {
+      adElement.win = iframe.win;
+      return getAdCid(adElement).then(cid => {
+        console.log('cid is ', cid);
+        expect(cid).to.be.undefined;
+      });
+    });
+  });
+});


### PR DESCRIPTION
fix #5121 

One thing I didn't refactor is `#createAdPromise` from `ad-iframe.js`, only `test-amp-ad-3p-impl.js` uses it now, but I don't if we are going to use it in the future, so I vote for leaving it in a separate file.