### PR TITLE
Fix local navigation history management by handling hash navigations

### DIFF
--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -219,8 +219,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
   <link rel="amp-manifest" href="medium-manifest.json">
-  <!--<script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>-->
-  <script async src="https://cdn.ampproject.org/viewer/google/v5.js"></script>
+  <script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>
 </head>
 <body>
   <amp-sidebar id="sidebar" layout="nodisplay">

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -219,7 +219,8 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
   <link rel="amp-manifest" href="medium-manifest.json">
-  <script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>
+  <!--<script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>-->
+  <script async src="https://cdn.ampproject.org/viewer/google/v5.js"></script>
 </head>
 <body>
   <amp-sidebar id="sidebar" layout="nodisplay">

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -15,7 +15,7 @@
  */
 
 import {CSS} from '../../../build/amp-sidebar-0.1.css';
-import {tryFocus} from '../../../src/dom';
+import {closestByTag, tryFocus} from '../../../src/dom';
 import {Layout} from '../../../src/layout';
 import {dev} from '../../../src/log';
 import {historyForDoc} from '../../../src/history';
@@ -125,11 +125,8 @@ export class AmpSidebar extends AMP.BaseElement {
     this.registerAction('close', this.close_.bind(this));
 
     this.element.addEventListener('click', e => {
-      const target = dev().assertElement(e.target);
-      if (!target) {
-        return;
-      }
-      if (target.tagName == 'A' && target.href) {
+      const target = closestByTag(dev().assertElement(e.target), 'A');
+      if (target && target.href) {
         this.close_();
       }
     }, true);

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -17,6 +17,7 @@
 import {CSS} from '../../../build/amp-sidebar-0.1.css';
 import {tryFocus} from '../../../src/dom';
 import {Layout} from '../../../src/layout';
+import {dev} from '../../../src/log';
 import {historyForDoc} from '../../../src/history';
 import {platformFor} from '../../../src/platform';
 import {setStyles, toggle} from '../../../src/style';
@@ -122,6 +123,16 @@ export class AmpSidebar extends AMP.BaseElement {
     this.registerAction('toggle', this.toggle_.bind(this));
     this.registerAction('open', this.open_.bind(this));
     this.registerAction('close', this.close_.bind(this));
+
+    this.element.addEventListener('click', e => {
+      const target = dev().assertElement(e.target);
+      if (!target) {
+        return;
+      }
+      if (target.tagName == 'A' && target.href) {
+        this.close_();
+      }
+    }, true);
   }
 
  /**

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -41,6 +41,9 @@ describe('amp-sidebar', () => {
         list.appendChild(li);
       }
       ampSidebar.appendChild(list);
+      const anchor = iframe.doc.createElement('a');
+      anchor.href = '#section1';
+      ampSidebar.appendChild(anchor);
       if (options.side) {
         ampSidebar.setAttribute('side', options.side);
       }
@@ -268,6 +271,74 @@ describe('amp-sidebar', () => {
       expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
       expect(sidebarElement.style.display).to.equal('none');
       expect(impl.schedulePause.callCount).to.equal(1);
+    });
+  });
+
+
+  it('should close sidebar if clicked on anchor', () => {
+    return getAmpSidebar().then(obj => {
+      const sidebarElement = obj.ampSidebar;
+      const anchor = sidebarElement.getElementsByTagName('a')[0];
+      const impl = sidebarElement.implementation_;
+      impl.schedulePause = sandbox.spy();
+      impl.vsync_ = {
+        mutate: function(callback) {
+          callback();
+        },
+      };
+      sandbox.stub(timer, 'delay', function(callback) {
+        callback();
+      });
+      expect(sidebarElement.hasAttribute('open')).to.be.false;
+      impl.open_();
+      expect(sidebarElement.hasAttribute('open')).to.be.true;
+      expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
+      const eventObj = document.createEventObject ?
+          document.createEventObject() : document.createEvent('Events');
+      if (eventObj.initEvent) {
+        eventObj.initEvent('click', true, true);
+      }
+      anchor.dispatchEvent ?
+          anchor.dispatchEvent(eventObj) :
+          anchor.fireEvent('onkeydown', eventObj);
+      expect(sidebarElement.hasAttribute('open')).to.be.false;
+      expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
+      expect(sidebarElement.style.display).to.equal('none');
+      expect(impl.schedulePause.callCount).to.equal(1);
+    });
+  });
+
+
+  it('should not close sidebar if clicked on non-anchor', () => {
+    return getAmpSidebar().then(obj => {
+      const sidebarElement = obj.ampSidebar;
+      const li = sidebarElement.getElementsByTagName('li')[0];
+      const impl = sidebarElement.implementation_;
+      impl.schedulePause = sandbox.spy();
+      impl.vsync_ = {
+        mutate: function(callback) {
+          callback();
+        },
+      };
+      sandbox.stub(timer, 'delay', function(callback) {
+        callback();
+      });
+      expect(sidebarElement.hasAttribute('open')).to.be.false;
+      impl.open_();
+      expect(sidebarElement.hasAttribute('open')).to.be.true;
+      expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
+      const eventObj = document.createEventObject ?
+          document.createEventObject() : document.createEvent('Events');
+      if (eventObj.initEvent) {
+        eventObj.initEvent('click', true, true);
+      }
+      li.dispatchEvent ?
+          li.dispatchEvent(eventObj) :
+          li.fireEvent('onkeydown', eventObj);
+      expect(sidebarElement.hasAttribute('open')).to.be.true;
+      expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
+      expect(sidebarElement.style.display).to.equal('');
+      expect(impl.schedulePause.callCount).to.equal(0);
     });
   });
 

--- a/src/document-click.js
+++ b/src/document-click.js
@@ -211,13 +211,7 @@ function handleHashClick_(e, tgtLoc, ampdoc, viewport, history) {
   // If possible do update the URL with the hash. As explained above
   // we do `replace` to avoid messing with the container's history.
   if (tgtLoc.hash != curLoc.hash) {
-    // Push a new state to history that would take us back to the current
-    // hash when users hit back.
-    history.push(() => {
-      win.location.replace(`${curLoc.hash || '#'}`);
-    }).then(() => {
-      // Replace the newly pushed state with the actual hash.
-      win.history.replaceState(null, null, `#${hash}`);
+    history.replaceStateForTarget(tgtLoc.hash, curLoc.hash).then(() => {
       scrollToElement(elem, win, viewport, hash);
     });
   } else {

--- a/src/document-click.js
+++ b/src/document-click.js
@@ -64,12 +64,13 @@ export class ClickHandler {
     /** @private @const {boolean} */
     this.isIosSafari_ = platform.isIos() && platform.isSafari();
 
-    // Only intercept clicks when iframed.
-    if (this.viewer_.isIframed() && this.viewer_.isOvertakeHistory()) {
-      /** @private @const {!function(!Event)|undefined} */
-      this.boundHandle_ = this.handle_.bind(this);
-      this.ampdoc.getRootNode().addEventListener('click', this.boundHandle_);
-    }
+    /** @private @const {boolean} */
+    this.isIframed_ = (this.viewer_.isIframed() &&
+        this.viewer_.isOvertakeHistory());
+
+    /** @private @const {!function(!Event)|undefined} */
+    this.boundHandle_ = this.handle_.bind(this);
+    this.ampdoc.getRootNode().addEventListener('click', this.boundHandle_);
   }
 
   /**
@@ -89,7 +90,8 @@ export class ClickHandler {
    */
   handle_(e) {
     onDocumentElementClick_(
-        e, this.ampdoc, this.viewport_, this.history_, this.isIosSafari_);
+        e, this.ampdoc, this.viewport_, this.history_, this.isIosSafari_,
+        this.isIframed_);
   }
 }
 
@@ -106,9 +108,10 @@ export class ClickHandler {
  * @param {!./service/viewport-impl.Viewport} viewport
  * @param {!./service/history-impl.History} history
  * @param {boolean} isIosSafari
+ * @param {boolean} isIframed
  */
 export function onDocumentElementClick_(
-    e, ampdoc, viewport, history, isIosSafari) {
+    e, ampdoc, viewport, history, isIosSafari, isIframed) {
   if (e.defaultPrevented) {
     return;
   }
@@ -119,10 +122,30 @@ export function onDocumentElementClick_(
   }
   urlReplacementsForDoc(ampdoc).maybeExpandLink(target);
 
+  const tgtLoc = parseUrl(target.href);
+  // Handle custom protocols only if the document is iframe'd.
+  if (isIframed) {
+    handleCustomProtocolClick_(e, target, tgtLoc, ampdoc, isIosSafari);
+  }
+
+  if (tgtLoc.hash) {
+    handleHashClick_(e, tgtLoc, ampdoc, viewport, history);
+  }
+}
+
+
+/**
+ * Handles clicking on a custom protocol link.
+ * @param {!Event} e
+ * @param {!Element} target
+ * @param {!Location} tgtLoc
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {boolean} isIosSafari
+ * @private
+ */
+function handleCustomProtocolClick_(e, target, tgtLoc, ampdoc, isIosSafari) {
   /** @const {!Window} */
   const win = ampdoc.win;
-  const tgtLoc = parseUrl(target.href);
-
   // On Safari iOS, custom protocol links will fail to open apps when the
   // document is iframed - in order to go around this, we set the top.location
   // to the custom protocol href.
@@ -141,11 +164,21 @@ export function onDocumentElementClick_(
     // in the case where there's no app to handle the custom protocol.
     e.preventDefault();
   }
+}
 
-  if (!tgtLoc.hash) {
-    return;
-  }
 
+/**
+ * Handles clicking on a link with hash navigation.
+ * @param {!Event} e
+ * @param {!Location} tgtLoc
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!./service/viewport-impl.Viewport} viewport
+ * @param {!./service/history-impl.History} history
+ * @private
+ */
+function handleHashClick_(e, tgtLoc, ampdoc, viewport, history) {
+  /** @const {!Window} */
+  const win = ampdoc.win;
   /** @const {!Location} */
   const curLoc = parseUrl(win.location.href);
   const tgtHref = `${tgtLoc.origin}${tgtLoc.pathname}${tgtLoc.search}`;
@@ -168,7 +201,7 @@ export function onDocumentElementClick_(
   let elem = null;
 
   if (hash) {
-    const escapedHash = escapeCssSelectorIdent(ampdoc.win, hash);
+    const escapedHash = escapeCssSelectorIdent(win, hash);
     elem = (ampdoc.getRootNode().getElementById(hash) ||
         // Fallback to anchor[name] if element with id is not found.
         // Linking to an anchor element with name is obsolete in html5.

--- a/src/document-click.js
+++ b/src/document-click.js
@@ -225,7 +225,7 @@ function handleHashClick_(e, tgtLoc, ampdoc, viewport, history) {
  * Scrolls the page to the given element.
  * @param {?Element} elem
  * @param {!Window} win
- * @param {!./service/viewer-impl.Viewer} viewer
+ * @param {!./service/viewport-impl.Viewport} viewport
  * @param {string} hash
  */
 function scrollToElement(elem, win, viewport, hash) {

--- a/src/document-click.js
+++ b/src/document-click.js
@@ -211,7 +211,7 @@ function handleHashClick_(e, tgtLoc, ampdoc, viewport, history) {
   // If possible do update the URL with the hash. As explained above
   // we do `replace` to avoid messing with the container's history.
   if (tgtLoc.hash != curLoc.hash) {
-    history.replaceStateForTarget(tgtLoc.hash, curLoc.hash).then(() => {
+    history.replaceStateForTarget(tgtLoc.hash).then(() => {
       scrollToElement(elem, win, viewport, hash);
     });
   } else {

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -358,7 +358,7 @@ export class HistoryBindingNatural_ {
     /**
      * Used to ignore `popstate` handler for cases where we know we caused the
      * popstate event through the use of location.replace.
-     * @private {boolean}
+     * @private {?string}
      **/
     this.lastNavigatedHash_ = null;
 
@@ -403,6 +403,9 @@ export class HistoryBindingNatural_ {
     // On pop, stack is not allowed to go prior to the starting point.
     stackIndex = Math.max(stackIndex, this.startIndex_);
     return this.whenReady_(() => {
+      // Popping history forget the last navigated hash since we can't really
+      // know what hash the browser is going to go to.
+      this.lastNavigatedHash_ = null;
       return this.back_(this.stackIndex_ - stackIndex + 1);
     });
   }
@@ -570,7 +573,7 @@ export class HistoryBindingNatural_ {
       this.lastNavigatedHash_ = target;
       // TODO(mkhatib, #6095): Chrome iOS will add extra states for location.replace.
       this.win.location.replace(target);
-      this.historyReplaceState_(undefined, undefined, this.win.location.href);
+      this.historyReplaceState_();
       return Promise.resolve();
     });
   }

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Pass} from '../pass';
 import {fromClass, getServiceForDoc} from '../service';
 import {getMode} from '../mode';
 import {dev} from '../log';
@@ -246,9 +245,9 @@ class HistoryBindingInterface {
 
   /**
    * Replaces the state for local target navigation.
-   * @param target
+   * @param unusedTarget
    */
-  replaceStateForTarget(target) {}
+  replaceStateForTarget(unusedTarget) {}
 }
 
 
@@ -557,7 +556,7 @@ export class HistoryBindingNatural_ {
    */
   replaceStateForTarget(target) {
     this.whenReady_(() => {
-      let hash = target.indexOf('#') == 0 ? target : `#${target}`;
+      const hash = target[0] == '#' ? target : `#${target}`;
       this.ignoreUpcomingPopstate_ = true;
       // TODO(mkhatib, #6095): Chrome iOS will add extra states for location.replace.
       this.win.location.replace(hash);
@@ -618,7 +617,7 @@ export class HistoryBindingVirtual_ {
    * @param {!./viewer-impl.Viewer} viewer
    */
   constructor(win, viewer) {
-    /** @private @const {!Window} */
+    /** @const {!Window} */
     this.win = win;
 
     /** @private @const {!./viewer-impl.Viewer} */
@@ -637,7 +636,7 @@ export class HistoryBindingVirtual_ {
 
   /** @override */
   replaceStateForTarget(target) {
-    let hash = target.indexOf('#') == 0 ? target : `#${target}`;
+    const hash = target[0] == '#' ? target : `#${target}`;
     this.win.location.replace(hash);
   }
 

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -570,6 +570,12 @@ export class HistoryBindingNatural_ {
   replaceStateForTarget(target) {
     dev().assert(target[0] == '#', 'target should start with a #');
     this.whenReady_(() => {
+      // location.replace will fire a popstate event, this is not a history
+      // event. This tells the popstate handler to not handle it by setting
+      // the lastNavigatedHash_ to the future hash we know we're going toward.
+      // As explained above in the function comment, typically we'd just do
+      // replaceState here but in order to trigger :target re-eval we have to
+      // use location.replace.
       this.lastNavigatedHash_ = target;
       // TODO(mkhatib, #6095): Chrome iOS will add extra states for location.replace.
       this.win.location.replace(target);

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -353,6 +353,14 @@ export class HistoryBindingNatural_ {
     history.pushState = this.historyPushState_.bind(this);
     history.replaceState = this.historyReplaceState_.bind(this);
 
+
+    /**
+     * Used to ignore `popstate` handler for cases where we know we don't want it
+     * handled.
+     * @private {boolean}
+     **/
+    this.ignoreUpcomingPopstate_ = false;
+
     this.popstateHandler_ = e => {
       if (this.ignoreUpcomingPopstate_) {
         return;
@@ -562,6 +570,7 @@ export class HistoryBindingNatural_ {
       this.win.location.replace(hash);
       this.ignoreUpcomingPopstate_ = false;
       this.historyReplaceState_();
+      return Promise.resolve();
     });
   }
 

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -118,6 +118,7 @@ export class History {
    * @return {!Promise}
    */
   replaceStateForTarget(target) {
+    dev().assert(target[0] == '#', 'target should start with a #');
     const previousHash = this.ampdoc_.win.location.hash;
     return this.push(() => {
       this.ampdoc_.win.location.replace(previousHash || '#');
@@ -563,12 +564,15 @@ export class HistoryBindingNatural_ {
    * @override
    */
   replaceStateForTarget(target) {
+    dev().assert(target[0] == '#', 'target should start with a #');
     this.whenReady_(() => {
-      const hash = target[0] == '#' ? target : `#${target}`;
       this.ignoreUpcomingPopstate_ = true;
       // TODO(mkhatib, #6095): Chrome iOS will add extra states for location.replace.
-      this.win.location.replace(hash);
-      this.ignoreUpcomingPopstate_ = false;
+      try {
+        this.win.location.replace(target);
+      } finally {
+        this.ignoreUpcomingPopstate_ = false;
+      }
       this.historyReplaceState_();
       return Promise.resolve();
     });
@@ -645,8 +649,8 @@ export class HistoryBindingVirtual_ {
 
   /** @override */
   replaceStateForTarget(target) {
-    const hash = target[0] == '#' ? target : `#${target}`;
-    this.win.location.replace(hash);
+    dev().assert(target[0] == '#', 'target should start with a #');
+    this.win.location.replace(target);
   }
 
   /** @override */

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -112,14 +112,16 @@ export class History {
   }
 
   /**
+   * Helper method to handle navigation to a local target, e.g. When a user clicks an
+   * anchor link to a local hash - <a href="#section1">Go to section 1</a>.
    *
    * @param {string} target
-   * @param {string} previousTarget
-   * @returns {Promise.<T>}
+   * @return {!Promise}
    */
-  replaceStateForTarget(target, previousTarget) {
+  replaceStateForTarget(target) {
+    const previousHash = this.ampdoc_.win.location.hash;
     return this.push(() => {
-      this.ampdoc_.win.location.replace(previousTarget || '#');
+      this.ampdoc_.win.location.replace(previousHash || '#');
     }).then(() => {
       this.binding_.replaceStateForTarget(target);
     });
@@ -555,9 +557,10 @@ export class HistoryBindingNatural_ {
    */
   replaceStateForTarget(target) {
     this.whenReady_(() => {
+      let hash = target.indexOf('#') == 0 ? target : `#${target}`;
       this.ignoreUpcomingPopstate_ = true;
       // TODO(mkhatib, #6095): Chrome iOS will add extra states for location.replace.
-      this.win.location.replace(target);
+      this.win.location.replace(hash);
       this.ignoreUpcomingPopstate_ = false;
       this.historyReplaceState_();
     });
@@ -570,6 +573,7 @@ export class HistoryBindingNatural_ {
    * @private
    */
   historyReplaceState_(state, title, url) {
+    this.assertReady_();
     if (!state) {
       state = {};
     }
@@ -631,20 +635,15 @@ export class HistoryBindingVirtual_ {
         this.onHistoryPopped_.bind(this));
   }
 
-  /**
-   * @param {string} target
-   * @override
-   */
+  /** @override */
   replaceStateForTarget(target) {
-    this.win.location.replace(target);
+    let hash = target.indexOf('#') == 0 ? target : `#${target}`;
+    this.win.location.replace(hash);
   }
 
   /** @override */
   cleanup_() {
     this.unlistenOnHistoryPopped_();
-    if (this.origReplaceState_) {
-      this.win.history.replaceState = this.origReplaceState_;
-    }
   }
 
   /** @override */

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -440,7 +440,9 @@ describes.fakeWin('Local Hash Navigation', {
 
   it('should push a new state and replace it for target on Virtual', () => {
     const viewer = {
-      onHistoryPoppedEvent: () => {},
+      onHistoryPoppedEvent: () => {
+        return () => {};
+      },
       postPushHistory: unusedStackIndex => {},
       postPopHistory: unusedStackIndex => {},
     };

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -27,7 +27,11 @@ import {parseUrl} from '../../src/url';
 import * as sinon from 'sinon';
 
 
-describe('History', () => {
+describes.fakeWin('History', {
+  win: {
+    location: '#first',
+  },
+}, env => {
 
   let sandbox;
   let clock;
@@ -36,7 +40,8 @@ describe('History', () => {
   let history;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    installTimerService(env.win);
+    sandbox = env.sandbox;
     clock = sandbox.useFakeTimers();
 
     const binding = {
@@ -46,16 +51,15 @@ describe('History', () => {
       },
       push: () => {},
       pop(unusedStackIndex) {},
+      replaceStateForTarget: () => {},
     };
     bindingMock = sandbox.mock(binding);
 
-    history = new History(new AmpDocSingle(window), binding);
+    history = new History(new AmpDocSingle(env.win), binding);
   });
 
   afterEach(() => {
     bindingMock.verify();
-    history.cleanup_();
-    sandbox.restore();
   });
 
   it('should initialize correctly', () => {
@@ -108,6 +112,20 @@ describe('History', () => {
       expect(history.stackOnPop_.length).to.equal(11);
       clock.tick(1);
       expect(onPop.callCount).to.equal(1);
+    });
+  });
+
+  it('should push a new state and replace it for target', () => {
+    bindingMock.expects('push').withExactArgs()
+        .returns(Promise.resolve(11)).once();
+    bindingMock.expects('pop')
+        .returns(Promise.resolve(10)).once();
+    bindingMock.expects('replaceStateForTarget').withExactArgs('#hello');
+    return history.replaceStateForTarget('#hello').then(() => {
+      return history.pop(history.stackIndex_).then(() => {
+        clock.tick(1);
+        expect(env.win.location.hash).to.equal('#first');
+      });
     });
   });
 });
@@ -321,7 +339,7 @@ describe('HistoryBindingVirtual', () => {
       postPopHistory: unusedStackIndex => {},
     };
     viewerMock = sandbox.mock(viewer);
-    history = new HistoryBindingVirtual_(viewer);
+    history = new HistoryBindingVirtual_(window, viewer);
     history.setOnStackIndexUpdated(onStackIndexUpdated);
   });
 
@@ -338,7 +356,8 @@ describe('HistoryBindingVirtual', () => {
   });
 
   it('should push new state to viewer and notify', () => {
-    viewerMock.expects('postPushHistory').withExactArgs(1).once();
+    viewerMock.expects('postPushHistory').withExactArgs(1).once().returns(
+        Promise.resolve());
     return history.push().then(stackIndex => {
       expect(stackIndex).to.equal(1);
       expect(history.stackIndex_).to.equal(1);
@@ -348,8 +367,10 @@ describe('HistoryBindingVirtual', () => {
   });
 
   it('should pop a state from the window.history and notify', () => {
-    viewerMock.expects('postPushHistory').withExactArgs(1).once();
-    viewerMock.expects('postPopHistory').withExactArgs(1).once();
+    viewerMock.expects('postPushHistory').withExactArgs(1).once().returns(
+        Promise.resolve());
+    viewerMock.expects('postPopHistory').withExactArgs(1).once().returns(
+        Promise.resolve());
     return history.push().then(stackIndex => {
       expect(stackIndex).to.equal(1);
       expect(onStackIndexUpdated.callCount).to.equal(1);
@@ -364,7 +385,8 @@ describe('HistoryBindingVirtual', () => {
   });
 
   it('should update its state and notify on history.back', () => {
-    viewerMock.expects('postPushHistory').withExactArgs(1).once();
+    viewerMock.expects('postPushHistory').withExactArgs(1).once().returns(
+        Promise.resolve());
     return history.push().then(stackIndex => {
       expect(stackIndex).to.equal(1);
       expect(onStackIndexUpdated.callCount).to.equal(1);
@@ -374,6 +396,72 @@ describe('HistoryBindingVirtual', () => {
       expect(history.stackIndex_).to.equal(0);
       expect(onStackIndexUpdated.callCount).to.equal(2);
       expect(onStackIndexUpdated.getCall(1).args[0]).to.equal(0);
+    });
+  });
+});
+
+describes.fakeWin('Local Hash Navigation', {
+  win: {
+    location: '#first',
+  },
+}, env => {
+
+  let sandbox;
+  let clock;
+  let history;
+
+  beforeEach(() => {
+    installTimerService(env.win);
+    sandbox = env.sandbox;
+    clock = sandbox.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (history) {
+      history.cleanup_();
+    }
+  });
+
+  it('should push a new state and replace it for target on Natural', () => {
+    history = new History(new AmpDocSingle(env.win),
+        new HistoryBindingNatural_(env.win));
+    const startIndex = env.win.history.index;
+    return history.replaceStateForTarget('#hello').then(() => {
+      clock.tick(1);
+      expect(env.win.location.hash).to.equal('#hello');
+      expect(env.win.history.index).to.equal(startIndex + 1);
+      return history.pop(history.stackIndex_).then(() => {
+        clock.tick(1);
+        expect(env.win.location.hash).to.equal('#first');
+        expect(env.win.history.index).to.equal(startIndex);
+      });
+    });
+  });
+
+  it('should push a new state and replace it for target on Virtual', () => {
+    const viewer = {
+      onHistoryPoppedEvent: () => {},
+      postPushHistory: unusedStackIndex => {},
+      postPopHistory: unusedStackIndex => {},
+    };
+    const viewerMock = sandbox.mock(viewer);
+    history = new History(new AmpDocSingle(env.win),
+        new HistoryBindingVirtual_(env.win, viewer));
+    const startIndex = history.stackIndex_;
+
+    viewerMock.expects('postPushHistory').withExactArgs(1).once().returns(
+        Promise.resolve());
+    viewerMock.expects('postPopHistory').withExactArgs(1).once().returns(
+        Promise.resolve());
+    return history.replaceStateForTarget('#hello').then(() => {
+      clock.tick(1);
+      expect(env.win.location.hash).to.equal('#hello');
+      expect(history.stackIndex_).to.equal(startIndex + 1);
+      return history.pop(history.stackIndex_).then(() => {
+        clock.tick(1);
+        expect(env.win.location.hash).to.equal('#first');
+        expect(history.stackIndex_).to.equal(startIndex);
+      });
     });
   });
 });

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -430,8 +430,10 @@ describes.fakeWin('Local Hash Navigation', {
       clock.tick(1);
       expect(env.win.location.hash).to.equal('#hello');
       expect(env.win.history.index).to.equal(startIndex + 1);
-      return history.pop(history.stackIndex_).then(() => {
-        clock.tick(1);
+      const historyPopPromise = history.pop(history.stackIndex_);
+
+      clock.tick(1);
+      return historyPopPromise.then(() => {
         expect(env.win.location.hash).to.equal('#first');
         expect(env.win.history.index).to.equal(startIndex);
       });

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -94,13 +94,17 @@ export class FakeWindow {
      * @return {number}
      * @const
      */
-    this.setTimeout = window.setTimeout;
+    this.setTimeout = function () {
+      return window.setTimeout.apply(window, arguments);
+    };
 
     /**
      * @param {number} id
      * @const
      */
-    this.clearTimeout = window.clearTimeout;
+    this.clearTimeout = function () {
+      return window.clearTimeout.apply(window, arguments);
+    };
 
     /**
      * @param {function()} handler
@@ -109,13 +113,17 @@ export class FakeWindow {
      * @return {number}
      * @const
      */
-    this.setInterval = window.setInterval;
+    this.setInterval = function () {
+      return window.setInterval.apply(window, arguments);
+    };
 
     /**
      * @param {number} id
      * @const
      */
-    this.clearInterval = window.clearInterval;
+    this.clearInterval = function () {
+      return window.clearInterval.apply(window, arguments);
+    };
 
     let raf = window.requestAnimationFrame
         || window.webkitRequestAnimationFrame;
@@ -331,7 +339,7 @@ class FakeLocation {
    */
   change_(args) {
     const change = parseUrl(this.url_.href);
-    Object.assign(change, args);
+    Object.assign({}, change, args);
     this.changes.push(change);
   }
 
@@ -427,6 +435,7 @@ export class FakeHistory {
       throw new Error('can\'t go forward');
     }
     this.index = newIndex;
+    this.win.eventListeners.fire({type: 'popstate'});
   }
 
   /**

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -435,6 +435,9 @@ export class FakeHistory {
       throw new Error('can\'t go forward');
     }
     this.index = newIndex;
+    // Make sure to restore the location href before firing popstate to match
+    // real browsers behaviors.
+    this.win.location.resetHref(this.stack[this.index].url);
     this.win.eventListeners.fire({type: 'popstate'});
   }
 


### PR DESCRIPTION
Previously we were only handling hash navigations in iframe'd docs, this change expands this to always install the `document.click` handler for standalone docs and let runtime handle hash navigation.

This allows our natural history implementation to properly queue popping/pushing states.

This should solve both natural and virtual history.

Related to: #4184 