### PR TITLE
Remove "experimental" label from amp-fx-flying-carpet.md

### DIFF
--- a/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
+++ b/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
@@ -23,7 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty" width="40%"><strong>Availability</strong></td>
-    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>


### PR DESCRIPTION
I think the component is now live, so I'm just submitting a tiny update to the docs I noticed while posting the roadmap.  PTAL

/to @jridgewell @jasti 