### PR TITLE
Fix amp-sidebar local navigation and history

### DIFF
--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -364,7 +364,7 @@
         throw new Error('Only one step push allowed');
       }
       this.stackIndex_ = stackIndex;
-      window.history.pushState({}, '');
+      window.history.pushState({stackIndex: stackIndex}, '');
       return Promise.resolve();
     };
 
@@ -381,10 +381,22 @@
     };
 
 
-    Viewer.prototype.onPopState_ = function() {
-      // Even more trivial. Always assumes that only one step was popped in
-      // history.
-      this.stackIndex_--;
+    Viewer.prototype.onPopState_ = function(e) {
+      if (this.visibilityState_ != 'visible') {
+        return;
+      }
+      console.log('popping: ', e.state);
+      var poppedIndex = e.state && e.state.stackIndex;
+
+      if (poppedIndex <= this.stackIndex_) {
+        // Going Back in history.
+        // Even more trivial. Always assumes that only one step was popped in
+        // history.
+        this.stackIndex_--;
+      } else {
+        // Going Forward in history.
+        this.stackIndex_++;
+      }
       this.sendRequest_('historyPopped', {
         newStackIndex: this.stackIndex_
       }, false);

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -364,7 +364,7 @@
         throw new Error('Only one step push allowed');
       }
       this.stackIndex_ = stackIndex;
-      window.history.pushState({stackIndex: stackIndex}, '');
+      window.history.pushState({}, '');
       return Promise.resolve();
     };
 
@@ -385,18 +385,9 @@
       if (this.visibilityState_ != 'visible') {
         return;
       }
-      console.log('popping: ', e.state);
-      var poppedIndex = e.state && e.state.stackIndex;
-
-      if (poppedIndex <= this.stackIndex_) {
-        // Going Back in history.
-        // Even more trivial. Always assumes that only one step was popped in
-        // history.
-        this.stackIndex_--;
-      } else {
-        // Going Forward in history.
-        this.stackIndex_++;
-      }
+      // Even more trivial. Always assumes that only one step was popped in
+      // history.
+      this.stackIndex_--;
       this.sendRequest_('historyPopped', {
         newStackIndex: this.stackIndex_
       }, false);

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -24,7 +24,6 @@ import {platformFor} from '../../../src/platform';
 import {setStyles, toggle} from '../../../src/style';
 import {vsyncFor} from '../../../src/vsync';
 import {timerFor} from '../../../src/timer';
-import {installGlobalClickListenerForDoc} from '../../../src/document-click';
 
 /** @const */
 const ANIMATION_TIMEOUT = 550;
@@ -111,16 +110,14 @@ export class AmpSidebar extends AMP.BaseElement {
     screenReaderCloseButton.classList.add('-amp-screen-reader');
     // This is for screen-readers only, should not get a tab stop.
     screenReaderCloseButton.tabIndex = -1;
-    screenReaderCloseButton.addEventListener('click', () => {
-      this.close_();
-    });
+    screenReaderCloseButton.addEventListener('click', () => this.close_());
     this.element.appendChild(screenReaderCloseButton);
 
     this.registerAction('toggle', this.toggle_.bind(this));
     this.registerAction('open', this.open_.bind(this));
     this.registerAction('close', this.close_.bind(this));
 
-    installGlobalClickListenerForDoc(this.getAmpDoc()).addBeforeHandler(e => {
+    this.element.addEventListener('click', e => {
       const target = closestByTag(dev().assertElement(e.target), 'A');
       if (!target) {
         return;
@@ -189,9 +186,7 @@ export class AmpSidebar extends AMP.BaseElement {
         }, ANIMATION_TIMEOUT);
       });
     });
-    this.getHistory_().push(() => {
-      this.close_();
-    }).then(historyId => {
+    this.getHistory_().push(() => this.close_()).then(historyId => {
       this.historyId_ = historyId;
     });
   }
@@ -232,9 +227,7 @@ export class AmpSidebar extends AMP.BaseElement {
     if (!this.maskElement_) {
       const mask = this.document_.createElement('div');
       mask.classList.add('-amp-sidebar-mask');
-      mask.addEventListener('click', () => {
-        this.close_();
-      });
+      mask.addEventListener('click', () => this.close_());
       this.element.parentNode.appendChild(mask);
       mask.addEventListener('touchmove', e => {
         e.preventDefault();

--- a/src/document-click.js
+++ b/src/document-click.js
@@ -33,7 +33,7 @@ import {timerFor} from './timer';
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  */
 export function installGlobalClickListenerForDoc(ampdoc) {
-  return fromClassForDoc(ampdoc, 'clickhandler', ClickHandler);
+  fromClassForDoc(ampdoc, 'clickhandler', ClickHandler);
 }
 
 
@@ -69,9 +69,6 @@ export class ClickHandler {
       this.boundHandle_ = this.handle_.bind(this);
       this.ampdoc.getRootNode().addEventListener('click', this.boundHandle_);
     }
-
-    /** @private {!Array<!function(!Event)>} */
-    this.beforeHandlers_ = [];
   }
 
   /**
@@ -90,19 +87,8 @@ export class ClickHandler {
    * @param {!Event} e
    */
   handle_(e) {
-    for (let i = 0; i < this.beforeHandlers_.length; i++) {
-      this.beforeHandlers_[i](e);
-    }
     onDocumentElementClick_(
         e, this.ampdoc, this.viewport_, this.history_, this.isIosSafari_);
-  }
-
-  /**
-   * Adds a before-handler that gets called before doc-click main handler.
-   * @param {!function(!Event)} handler
-   */
-  addBeforeHandler(handler) {
-    this.beforeHandlers_.push(handler);
   }
 }
 

--- a/src/document-click.js
+++ b/src/document-click.js
@@ -217,11 +217,9 @@ export function onDocumentElementClick_(
   }
 
   if (tgtLoc.hash != curLoc.hash) {
-    timerFor(win).delay(() => {
     // Push/pop history.
-      history.push(() => {
-        win.location.replace(`${curLoc.hash || '#'}`);
-      });
-    }, 1000);
+    history.push(() => {
+      win.location.replace(`${curLoc.hash || '#'}`);
+    });
   }
 }

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -595,7 +595,7 @@ export class HistoryBindingVirtual_ {
     /** @private {!Promise} */
     this.awaitPoppingPromise_ = Promise.resolve();
 
-    /** @private {!function(*)) */
+    /** @private {?function(*)) */
     this.awaitPoppingPromiseResolver_ = null;
   }
 

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -573,8 +573,12 @@ export class HistoryBindingVirtual_ {
 
   /**
    * @param {!./viewer-impl.Viewer} viewer
+   * @param {!Window} win
    */
-  constructor(viewer) {
+  constructor(viewer, win) {
+    /** @private @const {!../service/timer-impl.Timer} */
+    this.timer_ = timerFor(win);
+
     /** @private @const */
     this.viewer_ = viewer;
 
@@ -587,6 +591,12 @@ export class HistoryBindingVirtual_ {
     /** @private {!UnlistenDef} */
     this.unlistenOnHistoryPopped_ = this.viewer_.onHistoryPoppedEvent(
         this.onHistoryPopped_.bind(this));
+
+    /** @private {!Promise} */
+    this.awaitPoppingPromise_ = Promise.resolve();
+
+    /** @private {!function(*)) */
+    this.awaitPoppingPromiseResolver_ = null;
   }
 
   /** @override */
@@ -601,14 +611,25 @@ export class HistoryBindingVirtual_ {
 
   /** @override */
   push() {
-    // Current implementation doesn't wait for response from viewer.
-    this.updateStackIndex_(this.stackIndex_ + 1);
-    this.viewer_.postPushHistory(this.stackIndex_);
-    return Promise.resolve(this.stackIndex_);
+    // Waiting for popping confirmation to happen otherwise a race condition
+    // between popping and pushing might happen causing history to be messed
+    // up. This will only wait 100ms to avoid getting stuck if confirmation
+    // never arrived.
+    return Promise.race([this.timer_.promise(100), this.awaitPoppingPromise_])
+        .then(() => {
+          // Current implementation doesn't wait for response from viewer.
+          this.updateStackIndex_(this.stackIndex_ + 1);
+          this.viewer_.postPushHistory(this.stackIndex_);
+          return Promise.resolve(this.stackIndex_);
+        });
   }
 
   /** @override */
   pop(stackIndex) {
+    this.awaitPoppingPromise_ = new Promise(resolve => {
+      this.awaitPoppingPromiseResolver_ = resolve;
+    });
+
     if (stackIndex > this.stackIndex_) {
       return Promise.resolve(this.stackIndex_);
     }
@@ -623,6 +644,10 @@ export class HistoryBindingVirtual_ {
    */
   onHistoryPopped_(event) {
     this.updateStackIndex_(event.newStackIndex);
+    if (this.awaitPoppingPromiseResolver_) {
+      this.awaitPoppingPromiseResolver_();
+      this.awaitPoppingPromiseResolver_ = null;
+    }
   }
 
   /**
@@ -652,7 +677,7 @@ function createHistory(ampdoc) {
   let binding;
   if (viewer.isOvertakeHistory() || getMode(ampdoc.win).test ||
           ampdoc.win.AMP_TEST_IFRAME) {
-    binding = new HistoryBindingVirtual_(viewer);
+    binding = new HistoryBindingVirtual_(viewer, ampdoc.win);
   } else {
     // Only one global "natural" binding is allowed since it works with the
     // global history stack.


### PR DESCRIPTION
Debugging and experimenting with amp-sidebar bug #4184

Try the [demo for this](http://amp-mk-2.herokuapp.com/examples/viewer.html). 
- On 2nd tab
- Open Sidebar
- Click Section 1 link
  - Notice it would close the tab and scroll correctly to the section.
- Scroll back up and open sidebar again
- Click Section 2 link
  - Notice it would close the tab and scroll correctly to the section.
- Scroll back up and open sidebar again
- Click Section 1 link
  - Notice it would close the tab and scroll correctly to the section.
- Hit Back button 
  - Notice it should scroll to Section 2.
- Hit Back button Again
  - Notice it should scroll to Section 1.
