### PR TITLE
Add support for Bind's linked carousels use case

### DIFF
--- a/examples/bind.amp.html
+++ b/examples/bind.amp.html
@@ -60,9 +60,8 @@
     <h2>Linked carousels</h2>
     <p [text]="'Selected slide: ' + selectedSlide">Selected slide: None<p>
 
-    <!-- Default [slide] to 0 if `selectedSlide` is null. -->
     <amp-carousel controls type=slides width=400 height=300
-        [slide]="selectedSlide || 0"
+        [slide]="selectedSlide"
         on="slidechange:AMP.setState(selectedSlide=event.slide)">
       <amp-img src="https://ampbyexample.com/img/image1.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image2.jpg" width=400 height=300></amp-img>

--- a/examples/bind.amp.html
+++ b/examples/bind.amp.html
@@ -61,8 +61,7 @@
     <p [text]="'Selected slide: ' + selectedSlide">Selected slide: None<p>
 
     <amp-carousel controls type=slides width=400 height=300
-        [slide]="selectedSlide"
-        on="slidechange:AMP.setState(selectedSlide=event.slide)">
+        [slide]="selectedSlide" on="goToSlide:AMP.setState(selectedSlide=event.index)">
       <amp-img src="https://ampbyexample.com/img/image1.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image2.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image3.jpg" width=400 height=300></amp-img>

--- a/examples/bind.amp.html
+++ b/examples/bind.amp.html
@@ -99,7 +99,7 @@
   </amp-carousel>
 
   <p>With &lt;amp-selector&gt;</p>
-  <amp-selector layout=container name="carousel-selector" [selected]="selectedSlide" on="select:AMP.setState(selectedSlide=event.option)">
+  <amp-selector layout=container name="carousel-selector" [selected]="selectedSlide" on="select:AMP.setState(selectedSlide=event.targetOption)">
     <amp-carousel controls width=400 height=100>
         <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75 option=0></amp-img>
         <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75 option=1></amp-img>

--- a/examples/bind.amp.html
+++ b/examples/bind.amp.html
@@ -10,15 +10,24 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
 
   <style amp-custom>
     .redBackground {
       background-color: red;
     }
+    amp-carousel .selected {
+      border: solid 2px red;
+    }
+    amp-img[selected] {
+      border: solid 2px green;
+    }
+    button {
+      border: solid 1px black;
+    }
   </style>
-</head>
 
-<body>
   <amp-state id="myState">
     <script type="application/json">
       {
@@ -26,9 +35,13 @@
       }
     </script>
   </amp-state>
+</head>
 
-  <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle Experiment</button>
+<body>
+  <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle &lt;amp-bind&gt; experiment</button>
+  <button onclick="AMP.toggleExperiment('amp-selector');window.location.href=window.location.href;">Toggle &lt;amp-selector&gt; experiment</button>
 
+  <h2>Basic example</h2>
   <p [text]="foo">After clicking the button below, this will read 'foo'<p>
   <p id="foo" [text]="foo + 'bar'">And this will read 'foobar'<p>
   <p [text]="myState.myStateKey1">This will read 'myStateValue1'<p>
@@ -39,8 +52,66 @@
   <!--
   <amp-video src="https://ampbyexample.com/video/tokyo.mp4" [src]="videoSrc" width=480 height=270 controls></amp-video>
   -->
-  <hr>
-  <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog', videoSrc='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4')">Click me</button>
+  <div>
+    <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog', videoSrc='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4')">Click me</button>
+  </div>
+
+  <div>
+    <h2>Linked carousels</h2>
+    <p [text]="'Selected slide: ' + selectedSlide">Selected slide: None<p>
+
+    <!-- Default [slide] to 0 if `selectedSlide` is null. -->
+    <amp-carousel controls type=slides width=400 height=300
+        [slide]="selectedSlide || 0"
+        on="slidechange:AMP.setState(selectedSlide=event.slide)">
+      <amp-img src="https://ampbyexample.com/img/image1.jpg" width=400 height=300></amp-img>
+      <amp-img src="https://ampbyexample.com/img/image2.jpg" width=400 height=300></amp-img>
+      <amp-img src="https://ampbyexample.com/img/image3.jpg" width=400 height=300></amp-img>
+      <amp-img src="https://ampbyexample.com/img/image1.jpg" width=400 height=300></amp-img>
+      <amp-img src="https://ampbyexample.com/img/image2.jpg" width=400 height=300></amp-img>
+      <amp-img src="https://ampbyexample.com/img/image3.jpg" width=400 height=300></amp-img>
+      <amp-img src="https://ampbyexample.com/img/image1.jpg" width=400 height=300></amp-img>
+      <amp-img src="https://ampbyexample.com/img/image2.jpg" width=400 height=300></amp-img>
+      <amp-img src="https://ampbyexample.com/img/image3.jpg" width=400 height=300></amp-img>
+    </amp-carousel>
+  </div>
+
+  <p>Without &lt;amp-selector&gt;</p>
+  <amp-carousel controls width=400 height=100>
+    <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
+        [class]="selectedSlide == 0 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=0)"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
+        [class]="selectedSlide == 1 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=1)"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
+        [class]="selectedSlide == 2 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=2)"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
+        [class]="selectedSlide == 3 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=3)"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
+        [class]="selectedSlide == 4 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=4)"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
+        [class]="selectedSlide == 5 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=5)"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
+        [class]="selectedSlide == 6 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=6)"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
+        [class]="selectedSlide == 7 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=7)"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
+        [class]="selectedSlide == 8 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=8)"></amp-img>
+  </amp-carousel>
+
+  <p>With &lt;amp-selector&gt;</p>
+  <amp-selector layout=container name="carousel-selector" [selected]="selectedSlide" on="select:AMP.setState(selectedSlide=event.option)">
+    <amp-carousel controls width=400 height=100>
+        <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75 option=0></amp-img>
+        <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75 option=1></amp-img>
+        <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75 option=2></amp-img>
+        <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75 option=3></amp-img>
+        <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75 option=4></amp-img>
+        <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75 option=5></amp-img>
+        <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75 option=6></amp-img>
+        <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75 option=7></amp-img>
+        <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75 option=8></amp-img>
+    </amp-carousel>
+  </amp-selector>
 
   <h2>XHR</h2>
   <p [text]="myState.bindXhrResult">This text will be updated with XHR results.</p>

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -173,19 +173,15 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    mutations.forEach(mutation => {
-      const newValue = mutation.newValue;
-      switch (mutation.name) {
-        case 'slide':
-          const slide = parseInt(newValue, 10);
-          if (isFinite(slide)) {
-            this.showSlide_(slide);
-          } else {
-            user().fine('Invalid [slide] value: %s', newValue);
-          }
-          break;
+    const slide = mutations['slide'];
+    if (slide) {
+      const index = parseInt(slide, 10);
+      if (isFinite(index)) {
+        this.showSlide_(index);
+      } else {
+        user().warn('Invalid [slide] value: %s', slide);
       }
-    });
+    }
   }
 
   /**
@@ -504,15 +500,15 @@ export class AmpSlideScroll extends BaseSlides {
   }
 
   /**
-   * Shows the slide at the given index and triggers a `slidechange` action.
+   * Shows the slide at the given index and triggers a `goToSlide` action.
    * @param {number} newIndex
    * @private
    */
   showSlideAndTriggerAction_(newIndex) {
     this.showSlide_(newIndex);
 
-    const name = 'slidechange';
-    const detail = {slide: newIndex};
+    const name = 'goToSlide';
+    const detail = {index: newIndex};
     const event = new CustomEvent(`slidescroll.${name}`, {detail});
     this.action_.trigger(this.element, name, event);
   }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -38,6 +38,8 @@ const NATIVE_TOUCH_TIMEOUT = 120;
 /** @const {number} */
 const CUSTOM_SNAP_TIMEOUT = 100;
 
+const TAG = 'AMP-CAROUSEL';
+
 export class AmpSlideScroll extends BaseSlides {
 
   /** @param {!AmpElement} element */
@@ -179,7 +181,7 @@ export class AmpSlideScroll extends BaseSlides {
       if (isFinite(index)) {
         this.showSlide_(index);
       } else {
-        user().warn('Invalid [slide] value: %s', slide);
+        user().warn(TAG, 'Invalid [slide] value: %s', slide);
       }
     }
   }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -177,7 +177,7 @@ export class AmpSlideScroll extends BaseSlides {
       const newValue = mutation.newValue;
       switch (mutation.name) {
         case 'slide':
-          const slide = parseInt(newValue);
+          const slide = parseInt(newValue, 10);
           user().assert(isFinite(slide), 'Invalid [slide] value: %s', newValue);
           this.showSlide_(slide);
           break;

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -278,7 +278,7 @@ export class AmpSlideScroll extends BaseSlides {
               (dir == 1 && !hasPrev) ? 0 : this.slideWidth_;
           this.customSnap_(currentScrollLeft, dir);
         } else {
-          this.showSlide_(newIndex, /* opt_isUserAction */ true);
+          this.showSlideAndTriggerAction_(newIndex);
         }
       }
     }
@@ -436,7 +436,7 @@ export class AmpSlideScroll extends BaseSlides {
         this.slidesContainer_.classList.add('-amp-no-scroll');
       }
       // Scroll to new slide and update scrollLeft to the correct slide.
-      this.showSlide_(newIndex, /* opt_isUserAction */ true);
+      this.showSlideAndTriggerAction_(newIndex);
       this.vsync_.mutate(() => {
         if (this.isIos_) {
           // Make the container scrollable again to enable user swiping.
@@ -451,10 +451,9 @@ export class AmpSlideScroll extends BaseSlides {
    * Makes the slide corresponding to the given index and the slides surrounding
    *    it available for display.
    * @param {number} newIndex Index of the slide to be displayed.
-   * @param {boolean=} opt_isUserAction
    * @private
    */
-  showSlide_(newIndex, opt_isUserAction) {
+  showSlide_(newIndex) {
     const noOfSlides_ = this.noOfSlides_;
     if (newIndex < 0 ||
       newIndex >= noOfSlides_ ||
@@ -499,11 +498,20 @@ export class AmpSlideScroll extends BaseSlides {
     this.slideIndex_ = newIndex;
     this.hideRestOfTheSlides_(showIndexArr);
     this.setControlsState();
+  }
 
-    if (opt_isUserAction) {
-      const event = new CustomEvent('SlideChange', {detail: {slide: newIndex}});
-      this.action_.trigger(this.element, 'slidechange', event);
-    }
+  /**
+   * Shows the slide at the given index and triggers a `slidechange` action.
+   * @param {number} newIndex
+   * @private
+   */
+  showSlideAndTriggerAction_(newIndex) {
+    this.showSlide_(newIndex);
+
+    const name = 'slidechange';
+    const detail = {slide: newIndex};
+    const event = new CustomEvent(`slidescroll.${name}`, {detail});
+    this.action_.trigger(this.element, name, event);
   }
 
   /**

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -178,8 +178,11 @@ export class AmpSlideScroll extends BaseSlides {
       switch (mutation.name) {
         case 'slide':
           const slide = parseInt(newValue, 10);
-          user().assert(isFinite(slide), 'Invalid [slide] value: %s', newValue);
-          this.showSlide_(slide);
+          if (isFinite(slide)) {
+            this.showSlide_(slide);
+          } else {
+            user().fine('Invalid [slide] value: %s', newValue);
+          }
           break;
       }
     });

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -940,14 +940,13 @@ describe('SlideScroll', () => {
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
 
-        impl.mutatedAttributesCallback([
-          {
-            name: 'slide',
-            oldValue: 0,
-            newValue: 2,
-          }
-        ]);
+        impl.mutatedAttributesCallback({slide: 2});
         expect(showSlideSpy).to.have.been.calledWith(2);
+
+        // Don't call showSlide_() if slide is not finite.
+        showSlideSpy.reset();
+        impl.mutatedAttributesCallback({slide: Number.POSITIVE_INFINITY});
+        expect(showSlideSpy.called).to.be.false;
       });
     });
 
@@ -960,14 +959,14 @@ describe('SlideScroll', () => {
         impl.goCallback(-1, /* animate */ false);
         expect(triggerSpy).to.have.been.calledWith(
             ampSlideScroll,
-            'slidechange',
-            /* CustomEvent */ sinon.match.has('detail', {slide: 4}));
+            'goToSlide',
+            /* CustomEvent */ sinon.match.has('detail', {index: 4}));
 
         impl.goCallback(1, /* animate */ false);
         expect(triggerSpy).to.have.been.calledWith(
             ampSlideScroll,
-            'slidechange',
-            /* CustomEvent */ sinon.match.has('detail', {slide: 0}));
+            'goToSlide',
+            /* CustomEvent */ sinon.match.has('detail', {index: 0}));
       });
     });
   });

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -933,5 +933,42 @@ describe('SlideScroll', () => {
         expect(showSlideSpy.callCount).to.equal(3);
       });
     });
+
+    it('should update slide when `slide` attribute is mutated', () => {
+      return getAmpSlideScroll(true).then(obj => {
+        const ampSlideScroll = obj.ampSlideScroll;
+        const impl = ampSlideScroll.implementation_;
+        const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+
+        impl.mutatedAttributesCallback([
+          {
+            name: 'slide',
+            oldValue: 0,
+            newValue: 2,
+          }
+        ]);
+        expect(showSlideSpy).to.have.been.calledWith(2);
+      });
+    });
+
+    it('should trigger `slide` action when user changes slides', () => {
+      return getAmpSlideScroll(true).then(obj => {
+        const ampSlideScroll = obj.ampSlideScroll;
+        const impl = ampSlideScroll.implementation_;
+        const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+
+        impl.goCallback(-1, /* animate */ false);
+        expect(triggerSpy).to.have.been.calledWith(
+            ampSlideScroll,
+            'slidechange',
+            /* CustomEvent */ sinon.match.has('detail', {slide: 4}));
+
+        impl.goCallback(1, /* animate */ false);
+        expect(triggerSpy).to.have.been.calledWith(
+            ampSlideScroll,
+            'slidechange',
+            /* CustomEvent */ sinon.match.has('detail', {slide: 0}));
+      });
+    });
   });
 });

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -93,9 +93,9 @@ export class AmpSelector extends AMP.BaseElement {
             }
             const query = selectors.join(',');
             const elements = this.element.querySelectorAll(query);
-            elements.forEach(element => {
-              this.setSelection_(element);
-            });
+            for (let i = 0; i < elements.length; i++) {
+              this.setSelection_(element[i]);
+            }
           }
           this.setInputs_();
           break;

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -74,22 +74,18 @@ export class AmpSelector extends AMP.BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    mutations.forEach(mutation => {
-      switch (mutation.name) {
-        case 'selected':
-          this.selectedAttributeMutated_(mutation.oldValue, mutation.newValue);
-          break;
-      }
-    });
+    const selected = mutations['selected'];
+    if (selected !== undefined) {
+      this.selectedAttributeMutated_(selected);
+    }
   }
 
   /**
    * Handles mutation of the `selected` attribute.
-   * @param {string|Array|null} unusedOldValue
    * @param {string|Array|null} newValue
    * @private
    */
-  selectedAttributeMutated_(unusedOldValue, newValue) {
+  selectedAttributeMutated_(newValue) {
     if (!newValue) {
       this.clearAllSelections_();
       return;

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -37,6 +37,7 @@ describes.realWin('amp-selector', {
     afterEach(() => {
       toggleExperiment(window, 'amp-selector', false);
     });
+
     function getSelector(options) {
       win = env.win;
       const attributes = options.attributes || {};
@@ -511,6 +512,53 @@ describes.realWin('amp-selector', {
       impl.clickHandler_(e);
       expect(setSelectionSpy).to.not.have.been.called;
       expect(clearSelectionSpy).to.not.have.been.called;
+    });
+
+    it('should update selection when `selected` attribute is mutated', () => {
+      const ampSelector = getSelector({
+        config: {
+          count: 5,
+          selectedCount: 1,
+        },
+      });
+
+      const impl = ampSelector.implementation_;
+      ampSelector.build();
+
+      expect(impl.options_[0].hasAttribute('selected')).to.be.true;
+      expect(impl.options_[3].hasAttribute('selected')).to.be.false;
+
+      impl.mutatedAttributesCallback([{
+        name: 'selected',
+        oldValue: '0',
+        newValue: '3',
+      }]);
+
+      expect(impl.options_[0].hasAttribute('selected')).to.be.false;
+      expect(impl.options_[3].hasAttribute('selected')).to.be.true;
+    });
+
+    it('should trigger `select` action when user selects an option', () => {
+      const ampSelector = getSelector({
+        config: {
+          count: 5,
+          selectedCount: 2,
+        },
+      });
+
+      const impl = ampSelector.implementation_;
+      const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+      ampSelector.build();
+
+      let e = {
+        target: impl.options_[3],
+      };
+      impl.clickHandler_(e);
+
+      const eventMatcher =
+          sandbox.match.has('detail', sandbox.match.has('targetOption', '3'));
+      expect(triggerSpy).to.have.been.calledWith(
+          ampSelector, 'select', /* CustomEvent */ eventMatcher);
     });
   });
 });

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -523,8 +523,8 @@ describes.realWin('amp-selector', {
       });
 
       const impl = ampSelector.implementation_;
-      const setInputsSpy = sandbox.spy(impl, 'setInputs_');
       ampSelector.build();
+      const setInputsSpy = sandbox.spy(impl, 'setInputs_');
 
       expect(impl.options_[0].hasAttribute('selected')).to.be.true;
       expect(impl.options_[3].hasAttribute('selected')).to.be.false;

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -523,19 +523,18 @@ describes.realWin('amp-selector', {
       });
 
       const impl = ampSelector.implementation_;
+      const setInputsSpy = sandbox.spy(impl, 'setInputs_');
       ampSelector.build();
 
       expect(impl.options_[0].hasAttribute('selected')).to.be.true;
       expect(impl.options_[3].hasAttribute('selected')).to.be.false;
 
-      impl.mutatedAttributesCallback([{
-        name: 'selected',
-        oldValue: '0',
-        newValue: '3',
-      }]);
+      impl.mutatedAttributesCallback({selected: '3'});
 
       expect(impl.options_[0].hasAttribute('selected')).to.be.false;
       expect(impl.options_[3].hasAttribute('selected')).to.be.true;
+
+      expect(setInputsSpy).calledOnce;
     });
 
     it('should trigger `select` action when user selects an option', () => {
@@ -550,10 +549,7 @@ describes.realWin('amp-selector', {
       const triggerSpy = sandbox.spy(impl.action_, 'trigger');
       ampSelector.build();
 
-      let e = {
-        target: impl.options_[3],
-      };
-      impl.clickHandler_(e);
+      impl.clickHandler_({target: impl.options_[3]});
 
       const eventMatcher =
           sandbox.match.has('detail', sandbox.match.has('targetOption', '3'));


### PR DESCRIPTION
Partial for #6199.

Adds partial binding support to `<amp-carousel>` and `<amp-selector>` for the "linked carousels" Bind use case.

- Support binding to [slide] in `<amp-carousel>` and add event `slidechange` with param `slide` 
- Support binding to [selected] in `<amp-selector>` and add event `select` with params `option` and `options`
- Add linked carousels example HTML to `examples/bind.amp.html`.

Requires #6779 to be merged first.

/to @camelburrito /cc @ericlindley-g