### PR TITLE
Remove Timer promises catch clause

### DIFF
--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -359,7 +359,7 @@ describe('amp-form', () => {
       expect(form.className).to.not.contain('amp-form-submit-error');
       expect(form.className).to.not.contain('amp-form-submit-success');
       fetchJsonResolver();
-      return timer.promise(0).then(() => {
+      return timer.promise(5).then(() => {
         expect(ampForm.state_).to.equal('submit-success');
         expect(form.className).to.not.contain('amp-form-submitting');
         expect(form.className).to.not.contain('amp-form-submit-error');
@@ -398,7 +398,7 @@ describe('amp-form', () => {
       expect(form.className).to.not.contain('amp-form-submit-error');
       expect(form.className).to.not.contain('amp-form-submit-success');
       fetchJsonRejecter();
-      return timer.promise(0).then(() => {
+      return timer.promise(5).then(() => {
         expect(button1.hasAttribute('disabled')).to.be.false;
         expect(button2.hasAttribute('disabled')).to.be.false;
         expect(ampForm.state_).to.equal('submit-error');
@@ -442,7 +442,7 @@ describe('amp-form', () => {
       };
       ampForm.handleSubmit_(event);
       fetchJsonRejecter({responseJson: {message: 'hello there'}});
-      return timer.promise(0).then(() => {
+      return timer.promise(5).then(() => {
         expect(ampForm.templates_.findAndRenderTemplate.called).to.be.true;
         expect(ampForm.templates_.findAndRenderTemplate.calledWith(
             errorContainer, {message: 'hello there'})).to.be.true;
@@ -489,7 +489,7 @@ describe('amp-form', () => {
       };
       ampForm.handleSubmit_(event);
       fetchJsonResolver({'message': 'What What'});
-      return timer.promise(0).then(() => {
+      return timer.promise(5).then(() => {
         expect(ampForm.templates_.findAndRenderTemplate.called).to.be.true;
         expect(ampForm.templates_.findAndRenderTemplate.calledWith(
             successContainer, {'message': 'What What'})).to.be.true;

--- a/src/service/timer-impl.js
+++ b/src/service/timer-impl.js
@@ -99,21 +99,14 @@ export class Timer {
    * @template RESULT
    */
   promise(opt_delay, opt_result) {
-    let timerKey = null;
-    return new Promise((resolve, reject) => {
-      timerKey = this.delay(() => {
-        timerKey = -1;
+    return new Promise(resolve => {
+      const timerKey = this.delay(() => {
         resolve(opt_result);
       }, opt_delay);
+
       if (timerKey == -1) {
-        reject(new Error('Failed to schedule timer.'));
+        throw new Error('Failed to schedule timer.');
       }
-    }).catch(error => {
-      // Clear the timer. The most likely reason is "cancel" signal.
-      if (timerKey != -1) {
-        this.cancel(timerKey);
-      }
-      throw error;
     });
   }
 
@@ -129,21 +122,14 @@ export class Timer {
    * @template RESULT
    */
   timeoutPromise(delay, opt_racePromise, opt_message) {
-    let timerKey = null;
     const delayPromise = new Promise((_resolve, reject) => {
-      timerKey = this.delay(() => {
-        timerKey = -1;
+      const timerKey = this.delay(() => {
         reject(user().createError(opt_message || 'timeout'));
       }, delay);
+
       if (timerKey == -1) {
-        reject(new Error('Failed to schedule timer.'));
+        throw new Error('Failed to schedule timer.');
       }
-    }).catch(error => {
-      // Clear the timer. The most likely reason is "cancel" signal.
-      if (timerKey != -1) {
-        this.cancel(timerKey);
-      }
-      throw error;
     });
     if (!opt_racePromise) {
       return delayPromise;


### PR DESCRIPTION
Timer's promises can only fail because of being unable to schedule.

So `timerKey` is either:
- `-1`, in which case the catch is unnecessary
- Some timer id, whose promise will eventually resolve.