### PR TITLE
Added amp-hulu example link to amp-hulu doc

### DIFF
--- a/extensions/amp-hulu/0.1/test/test-amp-hulu.js
+++ b/extensions/amp-hulu/0.1/test/test-amp-hulu.js
@@ -36,16 +36,16 @@ describe('amp-hulu', () => {
   }
 
   it('renders', () => {
-    return getHulu('Bx6H30RBVFNpOe-iiOxp3A').then(hulu => {
+    return getHulu('4Dk5F2PYTtrgciuvloH3UA').then(hulu => {
       const iframe = hulu.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
-      expect(iframe.src).to.equal('https://secure.hulu.com/dash/mobile_embed.html?eid=Bx6H30RBVFNpOe-iiOxp3A');
+      expect(iframe.src).to.equal('https://secure.hulu.com/dash/mobile_embed.html?eid=4Dk5F2PYTtrgciuvloH3UA');
     });
   });
 
   it('renders responsively', () => {
-    return getHulu('Bx6H30RBVFNpOe-iiOxp3A', true).then(hulu => {
+    return getHulu('4Dk5F2PYTtrgciuvloH3UA', true).then(hulu => {
       const iframe = hulu.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.className).to.match(/-amp-fill-content/);

--- a/extensions/amp-hulu/amp-hulu.md
+++ b/extensions/amp-hulu/amp-hulu.md
@@ -31,7 +31,11 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
+    <td>fill, fixed, fixed-height, flex-item, responsive</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td><a href="https://ampbyexample.com/components/amp-hulu/">Annotated code example for amp-hulu</a></td>
   </tr>
 </table>
 
@@ -39,7 +43,7 @@ limitations under the License.
 
 ```html
 <amp-hulu width="412" height="213" layout="responsive"
-  data-eid="Bx6H30RBVFNpOe-iiOxp3A">
+  data-eid="4Dk5F2PYTtrgciuvloH3UA">
 </amp-hulu>
 ```
 
@@ -47,5 +51,5 @@ limitations under the License.
 
 **data-eid**
 
-In a URL like https://secure.hulu.com/embed.html?eid=Bx6H30RBVFNpOe-iiOxp3A `Bx6H30RBVFNpOe-iiOxp3A` is the eid.
+In a URL like https://secure.hulu.com/embed.html?eid=4Dk5F2PYTtrgciuvloH3UA `4Dk5F2PYTtrgciuvloH3UA` is the eid.
 


### PR DESCRIPTION
[amp-hulu example](https://ampbyexample.com/components/amp-hulu/) is ready, so add the link to it's doc

More please see [https://github.com/ampproject/amp-by-example/pull/505](https://github.com/ampproject/amp-by-example/pull/505)