### PR TITLE
Add DOM fingerprint for ad requests

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -23,6 +23,7 @@ import {getMode} from '../../../src/mode';
 import {isProxyOrigin} from '../../../src/url';
 import {viewerForDoc} from '../../../src/viewer';
 import {base64UrlDecodeToBytes} from '../../../src/utils/base64';
+import {domFingerprint} from '../../../src/utils/dom-fingerprint';
 
 /** @const {string} */
 const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
@@ -128,6 +129,7 @@ function buildAdUrl(
   const viewportRect = a4a.getViewport().getRect();
   const iframeDepth = iframeNestingDepth(global);
   const dtdParam = {name: 'dtd'};
+  const adElement = a4a.element;
   const allQueryParams = queryParams.concat(
     [
       {
@@ -135,14 +137,15 @@ function buildAdUrl(
         value: AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP,
       },
       {name: 'amp_v', value: '$internalRuntimeVersion$'},
+      {name: 'd_imp', value: '1'},
       {name: 'dt', value: startTime},
-      {name: 'adk', value: adKey(slotNumber, slotRect, viewportRect)},
+      {name: 'adf', value: domFingerprint(adElement)},
       {name: 'c', value: makeCorrelator(clientId, documentInfo.pageViewId)},
       {name: 'output', value: 'html'},
       {name: 'nhd', value: iframeDepth},
-      {name: 'eid', value: a4a.element.getAttribute('data-experiment-id')},
-      {name: 'bih', value: viewportRect.height},
+      {name: 'eid', value: adElement.getAttribute('data-experiment-id')},
       {name: 'biw', value: viewportRect.width},
+      {name: 'bih', value: viewportRect.height},
       {name: 'adx', value: slotRect.left},
       {name: 'ady', value: slotRect.top},
       {name: 'u_hist', value: getHistoryLength(global)},
@@ -205,35 +208,6 @@ function iframeNestingDepth(global) {
   }
   dev().assert(win == global.top);
   return depth;
-}
-
-/**
- * @param {number} slotNumber
- * @param {!../../../src/layout-rect.LayoutRectDef} slotRect
- * @param {!../../../src/layout-rect.LayoutRectDef} viewportRect
- * @return {string}
- */
-function adKey(slotNumber, slotRect, viewportRect) {
-  return formatFixedWidthInteger(slotNumber, 2) +
-    // ad slot top, in 1/5 viewport height units
-    formatFixedWidthInteger(slotRect.top * 5 / viewportRect.height, 4) +
-    // ad slot left, in 1/5 viewport width units
-    formatFixedWidthInteger(slotRect.left * 5 / viewportRect.width, 4);
-}
-
-/**
- * @param {number} num Number, non-negative.
- * @param {number} digits Number of digits, max 20.
- * @return {string}
- */
-function formatFixedWidthInteger(num, digits) {
-  const intPart = String(Math.max(Math.round(num), 0));
-  const len = intPart.length;
-  digits = Math.min(digits, 20);
-  if (len > digits) {
-    return '99999999999999999999'.substr(0, digits);
-  }
-  return '00000000000000000000'.substr(0, digits - len) + intPart;
 }
 
 /**

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -82,6 +82,7 @@ exports.rules = [
     mustNotDependOn: 'src/**/*.js',
     whitelist: [
       'ads/**->src/utils/base64.js',
+      'ads/**->src/utils/dom-fingerprint.js',
       'ads/**->src/log.js',
       'ads/**->src/mode.js',
       'ads/**->src/url.js',

--- a/examples/adsense.amp.html
+++ b/examples/adsense.amp.html
@@ -82,7 +82,7 @@
   </div>
 
   <h2>AdSense ad 2</h2>
-  
+
   <amp-ad width=300 height=250
       type="adsense"
       data-ad-client="ca-pub-2005682797531342"

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -33,6 +33,10 @@ import {
 import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
 import {documentStateFor} from '../../../src/document-state';
 import {getMode} from '../../../src/mode';
+import {
+  domFingerprintString,
+  stringHash32,
+} from '../../../src/utils/dom-fingerprint';
 
 /** @const {string} */
 const ADSENSE_BASE_URL = 'https://googleads.g.doubleclick.net/pagead/ads';
@@ -78,20 +82,21 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const visibilityState = documentStateFor(global).getVisibilityState();
     const adTestOn = this.element.getAttribute('data-adtest') ||
         isInManualExperiment(this.element);
+    const format = `${slotRect.width}x${slotRect.height}`;
     return googleAdUrl(this, ADSENSE_BASE_URL, startTime, slotIdNumber, [
       {name: 'client', value: this.element.getAttribute('data-ad-client')},
-      {name: 'format', value: `${slotRect.width}x${slotRect.height}`},
+      {name: 'format', value: format},
       {name: 'w', value: slotRect.width},
       {name: 'h', value: slotRect.height},
       {name: 'iu', value: this.element.getAttribute('data-ad-slot')},
       {name: 'adtest', value: adTestOn},
+      {name: 'adk', value: this.adKey_(format)},
       {
         name: 'bc',
         value: global.SVGElement && global.document.createElementNS ?
             '1' : null,
       },
       {name: 'ctypes', value: this.getCtypes_()},
-      {name: 'd_imp', value: '1'},
       {name: 'host', value: this.element.getAttribute('data-ad-host')},
       {name: 'ifi', value: slotIdNumber},
       {name: 'c', value: correlator},
@@ -110,6 +115,18 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   /** @override */
   extractCreativeAndSignature(responseText, responseHeaders) {
     return extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
+  }
+
+  /**
+   * @param {string} format
+   * @return {string} The ad unit hash key string.
+   * @private
+   */
+  adKey_(format) {
+    const element = this.element;
+    const slot = element.getAttribute('data-ad-slot') || '';
+    const string = `${slot}:${format}:${domFingerprintString(element)}`;
+    return stringHash32(string).toString();
   }
 
   /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -34,7 +34,7 @@ import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
 import {documentStateFor} from '../../../src/document-state';
 import {getMode} from '../../../src/mode';
 import {
-  domFingerprintString,
+  domFingerprintPlain,
   stringHash32,
 } from '../../../src/utils/dom-fingerprint';
 
@@ -125,7 +125,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   adKey_(format) {
     const element = this.element;
     const slot = element.getAttribute('data-ad-slot') || '';
-    const string = `${slot}:${format}:${domFingerprintString(element)}`;
+    const string = `${slot}:${format}:${domFingerprintPlain(element)}`;
     return stringHash32(string).toString();
   }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -33,10 +33,8 @@ import {
 import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
 import {documentStateFor} from '../../../src/document-state';
 import {getMode} from '../../../src/mode';
-import {
-  domFingerprintPlain,
-  stringHash32,
-} from '../../../src/utils/dom-fingerprint';
+import {stringHash32} from '../../../src/crypto';
+import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 
 /** @const {string} */
 const ADSENSE_BASE_URL = 'https://googleads.g.doubleclick.net/pagead/ads';
@@ -126,7 +124,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const element = this.element;
     const slot = element.getAttribute('data-ad-slot') || '';
     const string = `${slot}:${format}:${domFingerprintPlain(element)}`;
-    return stringHash32(string).toString();
+    return stringHash32(string);
   }
 
   /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -15,6 +15,10 @@
  */
 
 import {AmpAdNetworkAdsenseImpl} from '../amp-ad-network-adsense-impl';
+import {AmpAdUIHandler} from '../../../amp-ad/0.1/amp-ad-ui'; // eslint-disable-line no-unused-vars
+import {
+  AmpAdXOriginIframeHandler,    // eslint-disable-line no-unused-vars
+} from '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
 import {utf8Encode} from '../../../../src/utils/bytes';
 import * as sinon from 'sinon';

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -32,7 +32,7 @@ import {
 } from '../../../ads/google/a4a/utils';
 import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
 import {
-  domFingerprintString,
+  domFingerprintPlain,
   stringHash32,
 } from '../../../src/utils/dom-fingerprint';
 
@@ -159,7 +159,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    */
   adKey_(size) {
     const element = this.element;
-    const domFingerprint = domFingerprintString(element);
+    const domFingerprint = domFingerprintPlain(element);
     const slot = element.getAttribute('data-slot') || '';
     const multiSize = element.getAttribute('data-multi-size') || '';
     const string = `${slot}:${size}:${multiSize}:${domFingerprint}`;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -31,10 +31,8 @@ import {
   getCorrelator,
 } from '../../../ads/google/a4a/utils';
 import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
-import {
-  domFingerprintPlain,
-  stringHash32,
-} from '../../../src/utils/dom-fingerprint';
+import {stringHash32} from '../../../src/crypto';
+import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 
 /** @const {string} */
 const DOUBLECLICK_BASE_URL =
@@ -163,7 +161,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const slot = element.getAttribute('data-slot') || '';
     const multiSize = element.getAttribute('data-multi-size') || '';
     const string = `${slot}:${size}:${multiSize}:${domFingerprint}`;
-    return stringHash32(string).toString();
+    return stringHash32(string);
   }
 }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -31,6 +31,10 @@ import {
   getCorrelator,
 } from '../../../ads/google/a4a/utils';
 import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
+import {
+  domFingerprintString,
+  stringHash32,
+} from '../../../src/utils/dom-fingerprint';
 
 /** @const {string} */
 const DOUBLECLICK_BASE_URL =
@@ -67,6 +71,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const slotIdNumber = Number(slotId);
     const correlator = getCorrelator(global, slotId);
     const slotRect = this.getIntersectionElementLayoutBox();
+    const size = `${slotRect.width}x${slotRect.height}`;
     const rawJson = this.element.getAttribute('json');
     const jsonParameters = rawJson ? JSON.parse(rawJson) : {};
     const tfcd = jsonParameters['tfcd'];
@@ -74,11 +79,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     return googleAdUrl(this, DOUBLECLICK_BASE_URL, startTime, slotIdNumber, [
       {name: 'iu', value: this.element.getAttribute('data-slot')},
       {name: 'co', value: jsonParameters['cookieOptOut'] ? '1' : null},
+      {name: 'adk', value: this.adKey_(size)},
       {name: 'gdfp_req', value: '1'},
-      {name: 'd_imp', value: '1'},
       {name: 'impl', value: 'ifr'},
       {name: 'sfv', value: 'A'},
-      {name: 'sz', value: `${slotRect.width}x${slotRect.height}`},
+      {name: 'sz', value: size},
       {name: 'tfcd', value: tfcd == undefined ? null : tfcd},
       {name: 'u_sd', value: global.devicePixelRatio},
       {name: 'adtest', value: adTestOn},
@@ -145,6 +150,20 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                               this.element.getAttribute(
                                   'data-amp-slot-index')));
     return reporter;
+  }
+
+  /**
+   * @param {string} size
+   * @return {string} The ad unit hash key string.
+   * @private
+   */
+  adKey_(size) {
+    const element = this.element;
+    const domFingerprint = domFingerprintString(element);
+    const slot = element.getAttribute('data-slot') || '';
+    const multiSize = element.getAttribute('data-multi-size') || '';
+    const string = `${slot}:${size}:${multiSize}:${domFingerprint}`;
+    return stringHash32(string).toString();
   }
 }
 

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -26,6 +26,7 @@ import {parseUrl, assertHttpsUrl} from './url';
 import {viewerForDoc} from './viewer';
 import {urls} from './config';
 import {setStyle} from './style';
+import {domFingerprint} from './utils/dom-fingerprint';
 
 
 /** @type {!Object<string,number>} Number of 3p frames on the for that type. */
@@ -80,6 +81,7 @@ function getFrameAttributes(parentWindow, element, opt_type, opt_context) {
     hidden: !viewer.isVisible(),
     amp3pSentinel: generateSentinel(parentWindow),
     initialIntersection: element.getIntersectionChangeEntry(),
+    domFingerprint: domFingerprint(element),
     startTime,
   };
   Object.assign(attributes._context, opt_context);

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -25,3 +25,20 @@ export function cryptoFor(window) {
       !../extensions/amp-analytics/0.1/crypto-impl.Crypto>} */ (
       getElementService(window, 'crypto', 'amp-analytics')));
 }
+
+/**
+ * Hash function djb2a
+ * This is intended to be a simple, fast hashing function using minimal code.
+ * It does *not* have good cryptographic properties.
+ * @param {string} str
+ * @return {string} 32-bit unsigned hash of the string
+ */
+export function stringHash32(str) {
+  const length = str.length;
+  let hash = 5381;
+  for (let i = 0; i < length; i++) {
+    hash = hash * 33 ^ str.charCodeAt(i);
+  }
+  // Convert from 32-bit signed to unsigned.
+  return String(hash >>> 0);
+};

--- a/src/utils/dom-fingerprint.js
+++ b/src/utils/dom-fingerprint.js
@@ -52,11 +52,7 @@ export function domFingerprintPlain(element) {
   let level = 0;
   while (element && element.nodeType == /* element */ 1 && level < 25) {
     let id = '';
-    if (element.id &&
-        // Skip AMP generated ids.
-        // TODO: Remove when issue #6000 removes generated ids.
-        !(element.getResourceId &&
-          (element.id == `AMP_${element.getResourceId()}`))) {
+    if (element.id) {
       id = `/${element.id}`;
     }
     const nodeName = element.nodeName.toLowerCase();

--- a/src/utils/dom-fingerprint.js
+++ b/src/utils/dom-fingerprint.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+/**
+ * Gets a string showing the index of an element within
+ * the children of its parent, counting only nodes with the same tag.
+ * Stop at 25, just to have a limit.
+ * @param {?Element} element DOM node to get index of.
+ * @return {string} '.<index>' or ''.
+ */
+function indexWithinParent(element) {
+  if (element && element.nodeName && element.parentElement) {
+    const elementParent = element.parentElement;
+    const nodeName = element.nodeName.toString().toLowerCase();
+    // Find my index within my parent's children
+    const children = elementParent.childNodes;
+    // Choose a limit that we hope will allow getting to 25
+    // matching nodes.
+    const limit = Math.min(children.length, 100);
+    let matchingNodeCount = 0;
+    for (let i = 0; i < limit && matchingNodeCount < 25; i++) {
+      const child = children[i];
+      // Some browsers treat childNodes differently.
+      // So we'll only count nodes with the same tag.
+      if (child.nodeName &&
+          child.nodeName.toString().toLowerCase() === nodeName) {
+        if (element === child) {
+          return '.' + matchingNodeCount;
+        }
+        ++matchingNodeCount;
+      }
+    }
+  }
+  return '';
+};
+
+
+/**
+ * Gets a string of concatenated element names and relative positions
+ * of the DOM element and its parentElement's (up to 25).  Relative position
+ * is the index of nodes with this tag within the parent's childNodes.
+ * The order is from the inner to outer nodes in DOM hierarchy.
+ *
+ * If a DOM hierarchy is the following:
+ *
+ * <div id='id1' ...>
+ *   <div id='id2' ...>
+ *     <table ...>       // table:0
+ *       <tr>            // tr:0
+ *         <td>...</td>  // td:0
+ *         <td>          // td:1
+ *           <amp-ad ...></amp-ad>
+ *         </td>
+ *       </tr>
+ *       <tr>...</tr>    // tr:1
+ *     </table>
+ *   </div>
+ * </div>
+ *
+ * With the amp-ad element passed in:
+ * 'amp-ad.0,td.1,tr.0,table.0,div/id2.0,div/id1.0'
+ *
+ * Note: 25 is chosen arbitrarily.
+ *
+ * @param {?Element} element DOM node from which to get fingerprint.
+ * @return {string} Concatenated element ids.
+ */
+export function domFingerprintString(element) {
+  const ids = [];
+  for (let level = 0; element && element.nodeType == /* element */ 1 &&
+           level < 25; ++level) {
+    // Skip generated id on amp-ad.
+    const id = level > 0 && element.id;
+    const nodeName = element.nodeName &&
+          element.nodeName.toString().toLowerCase();
+    ids.push(nodeName + (id ? '/' + id : '') +
+             indexWithinParent(element));
+    element = element.parentElement;
+  }
+
+  return ids.join();
+};
+
+/**
+ * Calculates ad slot DOM fingerprint.  This key is intended to
+ * identify "same" ad unit across many page views. This is
+ * based on where the ad appears within the page's DOM structure.
+ *
+ * @param {?Element} element The DOM element from which to collect
+ *     the DOM chain element IDs.  If null, DOM chain element IDs are not
+ *     included in the hash.
+ * @return {string} The ad unit hash key string.
+ */
+export function domFingerprint(element) {
+  return stringHash32(domFingerprintString(element)).toString();
+};
+
+/**
+ * Hash function djb2a
+ * @param {string} str
+ * @return {number} 32-bit unsigned hash of the string
+ */
+export function stringHash32(str) {
+  const length = str.length;
+  let hash = 5381;
+  for (let i = 0; i < length; i++) {
+    hash = hash * 33 ^ str.charCodeAt(i);
+  }
+  // Convert from 32-bit signed to unsigned.
+  return hash >>> 0;
+};

--- a/src/utils/dom-fingerprint.js
+++ b/src/utils/dom-fingerprint.js
@@ -107,5 +107,5 @@ function indexWithinParent(element) {
     sibling = sibling.previousElementSibling;
   }
   // If we got to the end, then the count is accurate; otherwise skip count.
-  return !sibling ? `.${count}` : '';
+  return count < 25 && i < 100 ? `.${count}` : '';
 };

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -165,6 +165,10 @@ describe('3p-frame', () => {
         '"test":false,"version":"$internalRuntimeVersion$"}' +
         ',"canary":true' +
         ',"hidden":false' +
+        // Note that DOM fingerprint will change if the document DOM changes
+        // Also, DOM structure for gulp test --files seems to be different from
+        // structure for gulp test. So use .only instead of --files here.
+        ',"domFingerprint":"932357496"' +
         ',"startTime":1234567888' +
         ',"amp3pSentinel":"' + amp3pSentinel + '"' +
         ',"initialIntersection":{"time":1234567888,' +

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -166,7 +166,8 @@ describe('3p-frame', () => {
         ',"canary":true' +
         ',"hidden":false' +
         // Note that DOM fingerprint will change if the document DOM changes
-        ',"domFingerprint":"258846393"' +
+        // Note also that running it using --files uses different DOM.
+        ',"domFingerprint":"1725030182"' +
         ',"startTime":1234567888' +
         ',"amp3pSentinel":"' + amp3pSentinel + '"' +
         ',"initialIntersection":{"time":1234567888,' +
@@ -179,7 +180,6 @@ describe('3p-frame', () => {
     const srcParts = src.split('#');
     expect(srcParts[0]).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
-    console.log(srcParts[1]);
     expect(JSON.parse(srcParts[1])).to.deep.equal(JSON.parse(fragment));
 
     // Switch to same origin for inner tests.

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -166,9 +166,7 @@ describe('3p-frame', () => {
         ',"canary":true' +
         ',"hidden":false' +
         // Note that DOM fingerprint will change if the document DOM changes
-        // Also, DOM structure for gulp test --files seems to be different from
-        // structure for gulp test. So use .only instead of --files here.
-        ',"domFingerprint":"932357496"' +
+        ',"domFingerprint":"258846393"' +
         ',"startTime":1234567888' +
         ',"amp3pSentinel":"' + amp3pSentinel + '"' +
         ',"initialIntersection":{"time":1234567888,' +
@@ -181,6 +179,7 @@ describe('3p-frame', () => {
     const srcParts = src.split('#');
     expect(srcParts[0]).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
+    console.log(srcParts[1]);
     expect(JSON.parse(srcParts[1])).to.deep.equal(JSON.parse(fragment));
 
     // Switch to same origin for inner tests.

--- a/test/functional/test-crypto.js
+++ b/test/functional/test-crypto.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {stringHash32} from '../../src/crypto';
+
+describe('stringHash32', () => {
+  it('should map a sample string appropriately', () => {
+    expect(stringHash32('')).to.equal('5381');
+    expect(stringHash32('abcd1234!@#$')).to.equal('1765632611');
+    expect(stringHash32('a/foo.3,b/bar.4')).to.equal('3546926170');
+  });
+});

--- a/test/functional/utils/test-dom-fingerprint.js
+++ b/test/functional/utils/test-dom-fingerprint.js
@@ -17,15 +17,8 @@
 import {
   domFingerprintPlain,
   domFingerprint,
-  stringHash32,
 } from '../../../src/utils/dom-fingerprint';
 
-
-describe('stringHash32', () => {
-  it('should map a sample string appropriately', () => {
-    expect(stringHash32('')).to.equal(5381);
-  });
-});
 
 describe('domFingerprint', () => {
   let div1;

--- a/test/functional/utils/test-dom-fingerprint.js
+++ b/test/functional/utils/test-dom-fingerprint.js
@@ -29,33 +29,18 @@ describe('domFingerprint', () => {
     while (body.firstChild) {
       body.removeChild(body.firstChild);
     }
-    /*
-      <div id='id1' ...>
-        <div id='id2' ...>
-          <table ...>       // table:0
-            <tr>            // tr:0
-              <td>...</td>  // td:0
-              <td>          // td:1
-                <amp-ad ...></amp-ad>
-              </td>
-            </tr>
-            <tr>...</tr>    // tr:1
-          </table>
-        </div>
-      </div>
-     */
     div1 = document.createElement('div');
     div1.id = 'id1';
     div1.innerHTML =
       `<div id='id2'>
-         <table>
-           <tr>
-             <td></td>
-             <td>
-               <amp-ad name="this one" type="adsense"></amp-ad>
+         <table>                <!-- table:0 -->
+           <tr>                 <!-- tr:0 -->
+             <td></td>          <!-- td:0 -->
+             <td>               <!-- td:1 -->
+               <amp-ad type="adsense"></amp-ad>
              </td>
            </tr>
-           <tr></tr>
+           <tr></tr>            <!-- tr:1 -->
          </table>
       </div>`;
 

--- a/test/functional/utils/test-dom-fingerprint.js
+++ b/test/functional/utils/test-dom-fingerprint.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  domFingerprintString,
+  domFingerprint,
+  stringHash32,
+} from '../../../src/utils/dom-fingerprint';
+
+
+describe('stringHash32', () => {
+  it('should map a sample string appropriately', () => {
+    expect(stringHash32('')).to.equal(5381);
+  });
+});
+
+describe('domFingerprint', () => {
+  let div1;
+  let ampAd;
+  const body = document.body;
+  beforeEach(() => {
+    // Start with empty body.
+    while (body.firstChild) {
+      body.removeChild(body.firstChild);
+    }
+    /*
+      <div id='id1' ...>
+        <div id='id2' ...>
+          <table ...>       // table:0
+            <tr>            // tr:0
+              <td>...</td>  // td:0
+              <td>          // td:1
+                <amp-ad ...></amp-ad>
+              </td>
+            </tr>
+            <tr>...</tr>    // tr:1
+          </table>
+        </div>
+      </div>
+     */
+    div1 = document.createElement('div');
+    div1.id = 'id1';
+    body.appendChild(div1);
+    const div2 = document.createElement('div');
+    div2.id = 'id2';
+    div1.appendChild(div2);
+    const table = document.createElement('table');
+    div2.appendChild(table);
+    const tr1 = document.createElement('tr');
+    table.appendChild(tr1);
+    const tr2 = document.createElement('tr');
+    table.appendChild(tr2);
+    const td1 = document.createElement('td');
+    tr1.appendChild(td1);
+    const td2 = document.createElement('td');
+    tr1.appendChild(td2);
+    ampAd = document.createElement('amp-ad');
+    td2.appendChild(ampAd);
+  });
+
+  it('should map a sample DOM structure to the right string', () => {
+    expect(domFingerprintString(ampAd)).to.equal(
+      'amp-ad.0,td.1,tr.0,table.0,div/id2.0,div/id1.0,body.0,html');
+  });
+  it('should map a sample DOM structure to the right hashed value', () => {
+    expect(domFingerprint(ampAd)).to.equal('491975076');
+  });
+
+  afterEach(() => {
+    body.removeChild(div1);
+  });
+});

--- a/test/functional/utils/test-dom-fingerprint.js
+++ b/test/functional/utils/test-dom-fingerprint.js
@@ -15,7 +15,7 @@
  */
 
 import {
-  domFingerprintString,
+  domFingerprintPlain,
   domFingerprint,
   stringHash32,
 } from '../../../src/utils/dom-fingerprint';
@@ -53,30 +53,29 @@ describe('domFingerprint', () => {
      */
     div1 = document.createElement('div');
     div1.id = 'id1';
+    div1.innerHTML =
+      `<div id='id2'>
+         <table>
+           <tr>
+             <td></td>
+             <td>
+               <amp-ad name="this one" type="adsense"></amp-ad>
+             </td>
+           </tr>
+           <tr></tr>
+         </table>
+      </div>`;
+
     body.appendChild(div1);
-    const div2 = document.createElement('div');
-    div2.id = 'id2';
-    div1.appendChild(div2);
-    const table = document.createElement('table');
-    div2.appendChild(table);
-    const tr1 = document.createElement('tr');
-    table.appendChild(tr1);
-    const tr2 = document.createElement('tr');
-    table.appendChild(tr2);
-    const td1 = document.createElement('td');
-    tr1.appendChild(td1);
-    const td2 = document.createElement('td');
-    tr1.appendChild(td2);
-    ampAd = document.createElement('amp-ad');
-    td2.appendChild(ampAd);
+    ampAd = document.getElementsByTagName('amp-ad')[0];
   });
 
   it('should map a sample DOM structure to the right string', () => {
-    expect(domFingerprintString(ampAd)).to.equal(
-      'amp-ad.0,td.1,tr.0,table.0,div/id2.0,div/id1.0,body.0,html');
+    expect(domFingerprintPlain(ampAd)).to.equal(
+      'amp-ad.0,td.1,tr.0,tbody.0,table.0,div/id2.0,div/id1.0,body.0,html.0');
   });
   it('should map a sample DOM structure to the right hashed value', () => {
-    expect(domFingerprint(ampAd)).to.equal('491975076');
+    expect(domFingerprint(ampAd)).to.equal('2437661740');
   });
 
   afterEach(() => {


### PR DESCRIPTION
Compute a "fingerprint" for amp-ad elements. This implements issue #5557. Make the fingerprint available in the 3p ad context object. Also use it as a parameter to A4A AdSense and DoubleClick ad requests.

For AdSense and DoubleClick, compute an additional "ad key", which combines the ad fingerprint with some other information about the ad request.