### PR TITLE
Update amphtml link rel to match file name in examples & fix comments

### DIFF
--- a/examples/metadata-examples/article-json-ld-twitter-card.amp.html
+++ b/examples/metadata-examples/article-json-ld-twitter-card.amp.html
@@ -16,11 +16,19 @@
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
 
-          <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" />
+          <link rel="amphtml" href="http://example.ampproject.org/article-json-ld-twitter-card.amp.html" />
 
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
+
+        Also, please be aware that some platforms that use AMP HTML have
+        further restrictions with regards to some schema components.
+
+         For example:
+
+           * All marked-up URL's should be absolute.
+           * The "logo" dimensions must not exceed 600x60.
     -->
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->

--- a/examples/metadata-examples/article-json-ld-twitter-card.amp.html
+++ b/examples/metadata-examples/article-json-ld-twitter-card.amp.html
@@ -21,14 +21,6 @@
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
-
-        Also, please be aware that some platforms that use AMP HTML have
-        further restrictions with regards to some schema components.
-
-         For example:
-
-           * All marked-up URL's should be absolute.
-           * The "logo" dimensions must not exceed 600x60.
     -->
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->

--- a/examples/metadata-examples/article-json-ld.amp.html
+++ b/examples/metadata-examples/article-json-ld.amp.html
@@ -16,11 +16,19 @@
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
 
-          <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" />
+          <link rel="amphtml" href="http://example.ampproject.org/article-json-ld.amp.html" />
 
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
+
+        Also, please be aware that some platforms that use AMP HTML have
+        further restrictions with regards to some schema components.
+
+         For example:
+
+           * All marked-up URL's should be absolute.
+           * The "logo" dimensions must not exceed 600x60.
     -->
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->

--- a/examples/metadata-examples/article-json-ld.amp.html
+++ b/examples/metadata-examples/article-json-ld.amp.html
@@ -21,14 +21,6 @@
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
-
-        Also, please be aware that some platforms that use AMP HTML have
-        further restrictions with regards to some schema components.
-
-         For example:
-
-           * All marked-up URL's should be absolute.
-           * The "logo" dimensions must not exceed 600x60.
     -->
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->

--- a/examples/metadata-examples/article-microdata.amp.html
+++ b/examples/metadata-examples/article-microdata.amp.html
@@ -16,7 +16,7 @@
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
 
-          <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" />
+          <link rel="amphtml" href="http://example.ampproject.org/article-microdata.amp.html" />
 
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this

--- a/examples/metadata-examples/recipe-json-ld.amp.html
+++ b/examples/metadata-examples/recipe-json-ld.amp.html
@@ -16,7 +16,7 @@
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
 
-          <link rel="amphtml" href="http://example.ampproject.org/recipe-metadata.amp.html" />
+          <link rel="amphtml" href="http://example.ampproject.org/recipe-json-ld.amp.html" />
 
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this

--- a/examples/metadata-examples/recipe-microdata.amp.html
+++ b/examples/metadata-examples/recipe-microdata.amp.html
@@ -12,15 +12,21 @@
     <link itemprop="mainEntityOfPage" rel="canonical" href="http://example.ampproject.org/recipe-metadata.html" />
     <!--
         The canonical document for this article should be linked, as above.
+
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
-          <link rel="amphtml" href="http://example.ampproject.org/recipe-metadata.amp.html" />
+
+          <link rel="amphtml" href="http://example.ampproject.org/recipe-json-ld.amp.html" />
+
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
+
         Also, please be aware that some platforms that use AMP HTML have
         further restrictions with regards to some schema components.
+
          For example:
+
            * All marked-up URL's should be absolute.
            * The "logo" dimensions must not exceed 600x60.
     -->

--- a/examples/metadata-examples/review-json-ld.amp.html
+++ b/examples/metadata-examples/review-json-ld.amp.html
@@ -12,15 +12,21 @@
     <link rel="canonical" href="http://example.ampproject.org/review-metadata.html" />
     <!--
         The canonical document for this article should be linked, as above.
+
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
-          <link rel="amphtml" href="http://example.ampproject.org/recipe-metadata.amp.html" />
+
+          <link rel="amphtml" href="http://example.ampproject.org/review-json-ld.amp.html" />
+
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
+
         Also, please be aware that some platforms that use AMP HTML have
         further restrictions with regards to some schema components.
+
          For example:
+
            * All marked-up URL's should be absolute.
            * The "logo" dimensions must not exceed 600x60.
     -->

--- a/examples/metadata-examples/review-microdata.amp.html
+++ b/examples/metadata-examples/review-microdata.amp.html
@@ -12,15 +12,21 @@
     <link itemprop="mainEntityOfPage" rel="canonical" href="http://example.ampproject.org/review-metadata.html" />
     <!--
         The canonical document for this article should be linked, as above.
+
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
-          <link rel="amphtml" href="http://example.ampproject.org/recipe-metadata.amp.html" />
+
+          <link rel="amphtml" href="http://example.ampproject.org/review-microdata.amp.html" />
+
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
+
         Also, please be aware that some platforms that use AMP HTML have
         further restrictions with regards to some schema components.
+
          For example:
+
            * All marked-up URL's should be absolute.
            * The "logo" dimensions must not exceed 600x60.
     -->

--- a/examples/metadata-examples/sports-article-json-ld.amp.html
+++ b/examples/metadata-examples/sports-article-json-ld.amp.html
@@ -21,14 +21,6 @@
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
-
-        Also, please be aware that some platforms that use AMP HTML have
-        further restrictions with regards to some schema components.
-
-         For example:
-
-           * All marked-up URL's should be absolute.
-           * The "logo" dimensions must not exceed 600x60.
     -->
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->

--- a/examples/metadata-examples/sports-article-json-ld.amp.html
+++ b/examples/metadata-examples/sports-article-json-ld.amp.html
@@ -9,18 +9,26 @@
   <head>
     <meta charset="utf-8">
     <title>Lorem Ipsum</title>
-    <link rel="canonical" href="https://intense-heat-6570.firebaseapp.com/index.html" />
+    <link rel="canonical" href="http://example.ampproject.org/sports-article-metadata.html" />
     <!--
         The canonical document for this article should be linked, as above.
 
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
 
-          <link rel="amphtml" href="http://example.ampproject.org/article-metadata.amp.html" />
+          <link rel="amphtml" href="http://example.ampproject.org/sports-article-json-ld.amp.html" />
 
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
+
+        Also, please be aware that some platforms that use AMP HTML have
+        further restrictions with regards to some schema components.
+
+         For example:
+
+           * All marked-up URL's should be absolute.
+           * The "logo" dimensions must not exceed 600x60.
     -->
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->

--- a/examples/metadata-examples/video-json-ld.amp.html
+++ b/examples/metadata-examples/video-json-ld.amp.html
@@ -12,12 +12,23 @@
     <link rel="canonical" href="http://example.ampproject.org/video-metadata.html" />
     <!--
         The canonical document for this article should be linked, as above.
+
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
-          <link rel="amphtml" href="http://example.ampproject.org/video-metadata.amp.html" />
+
+          <link rel="amphtml" href="http://example.ampproject.org/video-json-ld.amp.html" />
+
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
+
+        Also, please be aware that some platforms that use AMP HTML have
+        further restrictions with regards to some schema components.
+
+         For example:
+
+           * All marked-up URL's should be absolute.
+           * The "logo" dimensions must not exceed 600x60.
     -->
     <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
     <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->

--- a/examples/metadata-examples/video-json-ld.amp.html
+++ b/examples/metadata-examples/video-json-ld.amp.html
@@ -21,14 +21,6 @@
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
-
-        Also, please be aware that some platforms that use AMP HTML have
-        further restrictions with regards to some schema components.
-
-         For example:
-
-           * All marked-up URL's should be absolute.
-           * The "logo" dimensions must not exceed 600x60.
     -->
     <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
     <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->

--- a/examples/metadata-examples/video-microdata.amp.html
+++ b/examples/metadata-examples/video-microdata.amp.html
@@ -12,15 +12,21 @@
     <link itemprop="mainEntityOfPage" rel="canonical" href="http://example.ampproject.org/video-metadata.html" />
     <!--
         The canonical document for this article should be linked, as above.
+
         The canonical document should also have a corresponding <link> tag
         within pointing at this AMP HTML file:
-          <link rel="amphtml" href="http://example.ampproject.org/video-metadata.amp.html" />
+
+          <link rel="amphtml" href="http://example.ampproject.org/video-microdata.amp.html" />
+
         It is possible that this AMP HTML document is the canonical document
         for this article, in which case, the canonical URL should point to this
         document, and no "amphtml" link is required.
+
         Also, please be aware that some platforms that use AMP HTML have
         further restrictions with regards to some schema components.
+
          For example:
+
            * All marked-up URL's should be absolute.
            * The "logo" dimensions must not exceed 600x60.
     -->


### PR DESCRIPTION
Just a few minor changes to the example within metadata:

* Formatting of the canonical comments in each example copied to stay
consistent between all. Some had additional information that wasn't
reflected across all examples.
* Updated the `<link rel="amphtml">` href attributes to match file names
for each. While the example URL does not function (404) it still serves
to show that we are referring to the current file.
* Updated the `sports-article-json-ld.amp.html` file's canonical to
mirror the other example URLs (using `example.ampproject.org` domain).