### PR TITLE
Migrate activity to doc-scope and fix instrumentation resolution

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -22,6 +22,7 @@
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>
 </head>
 <body>
 

--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -22,7 +22,6 @@
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async src="./viewer-integr.js" data-amp-report-test="viewer-integr.js"></script>
 </head>
 <body>
 

--- a/examples/pwa/pwa.html
+++ b/examples/pwa/pwa.html
@@ -92,6 +92,12 @@
           <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
         </a>
       </article>
+      <article class="card">
+        <a href="/pwa/examples/analytics.amp.max.html">
+          <h4>Analytics</h4>
+          <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
+        </a>
+      </article>
     </section>
 
     <div id="doc-container" class="doc-container">

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -19,7 +19,6 @@
  * has performed on the page.
  */
 
-import {fromClass} from '../../../src/service';
 import {viewerForDoc} from '../../../src/viewer';
 import {viewportForDoc} from '../../../src/viewport';
 import {listen} from '../../../src/event-helper';
@@ -139,11 +138,11 @@ export class Activity {
    *  - At any point after instantiation, `getTotalEngagedTime` can be used
    *    to get the engage time up to the time the function is called. If
    *    `whenFirstVisible` has not yet resolved, engaged time is 0.
-   * @param {!Window} win
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
-  constructor(win) {
-    /** @private @const */
-    this.win_ = win;
+  constructor(ampdoc) {
+    /** @const {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
+    this.ampdoc = ampdoc;
 
     /** @private @const {function()} */
     this.boundStopIgnore_ = this.stopIgnore_.bind(this);
@@ -170,10 +169,10 @@ export class Activity {
     this.activityHistory_ = new ActivityHistory();
 
     /** @private @const {!../../../src/service/viewer-impl.Viewer} */
-    this.viewer_ = viewerForDoc(this.win_.document);
+    this.viewer_ = viewerForDoc(this.ampdoc);
 
     /** @private @const {!../../../src/service/viewport-impl.Viewport} */
-    this.viewport_ = viewportForDoc(this.win_.document);
+    this.viewport_ = viewportForDoc(this.ampdoc);
 
     this.viewer_.whenFirstVisible().then(this.start_.bind(this));
   }
@@ -209,7 +208,7 @@ export class Activity {
   /** @private */
   setUpActivityListeners_() {
     for (let i = 0; i < ACTIVE_EVENT_TYPES.length; i++) {
-      this.unlistenFuncs_.push(listen(this.win_.document,
+      this.unlistenFuncs_.push(listen(this.ampdoc.getRootNode(),
         ACTIVE_EVENT_TYPES[i], this.boundHandleActivity_));
     }
 
@@ -300,13 +299,4 @@ export class Activity {
     const secondsSinceStart = Math.floor(this.getTimeSinceStart_() / 1000);
     return this.activityHistory_.getTotalEngagedTime(secondsSinceStart);
   }
-};
-
-
-/**
- * @param  {!Window} win
- * @return {!Activity}
- */
-export function installActivityService(win) {
-  return fromClass(win, 'activity', Activity);
 };

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -127,12 +127,12 @@ export class AmpAnalytics extends AMP.BaseElement {
     // resource consumption.
     toggle(this.element, false);
 
-    return instrumentationServiceForDoc(this.getAmpDoc())
+    return this.consentPromise_
+        .then(this.fetchRemoteConfig_.bind(this))
+        .then(() => instrumentationServiceForDoc(this.getAmpDoc()))
         .then(instrumentation => {
           this.instrumentation_ = instrumentation;
         })
-        .then(() => this.consentPromise_)
-        .then(this.fetchRemoteConfig_.bind(this))
         .then(this.onFetchRemoteConfigSuccess_.bind(this));
   }
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -262,7 +262,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       fetchConfig.credentials = this.element.getAttribute('data-credentials');
     }
     const ampdoc = this.getAmpDoc();
-    return urlReplacementsForDoc(ampdoc).expandAsync(remoteConfigUrl)
+    return urlReplacementsForDoc(this.element).expandAsync(remoteConfigUrl)
         .then(expandedUrl => {
           remoteConfigUrl = expandedUrl;
           return xhrFor(ampdoc.win).fetchJson(remoteConfigUrl, fetchConfig);
@@ -438,7 +438,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     request = this.expandTemplate_(request, trigger, event);
 
     // For consistency with amp-pixel we also expand any url replacements.
-    return urlReplacementsForDoc(this.getAmpDoc()).expandAsync(request)
+    return urlReplacementsForDoc(this.element).expandAsync(request)
         .then(request => {
           this.sendRequest_(request, trigger);
           return request;
@@ -466,7 +466,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     const threshold = parseFloat(spec['threshold']); // Threshold can be NaN.
     if (threshold >= 0 && threshold <= 100) {
       const key = this.expandTemplate_(spec['sampleOn'], trigger);
-      const keyPromise = urlReplacementsForDoc(this.getAmpDoc())
+      const keyPromise = urlReplacementsForDoc(this.element)
           .expandAsync(key);
       const cryptoPromise = cryptoFor(this.win);
       return Promise.all([keyPromise, cryptoPromise])

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -17,7 +17,7 @@
 import {dev, user} from '../../../src/log';
 import {getElement, isVisibilitySpecValid} from './visibility-impl';
 import {Observable} from '../../../src/observable';
-import {getElementServiceForDoc} from '../../../src/element-service';
+import {getServicePromiseForDoc} from '../../../src/service';
 import {timerFor} from '../../../src/timer';
 import {viewerForDoc} from '../../../src/viewer';
 import {viewportForDoc} from '../../../src/viewport';
@@ -528,6 +528,5 @@ export class InstrumentationService {
  */
 export function instrumentationServiceForDoc(nodeOrDoc) {
   return /** @type {!Promise<InstrumentationService>} */ (
-      getElementServiceForDoc(
-          nodeOrDoc, 'amp-analytics-instrumentation', 'amp-analytics'));
+      getServicePromiseForDoc(nodeOrDoc, 'amp-analytics-instrumentation'));
 }

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -17,7 +17,7 @@
 import {dev, user} from '../../../src/log';
 import {getElement, isVisibilitySpecValid} from './visibility-impl';
 import {Observable} from '../../../src/observable';
-import {getExistingServiceForDoc} from '../../../src/service';
+import {getElementServiceForDoc} from '../../../src/element-service';
 import {timerFor} from '../../../src/timer';
 import {viewerForDoc} from '../../../src/viewer';
 import {viewportForDoc} from '../../../src/viewport';
@@ -519,10 +519,15 @@ export class InstrumentationService {
 }
 
 /**
+ * It's important to resolve instrumentation asynchronously in elements that depends on
+ * it in multi-doc scope. Otherwise an element life-cycle could resolve way before we
+ * have the service available.
+ *
  * @param {!Node|!../../../src/service/ampdoc-impl.AmpDoc} nodeOrDoc
- * @return {!InstrumentationService}
+ * @return {!Promise<InstrumentationService>}
  */
 export function instrumentationServiceForDoc(nodeOrDoc) {
-  return /** @type {!InstrumentationService} */ (getExistingServiceForDoc(
-      nodeOrDoc, 'amp-analytics-instrumentation'));
+  return /** @type {!Promise<InstrumentationService>} */ (
+      getElementServiceForDoc(
+          nodeOrDoc, 'amp-analytics-instrumentation', 'amp-analytics'));
 }

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -17,10 +17,7 @@
 import {ANALYTICS_CONFIG} from '../vendors';
 import {AmpAnalytics} from '../amp-analytics';
 import {Crypto} from '../crypto-impl';
-import {
-  InstrumentationService,
-  instrumentationServiceForDoc,
-} from '../instrumentation';
+import {InstrumentationService} from '../instrumentation';
 import {
   installUserNotificationManager,
 } from '../../../amp-user-notification/0.1/amp-user-notification';

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -54,6 +54,7 @@ describe('amp-analytics', function() {
   let uidService;
   let crypto;
   let ampdoc;
+  let ins;
 
   const jsonMockResponses = {
     'config1': '{"vars": {"title": "remote"}}',
@@ -99,7 +100,7 @@ describe('amp-analytics', function() {
       windowApi = iframe.win;
       ampdoc = new AmpDocSingle(windowApi);
 
-      fromClassForDoc(
+      ins = fromClassForDoc(
           ampdoc, 'amp-analytics-instrumentation', InstrumentationService);
     });
   });
@@ -494,7 +495,6 @@ describe('amp-analytics', function() {
   it('expands element level vars with higher precedence than trigger vars',
     () => {
       const analytics = getAnalyticsTag();
-      const ins = instrumentationServiceForDoc(ampdoc);
       sandbox.stub(ins, 'isTriggerAllowed_').returns(true);
       const el1 = windowApi.document.createElement('div');
       el1.className = 'x';
@@ -624,7 +624,6 @@ describe('amp-analytics', function() {
   });
 
   it('expands selector with config variable', () => {
-    const ins = instrumentationServiceForDoc(ampdoc);
     const addListenerSpy = sandbox.spy(ins, 'addListener');
     const analytics = getAnalyticsTag({
       requests: {foo: 'https://example.com/bar'},
@@ -639,7 +638,6 @@ describe('amp-analytics', function() {
 
   function selectorExpansionTest(selector) {
     it('expand selector value: ' + selector, () => {
-      const ins = instrumentationServiceForDoc(ampdoc);
       const addListenerSpy = sandbox.spy(ins, 'addListener');
       const analytics = getAnalyticsTag({
         requests: {foo: 'https://example.com/bar'},
@@ -661,7 +659,6 @@ describe('amp-analytics', function() {
         .map(selectorExpansionTest);
 
   it('does not expands selector with platform variable', () => {
-    const ins = instrumentationServiceForDoc(ampdoc);
     const addListenerSpy = sandbox.spy(ins, 'addListener');
     const analytics = getAnalyticsTag({
       requests: {foo: 'https://example.com/bar'},

--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -438,9 +438,9 @@ describe('amp-analytics.visibility', () => {
           .to.equal(div);
       expect(getElement(ampdoc, 'amp-img', analytics, 'closest'))
           .to.equal(img1);
-      // Should restrict elements to contained ampdoc.
       expect(getElement(ampdoc, 'amp-img', iframeAnalytics, 'closest'))
-          .to.equal(null);
+          .to.equal(iframe.contentDocument.querySelector('amp-img'));
+      // Should restrict elements to contained ampdoc.
       expect(getElement(iframeAmpDoc, 'amp-img', analytics, 'closest'))
           .to.equal(null);
     });

--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -30,6 +30,7 @@ import {viewportForDoc} from '../../../../src/viewport';
 import {loadPromise} from '../../../../src/event-helper';
 
 import * as sinon from 'sinon';
+import {setParentWindow} from '../../../../src/service';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {installTimerService} from '../../../../src/service/timer-impl';
 import {installPlatformService} from '../../../../src/service/platform-impl';
@@ -417,6 +418,7 @@ describe('amp-analytics.visibility', () => {
       ampEl.appendChild(iframe);
       iframeAmpDoc = new AmpDocSingle(iframe.contentWindow);
       return loaded.then(() => {
+        setParentWindow(iframe.contentWindow, window);
         iframeAnalytics = iframe.contentDocument.querySelector(
             'amp-analytics');
       });
@@ -457,12 +459,17 @@ describe('amp-analytics.visibility', () => {
           .to.equal(null);
       expect(getElement(ampdoc, 'amp-img', analytics, 'scope'))
           .to.equal(img2);
+      expect(getElement(ampdoc, 'div', iframeAnalytics, 'scope'))
+          .to.equal(null);
+      expect(getElement(ampdoc, 'amp-img', iframeAnalytics, 'scope'))
+          .to.equal(iframe.contentDocument.querySelectorAll('amp-img')[1]);
     });
 
     it('finds element for selectionMethod=host', () => {
-      expect(getElement(iframeAmpDoc, ':host', iframeAnalytics))
-          .to.equal(ampEl);
-      expect(getElement(iframeAmpDoc, ':root', iframeAnalytics, 'something'))
+      expect(getElement(ampdoc, ':host', analytics)).to.equal(null);
+      expect(getElement(ampdoc, ':root', analytics)).to.equal(null);
+      expect(getElement(ampdoc, ':host', iframeAnalytics)).to.equal(ampEl);
+      expect(getElement(ampdoc, ':root', iframeAnalytics, 'something'))
           .to.equal(ampEl);
     });
   });

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -164,8 +164,9 @@ export function getElement(ampdoc, selector, analyticsEl, selectionMethod) {
   let foundEl;
   const friendlyFrame = getParentWindowFrameElement(analyticsEl, ampdoc.win);
   // Special case for root selector.
-  if (friendlyFrame && (selector == ':host' || selector == ':root')) {
-    foundEl = closestBySelector(friendlyFrame, '.-amp-element');
+  if (selector == ':host' || selector == ':root') {
+    foundEl = friendlyFrame ?
+        closestBySelector(friendlyFrame, '.-amp-element') : null;
   } else if (selectionMethod == 'closest') {
     // Only tag names are supported currently.
     foundEl = closestByTag(analyticsEl, selector);

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -180,7 +180,7 @@ export function getElement(ampdoc, selector, el, selectionMethod) {
 
   if (foundEl) {
     // Restrict result to be contained by ampdoc.
-    let isContainedInDoc = ampdoc.contains(
+    const isContainedInDoc = ampdoc.contains(
         elWin === ampdoc.win ? foundEl : elWin.frameElement);
     if (isContainedInDoc) {
       return foundEl;

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -159,27 +159,32 @@ export function getElement(ampdoc, selector, el, selectionMethod) {
     return null;
   }
 
+  const elWin = el.ownerDocument.defaultView;
   // Special case for root selector.
   if (selector == ':host' || selector == ':root') {
-    const elWin = ampdoc.win;
     const parentEl = elWin.frameElement && elWin.frameElement.parentElement;
     if (parentEl) {
       return closestBySelector(parentEl, '.-amp-element');
     }
   }
 
+  let foundEl;
   if (selectionMethod == 'closest') {
     // Only tag names are supported currently.
-    const closestEl = closestByTag(el, selector);
-    // Restrict result to be contained by ampdoc.
-    if (closestEl && ampdoc.contains(closestEl)) {
-      return closestEl;
-    }
-    return null;
+    foundEl = closestByTag(el, selector);
   } else if (selectionMethod == 'scope') {
-    return el.parentElement.querySelector(selector);
+    foundEl = el.parentElement.querySelector(selector);
   } else if (selector[0] == '#') {
-    return ampdoc.getElementById(selector.slice(1));
+    foundEl = el.ownerDocument.getElementById(selector.slice(1));
+  }
+
+  if (foundEl) {
+    // Restrict result to be contained by ampdoc.
+    let isContainedInDoc = ampdoc.contains(
+        elWin === ampdoc.win ? foundEl : elWin.frameElement);
+    if (isContainedInDoc) {
+      return foundEl;
+    }
   }
   return null;
 }

--- a/src/activity.js
+++ b/src/activity.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import {getElementService} from './element-service';
+import {getElementServiceForDoc} from './element-service';
+
 
 /**
- * @param {!Window} win
+ * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @return {!Promise<!Activity>}
  */
-export function activityFor(win) {
+export function activityForDoc(nodeOrDoc) {
   return /** @type {!Promise<!Activity>} */ (
-      getElementService(win, 'activity', 'amp-analytics'));
+      getElementServiceForDoc(nodeOrDoc, 'activity', 'amp-analytics'));
 };

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -25,7 +25,7 @@ import {parseUrl, removeFragment, parseQueryString} from '../url';
 import {viewerForDoc} from '../viewer';
 import {viewportForDoc} from '../viewport';
 import {userNotificationManagerFor} from '../user-notification';
-import {activityFor} from '../activity';
+import {activityForDoc} from '../activity';
 import {isExperimentOn} from '../experiments';
 import {getTrackImpressionPromise} from '../impression.js';
 import {
@@ -420,7 +420,7 @@ export class GlobalVariableSource extends VariableSource {
 
     // Returns the total engaged time since the content became viewable.
     this.setAsync('TOTAL_ENGAGED_TIME', () => {
-      return activityFor(this.ampdoc.win).then(activity => {
+      return activityForDoc(this.ampdoc).then(activity => {
         return activity.getTotalEngagedTime();
       });
     });
@@ -454,7 +454,7 @@ export class GlobalVariableSource extends VariableSource {
     this.set('AMP_VERSION', () => '$internalRuntimeVersion$');
 
     this.set('BACKGROUND_STATE', () => {
-      return viewerForDoc(this.ampdoc.win.document).isVisible() ? '0' : '1';
+      return viewerForDoc(this.ampdoc).isVisible() ? '0' : '1';
     });
   }
 

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -15,9 +15,9 @@
  */
 
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
-import {installActivityService,} from
-    '../../extensions/amp-analytics/0.1/activity-impl';
-import {activityFor} from '../../src/activity';
+import {Activity} from '../../extensions/amp-analytics/0.1/activity-impl';
+import {activityForDoc} from '../../src/activity';
+import {fromClassForDoc} from '../../src/service';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installViewerServiceForDoc} from '../../src/service/viewer-impl';
 import {installTimerService} from '../../src/service/timer-impl';
@@ -114,9 +114,9 @@ describe('Activity getTotalEngagedTime', () => {
       scrollObservable.add(handler);
     });
 
-    installActivityService(fakeWin);
+    fromClassForDoc(ampdoc, 'activity', Activity);
 
-    return activityFor(fakeWin).then(a => {
+    return activityForDoc(ampdoc).then(a => {
       activity = a;
     });
   });

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -25,12 +25,11 @@ import {installCryptoService,} from
 import {installDocService} from '../../src/service/ampdoc-impl';
 import {installDocumentInfoServiceForDoc,} from
     '../../src/service/document-info-impl';
-import {installActivityService,} from
-    '../../extensions/amp-analytics/0.1/activity-impl';
+import {Activity} from '../../extensions/amp-analytics/0.1/activity-impl';
 import {
   installUrlReplacementsServiceForDoc,
 } from '../../src/service/url-replacements-impl';
-import {getService} from '../../src/service';
+import {getService, fromClassForDoc} from '../../src/service';
 import {setCookie} from '../../src/cookies';
 import {parseUrl} from '../../src/url';
 import {toggleExperiment} from '../../src/experiments';
@@ -74,7 +73,7 @@ describe('UrlReplacements', () => {
         }
         if (opt_options.withActivity) {
           markElementScheduledForTesting(iframe.win, 'amp-analytics');
-          installActivityService(iframe.win);
+          fromClassForDoc(iframe.ampdoc, 'activity', Activity);
         }
         if (opt_options.withVariant) {
           markElementScheduledForTesting(iframe.win, 'amp-experiment');


### PR DESCRIPTION
More for: #5565 

Testing this with `pwa.html` example looks good. Analytics events triggered and all. But something seems broken for some reason in that example, like I can't really see the document (or scroll it) but I was able to do scroll-element-into-view through the elements panel in devtools. So not sure what's going on there - body for the shadow dom is 0px height.

@dvoytenko as we chatted, instrumentation is now resolved async in amp-analytics due to the race condition between the life cycle of the element and the time we actually install these services.

Let me know if this looks good so I can fix up the tests.