### PR TITLE
Add endpoints to get public keys to verify Cloudflare signatures.

### DIFF
--- a/ads/_a4a-config.js
+++ b/ads/_a4a-config.js
@@ -66,4 +66,6 @@ if (getMode().localDev || getMode().test) {
 export const signingServerURLs = {
   'google': 'https://cdn.ampproject.org/amp-ad-verifying-keyset.json',
   'google-dev': 'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
+  'cloudflare': 'https://amp.cloudflare.com/amp-ad-verifying-keyset.json',
+  'cloudflare-dev': 'https://amp.cloudflare.com/amp-ad-verifying-keyset-dev.json',
 };


### PR DESCRIPTION
This integrates the signing key endpoints, so that ad networks that reference the cloudflare signing names will allow ad verification against our keys.