### PR TITLE
Workaround for misbehaving webview viewer

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -682,6 +682,12 @@ export class Viewer {
    * @private
    */
   isTrustedViewerOrigin_(urlString) {
+    // TEMPORARY HACK due to a misbehaving native app. See b/32626673
+    // In native apps all security bets are off anyway, and in browser
+    // origins never take the form that is matched here.
+    if (this.isWebviewEmbedded_ && /^www\.[.a-z]+$/.test(urlString)) {
+      return TRUSTED_VIEWER_HOSTS.some(th => th.test(urlString));
+    }
     /** @const {!Location} */
     const url = parseUrl(urlString);
     if (url.protocol != 'https:') {

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -799,11 +799,6 @@ describe('Viewer', () => {
 
   describe('isTrustedViewer', () => {
 
-    function test(origin, toBeTrusted) {
-      const viewer = new Viewer(ampdoc);
-      expect(viewer.isTrustedViewerOrigin_(origin)).to.equal(toBeTrusted);
-    }
-
     it('should consider non-trusted when not iframed', () => {
       windowApi.parent = windowApi;
       windowApi.location.ancestorOrigins = ['https://google.com'];
@@ -992,7 +987,15 @@ describe('Viewer', () => {
       });
     });
 
-    it('should trust domain variations', () => {
+    function test(origin, toBeTrusted, opt_inWebView) {
+      it ('testing ' + origin, () => {
+        const viewer = new Viewer(ampdoc);
+        viewer.isWebviewEmbedded_ = !!opt_inWebView;
+        expect(viewer.isTrustedViewerOrigin_(origin)).to.equal(toBeTrusted);
+      });
+    }
+
+    describe('should trust domain variations', () => {
       test('https://google.com', true);
       test('https://www.google.com', true);
       test('https://news.google.com', true);
@@ -1011,11 +1014,12 @@ describe('Viewer', () => {
       test('https://www.google.cat', true);
     });
 
-    it('should not trust host as referrer with http', () => {
+    describe('should not trust host as referrer with http', () => {
       test('http://google.com', false);
     });
 
-    it('should NOT trust wrong or non-whitelisted domain variations', () => {
+    describe('should NOT trust wrong or non-whitelisted domain variations',
+      () => {
       test('https://google.net', false);
       test('https://google.other.com', false);
       test('https://www.google.other.com', false);
@@ -1024,6 +1028,17 @@ describe('Viewer', () => {
       test('https://google', false);
       test('https://www.google', false);
     });
+
+    describe('tests for b/32626673', () => {
+      test('www.google.com', true, true);
+      test('www.google.com', false, /* not in webview */ false);
+      test('www.google.de', true, true);
+      test('www.google.co.uk', true, true);
+      test(':www.google.de', false, true);
+      test('news.google.de', false, true);
+      test('www.google.de/', false, true);
+      test('www.acme.com', false, true);
+    })
   });
 
   describe('referrer', () => {

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -988,7 +988,7 @@ describe('Viewer', () => {
     });
 
     function test(origin, toBeTrusted, opt_inWebView) {
-      it ('testing ' + origin, () => {
+      it('testing ' + origin, () => {
         const viewer = new Viewer(ampdoc);
         viewer.isWebviewEmbedded_ = !!opt_inWebView;
         expect(viewer.isTrustedViewerOrigin_(origin)).to.equal(toBeTrusted);
@@ -1020,14 +1020,14 @@ describe('Viewer', () => {
 
     describe('should NOT trust wrong or non-whitelisted domain variations',
       () => {
-      test('https://google.net', false);
-      test('https://google.other.com', false);
-      test('https://www.google.other.com', false);
-      test('https://withgoogle.com', false);
-      test('https://acme.com', false);
-      test('https://google', false);
-      test('https://www.google', false);
-    });
+        test('https://google.net', false);
+        test('https://google.other.com', false);
+        test('https://www.google.other.com', false);
+        test('https://withgoogle.com', false);
+        test('https://acme.com', false);
+        test('https://google', false);
+        test('https://www.google', false);
+      });
 
     describe('tests for b/32626673', () => {
       test('www.google.com', true, true);
@@ -1038,7 +1038,7 @@ describe('Viewer', () => {
       test('news.google.de', false, true);
       test('www.google.de/', false, true);
       test('www.acme.com', false, true);
-    })
+    });
   });
 
   describe('referrer', () => {


### PR DESCRIPTION
A webview viewer from Google is seing origins of the form `www.google.com`.

For the time being we accept these as they trigger errors in our error reporting that aren't useful. As this form of origins can only occur with webviews that have full control over the page via JS injection anyway, this change should make no difference for normal web usage.