### PR TITLE
Explicitly specify requireAmpResponseSourceOrigin=false if missing

### DIFF
--- a/extensions/amp-access/0.1/amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/amp-access-server-jwt.js
@@ -313,6 +313,7 @@ export class AccessServerJwtAdapter {
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded',
             },
+            requireAmpResponseSourceOrigin: false,
           })).then(response => {
             dev().fine(TAG, 'Authorization response: ', response);
             return this.replaceSections_(response);

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -157,6 +157,7 @@ export class AccessServerAdapter {
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded',
             },
+            requireAmpResponseSourceOrigin: false,
           }));
     }).then(response => {
       dev().fine(TAG, 'Authorization response: ', response);

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -222,6 +222,7 @@ describe('AccessServerJwtAdapter', () => {
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },
+              requireAmpResponseSourceOrigin: false,
             })
             .returns(Promise.resolve(responseDoc))
             .once();
@@ -254,6 +255,7 @@ describe('AccessServerJwtAdapter', () => {
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },
+              requireAmpResponseSourceOrigin: false,
             })
             .returns(Promise.reject('intentional'))
             .once();
@@ -288,6 +290,7 @@ describe('AccessServerJwtAdapter', () => {
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },
+              requireAmpResponseSourceOrigin: false,
             })
             .returns(new Promise(() => {}))  // Never resolved.
             .once();

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -178,6 +178,7 @@ describe('AccessServerAdapter', () => {
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },
+              requireAmpResponseSourceOrigin: false,
             })
             .returns(Promise.resolve(responseDoc))
             .once();
@@ -218,6 +219,7 @@ describe('AccessServerAdapter', () => {
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },
+              requireAmpResponseSourceOrigin: false,
             })
             .returns(Promise.reject('intentional'))
             .once();
@@ -254,6 +256,7 @@ describe('AccessServerAdapter', () => {
               headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
               },
+              requireAmpResponseSourceOrigin: false,
             })
             .returns(new Promise(() => {}))  // Never resolved.
             .once();

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -84,7 +84,9 @@ export class AmpAdCustom extends AMP.BaseElement {
     // If this promise has no URL yet, create one for it.
     if (!(fullUrl in ampCustomadXhrPromises)) {
       // Here is a promise that will return the data for this URL
-      ampCustomadXhrPromises[fullUrl] = xhrFor(this.win).fetchJson(fullUrl);
+      ampCustomadXhrPromises[fullUrl] = xhrFor(this.win).fetchJson(fullUrl, {
+        requireAmpResponseSourceOrigin: false,
+      });
     }
     return ampCustomadXhrPromises[fullUrl].then(data => {
       this.uiHandler.setDisplayState(AdDisplayState.LOADING);

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -149,7 +149,9 @@ class AmpApesterMedia extends AMP.BaseElement {
    **/
   queryMedia_() {
     const url = this.buildUrl_();
-    return xhrFor(this.win).fetchJson(url);
+    return xhrFor(this.win).fetchJson(url, {
+      requireAmpResponseSourceOrigin: false,
+    });
   }
 
   /** @param {string} id

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -398,8 +398,9 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
       return Promise.resolve();
     }
 
-    return xhrFor(this.win).fetchJson(this.manifestHref_)
-        .then(response => this.parseManifest_(response))
+    return xhrFor(this.win).fetchJson(this.manifestHref_, {
+      requireAmpResponseSourceOrigin: false,
+    }).then(response => this.parseManifest_(response))
         .catch(error => {
           this.hide_();
           rethrowAsync(error);

--- a/extensions/amp-fresh/0.1/amp-fresh-manager.js
+++ b/extensions/amp-fresh/0.1/amp-fresh-manager.js
@@ -78,7 +78,9 @@ export class AmpFreshManager {
     const url = addParamToUrl(this.ampdoc.win.location.href,
         'amp-fresh', String(Date.now()));
     return Promise.all([
-      xhrFor(this.ampdoc.win).fetchDocument(url),
+      xhrFor(this.ampdoc.win).fetchDocument(url, {
+        requireAmpResponseSourceOrigin: false,
+      }),
       this.ampdoc.whenReady(),
     ]).then(args => args[0]);
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -55,9 +55,7 @@ export class AmpList extends AMP.BaseElement {
           if (this.element.hasAttribute('credentials')) {
             opts.credentials = this.element.getAttribute('credentials');
           }
-          if (opts.credentials) {
-            opts.requireAmpResponseSourceOrigin = true;
-          }
+          opts.requireAmpResponseSourceOrigin = !!opts.credentials;
           return xhrFor(this.win).fetchJson(src, opts);
         }).then(data => {
           user().assert(data != null

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -113,8 +113,9 @@ export class LiveListManager {
     }
     return xhrFor(this.win)
         // TODO(erwinm): add update time here when possible.
-        .fetchDocument(url)
-        .then(this.getLiveLists_.bind(this));
+        .fetchDocument(url, {
+          requireAmpResponseSourceOrigin: false,
+        }).then(this.getLiveLists_.bind(this));
   }
 
   /**

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -65,12 +65,13 @@ export class PinWidget {
   fetchPin() {
     const baseUrl = 'https://widgets.pinterest.com/v3/pidgets/pins/info/?';
     const query = `pin_ids=${this.pinId}&sub=www&base_scheme=https`;
-    return this.xhr.fetchJson(baseUrl + query)
-      .then(response => {
-        try {
-          return response.data[0];
-        } catch (e) { return null; }
-      });
+    return this.xhr.fetchJson(baseUrl + query, {
+      requireAmpResponseSourceOrigin: false,
+    }).then(response => {
+      try {
+        return response.data[0];
+      } catch (e) { return null; }
+    });
   }
 
   renderPin(pin) {

--- a/extensions/amp-pinterest/0.1/pinit-button.js
+++ b/extensions/amp-pinterest/0.1/pinit-button.js
@@ -74,7 +74,9 @@ export class PinItButton {
    */
   fetchCount() {
     const url = `https://widgets.pinterest.com/v1/urls/count.json?return_jsonp=false&url=${this.url}`;
-    return this.xhr.fetchJson(url);
+    return this.xhr.fetchJson(url, {
+      requireAmpResponseSourceOrigin: false,
+    });
   }
 
   /**

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -186,6 +186,7 @@ export class AmpUserNotification extends AMP.BaseElement {
     return this.buildGetHref_(ampUserId).then(href => {
       const getReq = {
         credentials: 'include',
+        requireAmpResponseSourceOrigin: false,
       };
       return xhrFor(this.win).fetchJson(href, getReq);
     });
@@ -200,6 +201,7 @@ export class AmpUserNotification extends AMP.BaseElement {
     return xhrFor(this.win).fetchJson(dev().assert(this.dismissHref_), {
       method: 'POST',
       credentials: 'include',
+      requireAmpResponseSourceOrigin: false,
       body: {
         'elementId': this.elementId_,
         'ampUserId': this.ampUserId_,

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -158,8 +158,9 @@ export class AmpVizVega extends AMP.BaseElement {
       // calls. We may want to intercept all "urls" in spec and do the loading
       // and parsing ourselves.
 
-      return xhrFor(this.win).fetchJson(dev().assertString(this.src_))
-      .then(data => {
+      return xhrFor(this.win).fetchJson(dev().assertString(this.src_), {
+        requireAmpResponseSourceOrigin: false,
+      }).then(data => {
         this.data_ = data;
       });
     }

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -119,6 +119,7 @@ export class Xhr {
    * @private
    */
   fetchAmpCors_(input, init = {}) {
+    dev().assert(init.requireAmpResponseSourceOrigin !== undefined);
     // Do not append __amp_source_origin if explicitly disabled.
     if (init.ampCors !== false) {
       input = this.getCorsUrl(this.win, input);

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -119,7 +119,13 @@ export class Xhr {
    * @private
    */
   fetchAmpCors_(input, init = {}) {
-    dev().assert(init.requireAmpResponseSourceOrigin !== undefined);
+    if (init.requireAmpResponseSourceOrigin === undefined) {
+      // TODO: this is an intermediate step of migrating
+      // requireAmpResponseSourceOrigin to ampCors. Once deployed to production,
+      // we can default requireAmpResponseSourceOrigin to true.
+      dev().error(
+          'XHR', 'Please explicitly specify requireAmpResponseSourceOrigin');
+    }
     // Do not append __amp_source_origin if explicitly disabled.
     if (init.ampCors !== false) {
       input = this.getCorsUrl(this.win, input);

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -25,7 +25,7 @@ import {
 import {getCookie} from '../../src/cookies';
 
 
-describe('XHR', function() {
+describe.skip('XHR', function() {
   let sandbox;
   let requests;
   const location = {href: 'https://acme.com/path'};

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -25,7 +25,7 @@ import {
 import {getCookie} from '../../src/cookies';
 
 
-describe.skip('XHR', function() {
+describe('XHR', function() {
   let sandbox;
   let requests;
   const location = {href: 'https://acme.com/path'};


### PR DESCRIPTION
This is the 1st step to deprecate field requireAmpResponseSourceOrigin. 
To make sure no version skew between runtime and extensions, we do
1) make all calls explicitly specify requireAmpResponseSourceOrigin.
2) Once change 1) is in production, we can default requireAmpResponseSourceOrigin to true.

/cc @keithwrightbos 