### PR TITLE
Be tolerant to string numbers in iframe resizing request.

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -220,8 +220,8 @@ export class AmpAdXOriginIframeHandler {
    * Updates the element's dimensions to accommodate the iframe's
    * requested dimensions. Notifies the window that request the resize
    * of success or failure.
-   * @param {number|undefined} height
-   * @param {number|undefined} width
+   * @param {number|string|undefined} height
+   * @param {number|string|undefined} width
    * @param {!Window} source
    * @param {string} origin
    * @private
@@ -230,11 +230,13 @@ export class AmpAdXOriginIframeHandler {
     // Calculate new width and height of the container to include the padding.
     // If padding is negative, just use the requested width and height directly.
     let newHeight, newWidth;
-    if (height !== undefined) {
+    height = parseInt(height, 10);
+    if (!isNaN(height)) {
       newHeight = Math.max(this.element_./*OK*/offsetHeight +
           height - this.iframe./*OK*/offsetHeight, height);
     }
-    if (width !== undefined) {
+    width = parseInt(width, 10);
+    if (!isNaN(width)) {
       newWidth = Math.max(this.element_./*OK*/offsetWidth +
           width - this.iframe./*OK*/offsetWidth, width);
     }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -104,7 +104,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         expect(iframe.style.visibility).to.equal('hidden');
         iframe.postMessageToParent({
           width: 114,
-          height: '217',
+          height: '217',  // should be tolerant to string number
           type: 'render-start',
           sentinel: 'amp3ptest' + testIndex,
         });
@@ -262,7 +262,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       });
       iframe.postMessageToParent({
         width: 114,
-        height: 217,
+        height: '217',  // should be tolerant to string number
         type: 'embed-size',
         sentinel: 'amp3ptest' + testIndex,
       });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -37,7 +37,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     sandbox = sinon.sandbox.create();
     const ampdocService = ampdocServiceFor(window);
     const ampdoc = ampdocService.getAmpDoc();
-    const adElement = document.createElement('amp-ad');
+    const adElement = document.createElement('container-element');
     adElement.getAmpDoc = () => ampdoc;
     adImpl = new BaseElement(adElement);
     document.body.appendChild(adElement);
@@ -52,7 +52,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
 
   afterEach(() => {
     sandbox.restore();
-    iframeHandler = null;
+    document.body.removeChild(adImpl.element);
   });
 
   describe('init() returned promise', () => {
@@ -189,13 +189,13 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       const noContentSpy =
           sandbox.spy/*OK*/(iframeHandler, 'freeXOriginIframe');
       const clock = sandbox.useFakeTimers();
-      clock.tick(0);
 
       iframe.name = 'test_master';
       initPromise = iframeHandler.init(iframe, true);
       iframe.onload = () => {
+        clock.tick(9999);
         expect(noContentSpy).to.not.be.called;
-        clock.tick(10001);
+        clock.tick(1);
         initPromise.then(() => {
           expect(iframe.style.visibility).to.equal('');
           expect(noContentSpy).to.be.calledOnce;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import {AmpAdXOriginIframeHandler,}
-    from '../amp-ad-xorigin-iframe-handler';
+import {AmpAdXOriginIframeHandler} from '../amp-ad-xorigin-iframe-handler';
 import {BaseElement} from '../../../../src/base-element';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 import {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -30,6 +30,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
   let sandbox;
   let adImpl;
   let iframeHandler;
+  let iframe;
   let testIndex = 0;
 
   beforeEach(() => {
@@ -39,9 +40,14 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     const adElement = document.createElement('amp-ad');
     adElement.getAmpDoc = () => ampdoc;
     adImpl = new BaseElement(adElement);
+    document.body.appendChild(adElement);
     adImpl.uiHandler = new AmpAdUIHandler(adImpl);
     iframeHandler = new AmpAdXOriginIframeHandler(adImpl);
     testIndex++;
+
+    iframe = createIframeWithMessageStub(window);
+    iframe.setAttribute('data-amp-3p-sentinel', 'amp3ptest' + testIndex);
+    iframe.name = 'test_nomaster';
   });
 
   afterEach(() => {
@@ -50,16 +56,14 @@ describe('amp-ad-xorigin-iframe-handler', () => {
   });
 
   describe('init() returned promise', () => {
-    let iframe;
     let initPromise;
 
     describe('if render-start is implemented', () => {
 
       let noContentSpy;
 
-      beforeEach(() => {
+      beforeEach(done => {
         adImpl.config = {renderStartImplemented: true};
-        iframeHandler = new AmpAdXOriginIframeHandler(adImpl);
         sandbox.stub(adImpl, 'attemptChangeSize', (height, width) => {
           expect(height).to.equal(217);
           expect(width).to.equal(114);
@@ -67,15 +71,11 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         });
         noContentSpy =
             sandbox.spy/*OK*/(iframeHandler, 'freeXOriginIframe');
-        const beforeAttachedToDom = element => {
-          element.setAttribute('data-amp-3p-sentinel', 'amp3ptest' + testIndex);
-          element.name = 'test_nomaster';
-          initPromise = iframeHandler.init(element, true);
+
+        initPromise = iframeHandler.init(iframe, true);
+        iframe.onload = () => {
+          done();
         };
-        return createIframeWithMessageStub(window, beforeAttachedToDom)
-            .then(newIframe => {
-              iframe = newIframe;
-            });
       });
 
       it('should resolve on message "render-start"', () => {
@@ -104,7 +104,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         expect(iframe.style.visibility).to.equal('hidden');
         iframe.postMessageToParent({
           width: 114,
-          height: 217,
+          height: '217',
           type: 'render-start',
           sentinel: 'amp3ptest' + testIndex,
         });
@@ -169,74 +169,56 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should resolve on message "bootstrap-loaded" if render-start is'
-        + 'NOT implemented', () => {
-      const beforeAttachedToDom = element => {
-        element.setAttribute('data-amp-3p-sentinel', 'amp3ptest' + testIndex);
-        initPromise = iframeHandler.init(element, true);
+        + 'NOT implemented', done => {
+
+      initPromise = iframeHandler.init(iframe, true);
+      iframe.onload = () => {
+        expect(iframe.style.visibility).to.equal('hidden');
+        iframe.postMessageToParent({
+          sentinel: 'amp3ptest' + testIndex,
+          type: 'bootstrap-loaded',
+        });
+        initPromise.then(() => {
+          expect(iframe.style.visibility).to.equal('');
+          done();
+        });
       };
-      return createIframeWithMessageStub(window, beforeAttachedToDom)
-          .then(newIframe => {
-            iframe = newIframe;
-            expect(iframe.style.visibility).to.equal('hidden');
-            iframe.postMessageToParent({
-              sentinel: 'amp3ptest' + testIndex,
-              type: 'bootstrap-loaded',
-            });
-            return initPromise.then(() => {
-              expect(iframe.style.visibility).to.equal('');
-            });
-          });
     });
 
-    it('should resolve on timeout', () => {
+    it('should resolve on timeout', done => {
       const noContentSpy =
           sandbox.spy/*OK*/(iframeHandler, 'freeXOriginIframe');
       const clock = sandbox.useFakeTimers();
       clock.tick(0);
-      const beforeAttachedToDom = element => {
-        element.setAttribute('data-amp-3p-sentinel', 'amp3ptest' + testIndex);
-        element.name = 'test_master';
-        initPromise = iframeHandler.init(element, true);
+
+      iframe.name = 'test_master';
+      initPromise = iframeHandler.init(iframe, true);
+      iframe.onload = () => {
+        expect(noContentSpy).to.not.be.called;
+        clock.tick(10001);
+        initPromise.then(() => {
+          expect(iframe.style.visibility).to.equal('');
+          expect(noContentSpy).to.be.calledOnce;
+          expect(noContentSpy).to.be.calledWith(true);
+          done();
+        });
       };
-      return createIframeWithMessageStub(window, beforeAttachedToDom)
-          .then(newIframe => {
-            iframe = newIframe;
-            expect(noContentSpy).to.not.be.called;
-            clock.tick(10001);
-            return initPromise.then(() => {
-              expect(iframe.style.visibility).to.equal('');
-              expect(noContentSpy).to.be.calledOnce;
-              expect(noContentSpy).to.be.calledWith(true);
-            });
-          });
     });
 
     it('should resolve directly if it is A4A', () => {
-      const beforeAttachedToDom = element => {
-        initPromise =
-            iframeHandler.init(element, true, undefined, true);
-      };
-      return createIframeWithMessageStub(window, beforeAttachedToDom)
-          .then(newIframe => {
-            return initPromise.then(() => {
-              expect(newIframe.style.visibility).to.equal('');
-            });
-          });
+      return iframeHandler.init(iframe, true, undefined, true).then(() => {
+        expect(iframe.style.visibility).to.equal('');
+      });
     });
   });
 
   describe('Initialized iframe', () => {
-    let iframe;
 
-    const beforeAttachedToDom = element => {
-      element.setAttribute('data-amp-3p-sentinel', 'amp3ptest' + testIndex);
-      iframeHandler.init(element, true);
-    };
-    beforeEach(() => {
-      return createIframeWithMessageStub(window, beforeAttachedToDom)
-        .then(newIframe => {
-          iframe = newIframe;
-        });
+    beforeEach(done => {
+      iframeHandler.init(iframe, true);
+      iframe.onload = () => {
+        done();
+      };
     });
 
     it('should be able to use embed-state API', () => {

--- a/test/functional/test-iframe-stub.js
+++ b/test/functional/test-iframe-stub.js
@@ -32,10 +32,12 @@ describe('test-iframe-createIframeWithMessageStub', () => {
 
   let iframe;
 
-  beforeEach(() => {
-    return createIframeWithMessageStub(window).then(newIframe => {
-      iframe = newIframe;
-    });
+  beforeEach(done => {
+    iframe = createIframeWithMessageStub(window);
+    document.body.appendChild(iframe);
+    iframe.onload = () => {
+      done();
+    };
   });
 
   it('should get message from fragment and post back to parent window', () => {

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -288,16 +288,11 @@ const IFRAME_STUB_URL =
  * See /test/fixtures/served/iframe-stub.html for implementation.
  *
  * @param win {!Window}
- * @param opt_beforeAttachToDom {function(!HTMLIFrameElement)=}
- * @returns {!Promise<!HTMLIFrameElement>}
+ * @returns {!HTMLIFrameElement}
  */
-export function createIframeWithMessageStub(win, opt_beforeAttachToDom) {
+export function createIframeWithMessageStub(win) {
   const element = win.document.createElement('iframe');
   element.src = IFRAME_STUB_URL;
-  if (opt_beforeAttachToDom) {
-    opt_beforeAttachToDom(element);
-  }
-  win.document.body.appendChild(element);
 
   /**
    * Instructs the iframe to send a message to parent window.
@@ -329,12 +324,7 @@ export function createIframeWithMessageStub(win, opt_beforeAttachToDom) {
       win.addEventListener('message', listener);
     });
   };
-
-  return new Promise(resolve => {
-    element.onload = () => {
-      resolve(element);
-    };
-  });
+  return element;
 }
 
 /**


### PR DESCRIPTION
Refactored test code to reproduce the issue in test. The iframe should not be attached to document.body, but amp-ad element.

Fixes #5608