### PR TITLE
amp-sticky-ad: Force background-color alpha to be 1

### DIFF
--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -23,7 +23,6 @@ amp-sticky-ad {
   z-index: 11;
   max-height: 100px !important;
   box-sizing: border-box;
-  background-color: #fff;
 }
 
 .-amp-sticky-ad-layout {

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -23,7 +23,7 @@ amp-sticky-ad {
   z-index: 11;
   max-height: 100px !important;
   box-sizing: border-box;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: #fff;
 }
 
 .-amp-sticky-ad-layout {

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -22,7 +22,7 @@ import {toggle} from '../../../src/style';
 import {listenOnce} from '../../../src/event-helper';
 import {
   setStyle,
-  removeAlphaFromBackgroundColor,
+  removeAlphaFromColor,
 } from '../../../src/style';
 import {isExperimentOn} from '../../../src/experiments';
 
@@ -226,7 +226,7 @@ class AmpStickyAd extends AMP.BaseElement {
 
     const backgroundColor = this.win./*OK*/getComputedStyle(this.element)
         .getPropertyValue('background-color');
-    const newBackgroundColor = removeAlphaFromBackgroundColor(backgroundColor);
+    const newBackgroundColor = removeAlphaFromColor(backgroundColor);
     if (backgroundColor == newBackgroundColor) {
       return;
     }

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -20,7 +20,12 @@ import {dev,user} from '../../../src/log';
 import {removeElement} from '../../../src/dom';
 import {toggle} from '../../../src/style';
 import {listenOnce} from '../../../src/event-helper';
+import {startsWith} from '../../../src/string';
+import {setStyle} from '../../../src/style';
+import {isExperimentOn} from '../../../src/experiments';
 
+/** @private @const {string} */
+const TAG = 'amp-sticky-ad-v1';
 
 class AmpStickyAd extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -169,6 +174,7 @@ class AmpStickyAd extends AMP.BaseElement {
         // Set sticky-ad to visible and change container style
         this.element.setAttribute('visible', '');
         this.element.classList.add('amp-sticky-ad-loaded');
+        this.forceOpacity_();
       });
     });
   }
@@ -201,6 +207,26 @@ class AmpStickyAd extends AMP.BaseElement {
       this.viewport_.updatePaddingBottom(0);
     });
   }
+
+  // Whoever call this needs to make sure it's in a vsync.
+  forceOpacity_() {
+    if (!isExperimentOn(this.win, TAG)) {
+      return;
+    }
+    const background = this.win.getComputedStyle(this.element)
+        .getPropertyValue('background-color');
+    if (!startsWith(background, 'rgba')) {
+      return;
+    }
+    user().warn('AMP-STICKY-AD', 'Do not allow container to be transparent');
+    const backgroundColor = background.substring(
+        background.indexOf('(') + 1,
+        background.lastIndexOf(','));
+    console.log('set styles');
+    setStyle(this.element, 'background-color', 'rgb(' + backgroundColor + ')');
+  }
 }
+
+
 
 AMP.registerElement('amp-sticky-ad', AmpStickyAd, CSS);

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -221,7 +221,7 @@ class AmpStickyAd extends AMP.BaseElement {
     }
 
     // TODO(@zhouyx): Move the opacity style to CSS after remove experiments
-    // Not using setStyles because we will remove this line later.
+    // Note: Use setStyle because we will remove this line later.
     setStyle(this.element, 'opacity', '1 !important');
 
     const backgroundColor = this.win./*OK*/getComputedStyle(this.element)
@@ -231,7 +231,8 @@ class AmpStickyAd extends AMP.BaseElement {
       return;
     }
 
-    user().warn('AMP-STICKY-AD', 'Do not allow container to be transparent');
+    user().warn('AMP-STICKY-AD',
+        'Do not allow container to be semitransparent');
     setStyle(this.element, 'background-color', newBackgroundColor);
   }
 }

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -25,7 +25,7 @@ import {setStyle} from '../../../src/style';
 import {isExperimentOn} from '../../../src/experiments';
 
 /** @private @const {string} */
-const TAG = 'amp-sticky-ad-v1';
+const UX_EXPERIMENT = 'amp-sticky-ad-better-ux';
 
 class AmpStickyAd extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -98,6 +98,7 @@ class AmpStickyAd extends AMP.BaseElement {
 
   /** @override */
   collapsedCallback() {
+    console.log('collapsed Callback being called');
     toggle(this.element, false);
     this.vsync_.mutate(() => {
       this.viewport_.updatePaddingBottom(0);
@@ -167,9 +168,11 @@ class AmpStickyAd extends AMP.BaseElement {
    * @private
    */
   layoutAd_() {
+    console.log('layout ad');
     this.updateInViewport(dev().assertElement(this.ad_), true);
     this.scheduleLayout(dev().assertElement(this.ad_));
     listenOnce(this.ad_, 'amp:load:end', () => {
+      console.log('ad loaded');
       this.vsync_.mutate(() => {
         // Set sticky-ad to visible and change container style
         this.element.setAttribute('visible', '');
@@ -210,14 +213,14 @@ class AmpStickyAd extends AMP.BaseElement {
 
   /**
    * To check for background-color alpha and force it to be 1.
-   * Whoever call this needs to make sure it's in a vsync.
+   * Whoever calls this needs to make sure it's in a vsync.
    * @private
    */
   forceOpacity_() {
-    if (!isExperimentOn(this.win, TAG)) {
+    if (!isExperimentOn(this.win, UX_EXPERIMENT)) {
       return;
     }
-    const background = this.win.getComputedStyle(this.element)
+    const background = this.win./*OK*/getComputedStyle(this.element)
         .getPropertyValue('background-color');
     if (!startsWith(background, 'rgba')) {
       return;
@@ -226,7 +229,10 @@ class AmpStickyAd extends AMP.BaseElement {
     const backgroundColor = background.substring(
         background.indexOf('(') + 1,
         background.lastIndexOf(','));
-    console.log('set styles');
+
+    // TODO(@zhouyx): Move the opacity style to CSS after remove experiments
+    // Not using setStyles because we will remove this line later.
+    setStyle(this.element, 'opacity', '1 !important');
     setStyle(this.element, 'background-color', 'rgb(' + backgroundColor + ')');
   }
 }

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -227,6 +227,4 @@ class AmpStickyAd extends AMP.BaseElement {
   }
 }
 
-
-
 AMP.registerElement('amp-sticky-ad', AmpStickyAd, CSS);

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -208,7 +208,11 @@ class AmpStickyAd extends AMP.BaseElement {
     });
   }
 
-  // Whoever call this needs to make sure it's in a vsync.
+  /**
+   * To check for background-color alpha and force it to be 1.
+   * Whoever call this needs to make sure it's in a vsync.
+   * @private
+   */
   forceOpacity_() {
     if (!isExperimentOn(this.win, TAG)) {
       return;

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -223,6 +223,7 @@ class AmpStickyAd extends AMP.BaseElement {
     // TODO(@zhouyx): Move the opacity style to CSS after remove experiments
     // Note: Use setStyle because we will remove this line later.
     setStyle(this.element, 'opacity', '1 !important');
+    setStyle(this.element, 'background-image', 'none');
 
     const backgroundColor = this.win./*OK*/getComputedStyle(this.element)
         .getPropertyValue('background-color');

--- a/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
@@ -400,4 +400,42 @@ describe('amp-sticky-ad', () => {
           .getPropertyValue('background-color')).to.equal('rgb(55, 55, 55)');
     });
   });
+
+  it('should not allow container to be set semitransparent in rgba', () => {
+    toggleExperiment(window, 'amp-sticky-ad-better-ux', true);
+    return getAmpStickyAd({
+      'style': 'background-color: rgba(55, 55, 55, 0.55) !important',
+    }).then(obj => {
+      console.log(obj.ampStickyAd);
+      const stickyAdElement = obj.ampStickyAd;
+      const impl = stickyAdElement.implementation_;
+      impl.vsync_.mutate = function(callback) {
+        callback();
+      };
+      impl.scheduleLayoutForAd_();
+      impl.ad_.dispatchEvent(new Event('amp:built'));
+      impl.ad_.dispatchEvent(new Event('amp:load:end'));
+      expect(window.getComputedStyle(stickyAdElement)
+          .getPropertyValue('background-color')).to.equal('rgb(55, 55, 55)');
+    });
+  });
+
+  it('should not allow container to be set to transparent', () => {
+    toggleExperiment(window, 'amp-sticky-ad-better-ux', true);
+    return getAmpStickyAd({
+      'style': 'background-color: transparent !important',
+    }).then(obj => {
+      console.log(obj.ampStickyAd);
+      const stickyAdElement = obj.ampStickyAd;
+      const impl = stickyAdElement.implementation_;
+      impl.vsync_.mutate = function(callback) {
+        callback();
+      };
+      impl.scheduleLayoutForAd_();
+      impl.ad_.dispatchEvent(new Event('amp:built'));
+      impl.ad_.dispatchEvent(new Event('amp:load:end'));
+      expect(window.getComputedStyle(stickyAdElement)
+          .getPropertyValue('background-color')).to.equal('rgb(0, 0, 0)');
+    });
+  });
 });

--- a/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
@@ -15,6 +15,7 @@
  */
 
 import {createIframePromise} from '../../../../testing/iframe';
+import {toggleExperiment} from '../../../../src/experiments';
 import * as sinon from 'sinon';
 import '../amp-sticky-ad';
 import '../../../amp-ad/0.1/amp-ad';
@@ -30,10 +31,13 @@ describe('amp-sticky-ad', () => {
     sandbox.restore();
   });
 
-  function getAmpStickyAd() {
+  function getAmpStickyAd(opt_attributes) {
     return createIframePromise().then(iframe => {
       const ampStickyAd = iframe.doc.createElement('amp-sticky-ad');
       ampStickyAd.setAttribute('layout', 'nodisplay');
+      for (const attr in opt_attributes) {
+        ampStickyAd.setAttribute(attr, opt_attributes[attr]);
+      }
       const ampAd = iframe.doc.createElement('amp-ad');
       ampAd.setAttribute('width', '300');
       ampAd.setAttribute('height', '50');
@@ -375,6 +379,25 @@ describe('amp-sticky-ad', () => {
       expect(stickyAdElement).to.have.attribute('visible');
       expect(stickyAdElement.classList.contains('amp-sticky-ad-loaded'))
           .to.be.true;
+    });
+  });
+
+  it('should not allow container to be set transparent', () => {
+    toggleExperiment(window, 'amp-sticky-ad-v1', true);
+    return getAmpStickyAd({
+      'style': 'background-color: rgba(55, 55, 55, 0.55) !important',
+    }).then(obj => {
+      console.log(obj.ampStickyAd);
+      const stickyAdElement = obj.ampStickyAd;
+      const impl = stickyAdElement.implementation_;
+      impl.vsync_.mutate = function(callback) {
+        callback();
+      };
+      impl.scheduleLayoutForAd_();
+      impl.ad_.dispatchEvent(new Event('amp:built'));
+      impl.ad_.dispatchEvent(new Event('amp:load:end'));
+      expect(window.getComputedStyle(stickyAdElement)
+          .getPropertyValue('background-color')).to.equal('rgb(55, 55, 55)');
     });
   });
 });

--- a/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
@@ -383,7 +383,7 @@ describe('amp-sticky-ad', () => {
   });
 
   it('should not allow container to be set transparent', () => {
-    toggleExperiment(window, 'amp-sticky-ad-v1', true);
+    toggleExperiment(window, 'amp-sticky-ad-better-ux', true);
     return getAmpStickyAd({
       'style': 'background-color: rgba(55, 55, 55, 0.55) !important',
     }).then(obj => {

--- a/src/style.js
+++ b/src/style.js
@@ -198,21 +198,13 @@ export function scale(value) {
 
 /**
  * Remove alpha value from a "background-color" CSS property.
- * Return the new "background-color" property without alpha.
+ * Return the new "background-color" property with alpha equals 1.
  * Note caller needs to make sure the input cssColorValue is a valid
  * CSS "background-color" value.
- * @param{string} cssColorValue
- * @return {?string}
+ * @param {string} cssColor
+ * @return {string}
  */
-export function removeAlphaFromBackgroundColor(cssColorValue) {
-  let res;
-  const sepIndex = cssColorValue.indexOf('(');
-  const method = cssColorValue.substring(0, sepIndex);
-  if (method == 'rgba' || method == 'hsla') {
-    const value = cssColorValue.substring(
-        sepIndex,
-        cssColorValue.lastIndexOf(','));
-    res = method.substring(0, 3) + value + ')';
-  }
-  return res || cssColorValue;
+export function removeAlphaFromColor(cssColor) {
+  return cssColor.replace(
+      /\(([^,]+),([^,]+),([^,)]+),[^)]+\)/g, '($1,$2,$3, 1)');
 }

--- a/src/style.js
+++ b/src/style.js
@@ -197,14 +197,13 @@ export function scale(value) {
 }
 
 /**
- * Remove alpha value from a color CSS property.
- * Return the new color property with alpha equals 1.
- * Note caller needs to make sure the input cssColorValue is a valid
- * CSS color value.
- * @param {string} cssColor
+ * Remove alpha value from a rgba color value.
+ * Return the new color property with alpha equals if has the alpha value.
+ * Caller needs to make sure the input color value is a valid rgba/rgb value
+ * @param {string} rgbaColor
  * @return {string}
  */
-export function removeAlphaFromColor(cssColor) {
-  return cssColor.replace(
+export function removeAlphaFromColor(rgbaColor) {
+  return rgbaColor.replace(
       /\(([^,]+),([^,]+),([^,)]+),[^)]+\)/g, '($1,$2,$3, 1)');
 }

--- a/src/style.js
+++ b/src/style.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 // Note: loaded by 3p system. Cannot rely on babel polyfills.
 
 /** @type {Object<string, string>} */
@@ -195,4 +194,25 @@ export function translate(x, opt_y) {
  */
 export function scale(value) {
   return `scale(${value})`;
+}
+
+/**
+ * Remove alpha value from a "background-color" CSS property.
+ * Return the new "background-color" property without alpha.
+ * Note caller needs to make sure the input cssColorValue is a valid
+ * CSS "background-color" value.
+ * @param{string} cssColorValue
+ * @return {?string}
+ */
+export function removeAlphaFromBackgroundColor(cssColorValue) {
+  let res;
+  const sepIndex = cssColorValue.indexOf('(');
+  const method = cssColorValue.substring(0, sepIndex);
+  if (method == 'rgba' || method == 'hsla') {
+    const value = cssColorValue.substring(
+        sepIndex,
+        cssColorValue.lastIndexOf(','));
+    res = method.substring(0, 3) + value + ')';
+  }
+  return res || cssColorValue;
 }

--- a/src/style.js
+++ b/src/style.js
@@ -197,10 +197,10 @@ export function scale(value) {
 }
 
 /**
- * Remove alpha value from a "background-color" CSS property.
- * Return the new "background-color" property with alpha equals 1.
+ * Remove alpha value from a color CSS property.
+ * Return the new color property with alpha equals 1.
  * Note caller needs to make sure the input cssColorValue is a valid
- * CSS "background-color" value.
+ * CSS color value.
  * @param {string} cssColor
  * @return {string}
  */

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -88,12 +88,16 @@ describe('Style', () => {
   it('removeAlphaFromColor', () => {
     expect(st.removeAlphaFromColor('rgba(1, 1, 1, 0)')).to.equal(
         'rgba(1, 1, 1, 1)');
-    expect(st.removeAlphaFromColor('hsla(1, 1, 1, 0.6)')).to.equal(
-        'hsla(1, 1, 1, 1)');
+    expect(st.removeAlphaFromColor('hsla(120, 100%, 25%, 0.6)')).to.equal(
+        'hsla(120, 100%, 25%, 1)');
     expect(st.removeAlphaFromColor('rgb(1, 1, 1)')).to.equal(
         'rgb(1, 1, 1)');
-    expect(st.removeAlphaFromColor('hsl(1, 1, 1)')).to.equal(
-        'hsl(1, 1, 1)');
+    expect(st.removeAlphaFromColor('hsl(120, 100%, 25%)')).to.equal(
+        'hsl(120, 100%, 25%)');
+    expect(st.removeAlphaFromColor('hsla(120, 100%, 25%, -0.5)')).to.equal(
+        'hsla(120, 100%, 25%, 1)');
+    expect(st.removeAlphaFromColor('white')).to.equal('white');
+    expect(st.removeAlphaFromColor('')).to.equal('');
   });
 
   describe('getVendorJsPropertyName', () => {

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -85,14 +85,14 @@ describe('Style', () => {
     expect(st.camelCaseToTitleCase(str)).to.equal('TheQuickBrownFox');
   });
 
-  it('removeAlphaFromBackgroundColor', () => {
-    expect(st.removeAlphaFromBackgroundColor('rgba(1, 1, 1, 0)')).to.equal(
+  it('removeAlphaFromColor', () => {
+    expect(st.removeAlphaFromColor('rgba(1, 1, 1, 0)')).to.equal(
+        'rgba(1, 1, 1, 1)');
+    expect(st.removeAlphaFromColor('hsla(1, 1, 1, 0.6)')).to.equal(
+        'hsla(1, 1, 1, 1)');
+    expect(st.removeAlphaFromColor('rgb(1, 1, 1)')).to.equal(
         'rgb(1, 1, 1)');
-    expect(st.removeAlphaFromBackgroundColor('hsla(1, 1, 1, 0.6)')).to.equal(
-        'hsl(1, 1, 1)');
-    expect(st.removeAlphaFromBackgroundColor('rgb(1, 1, 1)')).to.equal(
-        'rgb(1, 1, 1)');
-    expect(st.removeAlphaFromBackgroundColor('hsla(1, 1, 1, 0.6)')).to.equal(
+    expect(st.removeAlphaFromColor('hsl(1, 1, 1)')).to.equal(
         'hsl(1, 1, 1)');
   });
 

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -85,6 +85,17 @@ describe('Style', () => {
     expect(st.camelCaseToTitleCase(str)).to.equal('TheQuickBrownFox');
   });
 
+  it('removeAlphaFromBackgroundColor', () => {
+    expect(st.removeAlphaFromBackgroundColor('rgba(1, 1, 1, 0)')).to.equal(
+        'rgb(1, 1, 1)');
+    expect(st.removeAlphaFromBackgroundColor('hsla(1, 1, 1, 0.6)')).to.equal(
+        'hsl(1, 1, 1)');
+    expect(st.removeAlphaFromBackgroundColor('rgb(1, 1, 1)')).to.equal(
+        'rgb(1, 1, 1)');
+    expect(st.removeAlphaFromBackgroundColor('hsla(1, 1, 1, 0.6)')).to.equal(
+        'hsl(1, 1, 1)');
+  });
+
   describe('getVendorJsPropertyName', () => {
 
     it('no prefix', () => {

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -88,16 +88,10 @@ describe('Style', () => {
   it('removeAlphaFromColor', () => {
     expect(st.removeAlphaFromColor('rgba(1, 1, 1, 0)')).to.equal(
         'rgba(1, 1, 1, 1)');
-    expect(st.removeAlphaFromColor('hsla(120, 100%, 25%, 0.6)')).to.equal(
-        'hsla(120, 100%, 25%, 1)');
     expect(st.removeAlphaFromColor('rgb(1, 1, 1)')).to.equal(
         'rgb(1, 1, 1)');
-    expect(st.removeAlphaFromColor('hsl(120, 100%, 25%)')).to.equal(
-        'hsl(120, 100%, 25%)');
-    expect(st.removeAlphaFromColor('hsla(120, 100%, 25%, -0.5)')).to.equal(
-        'hsla(120, 100%, 25%, 1)');
-    expect(st.removeAlphaFromColor('white')).to.equal('white');
-    expect(st.removeAlphaFromColor('')).to.equal('');
+    expect(st.removeAlphaFromColor('rgba(0, 0, 0,-0.5)')).to.equal(
+      'rgba(0, 0, 0, 1)');
   });
 
   describe('getVendorJsPropertyName', () => {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -218,6 +218,11 @@ const EXPERIMENTS = [
     name: 'Split AMP\'s loading phase into chunks',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5535',
   },
+  {
+    id: 'amp-sticky-ad-v1',
+    name: 'New breaking UX changes make to amp-sticky-ad',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5432',
+  },
 ];
 
 if (getMode().localDev) {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -219,9 +219,9 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5535',
   },
   {
-    id: 'amp-sticky-ad-v1',
+    id: 'amp-sticky-ad-better-ux',
     name: 'New breaking UX changes make to amp-sticky-ad',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5432',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5822',
   },
 ];
 


### PR DESCRIPTION
I force the `background-color` alpha to be 1 in this PR. Didn't add `opacity: 1 !important` though. `opacity:0` will also apply opacity to `amp-ad`, I assume no one is using that. 

cc @jasti 