### PR TITLE
Fix init() param for 3p ad

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -230,7 +230,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
           this.element, undefined, opt_context);
       this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(
           this);
-      return this.xOriginIframeHandler_.init(iframe, true);
+      return this.xOriginIframeHandler_.init(iframe);
     });
   }
 


### PR DESCRIPTION
This is a follow up fix for #5882. `xOriginIframeHandler_` receive `opt_isA4A` as param, and 3p ad should not assign any value to it. 