### PR TITLE
Switching from `canplay` to `loadstart` event

### DIFF
--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -15,7 +15,6 @@
  */
 
 import {BaseElement} from '../src/base-element';
-import {listenOnce} from '../src/event-helper';
 import {assertHttpsUrl} from '../src/url';
 import {isLayoutSizeDefined} from '../src/layout';
 import {registerElement} from '../src/custom-element';
@@ -62,8 +61,6 @@ export function installVideo(win) {
       // Disable video preload in prerender mode.
       this.video_.setAttribute('preload', 'none');
       this.propagateAttributes(['poster', 'controls'], this.video_);
-      this.forwardEvents([VideoEvents.CANPLAY], this.video_);
-      this.fixIOSCanplayEventForAutoplay_();
       this.applyFillContent(this.video_, true);
       this.element.appendChild(this.video_);
 
@@ -111,7 +108,9 @@ export function installVideo(win) {
         this.video_.appendChild(child);
       });
 
-      return this.loadPromise(this.video_);
+      return this.loadPromise(this.video_).then(() => {
+        this.element.dispatchCustomEvent(VideoEvents.LOAD);
+      });
     }
 
     /** @override */
@@ -124,29 +123,6 @@ export function installVideo(win) {
     /** @private */
     isVideoSupported_() {
       return !!this.video_.play;
-    }
-
-    /**
-     * Safari on iOS does not trigger the `canplay` event for muted inline
-     * videos despite the fact that calls to `play` are allowed for muted inline
-     * videos in iOS 10.
-     * It does trigger `canplay` if `autoplay` attribute is set however.
-     * Since VideoManager handles autoplay behaviour for AMP, we do not
-     * propagate the `autoplay` attribute to the underlying video element but
-     * to get around the iOS bug, we will temporarily propagate `autoplay`
-     * attribute until we get the `canplay` event and then remove it.
-     * {@see https://bugs.webkit.org/show_bug.cgi?id=161804}
-     * @private
-     */
-    fixIOSCanplayEventForAutoplay_() {
-      if (!this.element.hasAttribute('autoplay') || !this.platform_.isIos()) {
-        return;
-      }
-
-      this.propagateAttributes(['autoplay'], this.video_);
-      listenOnce(this.video_, VideoEvents.CANPLAY, () => {
-        this.video_.removeAttribute('autoplay');
-      });
     }
 
     // VideoInterface Implementation. See ../src/video-interface.VideoInterface

--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -108,6 +108,7 @@ export function installVideo(win) {
         this.video_.appendChild(child);
       });
 
+      // loadPromise for media elements listens to `loadstart`
       return this.loadPromise(this.video_).then(() => {
         this.element.dispatchCustomEvent(VideoEvents.LOAD);
       });

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -145,7 +145,7 @@ class VideoEntry {
 
     const element = dev().assert(video.element);
 
-    listenOncePromise(element, VideoEvents.CANPLAY)
+    listenOncePromise(element, VideoEvents.LOAD)
       .then(() => this.videoLoaded_());
 
     // Currently we only register after video player is build.

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -148,14 +148,14 @@ export const VideoAttributes = {
  */
 export const VideoEvents = {
   /**
-   * canplay
+   * load
    *
-   * Fired when the video player can start playing the video.
-   * Normally fired from `layoutCallback`.
+   * Fired when the video player is loaded and calls to methods such as `play()`
+   * are allowed.
    *
-   * @event canplay
+   * @event load
    */
-  CANPLAY: 'canplay',
+  LOAD: 'load',
 
   /**
    * amp:video:visibility


### PR DESCRIPTION
`canplay` event is not reliable and also not needed before calls to `play()` method are allowed. Switching from `canplay` to `loadstart`.

This fixed a bug where autoplaying videos did not work on Chrome when user is on LTE (because Chrome did not preload on LTE and never fired `canplay` event)

Demo: https://goo.gl/M1Ec2g 