### PR TITLE
Fix AmpAdApiHandler type check

### DIFF
--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -20,6 +20,11 @@
 function BaseElement$$module$src$base_element() {};
 /** @constructor */
 function AmpAdApiHandler$$module$extensions$amp_ad$0_1$amp_ad_api_handler() {};
+/** @constructor */
+function AmpAd3PImpl$$module$extensions$amp_ad$0_1$amp_ad_3p_impl() {};
+/** @constructor */
+function AmpA4A$$module$extensions$amp_a4a$0_1$amp_a4a() {};
+
 
 // Long list of, uhm, stuff the ads code needs to compile.
 // All unquoted external properties need to be added here.

--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -106,6 +106,9 @@ function isInReportableBranch(ampElement, namespace) {
   }
 }
 
+/**
+ * @return {!AmpAdLifecycleReporter|!NullLifecycleReporter}
+ */
 export function getLifecycleReporter(ampElement, namespace) {
   // Carve-outs: We only want to enable profiling pingbacks when:
   //   - The ad is from one of the Google networks (AdSense or Doubleclick).

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -188,12 +188,12 @@ AMP.BaseElement = class {
  */
 AMP.AmpAdApiHandler = class {
   /**
-   * @param {!AMP.BaseElement} baseInstance
+   * @param {!AmpAd3PImpl$$module$extensions$amp_ad$0_1$amp_ad_3p_impl|!AmpA4A$$module$extensions$amp_a4a$0_1$amp_a4a} baseInstance
    * @param {!Element} element
    * @param {function()=} opt_noContentCallback
    */
   constructor(baseInstance, element, opt_noContentCallback) {}
-}
+};
 
 /*
      \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  /  _____|

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -162,7 +162,7 @@ export class AmpA4A extends AMP.BaseElement {
     this.experimentalNonAmpCreativeRenderMethod_ = null;
 
     /** @public {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
-    this.lifeCycleReporter = getLifecycleReporter(this, 'a4a');
+    this.lifecycleReporter = getLifecycleReporter(this, 'a4a');
     // Note: The reporting ping should be the last action in the constructor.
     this.lifecycleReporter.sendPing('adSlotBuilt');
   }
@@ -793,7 +793,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   renderViaSafeFrame_(creativeBody) {
-    this.lifecycleReporter_.sendPing('renderSafeFrameStart');
+    this.lifecycleReporter.sendPing('renderSafeFrameStart');
     utf8Decode(creativeBody).then(creative => {
       /** @const {!Element} */
       const iframe = createElementWithAttributes(

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -297,7 +297,7 @@ export class AmpA4A extends AMP.BaseElement {
         /** @return {!Promise<?string>} */
         .then(() => {
           checkStillCurrent(promiseId);
-          this.lifeCycleReporter.sendPing('urlBuilt');
+          this.lifecycleReporter.sendPing('urlBuilt');
           return /** @type {!Promise<?string>} */ (this.getAdUrl());
         })
         // This block returns the (possibly empty) response to the XHR request.
@@ -343,7 +343,7 @@ export class AmpA4A extends AMP.BaseElement {
         .then(responseParts => {
           checkStillCurrent(promiseId);
           if (responseParts) {
-            this.lifeCycleReporter.sendPing('extractCreativeAndSignature');
+            this.lifecycleReporter.sendPing('extractCreativeAndSignature');
           }
           return responseParts && this.extractCreativeAndSignature(
               responseParts.bytes, responseParts.headers);
@@ -366,7 +366,7 @@ export class AmpA4A extends AMP.BaseElement {
           if (!creativeParts || !creativeParts.signature) {
             return /** @type {!Promise<?string>} */ (Promise.resolve(null));
           }
-          this.lifeCycleReporter.sendPing('adResponseValidateStart');
+          this.lifecycleReporter.sendPing('adResponseValidateStart');
 
           // For each signing service, we have exactly one Promise,
           // keyInfoSetPromise, that holds an Array of Promises of signing keys.
@@ -466,7 +466,7 @@ export class AmpA4A extends AMP.BaseElement {
     // creatives which rendered via the buildCallback promise chain.  Ensure
     // slot counts towards 3p loading count until we know that the creative is
     // valid AMP.
-    this.lifeCycleReporter.sendPing('preAdThrottle');
+    this.lifecycleReporter.sendPing('preAdThrottle');
     this.timerId_ = incrementLoadingAds(this.win);
     return this.adPromise_.then(rendered => {
       if (rendered instanceof Error || !rendered) {
@@ -492,7 +492,7 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override  */
   unlayoutCallback() {
-    this.lifeCycleReporter.sendPing('adSlotCleared');
+    this.lifecycleReporter.sendPing('adSlotCleared');
     // Remove creative and reset to allow for creation of new ad.
     if (!this.layoutMeasureExecuted_) {
       return true;
@@ -562,7 +562,7 @@ export class AmpA4A extends AMP.BaseElement {
    * publisher page.  To be overridden by network implementations as needed.
    */
   onAmpCreativeRender() {
-    this.lifeCycleReporter.sendPing('renderFriendlyEnd');
+    this.lifecycleReporter.sendPing('renderFriendlyEnd');
   }
 
   /**
@@ -572,7 +572,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   sendXhrRequest_(adUrl) {
-    this.lifeCycleReporter.sendPing('adRequestStart');
+    this.lifecycleReporter.sendPing('adRequestStart');
     const xhrInit = {
       mode: 'cors',
       method: 'GET',
@@ -658,7 +658,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   maybeRenderAmpAd_(bytes) {
-    this.lifeCycleReporter.sendPing('renderFriendlyStart');
+    this.lifecycleReporter.sendPing('renderFriendlyStart');
     // Timer id will be set if we have entered layoutCallback at which point
     // 3p throttling count was incremented.  We want to "release" the throttle
     // immediately since we now know we are not a 3p ad.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -161,7 +161,7 @@ export class AmpA4A extends AMP.BaseElement {
     /** @private {?string} */
     this.experimentalNonAmpCreativeRenderMethod_ = null;
 
-    /** @public {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
+    /** {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
     this.lifecycleReporter = getLifecycleReporter(this, 'a4a');
     // Note: The reporting ping should be the last action in the constructor.
     this.lifecycleReporter.sendPing('adSlotBuilt');

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -161,9 +161,10 @@ export class AmpA4A extends AMP.BaseElement {
     /** @private {?string} */
     this.experimentalNonAmpCreativeRenderMethod_ = null;
 
-    this.lifecycleReporter_ = getLifecycleReporter(this, 'a4a');
+    /** @public {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
+    this.lifeCycleReporter = getLifecycleReporter(this, 'a4a');
     // Note: The reporting ping should be the last action in the constructor.
-    this.lifecycleReporter_.sendPing('adSlotBuilt');
+    this.lifecycleReporter.sendPing('adSlotBuilt');
   }
 
   /** @override */
@@ -296,7 +297,7 @@ export class AmpA4A extends AMP.BaseElement {
         /** @return {!Promise<?string>} */
         .then(() => {
           checkStillCurrent(promiseId);
-          this.lifecycleReporter_.sendPing('urlBuilt');
+          this.lifeCycleReporter.sendPing('urlBuilt');
           return /** @type {!Promise<?string>} */ (this.getAdUrl());
         })
         // This block returns the (possibly empty) response to the XHR request.
@@ -314,7 +315,7 @@ export class AmpA4A extends AMP.BaseElement {
           if (!fetchResponse || !fetchResponse.arrayBuffer) {
             return null;
           }
-          this.lifecycleReporter_.sendPing('adRequestEnd');
+          this.lifecycleReporter.sendPing('adRequestEnd');
           // TODO(tdrl): Temporary, while we're verifying whether SafeFrame is
           // an acceptable solution to the 'Safari on iOS doesn't fetch
           // iframe src from cache' issue.  See
@@ -342,7 +343,7 @@ export class AmpA4A extends AMP.BaseElement {
         .then(responseParts => {
           checkStillCurrent(promiseId);
           if (responseParts) {
-            this.lifecycleReporter_.sendPing('extractCreativeAndSignature');
+            this.lifeCycleReporter.sendPing('extractCreativeAndSignature');
           }
           return responseParts && this.extractCreativeAndSignature(
               responseParts.bytes, responseParts.headers);
@@ -365,7 +366,7 @@ export class AmpA4A extends AMP.BaseElement {
           if (!creativeParts || !creativeParts.signature) {
             return /** @type {!Promise<?string>} */ (Promise.resolve(null));
           }
-          this.lifecycleReporter_.sendPing('adResponseValidateStart');
+          this.lifeCycleReporter.sendPing('adResponseValidateStart');
 
           // For each signing service, we have exactly one Promise,
           // keyInfoSetPromise, that holds an Array of Promises of signing keys.
@@ -465,7 +466,7 @@ export class AmpA4A extends AMP.BaseElement {
     // creatives which rendered via the buildCallback promise chain.  Ensure
     // slot counts towards 3p loading count until we know that the creative is
     // valid AMP.
-    this.lifecycleReporter_.sendPing('preAdThrottle');
+    this.lifeCycleReporter.sendPing('preAdThrottle');
     this.timerId_ = incrementLoadingAds(this.win);
     return this.adPromise_.then(rendered => {
       if (rendered instanceof Error || !rendered) {
@@ -491,7 +492,7 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override  */
   unlayoutCallback() {
-    this.lifecycleReporter_.sendPing('adSlotCleared');
+    this.lifeCycleReporter.sendPing('adSlotCleared');
     // Remove creative and reset to allow for creation of new ad.
     if (!this.layoutMeasureExecuted_) {
       return true;
@@ -561,7 +562,7 @@ export class AmpA4A extends AMP.BaseElement {
    * publisher page.  To be overridden by network implementations as needed.
    */
   onAmpCreativeRender() {
-    this.lifecycleReporter_.sendPing('renderFriendlyEnd');
+    this.lifeCycleReporter.sendPing('renderFriendlyEnd');
   }
 
   /**
@@ -571,7 +572,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   sendXhrRequest_(adUrl) {
-    this.lifecycleReporter_.sendPing('adRequestStart');
+    this.lifeCycleReporter.sendPing('adRequestStart');
     const xhrInit = {
       mode: 'cors',
       method: 'GET',
@@ -657,7 +658,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   maybeRenderAmpAd_(bytes) {
-    this.lifecycleReporter_.sendPing('renderFriendlyStart');
+    this.lifeCycleReporter.sendPing('renderFriendlyStart');
     // Timer id will be set if we have entered layoutCallback at which point
     // 3p throttling count was incremented.  We want to "release" the throttle
     // immediately since we now know we are not a 3p ad.
@@ -770,7 +771,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   renderViaCachedContentIframe_(adUrl, opt_isNonAmpCreative) {
-    this.lifecycleReporter_.sendPing('renderCrossDomainStart');
+    this.lifecycleReporter.sendPing('renderCrossDomainStart');
     /** @const {!Element} */
     const iframe = createElementWithAttributes(
         /** @type {!Document} */(this.element.ownerDocument),

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -86,6 +86,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
     /** @public {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
     this.lifecycleReporter = getLifecycleReporter(this, 'amp');
+
     this.lifecycleReporter.sendPing('adSlotBuilt');
   }
 
@@ -202,7 +203,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (this.layoutPromise_) {
       return this.layoutPromise_;
     }
-    this.lifeCycleReporter.sendPing('preAdThrottle');
+    this.lifecycleReporter.sendPing('preAdThrottle');
     user().assert(!this.isInFixedContainer_,
         '<amp-ad> is not allowed to be placed in elements with ' +
         'position:fixed: %s', this.element);
@@ -216,7 +217,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       // because both happen inside a cross-domain iframe.  Separating them
       // here, though, allows us to measure the impact of ad throttling via
       // incrementLoadingAds().
-      this.lifeCycleReporter.sendPing('adRequestStart');
+      this.lifecycleReporter.sendPing('adRequestStart');
       this.iframe_ = getIframe(this.element.ownerDocument.defaultView,
           this.element, undefined, opt_context);
       this.apiHandler_ = new AmpAdApiHandler(
@@ -286,7 +287,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.apiHandler_.unlayoutCallback();
       this.apiHandler_ = null;
     }
-    this.lifeCycleReporter.sendPing('adSlotCleared');
+    this.lifecycleReporter.sendPing('adSlotCleared');
     return true;
   }
 }

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -219,7 +219,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.lifeCycleReporter.sendPing('adRequestStart');
       this.iframe_ = getIframe(this.element.ownerDocument.defaultView,
           this.element, undefined, opt_context);
-      ///** {sdfdsf} */(this)
       this.apiHandler_ = new AmpAdApiHandler(
           this, this.element, this.boundNoContentHandler_);
       return this.apiHandler_.startUp(this.iframe_, true);

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -84,7 +84,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     /** @private {?Promise} */
     this.layoutPromise_ = null;
 
-    /** @public {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
+    /** {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
     this.lifecycleReporter = getLifecycleReporter(this, 'amp');
 
     this.lifecycleReporter.sendPing('adSlotBuilt');

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -84,8 +84,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     /** @private {?Promise} */
     this.layoutPromise_ = null;
 
-    this.lifecycleReporter_ = getLifecycleReporter(this, 'amp');
-    this.lifecycleReporter_.sendPing('adSlotBuilt');
+    /** @public {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
+    this.lifecycleReporter = getLifecycleReporter(this, 'amp');
+    this.lifecycleReporter.sendPing('adSlotBuilt');
   }
 
   /** @override */
@@ -201,7 +202,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (this.layoutPromise_) {
       return this.layoutPromise_;
     }
-    this.lifecycleReporter_.sendPing('preAdThrottle');
+    this.lifeCycleReporter.sendPing('preAdThrottle');
     user().assert(!this.isInFixedContainer_,
         '<amp-ad> is not allowed to be placed in elements with ' +
         'position:fixed: %s', this.element);
@@ -215,9 +216,10 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       // because both happen inside a cross-domain iframe.  Separating them
       // here, though, allows us to measure the impact of ad throttling via
       // incrementLoadingAds().
-      this.lifecycleReporter_.sendPing('adRequestStart');
+      this.lifeCycleReporter.sendPing('adRequestStart');
       this.iframe_ = getIframe(this.element.ownerDocument.defaultView,
           this.element, undefined, opt_context);
+      ///** {sdfdsf} */(this)
       this.apiHandler_ = new AmpAdApiHandler(
           this, this.element, this.boundNoContentHandler_);
       return this.apiHandler_.startUp(this.iframe_, true);
@@ -285,7 +287,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.apiHandler_.unlayoutCallback();
       this.apiHandler_ = null;
     }
-    this.lifecycleReporter_.sendPing('adSlotCleared');
+    this.lifeCycleReporter.sendPing('adSlotCleared');
     return true;
   }
 }

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -32,12 +32,13 @@ const TIMEOUT_VALUE = 10000;
 export class AmpAdApiHandler {
 
   /**
-   * @param {!AMP.BaseElement} baseInstance
+   * @param {!./amp-ad-3p-impl.AmpAd3PImpl|../../amp-a4a/0.1/amp-a4a.AmpA4A} baseInstance
    * @param {!Element} element
    * @param {function()=} opt_noContentCallback
    */
   constructor(baseInstance, element, opt_noContentCallback) {
-    /** @private {!AMP.BaseElement} */
+
+    /** @private {!./amp-ad-3p-impl.AmpAd3PImpl|../../amp-a4a/0.1/amp-a4a.AmpA4A}*/
     this.baseInstance_ = baseInstance;
 
     /** @private {!Element} */
@@ -84,6 +85,8 @@ export class AmpAdApiHandler {
     this.is3p_ = is3p;
     this.iframe_.setAttribute('scrolling', 'no');
     this.baseInstance_.applyFillContent(this.iframe_);
+    /** @const {AMP.BaseElement} */
+    const baseInstance = this.baseInstance_;
     this.intersectionObserver_ = new IntersectionObserver(
         this.baseInstance_, this.iframe_, is3p);
     this.embedStateApi_ = new SubscriptionApi(
@@ -110,14 +113,13 @@ export class AmpAdApiHandler {
         ['render-start', 'no-content'], this.is3p_).then(info => {
           const data = info.data;
           if (data.type == 'render-start') {
-            this.updateSize_(data.height, data.width,
-                info.source, info.origin);
-            if (this.baseInstance_.lifecyleReporter_) {
-              this.baseInstance_.lifecycleReporter_.sendPing(
-                  'renderCrossDomainStart');
-            }
+            this.renderStart_(info);
             //report performance
           } else {
+            if (baseInstance.lifecyleReporter_) {
+              baseInstance.lifecycleReporter_.sendPing(
+                  'renderCrossDomainStart');
+            }
             this.noContent_();
           }
         });
@@ -154,6 +156,21 @@ export class AmpAdApiHandler {
             }
           });
     });
+  }
+
+  /**
+   * callback functon on receiving render-start
+   * @param {!Object} info
+   * @private
+   */
+  renderStart_(info) {
+    const data = info.data;
+    this.updateSize_(data.height, data.width,
+                info.source, info.origin);
+    if (this.baseInstance_.lifecycleReporter) {
+      this.baseInstance_.lifecycleReporter.sendPing(
+          'renderCrossDomainStart');
+    }
   }
 
   /** See BaseElement.  */

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -38,7 +38,7 @@ export class AmpAdApiHandler {
    */
   constructor(baseInstance, element, opt_noContentCallback) {
 
-    /** @private {!./amp-ad-3p-impl.AmpAd3PImpl|../../amp-a4a/0.1/amp-a4a.AmpA4A}*/
+    /** @private {!./amp-ad-3p-impl.AmpAd3PImpl|!../../amp-a4a/0.1/amp-a4a.AmpA4A}*/
     this.baseInstance_ = baseInstance;
 
     /** @private {!Element} */

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -32,7 +32,7 @@ const TIMEOUT_VALUE = 10000;
 export class AmpAdApiHandler {
 
   /**
-   * @param {!./amp-ad-3p-impl.AmpAd3PImpl|../../amp-a4a/0.1/amp-a4a.AmpA4A} baseInstance
+   * @param {!./amp-ad-3p-impl.AmpAd3PImpl|!../../amp-a4a/0.1/amp-a4a.AmpA4A} baseInstance
    * @param {!Element} element
    * @param {function()=} opt_noContentCallback
    */

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -38,7 +38,7 @@ export class AmpAdApiHandler {
    */
   constructor(baseInstance, element, opt_noContentCallback) {
 
-    /** @private {!./amp-ad-3p-impl.AmpAd3PImpl|!../../amp-a4a/0.1/amp-a4a.AmpA4A}*/
+    /** @private */
     this.baseInstance_ = baseInstance;
 
     /** @private {!Element} */

--- a/extensions/amp-ad/0.1/amp-ad-api-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-api-handler.js
@@ -85,8 +85,6 @@ export class AmpAdApiHandler {
     this.is3p_ = is3p;
     this.iframe_.setAttribute('scrolling', 'no');
     this.baseInstance_.applyFillContent(this.iframe_);
-    /** @const {AMP.BaseElement} */
-    const baseInstance = this.baseInstance_;
     this.intersectionObserver_ = new IntersectionObserver(
         this.baseInstance_, this.iframe_, is3p);
     this.embedStateApi_ = new SubscriptionApi(
@@ -116,10 +114,6 @@ export class AmpAdApiHandler {
             this.renderStart_(info);
             //report performance
           } else {
-            if (baseInstance.lifecyleReporter_) {
-              baseInstance.lifecycleReporter_.sendPing(
-                  'renderCrossDomainStart');
-            }
             this.noContent_();
           }
         });


### PR DESCRIPTION
AmpAdApiHandler is calling `AmpAd3PImpl` or `AmpA4A` method, however `BaseElement` don't have these method type so there will be type check errors. This is to fix the issue by restricting the `AmpAdApiHandler` `baseInstance` to be either `AmpAd3pImpl` or `AmpA4`. This also helps for code sharing #5356 later, so that I can access their `UIHandler` without type check errors. 
PTAL