### PR TITLE
Allow amp-form to update amp-state

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -521,7 +521,12 @@ app.get('/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.json.html', func
   });
 });
 
-
+app.use('/bind/form/get', function(req, res, next) {
+  assertCors(req, res, ['GET']);
+  res.json({
+    bindXhrResult: 'I was fetched from the server!'
+  });
+});
 
 /*
  * Start Cache SW LOCALDEV section

--- a/examples/bind.amp.html
+++ b/examples/bind.amp.html
@@ -9,6 +9,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
 
   <style amp-custom>
     .redBackground {
@@ -40,5 +41,13 @@
   -->
   <hr>
   <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog', videoSrc='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4')">Click me</button>
+
+  <h2>XHR</h2>
+  <p [text]="myState.bindXhrResult">This text will be updated with XHR results.</p>
+  <form method="GET" action="/bind/form/get" action-xhr="/bind/form/get" target="_blank"
+      on="submit-success:myState">
+    <input type="submit" value="Submit">
+  </form>
+
 </body>
 </html>

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -20,8 +20,6 @@ import {toggle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
 
-const TAG = 'AMP-STATE';
-
 export class AmpState extends AMP.BaseElement {
   /** @override */
   getPriority() {
@@ -42,35 +40,33 @@ export class AmpState extends AMP.BaseElement {
   /** @override */
   activate(invocation) {
     const event = invocation.event;
-    if (event && event.detail && event.detail.response) {
+    if (event && event.detail) {
       this.updateState_(event.detail.response);
     }
   }
 
   /** @override */
   buildCallback() {
-    const name = this.getName_();
+    const TAG = this.getName_();
 
     toggle(this.element, false);
     this.element.setAttribute('aria-hidden', 'true');
 
-    let json;
     const children = this.element.children;
     if (children.length == 1) {
       const child = children[0];
       if (isJsonScriptTag(child)) {
-        json = tryParseJson(children[0].textContent, e => {
-          user().error(name, 'Failed to parse state. Is it valid JSON?', e);
+        const json = tryParseJson(children[0].textContent, e => {
+          user().error(TAG, 'Failed to parse state. Is it valid JSON?', e);
         });
+        this.updateState_(json, true);
       } else {
-        user().error(name,
+        user().error(TAG,
             'State should be in a <script> tag with type="application/json"');
       }
     } else if (children.length > 1) {
-      user().error(name, 'Should contain only one <script> child.');
+      user().error(TAG, 'Should contain only one <script> child.');
     }
-
-    this.updateState_(json, true);
   }
 
   /** @override */
@@ -80,15 +76,15 @@ export class AmpState extends AMP.BaseElement {
   }
 
   /**
-   * @param {?JSONType} json
+   * @param {*} json
    * @param {boolean=} opt_isInit
    * @private
    */
   updateState_(json, opt_isInit) {
-    if (!json) {
+    if (json === undefined || json === null) {
       return;
     }
-    const id = user().assert(this.element.id, '%s must have an id.', TAG);
+    const id = user().assert(this.element.id, '<amp-state> must have an id.');
     const state = Object.create(null);
     state[id] = json;
     bindForDoc(this.getAmpDoc()).then(bind => {
@@ -102,7 +98,7 @@ export class AmpState extends AMP.BaseElement {
    * @private
    */
   getName_() {
-    return '<' + TAG + '> ' +
+    return '<amp-state> ' +
         (this.element.getAttribute('id') || '<unknown id>');
   }
 }

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -59,7 +59,7 @@ export class AmpState extends AMP.BaseElement {
         const json = tryParseJson(children[0].textContent, e => {
           user().error(TAG, 'Failed to parse state. Is it valid JSON?', e);
         });
-        this.updateState_(json, true);
+        this.updateState_(json, /* opt_isInit */ true);
       } else {
         user().error(TAG,
             'State should be in a <script> tag with type="application/json"');

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -251,13 +251,14 @@ export class AmpForm {
           credentials: 'include',
           requireAmpResponseSourceOrigin: true,
         }).then(response => {
-          this.triggerAction_(true, response);
+          this.triggerAction_(/** success */ true, response);
           // TODO(mkhatib, #6032): Update docs to reflect analytics events.
           this.analyticsEvent_('amp-form-submit-success');
           this.setState_(FormState_.SUBMIT_SUCCESS);
           this.renderTemplate_(response || {});
         }).catch(error => {
-          this.triggerAction_(false, error.responseJson);
+          this.triggerAction_(
+              /** success */ false, error ? error.responseJson : null);
           this.analyticsEvent_('amp-form-submit-error');
           this.setState_(FormState_.SUBMIT_ERROR);
           this.renderTemplate_(error.responseJson || {});

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -251,13 +251,13 @@ export class AmpForm {
           credentials: 'include',
           requireAmpResponseSourceOrigin: true,
         }).then(response => {
-          this.actions_.trigger(this.form_, 'submit-success', null);
+          this.triggerAction_(true, response);
           // TODO(mkhatib, #6032): Update docs to reflect analytics events.
           this.analyticsEvent_('amp-form-submit-success');
           this.setState_(FormState_.SUBMIT_SUCCESS);
           this.renderTemplate_(response || {});
         }).catch(error => {
-          this.actions_.trigger(this.form_, 'submit-error', null);
+          this.triggerAction_(false, error.responseJson);
           this.analyticsEvent_('amp-form-submit-error');
           this.setState_(FormState_.SUBMIT_ERROR);
           this.renderTemplate_(error.responseJson || {});
@@ -279,6 +279,18 @@ export class AmpForm {
         this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
       }
     }
+  }
+
+  /**
+   * Triggers either a submit-success or submit-error action with response data.
+   * @param {boolean} success
+   * @param {?JSONType} json
+   * @private
+   */
+  triggerAction_(success, json) {
+    const name = success ? FormState_.SUBMIT_SUCCESS : FormState_.SUBMIT_ERROR;
+    const event = new CustomEvent(`${TAG}.${name}`, {detail: {response: json}});
+    this.actions_.trigger(this.form_, name, event);
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -251,14 +251,14 @@ export class AmpForm {
           credentials: 'include',
           requireAmpResponseSourceOrigin: true,
         }).then(response => {
-          this.triggerAction_(/** success */ true, response);
+          this.triggerAction_(/* success */ true, response);
           // TODO(mkhatib, #6032): Update docs to reflect analytics events.
           this.analyticsEvent_('amp-form-submit-success');
           this.setState_(FormState_.SUBMIT_SUCCESS);
           this.renderTemplate_(response || {});
         }).catch(error => {
           this.triggerAction_(
-              /** success */ false, error ? error.responseJson : null);
+              /* success */ false, error ? error.responseJson : null);
           this.analyticsEvent_('amp-form-submit-error');
           this.setState_(FormState_.SUBMIT_ERROR);
           this.renderTemplate_(error.responseJson || {});

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -436,7 +436,9 @@ describe('amp-form', () => {
         expect(form.className).to.contain('amp-form-submit-success');
         expect(ampForm.actions_.trigger).to.be.called;
         expect(ampForm.actions_.trigger.calledWith(
-            form, 'submit-success', null)).to.be.true;
+            form,
+            'submit-success',
+            /** CustomEvent */ sinon.match.has('detail'))).to.be.true;
         expect(ampForm.analyticsEvent_).to.be.calledWith(
             'amp-form-submit-success');
       });
@@ -481,7 +483,9 @@ describe('amp-form', () => {
         expect(form.className).to.contain('amp-form-submit-error');
         expect(ampForm.actions_.trigger).to.be.called;
         expect(ampForm.actions_.trigger.calledWith(
-            form, 'submit-error', null)).to.be.true;
+            form,
+            'submit-error',
+            /** CustomEvent */ sinon.match.has('detail'))).to.be.true;
         expect(ampForm.analyticsEvent_).to.be.calledWith(
             'amp-form-submit-error');
       });


### PR DESCRIPTION
Partial for #6199.

- Allows JSON results of a form submission to be passed to `<amp-state>` 
- To support "smart buttons" use case for Bind: #3459