### PR TITLE
Rename a4a-v0.js to amp4ads-v0.js

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -501,14 +501,14 @@ function replaceUrls(mode, file) {
     file = file.replace('https://cdn.ampproject.org/viewer/google/v5.js', 'https://cdn1.ampproject.org/viewer/google/v5.js');
     file = file.replace(/(https:\/\/cdn.ampproject.org\/.+?).js/g, '$1.max.js');
     file = file.replace('https://cdn.ampproject.org/v0.max.js', '/dist/amp.js');
-    file = file.replace('https://cdn.ampproject.org/a4a-v0.max.js', '/dist/amp-inabox.js');
+    file = file.replace('https://cdn.ampproject.org/amp4ads-v0.max.js', '/dist/amp-inabox.js');
     file = file.replace(/https:\/\/cdn.ampproject.org\/v0\//g, '/dist/v0/');
     file = file.replace('https://cdn1.ampproject.org/viewer/google/v5.js', 'https://cdn.ampproject.org/viewer/google/v5.js');
   }
   if (mode == 'min') {
     file = file.replace(/\.max\.js/g, '.js');
     file = file.replace('/dist/amp.js', '/dist/v0.js');
-    file = file.replace('/dist/amp-inabox.js', '/dist/a4a-v0.js');
+    file = file.replace('/dist/amp-inabox.js', '/dist/amp4ads-v0.js');
   }
   return file;
 }

--- a/build-system/tasks/size.js
+++ b/build-system/tasks/size.js
@@ -103,9 +103,9 @@ function normalizeRows(rows) {
   // normalize amp-shadow.js
   normalizeRow(rows, 'shadow-v0.js', 'amp-shadow.js', true);
 
-  normalizeRow(rows, 'a4a-v0.js', 'amp-inabox.js', true);
+  normalizeRow(rows, 'amp4ads-v0.js', 'amp-inabox.js', true);
 
-  normalizeRow(rows, 'a4a-host-v0.js', 'amp-inabox-host.js', true);
+  normalizeRow(rows, 'amp4ads-host-v0.js', 'amp-inabox-host.js', true);
 
   // normalize sw.js
   normalizeRow(rows, 'sw.js', 'sw.max.js', true);

--- a/examples/inabox.amp.html
+++ b/examples/inabox.amp.html
@@ -5,7 +5,7 @@
   <link rel="canonical" href="http://nonblocking.io/" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="https://cdn.ampproject.org/a4a-v0.js"></script>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 </head>
 <body>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -209,7 +209,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
   // Entry point for inabox runtime.
   compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
     toName: 'amp-inabox.js',
-    minifiedName: 'a4a-v0.js',
+    minifiedName: 'amp4ads-v0.js',
     includePolyfills: true,
     checkTypes: opt_checkTypes,
     watch: watch,
@@ -221,7 +221,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
   // inabox-host
   compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
     toName: 'amp-inabox-host.js',
-    minifiedName: 'a4a-host-v0.js',
+    minifiedName: 'amp4ads-host-v0.js',
     includePolyfills: false,
     checkTypes: opt_checkTypes,
     watch: watch,


### PR DESCRIPTION
As suggested by @Gregable, this is to be consistent with the `<html amp4ads>` tag.