### PR TITLE
Export function getPageViewId

### DIFF
--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -84,6 +84,7 @@ export class DocInfo {
   }
 }
 
+const pageViewIdByWindow = {};
 
 /**
  * Returns a relatively low entropy random string.
@@ -92,6 +93,9 @@ export class DocInfo {
  * @param {!Window} win
  * @return {string}
  */
-function getPageViewId(win) {
-  return String(Math.floor(win.Math.random() * 10000));
+export function getPageViewId(win) {
+  if (!pageViewIdByWindow[win]) {
+    pageViewIdByWindow[win] = String(Math.floor(win.Math.random() * 10000));
+  }
+  return pageViewIdByWindow[win];
 }

--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -84,8 +84,6 @@ export class DocInfo {
   }
 }
 
-const pageViewIdByWindow = {};
-
 /**
  * Returns a relatively low entropy random string.
  * This should be called once per window and then cached for subsequent
@@ -94,8 +92,8 @@ const pageViewIdByWindow = {};
  * @return {string}
  */
 export function getPageViewId(win) {
-  if (!pageViewIdByWindow[win]) {
-    pageViewIdByWindow[win] = String(Math.floor(win.Math.random() * 10000));
+  if (!win.pageViewId) {
+    win.pageViewId = String(Math.floor(win.Math.random() * 10000));
   }
-  return pageViewIdByWindow[win];
+  return win.pageViewId;
 }


### PR DESCRIPTION
This needs to be exposed because it needs to be called separately from the class that was using it for building AmpContext objects