### PR TITLE
Validator Changes Rollup

### DIFF
--- a/validator/engine/dom-walker.js
+++ b/validator/engine/dom-walker.js
@@ -26,6 +26,9 @@
  *
  * See the {@code goog.string.html.HtmlParser}, this is simulating that
  * interface.
+ *
+ * TODO(powdercloud): We're not currently using this, but may use it. Ronsider
+ * removing it if not used after 2017-04-01.
  */
 
 goog.provide('amp.domwalker');

--- a/validator/engine/saxasjson.js
+++ b/validator/engine/saxasjson.js
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the license.
+ */
+goog.provide('amp.htmlparser.dumpSaxAsJson');
+goog.require('amp.htmlparser.HtmlParser');
+goog.require('amp.htmlparser.HtmlSaxHandler');
+
+/** @private  */
+class JsonOutHandler extends amp.htmlparser.HtmlSaxHandler {
+  /**
+   * @param {!Array<!Array<string>>} out
+   */
+  constructor(out) {
+    super();
+    /** @type {!Array<!Array<string>>} */
+    this.out = out;
+  }
+
+  /** @override */
+  startDoc() {
+    this.out.push(['startDoc']);
+  }
+
+  /** @override */
+  cdata(text) {
+    this.out.push(['cdata', text]);
+  }
+
+  /** @override */
+  pcdata(text) {
+    this.out.push(['pcdata', text]);
+  }
+
+  /** @override */
+  rcdata(text) {
+    this.out.push(['rcdata', text]);
+  }
+
+  /** @override */
+  endDoc() {
+    this.out.push(['endDoc']);
+  }
+
+  /** @override */
+  markManufacturedBody() {
+    this.out.push(['markManufacturedBody']);
+  }
+
+  /** @override */
+  startTag(tagName, attrs) {
+    this.out.push(['startTag', tagName].concat(attrs));
+  }
+
+  /** @override */
+  endTag(tagName) {
+    this.out.push(['endTag', tagName]);
+  }
+}
+
+/**
+ * Returns the SAX events that htmlparser.js generates as JSON.
+ * EXPERIMENTAL: Do not rely on this API, it may change and/or go away
+ * without notice.
+ * @param {string} htmlText
+ * @return {!Array<!Array<string>>}
+ * @export
+ */
+amp.htmlparser.saxAsJson = function(htmlText) {
+  const jsonArray = [];
+  const handler = new JsonOutHandler(jsonArray);
+  const parser = new amp.htmlparser.HtmlParser();
+  parser.parse(handler, htmlText);
+  return jsonArray;
+};

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -30,7 +30,7 @@
 </head>
 <body>
   <!-- Valid form -->
-  <form method="post" action="https://example.com/subscribe" target="_blank"
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank"
     custom-validation-reporting="as-you-go">
     <fieldset>
       <label>
@@ -48,7 +48,7 @@
     <div submit-error><template type="amp-mustache">Error</template></div>
   </form>
   <!-- More valid tags (datalist and optgroup) -->
-  <form method="post" action="https://example.com/subscribe" target="_blank">
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <label>Choose a browser from this list:
     <input list="browsers" name="myBrowser" /></label>
     <datalist id="browsers">
@@ -75,19 +75,19 @@
     </select>
   </form>
   <!-- Invalid form action must not be a relative url -->
-  <form method="post" action="/subscribe" target="_blank">
+  <form method="post" action-xhr="/subscribe" target="_blank">
     <input type="submit" value="Subscribe">
   </form>
   <!-- Invalid: form action must be https. -->
-  <form method="post" action="http://example.com/subscribe" target="_blank">
+  <form method="post" action-xhr="http://example.com/subscribe" target="_blank">
     <input type="submit" value="Subscribe">
   </form>
   <!-- Invalid: form action must be a non-cdn link. -->
-  <form method="post" action="https://cdn.ampproject.org/subscribe" target="_blank">
+  <form method="post" action-xhr="https://cdn.ampproject.org/subscribe" target="_blank">
     <input type="submit" value="Subscribe">
   </form>
   <!-- Invalid: form target must be _blank or _top -->
-  <form method="post" action="https://example/subscribe" target="_new">
+  <form method="post" action-xhr="https://example/subscribe" target="_new">
     <input type="submit" value="Subscribe">
   </form>
   <!-- Invalid: input, select, option and textarea must be children of form. -->
@@ -97,7 +97,7 @@
   </select>
   <textarea name="comment"></textarea>
   <!-- Invalid: input can not be type="button|file|image|password". -->
-  <form method="post" action="https://example.com/subscribe" target="_blank">
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <input type="button" name="button">
     <input type="file" name="file">
     <input type="image" name="image">
@@ -111,16 +111,25 @@
   </form>
   <!-- Invalid: template child missing from submit-success and submit-error,
        misplaced submit-error -->
-  <form method="post" action="https://example.com/subscribe" target="_blank"
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank"
     custom-validation-reporting="as-you-go">
     <input submit-error type="submit" value="Subscribe">
     <div submit-success></div>
     <div submit-error></div>
   </form>
   <!-- Invalid: submit-success must be a div -->
-  <form method="post" action="https://example.com/subscribe" target="_blank"
+  <form method="post" action-xhr="https://example.com/subscribe" target="_blank"
     custom-validation-reporting="as-you-go">
     <span submit-success><template type="amp-mustache">Success</template></span>
+  </form>
+  <!-- Invalid: post implies action-xhr -->
+  <form method="post" action="https://example.com/subscribe" target="_top">
+  </form>
+  <!-- Invalid: get implies action -->
+  <form method="get" action-xhr="https://example.com/subscribe" target="_top">
+  </form>
+  <!-- Invalid: get implies action, default method is get -->
+  <form action-xhr="https://example.com/subscribe" target="_top">
   </form>
 </body>
 </html>

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -1,7 +1,7 @@
 FAIL
-feature_tests/forms.html:82:2 Invalid URL protocol 'http:' for attribute 'action' in tag 'form'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
-feature_tests/forms.html:86:2 The domain 'cdn.ampproject.org' for attribute 'action' in tag 'form' is disallowed. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
-feature_tests/forms.html:90:2 The attribute 'target' in tag 'form' is set to the invalid value '_new'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
+feature_tests/forms.html:82:2 Invalid URL protocol 'http:' for attribute 'action-xhr' in tag 'FORM [method=POST]'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
+feature_tests/forms.html:86:2 The domain 'cdn.ampproject.org' for attribute 'action-xhr' in tag 'FORM [method=POST]' is disallowed. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
+feature_tests/forms.html:90:2 The attribute 'target' in tag 'FORM [method=POST]' is set to the invalid value '_new'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
 feature_tests/forms.html:95:2 The tag 'select' may only appear as a descendant of tag 'form'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
 feature_tests/forms.html:96:4 The tag 'option' may only appear as a descendant of tag 'form'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
 feature_tests/forms.html:98:2 The tag 'textarea' may only appear as a descendant of tag 'form'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
@@ -15,3 +15,6 @@ feature_tests/forms.html:116:4 The attribute 'submit-error' may not appear in ta
 feature_tests/forms.html:117:4 Tag 'FORM > DIV [submit-success]' must have 1 child tags - saw 0 child tags. [DISALLOWED_HTML]
 feature_tests/forms.html:118:4 Tag 'FORM > DIV [submit-error]' must have 1 child tags - saw 0 child tags. [DISALLOWED_HTML]
 feature_tests/forms.html:123:4 The attribute 'submit-success' may not appear in tag 'span'. [DISALLOWED_HTML]
+feature_tests/forms.html:126:2 The attribute 'action' may not appear in tag 'FORM [method=POST]'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
+feature_tests/forms.html:129:2 The mandatory attribute 'action' is missing in tag 'FORM [method=GET]'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]
+feature_tests/forms.html:132:2 The mandatory attribute 'action' is missing in tag 'FORM [method=GET]'. (see https://www.ampproject.org/docs/reference/extended/amp-form.html) [DISALLOWED_HTML]

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 185
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 300
+spec_file_revision: 301
 
 # Validator extensions.
 # =====================
@@ -2176,7 +2176,6 @@ tags {
 # 4.10.4 The label element
 tags: {
   tag_name: "LABEL"
-  also_requires_tag: "amp-form extension .js script"
   attrs: { name: "for" }
   attrs: { name: "form" }
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-form.html"
@@ -2184,7 +2183,6 @@ tags: {
 # 4.10.5 The input element
 tags: {
   tag_name: "INPUT"
-  also_requires_tag: "amp-form extension .js script"
   attrs: { name: "accept" }
   attrs: { name: "accesskey" }
   attrs: { name: "autocomplete" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 185
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 303
+spec_file_revision: 305
 
 # Validator extensions.
 # =====================

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 185
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 302
+spec_file_revision: 303
 
 # Validator extensions.
 # =====================
@@ -2118,12 +2118,14 @@ tags: {
 # Form elements are allowed only when amp-form extension script is included
 # with the exception of the button element which is always allowed.
 # 4.10.3 The form element
-tags {
+tags {  # <form method=GET ...>
   tag_name: "FORM"
+  spec_name: "FORM [method=GET]"
   also_requires_tag: "amp-form extension .js script"
   disallowed_ancestor: "AMP-APP-BANNER"
   attrs: { name: "accept" }
   attrs: { name: "accept-charset" }
+  # For method=GET forms, we require `action` and allow `action-xhr`.
   attrs: {
     name: "action"
     mandatory: true
@@ -2134,14 +2136,66 @@ tags {
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
-  attrs: { name: "action-xhr" }
+  attrs: {
+    name: "action-xhr"
+    value_url: {
+      allow_relative: true
+      allowed_protocol: "https"
+      disallowed_domain: "cdn.ampproject.org"
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
   attrs: { name: "autocomplete" }
   attrs: {
     name: "custom-validation-reporting"
     value_regex: "(show-first-on-submit|show-all-on-submit|as-you-go)"
   }
   attrs: { name: "enctype" }
-  attrs: { name: "method" }
+  attrs: {
+    name: "method"
+    # Default value is GET, so if method attribute is missing,
+    # it matches this tagspec.
+    value_casei: "get"
+  }
+  attrs: { name: "name" }
+  attrs: { name: "novalidate" }
+  attrs: {
+    name: "target"
+    mandatory: true
+    value_regex_casei: "(_blank|_top)"
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/extended/amp-form.html"
+}
+tags {  # <form method=POST ...>
+  tag_name: "FORM"
+  spec_name: "FORM [method=POST]"
+  also_requires_tag: "amp-form extension .js script"
+  disallowed_ancestor: "AMP-APP-BANNER"
+  attrs: { name: "accept" }
+  attrs: { name: "accept-charset" }
+  # For method=POST forms, we require `action-xhr` and disallow `action`.
+  attrs: {
+    name: "action-xhr"
+    mandatory: true
+    value_url: {
+      allow_relative: true
+      allowed_protocol: "https"
+      disallowed_domain: "cdn.ampproject.org"
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  attrs: { name: "autocomplete" }
+  attrs: {
+    name: "custom-validation-reporting"
+    value_regex: "(show-first-on-submit|show-all-on-submit|as-you-go)"
+  }
+  attrs: { name: "enctype" }
+  attrs: {
+    name: "method"
+    mandatory: true
+    value_casei: "post"
+    dispatch_key: true
+  }
   attrs: { name: "name" }
   attrs: { name: "novalidate" }
   attrs: {
@@ -2177,7 +2231,6 @@ tags {
 tags: {
   tag_name: "LABEL"
   attrs: { name: "for" }
-  attrs: { name: "form" }
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-form.html"
 }
 # 4.10.5 The input element
@@ -2189,9 +2242,6 @@ tags: {
   attrs: { name: "autofocus" }
   attrs: { name: "checked" }
   attrs: { name: "disabled" }
-  attrs: { name: "form" }
-  attrs: { name: "formmethod" }
-  attrs: { name: "formnovalidate" }
   attrs: { name: "height" }
   attrs: { name: "inputmode" }
   attrs: { name: "list" }
@@ -2244,10 +2294,6 @@ tags: {
   }
   attrs: { name: "type" }
   attrs: { name: "value" }
-  attrs: {
-    name: "formtarget"
-    value_regex_casei: "(_blank|_top)"
-  }
 }
 # Button variant specifically supporting <amp-app-banner> tag with the
 # open-button attribute.
@@ -2278,7 +2324,6 @@ tags: {
   also_requires_tag: "amp-form extension .js script"
   attrs: { name: "autofocus" }
   attrs: { name: "disabled" }
-  attrs: { name: "form" }
   attrs: { name: "multiple" }
   attrs: { name: "name" }
   attrs: { name: "required" }
@@ -2321,7 +2366,6 @@ tags: {
   attrs: { name: "autofocus" }
   attrs: { name: "cols" }
   attrs: { name: "disabled" }
-  attrs: { name: "form" }
   attrs: { name: "maxlength" }
   attrs: { name: "minlength" }
   attrs: { name: "name" }
@@ -2340,7 +2384,6 @@ tags: {
 tags: {
   tag_name: "FIELDSET"
   attrs: { name: "disabled" }
-  attrs: { name: "form" }
   attrs: { name: "name" }
 }
 # 4.10.17 The legend element

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 185
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 301
+spec_file_revision: 302
 
 # Validator extensions.
 # =====================
@@ -1862,7 +1862,7 @@ tags: {
   attrs: { name: "class" }
   attrs: { name: "externalresourcesrequired" }
   attrs: { name: "gradientunits" }
-  attrs: { name: "gradientransform" }
+  attrs: { name: "gradienttransform" }
   attrs: { name: "spreadmethod" }
   attrs: { name: "x1" }
   attrs: { name: "y1" }


### PR DESCRIPTION
- Don't require the amp-form extension for label and/or input. #5055 
- gradientTransform attribute misspelled in validation #5615 
- Fixes to form action* attributes. #4880 
- Add saxAsJson format as validator input.