### PR TITLE
Remove unnecessary services in amp-inabox entry point.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -199,6 +199,10 @@ var forbiddenTerms = {
     whitelist: [
       'src/runtime.js',
       'src/service/viewer-impl.js',
+      'src/amp.js',
+      'src/inabox/amp-inabox.js',
+      'testing/iframe.js',
+      'testing/describes.js',
     ],
   },
   'setViewerVisibilityState': {
@@ -213,6 +217,10 @@ var forbiddenTerms = {
     whitelist: [
       'src/runtime.js',
       'src/service/viewport-impl.js',
+      'src/amp.js',
+      'src/inabox/amp-inabox.js',
+      'testing/iframe.js',
+      'testing/describes.js',
     ],
   },
   'installVsyncService': {

--- a/src/amp.js
+++ b/src/amp.js
@@ -35,6 +35,8 @@ import {
   installRuntimeServices,
   adopt,
 } from './runtime';
+import {installViewerServiceForDoc} from './service/viewer-impl';
+import {installViewportServiceForDoc} from './service/viewport-impl';
 import {cssText} from '../build/css';
 import {maybeValidate} from './validator-integration';
 import {maybeTrackImpression} from './impression';
@@ -67,6 +69,8 @@ chunk(self.document, function initial() {
       // Core services.
       installRuntimeServices(self);
       fontStylesheetTimeout(self);
+      installViewerServiceForDoc(ampdoc);
+      installViewportServiceForDoc(ampdoc);
       installAmpdocServices(ampdoc);
       // We need the core services (viewer/resources) to start instrumenting
       perf.coreServicesAvailable();

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -22,7 +22,6 @@ import '../../third_party/babel/custom-babel-helpers';
 import '../polyfills';
 import {chunk} from '../chunk';
 import {fontStylesheetTimeout} from '../font-stylesheet-timeout';
-import {installGlobalClickListenerForDoc} from '../document-click';
 import {installStyles, makeBodyVisible} from '../style-installer';
 import {installErrorReporting} from '../error';
 import {installDocService} from '../service/ampdoc-impl';
@@ -87,8 +86,6 @@ chunk(self.document, function initial() {
       stubElements(self);
     });
     chunk(self.document, function final() {
-      installGlobalClickListenerForDoc(ampdoc);
-
       maybeValidate(self);
       makeBodyVisible(self.document, /* waitForServices */ true);
     });

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -22,13 +22,10 @@ import '../../third_party/babel/custom-babel-helpers';
 import '../polyfills';
 import {chunk} from '../chunk';
 import {fontStylesheetTimeout} from '../font-stylesheet-timeout';
-import {installPerformanceService} from '../service/performance-impl';
-import {installPullToRefreshBlocker} from '../pull-to-refresh';
 import {installGlobalClickListenerForDoc} from '../document-click';
 import {installStyles, makeBodyVisible} from '../style-installer';
 import {installErrorReporting} from '../error';
 import {installDocService} from '../service/ampdoc-impl';
-import {installCacheServiceWorker} from '../service-worker/install';
 import {stubElements} from '../custom-element';
 import {
     installAmpdocServices,
@@ -36,9 +33,10 @@ import {
     installRuntimeServices,
     adopt,
 } from '../runtime';
+import {installViewerServiceForDoc} from '../service/viewer-impl';
+import {installViewportServiceForDoc} from '../service/viewport-impl';
 import {cssText} from '../../build/css';
 import {maybeValidate} from '../validator-integration';
-import {maybeTrackImpression} from '../impression';
 import {Inabox} from './inabox';
 
 
@@ -66,18 +64,17 @@ try {
 chunk(self.document, function initial() {
   /** @const {!../service/ampdoc-impl.AmpDoc} */
   const ampdoc = ampdocService.getAmpDoc(self.document);
-  /** @const {!../service/performance-impl.Performance} */
-  const perf = installPerformanceService(self);
-  perf.tick('is');
+
   installStyles(self.document, cssText, () => {
     chunk(self.document, function services() {
       // Core services.
       installRuntimeServices(self);
       fontStylesheetTimeout(self);
+
+      // TODO: replace viewer impl and viewport impl.
+      installViewerServiceForDoc(ampdoc);
+      installViewportServiceForDoc(ampdoc);
       installAmpdocServices(ampdoc);
-      // We need the core services (viewer/resources) to start instrumenting
-      perf.coreServicesAvailable();
-      maybeTrackImpression(self);
     });
     chunk(self.document, function builtins() {
       // Builtins.
@@ -90,18 +87,10 @@ chunk(self.document, function initial() {
       stubElements(self);
     });
     chunk(self.document, function final() {
-      installPullToRefreshBlocker(self);
       installGlobalClickListenerForDoc(ampdoc);
 
       maybeValidate(self);
       makeBodyVisible(self.document, /* waitForServices */ true);
-      installCacheServiceWorker(self);
-    });
-    chunk(self.document, function finalTick() {
-      perf.tick('e_is');
-      // TODO(erwinm): move invocation of the `flush` method when we have the
-      // new ticks in place to batch the ticks properly.
-      perf.flush();
     });
   }, /* opt_isRuntimeCss */ true, /* opt_ext */ 'amp-runtime');
 });
@@ -111,7 +100,7 @@ chunk(self.document, function initial() {
 // (At least by sophisticated users).
 if (self.console) {
   (console.info || console.log).call(console,
-      'Powered by AMP ⚡ HTML – Version $internalRuntimeVersion$',
+      'Powered by AMP ⚡4ads HTML – Version $internalRuntimeVersion$',
       self.location.href);
 }
 self.document.documentElement.setAttribute('amp-version',

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -108,8 +108,6 @@ export function installRuntimeServices(global) {
  */
 export function installAmpdocServices(ampdoc) {
   installDocumentInfoServiceForDoc(ampdoc);
-  // installViewerServiceForDoc(ampdoc);
-  // installViewportServiceForDoc(ampdoc);
   installHistoryServiceForDoc(ampdoc);
   installResourcesServiceForDoc(ampdoc);
   installUrlReplacementsServiceForDoc(ampdoc);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -105,12 +105,11 @@ export function installRuntimeServices(global) {
 /**
  * Install ampdoc-level services.
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
- * @param {!Object<string, string>=} opt_initParams
  */
-export function installAmpdocServices(ampdoc, opt_initParams) {
+export function installAmpdocServices(ampdoc) {
   installDocumentInfoServiceForDoc(ampdoc);
-  installViewerServiceForDoc(ampdoc, opt_initParams);
-  installViewportServiceForDoc(ampdoc);
+  // installViewerServiceForDoc(ampdoc);
+  // installViewportServiceForDoc(ampdoc);
   installHistoryServiceForDoc(ampdoc);
   installResourcesServiceForDoc(ampdoc);
   installUrlReplacementsServiceForDoc(ampdoc);
@@ -549,8 +548,10 @@ class MultidocManager {
     installStylesForShadowRoot(shadowRoot, cssText,
         /* opt_isRuntimeCss */ true);
 
+    installViewerServiceForDoc(ampdoc, opt_initParams || Object.create(null));
+    installViewportServiceForDoc(ampdoc);
     // Instal doc services.
-    installAmpdocServices(ampdoc, opt_initParams || Object.create(null));
+    installAmpdocServices(ampdoc);
     const viewer = viewerForDoc(ampdoc);
 
     /**

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -23,6 +23,8 @@ import {
   installAmpdocServices,
   installRuntimeServices,
 } from '../src/runtime';
+import {installViewerServiceForDoc} from '../src/service/viewer-impl';
+import {installViewportServiceForDoc} from '../src/service/viewport-impl';
 import {activateChunkingForTesting} from '../src/chunk';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {platformFor} from '../src/platform';
@@ -183,6 +185,8 @@ function beforeTest() {
   const ampdocService = installDocService(window, true);
   const ampdoc = ampdocService.getAmpDoc(window.document);
   installRuntimeServices(window);
+  installViewerServiceForDoc(ampdoc);
+  installViewportServiceForDoc(ampdoc);
   installAmpdocServices(ampdoc);
 }
 

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -29,6 +29,8 @@ import {
   installRuntimeServices,
   registerElementForTesting,
 } from '../src/runtime';
+import {installViewerServiceForDoc} from '../src/service/viewer-impl';
+import {installViewportServiceForDoc} from '../src/service/viewport-impl';
 import {cssText} from '../build/css';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {installExtensionsService} from '../src/service/extensions-impl';
@@ -420,7 +422,9 @@ class AmpFixture {
       completePromise = installRuntimeStylesPromise(win);
       const ampdoc = ampdocService.getAmpDoc(win.document);
       env.ampdoc = ampdoc;
-      installAmpdocServices(ampdoc, spec.params);
+      installViewerServiceForDoc(ampdoc, spec.params);
+      installViewportServiceForDoc(ampdoc);
+      installAmpdocServices(ampdoc);
       adopt(win);
     } else if (ampdocType == 'multi') {
       adoptShadowMode(win);

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -25,6 +25,8 @@ import {
   installRuntimeServices,
   registerForUnitTest,
 } from '../src/runtime';
+import {installViewerServiceForDoc} from '../src/service/viewer-impl';
+import {installViewportServiceForDoc} from '../src/service/viewport-impl';
 import {installStyles} from '../src/style-installer';
 import {cssText} from '../build/css';
 
@@ -213,6 +215,8 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
       installExtensionsService(iframe.contentWindow);
       installRuntimeServices(iframe.contentWindow);
       installCustomElements(iframe.contentWindow);
+      installViewerServiceForDoc(ampdoc);
+      installViewportServiceForDoc(ampdoc);
       installAmpdocServices(ampdoc);
       registerForUnitTest(iframe.contentWindow);
       // Act like no other elements were loaded by default.


### PR DESCRIPTION
This PR does 2 things:
- Remove unnecessary services in amp-inabox entry point
-- performance service (not needed as there will be no viewer)
-- alp related stuff
-- pull to refresh
-- document click handler (not needed as there will be no viewer)
-- service worker (might add back later)
- Split off `installViewer` and `installViewport` from `installAmpDocServices`, so that amp-inabox can choose to install different impl.

For #5700