### PR TITLE
Send vars from carousel to amp-analytics

### DIFF
--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -204,9 +204,10 @@ export class InstrumentationService {
   /**
    * Triggers the analytics event with the specified type.
    * @param {string} eventType
+   * @param {!Object<string, string>=} opt_vars A map of vars and their values.
    */
-  triggerEvent(eventType) {
-    const event = new AnalyticsEvent(eventType);
+  triggerEvent(eventType, opt_vars) {
+    const event = new AnalyticsEvent(eventType, opt_vars);
 
     // Enqueue.
     if (this.customEventBuffer_) {

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -89,8 +89,8 @@ export class AmpSlideScroll extends BaseSlides {
     /** @private {number} */
     this.previousScrollLeft_ = 0;
 
-    /** @private {Array<?string>} */
-    this.dataSlideIdArr = [];
+    /** @private {!Array<?string>} */
+    this.dataSlideIdArr_ = [];
 
     /** @private {?Promise<?../../amp-analytics/0.1/instrumentation.InstrumentationService>} */
     this.analyticsPromise_ = null;
@@ -129,8 +129,8 @@ export class AmpSlideScroll extends BaseSlides {
     }
 
     this.slides_.forEach((slide, index) => {
-      this.dataSlideIdArr.push(
-          slide.getAttribute('data-slide-id') || index + '');
+      this.dataSlideIdArr_.push(
+          slide.getAttribute('data-slide-id') || index.toString());
       this.setAsOwner(slide);
       const slideWrapper = this.win.document.createElement('div');
       slide.classList.add('amp-carousel-slide');
@@ -563,8 +563,8 @@ export class AmpSlideScroll extends BaseSlides {
       direction = direction < 0 ? 1 : -1;
     }
     const vars = {
-      'fromSlide': this.dataSlideIdArr[this.slideIndex_],
-      'toSlide': this.dataSlideIdArr[newSlideIndex],
+      'fromSlide': this.dataSlideIdArr_[this.slideIndex_],
+      'toSlide': this.dataSlideIdArr_[newSlideIndex],
     };
     this.analyticsEvent_('amp-carousel-change', vars);
     // At this point direction can be only +1 or -1.

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -563,7 +563,7 @@ export class AmpSlideScroll extends BaseSlides {
       direction = direction < 0 ? 1 : -1;
     }
     const vars = {
-      'fromSlide': this.dataSlideIdArr_[this.slideIndex_],
+      'fromSlide': this.dataSlideIdArr_[dev().assertNumber(this.slideIndex_)],
       'toSlide': this.dataSlideIdArr_[newSlideIndex],
     };
     this.analyticsEvent_('amp-carousel-change', vars);

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -89,6 +89,9 @@ export class AmpSlideScroll extends BaseSlides {
     /** @private {number} */
     this.previousScrollLeft_ = 0;
 
+    /** @private {Array<?string>} */
+    this.dataSlideIdArr = [];
+
     /** @private {?Promise<?../../amp-analytics/0.1/instrumentation.InstrumentationService>} */
     this.analyticsPromise_ = null;
   }
@@ -125,7 +128,9 @@ export class AmpSlideScroll extends BaseSlides {
       this.slidesContainer_.appendChild(end);
     }
 
-    this.slides_.forEach(slide => {
+    this.slides_.forEach((slide, index) => {
+      this.dataSlideIdArr.push(
+          slide.getAttribute('data-slide-id') || index + '');
       this.setAsOwner(slide);
       const slideWrapper = this.win.document.createElement('div');
       slide.classList.add('amp-carousel-slide');
@@ -458,7 +463,6 @@ export class AmpSlideScroll extends BaseSlides {
         this.schedulePreload(this.slides_[showIndex]);
       }
     });
-
     this.slidesContainer_./*OK*/scrollLeft =
         this.getScrollLeftForIndex_(newIndex);
     this.triggerAnalyticsEvent_(newIndex);
@@ -558,26 +562,31 @@ export class AmpSlideScroll extends BaseSlides {
       // Set the correct direction.
       direction = direction < 0 ? 1 : -1;
     }
-    this.analyticsEvent_('amp-carousel-change');
+    const vars = {
+      'fromSlide': this.dataSlideIdArr[this.slideIndex_],
+      'toSlide': this.dataSlideIdArr[newSlideIndex],
+    };
+    this.analyticsEvent_('amp-carousel-change', vars);
     // At this point direction can be only +1 or -1.
     if (direction == 1) {
-      this.analyticsEvent_('amp-carousel-next');
+      this.analyticsEvent_('amp-carousel-next', vars);
     } else {
-      this.analyticsEvent_('amp-carousel-prev');
+      this.analyticsEvent_('amp-carousel-prev', vars);
     }
   }
 
   /**
    * @param {string} eventType
+   * @param {!Object<string, string>} vars A map of vars and their values.
    * @private
    */
-  analyticsEvent_(eventType) {
+  analyticsEvent_(eventType, vars) {
     if (this.analyticsPromise_) {
       this.analyticsPromise_.then(analytics => {
         if (!analytics) {
           return;
         }
-        analytics.triggerEvent(eventType);
+        analytics.triggerEvent(eventType, vars);
       });
     }
   }

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -35,6 +35,8 @@ describe('SlideScroll', () => {
   function getAmpSlideScroll(opt_hasLooping, opt_slideCount = 5) {
     return createIframePromise().then(iframe => {
       toggleExperiment(iframe.win, 'amp-slidescroll', true);
+      iframe.width = '1000';
+      iframe.height = '1000';
       const imgUrl = 'https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-' +
           'Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no';
       const slideScrollHtml = "<amp-carousel type='slides'></amp-carousel>";
@@ -43,6 +45,7 @@ describe('SlideScroll', () => {
       const ampSlideScroll = dummyDiv.children[0];
       ampSlideScroll.setAttribute('width', '400');
       ampSlideScroll.setAttribute('height', '300');
+      ampSlideScroll.style.position = 'relative';
       ampSlideScroll.setAttribute('controls', '');
       if (opt_hasLooping) {
         ampSlideScroll.setAttribute('loop', '');
@@ -50,11 +53,14 @@ describe('SlideScroll', () => {
 
       for (let i = 0; i < opt_slideCount; i++) {
         const img = document.createElement('amp-img');
-        ampSlideScroll.setAttribute('src', imgUrl);
-        ampSlideScroll.setAttribute('width', '400');
-        ampSlideScroll.setAttribute('height', '300');
+        img.setAttribute('src', imgUrl);
+        img.setAttribute('width', '400');
+        img.setAttribute('height', '300');
         // See https://github.com/ampproject/amphtml/issues/3989
-        ampSlideScroll.style.display = 'inline';
+        img.style.display = 'inline';
+        if (i == 0) {
+          img.setAttribute('data-slide-id', 'slide-id');
+        }
         ampSlideScroll.appendChild(img);
       }
       return iframe.addElement(ampSlideScroll).then(() => {
@@ -108,7 +114,6 @@ describe('SlideScroll', () => {
       const ampSlideScroll = obj.ampSlideScroll;
       const impl = ampSlideScroll.implementation_;
       const showSlideSpy = sandbox.spy(impl, 'showSlide_');
-      impl.slideWidth_ = 400;
 
       impl.goCallback(1);
       expect(showSlideSpy).to.have.been.calledWith(1);
@@ -158,7 +163,6 @@ describe('SlideScroll', () => {
       expect(setControlsStateSpy).to.not.have.been.called;
       expect(analyticsEventSpy).to.not.have.been.called;
 
-
       impl.showSlide_(1);
       expect(updateInViewportSpy).to.have.been.calledWith(
           impl.slides_[0], false);
@@ -182,8 +186,10 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(1);
       expect(setControlsStateSpy.callCount).to.equal(1);
       expect(analyticsEventSpy.callCount).to.equal(2);
-      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-next');
-      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change');
+      expect(analyticsEventSpy).to.have.been.calledWith(
+          'amp-carousel-next', {'fromSlide': 'slide-id', 'toSlide': '1'});
+      expect(analyticsEventSpy).to.have.been.calledWith(
+          'amp-carousel-change', {'fromSlide': 'slide-id', 'toSlide': '1'});
 
       impl.showSlide_(0);
 
@@ -208,8 +214,10 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(2);
       expect(setControlsStateSpy.callCount).to.equal(2);
       expect(analyticsEventSpy.callCount).to.equal(4);
-      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev');
-      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change');
+      expect(analyticsEventSpy).to.have.been.calledWith(
+          'amp-carousel-prev', {'fromSlide': '1', 'toSlide': 'slide-id'});
+      expect(analyticsEventSpy).to.have.been.calledWith(
+          'amp-carousel-change', {'fromSlide': '1', 'toSlide': 'slide-id'});
 
       impl.showSlide_(4);
 
@@ -232,8 +240,10 @@ describe('SlideScroll', () => {
       expect(hideRestOfTheSlidesSpy.callCount).to.equal(3);
       expect(setControlsStateSpy.callCount).to.equal(3);
       expect(analyticsEventSpy.callCount).to.equal(6);
-      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev');
-      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change');
+      expect(analyticsEventSpy).to.have.been.calledWith(
+          'amp-carousel-prev', {'fromSlide': 'slide-id', 'toSlide': '4'});
+      expect(analyticsEventSpy).to.have.been.calledWith(
+          'amp-carousel-change', {'fromSlide': 'slide-id', 'toSlide': '4'});
     });
   });
 
@@ -355,8 +365,6 @@ describe('SlideScroll', () => {
         },
       };
 
-      impl.slideWidth_ = 400;
-
       // Move to slide 1 (from slide 0).
       impl.showSlide_(1);
       expect(showSlideSpy).to.be.calledWith(1);
@@ -388,7 +396,6 @@ describe('SlideScroll', () => {
     return getAmpSlideScroll().then(obj => {
       const ampSlideScroll = obj.ampSlideScroll;
       const impl = ampSlideScroll.implementation_;
-      impl.slideWidth_ = 400;
 
       // Already at slide 0;
       expect(impl.getNextSlideIndex_(0)).to.equal(0);
@@ -419,7 +426,6 @@ describe('SlideScroll', () => {
       const ampSlideScroll = obj.ampSlideScroll;
       const impl = ampSlideScroll.implementation_;
       const animateScrollLeftSpy = sandbox.spy(impl, 'animateScrollLeft_');
-      impl.slideWidth_ = 400;
 
       impl.customSnap_(0);
       expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
@@ -486,7 +492,6 @@ describe('SlideScroll', () => {
       const ampSlideScroll = obj.ampSlideScroll;
       const impl = ampSlideScroll.implementation_;
       const animateScrollLeftSpy = sandbox.spy(impl, 'animateScrollLeft_');
-      impl.slideWidth_ = 400;
 
       impl.customSnap_(0, 1);
       expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
@@ -509,7 +514,6 @@ describe('SlideScroll', () => {
           },
         };
       });
-      impl.slideWidth_ = 400;
 
       impl.handleCustomElasticScroll_(-10);
       expect(impl.elasticScrollState_).to.equal(-1);
@@ -537,14 +541,14 @@ describe('SlideScroll', () => {
       impl.slideIndex_ = null;
       impl.onLayoutMeasure();
       expect(getLayoutWidthSpy).to.have.been.called;
-      expect(impl.slideWidth_).to.equal(400);
+      expect(impl.slideWidth_).to.equal(200);
 
       impl.showSlide_(1);
-      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(400);
+      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(200);
       impl.onLayoutMeasure();
       expect(getLayoutWidthSpy.callCount).to.equal(2);
-      expect(impl.slideWidth_).to.equal200;
-      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(200);
+      expect(impl.slideWidth_).to.equal(400);
+      expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(400);
     });
   });
 
@@ -628,7 +632,7 @@ describe('SlideScroll', () => {
         expect(scheduleLayoutSpy.callCount).to.equal(2);
         expect(schedulePreloadSpy.callCount).to.equal(4);
         expect(impl.slideIndex_).to.equal(0);
-        expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(0);
+        expect(impl.slidesContainer_./*OK*/scrollLeft).to.equal(400);
         expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([4, 0, 1]);
         expect(hideRestOfTheSlidesSpy.callCount).to.equal(2);
         expect(setControlsStateSpy.callCount).to.equal(2);
@@ -770,7 +774,7 @@ describe('SlideScroll', () => {
     });
 
     it('should set the correct scrollLeft when there is only one slide', () => {
-      return getAmpSlideScroll(true).then(obj => {
+      return getAmpSlideScroll(true, 1).then(obj => {
         const ampSlideScroll = obj.ampSlideScroll;
         const impl = ampSlideScroll.implementation_;
 
@@ -791,8 +795,6 @@ describe('SlideScroll', () => {
             cb();
           },
         };
-
-        impl.slideWidth_ = 400;
 
         // Move to slide 1 (from slide 0).
         impl.showSlide_(1);
@@ -829,8 +831,6 @@ describe('SlideScroll', () => {
         const ampSlideScroll = obj.ampSlideScroll;
         const impl = ampSlideScroll.implementation_;
 
-        //Slide width = 400
-        impl.slideWidth_ = 400;
         // Already at slide 0;
 
         expect(impl.getNextSlideIndex_(0)).to.equal(4);
@@ -867,7 +867,6 @@ describe('SlideScroll', () => {
         const ampSlideScroll = obj.ampSlideScroll;
         const impl = ampSlideScroll.implementation_;
         const animateScrollLeftSpy = sandbox.spy(impl, 'animateScrollLeft_');
-        impl.slideWidth_ = 400;
 
         impl.customSnap_(0);
         expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
@@ -896,7 +895,6 @@ describe('SlideScroll', () => {
         const ampSlideScroll = obj.ampSlideScroll;
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
-        impl.slideWidth_ = 400;
 
         impl.goCallback(-1);
         expect(showSlideSpy).to.have.been.calledWith(4);

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -538,7 +538,6 @@ describe('SlideScroll', () => {
       const getLayoutWidthSpy = sandbox.stub(impl, 'getLayoutWidth', () => {
         return impl.slideWidth_ == 400 ? 200 : 400;
       });
-      impl.slideIndex_ = null;
       impl.onLayoutMeasure();
       expect(getLayoutWidthSpy).to.have.been.called;
       expect(impl.slideWidth_).to.equal(200);


### PR DESCRIPTION
Part 2 for #4292

- [x]  Enable Instrumentation.triggerEvent to accept object params (and observable to send params)
- [x]  Have carousel send carousel-id and data-slide-id to analytics