### PR TITLE
Add link for LOKA amp-ad

### DIFF
--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -113,6 +113,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [Industrybrains](../../ads/industrybrains.md)
 - [InMobi](../../ads/inmobi.md)
 - [Kargo](../../ads/kargo.md)
+- [LOKA](../../ads/loka.md)
 - [MADS](../../ads/mads.md)
 - [MANTIS](../../ads/mantis.md)
 - [MediaImpact](../../ads/mediaimpact.md)


### PR DESCRIPTION
Merged amp-ad implementation for LOKA. (https://github.com/ampproject/amphtml/pull/4832)
But missed link in `extensions/amp-ad/amp-ad.md`.