### PR TITLE
make sure to init instances extensions can use

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -104,8 +104,6 @@ import {yieldone} from '../ads/yieldone';
 import {zergnet} from '../ads/zergnet';
 import {zucks} from '../ads/zucks';
 
-initLogConstructor();
-
 /**
  * Whether the embed type may be used with amp-embed tag.
  * @const {!Object<string, boolean>}
@@ -120,6 +118,9 @@ const AMP_EMBED_ALLOWED = {
 
 const data = parseFragment(location.hash);
 window.context = data._context;
+
+// This should only be invoked after window.context is set
+initLogConstructor();
 
 if (getMode().test || getMode().localDev) {
   register('_ping_', _ping_);

--- a/src/log.js
+++ b/src/log.js
@@ -422,6 +422,9 @@ let logConstructor = null;
 
 export function initLogConstructor() {
   logConstructor = Log;
+  // Initialize instances for use
+  dev();
+  user();
 }
 
 export function resetLogConstructorForTesting() {

--- a/src/log.js
+++ b/src/log.js
@@ -422,7 +422,15 @@ let logConstructor = null;
 
 export function initLogConstructor() {
   logConstructor = Log;
-  // Initialize instances for use
+  // Initialize instances for use. If a binary (an extension for example) that
+  // does not call `initLogConstructor` invokes `dev()` or `user()` earlier
+  // than the binary that does call `initLogConstructor` (amp.js), the extension
+  // will throw an error as that extension will never be able to initialize
+  // the log instances and we also don't want it to call `initLogConstructor`
+  // either (since that will cause the Log implementation to be bundled into that
+  // binary). So we must initialize the instances eagerly so that they are
+  // ready for use (stored globally) after the main binary calls
+  // `initLogConstructor`.
   dev();
   user();
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -27,7 +27,7 @@ import {
 } from './service/extensions-impl';
 import {ampdocServiceFor} from './ampdoc';
 import {cssText} from '../build/css';
-import {dev, user} from './log';
+import {dev, user, initLogConstructor} from './log';
 import {fromClassForDoc, getService, getServiceForDoc} from './service';
 import {childElementsByTag} from './dom';
 import {
@@ -59,7 +59,6 @@ import {installViewportService} from './service/viewport-impl';
 import {installVsyncService} from './service/vsync-impl';
 import {installXhrService} from './service/xhr-impl';
 import {isExperimentOn, toggleExperiment} from './experiments';
-import {initLogConstructor} from './log';
 import {platformFor} from './platform';
 import {registerElement} from './custom-element';
 import {registerExtendedElement} from './extended-element';

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,5 +1,6 @@
       max   |         min   |        gzip   |   file
       ---   |         ---   |         ---   |   ---
+<<<<<<< c75bcc7bed5c1f1d7059989f32e4c80fbc238932
  71.84 kB   |     5.87 kB   |     2.53 kB   |   alp.js / alp.max.js
 845.35 kB   |   163.44 kB   |    51.78 kB   |   shadow-v0.js / amp-shadow.js
    5.8 kB   |       428 B   |       278 B   |   sw-kill.js / sw-kill.max.js
@@ -59,3 +60,64 @@
 154.14 kB   |     4.29 kB   |     1.97 kB   |   v0/amp-youtube-0.1.js
  15.89 kB   |     1.55 kB   |       801 B   |   v0/cache-service-worker-0.1.js
 212.75 kB   |    46.66 kB   |    16.28 kB   |   current-min/f.js / current/integration.js
+=======
+ 71.89 kB   |     6.07 kB   |     2.58 kB   |   alp.js / alp.max.js
+844.87 kB   |   163.27 kB   |    51.71 kB   |   shadow-v0.js / amp-shadow.js
+   5.8 kB   |       428 B   |       278 B   |   sw-kill.js / sw-kill.max.js
+366.05 kB   |       681 B   |       450 B   |   sw.js / sw.max.js
+884.66 kB   |   165.68 kB   |    52.54 kB   |   v0.js / amp.js
+320.09 kB   |    37.39 kB   |    12.62 kB   |   v0/amp-access-0.1.js
+ 55.57 kB   |     3.45 kB   |     1.41 kB   |   v0/amp-accordion-0.1.js
+305.26 kB   |    30.07 kB   |       11 kB   |   v0/amp-ad-0.1.js
+   313 kB   |    28.89 kB   |    10.79 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+312.67 kB   |    26.99 kB   |    10.18 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+242.59 kB   |    19.96 kB   |     7.48 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+294.15 kB   |    54.97 kB   |    20.12 kB   |   v0/amp-analytics-0.1.js
+ 49.71 kB   |     3.74 kB   |     1.72 kB   |   v0/amp-anim-0.1.js
+ 136.8 kB   |     4.84 kB   |     2.09 kB   |   v0/amp-apester-media-0.1.js
+174.47 kB   |    10.91 kB   |     4.37 kB   |   v0/amp-app-banner-0.1.js
+ 51.58 kB   |     2.31 kB   |     1.15 kB   |   v0/amp-audio-0.1.js
+  41.4 kB   |     3.15 kB   |     1.33 kB   |   v0/amp-brid-player-0.1.js
+ 72.92 kB   |     2.79 kB   |     1.25 kB   |   v0/amp-brightcove-0.1.js
+269.53 kB   |    32.55 kB   |     9.93 kB   |   v0/amp-carousel-0.1.js
+  34.1 kB   |     1.81 kB   |       920 B   |   v0/amp-dailymotion-0.1.js
+147.06 kB   |     3.92 kB   |     1.73 kB   |   v0/amp-dynamic-css-classes-0.1.js
+149.21 kB   |     5.34 kB   |     2.36 kB   |   v0/amp-experiment-0.1.js
+163.31 kB   |    10.55 kB   |     4.64 kB   |   v0/amp-facebook-0.1.js
+ 42.56 kB   |     3.11 kB   |     1.38 kB   |   v0/amp-fit-text-0.1.js
+132.03 kB   |     4.05 kB   |     1.82 kB   |   v0/amp-font-0.1.js
+203.52 kB   |    14.28 kB   |     5.36 kB   |   v0/amp-form-0.1.js
+153.21 kB   |     3.49 kB   |     1.65 kB   |   v0/amp-fresh-0.1.js
+ 52.61 kB   |     4.22 kB   |     1.81 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 33.47 kB   |     1.55 kB   |       790 B   |   v0/amp-gfycat-0.1.js
+  62.3 kB   |     3.78 kB   |     1.73 kB   |   v0/amp-google-vrview-image-0.1.js
+186.03 kB   |    10.79 kB   |     4.47 kB   |   v0/amp-iframe-0.1.js
+263.78 kB   |    27.57 kB   |     9.01 kB   |   v0/amp-image-lightbox-0.1.js
+ 60.81 kB   |     2.75 kB   |     1.29 kB   |   v0/amp-instagram-0.1.js
+118.17 kB   |     5.29 kB   |     2.48 kB   |   v0/amp-install-serviceworker-0.1.js
+ 40.66 kB   |     2.58 kB   |     1.21 kB   |   v0/amp-jwplayer-0.1.js
+ 78.35 kB   |     3.67 kB   |     1.62 kB   |   v0/amp-kaltura-player-0.1.js
+169.85 kB   |     8.21 kB   |     3.13 kB   |   v0/amp-lightbox-0.1.js
+170.17 kB   |    12.48 kB   |     4.21 kB   |   v0/amp-lightbox-viewer-0.1.js
+123.26 kB   |     2.96 kB   |      1.4 kB   |   v0/amp-list-0.1.js
+182.99 kB   |     9.19 kB   |     3.57 kB   |   v0/amp-live-list-0.1.js
+156.29 kB   |    37.36 kB   |    13.39 kB   |   v0/amp-mustache-0.1.js
+  34.5 kB   |     2.24 kB   |       972 B   |   v0/amp-o2-player-0.1.js
+   167 kB   |    17.42 kB   |     4.97 kB   |   v0/amp-pinterest-0.1.js
+ 33.21 kB   |     1.39 kB   |       704 B   |   v0/amp-reach-player-0.1.js
+121.47 kB   |     3.03 kB   |     1.47 kB   |   v0/amp-share-tracking-0.1.js
+117.56 kB   |     5.35 kB   |     2.15 kB   |   v0/amp-sidebar-0.1.js
+139.37 kB   |     7.27 kB   |        3 kB   |   v0/amp-slides-0.1.js
+148.89 kB   |     9.35 kB   |     3.65 kB   |   v0/amp-social-share-0.1.js
+ 34.22 kB   |     1.79 kB   |       870 B   |   v0/amp-soundcloud-0.1.js
+ 41.68 kB   |     3.33 kB   |     1.32 kB   |   v0/amp-springboard-player-0.1.js
+132.81 kB   |     4.68 kB   |     1.87 kB   |   v0/amp-sticky-ad-0.1.js
+163.67 kB   |    10.67 kB   |     4.68 kB   |   v0/amp-twitter-0.1.js
+154.45 kB   |     7.66 kB   |     3.06 kB   |   v0/amp-user-notification-0.1.js
+ 33.52 kB   |     1.56 kB   |       803 B   |   v0/amp-vimeo-0.1.js
+ 33.12 kB   |     1.43 kB   |       759 B   |   v0/amp-vine-0.1.js
+664.96 kB   |   511.38 kB   |   167.49 kB   |   v0/amp-viz-vega-0.1.js
+154.19 kB   |     4.29 kB   |     1.97 kB   |   v0/amp-youtube-0.1.js
+ 15.89 kB   |     1.55 kB   |       800 B   |   v0/cache-service-worker-0.1.js
+212.81 kB   |    46.83 kB   |    16.32 kB   |   current-min/f.js / current/integration.js
+>>>>>>> make sure to init instances extensions can use

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,6 +1,5 @@
       max   |         min   |        gzip   |   file
       ---   |         ---   |         ---   |   ---
-<<<<<<< c75bcc7bed5c1f1d7059989f32e4c80fbc238932
  71.84 kB   |     5.87 kB   |     2.53 kB   |   alp.js / alp.max.js
 845.35 kB   |   163.44 kB   |    51.78 kB   |   shadow-v0.js / amp-shadow.js
    5.8 kB   |       428 B   |       278 B   |   sw-kill.js / sw-kill.max.js
@@ -60,64 +59,3 @@
 154.14 kB   |     4.29 kB   |     1.97 kB   |   v0/amp-youtube-0.1.js
  15.89 kB   |     1.55 kB   |       801 B   |   v0/cache-service-worker-0.1.js
 212.75 kB   |    46.66 kB   |    16.28 kB   |   current-min/f.js / current/integration.js
-=======
- 71.89 kB   |     6.07 kB   |     2.58 kB   |   alp.js / alp.max.js
-844.87 kB   |   163.27 kB   |    51.71 kB   |   shadow-v0.js / amp-shadow.js
-   5.8 kB   |       428 B   |       278 B   |   sw-kill.js / sw-kill.max.js
-366.05 kB   |       681 B   |       450 B   |   sw.js / sw.max.js
-884.66 kB   |   165.68 kB   |    52.54 kB   |   v0.js / amp.js
-320.09 kB   |    37.39 kB   |    12.62 kB   |   v0/amp-access-0.1.js
- 55.57 kB   |     3.45 kB   |     1.41 kB   |   v0/amp-accordion-0.1.js
-305.26 kB   |    30.07 kB   |       11 kB   |   v0/amp-ad-0.1.js
-   313 kB   |    28.89 kB   |    10.79 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-312.67 kB   |    26.99 kB   |    10.18 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-242.59 kB   |    19.96 kB   |     7.48 kB   |   v0/amp-ad-network-fake-impl-0.1.js
-294.15 kB   |    54.97 kB   |    20.12 kB   |   v0/amp-analytics-0.1.js
- 49.71 kB   |     3.74 kB   |     1.72 kB   |   v0/amp-anim-0.1.js
- 136.8 kB   |     4.84 kB   |     2.09 kB   |   v0/amp-apester-media-0.1.js
-174.47 kB   |    10.91 kB   |     4.37 kB   |   v0/amp-app-banner-0.1.js
- 51.58 kB   |     2.31 kB   |     1.15 kB   |   v0/amp-audio-0.1.js
-  41.4 kB   |     3.15 kB   |     1.33 kB   |   v0/amp-brid-player-0.1.js
- 72.92 kB   |     2.79 kB   |     1.25 kB   |   v0/amp-brightcove-0.1.js
-269.53 kB   |    32.55 kB   |     9.93 kB   |   v0/amp-carousel-0.1.js
-  34.1 kB   |     1.81 kB   |       920 B   |   v0/amp-dailymotion-0.1.js
-147.06 kB   |     3.92 kB   |     1.73 kB   |   v0/amp-dynamic-css-classes-0.1.js
-149.21 kB   |     5.34 kB   |     2.36 kB   |   v0/amp-experiment-0.1.js
-163.31 kB   |    10.55 kB   |     4.64 kB   |   v0/amp-facebook-0.1.js
- 42.56 kB   |     3.11 kB   |     1.38 kB   |   v0/amp-fit-text-0.1.js
-132.03 kB   |     4.05 kB   |     1.82 kB   |   v0/amp-font-0.1.js
-203.52 kB   |    14.28 kB   |     5.36 kB   |   v0/amp-form-0.1.js
-153.21 kB   |     3.49 kB   |     1.65 kB   |   v0/amp-fresh-0.1.js
- 52.61 kB   |     4.22 kB   |     1.81 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 33.47 kB   |     1.55 kB   |       790 B   |   v0/amp-gfycat-0.1.js
-  62.3 kB   |     3.78 kB   |     1.73 kB   |   v0/amp-google-vrview-image-0.1.js
-186.03 kB   |    10.79 kB   |     4.47 kB   |   v0/amp-iframe-0.1.js
-263.78 kB   |    27.57 kB   |     9.01 kB   |   v0/amp-image-lightbox-0.1.js
- 60.81 kB   |     2.75 kB   |     1.29 kB   |   v0/amp-instagram-0.1.js
-118.17 kB   |     5.29 kB   |     2.48 kB   |   v0/amp-install-serviceworker-0.1.js
- 40.66 kB   |     2.58 kB   |     1.21 kB   |   v0/amp-jwplayer-0.1.js
- 78.35 kB   |     3.67 kB   |     1.62 kB   |   v0/amp-kaltura-player-0.1.js
-169.85 kB   |     8.21 kB   |     3.13 kB   |   v0/amp-lightbox-0.1.js
-170.17 kB   |    12.48 kB   |     4.21 kB   |   v0/amp-lightbox-viewer-0.1.js
-123.26 kB   |     2.96 kB   |      1.4 kB   |   v0/amp-list-0.1.js
-182.99 kB   |     9.19 kB   |     3.57 kB   |   v0/amp-live-list-0.1.js
-156.29 kB   |    37.36 kB   |    13.39 kB   |   v0/amp-mustache-0.1.js
-  34.5 kB   |     2.24 kB   |       972 B   |   v0/amp-o2-player-0.1.js
-   167 kB   |    17.42 kB   |     4.97 kB   |   v0/amp-pinterest-0.1.js
- 33.21 kB   |     1.39 kB   |       704 B   |   v0/amp-reach-player-0.1.js
-121.47 kB   |     3.03 kB   |     1.47 kB   |   v0/amp-share-tracking-0.1.js
-117.56 kB   |     5.35 kB   |     2.15 kB   |   v0/amp-sidebar-0.1.js
-139.37 kB   |     7.27 kB   |        3 kB   |   v0/amp-slides-0.1.js
-148.89 kB   |     9.35 kB   |     3.65 kB   |   v0/amp-social-share-0.1.js
- 34.22 kB   |     1.79 kB   |       870 B   |   v0/amp-soundcloud-0.1.js
- 41.68 kB   |     3.33 kB   |     1.32 kB   |   v0/amp-springboard-player-0.1.js
-132.81 kB   |     4.68 kB   |     1.87 kB   |   v0/amp-sticky-ad-0.1.js
-163.67 kB   |    10.67 kB   |     4.68 kB   |   v0/amp-twitter-0.1.js
-154.45 kB   |     7.66 kB   |     3.06 kB   |   v0/amp-user-notification-0.1.js
- 33.52 kB   |     1.56 kB   |       803 B   |   v0/amp-vimeo-0.1.js
- 33.12 kB   |     1.43 kB   |       759 B   |   v0/amp-vine-0.1.js
-664.96 kB   |   511.38 kB   |   167.49 kB   |   v0/amp-viz-vega-0.1.js
-154.19 kB   |     4.29 kB   |     1.97 kB   |   v0/amp-youtube-0.1.js
- 15.89 kB   |     1.55 kB   |       800 B   |   v0/cache-service-worker-0.1.js
-212.81 kB   |    46.83 kB   |    16.32 kB   |   current-min/f.js / current/integration.js
->>>>>>> make sure to init instances extensions can use


### PR DESCRIPTION
@cramforce there was a scenario that @mkhatib discovered where his extension (amp-form) was the first one to invoke `user()` and tries to access `logs.user` which doesn't exist, and the amp-form.js instantly throws an error since it does not have the `Log` class implementation