### PR TITLE
Prepare `BaseCustomElementProto` for Custom Elements V1

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -400,16 +400,15 @@ function createBaseAmpElementProto(win) {
    * @final @this {!Element}
    */
   ElementProto.createdCallback = function() {
-    this.classList.add('-amp-element');
-
     // Flag "notbuilt" is removed by Resource manager when the resource is
     // considered to be built. See "setBuilt" method.
     /** @private {boolean} */
     this.built_ = false;
-    this.classList.add('-amp-notbuilt');
-    this.classList.add('amp-notbuilt');
 
+    /** @type {string} */
     this.readyState = 'loading';
+
+    /** @type {boolean} */
     this.everAttached = false;
 
     /**
@@ -783,6 +782,10 @@ function createBaseAmpElementProto(win) {
    * @final @this {!Element}
    */
   ElementProto.attachedCallback = function() {
+    this.classList.add('-amp-element');
+    this.classList.add('-amp-notbuilt');
+    this.classList.add('amp-notbuilt');
+
     if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
       this.isInTemplate_ = !!dom.closestByTag(this, 'template');
     }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -782,9 +782,11 @@ function createBaseAmpElementProto(win) {
    * @final @this {!Element}
    */
   ElementProto.attachedCallback = function() {
-    this.classList.add('-amp-element');
-    this.classList.add('-amp-notbuilt');
-    this.classList.add('amp-notbuilt');
+    if (!this.everAttached) {
+      this.classList.add('-amp-element');
+      this.classList.add('-amp-notbuilt');
+      this.classList.add('amp-notbuilt');
+    }
 
     if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
       this.isInTemplate_ = !!dom.closestByTag(this, 'template');

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -302,8 +302,6 @@ describe('CustomElement', () => {
 
   it.only('Element - should only add classes on first attachedCallback', () => {
     const element = new ElementClass();
-    const build = sandbox.stub(element, 'build');
-
     expect(element).to.not.have.class('-amp-element');
     expect(element).to.not.have.class('-amp-notbuilt');
     expect(element).to.not.have.class('amp-notbuilt');
@@ -314,7 +312,6 @@ describe('CustomElement', () => {
     expect(element).to.have.class('-amp-element');
     expect(element).to.have.class('-amp-notbuilt');
     expect(element).to.have.class('amp-notbuilt');
-
     element.classList.remove('-amp-element');
     element.classList.remove('-amp-notbuilt');
     element.classList.remove('amp-notbuilt');

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -255,10 +255,10 @@ describe('CustomElement', () => {
 
   it('Element - createdCallback', () => {
     const element = new ElementClass();
-    expect(element).to.have.class('-amp-element');
+    const build = sandbox.stub(element, 'build');
+
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
+    expect(element.hasAttributes()).to.equal(false);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.upgradeState_).to.equal(/* NOT_UPGRADED */ 1);
     expect(element.readyState).to.equal('loading');
@@ -268,17 +268,21 @@ describe('CustomElement', () => {
 
     container.appendChild(element);
     element.attachedCallback();
+    expect(element).to.have.class('-amp-element');
+    expect(element).to.have.class('-amp-notbuilt');
+    expect(element).to.have.class('amp-notbuilt');
     expect(element.everAttached).to.equal(true);
     expect(testElementCreatedCallback.callCount).to.equal(1);
     expect(element.isUpgraded()).to.equal(true);
+    expect(build.calledOnce);
   });
 
   it('StubElement - createdCallback', () => {
     const element = new StubElementClass();
-    expect(element).to.have.class('-amp-element');
+    const build = sandbox.stub(element, 'build');
+
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
+    expect(element.hasAttributes()).to.equal(false);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.readyState).to.equal('loading');
     expect(element.everAttached).to.equal(false);
@@ -287,9 +291,13 @@ describe('CustomElement', () => {
 
     container.appendChild(element);
     element.attachedCallback();
+    expect(element).to.have.class('-amp-element');
+    expect(element).to.have.class('-amp-notbuilt');
+    expect(element).to.have.class('amp-notbuilt');
     expect(element.everAttached).to.equal(true);
     expect(testElementCreatedCallback.callCount).to.equal(0);
     expect(element.isUpgraded()).to.equal(false);
+    expect(build.calledOnce);
   });
 
   it('Element - getIntersectionChangeEntry', () => {
@@ -476,10 +484,7 @@ describe('CustomElement', () => {
     const element = new ElementClass();
     element.tryUpgrade_();
 
-    expect(element).to.have.class('-amp-element');
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
     expect(testElementBuildCallback.callCount).to.equal(0);
 
     element.build();
@@ -534,10 +539,7 @@ describe('CustomElement', () => {
 
   it('Element - build NOT allowed when in template', () => {
     const element = new ElementClass();
-    expect(element).to.have.class('-amp-element');
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
     expect(testElementBuildCallback.callCount).to.equal(0);
 
     element.isInTemplate_ = true;
@@ -551,10 +553,7 @@ describe('CustomElement', () => {
 
   it('StubElement - build never allowed', () => {
     const element = new StubElementClass();
-    expect(element).to.have.class('-amp-element');
     expect(element.isBuilt()).to.equal(false);
-    expect(element).to.have.class('-amp-notbuilt');
-    expect(element).to.have.class('amp-notbuilt');
     expect(testElementBuildCallback.callCount).to.equal(0);
 
     expect(() => {

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -302,6 +302,8 @@ describe('CustomElement', () => {
 
   it('Element - should only add classes on first attachedCallback', () => {
     const element = new ElementClass();
+    sandbox.stub(element, 'build');
+
     expect(element).to.not.have.class('-amp-element');
     expect(element).to.not.have.class('-amp-notbuilt');
     expect(element).to.not.have.class('amp-notbuilt');

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -300,7 +300,7 @@ describe('CustomElement', () => {
     expect(build.calledOnce);
   });
 
-  it.only('Element - should only add classes on first attachedCallback', () => {
+  it('Element - should only add classes on first attachedCallback', () => {
     const element = new ElementClass();
     expect(element).to.not.have.class('-amp-element');
     expect(element).to.not.have.class('-amp-notbuilt');

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -300,6 +300,32 @@ describe('CustomElement', () => {
     expect(build.calledOnce);
   });
 
+  it.only('Element - should only add classes on first attachedCallback', () => {
+    const element = new ElementClass();
+    const build = sandbox.stub(element, 'build');
+
+    expect(element).to.not.have.class('-amp-element');
+    expect(element).to.not.have.class('-amp-notbuilt');
+    expect(element).to.not.have.class('amp-notbuilt');
+
+    container.appendChild(element);
+    element.attachedCallback();
+
+    expect(element).to.have.class('-amp-element');
+    expect(element).to.have.class('-amp-notbuilt');
+    expect(element).to.have.class('amp-notbuilt');
+
+    element.classList.remove('-amp-element');
+    element.classList.remove('-amp-notbuilt');
+    element.classList.remove('amp-notbuilt');
+
+    element.attachedCallback();
+
+    expect(element).to.not.have.class('-amp-element');
+    expect(element).to.not.have.class('-amp-notbuilt');
+    expect(element).to.not.have.class('amp-notbuilt');
+  });
+
   it('Element - getIntersectionChangeEntry', () => {
     const element = new ElementClass();
     container.appendChild(element);


### PR DESCRIPTION
Custom Elements V1 removes `createdCallback` in favor of the element constructor. As is, this will result in a violation of the [DOM spec's "create element" concept 6.4](https://dom.spec.whatwg.org/#concept-create-element) when we migrate to V1:

> If result’s attribute list is not empty, then throw a NotSupportedError.

This was [recently added to Chrome](https://codereview.chromium.org/2054433002) for Custom Elements V1.

To avoid this, this PR moves the addition of classes from `createdCallback` to `attachedCallback` and fix corresponding unit tests.