### PR TITLE
Hide amp-app-banner with a warning on iOS for temp fix

### DIFF
--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -213,6 +213,9 @@ export class AmpIosAppBanner extends AbstractAppBanner {
 
     /** @private {?Element} */
     this.metaTag_ = null;
+
+    /** @private {boolean} */
+    this.isEmbeddedSafari_ = false;
   }
 
   /**
@@ -246,6 +249,16 @@ export class AmpIosAppBanner extends AbstractAppBanner {
       return;
     }
 
+    this.isEmbeddedSafari_ = viewer.isEmbedded() && platform.isSafari();
+    if (this.isEmbeddedSafari_) {
+      user().warn(TAG,
+          'Due to a bug in browser, we are unable to show amp-app-banner. ' +
+          'Please refer to https://github.com/ampproject/amphtml/issues/6454 ' +
+          'for more details.');
+      this.hide_();
+      return;
+    }
+
     this.metaTag_ = this.win.document.head.querySelector(
         'meta[name=apple-itunes-app]');
     if (!this.metaTag_) {
@@ -267,6 +280,10 @@ export class AmpIosAppBanner extends AbstractAppBanner {
     }
 
     if (this.canShowBuiltinBanner_) {
+      return Promise.resolve();
+    }
+
+    if (this.isEmbeddedSafari_) {
       return Promise.resolve();
     }
 

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -27,7 +27,8 @@ import {xhrFor} from '../../../../src/xhr';
 import {timerFor} from '../../../../src/timer';
 import '../../../amp-analytics/0.1/amp-analytics';
 import * as sinon from 'sinon';
-
+import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
+import {viewerForDoc} from '../../../../src/viewer';
 
 describe('amp-app-banner', () => {
 
@@ -38,6 +39,7 @@ describe('amp-app-banner', () => {
   let isIos = false;
   let isChrome = false;
   let isSafari = false;
+  let isEmbedded = false;
 
   const meta = {
     content: 'app-id=828256236, app-argument=medium://p/cb7f223fad86',
@@ -67,6 +69,9 @@ describe('amp-app-banner', () => {
 
   function getTestFrame() {
     return createIframePromise(true).then(iframe => {
+      const ampdoc = new AmpDocSingle(iframe.win);
+      const viewer = viewerForDoc(ampdoc);
+      sandbox.stub(viewer, 'isEmbedded', () => isEmbedded);
       platform = platformFor(iframe.win);
       sandbox.stub(platform, 'isIos', () => isIos);
       sandbox.stub(platform, 'isAndroid', () => isAndroid);
@@ -202,6 +207,7 @@ describe('amp-app-banner', () => {
     isIos = false;
     isChrome = false;
     isSafari = false;
+    isEmbedded = false;
   });
 
   afterEach(() => {
@@ -270,8 +276,17 @@ describe('amp-app-banner', () => {
       });
     });
 
-    it('should remove banner if safari', () => {
+    it('should remove banner if safari and not embedded', () => {
       isSafari = true;
+      isEmbedded = false;
+      return getAppBanner().then(banner => {
+        expect(banner.parentElement).to.be.null;
+      });
+    });
+
+    it('should remove banner if safari and embedded', () => {
+      isSafari = true;
+      isEmbedded = true;
       return getAppBanner().then(banner => {
         expect(banner.parentElement).to.be.null;
       });

--- a/extensions/amp-app-banner/amp-app-banner.md
+++ b/extensions/amp-app-banner/amp-app-banner.md
@@ -109,7 +109,7 @@ Because native app banners currently are not shown in the viewer context, `<amp-
   <tr>
     <td>In AMP viewer</td>
     <td>Show amp-app-banner</td>
-    <td>Show amp-app-banner</td>
+    <td>Currently, will not show anything due to #6454</td>
     <td>Show amp-app-banner</td>
   </tr>
   <tr>


### PR DESCRIPTION
Due to #6454 and our inability to launch app-store we've decided to hide amp-app-banner on iOS for now until we develop a different solution or figure out a way to fix this.