### PR TITLE
Old Browser tests should run with compiled flag, like other tests

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -154,7 +154,7 @@ function main(argv) {
     // All unit tests with an old chrome (best we can do right now to pass tests
     // and not start relying on new features).
     // Disabled because it regressed. Better to run the other saucelabs tests.
-    execOrDie(`${gulp} test --saucelabs --oldchrome`);
+    execOrDie(`${gulp} test --nobuild --saucelabs --oldchrome --compiled`);
   }
 
   if (buildTargets.has('VALIDATOR_WEBUI')) {


### PR DESCRIPTION
Fixes 404 errors that have been failing the --oldbrowser tests ( like `404: /base/dist/v0/amp-youtube-0.1.max.js`)

I am pretty sure (for the 5th) this is it and will make master green.
