### PR TITLE
Bind validator

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -15,8 +15,8 @@
  */
 
 import {BindEvaluator} from './bind-evaluator';
-import {user} from '../../../src/log';
 import {BindValidator} from './bind-validator';
+import {user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
@@ -174,7 +174,7 @@ export class Bind {
    * attribute param, if applicable.
    * @param {!Attr} attribute
    * @param {!Element} unusedElement
-   * @return {?BindingDef}
+   * @return {?{property: string, expressionString: string}}
    * @private
    */
   bindingForAttribute_(attribute, element) {
@@ -182,7 +182,10 @@ export class Bind {
     if (name.length > 2 && name[0] === '[' && name[name.length - 1] === ']') {
       const property = name.substr(1, name.length - 2);
       if (this.validator_.canBind(element.tagName, property)) {
-        return {property, expression: attribute.value, element};
+        return {property, expressionString: attribute.value};
+      } else {
+        user().warn(TAG,
+            `<${element.tagName} [${property}]> binding is not allowed.`);
       }
     }
     return null;

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -16,6 +16,7 @@
 
 import {BindEvaluator} from './bind-evaluator';
 import {user} from '../../../src/log';
+import {BindValidator} from './bind-validator';
 import {getMode} from '../../../src/mode';
 import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
@@ -70,6 +71,9 @@ export class Bind {
 
     /** {!Array<BoundElementDef>} */
     this.boundElements_ = [];
+
+    /** @const {!./bind-validator.BindValidator} */
+    this.validator_ = new BindValidator();
 
     /** @const {!Object} */
     this.scope_ = Object.create(null);
@@ -173,12 +177,13 @@ export class Bind {
    * @return {?BindingDef}
    * @private
    */
-  bindingForAttribute_(attribute, unusedElement) {
+  bindingForAttribute_(attribute, element) {
     const name = attribute.name;
     if (name.length > 2 && name[0] === '[' && name[name.length - 1] === ']') {
       const property = name.substr(1, name.length - 2);
-      // TODO(choumx): Validate that (unusedElement, attribute) can be bound.
-      return {property, expressionString: attribute.value};
+      if (this.validator_.canBind(element.tagName, property)) {
+        return {property, expression: attribute.value, element};
+      }
     }
     return null;
   }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -173,7 +173,7 @@ export class Bind {
    * Returns a struct representing the binding corresponding to the
    * attribute param, if applicable.
    * @param {!Attr} attribute
-   * @param {!Element} unusedElement
+   * @param {!Element} element
    * @return {?{property: string, expressionString: string}}
    * @private
    */

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -23,16 +23,8 @@
 let PropertyRulesDef;
 
 /**
- * Maps tag names to property names to PropertyRulesDef.
- * If `RulesDef[tagName][propertyName]` is null, then all values are valid
- * for that property in that tag.
- * @typedef {Object<string,Object<string,?PropertyRulesDef>>}}
- */
-let RulesDef;
-
-/**
  * Property rules that apply to any and all tags.
- * @type {Object<string,?PropertyRulesDef>}
+ * @private {Object<string, ?PropertyRulesDef>}
  */
 const GLOBAL_PROPERTY_RULES = {
   'class': {
@@ -41,19 +33,20 @@ const GLOBAL_PROPERTY_RULES = {
 };
 
 /**
+ * Maps tag names to property names to PropertyRulesDef.
+ * If `ELEMENT_RULES[tag][property]` is null, then all values are valid
+ * for that property in that tag.
+ * @private {Object<string, Object<string, ?PropertyRulesDef>>}}
+ */
+const ELEMENT_RULES = createElementRules_();
+
+/**
  * BindValidator performs runtime validation of Bind expression results.
+ *
  * For performance reasons, the validation rules enforced are a subset
  * of the AMP validator's, selected with a focus on security and UX.
  */
 export class BindValidator {
-  constructor() {
-    /**
-     * A map of tag names to property names to PropertyRules.
-     * @const {!RulesDef}
-     */
-    this.rules_ = this.createRules_();
-  }
-
   /**
    * Returns true if (tag, property) binding is allowed.
    * Otherwise, returns false.
@@ -65,7 +58,6 @@ export class BindValidator {
   canBind(tag, property) {
     return (this.rulesForTagAndProperty_(tag, property) !== undefined);
   }
-
 
   /**
    * Returns true if `value` is a valid result for a (tag, property) binding.
@@ -140,201 +132,203 @@ export class BindValidator {
     if (GLOBAL_PROPERTY_RULES.hasOwnProperty(property)) {
       return GLOBAL_PROPERTY_RULES[property];
     }
+
     let tagRules;
-    if (this.rules_.hasOwnProperty(tag)) {
-      tagRules = this.rules_[tag];
+    if (ELEMENT_RULES.hasOwnProperty(tag)) {
+      tagRules = ELEMENT_RULES[tag];
     }
     if (tagRules && tagRules.hasOwnProperty(property)) {
       return tagRules[property];
     }
+
     return undefined;
   }
+}
 
-  /**
-   * @return {!RulesDef}
-   * @private
-   */
-  createRules_() {
-    // Initialize `rules` with tag-specific constraints.
-    const rules = {
-      'AMP-IMG': {
-        alt: null,
-        'aria-describedby': null,
-        'aria-label': null,
-        'aria-labelledby': null,
-        referrerpolicy: null,
-        src: {
-          allowedProtocols: {
-            data: true,
-            http: true,
-            https: true,
-          },
-          blockedURLs: ['__amp_source_origin'],
+/**
+ * @return {Object<string, Object<string, ?PropertyRulesDef>>}}
+ * @private
+ */
+function createElementRules_() {
+  // Initialize `rules` with tag-specific constraints.
+  const rules = {
+    'AMP-IMG': {
+      alt: null,
+      'aria-describedby': null,
+      'aria-label': null,
+      'aria-labelledby': null,
+      referrerpolicy: null,
+      src: {
+        allowedProtocols: {
+          data: true,
+          http: true,
+          https: true,
         },
-        srcset: {
-          allowedProtocols: {
-            data: true,
-            http: true,
-            https: true,
-          },
-          blockedURLs: ['__amp_source_origin'],
+        blockedURLs: ['__amp_source_origin'],
+      },
+      srcset: {
+        allowedProtocols: {
+          data: true,
+          http: true,
+          https: true,
         },
+        blockedURLs: ['__amp_source_origin'],
       },
-      A: {
-        href: {
-          allowedProtocols: {
-            ftp: true,
-            http: true,
-            https: true,
-            mailto: true,
-            'fb-messenger': true,
-            intent: true,
-            skype: true,
-            sms: true,
-            snapchat: true,
-            tel: true,
-            tg: true,
-            threema: true,
-            twitter: true,
-            viber: true,
-            whatsapp: true,
-          },
-          blockedURLs: ['__amp_source_origin'],
+    },
+    A: {
+      href: {
+        allowedProtocols: {
+          ftp: true,
+          http: true,
+          https: true,
+          mailto: true,
+          'fb-messenger': true,
+          intent: true,
+          skype: true,
+          sms: true,
+          snapchat: true,
+          tel: true,
+          tg: true,
+          threema: true,
+          twitter: true,
+          viber: true,
+          whatsapp: true,
         },
+        blockedURLs: ['__amp_source_origin'],
       },
-      BUTTON: {
-        disabled: null,
-        type: null,
-        value: null,
+    },
+    BUTTON: {
+      disabled: null,
+      type: null,
+      value: null,
+    },
+    FIELDSET: {
+      disabled: null,
+    },
+    INPUT: {
+      accept: null,
+      accesskey: null,
+      autocomplete: null,
+      checked: null,
+      disabled: null,
+      height: null,
+      inputmode: null,
+      max: null,
+      maxlength: null,
+      min: null,
+      minlength: null,
+      multiple: null,
+      name: {
+        blockedURLs: ['__amp_source_origin'],
       },
-      FIELDSET: {
-        disabled: null,
+      pattern: null,
+      placeholder: null,
+      readonly: null,
+      required: null,
+      selectiondirection: null,
+      size: null,
+      spellcheck: null,
+      step: null,
+      type: {
+        blacklistedValueRegex: '(^|\\s)(button|file|image|password|)(\\s|$)',
       },
-      INPUT: {
-        accept: null,
-        accesskey: null,
-        autocomplete: null,
-        checked: null,
-        disabled: null,
-        height: null,
-        inputmode: null,
-        max: null,
-        maxlength: null,
-        min: null,
-        minlength: null,
-        multiple: null,
-        name: {
-          blockedURLs: ['__amp_source_origin'],
+      value: null,
+      width: null,
+    },
+    OPTION: {
+      disabled: null,
+      label: null,
+      selected: null,
+      value: null,
+    },
+    OPTGROUP: {
+      disabled: null,
+      label: null,
+    },
+    SELECT: {
+      disabled: null,
+      multiple: null,
+      name: null,
+      required: null,
+      size: null,
+    },
+    SOURCE: {
+      src: {
+        allowedProtocols: {
+          https: true,
         },
-        pattern: null,
-        placeholder: null,
-        readonly: null,
-        required: null,
-        selectiondirection: null,
-        size: null,
-        spellcheck: null,
-        step: null,
-        type: {
-          blacklistedValueRegex: '(^|\\s)(button|file|image|password|)(\\s|$)',
+        blockedURLs: ['__amp_source_origin'],
+      },
+      type: null,
+    },
+    TRACK: {
+      label: null,
+      src: {
+        allowedProtocols: {
+          https: true,
         },
-        value: null,
-        width: null,
+        blockedURLs: ['__amp_source_origin'],
       },
-      OPTION: {
-        disabled: null,
-        label: null,
-        selected: null,
-        value: null,
-      },
-      OPTGROUP: {
-        disabled: null,
-        label: null,
-      },
-      SELECT: {
-        disabled: null,
-        multiple: null,
-        name: null,
-        required: null,
-        size: null,
-      },
-      SOURCE: {
-        src: {
-          allowedProtocols: {
-            https: true,
-          },
-          blockedURLs: ['__amp_source_origin'],
-        },
-        type: null,
-      },
-      TRACK: {
-        label: null,
-        src: {
-          allowedProtocols: {
-            https: true,
-          },
-          blockedURLs: ['__amp_source_origin'],
-        },
-        srclang: null,
-      },
-      TEXTAREA: {
-        autocomplete: null,
-        cols: null,
-        disabled: null,
-        maxlength: null,
-        minlength: null,
-        name: null,
-        placeholder: null,
-        readonly: null,
-        required: null,
-        rows: null,
-        selectiondirection: null,
-        selectionend: null,
-        selectionstart: null,
-        spellcheck: null,
-        wrap: null,
-      },
-    };
+      srclang: null,
+    },
+    TEXTAREA: {
+      autocomplete: null,
+      cols: null,
+      disabled: null,
+      maxlength: null,
+      minlength: null,
+      name: null,
+      placeholder: null,
+      readonly: null,
+      required: null,
+      rows: null,
+      selectiondirection: null,
+      selectionend: null,
+      selectionstart: null,
+      spellcheck: null,
+      wrap: null,
+    },
+  };
 
-    // Collate all standard elements that should support [text] binding
-    // and add them to `rules` object.
-    // 4.3 Sections
-    const sectionTags = ['ASIDE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
-        'HEADER', 'FOOTER', 'ADDRESS'];
-    // 4.4 Grouping content
-    const groupingTags = ['P', 'PRE', 'BLOCKQUOTE', 'LI', 'DT', 'DD',
-        'FIGCAPTION', 'DIV'];
-    // 4.5 Text-level semantics
-    const textTags = ['A', 'EM', 'STRONG', 'SMALL', 'S', 'CITE', 'Q',
-        'DFN', 'ABBR', 'DATA', 'TIME', 'CODE', 'VAR', 'SAMP', 'KBD',
-        'SUB', 'SUP', 'I', 'B', 'U', 'MARK', 'RUBY', 'RB', 'RT', 'RTC',
-        'RP', 'BDI', 'BDO', 'SPAN'];
-    // 4.6 Edits
-    const editTags = ['INS', 'DEL'];
-    // 4.9 Tabular data
-    const tabularTags = ['CAPTION', 'THEAD', 'TFOOT', 'TD'];
-    // 4.10 Forms
-    const formTags = ['BUTTON', 'LABEL', 'LEGEND', 'OPTION',
-        'OUTPUT', 'PROGRESS', 'TEXTAREA'];
-    const allTextTags = sectionTags.concat(groupingTags).concat(textTags)
-        .concat(editTags).concat(tabularTags).concat(formTags);
-    allTextTags.forEach(tag => {
-      if (rules[tag] === undefined) {
-        rules[tag] = {};
-      }
-      rules[tag]['text'] = null;
-    });
+  // Collate all standard elements that should support [text] binding
+  // and add them to `rules` object.
+  // 4.3 Sections
+  const sectionTags = ['ASIDE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
+      'HEADER', 'FOOTER', 'ADDRESS'];
+  // 4.4 Grouping content
+  const groupingTags = ['P', 'PRE', 'BLOCKQUOTE', 'LI', 'DT', 'DD',
+      'FIGCAPTION', 'DIV'];
+  // 4.5 Text-level semantics
+  const textTags = ['A', 'EM', 'STRONG', 'SMALL', 'S', 'CITE', 'Q',
+      'DFN', 'ABBR', 'DATA', 'TIME', 'CODE', 'VAR', 'SAMP', 'KBD',
+      'SUB', 'SUP', 'I', 'B', 'U', 'MARK', 'RUBY', 'RB', 'RT', 'RTC',
+      'RP', 'BDI', 'BDO', 'SPAN'];
+  // 4.6 Edits
+  const editTags = ['INS', 'DEL'];
+  // 4.9 Tabular data
+  const tabularTags = ['CAPTION', 'THEAD', 'TFOOT', 'TD'];
+  // 4.10 Forms
+  const formTags = ['BUTTON', 'LABEL', 'LEGEND', 'OPTION',
+      'OUTPUT', 'PROGRESS', 'TEXTAREA'];
+  const allTextTags = sectionTags.concat(groupingTags).concat(textTags)
+      .concat(editTags).concat(tabularTags).concat(formTags);
+  allTextTags.forEach(tag => {
+    if (rules[tag] === undefined) {
+      rules[tag] = {};
+    }
+    rules[tag]['text'] = null;
+  });
 
-    // AMP extensions support additional properties.
-    const ampExtensions = ['AMP-IMG'];
-    ampExtensions.forEach(tag => {
-      if (rules[tag] === undefined) {
-        rules[tag] = {};
-      }
-      const tagRule = rules[tag];
-      tagRule['width'] = null;
-      tagRule['height'] = null;
-    });
+  // AMP extensions support additional properties.
+  const ampExtensions = ['AMP-IMG'];
+  ampExtensions.forEach(tag => {
+    if (rules[tag] === undefined) {
+      rules[tag] = {};
+    }
+    const tagRule = rules[tag];
+    tagRule['width'] = null;
+    tagRule['height'] = null;
+  });
 
-    return rules;
-  }
+  return rules;
 }

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -16,6 +16,7 @@
 
 import {Bind} from '../bind-impl';
 import {BindExpression} from '../bind-expression';
+import {BindValidator} from '../bind-validator';
 import {toArray} from '../../../../src/types';
 import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
@@ -27,8 +28,19 @@ describes.realWin('amp-bind', {
 }, env => {
   let bind;
 
+  // BindValidator method stubs.
+  let canBindStub;
+  let isResultValidStub;
+
   beforeEach(() => {
     toggleExperiment(env.win, 'AMP-BIND', true);
+
+    // Stub validator methods to return true for ease of testing.
+    canBindStub = env.sandbox.stub(
+        BindValidator.prototype, 'canBind').returns(true);
+    isResultValidStub = env.sandbox.stub(
+        BindValidator.prototype, 'isResultValid').returns(true);
+
     bind = new Bind(env.ampdoc);
   });
 
@@ -265,6 +277,23 @@ describes.realWin('amp-bind', {
     stub.returns('stubbed');
     return onBindReadyAndSetState({}, () => {
       expect(stub.calledOnce).to.be.true;
+    });
+  });
+
+  it('should NOT evaluate expression if binding is NOT allowed', () => {
+    canBindStub.returns(false);
+    createElementWithBinding(`[onePlusOne]="1+1"`);
+    return onBindReadyAndSetState({}, () => {
+      expect(canBindStub.calledOnce).to.be.true;
+      expect(isResultValidStub.called).to.be.false;
+    });
+  });
+
+  it('should validate expression result if binding is allowed', () => {
+    createElementWithBinding(`[onePlusOne]="1+1"`);
+    return onBindReadyAndSetState({}, () => {
+      expect(canBindStub.calledOnce).to.be.true;
+      expect(isResultValidStub.calledOnce).to.be.true;
     });
   });
 });

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -30,6 +30,7 @@ describes.realWin('amp-bind', {
 
   // BindValidator method stubs.
   let canBindStub;
+  let isResultValidStub;
 
   beforeEach(() => {
     toggleExperiment(env.win, 'AMP-BIND', true);
@@ -37,6 +38,8 @@ describes.realWin('amp-bind', {
     // Stub validator methods to return true for ease of testing.
     canBindStub = env.sandbox.stub(
         BindValidator.prototype, 'canBind').returns(true);
+    isResultValidStub = env.sandbox.stub(
+        BindValidator.prototype, 'isResultValid').returns(true);
 
     bind = new Bind(env.ampdoc);
   });

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -30,7 +30,6 @@ describes.realWin('amp-bind', {
 
   // BindValidator method stubs.
   let canBindStub;
-  let isResultValidStub;
 
   beforeEach(() => {
     toggleExperiment(env.win, 'AMP-BIND', true);
@@ -38,7 +37,7 @@ describes.realWin('amp-bind', {
     // Stub validator methods to return true for ease of testing.
     canBindStub = env.sandbox.stub(
         BindValidator.prototype, 'canBind').returns(true);
-    isResultValidStub = env.sandbox.stub(
+    env.sandbox.stub(
         BindValidator.prototype, 'isResultValid').returns(true);
 
     bind = new Bind(env.ampdoc);

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -30,7 +30,6 @@ describes.realWin('amp-bind', {
 
   // BindValidator method stubs.
   let canBindStub;
-  let isResultValidStub;
 
   beforeEach(() => {
     toggleExperiment(env.win, 'AMP-BIND', true);
@@ -38,8 +37,6 @@ describes.realWin('amp-bind', {
     // Stub validator methods to return true for ease of testing.
     canBindStub = env.sandbox.stub(
         BindValidator.prototype, 'canBind').returns(true);
-    isResultValidStub = env.sandbox.stub(
-        BindValidator.prototype, 'isResultValid').returns(true);
 
     bind = new Bind(env.ampdoc);
   });
@@ -282,18 +279,10 @@ describes.realWin('amp-bind', {
 
   it('should NOT evaluate expression if binding is NOT allowed', () => {
     canBindStub.returns(false);
-    createElementWithBinding(`[onePlusOne]="1+1"`);
+    const element = createElementWithBinding(`[onePlusOne]="1+1"`);
     return onBindReadyAndSetState({}, () => {
       expect(canBindStub.calledOnce).to.be.true;
-      expect(isResultValidStub.called).to.be.false;
-    });
-  });
-
-  it('should validate expression result if binding is allowed', () => {
-    createElementWithBinding(`[onePlusOne]="1+1"`);
-    return onBindReadyAndSetState({}, () => {
-      expect(canBindStub.calledOnce).to.be.true;
-      expect(isResultValidStub.calledOnce).to.be.true;
+      expect(element.getAttribute('oneplusone')).to.be.null;
     });
   });
 });

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BindValidator} from '../bind-validator';
+
+describe('BindValidator', () => {
+  let val;
+
+  beforeEach(() => {
+    val = new BindValidator();
+  });
+
+  describe('canBind()', () => {
+    it('should allow binding to "class" for any element', () => {
+      expect(val.canBind('DIV', 'class')).to.be.true;
+      expect(val.canBind('ANY-TAG-REAL-OR-FAKE', 'class')).to.be.true;
+    });
+
+    it('should allow binding to "text" for whitelisted elements', () => {
+      expect(val.canBind('H1', 'text')).to.be.true;
+      expect(val.canBind('P', 'text')).to.be.true;
+      expect(val.canBind('SPAN', 'text')).to.be.true;
+      expect(val.canBind('A', 'text')).to.be.true;
+      expect(val.canBind('BUTTON', 'text')).to.be.true;
+      expect(val.canBind('CAPTION', 'text')).to.be.true;
+
+      expect(val.canBind('HEAD', 'text')).to.be.false;
+      expect(val.canBind('FORM', 'text')).to.be.false;
+      expect(val.canBind('AMP-IMG', 'text')).to.be.false;
+    });
+
+    it('should NOT allow binding to "style"', () => {
+      expect(val.canBind('DIV', 'style')).to.be.false;
+      expect(val.canBind('P', 'style')).to.be.false;
+      expect(val.canBind('SPAN', 'style')).to.be.false;
+      expect(val.canBind('OL', 'style')).to.be.false;
+      expect(val.canBind('BODY', 'style')).to.be.false;
+    });
+
+    it('should NOT allow binding to "on" event handlers', () => {
+      expect(val.canBind('BODY', 'onafterprint')).to.be.false;
+      expect(val.canBind('BODY', 'onbeforeprint')).to.be.false;
+      expect(val.canBind('BODY', 'onbeforeunload')).to.be.false;
+      expect(val.canBind('BODY', 'onhashchange')).to.be.false;
+      expect(val.canBind('BODY', 'onload')).to.be.false;
+      expect(val.canBind('BODY', 'onmessage')).to.be.false;
+      expect(val.canBind('BODY', 'onoffline')).to.be.false;
+      expect(val.canBind('BODY', 'ononline')).to.be.false;
+      expect(val.canBind('BODY', 'onpagehide')).to.be.false;
+      expect(val.canBind('BODY', 'onpageshow')).to.be.false;
+      expect(val.canBind('BODY', 'onpopstate')).to.be.false;
+      expect(val.canBind('BODY', 'onresize')).to.be.false;
+      expect(val.canBind('BODY', 'onstorage')).to.be.false;
+      expect(val.canBind('BODY', 'onunload')).to.be.false;
+
+      expect(val.canBind('FORM', 'onblur')).to.be.false;
+      expect(val.canBind('FORM', 'onchange')).to.be.false;
+      expect(val.canBind('FORM', 'oncontextmenu')).to.be.false;
+      expect(val.canBind('FORM', 'onfocus')).to.be.false;
+      expect(val.canBind('FORM', 'oninput')).to.be.false;
+      expect(val.canBind('FORM', 'oninvalid')).to.be.false;
+      expect(val.canBind('FORM', 'onreset')).to.be.false;
+      expect(val.canBind('FORM', 'onsearch')).to.be.false;
+      expect(val.canBind('FORM', 'onselect')).to.be.false;
+      expect(val.canBind('FORM', 'onsubmit')).to.be.false;
+
+      expect(val.canBind('INPUT', 'onkeydown')).to.be.false;
+      expect(val.canBind('INPUT', 'onkeypress')).to.be.false;
+      expect(val.canBind('INPUT', 'onkeyup')).to.be.false;
+
+      expect(val.canBind('BUTTON', 'onclick')).to.be.false;
+      expect(val.canBind('BUTTON', 'ondblclick')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmousedown')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmousemove')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmouseout')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmouseover')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmouseup')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmousewheel')).to.be.false;
+      expect(val.canBind('BUTTON', 'onwheel')).to.be.false;
+
+      expect(val.canBind('DIV', 'ondrag')).to.be.false;
+      expect(val.canBind('DIV', 'ondragend')).to.be.false;
+      expect(val.canBind('DIV', 'ondragenter')).to.be.false;
+      expect(val.canBind('DIV', 'ondragleave')).to.be.false;
+      expect(val.canBind('DIV', 'ondragover')).to.be.false;
+      expect(val.canBind('DIV', 'ondragstart')).to.be.false;
+      expect(val.canBind('DIV', 'ondrop')).to.be.false;
+      expect(val.canBind('DIV', 'onscroll')).to.be.false;
+
+      expect(val.canBind('INPUT', 'oncopy')).to.be.false;
+      expect(val.canBind('INPUT', 'oncut')).to.be.false;
+      expect(val.canBind('INPUT', 'onpaste')).to.be.false;
+    });
+
+    it('should NOT allow binding to Object.prototype keys', () => {
+      expect(val.canBind('constructor', 'constructor')).to.be.false;
+      expect(val.canBind('toString', 'constructor')).to.be.false;
+      expect(val.canBind('hasOwnProperty', 'constructor')).to.be.false;
+      expect(val.canBind('isPrototypeOf', 'constructor')).to.be.false;
+      expect(val.canBind('__defineGetter__', 'constructor')).to.be.false;
+      expect(val.canBind('__defineSetter__', 'constructor')).to.be.false;
+      expect(val.canBind('__proto__', 'constructor')).to.be.false;
+
+      expect(val.canBind('P', 'constructor')).to.be.false;
+      expect(val.canBind('P', 'toString')).to.be.false;
+      expect(val.canBind('P', 'hasOwnProperty')).to.be.false;
+      expect(val.canBind('P', 'isPrototypeOf')).to.be.false;
+      expect(val.canBind('P', '__defineGetter__')).to.be.false;
+      expect(val.canBind('P', '__defineSetter__')).to.be.false;
+      expect(val.canBind('P', '__proto__')).to.be.false;
+    });
+  });
+
+  describe('isResultValid()', () => {
+    it('should NOT allow invalid "class" attribute values', () => {
+      expect(val.isResultValid('DIV', 'class', 'foo')).to.be.true;
+
+      expect(val.isResultValid(
+          'DIV', 'class', 'i-amphtml-foo')).to.be.false;
+      expect(val.isResultValid(
+          'DIV', 'class', 'foo i-amphtml-bar')).to.be.false;
+    });
+
+    it('should NOT sanitize "text" attribute values', () => {
+      expect(val.isResultValid('P', 'text', 'Hello World')).to.be.true;
+      expect(val.isResultValid('P', 'text', '')).to.be.true;
+      expect(val.isResultValid('P', 'text', null)).to.be.true;
+      expect(val.isResultValid(
+          'P', 'text', '<script>alert(1);</script>')).to.be.true;
+    });
+
+    it('should block dangerous attribute URLs in standard elements', () => {
+      expect(val.isResultValid('A', 'href',
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
+      expect(val.isResultValid('A', 'href',
+        '__amp_source_origin')).to.be.false;
+
+      expect(val.isResultValid('SOURCE', 'src',
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
+      expect(val.isResultValid('SOURCE', 'src',
+          '__amp_source_origin')).to.be.false;
+
+      expect(val.isResultValid('TRACK', 'src',
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
+      expect(val.isResultValid('TRACK', 'src',
+          '__amp_source_origin')).to.be.false;
+    });
+
+    it('should NOT allow unsupported <input> "type" values', () => {
+      expect(val.isResultValid('INPUT', 'type', 'checkbox')).to.be.true;
+      expect(val.isResultValid('INPUT', 'type', 'email')).to.be.true;
+
+      expect(val.isResultValid('INPUT', 'type', 'BUTTON')).to.be.false;
+      expect(val.isResultValid('INPUT', 'type', 'file')).to.be.false;
+      expect(val.isResultValid('INPUT', 'type', 'image')).to.be.false;
+      expect(val.isResultValid('INPUT', 'type', 'password')).to.be.false;
+    });
+  });
+
+  describe('AMP extensions', () => {
+    it('should support <amp-img>', () => {
+      expect(val.canBind('AMP-IMG', 'src')).to.be.true;
+      expect(val.canBind('AMP-IMG', 'srcset')).to.be.true;
+      expect(val.canBind('AMP-IMG', 'width')).to.be.true;
+      expect(val.canBind('AMP-IMG', 'height')).to.be.true;
+
+      expect(val.isResultValid(
+          'AMP-IMG', 'src', 'http://foo.com/bar.jpg')).to.be.true;
+      expect(val.isResultValid('AMP-IMG', 'src',
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-IMG', 'src', '__amp_source_origin')).to.be.false;
+      expect(val.isResultValid('AMP-IMG', 'srcset',
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-IMG', 'srcset', '__amp_source_origin')).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Partial for #6199.

- Adds a new file `bind-validator.js` that checks whether binding to (tag, attribute) is allowed and validates expression results
- Bind validation is a subset of AMP validator's rules and based off logic in `validator/validator-main.protoascii` and `validator/engine/validator.js`