### PR TITLE
Rename the max script "a4a-host.js" to "amp-inabox-host.js".

### DIFF
--- a/examples/inabox.host.html
+++ b/examples/inabox.host.html
@@ -26,7 +26,7 @@
      * @param {!Window} win
      */
     function initInaboxHost(win) {
-      const hostScriptUrl = 'http://localhost:8000/dist/a4a-host.js';
+      const hostScriptUrl = 'http://localhost:8000/dist/amp-inabox-host.js';
       preloadScript(win, hostScriptUrl);
       // Optional: preload a4a-v0.js as well.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -219,7 +219,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
 
   // inabox-host
   compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
-    toName: 'a4a-host.js',
+    toName: 'amp-inabox-host.js',
     minifiedName: 'a4a-host-v0.js',
     includePolyfills: false,
     checkTypes: opt_checkTypes,


### PR DESCRIPTION
So we have sort of consistent naming:
Max version: amp-inabox.js & amp-inabox-host.js
Min version: a4a-v0.js & a4a-host-v0.js