### PR TITLE
Split url-replacement to var-substitution to allow non-url subs

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -187,6 +187,13 @@ var forbiddenTerms = {
       'src/service/template-impl.js',
     ],
   },
+  'installVarSubstitutionServiceForDoc': {
+    message: privateServiceFactory,
+    whitelist: [
+      'src/service/url-replacements-impl.js',
+      'src/service/var-substitution-impl.js',
+    ],
+  },
   'installUrlReplacementsServiceForDoc': {
     message: privateServiceFactory,
     whitelist: [
@@ -269,7 +276,7 @@ var forbiddenTerms = {
       'src/ad-cid.js',
       'src/cid.js',
       'src/service/cid-impl.js',
-      'src/service/url-replacements-impl.js',
+      'src/service/var-substitution-impl.js',
       'extensions/amp-access/0.1/amp-access.js',
       'extensions/amp-experiment/0.1/variant.js',
       'extensions/amp-user-notification/0.1/amp-user-notification.js',
@@ -307,6 +314,13 @@ var forbiddenTerms = {
       'src/experiments.js',
       'tools/experiments/experiments.js',
     ]
+  },
+  'varSubstitutionsForDoc': {
+    message: requiresReviewPrivacy,
+    whitelist: [
+      'src/service/url-replacements-impl.js',
+      'src/service/var-substitution-impl.js',
+    ],
   },
   'isDevChannel\\W': {
     message: requiresReviewPrivacy,
@@ -371,7 +385,7 @@ var forbiddenTerms = {
     whitelist: [
       'build-system/amp.extern.js',
       'extensions/amp-access/0.1/amp-access.js',
-      'src/service/url-replacements-impl.js',
+      'src/service/var-substitution-impl.js',
     ]
   },
   'getAuthdataField': {
@@ -379,7 +393,7 @@ var forbiddenTerms = {
     whitelist: [
       'build-system/amp.extern.js',
       'extensions/amp-access/0.1/amp-access.js',
-      'src/service/url-replacements-impl.js',
+      'src/service/var-substitution-impl.js',
     ]
   },
   'debugger': '',

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -24,10 +24,6 @@ import {
   installVarSubstitutionForEmbed,
 } from './var-substitution-impl';
 import {varSubstitutionForDoc} from '../var-substitution';
-import {
-    ResolverReturnDef,
-    SyncResolverDef,
-} from './variable-source';
 
 /** @private @const {string} */
 const TAG = 'UrlReplacements';
@@ -53,8 +49,8 @@ export class UrlReplacements {
    * their resolved values. Optional `opt_bindings` can be used to add new
    * variables or override existing ones.  Any async bindings are ignored.
    * @param {string} url
-   * @param {!Object<string, (ResolverReturnDef|!SyncResolverDef)>=} opt_bindings
-   * @param {!Object<string, ResolverReturnDef>=} opt_collectVars
+   * @param {!Object<string, (./variable-source.ResolverReturnDef|!./variable-source.SyncResolverDef)>=} opt_bindings
+   * @param {!Object<string, ./variable-source.ResolverReturnDef>=} opt_collectVars
    * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
    *     that can be substituted.
    * @return {string}

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -14,496 +14,25 @@
  * limitations under the License.
  */
 
-import {accessServiceForOrNull} from '../access-service';
-import {cidFor} from '../cid';
-import {variantForOrNull} from '../variant-service';
-import {shareTrackingForOrNull} from '../share-tracking-service';
-import {dev, user, rethrowAsync} from '../log';
+import {dev, user} from '../log';
 import {documentInfoForDoc} from '../document-info';
 import {getServiceForDoc, installServiceInEmbedScope} from '../service';
-import {parseUrl, removeFragment, parseQueryString} from '../url';
-import {viewerForDoc} from '../viewer';
-import {viewportForDoc} from '../viewport';
-import {userNotificationManagerFor} from '../user-notification';
-import {activityFor} from '../activity';
+import {parseUrl} from '../url';
 import {isExperimentOn} from '../experiments';
-import {getTrackImpressionPromise} from '../impression.js';
 import {
-  VariableSource,
-  AsyncResolverDef,
-  ResolverReturnDef,
-  SyncResolverDef,
-  getNavigationData,
-  getTimingDataSync,
-  getTimingDataAsync,
+  installVarSubstitutionServiceForDoc,
+  installVarSubstitutionForEmbed,
+} from './var-substitution-impl';
+import {varSubstitutionForDoc} from '../var-substitution';
+import {
+    VariableSource,
+    ResolverReturnDef,
+    SyncResolverDef,
 } from './variable-source';
-
 
 /** @private @const {string} */
 const TAG = 'UrlReplacements';
-const EXPERIMENT_DELIMITER = '!';
-const VARIANT_DELIMITER = '.';
 const ORIGINAL_HREF_PROPERTY = 'amp-original-href';
-
-/**
- * Returns a encoded URI Component, or an empty string if the value is nullish.
- * @param {*} val
- * @return {string}
- */
-function encodeValue(val) {
-  if (val == null) {
-    return '';
-  }
-  return encodeURIComponent(/** @type {string} */(val));
-};
-
-/**
- * Class to provide variables that pertain to top level AMP window.
- */
-export class GlobalVariableSource extends VariableSource {
-
-  constructor(ampdoc) {
-    super();
-
-    /** @const {!./ampdoc-impl.AmpDoc} */
-    this.ampdoc = ampdoc;
-
-    /** @private @const {function(!Window):!Promise<?AccessService>} */
-    this.getAccessService_ = accessServiceForOrNull;
-
-    /** @private @const {!Promise<?Object<string, string>>} */
-    this.variants_ = variantForOrNull(this.ampdoc.win);
-
-    /**
-     * @private @const {
-     *   !Promise<(?{incomingFragment: string, outgoingFragment: string})>}
-     */
-    this.shareTrackingFragments_ = shareTrackingForOrNull(this.ampdoc.win);
-  }
-
-  /**
-   * Utility function for setting resolver for timing data that supports
-   * sync and async.
-   * @param {string} varName
-   * @param {string} startEvent
-   * @param {string=} endEvent
-   * @return {!VariableSource}
-   * @private
-   */
-  setTimingResolver_(varName, startEvent, endEvent) {
-    return this.setBoth(varName, () => {
-      return getTimingDataSync(this.ampdoc.win, startEvent, endEvent);
-    }, () => {
-      return getTimingDataAsync(this.ampdoc.win, startEvent, endEvent);
-    });
-  }
-
-  /** @override */
-  initialize() {
-
-    /** @const {!./viewport-impl.Viewport} */
-    const viewport = viewportForDoc(this.ampdoc);
-
-    // Returns a random value for cache busters.
-    this.set('RANDOM', () => {
-      return Math.random();
-    });
-
-    // Provides a counter starting at 1 per given scope.
-    let counterStore = null;
-    this.set('COUNTER', scope => {
-      if (!counterStore) {
-        counterStore = Object.create(null);
-      }
-      if (!counterStore[scope]) {
-        counterStore[scope] = 0;
-      }
-      return ++counterStore[scope];
-    });
-
-    // Returns the canonical URL for this AMP document.
-    this.set('CANONICAL_URL', this.getDocInfoValue_.bind(this, info => {
-      return info.canonicalUrl;
-    }));
-
-    // Returns the host of the canonical URL for this AMP document.
-    this.set('CANONICAL_HOST', this.getDocInfoValue_.bind(this, info => {
-      const url = parseUrl(info.canonicalUrl);
-      return url && url.host;
-    }));
-
-    // Returns the hostname of the canonical URL for this AMP document.
-    this.set('CANONICAL_HOSTNAME', this.getDocInfoValue_.bind(this, info => {
-      const url = parseUrl(info.canonicalUrl);
-      return url && url.hostname;
-    }));
-
-    // Returns the path of the canonical URL for this AMP document.
-    this.set('CANONICAL_PATH', this.getDocInfoValue_.bind(this, info => {
-      const url = parseUrl(info.canonicalUrl);
-      return url && url.pathname;
-    }));
-
-    // Returns the referrer URL.
-    this.setAsync('DOCUMENT_REFERRER', /** @type {AsyncResolverDef} */(() => {
-      return viewerForDoc(this.ampdoc).getReferrerUrl();
-    }));
-
-    // Returns the title of this AMP document.
-    this.set('TITLE', () => {
-      return this.ampdoc.win.document.title;
-    });
-
-    // Returns the URL for this AMP document.
-    this.set('AMPDOC_URL', () => {
-      return removeFragment(this.ampdoc.win.location.href);
-    });
-
-    // Returns the host of the URL for this AMP document.
-    this.set('AMPDOC_HOST', () => {
-      const url = parseUrl(this.ampdoc.win.location.href);
-      return url && url.host;
-    });
-
-    // Returns the hostname of the URL for this AMP document.
-    this.set('AMPDOC_HOSTNAME', () => {
-      const url = parseUrl(this.ampdoc.win.location.href);
-      return url && url.hostname;
-    });
-
-    // Returns the Source URL for this AMP document.
-    this.setBoth('SOURCE_URL', this.getDocInfoValue_.bind(this, info => {
-      return removeFragment(info.sourceUrl);
-    }), () => {
-      return getTrackImpressionPromise().then(() => {
-        return this.getDocInfoValue_(info => {
-          return removeFragment(info.sourceUrl);
-        });
-      });
-    });
-
-    // Returns the host of the Source URL for this AMP document.
-    this.set('SOURCE_HOST', this.getDocInfoValue_.bind(this, info => {
-      return parseUrl(info.sourceUrl).host;
-    }));
-
-    // Returns the hostname of the Source URL for this AMP document.
-    this.set('SOURCE_HOSTNAME', this.getDocInfoValue_.bind(this, info => {
-      return parseUrl(info.sourceUrl).hostname;
-    }));
-
-    // Returns the path of the Source URL for this AMP document.
-    this.set('SOURCE_PATH', this.getDocInfoValue_.bind(this, info => {
-      return parseUrl(info.sourceUrl).pathname;
-    }));
-
-    // Returns a random string that will be the constant for the duration of
-    // single page view. It should have sufficient entropy to be unique for
-    // all the page views a single user is making at a time.
-    this.set('PAGE_VIEW_ID', this.getDocInfoValue_.bind(this, info => {
-      return info.pageViewId;
-    }));
-
-    this.setBoth('QUERY_PARAM', (param, defaultValue = '') => {
-      return this.getQueryParamData_(param, defaultValue);
-    }, (param, defaultValue = '') => {
-      return getTrackImpressionPromise().then(() => {
-        return this.getQueryParamData_(param, defaultValue);
-      });
-    });
-
-    /**
-     * Stores client ids that were generated during this page view
-     * indexed by scope.
-     * @type {?Object<string, string>}
-     */
-    let clientIds = null;
-    // Synchronous alternative. Only works for scopes that were previously
-    // requested using the async method.
-    this.setBoth('CLIENT_ID', scope => {
-      if (!clientIds) {
-        return null;
-      }
-      return clientIds[dev().assertString(scope)];
-    }, (scope, opt_userNotificationId) => {
-      user().assertString(scope,
-            'The first argument to CLIENT_ID, the fallback c' +
-            /*OK*/'ookie name, is required');
-      let consent = Promise.resolve();
-
-        // If no `opt_userNotificationId` argument is provided then
-        // assume consent is given by default.
-      if (opt_userNotificationId) {
-        consent = userNotificationManagerFor(this.ampdoc.win)
-              .then(service => {
-                return service.get(opt_userNotificationId);
-              });
-      }
-      return cidFor(this.ampdoc.win).then(cid => {
-        return cid.get({
-          scope: dev().assertString(scope),
-          createCookieIfNotPresent: true,
-        }, consent);
-      }).then(cid => {
-        if (!clientIds) {
-          clientIds = Object.create(null);
-        }
-        clientIds[scope] = cid;
-        return cid;
-      });
-    });
-
-    // Returns assigned variant name for the given experiment.
-    this.setAsync('VARIANT', experiment => {
-      return this.variants_.then(variants => {
-        user().assert(variants,
-            'To use variable VARIANT, amp-experiment should be configured');
-        const variant = variants[/** @type {string} */(experiment)];
-        user().assert(variant !== undefined,
-            'The value passed to VARIANT() is not a valid experiment name:' +
-                experiment);
-        // When no variant assigned, use reserved keyword 'none'.
-        return variant === null ? 'none' : /** @type {string} */(variant);
-      });
-    });
-
-    // Returns all assigned experiment variants in a serialized form.
-    this.setAsync('VARIANTS', () => {
-      return this.variants_.then(variants => {
-        user().assert(variants,
-            'To use variable VARIANTS, amp-experiment should be configured');
-
-        const experiments = [];
-        for (const experiment in variants) {
-          const variant = variants[experiment];
-          experiments.push(
-              experiment + VARIANT_DELIMITER + (variant || 'none'));
-        }
-
-        return experiments.join(EXPERIMENT_DELIMITER);
-      });
-    });
-
-    // Returns incoming share tracking fragment.
-    this.setAsync('SHARE_TRACKING_INCOMING', () => {
-      return this.shareTrackingFragments_.then(fragments => {
-        user().assert(fragments, 'To use variable SHARE_TRACKING_INCOMING, ' +
-            'amp-share-tracking should be configured');
-        return fragments.incomingFragment;
-      });
-    });
-
-    // Returns outgoing share tracking fragment.
-    this.setAsync('SHARE_TRACKING_OUTGOING', () => {
-      return this.shareTrackingFragments_.then(fragments => {
-        user().assert(fragments, 'To use variable SHARE_TRACKING_OUTGOING, ' +
-            'amp-share-tracking should be configured');
-        return fragments.outgoingFragment;
-      });
-    });
-
-    // Returns the number of milliseconds since 1 Jan 1970 00:00:00 UTC.
-    this.set('TIMESTAMP', () => {
-      return Date.now();
-    });
-
-    // Returns the user's time-zone offset from UTC, in minutes.
-    this.set('TIMEZONE', () => {
-      return new Date().getTimezoneOffset();
-    });
-
-    // Returns a promise resolving to viewport.getScrollTop.
-    this.set('SCROLL_TOP', () => viewport.getScrollTop());
-
-    // Returns a promise resolving to viewport.getScrollLeft.
-    this.set('SCROLL_LEFT', () => viewport.getScrollLeft());
-
-    // Returns a promise resolving to viewport.getScrollHeight.
-    this.set('SCROLL_HEIGHT', () => viewport.getScrollHeight());
-
-    // Returns a promise resolving to viewport.getScrollWidth.
-    this.set('SCROLL_WIDTH', () => viewport.getScrollWidth());
-
-    // Returns the viewport height.
-    this.set('VIEWPORT_HEIGHT', () => viewport.getSize().height);
-
-    // Returns the viewport width.
-    this.set('VIEWPORT_WIDTH', () => viewport.getSize().width);
-
-    // Returns screen.width.
-    this.set('SCREEN_WIDTH', () => this.ampdoc.win.screen.width);
-
-    // Returns screen.height.
-    this.set('SCREEN_HEIGHT', () => this.ampdoc.win.screen.height);
-
-    // Returns screen.availHeight.
-    this.set('AVAILABLE_SCREEN_HEIGHT',
-        () => this.ampdoc.win.screen.availHeight);
-
-    // Returns screen.availWidth.
-    this.set('AVAILABLE_SCREEN_WIDTH',
-        () => this.ampdoc.win.screen.availWidth);
-
-    // Returns screen.ColorDepth.
-    this.set('SCREEN_COLOR_DEPTH',
-        () => this.ampdoc.win.screen.colorDepth);
-
-    // Returns document characterset.
-    this.set('DOCUMENT_CHARSET', () => {
-      const doc = this.ampdoc.win.document;
-      return doc.characterSet || doc.charset;
-    });
-
-    // Returns the browser language.
-    this.set('BROWSER_LANGUAGE', () => {
-      const nav = this.ampdoc.win.navigator;
-      return (nav.language || nav.userLanguage || nav.browserLanguage || '')
-          .toLowerCase();
-    });
-
-    // Returns the time it took to load the whole page. (excludes amp-* elements
-    // that are not rendered by the system yet.)
-    this.setTimingResolver_(
-      'PAGE_LOAD_TIME', 'navigationStart', 'loadEventStart');
-
-    // Returns the time it took to perform DNS lookup for the domain.
-    this.setTimingResolver_(
-      'DOMAIN_LOOKUP_TIME', 'domainLookupStart', 'domainLookupEnd');
-
-    // Returns the time it took to connect to the server.
-    this.setTimingResolver_(
-      'TCP_CONNECT_TIME', 'connectStart', 'connectEnd');
-
-    // Returns the time it took for server to start sending a response to the
-    // request.
-    this.setTimingResolver_(
-      'SERVER_RESPONSE_TIME', 'requestStart', 'responseStart');
-
-    // Returns the time it took to download the page.
-    this.setTimingResolver_(
-      'PAGE_DOWNLOAD_TIME', 'responseStart', 'responseEnd');
-
-    // Returns the time it took for redirects to complete.
-    this.setTimingResolver_(
-      'REDIRECT_TIME', 'navigationStart', 'fetchStart');
-
-    // Returns the time it took for DOM to become interactive.
-    this.setTimingResolver_(
-      'DOM_INTERACTIVE_TIME', 'navigationStart', 'domInteractive');
-
-    // Returns the time it took for content to load.
-    this.setTimingResolver_(
-      'CONTENT_LOAD_TIME', 'navigationStart', 'domContentLoadedEventStart');
-
-    // Access: Reader ID.
-    this.setAsync('ACCESS_READER_ID', /** @type {AsyncResolverDef} */(() => {
-      return this.getAccessValue_(accessService => {
-        return accessService.getAccessReaderId();
-      }, 'ACCESS_READER_ID');
-    }));
-
-    // Access: data from the authorization response.
-    this.setAsync('AUTHDATA', /** @type {AsyncResolverDef} */(field => {
-      user().assert(field,
-          'The first argument to AUTHDATA, the field, is required');
-      return this.getAccessValue_(accessService => {
-        return accessService.getAuthdataField(field);
-      }, 'AUTHDATA');
-    }));
-
-    // Returns an identifier for the viewer.
-    this.setAsync('VIEWER', () => {
-      return viewerForDoc(this.ampdoc).getViewerOrigin().then(viewer => {
-        return viewer == undefined ? '' : viewer;
-      });
-    });
-
-    // Returns the total engaged time since the content became viewable.
-    this.setAsync('TOTAL_ENGAGED_TIME', () => {
-      return activityFor(this.ampdoc.win).then(activity => {
-        return activity.getTotalEngagedTime();
-      });
-    });
-
-    this.set('NAV_TIMING', (startAttribute, endAttribute) => {
-      user().assert(startAttribute, 'The first argument to NAV_TIMING, the ' +
-          'start attribute name, is required');
-      return getTimingDataSync(
-          this.ampdoc.win,
-          /**@type {string}*/(startAttribute),
-          /**@type {string}*/(endAttribute));
-    });
-    this.setAsync('NAV_TIMING', (startAttribute, endAttribute) => {
-      user().assert(startAttribute, 'The first argument to NAV_TIMING, the ' +
-          'start attribute name, is required');
-      return getTimingDataAsync(
-          this.ampdoc.win,
-          /**@type {string}*/(startAttribute),
-          /**@type {string}*/(endAttribute));
-    });
-
-    this.set('NAV_TYPE', () => {
-      return getNavigationData(this.ampdoc.win, 'type');
-    });
-
-    this.set('NAV_REDIRECT_COUNT', () => {
-      return getNavigationData(this.ampdoc.win, 'redirectCount');
-    });
-
-    // returns the AMP version number
-    this.set('AMP_VERSION', () => '$internalRuntimeVersion$');
-
-    this.set('BACKGROUND_STATE', () => {
-      return viewerForDoc(this.ampdoc.win.document).isVisible() ? '0' : '1';
-    });
-  }
-
-  /**
-   * Resolves the value via document info.
-   * @param {function(!./document-info-impl.DocumentInfoDef):T} getter
-   * @return {T}
-   * @template T
-   */
-  getDocInfoValue_(getter) {
-    return getter(documentInfoForDoc(this.ampdoc));
-  }
-
-  /**
-   * Resolves the value via access service. If access service is not configured,
-   * the resulting value is `null`.
-   * @param {function(!AccessService):(T|!Promise<T>)} getter
-   * @param {string} expr
-   * @return {T|null}
-   * @template T
-   */
-  getAccessValue_(getter, expr) {
-    return this.getAccessService_(this.ampdoc.win).then(accessService => {
-      if (!accessService) {
-        // Access service is not installed.
-        user().error(TAG, 'Access service is not installed to access: ', expr);
-        return null;
-      }
-      return getter(accessService);
-    });
-  }
-
-  /**
-   * Return the QUERY_PARAM from the current location href
-   * @param {*} param
-   * @param {string} defaultValue
-   * @return {string}
-   */
-  getQueryParamData_(param, defaultValue) {
-    user().assert(param,
-        'The first argument to QUERY_PARAM, the query string ' +
-        'param is required');
-    user().assert(typeof param == 'string', 'param should be a string');
-    const url = parseUrl(this.ampdoc.win.location.href);
-    const params = parseQueryString(url.search);
-    return (typeof params[param] !== 'undefined')
-        ? params[param] : defaultValue;
-  }
-}
 
 /**
  * This class replaces substitution variables with their values.
@@ -512,12 +41,12 @@ export class GlobalVariableSource extends VariableSource {
  */
 export class UrlReplacements {
   /** @param {!./ampdoc-impl.AmpDoc} ampdoc */
-  constructor(ampdoc, variableSource) {
+  constructor(ampdoc) {
     /** @const {!./ampdoc-impl.AmpDoc} */
     this.ampdoc = ampdoc;
 
-    /** @type {VariableSource} */
-    this.variableSource_ = variableSource;
+    /** @private @const @type {!./var-substitution-impl.VarSubstitution} */
+    this.varSub_ = varSubstitutionForDoc(ampdoc);
   }
 
   /**
@@ -532,9 +61,9 @@ export class UrlReplacements {
    * @return {string}
    */
   expandSync(url, opt_bindings, opt_collectVars, opt_whiteList) {
-    return /** @type {string} */(
-        this.expand_(url, opt_bindings, opt_collectVars, /* opt_sync */ true,
-            opt_whiteList));
+    return /** @type {string} */ (
+        this.ensureProtocolMatches_(url, this.varSub_.expandSync(
+            url, opt_bindings, opt_collectVars, opt_whiteList)));
   }
 
   /**
@@ -546,7 +75,9 @@ export class UrlReplacements {
    * @return {!Promise<string>}
    */
   expandAsync(url, opt_bindings) {
-    return /** @type {!Promise<string>} */(this.expand_(url, opt_bindings));
+    return /** @type {!Promise<string>} */ (
+        this.varSub_.expandAsync(url, opt_bindings).then(
+            replacement => this.ensureProtocolMatches_(url, replacement)));
   }
 
   /**
@@ -603,97 +134,6 @@ export class UrlReplacements {
   }
 
   /**
-   * @param {string} url
-   * @param {!Object<string, *>=} opt_bindings
-   * @param {!Object<string, *>=} opt_collectVars
-   * @param {boolean=} opt_sync
-   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
-   *     that can be substituted.
-   * @return {!Promise<string>|string}
-   * @private
-   */
-  expand_(url, opt_bindings, opt_collectVars, opt_sync, opt_whiteList) {
-    const expr = this.variableSource_.getExpr(opt_bindings);
-    let replacementPromise;
-    let replacement = url.replace(expr, (match, name, opt_strargs) => {
-      let args = [];
-      if (typeof opt_strargs == 'string') {
-        args = opt_strargs.split(',');
-      }
-      if (opt_whiteList && !opt_whiteList[name]) {
-        // Do not perform substitution and just return back the original
-        // match, so that the string doesn't change.
-        return match;
-      }
-      let binding;
-      if (opt_bindings && (name in opt_bindings)) {
-        binding = opt_bindings[name];
-      } else if ((binding = this.variableSource_.get(name))) {
-        if (opt_sync) {
-          binding = binding.sync;
-          if (!binding) {
-            user().error(TAG, 'ignoring async replacement key: ', name);
-            return '';
-          }
-        } else {
-          binding = binding.async || binding.sync;
-        }
-      }
-      let val;
-      try {
-        val = (typeof binding == 'function') ?
-            binding.apply(null, args) : binding;
-      } catch (e) {
-        // Report error, but do not disrupt URL replacement. This will
-        // interpolate as the empty string.
-        if (opt_sync) {
-          val = '';
-        }
-        rethrowAsync(e);
-      }
-      // In case the produced value is a promise, we don't actually
-      // replace anything here, but do it again when the promise resolves.
-      if (val && val.then) {
-        if (opt_sync) {
-          user().error(TAG, 'ignoring promise value for key: ', name);
-          return '';
-        }
-        /** @const {Promise<string>} */
-        const p = val.catch(err => {
-          // Report error, but do not disrupt URL replacement. This will
-          // interpolate as the empty string.
-          rethrowAsync(err);
-        }).then(v => {
-          replacement = replacement.replace(match, encodeValue(v));
-          if (opt_collectVars) {
-            opt_collectVars[match] = v;
-          }
-        });
-        if (replacementPromise) {
-          replacementPromise = replacementPromise.then(() => p);
-        } else {
-          replacementPromise = p;
-        }
-        return match;
-      }
-      if (opt_collectVars) {
-        opt_collectVars[match] = val;
-      }
-      return encodeValue(val);
-    });
-
-    if (replacementPromise) {
-      replacementPromise = replacementPromise.then(() => replacement);
-    }
-
-    if (opt_sync) {
-      return this.ensureProtocolMatches_(url, replacement);
-    }
-    return (replacementPromise || Promise.resolve(replacement))
-        .then(replacement => this.ensureProtocolMatches_(url, replacement));
-  }
-
-  /**
    * Collects all substitutions in the provided URL and expands them to the
    * values for known variables. Optional `opt_bindings` can be used to add
    * new variables or override existing ones.
@@ -702,8 +142,7 @@ export class UrlReplacements {
    * @return {!Promise<!Object<string, *>>}
    */
   collectVars(url, opt_bindings) {
-    const vars = Object.create(null);
-    return this.expand_(url, opt_bindings, vars).then(() => vars);
+    return this.varSub_.collectVars(url, opt_bindings);
   }
 
 
@@ -732,7 +171,7 @@ export class UrlReplacements {
    * @return {VariableSource}
    */
   getVariableSource() {
-    return this.variableSource_;
+    return this.varSub_.getVariableSource();
   }
 }
 
@@ -743,7 +182,8 @@ export class UrlReplacements {
  */
 export function installUrlReplacementsServiceForDoc(ampdoc) {
   return getServiceForDoc(ampdoc, 'url-replace', doc => {
-    return new UrlReplacements(doc, new GlobalVariableSource(doc));
+    installVarSubstitutionServiceForDoc(ampdoc);
+    return new UrlReplacements(doc);
   });
 }
 
@@ -753,6 +193,7 @@ export function installUrlReplacementsServiceForDoc(ampdoc) {
  * @param {*} varSource
  */
 export function installUrlReplacementsForEmbed(ampdoc, embedWin, varSource) {
+  installVarSubstitutionForEmbed(ampdoc, embedWin, varSource);
   installServiceInEmbedScope(embedWin, 'url-replace',
-      new UrlReplacements(ampdoc, varSource));
+      new UrlReplacements(ampdoc));
 }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -25,7 +25,6 @@ import {
 } from './var-substitution-impl';
 import {varSubstitutionForDoc} from '../var-substitution';
 import {
-    VariableSource,
     ResolverReturnDef,
     SyncResolverDef,
 } from './variable-source';
@@ -168,7 +167,7 @@ export class UrlReplacements {
   }
 
   /**
-   * @return {VariableSource}
+   * @return {?./variable-source.VariableSource}
    */
   getVariableSource() {
     return this.varSub_.getVariableSource();
@@ -190,7 +189,7 @@ export function installUrlReplacementsServiceForDoc(ampdoc) {
 /**
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  * @param {!Window} embedWin
- * @param {*} varSource
+ * @param {!./variable-source.VariableSource} varSource
  */
 export function installUrlReplacementsForEmbed(ampdoc, embedWin, varSource) {
   installVarSubstitutionForEmbed(ampdoc, embedWin, varSource);

--- a/src/service/var-substitution-impl.js
+++ b/src/service/var-substitution-impl.js
@@ -1,0 +1,681 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {accessServiceForOrNull} from '../access-service';
+import {cidFor} from '../cid';
+import {variantForOrNull} from '../variant-service';
+import {shareTrackingForOrNull} from '../share-tracking-service';
+import {dev, user, rethrowAsync} from '../log';
+import {documentInfoForDoc} from '../document-info';
+import {getServiceForDoc, installServiceInEmbedScope} from '../service';
+import {parseUrl, removeFragment, parseQueryString} from '../url';
+import {viewerForDoc} from '../viewer';
+import {viewportForDoc} from '../viewport';
+import {userNotificationManagerFor} from '../user-notification';
+import {activityFor} from '../activity';
+import {getTrackImpressionPromise} from '../impression.js';
+import {
+    VariableSource,
+    AsyncResolverDef,
+    ResolverReturnDef,
+    SyncResolverDef,
+    getNavigationData,
+    getTimingDataSync,
+    getTimingDataAsync,
+} from './variable-source';
+
+
+/** @private @const {string} */
+const TAG = 'VarSubstitution';
+const EXPERIMENT_DELIMITER = '!';
+const VARIANT_DELIMITER = '.';
+
+
+/**
+ * Returns a encoded URI Component, or an empty string if the value is nullish.
+ * @param {*} val
+ * @return {string}
+ */
+function encodeValue(val) {
+  if (val == null) {
+    return '';
+  }
+  return encodeURIComponent(/** @type {string} */(val));
+};
+
+/**
+ * Class to provide variables that pertain to top level AMP window.
+ */
+export class GlobalVariableSource extends VariableSource {
+
+  constructor(ampdoc) {
+    super();
+
+    /** @const {!./ampdoc-impl.AmpDoc} */
+    this.ampdoc = ampdoc;
+
+    /** @private @const {function(!Window):!Promise<?AccessService>} */
+    this.getAccessService_ = accessServiceForOrNull;
+
+    /** @private @const {!Promise<?Object<string, string>>} */
+    this.variants_ = variantForOrNull(this.ampdoc.win);
+
+    /**
+     * @private @const {
+     *   !Promise<(?{incomingFragment: string, outgoingFragment: string})>}
+     */
+    this.shareTrackingFragments_ = shareTrackingForOrNull(this.ampdoc.win);
+  }
+
+  /**
+   * Utility function for setting resolver for timing data that supports
+   * sync and async.
+   * @param {string} varName
+   * @param {string} startEvent
+   * @param {string=} endEvent
+   * @return {!VariableSource}
+   * @private
+   */
+  setTimingResolver_(varName, startEvent, endEvent) {
+    return this.setBoth(varName, () => {
+      return getTimingDataSync(this.ampdoc.win, startEvent, endEvent);
+    }, () => {
+      return getTimingDataAsync(this.ampdoc.win, startEvent, endEvent);
+    });
+  }
+
+  /** @override */
+  initialize() {
+
+    /** @const {!./viewport-impl.Viewport} */
+    const viewport = viewportForDoc(this.ampdoc);
+
+    // Returns a random value for cache busters.
+    this.set('RANDOM', () => {
+      return Math.random();
+    });
+
+    // Provides a counter starting at 1 per given scope.
+    let counterStore = null;
+    this.set('COUNTER', scope => {
+      if (!counterStore) {
+        counterStore = Object.create(null);
+      }
+      if (!counterStore[scope]) {
+        counterStore[scope] = 0;
+      }
+      return ++counterStore[scope];
+    });
+
+    // Returns the canonical URL for this AMP document.
+    this.set('CANONICAL_URL', this.getDocInfoValue_.bind(this, info => {
+      return info.canonicalUrl;
+    }));
+
+    // Returns the host of the canonical URL for this AMP document.
+    this.set('CANONICAL_HOST', this.getDocInfoValue_.bind(this, info => {
+      const url = parseUrl(info.canonicalUrl);
+      return url && url.host;
+    }));
+
+    // Returns the hostname of the canonical URL for this AMP document.
+    this.set('CANONICAL_HOSTNAME', this.getDocInfoValue_.bind(this, info => {
+      const url = parseUrl(info.canonicalUrl);
+      return url && url.hostname;
+    }));
+
+    // Returns the path of the canonical URL for this AMP document.
+    this.set('CANONICAL_PATH', this.getDocInfoValue_.bind(this, info => {
+      const url = parseUrl(info.canonicalUrl);
+      return url && url.pathname;
+    }));
+
+    // Returns the referrer URL.
+    this.setAsync('DOCUMENT_REFERRER', /** @type {AsyncResolverDef} */(() => {
+      return viewerForDoc(this.ampdoc).getReferrerUrl();
+    }));
+
+    // Returns the title of this AMP document.
+    this.set('TITLE', () => {
+      return this.ampdoc.win.document.title;
+    });
+
+    // Returns the URL for this AMP document.
+    this.set('AMPDOC_URL', () => {
+      return removeFragment(this.ampdoc.win.location.href);
+    });
+
+    // Returns the host of the URL for this AMP document.
+    this.set('AMPDOC_HOST', () => {
+      const url = parseUrl(this.ampdoc.win.location.href);
+      return url && url.host;
+    });
+
+    // Returns the hostname of the URL for this AMP document.
+    this.set('AMPDOC_HOSTNAME', () => {
+      const url = parseUrl(this.ampdoc.win.location.href);
+      return url && url.hostname;
+    });
+
+    // Returns the Source URL for this AMP document.
+    this.setBoth('SOURCE_URL', this.getDocInfoValue_.bind(this, info => {
+      return removeFragment(info.sourceUrl);
+    }), () => {
+      return getTrackImpressionPromise().then(() => {
+        return this.getDocInfoValue_(info => {
+          return removeFragment(info.sourceUrl);
+        });
+      });
+    });
+
+    // Returns the host of the Source URL for this AMP document.
+    this.set('SOURCE_HOST', this.getDocInfoValue_.bind(this, info => {
+      return parseUrl(info.sourceUrl).host;
+    }));
+
+    // Returns the hostname of the Source URL for this AMP document.
+    this.set('SOURCE_HOSTNAME', this.getDocInfoValue_.bind(this, info => {
+      return parseUrl(info.sourceUrl).hostname;
+    }));
+
+    // Returns the path of the Source URL for this AMP document.
+    this.set('SOURCE_PATH', this.getDocInfoValue_.bind(this, info => {
+      return parseUrl(info.sourceUrl).pathname;
+    }));
+
+    // Returns a random string that will be the constant for the duration of
+    // single page view. It should have sufficient entropy to be unique for
+    // all the page views a single user is making at a time.
+    this.set('PAGE_VIEW_ID', this.getDocInfoValue_.bind(this, info => {
+      return info.pageViewId;
+    }));
+
+    this.setBoth('QUERY_PARAM', (param, defaultValue = '') => {
+      return this.getQueryParamData_(param, defaultValue);
+    }, (param, defaultValue = '') => {
+      return getTrackImpressionPromise().then(() => {
+        return this.getQueryParamData_(param, defaultValue);
+      });
+    });
+
+    /**
+     * Stores client ids that were generated during this page view
+     * indexed by scope.
+     * @type {?Object<string, string>}
+     */
+    let clientIds = null;
+    // Synchronous alternative. Only works for scopes that were previously
+    // requested using the async method.
+    this.setBoth('CLIENT_ID', scope => {
+      if (!clientIds) {
+        return null;
+      }
+      return clientIds[dev().assertString(scope)];
+    }, (scope, opt_userNotificationId) => {
+      user().assertString(scope,
+          'The first argument to CLIENT_ID, the fallback c' +
+            /*OK*/'ookie name, is required');
+      let consent = Promise.resolve();
+
+      // If no `opt_userNotificationId` argument is provided then
+      // assume consent is given by default.
+      if (opt_userNotificationId) {
+        consent = userNotificationManagerFor(this.ampdoc.win)
+            .then(service => {
+              return service.get(opt_userNotificationId);
+            });
+      }
+      return cidFor(this.ampdoc.win).then(cid => {
+        return cid.get({
+          scope: dev().assertString(scope),
+          createCookieIfNotPresent: true,
+        }, consent);
+      }).then(cid => {
+        if (!clientIds) {
+          clientIds = Object.create(null);
+        }
+        clientIds[scope] = cid;
+        return cid;
+      });
+    });
+
+    // Returns assigned variant name for the given experiment.
+    this.setAsync('VARIANT', experiment => {
+      return this.variants_.then(variants => {
+        user().assert(variants,
+            'To use variable VARIANT, amp-experiment should be configured');
+        const variant = variants[/** @type {string} */(experiment)];
+        user().assert(variant !== undefined,
+            'The value passed to VARIANT() is not a valid experiment name:' +
+            experiment);
+        // When no variant assigned, use reserved keyword 'none'.
+        return variant === null ? 'none' : /** @type {string} */(variant);
+      });
+    });
+
+    // Returns all assigned experiment variants in a serialized form.
+    this.setAsync('VARIANTS', () => {
+      return this.variants_.then(variants => {
+        user().assert(variants,
+            'To use variable VARIANTS, amp-experiment should be configured');
+
+        const experiments = [];
+        for (const experiment in variants) {
+          const variant = variants[experiment];
+          experiments.push(
+              experiment + VARIANT_DELIMITER + (variant || 'none'));
+        }
+
+        return experiments.join(EXPERIMENT_DELIMITER);
+      });
+    });
+
+    // Returns incoming share tracking fragment.
+    this.setAsync('SHARE_TRACKING_INCOMING', () => {
+      return this.shareTrackingFragments_.then(fragments => {
+        user().assert(fragments, 'To use variable SHARE_TRACKING_INCOMING, ' +
+            'amp-share-tracking should be configured');
+        return fragments.incomingFragment;
+      });
+    });
+
+    // Returns outgoing share tracking fragment.
+    this.setAsync('SHARE_TRACKING_OUTGOING', () => {
+      return this.shareTrackingFragments_.then(fragments => {
+        user().assert(fragments, 'To use variable SHARE_TRACKING_OUTGOING, ' +
+            'amp-share-tracking should be configured');
+        return fragments.outgoingFragment;
+      });
+    });
+
+    // Returns the number of milliseconds since 1 Jan 1970 00:00:00 UTC.
+    this.set('TIMESTAMP', () => {
+      return Date.now();
+    });
+
+    // Returns the user's time-zone offset from UTC, in minutes.
+    this.set('TIMEZONE', () => {
+      return new Date().getTimezoneOffset();
+    });
+
+    // Returns a promise resolving to viewport.getScrollTop.
+    this.set('SCROLL_TOP', () => viewport.getScrollTop());
+
+    // Returns a promise resolving to viewport.getScrollLeft.
+    this.set('SCROLL_LEFT', () => viewport.getScrollLeft());
+
+    // Returns a promise resolving to viewport.getScrollHeight.
+    this.set('SCROLL_HEIGHT', () => viewport.getScrollHeight());
+
+    // Returns a promise resolving to viewport.getScrollWidth.
+    this.set('SCROLL_WIDTH', () => viewport.getScrollWidth());
+
+    // Returns the viewport height.
+    this.set('VIEWPORT_HEIGHT', () => viewport.getSize().height);
+
+    // Returns the viewport width.
+    this.set('VIEWPORT_WIDTH', () => viewport.getSize().width);
+
+    // Returns screen.width.
+    this.set('SCREEN_WIDTH', () => this.ampdoc.win.screen.width);
+
+    // Returns screen.height.
+    this.set('SCREEN_HEIGHT', () => this.ampdoc.win.screen.height);
+
+    // Returns screen.availHeight.
+    this.set('AVAILABLE_SCREEN_HEIGHT',
+        () => this.ampdoc.win.screen.availHeight);
+
+    // Returns screen.availWidth.
+    this.set('AVAILABLE_SCREEN_WIDTH',
+        () => this.ampdoc.win.screen.availWidth);
+
+    // Returns screen.ColorDepth.
+    this.set('SCREEN_COLOR_DEPTH',
+        () => this.ampdoc.win.screen.colorDepth);
+
+    // Returns document characterset.
+    this.set('DOCUMENT_CHARSET', () => {
+      const doc = this.ampdoc.win.document;
+      return doc.characterSet || doc.charset;
+    });
+
+    // Returns the browser language.
+    this.set('BROWSER_LANGUAGE', () => {
+      const nav = this.ampdoc.win.navigator;
+      return (nav.language || nav.userLanguage || nav.browserLanguage || '')
+          .toLowerCase();
+    });
+
+    // Returns the time it took to load the whole page. (excludes amp-* elements
+    // that are not rendered by the system yet.)
+    this.setTimingResolver_(
+        'PAGE_LOAD_TIME', 'navigationStart', 'loadEventStart');
+
+    // Returns the time it took to perform DNS lookup for the domain.
+    this.setTimingResolver_(
+        'DOMAIN_LOOKUP_TIME', 'domainLookupStart', 'domainLookupEnd');
+
+    // Returns the time it took to connect to the server.
+    this.setTimingResolver_(
+        'TCP_CONNECT_TIME', 'connectStart', 'connectEnd');
+
+    // Returns the time it took for server to start sending a response to the
+    // request.
+    this.setTimingResolver_(
+        'SERVER_RESPONSE_TIME', 'requestStart', 'responseStart');
+
+    // Returns the time it took to download the page.
+    this.setTimingResolver_(
+        'PAGE_DOWNLOAD_TIME', 'responseStart', 'responseEnd');
+
+    // Returns the time it took for redirects to complete.
+    this.setTimingResolver_(
+        'REDIRECT_TIME', 'navigationStart', 'fetchStart');
+
+    // Returns the time it took for DOM to become interactive.
+    this.setTimingResolver_(
+        'DOM_INTERACTIVE_TIME', 'navigationStart', 'domInteractive');
+
+    // Returns the time it took for content to load.
+    this.setTimingResolver_(
+        'CONTENT_LOAD_TIME', 'navigationStart', 'domContentLoadedEventStart');
+
+    // Access: Reader ID.
+    this.setAsync('ACCESS_READER_ID', /** @type {AsyncResolverDef} */(() => {
+      return this.getAccessValue_(accessService => {
+        return accessService.getAccessReaderId();
+      }, 'ACCESS_READER_ID');
+    }));
+
+    // Access: data from the authorization response.
+    this.setAsync('AUTHDATA', /** @type {AsyncResolverDef} */(field => {
+      user().assert(field,
+          'The first argument to AUTHDATA, the field, is required');
+      return this.getAccessValue_(accessService => {
+        return accessService.getAuthdataField(field);
+      }, 'AUTHDATA');
+    }));
+
+    // Returns an identifier for the viewer.
+    this.setAsync('VIEWER', () => {
+      return viewerForDoc(this.ampdoc).getViewerOrigin().then(viewer => {
+        return viewer == undefined ? '' : viewer;
+      });
+    });
+
+    // Returns the total engaged time since the content became viewable.
+    this.setAsync('TOTAL_ENGAGED_TIME', () => {
+      return activityFor(this.ampdoc.win).then(activity => {
+        return activity.getTotalEngagedTime();
+      });
+    });
+
+    this.set('NAV_TIMING', (startAttribute, endAttribute) => {
+      user().assert(startAttribute, 'The first argument to NAV_TIMING, the ' +
+          'start attribute name, is required');
+      return getTimingDataSync(
+          this.ampdoc.win,
+          /**@type {string}*/(startAttribute),
+          /**@type {string}*/(endAttribute));
+    });
+    this.setAsync('NAV_TIMING', (startAttribute, endAttribute) => {
+      user().assert(startAttribute, 'The first argument to NAV_TIMING, the ' +
+          'start attribute name, is required');
+      return getTimingDataAsync(
+          this.ampdoc.win,
+          /**@type {string}*/(startAttribute),
+          /**@type {string}*/(endAttribute));
+    });
+
+    this.set('NAV_TYPE', () => {
+      return getNavigationData(this.ampdoc.win, 'type');
+    });
+
+    this.set('NAV_REDIRECT_COUNT', () => {
+      return getNavigationData(this.ampdoc.win, 'redirectCount');
+    });
+
+    // returns the AMP version number
+    this.set('AMP_VERSION', () => '$internalRuntimeVersion$');
+
+    this.set('BACKGROUND_STATE', () => {
+      return viewerForDoc(this.ampdoc.win.document).isVisible() ? '0' : '1';
+    });
+  }
+
+  /**
+   * Resolves the value via document info.
+   * @param {function(!./document-info-impl.DocumentInfoDef):T} getter
+   * @return {T}
+   * @template T
+   */
+  getDocInfoValue_(getter) {
+    return getter(documentInfoForDoc(this.ampdoc));
+  }
+
+  /**
+   * Resolves the value via access service. If access service is not configured,
+   * the resulting value is `null`.
+   * @param {function(!AccessService):(T|!Promise<T>)} getter
+   * @param {string} expr
+   * @return {T|null}
+   * @template T
+   */
+  getAccessValue_(getter, expr) {
+    return this.getAccessService_(this.ampdoc.win).then(accessService => {
+      if (!accessService) {
+        // Access service is not installed.
+        user().error(TAG, 'Access service is not installed to access: ', expr);
+        return null;
+      }
+      return getter(accessService);
+    });
+  }
+
+  /**
+   * Return the QUERY_PARAM from the current location href
+   * @param {*} param
+   * @param {string} defaultValue
+   * @return {string}
+   */
+  getQueryParamData_(param, defaultValue) {
+    user().assert(param,
+        'The first argument to QUERY_PARAM, the query string ' +
+        'param is required');
+    user().assert(typeof param == 'string', 'param should be a string');
+    const url = parseUrl(this.ampdoc.win.location.href);
+    const params = parseQueryString(url.search);
+    return (typeof params[param] !== 'undefined')
+        ? params[param] : defaultValue;
+  }
+}
+
+/**
+ * This class replaces substitution variables with their values.
+ * Document new values in ../spec/amp-var-substitutions.md
+ * @package For export
+ */
+export class VarSubstitution {
+  /** @param {!./ampdoc-impl.AmpDoc} ampdoc */
+  constructor(ampdoc, variableSource) {
+    /** @const {!./ampdoc-impl.AmpDoc} */
+    this.ampdoc = ampdoc;
+
+    /** @type {VariableSource} */
+    this.variableSource_ = variableSource;
+  }
+
+  /**
+   * Synchronously expands the provided source by replacing all known variables with
+   * their resolved values. Optional `opt_bindings` can be used to add new
+   * variables or override existing ones.  Any async bindings are ignored.
+   * @param {string} source
+   * @param {!Object<string, (ResolverReturnDef|!SyncResolverDef)>=} opt_bindings
+   * @param {!Object<string, ResolverReturnDef>=} opt_collectVars
+   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
+   *     that can be substituted.
+   * @return {string}
+   */
+  expandSync(source, opt_bindings, opt_collectVars, opt_whiteList) {
+    return /** @type {string} */(
+        this.expand_(source, opt_bindings, opt_collectVars, /* opt_sync */ true,
+            opt_whiteList));
+  }
+
+  /**
+   * Expands the provided source by replacing all known variables with their
+   * resolved values. Optional `opt_bindings` can be used to add new variables
+   * or override existing ones.
+   * @param {string} source
+   * @param {!Object<string, *>=} opt_bindings
+   * @return {!Promise<string>}
+   */
+  expandAsync(source, opt_bindings) {
+    return /** @type {!Promise<string>} */(this.expand_(source, opt_bindings));
+  }
+
+  /**
+   * @param {string} source
+   * @param {!Object<string, *>=} opt_bindings
+   * @param {!Object<string, *>=} opt_collectVars
+   * @param {boolean=} opt_sync
+   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
+   *     that can be substituted.
+   * @return {!Promise<string>|string}
+   * @private
+   */
+  expand_(source, opt_bindings, opt_collectVars, opt_sync, opt_whiteList) {
+    const expr = this.variableSource_.getExpr(opt_bindings);
+    let replacementPromise;
+    let replacement = source.replace(expr, (match, name, opt_strargs) => {
+      let args = [];
+      if (typeof opt_strargs == 'string') {
+        args = opt_strargs.split(',');
+      }
+      if (opt_whiteList && !opt_whiteList[name]) {
+        // Do not perform substitution and just return back the original
+        // match, so that the string doesn't change.
+        return match;
+      }
+      let binding;
+      if (opt_bindings && (name in opt_bindings)) {
+        binding = opt_bindings[name];
+      } else if ((binding = this.variableSource_.get(name))) {
+        if (opt_sync) {
+          binding = binding.sync;
+          if (!binding) {
+            user().error(TAG, 'ignoring async replacement key: ', name);
+            return '';
+          }
+        } else {
+          binding = binding.async || binding.sync;
+        }
+      }
+      let val;
+      try {
+        val = (typeof binding == 'function') ?
+            binding.apply(null, args) : binding;
+      } catch (e) {
+        // Report error, but do not disrupt URL replacement. This will
+        // interpolate as the empty string.
+        if (opt_sync) {
+          val = '';
+        }
+        rethrowAsync(e);
+      }
+      // In case the produced value is a promise, we don't actually
+      // replace anything here, but do it again when the promise resolves.
+      if (val && val.then) {
+        if (opt_sync) {
+          user().error(TAG, 'ignoring promise value for key: ', name);
+          return '';
+        }
+        /** @const {Promise<string>} */
+        const p = val.catch(err => {
+          // Report error, but do not disrupt URL replacement. This will
+          // interpolate as the empty string.
+          rethrowAsync(err);
+        }).then(v => {
+          replacement = replacement.replace(match, encodeValue(v));
+          if (opt_collectVars) {
+            opt_collectVars[match] = v;
+          }
+        });
+        if (replacementPromise) {
+          replacementPromise = replacementPromise.then(() => p);
+        } else {
+          replacementPromise = p;
+        }
+        return match;
+      }
+      if (opt_collectVars) {
+        opt_collectVars[match] = val;
+      }
+      return encodeValue(val);
+    });
+
+    if (replacementPromise) {
+      replacementPromise = replacementPromise.then(() => replacement);
+    }
+
+    if (opt_sync) {
+      return replacement;
+    }
+    return replacementPromise || Promise.resolve(replacement);
+  }
+
+  /**
+   * Collects all substitutions in the provided source and expands them to the
+   * values for known variables. Optional `opt_bindings` can be used to add
+   * new variables or override existing ones.
+   * @param {string} source
+   * @param {!Object<string, *>=} opt_bindings
+   * @return {!Promise<!Object<string, *>>}
+   */
+  collectVars(source, opt_bindings) {
+    const vars = Object.create(null);
+    return this.expand_(source, opt_bindings, vars).then(() => vars);
+  }
+
+  /**
+   * @return {VariableSource}
+   */
+  getVariableSource() {
+    return this.variableSource_;
+  }
+}
+
+
+/**
+ * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ * @return {!VarSubstitution}
+ */
+export function installVarSubstitutionServiceForDoc(ampdoc) {
+  return getServiceForDoc(ampdoc, 'var-substitution', doc => {
+    return new VarSubstitution(doc, new GlobalVariableSource(doc));
+  });
+}
+
+/**
+ * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Window} embedWin
+ * @param {*} varSource
+ */
+export function installVarSubstitutionForEmbed(ampdoc, embedWin, varSource) {
+  installServiceInEmbedScope(embedWin, 'var-substitution',
+      new VarSubstitution(ampdoc, varSource));
+}

--- a/src/service/var-substitution-impl.js
+++ b/src/service/var-substitution-impl.js
@@ -510,12 +510,15 @@ export class GlobalVariableSource extends VariableSource {
  * @package For export
  */
 export class VarSubstitution {
-  /** @param {!./ampdoc-impl.AmpDoc} ampdoc */
+  /**
+   * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   * @param {!VariableSource} variableSource
+   */
   constructor(ampdoc, variableSource) {
     /** @const {!./ampdoc-impl.AmpDoc} */
     this.ampdoc = ampdoc;
 
-    /** @type {VariableSource} */
+    /** @type {!VariableSource} */
     this.variableSource_ = variableSource;
   }
 
@@ -673,7 +676,7 @@ export function installVarSubstitutionServiceForDoc(ampdoc) {
 /**
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  * @param {!Window} embedWin
- * @param {*} varSource
+ * @param {!VariableSource} varSource
  */
 export function installVarSubstitutionForEmbed(ampdoc, embedWin, varSource) {
   installServiceInEmbedScope(embedWin, 'var-substitution',

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -18,13 +18,13 @@ import {whenDocumentComplete} from '../document-ready';
 import {isFiniteNumber} from '../types';
 
 /** @typedef {string|number|boolean|undefined|null} */
-let ResolverReturnDef;
+export let ResolverReturnDef;
 
 /** @typedef {function(...*):ResolverReturnDef} */
-let SyncResolverDef;
+export let SyncResolverDef;
 
 /** @typedef {function(...*):!Promise<ResolverReturnDef>} */
-let AsyncResolverDef;
+export let AsyncResolverDef;
 
 /** @typedef {{sync: SyncResolverDef, async: AsyncResolverDef}} */
 let ReplacementDef;

--- a/src/var-substitution.js
+++ b/src/var-substitution.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getExistingServiceForDocInEmbedScope} from './service';
+
+
+/**
+ * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+ * @return {!./service/var-substitution-impl.VarSubstitution}
+ */
+export function varSubstitutionForDoc(nodeOrDoc) {
+  return /** @type {!./service/var-substitution-impl.VarSubstitution} */ (
+      getExistingServiceForDocInEmbedScope(nodeOrDoc, 'var-substitution'));
+}

--- a/test/functional/test-var-substitution.js
+++ b/test/functional/test-var-substitution.js
@@ -1,0 +1,927 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Observable} from '../../src/observable';
+import {createIframePromise} from '../../testing/iframe';
+import {user} from '../../src/log';
+import {varSubstitutionForDoc} from '../../src/var-substitution';
+import {markElementScheduledForTesting} from '../../src/custom-element';
+import {installCidService} from '../../extensions/amp-analytics/0.1/cid-impl';
+import {installCryptoService,} from
+    '../../extensions/amp-analytics/0.1/crypto-impl';
+import {installDocService} from '../../src/service/ampdoc-impl';
+import {installDocumentInfoServiceForDoc,} from
+    '../../src/service/document-info-impl';
+import {installActivityService,} from
+    '../../extensions/amp-analytics/0.1/activity-impl';
+import {
+    installVarSubstitutionServiceForDoc,
+} from '../../src/service/var-substitution-impl';
+import {getService} from '../../src/service';
+import {setCookie} from '../../src/cookies';
+import {parseUrl} from '../../src/url';
+import {viewerForDoc} from '../../src/viewer';
+import * as trackPromise from '../../src/impression';
+import * as sinon from 'sinon';
+
+
+describe('VarSubstitution', () => {
+
+  let canonical;
+  let sandbox;
+  let loadObservable;
+  let replacements;
+  let viewerService;
+  let userErrorStub;
+
+  beforeEach(() => {
+    canonical = 'https://canonical.com/doc1';
+    sandbox = sinon.sandbox.create();
+    userErrorStub = sandbox.stub(user(), 'error');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function getVarSub(opt_options) {
+    return createIframePromise().then(iframe => {
+      iframe.doc.title = 'Pixel Test';
+      const link = iframe.doc.createElement('link');
+      link.setAttribute('href', 'https://pinterest.com:8080/pin1');
+      link.setAttribute('rel', 'canonical');
+      iframe.doc.head.appendChild(link);
+      installDocumentInfoServiceForDoc(iframe.ampdoc);
+      if (opt_options) {
+        if (opt_options.withCid) {
+          markElementScheduledForTesting(iframe.win, 'amp-analytics');
+          installCidService(iframe.win);
+          installCryptoService(iframe.win);
+        }
+        if (opt_options.withActivity) {
+          markElementScheduledForTesting(iframe.win, 'amp-analytics');
+          installActivityService(iframe.win);
+        }
+        if (opt_options.withVariant) {
+          markElementScheduledForTesting(iframe.win, 'amp-experiment');
+          getService(iframe.win, 'variant', () => Promise.resolve({
+            'x1': 'v1',
+            'x2': null,
+          }));
+        }
+        if (opt_options.withShareTracking) {
+          markElementScheduledForTesting(iframe.win, 'amp-share-tracking');
+          getService(iframe.win, 'share-tracking', () => Promise.resolve({
+            incomingFragment: '12345',
+            outgoingFragment: '54321',
+          }));
+        }
+      }
+      viewerService = viewerForDoc(iframe.ampdoc);
+      replacements = varSubstitutionForDoc(iframe.ampdoc);
+      return replacements;
+    });
+  }
+
+  function expandAsync(url, opt_bindings, opt_options) {
+    return getVarSub(opt_options).then(
+        replacements => replacements.expandAsync(url, opt_bindings)
+    );
+  }
+
+  function getFakeWindow() {
+    loadObservable = new Observable();
+    const win = {
+      addEventListener: function(type, callback) {
+        loadObservable.add(callback);
+      },
+      Object,
+      performance: {
+        timing: {
+          navigationStart: 100,
+          loadEventStart: 0,
+        },
+      },
+      removeEventListener: function(type, callback) {
+        loadObservable.remove(callback);
+      },
+      document: {
+        nodeType: /* document */ 9,
+        querySelector: () => {return {href: canonical};},
+        cookie: '',
+      },
+      Math: window.Math,
+      services: {
+        'viewport': {obj: {}},
+        'cid': {
+          promise: Promise.resolve({
+            get: config => Promise.resolve('test-cid(' + config.scope + ')'),
+          }),
+        },
+      },
+    };
+    win.document.defaultView = win;
+    const ampdocService = installDocService(win, true);
+    const ampdoc = ampdocService.getAmpDoc(win.document);
+    installDocumentInfoServiceForDoc(ampdoc);
+    win.ampdoc = ampdoc;
+    return win;
+  }
+
+  it('should replace RANDOM', () => {
+    return expandAsync('ord=RANDOM').then(res => {
+      expect(res).to.match(/ord=(\d+(\.\d+)?)$/);
+    });
+  });
+
+  it('should replace COUNTER', () => {
+    return expandAsync(
+        'COUNTER(foo),COUNTER(bar),COUNTER(foo),COUNTER(bar),COUNTER(bar)')
+        .then(res => {
+          expect(res).to.equal('1,1,2,2,3');
+        });
+  });
+
+  it('should replace CANONICAL_URL', () => {
+    return expandAsync('URL:CANONICAL_URL').then(res => {
+      expect(res).to.equal('URL:https%3A%2F%2Fpinterest.com%3A8080%2Fpin1');
+    });
+  });
+
+  it('should replace CANONICAL_HOST', () => {
+    return expandAsync('host:CANONICAL_HOST').then(res => {
+      expect(res).to.equal('host:pinterest.com%3A8080');
+    });
+  });
+
+  it('should replace CANONICAL_HOSTNAME', () => {
+    return expandAsync('host:CANONICAL_HOSTNAME').then(res => {
+      expect(res).to.equal('host:pinterest.com');
+    });
+  });
+
+  it('should replace CANONICAL_PATH', () => {
+    return expandAsync('path=CANONICAL_PATH').then(res => {
+      expect(res).to.equal('path=%2Fpin1');
+    });
+  });
+
+  it('should replace DOCUMENT_REFERRER', () => {
+    return expandAsync('ref=DOCUMENT_REFERRER').then(res => {
+      expect(res).to.equal('ref=http%3A%2F%2Flocalhost%3A9876%2Fcontext.html');
+    });
+  });
+
+  it('should replace TITLE', () => {
+    return expandAsync('title=TITLE').then(res => {
+      expect(res).to.equal('title=Pixel%20Test');
+    });
+  });
+
+  it('should replace AMPDOC_URL', () => {
+    return expandAsync('ref=AMPDOC_URL').then(res => {
+      expect(res).to.not.match(/AMPDOC_URL/);
+    });
+  });
+
+  it('should replace AMPDOC_HOST', () => {
+    return expandAsync('ref=AMPDOC_HOST').then(res => {
+      expect(res).to.not.match(/AMPDOC_HOST/);
+    });
+  });
+
+  it('should replace AMPDOC_HOSTNAME', () => {
+    return expandAsync('ref=AMPDOC_HOSTNAME').then(res => {
+      expect(res).to.not.match(/AMPDOC_HOSTNAME/);
+    });
+  });
+
+  it('should replace SOURCE_URL and _HOST', () => {
+    sandbox.stub(trackPromise, 'getTrackImpressionPromise', () => {
+      return Promise.resolve();
+    });
+    return expandAsync('url=SOURCE_URL&host=SOURCE_HOST').then(res => {
+      expect(res).to.not.match(/SOURCE_URL/);
+      expect(res).to.not.match(/SOURCE_HOST/);
+    });
+  });
+
+  it('should replace SOURCE_URL and _HOSTNAME', () => {
+    sandbox.stub(trackPromise, 'getTrackImpressionPromise', () => {
+      return Promise.resolve();
+    });
+    return expandAsync('url=SOURCE_URL&host=SOURCE_HOSTNAME').then(res => {
+      expect(res).to.not.match(/SOURCE_URL/);
+      expect(res).to.not.match(/SOURCE_HOSTNAME/);
+    });
+  });
+
+  it('should update SOURCE_URL after track impression', () => {
+    const win = getFakeWindow();
+    win.location = parseUrl('https://wrong.com');
+    sandbox.stub(trackPromise, 'getTrackImpressionPromise', () => {
+      return new Promise(resolve => {
+        win.location = parseUrl('https://example.com?gclid=123456');
+        resolve();
+      });
+    });
+    return installVarSubstitutionServiceForDoc(win.ampdoc)
+        .expandAsync('url=SOURCE_URL')
+        .then(res => {
+          expect(res).to.contain('example.com');
+        });
+  });
+
+  it('should replace SOURCE_PATH', () => {
+    return expandAsync('path=SOURCE_PATH').then(res => {
+      expect(res).to.not.match(/SOURCE_PATH/);
+    });
+  });
+
+  it('should replace PAGE_VIEW_ID', () => {
+    return expandAsync('pid=PAGE_VIEW_ID').then(res => {
+      expect(res).to.match(/pid=\d+/);
+    });
+  });
+
+  it('should replace CLIENT_ID', () => {
+    setCookie(window, 'url-abc', 'cid-for-abc');
+    // Make sure cookie does not exist
+    setCookie(window, 'url-xyz', '');
+    return expandAsync('a=CLIENT_ID(url-abc)&b=CLIENT_ID(url-xyz)',
+        /*opt_bindings*/undefined, {withCid: true}).then(res => {
+          expect(res).to.match(/^a=cid-for-abc\&b=amp-([a-zA-Z0-9_-]+){10,}/);
+        });
+  });
+
+  it('should replace CLIENT_ID synchronously when available', () => {
+    return getVarSub({withCid: true}).then(varSub => {
+      setCookie(window, 'url-abc', 'cid-for-abc');
+      setCookie(window, 'url-xyz', 'cid-for-xyz');
+      // Only requests cid-for-xyz in async path
+      return varSub.expandAsync('b=CLIENT_ID(url-xyz)').then(res => {
+        expect(res).to.equal('b=cid-for-xyz');
+      }).then(() => {
+        const result = varSub.expandSync(
+            'a=CLIENT_ID(url-abc)&b=CLIENT_ID(url-xyz)&c=CLIENT_ID(other)');
+        expect(result).to.equal('a=&b=cid-for-xyz&c=');
+      });
+    });
+  });
+
+  it('should replace VARIANT', () => {
+    return expect(expandAsync('x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)',
+        /*opt_bindings*/undefined, {withVariant: true}))
+        .to.eventually.equal('x1=v1&x2=none&x3=');
+  });
+
+  it('should replace VARIANT with empty string if ' +
+      'amp-experiment is not configured ', () => {
+    return expect(expandAsync('x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)'))
+        .to.eventually.equal('x1=&x2=&x3=');
+  });
+
+  it('should replace VARIANTS', () => {
+    return expect(expandAsync('VARIANTS', /*opt_bindings*/undefined,
+        {withVariant: true})).to.eventually.equal('x1.v1!x2.none');
+  });
+
+  it('should replace VARIANTS with empty string if ' +
+      'amp-experiment is not configured ', () => {
+    return expect(expandAsync('VARIANTS')).to.eventually.equal('');
+  });
+
+  it('should replace SHARE_TRACKING_INCOMING and' +
+      'SHARE_TRACKING_OUTGOING', () => {
+    return expect(
+        expandAsync('in=SHARE_TRACKING_INCOMING&out=SHARE_TRACKING_OUTGOING',
+            /*opt_bindings*/undefined, {withShareTracking: true}))
+        .to.eventually.equal('in=12345&out=54321');
+  });
+
+  it('should replace SHARE_TRACKING_INCOMING and SHARE_TRACKING_OUTGOING' +
+      'with empty string if amp-share-tracking is not configured', () => {
+    return expect(
+        expandAsync('in=SHARE_TRACKING_INCOMING&out=SHARE_TRACKING_OUTGOING'))
+        .to.eventually.equal('in=&out=');
+  });
+
+  it('should replace TIMESTAMP', () => {
+    return expandAsync('ts=TIMESTAMP').then(res => {
+      expect(res).to.match(/ts=\d+/);
+    });
+  });
+
+  it('should replace TIMEZONE', () => {
+    return expandAsync('tz=TIMEZONE').then(res => {
+      expect(res).to.match(/tz=-?\d+/);
+    });
+  });
+
+  it('should replace SCROLL_TOP', () => {
+    return expandAsync('scrollTop=SCROLL_TOP').then(res => {
+      expect(res).to.match(/scrollTop=\d+/);
+    });
+  });
+
+  it('should replace SCROLL_LEFT', () => {
+    return expandAsync('scrollLeft=SCROLL_LEFT').then(res => {
+      expect(res).to.match(/scrollLeft=\d+/);
+    });
+  });
+
+  it('should replace SCROLL_HEIGHT', () => {
+    return expandAsync('scrollHeight=SCROLL_HEIGHT').then(res => {
+      expect(res).to.match(/scrollHeight=\d+/);
+    });
+  });
+
+  it('should replace SCREEN_WIDTH', () => {
+    return expandAsync('sw=SCREEN_WIDTH').then(res => {
+      expect(res).to.match(/sw=\d+/);
+    });
+  });
+
+  it('should replace SCREEN_HEIGHT', () => {
+    return expandAsync('sh=SCREEN_HEIGHT').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace VIEWPORT_WIDTH', () => {
+    return expandAsync('vw=VIEWPORT_WIDTH').then(res => {
+      expect(res).to.match(/vw=\d+/);
+    });
+  });
+
+  it('should replace VIEWPORT_HEIGHT', () => {
+    return expandAsync('vh=VIEWPORT_HEIGHT').then(res => {
+      expect(res).to.match(/vh=\d+/);
+    });
+  });
+
+  it('should replace PAGE_LOAD_TIME', () => {
+    return expandAsync('sh=PAGE_LOAD_TIME').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('Should replace BACKGROUND_STATE with 0', () => {
+    const win = getFakeWindow();
+    win.services.viewer = {
+      obj: {isVisible: () => true},
+    };
+    return installVarSubstitutionServiceForDoc(win.ampdoc)
+        .expandAsync('sh=BACKGROUND_STATE')
+        .then(res => {
+          expect(res).to.equal('sh=0');
+        });
+  });
+
+  it('Should replace BACKGROUND_STATE with 1', () => {
+    const win = getFakeWindow();
+    win.services.viewer = {
+      obj: {isVisible: () => false},
+    };
+    return installVarSubstitutionServiceForDoc(win.ampdoc)
+        .expandAsync('sh=BACKGROUND_STATE')
+        .then(res => {
+          expect(res).to.equal('sh=1');
+        });
+  });
+
+  describe('PAGE_LOAD_TIME', () => {
+    let win;
+    let ampdoc;
+    let eventListeners;
+    beforeEach(() => {
+      win = getFakeWindow();
+      ampdoc = win.ampdoc;
+      eventListeners = {};
+      win.document.readyState = 'loading';
+      win.document.addEventListener = function(eventType, handler) {
+        eventListeners[eventType] = handler;
+      };
+      win.document.removeEventListener = function(eventType, handler) {
+        if (eventListeners[eventType] == handler) {
+          delete eventListeners[eventType];
+        }
+      };
+    });
+
+    it('is replaced if timing info is not available', () => {
+      win.document.readyState = 'complete';
+      return installVarSubstitutionServiceForDoc(ampdoc)
+          .expandAsync('sh=PAGE_LOAD_TIME&s')
+          .then(res => {
+            expect(res).to.match(/sh=&s/);
+          });
+    });
+
+    it('is replaced if PAGE_LOAD_TIME is available within a delay', () => {
+      const varSub = installVarSubstitutionServiceForDoc(ampdoc);
+      const validMetric = varSub.expandAsync('sh=PAGE_LOAD_TIME&s');
+      varSub.ampdoc.win.performance.timing.loadEventStart = 109;
+      win.document.readyState = 'complete';
+      eventListeners['readystatechange']();
+      return validMetric.then(res => {
+        expect(res).to.match(/sh=9&s/);
+      });
+    });
+  });
+
+  it('should replace NAV_REDIRECT_COUNT', () => {
+    return expandAsync('sh=NAV_REDIRECT_COUNT').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace NAV_TIMING', () => {
+    return expandAsync('a=NAV_TIMING(navigationStart)' +
+        '&b=NAV_TIMING(navigationStart,responseStart)').then(res => {
+          expect(res).to.match(/a=\d+&b=\d+/);
+        });
+  });
+
+  it('should replace NAV_TIMING when attribute names are invalid', () => {
+    return expandAsync('a=NAV_TIMING(invalid)&b=NAV_TIMING(invalid,invalid)' +
+        '&c=NAV_TIMING(navigationStart,invalid)' +
+        '&d=NAV_TIMING(invalid,responseStart)').then(res => {
+          expect(res).to.match(/a=&b=&c=&d=/);
+        });
+  });
+
+  it('should replace NAV_TYPE', () => {
+    return expandAsync('sh=NAV_TYPE').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace DOMAIN_LOOKUP_TIME', () => {
+    return expandAsync('sh=DOMAIN_LOOKUP_TIME').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace TCP_CONNECT_TIME', () => {
+    return expandAsync('sh=TCP_CONNECT_TIME').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace SERVER_RESPONSE_TIME', () => {
+    return expandAsync('sh=SERVER_RESPONSE_TIME').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace PAGE_DOWNLOAD_TIME', () => {
+    return expandAsync('sh=PAGE_DOWNLOAD_TIME').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace REDIRECT_TIME', () => {
+    return expandAsync('sh=REDIRECT_TIME').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace DOM_INTERACTIVE_TIME', () => {
+    return expandAsync('sh=DOM_INTERACTIVE_TIME').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace CONTENT_LOAD_TIME', () => {
+    return expandAsync('sh=CONTENT_LOAD_TIME').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace AVAILABLE_SCREEN_HEIGHT', () => {
+    return expandAsync('sh=AVAILABLE_SCREEN_HEIGHT').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace AVAILABLE_SCREEN_WIDTH', () => {
+    return expandAsync('sh=AVAILABLE_SCREEN_WIDTH').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace SCREEN_COLOR_DEPTH', () => {
+    return expandAsync('sh=SCREEN_COLOR_DEPTH').then(res => {
+      expect(res).to.match(/sh=\d+/);
+    });
+  });
+
+  it('should replace BROWSER_LANGUAGE', () => {
+    return expandAsync('sh=BROWSER_LANGUAGE').then(res => {
+      expect(res).to.match(/sh=\w+/);
+    });
+  });
+
+  it('should replace VIEWER with origin', () => {
+    return getVarSub().then(replacements => {
+      sandbox.stub(viewerService, 'getViewerOrigin').returns(
+          Promise.resolve('https://www.google.com'));
+      return replacements.expandAsync('sh=VIEWER').then(res => {
+        expect(res).to.equal('sh=https%3A%2F%2Fwww.google.com');
+      });
+    });
+  });
+
+  it('should replace VIEWER with empty string', () => {
+    return getVarSub().then(replacements => {
+      sandbox.stub(viewerService, 'getViewerOrigin').returns(
+          Promise.resolve(''));
+      return replacements.expandAsync('sh=VIEWER').then(res => {
+        expect(res).to.equal('sh=');
+      });
+    });
+  });
+
+  it('should replace TOTAL_ENGAGED_TIME', () => {
+    return expandAsync('sh=TOTAL_ENGAGED_TIME', /*opt_bindings*/undefined,
+        {withActivity: true}).then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+  });
+
+  it('should replace AMP_VERSION', () => {
+    return expandAsync('sh=AMP_VERSION').then(res => {
+      expect(res).to.equal('sh=%24internalRuntimeVersion%24');
+    });
+  });
+
+  it('should accept $expressions', () => {
+    return expandAsync('href=$CANONICAL_URL').then(res => {
+      expect(res).to.equal('href=https%3A%2F%2Fpinterest.com%3A8080%2Fpin1');
+    });
+  });
+
+  it('should ignore unknown substitutions', () => {
+    return expandAsync('a=UNKNOWN').then(res => {
+      expect(res).to.equal('a=UNKNOWN');
+    });
+  });
+
+  it('should replace several substitutions', () => {
+    return expandAsync('a=UNKNOWN&href=CANONICAL_URL&title=TITLE')
+        .then(res => {
+          expect(res).to.equal('a=UNKNOWN' +
+              '&href=https%3A%2F%2Fpinterest.com%3A8080%2Fpin1' +
+              '&title=Pixel%20Test');
+        });
+  });
+
+  it('should replace new substitutions', () => {
+    const replacements = varSubstitutionForDoc(window.document);
+    replacements.getVariableSource().set('ONE', () => 'a');
+    expect(replacements.expandAsync('a=ONE')).to.eventually.equal('a=a');
+    replacements.getVariableSource().set('ONE', () => 'b');
+    replacements.getVariableSource().set('TWO', () => 'b');
+    return expect(replacements.expandAsync('a=ONE&b=TWO'))
+        .to.eventually.equal('a=b&b=b');
+  });
+
+  it('should report errors & replace them with empty string (sync)', () => {
+    const clock = sandbox.useFakeTimers();
+    const replacements = varSubstitutionForDoc(window.document);
+    replacements.getVariableSource().set('ONE', () => {
+      throw new Error('boom');
+    });
+    const p = expect(replacements.expandAsync('a=ONE')).to.eventually
+        .equal('a=');
+    expect(() => {
+      clock.tick(1);
+    }).to.throw(/boom/);
+    return p;
+  });
+
+  it('should report errors & replace them with empty string (promise)', () => {
+    const clock = sandbox.useFakeTimers();
+    const replacements = varSubstitutionForDoc(window.document);
+    replacements.getVariableSource().set('ONE', () => {
+      return Promise.reject(new Error('boom'));
+    });
+    return expect(replacements.expandAsync('a=ONE')).to.eventually.equal('a=')
+        .then(() => {
+          expect(() => {
+            clock.tick(1);
+          }).to.throw(/boom/);
+        });
+  });
+
+  it('should support positional arguments', () => {
+    const replacements = varSubstitutionForDoc(window.document);
+    replacements.getVariableSource().set('FN', one => one);
+    return expect(replacements.expandAsync('a=FN(xyz1)')).to
+        .eventually.equal('a=xyz1');
+  });
+
+  it('should support multiple positional arguments', () => {
+    const replacements = varSubstitutionForDoc(window.document);
+    replacements.getVariableSource().set('FN', (one, two) => {
+      return one + '-' + two;
+    });
+    return expect(replacements.expandAsync('a=FN(xyz,abc)')).to
+        .eventually.equal('a=xyz-abc');
+  });
+
+  it('should support multiple positional arguments with dots', () => {
+    const replacements = varSubstitutionForDoc(window.document);
+    replacements.getVariableSource().set('FN', (one, two) => {
+      return one + '-' + two;
+    });
+    return expect(replacements.expandAsync('a=FN(xy.z,ab.c)')).to
+        .eventually.equal('a=xy.z-ab.c');
+  });
+
+  it('should support promises as replacements', () => {
+    const replacements = varSubstitutionForDoc(window.document);
+    replacements.getVariableSource().set('P1', () => Promise.resolve('abc '));
+    replacements.getVariableSource().set('P2', () => Promise.resolve('xyz'));
+    replacements.getVariableSource().set('P3', () => Promise.resolve('123'));
+    replacements.getVariableSource().set('OTHER', () => 'foo');
+    return expect(replacements.expandAsync('a=P1&b=P2&c=P3&d=OTHER'))
+        .to.eventually.equal('a=abc%20&b=xyz&c=123&d=foo');
+  });
+
+  it('should override an existing binding', () => {
+    return expandAsync('ord=RANDOM', {'RANDOM': 'abc'}).then(res => {
+      expect(res).to.match(/ord=abc$/);
+    });
+  });
+
+  it('should add an additional binding', () => {
+    return expandAsync('rid=NONSTANDARD', {'NONSTANDARD': 'abc'}).then(res => {
+      expect(res).to.match(/rid=abc$/);
+    });
+  });
+
+  it('should NOT overwrite the cached expression with new bindings', () => {
+    return expandAsync('rid=NONSTANDARD', {'NONSTANDARD': 'abc'}).then(res => {
+      expect(res).to.match(/rid=abc$/);
+      return expandAsync('rid=NONSTANDARD').then(res => {
+        expect(res).to.match(/rid=NONSTANDARD$/);
+      });
+    });
+  });
+
+  it('should expand bindings as functions', () => {
+    return expandAsync('rid=FUNC(abc)', {'FUNC': value => 'func_' + value})
+        .then(
+            res => {
+              expect(res).to.match(/rid=func_abc$/);
+            });
+  });
+
+  it('should expand bindings as functions with promise', () => {
+    return expandAsync('rid=FUNC(abc)', {
+      'FUNC': value => Promise.resolve('func_' + value),
+    }).then(res => {
+      expect(res).to.match(/rid=func_abc$/);
+    });
+  });
+
+  it('should expand null as empty string', () => {
+    return expandAsync('v=VALUE', {'VALUE': null}).then(res => {
+      expect(res).to.equal('v=');
+    });
+  });
+
+  it('should expand undefined as empty string', () => {
+    return expandAsync('v=VALUE', {'VALUE': undefined}).then(res => {
+      expect(res).to.equal('v=');
+    });
+  });
+
+  it('should expand empty string as empty string', () => {
+    return expandAsync('v=VALUE', {'VALUE': ''}).then(res => {
+      expect(res).to.equal('v=');
+    });
+  });
+
+  it('should expand zero as zero', () => {
+    return expandAsync('v=VALUE', {'VALUE': 0}).then(res => {
+      expect(res).to.equal('v=0');
+    });
+  });
+
+  it('should expand false as false', () => {
+    return expandAsync('v=VALUE', {'VALUE': false}).then(res => {
+      expect(res).to.equal('v=false');
+    });
+  });
+
+  it('should resolve sub-included bindings', () => {
+    // RANDOM is a standard property and we add RANDOM_OTHER.
+    return expandAsync('r=RANDOM&ro=RANDOM_OTHER', {'RANDOM_OTHER': 'ABC'})
+        .then(
+            res => {
+              expect(res).to.match(/r=(\d+(\.\d+)?)&ro=ABC$/);
+            });
+  });
+
+  it('should expand multiple vars', () => {
+    return expandAsync('a=VALUEA&b=VALUEB', {
+      'VALUEA': 'aaa',
+      'VALUEB': 'bbb',
+    }).then(res => {
+      expect(res).to.match(/a=aaa&b=bbb$/);
+    });
+  });
+
+  it('should replace QUERY_PARAM with foo', () => {
+    const win = getFakeWindow();
+    win.location = parseUrl('https://example.com?query_string_param1=wrong');
+    sandbox.stub(trackPromise, 'getTrackImpressionPromise', () => {
+      return new Promise(resolve => {
+        win.location =
+            parseUrl('https://example.com?query_string_param1=foo');
+        resolve();
+        console.log('promise resolve');
+      });
+    });
+    return installVarSubstitutionServiceForDoc(win.ampdoc)
+        .expandAsync('sh=QUERY_PARAM(query_string_param1)&s')
+        .then(res => {
+          console.log('compare happend', res);
+          expect(res).to.match(/sh=foo&s/);
+        });
+  });
+
+  it('should replace QUERY_PARAM with ""', () => {
+    const win = getFakeWindow();
+    win.location = parseUrl('https://example.com');
+    sandbox.stub(trackPromise, 'getTrackImpressionPromise', () => {
+      return Promise.resolve();
+    });
+    return installVarSubstitutionServiceForDoc(win.ampdoc)
+        .expandAsync('sh=QUERY_PARAM(query_string_param1)&s')
+        .then(res => {
+          expect(res).to.match(/sh=&s/);
+        });
+  });
+
+  it('should replace QUERY_PARAM with default_value', () => {
+    const win = getFakeWindow();
+    win.location = parseUrl('https://example.com');
+    sandbox.stub(trackPromise, 'getTrackImpressionPromise', () => {
+      return Promise.resolve();
+    });
+    return installVarSubstitutionServiceForDoc(win.ampdoc)
+        .expandAsync('sh=QUERY_PARAM(query_string_param1,default_value)&s')
+        .then(res => {
+          expect(res).to.match(/sh=default_value&s/);
+        });
+  });
+
+  it('should collect vars', () => {
+    const win = getFakeWindow();
+    win.location = parseUrl('https://example.com?p1=foo');
+    sandbox.stub(trackPromise, 'getTrackImpressionPromise', () => {
+      return Promise.resolve();
+    });
+    return installVarSubstitutionServiceForDoc(win.ampdoc)
+        .collectVars('SOURCE_HOST&QUERY_PARAM(p1)&SIMPLE&FUNC&PROMISE', {
+          'SIMPLE': 21,
+          'FUNC': () => 22,
+          'PROMISE': () => Promise.resolve(23),
+        })
+        .then(res => {
+          expect(res).to.deep.equal({
+            'SOURCE_HOST': 'example.com',
+            'QUERY_PARAM(p1)': 'foo',
+            'SIMPLE': 21,
+            'FUNC': 22,
+            'PROMISE': 23,
+          });
+        });
+  });
+
+  describe('sync expansion', () => {
+    it('should expand w/ collect vars (skip async macro)', () => {
+      const win = getFakeWindow();
+      const varSub = installVarSubstitutionServiceForDoc(win.ampdoc);
+      varSub.ampdoc.win.performance.timing.loadEventStart = 109;
+      const collectVars = {};
+      const expanded = varSub.expandSync(
+          'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
+        {
+          'CONST': 'ABC',
+          'FUNCT': function(a, b) { return a + b; },
+            // Will ignore promise based result and instead insert empty string.
+          'PROM': function() { return Promise.resolve('boo'); },
+        }, collectVars);
+      expect(expanded).to.match(/^r=\d(\.\d+)?&c=ABC&f=helloworld&a=b&d=&e=9$/);
+      expect(collectVars).to.deep.equal({
+        'RANDOM': parseFloat(/^r=(\d+(\.\d+)?)/.exec(expanded)[1]),
+        'CONST': 'ABC',
+        'FUNCT(hello,world)': 'helloworld',
+        'PAGE_LOAD_TIME': 9,
+      });
+    });
+  });
+
+  it('should expand sync and respect white list', () => {
+    const win = getFakeWindow();
+    const varSub = installVarSubstitutionServiceForDoc(win.ampdoc);
+    const expanded = varSub.expandSync(
+        'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
+      {
+        'CONST': 'ABC',
+        'FUNCT': () => {
+          throw Error('Should not be called');
+        },
+      }, undefined, {
+        'CONST': true,
+      });
+    expect(expanded).to.equal('r=RANDOM&c=ABC&f=FUNCT(hello,world)' +
+        '&a=b&d=PROM&e=PAGE_LOAD_TIME');
+  });
+
+  describe('access values', () => {
+
+    let accessService;
+    let accessServiceMock;
+
+    beforeEach(() => {
+      accessService = {
+        getAccessReaderId: () => {},
+        getAuthdataField: () => {},
+      };
+      accessServiceMock = sandbox.mock(accessService);
+    });
+
+    afterEach(() => {
+      accessServiceMock.verify();
+    });
+
+    function expandAsync(url, opt_disabled) {
+      return createIframePromise().then(iframe => {
+        iframe.doc.title = 'Pixel Test';
+        const link = iframe.doc.createElement('link');
+        link.setAttribute('href', 'https://pinterest.com/pin1');
+        link.setAttribute('rel', 'canonical');
+        iframe.doc.head.appendChild(link);
+
+        const replacements = varSubstitutionForDoc(iframe.ampdoc);
+        replacements.getVariableSource().getAccessService_ = () => {
+          if (opt_disabled) {
+            return Promise.resolve(null);
+          }
+          return Promise.resolve(accessService);
+        };
+        return replacements.expandAsync(url);
+      });
+    }
+
+    it('should replace ACCESS_READER_ID', () => {
+      accessServiceMock.expects('getAccessReaderId')
+          .returns(Promise.resolve('reader1'))
+          .once();
+      return expandAsync('a=ACCESS_READER_ID') .then(res => {
+        expect(res).to.match(/a=reader1/);
+        expect(userErrorStub.callCount).to.equal(0);
+      });
+    });
+
+    it('should replace AUTHDATA', () => {
+      accessServiceMock.expects('getAuthdataField')
+          .withExactArgs('field1')
+          .returns(Promise.resolve('value1'))
+          .once();
+      return expandAsync('a=AUTHDATA(field1)').then(res => {
+        expect(res).to.match(/a=value1/);
+        expect(userErrorStub.callCount).to.equal(0);
+      });
+    });
+
+    it('should report error if not available', () => {
+      accessServiceMock.expects('getAccessReaderId')
+          .never();
+      return expandAsync('a=ACCESS_READER_ID;', /* disabled */ true)
+          .then(res => {
+            expect(res).to.match(/a=;/);
+            expect(userErrorStub.callCount).to.equal(1);
+          });
+    });
+  });
+});


### PR DESCRIPTION
As per [this discussion](https://github.com/ampproject/amphtml/pull/6130#discussion_r87474353) moving var-sub to its own service. 