### PR TITLE
Lightbox 2.0: Use object-fit:cover for thumbnails

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -124,7 +124,6 @@
 }
 
 .-amp-lbv-gallery-thumbnail {
-  object-fit: contain;
   width: calc(100vw/3);
   height: calc(100vw/3);
   padding: 5px;
@@ -133,6 +132,7 @@
 }
 
 .-amp-lbv-gallery-thumbnail-img {
+  object-fit: cover;
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
Before:
![pbl9ulyvuz5](https://cloud.githubusercontent.com/assets/2099009/19175266/1557a792-8bea-11e6-981a-9e40bdd69d6f.png)

After:
![jtw9iefbehv](https://cloud.githubusercontent.com/assets/2099009/19175267/167a4e9a-8bea-11e6-9b89-d860e72c371b.png)

