### PR TITLE
Add Flying Carpet to FixedLayer

### DIFF
--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -25,6 +25,40 @@ const EXPERIMENT = 'amp-fx-flying-carpet';
 
 class AmpFlyingCarpet extends AMP.BaseElement {
 
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /**
+     * Preserved so that we may keep track of the "good" children. When an
+     * element collapses, we remove it from the list.
+     *
+     * @type{!Array<!Element>}
+     * @private
+     */
+    this.children_ = [];
+
+    /**
+     * The number of non-empty child nodes left that are still "good". If no
+     * more are left, we attempt to collapse the flying carpet.
+     * Note that this may not be the number for child elements, since Text also
+     * appears inside the flying carpet.
+     *
+     * @type {number}
+     * @private
+     */
+    this.totalChildren_ = 0;
+
+    /**
+     * A cached reference to the container, used to set its width to match
+     * the flying carpet's.
+     * @type {?Element}
+     * @private
+     */
+    this.container_ = null;
+  }
+
+
   /** @override */
   isLayoutSupported(layout) {
     return layout == Layout.FIXED_HEIGHT;
@@ -32,8 +66,7 @@ class AmpFlyingCarpet extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.isExperimentOn_ = isExperimentOn(this.win, EXPERIMENT);
-    if (!this.isExperimentOn_) {
+    if (!isExperimentOn(this.win, EXPERIMENT)) {
       dev().warn(EXPERIMENT, `Experiment ${EXPERIMENT} disabled`);
       toggle(this.element, false);
       return;
@@ -41,39 +74,19 @@ class AmpFlyingCarpet extends AMP.BaseElement {
 
     const doc = this.element.ownerDocument;
     const container = doc.createElement('div');
-    const childNodes = this.getRealChildNodes();
 
-    /** @const @private {!Vsync} */
-    this.vsync_ = this.getVsync();
-
-    /**
-     * Preserved so that we may keep track of the "good" children. When an
-     * element collapses, we remove it from the list.
-     * @private @const
-     */
     this.children_ = this.getRealChildren();
+    this.container_ = container;
 
-    /**
-     * The number of non-empty child nodes left that are still "good". If no
-     * more are left, we attempt to collapse the flying carpet.
-     * Note that this may not be the number for child elements, since Text also
-     * appears inside the flying carpet.
-     * @private
-     */
+    const childNodes = this.getRealChildNodes();
     this.totalChildren_ = this.visibileChildren_(childNodes).length;
 
-    /**
-     * A cached reference to the container, used to set its width to match
-     * the flying carpet's.
-     * @private @const
-     */
-    this.container_ = container;
+    this.children_.forEach(child => this.setAsOwner(child));
 
     const clip = doc.createElement('div');
     clip.setAttribute('class', '-amp-fx-flying-carpet-clip');
     container.setAttribute('class', '-amp-fx-flying-carpet-container');
 
-    this.children_.forEach(child => this.setAsOwner(child));
     childNodes.forEach(child => container.appendChild(child));
     clip.appendChild(container);
     this.element.appendChild(clip);
@@ -83,7 +96,7 @@ class AmpFlyingCarpet extends AMP.BaseElement {
 
   onLayoutMeasure() {
     const width = this.getLayoutWidth();
-    this.vsync_.mutate(() => {
+    this.getVsync().mutate(() => {
       setStyle(this.container_, 'width', width, 'px');
     });
   }
@@ -150,11 +163,11 @@ class AmpFlyingCarpet extends AMP.BaseElement {
    */
   visibileChildren_(nodes) {
     return nodes.filter(node => {
-      if (node.nodeType === /* Element */1) {
+      if (node.nodeType === /* Element */ 1) {
         return true;
       }
 
-      if (node.nodeType === /* Text */3) {
+      if (node.nodeType === /* Text */ 3) {
         // Is there a non-whitespace character?
         return /\S/.test(node.textContent);
       }

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -77,6 +77,8 @@ class AmpFlyingCarpet extends AMP.BaseElement {
     childNodes.forEach(child => container.appendChild(child));
     clip.appendChild(container);
     this.element.appendChild(clip);
+
+    this.getViewport().addToFixedLayer(container);
   }
 
   onLayoutMeasure() {

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -121,7 +121,7 @@ describe('amp-fx-flying-carpet', () => {
       const container = flyingCarpet.firstChild.firstChild;
       let width = 10;
 
-      impl.vsync_.mutate = function(callback) {
+      impl.getVsync().mutate = function(callback) {
         callback();
       };
       impl.getLayoutWidth = () => width;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,7 +68,7 @@ declareExtension('amp-fit-text', '0.1', true, 'NO_TYPE_CHECK');
 declareExtension('amp-font', '0.1', false, 'NO_TYPE_CHECK');
 declareExtension('amp-form', '0.1', true);
 declareExtension('amp-fresh', '0.1', true);
-declareExtension('amp-fx-flying-carpet', '0.1', true, 'NO_TYPE_CHECK');
+declareExtension('amp-fx-flying-carpet', '0.1', true);
 declareExtension('amp-gfycat', '0.1', false);
 declareExtension('amp-iframe', '0.1', false, 'NO_TYPE_CHECK');
 declareExtension('amp-image-lightbox', '0.1', true);


### PR DESCRIPTION
The final final fix for #3812, so that resources correctly detects the contents of a Flying Carpet are fixed position. That triggers #5624's behavior, and that gives us the correct visibility metrics! Huray!

Also adds type checking.

Fixes #3812.
/cc @jasti, @muxin 