### PR TITLE
Remove amp-scrollable-carousel experiment flag

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,7 +8,6 @@
   "a4aProfilingRate": 1,
   "amp-form": 1,
   "form-submit": 1,
-  "amp-scrollable-carousel": 1,
   "amp-fx-flying-carpet": 1,
   "ios-embed-wrapper": 1,
   "make-body-relative": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,7 +8,6 @@
   "a4aProfilingRate": 1,
   "amp-form": 1,
   "form-submit": 1,
-  "amp-scrollable-carousel": 1,
   "amp-fx-flying-carpet": 1,
   "ios-embed-wrapper": 1,
   "amp-app-banner": 1

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -15,7 +15,6 @@
  */
 
 import {createIframePromise} from '../../../../testing/iframe';
-import {toggleExperiment} from '../../../../src/experiments';
 import * as sinon from 'sinon';
 
 describe('ScrollableCarousel', () => {
@@ -32,7 +31,6 @@ describe('ScrollableCarousel', () => {
 
   function getAmpScrollableCarousel() {
     return createIframePromise().then(iframe => {
-      toggleExperiment(iframe.win, 'amp-scrollable-carousel', true);
       iframe.width = '300';
       iframe.height = '200';
       const imgUrl = 'https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-' +

--- a/test/manual/amp-carousel-scroll-test.amp.html
+++ b/test/manual/amp-carousel-scroll-test.amp.html
@@ -43,8 +43,6 @@
 </head>
 <body>
   <h1>amp #0</h1>
-  <button onclick="AMP.toggleExperiment('amp-slidescroll');window.location.href=window.location.href;">Toggle Experiment slide</button>
-  <button onclick="AMP.toggleExperiment('amp-scrollable-carousel');window.location.href=window.location.href;">Toggle Experiment scroll</button>
   <h1>Test for scroll event scroll carousel</h1>
   <div id='wrapper'>
     <div id='test'>
@@ -82,4 +80,3 @@
   </div>
 </body>
 </html>
-

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -93,12 +93,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6156',
   },
   {
-    id: 'amp-scrollable-carousel',
-    name: 'AMP carousel using horizontal scroll',
-    spec: '',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/4232',
-  },
-  {
     id: 'amp-form-custom-validations',
     name: 'AMP Form Custom Validations',
     spec: 'https://github.com/ampproject/amphtml/issues/3343',


### PR DESCRIPTION
Fixes #4232

@erwinmombay The [PR](https://github.com/ampproject/amphtml/pull/6065) that always uses the new scrollable-carousel is not live yet. Do we have to wait for it to go live and then make this config change?