### PR TITLE
Test flake intersection observer

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -57,6 +57,11 @@ var forbiddenTerms = {
   'sinon\\.useFake\\w+': {
     message: 'Use a sandbox instead to avoid repeated `#restore` calls'
   },
+  'sandbox\\.(spy|stub|mock)\\([^,\\s]*[iI]?frame[^,\\s]*,': {
+    message: 'Do NOT stub on a cross domain iframe! #5359\n' +
+        '  If this is same domain, mark /*OK*/.\n' +
+        '  If this is cross domain, overwrite the method directly.'
+  },
   'console\\.\\w+\\(': {
     message: 'If you run against this, use console/*OK*/.log to ' +
       'whitelist a legit case.',

--- a/extensions/amp-font/0.1/test/test-fontloader.js
+++ b/extensions/amp-font/0.1/test/test-fontloader.js
@@ -87,8 +87,8 @@ describe('FontLoader', () => {
       textEl.textContent =
           'Neque porro quisquam est qui dolorem ipsum quia dolor';
       iframe.doc.body.appendChild(textEl);
-      setupFontCheckSpy = sandbox.spy(iframe.doc.fonts, 'check');
-      setupFontLoadSpy = sandbox.spy(iframe.doc.fonts, 'load');
+      setupFontCheckSpy = sandbox./*OK*/spy(iframe.doc.fonts, 'check');
+      setupFontLoadSpy = sandbox./*OK*/spy(iframe.doc.fonts, 'load');
       fontloader = new FontLoader(iframe.win);
       return Promise.resolve(iframe);
     });

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -470,7 +470,7 @@ describe('amp-iframe', () => {
 
   it('should listen for embed-ready event', () => {
     const activateIframeSpy_ =
-        sandbox.spy(AmpIframe.prototype, 'activateIframe_');
+        sandbox./*OK*/spy(AmpIframe.prototype, 'activateIframe_');
     return getAmpIframe({
       src: clickableIframeSrc,
       sandbox: 'allow-scripts allow-same-origin',

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -40,7 +40,7 @@ describe('amp-social-share', () => {
 
   function getShare(type, opt_endpoint, opt_params) {
     return getCustomShare(iframe => {
-      sandbox.stub(iframe.win, 'open').returns(true);
+      sandbox./*OK*/stub(iframe.win, 'open').returns(true);
       const share = iframe.doc.createElement('amp-social-share');
       share.addEventListener = sandbox.spy();
       if (opt_endpoint) {

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -416,10 +416,10 @@ describe('IntersectionObserver', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
     insert(testIframe);
-    sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
+    testIframe.contentWindow.postMessage = message => {
       // Copy because arg is modified in place.
       messages.push(JSON.parse(JSON.stringify(message)));
-    });
+    };
     clock.tick(33);
     ioInstance.postMessageApi_.clientWindows_ =
         [{win: testIframe.contentWindow, origin: '*'}];
@@ -435,10 +435,10 @@ describe('IntersectionObserver', () => {
     const messages = [];
     const ioInstance = new IntersectionObserver(element, testIframe);
     insert(testIframe);
-    sandbox.stub(testIframe.contentWindow, 'postMessage', message => {
+    testIframe.contentWindow.postMessage = message => {
       // Copy because arg is modified in place.
       messages.push(JSON.parse(JSON.stringify(message)));
-    });
+    };
     ioInstance.postMessageApi_.clientWindows_ =
         [{win: testIframe.contentWindow, origin: '*'}];
     ioInstance.startSendingIntersectionChanges_();


### PR DESCRIPTION
Stubbing on a cross-domain iframe causes errors, but we only notice them if the tests are running slowly.

The fix is to directly modify the iframe's window, not stub. Stubs are unnecessary anyways, since the iframe is in a different `window`.

Fixes #5359.