### PR TITLE
Allow `default-value` in amp-forms `input`

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2240,6 +2240,7 @@ tags: {
   attrs: { name: "autocomplete" }
   attrs: { name: "autofocus" }
   attrs: { name: "checked" }
+  attrs: { name: "default-value" }
   attrs: { name: "disabled" }
   attrs: { name: "height" }
   attrs: { name: "inputmode" }


### PR DESCRIPTION
Per #6421.