### PR TITLE
Observable: add the ability to pass params to handlers.

### DIFF
--- a/src/observable.js
+++ b/src/observable.js
@@ -69,7 +69,11 @@ export class Observable {
     const handlers = this.handlers_;
     for (let i = 0; i < handlers.length; i++) {
       const handler = handlers[i];
-      handler.apply(null, arguments);
+      if (var_args) {
+        handler.apply(null, arguments);
+      } else {
+        handler(opt_event);
+      }
     }
   }
 

--- a/src/observable.js
+++ b/src/observable.js
@@ -60,13 +60,16 @@ export class Observable {
 
   /**
    * Fires an event. All observers are called.
+   * @param {...*} var_args Arguments that are applied to each subscription
+   *     function.
    * @param {TYPE=} opt_event
+   *
    */
-  fire(opt_event) {
+  fire(opt_event, var_args) {
     const handlers = this.handlers_;
     for (let i = 0; i < handlers.length; i++) {
       const handler = handlers[i];
-      handler(opt_event);
+      handler.apply(null, arguments);
     }
   }
 

--- a/src/observable.js
+++ b/src/observable.js
@@ -67,9 +67,11 @@ export class Observable {
    */
   fire(opt_event, var_args) {
     const handlers = this.handlers_;
+    const hasArgs = arguments.length > 1;
     for (let i = 0; i < handlers.length; i++) {
       const handler = handlers[i];
-      if (var_args) {
+      if (hasArgs) {
+        // Use this only when there is var_args.
         handler.apply(null, arguments);
       } else {
         handler(opt_event);

--- a/test/functional/test-observable.js
+++ b/test/functional/test-observable.js
@@ -17,7 +17,7 @@
 import {Observable} from '../../src/observable';
 import * as sinon from 'sinon';
 
-describe('Observable', () => {
+describe.only('Observable', () => {
 
   let sandbox;
   let observable;
@@ -67,6 +67,12 @@ describe('Observable', () => {
     observable.fire('D');
     expect(observer1Called).to.equal(1);
     expect(observer2Called).to.equal(2);
+
+    const observer3 = sandbox.spy();
+    observable.add(observer3);
+    observable.fire('E', 'arg1', 'arg2');
+    expect(observer3.callCount).to.equal(1);
+    expect(observer3).to.have.been.calledWith('E', 'arg1', 'arg2');
   });
 
 });


### PR DESCRIPTION
Part 2 for #4292


**Yet to come**

- [ ]  Enable Instrumentation.triggerEvent to accept object params (and observable to send params)
- [ ]  Have carousel send carousel-id and data-slide-id to analytics


