### PR TITLE
Adopt core embed window services

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -56,9 +56,6 @@ import {A4AVariableSource} from './a4a-variable-source';
 import {rethrowAsync} from '../../../src/log';
 
 /** @private @const {string} */
-const TAG = 'amp-a4a';
-
-/** @private @const {string} */
 const ORIGINAL_HREF_ATTRIBUTE = 'data-a4a-orig-href';
 
 /** @type {string} */
@@ -354,7 +351,7 @@ export class AmpA4A extends AMP.BaseElement {
               this.experimentalNonAmpCreativeRenderMethod_;
           this.experimentalNonAmpCreativeRenderMethod_ = method;
           if (!isEnumValue(XORIGIN_MODE, method)) {
-            dev().error(TAG, `cross-origin render mode header ${method}`);
+            dev().error('AMP-A4A', `cross-origin render mode header ${method}`);
           }
           // Note: Resolving a .then inside a .then because we need to capture
           // two fields of fetchResponse, one of which is, itself, a promise,
@@ -508,7 +505,6 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   promiseErrorHandler_(error) {
-    dev().error(TAG, 'friendly iframe failed: ', error);
     if (error && error.message) {
       if (error.message.indexOf(TAG) == 0) {
         // caught previous call to promiseErrorHandler?  Infinite loop?
@@ -524,6 +520,7 @@ export class AmpA4A extends AMP.BaseElement {
     const adQueryIdx = this.adUrl_ ? this.adUrl_.indexOf('?') : -1;
     const state = {
       'm': error instanceof Error ? error.message : error,
+      's': error instanceof Error ? error.stack : '',
       'tag': this.element.tagName,
       'type': this.element.getAttribute('type'),
       'au': adQueryIdx < 0 ? '' :

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -56,6 +56,9 @@ import {A4AVariableSource} from './a4a-variable-source';
 import {rethrowAsync} from '../../../src/log';
 
 /** @private @const {string} */
+const TAG = 'amp-a4a';
+
+/** @private @const {string} */
 const ORIGINAL_HREF_ATTRIBUTE = 'data-a4a-orig-href';
 
 /** @type {string} */
@@ -351,7 +354,7 @@ export class AmpA4A extends AMP.BaseElement {
               this.experimentalNonAmpCreativeRenderMethod_;
           this.experimentalNonAmpCreativeRenderMethod_ = method;
           if (!isEnumValue(XORIGIN_MODE, method)) {
-            dev().error('AMP-A4A', `cross-origin render mode header ${method}`);
+            dev().error(TAG, `cross-origin render mode header ${method}`);
           }
           // Note: Resolving a .then inside a .then because we need to capture
           // two fields of fetchResponse, one of which is, itself, a promise,
@@ -505,6 +508,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   promiseErrorHandler_(error) {
+    dev().error(TAG, 'friendly iframe failed: ', error);
     if (error && error.message) {
       if (error.message.indexOf(TAG) == 0) {
         // caught previous call to promiseErrorHandler?  Infinite loop?

--- a/src/action.js
+++ b/src/action.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getExistingServiceForDoc} from './service';
+import {getExistingServiceForDocInEmbedScope} from './service';
 
 
 /**
@@ -23,5 +23,5 @@ import {getExistingServiceForDoc} from './service';
  */
 export function actionServiceForDoc(nodeOrDoc) {
   return /** @type {!./service/action-impl.ActionService} */ (
-      getExistingServiceForDoc(nodeOrDoc, 'action'));
+      getExistingServiceForDocInEmbedScope(nodeOrDoc, 'action'));
 }

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import {actionServiceForDoc} from '../action';
 import {fromClassForDoc} from '../service';
-import {installActionServiceForDoc} from './action-impl';
 import {installResourcesServiceForDoc} from './resources-impl';
 import {toggle} from '../style';
 
@@ -23,6 +23,7 @@ import {toggle} from '../style';
 /**
  * This service contains implementations of some of the most typical actions,
  * such as hiding DOM elements.
+ * @implements {../service.EmbeddableService}
  * @private Visible for testing.
  */
 export class StandardActions {
@@ -31,12 +32,25 @@ export class StandardActions {
    */
   constructor(ampdoc) {
     /** @const @private {!./action-impl.ActionService} */
-    this.actions_ = installActionServiceForDoc(ampdoc);
+    this.actions_ = actionServiceForDoc(ampdoc);
 
     /** @const @private {!./resources-impl.Resources} */
     this.resources_ = installResourcesServiceForDoc(ampdoc);
 
-    this.actions_.addGlobalMethodHandler('hide', this.handleHide.bind(this));
+    this.installActions_(this.actions_);
+  }
+
+  /** @override */
+  adoptEmbedWindow(embedWin) {
+    this.installActions_(actionServiceForDoc(embedWin.document));
+  }
+
+  /**
+   * @param {!./action-impl.ActionService} actionService
+   * @private
+   */
+  installActions_(actionService) {
+    actionService.addGlobalMethodHandler('hide', this.handleHide.bind(this));
   }
 
   /**

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -16,6 +16,7 @@
 
 import {ActionService, parseActionMap} from '../../src/service/action-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
+import {setParentWindow} from '../../src/service';
 import * as sinon from 'sinon';
 
 
@@ -252,14 +253,51 @@ describe('Action parseActionMap', () => {
 });
 
 
-describe('Action findAction', () => {
+describes.sandboxed('Action adoptEmbedWindow', {}, () => {
+  let win;
+  let action;
+  let embedWin;
 
+  beforeEach(() => {
+    win = {
+      document: {body: {}},
+      services: {
+        vsync: {obj: {}},
+      },
+    };
+    action = new ActionService(new AmpDocSingle(win), document);
+    embedWin = {
+      frameElement: document.createElement('div'),
+      document: document.implementation.createHTMLDocument(''),
+    };
+    setParentWindow(embedWin, win);
+  });
+
+  it('should create embedded action service', () => {
+    action.adoptEmbedWindow(embedWin);
+    const embedService = embedWin.services.action
+        && embedWin.services.action.obj;
+    expect(embedService).to.exist;
+    expect(embedService.ampdoc).to.equal(action.ampdoc);
+    expect(embedService.root_).to.equal(embedWin.document);
+  });
+});
+
+
+describe('Action findAction', () => {
   let sandbox;
+  let win;
   let action;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    action = new ActionService(new AmpDocSingle(window));
+    win = {
+      document: {body: {}},
+      services: {
+        vsync: {obj: {}},
+      },
+    };
+    action = new ActionService(new AmpDocSingle(win), document);
   });
 
   afterEach(() => {
@@ -313,15 +351,21 @@ describe('Action findAction', () => {
 
 
 describe('Action method', () => {
-
   let sandbox;
+  let win;
   let action;
   let onEnqueue;
   let targetElement, parent, child, execElement;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    action = new ActionService(new AmpDocSingle(window));
+    win = {
+      document: {body: {}},
+      services: {
+        vsync: {obj: {}},
+      },
+    };
+    action = new ActionService(new AmpDocSingle(win), document);
     onEnqueue = sandbox.spy();
     targetElement = document.createElement('target');
     const id = ('E' + Math.random()).replace('.', '');
@@ -421,8 +465,8 @@ describe('Action method', () => {
 
 
 describe('Action interceptor', () => {
-
   let sandbox;
+  let win;
   let clock;
   let action;
   let target;
@@ -430,7 +474,13 @@ describe('Action interceptor', () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     clock = sandbox.useFakeTimers();
-    action = new ActionService(new AmpDocSingle(window));
+    win = {
+      document: {body: {}},
+      services: {
+        vsync: {obj: {}},
+      },
+    };
+    action = new ActionService(new AmpDocSingle(win), document);
     target = document.createElement('target');
     target.setAttribute('id', 'amp-test-1');
   });
@@ -509,14 +559,20 @@ describe('Action interceptor', () => {
 
 
 describe('Action common handler', () => {
-
   let sandbox;
+  let win;
   let action;
   let target;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    action = new ActionService(new AmpDocSingle(window));
+    win = {
+      document: {body: {}},
+      services: {
+        vsync: {obj: {}},
+      },
+    };
+    action = new ActionService(new AmpDocSingle(win), document);
     target = document.createElement('target');
     target.setAttribute('id', 'amp-test-1');
 
@@ -548,13 +604,20 @@ describe('Action common handler', () => {
 
 describe('Core events', () => {
   let sandbox;
+  let win;
   let action;
   let target;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(window.document, 'addEventListener');
-    action = new ActionService(new AmpDocSingle(window));
+    win = {
+      document: {body: {}},
+      services: {
+        vsync: {obj: {}},
+      },
+    };
+    action = new ActionService(new AmpDocSingle(win), document);
     sandbox.stub(action, 'trigger');
     target = document.createElement('target');
     target.setAttribute('id', 'amp-test-1');


### PR DESCRIPTION
This is a simplified solution for core service embedding for friendly iframes. A more complete solution would also adopt services contributed by extensions. However, that will require a deeper refactoring and thus postponed until the need arises.