### PR TITLE
Core Css class for visually invisible but screen-reader accessible elements

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -126,6 +126,20 @@ i-amp-sizer {
   /* TODO(dvoytenko): explore adding here object-fit. */
 }
 
+/* off-screen, hidden nodes that are invisible but read by screen-readers */
+.-amp-screen-reader {
+  position: fixed !important;
+  top: -1000px !important;
+  width: 0 !important;
+  height: 0 !important;
+  opacity: 0 !important;
+  border: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  display: block !important;
+  visibility: visible !important;
+}
+
 /* For author styling. */
 .amp-unresolved {
 }

--- a/css/amp.css
+++ b/css/amp.css
@@ -121,7 +121,6 @@ i-amp-sizer {
 }
 
 .-amp-replaced-content {
-
   padding: 0 !important;
   border: none !important;
   /* TODO(dvoytenko): explore adding here object-fit. */

--- a/css/amp.css
+++ b/css/amp.css
@@ -121,34 +121,39 @@ i-amp-sizer {
 }
 
 .-amp-replaced-content {
+
   padding: 0 !important;
   border: none !important;
   /* TODO(dvoytenko): explore adding here object-fit. */
 }
 
 /**
- * Makes nodes visually invisible but still accessible to screen-readers.
+ * Makes elements visually invisible but still accessible to screen-readers.
  *
- * This is a public class so page authors can use it for similiar a11y purposes
- * within their AMP documents on any element.
- *
- * This css has been carefully tested to ensure screen-readers can read and
+ * This Css has been carefully tested to ensure screen-readers can read and
  * activate (in case of links and buttons) the elements with this class. Please
  * use caution when changing anything, even seemingly safe ones. For example
  * changing width from 1 to 0 would prevent TalkBack from activating (clicking)
- * buttons despite TalkBack reading them just fine.
+ * buttons despite TalkBack reading them just fine. This is because
+ * element needs to have a defined size and be on viewport otherwise TalkBack
+ * does not allow activation of buttons.
  */
-.amp-screen-reader {
+.-amp-screen-reader {
   position: fixed !important;
+  /* keep it on viewport */
   top: 0px !important;
   left: 0px !important;
+  /* give it non-zero size */
   width: 1px !important;
   height: 1px !important;
+  /* visually hide it with overflow and opacity */
   opacity: 0 !important;
   overflow: hidden !important;
+  /* remove any margin or padding */
   border: none !important;
   margin: 0 !important;
   padding: 0 !important;
+  /* ensure no other style sets display to none */
   display: block !important;
   visibility: visible !important;
 }

--- a/css/amp.css
+++ b/css/amp.css
@@ -126,13 +126,26 @@ i-amp-sizer {
   /* TODO(dvoytenko): explore adding here object-fit. */
 }
 
-/* off-screen, hidden nodes that are invisible but read by screen-readers */
-.-amp-screen-reader {
+/**
+ * Makes nodes visually invisible but still accessible to screen-readers.
+ *
+ * This is a public class so page authors can use it for similiar a11y purposes
+ * within their AMP documents on any element.
+ *
+ * This css has been carefully tested to ensure screen-readers can read and
+ * activate (in case of links and buttons) the elements with this class. Please
+ * use caution when changing anything, even seemingly safe ones. For example
+ * changing width from 1 to 0 would prevent TalkBack from activating (clicking)
+ * buttons despite TalkBack reading them just fine.
+ */
+.amp-screen-reader {
   position: fixed !important;
-  top: -1000px !important;
-  width: 0 !important;
-  height: 0 !important;
+  top: 0px !important;
+  left: 0px !important;
+  width: 1px !important;
+  height: 1px !important;
   opacity: 0 !important;
+  overflow: hidden !important;
   border: none !important;
   margin: 0 !important;
   padding: 0 !important;

--- a/css/amp.css
+++ b/css/amp.css
@@ -143,9 +143,10 @@ i-amp-sizer {
   /* keep it on viewport */
   top: 0px !important;
   left: 0px !important;
-  /* give it non-zero size */
-  width: 1px !important;
-  height: 1px !important;
+  /* give it non-zero size, VoiceOver on Safari requires at least 2 pixels
+     before allowing buttons to be activated. */
+  width: 2px !important;
+  height: 2px !important;
   /* visually hide it with overflow and opacity */
   opacity: 0 !important;
   overflow: hidden !important;

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -44,7 +44,11 @@ describe('amp-fx-flying-carpet', () => {
       iframe = i;
       toggleExperiment(iframe.win, 'amp-fx-flying-carpet', true);
 
-      iframe.doc.body.style.height = '400vh';
+      const bodyResizer = iframe.doc.createElement('div');
+      bodyResizer.style.height = '400vh';
+      bodyResizer.style.width = '1px';
+      iframe.doc.body.appendChild(bodyResizer);
+
       iframe.doc.body.style.position = 'relative';
       viewport = viewportForDoc(iframe.win.document);
       viewport.resize_();

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -99,7 +99,17 @@ export class AmpSidebar extends AMP.BaseElement {
         this.close_();
       }
     });
-    //TODO (skrish, #2712) Add history support on back button.
+
+    // Invisible close button at the end of sidebar for screen-readers.
+    const screenReaderCloseButton = this.document_.createElement('button');
+    // TODO(aghassemi, #4146) i18n
+    screenReaderCloseButton.setAttribute('aria-label', 'Close the sidebar');
+    screenReaderCloseButton.classList.add('-amp-screen-reader');
+    screenReaderCloseButton.addEventListener('click', () => {
+      this.close_();
+    });
+    this.element.appendChild(screenReaderCloseButton);
+
     this.registerAction('toggle', this.toggle_.bind(this));
     this.registerAction('open', this.open_.bind(this));
     this.registerAction('close', this.close_.bind(this));

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -104,7 +104,7 @@ export class AmpSidebar extends AMP.BaseElement {
     const screenReaderCloseButton = this.document_.createElement('button');
     // TODO(aghassemi, #4146) i18n
     screenReaderCloseButton.textContent = 'Close the sidebar';
-    screenReaderCloseButton.classList.add('amp-screen-reader');
+    screenReaderCloseButton.classList.add('-amp-screen-reader');
     // This is for screen-readers only, should not get a tab stop.
     screenReaderCloseButton.tabIndex = -1;
     screenReaderCloseButton.addEventListener('click', () => {

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -103,8 +103,10 @@ export class AmpSidebar extends AMP.BaseElement {
     // Invisible close button at the end of sidebar for screen-readers.
     const screenReaderCloseButton = this.document_.createElement('button');
     // TODO(aghassemi, #4146) i18n
-    screenReaderCloseButton.setAttribute('aria-label', 'Close the sidebar');
-    screenReaderCloseButton.classList.add('-amp-screen-reader');
+    screenReaderCloseButton.textContent = 'Close the sidebar';
+    screenReaderCloseButton.classList.add('amp-screen-reader');
+    // This is for screen-readers only, should not get a tab stop.
+    screenReaderCloseButton.tabIndex = -1;
     screenReaderCloseButton.addEventListener('click', () => {
       this.close_();
     });

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -19,7 +19,7 @@ import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
 import {platformFor} from '../../../../src/platform';
 import {timerFor} from '../../../../src/timer';
-import {assertScreenReaderNode} from '../../../../testing/test-helper';
+import {assertScreenReaderElement} from '../../../../testing/test-helper';
 import * as sinon from 'sinon';
 import '../amp-sidebar';
 
@@ -106,7 +106,7 @@ describe('amp-sidebar', () => {
       const closeButton = sidebarElement.lastElementChild;
       expect(closeButton).to.exist;
       expect(closeButton.tagName).to.equal('BUTTON');
-      assertScreenReaderNode(closeButton);
+      assertScreenReaderElement(closeButton);
       expect(impl.close_.callCount).to.equal(0);
       closeButton.click();
       expect(impl.close_.callCount).to.equal(1);

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -19,6 +19,7 @@ import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
 import {platformFor} from '../../../../src/platform';
 import {timerFor} from '../../../../src/timer';
+import {assertScreenReaderNode} from '../../../../testing/test-helper';
 import * as sinon from 'sinon';
 import '../amp-sidebar';
 
@@ -94,6 +95,21 @@ describe('amp-sidebar', () => {
       impl.open_();
       expect(iframe.doc.querySelectorAll('.-amp-sidebar-mask').length)
           .to.equal(1);
+    });
+  });
+
+  it('should create an invisible close button for screen readers only', () => {
+    return getAmpSidebar().then(obj => {
+      const sidebarElement = obj.ampSidebar;
+      const impl = sidebarElement.implementation_;
+      impl.close_ = sandbox.spy();
+      const closeButton = sidebarElement.lastElementChild;
+      expect(closeButton).to.exist;
+      expect(closeButton.tagName).to.equal('BUTTON');
+      assertScreenReaderNode(closeButton);
+      expect(impl.close_.callCount).to.equal(0);
+      closeButton.click();
+      expect(impl.close_.callCount).to.equal(1);
     });
   });
 

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -48,8 +48,8 @@ export function assertScreenReaderElement(element) {
   expect(computedStyle.getPropertyValue('position')).to.equal('fixed');
   expect(computedStyle.getPropertyValue('top')).to.equal('0px');
   expect(computedStyle.getPropertyValue('left')).to.equal('0px');
-  expect(computedStyle.getPropertyValue('width')).to.equal('1px');
-  expect(computedStyle.getPropertyValue('height')).to.equal('1px');
+  expect(computedStyle.getPropertyValue('width')).to.equal('2px');
+  expect(computedStyle.getPropertyValue('height')).to.equal('2px');
   expect(computedStyle.getPropertyValue('opacity')).to.equal('0');
   expect(computedStyle.getPropertyValue('overflow')).to.equal('hidden');
   expect(computedStyle.getPropertyValue('border')).to.contain('none');

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -35,3 +35,35 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
   });
   return stub;
 }
+
+/**
+ * Asserts that the given element is only visible to screen readers.
+ * @param {!Element} node
+ */
+export function assertScreenReaderNode(element) {
+  expect(element).to.exist;
+  expect(element.classList.contains('-amp-screen-reader')).to.be.true;
+  const win = element.ownerDocument.defaultView;
+  const computedStyle = win.getComputedStyle(element);
+  expect(computedStyle.getPropertyValue('position')).to.equal('fixed');
+  expect(computedStyle.getPropertyValue('top')).to.equal('-1000px');
+  // We should not set left like other off-screen implementations out there,
+  // if we set left, RTL pages will overflow.
+  expect(computedStyle.getPropertyValue('left')).to.equal('0px');
+  expect(computedStyle.getPropertyValue('width')).to.equal('0px');
+  expect(computedStyle.getPropertyValue('height')).to.equal('0px');
+  expect(computedStyle.getPropertyValue('opacity')).to.equal('0');
+  // Display or visibility should never become none/hidden or screen readers
+  // won't read it anymore.
+  expect(computedStyle.getPropertyValue('display')).to.equal('block');
+  expect(computedStyle.getPropertyValue('visibility')).to.equal('visible');
+
+  expect(computedStyle.getPropertyValue('border')).to.contain('none');
+  expect(computedStyle.getPropertyValue('margin')).to.equal('0px');
+  expect(computedStyle.getPropertyValue('padding')).to.equal('0px');
+
+  expect(element.offsetWidth).to.equal(0);
+  expect(element.offsetHeight).to.equal(0);
+  expect(element.offsetTop).to.equal(-1000);
+  expect(element.offsetLeft).to.equal(0);
+}

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -42,7 +42,7 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
  */
 export function assertScreenReaderElement(element) {
   expect(element).to.exist;
-  expect(element.classList.contains('amp-screen-reader')).to.be.true;
+  expect(element.classList.contains('-amp-screen-reader')).to.be.true;
   const win = element.ownerDocument.defaultView;
   const computedStyle = win.getComputedStyle(element);
   expect(computedStyle.getPropertyValue('position')).to.equal('fixed');

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -40,30 +40,21 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
  * Asserts that the given element is only visible to screen readers.
  * @param {!Element} node
  */
-export function assertScreenReaderNode(element) {
+export function assertScreenReaderElement(element) {
   expect(element).to.exist;
-  expect(element.classList.contains('-amp-screen-reader')).to.be.true;
+  expect(element.classList.contains('amp-screen-reader')).to.be.true;
   const win = element.ownerDocument.defaultView;
   const computedStyle = win.getComputedStyle(element);
   expect(computedStyle.getPropertyValue('position')).to.equal('fixed');
-  expect(computedStyle.getPropertyValue('top')).to.equal('-1000px');
-  // We should not set left like other off-screen implementations out there,
-  // if we set left, RTL pages will overflow.
+  expect(computedStyle.getPropertyValue('top')).to.equal('0px');
   expect(computedStyle.getPropertyValue('left')).to.equal('0px');
-  expect(computedStyle.getPropertyValue('width')).to.equal('0px');
-  expect(computedStyle.getPropertyValue('height')).to.equal('0px');
+  expect(computedStyle.getPropertyValue('width')).to.equal('1px');
+  expect(computedStyle.getPropertyValue('height')).to.equal('1px');
   expect(computedStyle.getPropertyValue('opacity')).to.equal('0');
-  // Display or visibility should never become none/hidden or screen readers
-  // won't read it anymore.
-  expect(computedStyle.getPropertyValue('display')).to.equal('block');
-  expect(computedStyle.getPropertyValue('visibility')).to.equal('visible');
-
+  expect(computedStyle.getPropertyValue('overflow')).to.equal('hidden');
   expect(computedStyle.getPropertyValue('border')).to.contain('none');
   expect(computedStyle.getPropertyValue('margin')).to.equal('0px');
   expect(computedStyle.getPropertyValue('padding')).to.equal('0px');
-
-  expect(element.offsetWidth).to.equal(0);
-  expect(element.offsetHeight).to.equal(0);
-  expect(element.offsetTop).to.equal(-1000);
-  expect(element.offsetLeft).to.equal(0);
+  expect(computedStyle.getPropertyValue('display')).to.equal('block');
+  expect(computedStyle.getPropertyValue('visibility')).to.equal('visible');
 }


### PR DESCRIPTION
This PR introduced a new core Css class `amp-screen-reader` that can be used by us or page authors to visually hide elements but keep them accessible to screen-readers.

We use this new class in sidebar to fix https://github.com/ampproject/amphtml/issues/5517.

Also as part of this PR, we are now installing core styles in the testing iframe so that we can use computedStyles to ensure proper Css is being applied. 

/cc @camelburrito @dvoytenko 