### PR TITLE
Turn on type checking for amp-lightbox and a tiny optimization.

### DIFF
--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -17,12 +17,30 @@
 import {Gestures} from '../../../src/gesture';
 import {Layout} from '../../../src/layout';
 import {SwipeXYRecognizer} from '../../../src/gesture-recognizers';
+import {dev} from '../../../src/log';
 import {historyForDoc} from '../../../src/history';
 import {vsyncFor} from '../../../src/vsync';
 import * as st from '../../../src/style';
 
 
 class AmpLightbox extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?Element} */
+    this.container_ = null;
+
+    /** @private {number} */
+    this.historyId_ = -1;
+
+    /** @private {boolean} */
+    this.active_ = false;
+
+    /**  @private {?function(this:AmpLightbox, Event)}*/
+    this.boundCloseOnEscape_ = null;
+  }
 
   /** @override */
   isLayoutSupported(layout) {
@@ -42,7 +60,6 @@ class AmpLightbox extends AMP.BaseElement {
 
     const children = this.getRealChildren();
 
-    /** @private {!Element} */
     this.container_ = this.element.ownerDocument.createElement('div');
     this.applyFillContent(this.container_);
     this.element.appendChild(this.container_);
@@ -56,12 +73,6 @@ class AmpLightbox extends AMP.BaseElement {
     gestures.onGesture(SwipeXYRecognizer, () => {
       // Consume to block scroll events and side-swipe.
     });
-
-    /** @private {number} */
-    this.historyId_ = -1;
-
-    /** @private {boolean} */
-    this.active_ = false;
   }
 
   /** @override */
@@ -74,7 +85,6 @@ class AmpLightbox extends AMP.BaseElement {
     if (this.active_) {
       return;
     }
-    /**  @private {function(this:AmpLightbox, Event)}*/
     this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
     this.win.document.documentElement.addEventListener(
         'keydown', this.boundCloseOnEscape_);
@@ -89,9 +99,11 @@ class AmpLightbox extends AMP.BaseElement {
         this.element.style.opacity = '';
       });
     }).then(() => {
-      this.updateInViewport(this.container_, true);
-      this.scheduleLayout(this.container_);
-      this.scheduleResume(this.container_);
+      const container = /** @type {!Element} */ (
+          dev().assert(this.container_));
+      this.updateInViewport(container, true);
+      this.scheduleLayout(container);
+      this.scheduleResume(container);
     });
 
     this.getHistory_().push(this.close.bind(this)).then(historyId => {
@@ -124,7 +136,8 @@ class AmpLightbox extends AMP.BaseElement {
     this.win.document.documentElement.removeEventListener(
         'keydown', this.boundCloseOnEscape_);
     this.boundCloseOnEscape_ = null;
-    this.schedulePause(this.container_);
+    this.schedulePause(/** @type {!Element} */ (
+        dev().assert(this.container_)));
     this.active_ = false;
   }
 

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -99,8 +99,7 @@ class AmpLightbox extends AMP.BaseElement {
         this.element.style.opacity = '';
       });
     }).then(() => {
-      const container = /** @type {!Element} */ (
-          dev().assert(this.container_));
+      const container = dev().assertElement(this.container_);
       this.updateInViewport(container, true);
       this.scheduleLayout(container);
       this.scheduleResume(container);
@@ -136,8 +135,7 @@ class AmpLightbox extends AMP.BaseElement {
     this.win.document.documentElement.removeEventListener(
         'keydown', this.boundCloseOnEscape_);
     this.boundCloseOnEscape_ = null;
-    this.schedulePause(/** @type {!Element} */ (
-        dev().assert(this.container_)));
+    this.schedulePause(dev().assertElement(this.container_));
     this.active_ = false;
   }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ declareExtension('amp-image-lightbox', '0.1', true);
 declareExtension('amp-instagram', '0.1', false);
 declareExtension('amp-install-serviceworker', '0.1', false);
 declareExtension('amp-jwplayer', '0.1', false, 'NO_TYPE_CHECK');
-declareExtension('amp-lightbox', '0.1', false, 'NO_TYPE_CHECK');
+declareExtension('amp-lightbox', '0.1', false);
 declareExtension('amp-lightbox-viewer', '0.1', true, 'NO_TYPE_CHECK');
 declareExtension('amp-list', '0.1', false, 'NO_TYPE_CHECK');
 declareExtension('amp-live-list', '0.1', true);

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -286,7 +286,7 @@ export class LocalStorageBinding {
     this.win = win;
 
     /** @private @const {boolean} */
-    this.isLocalStorageSupported_ = !!this.win.localStorage;
+    this.isLocalStorageSupported_ = 'localStorage' in this.win;
 
     if (!this.isLocalStorageSupported_) {
       dev().error(TAG, 'localStorage not supported.');


### PR DESCRIPTION
Do not force bringing up `localStorage` just to check whether it is
supported in the Storage service.