### PR TITLE
Position observer prototype

### DIFF
--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -182,7 +182,6 @@ export class IntersectionObserverPolyfill {
    * @param {Object=} opt_option
    */
   constructor(callback, opt_option) {
-    console.log('constructor');
     /** @private @const {function(?Array<!IntersectionObserverEntry>)} */
     this.callback_ = callback;
 
@@ -211,7 +210,6 @@ export class IntersectionObserverPolyfill {
    * @param {!Element} element
    */
   observe(element) {
-    console.log('observe');
     // Check the element is an AMP element
     dev().assert(element.isBuilt && element.isBuilt());
 
@@ -254,7 +252,6 @@ export class IntersectionObserverPolyfill {
    * @param {./layout-rect.LayoutRectDef=} opt_iframe
    */
   tick(hostViewport, opt_iframe) {
-    console.log('tick');
 
     if (opt_iframe) {
       // If element inside an iframe. Adjust origin to the iframe.left/top.
@@ -263,8 +260,6 @@ export class IntersectionObserverPolyfill {
       opt_iframe =
           moveLayoutRect(opt_iframe, -opt_iframe.left, -opt_iframe.top);
     }
-
-    console.log(hostViewport);
 
     const changes = [];
 

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -182,6 +182,7 @@ export class IntersectionObserverPolyfill {
    * @param {Object=} opt_option
    */
   constructor(callback, opt_option) {
+    console.log('constructor');
     /** @private @const {function(?Array<!IntersectionObserverEntry>)} */
     this.callback_ = callback;
 
@@ -210,6 +211,7 @@ export class IntersectionObserverPolyfill {
    * @param {!Element} element
    */
   observe(element) {
+    console.log('observe');
     // Check the element is an AMP element
     dev().assert(element.isBuilt && element.isBuilt());
 
@@ -252,6 +254,7 @@ export class IntersectionObserverPolyfill {
    * @param {./layout-rect.LayoutRectDef=} opt_iframe
    */
   tick(hostViewport, opt_iframe) {
+    console.log('tick');
 
     if (opt_iframe) {
       // If element inside an iframe. Adjust origin to the iframe.left/top.
@@ -260,6 +263,8 @@ export class IntersectionObserverPolyfill {
       opt_iframe =
           moveLayoutRect(opt_iframe, -opt_iframe.left, -opt_iframe.top);
     }
+
+    console.log(hostViewport);
 
     const changes = [];
 

--- a/src/position-observer.js
+++ b/src/position-observer.js
@@ -19,7 +19,7 @@ import {getExistingServiceForDoc} from './service';
 
 /**
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
- * @return {!./service/resources-impl.Resources}
+ * @return {!./service/position-observer-impl.PositionObserver}
  */
 export function positionObserverForDoc(nodeOrDoc) {
   return /** @type {!./service/position-observer-impl.PositionObserver} */ (

--- a/src/position-observer.js
+++ b/src/position-observer.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getExistingServiceForDoc} from './service';
+
+
+/**
+ * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+ * @return {!./service/resources-impl.Resources}
+ */
+export function positionObserverForDoc(nodeOrDoc) {
+  return /** @type {!./service/position-observer-impl.PositionObserver} */ (
+      getExistingServiceForDoc(nodeOrDoc, 'position-observer'));
+};

--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -114,10 +114,11 @@ export class PositionObserver {
   tick() {
     // TODO(zhouyx): Optimize this function to limit change to this layer and
     // child layer.
-    // TODO(zhouyx): Modifty #tick function of IntersectionObserverPolyfill to
+    // A list of things can do here:
+    // Modifty #tick function of IntersectionObserverPolyfill to
     // accept elements. Don't calculate for elements of other layer.
-    // Or I suggest layout manager only call tick(layer),
-    // and in IntersectionObserverPolyfill call callback for observed elements
+    // Or have layout manager tick with layer,
+    // IntersectionObserverPolyfill call only tick for observed elements
     // live inside child layer.
     const viewportRect = viewportForDoc(this.ampdoc).getRect();
     const keys = Object.keys(this.intersectionObservers_);
@@ -128,6 +129,13 @@ export class PositionObserver {
     }
   }
 
+  /**
+   * Function that get the IntersectionObserverDef through trackOption id
+   * If it is not exists, create a new one
+   * @param {!PosObTrackOptionDef} trackOption
+   * @return {Object}
+   * @private
+   */
   getInOb_(trackOption) {
     // return existing IntersectionObserver if there's one.
     if (this.intersectionObservers_[trackOption.id]) {
@@ -157,16 +165,27 @@ export class PositionObserver {
   }
 }
 
-
+/**
+ * Helper class to have an element mapped observable
+ * attached to one IntersectionObserver
+ */
 class elementObservables {
   constructor() {
     this.handlerMap_ = map();
   }
 
+  /**
+   * @param {!Element} element
+   * @return {boolean}
+   */
   hasElement(element) {
     return this.handlerMap_[element];
   }
 
+  /**
+   * @param {!Element} element
+   * @param {!function(Object)} callback
+   */
   add(element, callback) {
     if (this.handlerMap_[element]) {
       this.handlerMap_[element].push(callback);
@@ -175,6 +194,10 @@ class elementObservables {
     }
   }
 
+  /**
+   * @param {!Element} element
+   * @param {!function(Object)} callback
+   */
   remove(element, callback) {
     // remove this callback from handlerMap_[element]
     const callbacks = this.handlerMap_[element];
@@ -189,6 +212,9 @@ class elementObservables {
     }
   }
 
+  /**
+   * @param {!Object} changes
+   */
   fire(changes) {
     for (let i = 0; i < changes.length; i++) {
       const change = changes[i];
@@ -202,6 +228,10 @@ class elementObservables {
   }
 }
 
+/**
+ * @param {!.ampdoc-impl.AmpDoc} ampdoc
+ * @return {!PositionObserver}
+ */
 export function installPositionObserverServiceForDoc(ampdoc) {
   return getServiceForDoc(ampdoc, 'position-observer',
       () => new PositionObserver(ampdoc));

--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {map} from '../types';
+import {getServiceForDoc} from '../service';
+import {viewportForDoc} from '../viewport';
+import {IntersectionObserverPolyfill} from '../intersection-observer-polyfill';
+
+export const trackOptionType = {
+  LAYOUT: 0,
+  VIEWPORT_CALLBACK: 1,
+};
+
+const trackOptionMap = {
+  0: {
+    useNative: false,
+    options: {
+      threshold: [0],
+    },
+  },
+  1: {
+    options: {
+      threshold: [0],
+    },
+  },
+};
+
+export class PositionObserver {
+  constructor(ampdoc) {
+    this.idIndex_ = 0;
+
+    this.win = ampdoc.win;
+
+    this.ampdoc = ampdoc;
+
+    this.intersectionObservers_ = Object.create(null);
+
+    this.observableMap_ = Object.create(null);
+  }
+
+  trackElement(element, trackOptionType, callback) {
+    //get/create InOb for this trackOptionType
+    const io = this.getInOb_(trackOptionType);
+    // observe element and register with callback
+    this.observableMap_[trackOptionType].add(element, callback);
+    // TODO(zhouyx): remove the warning for observe same element multi times.
+    io.observe(element);
+    return () => {
+      this.observableMap_[trackOptionType].remove(element, callback);
+      if (!this.observableMap_[trackOptionType].element) {
+        io.unobserve(element);
+      }
+    };
+  }
+
+  tick() {
+    // TODO(zhouyx): Modifty #tick function of IntersectionObserverPolyfill to
+    // accept elements. Don't calculate for elements of other layer.
+    // Or I suggest layout manager only call tick(layer),
+    // and in IntersectionObserverPolyfill call callback for observed elements
+    // live inside child layer.
+    console.log('tick');
+    const viewportRect = viewportForDoc(this.ampdoc).getRect();
+    console.log(this.intersectionObservers_);
+    const keys = Object.keys(this.intersectionObservers_);
+    for (let i = 0; i < keys.length; i++) {
+      console.log('aaa');
+      console.log(keys[i]);
+      if (!this.intersectionObservers_[keys[i]].native) {
+        console.log('not native');
+        this.intersectionObservers_[keys[i]].io.tick(viewportRect);
+      }
+    }
+  }
+
+  getInOb_(trackOptionType) {
+    // map trackoptions and callback to a certain intersectionObserver
+    if (this.intersectionObservers_[trackOptionType]) {
+      return this.intersectionObservers_[trackOptionType].io;
+    }
+    const trackOption = trackOptionMap[trackOptionType];
+    // Create a new observableMap
+    this.observableMap_ = map();
+    this.observableMap_[trackOption] = new elementObservables();
+    // create a new intersectionObserver
+    const ioEntry = Object.create(null);
+    console.log(trackOption);
+    if (trackOption.useNative !== false &&
+        this.win.IntersectionObserver &&
+        this.win.IntersectionObserver.prototype.observe) {
+      // use native IntersectionObserver
+      console.log('native');
+      ioEntry.io = new this.win.IntersectionObserver(changes => {
+        this.observableMap_[trackOptionType].fire(changes);
+      }, trackOption.options);
+      ioEntry.native = true;
+    } else {
+      // use IntersectionObserver Polyfill.
+      console.log('polyfill');
+      ioEntry.io = new IntersectionObserverPolyfill(changes => {
+        this.observableMap_[trackOptionType].fire(changes);
+      }, trackOption.options);
+    }
+    this.intersectionObservers_[trackOptionType] = ioEntry;
+    return ioEntry.io;
+  }
+}
+
+
+class elementObservables {
+  constructor() {
+    this.handlerMap_ = map();
+  }
+
+  add(element, callback) {
+    if (this.handlerMap_[element]) {
+      this.handlerMap_[element].push(callback);
+    } else {
+      this.handlerMap_[element] = [callback];
+    }
+  }
+
+  remove(element, callback) {
+    // remove this callback from handlerMap_[element]
+    const callbacks = this.handlerMap_[element];
+    for (let i = 0; i < callbacks.length; i++) {
+      if (callbacks[i] === callback) {
+        callbacks.splice(i, 1);
+        if (callbacks.length == 0) {
+          this.handleMap_[element] = null;
+        }
+        return;
+      }
+    }
+  }
+
+  fire(changes) {
+    for (let i = 0; i < changes.length; i++) {
+      const change = changes[i];
+      const callbacks = this.handlerMap_[change.target];
+      if (callbacks) {
+        for (let j = 0; j < changes.length; j++) {
+          callbacks[j](change);
+        }
+      }
+    }
+  }
+}
+
+export function installPositionObserverServiceForDoc(ampdoc) {
+  return getServiceForDoc(ampdoc, 'position-observer',
+      () => new PositionObserver(ampdoc));
+};

--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -88,6 +88,7 @@ export class PositionObserver {
    */
   trackElement(element, trackOption, callback) {
     // TODO: Do we want to support user customized trackOption.
+    // TODO: Do want to support multi callbacks
 
     //get the InOb for this trackOptionType
     const io = this.getInOb_(trackOption);
@@ -113,12 +114,12 @@ export class PositionObserver {
    */
   tick() {
     // TODO(zhouyx): Optimize this function to limit change to this layer and
-    // child layer.
+    // child layer. Also take in params from layout manager.
     // A list of things can do here:
     // Modifty #tick function of IntersectionObserverPolyfill to
     // accept elements. Don't calculate for elements of other layer.
-    // Or have layout manager tick with layer,
-    // IntersectionObserverPolyfill call only tick for observed elements
+    // Have layout manager tick with layer,
+    // IntersectionObserverPolyfill can only tick for observed elements
     // live inside child layer.
     const viewportRect = viewportForDoc(this.ampdoc).getRect();
     const keys = Object.keys(this.intersectionObservers_);

--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -30,7 +30,7 @@ let IntersectionObserverDef;
 /**
  * @typedef {{
  *   id: string,
- *   useNative: boolean|undefine,
+ *   useNative: (boolean|undefine),
  *   options: Object,
  * }}
  */
@@ -66,10 +66,10 @@ export class PositionObserver {
   /** @param {!./ampdoc-impl.AmpDoc} ampdoc */
   constructor(ampdoc) {
     /** @const @private {!Window} */
-    this.win = ampdoc.win;
+    this.win_ = ampdoc.win;
 
     /** @const @private {!./ampdoc-impl.AmpDoc} */
-    this.ampdoc = ampdoc;
+    this.ampdoc_ = ampdoc;
 
     /** @const @private {!Object<string, IntersectionObserverDef>} */
     this.intersectionObservers_ = map();
@@ -121,7 +121,7 @@ export class PositionObserver {
     // Have layout manager tick with layer,
     // IntersectionObserverPolyfill can only tick for observed elements
     // live inside child layer.
-    const viewportRect = viewportForDoc(this.ampdoc).getRect();
+    const viewportRect = viewportForDoc(this.ampdoc_).getRect();
     const keys = Object.keys(this.intersectionObservers_);
     for (let i = 0; i < keys.length; i++) {
       if (!this.intersectionObservers_[keys[i]].native) {
@@ -148,10 +148,10 @@ export class PositionObserver {
     // create a new IntersectionObserver
     const ioEntry = Object.create(null);
     if (trackOption.useNative !== false &&
-        this.win.IntersectionObserver &&
-        this.win.IntersectionObserver.prototype.observe) {
+        this.win_.IntersectionObserver &&
+        this.win_.IntersectionObserver.prototype.observe) {
       // use native IntersectionObserver
-      ioEntry.io = new this.win.IntersectionObserver(changes => {
+      ioEntry.io = new this.win_.IntersectionObserver(changes => {
         this.observableMap_[trackOption.id].fire(changes);
       }, trackOption.options);
       ioEntry.native = true;

--- a/test/functional/test-position-observer.js
+++ b/test/functional/test-position-observer.js
@@ -16,12 +16,10 @@
 
 import {
   installPositionObserverServiceForDoc,
-  trackOptionType,
+  PosObTrackOption,
 } from '../../src/service/position-observer-impl';
 import {positionObserverForDoc} from '../../src/position-observer';
-import {
-  IntersectionObserverPolyfill,
-} from '../../src/intersection-observer-polyfill';
+import {IntersectionObserverPolyfill} from '../../src/intersection-observer-polyfill';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import * as sinon from 'sinon';
 
@@ -32,7 +30,32 @@ describes.realWin.only('PositionObserver', {
 }, env => {
   let positionObserver;
   let sandbox;
+  let element;
+  let element2;
+  const trackOption = {
+    id: 'testpolyfill',
+    useNative: false,
+    options: {
+      threshold: [0],
+    },
+  };
+  const trackOption2 = {
+    id: 'testpolyfill2',
+    useNative: false,
+    options: {
+      threshold: [0],
+    },
+  };
   beforeEach(() => {
+    element = document.createElement('div');
+    element.isBuilt = () => {return true;};
+    element.getOwner = () => {return null;};
+    element.getLayoutBox = () => {return layoutRectLtwh(0, 0, 100, 100);};
+
+    element2 = document.createElement('div');
+    element2.isBuilt = () => {return true;};
+    element2.getOwner = () => {return null;};
+    element2.getLayoutBox = () => {return layoutRectLtwh(0, 0, 100, 100);};
     sandbox = sinon.sandbox.create();
     installPositionObserverServiceForDoc(env.ampdoc);
     positionObserver = positionObserverForDoc(env.ampdoc);
@@ -40,72 +63,94 @@ describes.realWin.only('PositionObserver', {
 
   afterEach(() => {
     sandbox.restore();
+    element = null;
   });
 
   describe('created InOb', () => {
-    let element;
-    beforeEach(() => {
-      element = document.createElement('div');
-      element.isBuilt = () => {return true;};
-      element.getOwner = () => {return null;};
-      element.getLayoutBox = () => {return layoutRectLtwh(0, 0, 100, 100);};
-    });
-    afterEach(() => {
-      element = null;
-    });
+    const nativeTrackOption = {
+      id: 'testnative',
+      options: {
+        threshold: [0],
+      },
+    };
 
     it('should be native/polyfill Inob as expected', () => {
-      const InObCallbackSpy = sandbox.spy();
-      positionObserver.trackElement(element,
-          trackOptionType.VIEWPORT,
-          InObCallbackSpy);
+      const polyfillInObSpy = sandbox.spy();
+      positionObserver.trackElement(element, nativeTrackOption,
+          polyfillInObSpy);
       positionObserver.tick();
-      expect(InObCallbackSpy).to.not.been.called;
-      positionObserver.trackElement(element,
-          trackOptionType.LAYOUT,
-          InObCallbackSpy);
+      expect(polyfillInObSpy).to.not.been.called;
+      positionObserver.trackElement(element, trackOption,
+          polyfillInObSpy);
       positionObserver.tick();
-      expect(InObCallbackSpy).to.be.calledOnce;
+      expect(polyfillInObSpy).to.be.calledOnce;
     });
 
-    it('should untrack callback or unobserve element', () => {
-      const InObCallbackSpy2 = sandbox.spy();
-      const unobserveSpy = sandbox.spy(IntersectionObserverPolyfill, 'unobserve');
+    it('should call observe/unobserve at correct time', () => {
+      const observeSpy =
+          sandbox.spy(IntersectionObserverPolyfill.prototype, 'observe');
+      const unobserveSpy =
+          sandbox.spy(IntersectionObserverPolyfill.prototype, 'unobserve');
       const unlisten1 = positionObserver.trackElement(
-          element, positionObserverTrackOption.LAYOUT, InObCallbackSpy);
+          element, trackOption, () => {});
+      expect(observeSpy).to.be.calledOnce;
       const unlisten2 = positionObserver.trackElement(
-          element, positionObserverTrackOption.LAYOUT, InObCallbackSpy2);
-      positionObserver.tick();
-      expect(InObCallbackSpy).to.be.calledOnce;
-      expect(InObCallbackSpy2).to.be.calledOnce;
+          element, trackOption, () => {});
+      expect(observeSpy).to.be.calledOnce;
       unlisten1();
-      positionObserver.tick();
-      expect(InObCallbackSpy).to.be.calledOnce;
-      expect(InObCallbackSpy2).to.be.calledTwice;
+      expect(unobserveSpy).to.not.be.called;
       unlisten2();
       expect(unobserveSpy).to.be.calledOnce;
-
-
     });
 
-    it('should unobserve element when only one callback is registerd', () => {
+    it('should be reused only with same trackoption', () => {
+      const InObTickSpy =
+          sandbox.spy(IntersectionObserverPolyfill.prototype, 'tick');
 
+      positionObserver.trackElement(element, trackOption, () => {});
+      positionObserver.trackElement(element2, trackOption, () => {});
+      positionObserver.tick();
+      expect(InObTickSpy).to.be.calledOnce;
+      InObTickSpy.reset();
+      positionObserver.trackElement(element, trackOption2, () => {});
+      positionObserver.trackElement(element2, trackOption2, () => {});
+      positionObserver.tick();
+      expect(InObTickSpy).to.be.calledTwice;
     });
   });
 
-  describe('when create InOb with same track option', () => {
-    it('should be reused when track multi elements', () => {
-
+  describe('registered callbacks', () => {
+    it('should all be called when same InOb observe multi elements', () => {
+      const callbackSpy1 = sandbox.spy();
+      const callbackSpy2 = sandbox.spy();
+      positionObserver.trackElement(element, trackOption, callbackSpy1);
+      positionObserver.trackElement(element2, trackOption, callbackSpy2);
+      positionObserver.tick();
+      expect(callbackSpy1).to.be.calledOnce;
+      expect(callbackSpy2).to.be.calledOnce;
     });
 
-    it('should support multi callbacks to one element', () => {
-
+    it('should all be called element has multi callbacks in same InOb', () => {
+      const callbackSpy1 = sandbox.spy();
+      const callbackSpy2 = sandbox.spy();
+      positionObserver.trackElement(element, trackOption, callbackSpy1);
+      positionObserver.trackElement(element, trackOption, callbackSpy2);
+      positionObserver.tick();
+      expect(callbackSpy1).to.be.calledOnce;
+      expect(callbackSpy2).to.be.calledOnce;
     });
-  });
 
-  describe('when create InOb with different track option', () => {
-    it('should all be ticked', () => {
-
+    it('should all be called with multi InOb', () => {
+      const callbackSpy1 = sandbox.spy();
+     // const callbackSpy2 = sandbox.spy();
+      const callbackSpy3 = sandbox.spy();
+      positionObserver.trackElement(element, trackOption, callbackSpy1);
+      //positionObserver.trackElement(element, trackOption2, callbackSpy2);
+      positionObserver.trackElement(element2, trackOption2, callbackSpy3);
+      positionObserver.tick();
+      expect(callbackSpy1).to.be.calledOnce;
+      //expect(callbackSpy2).to.be.calledOnce;
+      expect(callbackSpy3).to.be.calledOnce;
     });
   });
 });

--- a/test/functional/test-position-observer.js
+++ b/test/functional/test-position-observer.js
@@ -97,6 +97,7 @@ describes.realWin('PositionObserver', {
       expect(observeSpy).to.be.calledOnce;
       const unlisten2 = positionObserver.trackElement(
           element, trackOption, () => {});
+      positionObserver.tick();
       expect(observeSpy).to.be.calledOnce;
       unlisten1();
       expect(unobserveSpy).to.not.be.called;
@@ -135,22 +136,30 @@ describes.realWin('PositionObserver', {
       const callbackSpy1 = sandbox.spy();
       const callbackSpy2 = sandbox.spy();
       positionObserver.trackElement(element, trackOption, callbackSpy1);
-      positionObserver.trackElement(element, trackOption, callbackSpy2);
+      const unlisten =
+          positionObserver.trackElement(element, trackOption, callbackSpy2);
       positionObserver.tick();
       expect(callbackSpy1).to.be.calledOnce;
+      expect(callbackSpy2).to.be.calledOnce;
+      // change the fake layoutbox of the element to tick
+      element.getLayoutBox =
+          () => {return layoutRectLtwh(-1, -1, 1, 1);};
+      unlisten();
+      positionObserver.tick();
+      expect(callbackSpy1).to.be.calledTwice;
       expect(callbackSpy2).to.be.calledOnce;
     });
 
     it('should all be called with multi InOb', () => {
       const callbackSpy1 = sandbox.spy();
-     // const callbackSpy2 = sandbox.spy();
+      const callbackSpy2 = sandbox.spy();
       const callbackSpy3 = sandbox.spy();
       positionObserver.trackElement(element, trackOption, callbackSpy1);
-      //positionObserver.trackElement(element, trackOption2, callbackSpy2);
+      positionObserver.trackElement(element, trackOption2, callbackSpy2);
       positionObserver.trackElement(element2, trackOption2, callbackSpy3);
       positionObserver.tick();
       expect(callbackSpy1).to.be.calledOnce;
-      //expect(callbackSpy2).to.be.calledOnce;
+      expect(callbackSpy2).to.be.calledOnce;
       expect(callbackSpy3).to.be.calledOnce;
     });
   });

--- a/test/functional/test-position-observer.js
+++ b/test/functional/test-position-observer.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  installPositionObserverServiceForDoc,
+  trackOptionType,
+} from '../../src/service/position-observer-impl';
+import {positionObserverForDoc} from '../../src/position-observer';
+import {
+  IntersectionObserverPolyfill,
+} from '../../src/intersection-observer-polyfill';
+import {layoutRectLtwh} from '../../src/layout-rect';
+import * as sinon from 'sinon';
+
+describes.realWin.only('PositionObserver', {
+  amp: {
+    ampdoc: 'single',
+  },
+}, env => {
+  let positionObserver;
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    installPositionObserverServiceForDoc(env.ampdoc);
+    positionObserver = positionObserverForDoc(env.ampdoc);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('created InOb', () => {
+    let element;
+    beforeEach(() => {
+      element = document.createElement('div');
+      element.isBuilt = () => {return true;};
+      element.getOwner = () => {return null;};
+      element.getLayoutBox = () => {return layoutRectLtwh(0, 0, 100, 100);};
+    });
+    afterEach(() => {
+      element = null;
+    });
+
+    it('should be native/polyfill Inob as expected', () => {
+      const InObCallbackSpy = sandbox.spy();
+      positionObserver.trackElement(element,
+          trackOptionType.VIEWPORT,
+          InObCallbackSpy);
+      positionObserver.tick();
+      expect(InObCallbackSpy).to.not.been.called;
+      positionObserver.trackElement(element,
+          trackOptionType.LAYOUT,
+          InObCallbackSpy);
+      positionObserver.tick();
+      expect(InObCallbackSpy).to.be.calledOnce;
+    });
+
+    it('should untrack callback or unobserve element', () => {
+      const InObCallbackSpy2 = sandbox.spy();
+      const unobserveSpy = sandbox.spy(IntersectionObserverPolyfill, 'unobserve');
+      const unlisten1 = positionObserver.trackElement(
+          element, positionObserverTrackOption.LAYOUT, InObCallbackSpy);
+      const unlisten2 = positionObserver.trackElement(
+          element, positionObserverTrackOption.LAYOUT, InObCallbackSpy2);
+      positionObserver.tick();
+      expect(InObCallbackSpy).to.be.calledOnce;
+      expect(InObCallbackSpy2).to.be.calledOnce;
+      unlisten1();
+      positionObserver.tick();
+      expect(InObCallbackSpy).to.be.calledOnce;
+      expect(InObCallbackSpy2).to.be.calledTwice;
+      unlisten2();
+      expect(unobserveSpy).to.be.calledOnce;
+
+
+    });
+
+    it('should unobserve element when only one callback is registerd', () => {
+
+    });
+  });
+
+  describe('when create InOb with same track option', () => {
+    it('should be reused when track multi elements', () => {
+
+    });
+
+    it('should support multi callbacks to one element', () => {
+
+    });
+  });
+
+  describe('when create InOb with different track option', () => {
+    it('should all be ticked', () => {
+
+    });
+  });
+});

--- a/test/functional/test-position-observer.js
+++ b/test/functional/test-position-observer.js
@@ -16,14 +16,15 @@
 
 import {
   installPositionObserverServiceForDoc,
-  PosObTrackOption,
 } from '../../src/service/position-observer-impl';
 import {positionObserverForDoc} from '../../src/position-observer';
-import {IntersectionObserverPolyfill} from '../../src/intersection-observer-polyfill';
+import {
+  IntersectionObserverPolyfill,
+} from '../../src/intersection-observer-polyfill';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import * as sinon from 'sinon';
 
-describes.realWin.only('PositionObserver', {
+describes.realWin('PositionObserver', {
   amp: {
     ampdoc: 'single',
   },


### PR DESCRIPTION
This implement the init prototype of PositionObserver. (Only the service, not used anywhere) Please advise.
One thing to note: I want to map an IntersectionObserver from a trackOption. However I don't think it's a good idea to have a map of Object to intersectionObserver and it would be hard to manage any random trackOptions.  So I create a list of all accepted trackOptions, and give id to each of them. I believe very few track options can cover all our use cases. 