### PR TITLE
[DO NOT SUBMIT] Always use the global sinon instance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,6 +65,7 @@
     "no-iterator": 2,
     "no-lone-blocks": 2,
     "no-multi-spaces": 2,
+    "no-mocking-unowned": 2,
     "no-native-reassign": 2,
     "no-redeclare": 2,
     "no-script-url": 2,

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -25,7 +25,6 @@ import {installPlatformService} from '../../../../src/service/platform-impl';
 import {installViewerServiceForDoc} from '../../../../src/service/viewer-impl';
 import {resetServiceForTesting} from '../../../../src/service';
 import {documentStateFor} from '../../../../src/document-state';
-import * as sinon from 'sinon';
 
 const EXP_ID = 'EXP_ID';
 /** @type {!Branches} */

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -30,7 +30,6 @@ import {
     DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
     DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES,
 } from '../../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config';  // eslint-disable-line max-len
-import * as sinon from 'sinon';
 
 /**
  * Verify that `address` matches all of the patterns in `matchlist`.

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -30,7 +30,6 @@ import {
   resetExperimentToggles_,
 } from '../../../../src/experiments';
 import {dev} from '../../../../src/log';
-import * as sinon from 'sinon';
 
 /** @private @const Tag used in dev log messages */
 const TAG_ = 'test-amp-ad';

--- a/build-system/eslint-rules/no-mocking-unowned.js
+++ b/build-system/eslint-rules/no-mocking-unowned.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// var astUtils = require('eslint/lib/ast-utils');
+
+module.exports = function(context) {
+  return {
+    CallExpression(node) {
+      if (context.getFilename().indexOf('test') === -1) {
+        return;
+      }
+
+      var callee = node.callee;
+      if (callee.type !== 'MemberExpression') {
+        return;
+      }
+      if (callee.object.name !== 'sandbox') {
+        return;
+      }
+      if (callee.property.name !== 'mock') {
+        return;
+      }
+
+      if (node.arguments.length !== 1) {
+        return context.report(node, 'Whatcha doing here?');
+      }
+
+      var mock = node.arguments[0];
+      if (mock.type !== 'Identifier') {
+        return;
+      }
+      context.report(node, "Do not mock things you don't own.");
+    }
+  };
+};

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -478,6 +478,9 @@ var forbiddenTerms = {
       'src/runtime.js',
     ],
   },
+  'import [^\']* from \'sinon\'': {
+    message: 'The global sinon must be used',
+  }
 };
 
 var ThreePTermsMessage = 'The 3p bootstrap iframe has no polyfills loaded and' +

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -32,7 +32,6 @@ import {
     upgradeOrRegisterElement,
 } from '../../../../src/custom-element';
 import {utf8Encode} from '../../../../src/utils/bytes';
-import * as sinon from 'sinon';
 
 // Integration tests for A4A.  These stub out accesses to the outside world
 // (e.g., XHR requests and interfaces to ad network-specific code), but

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -34,7 +34,6 @@ import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
 import {utf8Encode} from '../../../../src/utils/bytes';
 import {resetScheduledElementForTesting} from '../../../../src/custom-element';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
-import * as sinon from 'sinon';
 
 /**
  * Create a promise for an iframe that has a super-minimal mock AMP environment

--- a/extensions/amp-access/0.1/test/test-amp-access-client.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-client.js
@@ -15,7 +15,6 @@
  */
 
 import {AccessClientAdapter} from '../amp-access-client';
-import * as sinon from 'sinon';
 import * as mode from '../../../../src/mode';
 
 describe('AccessClientAdapter', () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-other.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-other.js
@@ -15,7 +15,6 @@
  */
 
 import {AccessOtherAdapter} from '../amp-access-other';
-import * as sinon from 'sinon';
 
 describe('AccessOtherAdapter', () => {
 

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -18,7 +18,6 @@ import {AccessServerJwtAdapter} from '../amp-access-server-jwt';
 import {getMode} from '../../../../src/mode';
 import {removeFragment, serializeQueryString} from '../../../../src/url';
 import {isUserErrorMessage} from '../../../../src/log';
-import * as sinon from 'sinon';
 
 describe('AccessServerJwtAdapter', () => {
 

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -16,7 +16,6 @@
 
 import {AccessServerAdapter} from '../amp-access-server';
 import {removeFragment} from '../../../../src/url';
-import * as sinon from 'sinon';
 
 describe('AccessServerAdapter', () => {
 

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -31,7 +31,6 @@ import {installPerformanceService,} from
     '../../../../src/service/performance-impl';
 import {markElementScheduledForTesting} from '../../../../src/custom-element';
 import {toggleExperiment} from '../../../../src/experiments';
-import * as sinon from 'sinon';
 
 
 describe('AccessService', () => {

--- a/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
@@ -15,7 +15,6 @@
  */
 
 import {LoginDoneDialog, buildLangSelector} from '../amp-login-done-dialog';
-import * as sinon from 'sinon';
 
 
 describe('LoginDoneDialog', () => {

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -16,7 +16,6 @@
 
 import {JwtHelper} from '../jwt';
 import {pemToBytes} from '../../../../src/utils/pem';
-import * as sinon from 'sinon';
 
 
 describe('JwtHelper', () => {

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -19,7 +19,6 @@ import {
   openLoginDialog,
 } from '../login-dialog';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
-import * as sinon from 'sinon';
 
 const RETURN_URL_ESC = encodeURIComponent('http://localhost:8000/extensions' +
     '/amp-access/0.1/amp-login-done.html?url=' +

--- a/extensions/amp-access/0.1/test/test-signin.js
+++ b/extensions/amp-access/0.1/test/test-signin.js
@@ -17,7 +17,6 @@
 import {SignInProtocol} from '../signin';
 import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
-import * as sinon from 'sinon';
 
 
 describe('SignInProtocol', () => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -17,7 +17,6 @@
 import {AmpAdNetworkAdsenseImpl} from '../amp-ad-network-adsense-impl';
 import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
 import {utf8Encode} from '../../../../src/utils/bytes';
-import * as sinon from 'sinon';
 
 describe('amp-ad-network-adsense-impl', () => {
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -27,7 +27,6 @@ import {
 import {resetExperimentToggles_} from '../../../../src/experiments';
 import {parseUrl} from '../../../../src/url';
 import {createIframePromise} from '../../../../testing/iframe';
-import * as sinon from 'sinon';
 
 describe('doubleclick-a4a-config', () => {
   let sandbox;

--- a/extensions/amp-ad/0.1/test/test-a2a-listener.js
+++ b/extensions/amp-ad/0.1/test/test-a2a-listener.js
@@ -16,7 +16,6 @@
 
 import {handleMessageEvent} from '../a2a-listener';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
-import * as sinon from 'sinon';
 
 describe('amp-ad a2a listener', function() {
   let sandbox;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -22,7 +22,6 @@ import * as adCid from '../../../../src/ad-cid';
 import '../../../amp-ad/0.1/amp-ad';
 import '../../../amp-sticky-ad/0.1/amp-sticky-ad';
 import * as lolex from 'lolex';
-import * as sinon from 'sinon';
 
 function createAmpAd(win) {
   const ampAdElement = createElementWithAttributes(win.document, 'amp-ad', {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -16,7 +16,6 @@
 
 import {AdDisplayState, AmpAdUIHandler} from '../amp-ad-ui';
 import {BaseElement} from '../../../../src/base-element';
-import * as sinon from 'sinon';
 
 describe('amp-ad-ui handler', () => {
   let sandbox;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -23,7 +23,6 @@ import {
 } from '../../../../testing/iframe';
 import {AmpAdUIHandler} from '../amp-ad-ui';
 import {timerFor} from '../../../../src/timer';
-import * as sinon from 'sinon';
 
 describe('amp-ad-xorigin-iframe-handler', () => {
   let sandbox;

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -21,7 +21,6 @@ import {AmpAd3PImpl} from '../amp-ad-3p-impl';
 import {childElement} from '../../../../src/dom';
 import {extensionsFor} from '../../../../src/extensions';
 import {stubService} from '../../../../testing/test-helper';
-import * as sinon from 'sinon';
 
 describe('A4A loader', () => {
   let sandbox;

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -28,7 +28,6 @@ import {markElementScheduledForTesting} from '../../../../src/custom-element';
 import {installCidService,} from
     '../../../../extensions/amp-analytics/0.1/cid-impl';
 import {urlReplacementsForDoc} from '../../../../src/url-replacements';
-import * as sinon from 'sinon';
 
 
 /* global require: false */

--- a/extensions/amp-analytics/0.1/test/test-crypto-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-crypto-impl.js
@@ -17,7 +17,6 @@
 import {Crypto} from '../crypto-impl';
 import {Platform} from '../../../../src/service/platform-impl';
 import * as lib from '../../../../third_party/closure-library/sha384-generated';
-import * as sinon from 'sinon';
 
 describe('crypto-impl', () => {
 

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -20,7 +20,6 @@ import {
 } from '../instrumentation.js';
 import {adopt} from '../../../../src/runtime';
 import {VisibilityState} from '../../../../src/visibility-state';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -17,7 +17,6 @@
 import {sendRequest, sendRequestUsingIframe, Transport} from '../transport';
 import {adopt} from '../../../../src/runtime';
 import {loadPromise} from '../../../../src/event-helper';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -28,9 +28,6 @@ import {VisibilityState} from '../../../../src/visibility-state';
 import {viewerForDoc} from '../../../../src/viewer';
 import {viewportForDoc} from '../../../../src/viewport';
 
-import * as sinon from 'sinon';
-
-
 adopt(window);
 
 describe('amp-analytics.visibility', () => {

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -22,7 +22,6 @@ import '../amp-apester-media';
 import {adopt} from '../../../../src/runtime';
 import {toggleExperiment} from '../../../../src/experiments';
 import {xhrFor} from '../../../../src/xhr';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -30,7 +30,6 @@ import {
 } from '../../../../src/service/performance-impl';
 import {timerFor} from '../../../../src/timer';
 import '../../../amp-analytics/0.1/amp-analytics';
-import * as sinon from 'sinon';
 
 
 describe('amp-app-banner', () => {

--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -18,7 +18,6 @@ import {AmpAudio} from '../amp-audio';
 import {adopt} from '../../../../src/runtime';
 import {naturalDimensions_} from '../../../../src/layout';
 import {createIframePromise} from '../../../../testing/iframe';
-import * as sinon from 'sinon';
 import '../amp-audio';
 
 adopt(window);

--- a/extensions/amp-carousel/0.1/test/test-base-slide.js
+++ b/extensions/amp-carousel/0.1/test/test-base-slide.js
@@ -31,7 +31,6 @@
  */
 
 import {BaseSlides} from '../base-slides';
-import * as sinon from 'sinon';
 
 describe('BaseSlides', () => {
 

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -16,7 +16,6 @@
 
 import {createIframePromise} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';
-import * as sinon from 'sinon';
 
 describe('ScrollableCarousel', () => {
 

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import '../amp-carousel';
 import {createIframePromise} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -18,7 +18,6 @@ import {createIframePromise} from '../../../../testing/iframe';
 import {AmpExperiment} from '../amp-experiment';
 import * as variant from '../variant';
 import {variantForOrNull} from '../../../../src/variant-service';
-import * as sinon from 'sinon';
 
 describe('amp-experiment', () => {
 

--- a/extensions/amp-experiment/0.1/test/test-variant.js
+++ b/extensions/amp-experiment/0.1/test/test-variant.js
@@ -17,7 +17,6 @@
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {allocateVariant} from '../variant';
 import {stubService, stubServiceForDoc} from '../../../../testing/test-helper';
-import * as sinon from 'sinon';
 
 
 describe('allocateVariant', () => {

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -18,7 +18,6 @@ import '../amp-font';
 import {FontLoader} from '../fontloader';
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/extensions/amp-font/0.1/test/test-fontloader.js
+++ b/extensions/amp-font/0.1/test/test-fontloader.js
@@ -17,7 +17,6 @@
 import {FontLoader} from '../fontloader';
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -23,7 +23,6 @@ import {
 import {
   setReportValiditySupported,
 } from '../form-validators';
-import * as sinon from 'sinon';
 import {timerFor} from '../../../../src/timer';
 import '../../../amp-mustache/0.1/amp-mustache';
 import {installTemplatesService} from '../../../../src/service/template-impl';

--- a/extensions/amp-form/0.1/test/test-form-validators.js
+++ b/extensions/amp-form/0.1/test/test-form-validators.js
@@ -15,7 +15,6 @@
  */
 
 import {createIframePromise} from '../../../../testing/iframe';
-import * as sinon from 'sinon';
 import {
   setReportValiditySupported,
   getFormValidator,

--- a/extensions/amp-form/0.1/test/test-validation-bubble.js
+++ b/extensions/amp-form/0.1/test/test-validation-bubble.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {ValidationBubble} from '../validation-bubble';
 import {createIframePromise} from '../../../../testing/iframe';
 

--- a/extensions/amp-fresh/0.1/test/test-amp-fresh-manager.js
+++ b/extensions/amp-fresh/0.1/test/test-amp-fresh-manager.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpFresh} from '../amp-fresh';
 import {getOrInsallAmpFreshManager} from '../amp-fresh-manager';
 import {installXhrService} from '../../../../src/service/xhr-impl';

--- a/extensions/amp-fresh/0.1/test/test-amp-fresh.js
+++ b/extensions/amp-fresh/0.1/test/test-amp-fresh.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpFresh} from '../amp-fresh';
 import {getOrInsallAmpFreshManager} from '../amp-fresh-manager';
 import {resetServiceForTesting} from '../../../../src/service';

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -19,7 +19,6 @@ import {createIframePromise} from '../../../../testing/iframe';
 import {installImg} from '../../../../builtins/amp-img';
 import {viewportForDoc} from '../../../../src/viewport';
 import {toggleExperiment} from '../../../../src/experiments';
-import * as sinon from 'sinon';
 import '../amp-fx-flying-carpet';
 
 adopt(window);

--- a/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
@@ -21,7 +21,6 @@ import {
 import '../amp-google-vrview-image';
 import {adopt} from '../../../../src/runtime';
 import {toggleExperiment} from '../../../../src/experiments';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -26,7 +26,6 @@ import {
   poll,
 } from '../../../../testing/iframe';
 import {viewportForDoc} from '../../../../src/viewport';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -22,7 +22,6 @@ import {
 } from '../amp-image-lightbox';
 import {adopt} from '../../../../src/runtime';
 import {parseSrcset} from '../../../../src/srcset';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -23,7 +23,6 @@ import {
 } from '../../../../src/service';
 import {loadPromise} from '../../../../src/event-helper';
 import {installTimerService} from '../../../../src/service/timer-impl';
-import * as sinon from 'sinon';
 
 
 describe('amp-install-serviceworker', () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -18,7 +18,6 @@ import {AmpList} from '../amp-list';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 import {templatesFor} from '../../../../src/template';
 import {installXhrService} from '../../../../src/service/xhr-impl';
-import * as sinon from 'sinon';
 
 
 describe('amp-list component', () => {

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpLiveList, getNumberMaxOrDefault} from '../amp-live-list';
 import {LiveListManager} from '../live-list-manager';

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {installLiveListManager, LiveListManager} from '../live-list-manager';
 import {installViewerServiceForDoc} from '../../../../src/service/viewer-impl';

--- a/extensions/amp-live-list/0.1/test/test-poller.js
+++ b/extensions/amp-live-list/0.1/test/test-poller.js
@@ -15,7 +15,6 @@
  */
 
 
-import * as sinon from 'sinon';
 import {Poller} from '../poller';
 import {timerFor} from '../../../../src/timer';
 

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -20,7 +20,6 @@ import {Viewer} from '../../../../src/service/viewer-impl';
 import {Xhr} from '../../../../src/service/xhr-impl';
 import {shareTrackingForOrNull} from '../../../../src/share-tracking-service';
 import {toggleExperiment} from '../../../../src/experiments';
-import * as sinon from 'sinon';
 import * as bytes from '../../../../src/utils/bytes';
 
 describe('amp-share-tracking', () => {

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -20,7 +20,6 @@ import {createIframePromise} from '../../../../testing/iframe';
 import {platformFor} from '../../../../src/platform';
 import {timerFor} from '../../../../src/timer';
 import {assertScreenReaderElement} from '../../../../testing/test-helper';
-import * as sinon from 'sinon';
 import '../amp-sidebar';
 
 adopt(window);

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -16,7 +16,6 @@
 
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
-import * as sinon from 'sinon';
 import '../amp-social-share';
 import {platformFor} from '../../../../src/platform';
 

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -20,7 +20,6 @@ import {
 } from '../amp-user-notification';
 import {createIframePromise} from '../../../../testing/iframe';
 import {getExistingServiceForDoc} from '../../../../src/service';
-import * as sinon from 'sinon';
 
 
 describe('amp-user-notification', () => {

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -21,7 +21,6 @@ import {
 import '../amp-youtube';
 import {adopt} from '../../../../src/runtime';
 import {timerFor} from '../../../../src/timer';
-import * as sinon from 'sinon';
 
 adopt(window);
 

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -316,5 +316,3 @@ chai.Assertion.addMethod('jsonEqual', function(compare) {
     b
   );
 });
-
-sinon = null;

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -28,7 +28,6 @@ import {loadPromise} from '../../src/event-helper';
 import {preconnectForElement} from '../../src/preconnect';
 import {validateData} from '../../3p/3p';
 import {viewerForDoc} from '../../src/viewer';
-import * as sinon from 'sinon';
 
 describe('3p-frame', () => {
 
@@ -141,10 +140,8 @@ describe('3p-frame', () => {
     };
 
     const viewer = viewerForDoc(window.document);
-    const viewerMock = sandbox.mock(viewer);
-    viewerMock.expects('getUnconfirmedReferrerUrl')
-        .returns('http://acme.org/')
-        .once();
+    const referrerUrl = sandbox.stub(viewer, 'getUnconfirmedReferrerUrl')
+        .returns('http://acme.org/');
 
     container.appendChild(div);
     const iframe = getIframe(window, div, '_ping_', {clientId: 'cidValue'});
@@ -185,6 +182,7 @@ describe('3p-frame', () => {
     document.body.appendChild(iframe);
     return loadPromise(iframe).then(() => {
       const win = iframe.contentWindow;
+      expect(referrerUrl).to.have.been.calledOnce;
       expect(win.context.canonicalUrl).to.equal('https://foo.bar/baz');
       expect(win.context.location.href).to.equal(locationHref);
       expect(win.context.location.origin).to.equal('http://localhost:9876');

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -22,7 +22,6 @@ import {
   validateData,
   loadScript,
 } from '../../3p/3p';
-import * as sinon from 'sinon';
 
 describe('3p', () => {
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -16,7 +16,6 @@
 
 import {ActionService, parseActionMap} from '../../src/service/action-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
-import * as sinon from 'sinon';
 
 
 describe('ActionService parseAction', () => {

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -24,7 +24,6 @@ import {installTimerService} from '../../src/service/timer-impl';
 import {installViewportServiceForDoc} from '../../src/service/viewport-impl';
 import {viewportForDoc} from '../../src/viewport';
 import {Observable} from '../../src/observable';
-import * as sinon from 'sinon';
 
 describe('Activity getTotalEngagedTime', () => {
 

--- a/test/functional/test-ad-cid.js
+++ b/test/functional/test-ad-cid.js
@@ -20,7 +20,6 @@ import {installCidService} from '../../extensions/amp-analytics/0.1/cid-impl';
 import {getAdCid} from '../../src/ad-cid';
 import {setCookie} from '../../src/cookies';
 import {timerFor} from '../../src/timer';
-import * as sinon from 'sinon';
 
 describe('ad-cid', () => {
   const cidScope = 'cid-in-ads-test';

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -16,7 +16,6 @@
 
 import {handleClick, warmupDynamic, warmupStatic} from '../../ads/alp/handler';
 import {parseUrl} from '../../src/url';
-import * as sinon from 'sinon';
 
 describe('alp-handler', () => {
 

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -18,7 +18,6 @@ import {createIframePromise} from '../../testing/iframe';
 import {BaseElement} from '../../src/base-element';
 import {installImg, AmpImg} from '../../builtins/amp-img';
 import {resourcesForDoc} from '../../src/resources';
-import * as sinon from 'sinon';
 
 describe('amp-img', () => {
   let sandbox;

--- a/test/functional/test-amp-video.js
+++ b/test/functional/test-amp-video.js
@@ -17,7 +17,6 @@
 import {createIframePromise} from '../../testing/iframe';
 import {installVideo} from '../../builtins/amp-video';
 import {installVideoManagerForDoc} from '../../src/service/video-manager-impl';
-import * as sinon from 'sinon';
 
 describe('amp-video', () => {
 

--- a/test/functional/test-ampdoc.js
+++ b/test/functional/test-ampdoc.js
@@ -25,7 +25,6 @@ import {
 import * as dom from '../../src/dom';
 import * as docready from '../../src/document-ready';
 import {createShadowRoot} from '../../src/shadow-embed';
-import * as sinon from 'sinon';
 
 
 describe('AmpDocService', () => {

--- a/test/functional/test-analytics.js
+++ b/test/functional/test-analytics.js
@@ -20,7 +20,6 @@ import {
 } from '../../src/service';
 import {triggerAnalyticsEvent} from '../../src/analytics';
 import {timerFor} from '../../src/timer';
-import * as sinon from 'sinon';
 
 describe('triggerAnalyticsEvent', () => {
   let sandbox;

--- a/test/functional/test-animation.js
+++ b/test/functional/test-animation.js
@@ -15,7 +15,6 @@
  */
 
 import {Animation} from '../../src/animation';
-import * as sinon from 'sinon';
 
 describe('Animation', () => {
 

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -18,7 +18,6 @@ import {listenOncePromise} from '../../src/event-helper';
 import {BaseElement} from '../../src/base-element';
 import {createAmpElementProto} from '../../src/custom-element';
 import {timerFor} from '../../src/timer';
-import * as sinon from 'sinon';
 
 describe('BaseElement', () => {
 

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {timerFor} from '../../src/timer';
 
 /**

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -27,7 +27,6 @@ import {timerFor} from '../../src/timer';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installViewerServiceForDoc} from '../../src/service/viewer-impl';
 import {installTimerService} from '../../src/service/timer-impl';
-import * as sinon from 'sinon';
 
 const DAY = 24 * 3600 * 1000;
 

--- a/test/functional/test-curve.js
+++ b/test/functional/test-curve.js
@@ -15,7 +15,6 @@
  */
 
 import {Curves, bezierCurve, getCurve} from '../../src/curve';
-import * as sinon from 'sinon';
 
 describe('Curve', () => {
 

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -20,7 +20,6 @@ import {LOADING_ELEMENTS_, Layout} from '../../src/layout';
 import {installPerformanceService} from '../../src/service/performance-impl';
 import {installResourcesServiceForDoc} from '../../src/service/resources-impl';
 import {vsyncFor} from '../../src/vsync';
-import * as sinon from 'sinon';
 
 import {getService, resetServiceForTesting} from '../../src/service';
 import {

--- a/test/functional/test-document-click.js
+++ b/test/functional/test-document-click.js
@@ -21,7 +21,6 @@ import {
 } from '../../src/service/url-replacements-impl';
 import {installDocumentInfoServiceForDoc,} from
     '../../src/service/document-info-impl';
-import * as sinon from 'sinon';
 import {toggleExperiment} from '../../src/experiments';
 
 describe('test-document-click onDocumentElementClick_', () => {

--- a/test/functional/test-document-info.js
+++ b/test/functional/test-document-info.js
@@ -19,7 +19,6 @@ import {documentInfoForDoc} from '../../src/document-info';
 import {installDocumentInfoServiceForDoc,} from
     '../../src/service/document-info-impl';
 import {installDocService} from '../../src/service/ampdoc-impl';
-import * as sinon from 'sinon';
 
 describe('document-info', () => {
   let sandbox;

--- a/test/functional/test-document-ready.js
+++ b/test/functional/test-document-ready.js
@@ -20,7 +20,6 @@ import {isDocumentReady,
   whenDocumentComplete,
 } from '../../src/document-ready';
 import {timerFor} from '../../src/timer';
-import * as sinon from 'sinon';
 
 
 describe('documentReady', () => {

--- a/test/functional/test-document-state.js
+++ b/test/functional/test-document-state.js
@@ -16,7 +16,6 @@
 
 import {DocumentState} from '../../src/document-state';
 import * as dom from '../../src/dom';
-import * as sinon from 'sinon';
 
 
 describe('DocumentState', () => {

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -15,7 +15,6 @@
  */
 
 import {onDocumentFormSubmit_} from '../../src/document-submit';
-import * as sinon from 'sinon';
 
 describe('test-document-submit onDocumentFormSubmit_', () => {
   let sandbox;

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -15,7 +15,6 @@
  */
 
 import * as dom from '../../src/dom';
-import * as sinon from 'sinon';
 
 
 describe('DOM', () => {

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -21,7 +21,6 @@ import {
 } from '../../src/error';
 import {parseUrl, parseQueryString} from '../../src/url';
 import {user} from '../../src/log';
-import * as sinon from 'sinon';
 
 
 describe('reportErrorToServer', () => {

--- a/test/functional/test-event-helper.js
+++ b/test/functional/test-event-helper.js
@@ -22,7 +22,6 @@ import {
   loadPromise,
 } from '../../src/event-helper';
 import {Observable} from '../../src/observable';
-import * as sinon from 'sinon';
 
 describe('EventHelper', () => {
 

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -22,7 +22,6 @@ import {
   toggleExperiment,
   resetExperimentToggles_,
 } from '../../src/experiments';
-import * as sinon from 'sinon';
 
 describe('isExperimentOn', () => {
   let win;

--- a/test/functional/test-exponential-backoff.js
+++ b/test/functional/test-exponential-backoff.js
@@ -16,7 +16,6 @@
 
 import {exponentialBackoff, exponentialBackoffClock,}
     from '../../src/exponential-backoff';
-import * as sinon from 'sinon';
 
 
 describe('exponentialBackoff', () => {

--- a/test/functional/test-finite-state-machine.js
+++ b/test/functional/test-finite-state-machine.js
@@ -15,7 +15,6 @@
  */
 
 import {FiniteStateMachine} from '../../src/finite-state-machine';
-import * as sinon from 'sinon';
 
 describe('Finite State Machine', () => {
 

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -17,7 +17,6 @@
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {FixedLayer} from '../../src/service/fixed-layer';
 import {installPlatformService} from '../../src/service/platform-impl';
-import * as sinon from 'sinon';
 
 
 describe('FixedLayer', () => {

--- a/test/functional/test-focus-history.js
+++ b/test/functional/test-focus-history.js
@@ -16,7 +16,6 @@
 
 import {FocusHistory} from '../../src/focus-history';
 import {installTimerService} from '../../src/service/timer-impl';
-import * as sinon from 'sinon';
 
 
 describe('FocusHistory', () => {

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -24,7 +24,6 @@ import {extensionsFor} from '../../src/extensions';
 import {installServiceInEmbedScope} from '../../src/service';
 import {loadPromise} from '../../src/event-helper';
 import {resourcesForDoc} from '../../src/resources';
-import * as sinon from 'sinon';
 
 
 describe('friendly-iframe-embed', () => {

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -17,7 +17,6 @@
 import {Gestures} from '../../src/gesture';
 import {DoubletapRecognizer, PinchRecognizer, SwipeXYRecognizer, TapRecognizer,
     TapzoomRecognizer} from '../../src/gesture-recognizers';
-import * as sinon from 'sinon';
 
 
 describe('TapRecognizer', () => {

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -15,7 +15,6 @@
  */
 
 import {GestureRecognizer, Gestures} from '../../src/gesture';
-import * as sinon from 'sinon';
 
 
 describe('Gestures', () => {

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -24,7 +24,6 @@ import {
 import {listenOncePromise} from '../../src/event-helper';
 import {installTimerService} from '../../src/service/timer-impl';
 import {parseUrl} from '../../src/url';
-import * as sinon from 'sinon';
 
 
 describe('History', () => {

--- a/test/functional/test-ie-media-bug.js
+++ b/test/functional/test-ie-media-bug.js
@@ -16,7 +16,6 @@
 
 import {checkAndFix} from '../../src/service/ie-media-bug';
 import {dev} from '../../src/log';
-import * as sinon from 'sinon';
 
 
 describe('ie-media-bug', () => {

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import * as IframeHelper from '../../src/iframe-helper';
-import * as sinon from 'sinon';
 import {createIframePromise} from '../../testing/iframe';
 import {generateSentinel} from '../../src/3p-frame.js';
 

--- a/test/functional/test-impression.js
+++ b/test/functional/test-impression.js
@@ -22,7 +22,6 @@ import {
 import {toggleExperiment} from '../../src/experiments';
 import {viewerForDoc} from '../../src/viewer';
 import {xhrFor} from '../../src/xhr';
-import * as sinon from 'sinon';
 
 describe('impression', () => {
 

--- a/test/functional/test-input.js
+++ b/test/functional/test-input.js
@@ -15,7 +15,6 @@
  */
 
 import {Input} from '../../src/input';
-import * as sinon from 'sinon';
 
 
 describe('Input', () => {

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -21,7 +21,6 @@ import {
 } from '../../src/intersection-observer';
 import {createAmpElementProto} from '../../src/custom-element';
 import {layoutRectLtwh} from '../../src/layout-rect';
-import * as sinon from 'sinon';
 
 
 describe('getIntersectionChangeEntry', () => {

--- a/test/functional/test-ios-scrollfreeze-bug.js
+++ b/test/functional/test-ios-scrollfreeze-bug.js
@@ -16,7 +16,6 @@
 
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {checkAndFix} from '../../src/service/ios-scrollfreeze-bug';
-import * as sinon from 'sinon';
 
 
 describe('ios-scrollfreeze-bug', () => {

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -23,7 +23,6 @@ import {
   rethrowAsync,
   user,
 } from '../../src/log';
-import * as sinon from 'sinon';
 
 describe('Logging', () => {
 

--- a/test/functional/test-motion.js
+++ b/test/functional/test-motion.js
@@ -15,7 +15,6 @@
  */
 
 import {calcVelocity, continueMotion} from '../../src/motion';
-import * as sinon from 'sinon';
 
 
 describe('Motion calcVelocity', () => {

--- a/test/functional/test-observable.js
+++ b/test/functional/test-observable.js
@@ -15,7 +15,6 @@
  */
 
 import {Observable} from '../../src/observable';
-import * as sinon from 'sinon';
 
 describe('Observable', () => {
 

--- a/test/functional/test-pass.js
+++ b/test/functional/test-pass.js
@@ -16,7 +16,6 @@
 
 import {Pass} from '../../src/pass';
 import {timerFor} from '../../src/timer';
-import * as sinon from 'sinon';
 
 describe('Pass', () => {
 

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {installPerformanceService} from '../../src/service/performance-impl';
 import {getService, resetServiceForTesting} from '../../src/service';
 import {viewerForDoc} from '../../src/viewer';

--- a/test/functional/test-polyfill-document-contains.js
+++ b/test/functional/test-polyfill-document-contains.js
@@ -15,7 +15,6 @@
  */
 
 import {install} from '../../src/polyfills/document-contains';
-import * as sinon from 'sinon';
 
 
 describe('HTMLDocument.contains', () => {

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -17,7 +17,6 @@
 import {createIframePromise} from '../../testing/iframe';
 import {preconnectForElement, setPreconnectFeaturesForTesting,} from
     '../../src/preconnect';
-import * as sinon from 'sinon';
 import * as lolex from 'lolex';
 
 describe('preconnect', () => {

--- a/test/functional/test-pull-to-refresh.js
+++ b/test/functional/test-pull-to-refresh.js
@@ -15,7 +15,6 @@
  */
 
 import {PullToRefreshBlocker} from '../../src/pull-to-refresh';
-import * as sinon from 'sinon';
 
 
 describe('PullToRefreshBlocker', () => {

--- a/test/functional/test-render-delaying-services.js
+++ b/test/functional/test-render-delaying-services.js
@@ -17,7 +17,6 @@
 import {waitForServices} from '../../src/render-delaying-services';
 import {createIframePromise} from '../../testing/iframe';
 import * as service from '../../src/service';
-import * as sinon from 'sinon';
 import * as lolex from 'lolex';
 
 describe('waitForServices', () => {

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -18,7 +18,6 @@ import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {Resources} from '../../src/service/resources-impl';
 import {Resource, ResourceState} from '../../src/service/resource';
 import {layoutRectLtwh} from '../../src/layout-rect';
-import * as sinon from 'sinon';
 
 
 describe('Resource', () => {

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -19,7 +19,6 @@ import {Resources} from '../../src/service/resources-impl';
 import {Resource, ResourceState} from '../../src/service/resource';
 import {VisibilityState} from '../../src/visibility-state';
 import {layoutRectLtwh} from '../../src/layout-rect';
-import * as sinon from 'sinon';
 
 /*eslint "google-camelcase/google-camelcase": 0*/
 describe('Resources', () => {

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -33,7 +33,6 @@ import * as extel from '../../src/extended-element';
 import * as styles from '../../src/style-installer';
 import * as shadowembed from '../../src/shadow-embed';
 import * as dom from '../../src/dom';
-import * as sinon from 'sinon';
 
 describes.sandboxed('runtime', {}, env => {
 

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -33,7 +33,6 @@ import {
   setParentWindow,
 } from '../../src/service';
 import {loadPromise} from '../../src/event-helper';
-import * as sinon from 'sinon';
 
 
 describe('service', () => {

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -29,7 +29,6 @@ import {
   setShadowDomSupportedForTesting,
 } from '../../src/shadow-embed';
 import {extensionsFor} from '../../src/extensions';
-import * as sinon from 'sinon';
 
 
 describe('shadow-embed', () => {

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -16,7 +16,6 @@
 
 import {StandardActions} from '../../src/service/standard-actions-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
-import * as sinon from 'sinon';
 
 
 describe('StandardActions', () => {

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -22,7 +22,6 @@ import {
   ViewerStorageBinding,
 } from '../../src/service/storage-impl';
 import {dev} from '../../src/log';
-import * as sinon from 'sinon';
 
 
 describe('Storage', () => {

--- a/test/functional/test-style-installer.js
+++ b/test/functional/test-style-installer.js
@@ -19,7 +19,6 @@ import * as rds from '../../src/render-delaying-services';
 import {installPerformanceService} from '../../src/service/performance-impl';
 import {createIframePromise} from '../../testing/iframe';
 import {installResourcesServiceForDoc} from '../../src/service/resources-impl';
-import * as sinon from 'sinon';
 import * as styles from '../../src/style-installer';
 
 

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -15,7 +15,6 @@
  */
 
 import * as st from '../../src/style';
-import * as sinon from 'sinon';
 
 describe('Style', () => {
 

--- a/test/functional/test-task-queue.js
+++ b/test/functional/test-task-queue.js
@@ -15,7 +15,6 @@
  */
 
 import {TaskQueue} from '../../src/service/task-queue';
-import * as sinon from 'sinon';
 
 
 describe('TaskQueue', () => {

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -15,7 +15,6 @@
  */
 
 import {Timer} from '../../src/service/timer-impl';
-import * as sinon from 'sinon';
 
 describe('Timer', () => {
 

--- a/test/functional/test-transition.js
+++ b/test/functional/test-transition.js
@@ -15,7 +15,6 @@
  */
 
 import * as tr from '../../src/transition';
-import * as sinon from 'sinon';
 
 describe('Transition', () => {
 

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -36,7 +36,6 @@ import {parseUrl} from '../../src/url';
 import {toggleExperiment} from '../../src/experiments';
 import {viewerForDoc} from '../../src/viewer';
 import * as trackPromise from '../../src/impression';
-import * as sinon from 'sinon';
 
 
 describe('UrlReplacements', () => {

--- a/test/functional/test-video-manager.js
+++ b/test/functional/test-video-manager.js
@@ -24,7 +24,6 @@ import {
 import {
   runVideoPlayerIntegrationTests,
 } from '../integration/test-video-players-helper';
-import * as sinon from 'sinon';
 
 describe('Fake Video Player Integration Tests', () => {
   // We run the video player integration tests on a fake video player as part

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -22,7 +22,6 @@ import {installPerformanceService} from '../../src/service/performance-impl';
 import {resetServiceForTesting} from '../../src/service';
 import {timerFor} from '../../src/timer';
 import {installTimerService} from '../../src/service/timer-impl';
-import * as sinon from 'sinon';
 
 
 describe('Viewer', () => {

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -34,7 +34,6 @@ import {loadPromise} from '../../src/event-helper';
 import {setParentWindow} from '../../src/service';
 import {toggleExperiment} from '../../src/experiments';
 import {vsyncFor} from '../../src/vsync';
-import * as sinon from 'sinon';
 
 describe('Viewport', () => {
   let sandbox;

--- a/test/functional/test-vsync.js
+++ b/test/functional/test-vsync.js
@@ -18,7 +18,6 @@ import {Vsync} from '../../src/service/vsync-impl';
 import {AmpDocShadow, installDocService} from '../../src/service/ampdoc-impl';
 import {installTimerService} from '../../src/service/timer-impl';
 import {viewerPromiseForDoc} from '../../src/viewer';
-import * as sinon from 'sinon';
 
 
 describe('vsync', () => {

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {utf8FromArrayBuffer} from '../../extensions/amp-a4a/0.1/amp-a4a';
 import {
   installXhrService,

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -23,7 +23,6 @@ import {createAmpElementProto} from '../../src/custom-element';
 import {viewerForDoc} from '../../src/viewer';
 import {resourcesForDoc} from '../../src/resources';
 import {VisibilityState} from '../../src/visibility-state';
-import * as sinon from 'sinon';
 
 describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
 

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -33,7 +33,6 @@ import {cssText} from '../build/css';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {installExtensionsService} from '../src/service/extensions-impl';
 import {resetScheduledElementForTesting} from '../src/custom-element';
-import * as sinon from 'sinon';
 
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';


### PR DESCRIPTION
This is so we can ensure sandboxes are always cleaned up. Let's see if
there's any flake with this before submitting.

Fixes #5568.
Fixes #5570.
Reverts #3087.
