### PR TITLE
Advanced localhost check for amp-iframe

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -23,7 +23,7 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {endsWith} from '../../../src/string';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
-import {removeFragment, parseUrl} from '../../../src/url';
+import {removeFragment, parseUrl, isSecureUrl} from '../../../src/url';
 import {timerFor} from '../../../src/timer';
 import {user, dev} from '../../../src/log';
 import {utf8EncodeSync} from '../../../src/utils/bytes.js';
@@ -55,9 +55,7 @@ export class AmpIframe extends AMP.BaseElement {
     // Checks are mostly there to prevent people easily do something
     // they did not mean to.
     user().assert(
-        url.protocol == 'https:' ||
-        url.protocol == 'data:' ||
-        /http:\/\/(\w*)\.{0,1}localhost(:|\/)(.*)/.test(url.origin),
+        isSecureUrl(url) || url.protocol == 'data:',
         'Invalid <amp-iframe> src. Must start with https://. Found %s',
         this.element);
     const containerUrl = parseUrl(containerSrc);

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -57,7 +57,7 @@ export class AmpIframe extends AMP.BaseElement {
     user().assert(
         url.protocol == 'https:' ||
         url.protocol == 'data:' ||
-        url.origin.indexOf('http://iframe.localhost:') == 0,
+        /http:\/\/(\w*)\.{0,1}localhost(:|\/)(.*)/.test(url.origin),
         'Invalid <amp-iframe> src. Must start with https://. Found %s',
         this.element);
     const containerUrl = parseUrl(containerSrc);

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -249,9 +249,7 @@ describe('amp-iframe', () => {
 
   it('should deny http', () => {
     return getAmpIframe({
-      // ads. is not whitelisted for http iframes.
-      src: 'http://ads.localhost:' + location.port +
-          '/test/fixtures/served/iframe.html',
+      src: 'http://google.com/fpp',
       sandbox: 'allow-scripts',
       width: 100,
       height: 100,

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -362,7 +362,7 @@ describe('amp-iframe', () => {
       }).to.throw(/Must start with https/);
 
       expect(() => {
-        amp.assertSource('./foo', 'https://foo.com', '');
+        amp.assertSource('./foo', 'https://foo.com', 'allow-same-origin');
       }).to.throw(/Must start with https/);
 
       amp.assertSource('http://iframe.localhost:123/foo',

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -362,7 +362,7 @@ describe('amp-iframe', () => {
       }).to.throw(/Must start with https/);
 
       expect(() => {
-        amp.assertSource('./foo', 'https://foo.com', 'allow-same-origin');
+        amp.assertSource('./foo', location.href, 'allow-same-origin');
       }).to.throw(/Must start with https/);
 
       amp.assertSource('http://iframe.localhost:123/foo',

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -363,7 +363,7 @@ describe('amp-iframe', () => {
 
       expect(() => {
         amp.assertSource('./foo', location.href, 'allow-same-origin');
-      }).to.throw(/Must start with https/);
+      }).to.throw(/must not be equal to container/);
 
       amp.assertSource('http://iframe.localhost:123/foo',
           'https://foo.com', '');


### PR DESCRIPTION
Not everyone has iframes at `iframe.localhost`. This regular expression should resolve all kinds of HTTP localhost locations such as `http://localhost:3001/iframe/etc` and others.

Example true values:

- `http://localhost:3001/iframe/etc`
- `http://whatever.localhost/`
- `http://whatever.localhost:3001/iframe`
- `http://localhost:3001/iframe/etc`
- `http://localhost/iframe/etc`