### PR TITLE
Fix the build. Sinon can't stub methods that don't exist.

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -512,8 +512,7 @@ describe('amp-analytics.visibility', () => {
       inObCallback = null;
     });
 
-    // TODO(lannka, #6429): Enable test after fixing it on Saucelabs
-    it.skip('should work for visible=true spec', () => {
+    it('should work for visible=true spec', () => {
 
       visibility.listenOnceV2({
         selector: '#abc',

--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -493,12 +493,14 @@ describe('amp-analytics.visibility', () => {
     let callbackSpy1;
     let callbackSpy2;
 
-    beforeEach(() => {
+    beforeEach(function() {
+      if (!ampdoc.win.IntersectionObserver) {
+        this.skip();
+      }
       observeSpy = sandbox.stub();
       unobserveSpy = sandbox.stub();
       callbackSpy1 = sandbox.stub();
       callbackSpy2 = sandbox.stub();
-      ampdoc.win.IntersectionObserver = {};
       sandbox.stub(ampdoc.win, 'IntersectionObserver', callback => {
         inObCallback = callback;
         return {
@@ -512,7 +514,7 @@ describe('amp-analytics.visibility', () => {
       inObCallback = null;
     });
 
-    it('should work for visible=true spec', () => {
+    it.only('should work for visible=true spec', () => {
 
       visibility.listenOnceV2({
         selector: '#abc',

--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -485,7 +485,10 @@ describe('amp-analytics.visibility', () => {
     });
   });
 
-  describe('listenOnceV2', () => {
+  describe
+  .configure()
+  .skip(() => typeof IntersectionObserver == 'undefined')
+  .run('listenOnceV2', () => {
 
     let inObCallback;
     let observeSpy;
@@ -493,10 +496,7 @@ describe('amp-analytics.visibility', () => {
     let callbackSpy1;
     let callbackSpy2;
 
-    beforeEach(function() {
-      if (!ampdoc.win.IntersectionObserver) {
-        this.skip();
-      }
+    beforeEach(() => {
       observeSpy = sandbox.stub();
       unobserveSpy = sandbox.stub();
       callbackSpy1 = sandbox.stub();

--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -498,6 +498,7 @@ describe('amp-analytics.visibility', () => {
       unobserveSpy = sandbox.stub();
       callbackSpy1 = sandbox.stub();
       callbackSpy2 = sandbox.stub();
+      ampdoc.win.IntersectionObserver = {};
       sandbox.stub(ampdoc.win, 'IntersectionObserver', callback => {
         inObCallback = callback;
         return {

--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -514,7 +514,7 @@ describe('amp-analytics.visibility', () => {
       inObCallback = null;
     });
 
-    it.only('should work for visible=true spec', () => {
+    it('should work for visible=true spec', () => {
 
       visibility.listenOnceV2({
         selector: '#abc',


### PR DESCRIPTION
Build has been failing on old Chrome since window.IntersectionObserver does not exist and sinon can't stub methods that don't exist.

Fixes #6429