### PR TITLE
[amp-youtube] Move all the param logic to getVideoIframeSrc_() 

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -60,6 +60,9 @@ class AmpYoutube extends AMP.BaseElement {
     /** @private {?Element} */
     this.iframe_ = null;
 
+    /** @private {?string} */
+    this.videoIframeSrc_ = null;
+
     /** @private {?Promise} */
     this.playerReadyPromise_ = null;
 
@@ -116,16 +119,11 @@ class AmpYoutube extends AMP.BaseElement {
 
   /** @return {string} */
   getVideoIframeSrc_() {
+    if (this.videoIframeSrc_) {
+      return this.videoIframeSrc_;
+    }
     dev().assert(this.videoid_);
-    return `https://www.youtube.com/embed/${encodeURIComponent(this.videoid_ || '')}?enablejsapi=1`;
-  }
-
-  /** @override */
-  layoutCallback() {
-    // See
-    // https://developers.google.com/youtube/iframe_api_reference
-    const iframe = this.element.ownerDocument.createElement('iframe');
-    let src = this.getVideoIframeSrc_();
+    let src = `https://www.youtube.com/embed/${encodeURIComponent(this.videoid_ || '')}?enablejsapi=1`;
 
     const params = getDataParamsFromAttributes(this.element);
     if ('autoplay' in params) {
@@ -158,6 +156,15 @@ class AmpYoutube extends AMP.BaseElement {
     }
 
     src = addParamsToUrl(src, params);
+    return this.videoIframeSrc_ = src;
+  }
+
+  /** @override */
+  layoutCallback() {
+    // See
+    // https://developers.google.com/youtube/iframe_api_reference
+    const iframe = this.element.ownerDocument.createElement('iframe');
+    const src = this.getVideoIframeSrc_();
 
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -257,7 +257,6 @@ describe('amp-youtube', function() {
       const preloadSpy = sandbox.spy(yt.implementation_.preconnect, 'preload');
       yt.implementation_.preconnectCallback();
       preloadSpy.should.have.been.calledWithExactly(src);
-      expect(preloadSpy.calledWith(src)).to.be.true;
     });
   });
 });

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -247,4 +247,17 @@ describe('amp-youtube', function() {
     });
   });
 
+  it.only('should preload the final url', () => {
+    return getYt({
+      'autoplay': '',
+      'data-videoid': 'mGENRKrdoGY',
+      'data-param-playsinline': '0',
+    }).then(yt => {
+      const src = yt.querySelector('iframe').src;
+      const preloadSpy = sandbox.spy(yt.implementation_.preconnect, 'preload');
+      yt.implementation_.preconnectCallback();
+      preloadSpy.should.have.been.calledWithExactly(src);
+      expect(preloadSpy.calledWith(src)).to.be.true;
+    });
+  });
 });

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -247,7 +247,7 @@ describe('amp-youtube', function() {
     });
   });
 
-  it.only('should preload the final url', () => {
+  it('should preload the final url', () => {
     return getYt({
       'autoplay': '',
       'data-videoid': 'mGENRKrdoGY',


### PR DESCRIPTION
Fixes: https://github.com/ampproject/amphtml/issues/5884 
Move all the param logic to `getVideoIframeSrc_()` so Url in `preconnect` and `Url` in `layoutCallback` are guaranteed ti be the same.
