### PR TITLE
[amp-bind]: Remove (relatively) newer functions from the whitelist.

### DIFF
--- a/extensions/amp-bind/0.1/bind-expr-impl.jison
+++ b/extensions/amp-bind/0.1/bind-expr-impl.jison
@@ -11,7 +11,6 @@ const functionWhitelist = (() => {
     '[object Array]':
       [
         Array.prototype.concat,
-        Array.prototype.includes,
         Array.prototype.indexOf,
         Array.prototype.join,
         Array.prototype.lastIndexOf,
@@ -22,10 +21,8 @@ const functionWhitelist = (() => {
         String.prototype.charAt,
         String.prototype.charCodeAt,
         String.prototype.concat,
-        String.prototype.includes,
         String.prototype.indexOf,
         String.prototype.lastIndexOf,
-        String.prototype.repeat,
         String.prototype.slice,
         String.prototype.split,
         String.prototype.substr,

--- a/extensions/amp-bind/0.1/bind-expr-impl.js
+++ b/extensions/amp-bind/0.1/bind-expr-impl.js
@@ -183,7 +183,7 @@ case 26:
         }
 
         throw new Error($$[$0-1] + '() is not a supported function.');
-      
+
 break;
 case 27: case 40:
 this.$ = [];
@@ -201,7 +201,7 @@ case 29:
         if (isCorrectType && hasOwnProperty.call($$[$0-1], $$[$0])) {
           this.$ = $$[$0-1][$$[$0]];
         }
-      
+
 break;
 case 32:
 this.$ = hasOwnProperty.call(yy, $$[$0]) ? yy[$$[$0]] : null;
@@ -430,7 +430,10 @@ const functionWhitelist = (() => {
     const functions = whitelist[type];
     for (let i = 0; i < functions.length; i++) {
       const f = functions[i];
-      out[type][f.name] = f;
+      // Not all browsers support all the whitelisted functions.
+      if (f) {
+        out[type][f.name] = f;
+      }
     }
   });
   return out;

--- a/extensions/amp-bind/0.1/bind-expr-impl.js
+++ b/extensions/amp-bind/0.1/bind-expr-impl.js
@@ -398,7 +398,6 @@ const functionWhitelist = (() => {
     '[object Array]':
       [
         Array.prototype.concat,
-        Array.prototype.includes,
         Array.prototype.indexOf,
         Array.prototype.join,
         Array.prototype.lastIndexOf,
@@ -409,10 +408,8 @@ const functionWhitelist = (() => {
         String.prototype.charAt,
         String.prototype.charCodeAt,
         String.prototype.concat,
-        String.prototype.includes,
         String.prototype.indexOf,
         String.prototype.lastIndexOf,
-        String.prototype.repeat,
         String.prototype.slice,
         String.prototype.split,
         String.prototype.substr,
@@ -430,10 +427,7 @@ const functionWhitelist = (() => {
     const functions = whitelist[type];
     for (let i = 0; i < functions.length; i++) {
       const f = functions[i];
-      // Not all browsers support all the whitelisted functions.
-      if (f) {
-        out[type][f.name] = f;
-      }
+      out[type][f.name] = f;
     }
   });
   return out;

--- a/extensions/amp-bind/0.1/test/test-bind-expr.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expr.js
@@ -101,10 +101,8 @@ describe('evaluateBindExpr', () => {
     expect(evaluateBindExpr('"abc".charAt(0)')).to.equal('a');
     expect(evaluateBindExpr('"abc".charCodeAt(0)')).to.equal(97);
     expect(evaluateBindExpr('"abc".concat("def")')).to.equal('abcdef');
-    expect(evaluateBindExpr('"abc".includes("ab")')).to.equal(true);
     expect(evaluateBindExpr('"abc".indexOf("b")')).to.equal(1);
     expect(evaluateBindExpr('"aaa".lastIndexOf("a")')).to.equal(2);
-    expect(evaluateBindExpr('"ab".repeat(2)')).to.equal('abab');
     expect(evaluateBindExpr('"abc".slice(0, 2)')).to.equal('ab');
     expect(evaluateBindExpr('"a-b-c".split("-")'))
         .to.deep.equal(['a', 'b', 'c']);
@@ -119,7 +117,13 @@ describe('evaluateBindExpr', () => {
       evaluateBindExpr('"abc".anchor()');
     }).to.throw(Error, unsupportedFunctionError);
     expect(() => {
+      evaluateBindExpr('"abc".includes("ab")');
+    }).to.throw(Error, unsupportedFunctionError);
+    expect(() => {
       evaluateBindExpr('"abc".link()');
+    }).to.throw(Error, unsupportedFunctionError);
+    expect(() => {
+      evaluateBindExpr('"abc".repeat(2)');
     }).to.throw(Error, unsupportedFunctionError);
     expect(() => {
       evaluateBindExpr('"abc".replace("bc", "xy")');
@@ -175,7 +179,6 @@ describe('evaluateBindExpr', () => {
   it('should support array whitelisted methods', () => {
     expect(evaluateBindExpr('["a", "b"].concat(["c", "d"])'))
         .to.deep.equal(['a', 'b', 'c', 'd']);
-    expect(evaluateBindExpr('["a"].includes("a")')).to.be.true;
     expect(evaluateBindExpr('["a", "a"].indexOf("a")')).to.equal(0);
     expect(evaluateBindExpr('["a", "b", "c"].join("-")')).to.equal('a-b-c');
     expect(evaluateBindExpr('["a", "a"].lastIndexOf("a")')).to.equal(1);
@@ -184,6 +187,9 @@ describe('evaluateBindExpr', () => {
   });
 
   it('should NOT allow access to array non-whitelisted methods', () => {
+    expect(() => {
+      evaluateBindExpr('["a", "b", "c"].includes("a")');
+    }).to.throw(Error, unsupportedFunctionError);
     expect(() => {
       evaluateBindExpr('["a", "b", "c"].find()');
     }).to.throw(Error, unsupportedFunctionError);

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -184,7 +184,6 @@ key_value:
 
 ```
 Array.concat
-Array.includes
 Array.indexOf
 Array.join
 Array.lastIndexOf
@@ -192,10 +191,8 @@ Array.slice
 String.charAt
 String.charCodeAt
 String.concat
-String.includes
 String.indexOf
 String.lastIndexOf
-String.repeat
 String.slice
 String.split
 String.substr


### PR DESCRIPTION
Tests were failing on Chrome 45 with
```
  Uncaught TypeError: Cannot read property 'name' of undefined
  at /tmp/504d278b3d2857f5072c7851f8a9da3e.browserify:34916 <- /home/travis/build/ampproject/amphtml/extensions/amp-bind/0.1/bind-expr-impl.js:433:6
```

root cause was Chrome 45 not supporting `Array.prototype.includes`

I suggest we should remove (relatively) newer functions that are not supported in Safari 8/Chrome 40s from the whitelist.

(another options is to do this based on browser support in which case bind expressions may or may not evaluate depending on the browser, but I argue this breaks AMP's cross-browser compatibility promise)