### PR TITLE
[Video] Move click handler out of video-manager

### DIFF
--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -109,13 +109,14 @@ export function installVideo(win) {
         this.video_.appendChild(child);
       });
 
+      // Dispatch a user tap event on click of the player.
+      listen(this.video_, 'click', () => {
+        this.element.dispatchCustomEvent(VideoEvents.USER_TAP);
+      });
+
       // loadPromise for media elements listens to `loadstart`
       return this.loadPromise(this.video_).then(() => {
         this.element.dispatchCustomEvent(VideoEvents.LOAD);
-        // Dispatch a user tap event on click of the player.
-        listen(this.video_, 'click', () => {
-          this.element.dispatchCustomEvent(VideoEvents.USER_TAP);
-        });
       });
     }
 

--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -15,6 +15,7 @@
  */
 
 import {BaseElement} from '../src/base-element';
+import {listen} from '../src/event-helper';
 import {assertHttpsUrl} from '../src/url';
 import {isLayoutSizeDefined} from '../src/layout';
 import {registerElement} from '../src/custom-element';
@@ -111,6 +112,10 @@ export function installVideo(win) {
       // loadPromise for media elements listens to `loadstart`
       return this.loadPromise(this.video_).then(() => {
         this.element.dispatchCustomEvent(VideoEvents.LOAD);
+        // Dispatch a user tap event on click of the player.
+        listen(this.video_, 'click', () => {
+          this.element.dispatchCustomEvent(VideoEvents.USER_TAP);
+        });
       });
     }
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -226,9 +226,7 @@ class VideoEntry {
       if (this.video.element.hasAttribute(VideoAttributes.CONTROLS)) {
         this.video.hideControls();
 
-        // TODO(aghassemi): This won't work for iframe players, we need a proper
-        // 'userInteracted' event.
-        listenOnce(this.video.element, 'click', () => {
+        listenOnce(this.video.element, VideoEvents.USER_TAP, () => {
           this.userInteracted_ = true;
           this.video.showControls();
           this.video.unmute();

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -158,6 +158,15 @@ export const VideoEvents = {
   LOAD: 'load',
 
   /**
+   * amp:video:usertap
+   *
+   * Fired when user taps any part of the video player.
+   *
+   * @event amp:video:usertap
+   */
+  USER_TAP: 'amp:video:usertap',
+
+  /**
    * amp:video:visibility
    *
    * Fired when the video's visibility changes. Normally fired

--- a/test/functional/test-amp-video.js
+++ b/test/functional/test-amp-video.js
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import {listenOncePromise} from '../../src/event-helper';
 import {createIframePromise} from '../../testing/iframe';
 import {installVideo} from '../../builtins/amp-video';
+import {VideoEvents} from '../../src/video-interface';
 import {installVideoManagerForDoc} from '../../src/service/video-manager-impl';
 import * as sinon from 'sinon';
 
@@ -270,6 +272,19 @@ describe('amp-video', () => {
       sandbox.spy(video, 'pause');
       impl.pauseCallback();
       expect(video.pause.called).to.be.true;
+    });
+  });
+
+  it('should dispatch VideoEvents.USER_TAP event when tapped', () => {
+    return getVideo({
+      src: 'video.mp4',
+      width: 160,
+      height: 90,
+    }).then(v => {
+      const video = v.querySelector('video');
+      const p = listenOncePromise(v, VideoEvents.USER_TAP);
+      video.dispatchEvent(new Event('click'));
+      return p;
     });
   });
 


### PR DESCRIPTION
Moving the click handler out of video-manager and creating a custom event type for it so that iframe-based players can also implement it.

We might also add an `user-interaction` event later but for autoplay we care about a `tap` anywhere on the player rather than a `user-interaction` which has a different meaning in my opinion (`user-interaction` implies playing, pausing, seeking, etc.. so a tap on the player that does not cause any action, won't be a `user-interaction`)

/to @mkhatib 
/cc @cramforce 