### PR TITLE
delay updateBorderPadding

### DIFF
--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -136,10 +136,6 @@ class AmpStickyAd extends AMP.BaseElement {
       this.deferMutate(() => {
         this.visible_ = true;
         this.viewport_.addToFixedLayer(this.element);
-        // Add border-bottom to the body to compensate space that was taken
-        // by sticky ad, so no content would be blocked by sticky ad unit.
-        const borderBottom = this.element./*OK*/offsetHeight;
-        this.viewport_.updatePaddingBottom(borderBottom);
         this.addCloseButton_();
         this.scheduleLayoutForAd_();
       });
@@ -173,6 +169,10 @@ class AmpStickyAd extends AMP.BaseElement {
       this.vsync_.mutate(() => {
         // Set sticky-ad to visible and change container style
         this.element.setAttribute('visible', '');
+        // Add border-bottom to the body to compensate space that was taken
+        // by sticky ad, so no content would be blocked by sticky ad unit.
+        const borderBottom = this.element./*OK*/offsetHeight;
+        this.viewport_.updatePaddingBottom(borderBottom);
         this.forceOpacity_();
       });
     });

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -333,6 +333,8 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     };
 
     impl.displayAfterScroll_();
+    impl.layoutAd_();
+    impl.ad_.dispatchEvent(new Event('amp:load:end'));
     return impl.viewport_.ampdoc.whenBodyAvailable().then(() => {
       let borderWidth = win.getComputedStyle(win.document.body, null)
           .getPropertyValue('border-bottom-width');
@@ -368,6 +370,8 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     };
 
     impl.displayAfterScroll_();
+    impl.layoutAd_();
+    impl.ad_.dispatchEvent(new Event('amp:load:end'));
     return impl.viewport_.ampdoc.whenBodyAvailable().then(() => {
       let borderWidth = win.getComputedStyle(win.document.body, null)
           .getPropertyValue('border-bottom-width');


### PR DESCRIPTION
Since on safari, body borderBottom is always visible, we should delay the display of borderBottom after ad layout.