### PR TITLE
Store either "someexp" or "-someexp" in cookie, never both. 

### DIFF
--- a/src/experiments.js
+++ b/src/experiments.js
@@ -173,9 +173,8 @@ export function toggleExperiment(win, experimentId, opt_on,
  * Returns a set of experiment IDs currently on.
  * @param {!Window} win
  * @return {!Object<string, boolean>}
- * @visibleForTesting
  */
-export function getExperimentTogglesFromCookie(win) {
+function getExperimentTogglesFromCookie(win) {
   if (win._experimentCookie) {
     return win._experimentCookie;
   }
@@ -197,6 +196,15 @@ export function getExperimentTogglesFromCookie(win) {
   return win._experimentCookie = toggles;
 }
 
+/**
+ * See getExperimentTogglesFromCookie().
+ * @param {!Window} win
+ * @return {!Object<string, boolean>}
+ * @visibleForTesting
+ */
+export function getExperimentToglesFromCookieForTesting(win) {
+  return getExperimentTogglesFromCookie(win);
+}
 
 /**
  * Saves a set of experiment IDs currently on.

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -159,9 +159,9 @@ export function toggleExperiment(win, experimentId, opt_on,
     const toggles = experimentToggles();
     toggles[experimentId] = on;
 
-    const cookieToggles = getExperimentTogglesFromCookie(win);
-    cookieToggles[experimentId] = on;
     if (!opt_transientExperiment) {
+      const cookieToggles = getExperimentTogglesFromCookie(win);
+      cookieToggles[experimentId] = on;
       saveExperimentTogglesToCookie(win, cookieToggles);
     }
   }

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -124,18 +124,10 @@ export function isExperimentOnAllowUrlOverride(win, experimentId) {
  * @return {boolean}
  */
 function calcExperimentOn(win, experimentId) {
-  const experiments = getExperimentIds(win);
+  const cookieToggles = getExperimentTogglesFromCookie(win);
 
-  // Disabling cookie flag.
-  const disableFlag = experiments.indexOf('-' + experimentId) != -1;
-  if (disableFlag) {
-    return false;
-  }
-
-  // Enabling cookie flag.
-  const cookieFlag = experiments.indexOf(experimentId) != -1;
-  if (cookieFlag) {
-    return true;
+  if (cookieToggles[experimentId] !== undefined) {
+    return cookieToggles[experimentId];
   }
 
   // Binary config.
@@ -161,21 +153,16 @@ function calcExperimentOn(win, experimentId) {
  */
 export function toggleExperiment(win, experimentId, opt_on,
     opt_transientExperiment) {
-  const toggles = experimentToggles();
-  const experimentIds = getExperimentIds(win);
-  const currentlyOn = (experimentIds.indexOf(experimentId) != -1) ||
-      (experimentId in toggles && toggles[experimentId]);
-  const on = opt_on !== undefined ? opt_on : !currentlyOn;
+  const currentlyOn = isExperimentOn(win, experimentId);
+  const on = !!(opt_on !== undefined ? opt_on : !currentlyOn);
   if (on != currentlyOn) {
-    if (on) {
-      experimentIds.push(experimentId);
-      toggles[experimentId] = true;
-    } else {
-      experimentIds.splice(experimentIds.indexOf(experimentId), 1);
-      toggles[experimentId] = false;
-    }
+    const toggles = experimentToggles();
+    toggles[experimentId] = on;
+
+    const cookieToggles = getExperimentTogglesFromCookie(win);
+    cookieToggles[experimentId] = on;
     if (!opt_transientExperiment) {
-      saveExperimentIds(win, experimentIds);
+      saveExperimentTogglesToCookie(win, cookieToggles);
     }
   }
   return on;
@@ -185,25 +172,44 @@ export function toggleExperiment(win, experimentId, opt_on,
 /**
  * Returns a set of experiment IDs currently on.
  * @param {!Window} win
- * @return {!Array<string>}
+ * @return {!Object<string, boolean>}
+ * @visibleForTesting
  */
-function getExperimentIds(win) {
+export function getExperimentTogglesFromCookie(win) {
   if (win._experimentCookie) {
     return win._experimentCookie;
   }
   const experimentCookie = getCookie(win, COOKIE_NAME);
-  return win._experimentCookie = (
-      experimentCookie ? experimentCookie.split(/\s*,\s*/g) : []);
+  const tokens = experimentCookie ? experimentCookie.split(/\s*,\s*/g) : [];
+
+  const toggles = Object.create(null);
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i].length == 0) {
+      continue;
+    }
+    if (tokens[i][0] == '-') {
+      toggles[tokens[i].substr(1)] = false;
+    } else {
+      toggles[tokens[i]] = true;
+    }
+  }
+
+  return win._experimentCookie = toggles;
 }
 
 
 /**
  * Saves a set of experiment IDs currently on.
  * @param {!Window} win
- * @param {!Array<string>} experimentIds
+ * @param {!Object<string, boolean>} toggles
  */
-function saveExperimentIds(win, experimentIds) {
+function saveExperimentTogglesToCookie(win, toggles) {
   win._experimentCookie = null;
+  const experimentIds = [];
+  for (const experiment in toggles) {
+    experimentIds.push((toggles[experiment] === false ? '-' : '') + experiment);
+  }
+
   setCookie(win, COOKIE_NAME, experimentIds.join(','),
       Date.now() + COOKIE_EXPIRATION_INTERVAL);
 }

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -267,28 +267,41 @@ describe('toggleExperiment', () => {
         cookie: '',
       },
     };
+    toggleExperiment(win, 'transient', true, true);
     toggleExperiment(win, 'e1', true);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e1', true);
     toggleExperiment(win, 'e2', true, false);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e2', true);
     toggleExperiment(win, 'e3', true, undefined);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e3', true);
     toggleExperiment(win, 'e4', undefined, false);
+
+    expect(getExperimentTogglesFromCookie(win))
+        .to.not.have.property('transient');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e1', true);
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e2', true);
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e3', true);
     expect(getExperimentTogglesFromCookie(win)).to.have.property('e4', true);
+
     // All of those experiment states should be durable in the window
     // environment.
+    expect(isExperimentOn(win, 'transient'), 'transient is on').to.be.true;
     expect(isExperimentOn(win, 'e1'), 'e1 is on').to.be.true;
     expect(isExperimentOn(win, 'e2'), 'e2 is on').to.be.true;
     expect(isExperimentOn(win, 'e3'), 'e3 is on').to.be.true;
     expect(isExperimentOn(win, 'e4'), 'e4 is on').to.be.true;
+
+    toggleExperiment(win, 'transient', false, true);
     toggleExperiment(win, 'e1', false);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e1', false);
     toggleExperiment(win, 'e2', false, false);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e2', false);
     toggleExperiment(win, 'e3', false, undefined);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e3', false);
     toggleExperiment(win, 'e4', undefined, false);
+
+    expect(getExperimentTogglesFromCookie(win))
+        .to.not.have.property('transient');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e1', false);
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e2', false);
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e3', false);
     expect(getExperimentTogglesFromCookie(win)).to.have.property('e4', false);
+
+    expect(isExperimentOn(win, 'transient'), 'transient is on').to.be.false;
     expect(isExperimentOn(win, 'e1'), 'e1 is on').to.be.false;
     expect(isExperimentOn(win, 'e2'), 'e2 is on').to.be.false;
     expect(isExperimentOn(win, 'e3'), 'e3 is on').to.be.false;

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -21,6 +21,7 @@ import {
   isExperimentOnAllowUrlOverride,
   toggleExperiment,
   resetExperimentToggles_,
+  getExperimentTogglesFromCookie,
 } from '../../src/experiments';
 import * as sinon from 'sinon';
 
@@ -73,10 +74,10 @@ describe('isExperimentOn', () => {
     });
 
     it('should return "off" when disabling value is in the list', () => {
-      expectExperiment('AMP_EXP=-e1,e1', 'e1').to.be.false;
-      expectExperiment('AMP_EXP=e1,e2,-e1', 'e1').to.be.false;
-      expectExperiment('AMP_EXP=e2,-e1,e1', 'e1').to.be.false;
-      expectExperiment('AMP_EXP=e2 , e1,  -e1', 'e1').to.be.false;
+      expectExperiment('AMP_EXP=-e1', 'e1').to.be.false;
+      expectExperiment('AMP_EXP=e2,-e1', 'e1').to.be.false;
+      expectExperiment('AMP_EXP=-e1,e2', 'e1').to.be.false;
+      expectExperiment('AMP_EXP=e2 , -e1', 'e1').to.be.false;
     });
   });
 
@@ -193,6 +194,7 @@ describe('toggleExperiment', () => {
     const doc = {
       cookie: cookiesString,
     };
+    resetExperimentToggles_();
     const on = toggleExperiment({document: doc}, experimentId, opt_on);
     const parts = doc.cookie.split(/\s*;\s*/g);
     if (parts.length > 1) {
@@ -215,9 +217,9 @@ describe('toggleExperiment', () => {
   });
 
   it('should toggle "off" when value is in the list', () => {
-    expectToggle('AMP_EXP=e1', 'e1').to.equal('false; AMP_EXP=');
-    expectToggle('AMP_EXP=e1,e2', 'e1').to.equal('false; AMP_EXP=e2');
-    expectToggle('AMP_EXP=e2,e1', 'e1').to.equal('false; AMP_EXP=e2');
+    expectToggle('AMP_EXP=e1', 'e1').to.equal('false; AMP_EXP=-e1');
+    expectToggle('AMP_EXP=e1,e2', 'e1').to.equal('false; AMP_EXP=-e1,e2');
+    expectToggle('AMP_EXP=e2,e1', 'e1').to.equal('false; AMP_EXP=e2,-e1');
   });
 
   it('should set "on" when requested', () => {
@@ -226,8 +228,9 @@ describe('toggleExperiment', () => {
   });
 
   it('should set "off" when requested', () => {
-    expectToggle('AMP_EXP=e2,e1', 'e1', false).to.equal('false; AMP_EXP=e2');
-    expectToggle('AMP_EXP=e1', 'e1', false).to.equal('false; AMP_EXP=');
+    expectToggle(
+        'AMP_EXP=e2,e1', 'e1', false).to.equal('false; AMP_EXP=e2,-e1');
+    expectToggle('AMP_EXP=e1', 'e1', false).to.equal('false; AMP_EXP=-e1');
   });
 
   it('should not set cookies when toggling and transientExperiment', () => {
@@ -265,13 +268,13 @@ describe('toggleExperiment', () => {
       },
     };
     toggleExperiment(win, 'e1', true);
-    expect(win.document.cookie).to.contain('e1');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e1', true);
     toggleExperiment(win, 'e2', true, false);
-    expect(win.document.cookie).to.contain('e2');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e2', true);
     toggleExperiment(win, 'e3', true, undefined);
-    expect(win.document.cookie).to.contain('e3');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e3', true);
     toggleExperiment(win, 'e4', undefined, false);
-    expect(win.document.cookie).to.contain('e4');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e4', true);
     // All of those experiment states should be durable in the window
     // environment.
     expect(isExperimentOn(win, 'e1'), 'e1 is on').to.be.true;
@@ -279,13 +282,13 @@ describe('toggleExperiment', () => {
     expect(isExperimentOn(win, 'e3'), 'e3 is on').to.be.true;
     expect(isExperimentOn(win, 'e4'), 'e4 is on').to.be.true;
     toggleExperiment(win, 'e1', false);
-    expect(win.document.cookie).to.not.contain('e1');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e1', false);
     toggleExperiment(win, 'e2', false, false);
-    expect(win.document.cookie).to.not.contain('e2');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e2', false);
     toggleExperiment(win, 'e3', false, undefined);
-    expect(win.document.cookie).to.not.contain('e3');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e3', false);
     toggleExperiment(win, 'e4', undefined, false);
-    expect(win.document.cookie).to.not.contain('e4');
+    expect(getExperimentTogglesFromCookie(win)).to.have.property('e4', false);
     expect(isExperimentOn(win, 'e1'), 'e1 is on').to.be.false;
     expect(isExperimentOn(win, 'e2'), 'e2 is on').to.be.false;
     expect(isExperimentOn(win, 'e3'), 'e3 is on').to.be.false;
@@ -340,6 +343,37 @@ describe('toggleExperiment', () => {
     expect(isExperimentOn(win, 'e5'), 'e5').to.be.true;
     expect(isExperimentOn(win, 'e6'), 'e6').to.be.false;
   });
+
+  it('should override global settings', () => {
+    const win = {
+      document: {
+        cookie: '',
+      },
+      'AMP_CONFIG': {
+        'e1': 1,
+      },
+    };
+
+    // e1 is on, according to the AMP_CONFIG global setting
+    expect(isExperimentOn(win, 'e1')).to.be.true;
+    // toggleExperiment should override the global setting
+    expect(toggleExperiment(win, 'e1')).to.be.false;
+    expect(isExperimentOn(win, 'e1')).to.be.false;
+
+    // The new setting should be persisted in cookie, so cache reset should not
+    // affect its status.
+    resetExperimentToggles_();
+    expect(isExperimentOn(win, 'e1')).to.be.false;
+
+    // Now let's explicitly toggle to true
+    expect(toggleExperiment(win, 'e1', true)).to.be.true;
+    expect(isExperimentOn(win, 'e1')).to.be.true;
+    resetExperimentToggles_();
+    expect(isExperimentOn(win, 'e1')).to.be.true;
+
+    // Sanity check, the global setting should never be changed.
+    expect(win.AMP_CONFIG.e1).to.equal(1);
+  });
 });
 
 describe('isDevChannel', () => {
@@ -369,3 +403,4 @@ describe('isDevChannel', () => {
     expect(isDevChannelVersionDoNotUse_(win)).to.be.true;
   });
 });
+

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -384,6 +384,12 @@ describe('toggleExperiment', () => {
     resetExperimentToggles_();
     expect(isExperimentOn(win, 'e1')).to.be.true;
 
+    // Toggle transiently should still work
+    expect(toggleExperiment(win, 'e1', false, true)).to.be.false;
+    expect(isExperimentOn(win, 'e1')).to.be.false;
+    resetExperimentToggles_(); // cache reset should bring it back to true
+    expect(isExperimentOn(win, 'e1')).to.be.true;
+
     // Sanity check, the global setting should never be changed.
     expect(win.AMP_CONFIG.e1).to.equal(1);
   });

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -21,7 +21,7 @@ import {
   isExperimentOnAllowUrlOverride,
   toggleExperiment,
   resetExperimentToggles_,
-  getExperimentTogglesFromCookie,
+  getExperimentToglesFromCookieForTesting,
 } from '../../src/experiments';
 import * as sinon from 'sinon';
 
@@ -273,12 +273,16 @@ describe('toggleExperiment', () => {
     toggleExperiment(win, 'e3', true, undefined);
     toggleExperiment(win, 'e4', undefined, false);
 
-    expect(getExperimentTogglesFromCookie(win))
+    expect(getExperimentToglesFromCookieForTesting(win))
         .to.not.have.property('transient');
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e1', true);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e2', true);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e3', true);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e4', true);
+    expect(getExperimentToglesFromCookieForTesting(win))
+        .to.have.property('e1', true);
+    expect(getExperimentToglesFromCookieForTesting(win))
+        .to.have.property('e2', true);
+    expect(getExperimentToglesFromCookieForTesting(win))
+        .to.have.property('e3', true);
+    expect(getExperimentToglesFromCookieForTesting(win))
+        .to.have.property('e4', true);
 
     // All of those experiment states should be durable in the window
     // environment.
@@ -294,12 +298,16 @@ describe('toggleExperiment', () => {
     toggleExperiment(win, 'e3', false, undefined);
     toggleExperiment(win, 'e4', undefined, false);
 
-    expect(getExperimentTogglesFromCookie(win))
+    expect(getExperimentToglesFromCookieForTesting(win))
         .to.not.have.property('transient');
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e1', false);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e2', false);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e3', false);
-    expect(getExperimentTogglesFromCookie(win)).to.have.property('e4', false);
+    expect(getExperimentToglesFromCookieForTesting(win))
+        .to.have.property('e1', false);
+    expect(getExperimentToglesFromCookieForTesting(win))
+        .to.have.property('e2', false);
+    expect(getExperimentToglesFromCookieForTesting(win))
+        .to.have.property('e3', false);
+    expect(getExperimentToglesFromCookieForTesting(win))
+        .to.have.property('e4', false);
 
     expect(isExperimentOn(win, 'transient'), 'transient is on').to.be.false;
     expect(isExperimentOn(win, 'e1'), 'e1 is on').to.be.false;


### PR DESCRIPTION
This is to fix the duplicated experiment entries in cookie as mentioned [here](https://github.com/ampproject/amphtml/pull/6709#discussion_r93081641) .

It's done by deserializing the experiment cookie into an object instead of an array:
`AMP_EXP=e1,-e2,e3` => 
```
{
  e1: true,
  e2: false,
  e3: true,
}
```
