### PR TITLE
DO NOT SUBMIT: Bind syntax proposal

### DIFF
--- a/examples/bind-shopping.amp.html
+++ b/examples/bind-shopping.amp.html
@@ -1,0 +1,454 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+
+  <style amp-custom>
+    body {
+      margin: auto;
+      font-family: sans-serif;
+    }
+    h1.header {
+      background-color: red;
+      color: white;
+      text-align: center;
+      margin: 0;
+      padding: 10px;
+      font-size: 24px;
+    }
+    .container {
+      padding: 0 10px;
+    }
+    button.buy {
+      margin: 20px 0;
+      width: 100%;
+      padding: 10px;
+      background-color: green;
+      color: white;
+      font-weight: bold;
+    }
+    button[disabled] {
+      background-color: red;
+    }
+    .thumbnails, .color {
+      margin-top: 10px;
+    }
+    .thumbnails amp-img {
+      border: solid 2px transparent;
+      padding: 2px;
+    }
+    .thumbnails amp-img[selected] {
+      border: solid 2px gray;
+    }
+    .thumbnails amp-img[out-of-stock] {
+      background-color: red;
+    }
+    amp-accordion {
+      margin-top: 10px;
+    }
+    .sizes button {
+      display: block;
+      width: 100%;
+      border: solid 1px gray;
+      padding: 5px;
+      background-color: #eee;
+    }
+    .change-size {
+      display: block;
+      width: 200px;
+      height: 30px;
+      padding: 5px;
+      background-color: #666;
+      color: white;
+    }
+    button[hidden] {
+      display: none;
+    }
+    p[hidden] {
+      display:none;
+    }
+  </style>
+</head>
+
+<body>
+  <h1 class="header">AMPWEAR</h1>
+  <div class="container">
+    <h2>MEN'S COTTON SHORT SLEEVE T-SHIRT</h2>
+
+    <amp-bind-dataset layout=nodisplay>
+      <script type="application/json">
+        {
+          "items": [
+            {
+              "id": "0",
+              "name": "09 BLACK",
+              "image": "./shirts/black.jpeg",
+              "sizes": ["S", "L"]
+            },
+            {
+              "id": "1",
+              "name": "34 BROWN",
+              "image": "./shirts/brown.jpeg",
+              "sizes": ["M", "L"]
+            },
+            {
+              "id": "2",
+              "name": "03 GRAY",
+              "image": "./shirts/gray.jpeg",
+              "sizes": ["S"]
+            },
+            {
+              "id": "3",
+              "name": "69 NAVY",
+              "image": "./shirts/navy.jpeg",
+              "sizes": ["S", "L"]
+            },
+            {
+              "id": "4",
+              "name": "19 WINE",
+              "image": "./shirts/wine.jpeg",
+              "sizes": []
+            },
+            {
+              "id": "5",
+              "name": "61 BLUE",
+              "image": "./shirts/blue.jpeg",
+              "sizes": ["L"]
+            },
+            {
+              "id": "6",
+              "name": "59 DARK GREEN",
+              "image": "./shirts/dark-green.jpeg",
+              "sizes": ["S"]
+            },
+            {
+              "id": "7",
+              "name": "02 LIGHT GRAY",
+              "image": "./shirts/light-gray.jpeg",
+              "sizes": ["S", "M", "L"]
+            },
+            {
+              "id": "8",
+              "name": "00 WHITE",
+              "image": "./shirts/white.jpeg",
+              "sizes": []
+            }
+          ]
+        }
+      </script>
+    </amp-bind-dataset>
+
+    <!--
+    <amp-carousel slide=0 id="carousel-1" width=1 height=1 layout=responsive type=slides controls
+        bind-attr="{slide: selected}"
+        on="slidechange:setState({selected: ampEventData})">
+    -->
+    <amp-carousel slide=0 id="carousel-1" width=1 height=1 layout=responsive type=slides controls>
+      <amp-bind-attribute layout=nodisplay
+          attr="slide"
+          value="{{selected}}">
+      </amp-bind-attribute>
+      <amp-bind-event layout=nodisplay
+          on="slidechange"
+          variable="selected"
+          value="{{ampEventData}}">
+      </amp-bind-event>
+
+      <amp-img src="./shirts/black.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/brown.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/gray.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/navy.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/wine.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/blue.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/dark-green.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/light-gray.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/white.jpeg" width=1 height=1 layout=responsive></amp-img>
+    </amp-carousel>
+
+    <!--
+    <amp-img class="color" width=355 height=50 src="https://placehold.it/355x50?text=COLOR%20???"
+        bind-src="https://placehold.it/300x400?text=COLOR%20{{items[selected].name}}">
+    -->
+    <amp-img class="color" width=355 height=50 src="https://placehold.it/355x50?text=COLOR%20???">
+      <amp-bind-attribute layout=nodisplay
+          attr="src"
+          value="{{'https://placehold.it/355x50?text=COLOR%20' + items[selected].name}}">
+      </amp-bind-attribute>
+    </amp-img>
+
+    <div class="thumbnails">
+      <!--
+      <amp-img src="./shirts/black.jpeg" width=50 height=50 layout=fixed
+        on="tap:setState({selected: 0})"
+        bind-attr="{selected: selected === 0}"
+        bind-class="{outOfStock: !items[0].sizes.length}">
+      -->
+      <amp-img src="./shirts/black.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{0}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 0}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[0].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+
+      <amp-img src="./shirts/brown.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{1}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 1}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[1].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+
+      <amp-img src="./shirts/gray.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{2}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 2}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[2].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+
+      <amp-img src="./shirts/navy.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{3}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 3}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[3].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+
+      <amp-img src="./shirts/wine.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{4}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 4}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[4].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+
+      <amp-img src="./shirts/blue.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{5}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 5}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[5].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+
+      <amp-img src="./shirts/dark-green.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{6}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 6}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[6].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+
+      <amp-img src="./shirts/light-gray.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{7}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 7}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[7].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+
+      <amp-img src="./shirts/white.jpeg" width=50 height=50 layout=fixed>
+        <amp-bind-event layout=nodisplay
+            on="tap"
+            variable="selected"
+            value="{{8}}">
+        </amp-bind-event>
+        <amp-bind-attribute layout=nodisplay
+            attr="selected"
+            toggle="{{selected === 8}}">
+        </amp-bind-attribute>
+        <amp-bind-attribute layout=nodisplay
+            attr="out-of-stock"
+            toggle="{{!items[8].sizes.length}}">
+        </amp-bind-attribute>
+      </amp-img>
+    </div>
+
+    <amp-accordion>
+      <!--
+      <section expanded bind-attr="{expanded: !size}">
+      -->
+      <section expanded>
+        <amp-bind-attribute width=355 height=50
+            attr="expanded"
+            toggle="{{!size}}">
+
+          <!-- Nested here due to accordion's child limit. -->
+          <!--
+          <amp-img width=355 height=50 src="https://placehold.it/355x50?text=SIZE%20???"
+              bind-src="https://placehold.it/355x50?text=SIZE%20{{size}}">
+          -->
+          <amp-img width=355 height=50 src="https://placehold.it/355x50?text=SIZE%20???">
+            <amp-bind-attribute layout=nodisplay
+                attr="src"
+                value="{{'https://placehold.it/355x50?text=SIZE%20' + size}}">
+            </amp-bind-attribute>
+          </amp-img>
+
+        </amp-bind-attribute>
+
+        <div class="sizes">
+          <!--
+          <button
+              on="tap:setState({size: 'SMALL'})"
+              bind-class="{hidden: items[selected].sizes.indexOf('S') < 0}">
+          -->
+          <button>
+            <amp-bind-event layout=nodisplay
+                on="tap"
+                variable="size"
+                value="{{'SMALL'}}">
+            </amp-bind-event>
+            <amp-bind-attribute layout=nodisplay
+                attr="hidden"
+                toggle="{{items[selected].sizes.indexOf('S') < 0}}">
+            </amp-bind-attribute>
+            SMALL - 38"
+          </button>
+          <button>
+            <amp-bind-event layout=nodisplay
+                on="tap"
+                variable="size"
+                value="{{'MEDIUM'}}">
+            </amp-bind-event>
+            <amp-bind-attribute layout=nodisplay
+                attr="hidden"
+                toggle="{{items[selected].sizes.indexOf('M') < 0}}">
+            </amp-bind-attribute>
+            MEDIUM - 38"
+          </button>
+          <button>
+            <amp-bind-event layout=nodisplay
+                on="tap"
+                variable="size"
+                value="{{'LARGE'}}">
+            </amp-bind-event>
+            <amp-bind-attribute layout=nodisplay
+                attr="hidden"
+                toggle="{{items[selected].sizes.indexOf('L') < 0}}">
+            </amp-bind-attribute>
+            LARGE - 46"
+          </button>
+        </div>
+      </section>
+    </amp-accordion>
+
+    <!--
+    <button class="change-size"
+        on="tap:setState({size: ''})"
+        bind-class="{hidden: !size}">
+    -->
+    <button class="change-size">
+      <amp-bind-event layout=nodisplay
+          on="tap"
+          variable="size"
+          value="{{''}}">
+      </amp-bind-event>
+      <amp-bind-attribute layout=nodisplay
+          attr="hidden"
+          toggle="{{!size}}">
+      </amp-bind-attribute>
+      Change Size
+    </button>
+
+    <!--
+    <p bind-class="{hidden: items[selected].sizes.length > 0}">
+    -->
+    <p>
+      <amp-bind-attribute layout=nodisplay
+          attr="hidden"
+          toggle="{{items[selected].sizes.length}}">
+      </amp-bind-attribute>
+      All sizes of this color are out of stock online
+    </p>
+
+    <!--
+    <button class="buy"
+        bind-attr="{disabled: items[selected].sizes.length === 0}">
+    -->
+    <button class="buy">
+      <amp-bind-attribute layout=nodisplay
+        attr="disabled"
+        toggle="{{!items[selected].sizes.length}}">
+      </amp-bind-attribute>
+      <span>ADD TO BAG</span>
+    </button>
+  </div>
+</body>
+</html>

--- a/examples/bind-shopping.proposed.amp.html
+++ b/examples/bind-shopping.proposed.amp.html
@@ -227,11 +227,10 @@
 
     <amp-accordion>
       <section expanded bind-attr="{expanded: !size}">
-          <!-- Nested here due to accordion's child limit. -->
-          <amp-img width=355 height=50 src="https://placehold.it/355x50?text=SIZE%20???"
-              bind-src="https://placehold.it/355x50?text=SIZE%20{{size}}">
-          </amp-img>
-        </amp-bind-attribute>
+        <!-- Nested here due to accordion's child limit. -->
+        <amp-img width=355 height=50 src="https://placehold.it/355x50?text=SIZE%20???"
+            bind-src="https://placehold.it/355x50?text=SIZE%20{{size}}">
+        </amp-img>
 
         <div class="sizes">
           <button

--- a/examples/bind-shopping.proposed.amp.html
+++ b/examples/bind-shopping.proposed.amp.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+
+  <style amp-custom>
+    body {
+      margin: auto;
+      font-family: sans-serif;
+    }
+    h1.header {
+      background-color: red;
+      color: white;
+      text-align: center;
+      margin: 0;
+      padding: 10px;
+      font-size: 24px;
+    }
+    .container {
+      padding: 0 10px;
+    }
+    button.buy {
+      margin: 20px 0;
+      width: 100%;
+      padding: 10px;
+      background-color: green;
+      color: white;
+      font-weight: bold;
+    }
+    button[disabled] {
+      background-color: red;
+    }
+    .thumbnails, .color {
+      margin-top: 10px;
+    }
+    .thumbnails amp-img {
+      border: solid 2px transparent;
+      padding: 2px;
+    }
+    .thumbnails amp-img[selected] {
+      border: solid 2px gray;
+    }
+    .thumbnails amp-img[out-of-stock] {
+      background-color: red;
+    }
+    amp-accordion {
+      margin-top: 10px;
+    }
+    .sizes button {
+      display: block;
+      width: 100%;
+      border: solid 1px gray;
+      padding: 5px;
+      background-color: #eee;
+    }
+    .change-size {
+      display: block;
+      width: 200px;
+      height: 30px;
+      padding: 5px;
+      background-color: #666;
+      color: white;
+    }
+    button[hidden] {
+      display: none;
+    }
+    p[hidden] {
+      display:none;
+    }
+  </style>
+</head>
+
+<body>
+  <h1 class="header">AMPWEAR</h1>
+  <div class="container">
+    <h2>MEN'S COTTON SHORT SLEEVE T-SHIRT</h2>
+
+    <amp-bind-dataset layout=nodisplay>
+      <script type="application/json">
+        {
+          "items": [
+            {
+              "id": "0",
+              "name": "09 BLACK",
+              "image": "./shirts/black.jpeg",
+              "sizes": ["S", "L"]
+            },
+            {
+              "id": "1",
+              "name": "34 BROWN",
+              "image": "./shirts/brown.jpeg",
+              "sizes": ["M", "L"]
+            },
+            {
+              "id": "2",
+              "name": "03 GRAY",
+              "image": "./shirts/gray.jpeg",
+              "sizes": ["S"]
+            },
+            {
+              "id": "3",
+              "name": "69 NAVY",
+              "image": "./shirts/navy.jpeg",
+              "sizes": ["S", "L"]
+            },
+            {
+              "id": "4",
+              "name": "19 WINE",
+              "image": "./shirts/wine.jpeg",
+              "sizes": []
+            },
+            {
+              "id": "5",
+              "name": "61 BLUE",
+              "image": "./shirts/blue.jpeg",
+              "sizes": ["L"]
+            },
+            {
+              "id": "6",
+              "name": "59 DARK GREEN",
+              "image": "./shirts/dark-green.jpeg",
+              "sizes": ["S"]
+            },
+            {
+              "id": "7",
+              "name": "02 LIGHT GRAY",
+              "image": "./shirts/light-gray.jpeg",
+              "sizes": ["S", "M", "L"]
+            },
+            {
+              "id": "8",
+              "name": "00 WHITE",
+              "image": "./shirts/white.jpeg",
+              "sizes": []
+            }
+          ]
+        }
+      </script>
+    </amp-bind-dataset>
+
+    <amp-carousel slide=0 id="carousel-1" width=1 height=1 layout=responsive type=slides controls
+        bind-attr="{slide: selected}"
+        on="slidechange:setState({selected: ampEventData})">
+
+      <amp-img src="./shirts/black.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/brown.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/gray.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/navy.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/wine.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/blue.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/dark-green.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/light-gray.jpeg" width=1 height=1 layout=responsive></amp-img>
+      <amp-img src="./shirts/white.jpeg" width=1 height=1 layout=responsive></amp-img>
+    </amp-carousel>
+
+    <amp-img class="color" width=355 height=50 src="https://placehold.it/355x50?text=COLOR%20???"
+        bind-src="https://placehold.it/300x400?text=COLOR%20{{items[selected].name}}">
+    </amp-img>
+
+    <div class="thumbnails">
+      <amp-img src="./shirts/black.jpeg" width=50 height=50 layout=fixed
+          on="tap:setState({selected: 0})"
+          bind-attr="{selected: selected === 0}"
+          bind-class="{outOfStock: !items[0].sizes.length}">
+      </amp-img>
+
+      <amp-img src="./shirts/brown.jpeg" width=50 height=50 layout=fixed
+          on="tap:setState({selected: 1})"
+          bind-attr="{selected: selected === 1}"
+          bind-class="{outOfStock: !items[1].sizes.length}">
+      </amp-img>
+
+      <amp-img src="./shirts/gray.jpeg" width=50 height=50 layout=fixed
+          on="tap:setState({selected: 2})"
+          bind-attr="{selected: selected === 2}"
+          bind-class="{outOfStock: !items[2].sizes.length}">
+      </amp-img>
+
+      <amp-img src="./shirts/navy.jpeg" width=50 height=50 layout=fixed
+        on="tap:setState({selected: 3})"
+        bind-attr="{selected: selected === 3}"
+        bind-class="{outOfStock: !items[3].sizes.length}">
+      </amp-img>
+
+      <amp-img src="./shirts/wine.jpeg" width=50 height=50 layout=fixed
+        on="tap:setState({selected: 4})"
+        bind-attr="{selected: selected === 4}"
+        bind-class="{outOfStock: !items[4].sizes.length}">
+      </amp-img>
+
+      <amp-img src="./shirts/blue.jpeg" width=50 height=50 layout=fixed
+        on="tap:setState({selected: 5})"
+        bind-attr="{selected: selected === 5}"
+        bind-class="{outOfStock: !items[5].sizes.length}">
+      </amp-img>
+
+      <amp-img src="./shirts/dark-green.jpeg" width=50 height=50 layout=fixed
+        on="tap:setState({selected: 6})"
+        bind-attr="{selected: selected === 6}"
+        bind-class="{outOfStock: !items[6].sizes.length}">
+      </amp-img>
+
+      <amp-img src="./shirts/light-gray.jpeg" width=50 height=50 layout=fixed
+        on="tap:setState({selected: 7})"
+        bind-attr="{selected: selected === 7}"
+        bind-class="{outOfStock: !items[7].sizes.length}">
+      </amp-img>
+
+      <amp-img src="./shirts/white.jpeg" width=50 height=50 layout=fixed
+        on="tap:setState({selected: 8})"
+        bind-attr="{selected: selected === 8}"
+        bind-class="{outOfStock: !items[8].sizes.length}">
+      </amp-img>
+    </div>
+
+    <amp-accordion>
+      <section expanded bind-attr="{expanded: !size}">
+          <!-- Nested here due to accordion's child limit. -->
+          <amp-img width=355 height=50 src="https://placehold.it/355x50?text=SIZE%20???"
+              bind-src="https://placehold.it/355x50?text=SIZE%20{{size}}">
+          </amp-img>
+        </amp-bind-attribute>
+
+        <div class="sizes">
+          <button
+              on="tap:setState({size: 'SMALL'})"
+              bind-class="{hidden: items[selected].sizes.indexOf('S') < 0}">
+            SMALL - 38"
+          </button>
+          <button
+              on="tap:setState({size: 'MEDIUM'})"
+              bind-class="{hidden: items[selected].sizes.indexOf('M') < 0}">
+            MEDIUM - 38"
+          </button>
+          <button
+              on="tap:setState({size: 'LARGE'})"
+              bind-class="{hidden: items[selected].sizes.indexOf('L') < 0}">
+            LARGE - 46"
+          </button>
+        </div>
+      </section>
+    </amp-accordion>
+
+    <button class="change-size"
+        on="tap:setState({size: ''})"
+        bind-class="{hidden: !size}">
+      Change Size
+    </button>
+
+    <p bind-class="{hidden: items[selected].sizes.length > 0}">
+      All sizes of this color are out of stock online
+    </p>
+
+    <button class="buy"
+        bind-attr="{disabled: items[selected].sizes.length === 0}">
+      <span>ADD TO BAG</span>
+    </button>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
# Bind syntax

This PR contains two HTML files that describe a sample e-commerce product page. The sample page contains a hero carousel for the product with color and size options. See [video demo](https://drive.google.com/open?id=0Bxatm4FLOzANaEx2Y0NxVWFsV0k).
1. **bind-shopping.amp.html**
   - Uses element-per-binding via `<amp-bind-event>`, `<amp-bind-attribute>`, etc. 
   - Minified char count: **10,424**
2. **bind-shopping.proposal.amp.html**
   - Replaces the binding elements with custom attributes `bind-attr`, `bind-class`, etc. 
   - Minified char count: **7,945**
## Proposal

(2) is my proposal. It combines ideas from React and Angular data binding and offers a concise, familiar syntax that's **2479** chars smaller than (1) after minimization.

**One-way binding**: user actions update the page's local state (a single JSON object), and the state of elements on the page are updated when the local state is updated. 
### Update local state

Updating local state happens via AMP's existing `on=""` attribute with a new function `setState()` [borrowed from React](https://facebook.github.io/react/docs/react-component.html#setstate):

> `<button on="tap:setState({ foo: 'bar' })"></button>`

`setState()` takes an JS object as a parameter and merges it into the local state. This also avoids assignment operator in expressions.
### Propagating local state updates to elements

As in Dima's original design, there are three ways an element can react to state updates: textContent, attributes and classes.

> `<p bind-text="Value of foo: {{foo}}"></p>`
> `<button bind-attr="{someAttribute: foo}"></button>`
> `<button bind-class="{someClass: foo === bar}"></button>`

`bind-text` takes a string with expressions embedded in `{{}}` (string interpolation). The values of `bind-attr` and `bind-class` must be expressions that evaluate to either a string, an array of strings, or an object that maps attribute/class to a string or truthy/falsy (for toggling).

Using custom attributes avoids "flash of unbound content". Being able to pass an object allows binding multiple attributes or classes in a single `bind-attr` or `bind-class`. This scheme is similar to Angular's [ngClass](https://docs.angularjs.org/api/ng/directive/ngClass).

**Optional:** We can also add convenience bindings with string interpolation for select attributes, e.g.:

> `<amp-img bind-src="http://foo.com/{{bar}}"`></amp-img>

This is syntactically nicer than:

> `<amp-img bind-attr="{src: 'http://foo.com/' + bar}"></amp-img>`
### Caveats
- This approach requires a one-time DOM scan to detect all bindings. This may have performance implications, but may be fine assuming that digest/evaluations are scheduled after initial layout
- The character count delta could be significantly reduced with better templating, e.g. maybe use `amp-list` for the thumbnails to reduce markup dupe
### Out of scope (for V1)
- Updating local state with XHRs (`amp-fresh`?)
- Binding to `window` state, e.g. reacting to scroll events or media query expressions
- Combining expressions and actions i.e. `BindAction` (all element updates must first mutate local state)
