### PR TITLE
Fix broken tests on Chrome 54

### DIFF
--- a/testing/describes.js
+++ b/testing/describes.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import installCustomElements from
+    'document-register-element/build/document-register-element.node';
 import {
   FakeCustomElements,
   FakeWindow,
@@ -323,6 +325,8 @@ class RealWinFixture {
 
         if (spec.fakeRegisterElement) {
           win.customElements = new FakeCustomElements(win);
+        } else {
+          installCustomElements(win);
         }
 
         // Intercept event listeners

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -16,6 +16,8 @@
 
 
 import {Timer} from '../src/timer';
+import installCustomElements from
+    'document-register-element/build/document-register-element.node';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {installExtensionsService} from '../src/service/extensions-impl';
 import {
@@ -208,6 +210,7 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
       const ampdoc = ampdocService.getAmpDoc(iframe.contentWindow.document);
       installExtensionsService(iframe.contentWindow);
       installRuntimeServices(iframe.contentWindow);
+      installCustomElements(iframe.contentWindow);
       installAmpdocServices(ampdoc);
       registerForUnitTest(iframe.contentWindow);
       // Act like no other elements were loaded by default.


### PR DESCRIPTION
Fixes #5611. 

The polyfill is automatically installed for the global window for Babel builds during import, but was missing from test iframe's `contentWindow`. This is unfortunately necessary due to an ES6 backwards compatibility issue with Custom Elements V1 ([more info](https://www.webreflection.co.uk/blog/2016/08/30/js-super-problem)).