### PR TITLE
<amp-img> Move property to constructor

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -29,6 +29,9 @@ export class AmpImg extends BaseElement {
     /** @private {boolean} */
     this.allowImgLoadFallback_ = true;
 
+    /** @private {boolean} */
+    this.isPrerenderAllowed_ = true;
+
     /** @private {?Element} */
     this.img_ = null;
 
@@ -38,7 +41,6 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   buildCallback() {
-    /** @private @const {boolean} */
     this.isPrerenderAllowed_ = !this.element.hasAttribute('noprerender');
   }
 


### PR DESCRIPTION
This wasn't caught with `check-types` due to #5335