### PR TITLE
Call installViewerForDoc and installViewportForDoc only in the entry point

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -198,11 +198,7 @@ var forbiddenTerms = {
     message: privateServiceFactory,
     whitelist: [
       'src/runtime.js',
-      'src/service/history-impl.js',
-      'src/service/resources-impl.js',
       'src/service/viewer-impl.js',
-      'src/service/viewport-impl.js',
-      'src/service/vsync-impl.js',
     ],
   },
   'setViewerVisibilityState': {
@@ -216,7 +212,6 @@ var forbiddenTerms = {
     message: privateServiceFactory,
     whitelist: [
       'src/runtime.js',
-      'src/service/resources-impl.js',
       'src/service/viewport-impl.js',
     ],
   },

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -19,7 +19,7 @@ import {fromClass, getServiceForDoc} from '../service';
 import {getMode} from '../mode';
 import {dev} from '../log';
 import {timerFor} from '../timer';
-import {installViewerServiceForDoc} from './viewer-impl';
+import {viewerForDoc} from '../viewer';
 
 
 /** @private @const */
@@ -648,7 +648,7 @@ export class HistoryBindingVirtual_ {
  * @private
  */
 function createHistory(ampdoc) {
-  const viewer = installViewerServiceForDoc(ampdoc);
+  const viewer = viewerForDoc(ampdoc);
   let binding;
   if (viewer.isOvertakeHistory() || getMode(ampdoc.win).test ||
           ampdoc.win.AMP_TEST_IFRAME) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -25,8 +25,8 @@ import {closest, hasNextNodeInDocumentOrder} from '../dom';
 import {expandLayoutRect} from '../layout-rect';
 import {fromClassForDoc} from '../service';
 import {inputFor} from '../input';
-import {installViewerServiceForDoc} from './viewer-impl';
-import {installViewportServiceForDoc} from './viewport-impl';
+import {viewerForDoc} from '../viewer';
+import {viewportForDoc} from '../viewport';
 import {installVsyncService} from './vsync-impl';
 import {isArray} from '../types';
 import {dev} from '../log';
@@ -71,7 +71,7 @@ export class Resources {
     this.win = ampdoc.win;
 
     /** @const @private {!./viewer-impl.Viewer} */
-    this.viewer_ = installViewerServiceForDoc(ampdoc);
+    this.viewer_ = viewerForDoc(ampdoc);
 
     /** @private {boolean} */
     this.isRuntimeOn_ = this.viewer_.isRuntimeOn();
@@ -149,7 +149,7 @@ export class Resources {
     this.isCurrentlyBuildingPendingResources_ = false;
 
     /** @private @const {!./viewport-impl.Viewport} */
-    this.viewport_ = installViewportServiceForDoc(this.ampdoc);
+    this.viewport_ = viewportForDoc(this.ampdoc);
 
     /** @private @const {!./vsync-impl.Vsync} */
     this.vsync_ = installVsyncService(this.win);

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -31,7 +31,7 @@ import {platformFor} from '../platform';
 import {px, setStyle, setStyles} from '../style';
 import {timerFor} from '../timer';
 import {installVsyncService} from './vsync-impl';
-import {installViewerServiceForDoc} from './viewer-impl';
+import {viewerForDoc} from '../viewer';
 import {isExperimentOn} from '../experiments';
 import {waitForBody} from '../dom';
 import {getMode} from '../mode';
@@ -1685,7 +1685,7 @@ export function updateViewportMetaString(currentValue, updateParams) {
  * @private
  */
 function createViewport(ampdoc) {
-  const viewer = installViewerServiceForDoc(ampdoc);
+  const viewer = viewerForDoc(ampdoc);
   let binding;
   if (ampdoc.isSingleDoc() &&
       getViewportType(ampdoc.win, viewer) == ViewportType.NATURAL_IOS_EMBED) {

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -1570,6 +1570,7 @@ describe('createViewport', () => {
         it('should bind to "natural" when not iframed', () => {
           win.parent = win;
           const ampDoc = installDocService(win, true).getAmpDoc();
+          installViewerServiceForDoc(ampDoc);
           const viewport = installViewportServiceForDoc(ampDoc);
           expect(viewport.binding_).to.be.instanceof(ViewportBindingNatural_);
         });
@@ -1577,6 +1578,7 @@ describe('createViewport', () => {
         it('should bind to "naturual" when iframed', () => {
           win.parent = {};
           const ampDoc = installDocService(win, true).getAmpDoc();
+          installViewerServiceForDoc(ampDoc);
           const viewport = installViewportServiceForDoc(ampDoc);
           expect(viewport.binding_).to.be.instanceof(ViewportBindingNatural_);
         });
@@ -1595,6 +1597,7 @@ describe('createViewport', () => {
         it('should bind to "natural" when not iframed', () => {
           win.parent = win;
           const ampDoc = installDocService(win, true).getAmpDoc();
+          installViewerServiceForDoc(ampDoc);
           const viewport = installViewportServiceForDoc(ampDoc);
           expect(viewport.binding_).to.be.instanceof(ViewportBindingNatural_);
         });
@@ -1602,6 +1605,7 @@ describe('createViewport', () => {
         it('should bind to "natural iOS embed" when iframed', () => {
           win.parent = {};
           const ampDoc = installDocService(win, true).getAmpDoc();
+          installViewerServiceForDoc(ampDoc);
           const viewport = installViewportServiceForDoc(ampDoc);
           expect(viewport.binding_).to
               .be.instanceof(ViewportBindingNaturalIosEmbed_);


### PR DESCRIPTION
Use viewerForDoc and viewportForDoc in other places. This helps amp-inabox to have an entry point that does not import viewport and viewer code.