### PR TITLE
Remove unsupported query selector feature

### DIFF
--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -60,7 +60,7 @@ export function fontStylesheetTimeout(win) {
     // Alright we timed out.
     // Find all stylesheets.
     const styleLinkElements = win.document.querySelectorAll(
-        'link[rel~="stylesheet" i]');
+        'link[rel~="stylesheet"]');
     for (let i = 0; i < styleLinkElements.length; i++) {
       const existingLink = styleLinkElements[i];
       const newLink = existingLink.cloneNode(/* not deep */ false);


### PR DESCRIPTION
Safari 8 does not support case-insensitive directive for query selector and throws DOM exception `DOM Exception 12: An invalid or illegal string was specified`

Based on my testing, it is not necessary and browsers seem to lower-case value of `type` attribute anyway.