### PR TITLE
Ensure that viewer handshake always happens quickly.

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -120,9 +120,11 @@ class Chunks {
     if (!this.active_) {
       return;
     }
-    if (!this.win_.requestIdleCallback) {
-      this.win_.addEventListener('message', this.boundExecute_);
-    }
+    this.win_.addEventListener('message', e => {
+      if (e.data = 'amp-macro-task') {
+        this.execute_();
+      }
+    });
     viewerPromiseForDoc(ampDoc).then(viewer => {
       this.viewer_ = viewer;
       viewer.onVisibilityChanged(() => {

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -55,6 +55,14 @@ export function chunk(nodeOrAmpDoc, fn) {
 };
 
 /**
+ * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrAmpDoc
+ * @return {!Chunks}
+ */
+export function chunkInstanceForTesting(nodeOrAmpDoc) {
+  return fromClassForDoc(nodeOrAmpDoc, 'chunk', Chunks);
+}
+
+/**
  * Use a standard micro task for every invocation. This should only
  * be called from the AMP bootstrap script if it is known that
  * chunking makes no sense. In particular this is the case when
@@ -178,7 +186,11 @@ class Chunks {
     }
     // If requestIdleCallback exists, schedule a task with it, but
     // do not wait longer than one second.
-    if (this.win_.requestIdleCallback) {
+    // We only start using requestIdleCallback when the viewer has
+    // been initialized. Otherwise we risk starving ourselves
+    // before we get into a state where the viewer can tell us
+    // that we are visible.
+    if (this.viewer_ && this.win_.requestIdleCallback) {
       onIdle(this.win_,
           // Wait until we have a budget of at least 15ms.
           // 15ms is a magic number. Budgets are higher when the user

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -84,6 +84,22 @@ import * as config from './config';
 
 initLogConstructor();
 
+/**
+ * - n is the name.
+ * - f is the function body of the extension.
+ * - p is the priority. Only supported value is "high".
+ *   high means, that the extension is not subject to chunking.
+ *   This should be used for work, that should always happen
+ *   as early as possible. Currently this is primarily used
+ *   for viewer communication setup.
+ * @typedef {{
+ *   n: string,
+ *   f: function(!Object),
+ *   p: (string|undefined),
+ * }}
+ */
+let ExtensionPayloadDef;
+
 /** @const @private {string} */
 const TAG = 'runtime';
 
@@ -159,7 +175,7 @@ function adoptShared(global, opts, callback) {
   global.AMP_TAG = true;
   // If there is already a global AMP object we assume it is an array
   // of functions
-  /** @const {!Array<function(!Object)|{n:string, f:function(!Object)}>} */
+  /** @const {!Array<function(!Object)|ExtensionPayloadDef>} */
   const preregisteredExtensions = global.AMP || [];
 
   /** @const {!./service/extensions-impl.Extensions} */
@@ -246,16 +262,26 @@ function adoptShared(global, opts, callback) {
   callback(global, extensions);
 
   /**
-   * @param {function(!Object)|{n:string, f:function(!Object)}} fnOrStruct
+   * @param {function(!Object)|ExtensionPayloadDef} fnOrStruct
    */
   function installExtension(fnOrStruct) {
-    if (typeof fnOrStruct == 'function') {
-      const fn = fnOrStruct;
-      chunk(global.document, () => fn(global.AMP));
+    const register = () => {
+      waitForBody(global.document, () => {
+        if (typeof fnOrStruct == 'function') {
+          fnOrStruct(global.AMP);
+        } else {
+          registerExtension(extensions, fnOrStruct.n, fnOrStruct.f, global.AMP);
+        }
+      });
+    };
+    if (typeof fnOrStruct == 'function' || fnOrStruct.p == 'high') {
+      // "High priority" extensions do not go through chunking.
+      // This should be used for extensions that need to run early.
+      // One example would be viewer communication that is required
+      // to transition document from pre-render to visible (which
+      // affects chunking itself).
+      Promise.resolve().then(register);
     } else {
-      const register = function() {
-        registerExtension(extensions, fnOrStruct.n, fnOrStruct.f, global.AMP);
-      };
       register.displayName = fnOrStruct.n;
       chunk(global.document, register);
     }
@@ -273,40 +299,29 @@ function adoptShared(global, opts, callback) {
 
   /**
    * Registers a new custom element.
-   * @param {function(!Object)|{n:string, f:function(!Object)}} fnOrStruct
+   * @param {function(!Object)|ExtensionPayloadDef} fnOrStruct
    */
   global.AMP.push = function(fnOrStruct) {
-    // Extensions are only processed once HEAD is complete.
-    const register = function() {
-      waitForBody(global.document, () => {
-        installExtension(fnOrStruct);
-      });
-    };
-    register.displayName = fnOrStruct.n;
-    chunk(global.document, register);
+    installExtension(fnOrStruct);
   };
 
   // Execute asynchronously scheduled elements.
-  // Extensions are only processed once HEAD is complete.
-  waitForBody(global.document, () => {
-    for (let i = 0; i < preregisteredExtensions.length; i++) {
-      const fnOrStruct = preregisteredExtensions[i];
-      try {
-        installExtension(fnOrStruct);
-      } catch (e) {
-        // Throw errors outside of loop in its own micro task to
-        // avoid on error stopping other extensions from loading.
-        dev().error(TAG, 'Extension failed: ', e, fnOrStruct.n);
-      }
+  for (let i = 0; i < preregisteredExtensions.length; i++) {
+    const fnOrStruct = preregisteredExtensions[i];
+    try {
+      installExtension(fnOrStruct);
+    } catch (e) {
+      // Throw errors outside of loop in its own micro task to
+      // avoid on error stopping other extensions from loading.
+      dev().error(TAG, 'Extension failed: ', e, fnOrStruct.n);
     }
+  }
+  // Make sure we empty the array of preregistered extensions.
+  // Technically this is only needed for testing, as everything should
+  // go out of scope here, but just making sure.
+  preregisteredExtensions.length = 0;
 
-    installAutoLoadExtensions();
-
-    // Make sure we empty the array of preregistered extensions.
-    // Technically this is only needed for testing, as everything should
-    // go out of scope here, but just making sure.
-    preregisteredExtensions.length = 0;
-  });
+  installAutoLoadExtensions();
 
   // For iOS we need to set `cursor:pointer` to ensure that click events are
   // delivered.

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -280,6 +280,10 @@ function adoptShared(global, opts, callback) {
       // One example would be viewer communication that is required
       // to transition document from pre-render to visible (which
       // affects chunking itself).
+      // We consider functions as high priority, because
+      // - if in doubt, that is a better default
+      // - the only actual  user is a viewer integration that should
+      //   be high priority.
       Promise.resolve().then(register);
     } else {
       register.displayName = fnOrStruct.n;

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -113,6 +113,9 @@ describe('chunk', () => {
       installDocService(env.win, true);
       expect(env.win.services.viewer).to.be.undefined;
       env.win.document.hidden = true;
+      env.win.requestIdleCallback = function() {
+        throw new Error('Should not be called');
+      };
       env.win.postMessage = function(data, targetOrigin) {
         expect(targetOrigin).to.equal('*');
         Promise.resolve().then(() => {

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -17,13 +17,14 @@
 import {
   activateChunkingForTesting,
   chunk,
+  chunkInstanceForTesting,
   deactivateChunking,
   onIdle,
   resolvedObjectforTesting,
 } from '../../src/chunk';
 import {installDocService} from '../../src/service/ampdoc-impl';
 import {toggleExperiment} from '../../src/experiments';
-import {viewerForDoc} from '../../src/viewer';
+import {viewerForDoc, viewerPromiseForDoc} from '../../src/viewer';
 import * as sinon from 'sinon';
 
 
@@ -49,9 +50,20 @@ describe('chunk', () => {
     beforeEach(() => {
       toggleExperiment(env.win, 'chunked-amp', experimentOn);
       fakeWin = env.win;
+      // If there is a viewer, wait for it, so we run with it being
+      // installed.
+      if (env.win.services.viewer) {
+        return viewerPromiseForDoc(env.win.document).then(() => {
+          // Make sure we make a chunk instance, so all runs
+          // have a viewer.
+          chunkInstanceForTesting(env.win.document);
+        });
+      }
     });
 
     it('should execute a chunk', done => {
+      expect(chunkInstanceForTesting(env.win.document).active_).to.equal(
+          experimentOn);
       chunk(fakeWin.document, done);
     });
 
@@ -149,10 +161,9 @@ describe('chunk', () => {
     describe('invisible experiment off', () => {
       beforeEach(() => {
         experimentOn = false;
-        const viewer = viewerForDoc(env.win.document);
-        env.sandbox.stub(viewer, 'isVisible', () => {
-          throw new Error('No calls expected: isVisible');
-        });
+        env.win.postMessage = () => {
+          throw new Error('No calls expected: postMessage');
+        };
         env.win.requestIdleCallback = () => {
           throw new Error('No calls expected: requestIdleCallback');
         };
@@ -171,7 +182,7 @@ describe('chunk', () => {
         env.win.requestIdleCallback =
             resolvingIdleCallbackWithTimeRemaining(15);
         env.sandbox.stub(resolved, 'then', () => {
-          throw new Error('No calls expected');
+          throw new Error('No calls expected .then');
         });
         env.win.location.resetHref('test#visibilityState=hidden');
       });

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -120,8 +120,8 @@ describe('chunk', () => {
         expect(targetOrigin).to.equal('*');
         Promise.resolve().then(() => {
           const event = {
+            data,
             type: 'message',
-            data: data,
           };
           env.win.eventListeners.fire(event);
         });

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -92,7 +92,7 @@ describe('chunk', () => {
     });
   }
 
-  describes.fakeWin('no amp', {
+  describes.fakeWin('visible no amp', {
     amp: false,
   }, env => {
 
@@ -100,6 +100,29 @@ describe('chunk', () => {
       installDocService(env.win, true);
       expect(env.win.services.viewer).to.be.undefined;
       env.win.document.hidden = false;
+    });
+
+    basicTests(env);
+  });
+
+  describes.fakeWin('invisible no amp', {
+    amp: false,
+  }, env => {
+
+    beforeEach(() => {
+      installDocService(env.win, true);
+      expect(env.win.services.viewer).to.be.undefined;
+      env.win.document.hidden = true;
+      env.win.postMessage = function(data, targetOrigin) {
+        expect(targetOrigin).to.equal('*');
+        Promise.resolve().then(() => {
+          const event = {
+            type: 'message',
+            data: data,
+          };
+          env.win.eventListeners.fire(event);
+        });
+      };
     });
 
     basicTests(env);

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -62,6 +62,13 @@ describes.fakeWin('runtime', {
     installAmpdocServices(ampdoc);
   });
 
+  function regularExtension(fn) {
+    return {
+      n: 'extension for testing',
+      f: fn,
+    };
+  }
+
   afterEach(() => {
     ampdocServiceMock.verify();
   });
@@ -122,39 +129,39 @@ describes.fakeWin('runtime', {
   it('should execute scheduled extensions & execute new extensions', () => {
     let progress = '';
     const queueExtensions = win.AMP;
-    win.AMP.push(amp => {
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '1';
-    });
-    win.AMP.push(amp => {
+    }));
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '2';
-    });
-    win.AMP.push(amp => {
+    }));
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '3';
-    });
+    }));
     expect(queueExtensions).to.have.length(3);
     adopt(win);
     runChunksForTesting(win.document);
     expect(queueExtensions).to.have.length(0);
     expect(progress).to.equal('123');
-    win.AMP.push(amp => {
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '4';
-    });
+    }));
     runChunksForTesting(win.document);
     expect(progress).to.equal('1234');
-    win.AMP.push(amp => {
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '5';
-    });
+    }));
     runChunksForTesting(win.document);
     expect(progress).to.equal('12345');
     expect(queueExtensions).to.have.length(0);
   });
 
-  it('should execute function and struct AMP.push callbacks', () => {
+  it('support struct AMP.push raw functions and high priority', () => {
     // New format: {n:string, f:function()}.
     let progress = '';
     const queueExtensions = win.AMP;
@@ -165,40 +172,52 @@ describes.fakeWin('runtime', {
       progress += '1';
     });
     win.AMP.push({
-      n: 'ext1',
+      n: 'ext2',
+      p: 'high',
       f: amp => {
         expect(amp).to.equal(win.AMP);
-        progress += 'A';
+        progress += 'HIGH';
       },
     });
     expect(queueExtensions).to.have.length(2);
     expect(progress).to.equal('');
     adopt(win);
-    runChunksForTesting(win.document);
     expect(queueExtensions).to.have.length(0);
-    expect(progress).to.equal('1A');
+    return Promise.resolve().then(() => {
+      expect(progress).to.equal('1HIGH');
+      win.AMP.push({
+        n: 'ext1',
+        f: amp => {
+          expect(amp).to.equal(win.AMP);
+          progress += 'A';
+        },
+      });
+      runChunksForTesting(win.document);
+      expect(progress).to.equal('1HIGHA');
 
-    // Runtime mode.
-    win.AMP.push(amp => {
-      expect(amp).to.equal(win.AMP);
-      progress += '2';
-    });
-    win.AMP.push({
-      n: 'ext2',
-      f: amp => {
+      // Runtime mode.
+      win.AMP.push(amp => {
         expect(amp).to.equal(win.AMP);
-        progress += 'B';
-      },
+        progress += '2';
+      });
+      win.AMP.push({
+        n: 'ext2',
+        f: amp => {
+          expect(amp).to.equal(win.AMP);
+          progress += 'B';
+        },
+      });
+      return Promise.resolve().then(() => {
+        expect(queueExtensions).to.have.length(0);
+
+        expect(progress).to.equal('1HIGHAB2');
+
+        const extensions = ext.installExtensionsService(win);
+        const ext1 = extensions.waitForExtension('ext1');
+        const ext2 = extensions.waitForExtension('ext2');
+        return Promise.all([ext1, ext2]);
+      });
     });
-    runChunksForTesting(win.document);
-    expect(queueExtensions).to.have.length(0);
-
-    expect(progress).to.equal('1A2B');
-
-    const extensions = ext.installExtensionsService(win);
-    const ext1 = extensions.waitForExtension('ext1');
-    const ext2 = extensions.waitForExtension('ext2');
-    return Promise.all([ext1, ext2]);
   });
 
   it('should wait for body before processing extensions', () => {
@@ -209,32 +228,29 @@ describes.fakeWin('runtime', {
 
     let progress = '';
     const queueExtensions = win.AMP;
-    win.AMP.push(amp => {
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '1';
-    });
-    win.AMP.push(amp => {
+    }));
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '2';
-    });
-    win.AMP.push(amp => {
+    }));
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '3';
-    });
-    expect(queueExtensions).to.have.length(3);
+    }));
     adopt(win);
     runChunksForTesting(win.document);
     // Extensions are still unprocessed
-    expect(queueExtensions).to.have.length(3);
     expect(progress).to.equal('');
 
     // Add one more
-    win.AMP.push(amp => {
+    win.AMP.push(regularExtension(amp => {
       expect(amp).to.equal(win.AMP);
       progress += '4';
-    });
+    }));
     runChunksForTesting(win.document);
-    expect(queueExtensions).to.have.length(3);
     expect(progress).to.equal('');
 
     // Body is available now.
@@ -246,15 +262,15 @@ describes.fakeWin('runtime', {
 
   it('should be robust against errors in early extensions', () => {
     let progress = '';
-    win.AMP.push(() => {
+    win.AMP.push(regularExtension(() => {
       progress += '1';
-    });
-    win.AMP.push(() => {
+    }));
+    win.AMP.push(regularExtension(() => {
       throw new Error('extension error');
-    });
-    win.AMP.push(() => {
+    }));
+    win.AMP.push(regularExtension(() => {
       progress += '3';
-    });
+    }));
     adopt(win);
     expect(() => {
       runChunksForTesting(win.document);


### PR DESCRIPTION
This fixes #6728. THe problem was that chunking can delay the handshake with the viewer for a very long time. During this time the viewer cannot tell the doc that it is now visible–and visibility triggers chunking to go into fast mode. With this change the aggressive chunking mode is only triggered when the doc has gotten into a state where it can communicate with the viewer; and the viewer communication code itself is never delayed in a chunk.