### PR TITLE
Upgrade old chrome to 45

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -89,7 +89,7 @@ var karma = {
     browsers: [
       'SL_Chrome_android',
       'SL_Chrome_latest',
-      'SL_Chrome_37',
+      'SL_Chrome_45',
       'SL_Firefox_latest',
       'SL_Safari_8',
       'SL_Safari_9',

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -50,7 +50,7 @@ function getConfig() {
     }
     const c = extend(obj, karmaConfig.saucelabs);
     if (argv.oldchrome) {
-      c.browsers = ['SL_Chrome_37']
+      c.browsers = ['SL_Chrome_45'];
     }
   }
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -730,7 +730,7 @@ describe('amp-a4a', () => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new AmpA4A(a4aElement);
-        a4a.adUrl_ = 'http://foo.com';
+        a4a.adUrl_ = 'https://nowhere.org';
         a4a.maybeRenderAmpAd_ = function() { return Promise.resolve(false); };
         return a4a.maybeRenderAmpAd_().then(rendered => {
           // Force vsync system to run all queued tasks, so that DOM mutations
@@ -747,7 +747,7 @@ describe('amp-a4a', () => {
             expect(a4aElement.children.length).to.equal(1);
             const iframe = a4aElement.children[0];
             expect(iframe.tagName).to.equal('IFRAME');
-            expect(iframe.src.indexOf('http://foo.com')).to.equal(0);
+            expect(iframe.src.indexOf('https://nowhere.org')).to.equal(0);
             expect(iframe.style.visibility).to.equal('');
           });
         });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -89,10 +89,10 @@ module.exports = function(config) {
         base: 'SauceLabs',
         browserName: 'chrome',
       },
-      SL_Chrome_37: {
+      SL_Chrome_45: {
         base: 'SauceLabs',
         browserName: 'chrome',
-        version: 37,
+        version: '45',
       },
       SL_iOS_9_1: {
         base: 'SauceLabs',

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -136,7 +136,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
       };
       let timeout = setTimeout(function() {
         reject(new Error('Timeout waiting for elements to start loading.'));
-      }, 1000);
+      }, 2000);
       // Declare the test ready to run when the document was fully parsed.
       window.afterLoad = function() {
         resolve({


### PR DESCRIPTION
The final PR to get Master to green again.

- Saucelabs integration test have been stable for the past 20 or so rounds
- Only remaining failure was unit test failing on Chrome 37
- https://github.com/ampproject/amphtml/pull/5902, https://github.com/ampproject/amphtml/pull/5895, https://github.com/ampproject/amphtml/pull/5881, https://github.com/ampproject/amphtml/pull/5876 include fixes so that unit tests can run on older versions of Chrome.
- Despite the fixes above, our code has diverged too much to be runnable on Chrome 37. Given 37 is just an arbitrary version and has become "too old", I am upgrading our old Chome to 45 (released more than a year ago)