### PR TITLE
Fix test-iframe-createIframeWithMessageStub failures on older browsers

### DIFF
--- a/test/fixtures/served/iframe-stub.html
+++ b/test/fixtures/served/iframe-stub.html
@@ -19,7 +19,7 @@
 
   // Echo back a message received from parent window with a marker field
   // 'testStubEcho'.
-  window.addEventListener('message', event => {
+  window.addEventListener('message', function(event) {
     if (event.source == window.parent && !event.data.testStubEcho) {
       const data = {
         testStubEcho: true,

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -115,7 +115,7 @@ describe('cid', () => {
           crypto = results[1];
           crypto.sha384Base64 = val => {
             if (val instanceof Uint8Array) {
-              val = '[' + val + ']';
+              val = '[' + Array.apply([], val).join(',') + ']';
             }
 
             return Promise.resolve('sha384(' + val + ')');
@@ -416,7 +416,7 @@ describe('cid', () => {
     let sha384Promise;
     crypto.sha384Base64 = val => {
       if (val instanceof Uint8Array) {
-        val = '[' + val + ']';
+        val = '[' + Array.apply([], val).join(',') + ']';
       }
 
       return sha384Promise = Promise.resolve('sha384(' + val + ')');


### PR DESCRIPTION
Partial for #5878 

failed by a `=>` bug ( no double entendre intended )