### PR TITLE
Rollback: anchor href expand on document click

### DIFF
--- a/src/document-click.js
+++ b/src/document-click.js
@@ -34,7 +34,6 @@ const ORIGINAL_HREF_ATTRIBUTE = 'data-amp-orig-href';
  */
 export function installGlobalClickListenerForDoc(ampdoc) {
   fromClassForDoc(ampdoc, 'clickhandler', ClickHandler);
-  fromClassForDoc(ampdoc, 'CaptureClickHandler', CaptureClickHandler);
 }
 
 


### PR DESCRIPTION
This "rollsback" #5053, since it won't cleanly revert. To rollforward, revert only this commit.

/cc @keithwrightbos 