### PR TITLE
If page is an iframed test page, use parent's location to determine script's location

### DIFF
--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -542,7 +542,12 @@ export class Extensions {
     scriptElement.async = true;
     scriptElement.setAttribute('custom-element', extensionId);
     scriptElement.setAttribute('data-script', extensionId);
-    const loc = this.win.location;
+    let loc = this.win.location;
+    if (getMode().test && this.win.AMP_TEST_IFRAME) {
+      // If this is a test iframe, location will be srcdoc or about:blank,
+      // use the parent location instead.
+      loc = this.win.parent.location;
+    }
     const useCompiledJs = shouldUseCompiledJs();
     const scriptSrc = calculateExtensionScriptUrl(loc, extensionId,
         getMode().localDev, getMode().test, useCompiledJs);


### PR DESCRIPTION
https://github.com/ampproject/amphtml/pull/6686 is blocked by this PR.

@chenshay After this PR, you should no longer need to add amp-video script to the `video-players.html` and we can leave the integration test to be in the backward compatibility mode.