### PR TITLE
If page is an iframed test page, use parent's location to determine script's location

### DIFF
--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -542,7 +542,12 @@ export class Extensions {
     scriptElement.async = true;
     scriptElement.setAttribute('custom-element', extensionId);
     scriptElement.setAttribute('data-script', extensionId);
-    const loc = this.win.location;
+    let loc = this.win.location;
+    if (getMode().test && this.win.AMP_TEST_IFRAME) {
+      // If this is a test iframe, location will be srcdoc or about:blank,
+      // use the parent location instead.
+      loc = this.win.parent.location;
+    }
     const useCompiledJs = shouldUseCompiledJs();
     const scriptSrc = calculateExtensionScriptUrl(loc, extensionId,
         getMode().localDev, getMode().test, useCompiledJs);

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -543,10 +543,8 @@ export class Extensions {
     scriptElement.setAttribute('custom-element', extensionId);
     scriptElement.setAttribute('data-script', extensionId);
     let loc = this.win.location;
-    if (getMode().test && this.win.AMP_TEST_IFRAME) {
-      // If this is a test iframe, location will be srcdoc or about:blank,
-      // use the parent location instead.
-      loc = this.win.parent.location;
+    if (getMode().test && this.win.testLocation) {
+      loc = this.win.testLocation;
     }
     const useCompiledJs = shouldUseCompiledJs();
     const scriptSrc = calculateExtensionScriptUrl(loc, extensionId,

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -19,6 +19,7 @@ import installCustomElements from
 import {BaseElement} from '../src/base-element';
 import {
   FakeCustomElements,
+  FakeLocation,
   FakeWindow,
   interceptEventListeners,
 } from './fake-dom';
@@ -345,6 +346,11 @@ class RealWinFixture {
 
         // Flag as being a test window.
         win.AMP_TEST_IFRAME = true;
+        // Set the testLocation on iframe to parent's location since location of
+        // the test iframe is about:srcdoc.
+        // Unfortunately location object is not configurable, so we have to
+        // define a new property.
+        win.testLocation = new FakeLocation(window.location.href, win);
 
         if (!spec.allowExternalResources) {
           doNotLoadExternalResourcesInTest(win);

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -310,7 +310,7 @@ export function interceptEventListeners(target) {
 /**
  * @extends {!Location}
  */
-class FakeLocation {
+export class FakeLocation {
 
   /**
    * @param {string} href

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -86,7 +86,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
       // the test iframe is about:srcdoc.
       // Unfortunately location object is not configurable, so we have to define
       // a new property.
-      win.testLocation = new FakeLocation(window.location.href, window);
+      win.testLocation = new FakeLocation(window.location.href, win);
       win.ampTestRuntimeConfig = window.ampTestRuntimeConfig;
       if (opt_beforeLoad) {
         opt_beforeLoad(win);
@@ -210,6 +210,8 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
     iframe.onload = function() {
       // Flag as being a test window.
       iframe.contentWindow.AMP_TEST_IFRAME = true;
+      iframe.contentWindow.testLocation = new FakeLocation(window.location.href,
+          iframe.contentWindow);
       if (opt_runtimeOff) {
         iframe.contentWindow.name = '__AMP__off=1';
       }

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-
+import {FakeLocation} from './fake-dom';
 import {Timer} from '../src/timer';
 import installCustomElements from
     'document-register-element/build/document-register-element.node';
@@ -82,6 +82,11 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
       // Flag as being a test window.
       win.AMP_TEST_IFRAME = true;
       win.AMP_TEST = true;
+      // Set the testLocation on iframe to parent's location since location of
+      // the test iframe is about:srcdoc.
+      // Unfortunately location object is not configurable, so we have to define
+      // a new propery.
+      win.testLocation = new FakeLocation(window.location.href, window);
       win.ampTestRuntimeConfig = window.ampTestRuntimeConfig;
       if (opt_beforeLoad) {
         opt_beforeLoad(win);

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -85,7 +85,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
       // Set the testLocation on iframe to parent's location since location of
       // the test iframe is about:srcdoc.
       // Unfortunately location object is not configurable, so we have to define
-      // a new propery.
+      // a new property.
       win.testLocation = new FakeLocation(window.location.href, window);
       win.ampTestRuntimeConfig = window.ampTestRuntimeConfig;
       if (opt_beforeLoad) {


### PR DESCRIPTION
#6686 is blocked by this PR.

@chenshay After this PR, you should no longer need to add amp-video script to the video-players.html and we can leave the integration test to be in the backward compatibility mode.