### PR TITLE
Disallowing resize of elements near top of viewport when viewport not scrolled

### DIFF
--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -32,8 +32,14 @@ describes.realWin('amp-strategy', {
 
   beforeEach(() => {
     sandbox = env.sandbox;
-    container = env.win.document.createElement('div');
+
     env.win.frameElement.style.height = '1000px';
+
+    const belowFoldSpacer = document.createElement('div');
+    belowFoldSpacer.style.height = '1000px';
+    env.win.document.body.appendChild(belowFoldSpacer);
+
+    container = env.win.document.createElement('div');
     env.win.document.body.appendChild(container);
   });
 

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -31,6 +31,13 @@ describes.realWin('placement', {
 
   beforeEach(() => {
     sandbox = env.sandbox.create();
+
+    env.win.frameElement.style.height = '1000px';
+
+    const belowFoldSpacer = document.createElement('div');
+    belowFoldSpacer.style.height = '1000px';
+    env.win.document.body.appendChild(belowFoldSpacer);
+
     container = env.win.document.createElement('div');
     env.win.document.body.appendChild(container);
   });

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1053,9 +1053,13 @@ export class Resources {
           // an element's boundary is not changed above the viewport after
           // resize.
           resize = true;
-        } else if (bottomDisplacedBoundary <= viewportRect.top + topOffset) {
+        } else if (viewportRect.top > 1 &&
+            bottomDisplacedBoundary <= viewportRect.top + topOffset) {
           // 5. Elements above the viewport can only be resized if we are able
-          // to compensate the height change by setting scrollTop.
+          // to compensate the height change by setting scrollTop and only if
+          // the page has already been scrolled by some amount (1px due to iOS).
+          // Otherwise the scrolling might move important things like the menu
+          // bar out of the viewport at initial page load.
           if (heightDiff < 0 &&
               viewportRect.top + aboveVpHeightChange < -heightDiff) {
             // Do nothing if height abobe viewport height can't compensate

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1848,7 +1848,7 @@ describe('Resources changeSize', () => {
       viewportMock.expects('setScrollTop').withExactArgs(2777).once();
       scrollAdjustTask.mutate(state);
       expect(resource1.changeSize).to.be.calledOnce;
-      expect(resource1.changeSize).to.be.calledWith(undefined, undefined,
+      expect(resource1.changeSize).to.be.calledWith(undefined, undefined, 
           {top: 1});
       expect(resources.relayoutTop_).to.equal(resource1.layoutBox_.top);
     });

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1848,7 +1848,7 @@ describe('Resources changeSize', () => {
       viewportMock.expects('setScrollTop').withExactArgs(2777).once();
       scrollAdjustTask.mutate(state);
       expect(resource1.changeSize).to.be.calledOnce;
-      expect(resource1.changeSize).to.be.calledWith(undefined, undefined, 
+      expect(resource1.changeSize).to.be.calledWith(undefined, undefined,
           {top: 1});
       expect(resources.relayoutTop_).to.equal(resource1.layoutBox_.top);
     });


### PR DESCRIPTION
Modifying resources-impl.js so that an attemptChangeSize request doesn't resize elements near the top of the viewport when the viewport has not been scrolled.

Currently if the bottom of something is within the viewport but less than 10% of the viewport height from the top it is treated as though it is above the viewport. This can have the bad consequence that if something very small at the top of the page gets resized it can push things at the top (like the nav-bar) above the viewport and out of view, which is currently a bad and confusing experience for users, since this can happen at initial page load.
