### PR TITLE
Setup 3p a4a via cross-origin domain

### DIFF
--- a/examples/a4a.amp.html
+++ b/examples/a4a.amp.html
@@ -58,7 +58,7 @@
       type="fake"
       data-use-a4a="true"
       data-vars-analytics-var="bar"
-      src="fake_amp.json.html">
+      src="//ads.localhost:8000/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.json.html">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>

--- a/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
+++ b/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import {base64DecodeToBytes} from '../../../src/utils/base64';
-import {utf8Decode} from '../../../src/utils/bytes';
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
+import {base64DecodeToBytes} from '../../../src/utils/base64';
 import {dev, user} from '../../../src/log';
+import {resolveRelativeUrl} from '../../../src/url';
+import {utf8Decode} from '../../../src/utils/bytes';
+
 
 export class AmpAdNetworkFakeImpl extends AmpA4A {
 
@@ -42,8 +44,9 @@ export class AmpAdNetworkFakeImpl extends AmpA4A {
 
   /** @override */
   getAdUrl() {
-    return '/extensions/amp-ad-network-fake-impl/0.1/data/' +
-        this.element.getAttribute('src');
+    return resolveRelativeUrl(
+        this.element.getAttribute('src'),
+        '/extensions/amp-ad-network-fake-impl/0.1/data/');
   }
 
   /** @override */


### PR DESCRIPTION
This should recreate the fully 3p context. Make sure that `ads.localhost` is setup as described in the DEVELOPING.md.