### PR TITLE
Skip chunk error handling tests for browsers that don't support unhandledrejection event

### DIFF
--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -104,7 +104,8 @@ describe('chunk', () => {
       basicTests(env);
     });
 
-    describe('error handling', () => {
+    describe.configure().skip(() => !('onunhandledrejection' in window))
+    .run('error handling', () => {
       let fakeWin;
       let done;
 


### PR DESCRIPTION
Fixes master since older browsers (Chrome 45 in this case, do not support `unhandledrejection`)