### PR TITLE
Change layout CSS class to -amp-layout-fixed after element resize.

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -813,6 +813,19 @@ function createBaseCustomElementClass(win) {
       if (newWidth !== undefined) {
         setStyle(this, 'width', newWidth, 'px');
       }
+
+      let newLayout = this.layout_;
+      if (newHeight !== undefined) {
+        newLayout = Layout.FIXED_HEIGHT;
+        if (newWidth !== undefined) {
+          newLayout = Layout.FIXED;
+        }
+      }
+
+      if (newLayout != this.layout_) {
+        this.classList.remove(getLayoutClass(this.layout_));
+        this.classList.add(getLayoutClass(newLayout));
+      }
     }
 
     /**


### PR DESCRIPTION
Fixes #6166

Tests to be added. Let me know if this makes sense.

Open question is if we want to change `this.layout_` to the new value as well.