### PR TITLE
Enable SauceLabs testing for iOS 8, 9 & 10

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -94,8 +94,9 @@ var karma = {
       'SL_Safari_8',
       'SL_Safari_9',
       'SL_Edge_latest',
-      // TODO(#895) Enable these.
-      //'SL_iOS_9_1',
+      'SL_iOS_8_4',
+      'SL_iOS_9_1',
+      'SL_iOS_10_0',
       //'SL_IE_11',
     ],
   })

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -94,10 +94,20 @@ module.exports = function(config) {
         browserName: 'chrome',
         version: '45',
       },
+      SL_iOS_8_4: {
+        base: 'SauceLabs',
+        browserName: 'iphone',
+        version: '8.4',
+      },
       SL_iOS_9_1: {
         base: 'SauceLabs',
         browserName: 'iphone',
         version: '9.1',
+      },
+      SL_iOS_10_0: {
+        base: 'SauceLabs',
+        browserName: 'iphone',
+        version: '10.0',
       },
       SL_Firefox_latest: {
         base: 'SauceLabs',

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -5,7 +5,6 @@
   <title>AMP #0</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <script async custom-element="amp-extended-sample" src="/dist/v0/sample-0.1.js"></script>
   <style amp-custom>
     h1 {color: red}
     body {

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -153,6 +153,9 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
     html = html.replace('>', '><script>parent.beforeLoad(window);</script>');
     html += '<script>parent.afterLoad(window);</script>';
     let iframe = document.createElement('iframe');
+    if (/iPhone|iPad|iPod/.test(navigator.userAgent)) {
+      iframe.setAttribute('scrolling', 'no');
+    }
     iframe.name = 'test_' + fixture + iframeCount++;
     iframe.onerror = function(event) {
       reject(event.error);


### PR DESCRIPTION
Not sure what happened and I'm hoping we didn't just hit a lucky day, but these tests now run just fine. Previously SC would just always fail to bring up the iOS simulator.

Needed to add the one `scrolling=no` change to `iframe.js` since this is required for our iOS embed mode to work.