### PR TITLE
Add a postinstall script for Windows.

### DIFF
--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -22,5 +22,8 @@
   },
   "devDependencies": {
     "jasmine": "2.3.2"
+  },
+  "scripts": {
+    "postinstall": "/bin/sh \"exit 0\" 2> NUL && rm NUL || node postinstall-windows.js"
   }
 }

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -24,6 +24,6 @@
     "jasmine": "2.3.2"
   },
   "scripts": {
-    "postinstall": "/bin/sh \"exit 0\" 2> NUL && rm NUL || node postinstall-windows.js"
+    "postinstall": "/bin/sh -c \"exit 0\" 2> NUL && rm NUL || node postinstall-windows.js"
   }
 }

--- a/validator/nodejs/postinstall-windows.js
+++ b/validator/nodejs/postinstall-windows.js
@@ -25,6 +25,11 @@ if (process.env.OS !== 'Windows_NT') {
   process.exit(1);
 }
 
+// We only want to modify the .cmd shim - this is what would run on a
+// normal Windows installation (not cygwin or similar). If we're on
+// something close enough to a Unix/Linux system (even if this were to
+// be Windows), we won't bother and this postinstall won't run because
+// /bin/sh -c "exit 0" will succeed (see package.json).
 var validatorShimPath =
     path.join(process.env.npm_config_prefix, 'amphtml-validator.cmd');
 var stats = fs.statSync(validatorShimPath);
@@ -33,6 +38,11 @@ if (!stats.isFile()) {
   process.exit(1);
 }
 
+// We take a quick look into the shim file that npm for Windows generates.
+// This will try to invoke the shell script, using /bin/sh as the interpreter -
+// which we already established won't work if this postinstall were to trigger
+// (again, see the command line in package.json and imagine what happens if
+// cmd.exe executes it).
 var contents = fs.readFileSync(validatorShimPath, 'utf8');
 if (contents.indexOf('"%~dp0\\node_modules\\amphtml-validator\\index.sh"') ===
     -1) {
@@ -40,6 +50,10 @@ if (contents.indexOf('"%~dp0\\node_modules\\amphtml-validator\\index.sh"') ===
   process.exit(1);
 }
 
+// Now we write a shim file that will likely work. We already know that the
+// node command works (since this is how we were invoked from the command line
+// in package.json), and we know that index.js is a sibling to index.sh.
+// So, we can just invoke that.
 fs.writeFileSync(
     validatorShimPath, '@ECHO OFF\r\n' +
         'node "%~dp0\\node_modules\\amphtml-validator\\index.js" %*');

--- a/validator/nodejs/postinstall-windows.js
+++ b/validator/nodejs/postinstall-windows.js
@@ -21,7 +21,8 @@ var path = require('path');
 var fs = require('fs');
 
 if (process.env.OS !== 'Windows_NT') {
-  console.error('postinstall-windows.js: This script is for Windows only.');
+  console./*OK*/ error(
+      'postinstall-windows.js: This script is for Windows only.');
   process.exit(1);
 }
 
@@ -34,7 +35,7 @@ var validatorShimPath =
     path.join(process.env.npm_config_prefix, 'amphtml-validator.cmd');
 var stats = fs.statSync(validatorShimPath);
 if (!stats.isFile()) {
-  console.error('postinstall-windows.js: amphtml-validator not found.');
+  console./*OK*/ error('postinstall-windows.js: amphtml-validator not found.');
   process.exit(1);
 }
 
@@ -46,7 +47,8 @@ if (!stats.isFile()) {
 var contents = fs.readFileSync(validatorShimPath, 'utf8');
 if (contents.indexOf('"%~dp0\\node_modules\\amphtml-validator\\index.sh"') ===
     -1) {
-  console.error('postinstall-windows.js: amphtml-validator not matched.');
+  console./*OK*/ error(
+      'postinstall-windows.js: amphtml-validator not matched.');
   process.exit(1);
 }
 
@@ -57,4 +59,5 @@ if (contents.indexOf('"%~dp0\\node_modules\\amphtml-validator\\index.sh"') ===
 fs.writeFileSync(
     validatorShimPath, '@ECHO OFF\r\n' +
         'node "%~dp0\\node_modules\\amphtml-validator\\index.js" %*');
-console.log('postinstall-windows.js: Modified amphtml-validator for Windows.');
+console./*OK*/ log(
+    'postinstall-windows.js: Modified amphtml-validator for Windows.');

--- a/validator/nodejs/postinstall-windows.js
+++ b/validator/nodejs/postinstall-windows.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+if (process.env.OS !== 'Windows_NT') {
+  console.error('postinstall-windows.js: This script is for Windows only.');
+  process.exit(1);
+}
+
+var validatorShimPath =
+    path.join(process.env.npm_config_prefix, 'amphtml-validator.cmd');
+var stats = fs.statSync(validatorShimPath);
+if (!stats.isFile()) {
+  console.error('postinstall-windows.js: amphtml-validator not found.');
+  process.exit(1);
+}
+
+var contents = fs.readFileSync(validatorShimPath, 'utf8');
+if (contents.indexOf('"%~dp0\\node_modules\\amphtml-validator\\index.sh"') ===
+    -1) {
+  console.error('postinstall-windows.js: amphtml-validator not matched.');
+  process.exit(1);
+}
+
+fs.writeFileSync(
+    validatorShimPath, '@ECHO OFF\r\n' +
+        'node "%~dp0\\node_modules\\amphtml-validator\\index.js" %*');
+console.log('postinstall-windows.js: Modified amphtml-validator for Windows.');


### PR DESCRIPTION
The command line is executed both for cmd.exe and sh, the Unix shell,
depending on where it runs. Note that cmd.exe is *really* different,
but there is a small subset that's common. So the postinstall command
line works on both.

1) For Windows: /bin/sh doesn't exist, so this is an error, which we
redirect to NUL (which is the Windows version of /dev/null). Then we
try to delete NUL, which won't work and give a non-zero exit status.
But up to here it's all quiet. Now we get to
|| node postinstall-windows.js, and this just runs the windows specific
postinstall script. This script locates the Windows shim and modifies
it so that it works. The shim that we put there just calls node with
the name of the script file (index.sh), so we're skipping the index.sh
dispatch script that we use for Debian-based (where node is called nodejs)
and other Linux distros (where it's called node).

2) For Unix-like platforms, /bin/sh -c "exit 0" will have exit status 0.
NUL will be a temporary file, which we then remove. This succeeds,
so we won't run the postinstall-windows.js script.

The index.sh script makes amphtml-validator work for both Ubuntu/Debian/etc.
and other installations (e.g. nvm), but this part isn't new.

This should fix https://github.com/ampproject/amphtml/issues/5855.