### PR TITLE
Fix social email share for iOS 10

### DIFF
--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -69,7 +69,7 @@ class AmpSocialShare extends AMP.BaseElement {
       // mailto: protocol breaks when opened in _blank on iOS Safari.
       const isMailTo = /^mailto:$/.test(parseUrl(href).protocol);
       const isIosSafari = this.platform_.isIos() && this.platform_.isSafari();
-      this.target_ = (isIosSafari && isMailTo) ? '_self' : '_blank';
+      this.target_ = (isIosSafari && isMailTo) ? '_top' : '_blank';
     });
 
     this.element.setAttribute('role', 'link');

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -187,7 +187,7 @@ describe('amp-social-share', () => {
     });
   });
 
-  it('opens mailto: window in _self on iOS Safari', () => {
+  it('opens mailto: window in _top on iOS Safari', () => {
     isIos = true;
     isSafari = true;
     return getShare('email').then(el => {
@@ -196,7 +196,7 @@ describe('amp-social-share', () => {
       expect(el.implementation_.win.open).to.be.calledWith(
           'mailto:?subject=doc%20title&' +
             'body=https%3A%2F%2Fcanonicalexample.com%2F',
-          '_self', 'resizable,scrollbars,width=640,height=480'
+          '_top', 'resizable,scrollbars,width=640,height=480'
       );
     });
   });


### PR DESCRIPTION
Fixes: https://github.com/ampproject/amphtml/issues/5302

`_self` no longer works on iOS 10, but `_top` does. Tested in iOS 9 as well and `_top` also works there
test page: https://amphtml-ae5fc.firebaseapp.com/test/manual/empty2.amp.html 