### PR TITLE
Clean up updateViewerViewport method

### DIFF
--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -153,7 +153,6 @@ export class Viewport {
     this.boundThrottledScroll_ = this.throttledScroll_.bind(this);
 
     this.viewer_.onViewportEvent(this.updateOnViewportEvent_.bind(this));
-    this.binding_.updateViewerViewport(this.viewer_);
     this.binding_.updatePaddingTop(this.paddingTop_);
 
     this.binding_.onScroll(this.scroll_.bind(this));
@@ -581,7 +580,6 @@ export class Viewport {
    * @private
    */
   updateOnViewportEvent_(event) {
-    this.binding_.updateViewerViewport(this.viewer_);
     const paddingTop = event['paddingTop'];
     const duration = event['duration'] || 0;
     const curve = event['curve'];
@@ -775,12 +773,6 @@ export class ViewportBindingDef {
   onResize(unusedCallback) {}
 
   /**
-   * Updates binding with the new viewer's viewport info.
-   * @param {!./viewer-impl.Viewer} unusedViewer
-   */
-  updateViewerViewport(unusedViewer) {}
-
-  /**
    * Updates binding with the new padding.
    * @param {number} unusedPaddingTop
    */
@@ -942,11 +934,6 @@ export class ViewportBindingNatural_ {
   /** @override */
   onResize(callback) {
     this.resizeObservable_.add(callback);
-  }
-
-  /** @override */
-  updateViewerViewport(unusedViewer) {
-    // Viewer's viewport is ignored since this window is fully accurate.
   }
 
   /** @override */
@@ -1209,11 +1196,6 @@ export class ViewportBindingNaturalIosEmbed_ {
   disconnect() {
     // Do nothing: ViewportBindingNaturalIosEmbed_ can only be used in the
     // single-doc mode.
-  }
-
-  /** @override */
-  updateViewerViewport(unusedViewer) {
-    // Viewer's viewport is ignored since this window is fully accurate.
   }
 
   /** @override */
@@ -1497,11 +1479,6 @@ export class ViewportBindingIosEmbedWrapper_ {
   /** @override */
   onResize(callback) {
     this.resizeObservable_.add(callback);
-  }
-
-  /** @override */
-  updateViewerViewport(unusedViewer) {
-    // Viewer's viewport is ignored since this window is fully accurate.
   }
 
   /** @override */

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -306,13 +306,6 @@ describe('Viewport', () => {
     expect(showFixedLayerStub.callCount).to.equal(1);
   });
 
-  it('should call binding.updateViewerViewport', () => {
-    const bindingMock = sandbox.mock(binding);
-    bindingMock.expects('updateViewerViewport').once();
-    viewerViewportHandler({paddingTop: 19});
-    bindingMock.verify();
-  });
-
   it('should send scroll events', () => {
     // 0         ->    6     ->      12   ->      16         ->   18
     // scroll-10    scroll-20    scroll-30   2nd anim frame    scroll-40


### PR DESCRIPTION
`updateViewerViewport` in `viewport-impl` is not currently used anywhere. Previously it is only useful in virtual viewport but the virtual viewport is removed in https://github.com/ampproject/amphtml/pull/3535. Therefore, `updateViewerViewport` could be deleted.