### PR TITLE
Wait for window to load before installing ServiceWorker.

### DIFF
--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -68,7 +68,7 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
     }
 
     if (parseUrl(win.location.href).origin == parseUrl(src).origin) {
-      this.loadPromise(() => {
+      this.loadPromise(this.win).then(() => {
         install(this.win, src);
       });
     } else {

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -17,6 +17,7 @@
 import {assertHttpsUrl, isProxyOrigin, parseUrl} from '../../../src/url';
 import {documentInfoForDoc} from '../../../src/document-info';
 import {getMode} from '../../../src/mode';
+import {loadPromise} from '../../../src/event-helper';
 import {timerFor} from '../../../src/timer';
 import {user} from '../../../src/log';
 import {viewerForDoc} from '../../../src/viewer';
@@ -111,13 +112,15 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
  * @param {string} src
  */
 function install(win, src) {
-  win.navigator.serviceWorker.register(src).then(function(registration) {
-    if (getMode().development) {
-      user().info(TAG, 'ServiceWorker registration successful with scope: ',
-          registration.scope);
-    }
-  }).catch(function(e) {
-    user().error(TAG, 'ServiceWorker registration failed:', e);
+  loadPromise(win).then(() => {
+    win.navigator.serviceWorker.register(src).then(function(registration) {
+      if (getMode().development) {
+        user().info(TAG, 'ServiceWorker registration successful with scope: ',
+            registration.scope);
+      }
+    }).catch(function(e) {
+      user().error(TAG, 'ServiceWorker registration failed:', e);
+    });
   });
 }
 

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -68,7 +68,7 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
     }
 
     if (parseUrl(win.location.href).origin == parseUrl(src).origin) {
-      this.laodPromise(() => {
+      this.loadPromise(() => {
         install(this.win, src);
       });
     } else {

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -17,7 +17,6 @@
 import {assertHttpsUrl, isProxyOrigin, parseUrl} from '../../../src/url';
 import {documentInfoForDoc} from '../../../src/document-info';
 import {getMode} from '../../../src/mode';
-import {loadPromise} from '../../../src/event-helper';
 import {timerFor} from '../../../src/timer';
 import {user} from '../../../src/log';
 import {viewerForDoc} from '../../../src/viewer';
@@ -69,7 +68,9 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
     }
 
     if (parseUrl(win.location.href).origin == parseUrl(src).origin) {
-      install(this.win, src);
+      this.laodPromise(() => {
+        install(this.win, src);
+      });
     } else {
       user().error(TAG,
           'Did not install ServiceWorker because it does not ' +
@@ -112,15 +113,13 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
  * @param {string} src
  */
 function install(win, src) {
-  loadPromise(win).then(() => {
-    win.navigator.serviceWorker.register(src).then(function(registration) {
-      if (getMode().development) {
-        user().info(TAG, 'ServiceWorker registration successful with scope: ',
-            registration.scope);
-      }
-    }).catch(function(e) {
-      user().error(TAG, 'ServiceWorker registration failed:', e);
-    });
+  win.navigator.serviceWorker.register(src).then(function(registration) {
+    if (getMode().development) {
+      user().info(TAG, 'ServiceWorker registration successful with scope: ',
+          registration.scope);
+    }
+  }).catch(function(e) {
+    user().error(TAG, 'ServiceWorker registration failed:', e);
   });
 }
 

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -22,6 +22,7 @@ import {
   getServiceForDoc,
   resetServiceForTesting,
 } from '../../../../src/service';
+import {loadPromise} from '../../../../src/event-helper';
 import {installTimerService} from '../../../../src/service/timer-impl';
 import * as sinon from 'sinon';
 
@@ -57,6 +58,7 @@ describe('amp-install-serviceworker', () => {
     let calledSrc;
     const p = new Promise(() => {});
     implementation.win = {
+      complete: true,
       location: {
         href: 'https://example.com/some/path',
       },
@@ -71,7 +73,10 @@ describe('amp-install-serviceworker', () => {
       },
     };
     implementation.buildCallback();
-    expect(calledSrc).to.equal('https://example.com/sw.js');
+    expect(calledSrc).to.be.undefined;
+    return loadPromise(implementation.win).then(() => {
+      expect(calledSrc).to.equal('https://example.com/sw.js');
+    });
   });
 
   it('should be ok without service worker.', () => {


### PR DESCRIPTION
The WPT waterfalls in #5573 showed that the SW can interfere pretty heavily with the current page load which is bad in cases where it downloads a lot of stuff not currently needed.