### PR TITLE
Content.ad: Utilize sourceUrl for validation

### DIFF
--- a/ads/contentad.js
+++ b/ads/contentad.js
@@ -32,15 +32,12 @@ export function contentad(global, data) {
   cadDiv.id = 'contentad' + global.wid;
   window.document.body.appendChild(cadDiv);
 
-  /* Capture or pass URL */
-  const host = window.context.location.host;
-  const domain = data.url || window.atob(data.d);
-  let adUrl = window.context.location.href;
-  /* Identify and remove CDN path */
-  const myreg = new RegExp(':\/\/.*?(?=([a-z0-9\-]+\.?)?' + domain + ')', 'i');
-  adUrl = adUrl.replace(myreg, '://');
-  if (data.url || !adUrl.includes(domain)) {
-    adUrl = adUrl.replace(host, domain);
+  /* Pass Source URL */
+  let sourceUrl = window.context.sourceUrl;
+  if (data.url) {
+    const host = window.context.location.host;
+    const domain = data.url || window.atob(data.d);
+    sourceUrl = sourceUrl.replace(host, domain);
   }
 
   /* Build API URL */
@@ -48,7 +45,7 @@ export function contentad(global, data) {
     + '?id=' + encodeURIComponent(global.id)
     + '&d=' + encodeURIComponent(global.d)
     + '&wid=' + global.wid
-    + '&url=' + encodeURIComponent(adUrl)
+    + '&url=' + encodeURIComponent(sourceUrl)
     + '&cb=' + Date.now();
 
   /* Call Content.ad Widget */

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -24,6 +24,7 @@ window.context = {};
 window.context.amp3pSentinel;
 window.context.clientId;
 window.context.initialIntersection;
+window.context.sourceUrl;
 
 // Service Holder
 window.services;


### PR DESCRIPTION
Updated the Content.ad logic to use the sourceUrl value for publisher domain validation.