### PR TITLE
Fix URL Replacements bug

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -702,7 +702,7 @@ export class UrlReplacements {
       return this.ensureProtocolMatches_(url, replacement);
     }
     return (replacementPromise || Promise.resolve(replacement))
-        .then((replacement) => this.ensureProtocolMatches_(url, replacement));
+        .then(replacement => this.ensureProtocolMatches_(url, replacement));
   }
 
   /**
@@ -783,7 +783,7 @@ export class UrlReplacements {
       user().error(TAG, 'Illegal replacement of the protocol: ', url);
       return url;
     }
-    user.assert(newProtocol !== 'javascript:', 'Illegal javascript link ' +
+    user.assert(newProtocol !== `javascript:`, 'Illegal javascript link ' +
         'protocol: ', url);
 
     return replacement;

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -783,6 +783,8 @@ export class UrlReplacements {
       user().error(TAG, 'Illegal replacement of the protocol: ', url);
       return url;
     }
+    user.assert(newProtocol !== 'javascript:', 'Illegal javascript link ' +
+        'protocol: ', url);
 
     return replacement;
   }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -61,16 +61,6 @@ function encodeValue(val) {
 };
 
 /**
- * Detects the protocol of the url, if there is one.
- * @param {string} url
- * @return {string}
- */
-function protocolOfUrl(url) {
-  const match = /^.*:/.exec(url);
-  return match ? match[0] : '';
-}
-
-/**
  * This class replaces substitution variables with their values.
  * Document new values in ../spec/amp-var-substitutions.md
  * @package For export.
@@ -787,7 +777,9 @@ export class UrlReplacements {
    * @return {string}
    */
   ensureProtocolMatches_(url, replacement) {
-    if (protocolOfUrl(replacement) !== protocolOfUrl(url)) {
+    const newProtocol = parseUrl(replacement, /* opt_nocache */false).protocol;
+    const oldProtocol = parseUrl(url, /* opt_nocache */false).protocol;
+    if (newProtocol != oldProtocol) {
       user().error(TAG, 'Illegal replacement of the protocol: ', url);
       return url;
     }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -50,7 +50,7 @@ let ReplacementDef;
 
 /**
  * Returns a encoded URI Component, or an empty string if the value is nullish.
- * @param {string|null|undefined}
+ * @param {ResolverReturnDef} val
  * @return {string}
  */
 function encodeValue(val) {

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -784,7 +784,7 @@ export class UrlReplacements {
       return url;
     }
     user().assert(newProtocol !== `javascript:`, 'Illegal javascript link ' +
-        'protocol: ', url);
+        'protocol: %s', url);
 
     return replacement;
   }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -708,22 +708,11 @@ export class UrlReplacements {
       replacementPromise = replacementPromise.then(() => replacement);
     }
 
-    const protocol = protocolOfUrl(url);
     if (opt_sync) {
-      if (protocolOfUrl(replacement) !== protocol) {
-        user().error(TAG, 'Illegal replacement of the protocol: ', url);
-        return url;
-      }
-      return replacement;
+      return this.ensureProtocolMatches_(url, replacement);
     }
     return (replacementPromise || Promise.resolve(replacement))
-        .then((replacement) => {
-          if (protocolOfUrl(replacement) !== protocol) {
-            user().error(TAG, 'Illegal replacement of the protocol: ', url);
-            return url;
-          }
-          return replacement;
-        });
+        .then((replacement) => this.ensureProtocolMatches_(url, replacement));
   }
 
   /**
@@ -787,6 +776,23 @@ export class UrlReplacements {
     // FOO_BAR(arg1)
     // FOO_BAR(arg1,arg2)
     return new RegExp('\\$?(' + all + ')(?:\\(([0-9a-zA-Z-_.,]+)\\))?', 'g');
+  }
+
+  /**
+   * Ensures that the protocol of the original url matches the protocol of the
+   * replacement url. Returns the replacement if they do, the original if they
+   * do not.
+   * @param {string} url
+   * @param {string} replacement
+   * @return {string}
+   */
+  ensureProtocolMatches_(url, replacement) {
+    if (protocolOfUrl(replacement) !== protocolOfUrl(url)) {
+      user().error(TAG, 'Illegal replacement of the protocol: ', url);
+      return url;
+    }
+
+    return replacement;
   }
 }
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -50,14 +50,14 @@ let ReplacementDef;
 
 /**
  * Returns a encoded URI Component, or an empty string if the value is nullish.
- * @param {ResolverReturnDef} val
+ * @param {*} val
  * @return {string}
  */
 function encodeValue(val) {
   if (val == null) {
     return '';
   }
-  return encodeURIComponent(val);
+  return encodeURIComponent(/** @type {string} */(val));
 };
 
 /**
@@ -783,7 +783,7 @@ export class UrlReplacements {
       user().error(TAG, 'Illegal replacement of the protocol: ', url);
       return url;
     }
-    user.assert(newProtocol !== `javascript:`, 'Illegal javascript link ' +
+    user().assert(newProtocol !== `javascript:`, 'Illegal javascript link ' +
         'protocol: ', url);
 
     return replacement;

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -777,8 +777,8 @@ export class UrlReplacements {
    * @return {string}
    */
   ensureProtocolMatches_(url, replacement) {
-    const newProtocol = parseUrl(replacement, /* opt_nocache */false).protocol;
-    const oldProtocol = parseUrl(url, /* opt_nocache */false).protocol;
+    const newProtocol = parseUrl(replacement, /* opt_nocache */ true).protocol;
+    const oldProtocol = parseUrl(url, /* opt_nocache */ true).protocol;
     if (newProtocol != oldProtocol) {
       user().error(TAG, 'Illegal replacement of the protocol: ', url);
       return url;

--- a/src/url.js
+++ b/src/url.js
@@ -63,7 +63,7 @@ export let Location;
  * @param {string} url
  * @return {!Location}
  */
-export function parseUrl(url) {
+export function parseUrl(url, opt_nocache) {
   if (!a) {
     a = /** @type {!HTMLAnchorElement} */ (self.document.createElement('a'));
     cache = self.UrlCache || (self.UrlCache = Object.create(null));
@@ -118,8 +118,12 @@ export function parseUrl(url) {
     info.origin = info.protocol + '//' + info.host;
   }
   // Freeze during testing to avoid accidental mutation.
-  cache[url] = (getMode().test && Object.freeze) ? Object.freeze(info) : info;
-  return info;
+  const frozen = (getMode().test && Object.freeze) ? Object.freeze(info) : info;
+
+  if (opt_nocache) {
+    return frozen;
+  }
+  return cache[url] = frozen;
 }
 
 /**

--- a/src/url.js
+++ b/src/url.js
@@ -61,6 +61,7 @@ export let Location;
  * Consider the returned object immutable. This is enforced during
  * testing by freezing the object.
  * @param {string} url
+ * @param {boolean=} opt_nocache
  * @return {!Location}
  */
 export function parseUrl(url, opt_nocache) {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -317,6 +317,19 @@ describe('UrlReplacements', () => {
     });
   });
 
+  it('should reject protocol changes', () => {
+    const win = getFakeWindow();
+    const urlReplacements = installUrlReplacementsService(win);
+    return urlReplacements.expandAsync(
+        'PROTOCOL://example.com/?r=RANDOM',
+        {
+          'PROTOCOL': Promise.resolve('abc'),
+        })
+        .then(expanded => {
+          expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
+        })
+  });
+
   describe('PAGE_LOAD_TIME', () => {
     let win;
     let eventListeners;
@@ -730,6 +743,21 @@ describe('UrlReplacements', () => {
       'FUNCT(hello,world)': 'helloworld',
       'PAGE_LOAD_TIME': 9,
     });
+  });
+
+  it('should reject protocol changes', () => {
+    const win = getFakeWindow();
+    const urlReplacements = installUrlReplacementsService(win);
+    let expanded = urlReplacements.expandSync(
+        'PROTOCOL://example.com/?r=RANDOM',
+        {'PROTOCOL': 'abc'});
+    expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
+    expanded = urlReplacements.expandSync(
+        'FUNCT()://example.com/?r=RANDOM',
+        {
+          'FUNCT': function() { return 'abc'; },
+        });
+    expect(expanded).to.equal('FUNCT()://example.com/?r=RANDOM');
   });
 
   describe('access values', () => {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -765,10 +765,10 @@ describe('UrlReplacements', () => {
           });
       expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
       expanded = urlReplacements.expandSync(
-          'FUNCT()://example.com/?r=RANDOM', {
+          'FUNCT://example.com/?r=RANDOM', {
             'FUNCT': function() { return 'abc'; },
           });
-      expect(expanded).to.equal('FUNCT()://example.com/?r=RANDOM');
+      expect(expanded).to.equal('FUNCT://example.com/?r=RANDOM');
     });
 
     it('should reject javascript protocol', () => {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -321,13 +321,11 @@ describe('UrlReplacements', () => {
     const win = getFakeWindow();
     const urlReplacements = installUrlReplacementsService(win);
     return urlReplacements.expandAsync(
-        'PROTOCOL://example.com/?r=RANDOM',
-        {
+        'PROTOCOL://example.com/?r=RANDOM', {
           'PROTOCOL': Promise.resolve('abc'),
-        })
-        .then(expanded => {
+        }).then(expanded => {
           expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
-        })
+        });
   });
 
   describe('PAGE_LOAD_TIME', () => {
@@ -726,11 +724,11 @@ describe('UrlReplacements', () => {
   it('should reject javascript protocol', () => {
     const win = getFakeWindow();
     const urlReplacements = installUrlReplacementsService(win);
-    return urlReplacements.expandAsync('javascript://example.com/?r=RANDOM')
+    return urlReplacements.expandAsync(`javascript://example.com/?r=RANDOM`)
         .then(
           () => { throw new Error('never here'); },
-          (err) => {
-            expect(error.message).to.match(/Illegal javascript/);
+          err => {
+            expect(err.message).to.match(/Illegal javascript/);
           }
         );
   });
@@ -762,14 +760,14 @@ describe('UrlReplacements', () => {
       const win = getFakeWindow();
       const urlReplacements = installUrlReplacementsService(win);
       let expanded = urlReplacements.expandSync(
-        'PROTOCOL://example.com/?r=RANDOM',
-        {'PROTOCOL': 'abc'});
+          'PROTOCOL://example.com/?r=RANDOM', {
+            'PROTOCOL': 'abc',
+          });
       expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
       expanded = urlReplacements.expandSync(
-        'FUNCT()://example.com/?r=RANDOM',
-        {
-          'FUNCT': function() { return 'abc'; },
-        });
+          'FUNCT()://example.com/?r=RANDOM', {
+            'FUNCT': function() { return 'abc'; },
+          });
       expect(expanded).to.equal('FUNCT()://example.com/?r=RANDOM');
     });
 
@@ -777,7 +775,7 @@ describe('UrlReplacements', () => {
       const win = getFakeWindow();
       const urlReplacements = installUrlReplacementsService(win);
       expect(() => {
-        urlReplacements.expandSync('javascript://example.com/?r=RANDOM');
+        urlReplacements.expandSync(`javascript://example.com/?r=RANDOM`);
       }).to.throw('Illegal javascript');
     });
   });

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -723,41 +723,43 @@ describe('UrlReplacements', () => {
         });
   });
 
-  it('should expand sync w/ collect vars (skip async macro)', () => {
-    const win = getFakeWindow();
-    const urlReplacements = installUrlReplacementsService(win);
-    urlReplacements.win_.performance.timing.loadEventStart = 109;
-    const collectVars = {};
-    const expanded = urlReplacements.expandSync(
-      'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
-      {
+  describe('sync expansion', () => {
+    it('should expand w/ collect vars (skip async macro)', () => {
+      const win = getFakeWindow();
+      const urlReplacements = installUrlReplacementsService(win);
+      urlReplacements.win_.performance.timing.loadEventStart = 109;
+      const collectVars = {};
+      const expanded = urlReplacements.expandSync(
+        'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
+        {
+          'CONST': 'ABC',
+          'FUNCT': function(a, b) { return a + b; },
+          // Will ignore promise based result and instead insert empty string.
+          'PROM': function() { return Promise.resolve('boo'); },
+        }, collectVars);
+      expect(expanded).to.match(/^r=\d(\.\d+)?&c=ABC&f=helloworld&a=b&d=&e=9$/);
+      expect(collectVars).to.deep.equal({
+        'RANDOM': parseFloat(/^r=(\d+(\.\d+)?)/.exec(expanded)[1]),
         'CONST': 'ABC',
-        'FUNCT': function(a, b) { return a + b; },
-        // Will ignore promise based result and instead insert empty string.
-        'PROM': function() { return Promise.resolve('boo'); },
-      }, collectVars);
-    expect(expanded).to.match(/^r=\d(\.\d+)?&c=ABC&f=helloworld&a=b&d=&e=9$/);
-    expect(collectVars).to.deep.equal({
-      'RANDOM': parseFloat(/^r=(\d+(\.\d+)?)/.exec(expanded)[1]),
-      'CONST': 'ABC',
-      'FUNCT(hello,world)': 'helloworld',
-      'PAGE_LOAD_TIME': 9,
+        'FUNCT(hello,world)': 'helloworld',
+        'PAGE_LOAD_TIME': 9,
+      });
     });
-  });
 
-  it('should reject protocol changes', () => {
-    const win = getFakeWindow();
-    const urlReplacements = installUrlReplacementsService(win);
-    let expanded = urlReplacements.expandSync(
+    it('should reject protocol changes', () => {
+      const win = getFakeWindow();
+      const urlReplacements = installUrlReplacementsService(win);
+      let expanded = urlReplacements.expandSync(
         'PROTOCOL://example.com/?r=RANDOM',
         {'PROTOCOL': 'abc'});
-    expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
-    expanded = urlReplacements.expandSync(
+      expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
+      expanded = urlReplacements.expandSync(
         'FUNCT()://example.com/?r=RANDOM',
         {
           'FUNCT': function() { return 'abc'; },
         });
-    expect(expanded).to.equal('FUNCT()://example.com/?r=RANDOM');
+      expect(expanded).to.equal('FUNCT()://example.com/?r=RANDOM');
+    });
   });
 
   describe('access values', () => {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -723,6 +723,18 @@ describe('UrlReplacements', () => {
         });
   });
 
+  it('should reject javascript protocol', () => {
+    const win = getFakeWindow();
+    const urlReplacements = installUrlReplacementsService(win);
+    return urlReplacements.expandAsync('javascript://example.com/?r=RANDOM')
+        .then(
+          () => { throw new Error('never here'); },
+          (err) => {
+            expect(error.message).to.match(/Illegal javascript/);
+          }
+        );
+  });
+
   describe('sync expansion', () => {
     it('should expand w/ collect vars (skip async macro)', () => {
       const win = getFakeWindow();
@@ -759,6 +771,14 @@ describe('UrlReplacements', () => {
           'FUNCT': function() { return 'abc'; },
         });
       expect(expanded).to.equal('FUNCT()://example.com/?r=RANDOM');
+    });
+
+    it('should reject javascript protocol', () => {
+      const win = getFakeWindow();
+      const urlReplacements = installUrlReplacementsService(win);
+      expect(() => {
+        urlReplacements.expandSync('javascript://example.com/?r=RANDOM');
+      }).to.throw('Illegal javascript');
     });
   });
 


### PR DESCRIPTION
This forces every URL that gets replaced to keep the same protocol afterwards. Otherwise, we reject the replacements and return the original URL.