### PR TITLE
A4A amp nameframe

### DIFF
--- a/3p/nameframe.max.html
+++ b/3p/nameframe.max.html
@@ -13,7 +13,7 @@
                 document.open();
                 document.write(name_data['creative']);
                 document.close();
-                window.name = null;
+                window.name = '';
             } catch (err) {
                 window.parent.postMessage(
                         {type: 'no-content', error: err.message}, '*');

--- a/3p/nameframe.max.html
+++ b/3p/nameframe.max.html
@@ -1,25 +1,25 @@
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html>
 <head>
-    <meta charset="UTF-8">
-    <script>
-        window.onload = function() {
-            try {
-                var name_data = JSON.parse(window.name);
-                if (!name_data || !name_data['creative']) {
-                    throw new Error('Missing or incorrectly formatted JSON ' +
-                        'input to nameframe');
-                }
-                document.open();
-                document.write(name_data['creative']);
-                document.close();
-                window.name = '';
-            } catch (err) {
-                window.parent.postMessage(
-                        {type: 'no-content', error: err.message}, '*');
-            }
-        };
-    </script>
+  <meta charset="utf-8">
+  <script>
+    window.onload = function() {
+      try {
+        var name_data = JSON.parse(window.name);
+        if (!name_data || !name_data['creative']) {
+          throw new Error('Missing or incorrectly formatted JSON ' +
+            'input to nameframe');
+        }
+        document.open();
+        document.write(name_data['creative']);
+        document.close();
+        window.name = '';
+      } catch (err) {
+        window.parent.postMessage(
+          {type: 'no-content', error: err.message}, '*');
+      }
+    };
+  </script>
 </head>
 <body style="visibility: hidden;">
 </body>

--- a/3p/nameframe.max.html
+++ b/3p/nameframe.max.html
@@ -13,6 +13,7 @@
                 document.open();
                 document.write(name_data['creative']);
                 document.close();
+                window.name = null;
             } catch (err) {
                 window.parent.postMessage(
                         {type: 'no-content', error: err.message}, '*');

--- a/3p/nameframe.max.html
+++ b/3p/nameframe.max.html
@@ -7,6 +7,7 @@
             document.open();
             document.write(window.name);
             document.close();
+            console.log('Nameframe loaded content successfully');
         };
     </script>
 </head>

--- a/3p/nameframe.max.html
+++ b/3p/nameframe.max.html
@@ -4,10 +4,19 @@
     <meta charset="UTF-8">
     <script>
         window.onload = function() {
-            document.open();
-            document.write(window.name);
-            document.close();
-            console.log('Nameframe loaded content successfully');
+            try {
+                var name_data = JSON.parse(window.name);
+                if (!name_data || !name_data['creative']) {
+                    throw new Error('Missing or incorrectly formatted JSON ' +
+                        'input to nameframe');
+                }
+                document.open();
+                document.write(name_data['creative']);
+                document.close();
+            } catch (err) {
+                window.parent.postMessage(
+                        {type: 'no-content', error: err.message}, '*');
+            }
         };
     </script>
 </head>

--- a/3p/nameframe.max.html
+++ b/3p/nameframe.max.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script>
+        window.onload = function() {
+            document.open();
+            document.write(window.name);
+            document.close();
+        };
+    </script>
+</head>
+<body style="visibility: hidden;">
+</body>
+</html>

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -514,7 +514,7 @@ function replaceUrls(mode, file) {
     file = file.replace('https://cdn.ampproject.org/amp4ads-v0.max.js', '/dist/amp-inabox.js');
     file = file.replace(/https:\/\/cdn.ampproject.org\/v0\//g, '/dist/v0/');
     file = file.replace('https://cdn1.ampproject.org/viewer/google/v5.js', 'https://cdn.ampproject.org/viewer/google/v5.js');
-    file = file.replace(/https:\/\/3p.ampproject.net\/(.+)\.html/,
+    file = file.replace(/https:\/\/3p.ampproject.net\/(?:\d+\/)?(.+)\.html/,
         '/dist.3p/current/$1.max.html');
   }
   if (mode == 'min') {

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -514,8 +514,6 @@ function replaceUrls(mode, file) {
     file = file.replace('https://cdn.ampproject.org/amp4ads-v0.max.js', '/dist/amp-inabox.js');
     file = file.replace(/https:\/\/cdn.ampproject.org\/v0\//g, '/dist/v0/');
     file = file.replace('https://cdn1.ampproject.org/viewer/google/v5.js', 'https://cdn.ampproject.org/viewer/google/v5.js');
-    file = file.replace(/https:\/\/3p.ampproject.net\/(?:\d+\/)?(.+)\.html/,
-        '/dist.3p/current/$1.max.html');
   }
   if (mode == 'min') {
     file = file.replace(/\.max\.js/g, '.js');

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -156,7 +156,7 @@ function assertCors(req, res, opt_validMethods) {
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Access-Control-Expose-Headers',
-      'AMP-Access-Control-Allow-Source-Origin')
+      'AMP-Access-Control-Allow-Source-Origin');
   res.setHeader('AMP-Access-Control-Allow-Source-Origin',
       req.query.__amp_source_origin);
 }
@@ -514,11 +514,15 @@ function replaceUrls(mode, file) {
     file = file.replace('https://cdn.ampproject.org/amp4ads-v0.max.js', '/dist/amp-inabox.js');
     file = file.replace(/https:\/\/cdn.ampproject.org\/v0\//g, '/dist/v0/');
     file = file.replace('https://cdn1.ampproject.org/viewer/google/v5.js', 'https://cdn.ampproject.org/viewer/google/v5.js');
+    file = file.replace(/https:\/\/3p.ampproject.net\/(.+)\.html/,
+        '/dist.3p/current/$1.max.html');
   }
   if (mode == 'min') {
     file = file.replace(/\.max\.js/g, '.js');
     file = file.replace('/dist/amp.js', '/dist/v0.js');
     file = file.replace('/dist/amp-inabox.js', '/dist/amp4ads-v0.js');
+    file = file.replace(/\/dist.3p\/current\/(.*)\.max.html/,
+        '/dist.3p/current-min/$1.html');
   }
   return file;
 }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -880,7 +880,7 @@ export class AmpA4A extends AMP.BaseElement {
               + ' attribute iframe rendering mode request: %s.  Unable to'
               + ' render a creative for'
               + ' slot %s.', method, this.element.getAttribute('id'));
-          return Promise.reject();
+          return Promise.reject('Unrecognized rendering mode request');
       }
       /** @const {!Element} */
       const iframe = createElementWithAttributes(

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -84,7 +84,7 @@ export const SAFEFRAME_IMPL_PATH =
 export const RENDERING_TYPE_HEADER = 'X-AmpAdRender';
 
 /** @enum {string} */
-export const CROSS_ORIGIN_RENDERING_MODE = {
+export const XORIGIN_MODE = {
   CLIENT_CACHE: 'client_cache',
   SAFEFRAME: 'safeframe',
   NAMEFRAME: 'nameframe',
@@ -182,9 +182,8 @@ export class AmpA4A extends AMP.BaseElement {
     /**
      * Note(keithwrightbos) - ensure the default here is null so that ios
      * uses safeframe when response header is not specified.
-     * @private {?string}
+     * @private {?CROSS_ORIGIN_RENDERING_MODE}
      */
-    /** @type {!CROSS_ORIGIN_RENDERING_MODE} @visibleForTesting */
     this.experimentalNonAmpCreativeRenderMethod_ =
       platformFor(this.win).isIos() ?
           CROSS_ORIGIN_RENDERING_MODE.SAFEFRAME : null;
@@ -397,7 +396,7 @@ export class AmpA4A extends AMP.BaseElement {
           // we should restructure the promise chain to pass this info along
           // more cleanly, without use of an object variable outside the chain.
           if (this.nonAmpCreativeRenderMethod_ !=
-              CROSS_ORIGIN_RENDERING_MODE.CLIENT_CACHE &&
+              XORIGIN_MODE.CLIENT_CACHE &&
               creativeParts &&
               creativeParts.creative) {
             this.creativeBody_ = creativeParts.creative;
@@ -537,8 +536,8 @@ export class AmpA4A extends AMP.BaseElement {
         // cross-domain iframe solutions.
         let renderPromise;
         const method = this.nonAmpCreativeRenderMethod_;
-        if ((method == CROSS_ORIGIN_RENDERING_MODE.SAFEFRAME ||
-             method == CROSS_ORIGIN_RENDERING_MODE.NAMEFRAME) &&
+        if ((method == XORIGIN_MODE.SAFEFRAME ||
+             method == XORIGIN_MODE.NAMEFRAME) &&
             this.creativeBody_) {
           renderPromise = this.renderViaNameAttrOfXDomIframe_(
               this.creativeBody_);
@@ -855,19 +854,19 @@ export class AmpA4A extends AMP.BaseElement {
    */
   renderViaNameAttrOfXDomIframe_(creativeBody) {
     const method = this.nonAmpCreativeRenderMethod_;
-    dev().assert(method == CROSS_ORIGIN_RENDERING_MODE.SAFEFRAME ||
-        method == CROSS_ORIGIN_RENDERING_MODE.NAMEFRAME,
+    dev().assert(method == XORIGIN_MODE.SAFEFRAME ||
+        method == XORIGIN_MODE.NAMEFRAME,
         'Unrecognized A4A cross-domain rendering mode: %s', method);
     this.emitLifecycleEvent('renderSafeFrameStart');
     return utf8Decode(creativeBody).then(creative => {
       let srcPath;
       let nameData;
       switch (method) {
-        case CROSS_ORIGIN_RENDERING_MODE.SAFEFRAME:
+        case XORIGIN_MODE.SAFEFRAME:
           srcPath = SAFEFRAME_IMPL_PATH + '?n=0';
           nameData = `${SAFEFRAME_VERSION};${creative.length};${creative}`;
           break;
-        case CROSS_ORIGIN_RENDERING_MODE.NAMEFRAME:
+        case XORIGIN_MODE.NAMEFRAME:
           srcPath = getDefaultBootstrapBaseUrl(this.win, 'nameframe');
           nameData = JSON.stringify({creative});
           break;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -75,8 +75,8 @@ const METADATA_STRING = '<script type="application/json" amp-ad-metadata>';
 // cache' issue.  See https://github.com/ampproject/amphtml/issues/5614
 /** @type {string} */
 const SAFEFRAME_VERSION = '1-0-4';
-/** @type {string} */
-const SAFEFRAME_IMPL_PATH =
+/** @type {string} @visibleForTesting */
+export const SAFEFRAME_IMPL_PATH =
     'https://tpc.googlesyndication.com/safeframe/' + SAFEFRAME_VERSION +
     '/html/container.html';
 
@@ -545,7 +545,7 @@ export class AmpA4A extends AMP.BaseElement {
           renderPromise = this.renderViaSafeFrame_(this.creativeBody_);
         } else if (this.experimentalNonAmpCreativeRenderMethod_ ==
             CROSS_ORIGIN_RENDERING_MODE.NAMEFRAME && this.creativeBody_) {
-          renderPromise = this.renderViaNameframe_(this.creativeBody_);
+          renderPromise = this.renderViaNameFrame_(this.creativeBody_);
         } else if (this.adUrl_) {
           renderPromise = this.renderViaCachedContentIframe_(this.adUrl_);
         } else {
@@ -871,7 +871,7 @@ export class AmpA4A extends AMP.BaseElement {
     });
   }
 
-  renderViaNameframe_(creativeBody) {
+  renderViaNameFrame_(creativeBody) {
     this.emitLifecycleEvent('renderSafeFrameStart');
     return utf8Decode(creativeBody).then(creative => {
       /** @const {!Element} */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -30,7 +30,7 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
-import {isArray, isObject} from '../../../src/types';
+import {isArray, isObject, isEnumValue} from '../../../src/types';
 import {urlReplacementsForDoc} from '../../../src/url-replacements';
 import {some} from '../../../src/utils/promise';
 import {utf8Decode} from '../../../src/utils/bytes';
@@ -356,12 +356,9 @@ export class AmpA4A extends AMP.BaseElement {
           this.experimentalNonAmpCreativeRenderMethod_ =
               fetchResponse.headers.get(RENDERING_TYPE_HEADER) ||
               this.experimentalNonAmpCreativeRenderMethod_;
-          try {
-            dev().assertEnumValue(XORIGIN_MODE,
-                                  this.experimentalNonAmpCreativeRenderMethod_,
-                                  'cross-origin render mode header');
-          } catch (err) {
-            dev().error('AMP-A4A', err.message);
+          if (!isEnumValue(XORIGIN_MODE, this.experimentalNonAmpCreativeRenderMethod_)) {
+            dev().error('AMP-A4A', 'cross-origin render mode header ' +
+                this.experimentalNonAmpCreativeRenderMethod_);
           }
           // Note: Resolving a .then inside a .then because we need to capture
           // two fields of fetchResponse, one of which is, itself, a promise,

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -356,6 +356,13 @@ export class AmpA4A extends AMP.BaseElement {
           this.experimentalNonAmpCreativeRenderMethod_ =
               fetchResponse.headers.get(RENDERING_TYPE_HEADER) ||
               this.experimentalNonAmpCreativeRenderMethod_;
+          try {
+            dev().assertEnumValue(XORIGIN_MODE,
+                                  this.experimentalNonAmpCreativeRenderMethod_,
+                                  'cross-origin render mode header');
+          } catch (err) {
+            dev().error('AMP-A4A', err.message);
+          }
           // Note: Resolving a .then inside a .then because we need to capture
           // two fields of fetchResponse, one of which is, itself, a promise,
           // and one of which isn't.  If we just return
@@ -539,7 +546,7 @@ export class AmpA4A extends AMP.BaseElement {
         if ((method == XORIGIN_MODE.SAFEFRAME ||
              method == XORIGIN_MODE.NAMEFRAME) &&
             this.creativeBody_) {
-          renderPromise = this.renderViaNameAttrOfXDomIframe_(
+          renderPromise = this.renderViaNameAttrOfXOriginIframe_(
               this.creativeBody_);
         } else if (this.adUrl_) {
           renderPromise = this.renderViaCachedContentIframe_(this.adUrl_);
@@ -852,7 +859,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @return {!Promise} awaiting load event for ad frame
    * @private
    */
-  renderViaNameAttrOfXDomIframe_(creativeBody) {
+  renderViaNameAttrOfXOriginIframe_(creativeBody) {
     const method = this.nonAmpCreativeRenderMethod_;
     dev().assert(method == XORIGIN_MODE.SAFEFRAME ||
         method == XORIGIN_MODE.NAMEFRAME,

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -400,7 +400,7 @@ export class AmpA4A extends AMP.BaseElement {
           // src cache issue.  If we decide to keep a SafeFrame-like solution,
           // we should restructure the promise chain to pass this info along
           // more cleanly, without use of an object variable outside the chain.
-          if (this.experimentalNonAmpCreativeRenderMethod_ !=
+          if (this.nonAmpCreativeRenderMethod_ !=
               CROSS_ORIGIN_RENDERING_MODE.CLIENT_CACHE &&
               creativeParts &&
               creativeParts.creative) {
@@ -540,10 +540,10 @@ export class AmpA4A extends AMP.BaseElement {
         // Haven't rendered yet, so try rendering via one of our
         // cross-domain iframe solutions.
         let renderPromise;
-        if (this.experimentalNonAmpCreativeRenderMethod_ ==
+        if (this.nonAmpCreativeRenderMethod_ ==
             CROSS_ORIGIN_RENDERING_MODE.SAFEFRAME && this.creativeBody_) {
           renderPromise = this.renderViaSafeFrame_(this.creativeBody_);
-        } else if (this.experimentalNonAmpCreativeRenderMethod_ ==
+        } else if (this.nonAmpCreativeRenderMethod_ ==
             CROSS_ORIGIN_RENDERING_MODE.NAMEFRAME && this.creativeBody_) {
           renderPromise = this.renderViaNameFrame_(this.creativeBody_);
         } else if (this.adUrl_) {
@@ -553,7 +553,7 @@ export class AmpA4A extends AMP.BaseElement {
               ' any ad');
         }
         this.creativeBody_ = null;  // Free resources.
-        this.experimentalNonAmpCreativeRenderMethod_ =
+        this.nonAmpCreativeRenderMethod_ =
             CROSS_ORIGIN_RENDERING_MODE.CLIENT_CACHE;
         return renderPromise;
       }
@@ -579,7 +579,8 @@ export class AmpA4A extends AMP.BaseElement {
       this.adUrl_ = null;
       this.creativeBody_ = null;
       this.experimentalNonAmpCreativeRenderMethod_ =
-          platformFor(this.win).isIos() ? 'safeframe' : null;
+          platformFor(this.win).isIos() ?
+              CROSS_ORIGIN_RENDERING_MODE.SAFEFRAME : null;
       this.rendered_ = false;
       if (this.xOriginIframeHandler_) {
         this.xOriginIframeHandler_.freeXOriginIframe();

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -875,15 +875,15 @@ export class AmpA4A extends AMP.BaseElement {
     this.emitLifecycleEvent('renderSafeFrameStart');
     return utf8Decode(creativeBody).then(creative => {
       /** @const {!Element} */
-      const name_data = Object.create(null);
-      name_data['creative'] = creative;
+      const nameData = Object.create(null);
+      nameData['creative'] = creative;
       const iframe = createElementWithAttributes(
           /** @type {!Document} */(this.element.ownerDocument),
           'iframe', Object.assign({
             'height': this.element.getAttribute('height'),
             'width': this.element.getAttribute('width'),
             'src': getDefaultBootstrapBaseUrl(this.win, 'nameframe'),
-            'name': JSON.stringify(name_data),
+            'name': JSON.stringify(nameData),
           }, SHARED_IFRAME_PROPERTIES));
       return this.iframeRenderHelper_(iframe);
     });

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -257,10 +257,8 @@ export class AmpA4A extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(unusedOnLayout) {
-    // TODO(tdrl): Temporary, while we're verifying whether SafeFrame is an
-    // acceptable solution to the 'Safari on iOS doesn't fetch iframe src from
-    // cache' issue.  See https://github.com/ampproject/amphtml/issues/5614
     this.preconnect.url(SAFEFRAME_IMPL_PATH);
+    this.preconnect.url(getDefaultBootstrapBaseUrl(this.win, 'nameframe'));
     if (!this.config) {
       return;
     }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -306,6 +306,9 @@ describe('amp-a4a', () => {
         a4a = new MockA4AImpl(a4aElement);
         verifyNonAMPRender(a4a);
         doc.body.appendChild(a4aElement);
+        a4a.createdCallback();
+        a4a.firstAttachedCallback();
+        a4a.buildCallback();
       });
     });
 
@@ -425,6 +428,21 @@ describe('amp-a4a', () => {
                   });
                 });
           });
+
+      it('should reset state to client_cache on unlayoutCallback', () => {
+        return a4a.layoutCallback().then(() => {
+          // Force vsync system to run all queued tasks, so that DOM mutations
+          // are actually completed before testing.
+          a4a.vsync_.runScheduledTasks_();
+          expect(a4a.nonAmpCreativeRenderMethod_).to.equal('safeframe');
+          a4a.unlayoutCallback();
+          // QUESTION TO REVIEWERS: Do we really need the vsync.mutate in
+          // AmpA4A.unlayoutCallback?  We have an open question there about
+          // whether it's necessary or perhaps hazardous.  Feedback welcome.
+          a4a.vsync_.runScheduledTasks_();
+          expect(a4a.nonAmpCreativeRenderMethod_).to.equal('client_cache');
+        });
+      });
     });
   });
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -334,7 +334,7 @@ describe('amp-a4a', () => {
         devErrLogSpy = sandbox.spy(dev(), 'error');
         // If rendering type is unknown, should fall back to cached content
         // iframe and generate an error.
-        mockResponse.headers.set(RENDERING_TYPE_HEADER, 'random illegal value');
+        headers[RENDERING_TYPE_HEADER] = 'random illegal value';
         a4a.onLayoutMeasure();
       });
 
@@ -355,7 +355,7 @@ describe('amp-a4a', () => {
     describe('#renderViaNameFrame', () => {
       beforeEach(() => {
         // If rendering type is nameframe, we SHOULD attach a NameFrame.
-        mockResponse.headers.set(RENDERING_TYPE_HEADER, 'nameframe');
+        headers[RENDERING_TYPE_HEADER] = 'nameframe';
         a4a.onLayoutMeasure();
       });
 
@@ -413,7 +413,7 @@ describe('amp-a4a', () => {
     describe('#renderViaSafeFrame', () => {
       beforeEach(() => {
         // If rendering type is safeframe, we SHOULD attach a SafeFrame.
-        mockResponse.headers.set(RENDERING_TYPE_HEADER, 'safeframe');
+        headers[RENDERING_TYPE_HEADER] = 'safeframe';
         a4a.onLayoutMeasure();
       });
 
@@ -446,7 +446,7 @@ describe('amp-a4a', () => {
                 () => {
                   // If rendering type is anything but safeframe, we SHOULD NOT attach a
                   // SafeFrame.
-                  mockResponse.headers.set(RENDERING_TYPE_HEADER, headerVal);
+                  headers[RENDERING_TYPE_HEADER] = headerVal;
                   a4a.onLayoutMeasure();
                   return a4a.layoutCallback().then(() => {
                     // Force vsync system to run all queued tasks, so that
@@ -508,7 +508,7 @@ describe('amp-a4a', () => {
 
     ['nameframe', 'safeframe'].forEach(renderType => {
       it(`should not use ${renderType} if creative is A4A`, () => {
-        mockResponse.headers.set(RENDERING_TYPE_HEADER, renderType);
+        headers[RENDERING_TYPE_HEADER] = renderType;
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           // Force vsync system to run all queued tasks, so that DOM mutations
@@ -520,7 +520,7 @@ describe('amp-a4a', () => {
 
       it(`should not use ${renderType} even if onLayoutMeasure called ` +
           'multiple times', () => {
-        mockResponse.headers.set(RENDERING_TYPE_HEADER, renderType);
+        headers[RENDERING_TYPE_HEADER] = renderType;
         a4a.onLayoutMeasure();
         a4a.onLayoutMeasure();
         a4a.onLayoutMeasure();

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -183,8 +183,8 @@ describe('amp-a4a', () => {
     const child = element.querySelector('iframe[src][name]');
     expect(child).to.be.ok;
     expect(child.src).to.match(/^https?:[^?#]+nameframe(\.max)?\.html/);
-    const name_data = child.getAttribute('name');
-    expect(JSON.parse.bind(null, name_data), name_data).not.to.throw(Error);
+    const nameData = child.getAttribute('name');
+    expect(JSON.parse.bind(null, nameData), nameData).not.to.throw(Error);
     expect(child).to.be.visible;
   }
 
@@ -429,6 +429,8 @@ describe('amp-a4a', () => {
   });
 
   describe('cross-domain vs A4A', () => {
+    let a4a;
+    let a4aElement;
     beforeEach(() => {
       xhrMock.withArgs(TEST_URL, {
         mode: 'cors',

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -42,6 +42,7 @@ import {urlReplacementsForDoc} from '../../../../src/url-replacements';
 import {platformFor} from '../../../../src/platform';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import {dev} from '../../../../src/log';
+import {createElementWithAttributes} from '../../../../src/dom';
 import * as sinon from 'sinon';
 
 /**
@@ -115,7 +116,11 @@ describe('amp-a4a', () => {
   });
 
   function createA4aElement(doc) {
-    const element = doc.createElement('amp-a4a');
+    const element = createElementWithAttributes(doc, 'amp-a4a', {
+      'width': '200',
+      'height': '50',
+      'type': 'adsense',
+    });
     element.getAmpDoc = () => {
       const ampdocService = ampdocServiceFor(doc.defaultView);
       return ampdocService.getAmpDoc(element);
@@ -214,9 +219,6 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(f => {
         fixture = f;
         a4aElement = createA4aElement(fixture.doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
         a4a = new MockA4AImpl(a4aElement);
         return fixture;
       });
@@ -228,7 +230,6 @@ describe('amp-a4a', () => {
       delete headers[SIGNATURE_HEADER];
       // If rendering type is safeframe, we SHOULD attach a SafeFrame.
       headers[RENDERING_TYPE_HEADER] = 'safeframe';
-      fixture.doc.body.appendChild(a4aElement);
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
         // Force vsync system to run all queued tasks, so that DOM mutations
@@ -266,7 +267,6 @@ describe('amp-a4a', () => {
       verifyNonAMPRender(a4a);
       // Make sure there's no signature, so that we go down the 3p iframe path.
       delete headers[SIGNATURE_HEADER];
-      fixture.doc.body.appendChild(a4aElement);
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
         // Force vsync system to run all queued tasks, so that DOM mutations
@@ -279,7 +279,6 @@ describe('amp-a4a', () => {
     });
 
     it('for A4A friendly iframe rendering case', () => {
-      fixture.doc.body.appendChild(a4aElement);
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
         // Force vsync system to run all queued tasks, so that DOM mutations
@@ -312,20 +311,12 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
         a4a = new MockA4AImpl(a4aElement);
         verifyNonAMPRender(a4a);
-        doc.body.appendChild(a4aElement);
         a4a.createdCallback();
         a4a.firstAttachedCallback();
         a4a.buildCallback();
       });
-    });
-
-    afterEach(() => {
-      expect(xhrMock).to.be.calledOnce;
     });
 
     describe('illegal render mode value', () => {
@@ -348,6 +339,7 @@ describe('amp-a4a', () => {
           expect(devErrLogSpy).to.be.calledOnce;
           expect(devErrLogSpy.getCall(0).args[1]).to.have.string(
             'random illegal value');
+          expect(xhrMock).to.be.calledOnce;
         });
       });
     });
@@ -365,6 +357,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifyNameFrameRender(a4aElement);
+          expect(xhrMock).to.be.calledOnce;
         });
       });
 
@@ -379,6 +372,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifyNameFrameRender(a4aElement);
+          expect(xhrMock).to.be.calledOnce;
         });
       });
 
@@ -405,6 +399,7 @@ describe('amp-a4a', () => {
                       expect(unsafeChild.getAttribute('src')).to.have.string(
                           TEST_URL);
                     }
+                    expect(xhrMock).to.be.calledOnce;
                   });
                 });
           });
@@ -423,6 +418,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifySafeFrameRender(a4aElement);
+          expect(xhrMock).to.be.calledOnce;
         });
       });
 
@@ -437,6 +433,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifySafeFrameRender(a4aElement);
+          expect(xhrMock).to.be.calledOnce;
         });
       });
 
@@ -461,6 +458,7 @@ describe('amp-a4a', () => {
                       expect(unsafeChild.getAttribute('src')).to.have.string(
                           TEST_URL);
                     }
+                    expect(xhrMock).to.be.calledOnce;
                   });
                 });
           });
@@ -477,6 +475,7 @@ describe('amp-a4a', () => {
           // whether it's necessary or perhaps hazardous.  Feedback welcome.
           a4a.vsync_.runScheduledTasks_();
           expect(a4a.nonAmpCreativeRenderMethod_).to.equal('client_cache');
+          expect(xhrMock).to.be.calledOnce;
         });
       });
     });
@@ -495,11 +494,7 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
         a4a = new MockA4AImpl(a4aElement);
-        doc.body.appendChild(a4aElement);
       });
     });
     afterEach(() => {
@@ -546,9 +541,6 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
         const a4a = new MockA4AImpl(a4aElement);
         let onAmpCreativeRenderFired = false;
         a4a.onAmpCreativeRender = () => {
@@ -559,7 +551,6 @@ describe('amp-a4a', () => {
             a4a, 'extractCreativeAndSignature');
         const maybeRenderAmpAdSpy = sandbox.spy(
             a4a, 'maybeRenderAmpAd_');
-        doc.body.appendChild(a4aElement);
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.instanceof(Promise);
         return a4a.adPromise_.then(() => {
@@ -571,7 +562,7 @@ describe('amp-a4a', () => {
               'extractCreativeAndSignatureSpy called exactly once').to.be.true;
           expect(maybeRenderAmpAdSpy.calledOnce,
               'maybeRenderAmpAd_ called exactly once').to.be.true;
-          expect(a4aElement.getElementsByTagName('iframe').length).to.equal(1);
+          expect(a4aElement.getElementsByTagName('iframe')).to.have.lengthOf(1);
           const friendlyIframe = a4aElement.querySelector('iframe[srcdoc]');
           expect(friendlyIframe).to.not.be.null;
           expect(friendlyIframe.getAttribute('src')).to.be.null;
@@ -604,15 +595,11 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
         const s = doc.createElement('style');
         s.textContent = '.fixed {position:fixed;}';
         doc.head.appendChild(s);
         a4aElement.className = 'fixed';
         const a4a = new MockA4AImpl(a4aElement);
-        doc.body.appendChild(a4aElement);
         expect(a4a.onLayoutMeasure.bind(a4a)).to.throw(/fixed/);
       });
     });
@@ -626,9 +613,6 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
         const a4a = new MockA4AImpl(a4aElement);
         verifyNonAMPRender(a4a);
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
@@ -641,14 +625,14 @@ describe('amp-a4a', () => {
               .to.be.true;
           expect(xhrMock.calledOnce,
               'xhr.fetchTextAndHeaders called exactly once').to.be.true;
-          expect(a4aElement.children.length, 'has no children').to.equal(0);
+          expect(a4aElement.children, 'has no children').to.have.lengthOf(0);
           expect(a4a.rendered_).to.be.false;
           return a4a.layoutCallback().then(() => {
             // Force vsync system to run all queued tasks, so that DOM mutations
             // are actually completed before testing.
             a4a.vsync_.runScheduledTasks_();
-            expect(a4aElement.getElementsByTagName('iframe').length)
-                .to.equal(1);
+            expect(a4aElement.getElementsByTagName('iframe'))
+                .to.have.lengthOf(1);
             const iframe = a4aElement.getElementsByTagName('iframe')[0];
             expect(iframe.getAttribute('srcdoc')).to.be.null;
             expect(iframe.src, 'verify iframe src w/ origin').to
@@ -669,10 +653,6 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
-        doc.body.appendChild(a4aElement);
         const a4a = new MockA4AImpl(a4aElement);
         const fullResponse = `<html amp>
             <body>
@@ -730,9 +710,6 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
         const a4a = new MockA4AImpl(a4aElement);
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
         verifyNonAMPRender(a4a);
@@ -743,7 +720,7 @@ describe('amp-a4a', () => {
           expect(getAdUrlSpy.calledOnce, 'getAdUrl called exactly once')
               .to.be.true;
           // Verify iframe presence and lack of visibility hidden
-          expect(a4aElement.children.length).to.equal(1);
+          expect(a4aElement.children).to.have.lengthOf(1);
           const iframe = a4aElement.querySelector('iframe[src]');
           expect(iframe).to.be.ok;
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
@@ -762,7 +739,7 @@ describe('amp-a4a', () => {
         return a4a.adPromise_.then(() => a4a.layoutCallback().then(() => {
           a4a.vsync_.runScheduledTasks_();
           // Verify iframe presence and lack of visibility hidden
-          expect(a4aElement.children.length).to.equal(1);
+          expect(a4aElement.children).to.have.lengthOf(1);
           const iframe = a4aElement.children[0];
           expect(iframe.tagName).to.equal('IFRAME');
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
@@ -786,7 +763,7 @@ describe('amp-a4a', () => {
         return layoutCallbackPromise.then(() => {
           a4a.vsync_.runScheduledTasks_();
           // Verify iframe presence and lack of visibility hidden
-          expect(a4aElement.children.length).to.equal(1);
+          expect(a4aElement.children).to.have.lengthOf(1);
           const iframe = a4aElement.children[0];
           expect(iframe.tagName).to.equal('IFRAME');
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
@@ -803,22 +780,22 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('type', 'adsense');
         const a4a = new MockA4AImpl(a4aElement);
         //a4a.config = {};
         a4a.buildCallback();
         a4a.preconnectCallback(false);
         const preconnects = doc.querySelectorAll('link[rel=preconnect]');
-        expect(preconnects.length).to.equal(3);
+        expect(preconnects).to.have.lengthOf(3);
         // SafeFrame origin.
-        expect(preconnects[0].getAttribute('href')).to
-            .equal('https://tpc.googlesyndication.com');
-        // NameFrame origin (in testing mode).
-        expect(preconnects[1].getAttribute('href')).to
-            .have.string('http://ads.localhost');
+        expect(preconnects[0]).to.have.property(
+            'href', 'https://tpc.googlesyndication.com/');
+        // NameFrame origin (in testing mode).  Use a substring match here to
+        // be agnostic about localhost server port.
+        expect(preconnects[1]).to.have.property('href')
+            .that.has.string('http://ads.localhost');
         // AdSense origin.
-        expect(preconnects[2].getAttribute('href')).to
-            .equal('https://googleads.g.doubleclick.net');
+        expect(preconnects[2]).to.have.property(
+            'href', 'https://googleads.g.doubleclick.net/');
       });
     });
   });
@@ -897,7 +874,7 @@ describe('amp-a4a', () => {
           return a4a.layoutCallback().then(() => {
             a4a.vsync_.runScheduledTasks_();
             // Verify iframe presence and lack of visibility hidden
-            expect(a4aElement.children.length).to.equal(1);
+            expect(a4aElement.children).to.have.lengthOf(1);
             const iframe = a4aElement.children[0];
             expect(iframe.tagName).to.equal('IFRAME');
             expect(iframe.src.indexOf('https://nowhere.org')).to.equal(0);
@@ -910,14 +887,13 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        doc.body.appendChild(a4aElement);
         const a4a = new AmpA4A(a4aElement);
         a4a.adUrl_ = 'https://nowhere.org';
         return buildCreativeArrayBuffer().then(bytes => {
           return a4a.maybeRenderAmpAd_(bytes).then(rendered => {
             expect(rendered).to.be.true;
             // Verify iframe presence.
-            expect(a4aElement.children.length).to.equal(1);
+            expect(a4aElement.children).to.have.lengthOf(1);
             const friendlyIframe = a4aElement.children[0];
             expect(friendlyIframe.tagName).to.equal('IFRAME');
             expect(friendlyIframe.src).to.not.be.ok;
@@ -941,7 +917,6 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        doc.body.appendChild(a4aElement);
         const a4a = new AmpA4A(a4aElement);
         a4a.adUrl_ = 'https://nowhere.org';
         return buildCreativeArrayBuffer().then(bytes => {
@@ -1002,10 +977,6 @@ describe('amp-a4a', () => {
       return createAdTestingIframePromise().then(fixture => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
-        doc.body.appendChild(a4aElement);
         const a4a = new MockA4AImpl(a4aElement);
         xhrMock.withArgs(TEST_URL, {
           mode: 'cors',
@@ -1015,7 +986,7 @@ describe('amp-a4a', () => {
         }).returns(Promise.resolve(mockResponse));
         return a4a.onLayoutMeasure(() => {
           expect(a4a.adPromise_).to.not.be.null;
-          expect(a4a.element.children.length).to.equal(1);
+          expect(a4a.element.children).to.have.lengthOf(1);
         });
       });
     });
@@ -1027,9 +998,6 @@ describe('amp-a4a', () => {
         }));
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 200);
-        a4aElement.setAttribute('height', 50);
-        a4aElement.setAttribute('type', 'adsense');
         const a4a = new MockA4AImpl(a4aElement);
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
         a4a.buildCallback();

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -463,18 +463,19 @@ describe('amp-a4a', () => {
                 });
           });
 
-      it('should reset state to client_cache on unlayoutCallback', () => {
+      it('should reset state to null on unlayoutCallback', () => {
         return a4a.layoutCallback().then(() => {
           // Force vsync system to run all queued tasks, so that DOM mutations
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
-          expect(a4a.nonAmpCreativeRenderMethod_).to.equal('safeframe');
+          expect(a4a.experimentalNonAmpCreativeRenderMethod_)
+              .to.equal('safeframe');
           a4a.unlayoutCallback();
           // QUESTION TO REVIEWERS: Do we really need the vsync.mutate in
           // AmpA4A.unlayoutCallback?  We have an open question there about
           // whether it's necessary or perhaps hazardous.  Feedback welcome.
           a4a.vsync_.runScheduledTasks_();
-          expect(a4a.nonAmpCreativeRenderMethod_).to.equal('client_cache');
+          expect(a4a.experimentalNonAmpCreativeRenderMethod_).to.be.null;
           expect(xhrMock).to.be.calledOnce;
         });
       });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -234,10 +234,18 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
   });
 
   var frameHtml = '3p/frame.max.html';
-  thirdPartyBootstrap(frameHtml, shouldMinify);
+  thirdPartyBootstrap(frameHtml, 'frame.html', shouldMinify);
   if (watch) {
     $$.watch(frameHtml, function() {
-      thirdPartyBootstrap(frameHtml, shouldMinify);
+      thirdPartyBootstrap(frameHtml, 'frame.html', shouldMinify);
+    });
+  }
+
+  var nameFrameHtml = '3p/nameframe.max.html';
+  thirdPartyBootstrap(nameFrameHtml, 'nameframe.html',shouldMinify);
+  if (watch) {
+    $$.watch(nameFrameHtml, function () {
+      thirdPartyBootstrap(nameFrameHtml, 'nameframe.html', shouldMinify);
     });
   }
 }
@@ -458,9 +466,10 @@ function checkTypes() {
  * copies, and generates symlink to it.
  *
  * @param {string} input
+ * @param {string} outputName
  * @param {boolean} shouldMinify
  */
-function thirdPartyBootstrap(input, shouldMinify) {
+function thirdPartyBootstrap(input, outputName, shouldMinify) {
   $$.util.log('Processing ' + input);
 
   if (!shouldMinify) {
@@ -479,7 +488,7 @@ function thirdPartyBootstrap(input, shouldMinify) {
   // Convert default relative URL to absolute min URL.
   var html = fs.readFileSync(input, 'utf8')
       .replace(/\.\/integration\.js/g, integrationJs);
-  $$.file('frame.html', html, {src: true})
+  $$.file(outputName, html, {src: true})
       .pipe(gulp.dest('dist.3p/' + internalRuntimeVersion))
       .on('end', function() {
         var aliasToLatestBuild = 'dist.3p/current-min';

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -215,21 +215,24 @@ export function resetBootstrapBaseUrlForTesting(win) {
 /**
  * Returns the default base URL for 3p bootstrap iframes.
  * @param {!Window} parentWindow
+ * @param {?string} opt_srcFileBasename
  * @return {string}
  */
-function getDefaultBootstrapBaseUrl(parentWindow) {
+export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
+  const srcFileBasename = opt_srcFileBasename || 'frame';
   if (getMode().localDev || getMode().test) {
     if (overrideBootstrapBaseUrl) {
       return overrideBootstrapBaseUrl;
     }
     return getAdsLocalhost(parentWindow)
         + '/dist.3p/'
-        + (getMode().minified ? '$internalRuntimeVersion$/frame'
-            : 'current/frame.max')
+        + (getMode().minified ? `$internalRuntimeVersion$/${srcFileBasename}`
+            : `current/${srcFileBasename}.max`)
         + '.html';
   }
   return 'https://' + getSubDomain(parentWindow) +
-      `.${urls.thirdPartyFrameHost}/$internalRuntimeVersion$/frame.html`;
+      `.${urls.thirdPartyFrameHost}/$internalRuntimeVersion$/` +
+      `${srcFileBasename}.html`;
 }
 
 function getAdsLocalhost(win) {

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -215,7 +215,7 @@ export function resetBootstrapBaseUrlForTesting(win) {
 /**
  * Returns the default base URL for 3p bootstrap iframes.
  * @param {!Window} parentWindow
- * @param {?string} opt_srcFileBasename
+ * @param {string=} opt_srcFileBasename
  * @return {string}
  */
 export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {

--- a/src/log.js
+++ b/src/log.js
@@ -16,6 +16,7 @@
 
 import {getMode} from './mode';
 import {getModeObject} from './mode-object';
+import {isEnumValue} from './types';
 
 
 /** @const Time when this JS loaded.  */
@@ -312,10 +313,8 @@ export class Log {
    */
   /*eslint "google-camelcase/google-camelcase": 2*/
   assertEnumValue(enumObj, s, opt_enumName) {
-    for (const k in enumObj) {
-      if (enumObj[k] == s) {
-        return enumObj[k];
-      }
+    if (isEnumValue(enumObj, s)) {
+      return s;
     }
     this.assert(false,
         'Unknown %s value: "%s"',

--- a/src/types.js
+++ b/src/types.js
@@ -103,6 +103,7 @@ export function isFormData(value) {
  * @param {!Object<T>} enumObj
  * @param {T} s
  * @return {boolean}
+ * @template T
  */
 export function isEnumValue(enumObj, s) {
   for (const k in enumObj) {

--- a/src/types.js
+++ b/src/types.js
@@ -96,3 +96,19 @@ export function isFiniteNumber(value) {
 export function isFormData(value) {
   return toString(value) === '[object FormData]';
 }
+
+/**
+ * Checks whether `s` is a valid value of `enumObj`.
+ *
+ * @param {!Object<T>} enumObj
+ * @param {T} s
+ * @return {boolean}
+ */
+export function isEnumValue(enumObj, s) {
+  for (const k in enumObj) {
+    if (enumObj[k] === s) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/test/functional/test-3p-nameframe.js
+++ b/test/functional/test-3p-nameframe.js
@@ -16,6 +16,45 @@
 
 import {createIframePromise} from '../../testing/iframe';
 
+// Is there a way to mark this .skip?  Neither describes.skip.sandboxed
+// nor describes.sandboxed.skip works.
+describes.sandboxed('alt nameframe', {}, () => {
+  describes.realWin('nameframe', {}, env => {
+    let fixture;
+    let win;
+    let doc;
+    let iframe;
+    beforeEach(() => {
+      fixture = env;
+      win = fixture.win;
+      doc = win.document;
+      iframe = doc.createElement('iframe');
+      iframe.src = 'http://localhost:9876/dist.3p/current/nameframe.max.html';
+      // Fails here.  srcdoc is not empty, so this iframe doesn't behave like a
+      // cross-origin iframe.
+      expect(iframe.getAttribute('srcdoc')).not.to.be.ok;
+    });
+
+    it('should load remote nameframe and succeed', done => {
+      iframe.name = JSON.stringify({
+        creative: `<html>
+                   <body>
+                     <script>
+                       window.parent.postMessage(
+                               {type: 'creative rendered'}, '*');
+                     </script>
+                   </body>
+                   </html>`,
+      });
+      win.addEventListener('message', content => {
+        expect(content.data.type).to.equal('creative rendered');
+        done();
+      });
+      doc.body.appendChild(iframe);
+    });
+  });
+});
+
 describes.sandboxed('nameframe', {}, () => {
   let fixture;
   let win;

--- a/test/functional/test-3p-nameframe.js
+++ b/test/functional/test-3p-nameframe.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describes.sandboxed('nameframe', {}, () => {
+  describes.realWin('frame load', {}, env => {
+    let win;
+    let doc;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+    });
+
+    it('should load from ampproject.net', () => {
+      win.addEventListener('message', event => {
+        console.log('Got message', event);
+      }, false);
+      const domain = win.location.origin;
+      const iframe = doc.createElement('iframe');
+      iframe.src = 'https://3p.ampproject.net/nameframe.html';
+      iframe.name = `<html>
+<body>
+<script>
+window.parent.postMessage('creative rendered', ${domain});
+console.log('sending message');
+</script>
+</body>
+</html>`;
+      doc.body.appendChild(iframe);
+    });
+
+  });
+});

--- a/test/functional/test-3p-nameframe.js
+++ b/test/functional/test-3p-nameframe.js
@@ -48,7 +48,7 @@ describes.sandboxed('nameframe', {}, () => {
 window.parent.postMessage({type: 'creative rendered'}, '*');
 </script>
 </body>
-</html>`
+</html>`,
     });
     win.addEventListener('message', content => {
       expect(content.data.type).to.equal('creative rendered');

--- a/test/functional/test-3p-nameframe.js
+++ b/test/functional/test-3p-nameframe.js
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-import {getDefaultBootstrapBaseUrl} from '../../src/3p-frame';
 import {createIframePromise} from '../../testing/iframe';
-
-function expectNoContent(win, done) {
-  win.addEventListener('message', content => {
-    expect(content.data).to.have.property('type');
-    expect(content.data.type).to.equal('no-content');
-    done();
-  });
-}
 
 describes.sandboxed('nameframe', {}, () => {
   let fixture;
@@ -36,19 +27,20 @@ describes.sandboxed('nameframe', {}, () => {
       win = fixture.win;
       doc = fixture.doc;
       iframe = doc.createElement('iframe');
-      iframe.src = getDefaultBootstrapBaseUrl(win, 'nameframe');
+      iframe.src = 'http://localhost:9876/dist.3p/current/nameframe.max.html';
     });
   });
 
   it('should load remote nameframe and succeed with valid JSON input', done => {
     iframe.name = JSON.stringify({
       creative: `<html>
-<body>
-<script>
-window.parent.postMessage({type: 'creative rendered'}, '*');
-</script>
-</body>
-</html>`,
+                 <body>
+                   <script>
+                     window.parent.postMessage(
+                             {type: 'creative rendered'}, '*');
+                   </script>
+                 </body>
+                 </html>`,
     });
     win.addEventListener('message', content => {
       expect(content.data.type).to.equal('creative rendered');
@@ -76,3 +68,11 @@ window.parent.postMessage({type: 'creative rendered'}, '*');
   });
 
 });
+
+function expectNoContent(win, done) {
+  win.addEventListener('message', content => {
+    expect(content.data).to.have.property('type');
+    expect(content.data.type).to.equal('no-content');
+    done();
+  });
+}

--- a/test/functional/test-3p-nameframe.js
+++ b/test/functional/test-3p-nameframe.js
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-import {createIframePromise} from '../../testing/iframe';
-
-// Is there a way to mark this .skip?  Neither describes.skip.sandboxed
-// nor describes.sandboxed.skip works.
 describes.sandboxed('alt nameframe', {}, () => {
-  describes.realWin('nameframe', {}, env => {
+  describes.realWin('nameframe', {allowExternalResources: true}, env => {
     let fixture;
     let win;
     let doc;
@@ -30,12 +26,9 @@ describes.sandboxed('alt nameframe', {}, () => {
       doc = win.document;
       iframe = doc.createElement('iframe');
       iframe.src = 'http://localhost:9876/dist.3p/current/nameframe.max.html';
-      // Fails here.  srcdoc is not empty, so this iframe doesn't behave like a
-      // cross-origin iframe.
-      expect(iframe.getAttribute('srcdoc')).not.to.be.ok;
     });
 
-    it('should load remote nameframe and succeed', done => {
+    it('should load remote nameframe and succeed w/ valid JSON', done => {
       iframe.name = JSON.stringify({
         creative: `<html>
                    <body>
@@ -52,60 +45,25 @@ describes.sandboxed('alt nameframe', {}, () => {
       });
       doc.body.appendChild(iframe);
     });
-  });
-});
 
-describes.sandboxed('nameframe', {}, () => {
-  let fixture;
-  let win;
-  let doc;
-  let iframe;
-  beforeEach(() => {
-    return createIframePromise(/* runtimeOff */ true).then(f => {
-      fixture = f;
-      win = fixture.win;
-      doc = fixture.doc;
-      iframe = doc.createElement('iframe');
-      iframe.src = 'http://localhost:9876/dist.3p/current/nameframe.max.html';
+    it('should fail if JSON is not paresable', done => {
+      iframe.name = 'not valid JSON';
+      expectNoContent(win, done);
+      doc.body.appendChild(iframe);
+    });
+
+    it('should fail if JSON is valid, but missing creative field', done => {
+      iframe.name = JSON.stringify({fnord: 'some meaningless data'});
+      expectNoContent(win, done);
+      doc.body.appendChild(iframe);
+    });
+
+    it('should fail if JSON is missing altogether', done => {
+      iframe.name = null;
+      expectNoContent(win, done);
+      doc.body.appendChild(iframe);
     });
   });
-
-  it('should load remote nameframe and succeed with valid JSON input', done => {
-    iframe.name = JSON.stringify({
-      creative: `<html>
-                 <body>
-                   <script>
-                     window.parent.postMessage(
-                             {type: 'creative rendered'}, '*');
-                   </script>
-                 </body>
-                 </html>`,
-    });
-    win.addEventListener('message', content => {
-      expect(content.data.type).to.equal('creative rendered');
-      done();
-    });
-    doc.body.appendChild(iframe);
-  });
-
-  it('should fail if JSON is not paresable', done => {
-    iframe.name = 'not valid JSON';
-    expectNoContent(win, done);
-    doc.body.appendChild(iframe);
-  });
-
-  it('should fail if JSON is valid, but missing creative field', done => {
-    iframe.name = JSON.stringify({fnord: 'some meaningless data'});
-    expectNoContent(win, done);
-    doc.body.appendChild(iframe);
-  });
-
-  it('should fail if JSON is missing altogether', done => {
-    iframe.name = null;
-    expectNoContent(win, done);
-    doc.body.appendChild(iframe);
-  });
-
 });
 
 function expectNoContent(win, done) {

--- a/test/functional/test-types.js
+++ b/test/functional/test-types.js
@@ -118,9 +118,9 @@ describe('Types', () => {
     it('should return false for non-enum values', () => {
       ['a', 'X', 'Z', {'x': 'x'}, ['y'], null, undefined, [], /x/, /y/, 42]
           .forEach(value => {
-        expect(types.isEnumValue(enumObj, value),
-            'enum value = ' + value).to.be.false;
-      });
+            expect(types.isEnumValue(enumObj, value),
+                'enum value = ' + value).to.be.false;
+          });
     });
   });
 });

--- a/test/functional/test-types.js
+++ b/test/functional/test-types.js
@@ -99,4 +99,28 @@ describe('Types', () => {
       expect(types.map(obj)).to.not.equal(obj);
     });
   });
+
+  describe('isEnumValue', () => {
+    /** @enum {string} */
+    const enumObj = {
+      X: 'x',
+      Y: 'y',
+      Z: 'z',
+    };
+
+    it('should return true for valid enum values', () => {
+      ['x', 'y', 'z'].forEach(value => {
+        expect(types.isEnumValue(enumObj, value),
+            'enum value = ' + value).to.be.true;
+      });
+    });
+
+    it('should return false for non-enum values', () => {
+      ['a', 'X', 'Z', {'x': 'x'}, ['y'], null, undefined, [], /x/, /y/, 42]
+          .forEach(value => {
+        expect(types.isEnumValue(enumObj, value),
+            'enum value = ' + value).to.be.false;
+      });
+    });
+  });
 });

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -142,7 +142,7 @@ export const realWin = describeEnv(spec => [
 
 
 /**
- * A test with in a described environment.
+ * A test within a described environment.
  * @param {function(!Object):!Array<?Fixture>} factory
  */
 function describeEnv(factory) {
@@ -308,7 +308,11 @@ class FakeWinFixture {
 /** @implements {Fixture} */
 class RealWinFixture {
 
-  /** @param {!{fakeRegisterElement: boolean, ampCss: boolean}} spec */
+  /** @param {!{
+  *   fakeRegisterElement: boolean,
+  *   ampCss: boolean,
+  *   allowExternalResources: boolean
+  * }} spec */
   constructor(spec) {
     /** @const */
     this.spec = spec;
@@ -336,7 +340,9 @@ class RealWinFixture {
         // Flag as being a test window.
         win.AMP_TEST_IFRAME = true;
 
-        doNotLoadExternalResourcesInTest(win);
+        if (!spec.allowExternalResources) {
+          doNotLoadExternalResourcesInTest(win);
+        }
 
         // Install AMP CSS if requested.
         if (spec.ampCss) {


### PR DESCRIPTION
NameFrame is an AMP alternative to SafeFrame, for use in A4A code.  It does **not** support the full SafeFrame API, but it does allow a creative to be set in a cross-domain iframe via the `name` attribute.  It also supports postMessaging out a `no-content` message in the case of rendering failure.