### PR TITLE
Early implementation of amp-access-laterpay

### DIFF
--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -121,20 +121,6 @@
       background-color: #f4f4f4;
     }
 
-    .login-section {
-      margin: 16px;
-      margin-top: 24px;
-      padding: 16px;
-      background: #ffc;
-    }
-
-    .meter-section {
-      margin: 16px;
-      margin-top: 24px;
-      padding: 16px;
-      background: #ffa;
-    }
-
     .error-section {
       margin: 16px;
       margin-top: 24px;
@@ -229,8 +215,8 @@
           </div>
         </div>
 
-        <section amp-access="NOT error AND NOT access" amp-access-hide class="login-section">
-          <div id="amp-access-laterpay-dialog"></div>
+        <section amp-access="NOT error AND NOT access" amp-access-hide>
+          <div id="amp-access-laterpay-dialog" class="amp-access-laterpay"></div>
         </section>
 
         <section amp-access="error" amp-access-hide class="error-section">

--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -9,7 +9,6 @@
   <script id="amp-access" type="application/json">
     {
       "vendor": "laterpay",
-      "authorizationFallbackResponse": {"error": true},
       "laterpay": {
         "articleTitleSelector": ".content-container > header > h1"
       }
@@ -24,11 +23,6 @@
 
     .brand-logo {
       font-family: 'Open Sans';
-    }
-
-    .ad-container {
-      display: flex;
-      justify-content: center;
     }
 
     .content-container p {
@@ -152,7 +146,6 @@
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <script async custom-element="amp-access" src="https://cdn.ampproject.org/v0/amp-access-0.1.js"></script>
   <script async custom-element="amp-access-laterpay" src="https://cdn.ampproject.org/v0/amp-access-laterpay-0.1.js"></script>
-  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -244,14 +237,6 @@
           Oops... Something broke.
         </section>
 
-        <amp-ad amp-access="access" amp-access-hide
-            width=300 height=250
-            type="a9"
-            data-aax_size="300x250"
-            data-aax_pubname="abc123"
-            data-aax_src="302">
-        </amp-ad>
-
         <div amp-access="access" amp-access-hide class="article-body" itemprop="articleBody">
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -271,15 +256,6 @@
             Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
             Nullam in libero nisi.
           </p>
-
-          <div class="ad-container">
-            <amp-ad width=300 height=250
-                type="a9"
-                data-aax_size="300x250"
-                data-aax_pubname="abc123"
-                data-aax_src="302">
-            </amp-ad>
-          </div>
 
           <p>
             Sed pharetra semper fringilla. Nulla fringilla, neque eget
@@ -339,13 +315,6 @@
             Ut elementum velit fermentum felis volutpat sodales in non libero.
             Aliquam erat volutpat.
           </p>
-
-          <div class="ad-container">
-            <amp-ad width=300 height=200
-                type="adsense"
-                data-ad-client="ca-pub-9350112648257122">
-            </amp-ad>
-          </div>
 
           <p>
             Morbi at velit vitae eros congue congue venenatis non dui.

--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -9,7 +9,9 @@
   <script id="amp-access" type="application/json">
     {
       "vendor": "laterpay",
-      "laterpay": {},
+      "laterpay": {
+        "access": true
+      },
       "authorizationFallbackResponse": {"error": true}
     }
   </script>
@@ -234,15 +236,8 @@
           </div>
         </div>
 
-        <section id="meter-notif" amp-access="views > 0" amp-access-hide class="meter-section">
-          <template amp-access-template type="amp-mustache">
-            You are viewing article {{views}} of {{maxViews}}!
-          </template>
-          <a on="tap:meter-notif.hide">[Close]</a>
-        </section>
-
         <section amp-access="NOT error AND NOT access" amp-access-hide class="login-section">
-          <a on="tap:amp-access.login">Login to read more!</a>
+          <amp-access-laterpay-list></amp-access-laterpay-list>
         </section>
 
         <section amp-access="error" amp-access-hide class="error-section">

--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -10,7 +10,6 @@
     {
       "vendor": "laterpay",
       "authorizationFallbackResponse": {"error": true},
-      "noPingback": true,
       "laterpay": {
         "articleTitleSelector": ".content-container > header > h1"
       }

--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -9,7 +9,11 @@
   <script id="amp-access" type="application/json">
     {
       "vendor": "laterpay",
-      "authorizationFallbackResponse": {"error": true}
+      "authorizationFallbackResponse": {"error": true},
+      "noPingback": true,
+      "laterpay": {
+        "articleTitleSelector": ".content-container > header > h1"
+      }
     }
   </script>
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>

--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -9,9 +9,6 @@
   <script id="amp-access" type="application/json">
     {
       "vendor": "laterpay",
-      "laterpay": {
-        "access": true
-      },
       "authorizationFallbackResponse": {"error": true}
     }
   </script>

--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -238,7 +238,7 @@
         </div>
 
         <section amp-access="NOT error AND NOT access" amp-access-hide class="login-section">
-          <amp-access-laterpay-list></amp-access-laterpay-list>
+          <div id="amp-access-laterpay-dialog"></div>
         </section>
 
         <section amp-access="error" amp-access-hide class="error-section">

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -1,9 +1,15 @@
 .amp-access-laterpay {
+  border: 1px solid black;
   padding: 16px;
-  width: 420px;
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+@media (min-width: 420px) {
+  .amp-access-laterpay {
+    width: 420px;
+  }
 }
 
 .amp-access-laterpay ul {

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .amp-access-laterpay {
   padding: 16px;
   display: flex;

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -1,5 +1,4 @@
 .amp-access-laterpay {
-  border: 1px solid black;
   padding: 16px;
   display: flex;
   flex-direction: column;

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -1,0 +1,55 @@
+.amp-access-laterpay {
+  padding: 16px;
+  width: 420px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.amp-access-laterpay ul {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.amp-access-laterpay li {
+  list-style: none;
+  display: flex;
+  margin-bottom: 20px;
+}
+
+.amp-access-laterpay label {
+  display: flex;
+  padding-left: 5px;
+}
+
+.amp-access-laterpay input {
+  width: 20px;
+}
+
+.amp-access-laterpay-metadata-container {
+  width: 90%;
+}
+
+.amp-access-laterpay-title {
+  font-size: 1.1em;
+  margin: 0;
+  padding: 0;
+}
+
+.amp-access-laterpay-description {
+  font-size: 0.9em;
+  margin: 0;
+  padding: 0;
+}
+
+.amp-access-laterpay-price-container {
+  margin-top: 0;
+  margin-left: auto;
+}
+
+.amp-access-laterpay-purchase-button {
+  font-size: 1.1em;
+  padding: 0.5em 0.8em;
+  width: 70%;
+}

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -417,6 +417,13 @@ export class LaterpayVendor {
         url, this.selectedPurchaseOption_.dataset.purchaseType);
     });
   }
+
+  /**
+   * @returns {boolean}
+   */
+  pingback() {
+    return true;
+  }
 }
 
 

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -102,25 +102,25 @@ export class LaterpayVendor {
     /** @const @private {!LaterpayConfigDef} */
     this.laterpayConfig_ = this.accessService_.getAdapterConfig();
 
-    /** @const @private {!PurchaseConfigDef} */
+    /** @private {?PurchaseConfigDef} */
     this.purchaseConfig_ = null;
 
-    /** @const @private {?Function} */
+    /** @private {?Function} */
     this.purchaseButtonListener_ = null;
 
-    /** @const @private {?Function} */
+    /** @private {?Function} */
     this.alreadyPurchasedListener_ = null;
 
     /** @const @private {!Array<Event>} */
     this.purchaseOptionListeners_ = [];
 
-    /** @const @private {!boolean} */
+    /** @private {!boolean} */
     this.containerEmpty_ = true;
 
-    /** @const @private {?Node} */
+    /** @private {?Node} */
     this.selectedPurchaseOption_ = null;
 
-    /** @const @private {?Node} */
+    /** @private {?Node} */
     this.purchaseButton_ = null;
 
     const configUrl = (
@@ -140,7 +140,7 @@ export class LaterpayVendor {
     this.purchaseConfigBaseUrl_ = configUrl + CONFIG_BASE_PATH;
     const articleId = this.laterpayConfig_.articleId;
     if (articleId) {
-      this.purchaseConfigBaseUrl_ += '&article_id=' + articleId;
+      this.purchaseConfigBaseUrl_ += '&article_id=' + encodeURIComponent(articleId);
     }
 
     /** @const @private {!Timer} */
@@ -216,7 +216,7 @@ export class LaterpayVendor {
   getArticleTitle_() {
     const title = this.doc_.querySelector(
       this.laterpayConfig_.articleTitleSelector);
-    dev().assert(
+    user().assert(
       title, 'No article title element found with selector %s',
       this.laterpayConfig_.articleTitleSelector);
     return title.textContent.trim();
@@ -227,12 +227,18 @@ export class LaterpayVendor {
    * @private
    */
   getContainer_() {
-    return this.doc_.getElementById(TAG + '-dialog');
+    const id = TAG + '-dialog';
+    const dialogContainer = this.doc_.getElementById(id);
+    user().assert(
+      dialogContainer,
+      'No element found with id %s', id
+    );
+    return dialogContainer;
   }
 
   /**
    * @private
-   * @returns Promise
+   * @returns {!Promise}
    */
   emptyContainer_() {
     // no need to do all of this if the container is already empty
@@ -443,10 +449,10 @@ export class LaterpayVendor {
   }
 
   /**
-   * @returns {boolean}
+   * @returns {!Promise}
    */
   pingback() {
-    return true;
+    return Promise.resolve();
   }
 }
 

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -49,6 +49,8 @@ const DEFAULT_MESSAGES = {
  *   configUrl: string=,
  *   articleId: string=,
  *   scrollTopAfterAuth: boolean=,
+ *   locale: string=,
+ *   localeMessages: object=,
  * }}
  */
 let LaterpayConfigDef;

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -50,7 +50,7 @@ const DEFAULT_MESSAGES = {
  *   articleId: string=
  * }}
  */
-let LaterpayConfig;
+let LaterpayConfigDef;
 
 /**
  * @typedef {{
@@ -64,17 +64,17 @@ let LaterpayConfig;
  *   validity_value: !number
  * }}
  */
-let PurchaseOption;
+let PurchaseOptionDef;
 
 /**
  * @typedef {{
  *   access: boolean,
  *   apl: string,
- *   premiumcontent: !PurchaseOption,
- *   timepasses: Array<PurchaseOption>=
+ *   premiumcontent: !PurchaseOptionDef,
+ *   timepasses: Array<PurchaseOptionDef>=
  * }}
  */
-let PurchaseConfig;
+let PurchaseConfigDef;
 
 
 /**
@@ -86,36 +86,36 @@ export class LaterpayVendor {
    * @param {!AccessService} accessService
    */
   constructor(accessService) {
-    /** @private @const {!AccessService} */
+    /** @const @private {!AccessService} */
     this.accessService_ = accessService;
 
-    /** @private @const {!Window} */
+    /** @const @private {!Window} */
     this.win_ = this.accessService_.win;
 
-    /** @private @const {!Document} */
+    /** @const @private {!Document} */
     this.doc_ = this.win_.document;
 
-    /** @private @const {!LaterpayConfig} */
+    /** @const @private {!LaterpayConfigDef} */
     this.laterpayConfig_ = this.accessService_.getAdapterConfig();
 
-    /** @private @const {!PurchaseConfig} */
+    /** @const @private {!PurchaseConfigDef} */
     this.purchaseConfig_ = null;
 
-    /** @private @const {?Function} */
+    /** @const @private {?Function} */
     this.purchaseButtonListener_ = null;
 
-    /** @private @const {?Function} */
+    /** @const @private {?Function} */
     this.alreadyPurchasedListener_ = null;
-    /** @private @const {!Array<Event>} */
+    /** @const @private {!Array<Event>} */
     this.purchaseOptionListeners_ = [];
 
-    /** @private @const {!boolean} */
+    /** @const @private {!boolean} */
     this.containerEmpty_ = true;
 
-    /** @private @const {?Node} */
+    /** @const @private {?Node} */
     this.selectedPurchaseOption_ = null;
 
-    /** @private @const {?Node} */
+    /** @const @private {?Node} */
     this.purchaseButton_ = null;
 
     const configUrl = (
@@ -141,10 +141,10 @@ export class LaterpayVendor {
     /** @const @private {!Timer} */
     this.timer_ = timerFor(this.win_);
 
-    /** @private @const {!Vsync} */
+    /** @const @private {!Vsync} */
     this.vsync_ = vsyncFor(this.win_);
 
-    /** @private @const {!Xhr} */
+    /** @const @private {!Xhr} */
     this.xhr_ = xhrFor(this.win_);
 
     installStyles(this.win_.document, CSS, () => {}, false, TAG);
@@ -186,7 +186,7 @@ export class LaterpayVendor {
    */
   getPurchaseConfig_() {
     const url = this.purchaseConfigBaseUrl_ +
-                '&article_title=' + this.getArticleTitle_();
+                '&article_title=' + encodeURIComponent(this.getArticleTitle_());
     const urlPromise = this.accessService_.buildUrl(
       url, /* useAuthData */ false);
     return urlPromise.then(url => {
@@ -280,7 +280,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @param {!PurchaseOption} option
+   * @param {!PurchaseOptionDef} option
    * @param {!string} purchaseActionLabel
    * @return {!Node}
    * @private
@@ -307,7 +307,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @param {!PurchaseOption} option
+   * @param {!PurchaseOptionDef} option
    * @param {!string} purchaseActionLabel
    * @return {!Node}
    * @private

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -37,7 +37,11 @@ export class LaterpayVendor {
     this.accessService_ = accessService;
     this.win_ = this.accessService_.win;
     this.doc_ = this.win_.document;
-    this.laterpayConfig_ = this.accessService_.adapter_.getConfig();
+
+    /** @private @const {!LaterpayConfig} */
+    this.laterpayConfig_ = this.accessService_.getAdapterConfig();
+
+    /** @private @const {!PurchaseConfig} */
     this.purchaseConfig_ = null;
     this.purchaseOptionListeners_ = [];
     this.selectedPurchaseOption_ = null;

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -15,8 +15,10 @@
  */
 
 import {accessServiceFor} from '../../../src/access-service';
+import {CSS} from '../../../build/amp-access-laterpay-0.1.css';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
+import {installStyles} from '../../../src/style-installer';
 import {getMode} from '../../../src/mode';
 import {listen} from '../../../src/event-helper';
 import {removeChildren} from '../../../src/dom';
@@ -141,6 +143,8 @@ export class LaterpayVendor {
 
     /** @private @const {!Xhr} */
     this.xhr_ = xhrFor(this.win_);
+
+    installStyles(this.win_.document, CSS, () => {}, false, TAG);
   }
 
   /**

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -111,7 +111,7 @@ export class LaterpayVendor {
     /** @private {?Function} */
     this.alreadyPurchasedListener_ = null;
 
-    /** @const @private {!Array<Event>} */
+    /** @const @private {!Array<function(!Event)>} */
     this.purchaseOptionListeners_ = [];
 
     /** @private {!boolean} */
@@ -133,14 +133,15 @@ export class LaterpayVendor {
     this.currentLocale_ = this.laterpayConfig_.locale || 'en';
 
     /** @private {Object} */
-    this.i18n_ = Object.assign(DEFAULT_MESSAGES,
+    this.i18n_ = Object.assign({}, DEFAULT_MESSAGES,
                   this.laterpayConfig_.localeMessages || {});
 
     /** @private {string} */
     this.purchaseConfigBaseUrl_ = configUrl + CONFIG_BASE_PATH;
     const articleId = this.laterpayConfig_.articleId;
     if (articleId) {
-      this.purchaseConfigBaseUrl_ += '&article_id=' + encodeURIComponent(articleId);
+      this.purchaseConfigBaseUrl_ +=
+        '&article_id=' + encodeURIComponent(articleId);
     }
 
     /** @const @private {!Timer} */
@@ -185,7 +186,7 @@ export class LaterpayVendor {
       } else {
         throw err;
       }
-      return {access: err.responseJson.access};
+      return {access: false};
     });
   }
 
@@ -229,16 +230,15 @@ export class LaterpayVendor {
   getContainer_() {
     const id = TAG + '-dialog';
     const dialogContainer = this.doc_.getElementById(id);
-    user().assert(
+    return user().assert(
       dialogContainer,
       'No element found with id %s', id
     );
-    return dialogContainer;
   }
 
   /**
    * @private
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   emptyContainer_() {
     // no need to do all of this if the container is already empty
@@ -251,9 +251,11 @@ export class LaterpayVendor {
     }
     if (this.purchaseButtonListener_) {
       this.purchaseButtonListener_();
+      this.purchaseButtonListener_ = null;
     }
     if (this.alreadyPurchasedListener_) {
       this.alreadyPurchasedListener_();
+      this.alreadyPurchasedListener_ = null;
     }
     return this.vsync_.mutatePromise(() => {
       this.containerEmpty_ = true;
@@ -393,7 +395,7 @@ export class LaterpayVendor {
 
   /**
    * @param {!string} href
-   * @returns {!Node}
+   * @return {!Node}
   */
   createAlreadyPurchasedLink_(href) {
     const p = this.doc_.createElement('p');
@@ -449,7 +451,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @returns {!Promise}
+   * @return{!Promise}
    */
   pingback() {
     return Promise.resolve();

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -23,6 +23,7 @@ import {getMode} from '../../../src/mode';
 import {listen} from '../../../src/event-helper';
 import {removeChildren} from '../../../src/dom';
 import {timerFor} from '../../../src/timer';
+import {viewportForDoc} from '../../../src/viewport';
 import {vsyncFor} from '../../../src/vsync';
 import {xhrFor} from '../../../src/xhr';
 
@@ -46,7 +47,8 @@ const DEFAULT_MESSAGES = {
  * @typedef {{
  *   articleTitleSelector: !string,
  *   configUrl: string=,
- *   articleId: string=
+ *   articleId: string=,
+ *   scrollTopAfterAuth: boolean=,
  * }}
  */
 let LaterpayConfigDef;
@@ -94,6 +96,9 @@ export class LaterpayVendor {
     /** @const @private {!Document} */
     this.doc_ = this.win_.document;
 
+    /** @private @const {!Viewport} */
+    this.viewport_ = viewportForDoc(this.win_.document);
+
     /** @const @private {!LaterpayConfigDef} */
     this.laterpayConfig_ = this.accessService_.getAdapterConfig();
 
@@ -105,6 +110,7 @@ export class LaterpayVendor {
 
     /** @const @private {?Function} */
     this.alreadyPurchasedListener_ = null;
+
     /** @const @private {!Array<Event>} */
     this.purchaseOptionListeners_ = [];
 
@@ -161,6 +167,10 @@ export class LaterpayVendor {
         throw user()
           .createError('No merchant domains have been matched for this ' +
             'article, or no paid content configurations are setup.');
+      }
+
+      if (this.laterpayConfig_.scrollTopAfterAuth) {
+        this.vsync_.mutate(() => this.viewport_.setScrollTop(0));
       }
       this.emptyContainer_();
       return {access: response.access};

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -147,7 +147,7 @@ export class LaterpayVendor {
    * @return {!Promise<!JSONType>}
    */
   authorize() {
-    user().assert(isExperimentOn(this.win_, 'amp-access-laterpay'),
+    user().assert(isExperimentOn(this.win_, TAG),
         'Enable "amp-access-laterpay" experiment');
     return this.getPurchaseConfig_()
     .then(response => {
@@ -211,7 +211,7 @@ export class LaterpayVendor {
    * @private
    */
   getContainer_() {
-    return this.doc_.querySelector(TAG + '-list');
+    return this.doc_.getElementById(TAG + '-dialog');
   }
 
   /**
@@ -376,7 +376,7 @@ export class LaterpayVendor {
    */
   handlePurchaseOptionSelection_(ev) {
     ev.preventDefault();
-    const selectedOptionClassname = 'amp-access-laterpay-selected';
+    const selectedOptionClassname = TAG + '-selected';
     const prevPurchaseOption = this.selectedPurchaseOption_;
     const purchaseActionLabel = ev.target.dataset.purchaseActionLabel;
     if (prevPurchaseOption &&

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -187,7 +187,7 @@ export class LaterpayVendor {
   getPurchaseConfig_() {
     const url = this.purchaseConfigBaseUrl_ +
                 '&article_title=' + this.getArticleTitle_();
-    const urlPromise = this.accessService_.buildUrl_(
+    const urlPromise = this.accessService_.buildUrl(
       url, /* useAuthData */ false);
     return urlPromise.then(url => {
       dev().fine(TAG, 'Authorization URL: ', url);
@@ -409,7 +409,7 @@ export class LaterpayVendor {
                 '?return_url=RETURN_URL' +
                 '&article_url=SOURCE_URL' +
                 '&amp_reader_id=READER_ID';
-    const urlPromise = this.accessService_.buildUrl_(
+    const urlPromise = this.accessService_.buildUrl(
       configuredUrl, /* useAuthData */ false);
     return urlPromise.then(url => {
       dev().fine(TAG, 'Authorization URL: ', url);

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -15,10 +15,10 @@
  */
 
 import {accessServiceFor} from '../../../src/access-service';
-import {xhrFor} from '../../../src/xhr';
 import {isExperimentOn} from '../../../src/experiments';
 import {dev, user} from '../../../src/log';
 import {listen, listenOnce} from '../../../src/event-helper';
+import {xhrFor} from '../../../src/xhr';
 
 const TAG = 'amp-access-laterpay';
 const CONFIG_URL = 'http://localhost:8080/api/public/initial_config';
@@ -36,6 +36,7 @@ export class LaterpayVendor {
     /** @private @const */
     this.accessService_ = accessService;
     this.win_ = this.accessService_.win;
+    this.doc_ = this.win_.document;
     this.laterpayConfig_ = this.accessService_.adapter_.getConfig();
     this.purchaseConfig_ = null;
     this.purchaseOptionListeners_ = [];
@@ -76,9 +77,9 @@ export class LaterpayVendor {
   }
 
   renderPurchaseOverlay_() {
-    const laterpayList = this.win_.document.querySelectorAll(
-      'amp-access-laterpay-list')[0];
-    const listContainer = document.createElement('ul');
+    const laterpayList = this.doc_.querySelector(
+      'amp-access-laterpay-list');
+    const listContainer = this.doc_.createElement('ul');
     // TODO set these up somewhere else and make them configurable
     this.purchaseConfig_.premiumcontent.title = 'Buy this article';
     this.purchaseConfig_.premiumcontent.description =
@@ -89,8 +90,8 @@ export class LaterpayVendor {
     this.purchaseConfig_.timepasses.forEach(timepass => {
       listContainer.appendChild(this.createPurchaseOption_(timepass));
     });
-    const purchaseButton = document.createElement('button');
-    purchaseButton.innerHTML = 'Confirm your selection';
+    const purchaseButton = this.doc_.createElement('button');
+    purchaseButton.textContent = 'Confirm your selection';
     purchaseButton.disabled = true;
     this.purchaseButton_ = purchaseButton;
     listenOnce(purchaseButton, 'click', this.handlePurchase_.bind(this));
@@ -100,19 +101,19 @@ export class LaterpayVendor {
   }
 
   createPurchaseOption_(option) {
-    const li = document.createElement('li');
-    const title = document.createElement('h3');
-    const link = document.createElement('a');
+    const li = this.doc_.createElement('li');
+    const title = this.doc_.createElement('h3');
+    const link = this.doc_.createElement('a');
     link.href = option.purchase_url;
-    link.innerHTML = option.title;
+    link.textContent = option.title;
     this.purchaseOptionListeners_.push(listen(
       link, 'click', this.handlePurchaseOptionSelection_.bind(this)
     ));
     title.appendChild(link);
-    const description = document.createElement('p');
-    description.innerHTML = option.description;
-    const price = document.createElement('p');
-    price.innerHTML = this.formatPrice_(option.price);
+    const description = this.doc_.createElement('p');
+    description.textContent = option.description;
+    const price = this.doc_.createElement('p');
+    price.textContent = this.formatPrice_(option.price);
     li.appendChild(title);
     li.appendChild(description);
     li.appendChild(price);
@@ -141,8 +142,8 @@ export class LaterpayVendor {
     }
   }
 
-  handlePurchase_(ev) {
-    const purchaseUrl = this.selectedPurchaseOption_.href;
+  handlePurchase_() {
+    //const purchaseUrl = this.selectedPurchaseOption_.href;
     let unlistener;
     while (unlistener = this.purchaseOptionListeners_.shift()) {
       unlistener();

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -316,6 +316,7 @@ export class LaterpayVendor {
     radio.id = option.tp_title;
     radio.value = option.purchase_url;
     radio.setAttribute('data-purchase-action-label', purchaseActionLabel);
+    radio.setAttribute('data-purchase-type', option['purchase_type']);
     this.purchaseOptionListeners_.push(listen(
       radio, 'change', this.handlePurchaseOptionSelection_.bind(this)
     ));
@@ -409,7 +410,8 @@ export class LaterpayVendor {
       configuredUrl, /* useAuthData */ false);
     return urlPromise.then(url => {
       dev().fine(TAG, 'Authorization URL: ', url);
-      this.accessService_.loginWithUrl(url);
+      this.accessService_.loginWithUrl(
+        url, this.selectedPurchaseOption_.dataset.purchaseType);
     });
   }
 }

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -49,7 +49,7 @@ const DEFAULT_MESSAGES = {
  *   articleTitleSelector: !string,
  *   configUrl: string=,
  *   articleId: string=,
- *   scrollTopAfterAuth: boolean=,
+ *   scrollToTopAfterAuth: boolean=,
  *   locale: string=,
  *   localeMessages: object=,
  *   sandbox: boolean=,
@@ -185,7 +185,7 @@ export class LaterpayVendor {
             'article, or no paid content configurations are setup.');
       }
 
-      if (this.laterpayConfig_.scrollTopAfterAuth) {
+      if (this.laterpayConfig_.scrollToTopAfterAuth) {
         this.vsync_.mutate(() => this.viewport_.setScrollTop(0));
       }
       this.emptyContainer_();

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -259,7 +259,8 @@ export class LaterpayVendor {
    * @private
    */
   renderPurchaseOverlay_() {
-    const laterpayList = this.getContainer_();
+    const dialogContainer = this.getContainer_();
+    this.renderTextBlock_('header');
     const listContainer = this.doc_.createElement('ul');
     this.purchaseConfig_.premiumcontent['tp_title'] =
       this.i18n_.premiumContentTitle;
@@ -278,12 +279,27 @@ export class LaterpayVendor {
     this.purchaseButtonListener_ = listen(purchaseButton, 'click', ev => {
       this.handlePurchase_(ev, this.selectedPurchaseOption_.value);
     });
-    laterpayList.appendChild(listContainer);
-    laterpayList.appendChild(purchaseButton);
-    laterpayList.appendChild(
+    dialogContainer.appendChild(listContainer);
+    dialogContainer.appendChild(purchaseButton);
+    dialogContainer.appendChild(
       this.createAlreadyPurchasedLink_(this.purchaseConfig_.apl));
+    this.renderTextBlock_('footer');
     this.containerEmpty_ = false;
   }
+
+  /**
+   * @private
+   * @param {!string} area
+   */
+  renderTextBlock_(area) {
+    if (this.i18n_[area]) {
+      const el = this.doc_.createElement('p');
+      el.className = TAG + '-' + area;
+      el.textContent = this.i18n_[area];
+      this.getContainer_().appendChild(el);
+    }
+  }
+
 
   /**
    * @param {!PurchaseOptionDef} option

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -118,9 +118,12 @@ export class LaterpayVendor {
     /** @private @const {?Node} */
     this.purchaseButton_ = null;
 
-    const configUrl = (getMode().development && this.laterpayConfig_.configUrl)
-                    ? this.laterpayConfig_.configUrl
-                    : CONFIG_URL;
+    const configUrl = (
+      (getMode().localDev || getMode().development) &&
+      this.laterpayConfig_.configUrl
+    ) ? this.laterpayConfig_.configUrl
+      : CONFIG_URL;
+
     /** @private {string} */
     this.currentLocale_ = this.laterpayConfig_.locale || 'en';
 

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -29,6 +29,7 @@ import {xhrFor} from '../../../src/xhr';
 
 const TAG = 'amp-access-laterpay';
 const CONFIG_URL = 'https://connector.laterpay.net';
+const SANDBOX_CONFIG_URL = 'https://connector.sandbox.laterpaytest.net';
 const CONFIG_BASE_PATH = '/api/public/amp?' +
                          'article_url=CANONICAL_URL' +
                          '&amp_reader_id=READER_ID' +
@@ -51,6 +52,7 @@ const DEFAULT_MESSAGES = {
  *   scrollTopAfterAuth: boolean=,
  *   locale: string=,
  *   localeMessages: object=,
+ *   sandbox: boolean=,
  * }}
  */
 let LaterpayConfigDef;
@@ -125,12 +127,6 @@ export class LaterpayVendor {
     /** @private {?Node} */
     this.purchaseButton_ = null;
 
-    const configUrl = (
-      (getMode().localDev || getMode().development) &&
-      this.laterpayConfig_.configUrl
-    ) ? this.laterpayConfig_.configUrl
-      : CONFIG_URL;
-
     /** @private {string} */
     this.currentLocale_ = this.laterpayConfig_.locale || 'en';
 
@@ -139,7 +135,7 @@ export class LaterpayVendor {
                   this.laterpayConfig_.localeMessages || {});
 
     /** @private {string} */
-    this.purchaseConfigBaseUrl_ = configUrl + CONFIG_BASE_PATH;
+    this.purchaseConfigBaseUrl_ = this.getConfigUrl_() + CONFIG_BASE_PATH;
     const articleId = this.laterpayConfig_.articleId;
     if (articleId) {
       this.purchaseConfigBaseUrl_ +=
@@ -156,6 +152,23 @@ export class LaterpayVendor {
     this.xhr_ = xhrFor(this.win_);
 
     installStyles(this.win_.document, CSS, () => {}, false, TAG);
+  }
+
+  /**
+   * @private
+   * @return {!string}
+   */
+  getConfigUrl_() {
+    if (
+      (getMode().localDev || getMode().development) &&
+      this.laterpayConfig_.configUrl
+    ) {
+      return this.laterpayConfig_.configUrl;
+    } else if (getMode().development && this.laterpayConfig_.sandbox) {
+      return SANDBOX_CONFIG_URL;
+    } else {
+      return CONFIG_URL;
+    }
   }
 
   /**

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -37,8 +37,8 @@ const AUTHORIZATION_TIMEOUT = 3000;
 const DEFAULT_MESSAGES = {
   decimalDelimeter: '.',
   premiumContentTitle: 'Buy only this article',
-  ppuButton: 'Buy Now, Pay Later',
-  sisButton: 'Buy Now',
+  payLaterButton: 'Buy Now, Pay Later',
+  payNowButton: 'Buy Now',
   defaultButton: 'Buy Now',
   alreadyPurchasedLink: 'I already bought this',
 };
@@ -256,13 +256,10 @@ export class LaterpayVendor {
       this.i18n_.premiumContentTitle;
     this.purchaseConfig_.premiumcontent.description = this.getArticleTitle_();
     listContainer.appendChild(
-      this.createPurchaseOption_(
-        this.purchaseConfig_.premiumcontent, this.i18n_.ppuButton)
+      this.createPurchaseOption_(this.purchaseConfig_.premiumcontent)
     );
     this.purchaseConfig_.timepasses.forEach(timepass => {
-      listContainer.appendChild(
-        this.createPurchaseOption_(timepass, this.i18n_.sisButton)
-      );
+      listContainer.appendChild(this.createPurchaseOption_(timepass));
     });
     const purchaseButton = this.doc_.createElement('button');
     purchaseButton.className = TAG + '-purchase-button';
@@ -281,15 +278,14 @@ export class LaterpayVendor {
 
   /**
    * @param {!PurchaseOptionDef} option
-   * @param {!string} purchaseActionLabel
    * @return {!Node}
    * @private
    */
-  createPurchaseOption_(option, purchaseActionLabel) {
+  createPurchaseOption_(option) {
     const li = this.doc_.createElement('li');
     const control = this.doc_.createElement('label');
     control.for = option.tp_title;
-    control.appendChild(this.createRadioControl_(option, purchaseActionLabel));
+    control.appendChild(this.createRadioControl_(option));
     const metadataContainer = this.doc_.createElement('div');
     metadataContainer.className = TAG + '-metadata';
     const title = this.doc_.createElement('span');
@@ -308,18 +304,19 @@ export class LaterpayVendor {
 
   /**
    * @param {!PurchaseOptionDef} option
-   * @param {!string} purchaseActionLabel
    * @return {!Node}
    * @private
    */
-  createRadioControl_(option, purchaseActionLabel) {
+  createRadioControl_(option) {
     const radio = this.doc_.createElement('input');
     radio.name = 'purchaseOption';
     radio.type = 'radio';
     radio.id = option.tp_title;
     radio.value = option.purchase_url;
+    const purchaseType = option['purchase_type'] === 'ppu' ? 'payLater' : 'payNow';
+    const purchaseActionLabel = this.i18n_[purchaseType + 'Button'];
     radio.setAttribute('data-purchase-action-label', purchaseActionLabel);
-    radio.setAttribute('data-purchase-type', option['purchase_type']);
+    radio.setAttribute('data-purchase-type', purchaseType);
     this.purchaseOptionListeners_.push(listen(
       radio, 'change', this.handlePurchaseOptionSelection_.bind(this)
     ));
@@ -367,7 +364,7 @@ export class LaterpayVendor {
   */
   createAlreadyPurchasedLink_(href) {
     const p = this.doc_.createElement('p');
-    p.className = TAG + '-already-purchased-container';
+    p.className = TAG + '-already-purchased-link-container';
     const a = this.doc_.createElement('a');
     a.href = href;
     a.textContent = this.i18n_.alreadyPurchasedLink;

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -35,7 +35,6 @@ const CONFIG_BASE_PATH = '/api/public/amp?' +
 const AUTHORIZATION_TIMEOUT = 3000;
 
 const DEFAULT_MESSAGES = {
-  decimalDelimeter: '.',
   premiumContentTitle: 'Buy only this article',
   payLaterButton: 'Buy Now, Pay Later',
   payNowButton: 'Buy Now',
@@ -313,7 +312,9 @@ export class LaterpayVendor {
     radio.type = 'radio';
     radio.id = option.tp_title;
     radio.value = option.purchase_url;
-    const purchaseType = option['purchase_type'] === 'ppu' ? 'payLater' : 'payNow';
+    const purchaseType = option['purchase_type'] === 'ppu' ?
+      'payLater' :
+      'payNow';
     const purchaseActionLabel = this.i18n_[purchaseType + 'Button'];
     radio.setAttribute('data-purchase-action-label', purchaseActionLabel);
     radio.setAttribute('data-purchase-type', purchaseType);

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -16,27 +16,48 @@
 
 import {LaterpayVendor} from '../amp-access-laterpay';
 import {toggleExperiment} from '../../../../src/experiments';
+import * as sinon from 'sinon';
 
-
-describes.fakeWin('LaterpayVendor', {}, env => {
-  let win;
+describe('LaterpayVendor', () => {
   let accessService;
   let accessServiceMock;
+  let xhrMock;
+  let articleTitle;
+  let laterpayConfig;
+  let sandbox;
   let vendor;
+  let win;
 
   beforeEach(() => {
-    win = env.win;
+    win = window;
+    laterpayConfig = {
+      articleTitleSelector: '#laterpay-test-title',
+    };
     accessService = {
       win,
+      getAdapterConfig: () => { return laterpayConfig; },
+      buildUrl: () => {},
+      loginWithUrl: () => {},
     };
+    sandbox = sinon.sandbox.create();
     accessServiceMock = sandbox.mock(accessService);
+
+    articleTitle = document.createElement('h1');
+    articleTitle.id = 'laterpay-test-title';
+    articleTitle.textContent = 'test title';
+    document.body.appendChild(articleTitle);
+
     vendor = new LaterpayVendor(accessService);
+    xhrMock = sandbox.mock(vendor.xhr_);
     toggleExperiment(win, 'amp-access-laterpay', true);
   });
 
   afterEach(() => {
+    articleTitle.parentNode.removeChild(articleTitle);
     toggleExperiment(win, 'amp-access-laterpay', false);
     accessServiceMock.verify();
+    xhrMock.verify();
+    sandbox.restore();
   });
 
   it('should fail without experiment', () => {
@@ -46,10 +67,172 @@ describes.fakeWin('LaterpayVendor', {}, env => {
     }).to.throw(/experiment/);
   });
 
-  it('should call authorize', () => {
-    // TODO: implement
-    return vendor.authorize().then(resp => {
-      expect(resp.access).to.be.true;
+  describe('authorize', () => {
+    let emptyContainerStub;
+    beforeEach(() => {
+      emptyContainerStub = sandbox.stub(vendor, 'emptyContainer_');
+      sandbox.stub(vendor, 'renderPurchaseOverlay_');
     });
+
+    it('successful authorization', () => {
+      vendor.purchaseConfigBaseUrl_ = 'https://baseurl?param';
+      accessServiceMock.expects('buildUrl')
+        .withExactArgs('https://baseurl?param&article_title=test%20title', false)
+        .returns(Promise.resolve('https://builturl'))
+        .once();
+      xhrMock.expects('fetchJson')
+        .withExactArgs('https://builturl', {
+          credentials: 'include',
+          requireAmpResponseSourceOrigin: true,
+        })
+        .returns(Promise.resolve({access: true}))
+        .once();
+      return vendor.authorize().then(resp => {
+        expect(resp.access).to.be.true;
+        expect(emptyContainerStub.called).to.be.true;
+      });
+    });
+
+    it('authorization fails due to lack of server config', done => {
+      accessServiceMock.expects('buildUrl')
+        .returns(Promise.resolve('https://builturl'))
+        .once();
+      xhrMock.expects('fetchJson')
+        .withExactArgs('https://builturl', {
+          credentials: 'include',
+          requireAmpResponseSourceOrigin: true,
+        })
+        .returns(Promise.resolve({status: 204}))
+        .once();
+      return vendor.authorize().catch(err => {
+        expect(err.message).to.exist;
+        done();
+      });
+    });
+
+    it('authorization response from server fails', done => {
+      accessServiceMock.expects('buildUrl')
+        .returns(Promise.resolve('https://builturl'))
+        .once();
+      xhrMock.expects('fetchJson')
+        .withExactArgs('https://builturl', {
+          credentials: 'include',
+          requireAmpResponseSourceOrigin: true,
+        })
+        .returns(Promise.reject({
+          response: {status: 402},
+          responseJson: {access: false},
+        }))
+        .once();
+      emptyContainerStub.returns(Promise.resolve());
+      return vendor.authorize().then(err => {
+        expect(err.access).to.be.false;
+        done();
+      });
+    });
+
   });
+
+  describe('create purchase overlay', () => {
+    let container;
+    beforeEach(() => {
+      container = document.createElement('div');
+      container.id = 'amp-access-laterpay-dialog';
+      document.body.appendChild(container);
+      vendor.i18n_ = {};
+      vendor.purchaseConfig_ = {
+        premiumcontent: {
+          price: {},
+        },
+        timepasses: [
+          {price: {}},
+        ],
+      };
+      vendor.renderPurchaseOverlay_();
+    });
+
+    afterEach(() => {
+      container.parentNode.removeChild(container);
+    });
+
+    it('renders list', () => {
+      expect(container.querySelector('ul')).to.not.be.null;
+    });
+
+    it('renders 2 purchase options', () => {
+      expect(container.querySelector('ul').childNodes.length).to.equal(2);
+    });
+
+  });
+
+  describe('purchase option selection', () => {
+    let container;
+    beforeEach(() => {
+      container = document.createElement('div');
+      container.id = 'amp-access-laterpay-dialog';
+      document.body.appendChild(container);
+      vendor.i18n_ = {};
+      vendor.purchaseConfig_ = {
+        premiumcontent: {
+          price: {},
+        },
+        timepasses: [
+          {price: {}},
+        ],
+      };
+      vendor.renderPurchaseOverlay_();
+      const ev = new Event('change');
+      container.querySelector('input').dispatchEvent(ev);
+    });
+
+    afterEach(() => {
+      container.parentNode.removeChild(container);
+    });
+
+    it('purchase option is selected', () => {
+      expect(vendor.selectedPurchaseOption_).to.not.be.null;
+      expect(vendor.selectedPurchaseOption_.classList
+        .contains('amp-access-laterpay-selected')).to.be.true;
+    });
+
+  });
+
+  describe('purchase', () => {
+    let container;
+    beforeEach(() => {
+      container = document.createElement('div');
+      container.id = 'amp-access-laterpay-dialog';
+      document.body.appendChild(container);
+      vendor.i18n_ = {};
+      vendor.purchaseConfig_ = {
+        premiumcontent: {
+          price: {},
+        },
+        timepasses: [
+          {price: {}},
+        ],
+      };
+      vendor.renderPurchaseOverlay_();
+      const changeEv = new Event('change');
+      container.querySelector('input').dispatchEvent(changeEv);
+    });
+
+    afterEach(() => {
+      container.parentNode.removeChild(container);
+    });
+
+    it('sends request for purchase', done => {
+      accessServiceMock.expects('buildUrl')
+        .returns(Promise.resolve('https://builturl'))
+        .once();
+      accessServiceMock.expects('loginWithUrl')
+        .once();
+      const clickEv = new Event('click');
+      container.querySelector('button').dispatchEvent(clickEv);
+      setTimeout(() => {done();}, 500);
+    });
+
+  });
+
+
 });

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -138,6 +138,9 @@ The structure created for the dialog looks as follows:
 
 ```html
 <div id="amp-access-laterpay-dialog">
+  <p class="amp-access-laterpay-header">
+    Optional, appears if header locale message is defined.
+  </p>
   <ul>
     <li>
       <label>
@@ -157,6 +160,9 @@ The structure created for the dialog looks as follows:
   <button class="amp-access-laterpay-purchase-button">Buy Now</button>
   <p class="amp-access-laterpay-already-purchased-container">
     <a href="...">I already bought this</a>
+  </p>
+  <p class="amp-access-laterpay-footer">
+    Optional, appears if footer locale message is defined.
   </p>
 </div>
 ```
@@ -212,6 +218,16 @@ The following message keys can be translated or customized, but be aware that th
     <td class="col-fourty"><code>alreadyPurchasedLink</code></td>
     <td>If the user has purchased the article in the past but they have lost their cookies (or are in a different device) they can use this link to login to LaterPay and retrieve their purchases.</td>
     <td>'I already bought this'</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>header</code></td>
+    <td>Optional header text.</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>footer</code></td>
+    <td>Optional footer text.</td>
+    <td></td>
   </tr>
 </table>
 

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -102,7 +102,7 @@ The following values can be set in the `laterpay` config object:
     <td>Allows the publisher to customize or localize the text present in the generated list of purchase options. See the [#localization](Localization) section for more information.</td>
   </tr>
   <tr>
-    <td class="col-fourty"><code>scrollTopAfterAuth</code></td>
+    <td class="col-fourty"><code>scrollToTopAfterAuth</code></td>
     <td>&lt;boolean&gt;</td>
     <td>If true, scrolls the page to the top after the authorization process is sucessful. This can be helpful if the place where you show the dialog is further below in the page and the user could be confused by their current scroll position after returning to the page.</td>
   </tr>

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -239,3 +239,7 @@ The following message keys can be translated or customized, but be aware that th
 * [LaterPay](https://www.laterpay.net)
 * [LaterPay: How we do MicroPayments](http://docs.laterpay.net/how_we_do_micropayments/)
 * [LaterPay Connector](https://connectormwi.laterpay.net/docs/index.html) - Similar to AMP Access LaterPay but for non AMP pages.
+
+## Validation
+
+See [amp-access-laterpay rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-access-laterpay/0.1/validator-amp-access-laterpay.protoascii) in the AMP validator specification.

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -101,6 +101,11 @@ The following values can be set in the `laterpay` config object:
     <td>&lt;object&gt;</td>
     <td>Allows the publisher to customize or localize the text present in the generated list of purchase options. See the [#localization](Localization) section for more information.</td>
   </tr>
+  <tr>
+    <td class="col-fourty"><code>scrollTopAfterAuth</code></td>
+    <td>&lt;boolean&gt;</td>
+    <td>If true, scrolls the page to the top after the authorization process is sucessful. This can be helpful if the place where you show the dialog is further below in the page and the user could be confused by their current scroll position after returning to the page.</td>
+  </tr>
 </table>
 
 ## Using Access Content Markup and showing the purchase list

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -1,0 +1,223 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<table>
+  <tr>
+    <td class="col-fourty"><strong>Description</strong></td>
+    <td>AMP Access LaterPay allows publishers to easily integrate with the micropayments platform <a href="https://www.laterpay.net">LaterPay</a>. It is based on, and requires <a href="https://www.ampproject.org/docs/reference/components/amp-access">AMP Access</a>.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong>Availability</strong></td>
+    <td>Experimental</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong>Required Script</strong></td>
+    <td>
+      <div>
+        <code>&lt;script async custom-element="amp-access" src="https://cdn.ampproject.org/v0/amp-access-0.1.js">&lt;/script></code>
+      </div>
+      <div>
+        <code>&lt;script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js">&lt;/script></code>
+      </div>
+      <div>
+        <code>&lt;script async custom-element="amp-access-laterpay" src="https://cdn.ampproject.org/v0/amp-access-laterpay-0.1.js">&lt;/script></code>
+      </div>
+      <small>Notice that both "amp-access" and "amp-analytics" scripts are required.</small>
+    </td>
+  </tr>
+</table>
+
+<a href="https://laterpay.net">LaterPay</a> is a micropayments platform which allows users to buy an individual article but only pay it when they reach a certain amount on their tab. It also allows users to buy passes which allow access to articles for an amount of time specified by the publisher.
+
+## Behavior
+
+This component uses AMP Access internally to provide a behavior similar to AMP Access, but tailored for usage with the LaterPay service.
+
+It does not require an authorization or pingback configuration, as it is pre-configured to work with the LaterPay service. It also does not require manually setup of login links.
+
+The different purchase options can be configured on the publisher's LaterPay account, and the component will retrieve the configuration and create a list of available purchase options.
+
+You can refer to the documenation on configuring the [LaterPay Connector](http://docs.laterpay.net/connector/configuring/), LaterPay's existing frontend integration, to learn how to configure the purchase options.
+
+The generated list can be styled and presented according to the publisher's preference.
+
+This component also relies on [Access Content Markup](https://www.ampproject.org/docs/reference/components/amp-access#access-content-markup) to show and hide content.
+
+## Configuration
+
+Configuration is similar to AMP Access, but no authorization, pingback and login links are required.
+
+```html
+<script id="amp-access" type="application/json">
+  {
+    "vendor": "laterpay",
+    "laterpay": {
+      "property": value
+    }
+  }
+</script>
+```
+
+The following values can be set in the `laterpay` config object:
+
+<table>
+  <tr>
+    <th>Property</th>
+    <th>Values</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>articleTitleSelector</code></td>
+    <td>CSS selector <strong>required</strong></td>
+    <td>A CSS selector which determines the element in the page which contains the title of the article. This will ensure the page presented for purchase of the article will contain this title so the user is aware of what they're purchasing.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>articleId</code></td>
+    <td>Comma separated list of identifiers</td>
+    <td>By default, the URL of an article is used to match it to a purchase option, but instead of specifying a URL path for a purchase option you can set an Article ID in the LaterPay Connector-UI and then use the `articleId` property to match the article with the purchase option.
+    <br />
+    This is necessary in cases where matching a purchase option by an article’s URL is not flexible enough. See the [configuration page for the LaterPay Connector](http://docs.laterpay.net/connector/inpage_configuration/article_id/) to see learn about some example scenarios in which this is useful.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>locale</code></td>
+    <td>&lt;string&gt;</td>
+    <td>Defines the style of price formatting appropriate for the locale.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>localeMessages</code></td>
+    <td>&lt;object&gt;</td>
+    <td>Allows the publisher to customize or localize the text present in the generated list of purchase options. See the [#localization](Localization) section for more information.</td>
+  </tr>
+</table>
+
+## Using Access Content Markup and showing the purchase list
+
+Access Content Markup should be used in the same way as with AMP Access.
+
+The element with id `amp-access-laterpay-dialog` will render a list of purchase options when the user does not have access to the article. This list has some very basic styling and can be customized to feel more integrated in the publisher's page.
+
+```html
+<section amp-access="NOT error AND NOT access" amp-access-hide class="login-section">
+  <div id="amp-access-laterpay-dialog"></div>
+</section>
+
+<section amp-access="error" amp-access-hide class="error-section">
+  Oops... Something broke.
+</section>
+
+<div amp-access="access" amp-access-hide>
+  <p>...article content...</p>
+</div>
+```
+
+## Styling
+
+Multiple classes are applied to some of the elements in the generated markup. Elements with no classes can be referred unambiguously through CSS element selectors.
+
+Some basic layout CSS already exists, but it's recommended that publishers style it to match the look and feel of their pages.
+
+The structure created for the dialog looks as follows:
+
+```html
+<div id="amp-access-laterpay-dialog">
+  <ul>
+    <li>
+      <label>
+        <input name="purchaseOption" type="radio" />
+        <div class="amp-access-laterpay-metadata">
+          <span class="amp-access-laterpay-title">Purchase option title</span>
+          <p class="amp-access-laterpay-description">Purchase option description</p>
+        </div>
+      </label>
+      <p class="amp-access-laterpay-price-container">
+        <span class="amp-access-laterpay-price">0.15</span>
+        <sup class="amp-access-laterpay-currency">USD</sup>
+      </p>
+    </li>
+    <!-- ... more list items for other purchase options ... -->
+  </ul>
+  <button class="amp-access-laterpay-purchase-button">Buy Now</button>
+  <p class="amp-access-laterpay-already-purchased-container">
+    <a href="...">I already bought this</a>
+  </p>
+</div>
+```
+
+## Localization
+
+The text shown in the dialog for the purchase options will be defined by the publisher in the LaterPay Connector UI.
+
+The remaining text is part of the extended component and can be changed and localized via the configuration options as follows:
+
+```html
+<script id="amp-access" type="application/json">
+  {
+    "vendor": "laterpay",
+    "laterpay": {
+      "localeMessages": {
+        "messageKey": "message value"
+      }
+    }
+  }
+</script>
+```
+
+The following message keys can be translated or customized, but be aware that they should retain their original meaning and intent.
+
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Description</th>
+    <th>Default value</th>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>premiumContentTitle</code></td>
+    <td>The Premium Content purchase option allows the user to buy just the currently shown article for the specified price. The title for this option cannot be specified in the Connector UI but it can be customized here.</td>
+    <td>'Buy only this article'</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>payLaterButton</code></td>
+    <td>Text shown in the purchase button for options that can be paid later.</td>
+    <td>'Buy Now, Pay Later'</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>payNowButton</code></td>
+    <td>Text shown in the purchase button for options which will have to paid in the moment of purchase.</td>
+    <td>'Buy Now'</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>defaultButton</code></td>
+    <td>Default text shown in the purchase button before any option is selected.</td>
+    <td>'Buy Now'</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>alreadyPurchasedLink</code></td>
+    <td>If the user has purchased the article in the past but they have lost their cookies (or are in a different device) they can use this link to login to LaterPay and retrieve their purchases.</td>
+    <td>'I already bought this'</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>decimalDelimeter</code></td>
+    <td>Decimal delimeter used in the price display.</td>
+    <td>'.'</td>
+  </tr>
+</table>
+
+## Related Documentation
+
+* [AMP Access](https://www.ampproject.org/docs/reference/components/amp-access)
+* [LaterPay](https://www.laterpay.net)
+* [LaterPay: How we do MicroPayments](http://docs.laterpay.net/how_we_do_micropayments/)
+* [LaterPay Connector](https://connectormwi.laterpay.net/docs/index.html) - Similar to AMP Access LaterPay but for non AMP pages.

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -106,6 +106,11 @@ The following values can be set in the `laterpay` config object:
     <td>&lt;boolean&gt;</td>
     <td>If true, scrolls the page to the top after the authorization process is sucessful. This can be helpful if the place where you show the dialog is further below in the page and the user could be confused by their current scroll position after returning to the page.</td>
   </tr>
+  <tr>
+    <td class="col-fourty"><code>sandbox</code></td>
+    <td>&lt;boolean&gt;</td>
+    <td>Only needed if you are using the sandbox mode to test out your server configuration. You also need to use AMP's [development mode](https://www.ampproject.org/docs/reference/spec#amp-runtime).</td>
+  </tr>
 </table>
 
 ## Using Access Content Markup and showing the purchase list

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -46,7 +46,7 @@ limitations under the License.
 
 This component uses AMP Access internally to provide a behavior similar to AMP Access, but tailored for usage with the LaterPay service.
 
-It does not require an authorization or pingback configuration, as it is pre-configured to work with the LaterPay service. It also does not require manually setup of login links.
+It does not require an authorization or pingback configuration, as it is pre-configured to work with the LaterPay service. It also does not require manual setup of login links.
 
 The different purchase options can be configured on the publisher's LaterPay account, and the component will retrieve the configuration and create a list of available purchase options.
 
@@ -207,11 +207,6 @@ The following message keys can be translated or customized, but be aware that th
     <td class="col-fourty"><code>alreadyPurchasedLink</code></td>
     <td>If the user has purchased the article in the past but they have lost their cookies (or are in a different device) they can use this link to login to LaterPay and retrieve their purchases.</td>
     <td>'I already bought this'</td>
-  </tr>
-  <tr>
-    <td class="col-fourty"><code>decimalDelimeter</code></td>
-    <td>Decimal delimeter used in the price display.</td>
-    <td>'.'</td>
   </tr>
 </table>
 

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -114,9 +114,11 @@ Access Content Markup should be used in the same way as with AMP Access.
 
 The element with id `amp-access-laterpay-dialog` will render a list of purchase options when the user does not have access to the article. This list has some very basic styling and can be customized to feel more integrated in the publisher's page.
 
+Make sure you add the `amp-access-laterpay` class if you want to use the default styling.
+
 ```html
-<section amp-access="NOT error AND NOT access" amp-access-hide class="login-section">
-  <div id="amp-access-laterpay-dialog"></div>
+<section amp-access="NOT error AND NOT access" amp-access-hide>
+  <div id="amp-access-laterpay-dialog" class="amp-access-laterpay"></div>
 </section>
 
 <section amp-access="error" amp-access-hide class="error-section">
@@ -137,7 +139,7 @@ Some basic layout CSS already exists, but it's recommended that publishers style
 The structure created for the dialog looks as follows:
 
 ```html
-<div id="amp-access-laterpay-dialog">
+<div id="amp-access-laterpay-dialog" class="amp-access-laterpay">
   <p class="amp-access-laterpay-header">
     Optional, appears if header locale message is defined.
   </p>

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ limitations under the License.
   </tr>
 </table>
 
-<a href="https://laterpay.net">LaterPay</a> is a micropayments platform which allows users to buy an individual article but only pay it when they reach a certain amount on their tab. It also allows users to buy passes which allow access to articles for an amount of time specified by the publisher.
+<a href="https://laterpay.net">LaterPay</a> is a micropayment platform which allows users to buy any online content with just two clicks, and get immediate access – without upfront registration, personal data, or payment. Users only pay, once their purchases have reached a total of $5 or 5€ across websites. Content providers can sell individual items or time passes, which allow flatrate access or time limited access to content.
 
 ## Behavior
 

--- a/extensions/amp-access/0.1/amp-access-vendor.js
+++ b/extensions/amp-access/0.1/amp-access-vendor.js
@@ -41,8 +41,12 @@ export class AccessVendorAdapter {
     this.vendorName_ = user().assert(configJson['vendor'],
         '"vendor" name must be specified');
 
+    /** @const @private {JSONType} */
+    this.vendorConfig_ = configJson[this.vendorName_];
+
     /** @const @private {boolean} */
     this.isPingbackEnabled_ = !configJson['noPingback'];
+
     /** @const @private {!Promise<!./access-vendor.AccessVendor>} */
     this.vendorPromise_ = new Promise(resolve => {
       /** @private {function(!./access-vendor.AccessVendor)|undefined} */
@@ -52,9 +56,7 @@ export class AccessVendorAdapter {
 
   /** @override */
   getConfig() {
-    return {
-      'vendor': this.vendorName_,
-    };
+    return this.vendorConfig_;
   }
 
   /**

--- a/extensions/amp-access/0.1/amp-access-vendor.js
+++ b/extensions/amp-access/0.1/amp-access-vendor.js
@@ -41,6 +41,8 @@ export class AccessVendorAdapter {
     this.vendorName_ = user().assert(configJson['vendor'],
         '"vendor" name must be specified');
 
+    /** @const @private {boolean} */
+    this.isPingbackEnabled_ = !configJson['noPingback'];
     /** @const @private {!Promise<!./access-vendor.AccessVendor>} */
     this.vendorPromise_ = new Promise(resolve => {
       /** @private {function(!./access-vendor.AccessVendor)|undefined} */
@@ -83,7 +85,7 @@ export class AccessVendorAdapter {
 
   /** @override */
   isPingbackEnabled() {
-    return true;
+    return this.isPingbackEnabled_;
   }
 
   /** @override */

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -812,6 +812,7 @@ export class AccessService {
    * Type can be either an empty string for a default login or a name of the
    * login URL.
    *
+   * @private
    * @param {string} loginUrl
    * @param {string} eventLabel A label used for the analytics event for this action
    * @return {!Promise}
@@ -827,7 +828,7 @@ export class AccessService {
       return this.loginPromise_;
     }
 
-    dev().fine(TAG, 'Start login: ', eventLabel);
+    dev().fine(TAG, 'Start login: ', loginUrl, eventLabel);
 
     this.loginAnalyticsEvent_(eventLabel, 'started');
     const dialogPromise = this.signIn_.requestSignIn(loginUrl) ||

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -228,6 +228,13 @@ export class AccessService {
   }
 
   /**
+   * @return {!JSONType}
+   */
+  getAdapterConfig() {
+    return this.adapter_.getConfig();
+  }
+
+  /**
    * @param {!JSONType} configJson
    * @return {!AccessType}
    */

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -769,12 +769,12 @@ export class AccessService {
       if (invocation.event) {
         invocation.event.preventDefault();
       }
-      this.login('');
+      this.loginWithType_('');
     } else if (invocation.method.indexOf('login-') == 0) {
       if (invocation.event) {
         invocation.event.preventDefault();
       }
-      this.login(invocation.method.substring('login-'.length));
+      this.loginWithType_(invocation.method.substring('login-'.length));
     }
   }
 

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -204,7 +204,7 @@ export class AccessService {
    */
   createAdapter_(configJson) {
     const context = /** @type {!AccessTypeAdapterContextDef} */ ({
-      buildUrl: this.buildUrl_.bind(this),
+      buildUrl: this.buildUrl.bind(this),
       collectUrlVars: this.collectUrlVars_.bind(this),
     });
     const isJwt = (this.isJwtEnabled_ && configJson['jwt'] === true);
@@ -382,9 +382,8 @@ export class AccessService {
    * @param {string} url
    * @param {boolean} useAuthData Allows `AUTH(field)` URL var substitutions.
    * @return {!Promise<string>}
-   * @private
    */
-  buildUrl_(url, useAuthData) {
+  buildUrl(url, useAuthData) {
     return this.prepareUrlVars_(useAuthData).then(vars => {
       return this.urlReplacements_.expandAsync(url, vars);
     });
@@ -895,7 +894,7 @@ export class AccessService {
     const promises = [];
     for (const k in this.loginConfig_) {
       promises.push(
-          this.buildUrl_(this.loginConfig_[k], /* useAuthData */ true)
+          this.buildUrl(this.loginConfig_[k], /* useAuthData */ true)
               .then(url => {
                 this.loginUrlMap_[k] = url;
                 return {type: k, url};

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -798,10 +798,11 @@ export class AccessService {
    * Runs the login flow opening the given url in the login window.
    *
    * @param {string} url
+   * @param {string} eventLabel A label used for the analytics event for this action
    * @return {!Promise}
    */
-  loginWithUrl(url) {
-    return this.login_(url, url);
+  loginWithUrl(url, eventLabel = '') {
+    return this.login_(url, eventLabel);
   }
 
   /**
@@ -813,7 +814,7 @@ export class AccessService {
    * login URL.
    *
    * @param {string} loginUrl
-   * @param {string} eventLabel
+   * @param {string} eventLabel A label used for the analytics event for this action
    * @return {!Promise}
    */
   login_(loginUrl, eventLabel) {

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -781,15 +781,16 @@ export class AccessService {
   /**
    * Runs the login flow using one of the predefined urls in the amp-access config
    *
+   * @private
    * @param {string} type Type of login defined in the config
    * @return {!Promise}
    */
   loginWithType_(type) {
+    user().assert(this.loginConfig_[type],
+        'Login URL is not configured: %s', type);
     // Login URL should always be available at this time.
     const loginUrl = user().assert(this.loginUrlMap_[type],
         'Login URL is not ready: %s', type);
-    user().assert(this.loginConfig_[type],
-        'Login URL is not configured: %s', type);
     return this.login_(loginUrl, type);
   }
 

--- a/extensions/amp-access/0.1/test/test-amp-access-vendor.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-vendor.js
@@ -24,6 +24,9 @@ describes.sandboxed('AccessVendorAdapter', {}, () => {
   beforeEach(() => {
     validConfig = {
       'vendor': 'vendor1',
+      'vendor1': {
+        'vendorConfigParam': 'vendorConfigValue',
+      },
     };
   });
 
@@ -32,7 +35,7 @@ describes.sandboxed('AccessVendorAdapter', {}, () => {
       const adapter = new AccessVendorAdapter(window, validConfig);
       expect(adapter.vendorName_).to.equal('vendor1');
       expect(adapter.getConfig()).to.deep.equal({
-        vendor: 'vendor1',
+        vendorConfigParam: 'vendorConfigValue',
       });
       expect(adapter.isAuthorizationEnabled()).to.be.true;
       expect(adapter.isPingbackEnabled()).to.be.true;

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -191,6 +191,18 @@ describe('AccessService', () => {
         .instanceOf(AccessVendorAdapter);
   });
 
+  it('should return adapter config', () => {
+    const config = {
+      type: 'vendor',
+      vendor: 'vendor1',
+    };
+    element.textContent = JSON.stringify(config);
+    const accessService = new AccessService(window);
+    sandbox.stub(accessService.adapter_, 'getConfig');
+    accessService.getAdapterConfig();
+    expect(accessService.adapter_.getConfig.called).to.be.true;
+  });
+
   it('should parse type for JWT w/o experiment', () => {
     const config = {
       'authorization': 'https://acme.com/a',

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -1316,7 +1316,7 @@ describe('AccessService login', () => {
   });
 
   it('should intercept global action to login', () => {
-    serviceMock.expects('login')
+    serviceMock.expects('loginWithType_')
         .withExactArgs('')
         .once();
     const event = {preventDefault: sandbox.spy()};
@@ -1325,7 +1325,7 @@ describe('AccessService login', () => {
   });
 
   it('should intercept global action to login-other', () => {
-    serviceMock.expects('login')
+    serviceMock.expects('loginWithType_')
         .withExactArgs('other')
         .once();
     const event = {preventDefault: sandbox.spy()};
@@ -1402,7 +1402,7 @@ describe('AccessService login', () => {
   it('should open dialog in the same microtask', () => {
     service.openLoginDialog_ = sandbox.stub();
     service.openLoginDialog_.returns(new Promise(() => {}));
-    service.login('');
+    service.loginWithType_('');
     expect(service.openLoginDialog_.callCount).to.equal(1);
     expect(service.openLoginDialog_.firstCall.args[0])
         .to.equal('https://acme.com/l?rid=R');
@@ -1412,7 +1412,7 @@ describe('AccessService login', () => {
 
   it('should fail to open dialog if loginUrl is not built yet', () => {
     service.loginUrlMap_[''] = null;
-    expect(() => service.login('')).to.throw(/Login URL is not ready/);
+    expect(() => service.loginWithType_('')).to.throw(/Login URL is not ready/);
   });
 
   it('should succeed login with success=true', () => {
@@ -1424,7 +1424,7 @@ describe('AccessService login', () => {
         .withExactArgs('https://acme.com/l?rid=R')
         .returns(Promise.resolve('#success=true'))
         .once();
-    return service.login('').then(() => {
+    return service.loginWithType_('').then(() => {
       expect(service.loginPromise_).to.not.exist;
       expect(authorizationStub.callCount).to.equal(1);
       expect(authorizationStub.calledWithExactly(
@@ -1450,7 +1450,7 @@ describe('AccessService login', () => {
         .withExactArgs('https://acme.com/l?rid=R')
         .returns(Promise.resolve('#success=no'))
         .once();
-    return service.login('').then(() => {
+    return service.loginWithType_('').then(() => {
       expect(service.loginPromise_).to.not.exist;
       expect(service.runAuthorization_.callCount).to.equal(0);
       expect(service.analyticsEvent_).to.have.been.calledWith(
@@ -1469,7 +1469,7 @@ describe('AccessService login', () => {
         .withExactArgs('https://acme.com/l?rid=R')
         .returns(Promise.resolve(''))
         .once();
-    return service.login('').then(() => {
+    return service.loginWithType_('').then(() => {
       expect(service.loginPromise_).to.not.exist;
       expect(authorizationStub.callCount).to.equal(1);
       expect(authorizationStub.calledWithExactly(
@@ -1494,7 +1494,8 @@ describe('AccessService login', () => {
         .withExactArgs('https://acme.com/l?rid=R')
         .returns(Promise.reject('abort'))
         .once();
-    return service.login('').then(() => 'S', () => 'ERROR').then(result => {
+    return service.loginWithType_('')
+    .then(() => 'S', () => 'ERROR').then(result => {
       expect(result).to.equal('ERROR');
       expect(service.loginPromise_).to.not.exist;
       expect(service.runAuthorization_.callCount).to.equal(0);
@@ -1521,7 +1522,7 @@ describe('AccessService login', () => {
         .withExactArgs('https://acme.com/l2?rid=R')
         .returns(Promise.resolve('#success=true'))
         .once();
-    return service.login('login2').then(() => {
+    return service.loginWithType_('login2').then(() => {
       expect(service.loginPromise_).to.not.exist;
       expect(authorizationStub.callCount).to.equal(1);
       expect(broadcastStub.callCount).to.equal(1);
@@ -1550,16 +1551,16 @@ describe('AccessService login', () => {
     openLoginDialogStub.onCall(0).returns(p1Promise);
     openLoginDialogStub.onCall(1).returns(new Promise(() => {}));
     openLoginDialogStub.onCall(2).throws();
-    const p1 = service.login('');
+    const p1 = service.loginWithType_('');
 
     // The immediate second attempt is blocked.
-    const p2 = service.login('');
+    const p2 = service.loginWithType_('');
     expect(service.loginPromise_).to.equal(p1);
     expect(p2).to.equal(p1);
 
     // The delayed third attempt succeeds after 1 second.
     clock.tick(1001);
-    const p3 = service.login('');
+    const p3 = service.loginWithType_('');
     expect(service.loginPromise_).to.equal(p3);
     expect(p3).to.not.equal(p1);
 
@@ -1571,12 +1572,19 @@ describe('AccessService login', () => {
     });
   });
 
+  it('should login with url only', () => {
+    serviceMock.expects('login_')
+        .withExactArgs('https://url', '')
+        .once();
+    service.loginWithUrl('https://url');
+  });
+
   it('should request sign-in when configured', () => {
     service.signIn_.requestSignIn = sandbox.stub();
     service.signIn_.requestSignIn.returns(Promise.resolve('#signin'));
     service.openLoginDialog_ = sandbox.stub();
     service.openLoginDialog_.returns(Promise.resolve('#login'));
-    service.login('');
+    service.loginWithType_('');
     expect(service.signIn_.requestSignIn.callCount).to.equal(1);
     expect(service.signIn_.requestSignIn.firstCall.args[0])
         .to.equal('https://acme.com/l?rid=R');
@@ -1594,7 +1602,7 @@ describe('AccessService login', () => {
         .withExactArgs('https://acme.com/l?rid=R')
         .returns(Promise.resolve('#success=true'))
         .once();
-    return service.login('').then(() => {
+    return service.loginWithType_('').then(() => {
       expect(service.loginPromise_).to.not.exist;
       expect(service.signIn_.postLoginResult.callCount).to.equal(1);
       expect(service.signIn_.postLoginResult.firstCall.args[0]).to.deep.equal({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ var extensions = {};
 // Each extension and version must be listed individually here.
 // NOTE: No new extensions must pass the NO_TYPE_CHECK argument.
 declareExtension('amp-access', '0.1', true, 'NO_TYPE_CHECK');
-declareExtension('amp-access-laterpay', '0.1', false, 'NO_TYPE_CHECK');
+declareExtension('amp-access-laterpay', '0.1', true, 'NO_TYPE_CHECK');
 declareExtension('amp-accordion', '0.1', true);
 declareExtension('amp-ad', '0.1', true);
 declareExtension('amp-ad-network-adsense-impl', 0.1, false);

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -418,7 +418,7 @@ function isRetriable(status) {
 
 /**
  * Returns the response if successful or otherwise throws an error.
- * @paran {!FetchResponse} response
+ * @param {!FetchResponse} response
  * @return {!Promise<!FetchResponse>}
  * @private Visible for testing
  */
@@ -427,6 +427,7 @@ export function assertSuccess(response) {
     if (response.status < 200 || response.status >= 300) {
       /** @const {!Error} */
       const err = user().createError(`HTTP error ${response.status}`);
+      err.response = response;
       if (isRetriable(response.status)) {
         err.retriable = true;
       }

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -409,7 +409,7 @@ function createXhrRequest(method, url) {
 
 /**
  * If 415 or in the 5xx range.
- * @param {string} status
+ * @param {number} status
  */
 function isRetriable(status) {
   return status == 415 || (status >= 500 && status < 600);

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -296,9 +296,16 @@ describe('XHR', function() {
         it('should reject if error', () => {
           mockXhr.status = 500;
           return assertSuccess(createResponseInstance('', mockXhr))
-              .then(response => {
-                expect(response.status).to.equal(500);
-              }).should.be.rejectedWith(/HTTP error 500/);
+              .should.be.rejectedWith(/HTTP error 500/);
+        });
+
+        it('should include response in error', () => {
+          mockXhr.status = 500;
+          return assertSuccess(createResponseInstance('', mockXhr))
+              .catch(error => {
+                expect(error.response).to.be.defined;
+                expect(error.response.status).to.equal(500);
+              });
         });
 
         it('should parse json content when error', () => {


### PR DESCRIPTION
This is the first attempt at an implementation for amp-access-laterpay.

(For anyone looking at this out of context, this comes as a follow up to some communication with @dvoytenko out of this repository and is based on some preparation work he did recently to allow for this implementation effort to occur)

This first implementation is mostly trying to get the basic workflow down, so no proper tests/docs/type hints yet (and could probably do with a WIP label 😄 )

Also, while I had quite a bit of a look at other modules, and some of the spec docs to get a better idea of the overall codebase patterns and existing methods and utilities I'm sure this still needs a bit of work in conforming to those. I'm adding some details below.

TODO
* [x] Add tests
* [x] Add documentation
* [x] Add docs and closure type hints
* [x] Improve code around creating the layout (see below)
* [x] Figure out details around opening login window (see below)
* [x] Understand what happens in regards to the login process in cached pages and make changes if necessary (see below)
* [x] Publish the mock service (and add some documentation on the expected service responses)

### Layout creation

The current attempt at an implementation merely injects some DOM elements into an `amp-access-laterpay-list` element. Looking at the [guidance here](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-components.md#width-height-and-layout) we could possibly ask the publisher to predefine a width/height for this to avoid reflows.

In such a case I feel like having an overlay rather than an in page list would be more appropriate, but we don't have a strong need here for one particular case or the other (in page or overlay), we can go with what works best for performance/ux reasons.

I'd also like to better understand if I need to use any specific pattern when rendering the list into the DOM. I've noticed the use of the vsync module in multiple places but don't entirely understand if I should be making use of it in this case or not.

### Opening the login window

At the moment the code which opens the login window is unfinished. The current `login` method in the `accessService` takes as an argument a `type` which refers to the login type defined in the login configuration. Given that in this case we're getting the login urls from the service, I'd like to just pass that URL directly to the login method, given that I also don't wish to reimplement everything else the login method is doing, given that that is useful for our use case as well, and for handing back control to `amp-access`.

My proposal would be to make some changes to the `login` method to take an URL instead and have the URL lookup happen before that method gets called (or as another code path inside of the method, but the previous solution sounds cleaner to me).

### What happens in cached pages?

At the moment, the configuration for our (LaterPay) service is defined in the module. While this shouldn't change in the future, in the case that it does it would probably mean that we'd have to publish a new version of this extension with a new configuration. In such a case we'd probably also advise our customers to make that update and follow the guidelines at https://developers.google.com/amp/cache/overview but given that we don't control the publisher page we can't ever be entirely sure if/when changes are properly made.

I was wondering if we should concern ourselves in any way with this potential situation for the case of this implementation and have any sort of fallback mechanism in case a user gets an out of date page trying to talk to a non existing authorization access point.