### PR TITLE
Refactor awkward traversal and removal

### DIFF
--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -123,6 +123,22 @@ public class AmpPassTest extends Es6CompilerTestCase {
              "  var someValue = true;",
              "  console.log('this is preserved', someValue);",
             "})()"));
+
+    test(
+        LINE_JOINER.join(
+             "(function() {",
+             "  function add(a, b) { return a + b; }",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  var someValue = add(module$src$log.dev().assert(3), module$src$log.dev().assert(3));",
+             "  console.log('this is preserved', someValue);",
+            "})()"),
+        LINE_JOINER.join(
+             "(function() {",
+             "  function add(a, b) { return a + b; }",
+             "  var module$src$log = { dev: function() { return { assert: function() {}} } };",
+             "  var someValue = add(3, 3);",
+             "  console.log('this is preserved', someValue);",
+            "})()"));
   }
 
   public void testShouldPreserveNoneCalls() throws Exception {


### PR DESCRIPTION
Because I was both traversing up and down the tree to figure out if it was the correct node to remove, the node removed is possibly still on the post order traversal queue but parentless.