### PR TITLE
Install core Css in the test iframe

### DIFF
--- a/testing/describes.js
+++ b/testing/describes.js
@@ -26,6 +26,8 @@ import {
 import {installDocService} from '../src/service/ampdoc-impl';
 import {installExtensionsService} from '../src/service/extensions-impl';
 import {resetScheduledElementForTesting} from '../src/custom-element';
+import {installStyles} from '../src/style-installer';
+import {cssText} from '../build/css';
 import * as sinon from 'sinon';
 
 /** Should have something in the name, otherwise nothing is shown. */
@@ -300,8 +302,7 @@ class RealWinFixture {
       env.iframe = iframe;
       iframe.name = 'test_' + iframeCount++;
       iframe.srcdoc = '<!doctype><html><head>' +
-          '<style>.-amp-element {display: block;}</style>' +
-          '<body style="margin:0"><div id=parent></div>';
+          '<body><div id=parent></div>';
       iframe.onload = function() {
         const win = iframe.contentWindow;
         env.win = win;
@@ -315,7 +316,7 @@ class RealWinFixture {
           win.customElements = new FakeCustomElements(win);
         }
 
-        resolve();
+        installStyles(win.document, cssText, resolve);
       };
       iframe.onerror = reject;
       document.body.appendChild(iframe);

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -196,8 +196,7 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
     let iframe = document.createElement('iframe');
     iframe.name = 'test_' + iframeCount++;
     iframe.srcdoc = '<!doctype><html><head>' +
-        '<style>.-amp-element {display: block;}</style>' +
-        '<body style="margin:0"><div id=parent></div>';
+        '<body><div id=parent></div>';
     iframe.onload = function() {
       // Flag as being a test window.
       iframe.contentWindow.AMP_TEST_IFRAME = true;
@@ -221,8 +220,6 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
           addElement: function(element) {
             const iWin = iframe.contentWindow;
             const p = onInsert(iWin).then(() => {
-              // Make sure it has dimensions since no styles are available.
-              element.style.display = 'block';
               element.build(true);
               if (!element.getPlaceholder()) {
                 const placeholder = element.createPlaceholder();


### PR DESCRIPTION
- Installs core Css in the new testing setup
- Removes custom styles from the old test-iframe (since were already installing core Css on it as part of https://github.com/ampproject/amphtml/pull/5542)