### PR TITLE
`layout-fill` needs `box-sizing: border-box` or it will overflow parent

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -79,6 +79,7 @@ body {
   display: block;
   overflow: hidden !important;
   position: relative;
+  box-sizing: border-box;
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
This won't make https://github.com/ampproject/amphtml/pull/4977 fully backward compatible (as @dvoytenko mentioned we still loose padding with 4977) but this fix is needed to ensure if padding/border are specified, we don't overflow the parent. Here are some fiddles comparing previous state, PR4977 and this PR. Parent being filled is a 300x300 div.

## No padding/border on element with layout="fill":
http://codepen.io/aghassemi/pen/YGNaJB
All versions are the same, all is good.

## No padding but 10px border on element with layout="fill":
http://codepen.io/aghassemi/pen/ampYRY
Without this fix, we overflow parent by 20 pixel compared to previous state.

## 30px padding and 10px border on element with layout="fill":
http://codepen.io/aghassemi/pen/EgkErE
We still lose padding compared to previous state, but without this fix, we would be overflowing 80px.


/cc @sriramkrish85 