### PR TITLE
Always always always throw/reject with an Error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -92,6 +92,7 @@
     "prefer-const": 2,
     "quotes": [2, "single", "avoid-escape"],
     "radix": 2,
+    "reject-with-error": 2,
     "semi": 2,
     "space-after-keywords": 2,
     "space-before-blocks": 2,

--- a/build-system/eslint-rules/reject-with-error.js
+++ b/build-system/eslint-rules/reject-with-error.js
@@ -1,0 +1,219 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var astUtils = require('eslint/lib/ast-utils');
+
+function leadingCommentMatches(leadingComments, regex) {
+  if (!leadingComments) {
+    return false;
+  }
+
+  return leadingComments.some(function(comment) {
+    return regex.test(comment.value);
+  });
+}
+
+function isLogCreateErrorCall(node) {
+  if (node.type != 'CallExpression') {
+    return false;
+  }
+
+  var call = node.callee;
+  return call.type == 'MemberExpression' &&
+      call.object.type === 'CallExpression' &&
+      /(user|dev)/.test(call.object.callee.name) &&
+      call.property.name === 'createError';
+}
+
+function isLogAssertErrorCall(node) {
+  if (node.type != 'CallExpression') {
+    return false;
+  }
+
+  var call = node.callee;
+  return call.type == 'MemberExpression' &&
+      call.object.type === 'CallExpression' &&
+      /(user|dev)/.test(call.object.callee.name) &&
+      call.property.name === 'assertError';
+}
+
+function isCancellationCall(node, context) {
+  if (node.type != 'CallExpression') {
+    return false;
+  }
+
+  var call = node.callee;
+  if (call.name !== 'cancellation') {
+    return false;
+  }
+
+  var variable = astUtils.getVariableByName(context.getScope(), call.name);
+  if (!variable || variable.defs.length != 1) {
+    return false;
+  }
+
+  var def = variable.defs[0];
+  if (def.type == 'ImportBinding' && /\/error$/.test(def.node.parent.source.value)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isPromiseOnRejected(node) {
+  var parent = node.parent;
+  if (parent.type != 'CallExpression') {
+    return false;
+  }
+
+  var call = parent.callee;
+  if (call.type != 'MemberExpression') {
+    return false;
+  }
+
+  // promise.then(() => {}, e => {... throw e; });
+  if (call.property.name == 'then' && parent.arguments[1] == node) {
+    return true;
+  }
+
+  // promise.catch(e => {... throw e; });
+  if (call.property.name == 'catch') {
+    return true;
+  }
+
+  return false;
+}
+
+function parameterIsExplicitlyError(param) {
+  var func = param.parent;
+  var regex = new RegExp('@param {!(Type)?Error} ' + param.name);
+  return leadingCommentMatches(func.leadingComments, regex) ||
+      leadingCommentMatches(func.parent.leadingComments, regex);
+}
+
+function isError(node, context) {
+  return isNewError(node) || // throw new Error()
+      isLogCreateErrorCall(node) || // throw user().createError()
+      isLogAssertErrorCall(node) || // throw dev().assertError()
+      isCancellationCall(node, context); // throw cancellation()
+}
+
+function variableIsError(variable, context) {
+  var declaration = variable.parent;
+  if (declaration.kind != 'const') {
+    return false;
+  }
+
+  var init = variable.init;
+  return !!init && isError(init, context);
+}
+
+function isNewError(node) {
+  return node.type == 'NewExpression' && /(Type)?Error/.test(node.callee.name);
+}
+
+module.exports = function(context) {
+
+  function isErrorThrown(node, message) {
+    var argument = node.argument;
+    // throw new Error('...')
+    if (isNewError(node.argument)) {
+      return;
+    }
+
+    if (argument.type == 'CallExpression') {
+      // throw user().createError(...)
+      if (isError(argument, context)) {
+        return;
+      }
+
+      return context.report(node, 'Unable to determine the return type. Please ' + message + ' an error.');
+    }
+
+    if (argument.type != 'Identifier' || argument.name == 'undefined') {
+      return context.report(node, 'MUST ' + message + ' an Error instance!');
+    }
+
+    var variable = astUtils.getVariableByName(context.getScope(), argument.name);
+    if (!variable || variable.defs.length != 1) {
+      return context.report(node, 'Unable to determine type. Please ' + message + ' an error.');
+    }
+
+    var def = variable.defs[0];
+
+    if (def.type == 'CatchClause') {
+      return;
+    }
+
+    if (def.type === 'Parameter') {
+      // promise.then(() => {}, e => {... throw e; });
+      // promise.catch(e => {... throw e; });
+      if (isPromiseOnRejected(def.node)) {
+        return;
+      }
+
+      // Function with explicit type parameter
+      if (parameterIsExplicitlyError(def.name)) {
+        return;
+      }
+
+      return context.report(node, 'Unable to determine parameter type. Please ' + message + ' an error.');
+    } else if (def.type === 'Variable') {
+      if (variableIsError(def.node, context)) {
+        return;
+      }
+      variableIsError(def.node, context);
+
+      return context.report(node, 'Unable to determine variable type. Please ' + message + ' an error.');
+    }
+
+    return context.report(node, 'Unable to determine type. Please ' + message + ' an error.');
+  }
+
+  return {
+    ThrowStatement: function(node) {
+      if (/test-/.test(context.getFilename())) {
+        return;
+      }
+
+      isErrorThrown({
+        argument: node.argument,
+        loc: node.loc,
+      }, 'throw');
+    },
+
+    CallExpression: function(node) {
+      if (/test-/.test(context.getFilename())) {
+        return;
+      }
+
+      var call = node.callee;
+      if (!(call.name == 'reject' ||
+          (call.type == 'MemberExpression' && /[Rr]eject/.test(call.property.name)))) {
+        return;
+      }
+
+      if (node.arguments.length != 1) {
+        return context.report(node, 'MUST reject with an error.')
+      }
+
+      isErrorThrown({
+        argument: node.arguments[0],
+        loc: node.loc,
+      }, 'reject');
+    }
+  };
+};

--- a/build-system/runner/src/org/ampproject/AmpCodingConvention.java
+++ b/build-system/runner/src/org/ampproject/AmpCodingConvention.java
@@ -48,6 +48,7 @@ public final class AmpCodingConvention extends CodingConventions.Proxy {
         new AssertionFunctionSpec("dev.assert", JSType.TRUTHY),
         new AssertionFunctionSpec("Log$$module$src$log.prototype.assert", JSType.TRUTHY),
         new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertElement", "Element"),
+        new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertError", "Error"),
         new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertString", "string"),
         new AssertFunctionByTypeName("Log$$module$src$log.prototype.assertNumber", "number")
     );

--- a/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
+++ b/build-system/runner/src/org/ampproject/AmpCommandLineRunner.java
@@ -49,7 +49,7 @@ public class AmpCommandLineRunner extends CommandLineRunner {
    */
   ImmutableMap<String, Set<String>> suffixTypes = ImmutableMap.of(
       "module$src$log.dev", ImmutableSet.of(
-          "assert", "fine", "assertElement", "assertString",
+          "assert", "fine", "assertElement", "assertError", "assertString",
           "assertNumber", "assertBoolean"),
       "module$src$log.user", ImmutableSet.of("fine"));
 

--- a/build-system/runner/test/org/ampproject/AmpPassTest.java
+++ b/build-system/runner/test/org/ampproject/AmpPassTest.java
@@ -20,7 +20,7 @@ public class AmpPassTest extends Es6CompilerTestCase {
 
   ImmutableMap<String, Set<String>> suffixTypes = ImmutableMap.of(
       "module$src$log.dev",
-          ImmutableSet.of("assert", "fine", "assertElement", "assertString", "assertNumber"),
+          ImmutableSet.of("assert", "fine", "assertElement", "assertError", "assertString", "assertNumber"),
       "module$src$log.user", ImmutableSet.of("fine"));
 
   ImmutableMap<String, Node> assignmentReplacements = ImmutableMap.of(

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -398,7 +398,7 @@ export class AmpA4A extends AMP.BaseElement {
                 // Resolve Promise into signing key.
                 return keyInfoPromise.then(keyInfo => {
                   if (!keyInfo) {
-                    return Promise.reject('Promise resolved to null key.');
+                    throw new Error('Promise resolved to null key.');
                   }
                   // If the key exists, try verifying with it.
                   return verifySignature(
@@ -409,11 +409,11 @@ export class AmpA4A extends AMP.BaseElement {
                         if (isValid) {
                           return creativeParts.creative;
                         }
-                        return Promise.reject(
-                            'Key failed to validate creative\'s signature.');
+                        throw new Error("Key failed to validate creative's " +
+                            'signature.');
                       },
                       err => {
-                        user().error('Amp Ad', err, this.element);
+                        throw user().createError('Amp Ad', err, this.element);
                       });
                 });
               }))
@@ -444,7 +444,6 @@ export class AmpA4A extends AMP.BaseElement {
   /**
    * Handles uncaught errors within promise flow.
    * @param {*} error
-   * @return {*}
    * @private
    */
   promiseErrorHandler_(error) {
@@ -455,7 +454,7 @@ export class AmpA4A extends AMP.BaseElement {
       }
       if (error.message == cancellation().message) {
         // Rethrow if cancellation
-        throw error;
+        throw dev().assertError(error);
       }
     }
     // Returning promise reject should trigger unhandledrejection which will
@@ -468,7 +467,7 @@ export class AmpA4A extends AMP.BaseElement {
       'au': adQueryIdx < 0 ? '' :
           this.adUrl_.substring(adQueryIdx + 1, adQueryIdx + 251),
     };
-    return new Error('amp-a4a: ' + JSON.stringify(state));
+    throw new Error('amp-a4a: ' + JSON.stringify(state));
   }
 
   /** @override */
@@ -501,9 +500,9 @@ export class AmpA4A extends AMP.BaseElement {
         }
       }
       if (rendered instanceof Error) {
-        throw rendered;
+        throw dev().assertError(rendered);
       }
-    }).catch(error => Promise.reject(this.promiseErrorHandler_(error)));
+    }).catch(error => this.promiseErrorHandler_(error));
   }
 
   /** @override  */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -450,7 +450,7 @@ export class AmpA4A extends AMP.BaseElement {
     if (error && error.message) {
       if (error.message.indexOf('amp-a4a: ') == 0) {
         // caught previous call to promiseErrorHandler?  Infinite loop?
-        return error;
+        throw error;
       }
       if (error.message == cancellation().message) {
         // Rethrow if cancellation

--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -267,7 +267,7 @@ export class WebLoginDialog {
     }
     dev().fine(TAG, 'Login done: ', result, opt_error);
     if (opt_error) {
-      this.reject_(opt_error);
+      this.reject_(user().createError('login failed', opt_error));
     } else {
       this.resolve_(result);
     }

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -396,7 +396,7 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
         .then(response => this.parseManifest_(response))
         .catch(error => {
           this.hide_();
-          rethrowAsync(error);
+          rethrowAsync(dev().assertError(error));
         });
   }
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -209,7 +209,7 @@ export class AmpForm {
         this.actions_.trigger(this.form_, 'submit-error', null);
         this.setState_(FormState_.SUBMIT_ERROR);
         this.renderTemplate_(error.responseJson || {});
-        rethrowAsync('Form submission failed:', error);
+        rethrowAsync(user().createError('Form submission failed:', error));
       });
     } else if (this.method_ == 'POST') {
       e.preventDefault();

--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -237,7 +237,7 @@ export class AbstractCustomValidator extends FormValidator {
    * @return {boolean}
    */
   shouldValidateOnInteraction(unusedInput) {
-    throw Error('Not Implemented');
+    throw new Error('Not Implemented');
   }
 
   /**

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -193,7 +193,7 @@ export class AmpVizVega extends AMP.BaseElement {
     const parsePromise = new Promise((resolve, reject) => {
       this.vega_.parse.spec(this.data_, (error, chartFactory) => {
         if (error) {
-          reject(dev().createError('parsing failed', error));
+          reject(user().createError('parsing failed', error));
         }
         resolve(chartFactory);
       });

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -193,7 +193,7 @@ export class AmpVizVega extends AMP.BaseElement {
     const parsePromise = new Promise((resolve, reject) => {
       this.vega_.parse.spec(this.data_, (error, chartFactory) => {
         if (error) {
-          reject(error);
+          reject(dev().createError('parsing failed', error));
         }
         resolve(chartFactory);
       });

--- a/src/animation.js
+++ b/src/animation.js
@@ -207,9 +207,6 @@ class AnimationPlayer {
    * @return {!Promise}
    */
   then(opt_resolve, opt_reject) {
-    if (!opt_resolve && !opt_reject) {
-      return this.promise_;
-    }
     return this.promise_.then(opt_resolve, opt_reject);
   }
 
@@ -234,7 +231,7 @@ class AnimationPlayer {
    * @param {number=} opt_dir
    */
   halt(opt_dir) {
-    this.complete_(/* success */ false, /* dir */ opt_dir || 0);
+    this.complete_(new Error('animation halted'), /* dir */ opt_dir || 0);
   }
 
   /**
@@ -247,16 +244,16 @@ class AnimationPlayer {
       this.task_(this.state_);
     } else {
       dev().warn(TAG_, 'cannot animate');
-      this.complete_(/* success */ false, /* dir */ 0);
+      this.complete_(new Error('cannot animate'), /* dir */ 0);
     }
   }
 
   /**
-   * @param {boolean} success
+   * @param {?Error} error the failure reason
    * @param {number} dir
    * @private
    */
-  complete_(success, dir) {
+  complete_(error, dir) {
     if (!this.running_) {
       return;
     }
@@ -281,16 +278,18 @@ class AnimationPlayer {
           }
         }
       } catch (e) {
-        dev().error(TAG_, 'completion failed: ' + e, e);
-        success = false;
+        error = dev().createError('completion failed', e);
+        dev().error(TAG_, error);
       }
     }
-    if (success) {
-      this.resolve_();
+    if (error) {
+      this.reject_(dev().assertError(error));
     } else {
-      this.reject_();
+      this.resolve_();
     }
   }
+
+
 
   /**
    * @param {!Object<string, *>} unusedState
@@ -323,13 +322,13 @@ class AnimationPlayer {
 
     // Complete or start next cycle.
     if (normLinearTime == 1) {
-      this.complete_(/* success */ true, /* dir */ 0);
+      this.complete_(null, /* dir */ 0);
     } else {
       if (this.vsync_.canAnimate(this.contextNode_)) {
         this.task_(this.state_);
       } else {
         dev().warn(TAG_, 'cancel animation');
-        this.complete_(/* success */ false, /* dir */ 0);
+        this.complete_(new Error('cancel animation'), /* dir */ 0);
       }
     }
   }
@@ -349,8 +348,9 @@ class AnimationPlayer {
         try {
           normTime = segment.curve(normLinearTime);
         } catch (e) {
-          dev().error(TAG_, 'step curve failed: ' + e, e);
-          this.complete_(/* success */ false, /* dir */ 0);
+          const error = dev().createError('step curve failed', e);
+          dev().error(TAG_, error);
+          this.complete_(error, /* dir */ 0);
           return;
         }
       }
@@ -364,8 +364,9 @@ class AnimationPlayer {
     try {
       segment.func(normTime, segment.completed);
     } catch (e) {
-      dev().error(TAG_, 'step mutate failed: ' + e, e);
-      this.complete_(/* success */ false, /* dir */ 0);
+      const error = dev().createError('step mutate failed', e);
+      dev().error(TAG_, error);
+      this.complete_(error, /* dir */ 0);
       return;
     }
   }

--- a/src/animation.js
+++ b/src/animation.js
@@ -184,7 +184,7 @@ class AnimationPlayer {
     /** @const {function()} */
     this.resolve_;
 
-    /** @const {function()} */
+    /** @const {function(!Error)} */
     this.reject_;
 
     /** @private {!Promise} */

--- a/src/animation.js
+++ b/src/animation.js
@@ -15,7 +15,8 @@
  */
 
 import {getCurve} from './curve';
-import {dev} from './log';
+import {dev, rethrowAsync} from './log';
+import {cancellation} from './error';
 import {vsyncFor} from './vsync';
 
 const TAG_ = 'Animation';
@@ -278,8 +279,7 @@ class AnimationPlayer {
           }
         }
       } catch (e) {
-        error = dev().createError('completion failed', e);
-        dev().error(TAG_, error);
+        rethrowAsync(dev().createError('completion failed', e));
       }
     }
     if (error) {
@@ -328,7 +328,7 @@ class AnimationPlayer {
         this.task_(this.state_);
       } else {
         dev().warn(TAG_, 'cancel animation');
-        this.complete_(new Error('cancel animation'), /* dir */ 0);
+        this.complete_(cancellation(), /* dir */ 0);
       }
     }
   }

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -71,18 +71,18 @@ export function activateChunkingForTesting() {
  */
 export function runChunksForTesting(nodeOrAmpDoc) {
   const service = fromClassForDoc(nodeOrAmpDoc, 'chunk', Chunks);
-  const errors = [];
-  while (true) {
-    try {
-      if (!service.execute_()) {
-        break;
-      }
-    } catch (e) {
-      errors.push(e);
+  runChunks(service);
+}
+
+function runChunks(service) {
+  try {
+    while (service.execute_()) {
+      // noop.
     }
-  }
-  if (errors.length) {
-    throw errors[0];
+  } catch (e) {
+    // Can you feel the recursion!
+    runChunks(service);
+    throw e;
   }
 }
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -894,7 +894,7 @@ function createBaseCustomElementClass(win) {
         // It's a promise: wait until it's done.
         res.then(impl => this.completeUpgrade_(impl)).catch(reason => {
           this.upgradeState_ = UpgradeState.UPGRADE_FAILED;
-          rethrowAsync(reason);
+          rethrowAsync(dev().assertError(reason));
         });
       } else {
         // It's an actual instance: upgrade immediately.
@@ -1219,8 +1219,8 @@ function createBaseCustomElementClass(win) {
       try {
         this.implementation_.executeAction(invocation, deferred);
       } catch (e) {
-        rethrowAsync('Action execution failed:', e,
-          invocation.target.tagName, invocation.method);
+        rethrowAsync(dev().createError('Action execution failed:', e,
+          invocation.target.tagName, invocation.method));
       }
     }
 

--- a/src/log.js
+++ b/src/log.js
@@ -186,7 +186,7 @@ export class Log {
       const error = createErrorVargs.apply(null,
           Array.prototype.slice.call(arguments, 1));
       this.prepareError_(error);
-      this.win.setTimeout(() => {throw error;});
+      rethrowAsync(error);
     }
   }
 

--- a/src/log.js
+++ b/src/log.js
@@ -220,7 +220,6 @@ export class Log {
    * @return {T} The value of shouldBeTrueish.
    * @template T
    */
-  /*eslint "google-camelcase/google-camelcase": 0*/
   assert(shouldBeTrueish, opt_message, var_args) {
     let firstElement;
     if (!shouldBeTrueish) {
@@ -258,14 +257,28 @@ export class Log {
    * @param {*} shouldBeElement
    * @param {string=} opt_message The assertion message
    * @return {!Element} The value of shouldBeTrueish.
-   * @template T
    */
-  /*eslint "google-camelcase/google-camelcase": 2*/
   assertElement(shouldBeElement, opt_message) {
     const shouldBeTrueish = shouldBeElement && shouldBeElement.nodeType == 1;
     this.assert(shouldBeTrueish, (opt_message || 'Element expected') + ': %s',
         shouldBeElement);
     return /** @type {!Element} */ (shouldBeElement);
+  }
+
+  /**
+   * Throws an error if the first argument isn't an Error
+   *
+   * Otherwise see `assert` for usage
+   *
+   * @param {*} shouldBeError
+   * @param {string=} opt_message The assertion message
+   * @return {!Error} The value of shouldBeTrueish.
+   */
+  assertError(shouldBeError, opt_message) {
+    const shouldBeTrueish = shouldBeError && shouldBeError instanceof Error;
+    this.assert(shouldBeTrueish, (opt_message || 'Error instance expected') +
+        ': %s', shouldBeElement);
+    return /** @type {!Error} */ (shouldBeError);
   }
 
   /**
@@ -276,9 +289,7 @@ export class Log {
    * @param {*} shouldBeString
    * @param {string=} opt_message The assertion message
    * @return {string} The value of shouldBeTrueish.
-   * @template T
    */
-  /*eslint "google-camelcase/google-camelcase": 2*/
   assertString(shouldBeString, opt_message) {
     this.assert(typeof shouldBeString == 'string',
         (opt_message || 'String expected') + ': %s', shouldBeString);
@@ -310,7 +321,6 @@ export class Log {
    * @return T
    * @template T
    */
-  /*eslint "google-camelcase/google-camelcase": 2*/
   assertEnumValue(enumObj, s, opt_enumName) {
     for (const k in enumObj) {
       if (enumObj[k] == s) {

--- a/src/log.js
+++ b/src/log.js
@@ -277,7 +277,7 @@ export class Log {
   assertError(shouldBeError, opt_message) {
     const shouldBeTrueish = shouldBeError && shouldBeError instanceof Error;
     this.assert(shouldBeTrueish, (opt_message || 'Error instance expected') +
-        ': %s', shouldBeElement);
+        ': %s', shouldBeError);
     return /** @type {!Error} */ (shouldBeError);
   }
 
@@ -402,10 +402,9 @@ function createErrorVargs(var_args) {
 /**
  * Rethrows the error without terminating the current context. This preserves
  * whether the original error designation is a user error or a dev error.
- * @param {...*} var_args
+ * @param {!Error} error
  */
-export function rethrowAsync(var_args) {
-  const error = createErrorVargs.apply(null, arguments);
+export function rethrowAsync(error) {
   setTimeout(() => {throw error;});
 }
 

--- a/src/motion.js
+++ b/src/motion.js
@@ -16,6 +16,7 @@
 
 import {vsyncFor} from './vsync';
 import {dev} from './log';
+import {cancellation} from './error';
 
 /** @const {function()} */
 const NOOP_CALLBACK_ = function() {};
@@ -175,7 +176,7 @@ export class Motion {
    */
   halt() {
     if (this.continuing_) {
-      this.completeContinue_(new Error('halting motion'));
+      this.completeContinue_(cancellation());
     }
   }
 

--- a/src/motion.js
+++ b/src/motion.js
@@ -140,10 +140,10 @@ export class Motion {
     /** @private {time} */
     this.lastTime_ = this.startTime_;
 
-    /** @private {!Function} */
+    /** @private {function()} */
     this.resolve_;
 
-    /** @private {!Function} */
+    /** @private {function(!Error)} */
     this.reject_;
 
     /** @private {!Promise} */

--- a/src/motion.js
+++ b/src/motion.js
@@ -15,6 +15,7 @@
  */
 
 import {vsyncFor} from './vsync';
+import {dev} from './log';
 
 /** @const {function()} */
 const NOOP_CALLBACK_ = function() {};
@@ -161,7 +162,7 @@ export class Motion {
     if (Math.abs(this.maxVelocityX_) <= MIN_VELOCITY_ &&
             Math.abs(this.maxVelocityY_) <= MIN_VELOCITY_) {
       this.fireMove_();
-      this.completeContinue_(true);
+      this.completeContinue_(null);
     } else {
       this.runContinuing_();
     }
@@ -174,19 +175,17 @@ export class Motion {
    */
   halt() {
     if (this.continuing_) {
-      this.completeContinue_(false);
+      this.completeContinue_(new Error('halting motion'));
     }
   }
 
   /**
    * Chains to the motion's promise that will resolve when the motion has
    * completed or will reject if motion has failed or was interrupted.
+   * @return {!Promise}
    * @override
    */
   then(opt_resolve, opt_reject) {
-    if (!opt_resolve && !opt_reject) {
-      return this.promise_;
-    }
     return this.promise_.then(opt_resolve, opt_reject);
   }
 
@@ -197,7 +196,7 @@ export class Motion {
    */
   thenAlways(opt_callback) {
     const callback = opt_callback || NOOP_CALLBACK_;
-    return /** @type {!Promise} */ (this.then(callback, callback));
+    return this.then(callback, callback);
   }
 
   /**
@@ -208,7 +207,7 @@ export class Motion {
     this.velocityX_ = this.maxVelocityX_;
     this.velocityY_ = this.maxVelocityY_;
     const boundStep = this.stepContinue_.bind(this);
-    const boundComplete = this.completeContinue_.bind(this, true);
+    const boundComplete = this.completeContinue_.bind(this, null);
     return this.vsync_.runAnimMutateSeries(this.contextNode_, boundStep, 5000)
         .then(boundComplete, boundComplete);
   }
@@ -240,20 +239,20 @@ export class Motion {
   }
 
   /**
-   * @param {boolean} success
+   * @param {?Error} error the failure reason
    * @private
    */
-  completeContinue_(success) {
+  completeContinue_(error) {
     if (!this.continuing_) {
       return;
     }
     this.continuing_ = false;
     this.lastTime_ = Date.now();
     this.fireMove_();
-    if (success) {
-      this.resolve_();
+    if (error) {
+      this.reject_(dev().assertError(error));
     } else {
-      this.reject_();
+      this.resolve_();
     }
   }
 

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -453,7 +453,7 @@ export class Extensions {
       if (holder.loaded) {
         holder.promise = Promise.resolve(holder.extension);
       } else if (holder.error) {
-        holder.promise = Promise.reject(holder.error);
+        holder.promise = Promise.reject(dev().assertError(holder.error));
       } else {
         holder.promise = new Promise((resolve, reject) => {
           holder.resolve = resolve;

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -314,14 +314,16 @@ export class Extensions {
           try {
             factory(/** @type {!ShadowRoot} */ (ampdoc.getRootNode()));
           } catch (e) {
-            rethrowAsync('ShadowRoot factory failed: ', e, extensionId);
+            rethrowAsync(dev().createError('ShadowRoot factory failed: ',
+                e, extensionId));
           }
         });
         holder.docFactories.forEach(factory => {
           try {
             factory(ampdoc);
           } catch (e) {
-            rethrowAsync('Doc factory failed: ', e, extensionId);
+            rethrowAsync(dev().createError('Doc factory failed: ', e,
+                extensionId));
           }
         });
       }));
@@ -346,7 +348,8 @@ export class Extensions {
           try {
             factory(/** @type {!ShadowRoot} */ (shadowRoot));
           } catch (e) {
-            rethrowAsync('ShadowRoot factory failed: ', e, extensionId);
+            rethrowAsync(dev().createError('ShadowRoot factory failed: ', e,
+                extensionId));
           }
         });
       }));

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -544,7 +544,7 @@ export class Resource {
       return Promise.resolve();
     }
     if (this.state_ == ResourceState.LAYOUT_FAILED) {
-      return Promise.reject('already failed');
+      return Promise.reject(new Error('layout already failed'));
     }
 
     dev().assert(this.state_ != ResourceState.NOT_BUILT,
@@ -614,7 +614,7 @@ export class Resource {
       dev().fine(TAG, 'layout complete:', this.debugid);
     } else {
       dev().fine(TAG, 'loading failed:', this.debugid, opt_reason);
-      return Promise.reject(opt_reason);
+      return Promise.reject(dev().createError('loading failed', opt_reason));
     }
   }
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1281,7 +1281,7 @@ export class Resources {
     if (!success) {
       dev().info(TAG_, 'task failed:',
           task.id, task.resource.debugid, opt_reason);
-      return Promise.reject(opt_reason);
+      return Promise.reject(dev().createError('task failed', opt_reason));
     }
   }
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -282,9 +282,8 @@ export class Viewer {
             20000,
             new Promise(resolve => {
               this.messagingReadyResolver_ = resolve;
-            })).catch(reason => {
-              throw getChannelError(/** @type {!Error|string|undefined} */ (
-                  reason));
+            })).catch(() => {
+              throw new Error('Timed out waiting for messaging channel');
             }) : null;
 
     /**
@@ -298,8 +297,7 @@ export class Viewer {
         this.messagingReadyPromise_
             .catch(reason => {
               // Don't fail promise, but still report.
-              reportError(getChannelError(
-                  /** @type {!Error|string|undefined} */ (reason)));
+              reportError(reason);
             }) : null;
 
     // Trusted viewer and referrer.
@@ -1035,7 +1033,7 @@ export class Viewer {
    */
   sendMessage(eventType, data, awaitResponse) {
     if (!this.messagingReadyPromise_) {
-      return Promise.reject(getChannelError());
+      return Promise.reject(new Error('No messaging channel'));
     }
     return this.messagingReadyPromise_.then(() => {
       return this.sendMessageUnreliable_(eventType, data, awaitResponse);
@@ -1143,19 +1141,6 @@ function parseParams_(str, allParams) {
   }
 }
 
-
-/**
- * Creates an error for the case where a channel cannot be established.
- * @param {*=} opt_reason
- * @return {!Error}
- */
-function getChannelError(opt_reason) {
-  if (opt_reason instanceof Error) {
-    opt_reason.message = 'No messaging channel: ' + opt_reason.message;
-    return opt_reason;
-  }
-  return new Error('No messaging channel: ' + opt_reason);
-}
 
 /**
  * @typedef {{

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -24,12 +24,14 @@ import {dev} from '../log';
  */
 export function utf8Decode(bytes) {
   if (TextDecoder) {
-    return Promise.resolve(new TextDecoder('utf-8').decode(bytes));
+    return new Promise(resolve => {
+      resolve(new TextDecoder('utf-8').decode(bytes));
+    });
   }
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onerror = () => {
-      reject(reader.error);
+      reject(dev().assertError(reader.error));
     };
     reader.onloadend = () => {
       resolve(reader.result);
@@ -45,12 +47,14 @@ export function utf8Decode(bytes) {
  */
 export function utf8Encode(string) {
   if (TextEncoder) {
-    return Promise.resolve(new TextEncoder('utf-8').encode(string));
+    return new Promise(resolve => {
+      resolve(new TextEncoder('utf-8').encode(string));
+    });
   }
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onerror = () => {
-      reject(reader.error);
+      reject(dev().assertError(reader.error));
     };
     reader.onloadend = () => {
       // Because we used readAsArrayBuffer, we know the result must be an

--- a/src/utils/promise.js
+++ b/src/utils/promise.js
@@ -49,7 +49,9 @@ export function some(promises, count = 1) {
         reasons.push(reason);
       }
       if (reasons.length > extra) {
-        reject(reasons);
+        const error = new Error('not enough promises resolved');
+        error.reasons = reasons;
+        reject(error);
       }
     };
     for (let i = 0; i < promises.length; i++) {

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -497,13 +497,6 @@ describe('Logging', () => {
       clock = sandbox.useFakeTimers();
     });
 
-    it('should rethrow error with single message', () => {
-      rethrowAsync('intended');
-      expect(() => {
-        clock.tick(1);
-      }).to.throw(Error, /^intended$/);
-    });
-
     it('should rethrow a single error', () => {
       const orig = new Error('intended');
       rethrowAsync(orig);
@@ -515,30 +508,6 @@ describe('Logging', () => {
       }
       expect(error).to.equal(orig);
       expect(error.message).to.equal('intended');
-    });
-
-    it('should rethrow error with many messages', () => {
-      rethrowAsync('first', 'second', 'third');
-      let error;
-      try {
-        clock.tick(1);
-      } catch (e) {
-        error = e;
-      }
-      expect(error.message).to.equal('first second third');
-    });
-
-    it('should rethrow error with original error and messages', () => {
-      const orig = new Error('intended');
-      rethrowAsync('first', orig, 'second', 'third');
-      let error;
-      try {
-        clock.tick(1);
-      } catch (e) {
-        error = e;
-      }
-      expect(error).to.equal(orig);
-      expect(error.message).to.equal('first second third: intended');
     });
 
     it('should preserve error suffix', () => {

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -513,7 +513,7 @@ describe('Logging', () => {
     it('should preserve error suffix', () => {
       const orig = user().createError('intended');
       expect(isUserErrorMessage(orig.message)).to.be.true;
-      rethrowAsync('first', orig, 'second');
+      rethrowAsync(orig);
       let error;
       try {
         clock.tick(1);


### PR DESCRIPTION
Sorry, this one changes a lot of areas. Please review that my assumptions are correct (that we are indeed throwing an Error instance), trace it if you have to.

When reviewing, please review 9129ef8. Except @erwinmombay, I need you to review 74435e5, too.

/to @tdrl: Please review A4A and `bytes.js` changes
/to @lannka: Please review A4A changes
/to @dvoytenko: Please review `<amp-access>`, `animation.js`, `motion.js`, `extensions-impl.js`, all the resources, and viewer changes. 😬
/to @aghassemi: Please review `<amp-viz-vega>` changes
/to @cramforce: Please review `chunk.js` changes
