### PR TITLE
A4A integration tests

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -103,14 +103,14 @@ describe('integration test: a4a', () => {
   });
 
   it('should render a single AMP ad in a friendly iframe', () => {
-    return fixture.addElement(a4aElement).then(element => {
+    return fixture.addElement(a4aElement).then(unusedElement => {
       expectRenderedInFriendlyIframe(a4aElement, 'Hello, world.');
     });
   });
 
   it('should fall back to 3p when no signature is present', () => {
     mockResponse.headers.delete(SIGNATURE_HEADER);
-    return fixture.addElement(a4aElement).then(element => {
+    return fixture.addElement(a4aElement).then(unusedElement => {
       expectRenderedInXDomainIframe(a4aElement, TEST_URL);
     });
   });
@@ -150,7 +150,7 @@ describe('integration test: a4a', () => {
         })
         .onSecondCall().throws(new Error(
             'Testing extractCreativeAndSignature should not occur error'));
-    return fixture.addElement(a4aElement).then(element => {
+    return fixture.addElement(a4aElement).then(unusedElement => {
       expectRenderedInXDomainIframe(a4aElement, TEST_URL);
     });
   });

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -34,68 +34,29 @@ import {
 } from '../../../../src/custom-element';
 import * as sinon from 'sinon';
 
-chai.Assertion.addMethod('renderedInFriendlyIframe', function(srcdoc) {
-  const obj = this._obj;
-  this.assert(obj,
-      'amp ad element should be #{exp}, got #{act}',  // if true message
-      'amp ad element should not be #{exp}, got #{act}',  // if negated message
-      'truthy',  // expected
-      obj);      // actual
-  const elementName = obj.tagName.toLowerCase();
-  const child = obj.querySelector('iframe[srcdoc]');
-  this.assert(child,
-      `child of amp ad element ${elementName} should be #{exp}, got #{act}`,
-      `child of amp ad element ${elementName} should not be #{exp}, got #{act}`,
-      'truthy',
-      child);
-  this.assert(child.getAttribute('srcdoc').indexOf(srcdoc) >= 0,
-      `iframe child of amp ad element ${elementName} should contain #{exp}, ` +
-      'was #{act}',
-      `iframe child of amp ad element ${elementName} should not contain ` +
-      '#{exp}, was #{act}',
-      srcdoc,
-      child.getAttribute('srcdoc'));
+function expectRenderedInFriendlyIframe(element, srcdoc) {
+  expect(element, 'ad element').to.be.ok;
+  const child = element.querySelector('iframe[srcdoc]');
+  expect(child, 'iframe child').to.be.ok;
+  expect(child.getAttribute('srcdoc')).to.contain.string(srcdoc);
   const childBody = child.contentDocument.body;
-  this.assert(childBody,
-      `iframe child of amp ad element ${elementName} should have #{exp}`,
-      `iframe child of amp ad element ${elementName} should have #{exp}, ` +
-      'got #{act}',
-      'body tag',
-      childBody);
-  [obj, child, childBody].forEach(toTest => {
+  expect(childBody, 'body of iframe doc').to.be.ok;
+  [element, child, childBody].forEach(toTest => {
     expect(toTest).to.be.visible;
   });
-});
+}
 
-chai.Assertion.addMethod('renderedInXDomainIframe', function(src) {
-  const obj = this._obj;
-  this.assert(obj,
-      'amp ad element should be #{exp}, got #{act}',  // if true message
-      'amp ad element should not be #{exp}, got #{act}',  // if negated message
-      'truthy',  // expected
-      obj);      // actual
-  const elementName = obj.tagName.toLowerCase();
-  const friendlyChild = obj.querySelector('iframe[srcdoc]');
-  this.assert(!friendlyChild,
-      `child of amp ad element ${elementName} should not be cross-domain`,
-      `child of amp ad element ${elementName} should be cross-domain`);
-  const child = obj.querySelector('iframe[src]');
-  this.assert(child,
-      `child of amp ad element ${elementName} should be #{exp}, got #{act}`,
-      `child of amp ad element ${elementName} should not be #{exp}, got #{act}`,
-      'truthy',
-      child);
-  this.assert(child.getAttribute('src').indexOf(src) >= 0,
-      `iframe child of amp ad element ${elementName} src should contain ` +
-      '#{exp}, was #{act}',
-      `iframe child of amp ad element ${elementName} src should not contain ` +
-      '#{exp}, was #{act}',
-      src,
-      child.getAttribute('src'));
-  [obj, child].forEach(toTest => {
+function expectRenderedInXDomainIframe(element, src) {
+  expect(element, 'ad element').to.be.ok;
+  expect(element.querySelector('iframe[srcdoc]'),
+      'does not have a friendly iframe child').to.not.be.ok;
+  const child = element.querySelector('iframe[src]');
+  expect(child, 'iframe child').to.be.ok;
+  expect(child.getAttribute('src')).to.contain.string(src);
+  [element, child].forEach(toTest => {
     expect(toTest).to.be.visible;
   });
-});
+}
 
 describe('integration test: a4a', () => {
   let sandbox;
@@ -143,14 +104,14 @@ describe('integration test: a4a', () => {
 
   it('should render a single AMP ad in a friendly iframe', () => {
     return fixture.addElement(a4aElement).then(element => {
-      expect(element).to.be.renderedInFriendlyIframe('Hello, world.');
+      expectRenderedInFriendlyIframe(a4aElement, 'Hello, world.');
     });
   });
 
   it('should fall back to 3p when no signature is present', () => {
     mockResponse.headers.delete(SIGNATURE_HEADER);
     return fixture.addElement(a4aElement).then(element => {
-      expect(element).to.be.renderedInXDomainIframe(TEST_URL);
+      expectRenderedInXDomainIframe(a4aElement, TEST_URL);
     });
   });
 
@@ -163,7 +124,7 @@ describe('integration test: a4a', () => {
     return fixture.addElement(a4aElement).catch(error => {
       expect(error.message).to.contain.string('Testing network error');
       expect(error.message).to.contain.string('amp-a4a:');
-      expect(a4aElement).to.be.renderedInXDomainIframe(TEST_URL);
+      expectRenderedInXDomainIframe(a4aElement, TEST_URL);
     });
   });
 
@@ -177,7 +138,7 @@ describe('integration test: a4a', () => {
       expect(error.message).to.contain.string(
           'Testing extractCreativeAndSignature error');
       expect(error.message).to.contain.string('amp-a4a:');
-      expect(a4aElement).to.be.renderedInXDomainIframe(TEST_URL);
+      expectRenderedInXDomainIframe(a4aElement, TEST_URL);
     });
   });
 
@@ -190,7 +151,7 @@ describe('integration test: a4a', () => {
         .onSecondCall().throws(new Error(
             'Testing extractCreativeAndSignature should not occur error'));
     return fixture.addElement(a4aElement).then(element => {
-      expect(element).to.be.renderedInXDomainIframe(TEST_URL);
+      expectRenderedInXDomainIframe(a4aElement, TEST_URL);
     });
   });
 
@@ -209,7 +170,7 @@ describe('integration test: a4a', () => {
         return fixture.addElement(a4aElement).catch(error => {
           expect(error.message).to.contain.string('Key failed to validate');
           expect(error.message).to.contain.string('amp-a4a:');
-          expect(a4aElement).to.be.renderedInXDomainIframe(TEST_URL);
+          expectRenderedInXDomainIframe(a4aElement, TEST_URL);
         });
       });
 });

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -17,7 +17,6 @@
 import {
     MockA4AImpl,
     stringToArrayBuffer,
-    isStyleVisible,
     SIGNATURE_HEADER,
     TEST_URL,
 } from './utils';
@@ -27,7 +26,6 @@ import {
     data as validCSSAmp,
 } from './testdata/valid_css_at_rules_amp.reserialized';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
-import '../../../../extensions/amp-ad/0.1/amp-ad-api-handler';
 import {adConfig} from '../../../../ads/_config';
 import {a4aRegistry} from '../../../../ads/_a4a-config';
 import {resetScheduledElementForTesting, upgradeOrRegisterElement} from '../../../../src/custom-element';

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {stringToArrayBuffer, isStyleVisible} from './utils';
+import {AmpA4A, RENDERING_TYPE_HEADER} from '../amp-a4a';
+import {Xhr} from '../../../../src/service/xhr-impl';
+import {Viewer} from '../../../../src/service/viewer-impl';
+import {ampdocServiceFor} from '../../../../src/ampdoc';
+import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
+import {cancellation} from '../../../../src/error';
+import {createIframePromise} from '../../../../testing/iframe';
+import {data as minimumAmp} from './testdata/minimum_valid_amp.reserialized';
+import {data as regexpsAmpData} from './testdata/regexps.reserialized';
+import {
+    data as validCSSAmp,
+} from './testdata/valid_css_at_rules_amp.reserialized';
+import {data as testFragments} from './testdata/test_fragments';
+import {data as expectations} from './testdata/expectations';
+import {installDocService} from '../../../../src/service/ampdoc-impl';
+import '../../../../extensions/amp-ad/0.1/amp-ad-api-handler';
+import {adConfig} from '../../../../ads/_config';
+import {a4aRegistry} from '../../../../ads/_a4a-config';
+import {resetScheduledElementForTesting, upgradeOrRegisterElement} from '../../../../src/custom-element';
+import * as sinon from 'sinon';
+
+/** @type {string} @private */
+const SIGNATURE_HEADER = 'X-AmpAdSignature';
+
+/** @type {string} @private */
+const TEST_URL = 'https://test.location.org/ad/012345?args';
+
+class MockA4AImpl extends AmpA4A {
+  getAdUrl() {
+    return Promise.resolve(TEST_URL);
+  }
+
+  extractCreativeAndSignature(responseArrayBuffer, responseHeaders) {
+    return Promise.resolve({
+      creative: responseArrayBuffer,
+      signature: responseHeaders.has(SIGNATURE_HEADER) ?
+          base64UrlDecodeToBytes(responseHeaders.get(SIGNATURE_HEADER)) : null,
+    });
+  }
+}
+
+describe('integration test: a4a', () => {
+  let sandbox;
+  let xhrMock;
+  let fixture;
+  let mockResponse;
+  let a4aElement;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    xhrMock = sandbox.stub(Xhr.prototype, 'fetch');
+    mockResponse = {
+      arrayBuffer: function() {
+        return Promise.resolve(stringToArrayBuffer(validCSSAmp.reserialized));
+      },
+      bodyUsed: false,
+      headers: new Headers(),
+    };
+    mockResponse.headers.append(SIGNATURE_HEADER, validCSSAmp.signature);
+    xhrMock.withArgs(TEST_URL, {
+      mode: 'cors',
+      method: 'GET',
+      credentials: 'include',
+      requireAmpResponseSourceOrigin: true,
+    }).onFirstCall().returns(Promise.resolve(mockResponse));
+    adConfig['mock'] = {};
+    a4aRegistry['mock'] = () => {return true;};
+    return createIframePromise().then(f => {
+      fixture = f;
+      installDocService(fixture.win, /* isSingleDoc */ true);
+      upgradeOrRegisterElement(fixture.win, 'amp-a4a', MockA4AImpl);
+      const doc = fixture.doc;
+      a4aElement = doc.createElement('amp-a4a');
+      a4aElement.setAttribute('width', 200);
+      a4aElement.setAttribute('height', 50);
+      a4aElement.setAttribute('type', 'mock');
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    resetScheduledElementForTesting(window, 'amp-a4a');
+    delete adConfig['mock'];
+    delete a4aRegistry['mock'];
+  });
+
+  it('should render a single AMP ad in a friendly iframe', () => {
+    return fixture.addElement(a4aElement).then(element => {
+      const child = element.querySelector('iframe[srcdoc]');
+      expect(child).to.be.ok;
+      expect(child.getAttribute('srcdoc')).to.contain.string('Hello, world.');
+      expect(isStyleVisible(fixture.win, element)).to.be.true;
+      expect(isStyleVisible(fixture.win, child)).to.be.true;
+    });
+  });
+
+  it('should fall back to 3p when no signature is present', () => {
+    mockResponse.headers.delete(SIGNATURE_HEADER);
+    return fixture.addElement(a4aElement).then(element => {
+      let child = element.querySelector('iframe[srcdoc]');
+      expect(child).to.not.be.ok;
+      child = element.querySelector('iframe[src]');
+      expect(child).to.be.ok;
+      expect(child.getAttribute('src')).to.contain.string(TEST_URL);
+      expect(isStyleVisible(fixture.win, element)).to.be.true;
+      expect(isStyleVisible(fixture.win, child)).to.be.true;
+    });
+  });
+
+  it('should fall back to 3p when the XHR fails', () => {
+    xhrMock.resetBehavior();
+    xhrMock.throws(new Error('Testing network error'));
+    return fixture.addElement(a4aElement).then(element => {
+      let child = element.querySelector('iframe[srcdoc]');
+      expect(child).to.not.be.ok;
+      child = element.querySelector('iframe[src]');
+      expect(child).to.be.ok;
+      expect(child.getAttribute('src')).to.contain.string(TEST_URL);
+      expect(isStyleVisible(fixture.win, element)).to.be.true;
+      expect(isStyleVisible(fixture.win, child)).to.be.true;
+    });
+  });
+
+  it('should fall back to 3p when extractCreative throws', () => {
+    sinon.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature').throws(
+        new Error('Testing extractCreativeAndSignature error'));
+    return fixture.addElement(a4aElement).then(element => {
+      let child = element.querySelector('iframe[srcdoc]');
+      expect(child).to.not.be.ok;
+      child = element.querySelector('iframe[src]');
+      expect(child).to.be.ok;
+      expect(child.getAttribute('src')).to.contain.string(TEST_URL);
+      expect(isStyleVisible(fixture.win, element)).to.be.true;
+      expect(isStyleVisible(fixture.win, child)).to.be.true;
+    });
+  });
+});

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -186,7 +186,7 @@ describe('integration test: a4a', () => {
   it('should fall back to 3p when the XHR fails', () => {
     xhrMock.resetBehavior();
     xhrMock.throws(new Error('Testing network error'));
-    // Note: Currently layoutCallback rejects, even though something *is*
+    // TODO(tdrl) Currently layoutCallback rejects, even though something *is*
     // rendered.  This should be fixed in a refactor, and we should change this
     // .catch to a .then.
     return fixture.addElement(a4aElement).catch(error => {
@@ -199,7 +199,7 @@ describe('integration test: a4a', () => {
   it('should fall back to 3p when extractCreative throws', () => {
     sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature').throws(
         new Error('Testing extractCreativeAndSignature error'));
-    // Note: Currently layoutCallback rejects, even though something *is*
+    // TODO(tdrl) Currently layoutCallback rejects, even though something *is*
     // rendered.  This should be fixed in a refactor, and we should change this
     // .catch to a .then.
     return fixture.addElement(a4aElement).catch(error => {
@@ -220,6 +220,24 @@ describe('integration test: a4a', () => {
             'Testing extractCreativeAndSignature should not occur error'));
     return fixture.addElement(a4aElement).then(element => {
       expect(element).to.be.renderedInXDomainIframe(TEST_URL);
+    })
+  });
+
+  it('should fall back to 3p when extractCreative returns empty creative', () => {
+    sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature')
+        .onFirstCall().returns({
+          creative: null,
+          signature: validCSSAmp.signature,
+        })
+        .onSecondCall().throws(new Error(
+        'Testing extractCreativeAndSignature should not occur error'));
+    // TODO(tdrl) Currently layoutCallback rejects, even though something *is*
+    // rendered.  This should be fixed in a refactor, and we should change this
+    // .catch to a .then.
+    return fixture.addElement(a4aElement).catch(error => {
+      expect(error.message).to.contain.string('Key failed to validate');
+      expect(error.message).to.contain.string('amp-a4a:');
+      expect(a4aElement).to.be.renderedInXDomainIframe(TEST_URL);
     })
   });
 });

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -59,23 +59,8 @@ chai.Assertion.addMethod('renderedInFriendlyIframe', function (srcdoc) {
       'got #{act}',
       'body tag',
       childBody);
-  // I would like to just invoke the .visible assertion from test/_init_test.js,
-  // but it doesn't work to just do this.assert(child).visible.  So just copy
-  // the test code from _init_test.js.  Bleh.
   [obj, child, childBody].forEach(toTest => {
-    const computedStyle =
-        toTest.ownerDocument.defaultView.getComputedStyle(toTest);
-    const visibility = computedStyle.getPropertyValue('visibility');
-    const opacity = computedStyle.getPropertyValue('opacity');
-    const tagName = toTest.tagName.toLowerCase();
-    this.assert(
-        visibility === 'visible' && parseInt(opacity, 10) > 0,
-        'expected element \'' +
-        tagName + '\' to be #{exp}, got #{act}. with classes: ' + obj.className,
-        'expected element \'' +
-        tagName + '\' not to be #{exp}. with classes: ' + obj.className,
-        'visible',
-        visibility);
+    expect(toTest).to.be.visible;
   });
 });
 
@@ -104,23 +89,8 @@ chai.Assertion.addMethod('renderedInXDomainIframe', function (src) {
       '#{exp}, was #{act}',
       src,
       child.getAttribute('src'));
-  // I would like to just invoke the .visible assertion from test/_init_test.js,
-  // but it doesn't work to just do this.assert(child).visible.  So just copy
-  // the test code from _init_test.js.  Bleh.
   [obj, child].forEach(toTest => {
-    const computedStyle =
-        toTest.ownerDocument.defaultView.getComputedStyle(toTest);
-    const visibility = computedStyle.getPropertyValue('visibility');
-    const opacity = computedStyle.getPropertyValue('opacity');
-    const tagName = toTest.tagName.toLowerCase();
-    this.assert(
-        visibility === 'visible' && parseInt(opacity, 10) > 0,
-        'expected element \'' +
-        tagName + '\' to be #{exp}, got #{act}. with classes: ' + obj.className,
-        'expected element \'' +
-        tagName + '\' not to be #{exp}. with classes: ' + obj.className,
-        'visible',
-        visibility);
+    expect(toTest).to.be.visible;
   });
 });
 

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -16,7 +16,6 @@
 
 import {
     MockA4AImpl,
-    stringToArrayBuffer,
     SIGNATURE_HEADER,
     TEST_URL,
 } from './utils';
@@ -32,6 +31,7 @@ import {
     resetScheduledElementForTesting,
     upgradeOrRegisterElement,
 } from '../../../../src/custom-element';
+import {utf8Encode} from '../../../../src/utils/bytes';
 import * as sinon from 'sinon';
 
 function expectRenderedInFriendlyIframe(element, srcdoc) {
@@ -69,7 +69,7 @@ describe('integration test: a4a', () => {
     xhrMock = sandbox.stub(Xhr.prototype, 'fetch');
     mockResponse = {
       arrayBuffer: function() {
-        return Promise.resolve(stringToArrayBuffer(validCSSAmp.reserialized));
+        return utf8Encode(validCSSAmp.reserialized);
       },
       bodyUsed: false,
       headers: new Headers(),
@@ -145,7 +145,7 @@ describe('integration test: a4a', () => {
   it('should fall back to 3p when extractCreative returns empty sig', () => {
     sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature')
         .onFirstCall().returns({
-          creative: stringToArrayBuffer(validCSSAmp.reserialized),
+          creative: utf8Encode(validCSSAmp.reserialized),
           signature: null,
         })
         .onSecondCall().throws(new Error(

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -28,10 +28,13 @@ import {
 import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {adConfig} from '../../../../ads/_config';
 import {a4aRegistry} from '../../../../ads/_a4a-config';
-import {resetScheduledElementForTesting, upgradeOrRegisterElement} from '../../../../src/custom-element';
+import {
+    resetScheduledElementForTesting,
+    upgradeOrRegisterElement,
+} from '../../../../src/custom-element';
 import * as sinon from 'sinon';
 
-chai.Assertion.addMethod('renderedInFriendlyIframe', function (srcdoc) {
+chai.Assertion.addMethod('renderedInFriendlyIframe', function(srcdoc) {
   const obj = this._obj;
   this.assert(obj,
       'amp ad element should be #{exp}, got #{act}',  // if true message
@@ -64,7 +67,7 @@ chai.Assertion.addMethod('renderedInFriendlyIframe', function (srcdoc) {
   });
 });
 
-chai.Assertion.addMethod('renderedInXDomainIframe', function (src) {
+chai.Assertion.addMethod('renderedInXDomainIframe', function(src) {
   const obj = this._obj;
   this.assert(obj,
       'amp ad element should be #{exp}, got #{act}',  // if true message
@@ -188,24 +191,31 @@ describe('integration test: a4a', () => {
             'Testing extractCreativeAndSignature should not occur error'));
     return fixture.addElement(a4aElement).then(element => {
       expect(element).to.be.renderedInXDomainIframe(TEST_URL);
-    })
+    });
   });
 
-  it('should fall back to 3p when extractCreative returns empty creative', () => {
-    sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature')
-        .onFirstCall().returns({
-          creative: null,
-          signature: validCSSAmp.signature,
-        })
-        .onSecondCall().throws(new Error(
-        'Testing extractCreativeAndSignature should not occur error'));
-    // TODO(tdrl) Currently layoutCallback rejects, even though something *is*
-    // rendered.  This should be fixed in a refactor, and we should change this
-    // .catch to a .then.
-    return fixture.addElement(a4aElement).catch(error => {
-      expect(error.message).to.contain.string('Key failed to validate');
-      expect(error.message).to.contain.string('amp-a4a:');
-      expect(a4aElement).to.be.renderedInXDomainIframe(TEST_URL);
-    })
-  });
+  it('should fall back to 3p when extractCreative returns empty creative',
+      () => {
+        sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature')
+            .onFirstCall().returns({
+              creative: null,
+              signature: validCSSAmp.signature,
+            })
+            .onSecondCall().throws(new Error(
+            'Testing extractCreativeAndSignature should not occur error'));
+        // TODO(tdrl) Currently layoutCallback rejects, even though something
+        // *is* rendered.  This should be fixed in a refactor, and we should
+        // change this .catch to a .then.
+        return fixture.addElement(a4aElement).catch(error => {
+          expect(error.message).to.contain.string('Key failed to validate');
+          expect(error.message).to.contain.string('amp-a4a:');
+          expect(a4aElement).to.be.renderedInXDomainIframe(TEST_URL);
+        });
+      });
 });
+
+// TODO(@ampproject/a4a): Need a test that double-checks that thrown errors
+// are propagated out and printed to console and/or sent upstream to error
+// logging systems.  This is a bit tricky, because it's handled by the AMP
+// runtime and can't be done within the context of a
+// fixture.addElement().then() or .catch().

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -34,6 +34,11 @@ import {
 import {utf8Encode} from '../../../../src/utils/bytes';
 import * as sinon from 'sinon';
 
+// Integration tests for A4A.  These stub out accesses to the outside world
+// (e.g., XHR requests and interfaces to ad network-specific code), but
+// otherwise test the complete A4A flow, without making assumptions about
+// the structure of that flow.
+
 function expectRenderedInFriendlyIframe(element, srcdoc) {
   expect(element, 'ad element').to.be.ok;
   const child = element.querySelector('iframe[srcdoc]');

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import {stringToArrayBuffer, isStyleVisible, MockA4AImpl, TEST_URL, SIGNATURE_HEADER} from './utils';
+import {
+  stringToArrayBuffer,
+  MockA4AImpl,
+  TEST_URL,
+  SIGNATURE_HEADER
+} from './utils';
 import {AmpA4A, RENDERING_TYPE_HEADER} from '../amp-a4a';
 import {Xhr} from '../../../../src/service/xhr-impl';
 import {Viewer} from '../../../../src/service/viewer-impl';
@@ -169,7 +174,7 @@ describe('amp-a4a', () => {
         a4a.vsync_.runScheduledTasks_();
         const child = a4aElement.querySelector('iframe[name]');
         expect(child).to.be.ok;
-        expect(isStyleVisible(fixture.win, child)).to.be.true;
+        expect(child).to.be.visible;
       });
     });
 
@@ -185,7 +190,7 @@ describe('amp-a4a', () => {
         a4a.vsync_.runScheduledTasks_();
         const child = a4aElement.querySelector('iframe[src]');
         expect(child).to.be.ok;
-        expect(isStyleVisible(fixture.win, child)).to.be.true;
+        expect(child).to.be.visible;
       });
     });
 
@@ -198,10 +203,10 @@ describe('amp-a4a', () => {
         a4a.vsync_.runScheduledTasks_();
         const child = a4aElement.querySelector('iframe[srcdoc]');
         expect(child).to.be.ok;
-        expect(isStyleVisible(fixture.win, child)).to.be.true;
+        expect(child).to.be.visible;
         const a4aBody = child.contentDocument.body;
         expect(a4aBody).to.be.ok;
-        expect(isStyleVisible(fixture.win, a4aBody)).to.be.true;
+        expect(a4aBody).to.be.visible;
       });
     });
   });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -18,7 +18,7 @@ import {
   stringToArrayBuffer,
   MockA4AImpl,
   TEST_URL,
-  SIGNATURE_HEADER
+  SIGNATURE_HEADER,
 } from './utils';
 import {AmpA4A, RENDERING_TYPE_HEADER} from '../amp-a4a';
 import {Xhr} from '../../../../src/service/xhr-impl';
@@ -33,7 +33,7 @@ import {
 import {data as testFragments} from './testdata/test_fragments';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-import {resetScheduledElementForTesting, upgradeOrRegisterElement} from '../../../../src/custom-element';
+import {resetScheduledElementForTesting} from '../../../../src/custom-element';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import * as sinon from 'sinon';
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -727,7 +727,7 @@ describe('amp-a4a', () => {
                 .contentDocument.querySelector('body');
             let clickHandlerCalled = 0;
 
-            adBody.onclick = function (e) {
+            adBody.onclick = function(e) {
               expect(e.defaultPrevented).to.be.false;
               e.preventDefault();  // Make the test not actually navigate.
               clickHandlerCalled++;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -36,9 +36,6 @@ import {resetScheduledElementForTesting} from '../../../../src/custom-element';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import * as sinon from 'sinon';
 
-const XHR_URL = 'http://iframe.localhost:' + location.port +
-    '/test/fixtures/served/iframe.html?args';
-
 /**
  * Create a promise for an iframe that has a super-minimal mock AMP environment
  * in it.
@@ -530,8 +527,8 @@ describe('amp-a4a', () => {
           expect(a4aElement.children.length).to.equal(1);
           const iframe = a4aElement.querySelector('iframe[src]');
           expect(iframe).to.be.ok;
-          expect(iframe.src.indexOf(XHR_URL)).to.equal(0);
-          expect(isStyleVisible(fixture.win, iframe)).to.be.true;
+          expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
+          expect(iframe).to.be.visible;
         });
       });
     });
@@ -549,8 +546,8 @@ describe('amp-a4a', () => {
           expect(a4aElement.children.length).to.equal(1);
           const iframe = a4aElement.children[0];
           expect(iframe.tagName).to.equal('IFRAME');
-          expect(iframe.src.indexOf(XHR_URL)).to.equal(0);
-          expect(isStyleVisible(fixture.win, iframe)).to.be.true;
+          expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
+          expect(iframe).to.be.visible;
         }));
       });
     });
@@ -573,7 +570,7 @@ describe('amp-a4a', () => {
           expect(a4aElement.children.length).to.equal(1);
           const iframe = a4aElement.children[0];
           expect(iframe.tagName).to.equal('IFRAME');
-          expect(iframe.src.indexOf(XHR_URL)).to.equal(0);
+          expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
           expect(iframe.style.visibility).to.equal('');
         });
       });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {stringToArrayBuffer, isStyleVisible} from './utils';
 import {AmpA4A, RENDERING_TYPE_HEADER} from '../amp-a4a';
 import {Xhr} from '../../../../src/service/xhr-impl';
 import {Viewer} from '../../../../src/service/viewer-impl';
@@ -28,6 +29,7 @@ import {
 import {data as testFragments} from './testdata/test_fragments';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {a4aRegistry} from '../../../../ads/_a4a-config';
+import {resetScheduledElementForTesting, upgradeOrRegisterElement} from '../../../../src/custom-element';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import * as sinon from 'sinon';
 
@@ -110,11 +112,8 @@ describe('amp-a4a', () => {
 
   afterEach(() => {
     sandbox.restore();
+    resetScheduledElementForTesting(window, 'amp-a4a');
   });
-
-  function stringToArrayBuffer(str) {
-    return utf8Encode(str);
-  }
 
   function createA4aElement(doc) {
     const element = doc.createElement('amp-a4a');
@@ -148,16 +147,6 @@ describe('amp-a4a', () => {
     a4a.onAmpCreativeRender = () => {
       assert.fail('AMP creative should never have rendered!');
     };
-  }
-
-  /**
-   *
-   * @param {!Window} win
-   * @param {!Element} element
-   */
-  function isStyleVisible(win, element) {
-    return win.getComputedStyle(element).getPropertyValue('visibility') ==
-        'visible';
   }
 
   describe('ads are visible', () => {
@@ -234,41 +223,6 @@ describe('amp-a4a', () => {
   });
 
   describe('#renderViaSafeFrame', () => {
-    // This is supposed to be an end-to-end test, but there seems to be an
-    // AMP initialization or upgrade issue somewhere, so the
-    // fixture.addElement() step fails with a 'element.build does not exist'
-    // error.  Skip this until we sort out how to properly do an E2E.
-    it.skip('should render a single AMP ad in a friendly iframe', () => {
-      xhrMock.withArgs(XHR_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-        requireAmpResponseSourceOrigin: true,
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
-      return createAdTestingIframePromise().then(fixture => {
-        const doc = fixture.doc;
-        a4aRegistry['mock'] = () => {return true;};
-        // const extensionsMock = sandbox.mock(extensionsFor(fixture.win));
-        // extensionsMock.expects('loadElementClass')
-        //     .withExactArgs('amp-ad-network-mock-impl')
-        //     .returns(Promise.resolve(MockA4AImpl))
-        //     .once();
-        const ampAdElement = doc.createElement('amp-a4a');
-        ampAdElement.setAttribute('width', 200);
-        ampAdElement.setAttribute('height', 50);
-        ampAdElement.setAttribute('type', 'mock');
-        // const ampAd = new MockA4AImpl(ampAdElement);
-        return fixture.addElement(ampAdElement);
-        // return ampAd.upgradeCallback().then(baseElement => {
-        //   extensionsMock.verify();
-        //   expect(ampAdElement.getAttribute('data-a4a-upgrade-type')).to.equal(
-        //       'amp-ad-network-mock-impl');
-        //   return fixture.addElement(ampAdElement).then(element => {
-        //     expect(element).to.not.be.null;
-        //   });
-        // });
-      });
-    });
 
     it('should attach a SafeFrame when header is set', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -27,9 +27,7 @@ import {
 } from './testdata/valid_css_at_rules_amp.reserialized';
 import {data as testFragments} from './testdata/test_fragments';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
-import '../../../../extensions/amp-ad/0.1/amp-ad-api-handler';
 import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-import {a4aRegistry} from '../../../../ads/_a4a-config';
 import {resetScheduledElementForTesting, upgradeOrRegisterElement} from '../../../../src/custom-element';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import * as sinon from 'sinon';

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -125,7 +125,7 @@ describe('amp-a4a', () => {
   }
 
   function buildCreativeArrayBuffer() {
-    return stringToArrayBuffer(buildCreativeString());
+    return utf8Encode(buildCreativeString());
   }
 
   function verifyNonAMPRender(a4a) {

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -37,6 +37,3 @@ export class MockA4AImpl extends AmpA4A {
   }
 }
 
-export function stringToArrayBuffer(str) {
-  return new TextEncoder('utf-8').encode(str);
-}

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AmpA4A, RENDERING_TYPE_HEADER} from '../amp-a4a';
+import {AmpA4A} from '../amp-a4a';
 import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
 
 /** @type {string} @private */

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -14,6 +14,29 @@
  * limitations under the License.
  */
 
+import {AmpA4A, RENDERING_TYPE_HEADER} from '../amp-a4a';
+import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
+
+/** @type {string} @private */
+export const SIGNATURE_HEADER = 'X-TestSignatureHeader';
+
+/** @type {string} @private */
+export const TEST_URL = 'https://test.location.org/ad/012345?args';
+
+export class MockA4AImpl extends AmpA4A {
+  getAdUrl() {
+    return Promise.resolve(TEST_URL);
+  }
+
+  extractCreativeAndSignature(responseArrayBuffer, responseHeaders) {
+    return Promise.resolve({
+      creative: responseArrayBuffer,
+      signature: responseHeaders.has(SIGNATURE_HEADER) ?
+          base64UrlDecodeToBytes(responseHeaders.get(SIGNATURE_HEADER)) : null,
+    });
+  }
+}
+
 export function stringToArrayBuffer(str) {
   return new TextEncoder('utf-8').encode(str);
 }

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -21,7 +21,8 @@ import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
 export const SIGNATURE_HEADER = 'X-TestSignatureHeader';
 
 /** @type {string} @private */
-export const TEST_URL = 'https://test.location.org/ad/012345?args';
+export const TEST_URL = 'http://iframe.localhost:' + location.port +
+    '/test/fixtures/served/iframe.html?args';
 
 export class MockA4AImpl extends AmpA4A {
   getAdUrl() {

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function stringToArrayBuffer(str) {
+  return new TextEncoder('utf-8').encode(str);
+}
+
+/**
+ *
+ * @param {!Window} win
+ * @param {!Element} element
+ */
+export function isStyleVisible(win, element) {
+  return win.getComputedStyle(element).getPropertyValue('visibility') ==
+      'visible';
+}
+
+

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -40,15 +40,3 @@ export class MockA4AImpl extends AmpA4A {
 export function stringToArrayBuffer(str) {
   return new TextEncoder('utf-8').encode(str);
 }
-
-/**
- *
- * @param {!Window} win
- * @param {!Element} element
- */
-export function isStyleVisible(win, element) {
-  return win.getComputedStyle(element).getPropertyValue('visibility') ==
-      'visible';
-}
-
-

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -259,13 +259,23 @@ chai.Assertion.addProperty('visible', function() {
   const opacity = computedStyle.getPropertyValue('opacity');
   const tagName = obj.tagName.toLowerCase();
   this.assert(
-    visibility === 'visible' || parseInt(opacity, 10) > 0,
+    visibility === 'visible',
     'expected element \'' +
         tagName + '\' to be #{exp}, got #{act}. with classes: ' + obj.className,
     'expected element \'' +
-        tagName + '\' not to be #{act}. with classes: ' + obj.className,
+        tagName + '\' not to be #{exp}. with classes: ' + obj.className,
     'visible',
     visibility
+  );
+  this.assert(
+    parseInt(opacity, 10) > 0,
+    'expected element \'' +
+        tagName + '\' to have #{exp}, got #{act}. with classes: ' +
+        obj.className,
+    'expected element \'' +
+        tagName + '\' not to be #{exp}. with classes: ' + obj.className,
+    'opacity > 0',
+    opacity
   );
 });
 

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -264,7 +264,8 @@ chai.Assertion.addProperty('visible', function() {
       'expected element \'' +
       tagName + '\' to be #{exp}, got #{act}. with classes: ' + obj.className,
       'expected element \'' +
-      tagName + '\' not to be #{exp}, got #{act}. with classes: ' + obj.className,
+      tagName + '\' not to be #{exp}, got #{act}. with classes: ' +
+      obj.className,
       'visible and opaque',
       `visibility = ${visibility} and opacity = ${opacity}`
   );

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -257,25 +257,16 @@ chai.Assertion.addProperty('visible', function() {
   const computedStyle = window.getComputedStyle(obj);
   const visibility = computedStyle.getPropertyValue('visibility');
   const opacity = computedStyle.getPropertyValue('opacity');
+  const isOpaque = parseInt(opacity, 10) > 0;
   const tagName = obj.tagName.toLowerCase();
   this.assert(
-    visibility === 'visible',
-    'expected element \'' +
-        tagName + '\' to be #{exp}, got #{act}. with classes: ' + obj.className,
-    'expected element \'' +
-        tagName + '\' not to be #{exp}. with classes: ' + obj.className,
-    'visible',
-    visibility
-  );
-  this.assert(
-    parseInt(opacity, 10) > 0,
-    'expected element \'' +
-        tagName + '\' to have #{exp}, got #{act}. with classes: ' +
-        obj.className,
-    'expected element \'' +
-        tagName + '\' not to be #{exp}. with classes: ' + obj.className,
-    'opacity > 0',
-    opacity
+      visibility === 'visible' && isOpaque,
+      'expected element \'' +
+      tagName + '\' to be #{exp}, got #{act}. with classes: ' + obj.className,
+      'expected element \'' +
+      tagName + '\' not to be #{exp}, got #{act}. with classes: ' + obj.className,
+      'visible and opaque',
+      `visibility = ${visibility} and opacity = ${opacity}`
   );
 });
 


### PR DESCRIPTION
First cut at A4A integration tests: Test the complete A4A flow, in AMP context, without calling out to a real ad server.  Test set is not as complete as we'd like yet, but provides a template for further tests.
