### PR TITLE
Use relative URL for the analytics ping URL in inabox example.

### DIFF
--- a/examples/inabox.amp.html
+++ b/examples/inabox.amp.html
@@ -19,7 +19,7 @@
       {
         "transport": {"beacon": false, "xhrpost": false},
         "requests": {
-          "visibility": "http://localhost:8000/?${type}&${elementY}"
+          "visibility": "/ping?${type}&${elementY}"
         },
         "triggers": {
           "pageVisible": {


### PR DESCRIPTION
To prevent console error when served in HTTPS mode.