### PR TITLE
A few small optimizations

### DIFF
--- a/src/base-element.js
+++ b/src/base-element.js
@@ -478,7 +478,8 @@ export class BaseElement {
     } else {
       this.initActionMap_();
       const handler = this.actionMap_[invocation.method];
-      user().assert(handler, `Method not found: ${invocation.method}`, this);
+      user().assert(handler, `Method not found: ${invocation.method} in %s`,
+          this);
       handler(invocation);
     }
   }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -20,6 +20,7 @@ import {preconnectForElement} from './preconnect';
 import {isArray} from './types';
 import {viewportForDoc} from './viewport';
 import {vsyncFor} from './vsync';
+import {user} from './log';
 
 
 /**
@@ -141,8 +142,8 @@ export class BaseElement {
     /** @public @const {!Window}  */
     this.win = element.ownerDocument.defaultView;
 
-    /** @private {!Object<string, function(!./service/action-impl.ActionInvocation)>} */
-    this.actionMap_ = this.win.Object.create(null);
+    /** @private {?Object<string, function(!./service/action-impl.ActionInvocation)>} */
+    this.actionMap_ = null;
 
     /** @public {!./preconnect.Preconnect} */
     this.preconnect = preconnectForElement(this.element);
@@ -444,6 +445,12 @@ export class BaseElement {
     return loadPromise(element, opt_timeout);
   }
 
+  initActionMap_() {
+    if (!this.actionMap_) {
+      this.actionMap_ = this.win.Object.create(null);
+    }
+  }
+
   /**
    * Registers the action handler for the method with the specified name.
    * @param {string} method
@@ -451,6 +458,7 @@ export class BaseElement {
    * @public
    */
   registerAction(method, handler) {
+    this.initActionMap_();
     this.actionMap_[method] = handler;
   }
 
@@ -468,10 +476,9 @@ export class BaseElement {
     if (invocation.method == 'activate') {
       this.activate(invocation);
     } else {
+      this.initActionMap_();
       const handler = this.actionMap_[invocation.method];
-      if (!handler) {
-        throw new Error(`Method not found: ${invocation.method}`);
-      }
+      user().assert(handler, `Method not found: ${invocation.method}`, this);
       handler(invocation);
     }
   }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -119,6 +119,8 @@ export function upgradeOrRegisterElement(win, name, toClass) {
     const element = stub.element;
     if (element.tagName.toLowerCase() == name) {
       tryUpgradeElementNoInline(element, toClass);
+      // Remove element from array.
+      stubbedElements.splice(i--, 1);
     }
   }
 }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -167,8 +167,6 @@ export class Resource {
     /** @private @const {!Promise} */
     this.loadPromise_ = new Promise(resolve => {
       this.loadPromiseResolve_ = resolve;
-    }).then(() => {
-      this.loadedOnce_ = true;
     });
 
     /** @private {boolean} */
@@ -571,7 +569,9 @@ export class Resource {
    */
   layoutComplete_(success, opt_reason) {
     this.loadPromiseResolve_();
+    this.loadPromiseResolve_ = null;
     this.layoutPromise_ = null;
+    this.loadedOnce_ = true;
     this.state_ = success ? ResourceState.LAYOUT_COMPLETE :
         ResourceState.LAYOUT_FAILED;
     if (success) {


### PR DESCRIPTION
- lazily init action map per element (most elements will never need it)
- clean up promise resolve for element loading state
- clean up elements from list of stubbed elements.