### PR TITLE
Add marginwidth and marginheight attributes to A4A iframes

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -81,6 +81,8 @@ const SHARED_IFRAME_PROPERTIES = {
   allowfullscreen: '',
   allowtransparency: '',
   scrolling: 'no',
+  marginwidth: '0',
+  marginheight: '0',
 };
 
 /** @typedef {{creative: ArrayBuffer, signature: ?Uint8Array}} */


### PR DESCRIPTION
It turns out that many ad creatives do not bother to set their body margins properly, and expect the iframe that they're in to use the `marginwidth` and `marginheight` attributes to override it. If this is not done, the browser default margin (8px on Chrome) will be used; consequently, extra unwanted margin will appear on the left and top edges of the creative, and the right and bottom edges will not be visible. The A4A fetching/rendering path did not do this properly; this change fixes that bug.