### PR TITLE
Calculate current absolute position of fixed-position elements

### DIFF
--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -466,7 +466,7 @@ function hideBanner(state) {
  * @param {!Object} state
  */
 function measureBanner(state) {
-  state.bannerRect = state.viewport.getLayoutRect(state.element);
+  state.bannerHeight = state.viewport.getLayoutRect(state.element).height;
 }
 
 
@@ -475,7 +475,7 @@ function measureBanner(state) {
  * @param {!Object} state.
  */
 function updateViewportPadding(state) {
-  state.viewport.updatePaddingBottom(state.bannerRect.height);
+  state.viewport.updatePaddingBottom(state.bannerHeight);
   state.viewport.addToFixedLayer(state.element);
 }
 

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -112,7 +112,7 @@ export class AmpVizVega extends AMP.BaseElement {
 
   /** @override */
   onLayoutMeasure() {
-    const box = this.element.getLayoutBox();
+    const box = this.getLayoutBox();
     if (this.measuredWidth_ == box.width &&
         this.measuredHeight_ == box.height) {
       return;

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -172,8 +172,7 @@ export class BaseElement {
    * @return {!./layout-rect.LayoutRectDef}
    */
   getLayoutBox() {
-    return this.element.getResources().getResourceForElement(
-        this.element).getLayoutBox();
+    return this.element.getLayoutBox();
   }
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -444,9 +444,6 @@ function createBaseCustomElementClass(win) {
       this.layout_ = Layout.NODISPLAY;
 
       /** @private {number} */
-      this.layoutWidth_ = -1;
-
-      /** @private {number} */
       this.layoutCount_ = 0;
 
       /** @private {boolean} */
@@ -707,6 +704,7 @@ function createBaseCustomElementClass(win) {
         this.implementation_.layoutWidth_ = this.layoutWidth_;
       }
       // TODO(malteubl): Forward for stubbed elements.
+      // TODO(jridgewell): We should pass the layoutBox down.
       this.implementation_.onLayoutMeasure();
 
       if (this.isLoadingEnabled_()) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -444,6 +444,9 @@ function createBaseCustomElementClass(win) {
       this.layout_ = Layout.NODISPLAY;
 
       /** @private {number} */
+      this.layoutWidth_ = -1;
+
+      /** @private {number} */
       this.layoutCount_ = 0;
 
       /** @private {boolean} */

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -313,11 +313,11 @@ export class Resource {
    */
   measure() {
     this.isMeasureRequested_ = false;
-    this.layoutBox_ = box;
 
     const box = this.resources_.getViewport().getLayoutRect(this.element);
     const oldBox = this.layoutBox_;
     const viewport = this.resources_.getViewport();
+    this.layoutBox_ = box;
 
     // Calculate whether the element is currently is or in `position:fixed`.
     let isFixed = false;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -144,8 +144,8 @@ export class Resource {
     /** @private {!../layout-rect.LayoutRectDef} */
     this.layoutBox_ = layoutRectLtwh(-10000, -10000, 0, 0);
 
-    /** @private {!../layout-rect.LayoutRectDef} */
-    this.initialLayoutBox_ = this.layoutBox_;
+    /** @private {?../layout-rect.LayoutRectDef} */
+    this.initialLayoutBox_ = null;
 
     /** @private {boolean} */
     this.isMeasureRequested_ = false;
@@ -393,7 +393,7 @@ export class Resource {
    * @return {boolean}
    */
   hasBeenMeasured() {
-    return this.layoutBox_.top != -10000;
+    return !!this.initialLayoutBox_;
   }
 
   /**
@@ -425,7 +425,9 @@ export class Resource {
    * @return {!../layout-rect.LayoutRectDef}
    */
   getInitialLayoutBox() {
-    return this.initialLayoutBox_;
+    // Before the first measure, there will be no initial layoutBox.
+    // Luckily, layoutBox will be present but essentially useless.
+    return this.initialLayoutBox_ || this.layoutBox_;
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -314,7 +314,7 @@ export class Resource {
   measure() {
     this.isMeasureRequested_ = false;
 
-    const box = this.resources_.getViewport().getLayoutRect(this.element);
+    let box = this.resources_.getViewport().getLayoutRect(this.element);
     const oldBox = this.layoutBox_;
     const viewport = this.resources_.getViewport();
     this.layoutBox_ = box;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1206,7 +1206,7 @@ export class Resources {
   calcTaskScore_(task) {
     const viewport = this.viewport_.getRect();
     const box = task.resource.getLayoutBox();
-    const posPriority = Math.floor((box.top - viewport.top) / viewport.height);
+    let posPriority = Math.floor((box.top - viewport.top) / viewport.height);
     if (Math.sign(posPriority) != this.getScrollDirection()) {
       posPriority *= 2;
     }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1070,7 +1070,7 @@ export class Resources {
       // layers. This is currently a short-term fix to the problem that
       // the fixed elements get incorrect top coord.
       const shouldBeInViewport = (this.visible_ && r.isDisplayed() &&
-          (r.isFixed() || r.overlaps(visibleRect)));
+          r.overlaps(visibleRect));
       r.setInViewport(shouldBeInViewport);
     }
 
@@ -1085,7 +1085,7 @@ export class Resources {
         // TODO(dvoytenko, #3434): Reimplement the use of `isFixed` with
         // layers. This is currently a short-term fix to the problem that
         // the fixed elements get incorrect top coord.
-        if (r.isDisplayed() && (r.isFixed() || r.overlaps(loadRect))) {
+        if (r.isDisplayed() && r.overlaps(loadRect)) {
           this.scheduleLayoutOrPreload_(r, /* layout */ true);
         }
       }
@@ -1204,15 +1204,9 @@ export class Resources {
    * @private
    */
   calcTaskScore_(task) {
-    let posPriority = 0;
-    // TODO(dvoytenko, #3434): Reimplement the use of `isFixed` with
-    // layers. This is currently a short-term fix to the problem that
-    // the fixed elements get incorrect top coord.
-    if (!task.resource.isFixed()) {
-      const viewport = this.viewport_.getRect();
-      const box = task.resource.getLayoutBox();
-      posPriority = Math.floor((box.top - viewport.top) / viewport.height);
-    }
+    const viewport = this.viewport_.getRect();
+    const box = task.resource.getLayoutBox();
+    const posPriority = Math.floor((box.top - viewport.top) / viewport.height);
     if (Math.sign(posPriority) != this.getScrollDirection()) {
       posPriority *= 2;
     }

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -43,10 +43,10 @@ describe('Resources', () => {
     sandbox.stub(resources.viewport_, 'getRect', () => viewportRect);
 
     // Task 1 is right in the middle of the viewport and priority 0
-    const task_vp0_p0 = {
+    const task_in_viewport_p0 = {
       resource: {
         getLayoutBox() {
-          return layoutRectLtwh(0, 100, 300, 100);
+          return layoutRectLtwh(0, 200, 300, 100);
         },
         isFixed() {
           return false;
@@ -55,10 +55,10 @@ describe('Resources', () => {
       priority: 0,
     };
     // Task 2 is in the viewport and priority 1
-    const task_vp0_p1 = {
+    const task_in_viewport_p1 = {
       resource: {
         getLayoutBox() {
-          return layoutRectLtwh(0, 100, 300, 100);
+          return layoutRectLtwh(0, 200, 300, 100);
         },
         isFixed() {
           return false;
@@ -67,7 +67,7 @@ describe('Resources', () => {
       priority: 1,
     };
     // Task 3 is above viewport and priority 0
-    const task_vpu_p0 = {
+    const task_above_viewport_p0 = {
       resource: {
         getLayoutBox() {
           return layoutRectLtwh(0, 0, 300, 50);
@@ -78,8 +78,8 @@ describe('Resources', () => {
       },
       priority: 0,
     };
-    // Task 4 is above viewport and priority 0
-    const task_vpu_p1 = {
+    // Task 4 is above viewport and priority 1
+    const task_above_viewport_p1 = {
       resource: {
         getLayoutBox() {
           return layoutRectLtwh(0, 0, 300, 50);
@@ -91,7 +91,7 @@ describe('Resources', () => {
       priority: 1,
     };
     // Task 5 is below viewport and priority 0
-    const task_vpd_p0 = {
+    const task_below_viewport_p0 = {
       resource: {
         getLayoutBox() {
           return layoutRectLtwh(0, 600, 300, 50);
@@ -102,8 +102,8 @@ describe('Resources', () => {
       },
       priority: 0,
     };
-    // Task 6 is below viewport and priority 0
-    const task_vpd_p1 = {
+    // Task 6 is below viewport and priority 1
+    const task_below_viewport_p1 = {
       resource: {
         getLayoutBox() {
           return layoutRectLtwh(0, 600, 300, 50);
@@ -114,45 +114,102 @@ describe('Resources', () => {
       },
       priority: 1,
     };
-    // Task 7 is fixed with priority 0.
-    const task_vpf_p0 = {
+    // Task 7 is fixed right in the middle of the viewport and priority 0
+    const task_fixed_in_viewport_p0 = {
       resource: {
         getLayoutBox() {
-          return layoutRectLtwh(0, 600, 300, 50);
+          return layoutRectLtwh(0, 200, 300, 100);
         },
         isFixed() {
-          return true;
+          return false;
         },
       },
       priority: 0,
     };
-    // Task 8 is fixed with priority 1.
-    const task_vpf_p1 = {
+    // Task 8 is fixed in the viewport and priority 1
+    const task_fixed_in_viewport_p1 = {
+      resource: {
+        getLayoutBox() {
+          return layoutRectLtwh(0, 200, 300, 100);
+        },
+        isFixed() {
+          return false;
+        },
+      },
+      priority: 1,
+    };
+    // Task 9 is fixed above viewport and priority 0
+    const task_fixed_above_viewport_p0 = {
+      resource: {
+        getLayoutBox() {
+          return layoutRectLtwh(0, 0, 300, 50);
+        },
+        isFixed() {
+          return false;
+        },
+      },
+      priority: 0,
+    };
+    // Task 10 is fixed above viewport and priority 1
+    const task_fixed_above_viewport_p1 = {
+      resource: {
+        getLayoutBox() {
+          return layoutRectLtwh(0, 0, 300, 50);
+        },
+        isFixed() {
+          return false;
+        },
+      },
+      priority: 1,
+    };
+    // Task 11 is fixed below viewport and priority 0
+    const task_fixed_below_viewport_p0 = {
       resource: {
         getLayoutBox() {
           return layoutRectLtwh(0, 600, 300, 50);
         },
         isFixed() {
-          return true;
+          return false;
+        },
+      },
+      priority: 0,
+    };
+    // Task 12 is fixed below viewport and priority 1
+    const task_fixed_below_viewport_p1 = {
+      resource: {
+        getLayoutBox() {
+          return layoutRectLtwh(0, 600, 300, 50);
+        },
+        isFixed() {
+          return false;
         },
       },
       priority: 1,
     };
 
-    expect(resources.calcTaskScore_(task_vp0_p0)).to.equal(0);
-    expect(resources.calcTaskScore_(task_vp0_p1)).to.equal(10);
+    // 0 for in viewport
+    expect(resources.calcTaskScore_(task_in_viewport_p0)).to.equal(0);
+    expect(resources.calcTaskScore_(task_in_viewport_p1)).to.equal(10);
 
     // +2 for "one viewport away" * 2 because dir is opposite
-    expect(resources.calcTaskScore_(task_vpu_p0)).to.equal(2);
-    expect(resources.calcTaskScore_(task_vpu_p1)).to.equal(12);
+    expect(resources.calcTaskScore_(task_above_viewport_p0)).to.equal(2);
+    expect(resources.calcTaskScore_(task_above_viewport_p1)).to.equal(12);
 
     // +1 for "one viewport away" * 1 because dir is the same
-    expect(resources.calcTaskScore_(task_vpd_p0)).to.equal(1);
-    expect(resources.calcTaskScore_(task_vpd_p1)).to.equal(11);
+    expect(resources.calcTaskScore_(task_below_viewport_p0)).to.equal(1);
+    expect(resources.calcTaskScore_(task_below_viewport_p1)).to.equal(11);
 
-    // 0 for fixed.
-    expect(resources.calcTaskScore_(task_vpf_p0)).to.equal(0);
-    expect(resources.calcTaskScore_(task_vpf_p1)).to.equal(10);
+    // 0 for fixed in viewport
+    expect(resources.calcTaskScore_(task_fixed_in_viewport_p0)).to.equal(0);
+    expect(resources.calcTaskScore_(task_fixed_in_viewport_p1)).to.equal(10);
+
+    // +2 for fixed "one viewport away", * 2 because dir is opposite
+    expect(resources.calcTaskScore_(task_fixed_above_viewport_p0)).to.equal(2);
+    expect(resources.calcTaskScore_(task_fixed_above_viewport_p1)).to.equal(12);
+
+    // +1 for fixed "one viewport away" * 1 because dir is the same
+    expect(resources.calcTaskScore_(task_fixed_below_viewport_p0)).to.equal(1);
+    expect(resources.calcTaskScore_(task_fixed_below_viewport_p1)).to.equal(11);
   });
 
   it('should calculate correct calcTaskTimeout', () => {


### PR DESCRIPTION
Currently, Resources caches the absolute position (`layoutBox`'s `top` and `bottom`). This works perfectly for the majority of elements, since they never move absolutely.

But fixed-position elements are different. They are positioned relative to the viewport, and the viewport moves. So, fixed-positions "move" absolutely. This change makes it so that we cache the relative positions of fixed-positions (to the viewport). When we later ask for the element's `layoutBox`, we'll calculate the "absolute" position by adding in the current `scrollTop` and `scrollLeft`. This is exactly the same as what I'm [doing for ad's `layoutBox`](https://github.com/ampproject/amphtml/pull/5271).

Part 2 (and hopefully the final) of #5149.
/cc @jasti.