### PR TITLE
Backward compatible way of stringifying Uint8Array

### DIFF
--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -115,7 +115,7 @@ describe('cid', () => {
           crypto = results[1];
           crypto.sha384Base64 = val => {
             if (val instanceof Uint8Array) {
-              val = '[' + val + ']';
+              val = '[' + Array.apply([], val).join(',') + ']';
             }
 
             return Promise.resolve('sha384(' + val + ')');
@@ -416,7 +416,7 @@ describe('cid', () => {
     let sha384Promise;
     crypto.sha384Base64 = val => {
       if (val instanceof Uint8Array) {
-        val = '[' + val + ']';
+        val = '[' + Array.apply([], val).join(',') + ']';
       }
 
       return sha384Promise = Promise.resolve('sha384(' + val + ')');


### PR DESCRIPTION
Partial for https://github.com/ampproject/amphtml/issues/5878
Fixes `expected 'sha384(sha384([[object Uint8Array]])http://www.origin.come2)' to equal 'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])/tmp/084c85012a4b79725a06e3c90013394b.browserify:104464:20 <- /home/travis/build/ampproject/amphtml/test/functional/test-cid.js:567:19
..` 
errors on old chrome.