### PR TITLE
Corrected lang from none to html - breaks doc build

### DIFF
--- a/extensions/amp-user-notification/amp-user-notification.md
+++ b/extensions/amp-user-notification/amp-user-notification.md
@@ -110,7 +110,7 @@ You can add it as a query string field. (ex.
     - `ampUserId`
 
   Example:
-  ```none
+  ```html
   https://foo.com/api/show-api?timestamp=1234567890&elementId=notification1&ampUserId=cid-value
   ```
 


### PR DESCRIPTION
Turns out you cannot specify "none" for default code block format; must be a valid lang. Related to #5186.

Worked out with @pbakaus.