### PR TITLE
Generate fallback clientId for Foreign Fetch

### DIFF
--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -402,13 +402,15 @@ self.addEventListener('fetch', event => {
 
 // Polyfill clientId into Foreign Fetch Events. This will generate a likely
 // unique id based on the request's referrer and a 60 batch timer.
-if (typeof ForeignFetchEvent !== 'undefined') {
+// Ugh, sometimes Closure Compiler kills me.
+const FFE = self['ForeignFetchEvent'];
+if (FFE) {
   const hasOwn = Object.prototype.hasOwnProperty;
-  if (!hasOwn.call(ForeignFetchEvent.prototype, 'clientId')) {
-    Object.defineProperty(ForeignFetchEvent.prototype, 'clientId', {
+  if (!hasOwn.call(FFE.prototype, 'clientId')) {
+    Object.defineProperty(FFE.prototype, 'clientId', {
       get() {
         return generateFallbackClientId(this.request.referrer);
-      }
+      },
     });
   }
 }

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -48,6 +48,34 @@ const BLACKLIST = self.AMP_CONFIG[`${TAG}-blacklist`] || [];
 const BASE_RTV_VERSION = self.AMP_CONFIG.v;
 
 /**
+ * Our cache of CDN JS files.
+ *
+ * @type {!Cache}
+ */
+let cache;
+
+/**
+ * A mapping from a Client's (unique per tab _and_ refresh) ID to the AMP
+ * release version we are serving it.
+ *
+ * @type {!Object<string, RtvVersion>}
+ */
+const clientsMap = Object.create(null);
+
+/**
+ * A mapping from a client's referrer into the time that referrer last made a
+ * request. This is used as a fallback to a clientId for Foreign Fetch, since
+ * it does not provide a unique clientId.
+ *
+ * This object will hopefully not grow too large. When the SW is terminated,
+ * it'll use a brand new object on restart.
+ *
+ * @type {!Object<string, number>}
+ */
+const referrersLastRequestTime = Object.create(null);
+
+
+/**
  * A regex that matches every CDN JS URL we care to cache.
  * The "experiments" JS is explicitly disallowed.
  *
@@ -163,19 +191,27 @@ export function isBlacklisted(version) {
 }
 
 /**
- * A mapping from a Client's (unique per tab _and_ refresh) ID to the AMP
- * release version we are serving it.
+ * Generates a clientId for Foreign Fetchs, since one is not provided.
  *
- * @type {!Object<string, RtvVersion>}
+ * The current strategy is to batch all requests from referrer that happen
+ * within 60 seconds (of the first request) into one clientId.
+ *
+ * @param {string} referrer
+ * @return {string}
+ * @visibleForTesting
  */
-const clientsMap = Object.create(null);
+export function generateFallbackClientId(referrer) {
+  const now = Date.now();
+  let lastRequestTime = referrersLastRequestTime[referrer] || 0;
 
-/**
- * Our cache of CDN JS files.
- *
- * @type {!Cache}
- */
-let cache;
+  // If last request was more than 60 seconds ago, we are now in a new
+  // "clientId".
+  if (lastRequestTime < now - (60 * 1000)) {
+    lastRequestTime = referrersLastRequestTime[referrer] = now;
+  }
+
+  return referrer + lastRequestTime;
+}
 
 /**
  * A promise to open up our CDN JS cache, which will be resolved before any
@@ -230,7 +266,6 @@ export function fetchAndCache(cache, request, requestPath, requestVersion) {
     return response;
   });
 }
-
 
 /**
  * Gets the version we have cached for this file. It's either:
@@ -339,6 +374,7 @@ export function handleFetch(request, maybeClientId) {
   });
 }
 
+
 self.addEventListener('install', install => {
   install.waitUntil(cachePromise);
   // Registers the SW for Foreign Fetch events, if they are supported.
@@ -362,6 +398,20 @@ self.addEventListener('fetch', event => {
 
   event.respondWith(response);
 });
+
+
+// Polyfill clientId into Foreign Fetch Events. This will generate a likely
+// unique id based on the request's referrer and a 60 batch timer.
+if (typeof ForeignFetchEvent !== 'undefined') {
+  const hasOwn = Object.prototype.hasOwnProperty;
+  if (!hasOwn.call(ForeignFetchEvent.prototype, 'clientId')) {
+    Object.defineProperty(ForeignFetchEvent.prototype, 'clientId', {
+      get() {
+        return generateFallbackClientId(this.request.referrer);
+      }
+    });
+  }
+}
 
 // Setup the Foreign Fetch listener, for when the client is on a Publisher
 // origin.

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -208,6 +208,40 @@ runner.run('Cache SW', () => {
     });
   });
 
+  describe('generateFallbackClientId', () => {
+    let clock;
+    let i = 0;
+    const referrer = 'https://publisher.com/amp/article';
+    const other = 'https://publisher.com/amp/other';
+
+    beforeEach(() => {
+      clock = sandbox.useFakeTimers();
+      i++;
+      // Ensure the clientIds are not cached.
+      clock.tick(61 * 1000 * i);
+    });
+
+    it('generates a clientId lumped in 60 second blocks', () => {
+      const clientId = sw.generateFallbackClientId(referrer);
+      expect(sw.generateFallbackClientId(referrer)).to.equal(clientId);
+    });
+
+    it('generates a new clientId after 60 seconds', () => {
+      const clientId = sw.generateFallbackClientId(referrer);
+      clock.tick(60 * 1000);
+      expect(sw.generateFallbackClientId(referrer)).to.equal(clientId);
+      clock.tick(1);
+      expect(sw.generateFallbackClientId(referrer)).not.to.equal(clientId);
+    });
+
+    it('generates a different clientId for different referrers', () => {
+      const clientId = sw.generateFallbackClientId(referrer);
+      const otherId = sw.generateFallbackClientId(other);
+      expect(otherId).not.to.equal(clientId);
+      expect(sw.generateFallbackClientId(other)).to.equal(otherId);
+    });
+  });
+
   describe('fetchAndCache', () => {
     const request = {url};
     const response = {


### PR DESCRIPTION
We use `clientId`s to distinguish between JS context windows, ensuring
that we serve one uniform AMP JS version to all requests from the
client.

Foreign Fetch, unfortunately, does not provide a `clientId`, so we must
generate our own.

This lumps all requests from a referrer into 60 second "batches",
generating a single `clientId` for those requests. After 60 seconds from
the first request, the batch's timer is invalidated and the next
request will generate a new `clientId` from the same referrer.

60 seconds was arbitrarily chosen to prevent version lock happening when
navigating back to the same page. We could have just used the referrer
as the `clientId`, but as long as the SW remains active, there would be
no way to distinguish between a navigation back. As we want to serve the
newer JS when possible, that seemed bad.