### PR TITLE
Never include Closure Compiler polyfills in codebase.

### DIFF
--- a/3p/polyfills.js
+++ b/3p/polyfills.js
@@ -21,3 +21,8 @@
 
 // This list should not get longer without a very good reason.
 import '../third_party/babel/custom-babel-helpers';
+import {install as installMathSign} from '../src/polyfills/math-sign';
+import {install as installObjectAssign} from '../src/polyfills/object-assign';
+
+installMathSign(self);
+installObjectAssign(self);

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -67,6 +67,9 @@ exports.rules = [
       '3p/**->src/url.js',
       '3p/**->src/config.js',
       '3p/**->src/mode.js',
+      '3p/**->src/mode.js',
+      '3p/polyfills.js->src/polyfills/math-sign.js',
+      '3p/polyfills.js->src/polyfills/object-assign.js',
     ],
   },
   {
@@ -130,8 +133,29 @@ exports.rules = [
     mustNotDependOn: 'src/base-element.js',
   },
   {
-    filesMatching: 'extensions/**/*.js',
+    filesMatching: '**/*.js',
     mustNotDependOn: 'src/polyfills/**/*.js',
+    whitelist: [
+      // DO NOT add extensions/ files
+      '3p/polyfills.js->src/polyfills/math-sign.js',
+      '3p/polyfills.js->src/polyfills/object-assign.js',
+      'src/polyfills.js->src/polyfills/*.js',
+      'src/polyfills.js->src/polyfills/document-contains.js',
+      'src/polyfills.js->src/polyfills/math-sign.js',
+      'src/polyfills.js->src/polyfills/object-assign.js',
+      'src/polyfills.js->src/polyfills/promise.js',
+      'src/service/extensions-impl.js->src/polyfills/document-contains.js',
+    ],
+  },
+  {
+    filesMatching: '**/*.js',
+    mustNotDependOn: 'src/polyfills.js',
+    whitelist: [
+      'src/amp.js->src/polyfills.js',
+      'src/service.js->src/polyfills.js',
+      'src/service/timer-impl.js->src/polyfills.js',
+      'src/service/extensions-impl.js->src/polyfills.js',
+    ],
   },
 
   // Rules for main src.

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -185,15 +185,8 @@ function compile(entryModuleFilenames, outputDir,
         '!build/fake-module/src/polyfills/**/*.js'
       );
     } else {
-      srcs.push(
-        '!src/polyfills.js',
-        '!src/polyfills/**/*.js'
-      );
-      unneededFiles.push(
-          'build/fake-module/src/polyfills.js',
-          'build/fake-module/src/polyfills/document-contains.js',
-          'build/fake-module/src/polyfills/promise.js',
-          'build/fake-module/src/polyfills/math-sign.js');
+      srcs.push('!src/polyfills.js');
+      unneededFiles.push('build/fake-module/src/polyfills.js');
     }
     unneededFiles.forEach(function(fake) {
       if (!fs.existsSync(fake)) {

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -227,8 +227,7 @@ function compile(entryModuleFilenames, outputDir,
         // Transpile from ES6 to ES5.
         language_in: 'ECMASCRIPT6',
         language_out: 'ECMASCRIPT5',
-        rewrite_polyfills: !!(
-            options.includePolyfills || options.includeBasicPolyfills),
+        rewrite_polyfills: false,
         externs: externs,
         js_module_root: [
           'node_modules/',

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -220,6 +220,9 @@ function compile(entryModuleFilenames, outputDir,
         // Transpile from ES6 to ES5.
         language_in: 'ECMASCRIPT6',
         language_out: 'ECMASCRIPT5',
+        // We do not use the polyfills provided by closure compiler.
+        // If you need a polyfill. Manually include them in the
+        // respective top level polyfills.js files.
         rewrite_polyfills: false,
         externs: externs,
         js_module_root: [

--- a/build-system/tasks/size.js
+++ b/build-system/tasks/size.js
@@ -211,7 +211,7 @@ function sizeTask() {
   gulp.src([
       'dist/**/*.js',
       '!dist/**/*-latest.js',
-      '!dist/**/check-types.js',
+      '!dist/**/*check-types.js',
       'dist.3p/{current,current-min}/**/*.js',
     ])
     .pipe(sizer())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -161,7 +161,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     minify: shouldMinify,
     preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
     externs: ['ads/ads.extern.js',],
-    includeBasicPolyfills: true,
     include3pDirectories: true,
   });
 
@@ -401,7 +400,6 @@ function checkTypes() {
   closureCompile(['./3p/integration.js'],  './dist',
       'integration-check-types.js', {
         externs: ['ads/ads.extern.js',],
-        includeBasicPolyfills: true,
         include3pDirectories: true,
         checkTypes: true,
       });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -162,6 +162,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
     externs: ['ads/ads.extern.js',],
     include3pDirectories: true,
+    includePolyfills: true,
   });
 
   // For compilation with babel we start with the amp-babel entry point,
@@ -401,6 +402,7 @@ function checkTypes() {
       'integration-check-types.js', {
         externs: ['ads/ads.extern.js',],
         include3pDirectories: true,
+        includePolyfills: true,
         checkTypes: true,
       });
 }

--- a/src/polyfills/object-assign.js
+++ b/src/polyfills/object-assign.js
@@ -45,7 +45,7 @@ export function assign(target) {
 
 
 /**
- * Sets the Math.sign polyfill if it does not exist.
+ * Sets the Object.assign polyfill if it does not exist.
  * @param {!Window} win
  */
 export function install(win) {

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,61 +1,62 @@
-      max   |         min   |         gzip   |   file
-      ---   |         ---   |          ---   |   ---
- 72.97 kB   |     6.04 kB   |      2.51 kB   |   alp.js / alp.max.js
-906.18 kB   |   181.52 kB   |     56.08 kB   |   shadow-v0.js / amp-shadow.js
-    386 B   |       250 B   |   sw-kill.js
-  1.34 kB   |       762 B   |        sw.js
-942.18 kB   |   180.41 kB   |     55.75 kB   |   v0.js / amp.js
-333.74 kB   |    38.45 kB   |     12.87 kB   |   v0/amp-access-0.1.js
-131.63 kB   |     2.42 kB   |      1.16 kB   |   v0/amp-access-laterpay-0.1.js
- 56.81 kB   |     3.46 kB   |       1.4 kB   |   v0/amp-accordion-0.1.js
-325.69 kB   |    33.24 kB   |     11.92 kB   |   v0/amp-ad-0.1.js
-362.39 kB   |    37.53 kB   |     13.02 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-362.11 kB   |    35.66 kB   |     12.44 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-360.27 kB   |    29.44 kB   |     10.21 kB   |   v0/amp-ad-network-fake-impl-0.1.js
-309.46 kB   |    57.42 kB   |     20.78 kB   |   v0/amp-analytics-0.1.js
- 51.41 kB   |     4.02 kB   |      1.85 kB   |   v0/amp-anim-0.1.js
-142.69 kB   |     4.81 kB   |      2.07 kB   |   v0/amp-apester-media-0.1.js
-181.64 kB   |    11.11 kB   |      4.41 kB   |   v0/amp-app-banner-0.1.js
- 52.64 kB   |     2.33 kB   |      1.15 kB   |   v0/amp-audio-0.1.js
- 36.72 kB   |     2.87 kB   |      1.05 kB   |   v0/amp-brid-player-0.1.js
- 73.56 kB   |     2.75 kB   |      1.22 kB   |   v0/amp-brightcove-0.1.js
-289.13 kB   |    30.18 kB   |      9.37 kB   |   v0/amp-carousel-0.1.js
- 35.17 kB   |     1.78 kB   |        895 B   |   v0/amp-dailymotion-0.1.js
-122.06 kB   |     2.04 kB   |      1.03 kB   |   v0/amp-dynamic-css-classes-0.1.js
-156.09 kB   |     5.49 kB   |       2.4 kB   |   v0/amp-experiment-0.1.js
-178.42 kB   |      9.2 kB   |      4.15 kB   |   v0/amp-facebook-0.1.js
- 43.66 kB   |     3.06 kB   |      1.35 kB   |   v0/amp-fit-text-0.1.js
-137.95 kB   |     4.02 kB   |      1.79 kB   |   v0/amp-font-0.1.js
-211.54 kB   |    14.46 kB   |       5.4 kB   |   v0/amp-form-0.1.js
-159.08 kB   |     3.46 kB   |      1.62 kB   |   v0/amp-fresh-0.1.js
- 53.85 kB   |     4.23 kB   |       1.8 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 34.54 kB   |     1.51 kB   |        765 B   |   v0/amp-gfycat-0.1.js
- 63.31 kB   |     3.75 kB   |       1.7 kB   |   v0/amp-google-vrview-image-0.1.js
-192.85 kB   |    11.07 kB   |      4.56 kB   |   v0/amp-iframe-0.1.js
-271.49 kB   |     28.1 kB   |      9.11 kB   |   v0/amp-image-lightbox-0.1.js
- 61.57 kB   |     2.71 kB   |      1.27 kB   |   v0/amp-instagram-0.1.js
-125.14 kB   |     5.52 kB   |      2.53 kB   |   v0/amp-install-serviceworker-0.1.js
- 35.82 kB   |     2.22 kB   |        942 B   |   v0/amp-jwplayer-0.1.js
- 72.91 kB   |     3.08 kB   |      1.34 kB   |   v0/amp-kaltura-player-0.1.js
-176.53 kB   |     8.26 kB   |      3.13 kB   |   v0/amp-lightbox-0.1.js
-184.59 kB   |    13.53 kB   |      4.49 kB   |   v0/amp-lightbox-viewer-0.1.js
-129.49 kB   |     3.26 kB   |      1.53 kB   |   v0/amp-list-0.1.js
- 188.5 kB   |     9.46 kB   |      3.68 kB   |   v0/amp-live-list-0.1.js
-160.17 kB   |    37.98 kB   |     13.64 kB   |   v0/amp-mustache-0.1.js
- 35.72 kB   |     2.24 kB   |        959 B   |   v0/amp-o2-player-0.1.js
-172.83 kB   |    17.39 kB   |      4.95 kB   |   v0/amp-pinterest-0.1.js
- 34.28 kB   |     1.34 kB   |        676 B   |   v0/amp-reach-player-0.1.js
- 131.3 kB   |     3.43 kB   |      1.65 kB   |   v0/amp-share-tracking-0.1.js
-143.49 kB   |      5.5 kB   |      2.12 kB   |   v0/amp-sidebar-0.1.js
- 144.9 kB   |     7.24 kB   |      2.97 kB   |   v0/amp-slides-0.1.js
-154.92 kB   |      9.7 kB   |       3.8 kB   |   v0/amp-social-share-0.1.js
- 35.29 kB   |     1.76 kB   |        844 B   |   v0/amp-soundcloud-0.1.js
- 36.74 kB   |      2.9 kB   |      1.02 kB   |   v0/amp-springboard-player-0.1.js
-144.98 kB   |     4.74 kB   |       1.9 kB   |   v0/amp-sticky-ad-0.1.js
-178.78 kB   |     9.32 kB   |       4.2 kB   |   v0/amp-twitter-0.1.js
-161.43 kB   |     7.99 kB   |      3.18 kB   |   v0/amp-user-notification-0.1.js
- 34.59 kB   |     1.53 kB   |        777 B   |   v0/amp-vimeo-0.1.js
- 34.19 kB   |     1.39 kB   |        728 B   |   v0/amp-vine-0.1.js
-670.75 kB   |   511.34 kB   |    167.46 kB   |   v0/amp-viz-vega-0.1.js
- 160.3 kB   |     4.26 kB   |      1.95 kB   |   v0/amp-youtube-0.1.js
-229.68 kB   |     48.7 kB   |     16.82 kB   |   current-min/f.js / current/integration.js
+      max   |         min   |        gzip   |   file
+      ---   |         ---   |         ---   |   ---
+ 72.97 kB   |     6.04 kB   |     2.51 kB   |   alp.js / alp.max.js
+906.18 kB   |   181.52 kB   |    56.08 kB   |   shadow-v0.js / amp-shadow.js
+   5.8 kB   |       386 B   |       250 B   |   sw-kill.js / sw-kill.max.js
+ 385.7 kB   |     1.34 kB   |       762 B   |   sw.js / sw.max.js
+942.18 kB   |   180.41 kB   |    55.75 kB   |   v0.js / amp.js
+333.74 kB   |    38.45 kB   |    12.87 kB   |   v0/amp-access-0.1.js
+131.63 kB   |     2.42 kB   |     1.16 kB   |   v0/amp-access-laterpay-0.1.js
+ 56.81 kB   |     3.46 kB   |      1.4 kB   |   v0/amp-accordion-0.1.js
+325.69 kB   |    33.24 kB   |    11.92 kB   |   v0/amp-ad-0.1.js
+362.39 kB   |    37.53 kB   |    13.02 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+362.11 kB   |    35.66 kB   |    12.44 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+360.27 kB   |    29.44 kB   |    10.21 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+309.46 kB   |    57.42 kB   |    20.78 kB   |   v0/amp-analytics-0.1.js
+ 51.41 kB   |     4.02 kB   |     1.85 kB   |   v0/amp-anim-0.1.js
+142.69 kB   |     4.81 kB   |     2.07 kB   |   v0/amp-apester-media-0.1.js
+181.65 kB   |    11.11 kB   |     4.41 kB   |   v0/amp-app-banner-0.1.js
+ 52.64 kB   |     2.33 kB   |     1.15 kB   |   v0/amp-audio-0.1.js
+ 36.72 kB   |     2.87 kB   |     1.05 kB   |   v0/amp-brid-player-0.1.js
+ 73.56 kB   |     2.75 kB   |     1.22 kB   |   v0/amp-brightcove-0.1.js
+289.13 kB   |    30.18 kB   |     9.37 kB   |   v0/amp-carousel-0.1.js
+ 35.17 kB   |     1.78 kB   |       895 B   |   v0/amp-dailymotion-0.1.js
+122.07 kB   |     2.04 kB   |     1.03 kB   |   v0/amp-dynamic-css-classes-0.1.js
+ 156.1 kB   |     5.49 kB   |      2.4 kB   |   v0/amp-experiment-0.1.js
+178.43 kB   |      9.2 kB   |     4.15 kB   |   v0/amp-facebook-0.1.js
+ 43.66 kB   |     3.06 kB   |     1.35 kB   |   v0/amp-fit-text-0.1.js
+137.95 kB   |     4.02 kB   |     1.79 kB   |   v0/amp-font-0.1.js
+211.54 kB   |    14.46 kB   |      5.4 kB   |   v0/amp-form-0.1.js
+159.08 kB   |     3.46 kB   |     1.62 kB   |   v0/amp-fresh-0.1.js
+ 53.85 kB   |     4.23 kB   |      1.8 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 34.54 kB   |     1.51 kB   |       765 B   |   v0/amp-gfycat-0.1.js
+ 63.31 kB   |     3.75 kB   |      1.7 kB   |   v0/amp-google-vrview-image-0.1.js
+192.85 kB   |    11.07 kB   |     4.56 kB   |   v0/amp-iframe-0.1.js
+271.49 kB   |     28.1 kB   |     9.11 kB   |   v0/amp-image-lightbox-0.1.js
+ 61.57 kB   |     2.71 kB   |     1.27 kB   |   v0/amp-instagram-0.1.js
+125.14 kB   |     5.52 kB   |     2.53 kB   |   v0/amp-install-serviceworker-0.1.js
+ 35.82 kB   |     2.22 kB   |       942 B   |   v0/amp-jwplayer-0.1.js
+ 72.91 kB   |     3.08 kB   |     1.34 kB   |   v0/amp-kaltura-player-0.1.js
+176.53 kB   |     8.26 kB   |     3.13 kB   |   v0/amp-lightbox-0.1.js
+ 184.6 kB   |    13.53 kB   |     4.49 kB   |   v0/amp-lightbox-viewer-0.1.js
+ 129.5 kB   |     3.26 kB   |     1.53 kB   |   v0/amp-list-0.1.js
+ 188.5 kB   |     9.46 kB   |     3.68 kB   |   v0/amp-live-list-0.1.js
+160.17 kB   |    37.98 kB   |    13.64 kB   |   v0/amp-mustache-0.1.js
+ 35.72 kB   |     2.24 kB   |       959 B   |   v0/amp-o2-player-0.1.js
+172.83 kB   |    17.39 kB   |     4.95 kB   |   v0/amp-pinterest-0.1.js
+ 34.28 kB   |     1.34 kB   |       676 B   |   v0/amp-reach-player-0.1.js
+ 131.3 kB   |     3.43 kB   |     1.65 kB   |   v0/amp-share-tracking-0.1.js
+143.49 kB   |      5.5 kB   |     2.12 kB   |   v0/amp-sidebar-0.1.js
+ 144.9 kB   |     7.24 kB   |     2.97 kB   |   v0/amp-slides-0.1.js
+154.92 kB   |      9.7 kB   |      3.8 kB   |   v0/amp-social-share-0.1.js
+ 35.29 kB   |     1.76 kB   |       844 B   |   v0/amp-soundcloud-0.1.js
+ 36.74 kB   |      2.9 kB   |     1.02 kB   |   v0/amp-springboard-player-0.1.js
+144.98 kB   |     4.74 kB   |      1.9 kB   |   v0/amp-sticky-ad-0.1.js
+178.79 kB   |     9.32 kB   |      4.2 kB   |   v0/amp-twitter-0.1.js
+161.43 kB   |     7.99 kB   |     3.18 kB   |   v0/amp-user-notification-0.1.js
+ 34.59 kB   |     1.53 kB   |       777 B   |   v0/amp-vimeo-0.1.js
+ 34.19 kB   |     1.39 kB   |       728 B   |   v0/amp-vine-0.1.js
+670.76 kB   |   511.34 kB   |   167.46 kB   |   v0/amp-viz-vega-0.1.js
+160.31 kB   |     4.26 kB   |     1.95 kB   |   v0/amp-youtube-0.1.js
+ 19.04 kB   |      1.9 kB   |       908 B   |   v0/cache-service-worker-0.1.js
+232.89 kB   |     48.7 kB   |    16.82 kB   |   current-min/f.js / current/integration.js

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,63 +1,62 @@
-      max   |         min   |                         gzip   |   file
-      ---   |         ---   |                          ---   |   ---
- 72.97 kB   |     6.04 kB   |                      2.51 kB   |   alp.js / alp.max.js
- 59.79 kB   |    19.46 kB   |   integration-check-types.js
-906.18 kB   |   181.52 kB   |                     56.08 kB   |   shadow-v0.js / amp-shadow.js
-   5.8 kB   |       386 B   |                        250 B   |   sw-kill.js / sw-kill.max.js
- 385.7 kB   |     1.34 kB   |                        761 B   |   sw.js / sw.max.js
-942.18 kB   |   180.41 kB   |                     55.75 kB   |   v0.js / amp.js
-333.74 kB   |    38.45 kB   |                     12.87 kB   |   v0/amp-access-0.1.js
-131.63 kB   |     2.42 kB   |                      1.16 kB   |   v0/amp-access-laterpay-0.1.js
- 56.81 kB   |     3.46 kB   |                       1.4 kB   |   v0/amp-accordion-0.1.js
-325.69 kB   |    33.24 kB   |                     11.92 kB   |   v0/amp-ad-0.1.js
-362.39 kB   |    37.53 kB   |                     13.02 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-362.11 kB   |    35.66 kB   |                     12.44 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-360.27 kB   |    29.44 kB   |                     10.21 kB   |   v0/amp-ad-network-fake-impl-0.1.js
-309.46 kB   |    57.42 kB   |                     20.78 kB   |   v0/amp-analytics-0.1.js
- 51.41 kB   |     4.02 kB   |                      1.85 kB   |   v0/amp-anim-0.1.js
-142.69 kB   |     4.81 kB   |                      2.07 kB   |   v0/amp-apester-media-0.1.js
-181.65 kB   |    11.11 kB   |                      4.41 kB   |   v0/amp-app-banner-0.1.js
- 52.64 kB   |     2.33 kB   |                      1.15 kB   |   v0/amp-audio-0.1.js
- 36.72 kB   |     2.87 kB   |                      1.05 kB   |   v0/amp-brid-player-0.1.js
- 73.56 kB   |     2.75 kB   |                      1.22 kB   |   v0/amp-brightcove-0.1.js
-289.13 kB   |    30.18 kB   |                      9.37 kB   |   v0/amp-carousel-0.1.js
- 35.17 kB   |     1.78 kB   |                        895 B   |   v0/amp-dailymotion-0.1.js
-122.07 kB   |     2.04 kB   |                      1.03 kB   |   v0/amp-dynamic-css-classes-0.1.js
- 156.1 kB   |     5.49 kB   |                       2.4 kB   |   v0/amp-experiment-0.1.js
-178.43 kB   |      9.2 kB   |                      4.15 kB   |   v0/amp-facebook-0.1.js
- 43.66 kB   |     3.06 kB   |                      1.35 kB   |   v0/amp-fit-text-0.1.js
-137.95 kB   |     4.02 kB   |                      1.79 kB   |   v0/amp-font-0.1.js
-211.54 kB   |    14.46 kB   |                       5.4 kB   |   v0/amp-form-0.1.js
-159.08 kB   |     3.46 kB   |                      1.62 kB   |   v0/amp-fresh-0.1.js
- 53.85 kB   |     4.23 kB   |                       1.8 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 34.54 kB   |     1.51 kB   |                        765 B   |   v0/amp-gfycat-0.1.js
- 63.31 kB   |     3.75 kB   |                       1.7 kB   |   v0/amp-google-vrview-image-0.1.js
-192.85 kB   |    11.07 kB   |                      4.56 kB   |   v0/amp-iframe-0.1.js
-271.49 kB   |     28.1 kB   |                      9.11 kB   |   v0/amp-image-lightbox-0.1.js
- 61.57 kB   |     2.71 kB   |                      1.27 kB   |   v0/amp-instagram-0.1.js
-125.14 kB   |     5.52 kB   |                      2.53 kB   |   v0/amp-install-serviceworker-0.1.js
- 35.82 kB   |     2.22 kB   |                        942 B   |   v0/amp-jwplayer-0.1.js
- 72.91 kB   |     3.08 kB   |                      1.34 kB   |   v0/amp-kaltura-player-0.1.js
-176.53 kB   |     8.26 kB   |                      3.13 kB   |   v0/amp-lightbox-0.1.js
- 184.6 kB   |    13.53 kB   |                      4.49 kB   |   v0/amp-lightbox-viewer-0.1.js
- 129.5 kB   |     3.26 kB   |                      1.53 kB   |   v0/amp-list-0.1.js
- 188.5 kB   |     9.46 kB   |                      3.68 kB   |   v0/amp-live-list-0.1.js
-160.17 kB   |    37.98 kB   |                     13.64 kB   |   v0/amp-mustache-0.1.js
- 35.72 kB   |     2.24 kB   |                        959 B   |   v0/amp-o2-player-0.1.js
-172.83 kB   |    17.39 kB   |                      4.95 kB   |   v0/amp-pinterest-0.1.js
- 34.28 kB   |     1.34 kB   |                        676 B   |   v0/amp-reach-player-0.1.js
- 131.3 kB   |     3.43 kB   |                      1.65 kB   |   v0/amp-share-tracking-0.1.js
-143.49 kB   |      5.5 kB   |                      2.12 kB   |   v0/amp-sidebar-0.1.js
- 144.9 kB   |     7.24 kB   |                      2.97 kB   |   v0/amp-slides-0.1.js
-154.92 kB   |      9.7 kB   |                       3.8 kB   |   v0/amp-social-share-0.1.js
- 35.29 kB   |     1.76 kB   |                        844 B   |   v0/amp-soundcloud-0.1.js
- 36.74 kB   |      2.9 kB   |                      1.02 kB   |   v0/amp-springboard-player-0.1.js
-144.98 kB   |     4.74 kB   |                       1.9 kB   |   v0/amp-sticky-ad-0.1.js
-178.79 kB   |     9.32 kB   |                      4.19 kB   |   v0/amp-twitter-0.1.js
-161.43 kB   |     7.99 kB   |                      3.18 kB   |   v0/amp-user-notification-0.1.js
- 34.59 kB   |     1.53 kB   |                        777 B   |   v0/amp-vimeo-0.1.js
- 34.19 kB   |     1.39 kB   |                        728 B   |   v0/amp-vine-0.1.js
-670.76 kB   |   511.34 kB   |                    167.46 kB   |   v0/amp-viz-vega-0.1.js
-160.31 kB   |     4.26 kB   |                      1.95 kB   |   v0/amp-youtube-0.1.js
- 19.04 kB   |      1.9 kB   |                        908 B   |   v0/cache-service-worker-0.1.js
-232.89 kB   |    49.12 kB   |                     16.96 kB   |   current-min/f.js / current/integration.js
+      max   |         min   |        gzip   |   file
+      ---   |         ---   |         ---   |   ---
+ 72.97 kB   |     6.04 kB   |     2.51 kB   |   alp.js / alp.max.js
+906.18 kB   |   181.52 kB   |    56.08 kB   |   shadow-v0.js / amp-shadow.js
+   5.8 kB   |       386 B   |       250 B   |   sw-kill.js / sw-kill.max.js
+ 385.7 kB   |     1.34 kB   |       761 B   |   sw.js / sw.max.js
+942.18 kB   |   180.41 kB   |    55.75 kB   |   v0.js / amp.js
+333.74 kB   |    38.45 kB   |    12.87 kB   |   v0/amp-access-0.1.js
+131.63 kB   |     2.42 kB   |     1.16 kB   |   v0/amp-access-laterpay-0.1.js
+ 56.81 kB   |     3.46 kB   |      1.4 kB   |   v0/amp-accordion-0.1.js
+325.69 kB   |    33.24 kB   |    11.92 kB   |   v0/amp-ad-0.1.js
+362.39 kB   |    37.53 kB   |    13.02 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+362.11 kB   |    35.66 kB   |    12.44 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+360.27 kB   |    29.44 kB   |    10.21 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+309.46 kB   |    57.42 kB   |    20.78 kB   |   v0/amp-analytics-0.1.js
+ 51.41 kB   |     4.02 kB   |     1.85 kB   |   v0/amp-anim-0.1.js
+142.69 kB   |     4.81 kB   |     2.07 kB   |   v0/amp-apester-media-0.1.js
+181.65 kB   |    11.11 kB   |     4.41 kB   |   v0/amp-app-banner-0.1.js
+ 52.64 kB   |     2.33 kB   |     1.15 kB   |   v0/amp-audio-0.1.js
+ 36.72 kB   |     2.87 kB   |     1.05 kB   |   v0/amp-brid-player-0.1.js
+ 73.56 kB   |     2.75 kB   |     1.22 kB   |   v0/amp-brightcove-0.1.js
+289.13 kB   |    30.18 kB   |     9.37 kB   |   v0/amp-carousel-0.1.js
+ 35.17 kB   |     1.78 kB   |       895 B   |   v0/amp-dailymotion-0.1.js
+122.07 kB   |     2.04 kB   |     1.03 kB   |   v0/amp-dynamic-css-classes-0.1.js
+ 156.1 kB   |     5.49 kB   |      2.4 kB   |   v0/amp-experiment-0.1.js
+178.43 kB   |      9.2 kB   |     4.15 kB   |   v0/amp-facebook-0.1.js
+ 43.66 kB   |     3.06 kB   |     1.35 kB   |   v0/amp-fit-text-0.1.js
+137.95 kB   |     4.02 kB   |     1.79 kB   |   v0/amp-font-0.1.js
+211.54 kB   |    14.46 kB   |      5.4 kB   |   v0/amp-form-0.1.js
+159.08 kB   |     3.46 kB   |     1.62 kB   |   v0/amp-fresh-0.1.js
+ 53.85 kB   |     4.23 kB   |      1.8 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 34.54 kB   |     1.51 kB   |       765 B   |   v0/amp-gfycat-0.1.js
+ 63.31 kB   |     3.75 kB   |      1.7 kB   |   v0/amp-google-vrview-image-0.1.js
+192.85 kB   |    11.07 kB   |     4.56 kB   |   v0/amp-iframe-0.1.js
+271.49 kB   |     28.1 kB   |     9.11 kB   |   v0/amp-image-lightbox-0.1.js
+ 61.57 kB   |     2.71 kB   |     1.27 kB   |   v0/amp-instagram-0.1.js
+125.14 kB   |     5.52 kB   |     2.53 kB   |   v0/amp-install-serviceworker-0.1.js
+ 35.82 kB   |     2.22 kB   |       942 B   |   v0/amp-jwplayer-0.1.js
+ 72.91 kB   |     3.08 kB   |     1.34 kB   |   v0/amp-kaltura-player-0.1.js
+176.53 kB   |     8.26 kB   |     3.13 kB   |   v0/amp-lightbox-0.1.js
+ 184.6 kB   |    13.53 kB   |     4.49 kB   |   v0/amp-lightbox-viewer-0.1.js
+ 129.5 kB   |     3.26 kB   |     1.53 kB   |   v0/amp-list-0.1.js
+ 188.5 kB   |     9.46 kB   |     3.68 kB   |   v0/amp-live-list-0.1.js
+160.17 kB   |    37.98 kB   |    13.64 kB   |   v0/amp-mustache-0.1.js
+ 35.72 kB   |     2.24 kB   |       959 B   |   v0/amp-o2-player-0.1.js
+172.83 kB   |    17.39 kB   |     4.95 kB   |   v0/amp-pinterest-0.1.js
+ 34.28 kB   |     1.34 kB   |       676 B   |   v0/amp-reach-player-0.1.js
+ 131.3 kB   |     3.43 kB   |     1.65 kB   |   v0/amp-share-tracking-0.1.js
+143.49 kB   |      5.5 kB   |     2.12 kB   |   v0/amp-sidebar-0.1.js
+ 144.9 kB   |     7.24 kB   |     2.97 kB   |   v0/amp-slides-0.1.js
+154.92 kB   |      9.7 kB   |      3.8 kB   |   v0/amp-social-share-0.1.js
+ 35.29 kB   |     1.76 kB   |       844 B   |   v0/amp-soundcloud-0.1.js
+ 36.74 kB   |      2.9 kB   |     1.02 kB   |   v0/amp-springboard-player-0.1.js
+144.98 kB   |     4.74 kB   |      1.9 kB   |   v0/amp-sticky-ad-0.1.js
+178.79 kB   |     9.32 kB   |     4.19 kB   |   v0/amp-twitter-0.1.js
+161.43 kB   |     7.99 kB   |     3.18 kB   |   v0/amp-user-notification-0.1.js
+ 34.59 kB   |     1.53 kB   |       777 B   |   v0/amp-vimeo-0.1.js
+ 34.19 kB   |     1.39 kB   |       728 B   |   v0/amp-vine-0.1.js
+670.76 kB   |   511.34 kB   |   167.46 kB   |   v0/amp-viz-vega-0.1.js
+160.31 kB   |     4.26 kB   |     1.95 kB   |   v0/amp-youtube-0.1.js
+ 19.04 kB   |      1.9 kB   |       908 B   |   v0/cache-service-worker-0.1.js
+232.89 kB   |    49.12 kB   |    16.96 kB   |   current-min/f.js / current/integration.js

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,62 +1,63 @@
-      max   |         min   |        gzip   |   file
-      ---   |         ---   |         ---   |   ---
- 72.97 kB   |     6.04 kB   |     2.51 kB   |   alp.js / alp.max.js
-906.18 kB   |   181.52 kB   |    56.08 kB   |   shadow-v0.js / amp-shadow.js
-   5.8 kB   |       386 B   |       250 B   |   sw-kill.js / sw-kill.max.js
- 385.7 kB   |     1.34 kB   |       762 B   |   sw.js / sw.max.js
-942.18 kB   |   180.41 kB   |    55.75 kB   |   v0.js / amp.js
-333.74 kB   |    38.45 kB   |    12.87 kB   |   v0/amp-access-0.1.js
-131.63 kB   |     2.42 kB   |     1.16 kB   |   v0/amp-access-laterpay-0.1.js
- 56.81 kB   |     3.46 kB   |      1.4 kB   |   v0/amp-accordion-0.1.js
-325.69 kB   |    33.24 kB   |    11.92 kB   |   v0/amp-ad-0.1.js
-362.39 kB   |    37.53 kB   |    13.02 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-362.11 kB   |    35.66 kB   |    12.44 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-360.27 kB   |    29.44 kB   |    10.21 kB   |   v0/amp-ad-network-fake-impl-0.1.js
-309.46 kB   |    57.42 kB   |    20.78 kB   |   v0/amp-analytics-0.1.js
- 51.41 kB   |     4.02 kB   |     1.85 kB   |   v0/amp-anim-0.1.js
-142.69 kB   |     4.81 kB   |     2.07 kB   |   v0/amp-apester-media-0.1.js
-181.65 kB   |    11.11 kB   |     4.41 kB   |   v0/amp-app-banner-0.1.js
- 52.64 kB   |     2.33 kB   |     1.15 kB   |   v0/amp-audio-0.1.js
- 36.72 kB   |     2.87 kB   |     1.05 kB   |   v0/amp-brid-player-0.1.js
- 73.56 kB   |     2.75 kB   |     1.22 kB   |   v0/amp-brightcove-0.1.js
-289.13 kB   |    30.18 kB   |     9.37 kB   |   v0/amp-carousel-0.1.js
- 35.17 kB   |     1.78 kB   |       895 B   |   v0/amp-dailymotion-0.1.js
-122.07 kB   |     2.04 kB   |     1.03 kB   |   v0/amp-dynamic-css-classes-0.1.js
- 156.1 kB   |     5.49 kB   |      2.4 kB   |   v0/amp-experiment-0.1.js
-178.43 kB   |      9.2 kB   |     4.15 kB   |   v0/amp-facebook-0.1.js
- 43.66 kB   |     3.06 kB   |     1.35 kB   |   v0/amp-fit-text-0.1.js
-137.95 kB   |     4.02 kB   |     1.79 kB   |   v0/amp-font-0.1.js
-211.54 kB   |    14.46 kB   |      5.4 kB   |   v0/amp-form-0.1.js
-159.08 kB   |     3.46 kB   |     1.62 kB   |   v0/amp-fresh-0.1.js
- 53.85 kB   |     4.23 kB   |      1.8 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 34.54 kB   |     1.51 kB   |       765 B   |   v0/amp-gfycat-0.1.js
- 63.31 kB   |     3.75 kB   |      1.7 kB   |   v0/amp-google-vrview-image-0.1.js
-192.85 kB   |    11.07 kB   |     4.56 kB   |   v0/amp-iframe-0.1.js
-271.49 kB   |     28.1 kB   |     9.11 kB   |   v0/amp-image-lightbox-0.1.js
- 61.57 kB   |     2.71 kB   |     1.27 kB   |   v0/amp-instagram-0.1.js
-125.14 kB   |     5.52 kB   |     2.53 kB   |   v0/amp-install-serviceworker-0.1.js
- 35.82 kB   |     2.22 kB   |       942 B   |   v0/amp-jwplayer-0.1.js
- 72.91 kB   |     3.08 kB   |     1.34 kB   |   v0/amp-kaltura-player-0.1.js
-176.53 kB   |     8.26 kB   |     3.13 kB   |   v0/amp-lightbox-0.1.js
- 184.6 kB   |    13.53 kB   |     4.49 kB   |   v0/amp-lightbox-viewer-0.1.js
- 129.5 kB   |     3.26 kB   |     1.53 kB   |   v0/amp-list-0.1.js
- 188.5 kB   |     9.46 kB   |     3.68 kB   |   v0/amp-live-list-0.1.js
-160.17 kB   |    37.98 kB   |    13.64 kB   |   v0/amp-mustache-0.1.js
- 35.72 kB   |     2.24 kB   |       959 B   |   v0/amp-o2-player-0.1.js
-172.83 kB   |    17.39 kB   |     4.95 kB   |   v0/amp-pinterest-0.1.js
- 34.28 kB   |     1.34 kB   |       676 B   |   v0/amp-reach-player-0.1.js
- 131.3 kB   |     3.43 kB   |     1.65 kB   |   v0/amp-share-tracking-0.1.js
-143.49 kB   |      5.5 kB   |     2.12 kB   |   v0/amp-sidebar-0.1.js
- 144.9 kB   |     7.24 kB   |     2.97 kB   |   v0/amp-slides-0.1.js
-154.92 kB   |      9.7 kB   |      3.8 kB   |   v0/amp-social-share-0.1.js
- 35.29 kB   |     1.76 kB   |       844 B   |   v0/amp-soundcloud-0.1.js
- 36.74 kB   |      2.9 kB   |     1.02 kB   |   v0/amp-springboard-player-0.1.js
-144.98 kB   |     4.74 kB   |      1.9 kB   |   v0/amp-sticky-ad-0.1.js
-178.79 kB   |     9.32 kB   |      4.2 kB   |   v0/amp-twitter-0.1.js
-161.43 kB   |     7.99 kB   |     3.18 kB   |   v0/amp-user-notification-0.1.js
- 34.59 kB   |     1.53 kB   |       777 B   |   v0/amp-vimeo-0.1.js
- 34.19 kB   |     1.39 kB   |       728 B   |   v0/amp-vine-0.1.js
-670.76 kB   |   511.34 kB   |   167.46 kB   |   v0/amp-viz-vega-0.1.js
-160.31 kB   |     4.26 kB   |     1.95 kB   |   v0/amp-youtube-0.1.js
- 19.04 kB   |      1.9 kB   |       908 B   |   v0/cache-service-worker-0.1.js
-232.89 kB   |     48.7 kB   |    16.82 kB   |   current-min/f.js / current/integration.js
+      max   |         min   |                         gzip   |   file
+      ---   |         ---   |                          ---   |   ---
+ 72.97 kB   |     6.04 kB   |                      2.51 kB   |   alp.js / alp.max.js
+ 59.79 kB   |    19.46 kB   |   integration-check-types.js
+906.18 kB   |   181.52 kB   |                     56.08 kB   |   shadow-v0.js / amp-shadow.js
+   5.8 kB   |       386 B   |                        250 B   |   sw-kill.js / sw-kill.max.js
+ 385.7 kB   |     1.34 kB   |                        761 B   |   sw.js / sw.max.js
+942.18 kB   |   180.41 kB   |                     55.75 kB   |   v0.js / amp.js
+333.74 kB   |    38.45 kB   |                     12.87 kB   |   v0/amp-access-0.1.js
+131.63 kB   |     2.42 kB   |                      1.16 kB   |   v0/amp-access-laterpay-0.1.js
+ 56.81 kB   |     3.46 kB   |                       1.4 kB   |   v0/amp-accordion-0.1.js
+325.69 kB   |    33.24 kB   |                     11.92 kB   |   v0/amp-ad-0.1.js
+362.39 kB   |    37.53 kB   |                     13.02 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+362.11 kB   |    35.66 kB   |                     12.44 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+360.27 kB   |    29.44 kB   |                     10.21 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+309.46 kB   |    57.42 kB   |                     20.78 kB   |   v0/amp-analytics-0.1.js
+ 51.41 kB   |     4.02 kB   |                      1.85 kB   |   v0/amp-anim-0.1.js
+142.69 kB   |     4.81 kB   |                      2.07 kB   |   v0/amp-apester-media-0.1.js
+181.65 kB   |    11.11 kB   |                      4.41 kB   |   v0/amp-app-banner-0.1.js
+ 52.64 kB   |     2.33 kB   |                      1.15 kB   |   v0/amp-audio-0.1.js
+ 36.72 kB   |     2.87 kB   |                      1.05 kB   |   v0/amp-brid-player-0.1.js
+ 73.56 kB   |     2.75 kB   |                      1.22 kB   |   v0/amp-brightcove-0.1.js
+289.13 kB   |    30.18 kB   |                      9.37 kB   |   v0/amp-carousel-0.1.js
+ 35.17 kB   |     1.78 kB   |                        895 B   |   v0/amp-dailymotion-0.1.js
+122.07 kB   |     2.04 kB   |                      1.03 kB   |   v0/amp-dynamic-css-classes-0.1.js
+ 156.1 kB   |     5.49 kB   |                       2.4 kB   |   v0/amp-experiment-0.1.js
+178.43 kB   |      9.2 kB   |                      4.15 kB   |   v0/amp-facebook-0.1.js
+ 43.66 kB   |     3.06 kB   |                      1.35 kB   |   v0/amp-fit-text-0.1.js
+137.95 kB   |     4.02 kB   |                      1.79 kB   |   v0/amp-font-0.1.js
+211.54 kB   |    14.46 kB   |                       5.4 kB   |   v0/amp-form-0.1.js
+159.08 kB   |     3.46 kB   |                      1.62 kB   |   v0/amp-fresh-0.1.js
+ 53.85 kB   |     4.23 kB   |                       1.8 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 34.54 kB   |     1.51 kB   |                        765 B   |   v0/amp-gfycat-0.1.js
+ 63.31 kB   |     3.75 kB   |                       1.7 kB   |   v0/amp-google-vrview-image-0.1.js
+192.85 kB   |    11.07 kB   |                      4.56 kB   |   v0/amp-iframe-0.1.js
+271.49 kB   |     28.1 kB   |                      9.11 kB   |   v0/amp-image-lightbox-0.1.js
+ 61.57 kB   |     2.71 kB   |                      1.27 kB   |   v0/amp-instagram-0.1.js
+125.14 kB   |     5.52 kB   |                      2.53 kB   |   v0/amp-install-serviceworker-0.1.js
+ 35.82 kB   |     2.22 kB   |                        942 B   |   v0/amp-jwplayer-0.1.js
+ 72.91 kB   |     3.08 kB   |                      1.34 kB   |   v0/amp-kaltura-player-0.1.js
+176.53 kB   |     8.26 kB   |                      3.13 kB   |   v0/amp-lightbox-0.1.js
+ 184.6 kB   |    13.53 kB   |                      4.49 kB   |   v0/amp-lightbox-viewer-0.1.js
+ 129.5 kB   |     3.26 kB   |                      1.53 kB   |   v0/amp-list-0.1.js
+ 188.5 kB   |     9.46 kB   |                      3.68 kB   |   v0/amp-live-list-0.1.js
+160.17 kB   |    37.98 kB   |                     13.64 kB   |   v0/amp-mustache-0.1.js
+ 35.72 kB   |     2.24 kB   |                        959 B   |   v0/amp-o2-player-0.1.js
+172.83 kB   |    17.39 kB   |                      4.95 kB   |   v0/amp-pinterest-0.1.js
+ 34.28 kB   |     1.34 kB   |                        676 B   |   v0/amp-reach-player-0.1.js
+ 131.3 kB   |     3.43 kB   |                      1.65 kB   |   v0/amp-share-tracking-0.1.js
+143.49 kB   |      5.5 kB   |                      2.12 kB   |   v0/amp-sidebar-0.1.js
+ 144.9 kB   |     7.24 kB   |                      2.97 kB   |   v0/amp-slides-0.1.js
+154.92 kB   |      9.7 kB   |                       3.8 kB   |   v0/amp-social-share-0.1.js
+ 35.29 kB   |     1.76 kB   |                        844 B   |   v0/amp-soundcloud-0.1.js
+ 36.74 kB   |      2.9 kB   |                      1.02 kB   |   v0/amp-springboard-player-0.1.js
+144.98 kB   |     4.74 kB   |                       1.9 kB   |   v0/amp-sticky-ad-0.1.js
+178.79 kB   |     9.32 kB   |                      4.19 kB   |   v0/amp-twitter-0.1.js
+161.43 kB   |     7.99 kB   |                      3.18 kB   |   v0/amp-user-notification-0.1.js
+ 34.59 kB   |     1.53 kB   |                        777 B   |   v0/amp-vimeo-0.1.js
+ 34.19 kB   |     1.39 kB   |                        728 B   |   v0/amp-vine-0.1.js
+670.76 kB   |   511.34 kB   |                    167.46 kB   |   v0/amp-viz-vega-0.1.js
+160.31 kB   |     4.26 kB   |                      1.95 kB   |   v0/amp-youtube-0.1.js
+ 19.04 kB   |      1.9 kB   |                        908 B   |   v0/cache-service-worker-0.1.js
+232.89 kB   |    49.12 kB   |                     16.96 kB   |   current-min/f.js / current/integration.js

--- a/test/size.txt
+++ b/test/size.txt
@@ -1,62 +1,61 @@
-      max   |         min   |        gzip   |   file
-      ---   |         ---   |         ---   |   ---
- 72.97 kB   |     6.14 kB   |     2.55 kB   |   alp.js / alp.max.js
-905.14 kB   |   183.16 kB   |    56.65 kB   |   shadow-v0.js / amp-shadow.js
-   5.8 kB   |       386 B   |       250 B   |   sw-kill.js / sw-kill.max.js
- 385.7 kB   |     1.34 kB   |       762 B   |   sw.js / sw.max.js
-941.14 kB   |   182.05 kB   |    56.31 kB   |   v0.js / amp.js
-333.74 kB   |    38.45 kB   |    12.87 kB   |   v0/amp-access-0.1.js
-131.63 kB   |     2.42 kB   |     1.16 kB   |   v0/amp-access-laterpay-0.1.js
- 56.81 kB   |     3.46 kB   |      1.4 kB   |   v0/amp-accordion-0.1.js
-325.69 kB   |    33.24 kB   |    11.92 kB   |   v0/amp-ad-0.1.js
-362.39 kB   |    37.53 kB   |    13.02 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
-362.11 kB   |    35.66 kB   |    12.44 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
-360.27 kB   |    29.44 kB   |    10.21 kB   |   v0/amp-ad-network-fake-impl-0.1.js
-309.46 kB   |    57.42 kB   |    20.78 kB   |   v0/amp-analytics-0.1.js
- 51.41 kB   |     4.02 kB   |     1.85 kB   |   v0/amp-anim-0.1.js
-142.69 kB   |     4.81 kB   |     2.07 kB   |   v0/amp-apester-media-0.1.js
-181.64 kB   |    11.11 kB   |     4.41 kB   |   v0/amp-app-banner-0.1.js
- 52.64 kB   |     2.33 kB   |     1.15 kB   |   v0/amp-audio-0.1.js
- 36.72 kB   |     2.87 kB   |     1.05 kB   |   v0/amp-brid-player-0.1.js
- 73.56 kB   |     2.75 kB   |     1.22 kB   |   v0/amp-brightcove-0.1.js
-289.13 kB   |    30.18 kB   |     9.37 kB   |   v0/amp-carousel-0.1.js
- 35.17 kB   |     1.78 kB   |       895 B   |   v0/amp-dailymotion-0.1.js
-122.06 kB   |     2.04 kB   |     1.03 kB   |   v0/amp-dynamic-css-classes-0.1.js
-156.09 kB   |     5.49 kB   |      2.4 kB   |   v0/amp-experiment-0.1.js
-178.42 kB   |      9.2 kB   |     4.15 kB   |   v0/amp-facebook-0.1.js
- 43.66 kB   |     3.06 kB   |     1.35 kB   |   v0/amp-fit-text-0.1.js
-137.95 kB   |     4.02 kB   |     1.79 kB   |   v0/amp-font-0.1.js
-211.54 kB   |    14.46 kB   |      5.4 kB   |   v0/amp-form-0.1.js
-159.08 kB   |     3.46 kB   |     1.62 kB   |   v0/amp-fresh-0.1.js
- 53.85 kB   |     4.23 kB   |      1.8 kB   |   v0/amp-fx-flying-carpet-0.1.js
- 34.54 kB   |     1.51 kB   |       765 B   |   v0/amp-gfycat-0.1.js
- 63.31 kB   |     3.75 kB   |      1.7 kB   |   v0/amp-google-vrview-image-0.1.js
-192.85 kB   |    11.07 kB   |     4.56 kB   |   v0/amp-iframe-0.1.js
-271.49 kB   |     28.1 kB   |     9.11 kB   |   v0/amp-image-lightbox-0.1.js
- 61.57 kB   |     2.71 kB   |     1.27 kB   |   v0/amp-instagram-0.1.js
-125.14 kB   |     5.52 kB   |     2.53 kB   |   v0/amp-install-serviceworker-0.1.js
- 35.82 kB   |     2.22 kB   |       942 B   |   v0/amp-jwplayer-0.1.js
- 72.91 kB   |     3.08 kB   |     1.34 kB   |   v0/amp-kaltura-player-0.1.js
-176.53 kB   |     8.26 kB   |     3.13 kB   |   v0/amp-lightbox-0.1.js
-184.59 kB   |    13.53 kB   |     4.49 kB   |   v0/amp-lightbox-viewer-0.1.js
-129.49 kB   |     3.26 kB   |     1.53 kB   |   v0/amp-list-0.1.js
- 188.5 kB   |     9.46 kB   |     3.68 kB   |   v0/amp-live-list-0.1.js
-160.17 kB   |    37.98 kB   |    13.64 kB   |   v0/amp-mustache-0.1.js
- 35.72 kB   |     2.24 kB   |       959 B   |   v0/amp-o2-player-0.1.js
-172.83 kB   |    17.39 kB   |     4.95 kB   |   v0/amp-pinterest-0.1.js
- 34.28 kB   |     1.34 kB   |       676 B   |   v0/amp-reach-player-0.1.js
-129.72 kB   |     3.24 kB   |     1.55 kB   |   v0/amp-share-tracking-0.1.js
-143.49 kB   |      5.5 kB   |     2.12 kB   |   v0/amp-sidebar-0.1.js
- 144.9 kB   |     7.24 kB   |     2.97 kB   |   v0/amp-slides-0.1.js
-154.92 kB   |      9.7 kB   |      3.8 kB   |   v0/amp-social-share-0.1.js
- 35.29 kB   |     1.76 kB   |       844 B   |   v0/amp-soundcloud-0.1.js
- 36.74 kB   |      2.9 kB   |     1.02 kB   |   v0/amp-springboard-player-0.1.js
-144.98 kB   |     4.74 kB   |      1.9 kB   |   v0/amp-sticky-ad-0.1.js
-178.78 kB   |     9.32 kB   |      4.2 kB   |   v0/amp-twitter-0.1.js
-161.43 kB   |     7.99 kB   |     3.18 kB   |   v0/amp-user-notification-0.1.js
- 34.59 kB   |     1.53 kB   |       777 B   |   v0/amp-vimeo-0.1.js
- 34.19 kB   |     1.39 kB   |       728 B   |   v0/amp-vine-0.1.js
-670.75 kB   |   511.34 kB   |   167.46 kB   |   v0/amp-viz-vega-0.1.js
- 160.3 kB   |     4.26 kB   |     1.95 kB   |   v0/amp-youtube-0.1.js
- 19.04 kB   |      1.9 kB   |       908 B   |   v0/cache-service-worker-0.1.js
-229.68 kB   |    50.25 kB   |    17.33 kB   |   current-min/f.js / current/integration.js
+      max   |         min   |         gzip   |   file
+      ---   |         ---   |          ---   |   ---
+ 72.97 kB   |     6.04 kB   |      2.51 kB   |   alp.js / alp.max.js
+906.18 kB   |   181.52 kB   |     56.08 kB   |   shadow-v0.js / amp-shadow.js
+    386 B   |       250 B   |   sw-kill.js
+  1.34 kB   |       762 B   |        sw.js
+942.18 kB   |   180.41 kB   |     55.75 kB   |   v0.js / amp.js
+333.74 kB   |    38.45 kB   |     12.87 kB   |   v0/amp-access-0.1.js
+131.63 kB   |     2.42 kB   |      1.16 kB   |   v0/amp-access-laterpay-0.1.js
+ 56.81 kB   |     3.46 kB   |       1.4 kB   |   v0/amp-accordion-0.1.js
+325.69 kB   |    33.24 kB   |     11.92 kB   |   v0/amp-ad-0.1.js
+362.39 kB   |    37.53 kB   |     13.02 kB   |   v0/amp-ad-network-adsense-impl-0.1.js
+362.11 kB   |    35.66 kB   |     12.44 kB   |   v0/amp-ad-network-doubleclick-impl-0.1.js
+360.27 kB   |    29.44 kB   |     10.21 kB   |   v0/amp-ad-network-fake-impl-0.1.js
+309.46 kB   |    57.42 kB   |     20.78 kB   |   v0/amp-analytics-0.1.js
+ 51.41 kB   |     4.02 kB   |      1.85 kB   |   v0/amp-anim-0.1.js
+142.69 kB   |     4.81 kB   |      2.07 kB   |   v0/amp-apester-media-0.1.js
+181.64 kB   |    11.11 kB   |      4.41 kB   |   v0/amp-app-banner-0.1.js
+ 52.64 kB   |     2.33 kB   |      1.15 kB   |   v0/amp-audio-0.1.js
+ 36.72 kB   |     2.87 kB   |      1.05 kB   |   v0/amp-brid-player-0.1.js
+ 73.56 kB   |     2.75 kB   |      1.22 kB   |   v0/amp-brightcove-0.1.js
+289.13 kB   |    30.18 kB   |      9.37 kB   |   v0/amp-carousel-0.1.js
+ 35.17 kB   |     1.78 kB   |        895 B   |   v0/amp-dailymotion-0.1.js
+122.06 kB   |     2.04 kB   |      1.03 kB   |   v0/amp-dynamic-css-classes-0.1.js
+156.09 kB   |     5.49 kB   |       2.4 kB   |   v0/amp-experiment-0.1.js
+178.42 kB   |      9.2 kB   |      4.15 kB   |   v0/amp-facebook-0.1.js
+ 43.66 kB   |     3.06 kB   |      1.35 kB   |   v0/amp-fit-text-0.1.js
+137.95 kB   |     4.02 kB   |      1.79 kB   |   v0/amp-font-0.1.js
+211.54 kB   |    14.46 kB   |       5.4 kB   |   v0/amp-form-0.1.js
+159.08 kB   |     3.46 kB   |      1.62 kB   |   v0/amp-fresh-0.1.js
+ 53.85 kB   |     4.23 kB   |       1.8 kB   |   v0/amp-fx-flying-carpet-0.1.js
+ 34.54 kB   |     1.51 kB   |        765 B   |   v0/amp-gfycat-0.1.js
+ 63.31 kB   |     3.75 kB   |       1.7 kB   |   v0/amp-google-vrview-image-0.1.js
+192.85 kB   |    11.07 kB   |      4.56 kB   |   v0/amp-iframe-0.1.js
+271.49 kB   |     28.1 kB   |      9.11 kB   |   v0/amp-image-lightbox-0.1.js
+ 61.57 kB   |     2.71 kB   |      1.27 kB   |   v0/amp-instagram-0.1.js
+125.14 kB   |     5.52 kB   |      2.53 kB   |   v0/amp-install-serviceworker-0.1.js
+ 35.82 kB   |     2.22 kB   |        942 B   |   v0/amp-jwplayer-0.1.js
+ 72.91 kB   |     3.08 kB   |      1.34 kB   |   v0/amp-kaltura-player-0.1.js
+176.53 kB   |     8.26 kB   |      3.13 kB   |   v0/amp-lightbox-0.1.js
+184.59 kB   |    13.53 kB   |      4.49 kB   |   v0/amp-lightbox-viewer-0.1.js
+129.49 kB   |     3.26 kB   |      1.53 kB   |   v0/amp-list-0.1.js
+ 188.5 kB   |     9.46 kB   |      3.68 kB   |   v0/amp-live-list-0.1.js
+160.17 kB   |    37.98 kB   |     13.64 kB   |   v0/amp-mustache-0.1.js
+ 35.72 kB   |     2.24 kB   |        959 B   |   v0/amp-o2-player-0.1.js
+172.83 kB   |    17.39 kB   |      4.95 kB   |   v0/amp-pinterest-0.1.js
+ 34.28 kB   |     1.34 kB   |        676 B   |   v0/amp-reach-player-0.1.js
+ 131.3 kB   |     3.43 kB   |      1.65 kB   |   v0/amp-share-tracking-0.1.js
+143.49 kB   |      5.5 kB   |      2.12 kB   |   v0/amp-sidebar-0.1.js
+ 144.9 kB   |     7.24 kB   |      2.97 kB   |   v0/amp-slides-0.1.js
+154.92 kB   |      9.7 kB   |       3.8 kB   |   v0/amp-social-share-0.1.js
+ 35.29 kB   |     1.76 kB   |        844 B   |   v0/amp-soundcloud-0.1.js
+ 36.74 kB   |      2.9 kB   |      1.02 kB   |   v0/amp-springboard-player-0.1.js
+144.98 kB   |     4.74 kB   |       1.9 kB   |   v0/amp-sticky-ad-0.1.js
+178.78 kB   |     9.32 kB   |       4.2 kB   |   v0/amp-twitter-0.1.js
+161.43 kB   |     7.99 kB   |      3.18 kB   |   v0/amp-user-notification-0.1.js
+ 34.59 kB   |     1.53 kB   |        777 B   |   v0/amp-vimeo-0.1.js
+ 34.19 kB   |     1.39 kB   |        728 B   |   v0/amp-vine-0.1.js
+670.75 kB   |   511.34 kB   |    167.46 kB   |   v0/amp-viz-vega-0.1.js
+ 160.3 kB   |     4.26 kB   |      1.95 kB   |   v0/amp-youtube-0.1.js
+229.68 kB   |     48.7 kB   |     16.82 kB   |   current-min/f.js / current/integration.js


### PR DESCRIPTION
- they are pretty complex (relying on a symbol polyfill).
- we actually had specific polyfills we need included ourselves duplicating the bytes.

Aspect of #5792