### PR TITLE
Allow Doubleclick publishers to force on A4A in beta-test mode

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -76,20 +76,19 @@ export const DOUBLECLICK_A4A_BETA_BRANCHES = {
  * @returns {boolean}
  */
 export function doubleclickIsA4AEnabled(win, element) {
-  const usesRemoteHTML =
-      !!win.document.querySelector('meta[name=amp-3p-iframe-src]');
-  const a4aRequested = !!element.getAttribute(
+  if (!!win.document.querySelector('meta[name=amp-3p-iframe-src]')) {
+    return false;
+  }
+  const a4aRequested = element.hasAttribute(
       'data-use-experimental-a4a-implementation');
   // Note: Under this logic, a4aRequested shortcuts googleAdsIsA4AEnabled and,
   // therefore, carves out of the experiment branches.  Any publisher using this
   // attribute will be excluded from the experiment altogether.
-  const enableA4A = !usesRemoteHTML &&
-      (googleAdsIsA4AEnabled(
+  const enableA4A = googleAdsIsA4AEnabled(
           win, element, DOUBLECLICK_A4A_EXPERIMENT_NAME,
           DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
           DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES) ||
-       (a4aRequested &&
-        (isProxyOrigin(win.location) || getMode(win).localDev)));
+      (a4aRequested && (isProxyOrigin(win.location) || getMode(win).localDev));
   if (enableA4A && a4aRequested && !isInManualExperiment(element)) {
     element.setAttribute(EXPERIMENT_ATTRIBUTE,
         DOUBLECLICK_A4A_BETA_BRANCHES.experiment);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -85,11 +85,15 @@ export function doubleclickIsA4AEnabled(win, element) {
   // Note: Under this logic, a4aRequested shortcuts googleAdsIsA4AEnabled and,
   // therefore, carves out of the experiment branches.  Any publisher using this
   // attribute will be excluded from the experiment altogether.
+  // TODO(tdrl): The "is this site eligible" logic has gotten scattered around
+  // and is now duplicated.  It should be cleaned up and factored into a single,
+  // shared location.
   const enableA4A = googleAdsIsA4AEnabled(
           win, element, DOUBLECLICK_A4A_EXPERIMENT_NAME,
           DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
           DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES) ||
-      (a4aRequested && (isProxyOrigin(win.location) || getMode(win).localDev));
+      (a4aRequested && (isProxyOrigin(win.location) ||
+       getMode(win).localDev || getMode(win).test));
   if (enableA4A && a4aRequested && !isInManualExperiment(element)) {
     element.setAttribute(EXPERIMENT_ATTRIBUTE,
         DOUBLECLICK_A4A_BETA_BRANCHES.experiment);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -22,6 +22,8 @@
 
 import {
   googleAdsIsA4AEnabled,
+  EXPERIMENT_ATTRIBUTE,
+  isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {getMode} from '../../../src/mode';
 import {isProxyOrigin} from '../../../src/url';
@@ -62,6 +64,12 @@ export const DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
   experiment: '117152681',
 };
 
+/** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
+export const DOUBLECLICK_A4A_BETA_BRANCHES = {
+  control: '2077830',
+  experiment: '2077831',
+};
+
 /**
  * @param {!Window} win
  * @param {!Element} element
@@ -76,11 +84,15 @@ export function doubleclickIsA4AEnabled(win, element) {
   // therefore, carves out of the experiment branches.  Any publisher using this
   // attribute will be excluded from the experiment altogether.
   const enableA4A = !usesRemoteHTML &&
-      ((a4aRequested &&
-        (isProxyOrigin(win.location) || getMode(win).localDev)) ||
-       googleAdsIsA4AEnabled(
+      (googleAdsIsA4AEnabled(
           win, element, DOUBLECLICK_A4A_EXPERIMENT_NAME,
           DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
-          DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES));
+          DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES) ||
+       (a4aRequested &&
+        (isProxyOrigin(win.location) || getMode(win).localDev)));
+  if (enableA4A && a4aRequested && !isInManualExperiment(element)) {
+    element.setAttribute(EXPERIMENT_ATTRIBUTE,
+        DOUBLECLICK_A4A_BETA_BRANCHES.experiment);
+  }
   return enableA4A;
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -70,6 +70,8 @@ export const DOUBLECLICK_A4A_BETA_BRANCHES = {
   experiment: '2077831',
 };
 
+export const BETA_ATTRIBUTE = 'data-use-beta-a4a-implementation';
+
 /**
  * @param {!Window} win
  * @param {!Element} element
@@ -79,8 +81,7 @@ export function doubleclickIsA4AEnabled(win, element) {
   if (!!win.document.querySelector('meta[name=amp-3p-iframe-src]')) {
     return false;
   }
-  const a4aRequested = element.hasAttribute(
-      'data-use-experimental-a4a-implementation');
+  const a4aRequested = element.hasAttribute(BETA_ATTRIBUTE);
   // Note: Under this logic, a4aRequested shortcuts googleAdsIsA4AEnabled and,
   // therefore, carves out of the experiment branches.  Any publisher using this
   // attribute will be excluded from the experiment altogether.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {doubleclickIsA4AEnabled} from '../doubleclick-a4a-config';
+import {
+  EXPERIMENT_ATTRIBUTE,
+} from '../../../../ads/google/a4a/traffic-experiments';
+import {resetExperimentToggles_} from '../../../../src/experiments';
+import {parseUrl} from '../../../../src/url';
+import {createIframePromise} from '../../../../testing/iframe';
+import * as sinon from 'sinon';
+
+describe('doubleclick-a4a-config', () => {
+  let sandbox;
+  let mockWin;
+  let iframe;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    mockWin = {
+      location: parseUrl('https://nowhere.org/a/place/page.html?s=foo&q=bar'),
+      document: {
+        querySelector: x => {return null;}
+      },
+      crypto: {
+        subtle: true,
+        webkitSubtle: true,
+      },
+    };
+    iframe = createIframePromise();
+  });
+  afterEach(() => {
+    sandbox.restore();
+    resetExperimentToggles_();
+  });
+
+  describe('#doubleclickIsA4AEnabled', () => {
+    it('should enable a4a when requested and on CDN', () => {
+      return iframe.then(fixture => {
+        mockWin.location = parseUrl(
+            'https://cdn.ampproject.org/some/path/to/content.html');
+        const elem = document.createElement('div');
+        elem.setAttribute('data-use-experimental-a4a-implementation', 'true');
+        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+        expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+      });
+    });
+
+    it('should enable a4a when requested and in local dev', () => {
+      return iframe.then(fixture => {
+        const elem = document.createElement('div');
+        elem.setAttribute('data-use-experimental-a4a-implementation', 'true');
+        mockWin.AMP_MODE = {localDev: true};
+        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+        expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+      });
+    });
+
+    it('should not enable a4a, even if requested, when on bad origin', () => {
+      return iframe.then(fixture => {
+        const elem = fixture.doc.createElement('div');
+        elem.setAttribute('data-use-experimental-a4a-implementation', 'true');
+        fixture.doc.body.appendChild(elem);
+        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
+        expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+      });
+    });
+
+    it('should carve out remote.html, in spite of experiment override', () => {
+      return iframe.then(fixture => {
+        const doc = fixture.doc;
+        mockWin.location = parseUrl(
+            'https://cdn.ampproject.org/some/path/to/content.html');
+        mockWin.document.querySelector = doc.querySelector.bind(doc);
+        const remoteTag = doc.createElement('meta');
+        remoteTag.setAttribute('name', 'amp-3p-iframe-src');
+        doc.head.appendChild(remoteTag);
+        const elem = doc.createElement('div');
+        elem.setAttribute('data-use-experimental-a4a-implementation', 'true');
+        doc.body.appendChild(elem);
+        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
+        expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+      });
+    });
+
+    [-1, 0, 1, 2].forEach(expFlagValue => {
+      it(`exp flag=${expFlagValue} should set eid attribute`, () => {
+        return iframe.then(fixture => {
+          mockWin.location = parseUrl(
+              'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:' +
+              String(expFlagValue));
+          const expectedEnabledState =
+              (expFlagValue == -1 || expFlagValue == 2);
+          const elem = fixture.doc.createElement('div');
+          fixture.doc.body.appendChild(elem);
+          expect(doubleclickIsA4AEnabled(mockWin, elem)).to.equal(
+              expectedEnabledState);
+          if (expFlagValue == 0) {
+            expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+          } else {
+            expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.be.ok;
+          }
+        });
+      });
+
+      it(`force a4a attribute should preempt exp flag=${expFlagValue}`, () => {
+        return iframe.then(fixture => {
+          mockWin.location = parseUrl(
+              'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:' +
+              String(expFlagValue));
+          const elem = fixture.doc.createElement('div');
+          elem.setAttribute('data-use-experimental-a4a-implementation', 'true');
+          fixture.doc.body.appendChild(elem);
+          expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+          expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+        });
+      });
+
+      it(`should carve out remote.html, in spite of exp flag=${expFlagValue}`,
+          () => {
+            return iframe.then(fixture => {
+              const doc = fixture.doc;
+              mockWin.location = parseUrl(
+                  'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:' +
+                  String(expFlagValue));
+              mockWin.document.querySelector = doc.querySelector.bind(doc);
+              const remoteTag = doc.createElement('meta');
+              remoteTag.setAttribute('name', 'amp-3p-iframe-src');
+              doc.head.appendChild(remoteTag);
+              const elem = doc.createElement('div');
+              doc.body.appendChild(elem);
+              expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
+              expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+            });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Some publishers want to beta test A4A.  This change adds a Doubleclick-only attribute that will allow them to force it on and send the necessary experiment ID to enable server support.  Such beta-mode requests are carved out of the existing experiments so that they will not contaminate "wild" traffic data.  In the case that a publisher tester uses both the "manual experiment trigger" (?exp=a4a:-1) parameter and the force attribute, the manual trigger will win.