### PR TITLE
Add variable references in action method arg values

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -516,9 +516,9 @@ function getActionInfoArgValue(token) {
  * @param {?ActionInfoArgsDef} args
  * @param {?Event} event
  * @return {?JSONType}
- * @private
+ * @private Visible for testing only.
  */
-function applyActionInfoArgs(args, event) {
+export function applyActionInfoArgs(args, event) {
   if (args) {
     const data = (event && event.detail) ? event.detail : null;
     const applied = map();

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -487,7 +487,7 @@ export function parseActionMap(s, context) {
  * If the token is an identifier `foo`, the function returns `data[foo]`.
  * Otherwise, the function returns the token value.
  * @param {!{type: TokenType, value: *}} token
- * @return {function(!Object):string}
+ * @return {?function(!Object):string}
  * @private
  */
 function getActionInfoArgValue(token) {
@@ -505,6 +505,8 @@ function getActionInfoArgValue(token) {
       }
       return value;
     };
+  } else {
+    return null;
   }
 }
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ActionService, parseActionMap} from '../../src/service/action-impl';
+import {ActionService, applyActionInfoArgs, parseActionMap} from '../../src/service/action-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {setParentWindow} from '../../src/service';
 import * as sinon from 'sinon';
@@ -180,6 +180,29 @@ describe('ActionService parseAction', () => {
     expect(a.args['key1']({foo: () => {}})).to.equal('foo');
   });
 
+  it('should apply arg functions with no event', () => {
+    const a = parseAction('e:t.m(key1=foo)');
+    expect(applyActionInfoArgs(a.args, null)).to.deep.equal({key1: 'foo'});
+  });
+
+  it('applied arg values should be proto-less objects', () => {
+    const a = parseAction('e:t.m(key1=foo)');
+    expect(applyActionInfoArgs(a.args, null).__proto__).to.be.undefined;
+    expect(applyActionInfoArgs(a.args, null).constructor).to.be.undefined;
+  });
+
+  it('should apply arg value functions with an event with data', () => {
+    const a = parseAction('e:t.m(key1=foo)');
+    const event = new CustomEvent('MyEvent', {detail: {foo: 'bar'}});
+    expect(applyActionInfoArgs(a.args, event)).to.deep.equal({key1: 'bar'});
+  });
+
+  it('should apply arg value functions with an event without data', () => {
+    const a = parseAction('e:t.m(key1=foo)');
+    const event = new CustomEvent('MyEvent');
+    expect(applyActionInfoArgs(a.args, event)).to.deep.equal({key1: 'foo'});
+  });
+
   it('should parse empty to null', () => {
     const a = parseAction('');
     expect(a).to.equal(null);
@@ -245,7 +268,6 @@ describe('ActionService parseAction', () => {
     }).to.throw(/Invalid action/);
   });
 });
-
 
 describe('Action parseActionMap', () => {
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -17,7 +17,7 @@
 import {
   ActionService,
   applyActionInfoArgs,
-  parseActionMap
+  parseActionMap,
 } from '../../src/service/action-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {setParentWindow} from '../../src/service';
@@ -207,7 +207,7 @@ describe('ActionService parseAction', () => {
     expect(a.args['key1'](null)).to.equal(null);
     expect(a.args['key1']({})).to.equal(null);
     expect(a.args['key1']({foo: null})).to.equal(null);
-  })
+  });
 
   it('should NOT dereference non-primitives in arg values', () => {
     const a = parseAction('e:t.m(key1=foo.bar)');

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {ActionService, applyActionInfoArgs, parseActionMap} from '../../src/service/action-impl';
+import {
+  ActionService,
+  applyActionInfoArgs,
+  parseActionMap
+} from '../../src/service/action-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {setParentWindow} from '../../src/service';
 import * as sinon from 'sinon';


### PR DESCRIPTION
Partial for #6199.

This allows method calls to reference data in the `Event` object that triggered them. For example:
```
<component on="myEvent:myTarget.myMethod(key=event.foo)">
```
If `myEvent` is triggered with a `CustomEvent.detail = {foo: 'bar'}`, then `myMethod()` will be called with args `{key: 'bar'}`.