### PR TITLE
Use #cloneNode to clone FixedLayer body

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -608,9 +608,8 @@ export class FixedLayer {
       return this.fixedLayer_;
     }
     const doc = this.ampdoc.win.document;
-    const bodyId = doc.body.id;
-    this.fixedLayer_ = doc.createElement('body');
-    this.fixedLayer_.id = bodyId || '-amp-fixedlayer';
+    this.fixedLayer_ = doc.body.cloneNode(/* deep */ false);
+    this.fixedLayer_.removeAttribute('style');
     setStyles(this.fixedLayer_, {
       position: 'absolute',
       top: 0,
@@ -637,15 +636,7 @@ export class FixedLayer {
       transition: 'none',
       visibility: 'visible',
     });
-    this.ampdoc.win.document.documentElement.appendChild(this.fixedLayer_);
-    // TODO(erwinm, #4097): Remove this when safari technology preview has merged
-    // the fix for https://github.com/ampproject/amphtml/issues/4047
-    // https://bugs.webkit.org/show_bug.cgi?id=159791 which is in r202950.
-    if (this.fixedLayer_.style['webkitAnimation'] !== undefined) {
-      this.fixedLayer_.style['webkitAnimation'] = 'none';
-    } else if (this.fixedLayer_.style['WebkitAnimation'] !== undefined) {
-      this.fixedLayer_.style['WebkitAnimation'] = 'none';
-    }
+    doc.documentElement.appendChild(this.fixedLayer_);
     return this.fixedLayer_;
   }
 

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -191,6 +191,9 @@ describe('FixedLayer', () => {
       setAttribute: (name, value) => {
         attrs[name] = value;
       },
+      removeAttribute: name => {
+        delete attrs[name];
+      },
       appendChild: child => {
         child.parentElement = elem;
         children.push(child);
@@ -209,6 +212,9 @@ describe('FixedLayer', () => {
         }
         newChild.parentElement = elem;
         children.push(newChild);
+      },
+      cloneNode() {
+        return createElement(this.id);
       },
     };
     Object.defineProperty(elem, 'offsetTop', {


### PR DESCRIPTION
Re: https://github.com/ampproject/amphtml/pull/6706#discussion_r92881310

Also removes a [temporary fix](https://github.com/ampproject/amphtml/issues/4097) that is [no longer necessary](https://github.com/ampproject/amphtml/pull/6033).