### PR TITLE
Refactor sendMessage and sendMessageAwaitResponse

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -267,8 +267,9 @@ var forbiddenTerms = {
     message: 'Usages must be reviewed.',
     whitelist: [
       'src/service/viewer-impl.js',
-      'src/service/performance-impl.js',
       'src/service/storage-impl.js',
+      'src/service/performance-impl.js',
+      'examples/viewer-integr-messaging.js',
       'extensions/amp-access/0.1/login-dialog.js',
       'extensions/amp-access/0.1/signin.js',
     ],

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -267,18 +267,19 @@ var forbiddenTerms = {
     message: 'Usages must be reviewed.',
     whitelist: [
       'src/service/viewer-impl.js',
-      'src/service/storage-impl.js',
       'src/service/performance-impl.js',
-      'examples/viewer-integr-messaging.js',
+      'src/service/storage-impl.js',
       'extensions/amp-access/0.1/login-dialog.js',
       'extensions/amp-access/0.1/signin.js',
     ],
   },
-  'sendMessageCancelUnsent': {
+  'sendMessageAwaitResponse': {
     message: 'Usages must be reviewed.',
     whitelist: [
       'src/service/viewer-impl.js',
-      'src/service/performance-impl.js',
+      'src/service/storage-impl.js',
+      'extensions/amp-access/0.1/login-dialog.js',
+      'extensions/amp-access/0.1/signin.js',
     ],
   },
   // Privacy sensitive

--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -79,9 +79,9 @@ class ViewerLoginDialog {
     return urlPromise.then(url => {
       const loginUrl = buildLoginUrl(url, 'RETURN_URL');
       dev().fine(TAG, 'Open viewer dialog: ', loginUrl);
-      return this.viewer.sendMessage('openDialog', {
+      return this.viewer.sendMessageAwaitResponse('openDialog', {
         'url': loginUrl,
-      }, true);
+      });
     });
   }
 }

--- a/extensions/amp-access/0.1/signin.js
+++ b/extensions/amp-access/0.1/signin.js
@@ -138,10 +138,10 @@ export class SignInProtocol {
       return null;
     }
     if (!this.accessTokenPromise_) {
-      this.accessTokenPromise_ = this.viewer_.sendMessage(
+      this.accessTokenPromise_ = this.viewer_.sendMessageAwaitResponse(
           'getAccessTokenPassive', {
             origin: this.pubOrigin_,
-          }, /* awaitResponse */ true).then(resp => {
+          }).then(resp => {
             return /** @type {?string} */ (resp);
           }).catch(reason => {
             user().error(TAG, 'Failed to retrieve access token: ', reason);
@@ -185,10 +185,10 @@ export class SignInProtocol {
     if (!authorizationCode) {
       return null;
     }
-    return this.viewer_.sendMessage('storeAccessToken', {
+    return this.viewer_.sendMessageAwaitResponse('storeAccessToken', {
       origin: this.pubOrigin_,
       authorizationCode,
-    }, /* awaitResponse */ true).then(resp => {
+    }).then(resp => {
       const accessToken = /** @type {?string} */ (resp);
       this.updateAccessToken_(accessToken);
       return accessToken;
@@ -218,10 +218,10 @@ export class SignInProtocol {
     if (!this.supportsSignInService_) {
       return null;
     }
-    return this.viewer_.sendMessage('requestSignIn', {
+    return this.viewer_.sendMessageAwaitResponse('requestSignIn', {
       origin: this.pubOrigin_,
       url,
-    }, /* awaitResponse */ true).then(resp => {
+    }).then(resp => {
       const accessToken = /** @type {?string} */ (resp);
       this.updateAccessToken_(accessToken);
       // Return empty dialog result.

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -42,7 +42,7 @@ describe('ViewerLoginDialog', () => {
         }
         return null;
       },
-      sendMessage: () => {},
+      sendMessageAwaitResponse: () => {},
     };
 
     windowApi = {
@@ -76,7 +76,7 @@ describe('ViewerLoginDialog', () => {
   });
 
   it('should delegate to viewer with url', () => {
-    const stub = sandbox.stub(viewer, 'sendMessage',
+    const stub = sandbox.stub(viewer, 'sendMessageAwaitResponse',
         () => Promise.resolve('#success=yes'));
     return openLoginDialog(windowApi, 'http://acme.com/login').then(res => {
       expect(res).to.equal('#success=yes');
@@ -85,12 +85,11 @@ describe('ViewerLoginDialog', () => {
       expect(stub.firstCall.args[1]).to.deep.equal({
         'url': 'http://acme.com/login?return=RETURN_URL',
       });
-      expect(stub.firstCall.args[2]).to.be.true;
     });
   });
 
   it('should delegate to viewer with url promise', () => {
-    const stub = sandbox.stub(viewer, 'sendMessage',
+    const stub = sandbox.stub(viewer, 'sendMessageAwaitResponse',
         () => Promise.resolve('#success=yes'));
     const urlPromise = Promise.resolve('http://acme.com/login');
     return openLoginDialog(windowApi, urlPromise).then(res => {
@@ -100,12 +99,11 @@ describe('ViewerLoginDialog', () => {
       expect(stub.firstCall.args[1]).to.deep.equal({
         'url': 'http://acme.com/login?return=RETURN_URL',
       });
-      expect(stub.firstCall.args[2]).to.be.true;
     });
   });
 
   it('should fail when url promise fails', () => {
-    sandbox.stub(viewer, 'sendMessage',
+    sandbox.stub(viewer, 'sendMessageAwaitResponse',
         () => Promise.resolve('#success=yes'));
     const urlPromise = Promise.reject('expected');
     return openLoginDialog(windowApi, urlPromise).then(() => {
@@ -116,7 +114,7 @@ describe('ViewerLoginDialog', () => {
   });
 
   it('should fail when viewer fails', () => {
-    sandbox.stub(viewer, 'sendMessage',
+    sandbox.stub(viewer, 'sendMessageAwaitResponse',
         () => Promise.reject('expected'));
     return openLoginDialog(windowApi, 'http://acme.com/login').then(() => {
       throw new Error('must not be here');
@@ -126,7 +124,7 @@ describe('ViewerLoginDialog', () => {
   });
 
   it('should have correct URL with other parameters', () => {
-    const stub = sandbox.stub(viewer, 'sendMessage',
+    const stub = sandbox.stub(viewer, 'sendMessageAwaitResponse',
         () => Promise.resolve('#success=yes'));
     const url = 'http://acme.com/login?a=b';
     return openLoginDialog(windowApi, url).then(() => {
@@ -137,7 +135,7 @@ describe('ViewerLoginDialog', () => {
   });
 
   it('should allow alternative form of return URL', () => {
-    const stub = sandbox.stub(viewer, 'sendMessage',
+    const stub = sandbox.stub(viewer, 'sendMessageAwaitResponse',
         () => Promise.resolve('#success=yes'));
     const url = 'http://acme.com/login?a=b&ret1=RETURN_URL';
     return openLoginDialog(windowApi, url).then(() => {

--- a/extensions/amp-access/0.1/test/test-signin.js
+++ b/extensions/amp-access/0.1/test/test-signin.js
@@ -52,7 +52,7 @@ describe('SignInProtocol', () => {
         }
         return undefined;
       },
-      sendMessage: () => Promise.resolve({}),
+      sendMessageAwaitResponse: () => Promise.resolve({}),
     };
     viewerMock = sandbox.mock(viewer);
 
@@ -142,10 +142,10 @@ describe('SignInProtocol', () => {
     });
 
     it('should call viewer for access token', () => {
-      viewerMock.expects('sendMessage')
+      viewerMock.expects('sendMessageAwaitResponse')
           .withExactArgs('getAccessTokenPassive', {
             origin: ORIGIN,
-          }, /* awaitResponse */ true)
+          })
           .returns(Promise.resolve('access token'))
           .once();
       return signin.getAccessTokenPassive().then(token => {
@@ -155,10 +155,10 @@ describe('SignInProtocol', () => {
     });
 
     it('should return null on viewer error for access token', () => {
-      viewerMock.expects('sendMessage')
+      viewerMock.expects('sendMessageAwaitResponse')
           .withExactArgs('getAccessTokenPassive', {
             origin: ORIGIN,
-          }, /* awaitResponse */ true)
+          })
           .returns(Promise.reject(new Error('intentional')))
           .once();
       return signin.getAccessTokenPassive().then(token => {
@@ -171,16 +171,16 @@ describe('SignInProtocol', () => {
     });
 
     it('should return null for post-login when no auth code in query', () => {
-      viewerMock.expects('sendMessage').never();
+      viewerMock.expects('sendMessageAwaitResponse').never();
       expect(signin.postLoginResult({})).to.be.null;
     });
 
     it('should call viewer for post-login with auth code', () => {
-      viewerMock.expects('sendMessage')
+      viewerMock.expects('sendMessageAwaitResponse')
           .withExactArgs('storeAccessToken', {
             origin: ORIGIN,
             authorizationCode: 'X',
-          }, /* awaitResponse */ true)
+          })
           .returns(Promise.resolve('access token X'))
           .once();
       return signin.postLoginResult({'code': 'X'}).then(token => {
@@ -195,11 +195,11 @@ describe('SignInProtocol', () => {
 
     it('should recorver from viewer error on post-login with auth code', () => {
       signin.updateAccessToken_('access token');
-      viewerMock.expects('sendMessage')
+      viewerMock.expects('sendMessageAwaitResponse')
           .withExactArgs('storeAccessToken', {
             origin: ORIGIN,
             authorizationCode: 'X',
-          }, /* awaitResponse */ true)
+          })
           .returns(Promise.reject(new Error('intentional')))
           .once();
       return signin.postLoginResult({'code': 'X'}).then(token => {
@@ -214,11 +214,11 @@ describe('SignInProtocol', () => {
 
     it('should call viewer for request sign-in', () => {
       const loginUrl = 'https://acme.com/login';
-      viewerMock.expects('sendMessage')
+      viewerMock.expects('sendMessageAwaitResponse')
           .withExactArgs('requestSignIn', {
             origin: ORIGIN,
             url: loginUrl,
-          }, /* awaitResponse */ true)
+          })
           .returns(Promise.resolve('access token X'))
           .once();
       return signin.requestSignIn(loginUrl).then(result => {
@@ -232,11 +232,11 @@ describe('SignInProtocol', () => {
 
     it('should fail on viewer error for request sign-in', () => {
       const loginUrl = 'https://acme.com/login';
-      viewerMock.expects('sendMessage')
+      viewerMock.expects('sendMessageAwaitResponse')
           .withExactArgs('requestSignIn', {
             origin: ORIGIN,
             url: loginUrl,
-          }, /* awaitResponse */ true)
+          })
           .returns(Promise.reject(new Error('intentional')))
           .once();
       return signin.requestSignIn(loginUrl).then(() => {
@@ -267,17 +267,17 @@ describe('SignInProtocol', () => {
     });
 
     it('should never call viewer for access token', () => {
-      viewerMock.expects('sendMessage').never();
+      viewerMock.expects('sendMessageAwaitResponse').never();
       signin.getAccessTokenPassive();
     });
 
     it('should return null for post-login', () => {
-      viewerMock.expects('sendMessage').never();
+      viewerMock.expects('sendMessageAwaitResponse').never();
       expect(signin.postLoginResult({'code': 'X'})).to.be.null;
     });
 
     it('should return null for request sign-in', () => {
-      viewerMock.expects('sendMessage').never();
+      viewerMock.expects('sendMessageAwaitResponse').never();
       expect(signin.requestSignIn('https://acme.com/login')).to.be.null;
     });
   });

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -221,8 +221,8 @@ export class Performance {
    * @private
    */
   setFlushParams_(params) {
-    this.viewer_.sendMessageCancelUnsent('setFlushParams', params,
-        /* awaitResponse */false);
+    this.viewer_.sendMessage('setFlushParams', params,
+        /* cancelUnsent */true);
   }
 
   /**
@@ -244,7 +244,7 @@ export class Performance {
         label,
         from: opt_from,
         value: opt_value,
-      }, /* awaitResponse */false);
+      });
     } else {
       this.queueTick_(label, opt_from, opt_value);
     }
@@ -287,8 +287,8 @@ export class Performance {
    */
   flush() {
     if (this.isMessagingReady_ && this.isPerformanceTrackingOn_) {
-      this.viewer_.sendMessageCancelUnsent('sendCsi', undefined,
-          /* awaitResponse */false);
+      this.viewer_.sendMessage('sendCsi', undefined,
+          /* cancelUnsent */true);
     }
   }
 
@@ -334,7 +334,7 @@ export class Performance {
     }
 
     this.events_.forEach(tickEvent => {
-      this.viewer_.sendMessage('tick', tickEvent, /* awaitResponse */false);
+      this.viewer_.sendMessage('tick', tickEvent);
     });
     this.events_.length = 0;
   }
@@ -372,8 +372,8 @@ export class Performance {
    */
   prerenderComplete_(value) {
     if (this.viewer_) {
-      this.viewer_.sendMessageCancelUnsent('prerenderComplete', {value},
-          /* awaitResponse */false);
+      this.viewer_.sendMessage('prerenderComplete', {value},
+          /* cancelUnsent */true);
     }
   }
 

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -344,15 +344,15 @@ export class ViewerStorageBinding {
 
   /** @override */
   loadBlob(origin) {
-    return this.viewer_.sendMessage('loadStore', {origin}, true).then(
+    return this.viewer_.sendMessageAwaitResponse('loadStore', {origin}).then(
       response => response['blob']
     );
   }
 
   /** @override */
   saveBlob(origin, blob) {
-    return /** @type {!Promise} */ (this.viewer_.sendMessage(
-        'saveStore', {origin, blob}, true));
+    return /** @type {!Promise} */ (this.viewer_.sendMessageAwaitResponse(
+        'saveStore', {origin, blob}));
   }
 }
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -1059,11 +1059,8 @@ export class Viewer {
       // Messaging is not expected.
       return;
     }
-    this.messagingMaybePromise_.then(() => {
-      if (this.messageDeliverer_) {
-        this.messageDeliverer_('broadcast', message, false);
-      }
-    });
+
+    this.sendMessage('broadcast', message);
   }
 
   /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -447,7 +447,7 @@ export class Viewer {
       this.sendMessage('a2a', {
         url,
         requestedBy,
-      }, /* awaitResponse */ false);
+      });
     } else {
       this.win.top.location.href = url;
     }
@@ -734,11 +734,12 @@ export class Viewer {
    * TODO: move this to resources-impl, and use sendMessage()
    */
   postDocumentReady() {
-    this.sendMessageCancelUnsent('documentLoaded', {
+    this.sendMessage('documentLoaded', {
       title: this.win.document.title,
       sourceUrl: getSourceUrl(this.ampdoc.getUrl()),
-    }, false);
+    }, /* cancelUnsent */true);
   }
+
 
   /**
    * Triggers "scroll" event for the viewer.
@@ -746,8 +747,8 @@ export class Viewer {
    * TODO: move this to viewport-impl
    */
   postScroll(scrollTop) {
-    this.sendMessageCancelUnsent(
-        'scroll', {scrollTop}, false);
+    this.sendMessage(
+        'scroll', {scrollTop}, /* cancelUnsent */true);
   }
 
   /**
@@ -758,7 +759,8 @@ export class Viewer {
    */
   requestFullOverlay() {
     return /** @type {!Promise} */ (
-        this.sendMessageCancelUnsent('requestFullOverlay', {}, true));
+        this.sendMessageAwaitResponse('requestFullOverlay', {},
+            /* cancelUnsent */true));
   }
 
   /**
@@ -769,29 +771,30 @@ export class Viewer {
    */
   cancelFullOverlay() {
     return /** @type {!Promise} */ (
-        this.sendMessageCancelUnsent('cancelFullOverlay', {}, true));
+        this.sendMessageAwaitResponse('cancelFullOverlay', {},
+            /* cancelUnsent */true));
   }
 
   /**
    * Triggers "pushHistory" event for the viewer.
    * @param {number} stackIndex
    * @return {!Promise}
-   * TODO: move this to history-impl and use sendMessage()
+   * TODO: move this to history-impl
    */
   postPushHistory(stackIndex) {
-    return /** @type {!Promise} */ (this.sendMessageCancelUnsent(
-        'pushHistory', {stackIndex}, true));
+    return /** @type {!Promise} */ (this.sendMessageAwaitResponse(
+        'pushHistory', {stackIndex}));
   }
 
   /**
    * Triggers "popHistory" event for the viewer.
    * @param {number} stackIndex
    * @return {!Promise}
-   * TODO: move this to history-impl and use sendMessage()
+   * TODO: move this to history-impl
    */
   postPopHistory(stackIndex) {
-    return /** @type {!Promise} */ (this.sendMessageCancelUnsent(
-        'popHistory', {stackIndex}, true));
+    return /** @type {!Promise} */ (this.sendMessageAwaitResponse(
+        'popHistory', {stackIndex}));
   }
 
   /**
@@ -805,7 +808,7 @@ export class Viewer {
       if (!trusted) {
         return undefined;
       }
-      const cidPromise = this.sendMessage('cid', opt_data, true)
+      const cidPromise = this.sendMessageAwaitResponse('cid', opt_data)
           .then(data => {
             // For backward compatibility: #4029
             if (data && !tryParseJson(data)) {
@@ -843,7 +846,8 @@ export class Viewer {
     if (!this.hasCapability('fragment')) {
       return Promise.resolve('');
     }
-    return this.sendMessageCancelUnsent('fragment', undefined, true).then(
+    return this.sendMessageAwaitResponse('fragment', undefined,
+        /* cancelUnsent */true).then(
         hash => {
           if (!hash) {
             return '';
@@ -861,7 +865,7 @@ export class Viewer {
    * The fragment variable should contain leading '#'
    * @param {string} fragment
    * @return {!Promise}
-   * TODO: move this to history-impl, and use sendMessage()
+   * TODO: move this to history-impl
    */
   updateFragment(fragment) {
     dev().assert(fragment[0] == '#', 'Fragment to be updated ' +
@@ -875,8 +879,8 @@ export class Viewer {
     if (!this.hasCapability('fragment')) {
       return Promise.resolve();
     }
-    return /** @type {!Promise} */ (this.sendMessageCancelUnsent(
-        'fragment', {fragment}, true));
+    return /** @type {!Promise} */ (this.sendMessageAwaitResponse(
+        'fragment', {fragment}, /* cancelUnsent */true));
   }
 
   /**
@@ -963,44 +967,63 @@ export class Viewer {
   }
 
   /**
-   * Sends the message to the viewer. This method will wait for the messaging
-   * channel to be established. If the messaging channel times out, the
-   * promise will fail.
+   * Sends the message to the viewer without waiting for any response.
+   * If cancelUnsent is true, the previous message of the same message type will
+   * be canceled.
    *
    * This is a restricted API.
    *
    * @param {string} eventType
    * @param {*} data
-   * @param {boolean} awaitResponse
-   * @return {!Promise<*>|undefined} the response promise if awaitResponse is
-   *     true, otherwise undefined
+   * @param {boolean=} cancelUnsent
    */
-  sendMessage(eventType, data, awaitResponse) {
-    if (!this.messagingReadyPromise_) {
-      return Promise.reject(getChannelError());
-    }
-    return this.messagingReadyPromise_.then(() => {
-      return this.messageDeliverer_(eventType, data, awaitResponse);
-    });
+  sendMessage(eventType, data, cancelUnsent = false) {
+    this.sendMessageInternal_(eventType, data, cancelUnsent, false);
   }
 
   /**
-   * Sends the message to the viewer. This method queues up the message if the
-   * communication channel isn't established yet. The message will cancel an
-   * unsent message of the same type if seen in the queue.
+   * Sends the message to the viewer and wait for response.
+   * If cancelUnsent is true, the previous message of the same message type will
+   * be canceled.
+   *
+   * This is a restricted API.
    *
    * @param {string} eventType
    * @param {*} data
-   * @param {boolean} awaitResponse
-   * @return {?Promise<*>|undefined} the response promise if awaitResponse is
-   *     true, otherwise undefined
+   * @param {boolean=} cancelUnsent
+   * @return {!Promise<*>} the response promise
    */
-  sendMessageCancelUnsent(eventType, data, awaitResponse) {
+  sendMessageAwaitResponse(eventType, data, cancelUnsent = false) {
+    return this.sendMessageInternal_(eventType, data, cancelUnsent, true);
+  }
+
+  /**
+   * Sends the message to the viewer.
+   *
+   * @param {string} eventType
+   * @param {*} data
+   * @param {boolean} cancelUnsent
+   * @param {boolean} awaitResponse
+   * @return {!Promise<*>} the response promise
+   */
+  sendMessageInternal_(eventType, data, cancelUnsent, awaitResponse) {
     if (this.messageDeliverer_) {
-      return this.messageDeliverer_(eventType, data, awaitResponse);
+      return /** @type {!Promise<*>} */ (this.messageDeliverer_(
+          eventType, data, awaitResponse));
     }
 
-    const found = findIndex(this.messageQueue_, m => m.eventType == eventType);
+    if (!this.messagingReadyPromise_) {
+      return Promise.reject(getChannelError());
+    }
+
+    if (!cancelUnsent) {
+      return this.messagingReadyPromise_.then(() => {
+        return this.messageDeliverer_(eventType, data, awaitResponse);
+      });
+    }
+
+    const found = findIndex(this.messageQueue_,
+        m => m.eventType == eventType);
 
     let message;
     if (found != -1) {
@@ -1021,7 +1044,7 @@ export class Viewer {
       };
     }
     this.messageQueue_.push(message);
-    return awaitResponse ? message.responsePromise : undefined;
+    return message.responsePromise;
   }
 
   /**

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -134,13 +134,10 @@ describe('performance', () => {
   describe('when viewer is ready,', () => {
     let viewer;
     let viewerSendMessageStub;
-    let viewerSendMessageCancelUnsentStub;
 
     beforeEach(() => {
       viewer = viewerForDoc(window.document);
       viewerSendMessageStub = sandbox.stub(viewer, 'sendMessage');
-      viewerSendMessageCancelUnsentStub = sandbox.stub(viewer,
-          'sendMessageCancelUnsent');
     });
 
 
@@ -314,8 +311,8 @@ describe('performance', () => {
           expect(perf.events_.length).to.equal(0);
 
           expect(viewerSendMessageStub.withArgs('tick')).to.not.be.called;
-          expect(viewerSendMessageCancelUnsentStub.withArgs('sendCsi'))
-              .to.not.be.called;
+          expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+              /* cancelUnsent */true)).to.not.be.called;
         });
       });
 
@@ -330,8 +327,8 @@ describe('performance', () => {
         perf.tick('start0');
         perf.flush();
         return perf.coreServicesAvailable().then(() => {
-          expect(viewerSendMessageCancelUnsentStub.withArgs('sendCsi'))
-              .to.not.be.called;
+          expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+              /* cancelUnsent */true)).to.not.be.called;
         });
       });
     });
@@ -401,18 +398,18 @@ describe('performance', () => {
       });
 
       it('should call the flush callback', () => {
-        expect(viewerSendMessageCancelUnsentStub.withArgs('sendCsi'))
-            .to.have.callCount(0);
+        expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+            /* cancelUnsent */true)).to.have.callCount(0);
         // coreServicesAvailable calls flush once.
         return perf.coreServicesAvailable().then(() => {
-          expect(viewerSendMessageCancelUnsentStub.withArgs('sendCsi'))
-              .to.have.callCount(1);
+          expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+              /* cancelUnsent */true)).to.have.callCount(1);
           perf.flush();
-          expect(viewerSendMessageCancelUnsentStub.withArgs('sendCsi'))
-              .to.have.callCount(2);
+          expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+              /* cancelUnsent */true)).to.have.callCount(2);
           perf.flush();
-          expect(viewerSendMessageCancelUnsentStub.withArgs('sendCsi'))
-              .to.have.callCount(3);
+          expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+              /* cancelUnsent */true)).to.have.callCount(3);
         });
       });
 
@@ -447,7 +444,7 @@ describe('performance', () => {
         ]);
 
         return perf.setDocumentInfoParams_().then(() => {
-          expect(viewerSendMessageCancelUnsentStub.withArgs('setFlushParams')
+          expect(viewerSendMessageStub.withArgs('setFlushParams')
               .lastCall.args[1]).to.be.jsonEqual({
                 sourceUrl: 'https://hello.world/baz/',
                 'amp-img': 2,
@@ -466,7 +463,7 @@ describe('performance', () => {
   describe('coreServicesAvailable', () => {
     let tickSpy;
     let viewer;
-    let viewerSendMessageCancelUnsentStub;
+    let viewerSendMessageStub;
     let whenFirstVisiblePromise;
     let whenFirstVisibleResolve;
     let whenReadyToRetrieveResourcesPromise;
@@ -483,8 +480,8 @@ describe('performance', () => {
       viewer = viewerForDoc(window.document);
       sandbox.stub(viewer, 'whenMessagingReady')
           .returns(Promise.resolve());
-      viewerSendMessageCancelUnsentStub = sandbox.stub(viewer,
-          'sendMessageCancelUnsent');
+      viewerSendMessageStub = sandbox.stub(viewer,
+          'sendMessage');
 
       tickSpy = sandbox.spy(perf, 'tick');
 
@@ -527,7 +524,7 @@ describe('performance', () => {
           whenReadyToRetrieveResourcesResolve();
           whenViewportLayoutCompleteResolve();
           return perf.whenViewportLayoutComplete_().then(() => {
-            expect(viewerSendMessageCancelUnsentStub.withArgs(
+            expect(viewerSendMessageStub.withArgs(
                 'prerenderComplete').firstCall.args[1].value).to.equal(400);
           });
         });
@@ -543,7 +540,7 @@ describe('performance', () => {
           whenReadyToRetrieveResourcesResolve();
           whenViewportLayoutCompleteResolve();
           return perf.whenViewportLayoutComplete_().then(() => {
-            expect(viewerSendMessageCancelUnsentStub.withArgs(
+            expect(viewerSendMessageStub.withArgs(
                 'prerenderComplete').firstCall.args[1].value).to.equal(400);
           });
         });
@@ -604,7 +601,7 @@ describe('performance', () => {
         whenReadyToRetrieveResourcesResolve();
         whenViewportLayoutCompleteResolve();
         return perf.whenViewportLayoutComplete_().then(() => {
-          expect(viewerSendMessageCancelUnsentStub.withArgs(
+          expect(viewerSendMessageStub.withArgs(
               'prerenderComplete').firstCall.args[1].value).to.equal(300);
         });
       });

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -879,10 +879,10 @@ describes.realWin('runtime multidoc', {
       const viewer = getServiceForDoc(ampdoc, 'viewer');
       const broadcastReceived = sandbox.spy();
       viewer.onBroadcast(broadcastReceived);
-      const onMessage = sandbox.spy();
+      const onMessage = sandbox.stub();
       amp.onMessage(function(eventType, data) {
         if (eventType == 'ignore' || eventType == 'documentLoaded') {
-          return undefined;
+          return Promise.resolve();
         }
         return onMessage(eventType, data);
       });
@@ -891,7 +891,7 @@ describes.realWin('runtime multidoc', {
 
     it('should broadcast to all but sender', () => {
       doc1.viewer.broadcast({test: 1});
-      return doc1.viewer.sendMessage('ignore', {}).then(() => {
+      return doc1.viewer.sendMessageAwaitResponse('ignore', {}).then(() => {
         return timer.promise(0);
       }).then(() => {
         // Sender is not called.
@@ -913,7 +913,7 @@ describes.realWin('runtime multidoc', {
     it('should stop broadcasting after close', () => {
       doc3.amp.close();
       doc1.viewer.broadcast({test: 1});
-      return doc1.viewer.sendMessage('ignore', {}).then(() => {
+      return doc1.viewer.sendMessageAwaitResponse('ignore', {}).then(() => {
         return timer.promise(0);
       }).then(() => {
         // Sender is not called, closed is not called.
@@ -929,7 +929,7 @@ describes.realWin('runtime multidoc', {
     it('should stop broadcasting after force-close', () => {
       doc3.hostElement.parentNode.removeChild(doc3.hostElement);
       doc1.viewer.broadcast({test: 1});
-      return doc1.viewer.sendMessage('ignore', {}).then(() => {
+      return doc1.viewer.sendMessageAwaitResponse('ignore', {}).then(() => {
         return timer.promise(0);
       }).then(() => {
         // Sender is not called, closed is not called.
@@ -942,14 +942,17 @@ describes.realWin('runtime multidoc', {
       });
     });
 
+
     it('should send message', () => {
-      return doc1.viewer.sendMessage('test3', {test: 3}).then(() => {
-        return timer.promise(0);
-      }).then(() => {
-        expect(doc1.onMessage).to.be.calledOnce;
-        expect(doc1.onMessage.args[0][0]).to.equal('test3');
-        expect(doc1.onMessage.args[0][1]).to.deep.equal({test: 3});
-      });
+      doc1.onMessage.returns(Promise.resolve());
+      return doc1.viewer.sendMessageAwaitResponse('test3', {test: 3}).then(
+          () => {
+            return timer.promise(0);
+          }).then(() => {
+            expect(doc1.onMessage).to.be.calledOnce;
+            expect(doc1.onMessage.args[0][0]).to.equal('test3');
+            expect(doc1.onMessage.args[0][1]).to.deep.equal({test: 3});
+          });
     });
 
     it('should receive message', () => {

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -543,7 +543,7 @@ describe('ViewerStorageBinding', () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     viewer = {
-      sendMessage: () => {},
+      sendMessageAwaitResponse: () => {},
     };
     viewerMock = sandbox.mock(viewer);
     binding = new ViewerStorageBinding(viewer);
@@ -554,10 +554,10 @@ describe('ViewerStorageBinding', () => {
   });
 
   it('should load store from viewer', () => {
-    viewerMock.expects('sendMessage')
+    viewerMock.expects('sendMessageAwaitResponse')
         .withExactArgs('loadStore', sinon.match(arg => {
           return (arg['origin'] == 'https://acme.com');
-        }), true)
+        }))
         .returns(Promise.resolve({'blob': 'BLOB1'}))
         .once();
     return binding.loadBlob('https://acme.com').then(blob => {
@@ -566,10 +566,10 @@ describe('ViewerStorageBinding', () => {
   });
 
   it('should load default store when not yet available', () => {
-    viewerMock.expects('sendMessage')
+    viewerMock.expects('sendMessageAwaitResponse')
         .withExactArgs('loadStore', sinon.match(arg => {
           return (arg['origin'] == 'https://acme.com');
-        }), true)
+        }))
         .returns(Promise.resolve({}))
         .once();
     return binding.loadBlob('https://acme.com').then(blob => {
@@ -578,10 +578,10 @@ describe('ViewerStorageBinding', () => {
   });
 
   it('should reject on viewer failure', () => {
-    viewerMock.expects('sendMessage')
+    viewerMock.expects('sendMessageAwaitResponse')
         .withExactArgs('loadStore', sinon.match(arg => {
           return (arg['origin'] == 'https://acme.com');
-        }), true)
+        }))
         .returns(Promise.reject('unknown'))
         .once();
     return binding.loadBlob('https://acme.com')
@@ -591,19 +591,19 @@ describe('ViewerStorageBinding', () => {
   });
 
   it('should save store', () => {
-    viewerMock.expects('sendMessage')
+    viewerMock.expects('sendMessageAwaitResponse')
         .withExactArgs('saveStore', sinon.match(arg => {
           return (arg['origin'] == 'https://acme.com' &&
               arg['blob'] == 'BLOB1');
-        }), true)
+        }))
         .returns(Promise.resolve())
         .once();
     return binding.saveBlob('https://acme.com', 'BLOB1');
   });
 
   it('should reject on save store failure', () => {
-    viewerMock.expects('sendMessage')
-        .withExactArgs('saveStore', sinon.match(() => true), true)
+    viewerMock.expects('sendMessageAwaitResponse')
+        .withExactArgs('saveStore', sinon.match(() => true))
         .returns(Promise.reject('unknown'))
         .once();
     return binding.saveBlob('https://acme.com', 'BLOB1')


### PR DESCRIPTION
Refactor `sendMessage` and `sendMessageCancelUnsent` in `viewer-impl` into
- `sendMessage(eventType, data, cancelUnsent)`: no return value
- `sendMessageAwaitResponse(eventType, data, cancelUnsent)`: wait for the response and return a promise