### PR TITLE
Cache SW: Serve version with most responses

### DIFF
--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -320,20 +320,58 @@ runner.run('Cache SW', () => {
   });
 
   describe('getCachedVersion', () => {
+    let keys;
     beforeEach(() => {
+      keys = [{url}];
       sandbox.stub(cache, 'keys', () => {
-        return Promise.resolve([{url}]);
+        return Promise.resolve(keys);
       });
     });
+
     it('returns cached rtv version, if file is cached', () => {
-      return sw.getCachedVersion(cache, '/v0.js').then(version => {
+      return sw.getCachedVersion(cache, '/v0.js', prevRtv).then(version => {
         expect(version).to.equal(rtv);
       });
     });
 
-    it('returns empty string, if file is not cached', () => {
-      return sw.getCachedVersion(cache, '/amp-comp.js').then(version => {
-        expect(version).to.equal('');
+    it('defaults to requested version, if file no files are cached', () => {
+      keys.length = 0;
+      return sw.getCachedVersion(cache, '/v0.js', prevRtv).then(version => {
+        expect(version).to.equal(prevRtv);
+      });
+    });
+
+    it('returns version with most responses', () => {
+      keys.splice(0, 1,
+          {url: `https://cdn.ampproject.org/rtv/${prevRtv}/v0/amp-1-0.1.js`},
+          {url: `https://cdn.ampproject.org/rtv/${prevRtv}/v0/amp-2-0.1.js`},
+          {url: `https://cdn.ampproject.org/rtv/${rtv}/v0/amp-3-0.1.js`});
+      return sw.getCachedVersion(cache, '/v0.js', rtv).then(version => {
+        expect(version).to.equal(prevRtv);
+      });
+    });
+
+    it('weights requested file cached version', () => {
+      keys.splice(0, 1,
+          {url: `https://cdn.ampproject.org/rtv/${prevRtv}/v0/amp-1-0.1.js`},
+          {url: `https://cdn.ampproject.org/rtv/${prevRtv}/v0/amp-2-0.1.js`},
+          {url: `https://cdn.ampproject.org/rtv/${rtv}/v0/amp-3-0.1.js`},
+          {url: `https://cdn.ampproject.org/rtv/${rtv}/v0/amp-4-0.1.js`});
+
+      return sw.getCachedVersion(cache, '/v0/amp-4-0.1.js', '123')
+        .then(version => {
+          expect(version).to.equal(rtv);
+        });
+    });
+
+    it('heavily weights main binary version', () => {
+      keys.splice(0, 1,
+          {url: `https://cdn.ampproject.org/rtv/${prevRtv}/v0/amp-1-0.1.js`},
+          {url: `https://cdn.ampproject.org/rtv/${prevRtv}/v0/amp-2-0.1.js`},
+          {url: `https://cdn.ampproject.org/rtv/${prevRtv}/v0/amp-3-0.1.js`},
+          {url: `https://cdn.ampproject.org/rtv/${rtv}/v0.js`});
+      return sw.getCachedVersion(cache, '/v0.js', '123').then(version => {
+        expect(version).to.equal(rtv);
       });
     });
   });
@@ -430,12 +468,11 @@ runner.run('Cache SW', () => {
         it('forces uniform RTV version of winner', () => {
           const timer = timerFor(window);
           // First call will resolve after the first.
-          const keys = sandbox.stub(cache, 'keys');
-          keys.returns(Promise.resolve([]));
-          keys.onCall(0).returns(timer.promise(100, []));
+          cache.cached.push([prevRequest, responseFromRequest(prevRequest)]);
+
           return Promise.all([
             sw.handleFetch(request, clientId),
-            sw.handleFetch(prevRequest, clientId),
+            sw.handleFetch(compRequest, clientId),
           ]).then(responses => {
             expect(sw.rtvVersion(responses[0].url)).to.equal(
                 sw.rtvVersion(prevRequest.url));
@@ -447,7 +484,6 @@ runner.run('Cache SW', () => {
 
       describe('with cached files', () => {
         beforeEach(() => {
-          cache.cached.push([request, responseFromRequest(request)]);
           cache.cached.push([prevRequest, responseFromRequest(prevRequest)]);
         });
 
@@ -468,7 +504,7 @@ runner.run('Cache SW', () => {
 
         describe('with blacklisted file', () => {
           beforeEach(() => {
-            cache.cached.splice(1, 1,
+            cache.cached.splice(0, 1,
                 [blacklistedRequest, responseFromRequest(blacklistedRequest)]);
           });
 
@@ -494,7 +530,7 @@ runner.run('Cache SW', () => {
               setTimeout(resolve, 50);
             });
           }).then(() => {
-            expect(cache.cached[1][0]).to.equal(prodRequest);
+            expect(cache.cached[0][0]).to.equal(prodRequest);
           });
         });
 

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -15,7 +15,6 @@
  */
 
 import * as sinon from 'sinon';
-import {timerFor} from '../../src/timer';
 
 /**
  * Cache SW has some side-effects, so we've got to do a little jig to test.
@@ -464,27 +463,23 @@ runner.run('Cache SW', () => {
         });
       });
 
-      describe('with multiple parallel requests', () => {
-        it('forces uniform RTV version of winner', () => {
-          const timer = timerFor(window);
-          // First call will resolve after the first.
-          cache.cached.push([prevRequest, responseFromRequest(prevRequest)]);
-
-          return Promise.all([
-            sw.handleFetch(request, clientId),
-            sw.handleFetch(compRequest, clientId),
-          ]).then(responses => {
-            expect(sw.rtvVersion(responses[0].url)).to.equal(
-                sw.rtvVersion(prevRequest.url));
-            expect(sw.rtvVersion(responses[1].url)).to.equal(
-                sw.rtvVersion(prevRequest.url));
-          });
-        });
-      });
-
       describe('with cached files', () => {
         beforeEach(() => {
           cache.cached.push([prevRequest, responseFromRequest(prevRequest)]);
+        });
+
+        describe('with multiple parallel requests', () => {
+          it('forces uniform RTV version of winner', () => {
+            return Promise.all([
+              sw.handleFetch(request, clientId),
+              sw.handleFetch(compRequest, clientId),
+            ]).then(responses => {
+              expect(sw.rtvVersion(responses[0].url)).to.equal(
+                sw.rtvVersion(prevRequest.url));
+              expect(sw.rtvVersion(responses[1].url)).to.equal(
+                sw.rtvVersion(prevRequest.url));
+            });
+          });
         });
 
         it('fulfills with cached version', () => {
@@ -544,6 +539,22 @@ runner.run('Cache SW', () => {
             });
           }).then(() => {
             expect(cache.cached[1][0]).to.equal(compRequest);
+          });
+        });
+      });
+
+      describe('without cached files', () => {
+        describe('with multiple parallel requests', () => {
+          it('forces uniform RTV version of winner', () => {
+            return Promise.all([
+              sw.handleFetch(request, clientId),
+              sw.handleFetch(prevRequest, clientId),
+            ]).then(responses => {
+              expect(sw.rtvVersion(responses[0].url)).to.equal(
+                sw.rtvVersion(request.url));
+              expect(sw.rtvVersion(responses[1].url)).to.equal(
+                sw.rtvVersion(request.url));
+            });
           });
         });
       });


### PR DESCRIPTION
I want to avoid the situation where `/v0/some-rarely-used-components.js` serves up a very old RTV, when we have multiple files of the newer version that could be served.

This heavily weights the main binary, places a small weight on the first requested file, and treats all other responses as normal. The version with the max score is what we’ll serve.