### PR TITLE
Enable default placeholder for amp-ad

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -585,7 +585,7 @@ describe('amp-a4a', () => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         a4aElement.setAttribute('type', 'adsense');
-        const a4a = new AmpA4A(a4aElement);
+        const a4a = new MockA4AImpl(a4aElement);
         //a4a.config = {};
         a4a.buildCallback();
         a4a.preconnectCallback(false);

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -36,5 +36,9 @@ export class MockA4AImpl extends AmpA4A {
           base64UrlDecodeToBytes(responseHeaders.get(SIGNATURE_HEADER)) : null,
     });
   }
+
+  getFallback() {
+    return null;
+  }
 }
 

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -66,9 +66,6 @@ export class AmpAdUIHandler {
 
     /** {?Element} */
     this.fallback_ = baseInstance.getFallback();
-
-    /** {?Element} */
-    this.holder_ = null;
   }
 
   /**
@@ -83,11 +80,11 @@ export class AmpAdUIHandler {
       return;
     }
 
-    //Apply default placeholder + fallback div
-    this.holder_ = document.createElement('div');
-    this.holder_.setAttribute('fallback', '');
-    this.holder_.classList.add('-amp-ad-holder');
-    this.baseInstance_.element.appendChild(this.holder_);
+    //Apply default fallback div when there's no default one
+    const holder = document.createElement('div');
+    holder.setAttribute('fallback', '');
+    holder.classList.add('-amp-ad-holder');
+    this.baseInstance_.element.appendChild(holder);
   }
 
   /**
@@ -145,6 +142,7 @@ export class AmpAdUIHandler {
    * @private
    */
   displayNoContentUI_() {
+    // The order here is user provided fallback > collapse > default fallback
     if (this.fallback_) {
       this.baseInstance_.deferMutate(() => {
         if (this.state == AdDisplayState.NOT_LAID_OUT) {

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -15,12 +15,11 @@
  */
 
 import {dev} from '../../../src/log';
+import {createElementWithAttributes} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
+import {UX_EXPERIMENT} from '../../../src/layout';
 
 const TAG = 'AmpAdUIHandler';
-
-/** @private @const {string} */
-const UX_EXPERIMENT = 'amp-ad-loading-ux';
 
 /**
  * Ad display state.
@@ -79,10 +78,11 @@ export class AmpAdUIHandler {
     if (this.fallback_) {
       return;
     }
-
     //Apply default fallback div when there's no default one
-    const holder = document.createElement('div');
-    holder.setAttribute('fallback', '');
+    const holder = createElementWithAttributes(document, 'div', {
+      'fallback': '',
+      'layout': 'fill',
+    });
     holder.classList.add('-amp-ad-holder');
     this.baseInstance_.element.appendChild(holder);
   }

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -63,8 +63,8 @@ export class AmpAdUIHandler {
     /** {number} */
     this.state = AdDisplayState.NOT_LAID_OUT;;
 
-    /** {?Element} */
-    this.pageProvidedFallback_ = baseInstance.getFallback();
+    /** {!boolean} */
+    this.hasPageProvidedFallback_ = !!baseInstance.getFallback();
   }
 
   /**
@@ -75,9 +75,10 @@ export class AmpAdUIHandler {
       return;
     }
 
-    if (this.pageProvidedFallback_) {
+    if (this.hasPageProvidedFallback_) {
       return;
     }
+
     // Apply default fallback div when there's no default one
     const holder = createElementWithAttributes(document, 'div', {
       'fallback': '',
@@ -142,7 +143,7 @@ export class AmpAdUIHandler {
    */
   displayNoContentUI_() {
     // The order here is user provided fallback > collapse > default fallback
-    if (this.pageProvidedFallback_) {
+    if (this.hasPageProvidedFallback_) {
       this.baseInstance_.deferMutate(() => {
         if (this.state == AdDisplayState.NOT_LAID_OUT) {
           // If already unlaid out, do not replace current placeholder then.

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -65,9 +65,6 @@ export class AmpAdUIHandler {
     this.state = AdDisplayState.NOT_LAID_OUT;;
 
     /** {?Element} */
-    this.placeholder_ = baseInstance.getPlaceholder();
-
-    /** {?Element} */
     this.fallback_ = baseInstance.getFallback();
 
     /** {?Element} */
@@ -91,6 +88,7 @@ export class AmpAdUIHandler {
 
     //Apply default placeholder + fallback div
     this.holder_ = document.createElement('div');
+    this.holder_.setAttribute('fallback', '');
     this.holder_.classList.add('-amp-ad-holder');
     this.baseInstance_.element.appendChild(this.holder_);
   }
@@ -130,7 +128,7 @@ export class AmpAdUIHandler {
    */
   displayLoadingUI_() {
     this.state = AdDisplayState.LOADING;
-    this.togglePlaceholder_(true);
+    this.baseInstance_.togglePlaceholder(true);
   }
 
   /**
@@ -139,7 +137,7 @@ export class AmpAdUIHandler {
    */
   displayRenderStartUI_() {
     this.state = AdDisplayState.LOADED_RENDER_START;
-    this.togglePlaceholder_(false);
+    this.baseInstance_.togglePlaceholder(false);
   }
 
   /**
@@ -150,13 +148,13 @@ export class AmpAdUIHandler {
    * @private
    */
   displayNoContentUI_() {
-    if (this.baseInstance_.getFallback()) {
+    if (this.fallback_) {
       this.baseInstance_.deferMutate(() => {
         if (this.state == AdDisplayState.NOT_LAID_OUT) {
           // If already unlaid out, do not replace current placeholder then.
           return;
         }
-        this.togglePlaceholder_(false);
+        this.baseInstance_.togglePlaceholder(false);
         this.baseInstance_.toggleFallback(true);
         this.state = AdDisplayState.LOADED_NO_CONTENT;
       });
@@ -165,8 +163,8 @@ export class AmpAdUIHandler {
         this.baseInstance_./*OK*/collapse();
         this.state = AdDisplayState.LOADED_NO_CONTENT;
       }, () => {
-        this.togglePlaceholder_(false);
-        this.toggleFallback_(true);
+        this.baseInstance_.togglePlaceholder(false);
+        this.baseInstance_.toggleFallback(true);
         this.state = AdDisplayState.LOADED_NO_CONTENT;
       });
     }
@@ -188,38 +186,6 @@ export class AmpAdUIHandler {
       this.togglePlaceholder_(true);
       this.baseInstance_.toggleFallback(false);
     });
-  }
-
-  /**
-   * togglePlaceholder, if use default placeholder, hide it.
-   * @param {boolean} state
-   * @private
-   */
-  togglePlaceholder_(state) {
-    if (this.placeholder_) {
-      this.baseInstance_.togglePlaceholder(state);
-      return;
-    }
-  }
-
-  /**
-   * toggleFallback, if use default fallback, hide it.
-   * @param {boolean} state
-   * @private
-   */
-  toggleFallback_(state) {
-    if (this.fallback_) {
-      this.baseInstance_.toggleFallback(state);
-      return;
-    }
-    if (!this.isExperimentOn_) {
-      return;
-    }
-    if (state) {
-      this.holder_.setAttribute('visible', '');
-    } else {
-      this.holder_.removeAttribute('visible');
-    }
   }
 }
 

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -64,7 +64,7 @@ export class AmpAdUIHandler {
     this.state = AdDisplayState.NOT_LAID_OUT;;
 
     /** {?Element} */
-    this.fallback_ = baseInstance.getFallback();
+    this.pageProvidedFallback_ = baseInstance.getFallback();
   }
 
   /**
@@ -75,15 +75,15 @@ export class AmpAdUIHandler {
       return;
     }
 
-    if (this.fallback_) {
+    if (this.pageProvidedFallback_) {
       return;
     }
-    //Apply default fallback div when there's no default one
+    // Apply default fallback div when there's no default one
     const holder = createElementWithAttributes(document, 'div', {
       'fallback': '',
       'layout': 'fill',
     });
-    holder.classList.add('-amp-ad-holder');
+    holder.classList.add('amp-ad-default-fallback');
     this.baseInstance_.element.appendChild(holder);
   }
 
@@ -143,7 +143,7 @@ export class AmpAdUIHandler {
    */
   displayNoContentUI_() {
     // The order here is user provided fallback > collapse > default fallback
-    if (this.fallback_) {
+    if (this.pageProvidedFallback_) {
       this.baseInstance_.deferMutate(() => {
         if (this.state == AdDisplayState.NOT_LAID_OUT) {
           // If already unlaid out, do not replace current placeholder then.
@@ -158,6 +158,7 @@ export class AmpAdUIHandler {
         this.baseInstance_./*OK*/collapse();
         this.state = AdDisplayState.LOADED_NO_CONTENT;
       }, () => {
+        // Apply default fallback when resize fail.
         this.baseInstance_.togglePlaceholder(false);
         this.baseInstance_.toggleFallback(true);
         this.state = AdDisplayState.LOADED_NO_CONTENT;

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -69,16 +69,13 @@ export class AmpAdUIHandler {
 
     /** {?Element} */
     this.holder_ = null;
-
-    /** {!boolean} */
-    this.isExperimentOn_ = isExperimentOn(baseInstance.win, UX_EXPERIMENT);
   }
 
   /**
    * TODO(@zhouyx): Add ad tag to the ad.
    */
   init() {
-    if (!this.isExperimentOn_) {
+    if (!isExperimentOn(this.baseInstance_.win, UX_EXPERIMENT)) {
       return;
     }
 
@@ -183,7 +180,7 @@ export class AmpAdUIHandler {
       if (this.state != AdDisplayState.NOT_LAID_OUT) {
         return;
       }
-      this.togglePlaceholder_(true);
+      this.baseInstance_.togglePlaceholder(true);
       this.baseInstance_.toggleFallback(false);
     });
   }

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -81,7 +81,6 @@ export class AmpAdUIHandler {
     // Apply default fallback div when there's no default one
     const holder = createElementWithAttributes(document, 'div', {
       'fallback': '',
-      'layout': 'fill',
     });
     holder.classList.add('amp-ad-default-fallback');
     this.baseInstance_.element.appendChild(holder);

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -23,3 +23,17 @@ amp-ad iframe {
   margin: 0 !important;
   padding: 0 !important;
 }
+
+.-amp-ad-holder {
+  background-color: #d3d3d3;
+  position: absolute !important;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  visibility: hidden;
+}
+
+.-amp-ad-holder[visible] {
+  visibility: visible;
+}

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -25,6 +25,6 @@ amp-ad iframe {
 }
 
 .amp-ad-default-fallback {
-  /* TODO(zhouyx): Confirm on the background-color value*/
+  /* TODO(zhouyx): Confirm on the background-color value */
   background-color: #d3d3d3;
 }

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -26,9 +26,4 @@ amp-ad iframe {
 
 .-amp-ad-holder {
   background-color: #d3d3d3;
-  position: absolute !important;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
 }

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -31,9 +31,4 @@ amp-ad iframe {
   left: 0;
   bottom: 0;
   right: 0;
-  visibility: hidden;
-}
-
-.-amp-ad-holder[visible] {
-  visibility: visible;
 }

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -24,6 +24,7 @@ amp-ad iframe {
   padding: 0 !important;
 }
 
-.-amp-ad-holder {
+.amp-ad-default-fallback {
+  /* TODO(zhouyx): Confirm on the background-color value*/
   background-color: #d3d3d3;
 }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -17,10 +17,8 @@
 import {AdDisplayState, AmpAdUIHandler} from '../amp-ad-ui';
 import {BaseElement} from '../../../../src/base-element';
 import {toggleExperiment} from '../../../../src/experiments';
+import {UX_EXPERIMENT} from '../../../../src/layout';
 import * as sinon from 'sinon';
-
-/** @private @const {string} */
-const UX_EXPERIMENT = 'amp-ad-loading-ux';
 
 describe('amp-ad-ui handler', () => {
   let sandbox;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -74,21 +74,23 @@ describe('amp-ad-ui handler', () => {
         expect(holder).to.have.attribute('fallback');
       });
     });
-  });
 
-  it('should NOT continue with display state UN_LAID_OUT', () => {
-    sandbox.stub(adImpl, 'getFallback', () => {
-      return true;
+    it('should NOT continue with display state UN_LAID_OUT', () => {
+      sandbox.stub(adImpl, 'getFallback', () => {
+        return document.createElement('div');
+      });
+      uiHandler = new AmpAdUIHandler(adImpl);
+      uiHandler.setDisplayState(AdDisplayState.LOADING);
+      const spy = sandbox.stub(adImpl, 'deferMutate', callback => {
+        uiHandler.state = AdDisplayState.NOT_LAID_OUT;
+        callback();
+      });
+      const placeHolderSpy = sandbox.stub(adImpl, 'togglePlaceholder');
+      uiHandler.init();
+      uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+      expect(spy).to.be.called;
+      expect(placeHolderSpy).to.not.be.called;
+      expect(uiHandler.state).to.equal(AdDisplayState.NOT_LAID_OUT);
     });
-    const spy = sandbox.stub(adImpl, 'deferMutate', callback => {
-      uiHandler.state = 0;
-      callback();
-    });
-    const placeHolderSpy = sandbox.stub(adImpl, 'togglePlaceholder');
-    uiHandler.init();
-    uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
-    expect(spy).to.be.called;
-    expect(placeHolderSpy).to.not.be.called;
-    expect(uiHandler.state).to.equal(0);
   });
 });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -67,7 +67,7 @@ describe('amp-ad-ui handler', () => {
       uiHandler.init();
       uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
       return Promise.resolve().then(() => {
-        const holder = adImpl.element.querySelector('.-amp-ad-holder');
+        const holder = adImpl.element.querySelector('.amp-ad-default-fallback');
         expect(holder).to.not.be.null;
         expect(holder).to.have.attribute('fallback');
       });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -71,7 +71,7 @@ describe('amp-ad-ui handler', () => {
       return Promise.resolve().then(() => {
         const holder = adImpl.element.querySelector('.-amp-ad-holder');
         expect(holder).to.not.be.null;
-        expect(holder).to.have.attribute('visible');
+        expect(holder).to.have.attribute('fallback');
       });
     });
   });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -39,6 +39,9 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     const adElement = document.createElement('container-element');
     adElement.getAmpDoc = () => ampdoc;
     adImpl = new BaseElement(adElement);
+    adImpl.getFallback = () => {
+      return null;
+    };
     document.body.appendChild(adElement);
     adImpl.uiHandler = new AmpAdUIHandler(adImpl);
     iframeHandler = new AmpAdXOriginIframeHandler(adImpl);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1348,7 +1348,7 @@ function createBaseCustomElementClass(win) {
       if (this.loadingDisabled_ === undefined) {
         this.loadingDisabled_ = this.hasAttribute('noloading');
       }
-      if (this.loadingDisabled_ || !isLoadingAllowed(this.tagName) ||
+      if (this.loadingDisabled_ || !isLoadingAllowed(this) ||
         this.layoutWidth_ < MIN_WIDTH_FOR_LOADING_ ||
         this.layoutCount_ > 0 ||
         isInternalOrServiceNode(this) || !isLayoutSizeDefined(this.layout_)) {

--- a/src/layout.js
+++ b/src/layout.js
@@ -24,8 +24,8 @@ import {isFiniteNumber} from './types';
 import {setStyles} from './style';
 import {isExperimentOn} from './experiments';
 
-/** @private @const {string} */
-const UX_EXPERIMENT = 'amp-ad-loading-ux';
+/** @const {string} */
+export const UX_EXPERIMENT = 'amp-ad-loading-ux';
 
 /**
  * @enum {string}

--- a/src/layout.js
+++ b/src/layout.js
@@ -22,7 +22,10 @@
 import {dev, user} from './log';
 import {isFiniteNumber} from './types';
 import {setStyles} from './style';
+import {isExperimentOn} from './experiments';
 
+/** @private @const {string} */
+const UX_EXPERIMENT = 'amp-ad-loading-ux';
 
 /**
  * @enum {string}
@@ -267,9 +270,16 @@ export function getNaturalDimensions(element) {
  * Whether the loading can be shown for the specified elemeent. This set has
  * to be externalized since the element's implementation may not be
  * downloaded yet.
- * @param {string} tagName The element tag name.
+ * @param {!Element} element.
  * @return {boolean}
  */
-export function isLoadingAllowed(tagName) {
-  return LOADING_ELEMENTS_[tagName.toUpperCase()] || false;
+export function isLoadingAllowed(element) {
+  const tagName = element.tagName.toUpperCase();
+  if (tagName == 'AMP-AD' || tagName == 'AMP-EMBED') {
+    const win = element.ownerDocument.defaultView;
+    if (isExperimentOn(win, UX_EXPERIMENT)) {
+      return true;
+    }
+  }
+  return LOADING_ELEMENTS_[tagName] || false;
 }

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -223,6 +223,11 @@ const EXPERIMENTS = [
         'amp-animation/amp-animation.md',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5888',
   },
+  {
+    id: 'amp-ad-loading-ux',
+    name: 'New default loading UX to amp-ad',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6009',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
@cramforce as we discussed.
This PR enable the default loading dot for `amp-ad` And apply a default fallback when user don't provide one. 