### PR TITLE
Fix slidescroll tests for Safari

### DIFF
--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -104,10 +104,10 @@ describe('SlideScroll', () => {
       impl.buildCarousel();
       expect(
           ampSlideScroll.getElementsByClassName(
-              '-amp-carousel-start-marker').length).to.equal(1);
+              '-amp-carousel-start-marker').length).to.be.at.least(1);
       expect(
           ampSlideScroll.getElementsByClassName(
-              '-amp-carousel-end-marker').length).to.equal(1);
+              '-amp-carousel-end-marker').length).to.be.at.least(1);
     });
   });
 


### PR DESCRIPTION
Partial for #6039 

Reason for `.least(1)` is that in Safari that already supports native scrollSnap, the call to buildCarousel will create an additional element so we have 2 instead of 1 which is the case for Chrome