### PR TITLE
Remove iframe measurements from amp-ad and amp-iframe

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -29,6 +29,7 @@ import {adConfig} from '../../../ads/_config';
 import {user} from '../../../src/log';
 import {getIframe} from '../../../src/3p-frame';
 import {setupA2AListener} from './a2a-listener';
+import {moveLayoutRect} from '../../../src/layout-rect';
 
 
 /** @const {!string} Tag name for 3P AD implementation. */
@@ -56,9 +57,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     this.isInFixedContainer_ = false;
 
     /**
-     * The layout box of the ad iframe (as opposed to the amp-ad tag).
-     * In practice it often has padding to create a grey or similar box
-     * around ads.
+     * The (relative) layout box of the ad iframe to the amp-ad tag.
      * @private {?../../../src/layout-rect.LayoutRectDef}
      */
     this.iframeLayoutBox_ = null;
@@ -169,7 +168,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    */
   measureIframeLayoutBox_() {
     if (this.iframe_) {
-      this.iframeLayoutBox_ = this.getViewport().getLayoutRect(this.iframe_);
+      const iframeBox = this.getViewport().getLayoutRect(this.iframe_);
+      const box = super.getIntersectionElementLayoutBox();
+      this.iframeLayoutBox_ = moveLayoutRect(iframeBox, -box.left, -box.top);
     }
   }
 
@@ -177,13 +178,16 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    * @override
    */
   getIntersectionElementLayoutBox() {
+    const box = super.getIntersectionElementLayoutBox();
     if (!this.iframe_) {
-      return super.getIntersectionElementLayoutBox();
+      return box;
     }
     if (!this.iframeLayoutBox_) {
       this.measureIframeLayoutBox_();
     }
-    return this.iframeLayoutBox_;
+    // If the iframe is full size, we avoid an object allocation by moving box.
+    return moveLayoutRect(box, this.iframeLayoutBox_.left,
+        this.iframeLayoutBox_.top);
   }
 
   /** @override */


### PR DESCRIPTION
Cache the ad's iframe's relative position to the ad. When we calculate the intersection layoutBox, we get the ad's layoutBox (which is cached) and add the relative positioning to it.

We need this because the fixed-position elements won't cache their layoutBox eventually (they'll cache a relative position to (0, 0) origin just like this is caching relative position to the ad). When fixed-positions start returning the correct values for the intersection layoutBox (they add their relative position to the current `scrollTop` and `scrollLeft`), we'll then get the correct values for the iframe relative to that layout box.

Part 1 of #5149.

/cc @jasti