### PR TITLE
Cleanup base64 encoding code

### DIFF
--- a/extensions/amp-access/0.1/jwt.js
+++ b/extensions/amp-access/0.1/jwt.js
@@ -15,10 +15,9 @@
  */
 
 import {
-  base64UrlDecode,
   base64UrlDecodeToBytes,
 } from '../../../src/utils/base64';
-import {stringToBytes} from '../../../src/utils/bytes';
+import {stringToBytes, utf8DecodeSync} from '../../../src/utils/bytes';
 import {pemToBytes} from '../../../src/utils/pem';
 import {tryParseJson} from '../../../src/json';
 
@@ -125,9 +124,11 @@ export class JwtHelper {
     if (parts.length != 3) {
       invalidToken();
     }
+    const headerUtf8Bytes = base64UrlDecodeToBytes(parts[0]);
+    const payloadUtf8Bytes = base64UrlDecodeToBytes(parts[1]);
     return {
-      header: tryParseJson(base64UrlDecode(parts[0]), invalidToken),
-      payload: tryParseJson(base64UrlDecode(parts[1]), invalidToken),
+      header: tryParseJson(utf8DecodeSync(headerUtf8Bytes), invalidToken),
+      payload: tryParseJson(utf8DecodeSync(payloadUtf8Bytes), invalidToken),
       verifiable: `${parts[0]}.${parts[1]}`,
       sig: parts[2],
     };

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -21,9 +21,13 @@ import * as sinon from 'sinon';
 
 describe('JwtHelper', () => {
 
+  // Generated from https://jwt.io/#debugger
+  // Name deliberately changed from "John Doe" to "John ௵Z加䅌ਇ☎Èʘغޝ" to test
+  // correct unicode handling on out part.
   const TOKEN_HEADER = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
   const TOKEN_PAYLOAD =
-      'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9';
+      'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4g4K-1' +
+      'WuWKoOSFjOCoh-KYjsOIypjYut6dIiwiYWRtaW4iOnRydWV9';
   const TOKEN_SIG = 'TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ';
   const TOKEN = `${TOKEN_HEADER}.${TOKEN_PAYLOAD}.${TOKEN_SIG}`;
 
@@ -49,7 +53,7 @@ describe('JwtHelper', () => {
       });
       expect(tok.payload).to.deep.equal({
         'sub': '1234567890',
-        'name': 'John Doe',
+        'name': 'John ௵Z加䅌ਇ☎Èʘغޝ',
         'admin': true,
       });
       expect(tok.verifiable).to.equal(

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -23,7 +23,7 @@ describe('JwtHelper', () => {
 
   // Generated from https://jwt.io/#debugger
   // Name deliberately changed from "John Doe" to "John ௵Z加䅌ਇ☎Èʘغޝ" to test
-  // correct unicode handling on out part.
+  // correct unicode handling on our part.
   const TOKEN_HEADER = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
   const TOKEN_PAYLOAD =
       'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4g4K-1' +

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {base64EncodeFromBytes} from '../../../src/utils/base64.js';
 import {IntersectionObserver} from '../../../src/intersection-observer';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -23,6 +24,7 @@ import {parseUrl} from '../../../src/url';
 import {removeElement} from '../../../src/dom';
 import {timerFor} from '../../../src/timer';
 import {user} from '../../../src/log';
+import {utf8EncodeSync} from '../../../src/utils/bytes.js';
 import {urls} from '../../../src/config';
 import {moveLayoutRect} from '../../../src/layout-rect';
 import {setStyle} from '../../../src/style';
@@ -106,13 +108,8 @@ export class AmpIframe extends AMP.BaseElement {
         'allow-same-origin is not allowed with the srcdoc attribute %s.',
         this.element);
 
-    // srcdoc is a DOMString and requires special handling for base64 encoding.
-    // See https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
-    const encodedSrcdoc = btoa(encodeURIComponent(srcdoc)
-      .replace(/%([0-9A-F]{2})/g, function(match, p1) {
-        return String.fromCharCode('0x' + p1);
-      }));
-    return 'data:text/html;charset=utf-8;base64,' + encodedSrcdoc;
+    return 'data:text/html;charset=utf-8;base64,' +
+        base64EncodeFromBytes(utf8EncodeSync(srcdoc));
   }
 
   /** @override */

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -29,40 +29,14 @@ const base64UrlDecodeSubs = {'-': '+', '_': '/', '.': '='};
 const base64UrlEncodeSubs = {'+': '-', '/': '_', '=': '.'};
 
 /**
- * Converts a string which is in base64url encoding into the decoded string.
- * base64url is defined in RFC 4648. It is sometimes referred to as "web safe".
- * Note that atob seems to accept input either with or without padding, so this
- * routine will also.
- * Note that the way this is currently implemented, it will also accept regular
- * base64 input. But that is not part of the contract, so do not count on it
- * being true in the future.
- * @param {string} str
- * @return {string}
- */
-export function base64UrlDecode(str) {
-  return atob(str.replace(/[-_.]/g, ch => base64UrlDecodeSubs[ch]));
-}
-
-/**
  * Converts a string which is in base64url encoding into a Uint8Array
  * containing the decoded value.
  * @param {string} str
  * @return {!Uint8Array}
  */
 export function base64UrlDecodeToBytes(str) {
-  return stringToBytes(base64UrlDecode(str));
-}
-
-/**
- * Converts a string which is in base64 encoding into the decoded string.
- * base64 is defined in RFC 4648.
- * Note that atob seems to accept input either with or without padding, so this
- * routine will also.
- * @param {string} str
- * @return {string}
- */
-export function base64Decode(str) {
-  return atob(str);
+  const encoded = atob(str.replace(/[-_.]/g, ch => base64UrlDecodeSubs[ch]));
+  return stringToBytes(encoded);
 }
 
 /**
@@ -72,17 +46,7 @@ export function base64Decode(str) {
  * @return {!Uint8Array}
  */
 export function base64DecodeToBytes(str) {
-  return stringToBytes(base64Decode(str));
-}
-
-/**
- * Converts a string into base64url encoded string.
- * base64url is defined in RFC 4648. It is sometimes referred to as "web safe".
- * @param {string} str
- * @return {string}
- */
-export function base64UrlEncode(str) {
-  return btoa(str).replace(/[+/=]/g, ch => base64UrlEncodeSubs[ch]);
+  return stringToBytes(atob(str));
 }
 
 /**
@@ -92,16 +56,8 @@ export function base64UrlEncode(str) {
  * @return {string}
  */
 export function base64UrlEncodeFromBytes(bytes) {
-  return base64UrlEncode(bytesToString(bytes));
-}
-
-/**
- * Converts a string into base64 encoded string.
- * @param {string} str
- * @return {string}
- */
-export function base64Encode(str) {
-  return btoa(str);
+  const str = bytesToString(bytes);
+  return btoa(str).replace(/[+/=]/g, ch => base64UrlEncodeSubs[ch]);
 }
 
 /**
@@ -110,5 +66,5 @@ export function base64Encode(str) {
  * @return {string}
  */
 export function base64EncodeFromBytes(bytes) {
-  return base64Encode(bytesToString(bytes));
+  return btoa(bytesToString(bytes));
 }

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -48,7 +48,7 @@ export function utf8DecodeSync(bytes) {
   if (typeof TextDecoder !== 'undefined') {
     return new TextDecoder('utf-8').decode(bytes);
   }
-  const asciiString = bytesToString(new Uint8Array(bytes));
+  const asciiString = bytesToString(new Uint8Array(bytes.buffer || bytes));
   return decodeURIComponent(escape(asciiString));
 }
 

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -48,7 +48,7 @@ export function utf8DecodeSync(bytes) {
   if (typeof TextDecoder !== 'undefined') {
     return new TextDecoder('utf-8').decode(bytes);
   }
-  const asciiString = bytesToString(/** @type{!Uint8Array} */(bytes));
+  const asciiString = bytesToString(new Uint8Array(bytes));
   return decodeURIComponent(escape(asciiString));
 }
 

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -16,7 +16,6 @@
 
 import {dev} from '../log';
 
-
 /**
  * Interpret a byte array as a UTF-8 string.
  * @param {!BufferSource} bytes
@@ -36,6 +35,21 @@ export function utf8Decode(bytes) {
     };
     reader.readAsText(new Blob([bytes]));
   });
+}
+
+// TODO(aghassemi, #6139): Remove the async version of utf8 encoding and rename
+// the sync versions to the canonical utf8Decode/utf8Encode.
+/**
+ * Interpret a byte array as a UTF-8 string.
+ * @param {!BufferSource} bytes
+ * @return {!string}
+ */
+export function utf8DecodeSync(bytes) {
+  if (typeof TextDecoder !== 'undefined') {
+    return new TextDecoder('utf-8').decode(bytes);
+  }
+  const binaryString = bytesToString(bytes);
+  return decodeURIComponent(escape(atob(binaryString)));
 }
 
 /**
@@ -59,6 +73,19 @@ export function utf8Encode(string) {
     };
     reader.readAsArrayBuffer(new Blob([string]));
   });
+}
+
+/**
+ * Turn a string into UTF-8 bytes.
+ * @param {string} string
+ * @return {!Uint8Array}
+ */
+export function utf8EncodeSync(string) {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder('utf-8').encode(string);
+  }
+
+  return btoa(unescape(encodeURIComponent(string)));
 }
 
 /**

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -48,8 +48,8 @@ export function utf8DecodeSync(bytes) {
   if (typeof TextDecoder !== 'undefined') {
     return new TextDecoder('utf-8').decode(bytes);
   }
-  const binaryString = bytesToString(bytes);
-  return decodeURIComponent(escape(atob(binaryString)));
+  const asciiString = bytesToString(/** @type{!Uint8Array} */(bytes));
+  return decodeURIComponent(escape(asciiString));
 }
 
 /**
@@ -84,8 +84,7 @@ export function utf8EncodeSync(string) {
   if (typeof TextEncoder !== 'undefined') {
     return new TextEncoder('utf-8').encode(string);
   }
-
-  return btoa(unescape(encodeURIComponent(string)));
+  return stringToBytes(unescape(encodeURIComponent(string)));
 }
 
 /**

--- a/test/functional/utils/test-base64.js
+++ b/test/functional/utils/test-base64.js
@@ -20,8 +20,46 @@ import {
   base64UrlEncodeFromBytes,
   base64EncodeFromBytes,
 } from '../../../src/utils/base64';
-import {stringToBytes} from '../../../src/utils/bytes';
+import {
+  stringToBytes,
+  utf8DecodeSync,
+  utf8EncodeSync,
+} from '../../../src/utils/bytes';
 
+describe('base64 <> utf-8 encode/decode', () => {
+  const testCases = [
+    'SimplyFoo',
+    'Unicode௵Z加䅌ਇ☎Èʘغޝ',
+    'Symbols/.,+-_()*&^%$#@!`~:="\'',
+  ];
+
+  describe('base64Encode/base64Decode', () => {
+    testCases.forEach(testCase => {
+      it(testCase, () => {
+        const utf8Bytes = utf8EncodeSync(testCase);
+        const encoded = base64EncodeFromBytes(utf8Bytes);
+        expect(encoded).not.to.equal(testCase);
+        const decodedUtf8Bytes = base64DecodeToBytes(encoded);
+        const decoded = utf8DecodeSync(decodedUtf8Bytes);
+        expect(decoded).to.equal(testCase);
+      });
+    });
+  });
+
+  describe('base64UrlEncode/base64UrlDecode', () => {
+    testCases.forEach(testCase => {
+      it(testCase, () => {
+        const utf8Bytes = utf8EncodeSync(testCase);
+        const encoded = base64UrlEncodeFromBytes(utf8Bytes);
+        expect(encoded).not.to.equal(testCase);
+        expect(encoded).not.to.match(/[+/=]/g);
+        const decodedUtf8Bytes = base64UrlDecodeToBytes(encoded);
+        const decoded = utf8DecodeSync(decodedUtf8Bytes);
+        expect(decoded).to.equal(testCase);
+      });
+    });
+  });
+});
 
 describe('base64UrlDecodeToBytes', () => {
   it('should map a sample string appropriately', () => {

--- a/test/functional/utils/test-base64.js
+++ b/test/functional/utils/test-base64.js
@@ -32,30 +32,55 @@ describe('base64 <> utf-8 encode/decode', () => {
     'Unicode௵Z加䅌ਇ☎Èʘغޝ',
     'Symbols/.,+-_()*&^%$#@!`~:="\'',
   ];
+  const scenarios = ['NativeTextEncoding', 'PolyfillTextEncoding', 'Mixed'];
 
-  describe('base64Encode/base64Decode', () => {
-    testCases.forEach(testCase => {
-      it(testCase, () => {
-        const utf8Bytes = utf8EncodeSync(testCase);
-        const encoded = base64EncodeFromBytes(utf8Bytes);
-        expect(encoded).not.to.equal(testCase);
-        const decodedUtf8Bytes = base64DecodeToBytes(encoded);
-        const decoded = utf8DecodeSync(decodedUtf8Bytes);
-        expect(decoded).to.equal(testCase);
+  scenarios.forEach(scenario => {
+    describe(scenario, () => {
+      const oldTextEncoder = window.TextEncoder;
+      const oldTextDecoder = window.TextDecoder;
+      beforeEach(() => {
+        // Forces use of the TextEncoding polyfill
+        if (scenario == 'PolyfillTextEncoding') {
+          window.TextEncoder = undefined;
+          window.TextDecoder = undefined;
+        }
+        // Tests a mixture where encoding is done by the polyfill but decoding
+        // is done by the native TextDecoder
+        if (scenario == 'Mixed') {
+          window.TextEncoder = undefined;
+        }
       });
-    });
-  });
 
-  describe('base64UrlEncode/base64UrlDecode', () => {
-    testCases.forEach(testCase => {
-      it(testCase, () => {
-        const utf8Bytes = utf8EncodeSync(testCase);
-        const encoded = base64UrlEncodeFromBytes(utf8Bytes);
-        expect(encoded).not.to.equal(testCase);
-        expect(encoded).not.to.match(/[+/=]/g);
-        const decodedUtf8Bytes = base64UrlDecodeToBytes(encoded);
-        const decoded = utf8DecodeSync(decodedUtf8Bytes);
-        expect(decoded).to.equal(testCase);
+      afterEach(() => {
+        window.TextEncoder = oldTextEncoder;
+        window.TextDecoder = oldTextDecoder;
+      });
+
+      describe('base64Encode/base64Decode', () => {
+        testCases.forEach(testCase => {
+          it(testCase, () => {
+            const utf8Bytes = utf8EncodeSync(testCase);
+            const encoded = base64EncodeFromBytes(utf8Bytes);
+            expect(encoded).not.to.equal(testCase);
+            const decodedUtf8Bytes = base64DecodeToBytes(encoded);
+            const decoded = utf8DecodeSync(decodedUtf8Bytes);
+            expect(decoded).to.equal(testCase);
+          });
+        });
+      });
+
+      describe('base64UrlEncode/base64UrlDecode', () => {
+        testCases.forEach(testCase => {
+          it(testCase, () => {
+            const utf8Bytes = utf8EncodeSync(testCase);
+            const encoded = base64UrlEncodeFromBytes(utf8Bytes);
+            expect(encoded).not.to.equal(testCase);
+            expect(encoded).not.to.match(/[+/=]/g);
+            const decodedUtf8Bytes = base64UrlDecodeToBytes(encoded);
+            const decoded = utf8DecodeSync(decodedUtf8Bytes);
+            expect(decoded).to.equal(testCase);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/6136
Related to: https://github.com/ampproject/amphtml/pull/6101

This refactoring removes any methods from `base64.js` that returned/expected "8-bit string representation of bytes". Now all methods in `base64.js` only deal with `Uint8Array`. 

The reasoning behind this decision is:
1- `base64Encode(str)` is misleading, it looks like `str` can be any JavaScript string (i.e. UTF-16) but in reality it expects a 8-bit string representation of `byte[]`. This confusion leads to bugs like: #6136
2- Trying to make the string-based base64Encode/Decode methods to assume UTF-8 is _arbitrary_. Base64 encoding and Text encoding are different concepts. Why would `base64Decode(str)` assume `str` is a base64 representation of a UTF-8 byte sequence? Why not assume UTF-16 or some other Text encoding?
3- Separating base64 encoding (which is dealing with uninterpreted bytes) from Text encoding (which is dealing with interpreted bytes) makes the API more understandable (Node.JS takes a similar approach and does not mix the two concepts)

This CL also provides an alternative polyfill to `TextEncoder` which can be done synchronously. For now we have both Sync and Async UTF decoders. https://github.com/ampproject/amphtml/issues/6139 to remove the async version.