### PR TITLE
Do not preload the URL of a youtube player.

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -75,6 +75,10 @@ class AmpYoutube extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
+    // NOTE: When preload `as=document` is natively supported in browsers
+    // we can switch to preloading the full source. For now this doesn't
+    // work, because we preload with a different type and in that case
+    // responses are only picked up if they are cacheable.
     this.preconnect.url(this.getVideoIframeSrc_());
     // Host that YT uses to serve JS needed by player.
     this.preconnect.url('https://s.ytimg.com', opt_onLayout);

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -75,7 +75,7 @@ class AmpYoutube extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.preload(this.getVideoIframeSrc_());
+    this.preconnect.url(this.getVideoIframeSrc_());
     // Host that YT uses to serve JS needed by player.
     this.preconnect.url('https://s.ytimg.com', opt_onLayout);
     // Load high resolution placeholder images for videos in prerender mode.

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -246,4 +246,17 @@ describe('amp-youtube', function() {
       expect(iframe.src).to.contain('iv_load_policy=3');
     });
   });
+
+  it('should preload the final url', () => {
+    return getYt({
+      'autoplay': '',
+      'data-videoid': 'mGENRKrdoGY',
+      'data-param-playsinline': '0',
+    }).then(yt => {
+      const src = yt.querySelector('iframe').src;
+      const preloadSpy = sandbox.spy(yt.implementation_.preconnect, 'url');
+      yt.implementation_.preconnectCallback();
+      preloadSpy.should.have.been.calledWithExactly(src);
+    });
+  });
 });

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -246,17 +246,4 @@ describe('amp-youtube', function() {
       expect(iframe.src).to.contain('iv_load_policy=3');
     });
   });
-
-  it('should preload the final url', () => {
-    return getYt({
-      'autoplay': '',
-      'data-videoid': 'mGENRKrdoGY',
-      'data-param-playsinline': '0',
-    }).then(yt => {
-      const src = yt.querySelector('iframe').src;
-      const preloadSpy = sandbox.spy(yt.implementation_.preconnect, 'preload');
-      yt.implementation_.preconnectCallback();
-      preloadSpy.should.have.been.calledWithExactly(src);
-    });
-  });
 });


### PR DESCRIPTION
This doesn't work for now because the responses aren't cacheable and preload can only preload uncacheable resources when the `as` type is correct. Unfortunately no browser supports the `document` value for as.