### PR TITLE
Standardize on rethrowAsync with an error instance

### DIFF
--- a/build-system/runner/src/org/ampproject/AmpCodingConvention.java
+++ b/build-system/runner/src/org/ampproject/AmpCodingConvention.java
@@ -48,6 +48,7 @@ public final class AmpCodingConvention extends CodingConventions.Proxy {
         new AssertionFunctionSpec("dev.assert", JSType.TRUTHY),
         new AssertionFunctionSpec("Log$$module$src$log.prototype.assert", JSType.TRUTHY),
         new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertElement", "Element"),
+        new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertError", "Error"),
         new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertString", "string"),
         new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertNumber", "number")
     );

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -49,7 +49,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
    */
   ImmutableMap<String, Set<String>> suffixTypes = ImmutableMap.of(
       "module$src$log.dev", ImmutableSet.of(
-          "assert", "fine", "assertElement", "assertString",
+          "assert", "fine", "assertElement", "assertError", "assertString",
           "assertNumber", "assertBoolean"),
       "module$src$log.user", ImmutableSet.of("fine"));
 

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -20,7 +20,7 @@ public class AmpPassTest extends Es6CompilerTestCase {
 
   ImmutableMap<String, Set<String>> suffixTypes = ImmutableMap.of(
       "module$src$log.dev",
-          ImmutableSet.of("assert", "fine", "assertElement", "assertString", "assertNumber"),
+          ImmutableSet.of("assert", "fine", "assertElement", "assertError", "assertString", "assertNumber"),
       "module$src$log.user", ImmutableSet.of("fine"));
 
   ImmutableMap<String, Node> assignmentReplacements = ImmutableMap.of(

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -396,7 +396,7 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
         .then(response => this.parseManifest_(response))
         .catch(error => {
           this.hide_();
-          rethrowAsync(error);
+          rethrowAsync(dev().assertError(error));
         });
   }
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -209,7 +209,7 @@ export class AmpForm {
         this.actions_.trigger(this.form_, 'submit-error', null);
         this.setState_(FormState_.SUBMIT_ERROR);
         this.renderTemplate_(error.responseJson || {});
-        rethrowAsync('Form submission failed:', error);
+        rethrowAsync(user().createError('Form submission failed:', error));
       });
     } else if (this.method_ == 'POST') {
       e.preventDefault();

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -894,7 +894,7 @@ function createBaseCustomElementClass(win) {
         // It's a promise: wait until it's done.
         res.then(impl => this.completeUpgrade_(impl)).catch(reason => {
           this.upgradeState_ = UpgradeState.UPGRADE_FAILED;
-          rethrowAsync(reason);
+          rethrowAsync(dev().assertError(reason));
         });
       } else {
         // It's an actual instance: upgrade immediately.
@@ -1219,8 +1219,8 @@ function createBaseCustomElementClass(win) {
       try {
         this.implementation_.executeAction(invocation, deferred);
       } catch (e) {
-        rethrowAsync('Action execution failed:', e,
-          invocation.target.tagName, invocation.method);
+        rethrowAsync(dev().createError('Action execution failed:', e,
+          invocation.target.tagName, invocation.method));
       }
     }
 

--- a/src/log.js
+++ b/src/log.js
@@ -220,7 +220,6 @@ export class Log {
    * @return {T} The value of shouldBeTrueish.
    * @template T
    */
-  /*eslint "google-camelcase/google-camelcase": 0*/
   assert(shouldBeTrueish, opt_message, var_args) {
     let firstElement;
     if (!shouldBeTrueish) {
@@ -258,14 +257,28 @@ export class Log {
    * @param {*} shouldBeElement
    * @param {string=} opt_message The assertion message
    * @return {!Element} The value of shouldBeTrueish.
-   * @template T
    */
-  /*eslint "google-camelcase/google-camelcase": 2*/
   assertElement(shouldBeElement, opt_message) {
     const shouldBeTrueish = shouldBeElement && shouldBeElement.nodeType == 1;
     this.assert(shouldBeTrueish, (opt_message || 'Element expected') + ': %s',
         shouldBeElement);
     return /** @type {!Element} */ (shouldBeElement);
+  }
+
+  /**
+   * Throws an error if the first argument isn't an Error
+   *
+   * Otherwise see `assert` for usage
+   *
+   * @param {*} shouldBeError
+   * @param {string=} opt_message The assertion message
+   * @return {!Error} The value of shouldBeTrueish.
+   */
+  assertError(shouldBeError, opt_message) {
+    const shouldBeTrueish = shouldBeError && shouldBeError instanceof Error;
+    this.assert(shouldBeTrueish, (opt_message || 'Error instance expected') +
+        ': %s', shouldBeElement);
+    return /** @type {!Error} */ (shouldBeError);
   }
 
   /**
@@ -276,9 +289,7 @@ export class Log {
    * @param {*} shouldBeString
    * @param {string=} opt_message The assertion message
    * @return {string} The value of shouldBeTrueish.
-   * @template T
    */
-  /*eslint "google-camelcase/google-camelcase": 2*/
   assertString(shouldBeString, opt_message) {
     this.assert(typeof shouldBeString == 'string',
         (opt_message || 'String expected') + ': %s', shouldBeString);
@@ -310,7 +321,6 @@ export class Log {
    * @return T
    * @template T
    */
-  /*eslint "google-camelcase/google-camelcase": 2*/
   assertEnumValue(enumObj, s, opt_enumName) {
     for (const k in enumObj) {
       if (enumObj[k] == s) {

--- a/src/log.js
+++ b/src/log.js
@@ -277,7 +277,7 @@ export class Log {
   assertError(shouldBeError, opt_message) {
     const shouldBeTrueish = shouldBeError && shouldBeError instanceof Error;
     this.assert(shouldBeTrueish, (opt_message || 'Error instance expected') +
-        ': %s', shouldBeElement);
+        ': %s', shouldBeError);
     return /** @type {!Error} */ (shouldBeError);
   }
 
@@ -402,10 +402,9 @@ function createErrorVargs(var_args) {
 /**
  * Rethrows the error without terminating the current context. This preserves
  * whether the original error designation is a user error or a dev error.
- * @param {...*} var_args
+ * @param {!Error} error
  */
-export function rethrowAsync(var_args) {
-  const error = createErrorVargs.apply(null, arguments);
+export function rethrowAsync(error) {
   setTimeout(() => {throw error;});
 }
 

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -314,14 +314,16 @@ export class Extensions {
           try {
             factory(/** @type {!ShadowRoot} */ (ampdoc.getRootNode()));
           } catch (e) {
-            rethrowAsync('ShadowRoot factory failed: ', e, extensionId);
+            rethrowAsync(dev().createError('ShadowRoot factory failed: ',
+                e, extensionId));
           }
         });
         holder.docFactories.forEach(factory => {
           try {
             factory(ampdoc);
           } catch (e) {
-            rethrowAsync('Doc factory failed: ', e, extensionId);
+            rethrowAsync(dev().createError('Doc factory failed: ', e,
+                extensionId));
           }
         });
       }));
@@ -346,7 +348,8 @@ export class Extensions {
           try {
             factory(/** @type {!ShadowRoot} */ (shadowRoot));
           } catch (e) {
-            rethrowAsync('ShadowRoot factory failed: ', e, extensionId);
+            rethrowAsync(dev().createError('ShadowRoot factory failed: ', e,
+                extensionId));
           }
         });
       }));

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -497,13 +497,6 @@ describe('Logging', () => {
       clock = sandbox.useFakeTimers();
     });
 
-    it('should rethrow error with single message', () => {
-      rethrowAsync('intended');
-      expect(() => {
-        clock.tick(1);
-      }).to.throw(Error, /^intended$/);
-    });
-
     it('should rethrow a single error', () => {
       const orig = new Error('intended');
       rethrowAsync(orig);
@@ -515,30 +508,6 @@ describe('Logging', () => {
       }
       expect(error).to.equal(orig);
       expect(error.message).to.equal('intended');
-    });
-
-    it('should rethrow error with many messages', () => {
-      rethrowAsync('first', 'second', 'third');
-      let error;
-      try {
-        clock.tick(1);
-      } catch (e) {
-        error = e;
-      }
-      expect(error.message).to.equal('first second third');
-    });
-
-    it('should rethrow error with original error and messages', () => {
-      const orig = new Error('intended');
-      rethrowAsync('first', orig, 'second', 'third');
-      let error;
-      try {
-        clock.tick(1);
-      } catch (e) {
-        error = e;
-      }
-      expect(error).to.equal(orig);
-      expect(error.message).to.equal('first second third: intended');
     });
 
     it('should preserve error suffix', () => {

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -513,7 +513,7 @@ describe('Logging', () => {
     it('should preserve error suffix', () => {
       const orig = user().createError('intended');
       expect(isUserErrorMessage(orig.message)).to.be.true;
-      rethrowAsync('first', orig, 'second');
+      rethrowAsync(orig);
       let error;
       try {
         clock.tick(1);


### PR DESCRIPTION
I want to move us away from using helpers to create errors, so that the stack is always correct.

Need @erwinmombay to recompile our closure jar.