### PR TITLE
Corrected code block rendering

### DIFF
--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -168,7 +168,7 @@ When configuring the URLs for various endpoints, the Publisher can use substitut
 | RANDOM            | A random number. Helpful to avoid browser cache. |
 
 Here’s an example of the URL extended with Reader ID, Canonical URL, Referrer information and random cachebuster:
-```
+```html
 https://pub.com/access?
    rid=READER_ID
   &url=CANONICAL_URL
@@ -182,24 +182,24 @@ response as an URL parameter. E.g. `AUTHDATA(isSubscriber)`. The nested expressi
 
 ### Access Content Markup
 
-Access Content Markup describes which sections are visible or hidden. It is comprised of two AMP attributes: ```amp-access``` and ```amp-access-hide``` that can be placed on any HTML element.
+Access Content Markup describes which sections are visible or hidden. It is comprised of two AMP attributes: `amp-access` and `amp-access-hide` that can be placed on any HTML element.
 
-The ```amp-access``` attribute provides the expression that yields true or false based on the authorization response returned by the Authorization endpoint. The resulting value indicates whether or not the element and its contents are visible.
+The `amp-access` attribute provides the expression that yields true or false based on the authorization response returned by the Authorization endpoint. The resulting value indicates whether or not the element and its contents are visible.
 
-The ```amp-access``` value is a boolean expression defined in a SQL-like language. The grammar is defined in the [Appendix A][1]. It is defined as following:
+The `amp-access` value is a boolean expression defined in a SQL-like language. The grammar is defined in the [Appendix A][1]. It is defined as following:
 ```html
 <div amp-access="expression">...</div>
 ```
 Properties and values refer to the properties and values of the Authorization response returned by the Authorization endpoint. This provides a flexible system to support different access scenarios.
 
-The ```amp-access-hide``` attribute can be used to optimistically hide the element before the Authorization response has been received, which can show it. It provides the semantics of “invisible by default”. The authorization response returned by the Authorization later may rescind this default and make section visible. When ```amp-access-hide``` attribute is omitted, the section will be shown/included by default. The ```amp-access-hide``` attribute can only be used in conjunction with the ```amp-access``` attribute.
+The `amp-access-hide` attribute can be used to optimistically hide the element before the Authorization response has been received, which can show it. It provides the semantics of “invisible by default”. The authorization response returned by the Authorization later may rescind this default and make section visible. When `amp-access-hide` attribute is omitted, the section will be shown/included by default. The `amp-access-hide` attribute can only be used in conjunction with the `amp-access` attribute.
 ```html
 <div amp-access="expression" amp-access-hide>...</div>
 ```
 
 If Authorization request fails, `amp-access` expressions are not evaluated and whether a section is visible or hidden is determined by the presence of the `amp-access-hide` attribute initially provided by the document.
 
-We can extend the set of ```amp-access-*``` attributes as needed to support different obfuscation and rendering needs.
+We can extend the set of `amp-access-*` attributes as needed to support different obfuscation and rendering needs.
 
 If Authorization request fails and the "authorizationFallbackResponse" response is not specified in the documentation, `amp-access` expressions are not evaluated and whether a section is visible or hidden is determined by the presence of the `amp-access-hide` attribute initially provided by the document.
 
@@ -243,20 +243,20 @@ And here’s an example that shows additional content to the premium subscribers
 
 ### Authorization Endpoint
 
-Authorization is configured via ```authorization``` property in the [AMP Access Configuration][8] section. It is a credentialed CORS GET endpoint. See [CORS Origin Security][9] for how this request should be secured.
+Authorization is configured via `authorization` property in the [AMP Access Configuration][8] section. It is a credentialed CORS GET endpoint. See [CORS Origin Security][9] for how this request should be secured.
 
 Authorization can take any parameters as defined in the [Access URL Variables][7] section. For instance, it could pass AMP Reader ID and document URL. Besides URL parameters, the Publisher may use any information naturally delivered via HTTP protocol, such as Reader’s IP address. The inclusion of the `READER_ID` is required.
 
 This endpoint produces the authorization response that can be used in the content markup expressions to show/hide different parts of content.
 
 The request format is:
-```
+```html
 https://publisher.com/amp-access.json?
    rid=READER_ID
   &url=SOURCE_URL
 ```
 The response is a free-form JSON object: it can contain any properties and values with few limitations. The limitations are:
- - The property names have to conform to the restrictions defined by the ```amp-access``` expressions grammar (see [Appendix A][1]. This mostly means that the property names cannot contain characters such as spaces, dashes and other characters that do not conform to the “amp-access” specification.
+ - The property names have to conform to the restrictions defined by the `amp-access` expressions grammar (see [Appendix A][1]. This mostly means that the property names cannot contain characters such as spaces, dashes and other characters that do not conform to the “amp-access” specification.
  - The property values can only be one of the types: string, number or boolean.
  - The total size of the serialized authorization response cannot exceed 500 bytes.
  - Please ensure that the response does not include any personally identifiable information (PII) or personal data.
@@ -287,8 +287,8 @@ This RPC may be called in the prerendering phase and thus it should not be used 
 Another important consideration is that in some cases AMP runtime may need to call Authorization endpoint multiple times per document impression. This can happen when AMP Runtime believes that the access parameters for the Reader have changed significantly, e.g. after a successful Login Flow.
 
 The authorization response may be used by AMP Runtime and extensions for three different purposes:
- 1. When evaluating ```amp-access``` expressions.
- 2. When evaluating ```<template>``` templates such as ```amp-mustache```.
+ 1. When evaluating `amp-access` expressions.
+ 2. When evaluating `<template>` templates such as `amp-mustache`.
  3. When providing additional variables to pingback and login URLs using `AUTHDATA(field)`.
 
 Authorization endpoint is called by AMP Runtime as a credentialed CORS endpoint. As such, it must implement CORS protocol. It should use CORS Origin and source origin to restrict the access to this service as described in the [CORS Origin Security][9]. This endpoint may use publisher cookies for its needs. For instance, it can associate the binding between the Reader ID and the Publisher’s own user identity. AMP itself does not need to know about this (and prefers not to). Reader more on [AMP Reader ID][2] and [AMP Access and Cookies][11] for more detail.
@@ -307,7 +307,7 @@ In the *server* option, the call to Authorization endpoint is done by Google AMP
 
 ### Pingback Endpoint
 
-Pingback is configured via ```pingback``` property in the [AMP Access Configuration][8] section. It is a credentialed CORS POST endpoint. See [CORS Origin Security][9]” for how this request should be secured.
+Pingback is configured via `pingback` property in the [AMP Access Configuration][8] section. It is a credentialed CORS POST endpoint. See [CORS Origin Security][9]” for how this request should be secured.
 
 Pingback URL is optional. It can be disabled with `"noPingback": true` configuration.
 
@@ -322,7 +322,7 @@ The publisher may choose to use the pingback as:
  - As a credentialed CORS endpoint it may contain publisher cookies. Thus it can be used to map AMP Reader ID to the Publisher’s identity.
 
 The request format is:
-```
+```html
 https://publisher.com/amp-pingback?
    rid=READER_ID
   &url=SOURCE_URL
@@ -333,14 +333,14 @@ https://publisher.com/amp-pingback?
 The URL of the Login Page(s) is configured via the `login` property in the [AMP Access Configuration][8] section.
 
 The configuration can specify either a single Login URL or a map of Login URL indexed by the type of login. An example of a single Login URL:
-```
+```json
 {
   "login": "https://publisher.com/amp-login.html?rid={READER_ID}"
 }
 ```
 
 An example of multiple Login URLs:
-```
+```json
 {
   "login": {
     "signin": "https://publisher.com/signin.html?rid={READER_ID}",
@@ -356,7 +356,7 @@ required and if the `RETURN_URL` substitution is not specified, it will be injec
 Login Page is simply a normal Web page with no special constraints, other than it should function well as a [browser dialog](https://developer.mozilla.org/en-US/docs/Web/API/Window/open). See the [Login Flow][14] section for more details.
 
 The request format is:
-```
+```html
 https://publisher.com/amp-login.html?
    rid=READER_ID
   &url=SOURCE_URL
@@ -364,7 +364,7 @@ https://publisher.com/amp-login.html?
 ```
 Notice that the “return” URL parameter is added by the AMP Runtime automatically if `RETURN_URL` substitution is not
 specified. Once Login Page completes its work, it must redirect back to the specified “Return URL” with the following format:
-```
+```html
 RETURN_URL#success=true|false
 ```
 Notice the use of a URL hash parameter “success”. The value is either “true” or “false” depending on whether the login succeeds or is abandoned. Ideally the Login Page, when possible, will send the signal in cases of both success or failure.
@@ -457,7 +457,7 @@ As usual, the Reader ID should be included in the call to Login Page and can be 
 The most recent BNF grammar is available in [access-expr-impl.jison](./0.1/access-expr-impl.jison) file.
 
 The key excerpt of this grammar is as following:
-```
+```javascript
 search_condition:
     search_condition OR search_condition
   | search_condition AND search_condition
@@ -485,7 +485,7 @@ field_ref: field_ref '.' field_name | field_name
 literal: STRING | NUMERIC | TRUE | FALSE | NULL
 ```
 
-Notice that ```amp-access``` expressions are evaluated by the AMP Runtime and Google AMP Cache. This is NOT part of the specification that the Publisher needs to implement. It is here simply for informational properties.
+Notice that `amp-access` expressions are evaluated by the AMP Runtime and Google AMP Cache. This is NOT part of the specification that the Publisher needs to implement. It is here simply for informational properties.
 
 ## Detailed Discussion
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -268,9 +268,8 @@ Adds support for Yandex Metrica.
   - `type` See [Analytics vendors](#analytics-vendors)
   - `config` Optional attribute. This attribute can be used to load a configuration from a specified remote URL. The URL specified here should use https scheme. See also `data-include-credentials` attribute below. The URL may include [AMP URL vars](../../spec/amp-var-substitutions.md).
 
-    ```
-    <amp-analytics config="https://example.com/analytics.config.json"></amp-analytics>
-    ```
+    `<amp-analytics config="https://example.com/analytics.config.json"></amp-analytics>`
+
     The response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
   - `data-credentials` Optional attribute. If set to `include` turns on the ability to read and write cookies on the request specified via `config` above.
   - `data-consent-notification-id` Optional attribute. If provided, the page will not process analytics requests until an [amp-user-notification](../../extensions/amp-user-notification/amp-user-notification.md) with
@@ -353,7 +352,7 @@ The `triggers` attribute describes when an analytics request should be sent. It 
     - `threshold` This configuration is used to filter out requests that do not meet particular criteria: For a request to go through to the analytics vendor, the following logic should be true `HASH(sampleOn) < threshold`.
 
   As an example, following configuration can be used to sample 50% of the requests based on random input or at 1% based on client id.
-  ```
+  ```javascript
   'triggers': {
     'sampledOnRandom': {
       'on': 'visible',

--- a/extensions/amp-user-notification/amp-user-notification.md
+++ b/extensions/amp-user-notification/amp-user-notification.md
@@ -98,7 +98,7 @@ Example:
 When specified, AMP will make a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
 GET request with credentials to this URL to determine whether the notification should be shown.
 We will append the `elementId` and `ampUserId` query string fields to the href provided
-on the `data-show-if-href` attribute. (see #1228 on why this is a GET instead of a POST)
+on the `data-show-if-href` attribute. (see [#1228](https://github.com/ampproject/amphtml/issues/1228) on why this is a GET instead of a POST)
 
 For best practice to not let the browser cache the GET response values you should add
 a [`TIMESTAMP` url replacement](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md) value to the `data-show-if-href` attribute value.
@@ -110,9 +110,9 @@ You can add it as a query string field. (ex.
     - `ampUserId`
 
   Example:
-    ```
-      https://foo.com/api/show-api?timestamp=1234567890&elementId=notification1&ampUserId=cid-value
-    ```
+  ```none
+  https://foo.com/api/show-api?timestamp=1234567890&elementId=notification1&ampUserId=cid-value
+  ```
 
  - `CORS GET response` json fields
     The response must contain a single JSON object with a field
@@ -186,7 +186,7 @@ This notification should ALWAYS show on every page visit.
 ```
 
 
---------
+---
 
 ## JSON Fields
 

--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -98,7 +98,7 @@ AMP HTML documents MUST
 - <a name="chrs"></a>contain a `<meta charset="utf-8">` tag as the first child of their head tag. [🔗](#chrs)
 - <a name="vprt"></a>contain a `<meta name="viewport" content="width=device-width,minimum-scale=1">` tag inside their head tag. It's also recommend to include `initial-scale=1` (1). [🔗](#vprt)
 - <a name="scrpt"></a>contain a `<script async src="https://cdn.ampproject.org/v0.js"></script>` tag inside their head tag. [🔗](#scrpt)
-- <a name="boilerplate"></a>contain the [AMP boilerplate code ('head > style[amp-boilerplate]' and 'noscript > style[amp-boilerplate]')](amp-boilerplate.md) in their head tag. [🔗](#boilerplate)
+- <a name="boilerplate"></a>contain the [AMP boilerplate code](amp-boilerplate.md) (`head > style[amp-boilerplate]` and `noscript > style[amp-boilerplate]`) in their head tag. [🔗](#boilerplate)
 
 (1) `width=device-width,minimum-scale=1` is required to ensure [GPU rasterization](https://www.chromium.org/developers/design-documents/chromium-graphics/how-to-get-gpu-rasterization) is enabled.
 
@@ -350,7 +350,7 @@ The `on` attribute is used to install event handlers on elements. The events tha
 
 The value for the syntax is a simple domain specific language of the form:
 
-```
+```javascript
 eventName:targetId[.methodName[(arg1=value, arg2=value)]]
 ```
 
@@ -389,7 +389,7 @@ The script URL must start with "https://cdn.ampproject.org" and must follow a ve
 
 The URL for extended components is of the form:
 
-```
+```html
 https://cdn.ampproject.org/$RUNTIME_VERSION/$ELEMENT_NAME-$ELEMENT_VERSION.js
 ```
 
@@ -438,7 +438,7 @@ See the documentation for a specific extended template on the syntax and restric
 
 The URL for extended components is of the form:
 
-```
+```html
 https://cdn.ampproject.org/$RUNTIME_VERSION/$TEMPLATE_TYPE-$TEMPLATE_VERSION.js
 ```
 


### PR DESCRIPTION
Code blocks that do not have a language specified do not render correctly.  Added language to "broken" codeblocks; fixes #5186.  Also fixed issue where HR had incorrect syntax so docs below that HR didn't render in amp-user-notification.md. Also, corrected syntax for element code styling in amp-access.md. 

cc: @pbakaus, @Meggin 