### PR TITLE
Owned resources may render to left or right of viewport

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -460,10 +460,14 @@ export class Resource {
     const multipler = Math.max(renders, 0);
     let scrollPenalty = 1;
     let distance;
-    // If outside of viewport's x-axis, element is not in viewport.
     if (viewportBox.right < layoutBox.left ||
         viewportBox.left > layoutBox.right) {
-      return false;
+      // If outside of viewport's x-axis, element is not in viewport.
+      // The exception is for owned resources, since they only attempt to
+      // render outside viewport when the owner has explicitly allowed it.
+      if (!this.hasOwner()) {
+        return false;
+      }
     }
     if (viewportBox.bottom < layoutBox.top) {
       // Element is below viewport

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -1137,6 +1137,26 @@ describe('Resource renderOutsideViewport', () => {
         resources.lastVelocity_ = 2;
         expect(resource.renderOutsideViewport()).to.equal(false);
       });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling towards on y-axis', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away on y-axis', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
     });
 
     describe('when element is on the right of viewport', () => {
@@ -1156,6 +1176,26 @@ describe('Resource renderOutsideViewport', () => {
       it('should disallow rendering when scrolling away on y-axis', () => {
         resources.lastVelocity_ = 2;
         expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling towards on y-axis', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away on y-axis', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
       });
     });
 
@@ -1177,6 +1217,26 @@ describe('Resource renderOutsideViewport', () => {
         resources.lastVelocity_ = 2;
         expect(resource.renderOutsideViewport()).to.equal(true);
       });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling towards on y-axis', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away on y-axis', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
     });
 
     describe('when element is partially in viewport', () => {
@@ -1196,6 +1256,26 @@ describe('Resource renderOutsideViewport', () => {
       it('should allow rendering when scrolling away', () => {
         resources.lastVelocity_ = 2;
         expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling towards on y-axis', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away on y-axis', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
       });
     });
   });


### PR DESCRIPTION
This allows owned resources to render when outside the viewport on the
x-axis (only). This works because owned resources will never be
prerendered until the owner explicitly allows it. So, the owner knows
better than Resources does at this point.

Fixes #5549.