### PR TITLE
<amp-iframe> proper box-sizing and defaulting frameborder to 0

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -381,7 +381,7 @@ amp-analytics {
  * or otherwise the iframe will oevrflow its parent when there is a border.
  */
 amp-iframe iframe {
-  box-sizing: border-box;
+  box-sizing: border-box !important;
 }
 
 /**

--- a/css/amp.css
+++ b/css/amp.css
@@ -376,6 +376,13 @@ amp-analytics {
   visibility: hidden;
 }
 
+/**
+ * Iframe allows setting frameborder, so we need to set box-sizing to border-box
+ * or otherwise the iframe will oevrflow its parent when there is a border.
+ */
+amp-iframe iframe {
+  box-sizing: border-box;
+}
 
 /**
  * Minimal AMP Access CSS. This part has to be here so that the correct UI

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -177,6 +177,10 @@ export class AmpIframe extends AMP.BaseElement {
 
     /** @private {!IntersectionObserver} */
     this.intersectionObserver_ = null;
+
+    if (!this.element.hasAttribute('frameborder')) {
+      this.element.setAttribute('frameborder', '0');
+    }
   }
 
   /**

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -174,6 +174,16 @@ describe('amp-iframe', () => {
     });
   });
 
+  it('should default frameborder to 0 if not set', () => {
+    return getAmpIframe({
+      src: iframeSrc,
+      width: 100,
+      height: 100,
+    }).then(amp => {
+      expect(amp.iframe.getAttribute('frameborder')).to.equal('0');
+    });
+  });
+
   it('should allow JS and propagate scrolling and have lower priority', () => {
     return getAmpIframe({
       src: iframeSrc,

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -77,6 +77,8 @@ The reasons for this policy are that:
 
 The attributes above should all behave like they do on standard iframes.
 
+If `frameborder` is not specified, it will be set to `0` by default.
+
 ### sandbox
 
 Iframes created by `amp-iframe` always have the `sandbox` attribute defined on them. By default the value is empty. That means that they are "maximum sandboxed" by default. By setting sandbox values, one can opt the iframe into being less sandboxed. All values supported by browsers are allowed. E.g. setting `sandbox="allow-scripts"` allows the iframe to run JavaScript, or `sandbox="allow-scripts allow-same-origin"` allows the iframe to run JavaScript, make non-CORS XHRs, and read/write cookies.


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/5140 and https://github.com/ampproject/amphtml/issues/5137

We want `box-sizing:border-box` for iframe otherwise setting any border on it will overflow the parent causing issues like #5137

Also defaulting `frameborder` to 0 is reasonable since in vast majority of cases border is not desirable and Browser's builtin CSS adds a 2 pixel border unless it is set to another value.