### PR TITLE
Add compiler warning for dangerous use of `this`

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -18,7 +18,6 @@ package org.ampproject;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CommandLineRunner;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CustomPassExecutionTime;
@@ -69,8 +68,6 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     }
     CompilerOptions options = super.createOptions();
     options.setCollapseProperties(true);
-    // Warn on improper uses of `this` that `collapseProperties` assumes.
-    options.setCheckGlobalThisLevel(CheckLevel.WARNING);
     AmpPass ampPass = new AmpPass(getCompiler(), is_production_env, suffixTypes, assignmentReplacements);
     options.addCustomPass(CustomPassExecutionTime.BEFORE_OPTIMIZATIONS, ampPass);
     options.setDevirtualizePrototypeMethods(true);

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -18,6 +18,7 @@ package org.ampproject;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CommandLineRunner;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CustomPassExecutionTime;
@@ -68,6 +69,8 @@ public class AmpCommandLineRunner extends CommandLineRunner {
     }
     CompilerOptions options = super.createOptions();
     options.setCollapseProperties(true);
+    // Warn on improper uses of `this` that `collapseProperties` assumes.
+    options.setCheckGlobalThisLevel(CheckLevel.WARNING);
     AmpPass ampPass = new AmpPass(getCompiler(), is_production_env, suffixTypes, assignmentReplacements);
     options.addCustomPass(CustomPassExecutionTime.BEFORE_OPTIMIZATIONS, ampPass);
     options.setDevirtualizePrototypeMethods(true);

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -270,7 +270,11 @@ function compile(entryModuleFilenames, outputDir,
       // it won't do strict type checking if its whitespace only.
       compilerOptions.compilerFlags.define.push('TYPECHECK_ONLY=true');
       compilerOptions.compilerFlags.jscomp_error.push(
-          'checkTypes', 'accessControls', 'const', 'constantProperty');
+          'checkTypes',
+          'accessControls',
+          'const',
+          'constantProperty',
+          'globalThis');
 
       // TODO(aghassemi): Remove when NTI is the default.
       if (argv.nti) {


### PR DESCRIPTION
Fixes #5229. 

From the [Closure documentation](https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/CompilerOptions.java#L242) for `checkGlobalThisLevel`:

> Checks for certain uses of the {@code this} keyword that are considered
unsafe because they are likely to reference the global {@code this}
object unintentionally.

> If this is off, but collapseProperties is on, then the compiler will
usually ignore you and run this check anyways.

Note: #5243 needs to land first to fix existing instances of this warning.