### PR TITLE
Add a newInstance method for creating a validator instance,

### DIFF
--- a/validator/nodejs/index.js
+++ b/validator/nodejs/index.js
@@ -291,6 +291,12 @@ Validator.prototype.validateString = function(inputString, htmlFormat) {
 var instanceByValidatorJs = {};
 
 /**
+ * Provided a URL or a filename from which to fetch the validator.js
+ * file, fetches, instantiates, and caches the validator instance
+ * asynchronously.  If you prefer to implement your own fetching /
+ * caching logic, you may want to consider createInstance() instead,
+ * which is synchronous and much simpler.
+ *
  * @param {string=} opt_validatorJs
  * @param {string=} opt_userAgent
  * @returns {!Promise<Validator>}
@@ -299,8 +305,7 @@ var instanceByValidatorJs = {};
 function getInstance(opt_validatorJs, opt_userAgent) {
   var validatorJs =
       opt_validatorJs || 'https://cdn.ampproject.org/v0/validator.js';
-  var userAgent =
-      opt_userAgent || DEFAULT_USER_AGENT;
+  var userAgent = opt_userAgent || DEFAULT_USER_AGENT;
   if (instanceByValidatorJs.hasOwnProperty(validatorJs)) {
     return Promise.resolve(instanceByValidatorJs[validatorJs]);
   }
@@ -323,6 +328,23 @@ function getInstance(opt_validatorJs, opt_userAgent) {
   });
 }
 exports.getInstance = getInstance;
+
+/**
+ * Provided the contents of the validator.js file, e.g. as downloaded from
+ * 'https://cdn.ampproject.org/v0/validator.js', returns a new validator
+ * instance. The tradeoff between this function and getInstance() is that this
+ * function is synchronous but requires the contents of the validator.js
+ * file as a parameter, while getInstance is asynchronous, fetches files
+ * from disk or the web, and caches them.
+ *
+ * @param {string} validatorJsContents
+ * @returns {!Validator}
+ * @export
+ */
+function newInstance(validatorJsContents) {
+  return new Validator(validatorJsContents);
+}
+exports.newInstance = newInstance;
 
 /**
  * Logs a validation result to the console using console.log, console.warn,

--- a/validator/nodejs/index_test.js
+++ b/validator/nodejs/index_test.js
@@ -141,7 +141,7 @@ it('handles syntax errors in validator file', function(done) {
 });
 
 it('also works with newInstance', function() {
-  var mini = fs.readFileSync(0
+  var mini = fs.readFileSync(
       '../testdata/feature_tests/minimum_valid_amp.html', 'utf-8');
   var validatorJsContents =
       fs.readFileSync('../dist/validator_minified.js', 'utf-8');

--- a/validator/nodejs/index_test.js
+++ b/validator/nodejs/index_test.js
@@ -140,6 +140,22 @@ it('handles syntax errors in validator file', function(done) {
       });
 });
 
+it('also works with newInstance', function() {
+  var mini = fs.readFileSync(0
+      '../testdata/feature_tests/minimum_valid_amp.html', 'utf-8');
+  var validatorJsContents =
+      fs.readFileSync('../dist/validator_minified.js', 'utf-8');
+  var resultForMini =
+      ampValidator.newInstance(validatorJsContents).validateString(mini);
+  expect(resultForMini.status).toBe('PASS');
+
+  var severalErrorsHtml =
+      fs.readFileSync('../testdata/feature_tests/several_errors.html', 'utf-8');
+  var resultForSeveralErrors = ampValidator.newInstance(validatorJsContents)
+                                   .validateString(severalErrorsHtml);
+  expect(resultForSeveralErrors.status).toBe('FAIL');
+});
+
 it('emits text if --format=text is specified on command line', function(done) {
   var severalErrorsOut =
       fs.readFileSync('../testdata/feature_tests/several_errors.out', 'utf-8')


### PR DESCRIPTION
which is synchronous and much simpler than the existing getInstance method
(it's just a constructor call thus far).