### PR TITLE
amp-brightcove: Play inline and support autoplay and muted atrttibutes

### DIFF
--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -56,8 +56,8 @@ class AmpBrightcove extends AMP.BaseElement {
     const embed = (this.element.getAttribute('data-embed') || 'default');
     const iframe = this.element.ownerDocument.createElement('iframe');
     let src = `https://players.brightcove.net/${encodeURIComponent(account)}/${encodeURIComponent(playerid)}_${encodeURIComponent(embed)}/index.html`;
-    let params = {
-      playsinline: true
+    const params = {
+      playsinline: true,
     };
 
     if (this.element.getAttribute('data-playlist-id')) {

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -56,6 +56,9 @@ class AmpBrightcove extends AMP.BaseElement {
     const embed = (this.element.getAttribute('data-embed') || 'default');
     const iframe = this.element.ownerDocument.createElement('iframe');
     let src = `https://players.brightcove.net/${encodeURIComponent(account)}/${encodeURIComponent(playerid)}_${encodeURIComponent(embed)}/index.html`;
+    let params = {
+      playsinline: true
+    };
 
     if (this.element.getAttribute('data-playlist-id')) {
       src += '?playlistId=';
@@ -64,6 +67,14 @@ class AmpBrightcove extends AMP.BaseElement {
       src += '?videoId=';
       src += this.encodeId_(this.element.getAttribute('data-video-id'));
     }
+
+    if (this.element.hasAttribute('muted')) {
+      params.muted = true;
+    }
+    if (this.element.hasAttribute('autoplay')) {
+      params.autoplay = true;
+    }
+    src = addParamsToUrl(src, params);
 
     // Pass through data-param-* attributes as params for plugin use
     src = addParamsToUrl(src, getDataParamsFromAttributes(this.element));

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -96,4 +96,18 @@ describe('amp-brightcove', () => {
       expect(params).to.contain('myParam=hello%20world');
     });
   });
+
+  it('adds autoplay and muted attributes to the iframe src', () => {
+    return getBrightcove({
+      'data-account': '906043040001',
+      'data-video-id': 'ref:ampdemo',
+      'autoplay': '',
+      'muted': ''
+    }).then(bc => {
+      const iframe = bc.querySelector('iframe');
+      const params = parseUrl(iframe.src).search.split('&');
+      expect(params).to.contain('autoplay=true');
+      expect(params).to.contain('muted=true');
+    });
+  });
 });

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -102,7 +102,7 @@ describe('amp-brightcove', () => {
       'data-account': '906043040001',
       'data-video-id': 'ref:ampdemo',
       'autoplay': '',
-      'muted': ''
+      'muted': '',
     }).then(bc => {
       const iframe = bc.querySelector('iframe');
       const params = parseUrl(iframe.src).search.split('&');

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -51,7 +51,7 @@ describe('amp-brightcove', () => {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
-          'https://players.brightcove.net/906043040001/default_default/index.html?videoId=ref:ampdemo');
+          'https://players.brightcove.net/906043040001/default_default/index.html?videoId=ref:ampdemo&playsinline=true');
     });
   });
 

--- a/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
@@ -64,6 +64,8 @@ tags: {  # <amp-brightcove>
   attrs: { name: "data-playlist-id" }
   # If data-video-id is not used for perform player and hence it is optional.
   attrs: { name: "data-video-id" }
+  attrs: { name: "autoplay" }
+  attrs: { name: "muted" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-brightcove.html"
   amp_layout: {

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -93,6 +93,14 @@ Keys and values will be URI encoded. Keys will be camel cased.
 - `data-param-language="de"` becomes `&language=de`
 - `data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`
 
+**autoplay**
+
+The video will autoplay. Mobile browsers will require `muted` to also be set.
+
+**muted**
+
+The video will be initially muted.
+
 ## Player configuration
 
 This script should be added to the configuration of Brightcove Players used with this component. This allows the AMP document to pause the player. Only the script need be added, no plugin name or JSON are needed.


### PR DESCRIPTION
Adds the `playsinline` attribute to the Brightcove Players as standard - desired behaviour based on [this comment](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/amp-youtube.js#L137)

Adds support for the `autoplay` and `muted` attributes.