### PR TITLE
Support Custom Elements V1 in `custom-element.js`

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -832,6 +832,12 @@ function createBaseAmpElementProto(win) {
     this.getResources().add(this);
   };
 
+ /**
+  * Replaces `attachedCallback` in Custom Elements V1.
+  * @final @this {!Element}
+  */
+  ElementProto.connectedCallback = ElementProto.attachedCallback;
+
   /**
    * Try to upgrade the element with the provided implementation.
    * @param {!./base-element.BaseElement=} opt_impl
@@ -877,6 +883,11 @@ function createBaseAmpElementProto(win) {
     this.implementation_.detachedCallback();
   };
 
+  /**
+   * Replaces `detachedCallback` in Custom Elements V1.
+   * @final @this {!Element}
+   */
+  ElementProto.disconnectedCallback = ElementProto.detachedCallback;
 
   /**
    * Dispatches a custom event.
@@ -1429,9 +1440,43 @@ function createBaseAmpElementProto(win) {
 export function registerElement(win, name, implementationClass) {
   knownElements[name] = implementationClass;
 
-  win.document.registerElement(name, {
-    prototype: createAmpElementProto(win, name),
-  });
+  const supportsCustomElementsV1 = 'customElements' in win;
+  if (supportsCustomElementsV1) {
+    // `customElements.define` requires a function or ES2015 class to be passed
+    // into the second arg. However, Babel transpilation for native extend
+    // fails for HTMLElement, so we need to use old prototype syntax.
+    // @see https://github.com/babel/babel/issues/4480
+    let cls = () => {
+      function constructor() {
+        // `createdCallback` is replaced by the constructor in V1.
+        this.createdCallback();
+      }
+      function BaseCustomElement() {
+        // HTMLElement requires the 'new' operator.
+        let self = win.Reflect.construct(
+            win.HTMLElement, arguments, this.constructor);
+        constructor.apply(self, arguments);
+        return self;
+      }
+      BaseCustomElement.prototype = Object.create(
+        createAmpElementProto(win, name),
+        {
+          constructor: {
+            configurable: true,
+            writable: true,
+            value: BaseCustomElement
+          }
+        }
+      );
+      return BaseCustomElement;
+    }();
+    win.customElements.define(name, cls);
+  } else {
+    // Fall back to Custom Elements V0 or polyfill.
+    win.document.registerElement(name, {
+      prototype: createAmpElementProto(win, name),
+    });
+  }
 }
 
 /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -400,16 +400,15 @@ function createBaseAmpElementProto(win) {
    * @final @this {!Element}
    */
   ElementProto.createdCallback = function() {
-    this.classList.add('-amp-element');
-
     // Flag "notbuilt" is removed by Resource manager when the resource is
     // considered to be built. See "setBuilt" method.
     /** @private {boolean} */
     this.built_ = false;
-    this.classList.add('-amp-notbuilt');
-    this.classList.add('amp-notbuilt');
 
+    /** @type {string} */
     this.readyState = 'loading';
+
+    /** @type {boolean} */
     this.everAttached = false;
 
     /**
@@ -783,6 +782,10 @@ function createBaseAmpElementProto(win) {
    * @final @this {!Element}
    */
   ElementProto.attachedCallback = function() {
+    this.classList.add('-amp-element');
+    this.classList.add('-amp-notbuilt');
+    this.classList.add('amp-notbuilt');
+
     if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
       this.isInTemplate_ = !!dom.closestByTag(this, 'template');
     }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1446,14 +1446,14 @@ export function registerElement(win, name, implementationClass) {
     // into the second arg. However, Babel transpilation for native extend
     // fails for HTMLElement, so we need to use old prototype syntax.
     // @see https://github.com/babel/babel/issues/4480
-    let cls = () => {
+    const cls = (function() {
       function constructor() {
         // `createdCallback` is replaced by the constructor in V1.
         this.createdCallback();
       }
       function BaseCustomElement() {
         // HTMLElement requires the 'new' operator.
-        let self = win.Reflect.construct(
+        const self = win.Reflect.construct(
             win.HTMLElement, arguments, this.constructor);
         constructor.apply(self, arguments);
         return self;
@@ -1464,12 +1464,12 @@ export function registerElement(win, name, implementationClass) {
           constructor: {
             configurable: true,
             writable: true,
-            value: BaseCustomElement
-          }
+            value: BaseCustomElement,
+          },
         }
       );
       return BaseCustomElement;
-    }();
+    })();
     win.customElements.define(name, cls);
   } else {
     // Fall back to Custom Elements V0 or polyfill.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1453,8 +1453,9 @@ export function registerElement(win, name, implementationClass) {
       }
       function BaseCustomElement() {
         // HTMLElement requires the 'new' operator.
+        const args = Array.from(arguments);
         const self = win.Reflect.construct(
-            win.HTMLElement, arguments, this.constructor);
+            win.HTMLElement, args, this.constructor);
         constructor.apply(self, arguments);
         return self;
       }
@@ -1470,7 +1471,7 @@ export function registerElement(win, name, implementationClass) {
       );
       return BaseCustomElement;
     })();
-    win.customElements.define(name, cls);
+    win['customElements'].define(name, cls);
   } else {
     // Fall back to Custom Elements V0 or polyfill.
     win.document.registerElement(name, {

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -255,10 +255,10 @@ describe('CustomElement', () => {
 
   it('Element - createdCallback', () => {
     const element = new ElementClass();
-    expect(element).to.have.class('-amp-element');
+    const build = sandbox.stub(element, 'build');
+
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
+    expect(element.hasAttributes()).to.equal(false);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.upgradeState_).to.equal(/* NOT_UPGRADED */ 1);
     expect(element.readyState).to.equal('loading');
@@ -268,17 +268,21 @@ describe('CustomElement', () => {
 
     container.appendChild(element);
     element.attachedCallback();
+    expect(element).to.have.class('-amp-element');
+    expect(element).to.have.class('-amp-notbuilt');
+    expect(element).to.have.class('amp-notbuilt');
     expect(element.everAttached).to.equal(true);
     expect(testElementCreatedCallback.callCount).to.equal(1);
     expect(element.isUpgraded()).to.equal(true);
+    expect(build.calledOnce);
   });
 
   it('StubElement - createdCallback', () => {
     const element = new StubElementClass();
-    expect(element).to.have.class('-amp-element');
+    const build = sandbox.stub(element, 'build');
+
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
+    expect(element.hasAttributes()).to.equal(false);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.readyState).to.equal('loading');
     expect(element.everAttached).to.equal(false);
@@ -287,9 +291,13 @@ describe('CustomElement', () => {
 
     container.appendChild(element);
     element.attachedCallback();
+    expect(element).to.have.class('-amp-element');
+    expect(element).to.have.class('-amp-notbuilt');
+    expect(element).to.have.class('amp-notbuilt');
     expect(element.everAttached).to.equal(true);
     expect(testElementCreatedCallback.callCount).to.equal(0);
     expect(element.isUpgraded()).to.equal(false);
+    expect(build.calledOnce);
   });
 
   it('Element - getIntersectionChangeEntry', () => {
@@ -476,10 +484,7 @@ describe('CustomElement', () => {
     const element = new ElementClass();
     element.tryUpgrade_();
 
-    expect(element).to.have.class('-amp-element');
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
     expect(testElementBuildCallback.callCount).to.equal(0);
 
     element.build();
@@ -534,10 +539,7 @@ describe('CustomElement', () => {
 
   it('Element - build NOT allowed when in template', () => {
     const element = new ElementClass();
-    expect(element).to.have.class('-amp-element');
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
     expect(testElementBuildCallback.callCount).to.equal(0);
 
     element.isInTemplate_ = true;
@@ -551,10 +553,7 @@ describe('CustomElement', () => {
 
   it('StubElement - build never allowed', () => {
     const element = new StubElementClass();
-    expect(element).to.have.class('-amp-element');
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
     expect(testElementBuildCallback.callCount).to.equal(0);
 
     expect(() => {


### PR DESCRIPTION
Fixes #5291.

- Supports Custom Elements V1 by using `customElements.define` if available and aliasing the callback methods as necessary (see [API changes compared to V0](https://github.com/shawnbot/custom-elements)).
- Relies on availability of `Reflect` due to insufficient ES2015 backwards compatibility ([more info](https://www.webreflection.co.uk/blog/2016/08/30/js-super-problem)).

QA: Tested manually on Chrome 54 (beta channel), which supports Custom Elements V1.

TODO:
- Verify all tests pass on Chrome 54 (looks like a few currently fail at HEAD)
- Profile V1 vs. V0 performance delta
- Investigate replacing `document-register-element` polyfill with 50% smaller `webcomponentsjs` polyfill