### PR TITLE
Add amp-izlesene extension to embed videos from izlesene.com

### DIFF
--- a/examples/izlesene.amp.html
+++ b/examples/izlesene.amp.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>Izlesene examples</title>
+    <link rel="canonical" href="amps.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+    <script async custom-element="amp-izlesene" src="https://cdn.ampproject.org/v0/amp-izlesene-0.1.js"></script>
+     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+<h2>Izlesene</h2>
+
+<amp-izlesene
+        data-videoid="6663596"
+        width="500"
+        height="281"
+        layout="responsive">
+</amp-izlesene>
+
+</body>
+</html>

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -56,6 +56,7 @@ Current list of extended components by category:
 | [`amp-brightcove`](amp-brightcove/amp-brightcove.md) | Displays a Brightcove Video Cloud or Perform player. |
 | [`amp-dailymotion`](amp-dailymotion/amp-dailymotion.md) | Displays a [Dailymotion](https://www.dailymotion.com) video. |
 | [`amp-gfycat`](amp-gfycat/amp-gfycat.md) | Displays a [Gfycat](https://gfycat.com) video GIF. |
+| [`amp-izlesene`](amp-izlesene/amp-izlesene.md) | Displays a Izlesene video. |
 | [`amp-jwplayer`](amp-jwplayer/amp-jwplayer.md) | Displays a cloud-hosted [JW Player](https://www.jwplayer.com/). |
 | [`amp-kaltura-player`](amp-kaltura-player/amp-kaltura-player.md) | Displays the Kaltura Player as used in [Kaltura's Video Platform](https://corp.kaltura.com/). |
 | [`amp-reach-player`](amp-reach-player/amp-reach-player.md) | Displays a [Beachfront Reach](https://beachfrontreach.com/) video player. |

--- a/extensions/amp-izlesene/0.1/amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/amp-izlesene.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import {addParamsToUrl} from '../../../src/url';
+ import {getDataParamsFromAttributes} from '../../../src/dom';
+ import {isLayoutSizeDefined} from '../../../src/layout';
+ import {dev, user} from '../../../src/log';
+
+ class AmpIzlesene extends AMP.BaseElement {
+  constructor(element) {
+    super(element);
+    /** @private {?string}  */
+    this.videoid_ = null;
+    /** @private {?Element} */
+    this.iframe_ = null;
+    /** @private {?string} */
+    this.videoIframeSrc_ = null;
+  }
+
+  /**
+   * @param {boolean=} opt_onLayout
+   * @override
+   */
+  preconnectCallback(opt_onLayout) {
+    this.preconnect.url(this.getVideoIframeSrc_());
+    // Host that Izlesene uses to serve poster frames needed by player.
+    this.preconnect.url('https://i1.imgiz.com', opt_onLayout);
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
+  /** @override */
+  buildCallback() {
+    this.videoid_ = user().assert(
+        this.element.getAttribute('data-videoid'),
+        'The data-videoid attribute is required for <amp-izlesene> %s',
+        this.element);
+  }
+
+  /** @return {string} */
+  getVideoIframeSrc_() {
+    if (this.videoIframeSrc_) {
+      return this.videoIframeSrc_;
+    }
+
+    dev().assert(this.videoid_);
+    let src = 'https://www.izlesene.com/embedplayer/' + encodeURIComponent(this.videoid_ || '') + '/?';
+
+    const params = getDataParamsFromAttributes(this.element);
+    if ('autoplay' in params) {
+      // Autoplay is managed by video manager, do not pass it.
+      delete params['autoplay'];
+    }
+
+    src = addParamsToUrl(src, params);
+    return this.videoIframeSrc_ = src;
+  }
+
+  /** @override */
+  layoutCallback() {
+
+    const iframe = this.element.ownerDocument.createElement('iframe');
+    const src = this.getVideoIframeSrc_();
+
+    iframe.setAttribute('frameborder', '0');
+    iframe.setAttribute('allowfullscreen', 'true');
+    iframe.src = src;
+    this.applyFillContent(iframe);
+    this.element.appendChild(iframe);
+    this.iframe_ = iframe;
+
+    return this.loadPromise(iframe);
+  }
+
+  /** @override */
+  pauseCallback() {
+    if (this.iframe_ && this.iframe_.contentWindow) {
+      this.iframe_.contentWindow./*OK*/postMessage({command: 'pause'}, '*');
+    }
+  }
+};
+
+ AMP.registerElement('amp-izlesene', AmpIzlesene);

--- a/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createIframePromise,
+  doNotLoadExternalResourcesInTest,
+} from '../../../../testing/iframe';
+import '../amp-izlesene';
+import {adopt} from '../../../../src/runtime';
+
+adopt(window);
+
+describe('amp-izlesene', () => {
+
+  function getIzlesene(videoId, opt_responsive) {
+    return createIframePromise().then(iframe => {
+      doNotLoadExternalResourcesInTest(iframe.win);
+      const izlesene = iframe.doc.createElement('amp-izlesene');
+      izlesene.setAttribute('data-videoid', videoId);
+      izlesene.setAttribute('width', '111');
+      izlesene.setAttribute('height', '222');
+      if (opt_responsive) {
+        izlesene.setAttribute('layout', 'responsive');
+      }
+      return iframe.addElement(izlesene);
+    });
+  }
+
+  it('renders', () => {
+    return getIzlesene('7221390').then(izlesene => {
+      const iframe = izlesene.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      expect(iframe.src).to.equal(
+          'https://www.izlesene.com/embedplayer/7221390/?');
+    });
+  });
+
+  it('renders responsively', () => {
+    return getIzlesene('7221390', true).then(izlesene => {
+      const iframe = izlesene.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.className).to.match(/-amp-fill-content/);
+    });
+  });
+
+  it('requires data-videoid', () => {
+    return getIzlesene('').should.eventually.be.rejectedWith(
+        /The data-videoid attribute is required for/);
+  });
+});

--- a/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.html
+++ b/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.html
@@ -1,0 +1,47 @@
+<!--
+  Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests validation for the amp-izlesene tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>İzlesene examples</title>
+    <link rel="canonical" href="amps.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+    <script async custom-element="amp-izlesene" src="https://cdn.ampproject.org/v0/amp-izlesene-0.1.js"></script>
+     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h2>İzlesene</h2>
+
+  <!-- Valid -->
+  <amp-izlesene data-videoid="7221390" width="480" height="270"></amp-izlesene>
+
+  <!-- Valid -->
+  <amp-izlesene data-videoid="7221390" width="480" height="270" layout="responsive"></amp-izlesene>
+
+  <!-- Invalid: bad data-videoid. -->
+  <amp-izlesene data-videoid="something else" width="480" height="270" layout="responsive"></amp-izlesene>
+
+  <!-- Invalid: data-videoid missing. -->
+  <amp-izlesene width="480" height="270" layout="responsive"></amp-izlesene>
+</body>
+</html>

--- a/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.out
+++ b/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.out
@@ -1,0 +1,3 @@
+FAIL
+amp-izlesene/0.1/test/validator-amp-izlesene.html:42:2 The attribute 'data-videoid' in tag 'amp-izlesene' is set to the invalid value 'something else'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/amp-izlesene.md) [AMP_TAG_PROBLEM]
+amp-izlesene/0.1/test/validator-amp-izlesene.html:45:2 The mandatory attribute 'data-videoid' is missing in tag 'amp-izlesene'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/amp-izlesene.md) [AMP_TAG_PROBLEM]

--- a/extensions/amp-izlesene/0.1/validator-amp-izlesene.protoascii
+++ b/extensions/amp-izlesene/0.1/validator-amp-izlesene.protoascii
@@ -1,0 +1,72 @@
+#
+# Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-izlesene
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amp-izlesene extension .js script"
+  satisfies: "amp-izlesene extension .js script"
+  mandatory_parent: "HEAD"
+  unique: true
+  extension_unused_unless_tag_present: "amp-izlesene"
+  attrs: {
+    name: "async"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "custom-element"
+    mandatory: true
+    value: "amp-izlesene"
+    dispatch_key: true
+  }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_regex: "https://cdn\\.ampproject\\.org/v0/amp-izlesene-(latest|0\\.1)\\.js"
+  }
+  attrs: {
+    name: "type"
+    value: "text/javascript"
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "."
+      error_message: "contents"
+    }
+  }
+  spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/amp-izlesene.md"
+}
+tags: {  # <amp-izlesene>
+  html_format: AMP
+  tag_name: "AMP-IZLESENE"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires: "amp-izlesene extension .js script"
+  attrs: {
+    name: "data-videoid"
+    mandatory: true
+    value_regex: "[0-9]+"
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/amp-izlesene.md"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: RESPONSIVE
+  }
+}

--- a/extensions/amp-izlesene/amp-izlesene.md
+++ b/extensions/amp-izlesene/amp-izlesene.md
@@ -1,0 +1,77 @@
+<!---
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# <a name="amp-izlesene"></a> `amp-izlesene`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Displays a <a href="https://www.izlesene.com/">Izlesene</a> video.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td>Stable</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-izlesene" src="https://cdn.ampproject.org/v0/amp-izlesene-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
+  </tr>
+</table>
+
+## Example
+
+With responsive layout the width and height from the example should yield correct layouts for 16:9 aspect ratio videos:
+
+```html
+<amp-izlesene
+    data-videoid="7221390"
+    layout="responsive"
+    width="480" height="270"></amp-izlesene>
+```
+
+## Required Attributes
+
+**data-videoid**
+
+The Izlesene video id found in every Izlesene video page URL
+
+E.g. in https://www.izlesene.com/video/yayin-yok/7221390 `"7221390"` is the video id.
+
+## Optional Attributes
+
+**data-param-showrel**
+
+Whether to show related content or not. (Not available for IOS devices)
+
+Value: `"1"` or `"0"`
+
+Default value: `"1"`
+
+**data-param-showreplay**
+
+Whether to show replay button at the end content or not.
+
+Value: `"1"` or `"0"`
+
+Default value: `"1"`
+
+## Validation
+
+See [amp-izlesene rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/0.1/validator-amp-izlesene.protoascii) in the AMP validator specification.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,6 +76,7 @@ declareExtension('amp-iframe', '0.1', false, 'NO_TYPE_CHECK');
 declareExtension('amp-image-lightbox', '0.1', true);
 declareExtension('amp-instagram', '0.1', false);
 declareExtension('amp-install-serviceworker', '0.1', false);
+declareExtension('amp-izlesene', '0.1', false);
 declareExtension('amp-jwplayer', '0.1', false, 'NO_TYPE_CHECK');
 declareExtension('amp-lightbox', '0.1', false);
 declareExtension('amp-lightbox-viewer', '0.1', true, 'NO_TYPE_CHECK');


### PR DESCRIPTION
We're the leading Turkish video network with millions of video views every single day. To enable our users embed videos on their AMP pages as well, we've created the amp-izlesene extension.

**Contributors:** @gberkman @ferrerodbgm