### PR TITLE
Reflect tracking nature of iframes in priority.

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -151,6 +151,9 @@ export class AmpIframe extends AMP.BaseElement {
     this.isAdLike_ = false;
 
     /** @private {boolean} */
+    this.isTrackingFrame_ = false;
+
+    /** @private {boolean} */
     this.isDisallowedAsAd_ = false;
 
     /**
@@ -191,6 +194,7 @@ export class AmpIframe extends AMP.BaseElement {
     this.measureIframeLayoutBox_();
 
     this.isAdLike_ = isAdLike(this);
+    this.isTrackingFrame_ = this.looksLikeTrackingIframe_();
     this.isDisallowedAsAd_ = this.isAdLike_ &&
         !isAdPositionAllowed(this.element, this.win);
 
@@ -250,8 +254,7 @@ export class AmpIframe extends AMP.BaseElement {
       return Promise.resolve();
     }
 
-    const isTracking = this.looksLikeTrackingIframe_();
-    if (isTracking) {
+    if (this.isTrackingFrame_) {
       trackingIframeCount++;
       if (trackingIframeCount > 1) {
         console/*OK*/.error('Only 1 analytics/tracking iframe allowed per ' +
@@ -280,7 +283,7 @@ export class AmpIframe extends AMP.BaseElement {
     setSandbox(this.element, iframe, this.sandbox_);
     iframe.src = this.iframeSrc;
 
-    if (!isTracking) {
+    if (!this.isTrackingFrame_) {
       this.intersectionObserver_ = new IntersectionObserver(this, iframe);
     }
 
@@ -290,7 +293,7 @@ export class AmpIframe extends AMP.BaseElement {
 
       this.activateIframe_();
 
-      if (isTracking) {
+      if (this.isTrackingFrame_) {
         // Prevent this iframe from ever being recreated.
         this.iframeSrc = null;
 
@@ -366,6 +369,9 @@ export class AmpIframe extends AMP.BaseElement {
   getPriority() {
     if (this.isAdLike_) {
       return 2; // See AmpAd3PImpl.
+    }
+    if (this.isTrackingFrame_) {
+      return 1;
     }
     return super.getPriority();
   }

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -514,9 +514,13 @@ describe('amp-iframe', () => {
       // appended amp-iframe 10x10
       expect(iframes[0].implementation_
           .looksLikeTrackingIframe_()).to.be.true;
+      expect(iframes[0].implementation_
+          .getPriority()).to.equal(1);
       // appended amp-iframe 100x100
       expect(iframes[1].implementation_
           .looksLikeTrackingIframe_()).to.be.false;
+      expect(iframes[1].implementation_
+          .getPriority()).to.equal(0);
       // amp-iframe 5x5
       expect(iframes[2].implementation_
           .looksLikeTrackingIframe_()).to.be.true;


### PR DESCRIPTION
I've seen them being positioned at `fixed 0,0` and AMP prioritizing the load over actual user content.