### PR TITLE
Errors might happen before the global AMP object is ever created.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -207,7 +207,7 @@ export function getErrorReportUrl(message, filename, line, col, error,
     url += '&iem=1';
   }
 
-  if (self.AMP.viewer) {
+  if (self.AMP && self.AMP.viewer) {
     const resolvedViewerUrl = self.AMP.viewer.getResolvedViewerUrl();
     const messagingOrigin = self.AMP.viewer.maybeGetMessagingOrigin();
     if (resolvedViewerUrl) {


### PR DESCRIPTION
This might explain the swallowing of very early errors we have been seeing!!

Because errors would often not be reported if no extension loaded yet when the error happened.

Fixes #6394