### PR TITLE
Fix link to server-side filtering doc; issue 5904

### DIFF
--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -187,7 +187,7 @@ that is not on the first page.
 
 ## Server Side filtering
 
-See the documentation for [Server side filtering](https://github.com/ampproject/amphtml/blob/master/extensions/amp-live-list/amp-live-list-server-side-filtering.md)
+See the documentation for [Server side filtering](../amp-live-list/amp-live-list-server-side-filtering.md).
 
 ## Attributes
 


### PR DESCRIPTION
Correct issue #5904 - link to Server-Side Filtering doc broken. It was using blob link that was rewritten by import-docs.js.  To correct it, I had to use a relative path url so import-docs.js generates correct link (I'll add a bug so import-docs.js handles absolute paths too - e.g., just "amp-live-list-server-side-filtering.md" instead of "../amp-live-list/amp-live-list-server-side-filtering.md".

cc: @pbakaus 