### PR TITLE
Stop submission before throwing errors when form is invalid.

### DIFF
--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -49,6 +49,23 @@ export function onDocumentFormSubmit_(e) {
     return;
   }
 
+  // amp-form extension will add novalidate to all forms to manually trigger
+  // validation. In that case `novalidate` doesn't have the same meaning.
+  const isAmpFormMarked = form.classList.contains('-amp-form');
+  let shouldValidate;
+  if (isAmpFormMarked) {
+    shouldValidate = !form.hasAttribute('amp-novalidate');
+  } else {
+    shouldValidate = !form.hasAttribute('novalidate');
+  }
+
+  // Safari does not trigger validation check on submission, hence we
+  // trigger it manually. In other browsers this would never execute since
+  // the submit event wouldn't be fired if the form is invalid.
+  if (shouldValidate && form.checkValidity && !form.checkValidity()) {
+    e.preventDefault();
+  }
+
   const inputs = form.elements;
   for (let i = 0; i < inputs.length; i++) {
     user().assert(!inputs[i].name ||
@@ -91,23 +108,5 @@ export function onDocumentFormSubmit_(e) {
       'form target=%s is invalid can only be _blank or _top: %s', target, form);
   if (actionXhr) {
     checkCorsUrl(actionXhr);
-  }
-
-  // amp-form extension will add novalidate to all forms to manually trigger
-  // validation. In that case `novalidate` doesn't have the same meaning.
-  const isAmpFormMarked = form.classList.contains('-amp-form');
-  let shouldValidate;
-  if (isAmpFormMarked) {
-    shouldValidate = !form.hasAttribute('amp-novalidate');
-  } else {
-    shouldValidate = !form.hasAttribute('novalidate');
-  }
-
-  // Safari does not trigger validation check on submission, hence we
-  // trigger it manually. In other browsers this would never execute since
-  // the submit event wouldn't be fired if the form is invalid.
-  if (shouldValidate && form.checkValidity && !form.checkValidity()) {
-    e.preventDefault();
-    return;
   }
 }

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -97,19 +97,20 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
     evt.target.setAttribute('method', 'post');
     expect(() => onDocumentFormSubmit_(evt))
         .to.throw(/Only XHR based \(via action-xhr attribute\) submissions/);
-    expect(preventDefaultSpy.callCount).to.equal(1);
+    expect(preventDefaultSpy).to.have.been.called;
+    const callCount = preventDefaultSpy.callCount;
 
     evt.target.setAttribute('method', 'post');
     evt.target.setAttribute('action-xhr', 'https://example.com');
     expect(() => onDocumentFormSubmit_(evt)).to.not.throw();
-    expect(preventDefaultSpy.callCount).to.equal(2);
+    expect(preventDefaultSpy.callCount).to.equal(callCount + 1);
   });
 
   it('should fail when action is provided for POST', () => {
     evt.target.setAttribute('method', 'post');
     expect(() => onDocumentFormSubmit_(evt))
         .to.throw(/form action attribute is invalid for method=POST/);
-    expect(preventDefaultSpy.callCount).to.equal(1);
+    expect(preventDefaultSpy).to.have.been.called;
   });
 
   it('should do nothing if already prevented', () => {


### PR DESCRIPTION
Prevent default before throwing an error to avoid submitting invalid forms.

Fixes #6124