### PR TITLE
Allow webviews to be set as trusted viewers

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -241,11 +241,17 @@ export class Viewer {
     dev().fine(TAG_, '- performanceTracking:', this.performanceTracking_);
 
     /**
+     * Whether the AMP document is embedded in a webview.
+     * @private @const {boolean}
+     */
+    this.isWebviewEmbedded_ = this.params_['webview'];
+
+    /**
      * Whether the AMP document is embedded in a viewer, such as an iframe or
      * a web view.
      * @private @const {boolean}
      */
-    this.isEmbedded_ = (this.isIframed_ || this.params_['webview'] === '1') &&
+    this.isEmbedded_ = (this.isIframed_ || this.isWebviewEmbedded_) &&
         !this.win.AMP_TEST_IFRAME;
 
     /** @private {boolean} */
@@ -293,7 +299,7 @@ export class Viewer {
       // Not embedded in IFrame - can't trust the viewer.
       trustedViewerResolved = false;
       trustedViewerPromise = Promise.resolve(false);
-    } else if (this.win.location.ancestorOrigins) {
+    } else if (this.win.location.ancestorOrigins && !this.isWebviewEmbedded_) {
       // Ancestors when available take precedence. This is the main API used
       // for this determination. Fallback is only done when this API is not
       // supported by the browser.

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -244,7 +244,7 @@ export class Viewer {
      * Whether the AMP document is embedded in a webview.
      * @private @const {boolean}
      */
-    this.isWebviewEmbedded_ = this.params_['webview'];
+    this.isWebviewEmbedded_ = !!this.params_['webview'];
 
     /**
      * Whether the AMP document is embedded in a viewer, such as an iframe or

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -244,7 +244,7 @@ export class Viewer {
      * Whether the AMP document is embedded in a webview.
      * @private @const {boolean}
      */
-    this.isWebviewEmbedded_ = !!this.params_['webview'];
+    this.isWebviewEmbedded_ = !this.isIframed_ && !!this.params_['webview'];
 
     /**
      * Whether the AMP document is embedded in a viewer, such as an iframe or

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -244,7 +244,8 @@ export class Viewer {
      * Whether the AMP document is embedded in a webview.
      * @private @const {boolean}
      */
-    this.isWebviewEmbedded_ = !this.isIframed_ && !!this.params_['webview'];
+    this.isWebviewEmbedded_ = !this.isIframed_ &&
+        this.params_['webview'] == '1';
 
     /**
      * Whether the AMP document is embedded in a viewer, such as an iframe or

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -882,6 +882,78 @@ describe('Viewer', () => {
       });
     });
 
+    describe('when in a fake webview (a bad actor iframe)', () => {
+      it('should consider trusted by ancestor', () => {
+        windowApi.parent = {};
+        windowApi.location.hash = '#webview=1';
+        windowApi.location.ancestorOrigins = ['https://google.com'];
+        return new Viewer(ampdoc).isTrustedViewer().then(res => {
+          expect(res).to.be.true;
+        });
+      });
+
+      it('should consider non-trusted without ancestor', () => {
+        windowApi.parent = {};
+        windowApi.location.hash = '#webview=1';
+        windowApi.location.ancestorOrigins = [];
+        return new Viewer(ampdoc).isTrustedViewer().then(res => {
+          expect(res).to.be.false;
+        });
+      });
+
+      it('should consider non-trusted with wrong ancestor', () => {
+        windowApi.parent = {};
+        windowApi.location.hash = '#webview=1';
+        windowApi.location.ancestorOrigins = ['https://untrusted.com'];
+        return new Viewer(ampdoc).isTrustedViewer().then(res => {
+          expect(res).to.be.false;
+        });
+      });
+
+      it('should decide trusted on connection with origin', () => {
+        windowApi.parent = {};
+        windowApi.location.hash = '#webview=1';
+        windowApi.location.ancestorOrigins = null;
+        const viewer = new Viewer(ampdoc);
+        viewer.setMessageDeliverer(() => {}, 'https://google.com');
+        return viewer.isTrustedViewer().then(res => {
+          expect(res).to.be.true;
+        });
+      });
+
+      it('should NOT allow channel without origin', () => {
+        windowApi.parent = {};
+        windowApi.location.hash = '#webview=1';
+        windowApi.location.ancestorOrigins = null;
+        const viewer = new Viewer(ampdoc);
+        expect(() => {
+          viewer.setMessageDeliverer(() => {});
+        }).to.throw(/message channel must have an origin/);
+      });
+
+      it('should decide non-trusted on connection with wrong origin', () => {
+        windowApi.parent = {};
+        windowApi.location.hash = '#webview=1';
+        windowApi.location.ancestorOrigins = null;
+        const viewer = new Viewer(ampdoc);
+        viewer.setMessageDeliverer(() => {}, 'https://untrusted.com');
+        return viewer.isTrustedViewer().then(res => {
+          expect(res).to.be.false;
+        });
+      });
+
+      it('should give precedence to ancestor', () => {
+        windowApi.parent = {};
+        windowApi.location.hash = '#webview=1';
+        windowApi.location.ancestorOrigins = ['https://google.com'];
+        const viewer = new Viewer(ampdoc);
+        viewer.setMessageDeliverer(() => {}, 'https://untrusted.com');
+        return viewer.isTrustedViewer().then(res => {
+          expect(res).to.be.true;
+        });
+      });
+    });
+
     it('should trust domain variations', () => {
       test('https://google.com', true);
       test('https://www.google.com', true);

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -843,6 +843,7 @@ describe('Viewer', () => {
         windowApi.parent = windowApi;
         windowApi.location.hash = '#webview=1';
         windowApi.location.ancestorOrigins = [];
+        const viewer = new Viewer(ampdoc);
         viewer.setMessageDeliverer(() => {}, 'https://google.com');
         return viewer.isTrustedViewer().then(res => {
           expect(res).to.be.true;


### PR DESCRIPTION
Webviews can't set `ancestorOrigins` properly (maybe?), we can't use it to tell if we are in a trusted viewer context. Instead, fall back to our "old browser" path, which creates a `trustedViewerResolver_`. When the webview's integration script [sets the message deliverer](https://github.com/ampproject/amphtml/blob/f28e116/src/service/viewer-impl.js#L947), it [will resolve](https://github.com/ampproject/amphtml/blob/f28e116/src/service/viewer-impl.js#L961-L962) to the webview's passed origin.

Fixes #5563.