### PR TITLE
Fix PR check on new branches

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -118,11 +118,7 @@ function determineBuildTargets(filePaths) {
  * @returns {number}
  */
 function main(argv) {
-  if (argv.length <= 2) {
-    console.error(`Usage: ${__filename} TRAVIS_COMMIT_RANGE`);
-    return -1;
-  }
-  const travisCommitRange = argv[2];
+  const travisCommitRange = argv[2] || '';
   const buildTargets = determineBuildTargets(filesInPr(travisCommitRange));
 
   const sortedBuildTargets = [];


### PR DESCRIPTION
Because the `TRAVIS_COMMIT_RANGE` is empty when testing a new branch, we can't assert that we have 2 arguments.