### PR TITLE
Do not use new iOS viewport in iOS7 and lower.

### DIFF
--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1689,7 +1689,9 @@ function createViewport(ampdoc) {
   let binding;
   if (ampdoc.isSingleDoc() &&
           viewer.getViewportType() == 'natural-ios-embed') {
-    if (isExperimentOn(ampdoc.win, 'ios-embed-wrapper')) {
+    if (isExperimentOn(ampdoc.win, 'ios-embed-wrapper')
+        // The overriding of document.body fails in iOS7.
+        && platformFor(ampdoc.win).getMajorVersion() > 7) {
       binding = new ViewportBindingIosEmbedWrapper_(ampdoc.win);
     } else {
       binding = new ViewportBindingNaturalIosEmbed_(ampdoc.win, ampdoc);


### PR DESCRIPTION
Because it doesn't allow overriding `document.body`.