### PR TITLE
Send text/html as the request header instead of */*

### DIFF
--- a/validator/chromeextension/background.js
+++ b/validator/chromeextension/background.js
@@ -242,6 +242,7 @@ function updateTabStatus(tabId, iconPrefix, title, text, color) {
 function validateUrlFromTab(tab) {
   var xhr = new XMLHttpRequest();
   xhr.open('GET', tab.url, true);
+  xhr.setRequestHeader('Accept', 'text/html');
   xhr.onreadystatechange = function() {
     if (xhr.readyState === 4) {
       const doc = xhr.responseText;


### PR DESCRIPTION
Sending `*/*` is dangerous, because it means that the validator accepts any content type. I am suggesting that it requests **text/html** specifically, although **text/\*** may make sense as well.