### PR TITLE
Introduce helper to make map-like objects.

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -24,6 +24,7 @@
 
 import {dev, user} from '../src/log';
 import {isArray} from '../src/types';
+import {map} from '../src/types';
 import {rethrowAsync} from '../src/log';
 
 
@@ -35,7 +36,7 @@ let ThirdPartyFunctionDef;
  * @const {!Object<ThirdPartyFunctionDef>}
  * @visibleForTesting
  */
-export const registrations = {};
+export const registrations = map();
 
 /** @type {number} */
 let syncScriptLoads = 0;

--- a/ads/_a4a-config.js
+++ b/ads/_a4a-config.js
@@ -26,6 +26,7 @@ import {
 } from
 '../extensions/amp-ad-network-fake-impl/0.1/fake-a4a-config';
 import {getMode} from '../src/mode';
+import {map} from '../src/types';
 
 /**
  * Registry for A4A (AMP Ads for AMPHTML pages) "is supported" predicates.
@@ -40,14 +41,14 @@ import {getMode} from '../src/mode';
  *
  * @type {!Object<!string, !function(!Window, !Element): boolean>}
  */
-export const a4aRegistry = {
+export const a4aRegistry = map({
   'adsense': adsenseIsA4AEnabled,
   'doubleclick': doubleclickIsA4AEnabled,
   // TODO: Add new ad network implementation "is enabled" functions here.  Note:
   // if you add a function here that requires a new "import", above, you'll
   // probably also need to add a whitelist exception to
   // build-system/dep-check-config.js in the "filesMatching: 'ads/**/*.js' rule.
-};
+});
 
 // Note: the 'fake' ad network implementation is only for local testing.
 // Normally, ad networks should add their *IsA4AEnabled callback directly

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -85,6 +85,7 @@ exports.rules = [
       'ads/**->src/log.js',
       'ads/**->src/mode.js',
       'ads/**->src/url.js',
+      'ads/**->src/types.js',
       // ads/google/a4a doesn't contain 3P ad code and should probably move
       // somewhere else at some point
       'ads/google/a4a/**->src/ad-cid.js',

--- a/build-system/eslint-rules/no-export-side-effect.js
+++ b/build-system/eslint-rules/no-export-side-effect.js
@@ -24,7 +24,9 @@ module.exports = function(context) {
               .map(function(declarator) {
                 return declarator.init
               }).filter(function(init) {
-                return init && /(?:Call|New)Expression/.test(init.type);
+                return init && /(?:Call|New)Expression/.test(init.type)
+                    // Special case creating a map object from a literal.
+                    && init.callee.name != 'map';
               }).forEach(function(init) {
                 context.report(init, 'Cannot export side-effect');
               });

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -19,7 +19,7 @@ import {fromClassForDoc} from '../service';
 import {getMode} from '../mode';
 import {timerFor} from '../timer';
 import {vsyncFor} from '../vsync';
-import {isArray} from '../types';
+import {isArray, map} from '../types';
 
 /** @const {string} */
 const TAG_ = 'Action';
@@ -98,7 +98,7 @@ export class ActionService {
     this.ampdoc = ampdoc;
 
     /** @const @private {!Object<string, function(!ActionInvocation)>} */
-    this.globalMethodHandlers_ = {};
+    this.globalMethodHandlers_ = map();
 
     /** @private {!./vsync-impl.Vsync} */
     this.vsync_ = vsyncFor(ampdoc.win);
@@ -395,7 +395,7 @@ export function parseActionMap(s, context) {
                   assertToken(toks.next(/* convertValue */ true),
                       TokenType.LITERAL).value;
               if (!args) {
-                args = Object.create(null);
+                args = map();
               }
               args[argKey] = argValue;
               peek = toks.peek();
@@ -420,7 +420,7 @@ export function parseActionMap(s, context) {
         str: s,
       };
       if (!actionMap) {
-        actionMap = {};
+        actionMap = map();
       }
       actionMap[action.event] = action;
     } else {

--- a/src/types.js
+++ b/src/types.js
@@ -54,20 +54,18 @@ export function toArray(arrayLike) {
 
 /**
  * Returns a map-like object.
- * If opt_initial is omitted returns an objects with a null prototype.
- * Otherwise takes the given object and sets its prototype to null.
+ * If opt_initial is provided, copies its own properties into the
+ * newly created object.
  * @param {T=} opt_initial This should typically be an object literal.
  * @return {T}
  * @template T
  */
 export function map(opt_initial) {
+  const obj = Object.create(null);
   if (opt_initial) {
-    if (opt_initial.__proto__) {
-      opt_initial.__proto__ = null;
-    }
-    return opt_initial
+    Object.assign(obj, opt_initial);
   }
-  return Object.create(null);
+  return obj;
 }
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -53,6 +53,24 @@ export function toArray(arrayLike) {
 }
 
 /**
+ * Returns a map-like object.
+ * If opt_initial is omitted returns an objects with a null prototype.
+ * Otherwise takes the given object and sets its prototype to null.
+ * @param {T=} opt_initial This should typically be an object literal.
+ * @return {T}
+ * @template T
+ */
+export function map(opt_initial) {
+  if (opt_initial) {
+    if (opt_initial.__proto__) {
+      opt_initial.__proto__ = null;
+    }
+    return opt_initial
+  }
+  return Object.create(null);
+}
+
+/**
  * Determines if value is actually an Object.
  * @param {*} value
  * @return {boolean}

--- a/test/functional/test-types.js
+++ b/test/functional/test-types.js
@@ -94,6 +94,9 @@ describe('Types', () => {
       expect(types.map({}).__proto__).to.be.undefined;
       expect(types.map({}).toString).to.be.undefined;
       expect(types.map({foo: 'bar'}).foo).to.equal('bar');
+      const obj = {foo: 'bar', test: 1};
+      expect(types.map(obj).test).to.equal(1);
+      expect(types.map(obj)).to.not.equal(obj);
     });
   });
 });

--- a/test/functional/test-types.js
+++ b/test/functional/test-types.js
@@ -81,4 +81,19 @@ describe('Types', () => {
       expect(types.isFiniteNumber(123e5)).to.be.true;
     });
   });
+
+  describe('map', () => {
+    it('should make map like objects', () => {
+      expect(types.map().prototype).to.be.undefined;
+      expect(types.map().__proto__).to.be.undefined;
+      expect(types.map().toString).to.be.undefined;
+    });
+
+    it('should make map like objects from objects', () => {
+      expect(types.map({}).prototype).to.be.undefined;
+      expect(types.map({}).__proto__).to.be.undefined;
+      expect(types.map({}).toString).to.be.undefined;
+      expect(types.map({foo: 'bar'}).foo).to.equal('bar');
+    });
+  });
 });


### PR DESCRIPTION
…using `Object.create(null)`.

And use it in a few places where it should be used.

I haven't yet migrated all usages of `Object.create(null)`.
