### PR TITLE
Allow dot character in CID fallback cookie

### DIFF
--- a/extensions/amp-analytics/0.1/cid-impl.js
+++ b/extensions/amp-analytics/0.1/cid-impl.js
@@ -112,9 +112,9 @@ class Cid {
     } else {
       getCidStruct = /** @type {!GetCidDef} */ (externalCidScope);
     }
-    user().assert(/^[a-zA-Z0-9-_]+$/.test(getCidStruct.scope),
+    user().assert(/^[a-zA-Z0-9-_.]+$/.test(getCidStruct.scope),
         'The client id name must only use the characters ' +
-        '[a-zA-Z0-9-_]+\nInstead found: %s', getCidStruct.scope);
+        '[a-zA-Z0-9-_.]+\nInstead found: %s', getCidStruct.scope);
     return consent.then(() => {
       return viewerForDoc(this.win.document).whenFirstVisible();
     }).then(() => {

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -553,6 +553,15 @@ describe('cid', () => {
     });
   });
 
+  it('should retreive cookie value with . in name', () => {
+    fakeWin.location.href =
+        'https://abc.org/';
+    fakeWin.document.cookie = '_sp_id.44=4567;';
+    return compare(
+        '_sp_id.44',
+        '4567');
+  });
+
   function compare(externalCidScope, compareValue) {
     return cid.get(externalCidScope, hasConsent).then(c => {
       expect(c).to.equal(compareValue);


### PR DESCRIPTION
See issue https://github.com/ampproject/amphtml/issues/5729. This allows the extra `.` character to be used for the cid name. Useful for instance if you are migrating from an existing system that used `.` characters in their cookies.