### PR TITLE
Allow data-attributes to pass through AMP sanitizer.

### DIFF
--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -40,6 +40,42 @@ describe('amp-mustache template', () => {
     expect(result./*OK*/innerHTML).to.equal('value = <a>abc</a>');
   });
 
+  describe('Sanitizing data- attributes', () => {
+    it('should parse data-&style=value output correctly', () => {
+      const templateElement = document.createElement('div');
+      templateElement./*OK*/innerHTML = 'value = <a href="{{value}}" data-&style="color:red;">abc</a>';
+      const template = new AmpMustache(templateElement);
+      template.compileCallback();
+      const result = template.render({
+        value: /*eslint no-script-url: 0*/ 'javascript:alert();',
+      });
+      expect(result./*OK*/innerHTML).to.equal('value = <a data-="">abc</a>');
+    });
+
+    it('should parse data-&attr=value output correctly', () => {
+      const templateElement = document.createElement('div');
+      templateElement./*OK*/innerHTML = 'value = <a data-&href="{{value}}">abc</a>';
+      const template = new AmpMustache(templateElement);
+      template.compileCallback();
+      const result = template.render({
+        value: 'https://google.com/',
+      });
+      expect(result./*OK*/innerHTML).to.equal('value = <a data-="" href="https://google.com/">abc</a>');
+    });
+
+    it('should allow for data-attr=value to output correctly', () => {
+      const templateElement = document.createElement('div');
+      templateElement./*OK*/innerHTML = 'value = <a data-my-attr="{{invalidValue}}" data-my-id="{{value}}">abc</a>';
+      const template = new AmpMustache(templateElement);
+      template.compileCallback();
+      const result = template.render({
+        value: 'myid',
+        invalidValue: /*eslint no-script-url: 0*/ 'javascript:alert();',
+      });
+      expect(result./*OK*/innerHTML).to.equal('value = <a data-my-id="myid">abc</a>');
+    });
+  });
+
   it('should sanitize triple-mustache', () => {
     const templateElement = document.createElement('div');
     templateElement.textContent = 'value = {{{value}}}';

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -43,7 +43,8 @@ describe('amp-mustache template', () => {
   describe('Sanitizing data- attributes', () => {
     it('should parse data-&style=value output correctly', () => {
       const templateElement = document.createElement('div');
-      templateElement./*OK*/innerHTML = 'value = <a href="{{value}}" data-&style="color:red;">abc</a>';
+      templateElement./*OK*/innerHTML = 'value = <a href="{{value}}"' +
+          ' data-&style="color:red;">abc</a>';
       const template = new AmpMustache(templateElement);
       template.compileCallback();
       const result = template.render({
@@ -54,25 +55,29 @@ describe('amp-mustache template', () => {
 
     it('should parse data-&attr=value output correctly', () => {
       const templateElement = document.createElement('div');
-      templateElement./*OK*/innerHTML = 'value = <a data-&href="{{value}}">abc</a>';
+      templateElement./*OK*/innerHTML = 'value = <a data-&href="{{value}}">' +
+          'abc</a>';
       const template = new AmpMustache(templateElement);
       template.compileCallback();
       const result = template.render({
         value: 'https://google.com/',
       });
-      expect(result./*OK*/innerHTML).to.equal('value = <a data-="" href="https://google.com/">abc</a>');
+      expect(result./*OK*/innerHTML).to.equal('value = <a data-=""' +
+          ' href="https://google.com/">abc</a>');
     });
 
     it('should allow for data-attr=value to output correctly', () => {
       const templateElement = document.createElement('div');
-      templateElement./*OK*/innerHTML = 'value = <a data-my-attr="{{invalidValue}}" data-my-id="{{value}}">abc</a>';
+      templateElement./*OK*/innerHTML = 'value = ' +
+          '<a data-my-attr="{{invalidValue}}" data-my-id="{{value}}">abc</a>';
       const template = new AmpMustache(templateElement);
       template.compileCallback();
       const result = template.render({
         value: 'myid',
         invalidValue: /*eslint no-script-url: 0*/ 'javascript:alert();',
       });
-      expect(result./*OK*/innerHTML).to.equal('value = <a data-my-id="myid">abc</a>');
+      expect(result./*OK*/innerHTML).to.equal(
+          'value = <a data-my-id="myid">abc</a>');
     });
   });
 

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -102,6 +102,10 @@ const WHITELISTED_ATTRS = [
 ];
 
 
+/** @const {!RegExp} */
+const WHITELISTED_ATTR_PREFIX_REGEX = /^data-/i;
+
+
 /** @const {!Array<string>} */
 const BLACKLISTED_ATTR_VALUES = [
   /*eslint no-script-url: 0*/ 'javascript:',
@@ -156,6 +160,8 @@ export function sanitizeHtml(html) {
           // for, such as "on".
           for (let i = 0; i < attribs.length; i += 2) {
             if (WHITELISTED_ATTRS.indexOf(attribs[i]) != -1) {
+              attribs[i + 1] = savedAttribs[i + 1];
+            } else if (attribs[i].search(WHITELISTED_ATTR_PREFIX_REGEX) == 0) {
               attribs[i + 1] = savedAttribs[i + 1];
             }
           }


### PR DESCRIPTION
Fixes #5281 