### PR TITLE
Revert "Clean up: Move viewport specific logic out from viewer."

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -16,6 +16,7 @@
 
 import {Observable} from '../observable';
 import {documentStateFor} from '../document-state';
+import {getMode} from '../mode';
 import {getServiceForDoc} from '../service';
 import {dev} from '../log';
 import {
@@ -24,6 +25,7 @@ import {
   parseUrl,
   removeFragment,
 } from '../url';
+import {platformFor} from '../platform';
 import {timerFor} from '../timer';
 import {reportError} from '../error';
 import {VisibilityState} from '../visibility-state';
@@ -40,6 +42,29 @@ const SENTINEL_ = '__AMP__';
  * @private {number}
  */
 const VIEWER_ORIGIN_TIMEOUT_ = 1000;
+
+/**
+ * The type of the viewport.
+ * @enum {string}
+ */
+export const ViewportType = {
+
+  /**
+   * Viewer leaves sizing and scrolling up to the AMP document's window.
+   */
+  NATURAL: 'natural',
+
+  /**
+   * This is AMP-specific type and doesn't come from viewer. This is the type
+   * that AMP sets when Viewer has requested "natural" viewport on a iOS
+   * device.
+   * See:
+   * https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md
+   * and {@link ViewportBindingNaturalIosEmbed_} for more details.
+   */
+  NATURAL_IOS_EMBED: 'natural-ios-embed',
+};
+
 
 /**
  * These domains are trusted with more sensitive viewer operations such as
@@ -110,6 +135,9 @@ export class Viewer {
 
     /** @private {number} */
     this.prerenderSize_ = 1;
+
+    /** @private {!ViewportType} */
+    this.viewportType_ = ViewportType.NATURAL;
 
     /** @private {number} */
     this.paddingTop_ = 0;
@@ -194,6 +222,22 @@ export class Viewer {
     this.prerenderSize_ = parseInt(this.params_['prerenderSize'], 10) ||
         this.prerenderSize_;
     dev().fine(TAG_, '- prerenderSize:', this.prerenderSize_);
+
+    this.viewportType_ = this.params_['viewportType'] || this.viewportType_;
+    // Configure scrolling parameters when AMP is iframed on iOS.
+    const platform = platformFor(this.win);
+    if (this.viewportType_ == ViewportType.NATURAL && this.isIframed_ &&
+            platform.isIos()) {
+      this.viewportType_ = ViewportType.NATURAL_IOS_EMBED;
+    }
+    // Enable iOS Embedded mode so that it's easy to test against a more
+    // realistic iOS environment.
+    if (platform.isIos() &&
+            this.viewportType_ != ViewportType.NATURAL_IOS_EMBED &&
+            (getMode(this.win).localDev || getMode(this.win).development)) {
+      this.viewportType_ = ViewportType.NATURAL_IOS_EMBED;
+    }
+    dev().fine(TAG_, '- viewportType:', this.viewportType_);
 
     this.paddingTop_ = parseInt(this.params_['paddingTop'], 10) ||
         this.paddingTop_;
@@ -599,6 +643,15 @@ export class Viewer {
    */
   getPrerenderSize() {
     return this.prerenderSize_;
+  }
+
+  /**
+   * See `ViewportType` enum for the set of allowed values.
+   * See {@link Viewport} and {@link ViewportBinding} for more details.
+   * @return {!ViewportType}
+   */
+  getViewportType() {
+    return this.viewportType_;
   }
 
   /**

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -34,7 +34,7 @@ import {installVsyncService} from './vsync-impl';
 import {installViewerServiceForDoc} from './viewer-impl';
 import {isExperimentOn} from '../experiments';
 import {waitForBody} from '../dom';
-import {getMode} from '../mode';
+
 
 const TAG_ = 'Viewport';
 
@@ -1688,7 +1688,7 @@ function createViewport(ampdoc) {
   const viewer = installViewerServiceForDoc(ampdoc);
   let binding;
   if (ampdoc.isSingleDoc() &&
-      getViewportType(ampdoc.win, viewer) == ViewportType.NATURAL_IOS_EMBED) {
+          viewer.getViewportType() == 'natural-ios-embed') {
     if (isExperimentOn(ampdoc.win, 'ios-embed-wrapper')) {
       binding = new ViewportBindingIosEmbedWrapper_(ampdoc.win);
     } else {
@@ -1700,46 +1700,6 @@ function createViewport(ampdoc) {
   return new Viewport(ampdoc, binding, viewer);
 }
 
-/**
- * The type of the viewport.
- * @enum {string}
- */
-const ViewportType = {
-
-  /**
-   * Viewer leaves sizing and scrolling up to the AMP document's window.
-   */
-  NATURAL: 'natural',
-
-  /**
-   * This is AMP-specific type and doesn't come from viewer. This is the type
-   * that AMP sets when Viewer has requested "natural" viewport on a iOS
-   * device.
-   * See:
-   * https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md
-   * and {@link ViewportBindingNaturalIosEmbed_} for more details.
-   */
-  NATURAL_IOS_EMBED: 'natural-ios-embed',
-};
-
-/**
- * @param {!Window} win
- * @param {!./viewer-impl.Viewer} viewer
- * @return {string}
- */
-function getViewportType(win, viewer) {
-  let viewportType = viewer.getParam('viewportType') || ViewportType.NATURAL;
-  if (platformFor(win).isIos()
-      && ((viewportType == ViewportType.NATURAL && viewer.isIframed())
-          // Enable iOS Embedded mode so that it's easy to test against a more
-          // realistic iOS environment.
-          || getMode(win).localDev
-          || getMode(win).development)) {
-    viewportType = ViewportType.NATURAL_IOS_EMBED;
-  }
-  dev().fine(TAG_, '- viewportType:', viewportType);
-  return viewportType;
-}
 
 /**
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
@@ -1748,4 +1708,4 @@ function getViewportType(win, viewer) {
 export function installViewportServiceForDoc(ampdoc) {
   return /** @type {!Viewport} */ (getServiceForDoc(ampdoc, 'viewport',
       ampdoc => createViewport(ampdoc)));
-}
+};

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -16,6 +16,7 @@
 
 import {Viewer} from '../../src/service/viewer-impl';
 import {dev} from '../../src/log';
+import {platformFor} from '../../src/platform';
 import {installDocService} from '../../src/service/ampdoc-impl';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installPerformanceService} from '../../src/service/performance-impl';
@@ -35,6 +36,7 @@ describe('Viewer', () => {
   let clock;
   let events;
   let errorStub;
+  let platform;
 
   function changeVisibility(vis) {
     windowApi.document.hidden = vis !== 'visible';
@@ -87,6 +89,7 @@ describe('Viewer', () => {
     events = {};
     errorStub = sandbox.stub(dev(), 'error');
     windowMock = sandbox.mock(windowApi);
+    platform = platformFor(windowApi);
     viewer = new Viewer(ampdoc);
   });
 
@@ -97,7 +100,8 @@ describe('Viewer', () => {
     sandbox.restore();
   });
 
-  it('should configure as 0 padding top by default', () => {
+  it('should configure as natural viewport by default', () => {
+    expect(viewer.getViewportType()).to.equal('natural');
     expect(viewer.getPaddingTop()).to.equal(0);
   });
 
@@ -105,6 +109,7 @@ describe('Viewer', () => {
     windowApi.name = '__AMP__viewportType=natural';
     windowApi.location.hash = '#paddingTop=17&other=something';
     const viewer = new Viewer(ampdoc);
+    expect(viewer.getViewportType()).to.equal('natural');
     expect(viewer.getPaddingTop()).to.equal(17);
 
     // All of the startup params are also available via getParam.
@@ -333,6 +338,27 @@ describe('Viewer', () => {
     const send = sandbox.stub(viewer, 'sendMessageUnreliable_');
     viewer.updateFragment('#bar');
     expect(send.callCount).to.equal(0);
+  });
+
+  it('should configure correctly for iOS embedding', () => {
+    windowApi.name = '__AMP__viewportType=natural';
+    windowApi.parent = {};
+    sandbox.mock(platform).expects('isIos').returns(true).atLeast(1);
+    const viewer = new Viewer(ampdoc);
+
+    expect(viewer.getViewportType()).to.equal('natural-ios-embed');
+  });
+
+  it('should NOT configure for iOS embedding if not embedded', () => {
+    windowApi.name = '__AMP__viewportType=natural';
+    windowApi.parent = windowApi;
+    sandbox.mock(platform).expects('isIos').returns(true).atLeast(1);
+    windowApi.AMP_MODE = {
+      localDev: false,
+      development: false,
+    };
+    const viewportType = new Viewer(ampdoc).getViewportType();
+    expect(viewportType).to.equal('natural');
   });
 
   it('should receive viewport event', () => {

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -16,7 +16,6 @@
 
 import {AmpDocSingle, installDocService} from '../../src/service/ampdoc-impl';
 import {
-  installViewportServiceForDoc,
   Viewport,
   ViewportBindingDef,
   ViewportBindingIosEmbedWrapper_,
@@ -1550,58 +1549,4 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
       expect(binding.getScrollTop()).to.equal(11);
     });
   });
-});
-
-describe('createViewport', () => {
-
-  describes.fakeWin('in Android', {win: {navigator: {userAgent: 'Android'}}},
-      env => {
-        let win;
-
-        beforeEach(() => {
-          win = env.win;
-          installPlatformService(win);
-          installTimerService(win);
-        });
-
-        it('should bind to "natural" when not iframed', () => {
-          win.parent = win;
-          const ampDoc = installDocService(win, true).getAmpDoc();
-          const viewport = installViewportServiceForDoc(ampDoc);
-          expect(viewport.binding_).to.be.instanceof(ViewportBindingNatural_);
-        });
-
-        it('should bind to "naturual" when iframed', () => {
-          win.parent = {};
-          const ampDoc = installDocService(win, true).getAmpDoc();
-          const viewport = installViewportServiceForDoc(ampDoc);
-          expect(viewport.binding_).to.be.instanceof(ViewportBindingNatural_);
-        });
-      });
-
-  describes.fakeWin('in iOS', {win: {navigator: {userAgent: 'iPhone'}}},
-      env => {
-        let win;
-
-        beforeEach(() => {
-          win = env.win;
-          installPlatformService(win);
-          installTimerService(win);
-        });
-
-        it('should bind to "natural" when not iframed', () => {
-          win.parent = win;
-          const ampDoc = installDocService(win, true).getAmpDoc();
-          const viewport = installViewportServiceForDoc(ampDoc);
-          expect(viewport.binding_).to.be.instanceof(ViewportBindingNatural_);
-        });
-
-        it('should bind to "natural iOS embed" when iframed', () => {
-          win.parent = {};
-          const ampDoc = installDocService(win, true).getAmpDoc();
-          const viewport = installViewportServiceForDoc(ampDoc);
-          expect(viewport.binding_).to
-              .be.instanceof(ViewportBindingNaturalIosEmbed_);
-        });
-      });
 });


### PR DESCRIPTION
Collateral damage for a bug fix that needs to merge against last canary.

Reverts ampproject/amphtml#5887