### PR TITLE
Fix scroll position adjustment for viewer header

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -452,9 +452,11 @@ app.get('/examples/*', function(req, res, next) {
  */
 function replaceUrls(mode, file) {
   if (mode) {
+    file = file.replace('https://cdn.ampproject.org/viewer/google/v5.js', 'https://cdn1.ampproject.org/viewer/google/v5.js');
     file = file.replace(/(https:\/\/cdn.ampproject.org\/.+?).js/g, '$1.max.js');
     file = file.replace('https://cdn.ampproject.org/v0.max.js', '/dist/amp.js');
     file = file.replace(/https:\/\/cdn.ampproject.org\/v0\//g, '/dist/v0/');
+    file = file.replace('https://cdn1.ampproject.org/viewer/google/v5.js', 'https://cdn.ampproject.org/viewer/google/v5.js');
   }
   if (mode == 'min') {
     file = file.replace(/\.max\.js/g, '.js');

--- a/css/amp.css
+++ b/css/amp.css
@@ -37,7 +37,7 @@ html, body {
  * and {@link ViewportBindingNaturalIosEmbed_} for more info.
  */
 body {
-  margin: 0;
+  margin: 0 !important;
 }
 
 /** These properties can be overriden by user stylesheets. */

--- a/css/amp.css
+++ b/css/amp.css
@@ -37,7 +37,7 @@ html, body {
  * and {@link ViewportBindingNaturalIosEmbed_} for more info.
  */
 body {
-  margin: 0 !important;
+  margin: 0;
 }
 
 /** These properties can be overriden by user stylesheets. */

--- a/examples/article-fixed-header.amp.html
+++ b/examples/article-fixed-header.amp.html
@@ -238,7 +238,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
   <link rel="amp-manifest" href="medium-manifest.json">
-  <script async="" src="https://cdn.ampproject.org/viewer/google/v5.js"></script>
+  <script async src="https://cdn.ampproject.org/viewer/google/v5.js"></script>
 </head>
 <body>
   <div class="logo"></div>

--- a/examples/article-fixed-header.amp.html
+++ b/examples/article-fixed-header.amp.html
@@ -238,7 +238,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
   <link rel="amp-manifest" href="medium-manifest.json">
-  <script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>
+  <script async="" src="https://cdn.ampproject.org/viewer/google/v5.js"></script>
 </head>
 <body>
   <div class="logo"></div>

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -896,9 +896,10 @@ export class Viewer {
       if (data['paddingTop'] !== undefined) {
         this.paddingTop_ = data['paddingTop'];
         this.viewportObservable_.fire(
-          /** @type {!JSONType|undefined} */ (data));
+          /** @type {!JSONType} */ (data));
+        return Promise.resolve();
       }
-      return Promise.resolve();
+      return undefined;
     }
     if (eventType == 'historyPopped') {
       this.historyPoppedObservable_.fire({

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -137,7 +137,7 @@ export class Viewer {
     /** @private {!Observable} */
     this.visibilityObservable_ = new Observable();
 
-    /** @private {!Observable<!{paddingTop: number, duration: (number|undefined), curve: (string|undefined)}>} */
+    /** @private {!Observable<!JSONType>} */
     this.viewportObservable_ = new Observable();
 
     /** @private {!Observable<!ViewerHistoryPoppedEventDef>} */
@@ -726,11 +726,7 @@ export class Viewer {
 
   /**
    * Adds a "viewport" event listener for viewer events.
-   * @param {function({
-   *   paddingTop: number,
-   *   duration: (number|undefined),
-   *   curve: (string|undefined)
-   * })} handler
+   * @param {function(!JSONType)} handler
    * @return {!UnlistenDef}
    */
   onViewportEvent(handler) {
@@ -899,13 +895,10 @@ export class Viewer {
     if (eventType == 'viewport') {
       if (data['paddingTop'] !== undefined) {
         this.paddingTop_ = data['paddingTop'];
-        this.viewportObservable_.fire({
-          paddingTop: this.paddingTop_,
-          duration: data['duration'],
-          curve: data['curve'],
-        });
+        this.viewportObservable_.fire(
+          /** @type {!JSONType|undefined} */ (data));
       }
-      return undefined;
+      return Promise.resolve();
     }
     if (eventType == 'historyPopped') {
       this.historyPoppedObservable_.fire({

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -203,29 +203,26 @@ describe('Viewport', () => {
     });
   });
 
-  it('should update padding when changed only', () => {
-    // Shouldn't call updatePaddingTop since it hasn't changed.
-    let bindingMock = sandbox.mock(binding);
+  it('should not do anything if padding is not changed', () => {
+    const bindingMock = sandbox.mock(binding);
     viewerViewportHandler({paddingTop: 19});
-    bindingMock.verify();
-
-    // Should call updatePaddingTop.
-    bindingMock = sandbox.mock(binding);
-    viewport.fixedLayer_ = {updatePaddingTop: () => {}};
-    bindingMock.expects('updatePaddingTop').withArgs(0, true, 19).once();
-    viewerViewportHandler({paddingTop: 0});
     bindingMock.verify();
   });
 
-  it('should update padding for fixed layer', () => {
-    // Should call updatePaddingTop.
+  it('should update padding when viewer wants to hide header', () => {
     const bindingMock = sandbox.mock(binding);
-    bindingMock.expects('updatePaddingTop').withArgs(0, true, 19).once();
+    viewport.fixedLayer_ = {updatePaddingTop: () => {}};
+    bindingMock.expects('hideViewerHeader').withArgs(19).once();
+    viewerViewportHandler({paddingTop: 0, duation: 300, curve: 'ease-in'});
+    bindingMock.verify();
+  });
+
+  it('should update padding for fixed layer when viewer wants to ' +
+      'hide header', () => {
     viewport.fixedLayer_ = {updatePaddingTop: () => {}};
     const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock.expects('updatePaddingTop').withArgs(0).once();
-    viewerViewportHandler({paddingTop: 0});
-    bindingMock.verify();
+    viewerViewportHandler({paddingTop: 0, duation: 300, curve: 'ease-in'});
     fixedLayerMock.verify();
   });
 

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -212,8 +212,9 @@ describe('Viewport', () => {
   it('should update padding when viewer wants to hide header', () => {
     const bindingMock = sandbox.mock(binding);
     viewport.fixedLayer_ = {updatePaddingTop: () => {}};
-    bindingMock.expects('hideViewerHeader').withArgs(19).once();
-    viewerViewportHandler({paddingTop: 0, duation: 300, curve: 'ease-in'});
+    bindingMock.expects('hideViewerHeader').withArgs(true, 19).once();
+    viewerViewportHandler({paddingTop: 0, duation: 300, curve: 'ease-in',
+        transient: true});
     bindingMock.verify();
   });
 
@@ -222,7 +223,8 @@ describe('Viewport', () => {
     viewport.fixedLayer_ = {updatePaddingTop: () => {}};
     const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock.expects('updatePaddingTop').withArgs(0).once();
-    viewerViewportHandler({paddingTop: 0, duation: 300, curve: 'ease-in'});
+    viewerViewportHandler({paddingTop: 0, duation: 300, curve: 'ease-in',
+        transient: 'true'});
     fixedLayerMock.verify();
   });
 


### PR DESCRIPTION
* change function `updatePaddingTop` to hideViewerHeader/showViewerHeader respectively
* in ios-embed mode, no need to adjust scroll position, we set the `borderTop` and `paddingTop` instead
* in android mode, no need to adjust scroll position, nothing need to be done
* rearrange the order of code execution
  * hideHeader: update padding/border first, then do animation
  * showHeader: do animation first, then update padding/border
* the scroll message sent to viewer is continuous after hide/show header event
* `viewport.getLayoutRect(el)` remains the same after hide/show header event