### PR TITLE
A4A and 3P safari tests fixes

### DIFF
--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -517,8 +517,9 @@ export class FetchResponse {
 
 /**
  * Provides access to the response headers as defined in the Fetch API.
+ * @private Visible for testing.
  */
-class FetchResponseHeaders {
+export class FetchResponseHeaders {
   /**
    * @param {!XMLHttpRequest|!XDomainRequest} xhr
    */
@@ -533,6 +534,14 @@ class FetchResponseHeaders {
    */
   get(name) {
     return this.xhr_.getResponseHeader(name);
+  }
+
+  /**
+   * @param {string} name
+   * @return {boolean}
+   */
+  has(name) {
+    return !!this.xhr_.getResponseHeader(name);
   }
 }
 

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -541,7 +541,7 @@ export class FetchResponseHeaders {
    * @return {boolean}
    */
   has(name) {
-    return !!this.xhr_.getResponseHeader(name);
+    return this.xhr_.getResponseHeader(name) != null;
   }
 }
 

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -180,7 +180,14 @@ describe('3p-frame', () => {
     const srcParts = src.split('#');
     expect(srcParts[0]).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
-    expect(JSON.parse(srcParts[1])).to.deep.equal(JSON.parse(fragment));
+    const expectedFragment = JSON.parse(srcParts[1]);
+    const parsedFragment = JSON.parse(fragment);
+    // Since DOM fingerprint changes between browsers and documents, to have
+    // stable tests, we can only verify its existence.
+    expect(expectedFragment._context.domFingerprint).to.exist;
+    delete expectedFragment._context.domFingerprint;
+    delete parsedFragment._context.domFingerprint;
+    expect(expectedFragment).to.deep.equal(parsedFragment);
 
     // Switch to same origin for inner tests.
     iframe.src = '/dist.3p/current/frame.max.html#' + fragment;


### PR DESCRIPTION
Also fixes a real bug: https://github.com/ampproject/amphtml/issues/6160 

1- Use `FetchResponseHeaders` (polyfill) instead of `Headers` (native) in testing
2- add `has()` to `FetchResponseHeaders` (root cause of #6160)

Only test in `extensions/amp-a4a/0.1/test/*.js` that still fails on Safari is `verifySignature  should not validate with wrong key`. Rest should be passing. Added https://github.com/ampproject/amphtml/issues/6162 for it.

/to @lannka 
/cc @ampproject/a4a 