### PR TITLE
Position:relative on body

### DIFF
--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -893,15 +893,27 @@ export class ViewportBindingNatural_ {
     /** @const {function()} */
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 
-    // Override a user-supplied `body{overflow}` to be always visible. This
-    // style is set in runtime vs css to avoid conflicts with ios-embedded
-    // mode and fixed transfer layer.
     if (this.win.document.defaultView) {
       waitForBody(this.win.document, () => {
+        // Override a user-supplied `body{overflow}` to be always visible. This
+        // style is set in runtime vs css to avoid conflicts with ios-embedded
+        // mode and fixed transfer layer.
         this.win.document.body.style.overflow = 'visible';
         if (this.platform_.isIos() &&
             this.viewer_.getParam('webview') === '1') {
           setStyles(this.win.document.body, {
+            overflowX: 'hidden',
+            overflowY: 'visible',
+          });
+        }
+
+        // Require `body{position:relative}`.
+        // TODO(dvoytenko, #5660): cleanup "make-body-relative" experiment by
+        // merging this style into `amp.css`.
+        if (isExperimentOn(this.win, 'make-body-relative')) {
+          setStyles(this.win.document.body, {
+            display: 'block',
+            position: 'relative',
             overflowX: 'hidden',
             overflowY: 'visible',
           });

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -950,6 +950,16 @@ describe('ViewportBindingNatural', () => {
     windowMock.verify();
     viewerMock.verify();
     sandbox.restore();
+    toggleExperiment(windowApi, 'make-body-relative', false);
+  });
+
+  it('should configure make-body-relative', () => {
+    toggleExperiment(windowApi, 'make-body-relative', true);
+    binding = new ViewportBindingNatural_(windowApi, viewer);
+    expect(documentBody.style.display).to.equal('block');
+    expect(documentBody.style.position).to.equal('relative');
+    expect(documentBody.style.overflowY).to.equal('visible');
+    expect(documentBody.style.overflowX).to.equal('hidden');
   });
 
   it('should setup overflow:visible on body', () => {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -183,6 +183,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5319',
   },
   {
+    id: 'make-body-relative',
+    name: 'Sets the body to position:relative.',
+    spec: '',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5660',
+  },
+  {
     id: 'link-url-replace',
     name: 'Enables replacing variables in URLs of outgoing links.',
     spec: 'https://github.com/ampproject/amphtml/issues/4078',

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -185,7 +185,7 @@ const EXPERIMENTS = [
   {
     id: 'make-body-relative',
     name: 'Sets the body to position:relative.',
-    spec: '',
+    spec: 'https://github.com/ampproject/amphtml/issues/5667',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5660',
   },
   {


### PR DESCRIPTION
Closes #5667.

This PR adds `body{position:relative}` CSS to ensure that content with `position:absolute` is positioned relative to the body and offset to be shown under the viewer's header, not behind it.