### PR TITLE
Fix `toggleExperiment` bug when

### DIFF
--- a/src/experiments.js
+++ b/src/experiments.js
@@ -153,7 +153,8 @@ export function toggleExperiment(win, experimentId, opt_on,
     opt_transientExperiment) {
   const toggles = experimentToggles();
   const experimentIds = getExperimentIds(win);
-  const currentlyOn = (experimentIds.indexOf(experimentId) != -1) ||
+  const index = experimentIds.indexOf(experimentId);
+  const currentlyOn = (index != -1) ||
       (experimentId in toggles && toggles[experimentId]);
   const on = opt_on !== undefined ? opt_on : !currentlyOn;
   if (on != currentlyOn) {
@@ -161,7 +162,9 @@ export function toggleExperiment(win, experimentId, opt_on,
       experimentIds.push(experimentId);
       toggles[experimentId] = true;
     } else {
-      experimentIds.splice(experimentIds.indexOf(experimentId), 1);
+      if (index != -1) {
+        experimentIds.splice(index, 1);
+      }
       toggles[experimentId] = false;
     }
     if (!opt_transientExperiment) {

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -181,10 +181,7 @@ describe('toggleExperiment', () => {
     const doc = {
       cookie: cookiesString,
     };
-    const fakeWin = {
-      document: doc,
-    };
-    const on = toggleExperiment(fakeWin, experimentId, opt_on);
+    const on = toggleExperiment({document: doc}, experimentId, opt_on);
     const parts = doc.cookie.split(/\s*;\s*/g);
     if (parts.length > 1) {
       expect(parts[1]).to.equal('path=/');

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -181,7 +181,10 @@ describe('toggleExperiment', () => {
     const doc = {
       cookie: cookiesString,
     };
-    const on = toggleExperiment({document: doc}, experimentId, opt_on);
+    const fakeWin = {
+      document: doc,
+    };
+    const on = toggleExperiment(fakeWin, experimentId, opt_on);
     const parts = doc.cookie.split(/\s*;\s*/g);
     if (parts.length > 1) {
       expect(parts[1]).to.equal('path=/');
@@ -206,6 +209,20 @@ describe('toggleExperiment', () => {
     expectToggle('AMP_EXP=e1', 'e1').to.equal('false; AMP_EXP=');
     expectToggle('AMP_EXP=e1,e2', 'e1').to.equal('false; AMP_EXP=e2');
     expectToggle('AMP_EXP=e2,e1', 'e1').to.equal('false; AMP_EXP=e2');
+  });
+
+  it('should not do not modify non-calculated experiment ids from cookie' +
+      'when toggle "off"', () => {
+    const fakeWin = {
+      document: {
+        cookie: 'AMP_EXP=e2,e3',
+      },
+    };
+    toggleExperiment(fakeWin, 'e1', true);
+    // override for test purpose, so we don't need to export getExperimentIds
+    fakeWin._experimentCookie = ['e2', 'e3'];
+    toggleExperiment(fakeWin, 'e1', false, /* opt_transientExperiment */ true);
+    expect(fakeWin._experimentCookie).to.deep.equal(['e2', 'e3']);
   });
 
   it('should set "on" when requested', () => {


### PR DESCRIPTION
This fixes the bug where `toggleExperiment` will remove the last experiment id from the experimentIds list. 