### PR TITLE
Make embedded detection based on params more liberal.

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -215,10 +215,15 @@ export class Viewer {
      * a web view, or a shadow doc in PWA.
      * @private @const {boolean}
      */
-    this.isEmbedded_ = (
+    this.isEmbedded_ = !!(
+        this.isIframed_ && !this.win.AMP_TEST_IFRAME
         // Checking param "origin", as we expect all viewers to provide it.
         // See https://github.com/ampproject/amphtml/issues/4183
-        this.isIframed_ && !this.win.AMP_TEST_IFRAME && this.params_['origin']
+        // There appears to be a bug under investigation where the
+        // origin is sometimes failed to be detected. Since failure mode
+        // if we fail to initialize communication is very bad, we also check
+        // for visibilityState.
+        && (this.params_['origin'] || this.params_['visibilityState'])
         || this.isWebviewEmbedded_
         || !ampdoc.isSingleDoc());
 

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -781,7 +781,13 @@ describe('Viewer', () => {
     it('should be embedded when iframed w/ "origin" in URL hash', () => {
       windowApi.parent = {};
       windowApi.location.hash = '#origin=g.com';
-      expect(new Viewer(ampdoc).isEmbedded()).to.be.ok;
+      expect(new Viewer(ampdoc).isEmbedded()).to.be.true;
+    });
+
+    it('should be embedded when iframed w/ "visibilityState"', () => {
+      windowApi.parent = {};
+      windowApi.location.hash = '#visibilityState=hidden';
+      expect(new Viewer(ampdoc).isEmbedded()).to.be.true;
     });
 
     it('should NOT be embedded when iframed w/o "origin" in URL hash', () => {
@@ -793,7 +799,7 @@ describe('Viewer', () => {
     it('should be embedded with "webview=1" param', () => {
       windowApi.parent = windowApi;
       windowApi.location.hash = '#webview=1';
-      expect(new Viewer(ampdoc).isEmbedded()).to.be.ok;
+      expect(new Viewer(ampdoc).isEmbedded()).to.be.true;
     });
   });
 


### PR DESCRIPTION
There is an ongoing bug where it appears the parent doesn't provide the origin even though it intends to. This is being worked around on the communication layer, by using `location.ancestorOrigins`, but we'd never initiate communication with the current state.

CC #4183 

Needs to be included in canary. CC @lannka 