### PR TITLE
Do not use AMP Version as RTV Versions

### DIFF
--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -178,8 +178,7 @@ export function warmupStatic(win) {
   const linkRel = /*OK*/document.createElement('link');
   linkRel.rel = 'preload';
   linkRel.setAttribute('as', 'script');
-  linkRel.href =
-      `${urls.cdn}/rtv/01$internalRuntimeVersion$/v0.js`;
+  linkRel.href = `${urls.cdn}/v0.js`;
   getHeadOrFallback(win.document).appendChild(linkRel);
 }
 

--- a/src/service-worker/shell.js
+++ b/src/service-worker/shell.js
@@ -21,6 +21,5 @@ import {calculateExtensionScriptUrl} from '../service/extensions-impl';
  * file is kept intentionally small, so that checking if it has changed (and
  * thus, if a new SW must be installed) will be very fast.
  */
-const url = calculateExtensionScriptUrl(self.location, 'cache-service-worker',
-    '$internalRuntimeVersion$', true);
+const url = calculateExtensionScriptUrl(self.location, 'cache-service-worker');
 importScripts(url);

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -35,7 +35,6 @@ import {urls} from '../config';
 const TAG = 'extensions';
 const UNKNOWN_EXTENSION = '_UNKNOWN_';
 
-
 /**
  * The structure that contains the declaration of a custom element.
  *
@@ -513,7 +512,7 @@ export class Extensions {
     const loc = this.win.location;
     const useCompiledJs = shouldUseCompiledJs();
     const scriptSrc = calculateExtensionScriptUrl(loc, extensionId,
-        getMode().version, getMode().localDev, getMode().test, useCompiledJs);
+        getMode().localDev, getMode().test, useCompiledJs);
     scriptElement.src = scriptSrc;
     return scriptElement;
   }
@@ -540,14 +539,13 @@ export function calculateScriptBaseUrl(location, isLocalDev, isTest) {
  * Calculate script url for amp-ad.
  * @param {!Location} location The window's location
  * @param {string} extensionId
- * @param {string} version
  * @param {boolean=} isLocalDev
  * @param {boolean=} isTest
  * @param {boolean=} isUsingCompiledJs
  * @return {string}
  */
-export function calculateExtensionScriptUrl(location, extensionId, version,
-    isLocalDev, isTest, isUsingCompiledJs) {
+export function calculateExtensionScriptUrl(location, extensionId, isLocalDev,
+    isTest, isUsingCompiledJs) {
   const base = calculateScriptBaseUrl(location, isLocalDev, isTest);
   if (isLocalDev) {
     if ((isTest && !isUsingCompiledJs) || isMax(location)) {
@@ -555,9 +553,7 @@ export function calculateExtensionScriptUrl(location, extensionId, version,
     }
     return `${base}/v0/${extensionId}-0.1.js`;
   }
-  const folderPath = version == '$internalRuntimeVersion$' ?
-      'v0' : `rtv/${version}/v0`;
-  return `${base}/${folderPath}/${extensionId}-0.1.js`;
+  return `${base}/rtv/${getMode().version}/v0/${extensionId}-0.1.js`;
 }
 
 

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -302,8 +302,7 @@ describe('alp-handler', () => {
     expect(win.document.head.appendChild.callCount).to.equal(1);
     const link = win.document.head.appendChild.lastCall.args[0];
     expect(link.rel).to.equal('preload');
-    expect(link.href).to.equal(
-        'https://cdn.ampproject.org/rtv/01$internalRuntimeVersion$/v0.js');
+    expect(link.href).to.equal('https://cdn.ampproject.org/v0.js');
   });
 
   it('should warmup dynamically', () => {

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -479,7 +479,7 @@ describes.sandboxed('Extensions', {}, () => {
         pathname: 'examples/ads.amp.html',
         host: 'localhost:8000',
         protocol: 'http:',
-      }, 'amp-ad', '123', true, true, true);
+      }, 'amp-ad', true, true, true);
       expect(script).to.equal('http://localhost:8000/dist/v0/amp-ad-0.1.js');
     });
 
@@ -488,7 +488,7 @@ describes.sandboxed('Extensions', {}, () => {
         pathname: 'examples/ads.amp.html',
         host: 'localhost:80',
         protocol: 'https:',
-      }, 'amp-ad', '123', true, true, false);
+      }, 'amp-ad', true, true, false);
       expect(script).to.equal('https://localhost:80/dist/v0/amp-ad-0.1.max.js');
     });
 
@@ -497,7 +497,7 @@ describes.sandboxed('Extensions', {}, () => {
         pathname: 'examples/ads.amp.html',
         host: 'localhost:8000',
         protocol: 'https:',
-      }, 'amp-ad', '123', true);
+      }, 'amp-ad', true);
       expect(script).to.equal('https://cdn.ampproject.org/v0/amp-ad-0.1.js');
     });
 
@@ -506,7 +506,7 @@ describes.sandboxed('Extensions', {}, () => {
         pathname: 'examples/ads.amp.min.html',
         host: 'localhost:8000',
         protocol: 'http:',
-      }, 'amp-ad', '123', true);
+      }, 'amp-ad', true);
       expect(script).to.equal('http://localhost:8000/dist/v0/amp-ad-0.1.js');
     });
 
@@ -515,7 +515,7 @@ describes.sandboxed('Extensions', {}, () => {
         pathname: 'examples/ads.amp.max.html',
         host: 'localhost:8000',
         protocol: 'http:',
-      }, 'amp-ad', '123', true);
+      }, 'amp-ad', true);
       expect(script).to.equal('http://localhost:8000/dist/v0/amp-ad-0.1.max.js');
     });
 
@@ -524,7 +524,7 @@ describes.sandboxed('Extensions', {}, () => {
         pathname: 'examples/ads.amp.min.html',
         host: 'localhost:8000',
         protocol: 'http:',
-      }, 'amp-ad', '123', false);
+      }, 'amp-ad', false);
       expect(script).to.equal(
           'https://cdn.ampproject.org/rtv/123/v0/amp-ad-0.1.js');
     });
@@ -534,7 +534,7 @@ describes.sandboxed('Extensions', {}, () => {
         pathname: '/max/output.jsbin.com/pegizoq/quiet',
         host: 'localhost:80',
         protocol: 'http:',
-      }, 'amp-ad', '123', true);
+      }, 'amp-ad', true);
       expect(script).to.equal('http://localhost:80/dist/v0/amp-ad-0.1.max.js');
     });
 
@@ -543,7 +543,7 @@ describes.sandboxed('Extensions', {}, () => {
         pathname: '/min/output.jsbin.com/pegizoq/quiet',
         host: 'localhost:80',
         protocol: 'http:',
-      }, 'amp-ad', '123', true);
+      }, 'amp-ad', true);
       expect(script).to.equal('http://localhost:80/dist/v0/amp-ad-0.1.js');
     });
   });

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -520,6 +520,7 @@ describes.sandboxed('Extensions', {}, () => {
     });
 
     it('with remote mode', () => {
+      window.AMP_MODE = {version: '123'};
       const script = calculateExtensionScriptUrl({
         pathname: 'examples/ads.amp.min.html',
         host: 'localhost:8000',


### PR DESCRIPTION
Closes #5471. #5471 is invalid:

The core issue is that the Cache SW will serve stale-while-revalidate serve last week's (let's call it `v1`) AMP version, but that request will still look like it's requesting the newest AMP version (`v2`). The runtime will then dynamically inject the `<amp-ad>`'s script url using its AMP version (`v1`, not `v2`), so it'll look like we've been served `v2` scripts but then requested the `v1` `<amp-ad>`.