### PR TITLE
`#setOwner` should rewrite `resource.owner_` value if it exist

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -100,7 +100,7 @@ export class Resource {
   static setOwner(element, owner) {
     dev().assert(owner.contains(element), 'Owner must contain the element');
     if (Resource.forElementOptional(element)) {
-      Resource.forElementOptional(element).owner_ = owner;
+      Resource.forElementOptional(element).updateOwner(owner);
     }
     element[OWNER_PROP_] = owner;
   }
@@ -186,6 +186,14 @@ export class Resource {
    */
   getId() {
     return this.id_;
+  }
+
+  /**
+   * Update owner element
+   * @param {!AmpElement} owner
+   */
+  updateOwner(owner) {
+    this.owner_ = owner;
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -99,6 +99,9 @@ export class Resource {
    */
   static setOwner(element, owner) {
     dev().assert(owner.contains(element), 'Owner must contain the element');
+    if (Resource.forElementOptional(element)) {
+      Resource.forElementOptional(element).owner_ = owner;
+    }
     element[OWNER_PROP_] = owner;
   }
 

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -513,6 +513,41 @@ describe('Resource', () => {
     });
   });
 
+  describe('Resource set/get ownership', () => {
+    let child;
+    let parentResource;
+    let resources;
+    beforeEach(() => {
+      const parent = {
+        ownerDocument: {defaultView: window},
+        tagName: 'AMP-STICKY-AD',
+        isBuilt: () => false,
+        contains: () => true,
+      };
+      child = {
+        ownerDocument: {defaultView: window},
+        tagName: 'AMP-AD',
+        isBuilt: () => false,
+        contains: () => true,
+      };
+      resources = new Resources(new AmpDocSingle(window));
+      parentResource = new Resource(1, parent, resources);
+    });
+
+    it('should set resource before Resource created for child element', () => {
+      resources.setOwner(child, parentResource.element);
+      const childResource = new Resource(1, child, resources);
+      expect(childResource.getOwner()).to.equal(parentResource.element);
+    });
+
+    it('should always get the lastest owner value', () => {
+      const childResource = new Resource(1, child, resources);
+      expect(childResource.getOwner()).to.be.null;
+      resources.setOwner(childResource.element, parentResource.element);
+      expect(childResource.owner_).to.equal(parentResource.element);
+      expect(childResource.getOwner()).to.equal(parentResource.element);
+    });
+  });
 
   describe('unlayoutCallback', () => {
     it('should NOT call unlayoutCallback on unbuilt element', () => {


### PR DESCRIPTION
extend #3595 
fix #5862

I didn't fix nested element owner update in this PR. 
