### PR TITLE
fix example of submit-error on amp-form.md

### DIFF
--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -65,7 +65,7 @@ Example:
             Subscription successful!
         </template>
     </div>
-    <div submit-failed>
+    <div submit-error>
         <template type="amp-mustache">
             Subscription failed!
         </template>


### PR DESCRIPTION
🆖  `submit-failed`
🆗  `submit-error`
Is it old spec?:)

ref:
<https://ampbyexample.com/components/amp-form/>
<https://www.ampproject.org/docs/reference/components/amp-form#events>
