### PR TITLE
Use Date.now() everywhere it is appropriate.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -593,6 +593,9 @@ var forbiddenTermsSrcInclusive = {
       'extensions/amp-analytics/0.1/transport.js',
     ]
   },
+  '\\.getTime\\(\\)': {
+    message: 'Unless you do weird date math (whitelist), use Date.now().',
+  },
 };
 
 // Terms that must appear in a source file.

--- a/src/log.js
+++ b/src/log.js
@@ -19,7 +19,7 @@ import {getModeObject} from './mode-object';
 
 
 /** @const Time when this JS loaded.  */
-const start = new Date().getTime();
+const start = Date.now();
 
 /**
  * Triple zero width space.


### PR DESCRIPTION
And forbid `#getTime()` for unwhitelisted use.

Aspect of #5792