### PR TITLE
Allows metadata string without quotes in tag.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -947,8 +947,10 @@ export class AmpA4A extends AMP.BaseElement {
    * TODO(keithwrightbos@): report error cases
    */
   getAmpAdMetadata_(creative) {
+    let metadataString = METADATA_STRING;
     let metadataStart = creative.lastIndexOf(METADATA_STRING);
     if (metadataStart < 0) {
+      metadataString = METADATA_STRING_NO_QUOTES;
       metadataStart = creative.lastIndexOf(METADATA_STRING_NO_QUOTES);
     }
     if (metadataStart < 0) {
@@ -967,7 +969,7 @@ export class AmpA4A extends AMP.BaseElement {
     }
     try {
       const metaDataObj = JSON.parse(
-        creative.slice(metadataStart + METADATA_STRING.length, metadataEnd));
+        creative.slice(metadataStart + metadataString.length, metadataEnd));
       const ampRuntimeUtf16CharOffsets =
         metaDataObj['ampRuntimeUtf16CharOffsets'];
       if (!isArray(ampRuntimeUtf16CharOffsets) ||

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -65,6 +65,10 @@ const ORIGINAL_HREF_ATTRIBUTE = 'data-a4a-orig-href';
 /** @type {string} */
 const METADATA_STRING = '<script type="application/json" amp-ad-metadata>';
 
+/** @type {string} */
+const METADATA_STRING_NO_QUOTES =
+      '<script type=application/json amp-ad-metadata>';
+
 // TODO(tdrl): Temporary, while we're verifying whether SafeFrame is an
 // acceptable solution to the 'Safari on iOS doesn't fetch iframe src from
 // cache' issue.  See https://github.com/ampproject/amphtml/issues/5614
@@ -944,6 +948,9 @@ export class AmpA4A extends AMP.BaseElement {
    */
   getAmpAdMetadata_(creative) {
     const metadataStart = creative.lastIndexOf(METADATA_STRING);
+    if (metadataStart < 0) {
+      metadataStart = creative.lastIndexOf(METADATA_STRING_NO_QUOTES);
+    }
     if (metadataStart < 0) {
       // Couldn't find a metadata blob.
       dev().warn(TAG, this.element.getAttribute('type'),

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -947,7 +947,7 @@ export class AmpA4A extends AMP.BaseElement {
    * TODO(keithwrightbos@): report error cases
    */
   getAmpAdMetadata_(creative) {
-    const metadataStart = creative.lastIndexOf(METADATA_STRING);
+    let metadataStart = creative.lastIndexOf(METADATA_STRING);
     if (metadataStart < 0) {
       metadataStart = creative.lastIndexOf(METADATA_STRING_NO_QUOTES);
     }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -867,6 +867,27 @@ describe('amp-a4a', () => {
       };
       expect(actual).to.deep.equal(expected);
     });
+    // TODO(levitzky) remove this test after metadata bug is fixed.
+    it('should parse metadata with wrong opening tag', () => {
+      const creative = buildCreativeString({
+        customElementExtensions: ['amp-vine', 'amp-vine', 'amp-vine'],
+        customStylesheets: [
+          {href: 'https://fonts.googleapis.com/css?foobar'},
+          {href: 'https://fonts.com/css?helloworld'},
+        ],
+      }).replace('<script type="application/json" amp-ad-metadata>',
+          '<script type=application/json amp-ad-metadata>');
+      const actual = a4a.getAmpAdMetadata_(creative);
+      const expected = {
+        minifiedCreative: testFragments.minimalDocOneStyleSrcDoc,
+        customElementExtensions: ['amp-vine', 'amp-vine', 'amp-vine'],
+        customStylesheets: [
+          {href: 'https://fonts.googleapis.com/css?foobar'},
+          {href: 'https://fonts.com/css?helloworld'},
+        ],
+      };
+      expect(actual).to.deep.equal(expected);
+    });
     it('should return null if missing ampRuntimeUtf16CharOffsets', () => {
       const baseTestDoc = testFragments.minimalDocOneStyle;
       const splicePoint = baseTestDoc.indexOf('</body>');

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -867,7 +867,8 @@ describe('amp-a4a', () => {
       };
       expect(actual).to.deep.equal(expected);
     });
-    // TODO(levitzky) remove this test after metadata bug is fixed.
+    // TODO(levitzky) remove the following two tests after metadata bug is
+    // fixed.
     it('should parse metadata with wrong opening tag', () => {
       const creative = buildCreativeString({
         customElementExtensions: ['amp-vine', 'amp-vine', 'amp-vine'],
@@ -888,6 +889,18 @@ describe('amp-a4a', () => {
       };
       expect(actual).to.deep.equal(expected);
     });
+    it('should return null if metadata opening tag is (truly) wrong', () => {
+      const creative = buildCreativeString({
+        customElementExtensions: ['amp-vine', 'amp-vine', 'amp-vine'],
+        customStylesheets: [
+          {href: 'https://fonts.googleapis.com/css?foobar'},
+          {href: 'https://fonts.com/css?helloworld'},
+        ],
+      }).replace('<script type="application/json" amp-ad-metadata>',
+          '<script type=application/json" amp-ad-metadata>');
+      expect(a4a.getAmpAdMetadata_(creative)).to.be.null;
+    });
+
     it('should return null if missing ampRuntimeUtf16CharOffsets', () => {
       const baseTestDoc = testFragments.minimalDocOneStyle;
       const splicePoint = baseTestDoc.indexOf('</body>');


### PR DESCRIPTION
While in code freeze, this temporary solution allows us to parse the creative's metadata, which is erroneously being delimited with a string missing quotes.