### PR TITLE
Eliminate useless The play() request was interrupted by a call to pause() errors from being logged

### DIFF
--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -153,7 +153,17 @@ export function installVideo(win) {
      * @override
      */
     play(unusedIsAutoplay) {
-      this.video_.play();
+      const ret = this.video_.play();
+
+      if (ret && ret.then) {
+        ret.catch(() => {
+          // Empty catch to prevent useless unhandled promise rejection logging.
+          // Play can fail for many reasons such as video getting paused before
+          // play() is finished.
+          // We use events to know the state of the video and do not care about
+          // the success or failure of the play()'s returned promise.
+        });
+      }
     }
 
     /**

--- a/builtins/amp-video.js
+++ b/builtins/amp-video.js
@@ -155,7 +155,7 @@ export function installVideo(win) {
     play(unusedIsAutoplay) {
       const ret = this.video_.play();
 
-      if (ret && ret.then) {
+      if (ret && ret.catch) {
         ret.catch(() => {
           // Empty catch to prevent useless unhandled promise rejection logging.
           // Play can fail for many reasons such as video getting paused before

--- a/test/functional/test-amp-video.js
+++ b/test/functional/test-amp-video.js
@@ -289,6 +289,22 @@ describe('amp-video', () => {
     });
   });
 
+  it('play() should not log promise rejections', () => {
+    const playPromise = Promise.reject('The play() request was interrupted');
+    const catchSpy = sandbox.spy(playPromise, 'catch');
+    return getVideo({
+      src: 'video.mp4',
+      width: 160,
+      height: 90,
+    }, null, function(element) {
+      const impl = element.implementation_;
+      sandbox.stub(impl.video_, 'play').returns(playPromise);
+      impl.play();
+    }).then(() => {
+      expect(catchSpy.called).to.be.true;
+    });
+  });
+
   it('should propagate ARIA attributes', () => {
     return getVideo({
       src: 'video.mp4',


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/6395