### PR TITLE
Improve error reporting to users.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -71,12 +71,12 @@ export function reportError(error, opt_associatedElement) {
     if (element) {
       (console.error || console.log).call(console,
           element.tagName + '#' + element.id, error.message);
+    } else if (!getMode().minified) {
+      (console.error || console.log).call(console, error.stack);
     } else {
       (console.error || console.log).call(console, error.message);
     }
-    if (!getMode().minified) {
-      (console.error || console.log).call(console, error.stack);
-    }
+
   }
   if (element && element.dispatchCustomEventForTesting) {
     element.dispatchCustomEventForTesting('amp:error', error.message);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1279,7 +1279,7 @@ export class Resources {
     this.exec_.dequeue(task);
     this.schedulePass(POST_TASK_PASS_DELAY_);
     if (!success) {
-      dev().error(TAG_, 'task failed:',
+      dev().info(TAG_, 'task failed:',
           task.id, task.resource.debugid, opt_reason);
       return Promise.reject(opt_reason);
     }


### PR DESCRIPTION
- Reduce severity of "task failed" messages that were confusing users. These errors get reported by themselves, which is more helpful.
- Don't report errors twice when in non-minified mode.