### PR TITLE
remove sticky-ad-better-ux experiment tag

### DIFF
--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -20,14 +20,6 @@ import {dev,user} from '../../../src/log';
 import {removeElement} from '../../../src/dom';
 import {toggle} from '../../../src/style';
 import {listenOnce} from '../../../src/event-helper';
-import {
-  setStyle,
-  removeAlphaFromColor,
-} from '../../../src/style';
-import {isExperimentOn} from '../../../src/experiments';
-
-/** @private @const {string} */
-const UX_EXPERIMENT = 'amp-sticky-ad-better-ux';
 
 class AmpStickyAd extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -176,7 +168,6 @@ class AmpStickyAd extends AMP.BaseElement {
         // Set sticky-ad to visible and change container style
         this.element.setAttribute('visible', '');
         this.element.classList.add('amp-sticky-ad-loaded');
-        this.forceOpacity_();
       });
     });
   }
@@ -208,33 +199,6 @@ class AmpStickyAd extends AMP.BaseElement {
       removeElement(this.element);
       this.viewport_.updatePaddingBottom(0);
     });
-  }
-
-  /**
-   * To check for background-color alpha and force it to be 1.
-   * Whoever calls this needs to make sure it's in a vsync.
-   * @private
-   */
-  forceOpacity_() {
-    if (!isExperimentOn(this.win, UX_EXPERIMENT)) {
-      return;
-    }
-
-    // TODO(@zhouyx): Move the opacity style to CSS after remove experiments
-    // Note: Use setStyle because we will remove this line later.
-    setStyle(this.element, 'opacity', '1 !important');
-    setStyle(this.element, 'background-image', 'none');
-
-    const backgroundColor = this.win./*OK*/getComputedStyle(this.element)
-        .getPropertyValue('background-color');
-    const newBackgroundColor = removeAlphaFromColor(backgroundColor);
-    if (backgroundColor == newBackgroundColor) {
-      return;
-    }
-
-    user().warn('AMP-STICKY-AD',
-        'Do not allow container to be semitransparent');
-    setStyle(this.element, 'background-color', newBackgroundColor);
   }
 }
 

--- a/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {toggleExperiment} from '../../../../src/experiments';
 import '../amp-sticky-ad';
 import '../../../amp-ad/0.1/amp-ad';
 
@@ -208,34 +207,6 @@ describes.realWin('amp-sticky-ad 0.1 version', {
       expect(ampStickyAd).to.have.attribute('visible');
       expect(ampStickyAd.classList.contains('amp-sticky-ad-loaded'))
           .to.be.true;
-    });
-
-    it('should not allow container to be set semi-transparent', () => {
-      toggleExperiment(window, 'amp-sticky-ad-better-ux', true);
-      ampStickyAd.setAttribute('style',
-          'background-color: rgba(55, 55, 55, 0.55) !important');
-      impl.vsync_.mutate = function(callback) {
-        callback();
-      };
-      impl.layoutAd_();
-      impl.ad_.dispatchEvent(new Event('amp:load:end'));
-      expect(window.getComputedStyle(ampStickyAd)
-          .getPropertyValue('background-color')).to.equal('rgb(55, 55, 55)');
-      toggleExperiment(window, 'amp-sticky-ad-better-ux', false);
-    });
-
-    it('should not allow container to be set to transparent', () => {
-      toggleExperiment(window, 'amp-sticky-ad-better-ux', true);
-      ampStickyAd.setAttribute('style',
-          'background-color: transparent !important');
-      impl.vsync_.mutate = function(callback) {
-        callback();
-      };
-      impl.layoutAd_();
-      impl.ad_.dispatchEvent(new Event('amp:load:end'));
-      expect(window.getComputedStyle(ampStickyAd)
-          .getPropertyValue('background-color')).to.equal('rgb(0, 0, 0)');
-      toggleExperiment(window, 'amp-sticky-ad-better-ux', false);
     });
   });
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -205,11 +205,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5535',
   },
   {
-    id: 'amp-sticky-ad-better-ux',
-    name: 'New breaking UX changes make to amp-sticky-ad',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5822',
-  },
-  {
     id: 'amp-animation',
     name: 'High-performing keyframe animations in AMP.',
     spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +


### PR DESCRIPTION
fix #5822 
since we have the new feature in v1.0 it should be ok to remove the experiment here. 