### PR TITLE
Do not trust Message Deliverer's Promise

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -907,6 +907,9 @@ export class Viewer {
    */
   sendMessageInternal_(eventType, data, cancelUnsent, awaitResponse) {
     if (this.messageDeliverer_) {
+      // Certain message deliverers return fake "Promise" instances called
+      // "Thenables". Convert from these values into trusted Promise instances,
+      // assimilating with the resolved (or rejected) internal value.
       return /** @type {!Promise<*>} */ (Promise.resolve(this.messageDeliverer_(
           eventType, data, awaitResponse)));
     }

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -907,8 +907,8 @@ export class Viewer {
    */
   sendMessageInternal_(eventType, data, cancelUnsent, awaitResponse) {
     if (this.messageDeliverer_) {
-      return /** @type {!Promise<*>} */ (this.messageDeliverer_(
-          eventType, data, awaitResponse));
+      return /** @type {!Promise<*>} */ (Promise.resolve(this.messageDeliverer_(
+          eventType, data, awaitResponse)));
     }
 
     if (!this.messagingReadyPromise_) {


### PR DESCRIPTION
Google's viewer integration returns a Thenable for some requests, which
does not have a `#catch`. Thankfully, `Promise.resolve` will cast the
return value from their thenable into a trusted Promise.

Fixes https://github.com/ampproject/amphtml/issues/6631.