### PR TITLE
Migrate document-submit to doc scope

### DIFF
--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -21,21 +21,14 @@ import {assertHttpsUrl, checkCorsUrl, SOURCE_ORIGIN_PARAM} from './url';
 import {urls} from './config';
 
 
-/** @const {string} */
-const PROP = '__AMP_SUBMIT';
-
-
 /**
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @return {!Object}
  */
 export function installGlobalSubmitListenerForDoc(ampdoc) {
   return /** @type {!Object} */ (getServiceForDoc(ampdoc, 'submit', ampdoc => {
-    if (!ampdoc.win[PROP]) {
-      ampdoc.win[PROP] = true;
-      ampdoc.win.document.documentElement.addEventListener(
-          'submit', onDocumentFormSubmit_, true);
-    }
+    ampdoc.getRootNode().addEventListener(
+        'submit', onDocumentFormSubmit_, true);
     return {};
   }));
 }

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -23,14 +23,13 @@ import {urls} from './config';
 
 /**
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
- * @return {!Object}
  */
 export function installGlobalSubmitListenerForDoc(ampdoc) {
-  return /** @type {!Object} */ (getServiceForDoc(ampdoc, 'submit', ampdoc => {
+  return getServiceForDoc(ampdoc, 'submit', ampdoc => {
     ampdoc.getRootNode().addEventListener(
         'submit', onDocumentFormSubmit_, true);
     return {};
-  }));
+  });
 }
 
 

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {getServiceForDoc} from './service';
 import {startsWith} from './string';
 import {user} from './log';
 import {assertHttpsUrl, checkCorsUrl, SOURCE_ORIGIN_PARAM} from './url';
@@ -25,14 +26,18 @@ const PROP = '__AMP_SUBMIT';
 
 
 /**
- * @param {!Window} window
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @return {!Object}
  */
-export function installGlobalSubmitListener(window) {
-  if (!window[PROP]) {
-    window[PROP] = true;
-    window.document.documentElement.addEventListener(
-        'submit', onDocumentFormSubmit_, true);
-  }
+export function installGlobalSubmitListenerForDoc(ampdoc) {
+  return /** @type {!Object} */ (getServiceForDoc(ampdoc, 'submit', ampdoc => {
+    if (!ampdoc.win[PROP]) {
+      ampdoc.win[PROP] = true;
+      ampdoc.win.document.documentElement.addEventListener(
+          'submit', onDocumentFormSubmit_, true);
+    }
+    return {};
+  }));
 }
 
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -43,7 +43,7 @@ import {
 } from './shadow-embed';
 import {getMode} from './mode';
 import {installActionServiceForDoc} from './service/action-impl';
-import {installGlobalSubmitListener} from './document-submit';
+import {installGlobalSubmitListenerForDoc} from './document-submit';
 import {extensionsFor} from './extensions';
 import {installHistoryServiceForDoc} from './service/history-impl';
 import {installPlatformService} from './service/platform-impl';
@@ -95,9 +95,6 @@ export function installRuntimeServices(global) {
   installVsyncService(global);
   installXhrService(global);
   installTemplatesService(global);
-  if (isExperimentOn(global, 'form-submit')) {
-    installGlobalSubmitListener(global);
-  }
 }
 
 
@@ -116,6 +113,9 @@ export function installAmpdocServices(ampdoc, opt_initParams) {
   installStandardActionsForDoc(ampdoc);
   installStorageServiceForDoc(ampdoc);
   installVideoManagerForDoc(ampdoc);
+  if (isExperimentOn(ampdoc.win, 'form-submit')) {
+    installGlobalSubmitListenerForDoc(ampdoc);
+  }
 }
 
 


### PR DESCRIPTION
@dvoytenko not sure if this the right thing to do or follow the `document-click` footstep in creating a class for it. I remember during initial review of `document-submit` we didn't want to do that but let me know if that changed with doc-scoped services.

Fixes #5399