### PR TITLE
call viewport.updateFixedLayer when we display amp-live-list update button

### DIFF
--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -264,6 +264,7 @@ export class AmpLiveList extends AMP.BaseElement {
     if (this.pendingItemsInsert_.length > 0) {
       this.deferMutate(() => {
         this.toggleUpdateButton_(true);
+        this.viewport_.updateFixedLayer();
       });
     } else if (this.pendingItemsReplace_.length > 0 ||
         this.pendingItemsTombstone_.length > 0) {

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -276,6 +276,17 @@ describe('amp-live-list', () => {
       expect(stub.callCount).to.equal(1);
     });
 
+    it('should call updateFixedLayer on update with inserts', () => {
+      buildElement(elem, dftAttrs);
+      liveList.buildCallback();
+      const spy = sandbox.spy(liveList.viewport_, 'updateFixedLayer');
+      expect(liveList.itemsSlot_.childElementCount).to.equal(0);
+      const fromServer1 = createFromServer([{id: 'id0'}]);
+      expect(spy).to.have.not.been.called;
+      liveList.update(fromServer1);
+      expect(spy).to.have.been.calledOnce;
+    });
+
     it('no items slot on update should be a no op update', () => {
       const update = document.createElement('div');
       expect(() => {

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -521,7 +521,7 @@ export class Viewport {
   /**
    * Updates the fixed layer.
    */
-  updatedFixedLayer() {
+  updateFixedLayer() {
     this.fixedLayer_.update();
   }
 


### PR DESCRIPTION
livelist update button was not visible on ios as it is hidden by viewer header

/to @dvoytenko 