### PR TITLE
Trigger analytics events when carousel switches slides.

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -553,14 +553,16 @@ export class AmpSlideScroll extends BaseSlides {
     if (direction == 0) {
       return;
     } else if (Math.abs(direction) !== 1) {
+      // When the direction is not +1 or -1 (happens with loops)
+      // Set the correct direction.
       direction = direction < 0 ? 1 : -1;
     }
+    this.analyticsEvent_('amp-carousel-change');
+    // At this point direction can be only +1 or -1.
     if (direction == 1) {
       this.analyticsEvent_('amp-carousel-next');
-      this.analyticsEvent_('amp-carousel-change');
-    } else if (direction == -1) {
+    } else {
       this.analyticsEvent_('amp-carousel-prev');
-      this.analyticsEvent_('amp-carousel-change');
     }
   }
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -548,7 +548,7 @@ export class AmpSlideScroll extends BaseSlides {
    */
   triggerAnalyticsEvent_(newSlideIndex) {
     let direction = newSlideIndex - this.slideIndex_;
-    if (direction === 0 ) {
+    if (direction === 0) {
       return;
     } else if (Math.abs(direction) !== 1) {
       direction = direction < 0 ? 1 : -1;

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -89,8 +89,8 @@ export class AmpSlideScroll extends BaseSlides {
     /** @private {number} */
     this.previousScrollLeft_ = 0;
 
-    /** @private {!Promise<?InstrumentationService>} */
-    this.analyticsPromise_ = analyticsForOrNull(this.win);
+    /** @private {?Promise<?../../amp-analytics/0.1/instrumentation.InstrumentationService>} */
+    this.analyticsPromise_ = null;
   }
 
   /** @override */
@@ -99,6 +99,8 @@ export class AmpSlideScroll extends BaseSlides {
   }
   /** @override */
   buildSlides() {
+    this.analyticsPromise_ = analyticsForOrNull(this.win);
+
     this.vsync_ = this.getVsync();
 
     this.hasNativeSnapPoints_ = (
@@ -548,15 +550,17 @@ export class AmpSlideScroll extends BaseSlides {
    */
   triggerAnalyticsEvent_(newSlideIndex) {
     let direction = newSlideIndex - this.slideIndex_;
-    if (direction === 0) {
+    if (direction == 0) {
       return;
     } else if (Math.abs(direction) !== 1) {
       direction = direction < 0 ? 1 : -1;
     }
-    if (direction === 1) {
+    if (direction == 1) {
       this.analyticsEvent_('amp-carousel-next');
-    } else if (direction === -1) {
+      this.analyticsEvent_('amp-carousel-change');
+    } else if (direction == -1) {
       this.analyticsEvent_('amp-carousel-prev');
+      this.analyticsEvent_('amp-carousel-change');
     }
   }
 
@@ -565,11 +569,13 @@ export class AmpSlideScroll extends BaseSlides {
    * @private
    */
   analyticsEvent_(eventType) {
-    this.analyticsPromise_.then(analytics => {
-      if (!analytics) {
-        return;
-      }
-      analytics.triggerEvent(eventType);
-    });
+    if (this.analyticsPromise_) {
+      this.analyticsPromise_.then(analytics => {
+        if (!analytics) {
+          return;
+        }
+        analytics.triggerEvent(eventType);
+      });
+    }
   }
 }

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -132,6 +132,7 @@ describe('SlideScroll', () => {
       const schedulePreloadSpy = sandbox.spy(impl, 'schedulePreload');
       const hideRestOfTheSlidesSpy = sandbox.spy(impl, 'hideRestOfTheSlides_');
       const setControlsStateSpy = sandbox.spy(impl, 'setControlsState');
+      const analyticsEventSpy = sandbox.spy(impl, 'analyticsEvent_');
 
       impl.showSlide_(-1);
       expect(updateInViewportSpy).to.not.have.been.called;
@@ -139,6 +140,7 @@ describe('SlideScroll', () => {
       expect(schedulePreloadSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
+      expect(analyticsEventSpy).to.not.have.been.called;
 
       impl.showSlide_(5);
       expect(updateInViewportSpy).to.not.have.been.called;
@@ -146,6 +148,7 @@ describe('SlideScroll', () => {
       expect(schedulePreloadSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
+      expect(analyticsEventSpy).to.not.have.been.called;
 
       impl.showSlide_(impl.slideIndex_);
       expect(updateInViewportSpy).to.not.have.been.called;
@@ -153,6 +156,7 @@ describe('SlideScroll', () => {
       expect(schedulePreloadSpy).to.not.have.been.called;
       expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
       expect(setControlsStateSpy).to.not.have.been.called;
+      expect(analyticsEventSpy).to.not.have.been.called;
 
 
       impl.showSlide_(1);
@@ -177,6 +181,8 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 2]);
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(1);
       expect(setControlsStateSpy.callCount).to.equal(1);
+      expect(analyticsEventSpy.callCount).to.equal(1);
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-next');
 
       impl.showSlide_(0);
 
@@ -200,6 +206,8 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(2);
       expect(setControlsStateSpy.callCount).to.equal(2);
+      expect(analyticsEventSpy.callCount).to.equal(2);
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev');
 
       impl.showSlide_(4);
 
@@ -221,6 +229,8 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4]);
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(3);
       expect(setControlsStateSpy.callCount).to.equal(3);
+      expect(analyticsEventSpy.callCount).to.equal(3);
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev');
     });
   });
 

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -181,8 +181,9 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 2]);
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(1);
       expect(setControlsStateSpy.callCount).to.equal(1);
-      expect(analyticsEventSpy.callCount).to.equal(1);
+      expect(analyticsEventSpy.callCount).to.equal(2);
       expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-next');
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change');
 
       impl.showSlide_(0);
 
@@ -206,8 +207,9 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(2);
       expect(setControlsStateSpy.callCount).to.equal(2);
-      expect(analyticsEventSpy.callCount).to.equal(2);
+      expect(analyticsEventSpy.callCount).to.equal(4);
       expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev');
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change');
 
       impl.showSlide_(4);
 
@@ -229,8 +231,9 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4]);
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(3);
       expect(setControlsStateSpy.callCount).to.equal(3);
-      expect(analyticsEventSpy.callCount).to.equal(3);
+      expect(analyticsEventSpy.callCount).to.equal(6);
       expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev');
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change');
     });
   });
 

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {getElementService} from './element-service';
+import {
+  getElementService,
+  getElementServiceIfAvailable,
+} from './element-service';
 
 
 /**
@@ -22,6 +25,17 @@ import {getElementService} from './element-service';
  * @return {!Promise<!InstrumentationService>}
  */
 export function analyticsFor(window) {
-  return getElementService(window, 'amp-analytics-instrumentation',
-      'amp-analytics');
+  return /** @type {!Promise<!InstrumentationService>} */ (
+      getElementService(
+          window, 'amp-analytics-instrumentation','amp-analytics'));
+};
+
+/**
+ * @param {!Window} window
+ * @return {!Promise<?InstrumentationService>}
+ */
+export function analyticsForOrNull(window) {
+  return /** @type {!Promise<!InstrumentationService>} */ (
+      getElementServiceIfAvailable(
+          window, 'amp-analytics-instrumentation','amp-analytics'));
 };

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -22,20 +22,20 @@ import {
 
 /**
  * @param {!Window} window
- * @return {!Promise<!InstrumentationService>}
+ * @return {!Promise<!../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>}
  */
 export function analyticsFor(window) {
-  return /** @type {!Promise<!InstrumentationService>} */ (
+  return /** @type {!Promise<!../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>} */ (
       getElementService(
-          window, 'amp-analytics-instrumentation','amp-analytics'));
+          window, 'amp-analytics-instrumentation', 'amp-analytics'));
 };
 
 /**
  * @param {!Window} window
- * @return {!Promise<?InstrumentationService>}
+ * @return {!Promise<?../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>}
  */
 export function analyticsForOrNull(window) {
-  return /** @type {!Promise<!InstrumentationService>} */ (
+  return /** @type {!Promise<?../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>} */ (
       getElementServiceIfAvailable(
-          window, 'amp-analytics-instrumentation','amp-analytics'));
+          window, 'amp-analytics-instrumentation', 'amp-analytics'));
 };

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -25,9 +25,10 @@ import {
  * @return {!Promise<!../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>}
  */
 export function analyticsFor(window) {
-  return /** @type {!Promise<!../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>} */ (
-      getElementService(
-          window, 'amp-analytics-instrumentation', 'amp-analytics'));
+  return (/** @type {!Promise<
+            !../extensions/amp-analytics/0.1/instrumentation.InstrumentationService
+          >} */ (getElementService(
+                window, 'amp-analytics-instrumentation', 'amp-analytics')));
 };
 
 /**
@@ -35,7 +36,8 @@ export function analyticsFor(window) {
  * @return {!Promise<?../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>}
  */
 export function analyticsForOrNull(window) {
-  return /** @type {!Promise<?../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>} */ (
-      getElementServiceIfAvailable(
-          window, 'amp-analytics-instrumentation', 'amp-analytics'));
+  return (/** @type {!Promise<
+            ?../extensions/amp-analytics/0.1/instrumentation.InstrumentationService
+          >} */ (getElementServiceIfAvailable(
+                window, 'amp-analytics-instrumentation', 'amp-analytics')));
 };

--- a/test/manual/amp-slidescroll.amp.html
+++ b/test/manual/amp-slidescroll.amp.html
@@ -8,6 +8,7 @@
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-carousel" src="../../dist/v0/amp-carousel-0.1.max.js"></script>
   <script async custom-element="amp-youtube" src="../../dist/v0/amp-youtube-0.1.max.js"></script>
+  <script async custom-element="amp-analytics" src="../../dist/v0/amp-analytics-0.1.js"></script>
   <style amp-custom>
   /* AMP.CSS */
   html, body {


### PR DESCRIPTION
Part 1 for #4292

- [x] This PR only triggers events `amp-carousel-next` and `amp-carousel-prev` and does not provide any more information to amp-analytics


Yet to come

- [ ] Enable Instrumentation.triggerEvent to accept object params (and observable to send params)
- [ ] Have carousel send `carousel-id` and `data-slide-id` to analytics
