### PR TITLE
Fix eating errors in chunk.

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -18,6 +18,7 @@ import {dev} from './log';
 import {fromClassForDoc} from './service';
 import {isExperimentOnAllowUrlOverride} from './experiments';
 import {makeBodyVisible} from './style-installer';
+import {rethrowAsync} from './log';
 import {viewerPromiseForDoc} from './viewer';
 
 /**
@@ -151,7 +152,7 @@ class Chunks {
     } catch (e) {
       // We run early in init. All errors should show the doc.
       makeBodyVisible(self.document);
-      throw e;
+      rethrowAsync(e);
     } finally {
       if (this.tasks_.length) {
         this.schedule_();

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -151,8 +151,8 @@ class Chunks {
       t();
     } catch (e) {
       // We run early in init. All errors should show the doc.
-      makeBodyVisible(self.document);
       rethrowAsync(e);
+      makeBodyVisible(self.document);
     } finally {
       if (this.tasks_.length) {
         this.schedule_();

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -109,6 +109,32 @@ describe('chunk', () => {
       basicTests(env);
     });
 
+    describe('error handling', () => {
+      let fakeWin;
+      let clock;
+
+      beforeEach(() => {
+        toggleExperiment(env.win, 'chunked-amp', experimentOn);
+        fakeWin = env.win;
+        const viewer = viewerForDoc(env.win.document);
+        env.sandbox.stub(viewer, 'isVisible', () => {
+          return true;
+        });
+        clock = env.sandbox.useFakeTimers();
+      });
+      it('should proceed on error and rethrowAsync', done => {
+        chunk(fakeWin.document, () => {
+          throw new Error('test async');
+        });
+        chunk(fakeWin.document, () => {
+          expect(() => {
+            clock.tick();
+          }).to.throw(/test async/);
+          done();
+        });
+      });
+    });
+
     describe('invisible experiment off', () => {
       beforeEach(() => {
         experimentOn = false;


### PR DESCRIPTION
No pun intended.

Somehow browsers do not report a throw in a then callback as a unhandled promise exception.