### PR TITLE
amp-bind: Refactor attribute mutation flow

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -53,7 +53,10 @@ export class AmpImg extends BaseElement {
 
       if (name === 'src') {
         this.srcset_ = srcsetFromElement(this.element);
-        this.updateImageSrc_();
+        // This element may not have been laid out yet.
+        if (this.img_) {
+          this.updateImageSrc_();
+        }
       } else if (this.img_ && ATTRIBUTES_TO_PROPAGATE.indexOf(name) >= 0) {
         this.propagateAttributes(name, this.img_,
             /* opt_removeMissingAttrs */ true);

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -48,19 +48,19 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    for (let i = 0; i < mutations.length; i++) {
-      const name = mutations[i].name;
-
-      if (name == 'src') {
-        this.srcset_ = srcsetFromElement(this.element);
-        // This element may not have been laid out yet.
-        if (this.img_) {
-          this.updateImageSrc_();
-        }
-      } else if (this.img_ && ATTRIBUTES_TO_PROPAGATE.indexOf(name) >= 0) {
-        this.propagateAttributes(
-          name, this.img_, /* opt_removeMissingAttrs */ true);
+    if (mutations['src'] !== undefined || mutations['srcset'] !== undefined) {
+      this.srcset_ = srcsetFromElement(this.element);
+      // This element may not have been laid out yet.
+      if (this.img_) {
+        this.updateImageSrc_();
       }
+    }
+
+    if (this.img_) {
+      const attrs = ATTRIBUTES_TO_PROPAGATE.filter(
+          value => mutations[value] !== undefined);
+      this.propagateAttributes(
+          attrs, this.img_, /* opt_removeMissingAttrs */ true);
     }
   }
 

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -48,8 +48,8 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    mutations.forEach(mutation => {
-      const name = mutation.name;
+    for (let i = 0; i < mutations.length; i++) {
+      const name = mutations[i].name;
 
       if (name == 'src') {
         this.srcset_ = srcsetFromElement(this.element);
@@ -61,7 +61,7 @@ export class AmpImg extends BaseElement {
         this.propagateAttributes(
           name, this.img_, /* opt_removeMissingAttrs */ true);
       }
-    });
+    }
   }
 
   /** @override */

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -51,15 +51,15 @@ export class AmpImg extends BaseElement {
     mutations.forEach(mutation => {
       const name = mutation.name;
 
-      if (name === 'src') {
+      if (name == 'src') {
         this.srcset_ = srcsetFromElement(this.element);
         // This element may not have been laid out yet.
         if (this.img_) {
           this.updateImageSrc_();
         }
       } else if (this.img_ && ATTRIBUTES_TO_PROPAGATE.indexOf(name) >= 0) {
-        this.propagateAttributes(name, this.img_,
-            /* opt_removeMissingAttrs */ true);
+        this.propagateAttributes(
+          name, this.img_, /* opt_removeMissingAttrs */ true);
       }
     });
   }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -47,14 +47,18 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override */
-  attributeChangedCallback(name, unusedOldValue, unusedNewValue) {
-    if (name === 'src') {
-      this.srcset_ = srcsetFromElement(this.element);
-      this.updateImageSrc_();
-    } else if (this.img_ && ATTRIBUTES_TO_PROPAGATE.indexOf(name) >= 0) {
-      this.propagateAttributes(name, this.img_,
-          /* opt_removeMissingAttrs */ true);
-    }
+  mutatedAttributesCallback(mutations) {
+    mutations.forEach(mutation => {
+      const name = mutation.name;
+
+      if (name === 'src') {
+        this.srcset_ = srcsetFromElement(this.element);
+        this.updateImageSrc_();
+      } else if (this.img_ && ATTRIBUTES_TO_PROPAGATE.indexOf(name) >= 0) {
+        this.propagateAttributes(name, this.img_,
+            /* opt_removeMissingAttrs */ true);
+      }
+    });
   }
 
   /** @override */

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -24,10 +24,18 @@ const TAG = 'AMP-BIND';
  *   tagName: string,
  *   property: string,
  *   expressionString: string,
- *   expression: (!BindExpression|undefined),
  * }}
  */
 export let EvaluateeDef;
+
+/**
+ * @typedef {{
+ *   tagName: string,
+ *   property: string,
+ *   expression: !BindExpression,
+ * }}
+ */
+let ParsedEvaluateeDef;
 
 /**
  * Asynchronously evaluates a set of Bind expressions.
@@ -37,7 +45,7 @@ export class BindEvaluator {
    * @param {!Array<EvaluateeDef>} evaluatees
    */
   constructor(evaluatees) {
-    /** @const {!Array<EvaluateeDef>} */
+    /** @const {!Array<ParsedEvaluateeDef>} */
     this.evaluatees_ = [];
 
     // TODO(choumx): Add expression result validation to this class.

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -24,7 +24,7 @@ const TAG = 'AMP-BIND';
  *   tagName: string,
  *   property: string,
  *   expressionString: string,
- *   expression: (BindExpression|undefined),
+ *   expression: (!BindExpression|undefined),
  * }}
  */
 export let EvaluateeDef;

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -20,40 +20,62 @@ import {user} from '../../../src/log';
 const TAG = 'AMP-BIND';
 
 /**
+ * @typedef {{
+ *   tagName: string,
+ *   property: string,
+ *   expressionString: string,
+ *   expression: (BindExpression|undefined),
+ * }}
+ */
+export let EvaluateeDef;
+
+/**
  * Asynchronously evaluates a set of Bind expressions.
  */
 export class BindEvaluator {
   /**
-   * @param {!Array<string>} expressionStrings
+   * @param {!Array<EvaluateeDef>} evaluatees
    */
-  constructor(expressionStrings) {
-    /** @const {!Array<!BindExpression>} */
-    this.expressions_ = [];
-    for (let i = 0; i < expressionStrings.length; i++) {
+  constructor(evaluatees) {
+    /** @const {!Array<EvaluateeDef>} */
+    this.evaluatees_ = [];
+
+    // TODO(choumx): Add expression result validation to this class.
+    evaluatees.forEach(e => {
+      let expression;
       try {
-        const expr = new BindExpression(expressionStrings[i]);
-        this.expressions_.push(expr);
+        expression = new BindExpression(e.expressionString);
       } catch (error) {
         user().error(TAG, 'Malformed expression:', error);
       }
-    }
+
+	  if (expression) {
+        this.evaluatees_.push({
+          tagName: e.tagName,
+          property: e.property,
+          expressionString: e.expressionString,
+          expression,
+        });
+      }
+    });
   }
 
   /**
    * Evaluates all expressions with the given `scope` data and resolves
-   * the returned Promise with the results.
+   * the returned Promise with a map of expression strings to results.
    * @param {!Object} scope
-   * @return {!Promise<!Object<string,*>>} Maps expression strings to results.
+   * @return {
+   *   !Promise<!Object<string, ./bind-expression.BindExpressionResultDef>>
+   * }
    */
   evaluate(scope) {
     return new Promise(resolve => {
-      /** @type {!Object<string,*>} */
       const cache = {};
-      this.expressions_.forEach(expression => {
-        const string = expression.expressionString;
+      this.evaluatees_.forEach(evaluatee => {
+        const string = evaluatee.expressionString;
         if (cache[string] === undefined) {
           try {
-            cache[string] = expression.evaluate(scope);
+            cache[string] = evaluatee.expression.evaluate(scope);
           } catch (error) {
             user().error(TAG, error);
           }

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -53,7 +53,6 @@ export class BindEvaluator {
         this.evaluatees_.push({
           tagName: e.tagName,
           property: e.property,
-          expressionString: e.expressionString,
           expression,
         });
       }
@@ -72,7 +71,7 @@ export class BindEvaluator {
     return new Promise(resolve => {
       const cache = {};
       this.evaluatees_.forEach(evaluatee => {
-        const string = evaluatee.expressionString;
+        const string = evaluatee.expression.expressionString;
         if (cache[string] === undefined) {
           try {
             cache[string] = evaluatee.expression.evaluate(scope);

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -57,7 +57,7 @@ export class BindEvaluator {
         user().error(TAG, 'Malformed expression:', error);
       }
 
-	  if (expression) {
+      if (expression) {
         this.evaluatees_.push({
           tagName: e.tagName,
           property: e.property,

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -98,7 +98,7 @@ export class BindExpression {
    * @param {?./bind-expr-defines.AstNode} node
    * @param {!Object} scope
    * @throws {Error}
-   * @return {*}
+   * @return {BindExpressionResultDef}
    * @private
    */
   eval_(node, scope) {
@@ -108,7 +108,8 @@ export class BindExpression {
 
     const {type, args, value} = node;
 
-    if (type === AstNodeType.LITERAL) {
+    // `value` should always exist for literals.
+    if (type === AstNodeType.LITERAL && value !== undefined) {
       return value;
     }
 
@@ -251,7 +252,7 @@ export class BindExpression {
             : this.eval_(args[2], scope);
 
       default:
-        throw new Error(`${type} is not a valid node type.`);
+        throw new Error(`Unexpected AstNodeType: ${type}.`);
     }
   }
 

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -18,6 +18,12 @@ import {AstNodeType} from './bind-expr-defines';
 import {parser} from './bind-expr-impl';
 
 /**
+ * Possible types of a Bind expression evaluation.
+ * @typedef {(null|boolean|string|number|Array|Object)}
+ */
+export let BindExpressionResultDef;
+
+/**
  * Map of object type to function name to whitelisted function.
  * @type {!Object<string, !Object<string, Function>>}
  */
@@ -81,7 +87,7 @@ export class BindExpression {
    * Evaluates the expression given a scope.
    * @param {!Object} scope
    * @throws {Error} On illegal function invocation.
-   * @return {*}
+   * @return {BindExpressionResultDef}
    */
   evaluate(scope) {
     return this.eval_(this.ast_, scope);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -15,41 +15,40 @@
  */
 
 import {BindEvaluator} from './bind-evaluator';
-import {dev, user} from '../../../src/log';
+import {user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber} from '../../../src/types';
-import {vsyncFor} from '../../../src/vsync';
+import {resourcesForDoc} from '../../../src/resources';
 
 const TAG = 'AMP-BIND';
 
 /**
- * A single binding, e.g. <element [property]="expression"></element>.
+ * Regular expression that identifies AMP CSS classes.
+ * @type {!RegExp}
+ */
+const AMP_CSS_RE = /^(-)?amp-/;
+
+/**
+ * A single binding, e.g. [property]="expression".
  * `previousResult` is the result of this expression during the last digest.
  * @typedef {{
- *   property: !string,
- *   expression: !string,
- *   element: !Element,
- *   previousResult: (BindExpressionResultDef|undefined)
+ *   property: string,
+ *   expression: string,
+ *   previousResult: (./bind-expression.BindExpressionResultDef|undefined),
  * }}
  */
 let BindingDef;
 
 /**
- * The state passed through vsync measure/mutate during a Bind digest cycle.
+ * A one or more bindings belonging to a single element.
  * @typedef {{
- *   results: !Object<string,BindExpressionResultDef>,
- *   verifyOnly: boolean
+ *   bindings: !Array<BindingDef>,
+ *   element: !Element,
  * }}
  */
-let BindVsyncStateDef;
-
-/**
- * Possible types of a Bind expression evaluation.
- * @typedef {(null|boolean|string|number|Array|Object)}
- */
-let BindExpressionResultDef;
+let BoundElementDef;
 
 /**
  * Bind is the service that handles the Bind lifecycle, from identifying
@@ -68,8 +67,8 @@ export class Bind {
     /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc = ampdoc;
 
-    /** {!Array<BindingDef>} */
-    this.bindings_ = [];
+    /** {!Array<BoundElementDef>} */
+    this.boundElements_ = [];
 
     /** @const {!Object} */
     this.scope_ = Object.create(null);
@@ -80,14 +79,8 @@ export class Bind {
     /** {?Promise<!Object<string,*>>} */
     this.evaluatePromise_ = null;
 
-    /** @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = vsyncFor(ampdoc.win);
-
-    /** @const {!Function} */
-    this.boundMeasure_ = this.measure_.bind(this);
-
-    /** @const {!Function} */
-    this.boundMutate_ = this.mutate_.bind(this);
+    /** @const {!../../../src/service/resources-impl.Resources} */
+    this.resources_ = resourcesForDoc(ampdoc);
 
     /**
      * Keys correspond to valid attribute value types.
@@ -100,9 +93,9 @@ export class Bind {
     };
 
     this.ampdoc.whenBodyAvailable().then(body => {
-      const {bindings, expressions} = this.scanForBindings_(body);
-      this.bindings_ = bindings;
-      this.evaluator_ = new BindEvaluator(expressions);
+      const {boundElements, evaluatees} = this.scanForBindings_(body);
+      this.boundElements_ = boundElements;
+      this.evaluator_ = new BindEvaluator(evaluatees);
 
       // Trigger verify-only digest in development.
       if (getMode().development) {
@@ -120,6 +113,7 @@ export class Bind {
   setState(state, opt_skipDigest) {
     user().assert(this.enabled_, `Experiment "${TAG}" is disabled.`);
 
+    // TODO(choumx): What if `state` contains references to globals?
     Object.assign(this.scope_, state);
 
     if (!opt_skipDigest) {
@@ -128,235 +122,268 @@ export class Bind {
   }
 
   /**
-   * Scans children for attributes that conform to bind syntax and returns
-   * all bindings.
+   * Scans `body` for attributes that conform to bind syntax and returns
+   * a tuple containing bound elements and binding data for the evaluator.
    * @param {!Element} body
-   * @return {{bindings: !Array<BindingDef>, expressions: !Array<string>}}
+   * @return {{
+   *   boundElements: !Array<BoundElementDef>,
+   *   evaluatees: !Array<./bind-evaluator.EvaluateeDef>,
+   * }}
    * @private
    */
   scanForBindings_(body) {
     // TODO(choumx): Chunk if taking too long in a single frame.
 
-    const bindings = [];
-    const expressions = [];
+    /** @type {!Array<BoundElementDef>} */
+    const boundElements = [];
+    /** @type {!Array<./bind-evaluator.EvaluateeDef>} */
+    const evaluatees = [];
+
     const elements = body.getElementsByTagName('*');
     for (let i = 0; i < elements.length; i++) {
-      const el = elements[i];
-      const attributes = el.attributes;
+      const element = elements[i];
+      const attributes = element.attributes;
+
+      const bindings = [];
       for (let j = 0; j < attributes.length; j++) {
-        const binding = this.bindingForAttribute_(attributes[j], el);
+        const binding = this.bindingForAttribute_(attributes[j], element);
         if (binding) {
           bindings.push(binding);
-          expressions.push(binding.expression);
+          evaluatees.push({
+            tagName: element.tagName,
+            property: binding.property,
+            expressionString: binding.expression,
+          });
         }
       }
+      if (bindings.length > 0) {
+        boundElements.push({element, bindings});
+      }
     }
-    return {bindings, expressions};
+    return {boundElements, evaluatees};
   }
 
   /**
    * Returns a struct representing the binding corresponding to the
    * attribute param, if applicable.
    * @param {!Attr} attribute
-   * @param {!Element} element
+   * @param {!Element} unusedElement
    * @return {?BindingDef}
    * @private
    */
-  bindingForAttribute_(attribute, element) {
-    // TODO(choumx): Only allow binding to attributes allowed by validator.
-
+  bindingForAttribute_(attribute, unusedElement) {
     const name = attribute.name;
-    if (name.length > 2) {
-      if (name[0] === '[' && name[name.length - 1] === ']') {
-        return {
-          property: name.substr(1, name.length - 2),
-          expression: attribute.value,
-          element,
-        };
-      }
+    if (name.length > 2 && name[0] === '[' && name[name.length - 1] === ']') {
+      const property = name.substr(1, name.length - 2);
+      // TODO(choumx): Validate that (unusedElement, attribute) can be bound.
+      return {property, expression: attribute.value};
     }
     return null;
   }
 
   /**
-   * Schedules a vsync task to reevaluate all binding expressions.
+   * Asynchronously reevaluates all expressions and applies results to DOM.
+   * If `opt_verifyOnly` is true, does not apply results but verifies them
+   * against current element values instead.
    * @param {boolean=} opt_verifyOnly
    * @private
    */
   digest_(opt_verifyOnly) {
-    // TODO(choumx): Chunk if takes too long for a single frame.
-
     this.evaluatePromise_ = this.evaluator_.evaluate(this.scope_);
     this.evaluatePromise_.then(results => {
-      /** {!VsyncTaskSpecDef} */
-      const task = {measure: this.boundMeasure_, mutate: this.boundMutate_};
-      this.vsync_.run(task, {
-        results,
-        verifyOnly: !!opt_verifyOnly,
-      });
+      if (!!opt_verifyOnly) {
+        this.verify_(results);
+      } else {
+        this.apply_(results);
+      }
     }).catch(error => {
       user().error(TAG, error);
     });
   }
 
   /**
-   * @param {BindVsyncStateDef} unusedState
+   * Verifies expression results against current DOM state.
+   * @param {Object<string, ./bind-expression.BindExpressionResultDef>} results
    * @private
    */
-  measure_(unusedState) {
-    // TODO(choumx): Validate here or in applyBinding_()?
+  verify_(results) {
+    this.boundElements_.forEach(boundElement => {
+      const {element, bindings} = boundElement;
+
+      bindings.forEach(binding => {
+        const newValue = results[binding.expression];
+        this.verifyBinding_(binding, element, newValue);
+      });
+    });
   }
 
   /**
-   * Either applies or verifies the binding evaluation results in `state`.
-   * @param {BindVsyncStateDef} state
+   * Applies expression results to DOM.
+   * @param {Object<string, ./bind-expression.BindExpressionResultDef>} results
    * @private
    */
-  mutate_(state) {
-    for (let i = 0; i < this.bindings_.length; i++) {
-      const binding = this.bindings_[i];
-      const expression = binding.expression;
-      const result = state.results[expression];
+  apply_(results) {
+    this.boundElements_.forEach(boundElement => {
+      const {element, bindings} = boundElement;
 
-      // Don't apply mutation if the result hasn't changed.
-      if (this.shallowEquals_(result, binding.previousResult)) {
-        continue;
-      } else {
-        binding.previousResult = result;
-      }
+      this.resources_.mutateElement(element, () => {
+        const attributeChanges = [];
+        let width, height;
 
-      if (state.verifyOnly) {
-        this.verifyBinding_(binding, result);
-      } else {
-        this.applyBinding_(binding, result);
-      }
-    }
-  }
+        bindings.forEach(binding => {
+          const newValue = results[binding.expression];
 
-  /**
-   * Applies `newValue` to the element bound in `binding`.
-   * @param {!BindingDef} binding
-   * @param {BindExpressionResultDef} newValue
-   * @private
-   */
-  applyBinding_(binding, newValue) {
-    const property = binding.property;
-    const element = binding.element;
+          // Don't apply mutation if the result hasn't changed.
+          if (this.shallowEquals_(newValue, binding.previousResult)) {
+            return;
+          } else {
+            binding.previousResult = newValue;
+          }
 
-    // TODO(choumx): Does `element.tagName` support binding to `property`?
-    // TODO(choumx): Support objects for attributes.
+          const attrChange = this.applyBinding_(binding, element, newValue);
+          if (attrChange) {
+            attributeChanges.push(attrChange);
+          }
 
-    if (property === 'text') {
-      // TODO(choumx): How to trigger reflow when necessary?
+          switch (binding.property) {
+            case 'width':
+              width = isFiniteNumber(newValue) ? Number(newValue) : width;
+              break;
+            case 'height':
+              height = isFiniteNumber(newValue) ? Number(newValue) : height;
+              break;
+          }
+        });
 
-      element.textContent = newValue;
-    } else if (property === 'class') {
-      // TODO(choumx): SVG elements are an issue, should disallow in validator.
-      // TODO(choumx): Avoid removing internal classes for AMP elements.
-
-      if (Array.isArray(newValue)) {
-        element.className = newValue.join(' ');
-      } else if (typeof newValue === 'string') {
-        element.className = newValue;
-      } else {
-        user().error(TAG, 'Invalid result for class binding', newValue);
-      }
-    } else {
-      // TODO(dvoytenko, #6794): Remove old `-amp-element` form after the new
-      // form is in PROD for 1-2 weeks.
-      const isAmpElement = (element.classList.contains('-amp-element') ||
-          element.classList.contains('i-amphtml-element'));
-      const oldValue = element.getAttribute(property);
-      /** @type {(boolean|number|string|null|undefined)} */
-      let attributeValue;
-
-      if (newValue === true) {
-        element.setAttribute(property, '');
-        attributeValue = '';
-      } else if (newValue === false) {
-        element.removeAttribute(property);
-        attributeValue = null;
-      } else {
-        dev().assert(oldValue !== newValue,
-          `Applying [${property}] binding but value hasn't changed.`);
-
-        attributeValue = this.attributeValueOf_(newValue);
-        if (attributeValue === null) {
-          user().error(TAG, 'Invalid result for attribute binding', newValue);
-          return;
+        if (width !== undefined || height !== undefined) {
+          // TODO(choumx): Add new Resources method for adding change-size
+          // request without scheduling vsync pass since `mutateElement()`
+          // will schedule a pass after a short delay anyways.
+          this.resources_./*OK*/changeSize(element, height, width);
         }
 
-        // TODO(choumx): Does `newValue` pass validator value_casei,
-        // value_regex, blacklisted_value_regex, value_url>allowed_protocol,
-        // mandatory?
+        if (typeof element.mutatedAttributesCallback === 'function') {
+          element.mutatedAttributesCallback(attributeChanges);
+        }
+      });
+    });
+  }
 
-        element.setAttribute(property, attributeValue);
+  /**
+   * Mutates the bound property of `element` with `newValue`.
+   * @param {!BindingDef} binding
+   * @param {!Element} element
+   * @param {./bind-expression.BindExpressionResultDef} newValue
+   * @return ({name: string, oldValue: ?string, newValue:?string}|null)
+   * @private
+   */
+  applyBinding_(binding, element, newValue) {
+    const property = binding.property;
 
-        // Update internal state for AMP elements.
-        if (isAmpElement) {
-          const resources = element.getResources();
-          if (property === 'width') {
-            user().assert(isFiniteNumber(attributeValue),
-                'Invalid result for [width]: %s', attributeValue);
-            resources./*OK*/changeSize(element, undefined, attributeValue);
-          } else if (property === 'height') {
-            user().assert(isFiniteNumber(attributeValue),
-                'Invalid result for [height]: %s', attributeValue);
-            resources./*OK*/changeSize(element, attributeValue, undefined);
+    switch (property) {
+      case 'text':
+        element.textContent = String(newValue);
+        break;
+
+      case 'class':
+        // Preserve internal AMP classes.
+        const ampClasses = [];
+        for (let i = 0; i < element.classList.length; i++) {
+          const cssClass = element.classList[i];
+          if (AMP_CSS_RE.test(cssClass)) {
+            ampClasses.push(cssClass);
           }
         }
-      }
+        if (Array.isArray(newValue)) {
+          element.className = ampClasses.concat(newValue).join(' ');
+        } else if (typeof newValue === 'string') {
+          element.className = ampClasses.join(' ') + ' ' + newValue;
+        } else {
+          user().error(TAG, 'Invalid result for class binding', newValue);
+        }
+        break;
 
-      if (isAmpElement) {
-        element.attributeChangedCallback(property, oldValue, attributeValue);
-      }
+      default:
+        const oldValue = element.getAttribute(property);
+
+        let attributeChanged = true;
+        if (newValue === true && oldValue !== '') {
+          element.setAttribute(property, '');
+        } else if (newValue === false && oldValue !== null) {
+          element.removeAttribute(property);
+        } else if (newValue !== oldValue) {
+          element.setAttribute(property, String(newValue));
+        } else {
+          attributeChanged = false;
+        }
+
+        if (attributeChanged) {
+          return {
+            name: property,
+            oldValue,
+            newValue: element.getAttribute(property),
+          };
+        }
+        break;
     }
+    return null;
   }
 
   /**
-   * If the current value of `binding` equals `expectedValue`, returns true.
+   * If current bound element state equals `expectedValue`, returns true.
    * Otherwise, returns false.
    * @param {!BindingDef} binding
-   * @param {BindExpressionResultDef} expectedValue
+   * @param {!Element} element
+   * @param {./bind-expression.BindExpressionResultDef} expectedValue
    * @private
    */
-  verifyBinding_(binding, expectedValue) {
+  verifyBinding_(binding, element, expectedValue) {
     const property = binding.property;
-    const element = binding.element;
-
-    // TODO(choumx): Support objects for attributes.
 
     let initialValue;
     let match = true;
 
-    if (property === 'text') {
-      initialValue = element.textContent;
-      expectedValue = Object.prototype.toString.call(expectedValue);
-      match = (initialValue.trim() === expectedValue.trim());
-    } else if (property === 'class') {
-      initialValue = element.classList;
-      /** @type {!Array<string>} */
-      let classes = [];
-      if (Array.isArray(expectedValue)) {
-        classes = expectedValue;
-      } else if (typeof expectedValue === 'string') {
-        classes = expectedValue.split(' ');
-      } else {
-        user().error(TAG,
-            'Unsupported result for class binding', expectedValue);
-      }
-      match = this.compareStringArrays_(initialValue, classes);
-    } else {
-      const attribute = element.getAttribute(property);
-      initialValue = attribute;
-      // Boolean attributes return values of either '' or null.
-      if (expectedValue === true) {
-        match = (initialValue === '');
-      } else if (expectedValue === false) {
-        match = (initialValue === null);
-      } else {
-        match = (initialValue === expectedValue);
-      }
+    switch (property) {
+      case 'text':
+        initialValue = element.textContent;
+        expectedValue = Object.prototype.toString.call(expectedValue);
+        match = (initialValue.trim() === expectedValue.trim());
+        break;
+
+      case 'class':
+        initialValue = [];
+        // Ignore internal AMP classes.
+        for (let i = 0; i < element.classList.length; i++) {
+          const cssClass = element.classList[i];
+          if (AMP_CSS_RE.test(cssClass)) {
+            initialValue.push(cssClass);
+          }
+        }
+        /** @type {!Array<string>} */
+        let classes = [];
+        if (Array.isArray(expectedValue)) {
+          classes = expectedValue;
+        } else if (typeof expectedValue === 'string') {
+          classes = expectedValue.split(' ');
+        } else {
+          user().error(TAG,
+              'Unsupported result for class binding', expectedValue);
+        }
+        match = this.compareStringArrays_(initialValue, classes);
+        break;
+
+      default:
+        const attribute = element.getAttribute(property);
+        initialValue = attribute;
+        // Boolean attributes return values of either '' or null.
+        if (expectedValue === true) {
+          match = (initialValue === '');
+        } else if (expectedValue === false) {
+          match = (initialValue === null);
+        } else {
+          match = (initialValue === expectedValue);
+        }
+        break;
     }
 
     if (!match) {
@@ -388,23 +415,9 @@ export class Bind {
   }
 
   /**
-   * Returns `value` if it's an appropriate Element attribute type.
-   * Otherwise, returns null.
-   * @param {BindExpressionResultDef} value
-   * @return {(string|boolean|number|null)}
-   */
-  attributeValueOf_(value) {
-    if (this.attributeValueTypes_[typeof value]) {
-      return /** @type {(string|boolean|number)} */ (value);
-    } else {
-      return null;
-    }
-  }
-
-  /**
    * Checks strict equality of 1D children in arrays and objects.
-   * @param {BindExpressionResultDef|undefined} a
-   * @param {BindExpressionResultDef|undefined} b
+   * @param {./bind-expression.BindExpressionResultDef|undefined} a
+   * @param {./bind-expression.BindExpressionResultDef|undefined} b
    * @return {boolean}
    */
   shallowEquals_(a, b) {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -229,7 +229,7 @@ export class Bind {
       const {element, bindings} = boundElement;
 
       this.resources_.mutateElement(element, () => {
-        const mutations = [];
+        const mutations = {};
         let width, height;
 
         bindings.forEach(binding => {
@@ -244,7 +244,7 @@ export class Bind {
 
           const mutation = this.applyBinding_(binding, element, newValue);
           if (mutation) {
-            mutations.push(mutation);
+            mutations[mutation.name] = mutation.value;
           }
 
           switch (binding.property) {
@@ -308,15 +308,18 @@ export class Bind {
       default:
         const oldValue = element.getAttribute(property);
 
-        let attributeChanged = true;
-        if (newValue === true && oldValue !== '') {
-          element.setAttribute(property, '');
-        } else if (newValue === false && oldValue !== null) {
-          element.removeAttribute(property);
+        let attributeChanged = false;
+        if (typeof newValue === 'boolean') {
+          if (newValue && oldValue !== '') {
+            element.setAttribute(property, '');
+            attributeChanged = true;
+          } else if (!newValue && oldValue !== null) {
+            element.removeAttribute(property);
+            attributeChanged = true;
+          }
         } else if (newValue !== oldValue) {
           element.setAttribute(property, String(newValue));
-        } else {
-          attributeChanged = false;
+          attributeChanged = true;
         }
 
         if (attributeChanged) {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -93,8 +93,9 @@ export class Bind {
       'number': true,
     };
 
-    this.ampdoc.whenBodyAvailable().then(body => {
-      const {boundElements, evaluatees} = this.scanForBindings_(body);
+    this.ampdoc.whenReady().then(() => {
+      const {boundElements, evaluatees} =
+          this.scanForBindings_(ampdoc.getBody());
       this.boundElements_ = boundElements;
       this.evaluator_ = new BindEvaluator(evaluatees);
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -229,7 +229,7 @@ export class Bind {
       const {element, bindings} = boundElement;
 
       this.resources_.mutateElement(element, () => {
-        const attributeChanges = [];
+        const mutations = [];
         let width, height;
 
         bindings.forEach(binding => {
@@ -242,9 +242,9 @@ export class Bind {
             binding.previousResult = newValue;
           }
 
-          const attrChange = this.applyBinding_(binding, element, newValue);
-          if (attrChange) {
-            attributeChanges.push(attrChange);
+          const mutation = this.applyBinding_(binding, element, newValue);
+          if (mutation) {
+            mutations.push(mutation);
           }
 
           switch (binding.property) {
@@ -265,7 +265,7 @@ export class Bind {
         }
 
         if (typeof element.mutatedAttributesCallback === 'function') {
-          element.mutatedAttributesCallback(attributeChanges);
+          element.mutatedAttributesCallback(mutations);
         }
       });
     });
@@ -276,7 +276,7 @@ export class Bind {
    * @param {!BindingDef} binding
    * @param {!Element} element
    * @param {./bind-expression.BindExpressionResultDef} newValue
-   * @return ({name: string, oldValue: ?string, newValue:?string}|null)
+   * @return (?{name: string, value:./bind-expression.BindExpressionResultDef})
    * @private
    */
   applyBinding_(binding, element, newValue) {
@@ -301,7 +301,7 @@ export class Bind {
         } else if (typeof newValue === 'string') {
           element.className = ampClasses.join(' ') + ' ' + newValue;
         } else {
-          user().error(TAG, 'Invalid result for class binding', newValue);
+          user().error(TAG, 'Invalid result for [class]', newValue);
         }
         break;
 
@@ -320,11 +320,7 @@ export class Bind {
         }
 
         if (attributeChanged) {
-          return {
-            name: property,
-            oldValue,
-            newValue: element.getAttribute(property),
-          };
+          return {name: property, value: newValue};
         }
         break;
     }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -26,9 +26,10 @@ const TAG = 'AMP-BIND';
 
 /**
  * Regular expression that identifies AMP CSS classes.
+ * Includes 'i-amphtml-', '-amp-', and 'amp-' prefixes.
  * @type {!RegExp}
  */
-const AMP_CSS_RE = /^(-)?amp-/;
+const AMP_CSS_RE = /^(i?-)?amp(html)?-/;
 
 /**
  * A single binding, e.g. [property]="expression".

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -36,7 +36,7 @@ const AMP_CSS_RE = /^(i?-)?amp(html)?-/;
  * `previousResult` is the result of this expression during the last digest.
  * @typedef {{
  *   property: string,
- *   expression: string,
+ *   expressionString: string,
  *   previousResult: (./bind-expression.BindExpressionResultDef|undefined),
  * }}
  */
@@ -154,7 +154,7 @@ export class Bind {
           evaluatees.push({
             tagName: element.tagName,
             property: binding.property,
-            expressionString: binding.expression,
+            expressionString: binding.expressionString,
           });
         }
       }
@@ -178,7 +178,7 @@ export class Bind {
     if (name.length > 2 && name[0] === '[' && name[name.length - 1] === ']') {
       const property = name.substr(1, name.length - 2);
       // TODO(choumx): Validate that (unusedElement, attribute) can be bound.
-      return {property, expression: attribute.value};
+      return {property, expressionString: attribute.value};
     }
     return null;
   }
@@ -193,7 +193,7 @@ export class Bind {
   digest_(opt_verifyOnly) {
     this.evaluatePromise_ = this.evaluator_.evaluate(this.scope_);
     this.evaluatePromise_.then(results => {
-      if (!!opt_verifyOnly) {
+      if (opt_verifyOnly) {
         this.verify_(results);
       } else {
         this.apply_(results);
@@ -213,7 +213,7 @@ export class Bind {
       const {element, bindings} = boundElement;
 
       bindings.forEach(binding => {
-        const newValue = results[binding.expression];
+        const newValue = results[binding.expressionString];
         this.verifyBinding_(binding, element, newValue);
       });
     });
@@ -233,7 +233,7 @@ export class Bind {
         let width, height;
 
         bindings.forEach(binding => {
-          const newValue = results[binding.expression];
+          const newValue = results[binding.expressionString];
 
           // Don't apply mutation if the result hasn't changed.
           if (this.shallowEquals_(newValue, binding.previousResult)) {

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -52,7 +52,8 @@ describes.realWin('amp-bind', {
    */
   function createAmpElementWithBinding(binding) {
     const parent = env.win.document.getElementById('parent');
-    parent.innerHTML = '<p class="-amp-fake" ' + binding + '></p>';
+    const ampCss = 'i-amphtml-foo -amp-foo amp-foo';
+    parent.innerHTML = `<p class="${ampCss}" ${binding}></p>`;
     const fakeAmpElement = parent.firstElementChild;
     fakeAmpElement.mutatedAttributesCallback = () => {};
     return fakeAmpElement;
@@ -190,9 +191,11 @@ describes.realWin('amp-bind', {
 
   it('should support NOT override internal AMP CSS classes', () => {
     const element = createAmpElementWithBinding(`[class]="['abc']"`);
-    expect(toArray(element.classList)).to.deep.equal(['-amp-fake']);
+    expect(toArray(element.classList)).to.deep.equal(
+        ['i-amphtml-foo', '-amp-foo', 'amp-foo']);
     return onBindReadyAndSetState({}, () => {
-      expect(toArray(element.classList)).to.deep.equal(['-amp-fake', 'abc']);
+      expect(toArray(element.classList)).to.deep.equal(
+          ['i-amphtml-foo', '-amp-foo', 'amp-foo', 'abc']);
     });
   });
 

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -200,16 +200,24 @@ describes.realWin('amp-bind', {
   });
 
   it('should call mutatedAttributesCallback on AMP elements', () => {
-    const binding = '[onePlusOne]="1+1" [added]="true" removed';
+    const binding = '[onePlusOne]="1+1" [twoPlusTwo]="2+2" twoPlusTwo="4"'
+        + '[add]="true" alreadyAdded [alreadyAdded]="true"'
+        + 'remove [remove]="false" [nothingToRemove]="false"';
     const element = createAmpElementWithBinding(binding);
     const spy = env.sandbox.spy(element, 'mutatedAttributesCallback');
-    spy.withArgs('onePlusOne', null, 2);
-    spy.withArgs('added', null, '');
-    spy.withArgs('removed', '', null);
     return onBindReadyAndSetState({}, () => {
-      expect(spy.withArgs('onePlusOne', null, 2).calledOnce);
-      expect(spy.withArgs('added', null, '').calledOnce);
-      expect(spy.withArgs('removed', '', null).calledOnce);
+      // Attribute names are automatically lower-cased.
+      expect(spy).calledWithMatch({
+        oneplusone: 2,
+        add: true,
+        remove: false,
+      });
+      // Callback shouldn't include attributes whose values haven't changed.
+      expect(spy.neverCalledWithMatch({
+        twoplustwo: 4,
+        alreadyadded: true,
+        nothingtoremove: false,
+      })).to.be.true; // sinon-chai doesn't support "never" API.
     });
   });
 

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -52,9 +52,9 @@ describes.realWin('amp-bind', {
    */
   function createAmpElementWithBinding(binding) {
     const parent = env.win.document.getElementById('parent');
-    parent.innerHTML = '<p ' + binding + '></p>';
+    parent.innerHTML = '<p class="-amp-fake" ' + binding + '></p>';
     const fakeAmpElement = parent.firstElementChild;
-    fakeAmpElement.attributeChangedCallback = () => {};
+    fakeAmpElement.mutatedAttributesCallback = () => {};
     return fakeAmpElement;
   }
 
@@ -101,9 +101,9 @@ describes.realWin('amp-bind', {
 
   it('should scan for bindings when body is available', () => {
     createElementWithBinding('[onePlusOne]="1+1"');
-    expect(bind.bindings_.length).to.equal(0);
+    expect(bind.boundElements_.length).to.equal(0);
     return onBindReady(() => {
-      expect(bind.bindings_.length).to.equal(1);
+      expect(bind.boundElements_.length).to.equal(1);
     });
   });
 
@@ -188,10 +188,18 @@ describes.realWin('amp-bind', {
     });
   });
 
-  it('should call attributeChangedCallback on AMP elements', () => {
+  it('should support NOT override internal AMP CSS classes', () => {
+    const element = createAmpElementWithBinding(`[class]="['abc']"`);
+    expect(toArray(element.classList)).to.deep.equal(['-amp-fake']);
+    return onBindReadyAndSetState({}, () => {
+      expect(toArray(element.classList)).to.deep.equal(['-amp-fake', 'abc']);
+    });
+  });
+
+  it('should call mutatedAttributesCallback on AMP elements', () => {
     const binding = '[onePlusOne]="1+1" [added]="true" removed';
     const element = createAmpElementWithBinding(binding);
-    const spy = env.sandbox.spy(element, 'attributeChangedCallback');
+    const spy = env.sandbox.spy(element, 'mutatedAttributesCallback');
     spy.withArgs('onePlusOne', null, 2);
     spy.withArgs('added', null, '');
     spy.withArgs('removed', '', null);
@@ -248,6 +256,4 @@ describes.realWin('amp-bind', {
       expect(stub.calledOnce).to.be.true;
     });
   });
-
-  // TODO(choumx): Add tests for security (binding to banned attributes, etc.).
 });

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -65,7 +65,7 @@ describes.realWin('amp-bind', {
    * @return {!Promise}
    */
   function onBindReady(callback) {
-    return env.ampdoc.whenBodyAvailable().then(() => {
+    return env.ampdoc.whenReady().then(() => {
       if (bind.evaluatePromise_) {
         return bind.evaluatePromise_.then(() => {
           env.flushVsync();
@@ -84,7 +84,7 @@ describes.realWin('amp-bind', {
    * @return {!Promise}
    */
   function onBindReadyAndSetState(state, callback) {
-    return env.ampdoc.whenBodyAvailable().then(() => {
+    return env.ampdoc.whenReady().then(() => {
       bind.setState(state);
       return bind.evaluatePromise_.then(() => {
         env.flushVsync();
@@ -100,7 +100,7 @@ describes.realWin('amp-bind', {
     }).to.throw('Experiment "AMP-BIND" is disabled.');
   });
 
-  it('should scan for bindings when body is available', () => {
+  it('should scan for bindings when ampdoc is ready', () => {
     createElementWithBinding('[onePlusOne]="1+1"');
     expect(bind.boundElements_.length).to.equal(0);
     return onBindReady(() => {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -827,14 +827,15 @@ export class BaseElement {
   }
 
   /**
-   * Called when an attribute's value changes.
+   * Called when one or more attributes are mutated.
+   * Must be invoked during `mutator` block in `Resources#mutateElement`.
    * Boolean attributes have a value of empty string and `null` when
    * present and missing, respectively.
-   * @param {string} unusedName
-   * @param {?string} unusedOldValue
-   * @param {?string} unusedNewValue
+   * @param {
+   *   !Array<{name: string, oldValue: ?string, newValue: ?string}>
+   * } unusedMutations
    */
-  attributeChangedCallback(unusedName, unusedOldValue, unusedNewValue) {
+  mutatedAttributesCallback(unusedMutations) {
     // Subclasses may override.
   }
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -828,11 +828,11 @@ export class BaseElement {
 
   /**
    * Called when one or more attributes are mutated.
-   * Must be invoked during `mutator` block in `Resources#mutateElement`.
-   * Boolean attributes have a value of empty string and `null` when
-   * present and missing, respectively.
+   * @note Must be called inside a mutate context.
+   * @note Boolean attributes have a value of '' and null when
+   *       present and missing, respectively.
    * @param {
-   *   !Array<{name: string, oldValue: ?string, newValue: ?string}>
+   *   !Array<{name: string, value: (null|boolean|string|number|Array|Object)}>
    * } unusedMutations
    */
   mutatedAttributesCallback(unusedMutations) {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -829,10 +829,10 @@ export class BaseElement {
   /**
    * Called when one or more attributes are mutated.
    * @note Must be called inside a mutate context.
-   * @note Boolean attributes have a value of '' and null when
+   * @note Boolean attributes have a value of `true` and `false` when
    *       present and missing, respectively.
    * @param {
-   *   !Array<{name: string, value: (null|boolean|string|number|Array|Object)}>
+   *   !Object<string, (null|boolean|string|number|Array|Object)>
    * } unusedMutations
    */
   mutatedAttributesCallback(unusedMutations) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1225,11 +1225,10 @@ function createBaseCustomElementClass(win) {
     /**
      * Called when one or more attributes are mutated.
      * @note Must be called inside a mutate context.
-     * @note Boolean attributes have a value of '' and null when
+     * @note Boolean attributes have a value of `true` and `false` when
      *       present and missing, respectively.
      * @param {
-     *   !Array<{name: string,
-     *           value: (null|boolean|string|number|Array|Object)}>
+     *   !Object<string, (null|boolean|string|number|Array|Object)>
      * } mutations
      */
     mutatedAttributesCallback(mutations) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1223,14 +1223,16 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * Called when an attribute's value changes.
-     * Only called for observedAttributes or from amp-bind.
-     * @param {!string} name
-     * @param {?string} oldValue
-     * @param {?string} newValue
+     * Called when one or more attributes are mutated.
+     * Must be invoked during `mutator` block in `Resources#mutateElement`.
+     * Boolean attributes have a value of empty string and `null` when
+     * present and missing, respectively.
+     * @param {
+     *   !Array<{name: string, oldValue: ?string, newValue: ?string}>
+     * } mutations
      */
-    attributeChangedCallback(name, oldValue, newValue) {
-      this.implementation_.attributeChangedCallback(name, oldValue, newValue);
+    mutatedAttributesCallback(mutations) {
+      this.implementation_.mutatedAttributesCallback(mutations);
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1224,11 +1224,12 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Called when one or more attributes are mutated.
-     * Must be invoked during `mutator` block in `Resources#mutateElement`.
-     * Boolean attributes have a value of empty string and `null` when
-     * present and missing, respectively.
+     * @note Must be called inside a mutate context.
+     * @note Boolean attributes have a value of '' and null when
+     *       present and missing, respectively.
      * @param {
-     *   !Array<{name: string, oldValue: ?string, newValue: ?string}>
+     *   !Array<{name: string,
+     *           value: (null|boolean|string|number|Array|Object)}>
      * } mutations
      */
     mutatedAttributesCallback(mutations) {


### PR DESCRIPTION
Partial for #6199.

- Changed attribute mutation to use `Resources#mutateElement` instead of `vsync` 
- Use a single callback per element with N mutations rather than N callbacks
- Avoid overwriting AMP CSS classes when applying `[class]` binding
- Pass additional data to `BindEvaluator` for performing runtime validation (to be added later)
- Convert new attribute values to `String` rather than restricting by type

Design details here: https://docs.google.com/a/google.com/document/d/1oQeCELbc_jjwH7MiP8kohYlHcP_XSXlPwhqPQ-KgVhI/pub#h.r5ma7fwbacw4