### PR TITLE
Add how amp-live-list works

### DIFF
--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -47,10 +47,6 @@ limitations under the License.
   </tr>
 </table>
 
-## How it works
-
-In the background, while an AMP page using `<amp-live-list>` is displayed on the client, the AMP runtime polls the origin document on the host for updates. When the client receives a response, it then [filters](#server-side-filtering) and dynamically inserts those updates back into the page on the client. Publishers can customize the polling rate in order to control the number of incoming requests, and AMP caches like the Google AMP Cache can perform optimizations to reduce the server response payload, saving client bandwidth and CPU cycles.
-
 ## Behavior
 
 `amp-live-list` provides support for content that is updated live on the client,
@@ -59,6 +55,10 @@ to refresh or navigate to a different page. The core use case for this component
 is live blogs: coverage for breaking news or live events where the user can stay
 on or keep returning to the same page to see new updates as they come in. Common
 examples are award shows, sporting events, and elections.
+
+## How it works
+
+In the background, while an AMP page using `<amp-live-list>` is displayed on the client, the AMP runtime polls the origin document on the host for updates. When the client receives a response, it then [filters](#server-side-filtering) and dynamically inserts those updates back into the page on the client. Publishers can customize the polling rate in order to control the number of incoming requests, and AMP caches like the Google AMP Cache can perform optimizations to reduce the server response payload, saving client bandwidth and CPU cycles.
 
 The `amp-live-list` component has 3 sections. We'll refer to these sections as
 "reference points" and they are denoted by an attribute. The 3 reference points are

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -47,6 +47,10 @@ limitations under the License.
   </tr>
 </table>
 
+## How it works
+
+In the background, while an AMP page using `<amp-live-list>` is displayed on the client, the AMP runtime polls the origin document on the host for updates. When the client receives a response, it then [filters](#server-side-filtering) and dynamically inserts those updates back into the page on the client. Publishers can customize the polling rate in order to control the number of incoming requests, and AMP caches like the Google AMP Cache can perform optimizations to reduce the server response payload, saving client bandwidth and CPU cycles.
+
 ## Behavior
 
 `amp-live-list` provides support for content that is updated live on the client,


### PR DESCRIPTION
That paragraph from [the blog](https://amphtml.wordpress.com/2016/07/26/live-updating-amps/) explained `amp-live-list` far better for me than the doc and [the amp-by-example sample](https://github.com/ampproject/amp-by-example/pull/457).

Even better - can we also add an image, such as [this one](https://amphtml.files.wordpress.com/2016/07/amp-live-list-flow.png?w=768) and [the animated demo](https://amphtml.files.wordpress.com/2016/07/amp-live-list-demo.gif?w=446&h=630)?
