### PR TITLE
Skeleton of <amp-auto-ads> implementation

### DIFF
--- a/examples/auto-ads.amp.html
+++ b/examples/auto-ads.amp.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>AMP #0</title>
+    <link rel="canonical" href="amps.html" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script async custom-element="amp-auto-ads" src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"></script>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <style>
+
+      body {
+        font-family: Arial;  
+      }
+
+      header {
+        margin-bottom: 15px;  
+      }
+
+      h1 {
+        width: 80%;
+        margin: 0px auto;
+        font-size: 40px;
+        color: #000;
+        text-align: center;
+        font-weight: normal;
+      }
+
+      .main-content p {
+        margin: 20px 30px;
+        font-size: 14px;
+      }
+
+      .main-content amp-img {
+         margin: 20px 0px;  
+      }
+
+      #footer {
+        width: 100%;
+        height: 30px;
+        background-color: #ababab;
+        font-size: 12px;
+        color: #fff;
+        text-align: center;
+        line-height: 30px; 
+      }
+
+    </style>
+  </head>
+  <body>
+    <amp-auto-ads type="adsense" data-ad-client="ca-pub-2005682797531342"></amp-auto-ads>
+    <header>
+      <amp-img layout="responsive" id="header-img" src="img/hero@2x.jpg" width="1200" height="900"></amp-img>
+    </header>
+    <h1>Title of Page</h1>
+    <div class="main-content">
+      <p>
+        Lorem ipsum dolor sit amet, has te dico epicuri, ad sumo constituam cum. Vix rebum partem graecis in, id legimus lobortis expetendis per. Zril tritani principes has in. Sea ei exerci ridens vituperatoribus. Id inermis invenire mei, ei iudico epicuri mea. Ad eos debet perfecto volutpat, suas error usu ut, est everti comprehensam no.
+      </p>
+      <p>
+        Dolor numquam consulatu ne cum, ei sed essent appellantur, eam et appetere partiendo. Vim mucius vituperatoribus ut. Consul virtute eum id, has no postulant dissentiet. Errem tibique copiosae ut has, ut labore nemore assentior per.
+      </p>
+      <p>
+        Essent signiferumque necessitatibus in mea. Sit minim petentium dissentiunt ei, ius inimicus mnesarchum ut. Errem maiestatis cu nec, dolor nusquam interesset ut qui. Mea in eripuit blandit complectitur. An eos recteque adversarium.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, has te dico epicuri, ad sumo constituam cum. Vix rebum partem graecis in, id legimus lobortis expetendis per. Zril tritani principes has in. Sea ei exerci ridens vituperatoribus. Id inermis invenire mei, ei iudico epicuri mea. Ad eos debet perfecto volutpat, suas error usu ut, est everti comprehensam no.
+      </p>
+      <p>
+        Dolor numquam consulatu ne cum, ei sed essent appellantur, eam et appetere partiendo. Vim mucius vituperatoribus ut. Consul virtute eum id, has no postulant dissentiet. Errem tibique copiosae ut has, ut labore nemore assentior per.
+      </p>
+    </div>
+    <div id="footer">Powered by AMP</div>
+  </body>
+</html>

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {dev, user} from '../../../src/log';
+import {xhrFor} from '../../../src/xhr';
+import {getConfigUrl} from './config-url';
+import {isExperimentOn} from '../../../src/experiments';
+
+/** @const */
+const TAG = 'amp-auto-ads';
+
+export class AmpAutoAds extends AMP.BaseElement {
+
+  /** @override */
+  buildCallback() {
+    user().assert(isExperimentOn(self, 'amp-auto-ads'), 'Experiment is off');
+
+    const type = this.element.getAttribute('type');
+    user().assert(type, 'Missing type attribute');
+
+    const configUrl = getConfigUrl(type, this.element);
+    if (!configUrl) {
+      return;
+    }
+    this.getConfig_(configUrl).then(() => {
+      // TODO: Use the configuration to place ads.
+    });
+  }
+
+  /** @override */
+  isLayoutSupported() {
+    return true;
+  }
+
+  /**
+   * Tries to load an auto-ads configuration from the given URL.
+   * @param {string} configUrl
+   * @return {!Promise<?JSONType>}
+   * @private
+   */
+  getConfig_(configUrl) {
+    const xhrInit = {
+      mode: 'cors',
+      method: 'GET',
+      requireAmpResponseSourceOrigin: false,
+    };
+    return xhrFor(this.win)
+        .fetchJson(configUrl, xhrInit)
+        .catch(reason => {
+          dev().error(TAG, 'amp-auto-ads config xhr failed: ' + reason);
+          return null;
+        });
+  }
+}
+
+AMP.registerElement('amp-auto-ads', AmpAutoAds);

--- a/extensions/amp-auto-ads/0.1/config-url.js
+++ b/extensions/amp-auto-ads/0.1/config-url.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {buildUrl} from '../../../ads/google/a4a/url-builder';
+import {user} from '../../../src/log';
+
+/** @const */
+const TAG = 'amp-auto-ads';
+
+/**
+ * Builds and returns a URL that can be used to fetch the auto-ads configuration
+ * for the given type.
+ * @param {string} type
+ * @param {!Element} autoAmpAdsElement
+ * @return {?string}
+ */
+export function getConfigUrl(type, autoAmpAdsElement) {
+  if (type == 'adsense') {
+    return getAdSenseConfigUrl(autoAmpAdsElement);
+  }
+  user().error(TAG,
+      'Unable to generate amp-auto-ads config URL for type: ' + type);
+  return null;
+}
+
+/**
+ * @param {!Element} autoAmpAdsElement
+ * @return {string}
+ */
+function getAdSenseConfigUrl(autoAmpAdsElement) {
+  return buildUrl('//pagead2.googlesyndication.com/getconfig/ama', [
+    {name: 'client', value: autoAmpAdsElement.getAttribute('data-ad-client')},
+    {name: 'plah', value: autoAmpAdsElement.ownerDocument.location.hostname},
+  ], 4096);
+}

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpAutoAds} from '../amp-auto-ads';
+import {toggleExperiment} from '../../../../src/experiments';
+import {xhrFor} from '../../../../src/xhr';
+import * as sinon from 'sinon';
+
+describe('amp-auto-ads', () => {
+
+  const AD_CLIENT = 'ca-pub-1234';
+
+  let sandbox;
+  let ampAutoAds;
+  let ampAutoAdsElem;
+  let xhr;
+
+  beforeEach(() => {
+    toggleExperiment(window, 'amp-auto-ads', true);
+    sandbox = sinon.sandbox.create();
+    ampAutoAdsElem = document.createElement('amp-auto-ads');
+    document.body.appendChild(ampAutoAdsElem);
+
+    xhr = xhrFor(window);
+    xhr.fetchJson = () => {
+      return Promise.resolve({
+        'testKey': 'testValue',
+      });
+    };
+    sandbox.spy(xhr, 'fetchJson');
+
+    ampAutoAds = new AmpAutoAds(ampAutoAdsElem);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    document.body.removeChild(ampAutoAdsElem);
+  });
+
+  it('should fetch a config from the correct URL', () => {
+    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+    ampAutoAdsElem.setAttribute('type', 'adsense');
+    ampAutoAds.buildCallback();
+
+    const hostname = window.location.hostname;
+    expect(xhr.fetchJson).to.have.been.calledWith(
+        '//pagead2.googlesyndication.com/getconfig/ama?client=' +
+        AD_CLIENT + '&plah=' + hostname, {
+          mode: 'cors',
+          method: 'GET',
+          requireAmpResponseSourceOrigin: false,
+        });
+    expect(xhr.fetchJson).to.be.calledOnce;
+  });
+
+  it('should throw an error if no type', () => {
+    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+    expect(() => ampAutoAds.buildCallback())
+        .to.throw(/Missing type attribute​​/);
+    expect(xhr.fetchJson).not.to.have.been.called;
+  });
+
+  it('should not try and fetch config if unknown type', () => {
+    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+    ampAutoAdsElem.setAttribute('type', 'unknowntype');
+    ampAutoAds.buildCallback();
+
+    expect(xhr.fetchJson).not.to.have.been.called;
+  });
+
+  it('should not try and fetch config if experiment off', () => {
+    toggleExperiment(window, 'amp-auto-ads', false);
+    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+    ampAutoAdsElem.setAttribute('type', 'adsense');
+
+    expect(() => ampAutoAds.buildCallback())
+        .to.throw(/Experiment is off​​​/);
+    expect(xhr.fetchJson).not.to.have.been.called;
+  });
+});

--- a/extensions/amp-auto-ads/0.1/test/test-config-url.js
+++ b/extensions/amp-auto-ads/0.1/test/test-config-url.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getConfigUrl} from '../config-url';
+
+describe('amp-auto-ads', () => {
+
+  let ampAutoAdsElem;
+
+  beforeEach(() => {
+    ampAutoAdsElem = document.createElement('amp-auto-ads');
+  });
+
+  it('should generate the config fetch URL for type=adsense', () => {
+    const AD_CLIENT = 'ca-pub-1234';
+    ampAutoAdsElem.setAttribute('data-ad-client', 'ca-pub-1234');
+    const hostname = window.location.hostname;
+    expect(getConfigUrl('adsense', ampAutoAdsElem)).to.equal(
+        '//pagead2.googlesyndication.com/getconfig/ama?client=' +
+        AD_CLIENT + '&plah=' + hostname);
+  });
+
+  it('should return null for unknown type', () => {
+    expect(getConfigUrl('unknowntype', ampAutoAdsElem)).to.be.null;
+  });
+});

--- a/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
+++ b/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
@@ -1,0 +1,53 @@
+#
+# Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+
+tags: {  # amp-auto-ads
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amp-auto-ads extension .js script"
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "async"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "custom-element"
+    mandatory: true
+    value: "amp-auto-ads"
+    dispatch_key: true
+  }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_regex: "https://cdn\\.ampproject\\.org/v0/amp-auto-ads-(latest|0\\.1).js"
+  }
+  attrs: {
+    name: "type"
+    value_casei: "text/javascript"
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "."
+      error_message: "contents"
+    }
+  }
+}
+tags: {  # <amp-auto-ads>
+  html_format: AMP
+  tag_name: "AMP-AUTO-ADS"
+  attrs: { name: "type" mandatory: true }
+  attr_lists: "extended-amp-global"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,6 +58,7 @@ declareExtension('amp-animation', '0.1', false);
 declareExtension('amp-apester-media', '0.1', true, 'NO_TYPE_CHECK');
 declareExtension('amp-app-banner', '0.1', true);
 declareExtension('amp-audio', '0.1', false);
+declareExtension('amp-auto-ads', '0.1', false);
 declareExtension('amp-brid-player', '0.1', false);
 declareExtension('amp-brightcove', '0.1', false);
 declareExtension('amp-kaltura-player', '0.1', false);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -92,6 +92,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/4226',
   },
   {
+    id: 'amp-auto-ads',
+    name: 'AMP Auto Ads',
+    spec: 'https://github.com/ampproject/amphtml/issues/6196',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6217',
+  },
+  {
     id: 'amp-inabox',
     name: 'AMP inabox',
     spec: 'https://github.com/ampproject/amphtml/issues/5700',


### PR DESCRIPTION
Initial skeleton implementation of `<amp-auto-ads>.` This interprets the attributes in the tag and fires an XHR request to fetch the configuration. Nothing is yet done with the configuration.

https://github.com/ampproject/amphtml/issues/6196