### PR TITLE
RFC: Separate the load phase of AMP into multiple chunks.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -460,6 +460,14 @@ var forbiddenTerms = {
       'dist.3p/current/integration.js',  // Includes the previous.
     ],
   },
+  'chunk\\(': {
+    message: 'chunk( should only be used during startup',
+    whitelist: [
+      'src/amp.js',
+      'src/chunk.js',
+      'src/runtime.js',
+    ],
+  },
 };
 
 var ThreePTermsMessage = 'The 3p bootstrap iframe has no polyfills loaded and' +

--- a/src/amp-shadow.js
+++ b/src/amp-shadow.js
@@ -27,8 +27,12 @@ import {
   installBuiltins,
   installRuntimeServices,
 } from './runtime';
+import {deactivateChunking} from './chunk';
 import {stubElements} from './custom-element';
 
+// This feature doesn't make sense in shadow mode as it only applies to
+// background rendered iframes;
+deactivateChunking();
 
 // Declare that this runtime will support multiple shadow-root docs.
 installDocService(self, /* isSingleDoc */ false);

--- a/src/amp.js
+++ b/src/amp.js
@@ -19,6 +19,7 @@
  */
 
 import './polyfills';
+import {chunk} from './chunk';
 import {installPerformanceService} from './service/performance-impl';
 import {installPullToRefreshBlocker} from './pull-to-refresh';
 import {installGlobalClickListenerForDoc} from './document-click';
@@ -37,6 +38,8 @@ import {cssText} from '../build/css';
 import {maybeValidate} from './validator-integration';
 import {maybeTrackImpression} from './impression';
 
+/** @type {!./service/ampdoc-impl.AmpDocService} */
+let ampdocService;
 // We must under all circumstances call makeBodyVisible.
 // It is much better to have AMP tags not rendered than having
 // a completely blank page.
@@ -46,50 +49,58 @@ try {
 
   // Declare that this runtime will support a single root doc. Should happen
   // as early as possible.
-  /** @const {!./service/ampdoc-impl.AmpDocService} */
-  const ampdocService = installDocService(self, /* isSingleDoc */ true);
+  ampdocService = installDocService(self, /* isSingleDoc */ true);
+} catch (e) {
+  // In case of an error call this.
+  makeBodyVisible(self.document);
+  throw e;
+}
+chunk(self.document, function initial() {
   /** @const {!./service/ampdoc-impl.AmpDoc} */
   const ampdoc = ampdocService.getAmpDoc(self.document);
   /** @const {!./service/performance-impl.Performance} */
   const perf = installPerformanceService(self);
   perf.tick('is');
   installStyles(self.document, cssText, () => {
-    try {
+    chunk(self.document, function services() {
       // Core services.
       installRuntimeServices(self);
       installAmpdocServices(ampdoc);
       // We need the core services (viewer/resources) to start instrumenting
       perf.coreServicesAvailable();
       maybeTrackImpression(self);
-
+    });
+    chunk(self.document, function builtins() {
       // Builtins.
       installBuiltins(self);
+    });
+    chunk(self.document, function adoptWindow() {
+      try {
+        adopt(self);
+      } finally {
+        // Everything from here is nested because adopt itself
+        // may add additional chunks that should run first.
+        chunk(self.document, function stub() {
+          stubElements(self);
+        });
+        chunk(self.document, function final() {
+          installPullToRefreshBlocker(self);
+          installGlobalClickListenerForDoc(ampdoc);
 
-      // Final configuration and stubbing.
-      adopt(self);
-      stubElements(self);
-
-      installPullToRefreshBlocker(self);
-      installGlobalClickListenerForDoc(ampdoc);
-
-      maybeValidate(self);
-      makeBodyVisible(self.document, /* waitForServices */ true);
-      installCacheServiceWorker(self);
-    } catch (e) {
-      makeBodyVisible(self.document);
-      throw e;
-    } finally {
-      perf.tick('e_is');
-      // TODO(erwinm): move invocation of the `flush` method when we have the
-      // new ticks in place to batch the ticks properly.
-      perf.flush();
-    }
+          maybeValidate(self);
+          makeBodyVisible(self.document, /* waitForServices */ true);
+          installCacheServiceWorker(self);
+        });
+        chunk(self.document, function finalTick() {
+          perf.tick('e_is');
+          // TODO(erwinm): move invocation of the `flush` method when we have the
+          // new ticks in place to batch the ticks properly.
+          perf.flush();
+        });
+      }
+    });
   }, /* opt_isRuntimeCss */ true, /* opt_ext */ 'amp-runtime');
-} catch (e) {
-  // In case of an error call this.
-  makeBodyVisible(self.document);
-  throw e;
-}
+});
 
 // Output a message to the console and add an attribute to the <html>
 // tag to give some information that can be used in error reports.

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {dev} from './log';
+import {fromClassForDoc} from './service';
+import {isExperimentOn} from './experiments';
+import {makeBodyVisible} from './style-installer';
+import {viewerPromiseForDoc} from './viewer';
+
+/**
+ * @const {boolean}
+ */
+const shouldNotUseMacroTask = /nochunking/.test(self.location.href);
+
+/**
+ * @const {!Promise}
+ */
+const resolved = Promise.resolve();
+
+/**
+ * Run the given function. For visible documents the function will be
+ * called in a micro task (Essentially ASAP). If the document is
+ * not visible, tasks will yield to the event loop (to give the browser
+ * time to do other things) and may even be further delayed until
+ * there is time.
+ *
+ * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrAmpDoc
+ * @param {function()} fn Function that will be called as a "chunk".
+ */
+export function chunk(nodeOrAmpDoc, fn) {
+  const service = fromClassForDoc(nodeOrAmpDoc, 'chunk', Chunk);
+  service.run_(fn);
+};
+
+
+class Chunk {
+  /**
+   * @param {!./service/ampdoc-impl.AmpDoc} ampDoc
+   */
+  constructor(ampDoc) {
+    /** @private @const */
+    this.ampDoc_ = ampDoc;
+    /** @private @const {!Window} */
+    this.win_ = ampDoc.win;
+    /** @private @const {!Array<function()>} */
+    this.tasks_ = [];
+    /** @private {?./service/viewer-impl.Viewer} */
+    this.viewer_ = null;
+    /** @private @const {function()} */
+    this.boundExecute_ = () => this.execute_();
+    /** @private @const {boolean} */
+    this.active_ = isExperimentOn(this.win_, 'chunked-amp')
+        && !shouldNotUseMacroTask;
+
+    if (!this.active_) {
+      return;
+    }
+    if (!this.win_.requestIdleCallback) {
+      this.win_.addEventListener('message', this.boundExecute_);
+    }
+    viewerPromiseForDoc(ampDoc).then(viewer => {
+      this.viewer_ = viewer;
+      viewer.onVisibilityChanged(() => {
+        if (viewer.isVisible()) {
+          this.execute_();
+        }
+      });
+      if (viewer.isVisible()) {
+        this.execute_();
+      }
+    });
+  }
+
+  /**
+   * Run fn as a "chunk". It'll run in a micro task when the doc is visible
+   * and otherwise run it after having yielded to the event queue once.
+   * @param {function()} fn
+   */
+  run_(fn) {
+    this.tasks_.push(fn);
+    this.schedule_();
+  }
+
+  /**
+   * Run a task.
+   * Schedule the next round if there are more tasks.
+   */
+  execute_() {
+    const t = this.tasks_.shift();
+    if (!t) {
+      return;
+    }
+    const before = Date.now();
+    try {
+      t();
+    } catch (e) {
+      // We run early in init. All errors should show the doc.
+      makeBodyVisible(self.document);
+      throw e;
+    } finally {
+      if (this.tasks_.length) {
+        this.schedule_();
+      }
+      dev().fine('chunk', t.displayName || t.name,
+          'Duration', Date.now() - before);
+    }
+  }
+
+  /**
+   * Schedule running a task.
+   */
+  schedule_() {
+    if (!this.active_ || this.isVisible_()) {
+      resolved.then(this.boundExecute_);
+      return;
+    }
+    // If requestIdleCallback exists, schedule a task with it, but
+    // do not wait longer than one second.
+    if (this.win_.requestIdleCallback) {
+      this.win_.requestIdleCallback(this.boundExecute_, {
+        timeout: 1000,
+      });
+      return;
+    }
+    // The message doesn't actually matter.
+    this.win_.postMessage/*OK*/('amp-macro-task', '*');
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isVisible_() {
+    // Ask the viewer or try to infer whether we are visible.
+    return this.viewer_
+        ? this.viewer_.isVisible()
+        : !(/visibilityState=hidden/.test(this.win_.location.hash));
+  }
+}
+
+/**
+ * @return {!Promise}
+ */
+export function resolvedObjectforTesting() {
+  return resolved;
+}

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -197,7 +197,8 @@ class Chunks {
       return false;
     }
     // Viewers send a URL param if we are not visible.
-    return !(/visibilityState=(hidden|prerender)/.test(this.win_.location.hash));
+    return !(/visibilityState=(hidden|prerender)/.test(
+        this.win_.location.hash));
   }
 }
 

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -197,7 +197,7 @@ class Chunks {
       return false;
     }
     // Viewers send a URL param if we are not visible.
-    return !(/visibilityState=prerender/.test(this.win_.location.hash));
+    return !(/visibilityState=hidden/.test(this.win_.location.hash));
   }
 }
 

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -197,7 +197,7 @@ class Chunks {
       return false;
     }
     // Viewers send a URL param if we are not visible.
-    return !(/visibilityState=hidden/.test(this.win_.location.hash));
+    return !(/visibilityState=(hidden|prerender)/.test(this.win_.location.hash));
   }
 }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -27,6 +27,7 @@ import {
   registerExtension,
 } from './service/extensions-impl';
 import {ampdocServiceFor} from './ampdoc';
+import {chunk} from './chunk';
 import {cssText} from '../build/css';
 import {dev, user, initLogConstructor} from './log';
 import {
@@ -246,9 +247,14 @@ function adoptShared(global, opts, callback) {
    */
   function installExtension(fnOrStruct) {
     if (typeof fnOrStruct == 'function') {
+      // @dvoytenko: CAN WE DELETE THIS?
       fnOrStruct(global.AMP);
     } else {
-      registerExtension(extensions, fnOrStruct.n, fnOrStruct.f, global.AMP);
+      const register = function() {
+        registerExtension(extensions, fnOrStruct.n, fnOrStruct.f, global.AMP);
+      };
+      register.displayName = fnOrStruct.n;
+      chunk(global.document, register);
     }
   }
 
@@ -268,9 +274,14 @@ function adoptShared(global, opts, callback) {
    */
   global.AMP.push = function(fnOrStruct) {
     // Extensions are only processed once HEAD is complete.
-    waitForBody(global.document, () => {
-      installExtension(fnOrStruct);
-    });
+    const register = function() {
+      waitForBody(global.document, () => {
+        installExtension(fnOrStruct);
+      });
+    };
+    register.displayName = fnOrStruct.n;
+    chunk(global.document, register);
+
   };
 
   // Execute asynchronously scheduled elements.

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -247,8 +247,8 @@ function adoptShared(global, opts, callback) {
    */
   function installExtension(fnOrStruct) {
     if (typeof fnOrStruct == 'function') {
-      // @dvoytenko: CAN WE DELETE THIS?
-      fnOrStruct(global.AMP);
+      const fn = fnOrStruct;
+      chunk(global.document, () => fn(global.AMP));
     } else {
       const register = function() {
         registerExtension(extensions, fnOrStruct.n, fnOrStruct.f, global.AMP);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -281,7 +281,6 @@ function adoptShared(global, opts, callback) {
     };
     register.displayName = fnOrStruct.n;
     chunk(global.document, register);
-
   };
 
   // Execute asynchronously scheduled elements.

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -23,6 +23,7 @@ import {
   installAmpdocServices,
   installRuntimeServices,
 } from '../src/runtime';
+import {activateChunkingForTesting} from '../src/chunk';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {platformFor} from '../src/platform';
 import {setDefaultBootstrapBaseUrlForTesting} from '../src/3p-frame';
@@ -153,6 +154,7 @@ sinon.sandbox.create = function(config) {
 beforeEach(beforeTest);
 
 function beforeTest() {
+  activateChunkingForTesting();
   window.AMP_MODE = null;
   window.AMP_CONFIG = {
     canary: 'testSentinel',

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {chunk, resolvedObjectforTesting} from '../../src/chunk';
+import {installDocService} from '../../src/service/ampdoc-impl';
+import {toggleExperiment} from '../../src/experiments';
+import {viewerForDoc} from '../../src/viewer';
+
+
+describe('chunk', () => {
+
+  let resolved;
+  let experimentOn;
+  beforeEach(() => {
+    resolved = resolvedObjectforTesting();
+    experimentOn = true;
+  });
+
+  function basicTests(env) {
+    let fakeWin;
+
+    beforeEach(() => {
+      toggleExperiment(env.win, 'chunked-amp', experimentOn);
+      fakeWin = env.win;
+    });
+
+    it('should execute a chunk', done => {
+      chunk(fakeWin.document, done);
+    });
+
+    it('should execute chunks', done => {
+      let count = 0;
+      let progress = '';
+      function complete(str) {
+        return function() {
+          progress += str;
+          if (++count == 6) {
+            expect(progress).to.equal('abcdef');
+            done();
+          }
+        };
+      }
+      chunk(fakeWin.document, complete('a'));
+      chunk(fakeWin.document, complete('b'));
+      chunk(fakeWin.document, function() {
+        complete('c')();
+        chunk(fakeWin.document, function() {
+          complete('d')();
+          chunk(fakeWin.document, complete('e'));
+          chunk(fakeWin.document, complete('f'));
+        });
+      });
+    });
+  }
+
+  describes.fakeWin('no amp', {
+    amp: false,
+  }, env => {
+
+    beforeEach(() => {
+      installDocService(env.win, true);
+      expect(env.win.services.viewer).to.be.undefined;
+    });
+
+    basicTests(env);
+  });
+
+  describes.fakeWin('with viewer', {
+    amp: true,
+  }, env => {
+
+    beforeEach(() => {
+      expect(env.win.services.viewer).to.not.be.undefined;
+    });
+
+    describe('visible', () => {
+      beforeEach(() => {
+        const viewer = viewerForDoc(env.win.document);
+        env.sandbox.stub(viewer, 'isVisible', () => {
+          return true;
+        });
+      });
+      basicTests(env);
+    });
+
+    describe('invisible experiment off', () => {
+      beforeEach(() => {
+        experimentOn = false;
+        const viewer = viewerForDoc(env.win.document);
+        env.sandbox.stub(viewer, 'isVisible', () => {
+          throw new Error('No calls expected: isVisible');
+        });
+        env.win.requestIdleCallback = () => {
+          throw new Error('No calls expected: requestIdleCallback');
+        };
+        env.win.location.setForTesting('test#visibilityState=hidden');
+      });
+
+      basicTests(env);
+    });
+
+    describe('invisible', () => {
+      beforeEach(() => {
+        const viewer = viewerForDoc(env.win.document);
+        env.sandbox.stub(viewer, 'isVisible', () => {
+          return false;
+        });
+        env.win.requestIdleCallback = fn => {
+          Promise.resolve().then(fn);
+        };
+        env.sandbox.stub(resolved, 'then', () => {
+          throw new Error('No calls expected');
+        });
+        env.win.location.setForTesting('test#visibilityState=hidden');
+      });
+
+      basicTests(env);
+    });
+
+    describe('invisible to visible', () => {
+      beforeEach(() => {
+        env.win.location.setForTesting('test#visibilityState=hidden');
+        const viewer = viewerForDoc(env.win.document);
+        let visible = false;
+        env.sandbox.stub(viewer, 'isVisible', () => {
+          return visible;
+        });
+        env.win.requestIdleCallback = () => {
+          // Don't call the callback, but transition to visible
+          visible = true;
+          viewer.onVisibilityChange_();
+        };
+      });
+
+      basicTests(env);
+    });
+
+    describe('invisible to visible after a while', () => {
+      beforeEach(() => {
+        env.win.location.setForTesting('test#visibilityState=hidden');
+        const viewer = viewerForDoc(env.win.document);
+        let visible = false;
+        env.sandbox.stub(viewer, 'isVisible', () => {
+          return visible;
+        });
+        env.win.requestIdleCallback = () => {
+          // Don't call the callback, but transition to visible
+          setTimeout(() => {
+            visible = true;
+            viewer.onVisibilityChange_();
+          }, 10);
+        };
+      });
+
+      basicTests(env);
+    });
+  });
+
+  describes.realWin('realWin', {
+    amp: true,
+  }, env => {
+    basicTests(env);
+  });
+
+  describes.realWin('realWin noIdleCallback', {
+    amp: true,
+  }, env => {
+    beforeEach(() => {
+      env.win.requestIdleCallback = null;
+      expect(env.win.requestIdleCallback).to.be.null;
+      const viewer = viewerForDoc(env.win.document);
+      env.sandbox.stub(viewer, 'isVisible', () => {
+        return false;
+      });
+    });
+    basicTests(env);
+  });
+});

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -119,7 +119,7 @@ describe('chunk', () => {
         env.win.requestIdleCallback = () => {
           throw new Error('No calls expected: requestIdleCallback');
         };
-        env.win.location.resetHref('test#visibilityState=prerender');
+        env.win.location.resetHref('test#visibilityState=hidden');
       });
 
       basicTests(env);
@@ -137,7 +137,7 @@ describe('chunk', () => {
         env.sandbox.stub(resolved, 'then', () => {
           throw new Error('No calls expected');
         });
-        env.win.location.resetHref('test#visibilityState=prerender');
+        env.win.location.resetHref('test#visibilityState=hidden');
       });
 
       basicTests(env);
@@ -153,7 +153,7 @@ describe('chunk', () => {
         env.win.requestIdleCallback = () => {
           throw new Error('No calls expected');
         };
-        env.win.location.resetHref('test#visibilityState=prerender');
+        env.win.location.resetHref('test#visibilityState=hidden');
       });
 
       basicTests(env);
@@ -181,7 +181,7 @@ describe('chunk', () => {
 
     describe('invisible to visible', () => {
       beforeEach(() => {
-        env.win.location.resetHref('test#visibilityState=prerender');
+        env.win.location.resetHref('test#visibilityState=hidden');
         const viewer = viewerForDoc(env.win.document);
         let visible = false;
         env.sandbox.stub(viewer, 'isVisible', () => {
@@ -199,7 +199,7 @@ describe('chunk', () => {
 
     describe('invisible to visible after a while', () => {
       beforeEach(() => {
-        env.win.location.resetHref('test#visibilityState=prerender');
+        env.win.location.resetHref('test#visibilityState=hidden');
         const viewer = viewerForDoc(env.win.document);
         let visible = false;
         env.sandbox.stub(viewer, 'isVisible', () => {

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -197,6 +197,24 @@ describe('chunk', () => {
       basicTests(env);
     });
 
+    describe('invisible to visible', () => {
+      beforeEach(() => {
+        env.win.location.resetHref('test#visibilityState=prerender');
+        const viewer = viewerForDoc(env.win.document);
+        let visible = false;
+        env.sandbox.stub(viewer, 'isVisible', () => {
+          return visible;
+        });
+        env.win.requestIdleCallback = () => {
+          // Don't call the callback, but transition to visible
+          visible = true;
+          viewer.onVisibilityChange_();
+        };
+      });
+
+      basicTests(env);
+    });
+
     describe('invisible to visible after a while', () => {
       beforeEach(() => {
         env.win.location.resetHref('test#visibilityState=hidden');

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -17,7 +17,6 @@
 import {AmpDocShadow, AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {Observable} from '../../src/observable';
 import {adopt, adoptShadowMode} from '../../src/runtime';
-import {dev} from '../../src/log';
 import {
   getServiceForDoc,
   getServicePromise,

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -27,6 +27,7 @@ import {installPlatformService} from '../../src/service/platform-impl';
 import {parseUrl} from '../../src/url';
 import {platformFor} from '../../src/platform';
 import {runChunksForTesting} from '../../src/chunk';
+import {timerFor} from '../../src/timer';
 import * as ext from '../../src/service/extensions-impl';
 import * as extel from '../../src/extended-element';
 import * as styles from '../../src/style-installer';
@@ -34,7 +35,7 @@ import * as shadowembed from '../../src/shadow-embed';
 import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 
-describes.sandboxed.only('runtime', {}, env => {
+describes.sandboxed('runtime', {}, env => {
 
   let win;
   let sandbox;

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -17,6 +17,7 @@
 import {AmpDocShadow, AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {Observable} from '../../src/observable';
 import {adopt, adoptShadowMode} from '../../src/runtime';
+import {deactivateChunking} from '../../src/chunk';
 import {
   getServiceForDoc,
   getServicePromise,
@@ -33,8 +34,7 @@ import * as shadowembed from '../../src/shadow-embed';
 import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 
-
-describes.sandboxed.only('runtime', {}, () => {
+describes.sandboxed.only('runtime', {}, env => {
 
   let win;
   let sandbox;
@@ -42,6 +42,7 @@ describes.sandboxed.only('runtime', {}, () => {
   let ampdocServiceMock;
 
   beforeEach(() => {
+    sandbox = env.sandbox;
     ampdocService = {
       isSingleDoc: () => true,
       getAmpDoc: () => null,
@@ -559,6 +560,7 @@ describes.realWin('runtime multidoc', {
     let ampdoc;
 
     beforeEach(() => {
+      deactivateChunking();
       clock = sandbox.useFakeTimers();
       hostElement = win.document.createElement('div');
       importDoc = win.document.implementation.createHTMLDocument('');

--- a/test/manual/pre-render-load.html
+++ b/test/manual/pre-render-load.html
@@ -1,0 +1,1 @@
+<iframe src="/examples/article.amp.max.html#prerender=1&visibilityState=hidden&viewerorigin=http://localhost:8000"></iframe>>

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -30,7 +30,6 @@ import {
 import {cssText} from '../build/css';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {installExtensionsService} from '../src/service/extensions-impl';
-import {installStyles} from '../src/style-installer';
 import {resetScheduledElementForTesting} from '../src/custom-element';
 import * as sinon from 'sinon';
 
@@ -309,7 +308,6 @@ class RealWinFixture {
           '<style>.-amp-element {display: block;}</style>' +
           '<body style="margin:0"><div id=parent></div>';
       iframe.onload = function() {
-        let completePromise;
         const win = iframe.contentWindow;
         env.win = win;
 
@@ -320,7 +318,7 @@ class RealWinFixture {
 
         // Install AMP CSS if requested.
         if (spec.ampCss) {
-          completePromise = installRuntimeStylesPromise(win);
+          installRuntimeStylesPromise(win);
         }
 
         if (spec.fakeRegisterElement) {
@@ -334,7 +332,7 @@ class RealWinFixture {
         interceptEventListeners(win.document.body);
         env.interceptEventListeners = interceptEventListeners;
 
-        resolve(completePromise);
+        resolve();
       };
       iframe.onerror = reject;
       document.body.appendChild(iframe);
@@ -416,14 +414,14 @@ class AmpFixture {
 
 /**
  * @param {!Window} win
- * @return {!Promise}
  */
 function installRuntimeStylesPromise(win) {
   if (win.document.querySelector('style[amp-runtime]')) {
     // Already installed.
-    return Promise.resolve();
+    return;
   }
-  return new Promise(resolve => {
-    installStyles(win.document, cssText, resolve);
-  });
+  const style = document.createElement('style');
+  style.setAttribute('amp-runtime', '');
+  style.textContent = cssText;
+  win.document.head.appendChild(style);
 }

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -365,6 +365,15 @@ class FakeLocation {
   reload(forceReload) {
     this.change_({reload: true, forceReload});
   }
+
+  /**
+   * Resets the URL without firing any events or triggering a history
+   * entry.
+   * @param {string} href
+   */
+  setForTesting(href) {
+    this.url_ = parseUrl(resolveRelativeUrl(href, this.url_));
+  }
 }
 
 

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -371,7 +371,7 @@ class FakeLocation {
    * entry.
    * @param {string} href
    */
-  setForTesting(href) {
+  resetHref(href) {
     this.url_ = parseUrl(resolveRelativeUrl(href, this.url_));
   }
 }

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -207,6 +207,11 @@ const EXPERIMENTS = [
     spec: '',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5639',
   },
+  {
+    id: 'chunked-amp',
+    name: 'Split AMP\'s loading phase into chunks',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5535',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
The general idea is that AMP can be instructed to not block the UI thread during load phase for long if the document itself is not visible.

The change may be quite impactful. It does split up work into neat chunks (about 10-20ms on desktop, longer on mobile) instead of one 400ms+ block. I validated that the number of style recalc doesn't change when the experiment is off.

- Current doesn't change `amp-shadow`. That will come in a follow up CL, but might not make as much sense.
- With the experiment not active the only thing this should change is that the initialization now goes through a bunch of micro tasks. This should behave as before in browsers with native promises.