### PR TITLE
Punt if we can't find the amphtml-validator.cmd file.

### DIFF
--- a/validator/nodejs/README.md
+++ b/validator/nodejs/README.md
@@ -61,3 +61,7 @@ As expected, this emits errors because the provided string in the example, `<htm
 ### 1.0.15
 * Added support for installing on Windows.
   `npm install -g amphtml-validator` should now just work.
+
+### 1.0.16
+* `npm install amphtml-validator` (local install) should now work on Windows,
+  for `require('amphtml-validator')`.

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphtml-validator",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Official validator for AMP HTML (www.ampproject.org)",
   "keywords": ["AMP", "validator", "validate", "AMP HTML", "Accelerated Mobile Pages"],
   "engines": {

--- a/validator/nodejs/postinstall-windows.js
+++ b/validator/nodejs/postinstall-windows.js
@@ -33,10 +33,17 @@ if (process.env.OS !== 'Windows_NT') {
 // /bin/sh -c "exit 0" will succeed (see package.json).
 var validatorShimPath =
     path.join(process.env.npm_config_prefix, 'amphtml-validator.cmd');
-var stats = fs.statSync(validatorShimPath);
-if (!stats.isFile()) {
-  console./*OK*/ error('postinstall-windows.js: amphtml-validator not found.');
-  process.exit(1);
+if (!fs.existsSync(validatorShimPath)) {
+  // We exit here because postinstall-windows.js will be invoked for both
+  // a local install and for a --global npm install. While both create a shim,
+  // the local install would place this shim into node_modules/.bin, and to
+  // determine which node_modules/.bin we'd need to reimplement the Node.js
+  // mechanism that's described in https://docs.npmjs.com/files/folders.
+  // So we punt here, because this is complex and a modified shim is mostly
+  // useful in the global install case.
+  console./*OK*/ log(
+      'postinstall-windows.js: No amphtml-validator shim found to modify.');
+  process.exit(0);
 }
 
 // We take a quick look into the shim file that npm for Windows generates.


### PR DESCRIPTION
I couldn't find an environment variable to distinguish
global and local install (other than parsing out the command
line for npm), so this is a relatively simple but crude
solution to cover a lot of cases.

This should fix https://github.com/ampproject/amphtml/issues/6354.