### PR TITLE
Fixing Safari tests across video-players

### DIFF
--- a/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
@@ -37,9 +37,7 @@ describe('amp-brid-player', () => {
       if (opt_responsive) {
         bc.setAttribute('layout', 'responsive');
       }
-      iframe.doc.body.appendChild(bc);
-      bc.implementation_.layoutCallback();
-      return bc;
+      return iframe.addElement(bc);
     });
   }
 

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -38,9 +38,7 @@ describe('amp-brightcove', () => {
       if (opt_responsive) {
         bc.setAttribute('layout', 'responsive');
       }
-      iframe.doc.body.appendChild(bc);
-      bc.implementation_.layoutCallback();
-      return bc;
+      return iframe.addElement(bc);
     });
   }
 

--- a/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
@@ -38,9 +38,7 @@ describe('amp-dailymotion', () => {
       if (optCustomSettings) {
         dailymotion.setAttribute('data-start', 123);
       }
-      iframe.doc.body.appendChild(dailymotion);
-      dailymotion.implementation_.layoutCallback();
-      return dailymotion;
+      return iframe.addElement(dailymotion);
     });
   }
 

--- a/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
@@ -38,9 +38,7 @@ describe('amp-gfycat', () => {
       if (opt_params && opt_params.noautoplay) {
         gfycat.setAttribute('noautoplay', '');
       }
-      iframe.doc.body.appendChild(gfycat);
-      gfycat.implementation_.layoutCallback();
-      return gfycat;
+      return iframe.addElement(gfycat);
     });
   }
 

--- a/extensions/amp-hulu/0.1/test/test-amp-hulu.js
+++ b/extensions/amp-hulu/0.1/test/test-amp-hulu.js
@@ -31,9 +31,7 @@ describe('amp-hulu', () => {
       if (opt_responsive) {
         hulu.setAttribute('layout', 'responsive');
       }
-      iframe.doc.body.appendChild(hulu);
-      hulu.implementation_.buildCallback();
-      return hulu;
+      return iframe.addElement(hulu);
     });
   }
 

--- a/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
@@ -36,9 +36,7 @@ describe('amp-kaltura-player', () => {
       if (opt_responsive) {
         kalturaPlayer.setAttribute('layout', 'responsive');
       }
-      iframe.doc.body.appendChild(kalturaPlayer);
-      kalturaPlayer.implementation_.layoutCallback();
-      return kalturaPlayer;
+      return iframe.addElement(kalturaPlayer);
     });
   }
 

--- a/extensions/amp-o2-player/0.1/amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/amp-o2-player.js
@@ -53,12 +53,12 @@ class AmpO2Player extends AMP.BaseElement {
   buildCallback() {
     this.pid_ = user().assert(
         this.element.getAttribute('data-pid'),
-        'Data-pid attribute is required for <amp-o2-player> %s',
+        'data-pid attribute is required for <amp-o2-player> %s',
         this.element);
 
     this.bcid_ = user().assert(
         this.element.getAttribute('data-bcid'),
-        'Data-bcid attribute is required for <amp-o2-player> %s',
+        'data-bcid attribute is required for <amp-o2-player> %s',
         this.element);
 
     const bid = this.element.getAttribute('data-bid');

--- a/extensions/amp-o2-player/0.1/amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/amp-o2-player.js
@@ -91,11 +91,11 @@ class AmpO2Player extends AMP.BaseElement {
   layoutCallback() {
     user().assert(
         this.pid_,
-        'Data-pid attribute is required for <amp-o2-player> %s',
+        'data-pid attribute is required for <amp-o2-player> %s',
         this.element);
     user().assert(
         this.bcid_,
-        'Data-bcid attribute is required for <amp-o2-player> %s',
+        'data-bcid attribute is required for <amp-o2-player> %s',
         this.element);
 
     const iframe = this.element.ownerDocument.createElement('iframe');

--- a/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
@@ -37,9 +37,7 @@ describe('amp-o2-player', () => {
       if (opt_responsive) {
         o2.setAttribute('layout', 'responsive');
       }
-      iframe.doc.body.appendChild(o2);
-      o2.implementation_.layoutCallback();
-      return o2;
+      return iframe.addElement(o2);
     });
   }
 

--- a/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
@@ -69,19 +69,19 @@ describe('amp-o2-player', () => {
     return getO2player({
       'data-bcid': '50d595ec0364e95588c77bd2',
     }).should.eventually.be.rejectedWith(
-        /Data-pid attribute is required for/);
+        /data-pid attribute is required for/);
   });
 
   it('requires data-bcid', () => {
     return getO2player({
       'data-pid': '573acb47e4b0564ec2e10011',
     }).should.eventually.be.rejectedWith(
-        /Data-bcid attribute is required for/);
+        /data-bcid attribute is required for/);
   });
 
   it('requires data-pid && data-bcid', () => {
     return getO2player({}).should.eventually.be.rejectedWith(
-        /Data-pid attribute is required for/);
+        /data-pid attribute is required for/);
   });
 
   it('renders with data-vid passed', () => {

--- a/extensions/amp-reach-player/0.1/test/test-amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/test/test-amp-reach-player.js
@@ -37,9 +37,7 @@ describe('amp-reach-player', () => {
       if (opt_responsive) {
         reach.setAttribute('layout', 'responsive');
       }
-      iframe.doc.body.appendChild(reach);
-      reach.implementation_.layoutCallback();
-      return reach;
+      return iframe.addElement(reach);
     });
   }
 

--- a/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
@@ -28,16 +28,14 @@ describe('amp-springboard-player', () => {
   function getSpringboardPlayer(attributes) {
     return createIframePromise().then(iframe => {
       doNotLoadExternalResourcesInTest(iframe.win);
-      const bc = iframe.doc.createElement('amp-springboard-player');
+      const sp = iframe.doc.createElement('amp-springboard-player');
       for (const key in attributes) {
-        bc.setAttribute(key, attributes[key]);
+        sp.setAttribute(key, attributes[key]);
       }
-      bc.setAttribute('width', '480');
-      bc.setAttribute('height', '270');
-      bc.setAttribute('layout', 'responsive');
-      iframe.doc.body.appendChild(bc);
-      bc.implementation_.layoutCallback();
-      return bc;
+      sp.setAttribute('width', '480');
+      sp.setAttribute('height', '270');
+      sp.setAttribute('layout', 'responsive');
+      return iframe.addElement(sp);
     });
   }
 
@@ -66,7 +64,7 @@ describe('amp-springboard-player', () => {
       'data-player-id': 'test401',
       'data-domain': 'test.com',
       'data-items': '10',
-    }, true).then(bc => {
+    }).then(bc => {
       const iframe = bc.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.className).to.match(/-amp-fill-content/);
@@ -74,8 +72,58 @@ describe('amp-springboard-player', () => {
   });
 
   it('requires data-site-id', () => {
-    return getSpringboardPlayer({}).should.eventually.be
+    return getSpringboardPlayer({
+      'data-mode': 'video',
+      'data-content-id': '1578473',
+      'data-player-id': 'test401',
+      'data-domain': 'test.com',
+      'data-items': '10',
+    }).should.eventually.be
         .rejectedWith(/The data-site-id attribute is required for/);
+  });
+
+  it('requires data-mode', () => {
+    return getSpringboardPlayer({
+      'data-site-id': '261',
+      'data-content-id': '1578473',
+      'data-player-id': 'test401',
+      'data-domain': 'test.com',
+      'data-items': '10',
+    }).should.eventually.be
+        .rejectedWith(/The data-mode attribute is required for/);
+  });
+
+  it('requires data-content-id', () => {
+    return getSpringboardPlayer({
+      'data-mode': 'video',
+      'data-site-id': '261',
+      'data-player-id': 'test401',
+      'data-domain': 'test.com',
+      'data-items': '10',
+    }).should.eventually.be
+        .rejectedWith(/The data-content-id attribute is required for/);
+  });
+
+  it('requires data-player-id', () => {
+    return getSpringboardPlayer({
+      'data-mode': 'video',
+      'data-site-id': '261',
+      'data-content-id': '1578473',
+      'data-domain': 'test.com',
+      'data-items': '10',
+    }).should.eventually.be
+        .rejectedWith(/The data-player-id attribute is required for/);
+  });
+
+  it('requires data-domain', () => {
+    return getSpringboardPlayer({
+      'data-mode': 'video',
+      'data-site-id': '261',
+      'data-content-id': '1578473',
+      'data-player-id': 'test401',
+      'data-items': '10',
+    }).should.eventually.be
+        .rejectedWith(/The data-domain attribute is required for/);
   });
 
   describe('createPlaceholderCallback', () => {

--- a/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
@@ -35,9 +35,7 @@ describe('amp-vimeo', () => {
       if (opt_responsive) {
         vimeo.setAttribute('layout', 'responsive');
       }
-      iframe.doc.body.appendChild(vimeo);
-      vimeo.implementation_.layoutCallback();
-      return vimeo;
+      return iframe.addElement(vimeo);
     });
   }
 

--- a/extensions/amp-vine/0.1/test/test-amp-vine.js
+++ b/extensions/amp-vine/0.1/test/test-amp-vine.js
@@ -34,9 +34,7 @@ describe('amp-vine', () => {
       if (opt_responsive) {
         vine.setAttribute('layout', 'responsive');
       }
-      iframe.doc.body.appendChild(vine);
-      vine.implementation_.layoutCallback();
-      return vine;
+      return iframe.addElement(vine);
     });
   }
 


### PR DESCRIPTION
Partial for #6039 

The pattern used for these tests (e.g. `appendChild(); layoutCallback();`) assumes `buildCallback` is called synchronously at append time, which is only the case when custom-elements can be upgraded synchronously at append time. In Safari, custom-elements may be upgraded asynchrnously which means we ran into cases where `layoutCallback` was called before `buildCallback`. I am switching these tests to just use `iframe.addElement` which handles all these cases properly (by calling `build` manually)