### PR TITLE
Cache SW: Do not cache experiments.js

### DIFF
--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -16,7 +16,6 @@
 
 import '../../third_party/babel/custom-babel-helpers';
 import {urls} from '../config';
-import {endsWith, startsWith} from '../string';
 
 /**
  * An AMP Release version, not to be confused with an RTV version
@@ -49,6 +48,35 @@ const BLACKLIST = self.AMP_CONFIG[`${TAG}-blacklist`] || [];
 const BASE_RTV_VERSION = self.AMP_CONFIG.v;
 
 /**
+ * A regex that matches every CDN JS URL we care to cache.
+ * The "experiments" JS is explicitly disallowed.
+ *
+ * The RTV will be the first capture group, if it is present.
+ * The pathname will be the second capture group.
+ *
+ * Matched URLS include:
+ *  - https://cdn.ampproject.org/v0.js
+ *  - https://cdn.ampproject.org/v0/amp-comp.js
+ *  - https://cdn.ampproject.org/rtv/123456789012345/v0.js
+ *  - https://cdn.ampproject.org/rtv/123456789012345/v0/amp-comp.js
+ *
+ * Unmatched URLS include:
+ *  - https://cdn.ampproject.org/v0/experiments.js
+ */
+const CDN_JS_REGEX = new RegExp(
+    // Require the CDN URL origin at the beginning.
+    `^${urls.cdn.replace(/\./g, '\\.')}` +
+    // Allow, but don't require, RTV.
+    `(?:/rtv/(\\d{2}\\d{13,}))?` +
+    // Require text "/v0"
+    `(/v0` +
+      // Allow, but don't require, an extension under the v0 directory.
+      // We explicitly forbid the `experiments` "extension".
+      `(?:/(?!experiments)[^.]+)?` +
+    // Require text ".js" at the end.
+    `\\.js)$`);
+
+/**
  * Returns the version of a given versioned JS file.
  *
  * @param {string} url
@@ -57,19 +85,20 @@ const BASE_RTV_VERSION = self.AMP_CONFIG.v;
  */
 export function rtvVersion(url) {
   // RTVs are 2 digit prefixes followed by the timestamp of the release.
-  const matches = /rtv\/(\d{2}\d{13,})/.exec(url);
-  return matches ? matches[1] : '';
+  const match = CDN_JS_REGEX.exec(url);
+  return (match && match[1]) || '';
 }
 
 /**
- * Returns the basename (AKA the filename) of a url, used to key a url (since
+ * Returns the pathname of a url, used to key a url (since
  * our JS filenames are unique).
  *
  * @param {string} url
  * @return {string}
  */
-function basename(url) {
-  return url.substr(url.lastIndexOf('/') + 1);
+function pathname(url) {
+  const match = CDN_JS_REGEX.exec(url);
+  return match ? match[2] : '';
 }
 
 /**
@@ -115,10 +144,7 @@ function normalizedRequest(request, version) {
  * @visibleForTesting
  */
 export function isCdnJsFile(url) {
-  return endsWith(url, '.js') && (
-    startsWith(url, `${urls.cdn}/rtv`) ||
-    startsWith(url, `${urls.cdn}/v0`)
-  );
+  return CDN_JS_REGEX.test(url);
 }
 
 /**
@@ -167,12 +193,12 @@ const cachePromise = self.caches.open('cdn-js').then(result => {
  *
  * @param {!Cache} cache
  * @param {!Request} request
- * @param {string} requestFile the basename of the request
+ * @param {string} requestPath the pathname of the request
  * @param {RtvVersion} requestVersion the version of the request
  * @return {!Promise<!Response>}
  * @visibleForTesting
  */
-export function fetchAndCache(cache, request, requestFile, requestVersion) {
+export function fetchAndCache(cache, request, requestPath, requestVersion) {
   // TODO(jridgewell): we should also fetch this requestVersion for all files
   // we know about.
   return fetch(request).then(response => {
@@ -189,7 +215,7 @@ export function fetchAndCache(cache, request, requestFile, requestVersion) {
         for (let i = 0; i < requests.length; i++) {
           const request = requests[i];
           const url = request.url;
-          if (requestFile !== basename(url)) {
+          if (requestPath !== pathname(url)) {
             continue;
           }
           if (requestVersion === rtvVersion(url)) {
@@ -213,17 +239,17 @@ export function fetchAndCache(cache, request, requestFile, requestVersion) {
  *  - An empty string, meaning we have nothing cached for this file.
  *
  * @param {!Cache} cache
- * @param {string} requestFile
+ * @param {string} requestPath
  * @return {!Promise<RtvVersion>}
  * @visibleForTesting
  */
-export function getCachedVersion(cache, requestFile) {
+export function getCachedVersion(cache, requestPath) {
   // TODO(jridgewell): We should make this a bit smarter, so that it selects
   // the version that has a lot of matches, not just this request file.
   return cache.keys().then(requests => {
     for (let i = 0; i < requests.length; i++) {
       const url = requests[i].url;
-      if (requestFile === basename(url)) {
+      if (requestPath === pathname(url)) {
         return rtvVersion(url);
       }
     }
@@ -256,7 +282,7 @@ export function handleFetch(request, maybeClientId) {
   // Closure Compiler!
   const clientId = /** @type {string} */(maybeClientId);
 
-  const requestFile = basename(url);
+  const requestPath = pathname(url);
   const requestVersion = rtvVersion(url) || BASE_RTV_VERSION;
   // Rewrite unversioned requests to the versioned RTV URL. This is a noop if
   // it's already versioned.
@@ -272,7 +298,7 @@ export function handleFetch(request, maybeClientId) {
     }
 
     // If not, do we have this version cached?
-    return getCachedVersion(cache, requestFile).then(version => {
+    return getCachedVersion(cache, requestPath).then(version => {
       // We have a cached version! Serve it up!
       if (version && !isBlacklisted(version)) {
         return version;
@@ -301,14 +327,14 @@ export function handleFetch(request, maybeClientId) {
         // they requested this exact version; If we served an old version,
         // let's get the new one.
         if (version !== requestVersion && requestVersion == BASE_RTV_VERSION) {
-          fetchAndCache(cache, request, requestFile, requestVersion);
+          fetchAndCache(cache, request, requestPath, requestVersion);
         }
 
         return response;
       }
 
       // If not, let's fetch and cache the request.
-      return fetchAndCache(cache, versionedRequest, requestFile, version);
+      return fetchAndCache(cache, versionedRequest, requestPath, version);
     });
   });
 }

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -136,7 +136,8 @@ runner.run('Cache SW', () => {
             'https://cdn.ampproject.org/rtv/123/v0.js');
       });
 
-      it('rewrites versioned v1 to other version', () => {
+      // When we finally release AMP v1
+      it.skip('rewrites versioned v1 to other version', () => {
         expect(sw.urlWithVersion(v1, '123')).to.equal(
             'https://cdn.ampproject.org/rtv/123/v1.js');
       });
@@ -146,7 +147,8 @@ runner.run('Cache SW', () => {
             'https://cdn.ampproject.org/rtv/123/v0/amp-comp.js');
       });
 
-      it('rewrites versioned v1 comp to other version', () => {
+      // When we finally release AMP v1
+      it.skip('rewrites versioned v1 comp to other version', () => {
         expect(sw.urlWithVersion(v1comp, '123')).to.equal(
             'https://cdn.ampproject.org/rtv/123/v1/amp-comp.js');
       });
@@ -230,7 +232,7 @@ runner.run('Cache SW', () => {
       });
 
       it('fetches the request', () => {
-        return sw.fetchAndCache(cache, request, 'v0.js', rtv).then(resp => {
+        return sw.fetchAndCache(cache, request, '/v0.js', rtv).then(resp => {
           expect(fetch).to.have.been.called;
           expect(resp).to.equal(response);
         });
@@ -239,14 +241,14 @@ runner.run('Cache SW', () => {
       it('stores response into cache', () => {
         const cloned = {};
         sandbox.stub(response, 'clone', () => cloned);
-        return sw.fetchAndCache(cache, request, 'v0.js', rtv).then(() => {
+        return sw.fetchAndCache(cache, request, '/v0.js', rtv).then(() => {
           expect(put).to.have.been.calledWith(request, cloned);
         });
       });
 
       it('prunes previous cached responses for file', () => {
         const deleter = sandbox.stub(cache, 'delete');
-        return sw.fetchAndCache(cache, request, 'v0.js', rtv).then(() => {
+        return sw.fetchAndCache(cache, request, '/v0.js', rtv).then(() => {
           expect(deleter).to.have.been.calledWith(cache.cached[0][0]);
           expect(deleter).to.not.have.been.calledWith(cache.cached[1][0]);
         });
@@ -259,20 +261,20 @@ runner.run('Cache SW', () => {
       });
 
       it('fetches the request', () => {
-        return sw.fetchAndCache(cache, request, 'v0.js', rtv).then(resp => {
+        return sw.fetchAndCache(cache, request, '/v0.js', rtv).then(resp => {
           expect(resp).to.equal(response);
         });
       });
 
       it('does not store response into cache', () => {
-        return sw.fetchAndCache(cache, request, 'v0.js', rtv).then(() => {
+        return sw.fetchAndCache(cache, request, '/v0.js', rtv).then(() => {
           expect(put).to.not.have.been.called;
         });
       });
 
       it('does not prune requests for file', () => {
         const deleter = sandbox.stub(cache, 'delete');
-        return sw.fetchAndCache(cache, request, 'v0.js', rtv).then(() => {
+        return sw.fetchAndCache(cache, request, '/v0.js', rtv).then(() => {
           expect(deleter).to.not.have.been.called;
         });
       });
@@ -286,13 +288,13 @@ runner.run('Cache SW', () => {
       });
     });
     it('returns cached rtv version, if file is cached', () => {
-      return sw.getCachedVersion(cache, 'v0.js').then(version => {
+      return sw.getCachedVersion(cache, '/v0.js').then(version => {
         expect(version).to.equal(rtv);
       });
     });
 
     it('returns empty string, if file is not cached', () => {
-      return sw.getCachedVersion(cache, 'amp-comp.js').then(version => {
+      return sw.getCachedVersion(cache, '/amp-comp.js').then(version => {
         expect(version).to.equal('');
       });
     });

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -167,16 +167,17 @@ runner.run('Cache SW', () => {
       expect(sw.isCdnJsFile(rtvless)).to.be.true;
     });
 
-    it('does not match for other CDN RTV files', () => {
-      const url = `https://cdn.ampproject.org/rtv/${rtv}/v0.json`;
-      const rtvless = `https://cdn.ampproject.org/v0.json`;
+    it('does not match for experiments.js', () => {
+      const url = `https://cdn.ampproject.org/v0/experiments.js`;
       expect(sw.isCdnJsFile(url)).to.be.false;
-      expect(sw.isCdnJsFile(rtvless)).to.be.false;
     });
 
     it('does not match for other CDN files', () => {
-      const url = `https://cdn.ampproject.org/c/amp/`;
-      expect(sw.isCdnJsFile(url)).to.be.false;
+      expect(sw.isCdnJsFile(`https://cdn.ampproject.org/c/amp.js`)).to.be.false;
+      expect(sw.isCdnJsFile(`https://cdn.ampproject.org/v/amp.js`)).to.be.false;
+      expect(sw.isCdnJsFile(`https://cdn.ampproject.org/i/amp.js`)).to.be.false;
+      expect(sw.isCdnJsFile(`https://cdn.ampproject.org/rtv/${rtv}/v0.json`)).to.be.false;
+      expect(sw.isCdnJsFile(`https://cdn.ampproject.org/v0.json`)).to.be.false;
     });
 
     it('does not match for non CDN domains', () => {


### PR DESCRIPTION
This explicitly disallows `v0/experiments.js` from being cached by our
SW. This is necessary because we do not host an RTV version of this
file, which is required for anything that's cached. Plus why would we
cache the experiments javascript?!

I've opted to de-duplicate a few areas into a single regex. Let me know
if this is too complicated. This will allow us to easily support v1, v2,
etc versions later on, too.
