### PR TITLE
Allow owned elements to render in any viewport

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -470,6 +470,16 @@ export class Resource {
    * @return {boolean}
    */
   renderOutsideViewport() {
+    // The exception is for owned resources, since they only attempt to
+    // render outside viewport when the owner has explicitly allowed it.
+    // TODO(jridgewell, #5803): Resources should be asking owner if it can
+    // prerender this resource, so that it can avoid expensive elements wayyy
+    // outside of viewport. For now, blindly trust that owner knows what it's
+    // doing.
+    if (this.hasOwner()) {
+      return true;
+    }
+
     const renders = this.element.renderOutsideViewport();
     // Boolean interface, element is either always allowed or never allowed to
     // render outside viewport.
@@ -487,11 +497,7 @@ export class Resource {
     if (viewportBox.right < layoutBox.left ||
         viewportBox.left > layoutBox.right) {
       // If outside of viewport's x-axis, element is not in viewport.
-      // The exception is for owned resources, since they only attempt to
-      // render outside viewport when the owner has explicitly allowed it.
-      if (!this.hasOwner()) {
-        return false;
-      }
+      return false;
     }
     if (viewportBox.bottom < layoutBox.top) {
       // Element is below viewport

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -710,10 +710,10 @@ describe('Resource', () => {
 describe('Resource renderOutsideViewport', () => {
   let sandbox;
   let element;
-  let elementMock;
   let resources;
   let resource;
   let viewport;
+  let renderOutsideViewport;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -738,16 +738,15 @@ describe('Resource renderOutsideViewport', () => {
       viewportCallback: () => {},
       getPriority: () => 0,
     };
-    elementMock = sandbox.mock(element);
 
     resources = new Resources(new AmpDocSingle(window));
     resource = new Resource(1, element, resources);
     viewport = resources.viewport_;
+    renderOutsideViewport = sandbox.stub(element, 'renderOutsideViewport');
     sandbox.stub(viewport, 'getRect').returns(layoutRectLtwh(0, 0, 100, 100));
   });
 
   afterEach(() => {
-    elementMock.verify();
     sandbox.restore();
   });
 
@@ -755,7 +754,7 @@ describe('Resource renderOutsideViewport', () => {
   describe('boolean API', () => {
     describe('when element returns true', () => {
       beforeEach(() => {
-        elementMock.expects('renderOutsideViewport').returns(true).once();
+        renderOutsideViewport.returns(true);
       });
 
       describe('when element is inside viewport', () => {
@@ -767,6 +766,22 @@ describe('Resource renderOutsideViewport', () => {
         it('should allow rendering when top falls outside', () => {
           resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
           expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when bottom falls outside', () => {
+            resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when top falls outside', () => {
+            resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
         });
       });
 
@@ -784,6 +799,22 @@ describe('Resource renderOutsideViewport', () => {
           resources.lastVelocity_ = -2;
           expect(resource.renderOutsideViewport()).to.equal(true);
         });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+        });
       });
 
       describe('when element is marginally below viewport', () => {
@@ -799,6 +830,22 @@ describe('Resource renderOutsideViewport', () => {
         it('should allow rendering when scrolling away', () => {
           resources.lastVelocity_ = -2;
           expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
         });
       });
 
@@ -820,6 +867,26 @@ describe('Resource renderOutsideViewport', () => {
           resources.lastVelocity_ = -2;
           expect(resource.renderOutsideViewport()).to.equal(true);
         });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering', () => {
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+        });
       });
 
       describe('when element is just above viewport', () => {
@@ -836,6 +903,22 @@ describe('Resource renderOutsideViewport', () => {
           resources.lastVelocity_ = 2;
           expect(resource.renderOutsideViewport()).to.equal(true);
         });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+        });
       });
 
       describe('when element is marginally above viewport', () => {
@@ -851,6 +934,22 @@ describe('Resource renderOutsideViewport', () => {
         it('should allow rendering when scrolling away', () => {
           resources.lastVelocity_ = 2;
           expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
         });
       });
 
@@ -871,13 +970,33 @@ describe('Resource renderOutsideViewport', () => {
         it('should allow rendering when scrolling away', () => {
           resources.lastVelocity_ = 2;
           expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering', () => {
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
         });
       });
     });
 
     describe('when element returns false', () => {
       beforeEach(() => {
-        elementMock.expects('renderOutsideViewport').returns(false).once();
+        renderOutsideViewport.returns(false);
       });
 
       describe('when element is inside viewport', () => {
@@ -889,6 +1008,22 @@ describe('Resource renderOutsideViewport', () => {
         it('should allow rendering when top falls outside', () => {
           resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
           expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when bottom falls outside', () => {
+            resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when top falls outside', () => {
+            resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
         });
       });
 
@@ -906,6 +1041,22 @@ describe('Resource renderOutsideViewport', () => {
           resources.lastVelocity_ = -2;
           expect(resource.renderOutsideViewport()).to.equal(false);
         });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+        });
       });
 
       describe('when element is marginally below viewport', () => {
@@ -921,6 +1072,22 @@ describe('Resource renderOutsideViewport', () => {
         it('should disallow rendering when scrolling away', () => {
           resources.lastVelocity_ = -2;
           expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
         });
       });
 
@@ -942,6 +1109,26 @@ describe('Resource renderOutsideViewport', () => {
           resources.lastVelocity_ = -2;
           expect(resource.renderOutsideViewport()).to.equal(false);
         });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering', () => {
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+        });
       });
 
       describe('when element is just above viewport', () => {
@@ -958,6 +1145,22 @@ describe('Resource renderOutsideViewport', () => {
           resources.lastVelocity_ = 2;
           expect(resource.renderOutsideViewport()).to.equal(false);
         });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+        });
       });
 
       describe('when element is marginally above viewport', () => {
@@ -973,6 +1176,22 @@ describe('Resource renderOutsideViewport', () => {
         it('should disallow rendering when scrolling away', () => {
           resources.lastVelocity_ = 2;
           expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
         });
       });
 
@@ -993,6 +1212,26 @@ describe('Resource renderOutsideViewport', () => {
         it('should disallow rendering when scrolling away', () => {
           resources.lastVelocity_ = 2;
           expect(resource.renderOutsideViewport()).to.equal(false);
+        });
+
+        describe('when element is owned', () => {
+          beforeEach(() => {
+            sandbox.stub(resource, 'hasOwner', () => true);
+          });
+
+          it('should allow rendering', () => {
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling towards', () => {
+            resources.lastVelocity_ = -2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
+
+          it('should allow rendering when scrolling away', () => {
+            resources.lastVelocity_ = 2;
+            expect(resource.renderOutsideViewport()).to.equal(true);
+          });
         });
       });
     });
@@ -1000,7 +1239,7 @@ describe('Resource renderOutsideViewport', () => {
 
   describe('number API', () => {
     beforeEach(() => {
-      elementMock.expects('renderOutsideViewport').returns(3).once();
+      renderOutsideViewport.returns(3);
     });
 
     describe('when element is inside viewport', () => {
@@ -1012,6 +1251,22 @@ describe('Resource renderOutsideViewport', () => {
       it('should allow rendering when top falls outside', () => {
         resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
         expect(resource.renderOutsideViewport()).to.equal(true);
+      });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering when bottom falls outside', () => {
+          resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when top falls outside', () => {
+          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
       });
     });
 
@@ -1029,6 +1284,22 @@ describe('Resource renderOutsideViewport', () => {
         resources.lastVelocity_ = -2;
         expect(resource.renderOutsideViewport()).to.equal(true);
       });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
     });
 
     describe('when element is marginally below viewport', () => {
@@ -1044,6 +1315,22 @@ describe('Resource renderOutsideViewport', () => {
       it('should disallow rendering when scrolling away', () => {
         resources.lastVelocity_ = -2;
         expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
       });
     });
 
@@ -1065,6 +1352,26 @@ describe('Resource renderOutsideViewport', () => {
         resources.lastVelocity_ = -2;
         expect(resource.renderOutsideViewport()).to.equal(false);
       });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
     });
 
     describe('when element is just above viewport', () => {
@@ -1081,6 +1388,22 @@ describe('Resource renderOutsideViewport', () => {
         resources.lastVelocity_ = 2;
         expect(resource.renderOutsideViewport()).to.equal(true);
       });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+      });
     });
 
     describe('when element is marginally above viewport', () => {
@@ -1096,6 +1419,22 @@ describe('Resource renderOutsideViewport', () => {
       it('should disallow rendering when scrolling away', () => {
         resources.lastVelocity_ = 2;
         expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
       });
     });
 
@@ -1116,6 +1455,26 @@ describe('Resource renderOutsideViewport', () => {
       it('should disallow rendering when scrolling away', () => {
         resources.lastVelocity_ = 2;
         expect(resource.renderOutsideViewport()).to.equal(false);
+      });
+
+      describe('when element is owned', () => {
+        beforeEach(() => {
+          sandbox.stub(resource, 'hasOwner', () => true);
+        });
+
+        it('should allow rendering', () => {
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling towards', () => {
+          resources.lastVelocity_ = -2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
+
+        it('should allow rendering when scrolling away', () => {
+          resources.lastVelocity_ = 2;
+          expect(resource.renderOutsideViewport()).to.equal(true);
+        });
       });
     });
 


### PR DESCRIPTION
If the owner has told the element to prerender, we'll do it (for now).

Fixes (badly) #5803.