### PR TITLE
Fix loadExtension tests

### DIFF
--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -29,6 +29,7 @@ import {
   initLogConstructor,
   resetLogConstructorForTesting,
 } from '../../src/log';
+import {resetScheduledElementForTesting} from '../../src/custom-element';
 import {loadPromise} from '../../src/event-helper';
 
 
@@ -309,28 +310,23 @@ describes.sandboxed('Extensions', {}, () => {
     it('should insert extension script correctly', () => {
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(0);
-      expect(extensions.getExtensionHolder_('amp-test').scriptPresent)
-          .to.be.undefined;
-
+      expect(extensions.extensions_['amp-test']).to.be.undefined;
       extensions.loadExtension('amp-test');
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(1);
-      expect(extensions.getExtensionHolder_('amp-test').scriptPresent)
-          .to.be.true;
-      expect(win.customElements.elements['amp-test']).to.exist;
+      expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
+      expect(win.ampExtendedElements['amp-test']).to.be.true;
     });
 
     it('should only insert script once', () => {
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(0);
-      expect(extensions.getExtensionHolder_('amp-test').scriptPresent)
-          .to.be.undefined;
+      expect(extensions.extensions_['amp-test']).to.be.undefined;
 
       extensions.loadExtension('amp-test');
       expect(doc.head.querySelectorAll('[custom-element="amp-test"]'))
           .to.have.length(1);
-      expect(extensions.getExtensionHolder_('amp-test').scriptPresent)
-          .to.be.true;
+      expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
 
       extensions.loadExtension('amp-test');
       expect(doc.head.querySelectorAll('[custom-element="amp-test"]'))
@@ -345,15 +341,13 @@ describes.sandboxed('Extensions', {}, () => {
       doc.head.appendChild(ampTestScript);
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(1);
-      expect(extensions.getExtensionHolder_('amp-test').scriptPresent)
-          .to.be.undefined;
+      expect(extensions.extensions_['amp-test']).to.be.undefined;
 
       extensions.loadExtension('amp-test');
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(1);
-      expect(extensions.getExtensionHolder_('amp-test').scriptPresent)
-          .to.be.true;
-      expect(win.customElements.elements['amp-test']).to.not.exist;
+      expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
+      expect(win.ampExtendedElements['amp-test']).to.be.undefined;
     });
 
     it('should give script correct attributes', () => {
@@ -376,8 +370,7 @@ describes.sandboxed('Extensions', {}, () => {
       extensions.loadExtension('amp-embed');
       expect(doc.head.querySelectorAll('[custom-element="amp-ad"]'))
           .to.have.length(1);
-      expect(extensions.getExtensionHolder_('amp-ad').scriptPresent)
-          .to.be.true;
+      expect(extensions.extensions_['amp-ad'].scriptPresent).to.be.true;
 
       // The amp-embed module has never been created.
       expect(doc.head.querySelectorAll('[custom-element="amp-embed"]'))
@@ -395,6 +388,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     beforeEach(() => {
       parentWin = env.win;
+      resetScheduledElementForTesting(parentWin, 'amp-test');
       extensions = installExtensionsService(parentWin);
       extensionsMock = sandbox.mock(extensions);
 

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -315,6 +315,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(1);
       expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
+      expect(win.customElements.elements['amp-test']).to.exist;
       expect(win.ampExtendedElements['amp-test']).to.be.true;
     });
 
@@ -347,6 +348,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(1);
       expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
+      expect(win.customElements.elements['amp-test']).to.not.exist;
       expect(win.ampExtendedElements['amp-test']).to.be.undefined;
     });
 


### PR DESCRIPTION
Fix https://github.com/ampproject/amphtml/issues/5787

For `loadExtension` tests, we should not call `extensions.getExtensionHolder_('amp-test')` directly in the test because this method will create a holder for `amp-test` before `extensions.loadExtension('amp-test')` is called. Because `getExtensionHolder_` is called inside `loadExtension` so I think it's better we don't interfere the testing of `loadExtension`.

The error `Cannot read property 'amp-test' of undefined` happened because when calling `win.customElements.elements['amp-test']`, `win.customElements` doesn't have property `elements`. This `elements` should be defined in https://github.com/ampproject/amphtml/blob/master/testing/describes.js#L327 but it's not. I don't know why that's the case. To fix the test failure, instead of checking `win.customElements.elements['amp-test']`, I think it's also fine to check `win.ampExtendedElements['amp-test']`.

The error `installExtensionsInChildWindow   should install extensions` happened because `amp-test` element is not reset before the test ran.