### PR TITLE
Fix silent Shadow DOM failure

### DIFF
--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -291,7 +291,11 @@ export function scopeShadowCss(shadowRoot, css) {
   }
 
   // Patch selectors.
-  return ShadowCSS.scopeRules.call(ShadowCSS, rules, `#${id}`, transformRootSelectors);
+  // Invoke `ShadowCSS.scopeRules` via `call` because the way it uses `this`
+  // internally conflicts with Closure compiler's advanced optimizations.
+  // eslint-disable-next-line no-useless-call
+  return ShadowCSS.scopeRules.call(ShadowCSS, rules, `#${id}`, 
+      transformRootSelectors);
 }
 
 

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -291,7 +291,7 @@ export function scopeShadowCss(shadowRoot, css) {
   }
 
   // Patch selectors.
-  return ShadowCSS.scopeRules(rules, `#${id}`, transformRootSelectors);
+  return ShadowCSS.scopeRules.call(ShadowCSS, rules, `#${id}`, transformRootSelectors);
 }
 
 

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -293,9 +293,8 @@ export function scopeShadowCss(shadowRoot, css) {
   // Patch selectors.
   // Invoke `ShadowCSS.scopeRules` via `call` because the way it uses `this`
   // internally conflicts with Closure compiler's advanced optimizations.
-  // eslint-disable-next-line no-useless-call
-  return ShadowCSS.scopeRules.call(ShadowCSS, rules, `#${id}`, 
-      transformRootSelectors);
+  const scopeRules = ShadowCSS.scopeRules;
+  return scopeRules.call(ShadowCSS, rules, `#${id}`, transformRootSelectors);
 }
 
 


### PR DESCRIPTION
Fixes silent Shadow DOM polyfill failure for compiled builds (for browsers that don't support Shadow DOM natively e.g. Safari). Both AMP PWA and Polymer PWA exhibit this bug.

`this` was incorrectly set to the window object within ShadowCSS, which resulted in all self-referential functions inside ShadowCSS to fail. My guess is that Closure's DCE simply stripped all of these method calls, which is why the failure was silent.

I'll survey the rest of the usages of `webcomponentsjs` within the AMP src to see if this is happening elsewhere and follow up with the `webcomponentsjs` team to see if they can switch to a less error-prone way of exporting objects.