### PR TITLE
override `isAlwaysFix` to get correct InOb entry

### DIFF
--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -86,6 +86,11 @@ class AmpStickyAd extends AMP.BaseElement {
   }
 
   /** @override */
+  isAlwaysFixed() {
+    return true;
+  }
+
+  /** @override */
   unlayoutCallback() {
     this.viewport_.updatePaddingBottom(0);
     return true;


### PR DESCRIPTION
a temporary fix for #6533.

we don't really have another fixed positioning layer for Chrome. So `addToFixedLayer(element)` in chrome will not result in a `mutateFixedElement_`. Then we will not remeasure the element and its `isFixed_` value will not be changed. This is not an issue unless we want to get element's layoutBox. The PR includes a temporary fix to get correct InOb entry for sticky-ad. 

@jridgewell  question: with layout manager, are we allowing moving element from one layer to another, or is it not an applicable use case?