### PR TITLE
Use #getLayoutBox in #getIntersectionElementLayoutBox

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -173,7 +173,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   measureIframeLayoutBox_() {
     if (this.iframe_) {
       const iframeBox = this.getViewport().getLayoutRect(this.iframe_);
-      const box = super.getIntersectionElementLayoutBox();
+      const box = this.getLayoutBox();
       this.iframeLayoutBox_ = moveLayoutRect(iframeBox, -box.left, -box.top);
     }
   }
@@ -182,10 +182,10 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    * @override
    */
   getIntersectionElementLayoutBox() {
-    const box = super.getIntersectionElementLayoutBox();
     if (!this.iframe_) {
-      return box;
+      return super.getIntersectionElementLayoutBox();
     }
+    const box = this.getLayoutBox();
     if (!this.iframeLayoutBox_) {
       this.measureIframeLayoutBox_();
     }

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -209,7 +209,7 @@ export class AmpIframe extends AMP.BaseElement {
   measureIframeLayoutBox_() {
     if (this.iframe_) {
       const iframeBox = this.getViewport().getLayoutRect(this.iframe_);
-      const box = super.getIntersectionElementLayoutBox();
+      const box = this.getLayoutBox();
       this.iframeLayoutBox_ = moveLayoutRect(iframeBox, -box.left, -box.top);
     }
   }
@@ -218,10 +218,10 @@ export class AmpIframe extends AMP.BaseElement {
    * @override
    */
   getIntersectionElementLayoutBox() {
-    const box = super.getIntersectionElementLayoutBox();
     if (!this.iframe_) {
-      return box;
+      return super.getIntersectionElementLayoutBox();
     }
+    const box = this.getLayoutBox();
     if (!this.iframeLayoutBox_) {
       this.measureIframeLayoutBox_();
     }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -168,6 +168,15 @@ export class BaseElement {
   }
 
   /**
+   * Returns a previously measured layout box of the element.
+   * @return {!./layout-rect.LayoutRectDef}
+   */
+  getLayoutBox() {
+    return this.element.getResources().getResourceForElement(
+        this.element).getLayoutBox();
+  }
+
+  /**
    * DO NOT CALL. Retained for backward compat during rollout.
    * @public @return {!Window}
    */
@@ -629,12 +638,12 @@ export class BaseElement {
   }
 
   /**
-   * Returns a previously measured layout box of the element.
+   * Returns the layout rectangle of the element used for reporting this
+   * element's intersection with the viewport.
    * @return {!./layout-rect.LayoutRectDef}
    */
   getIntersectionElementLayoutBox() {
-    return this.element.getResources().getResourceForElement(
-        this.element).getLayoutBox();
+    return this.getLayoutBox();
   }
 
   /**


### PR DESCRIPTION
This avoid a very confusing call cycle for `<amp-ad>`, where `#getIntersectionElementLayoutBox` may call `super#getIntersectionElementLayoutBox` as a shorthand for getting the element's `layoutBox`.