### PR TITLE
While serving ads.amp.html example page, filter the ads by type if specified in URL query.

### DIFF
--- a/ads/README.md
+++ b/ads/README.md
@@ -231,7 +231,7 @@ If you're adding support for a new 3P ad service, changes to the following files
 
 ### Verify your examples
 
-To verify the examples that you have put in `/examples/ads.amp.html`, you will need to start a local gulp web server by running command `gulp`. Then visit `http://localhost:8000/examples/ads.amp.max.html` in your browser to make sure the examples load ads.
+To verify the examples that you have put in `/examples/ads.amp.html`, you will need to start a local gulp web server by running command `gulp`. Then visit `http://localhost:8000/examples/ads.amp.max.html?type=yournetwork` in your browser to make sure the examples load ads.
 
 Please consider having the example consistently load a fake ad (with ad targeting disabled). Not only it will be a more confident example for publishers to follow, but also for us to catch any regression bug during our releases.
 

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -440,6 +440,15 @@ app.get(['/examples/*', '/test/manual/*'], function(req, res, next) {
   filePath = filePath.substr(0, filePath.length - 9) + '.html';
   fs.readFileAsync(process.cwd() + filePath, 'utf8').then(file => {
     file = replaceUrls(mode, file);
+
+    // Extract amp-ad for the given 'type' specified in URL query.
+    if (req.path.indexOf('/examples/ads.amp') == 0 && req.query.type) {
+      var ads = file.match(new RegExp('<amp-ad [^>]*'
+          + req.query.type + '[^>]*>([\\s\\S]+?)<\/amp-ad>', 'gm'));
+      file = file.replace(
+          /<body>[\s\S]+<\/body>/m, '<body>' + ads.join('') + '</body>');
+    }
+
     res.send(file);
   }).catch(() => {
     next();


### PR DESCRIPTION
This let's you do `http://localhost:8000/examples/ads.amp.max.html?type=doubleclick` to list only DoubleClick examples, so we can have more relevant console logs.