### PR TITLE
Fix amp-iframe doc description about intersection observer

### DIFF
--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -157,19 +157,19 @@ window.parent.postMessage({
 
 ## Iframe viewability
 
-Iframes can send a  `send-intersection` message to its parent to start receiving IntersectionObserver style [change records](http://rawgit.com/slightlyoff/IntersectionObserver/master/index.html#intersectionobserverentry) of the iframe's intersection with the parent viewport.
+Iframes can send a  `send-intersections` message to its parent to start receiving IntersectionObserver style [change records](http://rawgit.com/slightlyoff/IntersectionObserver/master/index.html#intersectionobserverentry) of the iframe's intersection with the parent viewport.
 
-Example of iframe `send-intersection` request:
+Example of iframe `send-intersections` request:
 ```javascript
 window.parent.postMessage({
   sentinel: 'amp',
-  type: 'send-intersection'
+  type: 'send-intersections'
 }, '*');
 ```
 
 The iframe can listen to an `intersection` message from the parent window to receive the intersection data.
 
-Example of iframe `send-intersection` request:
+Example of iframe `send-intersections` request:
 ```javascript
 window.addEventListener('message', function(event) {
   const listener = function(event) {

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -113,7 +113,7 @@ export function getIntersectionChangeEntry(element, owner, viewport) {
  * The IntersectionObserver class lets any element share its viewport
  * intersection data with an iframe of its choice (most likely contained within
  * the element itself.). When instantiated the class will start listening for
- * a 'send-intersection' postMessage from the iframe, and only then  would start
+ * a 'send-intersections' postMessage from the iframe, and only then  would start
  * sending intersection data to the iframe. The intersection data would be sent
  * when the element is moved inside or outside the viewport as well as on
  * scroll and resize.


### PR DESCRIPTION
The issue is we declare `send-intersection` in amp-iframe.md, but we are actually listening to `send-intersections`.
Basically there're two ways to fix this. Change source code or change doc.
The reason I choose to change doc is: if people really need this feature, they should already have figured out the difference. I don't want to break their existing pages. 
