### PR TITLE
Introduce timeout for font stylsheets in AMP.

### DIFF
--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -5,7 +5,8 @@
   <title>Lorem Ipsum | PublisherName</title>
   <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+
   <style amp-custom>
     body {
       margin: 0;
@@ -210,12 +211,12 @@
     }
 
   </style>
+  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
   <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js" data-amp-report-test="amp-app-banner.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
   <link rel="amp-manifest" href="medium-manifest.json">
   <script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>

--- a/src/amp.js
+++ b/src/amp.js
@@ -20,6 +20,7 @@
 
 import './polyfills';
 import {chunk} from './chunk';
+import {fontStylesheetTimeout} from './font-stylesheet-timeout';
 import {installPerformanceService} from './service/performance-impl';
 import {installPullToRefreshBlocker} from './pull-to-refresh';
 import {installGlobalClickListenerForDoc} from './document-click';
@@ -65,6 +66,7 @@ chunk(self.document, function initial() {
     chunk(self.document, function services() {
       // Core services.
       installRuntimeServices(self);
+      fontStylesheetTimeout(self);
       installAmpdocServices(ampdoc);
       // We need the core services (viewer/resources) to start instrumenting
       perf.coreServicesAvailable();

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -63,10 +63,19 @@ export function fontStylesheetTimeout(win) {
         'link[rel~="stylesheet"]');
     for (let i = 0; i < styleLinkElements.length; i++) {
       const existingLink = styleLinkElements[i];
+      const media = existingLink.media || 'all';
       // Make a new link tag, copying the href from the original.
       const newLink = win.document.createElement('link');
-      newLink.setAttribute('rel', existingLink.rel);
-      newLink.setAttribute('href', existingLink.href);
+      newLink.rel = existingLink.rel;
+      newLink.href = existingLink.href;
+      // To avoid blocking the render, we assign a non-matching media
+      // attribute first…
+      newLink.media = 'not-matching';
+      // And then switch it back to the original after the stylesheet
+      // loaded.
+      newLink.onload = () => {
+        newLink.media = media;
+      };
       newLink.setAttribute('i-amp-timeout', timeout);
       const parent = existingLink.parentElement;
       // Insert the stylesheet. We do it right before the existing one,

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isDocumentReady} from './document-ready';
+import {timerFor} from './timer';
+
+/**
+ * While browsers put a timeout on font downloads (3s by default,
+ * some less on slow connections), there is no such timeout for style
+ * sheets. In the case of AMP external stylesheets are ONLY used to
+ * download fonts, but browsers have no reasonable timeout for
+ * stylesheets. Users may thus wait a long time for these to download
+ * even though all they do is reference fonts.
+ *
+ * For that reasons this function identifies fonts that have not
+ * downloaded within 1 second of the page response starting and turns
+ * the respective reinserts the link tags dynamically. This removes
+ * their blocking nature and lets the doc render.
+ *
+ * 1 second was picked, because the fonf-stylesheets are typically
+ * tiny. If a connection wasn't able to deliver them within 1s
+ * of page load start, then it is unlikely that it will be able
+ * to download the font itself within 3s.
+ *
+ * @param {!Window} win
+ */
+export function fontStylesheetTimeout(win) {
+  let timeSinceResponseStart = 0;
+  // If available, we start counting from the time the HTTP response
+  // for the page started. The preload scanner should then quickly
+  // start the CSS download.
+  const perf = win.performance;
+  if (perf && perf.timing && perf.timing.responseStart) {
+    timeSinceResponseStart = Date.now() - perf.timing.responseStart;
+  }
+  const timeout = Math.max(1, 1000 - timeSinceResponseStart);
+
+  timerFor(win).delay(() => {
+    // We waited for the timeout period. There is no way to check whether
+    // the stylesheets actually loaded. For that reason we check whether
+    // the document is ready instead. The link tags block the readiness
+    // and they are the only external resource that does, so if the doc
+    // isn't ready yet it is probably the stylesheet's fault.
+    if (isDocumentReady(win.document)) {
+      return;
+    }
+    // Alright we timed out.
+    // Find all stylesheets.
+    const styleLinkElements = win.document.querySelectorAll(
+        'link[rel~="stylesheet"]');
+    for (let i = 0; i < styleLinkElements.length; i++) {
+      const existingLink = styleLinkElements[i];
+      // Make a new link tag, copying the href from the original.
+      const newLink = win.document.createElement('link');
+      newLink.setAttribute('rel', existingLink.rel);
+      newLink.setAttribute('href', existingLink.href);
+      newLink.setAttribute('i-amp-timeout', timeout);
+      const parent = existingLink.parentElement;
+      // Insert the stylesheet. We do it right before the existing one,
+      // so that
+      // - we pick up its HTTP request.
+      // - CSS evaluation order doen't change.
+      parent.insertBefore(newLink, existingLink);
+      // And remove the blocking stylsheet.
+      parent.removeChild(existingLink);
+    }
+  }, timeout);
+}

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -25,12 +25,12 @@ import {timerFor} from './timer';
  * stylesheets. Users may thus wait a long time for these to download
  * even though all they do is reference fonts.
  *
- * For that reasons this function identifies fonts that have not
- * downloaded within 1 second of the page response starting and turns
- * the respective reinserts the link tags dynamically. This removes
- * their blocking nature and lets the doc render.
+ * For that reasons this function identifies (or rather infers) font
+ * stylesheets that have not downloaded within 1 second of the page
+ * response starting and reinserts equivalent link tags  dynamically. This
+ * removes their page-render-blocking nature and lets the doc render.
  *
- * 1 second was picked, because the fonf-stylesheets are typically
+ * 1 second was picked, because the font-stylesheets are typically
  * tiny. If a connection wasn't able to deliver them within 1s
  * of page load start, then it is unlikely that it will be able
  * to download the font itself within 3s.

--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -74,7 +74,7 @@ describes.realWin('font-stylesheet-timeout', {
         'link[rel="stylesheet"]')).to.equal(link);
   });
 
-  it('should time out if doc is not interactive', () => {
+  it('should time out if doc is not interactive', done => {
     readyState = 'loading';
     const link = addLink();
     fontStylesheetTimeout(win);
@@ -84,10 +84,15 @@ describes.realWin('font-stylesheet-timeout', {
     clock.tick(1);
     expect(win.document.querySelectorAll(
         'link[rel="stylesheet"][i-amp-timeout]')).to.have.length(1);
-    expect(win.document.querySelector(
-        'link[rel="stylesheet"]')).to.not.equal(link);
-    expect(win.document.querySelector(
-        'link[rel="stylesheet"]').href).to.equal(link.href);
+    const after = win.document.querySelector(
+        'link[rel="stylesheet"]');
+    expect(after).to.not.equal(link);
+    expect(after.href).to.equal(link.href);
+    expect(after.media).to.equal('not-matching');
+    after.addEventListener('load', () => {
+      expect(after.media).to.equal('all');
+      done();
+    });
   });
 
   it('should time out from response start', () => {

--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  fontStylesheetTimeout,
+} from '../../src/font-stylesheet-timeout';
+
+
+describes.realWin('font-stylesheet-timeout', {
+  amp: true,
+}, env => {
+  let clock;
+  let win;
+  let readyState;
+  let responseStart;
+
+  beforeEach(() => {
+    clock = env.sandbox.useFakeTimers();
+    win = env.win;
+    win.setTimeout = self.setTimeout;
+    readyState = 'interactive';
+    responseStart = 0;
+    Object.defineProperty(win.document, 'readyState', {
+      get: function() {
+        return readyState;
+      },
+    });
+    Object.defineProperty(win.performance.timing, 'responseStart', {
+      get: function() {
+        return responseStart;
+      },
+    });
+  });
+
+  function addLink(opt_content) {
+    const link = document.createElement('link');
+    link.href = 'data:text/css;charset=utf-8,' + (opt_content || '');
+    link.setAttribute('rel', 'stylesheet');
+    win.document.head.appendChild(link);
+    return link;
+  }
+
+  it('should not time out for ready doc', () => {
+    const link = addLink();
+    fontStylesheetTimeout(win);
+    clock.tick(10000);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"]')).to.have.length(1);
+    expect(win.document.querySelector(
+        'link[rel="stylesheet"]')).to.equal(link);
+  });
+
+  it('should not time out for complete doc', () => {
+    readyState = 'complete';
+    const link = addLink();
+    fontStylesheetTimeout(win);
+    clock.tick(10000);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"]')).to.have.length(1);
+    expect(win.document.querySelector(
+        'link[rel="stylesheet"]')).to.equal(link);
+  });
+
+  it('should time out if doc is not interactive', () => {
+    readyState = 'loading';
+    const link = addLink();
+    fontStylesheetTimeout(win);
+    clock.tick(999);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"][i-amp-timeout]')).to.have.length(0);
+    clock.tick(1);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"][i-amp-timeout]')).to.have.length(1);
+    expect(win.document.querySelector(
+        'link[rel="stylesheet"]')).to.not.equal(link);
+    expect(win.document.querySelector(
+        'link[rel="stylesheet"]').href).to.equal(link.href);
+  });
+
+  it('should time out from response start', () => {
+    responseStart = 500;
+    clock.tick(1000);
+    readyState = 'loading';
+    const link = addLink();
+    fontStylesheetTimeout(win);
+    clock.tick(499);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"][i-amp-timeout]')).to.have.length(0);
+    clock.tick(1);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"][i-amp-timeout]')).to.have.length(1);
+    expect(win.document.querySelector(
+        'link[rel="stylesheet"]')).to.not.equal(link);
+    expect(win.document.querySelector(
+        'link[rel="stylesheet"]').href).to.equal(link.href);
+  });
+
+  it('should time out multiple style sheets', () => {
+    responseStart = 500;
+    clock.tick(10000);
+    readyState = 'loading';
+    const link0 = addLink(1);
+    const link1 = addLink(2);
+    fontStylesheetTimeout(win);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"][i-amp-timeout]')).to.have.length(0);
+    clock.tick(1);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"][i-amp-timeout]')).to.have.length(2);
+    expect(win.document.querySelector(
+        'link[rel="stylesheet"]')).to.not.equal(link0);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"]')[0].href).to.equal(link0.href);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"]')[1].href).to.equal(link1.href);
+  });
+});


### PR DESCRIPTION
All external stylesheets in AMP have the sole purpose of loading fonts. While browsers have a timeout for fonts (3s or lower), they don't have a similar timeout for stylesheets. Thus a user will often wait a long time for the stylesheet, only to run into the next timeout for the font itself.

With this change, if the page has not reached ready state 1s after the response started arriving on the client, AMP will look for external stylesheets referenced in the doc and replace them with dynamically inserted stylesheets, which do not block displaying the page.

As far as I know there is no way to tell whether a stylesheet has loaded. For this reason, we use `document.readyState` as a signal, since it is blocked by external stylesheets.

This change may have significant impact on AMP's 99%ile load performance.
