### PR TITLE
Update A4A spec to use amp4ads-v0.js instead of v0.js

### DIFF
--- a/extensions/amp-a4a/amp-a4a-format.md
+++ b/extensions/amp-a4a/amp-a4a-format.md
@@ -49,10 +49,10 @@ access to a limited set of allowed tags, capabilities, and extensions.
    _Rationale_: Allows validators to identify a creative document as either a 
    general AMP doc or a restricted A4A doc and to dispatch appropriately.
 
-1. The creative must include `<script async src="https://cdn.ampproject.org/a4a-v0.js"></script>`
+1. The creative must include `<script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>`
    as the runtime script instead of `https://cdn.ampproject.org/v0.js`.
 
-   _Rationale_: Allows different runtime behaviors taylored to A4A.
+   _Rationale_: Allows tailored runtime behaviors for A4A served in cross-origin iframes.
 
 1. Unlike in general AMP, the creative must not include a `<link 
 rel="canonical">` tag.

--- a/extensions/amp-a4a/amp-a4a-format.md
+++ b/extensions/amp-a4a/amp-a4a-format.md
@@ -49,6 +49,11 @@ access to a limited set of allowed tags, capabilities, and extensions.
    _Rationale_: Allows validators to identify a creative document as either a 
    general AMP doc or a restricted A4A doc and to dispatch appropriately.
 
+1. The creative must include `<script async src="https://cdn.ampproject.org/a4a-v0.js"></script>`
+   as the runtime script instead of `https://cdn.ampproject.org/v0.js`.
+
+   _Rationale_: Allows different runtime behaviors taylored to A4A.
+
 1. Unlike in general AMP, the creative must not include a `<link 
 rel="canonical">` tag.
 


### PR DESCRIPTION
will wait till 
- the validator change gets in
- `amp4ads-v0.js` is released to production

For #5700