### PR TITLE
Add ability for experiments to opt-into being toggled via the URL.

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -16,7 +16,7 @@
 
 import {dev} from './log';
 import {fromClassForDoc} from './service';
-import {isExperimentOn} from './experiments';
+import {isExperimentOnAllowUrlOverride} from './experiments';
 import {makeBodyVisible} from './style-installer';
 import {viewerPromiseForDoc} from './viewer';
 
@@ -102,7 +102,7 @@ class Chunks {
     /** @private @const {function()} */
     this.boundExecute_ = () => this.execute_();
     /** @private @const {boolean} */
-    this.active_ = isExperimentOn(this.win_, 'chunked-amp');
+    this.active_ = isExperimentOnAllowUrlOverride(this.win_, 'chunked-amp');
 
     if (!this.active_) {
       return;

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -22,6 +22,7 @@
  */
 
 import {getCookie, setCookie} from './cookies';
+import {parseQueryString} from './url';
 
 
 /** @const {string} */
@@ -87,6 +88,32 @@ export function isExperimentOn(win, experimentId) {
     return toggles[experimentId];
   }
   return toggles[experimentId] = calcExperimentOn(win, experimentId);
+}
+
+/**
+ * Check whether an experiment is on while allowing viewers to force
+ * the experiment state via a viewer URL param of the form:
+ * `e-$experimentId=1` (on) or `e-$experimentId=0` (off).
+ * NOTE: This should only be used if it is needed and if turning the
+ * experiment on or off does not have security implications.
+ * @param {!Window} win
+ * @param {string} experimentId
+ * @return {boolean}
+ */
+export function isExperimentOnAllowUrlOverride(win, experimentId) {
+  const hash = win.location.originalHash || win.location.hash;
+  if (hash) {
+    // Note: If this is used a lot, this should be optimized to only
+    // parse once per page load.
+    const param = parseQueryString(hash)['e-' + experimentId];
+    if (param == '1') {
+      return true;
+    }
+    if (param == '0') {
+      return false;
+    }
+  }
+  return isExperimentOn(win, experimentId);
 }
 
 /**

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -15,9 +15,13 @@
  */
 
 import {
-  isDevChannel, isDevChannelVersionDoNotUse_,
-  isExperimentOn, toggleExperiment,
-  resetExperimentToggles_} from '../../src/experiments';
+  isDevChannel,
+  isDevChannelVersionDoNotUse_,
+  isExperimentOn,
+  isExperimentOnAllowUrlOverride,
+  toggleExperiment,
+  resetExperimentToggles_,
+} from '../../src/experiments';
 import * as sinon from 'sinon';
 
 describe('isExperimentOn', () => {
@@ -26,7 +30,15 @@ describe('isExperimentOn', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    win = {document: {}, AMP_CONFIG: {}};
+    win = {
+      document: {
+        cookie: '',
+      },
+      AMP_CONFIG: {},
+      location: {
+        hash: '',
+      },
+    };
   });
 
   afterEach(() => {
@@ -124,6 +136,25 @@ describe('isExperimentOn', () => {
 
       expect(Math.random()).to.equal(0.9);
       expectExperiment('', 'e2').to.be.false;
+    });
+  });
+
+  describe('isExperimentOnAllowUrlOverride', () => {
+
+    function expectUrlExperiment(hashOverride, cookieString, experimentId) {
+      win.document.cookie = cookieString;
+      win.location.hash = hashOverride;
+      return expect(isExperimentOnAllowUrlOverride(win, experimentId));
+    }
+
+    it('should accept override', () => {
+      const cookie = 'AMP_EXP=e2,e4';
+      const url = '#e-e1=1&e-e2=0&e-complexName=1';
+      expectUrlExperiment(url, cookie, 'e1').to.be.true;
+      expectUrlExperiment(url, cookie, 'e2').to.be.false;
+      expectUrlExperiment(url, cookie, 'e4').to.be.true;
+      expectUrlExperiment(url, cookie, 'unknown').to.be.false;
+      expectUrlExperiment(url, cookie, 'complexName').to.be.true;
     });
   });
 });


### PR DESCRIPTION
This is useful for experiments where the referrer would like to actually experiment with the experiment.

Uses the feature with the chunking experiment.