### PR TITLE
Correct what layouts are supported for type=carousel

### DIFF
--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -99,8 +99,9 @@ attribute if present (minimum of 1000 ms; an error will be thrown if it's any lo
 ## Styling
 - You may use the `amp-carousel` element selector to style it freely.
 - You may use the `.amp-carousel-slide` class selector to target carousel items.
-- By default, `.amp-carousel-button` uses an inlined SVG as the background-image of the buttons. You may override this with your own SVG or image as in the example below.
 - The visual state of an `amp-carousel` button when it's disabled is hidden.
+- By default, `.amp-carousel-button` uses an inlined SVG as the background-image of the buttons. You may override this with your own SVG or image as in the example below.
+
 
 **Example**: Default `.amp-carousel-button` inlined SVG
 

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -75,7 +75,7 @@ Usage example:
 **type**
 
 - `carousel` (default): All slides are shown and are scrollable horizontally.
-  The `carousel` type only supports `layout="fixed"` and `layout="fixed-height"`.
+  The `carousel` type only supports the following layouts: `fixed`, `fixed-height`, and `nodisplay`.
 - `slides`: Shows a single slide at a time. It supports the following layouts: `fill`, `fixed`, `fixed-height`, `flex-item`, `nodisplay`, and `responsive`.
 
 **loop** (type=slides only)

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -76,7 +76,7 @@ Usage example:
 
 - `carousel` (default): All slides are shown and are scrollable horizontally.
   The `carousel` type only supports `layout="fixed"` and `layout="fixed-height"`.
-- `slides`: Shows a single slide at a time. 
+- `slides`: Shows a single slide at a time. It supports the following layouts: `fill`, `fixed`, `fixed-height`, `flex-item`, `nodisplay`, and `responsive`.
 
 **loop** (type=slides only)
 
@@ -100,7 +100,7 @@ attribute if present (minimum of 1000 ms; an error will be thrown if it's any lo
 - You may use the `amp-carousel` element selector to style it freely.
 - You may use the `.amp-carousel-slide` class selector to target carousel items.
 - By default, `.amp-carousel-button` uses an inlined SVG as the background-image of the buttons. You may override this with your own SVG or image as in the example below.
-- By default, the visual state of an `amp-carousel` button when it's disabled is hidden. You may override this visual state of an `amp-carousel` button by setting the visibility to `visible` as in the example below.
+- The visual state of an `amp-carousel` button when it's disabled is hidden.
 
 **Example**: Default `.amp-carousel-button` inlined SVG
 
@@ -117,17 +117,6 @@ attribute if present (minimum of 1000 ms; an error will be thrown if it's any lo
 .amp-carousel-button-prev {
   left: 5%;
   background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M11.56 5.56L10.5 4.5 6 9l4.5 4.5 1.06-1.06L8.12 9z" fill="#fff" /></svg>');
-}
-```
-
-**Example**: Overriding the visual state of a disabled `amp-carousel` button 
-
-```css
-.amp-carousel-button.amp-disabled {
-  /* make sure we make it visible */
-  visibility: visible;
-  /* choose our own background styling, red'ish */
-  background-color: rgba(255, 0, 0, .5);
 }
 ```
 

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -46,6 +46,9 @@ Each of the `amp-carousel` component’s immediate children is considered an ite
 The carousel consists of an arbitrary number of items, as well as optional navigational arrows to go forward or backwards a single item.
 
 The carousel advances between items if the user swipes, uses arrow keys, or clicks an optional navigation arrow.
+
+**Example**: While the example shows a carousel of images, `amp-carousel` supports arbitrary children.
+
 ```html
 <amp-carousel width=300 height=400>
   <amp-img src="my-img1.png" width=300 height=400></amp-img>
@@ -53,8 +56,6 @@ The carousel advances between items if the user swipes, uses arrow keys, or clic
   <amp-img src="my-img3.png" width=300 height=400></amp-img>
 </amp-carousel>
 ```
-
-Note that while the example shows a carousel of images, `amp-carousel` support arbitrary children.
 
 ## Attributes
 
@@ -72,9 +73,10 @@ Usage example:
 ```
 
 **type**
-- `carousel` (default) - All slides are shown and are scrollable horizontally.
-  Be aware that `type=carousel` does not currently support `layout=responsive`.
-- `slides` - Shows a single slide at a time. Supports `layout=responsive`.
+
+- `carousel` (default): All slides are shown and are scrollable horizontally.
+  The `carousel` type only supports `layout="fixed"` and `layout="fixed-height"`.
+- `slides`: Shows a single slide at a time. 
 
 **loop** (type=slides only)
 
@@ -82,25 +84,25 @@ If present, the user may advance past the first item or the final item.
 
 **autoplay** (type=slides only)
 
-If present, advances the slide to the next slide without user interaction.
-By default it will advance a slide in 5000 millisecond intervals (5 seconds)
-and can be overridden by the `delay` attribute.
-If `autoplay` is present it will also attach the `loop` attribute to
-`amp-carousel` if `loop` is not already present.
+If present:
+
+- Advances the slide to the next slide without user interaction.
+By default, `autoplay` advances a slide in 5000 millisecond intervals (5 seconds); this can be overridden by the `delay` attribute.
+- Attaches the `loop` attribute to `amp-carousel` if `loop` is not already present.
 
 **delay** (type=slides only)
-By default a slide will advance in 5000 millisecond intervals (5 seconds)
+
+By default, a slide will advance in 5000 millisecond intervals (5 seconds)
 when `autoplay` is specified and will use the value of the `delay`
-attribute if present (minimum of 1000 ms; an error will be thrown if it's any lower).
-The value of `delay` must be a number of milliseconds, e.g. `delay=5000`.
+attribute if present (minimum of 1000 ms; an error will be thrown if it's any lower). The value of `delay` must be a number of milliseconds, e.g. `delay=5000`.
 
 ## Styling
 - You may use the `amp-carousel` element selector to style it freely.
 - You may use the `.amp-carousel-slide` class selector to target carousel items.
-- `.amp-carousel-button` by default uses an inlined SVG as the background-image of the buttons.
-You may override this with your own SVG or image like so:
+- By default, `.amp-carousel-button` uses an inlined SVG as the background-image of the buttons. You may override this with your own SVG or image as in the example below.
+- By default, the visual state of an `amp-carousel` button when it's disabled is hidden. You may override this visual state of an `amp-carousel` button by setting the visibility to `visible` as in the example below.
 
-  **default**
+**Example**: Default `.amp-carousel-button` inlined SVG
 
 ```css
 .amp-carousel-button-prev {
@@ -109,15 +111,16 @@ You may override this with your own SVG or image like so:
 }
 ```
 
-  **override**
+**Example**: Overriding the default `.amp-carousel-button` inlined SVG
+
 ```css
 .amp-carousel-button-prev {
   left: 5%;
   background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M11.56 5.56L10.5 4.5 6 9l4.5 4.5 1.06-1.06L8.12 9z" fill="#fff" /></svg>');
 }
 ```
-- By default the visual state of an `amp-carousel` button when it is disabled is that it is hidden.
-  You may override this visual state of an `amp-carousel` button in the disabled state by:
+
+**Example**: Overriding the visual state of a disabled `amp-carousel` button 
 
 ```css
 .amp-carousel-button.amp-disabled {
@@ -127,6 +130,7 @@ You may override this with your own SVG or image like so:
   background-color: rgba(255, 0, 0, .5);
 }
 ```
+
 ## Validation
 
 See [amp-carousel rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii) in the AMP validator specification.


### PR DESCRIPTION
Specify that only "fixed" and "fixed-layout" are supported for "type=carousel". Also, did some minor doc cleanup.

to/ @muxin 

