### PR TITLE
Add runtime RTV version to post message

### DIFF
--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -25,6 +25,8 @@ export class IframeMessagingClient {
   constructor(win) {
     /** @private {!Window} */
     this.win_ = win;
+    /** @private {?string} */
+    this.rtvVersion_ = (win.AMP_CONFIG && win.AMP_CONFIG.v) || null;
     /** @private {!Window} */
     this.hostWindow_ = win.parent;
     /** @private {?string} */
@@ -74,8 +76,8 @@ export class IframeMessagingClient {
    *  @param {Object=} opt_payload The payload of message to send.
    */
   sendMessage(type, opt_payload) {
-    this.hostWindow_.postMessage/*OK*/(
-        serializeMessage(type, this.sentinel_, opt_payload), '*');
+    this.hostWindow_.postMessage/*OK*/(serializeMessage(
+        type, this.sentinel_, opt_payload, this.rtvVersion_), '*');
   }
 
   /**

--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -16,6 +16,7 @@
 import {listen} from '../src/event-helper';
 import {map} from '../src/utils/object';
 import {serializeMessage, deserializeMessage} from '../src/3p-frame';
+import {dev} from '../src/log';
 
 export class IframeMessagingClient {
 
@@ -76,8 +77,11 @@ export class IframeMessagingClient {
    *  @param {Object=} opt_payload The payload of message to send.
    */
   sendMessage(type, opt_payload) {
-    this.hostWindow_.postMessage/*OK*/(serializeMessage(
-        type, this.sentinel_, opt_payload, this.rtvVersion_), '*');
+    this.hostWindow_.postMessage/*OK*/(
+        serializeMessage(
+            type, dev().assertString(this.sentinel_),
+            opt_payload, this.rtvVersion_),
+        '*');
   }
 
   /**

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -354,16 +354,16 @@ export const MessageType = {
  * 'amp-011481323099490{"type":"position","sentinel":"12345","foo":"bar"}'
  * @param {string} type
  * @param {string} sentinel
- * @param {Object=} opt_data
- * @param {?string=} opt_rtvVersion
+ * @param {Object=} data
+ * @param {?string=} rtvVersion
  * @returns {string}
  */
-export function serializeMessage(type, sentinel, opt_data, opt_rtvVersion) {
+export function serializeMessage(type, sentinel, data = {}, rtvVersion = null) {
   // TODO: consider wrap the data in a "data" field. { type, sentinal, data }
-  const message = opt_data || {};
+  const message = data;
   message.type = type;
   message.sentinel = sentinel;
-  return AMP_MESSAGE_PREFIX + (opt_rtvVersion || '') + JSON.stringify(message);
+  return AMP_MESSAGE_PREFIX + (rtvVersion || '') + JSON.stringify(message);
 }
 
 /**

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -350,19 +350,20 @@ export const MessageType = {
 };
 
 /**
- * Serialize an AMP post message.
- *
- * @param type {string}
- * @param sentinel {string}
- * @param opt_data {Object=}
+ * Serialize an AMP post message. Output looks like:
+ * 'amp-011481323099490{"type":"position","sentinel":"12345","foo":"bar"}'
+ * @param {string} type
+ * @param {string} sentinel
+ * @param {Object=} opt_data
+ * @param {string=} opt_rtvVersion
  * @returns {string}
  */
-export function serializeMessage(type, sentinel, opt_data) {
+export function serializeMessage(type, sentinel, opt_data, opt_rtvVersion) {
   // TODO: consider wrap the data in a "data" field. { type, sentinal, data }
   const message = opt_data || {};
   message.type = type;
   message.sentinel = sentinel;
-  return AMP_MESSAGE_PREFIX + JSON.stringify(message);
+  return AMP_MESSAGE_PREFIX + (opt_rtvVersion || '') + JSON.stringify(message);
 }
 
 /**
@@ -376,9 +377,13 @@ export function deserializeMessage(message) {
   if (typeof message !== 'string' || message.indexOf(AMP_MESSAGE_PREFIX) != 0) {
     return null;
   }
+  const startPos = message.indexOf('{');
+  if (startPos == -1) {
+    dev().error('MESSAGING', 'Failed to parse message: ' + message);
+    return null;
+  }
   try {
-    return /** @type {!JSONType} */ (JSON.parse(
-        message.substr(AMP_MESSAGE_PREFIX.length)));
+    return /** @type {!JSONType} */ (JSON.parse(message.substr(startPos)));
   } catch (e) {
     dev().error('MESSAGING', 'Failed to parse message: ' + message, e);
     return null;

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -355,7 +355,7 @@ export const MessageType = {
  * @param {string} type
  * @param {string} sentinel
  * @param {Object=} opt_data
- * @param {string=} opt_rtvVersion
+ * @param {?string=} opt_rtvVersion
  * @returns {string}
  */
 export function serializeMessage(type, sentinel, opt_data, opt_rtvVersion) {

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -367,12 +367,39 @@ describe('3p-frame', () => {
         y: 'abc',
       });
     });
+
+    it('should work with rtvVersion', () => {
+      const message = serializeMessage('msgtype', 'msgsentinel', {
+        type: 'type_override', // override should be ignored
+        sentinel: 'sentinel_override', // override should be ignored
+        x: 1,
+        y: 'abc',
+      }, 'rtv123');
+      expect(deserializeMessage(message)).to.deep.equal({
+        type: 'msgtype',
+        sentinel: 'msgsentinel',
+        x: 1,
+        y: 'abc',
+      });
+    });
   });
 
   describe('deserializeMessage', () => {
     it('should deserialize valid message', () => {
       const message = deserializeMessage(
           'amp-{"type":"msgtype","sentinel":"msgsentinel","x":1,"y":"abc"}');
+      expect(message).to.deep.equal({
+        type: 'msgtype',
+        sentinel: 'msgsentinel',
+        x: 1,
+        y: 'abc',
+      });
+    });
+
+    it('should deserialize valid message with rtv version', () => {
+      const message = deserializeMessage(
+          'amp-rtv123{"type":"msgtype","sentinel":"msgsentinel",' +
+          '"x":1,"y":"abc"}');
       expect(message).to.deep.equal({
         type: 'msgtype',
         sentinel: 'msgsentinel',

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -420,6 +420,9 @@ describe('3p-frame', () => {
     it('should return null if failed to parse the input', () => {
       expect(deserializeMessage(
           'amp-"type":"msgtype","sentinel":"msgsentinel"}')).to.be.null;
+
+      expect(deserializeMessage(
+          'amp-{"type":"msgtype"|"sentinel":"msgsentinel"}')).to.be.null;
     });
   });
 });


### PR DESCRIPTION
The message format:
`amp-[rtvVersion]$(stringifiedJsonPayload)`

Note the rtvVersion is a string, and is optional. 

```
amp-12345{"type":"position","sentinel"...}   // rtv = "12345"
amp-abc123{"type":"position","sentinel"...}  // rtv = "abc123"
amp-{"type":"position","sentinel"...}  // rtv = null
```

For #5700

