### PR TITLE
Revert "small fix to fake function prototype"

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -439,13 +439,8 @@ function triggerRenderStart(opt_data) {
  */
 function observeIntersection(observerCallback) {
   // Send request to received records.
-  if (window.IntersectionObserver &&
-      window.IntersectionObserver.prototype.observe) {
-    // NOTE: Add extra check for `IntersectionObserver.prototype.observe`
-    // so that we can still test our IntersectionObserver polyfill impl by
-    // setting `IntersectionObserver.prototype` to a null object.
-
-    // use native IntersectionObserver if it exists.
+  if (window.IntersectionObserver && window.IntersectionObserver.prototype) {
+    // use native IntersectionObserver if exist
     const io = new window.IntersectionObserver(changes => {
       observerCallback(changes);
     }, {

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -23,8 +23,8 @@ import {dev} from '../src/log';
 export function _ping_(global, data) {
   global.document.getElementById('c').textContent = data.ping;
   if (!data.nativeIntersectionObserver) {
-    function nullIO() {};
-    nullIO.prototype = Object.create(null);
+    const nullIO = () => {};
+    nullIO.prototype = null;
     global.IntersectionObserver = nullIO;
   }
   if (data.ad_container) {


### PR DESCRIPTION
Reverts ampproject/amphtml#6527

This and #6503 are being reverted because of breakage in canary of ads frames accessing `rootBouds` that are no longer available on the native IntersectionObserver.