### PR TITLE
Turns AmpContext and IframeMessagingClient into composite pattern

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -47,8 +47,8 @@ export class AmpContext {
 
   /**
    *  Send message to runtime to start sending page visibility messages.
-   *  @param {function(Object)} callback Function to call every time we receive a
-   *    page visibility message.
+   *  @param {function(Object)} callback Function to call every time we receive
+   *    a page visibility message.
    *  @returns {function()} that when called stops triggering the callback
    *    every time we receive a page visibility message.
    */
@@ -61,8 +61,8 @@ export class AmpContext {
 
   /**
    *  Send message to runtime to start sending intersection messages.
-   *  @param {function(Object)} callback Function to call every time we receive an
-   *    intersection message.
+   *  @param {function(Object)} callback Function to call every time we receive
+   *  an intersection message.
    *  @returns {function()} that when called stops triggering the callback
    *    every time we receive an intersection message.
    */
@@ -80,7 +80,7 @@ export class AmpContext {
    *  @param {int} width The new width for the ad we are requesting.
    */
   requestResize(height, width) {
-    this.client_.messageHost(MessageType_.EMBED_SIZE, {width, height});
+    this.client_.sendMessage(MessageType_.EMBED_SIZE, {width, height});
   };
 
   /**
@@ -91,7 +91,7 @@ export class AmpContext {
    *    to call if the resize request succeeds.
    */
   onResizeSuccess(callback) {
-    this.client_.registerCallback(MessageType_.EMBED_SIZE_CHANGED, function(obj) {
+    this.client_.registerCallback(MessageType_.EMBED_SIZE_CHANGED, obj => {
       callback(obj.requestedHeight, obj.requestedWidth); });
   };
 
@@ -103,7 +103,7 @@ export class AmpContext {
    *    to call if the resize request is denied.
    */
   onResizeDenied(callback) {
-    this.client_.registerCallback(MessageType_.EMBED_SIZE_DENIED, function(obj) {
+    this.client_.registerCallback(MessageType_.EMBED_SIZE_DENIED, obj => {
       callback(obj.requestedHeight, obj.requestedWidth);
     });
   };

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -33,21 +33,16 @@ export const MessageType_ = {
   EMBED_SIZE_DENIED: 'embed-size-denied',
 };
 
-export class AmpContext extends IframeMessagingClient {
+export class AmpContext {
 
   /**
    *  @param {Window} win The window that the instance is built inside.
    */
   constructor(win) {
-    super(win);
     this.setupMetadata_();
-  }
-
-  /** @override */
-  registerCallback_(messageType, callback) {
-    user().assertEnumValue(MessageType_, messageType);
-    this.callbackFor_[messageType] = callback;
-    return () => { delete this.callbackFor_[messageType]; };
+    this.client_ = new IframeMessagingClient(win);
+    this.client_.setHostWindow(this.getHostWindow_());
+    this.client_.setSentinel(this.sentinel);
   }
 
   /**
@@ -58,14 +53,10 @@ export class AmpContext extends IframeMessagingClient {
    *    every time we receive a page visibility message.
    */
   observePageVisibility(callback) {
-    const stopObserveFunc = this.registerCallback_(
-        MessageType_.EMBED_STATE, callback);
-    this.messageHost_({
-      sentinel: this.sentinel,
-      type: MessageType_.SEND_EMBED_STATE,
-    });
-
-    return stopObserveFunc;
+    return this.client_.makeRequest(
+        MessageType_.SEND_EMBED_STATE,
+        MessageType_.EMBED_STATE,
+        callback);
   };
 
   /**
@@ -74,16 +65,12 @@ export class AmpContext extends IframeMessagingClient {
    *    intersection message.
    *  @returns {function()} that when called stops triggering the callback
    *    every time we receive an intersection message.
-
    */
   observeIntersection(callback) {
-    const stopObserveFunc = this.registerCallback_(
-        MessageType_.INTERSECTION, callback);
-    this.messageHost_({
-      sentinel: this.getSentinel(),
-      type: MessageType_.SEND_INTERSECTIONS});
-
-    return stopObserveFunc;
+    return this.client_.makeRequest(
+        MessageType_.SEND_INTERSECTIONS,
+        MessageType_.INTERSECTION,
+        callback);
   };
 
   /**
@@ -93,12 +80,7 @@ export class AmpContext extends IframeMessagingClient {
    *  @param {int} width The new width for the ad we are requesting.
    */
   requestResize(height, width) {
-    this.messageHost_({
-      sentinel: this.sentinel,
-      type: MessageType_.EMBED_SIZE,
-      width,
-      height,
-    });
+    this.client_.messageHost(MessageType_.EMBED_SIZE, {width, height});
   };
 
   /**
@@ -109,7 +91,7 @@ export class AmpContext extends IframeMessagingClient {
    *    to call if the resize request succeeds.
    */
   onResizeSuccess(callback) {
-    this.registerCallback_(MessageType_.EMBED_SIZE_CHANGED, function(obj) {
+    this.client_.registerCallback(MessageType_.EMBED_SIZE_CHANGED, function(obj) {
       callback(obj.requestedHeight, obj.requestedWidth); });
   };
 
@@ -121,8 +103,9 @@ export class AmpContext extends IframeMessagingClient {
    *    to call if the resize request is denied.
    */
   onResizeDenied(callback) {
-    this.registerCallback_(MessageType_.EMBED_SIZE_DENIED, function(obj) {
-      callback(obj.requestedHeight, obj.requestedWidth); });
+    this.client_.registerCallback(MessageType_.EMBED_SIZE_DENIED, function(obj) {
+      callback(obj.requestedHeight, obj.requestedWidth);
+    });
   };
 
   /**
@@ -159,7 +142,7 @@ export class AmpContext extends IframeMessagingClient {
    *  Calculate the hostWindow
    *  @private
    */
-  generateWindow_() {
+  getHostWindow_() {
     const sentinelMatch = this.sentinel.match(/((\d+)-\d+)/);
     dev().assert(sentinelMatch, 'Incorrect sentinel format');
     const depth = Number(sentinelMatch[2]);
@@ -170,5 +153,4 @@ export class AmpContext extends IframeMessagingClient {
     }
     return ancestors[(ancestors.length - 1) - depth];
   }
-
-};
+}

--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -15,14 +15,10 @@
  */
 import './polyfills';
 import {listen} from '../src/event-helper';
-import {getRandom} from '../src/3p-frame';
 import {map} from '../src/types';
 import {user} from '../src/log';
 import {startsWith} from '../src/string';
 
-/**
- * @abstract
- */
 export class IframeMessagingClient {
 
   /**
@@ -31,6 +27,7 @@ export class IframeMessagingClient {
   constructor(win) {
     /** @private {!Window} */
     this.win_ = win;
+    this.hostWindow_ = win.parent;
     /** Map messageType keys to callback functions for when we receive
      *  that message
      *  @private {!Object}
@@ -40,15 +37,29 @@ export class IframeMessagingClient {
   }
 
   /**
+   * Make an event listening request to the host window.
+   *
+   * @param {string} requestType The type of the request message.
+   * @param {string} responseType The type of the response message.
+   * @param {function(object)} callback The callback function to call
+   *   when a message with type responseType is received.
+   */
+  makeRequest(requestType, responseType, callback) {
+    const unlisten = this.registerCallback(responseType, callback);
+    this.messageHost(requestType);
+    return unlisten;
+  }
+
+  /**
    * Register callback function for message with type messageType.
    *   As it stands right now, only one callback can exist at a time.
    *   All future calls will overwrite any previously registered
    *   callbacks.
    * @param {string} messageType The type of the message.
-   * @param {function(object)} callback The callback function to call
+   * @param {function()} callback The callback function to call
    *   when a message with type messageType is received.
    */
-  registerCallback_(messageType, callback) {
+  registerCallback(messageType, callback) {
     // NOTE : no validation done here. any callback can be register
     // for any callback, and then if that message is received, this
     // class *will execute* that callback
@@ -58,11 +69,13 @@ export class IframeMessagingClient {
 
   /**
    *  Send a postMessage to Host Window
-   *  @param {object} message The message to send.
-   *  @private
+   *  @param {string} type The type of message to send.
+   *  @param {Object=} opt_payload The payload of message to send.
    */
-  messageHost_(message) {
-    this.getHostWindow().postMessage/*OK*/(message, '*');
+  messageHost(type, opt_payload) {
+    const message = {type, sentinel: this.sentinel_};
+    this.hostWindow_.postMessage/*OK*/(
+        Object.assign(message, opt_payload), '*');
   }
 
   /**
@@ -77,7 +90,7 @@ export class IframeMessagingClient {
   setupEventListener_() {
     listen(this.win_, 'message', message => {
       // Does it look a message from AMP?
-      if (message.source != this.getHostWindow()) {
+      if (message.source != this.hostWindow_) {
         return;
       }
       if (!message.data) {
@@ -91,7 +104,7 @@ export class IframeMessagingClient {
       try {
         const payload = JSON.parse(message.data.substring(4));
         // Check the sentinel as well.
-        if (payload.sentinel == this.getSentinel() &&
+        if (payload.sentinel == this.sentinel_ &&
             this.callbackFor_[payload.type]) {
           try {
             // We should probably report exceptions within callback
@@ -110,36 +123,11 @@ export class IframeMessagingClient {
     });
   }
 
-  /**
-   *  This must be overwritten by classes that extend this base class
-   *  As implemented, this will only work for messaging the parent iframe.
-   */
-  getSentinel() {
-    if (!this.sentinel) {
-      this.sentinel = this.generateSentinel_();
-    }
-    return this.sentinel;
+  setHostWindow(win) {
+    this.hostWindow_ = win;
   }
 
-  /**
-   *  Only valid for the trivial case when we will always be messaging our parent
-   *  Should be overwritten for subclasses
-   */
-  getHostWindow() {
-    if (!this.hostWindow) {
-      this.hostWindow = this.generateWindow_();
-    }
-    return this.hostWindow;
+  setSentinel(sentinel) {
+    this.sentinel_ = sentinel;
   }
-
-  /**
-   *  @private
-   */
-  generateWindow_() {
-    return this.win_.parent;
-  }
-
-  generateSentinel_() {
-    return '0-' + getRandom(this.win_);
-  }
-};
+}

--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -46,7 +46,7 @@ export class IframeMessagingClient {
    */
   makeRequest(requestType, responseType, callback) {
     const unlisten = this.registerCallback(responseType, callback);
-    this.messageHost(requestType);
+    this.sendMessage(requestType);
     return unlisten;
   }
 
@@ -72,7 +72,7 @@ export class IframeMessagingClient {
    *  @param {string} type The type of message to send.
    *  @param {Object=} opt_payload The payload of message to send.
    */
-  messageHost(type, opt_payload) {
+  sendMessage(type, opt_payload) {
     const message = {type, sentinel: this.sentinel_};
     this.hostWindow_.postMessage/*OK*/(
         Object.assign(message, opt_payload), '*');

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -266,12 +266,17 @@ var forbiddenTerms = {
   'sendMessage': {
     message: 'Usages must be reviewed.',
     whitelist: [
+      // viewer-impl.sendMessage
       'src/service/viewer-impl.js',
       'src/service/storage-impl.js',
       'src/service/performance-impl.js',
       'examples/viewer-integr-messaging.js',
       'extensions/amp-access/0.1/login-dialog.js',
       'extensions/amp-access/0.1/signin.js',
+
+      // iframe-messaging-client.sendMessage
+      '3p/iframe-messaging-client.js',
+      '3p/ampcontext.js',
     ],
   },
   'sendMessageCancelUnsent': {
@@ -509,12 +514,6 @@ var forbidden3pTerms = {
   // usage in babel's external helpers that is in a code path that we do
   // not use.
   '\\.then\\((?!callNext)': ThreePTermsMessage,
-  'Math\\.sign': ThreePTermsMessage,
-  'Object\\.assign': {
-    message: ThreePTermsMessage,
-    // See https://github.com/ampproject/amphtml/issues/4877
-    whitelist: ['ads/openx.js'],
-  },
 };
 
 var bannedTermsHelpString = 'Please review viewport.js for a helper method ' +

--- a/test/functional/3p/test-iframe-messaging-client.js
+++ b/test/functional/3p/test-iframe-messaging-client.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {IframeMessagingClient} from '../../../3p/iframe-messaging-client';
+
+describes.realWin('iframe-messaging-client', {}, env => {
+
+  let win;
+  let client;
+  let postMessageStub;
+  let hostWindow;
+
+  beforeEach(() => {
+    win = env.win;
+    postMessageStub = sandbox.stub();
+    hostWindow = {postMessage: postMessageStub};
+    client = new IframeMessagingClient(win);
+    client.setHostWindow(hostWindow);
+    client.setSentinel('sentinel-123');
+  });
+
+  describe('makeRequest', () => {
+    it('should send the request via postMessage', () => {
+      const callbackSpy = sandbox.spy();
+      client.makeRequest('request-type', 'response-type', callbackSpy);
+      expect(postMessageStub).to.be.calledWith({
+        type: 'request-type',
+        sentinel: 'sentinel-123',
+      });
+
+      postAmpMessage({type: 'response-type', sentinel: 'sentinel-123'});
+      expect(callbackSpy).to.be.calledOnce;
+    });
+  });
+
+  describe('registerCallback', () => {
+    it('should invoke callback on receiving a message of' +
+        ' expected response type', () => {
+      const callbackSpy = sandbox.spy();
+      client.registerCallback('response-type', callbackSpy);
+
+      postAmpMessage({
+        type: 'response-type',
+        sentinel: 'sentinel-123',
+        x: 1,
+        y: 'abc',
+      });
+      expect(callbackSpy).to.be.calledWith({
+        type: 'response-type',
+        sentinel: 'sentinel-123',
+        x: 1,
+        y: 'abc',
+      });
+    });
+
+    it('should not invoke callback on receiving a message of' +
+        ' irrelevant response type', () => {
+      const callbackSpy = sandbox.spy();
+      client.registerCallback('response-type', callbackSpy);
+
+      postAmpMessage({type: 'response-type-2', sentinel: 'sentinel-123'});
+      expect(callbackSpy).to.not.be.called;
+    });
+
+    it('should not invoke callback on receiving a non-AMP message', () => {
+      const callbackSpy = sandbox.spy();
+      client.registerCallback('response-type', callbackSpy);
+
+      win.eventListeners.fire({
+        type: 'message',
+        source: hostWindow,
+        origin: 'http://www.example.com',
+        data: 'nonamp-' + JSON.stringify({
+          type: 'response-type',
+          sentinel: 'sentinel-123',
+        }),
+      });
+      expect(callbackSpy).to.not.be.called;
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('should send postMessage to host window', () => {
+      client.sendMessage('request-type', {x: 1, y: 'abc'});
+      expect(postMessageStub).to.be.calledWith({
+        type: 'request-type',
+        sentinel: 'sentinel-123',
+        x: 1,
+        y: 'abc',
+      });
+    });
+  });
+
+  function postAmpMessage(data) {
+    win.eventListeners.fire({
+      type: 'message',
+      source: hostWindow,
+      origin: 'http://www.example.com',
+      data: 'amp-' + JSON.stringify(data),
+    });
+  }
+});


### PR DESCRIPTION
It will make the use of IframeMessageClient in amp-inabox easier.

Added unit test for IframeMessagingClient.
