### PR TITLE
jw-player, no longer unlayout on pause since #6483 is fixed now

### DIFF
--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -89,13 +89,6 @@ class AmpJWPlayer extends AMP.BaseElement {
   }
 
   /** @override */
-  unlayoutOnPause() {
-    // TODO(aghassemi, #6483): Temporarily unlayout on pause until JWPlayer
-    // fixes the "pause" behaviour as described in bug #6483.
-    return true;
-  }
-
-  /** @override */
   unlayoutCallback() {
     if (this.iframe_) {
       removeElement(this.iframe_);


### PR DESCRIPTION
jwplayer team has launched a fix for #6483 so we no longer need to unlayout on pause.
essentially a revert of https://github.com/ampproject/amphtml/pull/6509 but I am leaving the `unlayoutCallback` code in there as it is needed regardless.