### PR TITLE
Trust the google.cat viewer domain

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -70,7 +70,7 @@ export const ViewportType = {
  *
  * @export {!Array<!RegExp>}
  */
-export const TRUSTED_VIEWER_HOSTS = [
+const TRUSTED_VIEWER_HOSTS = [
   /**
    * Google domains, including country-codes and subdomains:
    * - google.com
@@ -78,13 +78,15 @@ export const TRUSTED_VIEWER_HOSTS = [
    * - google.co
    * - www.google.co
    * - google.az
-   * - www.google..az
+   * - www.google.az
    * - google.com.az
    * - www.google.com.az
    * - google.co.az
    * - www.google.co.az
+   * - google.cat
+   * - www.google.cat
    */
-  /(^|\.)google\.(com?|[a-z]{2}|com?\.[a-z]{2})$/,
+  /(^|\.)google\.(com?|[a-z]{2}|com?\.[a-z]{2}|cat)$/,
 ];
 
 

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -853,6 +853,8 @@ describe('Viewer', () => {
       test('https://www.google.de', true);
       test('https://news.google.de', true);
       test('https://abc.www.google.com', true);
+      test('https://google.cat', true);
+      test('https://www.google.cat', true);
     });
 
     it('should not trust host as referrer with http', () => {


### PR DESCRIPTION
Confirmed this is the only exception to the usual domains that Google
supports.