### PR TITLE
Allow AMP access field names to be numeric.

### DIFF
--- a/extensions/amp-access/0.1/access-expr-impl.jison
+++ b/extensions/amp-access/0.1/access-expr-impl.jison
@@ -156,6 +156,8 @@ field_ref:
 field_name:
     NAME
       {$$ = yytext;}
+  | NUMERIC
+      {$$ = yytext;}
   ;
 
 /**

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -200,6 +200,7 @@ describe('evaluateAccessExpr', () => {
         str: 'A',
         num: 11,
         bool: true,
+        12: true,
       },
     };
 
@@ -214,11 +215,13 @@ describe('evaluateAccessExpr', () => {
     expect(evaluateAccessExpr('obj.str', resp)).to.be.true;
     expect(evaluateAccessExpr('obj.num', resp)).to.be.true;
     expect(evaluateAccessExpr('obj.other', resp)).to.be.false;
+    expect(evaluateAccessExpr('obj.12', resp)).to.be.true;
 
     expect(evaluateAccessExpr('NOT obj.bool', resp)).to.be.false;
     expect(evaluateAccessExpr('NOT obj.str', resp)).to.be.false;
     expect(evaluateAccessExpr('NOT obj.num', resp)).to.be.false;
     expect(evaluateAccessExpr('NOT obj.other', resp)).to.be.true;
+    expect(evaluateAccessExpr('NOT obj.12', resp)).to.be.false;
   });
 
   it('should shortcircuit nested expressions with missing parent', () => {


### PR DESCRIPTION
Field names in JSON responses should be allowed to be numberic. For instance, if I have "tiers" of subscription levels - I may have a response similar to:

``` json
{
    "username": "myUser",
    "subscriptions": {
        "1": true,
        "2": true,
        "3": false,
        "4": true
    }
}
```

As a user, I would expect this to have worked with something like this:

``` html
<section amp-access="username AND subscriptions.2"></section>
```

However, it fails because `2` is a _NUMERIC_ token and a _NAME_ was expected. I think that this pull request may solve the problem, but I'm not sure how to compile the jison file. I think there is still an issue here that has yet to be finished to explain how the jison file works, but it seems to not have been implemented yet: https://github.com/ampproject/amphtml/issues/1347

I think that bugs don't count as new features in as per the [CONTRIBUTING](https://github.com/ampproject/amphtml/blob/1769fd0a7ea6645739b7cafa4e050380804b5750/CONTRIBUTING.md) file, but if anyone considers this a feature instead of a bug then I can add an issue along with this pull request.

Let me know if I'm missing anything, and thanks!!! :)
