### PR TITLE
Add alert role to user-notification by default

### DIFF
--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -138,6 +138,12 @@ export class AmpUserNotification extends AMP.BaseElement {
       assertHttpsUrl(this.dismissHref_, this.element);
     }
 
+    // Default to alert role if unspecified.
+    const roleAttribute = this.element.getAttribute('role');
+    if (!roleAttribute) {
+      this.element.setAttribute('role', 'alert');
+    }
+
     const persistDismissal = this.element.getAttribute(
         'data-persist-dismissal');
     /** @private @const {boolean} */

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -479,6 +479,22 @@ describe('amp-user-notification', () => {
     });
   });
 
+  it('should have an default `role` if unspecified', () => {
+    return getUserNotification({ id: 'n1' }).then(el => {
+      const impl = el.implementation_;
+      impl.buildCallback();
+      expect(el.getAttribute('role')).to.equal('alert');
+    });
+  });
+
+  it('should not override `role` if specified', () => {
+    return getUserNotification({ id: 'n1', role: 'status' }).then(el => {
+      const impl = el.implementation_;
+      impl.buildCallback();
+      expect(el.getAttribute('role')).to.equal('status');
+    });
+  });
+
   describe('buildGetHref_', () => {
 
     it('should do url replacement', () => {

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -480,7 +480,7 @@ describe('amp-user-notification', () => {
   });
 
   it('should have a default `role` if unspecified', () => {
-    return getUserNotification({ id: 'n1' }).then(el => {
+    return getUserNotification({id: 'n1'}).then(el => {
       const impl = el.implementation_;
       impl.buildCallback();
       expect(el.getAttribute('role')).to.equal('alert');
@@ -488,7 +488,7 @@ describe('amp-user-notification', () => {
   });
 
   it('should not override `role` if specified', () => {
-    return getUserNotification({ id: 'n1', role: 'status' }).then(el => {
+    return getUserNotification({id: 'n1', role: 'status'}).then(el => {
       const impl = el.implementation_;
       impl.buildCallback();
       expect(el.getAttribute('role')).to.equal('status');

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -479,7 +479,7 @@ describe('amp-user-notification', () => {
     });
   });
 
-  it('should have an default `role` if unspecified', () => {
+  it('should have a default `role` if unspecified', () => {
     return getUserNotification({ id: 'n1' }).then(el => {
       const impl = el.implementation_;
       impl.buildCallback();


### PR DESCRIPTION
Fixes #5519. Tested using VoiceOver on macOS.