### PR TITLE
Adding margin support to attemptChangeSize

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -846,10 +846,11 @@ function createBaseCustomElementClass(win) {
      *
      * @param {number|undefined} newHeight
      * @param {number|undefined} newWidth
+     * @param {!./layout-rect.LayoutMarginsDef=} opt_newMargins
      * @final
      * @package @this {!Element}
      */
-    changeSize(newHeight, newWidth) {
+    changeSize(newHeight, newWidth, opt_newMargins) {
       const sizer = this.getSizer_();
       if (sizer) {
         // From the moment height is changed the element becomes fully
@@ -868,6 +869,20 @@ function createBaseCustomElementClass(win) {
       }
       if (newWidth !== undefined) {
         setStyle(this, 'width', newWidth, 'px');
+      }
+      if (opt_newMargins) {
+        if (opt_newMargins.top != null) {
+          setStyle(this, 'marginTop', opt_newMargins.top, 'px');
+        }
+        if (opt_newMargins.right != null) {
+          setStyle(this, 'marginRight', opt_newMargins.right, 'px');
+        }
+        if (opt_newMargins.bottom != null) {
+          setStyle(this, 'marginBottom', opt_newMargins.bottom, 'px');
+        }
+        if (opt_newMargins.left != null) {
+          setStyle(this, 'marginLeft', opt_newMargins.left, 'px');
+        }
       }
     }
 

--- a/src/layout-rect.js
+++ b/src/layout-rect.js
@@ -32,6 +32,34 @@ export let LayoutRectDef;
 
 
 /**
+ * The structure that represents the margins of an Element.
+ *
+ * @typedef {{
+ *   top: number,
+ *   right: number,
+ *   bottom: number,
+ *   left: number
+ * }}
+ */
+export let LayoutMarginsDef;
+
+
+/**
+ * The structure that represents a requested change to the margins of an
+ * Element. Any new values specified will replace existing ones (rather than
+ * being additive).
+ *
+ * @typedef {{
+ *   top: (number|undefined),
+ *   right: (number|undefined),
+ *   bottom: (number|undefined),
+ *   left: (number|undefined)
+ * }}
+ */
+export let LayoutMarginsChangeDef;
+
+
+/**
  * Creates a layout rect based on the left, top, width and height parameters
  * in that order.
  * @param {number} left
@@ -138,4 +166,17 @@ export function moveLayoutRect(rect, dx, dy) {
   }
   return layoutRectLtwh(rect.left + dx, rect.top + dy,
       rect.width, rect.height);
+}
+
+
+/**
+ * @param {!LayoutMarginsDef} margins
+ * @param {!LayoutMarginsChangeDef} change
+ * @return {boolean}
+ */
+export function areMarginsChanged(margins, change) {
+  return (change.top !== undefined && change.top != margins.top) ||
+      (change.right !== undefined && change.right != margins.right) ||
+      (change.bottom !== undefined && change.bottom != margins.bottom) ||
+      (change.left !== undefined && change.left != margins.left);
 }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -309,9 +309,10 @@ export class Resource {
    * awaiting the measure and possibly layout.
    * @param {number|undefined} newHeight
    * @param {number|undefined} newWidth
+   * @param {!../layout-rect.LayoutMarginsChangeDef=} opt_newMargins
    */
-  changeSize(newHeight, newWidth) {
-    this.element./*OK*/changeSize(newHeight, newWidth);
+  changeSize(newHeight, newWidth, opt_newMargins) {
+    this.element./*OK*/changeSize(newHeight, newWidth, opt_newMargins);
     // Schedule for re-layout.
     if (this.state_ != ResourceState.NOT_BUILT) {
       this.state_ = ResourceState.NOT_LAID_OUT;
@@ -323,15 +324,20 @@ export class Resource {
    * @param {boolean} overflown
    * @param {number|undefined} requestedHeight
    * @param {number|undefined} requestedWidth
+   * @param {!../layout-rect.LayoutMarginsChangeDef|undefined}
+   *     requestedMargins
    */
-  overflowCallback(overflown, requestedHeight, requestedWidth) {
+  overflowCallback(overflown, requestedHeight, requestedWidth,
+      requestedMargins) {
     if (overflown) {
       this.pendingChangeSize_ = {
         height: requestedHeight,
         width: requestedWidth,
+        margins: requestedMargins,
       };
     }
-    this.element.overflowCallback(overflown, requestedHeight, requestedWidth);
+    this.element.overflowCallback(overflown, requestedHeight, requestedWidth,
+        requestedMargins);
   }
 
   resetPendingChangeSize() {

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -917,9 +917,13 @@ describe('CustomElement', () => {
 
   it('should change size without sizer', () => {
     const element = new ElementClass();
-    element.changeSize(111, 222);
+    element.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
     expect(element.style.height).to.equal('111px');
     expect(element.style.width).to.equal('222px');
+    expect(element.style.marginTop).to.equal('1px');
+    expect(element.style.marginRight).to.equal('2px');
+    expect(element.style.marginBottom).to.equal('3px');
+    expect(element.style.marginLeft).to.equal('4px');
   });
 
   it('should change size - height only without sizer', () => {
@@ -934,15 +938,49 @@ describe('CustomElement', () => {
     expect(element.style.width).to.equal('111px');
   });
 
+  it('should change size - margins only without sizer', () => {
+    const element = new ElementClass();
+    element.changeSize(undefined, undefined,
+        {top: 1, right: 2, bottom: 3, left: 4});
+    expect(element.style.marginTop).to.equal('1px');
+    expect(element.style.marginRight).to.equal('2px');
+    expect(element.style.marginBottom).to.equal('3px');
+    expect(element.style.marginLeft).to.equal('4px');
+  });
+
+  it('should change size - some margins only without sizer', () => {
+    const element = new ElementClass();
+    element.style.margin = '1px 2px 3px 4px';
+    element.changeSize(undefined, undefined, {top: 5, left: 6});
+    expect(element.style.marginTop).to.equal('5px');
+    expect(element.style.marginRight).to.equal('2px');
+    expect(element.style.marginBottom).to.equal('3px');
+    expect(element.style.marginLeft).to.equal('6px');
+  });
+
+  it('should change size - some margins only without sizer', () => {
+    const element = new ElementClass();
+    element.style.margin = '1px 2px 3px 4px';
+    element.changeSize(undefined, undefined, {top: 5, left: 6});
+    expect(element.style.marginTop).to.equal('5px');
+    expect(element.style.marginRight).to.equal('2px');
+    expect(element.style.marginBottom).to.equal('3px');
+    expect(element.style.marginLeft).to.equal('6px');
+  });
+
   it('should change size with sizer', () => {
     const element = new ElementClass();
     const sizer = document.createElement('div');
     element.sizerElement_ = sizer;
-    element.changeSize(111, 222);
+    element.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
     expect(parseInt(sizer.style.paddingTop, 10)).to.equal(0);
     expect(element.sizerElement_).to.be.null;
     expect(element.style.height).to.equal('111px');
     expect(element.style.width).to.equal('222px');
+    expect(element.style.marginTop).to.equal('1px');
+    expect(element.style.marginRight).to.equal('2px');
+    expect(element.style.marginBottom).to.equal('3px');
+    expect(element.style.marginLeft).to.equal('4px');
   });
 
   it('should NOT apply media condition in template', () => {

--- a/test/functional/test-layout-rect.js
+++ b/test/functional/test-layout-rect.js
@@ -109,3 +109,84 @@ describe('LayoutRect', () => {
     expect(lr.rectIntersection(rect1, rect2, rect3, rect4)).to.be.null;
   });
 });
+
+describe('areMarginsChanged', () => {
+  it('should find margins are not changed when values the same', () => {
+    const margins = {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    };
+    const changes = {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    };
+    expect(lr.areMarginsChanged(margins, changes)).to.be.false;
+  });
+
+  it('should find margins are not changed when all changes undefined', () => {
+    const margins = {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    };
+    const changes = {};
+    expect(lr.areMarginsChanged(margins, changes)).to.be.false;
+  });
+
+  it('should find margins to be changed when top different', () => {
+    const margins = {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    };
+    const changes = {
+      top: 5,
+    };
+    expect(lr.areMarginsChanged(margins, changes)).to.be.true;
+  });
+
+  it('should find margins to be changed when right different', () => {
+    const margins = {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    };
+    const changes = {
+      right: 5,
+    };
+    expect(lr.areMarginsChanged(margins, changes)).to.be.true;
+  });
+
+  it('should find margins to be changed when bottom different', () => {
+    const margins = {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    };
+    const changes = {
+      bottom: 5,
+    };
+    expect(lr.areMarginsChanged(margins, changes)).to.be.true;
+  });
+
+  it('should find margins to be changed when left different', () => {
+    const margins = {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    };
+    const changes = {
+      left: 5,
+    };
+    expect(lr.areMarginsChanged(margins, changes)).to.be.true;
+  });
+});

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -57,6 +57,12 @@ describe('Resource', () => {
       togglePlaceholder: () => sandbox.spy(),
       getPriority: () => 2,
       dispatchCustomEvent: () => {},
+      fakeComputedStyle: {
+        marginTop: '1px',
+        marginRight: '2px',
+        marginBottom: '3px',
+        marginLeft: '4px',
+      },
     };
     elementMock = sandbox.mock(element);
 
@@ -65,6 +71,14 @@ describe('Resource', () => {
     resources = new Resources(new AmpDocSingle(window));
     resource = new Resource(1, element, resources);
     viewportMock = sandbox.mock(resources.viewport_);
+
+    resources.win = {
+      document,
+      getComputedStyle: el => {
+        return el.fakeComputedStyle ?
+            el.fakeComputedStyle : window.getComputedStyle(el);
+      },
+    };
   });
 
   afterEach(() => {
@@ -141,10 +155,7 @@ describe('Resource', () => {
         return false;
       },
     };
-    resource.resources_ = {
-      win: window,
-      getViewport: () => viewport,
-    };
+    resource.resources_.getViewport = () => viewport;
     expect(() => {
       resource.measure();
     }).to.not.throw();
@@ -491,15 +502,17 @@ describe('Resource', () => {
 
   it('should change size and update state', () => {
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
-    elementMock.expects('changeSize').withExactArgs(111, 222).once();
-    resource.changeSize(111, 222);
+    elementMock.expects('changeSize').withExactArgs(111, 222,
+        {top: 1, right: 2, bottom: 3, left: 4}).once();
+    resource.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
     expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
   });
 
   it('should change size but not state', () => {
     resource.state_ = ResourceState.NOT_BUILT;
-    elementMock.expects('changeSize').withExactArgs(111, 222).once();
-    resource.changeSize(111, 222);
+    elementMock.expects('changeSize').withExactArgs(111, 222,
+        {top: 1, right: 2, bottom: 3, left: 4}).once();
+    resource.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
     expect(resource.getState()).to.equal(ResourceState.NOT_BUILT);
   });
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -721,6 +721,12 @@ describe('Resources discoverWork', () => {
       unlayoutOnPause: () => true,
       togglePlaceholder: () => sandbox.spy(),
       getPriority: () => 1,
+      fakeComputedStyle: {
+        marginTop: '0px',
+        marginRight: '0px',
+        marginBottom: '0px',
+        marginLeft: '0px',
+      },
     };
   }
 
@@ -740,6 +746,14 @@ describe('Resources discoverWork', () => {
     sandbox = sinon.sandbox.create();
     resources = new Resources(new AmpDocSingle(window));
     viewportMock = sandbox.mock(resources.viewport_);
+
+    resources.win = {
+      document,
+      getComputedStyle: el => {
+        return el.fakeComputedStyle ?
+            el.fakeComputedStyle : window.getComputedStyle(el);
+      },
+    };
 
     resource1 = createResource(1, layoutRectLtwh(10, 10, 100, 100));
     resource2 = createResource(2, layoutRectLtwh(10, 1010, 100, 100));
@@ -1046,6 +1060,12 @@ describe('Resources changeSize', () => {
           (unused_overflown, unused_requestedHeight, unused_requestedWidth) => {
           },
       getPriority: () => 0,
+      fakeComputedStyle: {
+        marginTop: '0px',
+        marginRight: '0px',
+        marginBottom: '0px',
+        marginLeft: '0px',
+      },
     };
   }
 
@@ -1069,6 +1089,12 @@ describe('Resources changeSize', () => {
     clock = sandbox.useFakeTimers();
     resources = new Resources(new AmpDocSingle(window));
     resources.isRuntimeOn_ = false;
+    resources.win = {
+      getComputedStyle: el => {
+        return el.fakeComputedStyle ?
+            el.fakeComputedStyle : window.getComputedStyle(el);
+      },
+    };
     viewportMock = sandbox.mock(resources.viewport_);
 
     resource1 = createResource(1, layoutRectLtwh(10, 10, 100, 100));
@@ -1082,8 +1108,8 @@ describe('Resources changeSize', () => {
   });
 
   it('should schedule separate requests', () => {
-    resources.scheduleChangeSize_(resource1, 111, 100, false);
-    resources.scheduleChangeSize_(resource2, 222, undefined, true);
+    resources.scheduleChangeSize_(resource1, 111, 100, undefined, false);
+    resources.scheduleChangeSize_(resource2, 222, undefined, undefined, true);
 
     expect(resources.requestsChangeSize_.length).to.equal(2);
     expect(resources.requestsChangeSize_[0].resource).to.equal(resource1);
@@ -1098,17 +1124,18 @@ describe('Resources changeSize', () => {
   });
 
   it('should schedule height only size change', () => {
-    resources.scheduleChangeSize_(resource1, 111, undefined, false);
+    resources.scheduleChangeSize_(resource1, 111, undefined, undefined, false);
     expect(resources.requestsChangeSize_.length).to.equal(1);
     expect(resources.requestsChangeSize_[0].resource).to.equal(resource1);
     expect(resources.requestsChangeSize_[0].newHeight).to.equal(111);
     expect(resources.requestsChangeSize_[0].newWidth).to.be.undefined;
+    expect(resources.requestsChangeSize_[0].newMargins).to.be.undefined;
     expect(resources.requestsChangeSize_[0].force).to.equal(false);
   });
 
   it('should remove request change size for unloaded resources', () => {
-    resources.scheduleChangeSize_(resource1, 111, undefined, false);
-    resources.scheduleChangeSize_(resource2, 111, undefined, false);
+    resources.scheduleChangeSize_(resource1, 111, undefined, undefined, false);
+    resources.scheduleChangeSize_(resource2, 111, undefined, undefined, false);
     expect(resources.requestsChangeSize_.length).to.equal(2);
     resource1.unload();
     resources.cleanupTasks_(resource1);
@@ -1117,17 +1144,33 @@ describe('Resources changeSize', () => {
   });
 
   it('should schedule width only size change', () => {
-    resources.scheduleChangeSize_(resource1, undefined, 111,false);
+    resources.scheduleChangeSize_(resource1, undefined, 111, undefined, false);
     expect(resources.requestsChangeSize_.length).to.equal(1);
     expect(resources.requestsChangeSize_[0].resource).to.equal(resource1);
     expect(resources.requestsChangeSize_[0].newWidth).to.equal(111);
     expect(resources.requestsChangeSize_[0].newHeight).to.be.undefined;
+    expect(resources.requestsChangeSize_[0].marginChange).to.be.undefined;
+    expect(resources.requestsChangeSize_[0].force).to.equal(false);
+  });
+
+  it('should schedule margin only size change', () => {
+    resources.scheduleChangeSize_(resource1, undefined, undefined,
+        {top: 1, right: 2, bottom: 3, left: 4}, false);
+    resources.vsync_.runScheduledTasks_();
+    expect(resources.requestsChangeSize_.length).to.equal(1);
+    expect(resources.requestsChangeSize_[0].resource).to.equal(resource1);
+    expect(resources.requestsChangeSize_[0].newWidth).to.be.undefined;
+    expect(resources.requestsChangeSize_[0].newHeight).to.be.undefined;
+    expect(resources.requestsChangeSize_[0].marginChange).to.eql({
+      newMargins: {top: 1, right: 2, bottom: 3, left: 4},
+      currentMargins: {top: 0, right: 0, bottom: 0, left: 0},
+    });
     expect(resources.requestsChangeSize_[0].force).to.equal(false);
   });
 
   it('should only schedule latest request for the same resource', () => {
-    resources.scheduleChangeSize_(resource1, 111, 100, true);
-    resources.scheduleChangeSize_(resource1, 222, 300, false);
+    resources.scheduleChangeSize_(resource1, 111, 100, undefined, true);
+    resources.scheduleChangeSize_(resource1, 222, 300, undefined, false);
 
     expect(resources.requestsChangeSize_.length).to.equal(1);
     expect(resources.requestsChangeSize_[0].resource).to.equal(resource1);
@@ -1137,7 +1180,7 @@ describe('Resources changeSize', () => {
   });
 
   it('should NOT change size if it didn\'t change', () => {
-    resources.scheduleChangeSize_(resource1, 100, 100, true);
+    resources.scheduleChangeSize_(resource1, 100, 100, undefined, true);
     resources.mutateWork_();
     expect(resources.relayoutTop_).to.equal(-1);
     expect(resources.requestsChangeSize_.length).to.equal(0);
@@ -1145,7 +1188,7 @@ describe('Resources changeSize', () => {
   });
 
   it('should change size', () => {
-    resources.scheduleChangeSize_(resource1, 111, 222, true);
+    resources.scheduleChangeSize_(resource1, 111, 222, undefined, true);
     resources.mutateWork_();
     expect(resources.relayoutTop_).to.equal(resource1.layoutBox_.top);
     expect(resources.requestsChangeSize_.length).to.equal(0);
@@ -1155,8 +1198,8 @@ describe('Resources changeSize', () => {
   });
 
   it('should pick the smallest relayoutTop', () => {
-    resources.scheduleChangeSize_(resource2, 111, 222, true);
-    resources.scheduleChangeSize_(resource1, 111, 222, true);
+    resources.scheduleChangeSize_(resource2, 111, 222, undefined, true);
+    resources.scheduleChangeSize_(resource1, 111, 222, undefined, true);
     resources.mutateWork_();
     expect(resources.relayoutTop_).to.equal(resource1.layoutBox_.top);
   });
@@ -1166,8 +1209,8 @@ describe('Resources changeSize', () => {
     resource1.measure = sandbox.spy();
     resource2.measure = sandbox.spy();
 
-    resources.scheduleChangeSize_(resource1, 111, 200, true);
-    resources.scheduleChangeSize_(resource2, 111, 222, true);
+    resources.scheduleChangeSize_(resource1, 111, 200, undefined, true);
+    resources.scheduleChangeSize_(resource2, 111, 222, undefined, true);
     expect(resource1.hasBeenMeasured()).to.be.false;
     expect(resource2.hasBeenMeasured()).to.be.true;
 
@@ -1205,8 +1248,8 @@ describe('Resources changeSize', () => {
       const callback = sandbox.spy();
       resource1.layoutBox_ = {top: 10, left: 0, right: 100, bottom: 210,
           height: 50};
-      resources.scheduleChangeSize_(resource1, 50, /* width */ undefined, false,
-          callback);
+      resources.scheduleChangeSize_(resource1, 50, /* width */ undefined,
+          undefined, false, callback);
       resources.mutateWork_();
       expect(resource1.changeSize).to.not.been.called;
       expect(overflowCallbackSpy).to.not.been.called;
@@ -1214,8 +1257,53 @@ describe('Resources changeSize', () => {
       expect(callback.args[0][0]).to.be.true;
     });
 
+    it('should NOT change size when height and margins are unchanged', () => {
+      const callback = sandbox.spy();
+      resource1.layoutBox_ = {top: 10, left: 0, right: 100, bottom: 210,
+          height: 50};
+      resource1.element.fakeComputedStyle = {
+        marginTop: '1px',
+        marginRight: '2px',
+        marginBottom: '3px',
+        marginLeft: '4px',
+      };
+      resources.scheduleChangeSize_(resource1, 50, /* width */ undefined,
+          {top: 1, right: 2, bottom: 3, left: 4}, false, callback);
+
+      expect(vsyncSpy.callCount).to.equal(1);
+      const task = vsyncSpy.lastCall.args[0];
+      task.measure({});
+
+      resources.mutateWork_();
+      expect(resource1.changeSize).to.not.been.called;
+      expect(overflowCallbackSpy).to.not.been.called;
+      expect(callback).to.be.calledOnce;
+      expect(callback.args[0][0]).to.be.true;
+    });
+
+    it('should change size when margins but not height changed', () => {
+      const callback = sandbox.spy();
+      resource1.layoutBox_ = {top: 10, left: 0, right: 100, bottom: 210,
+          height: 50};
+      resource1.element.fakeComputedStyle = {
+        marginTop: '1px',
+        marginRight: '2px',
+        marginBottom: '3px',
+        marginLeft: '4px',
+      };
+      resources.scheduleChangeSize_(resource1, 50, /* width */ undefined,
+          {top: 1, right: 2, bottom: 4, left: 4}, false, callback);
+
+      expect(vsyncSpy.callCount).to.equal(1);
+      const task = vsyncSpy.lastCall.args[0];
+      task.measure({});
+
+      resources.mutateWork_();
+      expect(resource1.changeSize).to.be.calledOnce;
+    });
+
     it('should change size when forced', () => {
-      resources.scheduleChangeSize_(resource1, 111, 222, true);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, true);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_).to.be.empty;
       expect(resource1.changeSize).to.be.calledOnce;
@@ -1228,7 +1316,7 @@ describe('Resources changeSize', () => {
       sandbox.stub(resources.viewer_, 'getVisibilityState').returns(
         VisibilityState.PRERENDER
       );
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_).to.be.empty;
       expect(resource1.changeSize).to.be.calledOnce;
@@ -1238,7 +1326,7 @@ describe('Resources changeSize', () => {
 
     it('should change size when active', () => {
       resource1.element.contains = () => true;
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_).to.be.empty;
       expect(resource1.changeSize).to.be.calledOnce;
@@ -1249,7 +1337,7 @@ describe('Resources changeSize', () => {
     it('should change size when below the viewport', () => {
       resource1.layoutBox_ = {top: 10, left: 0, right: 100, bottom: 1050,
           height: 50};
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_).to.be.empty;
       expect(resource1.changeSize).to.be.calledOnce;
@@ -1262,7 +1350,7 @@ describe('Resources changeSize', () => {
           height: 50};
       resources.lastVelocity_ = 10;
       resources.lastScrollTime_ = Date.now();
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_.length).to.equal(1);
       expect(resource1.changeSize).to.not.been.called;
@@ -1276,7 +1364,7 @@ describe('Resources changeSize', () => {
           height: 50};
       resources.lastVelocity_ = 0;
       clock.tick(5000);
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_).to.be.empty;
       expect(resource1.changeSize).to.not.been.called;
@@ -1303,7 +1391,7 @@ describe('Resources changeSize', () => {
           height: 50};
       resources.lastVelocity_ = 0;
       clock.tick(5000);
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_).to.be.empty;
       expect(resource1.changeSize).to.not.been.called;
@@ -1324,7 +1412,7 @@ describe('Resources changeSize', () => {
     });
 
     it('in vp should NOT call overflowCallback if new height smaller', () => {
-      resources.scheduleChangeSize_(resource1, 10, 11, false);
+      resources.scheduleChangeSize_(resource1, 10, 11, undefined, false);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_).to.be.empty;
       expect(resource1.changeSize).to.not.been.called;
@@ -1332,28 +1420,99 @@ describe('Resources changeSize', () => {
     });
 
     it('in viewport should NOT change size and calls overflowCallback', () => {
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222,
+          {top: 1, right: 2, bottom: 3, left: 4}, false);
+
+      expect(vsyncSpy.callCount).to.equal(1);
+      const task = vsyncSpy.lastCall.args[0];
+      task.measure({});
+
       resources.mutateWork_();
       expect(resources.requestsChangeSize_.length).to.equal(0);
       expect(resource1.changeSize).to.not.been.called;
       expect(overflowCallbackSpy).to.be.calledOnce;
-      expect(overflowCallbackSpy).to.be.calledWith(true, 111, 222);
+      expect(overflowCallbackSpy).to.be.calledWith(true, 111, 222,
+          {top: 1, right: 2, bottom: 3, left: 4});
       expect(resource1.getPendingChangeSize()).to.jsonEqual(
-          {height: 111, width: 222});
+          {height: 111, width: 222,
+           margins: {top: 1, right: 2, bottom: 3, left: 4}});
+    });
+
+    it('should NOT change size when resized margin in viewport and should ' +
+        'call overflowCallback', () => {
+      resource1.layoutBox_ = {top: -50, left: 0, right: 100, bottom: 0,
+          height: 50};
+      resource1.element.fakeComputedStyle = {
+        marginBottom: '21px',
+      };
+
+      resources.scheduleChangeSize_(resource1, undefined, undefined,
+          {bottom: 22}, false);
+
+      expect(vsyncSpy.callCount).to.equal(1);
+      const task = vsyncSpy.lastCall.args[0];
+      task.measure({});
+
+      resources.mutateWork_();
+      expect(resources.requestsChangeSize_.length).to.equal(0);
+      expect(resource1.changeSize).to.not.been.called;
+      expect(overflowCallbackSpy).to.be.calledOnce;
+      expect(overflowCallbackSpy).to.be.calledWith(true, undefined,
+          undefined, {bottom: 22});
+      expect(resource1.getPendingChangeSize()).to.jsonEqual(
+          {height: undefined, width: undefined, margins: {bottom: 22}});
+    });
+
+    it('should change size when resized margin above viewport', () => {
+      resource1.layoutBox_ = {top: -50, left: 0, right: 100, bottom: 0,
+          height: 50};
+      resource1.element.fakeComputedStyle = {
+        marginBottom: '21px',
+      };
+      viewportMock.expects('getScrollHeight').returns(2999).once();
+      viewportMock.expects('getScrollTop').returns(1777).once();
+
+      resources.lastVelocity_ = 0;
+      clock.tick(5000);
+      resources.scheduleChangeSize_(resource1, undefined, undefined,
+          {top: 1}, false);
+
+      expect(vsyncSpy.callCount).to.equal(1);
+      const marginsTask = vsyncSpy.lastCall.args[0];
+      marginsTask.measure({});
+
+      resources.mutateWork_();
+      expect(resources.requestsChangeSize_).to.be.empty;
+      expect(resource1.changeSize).to.not.been.called;
+
+      expect(vsyncSpy.callCount).to.be.greaterThan(2);
+      const scrollAdjustTask = vsyncSpy.lastCall.args[0];
+      const state = {};
+      scrollAdjustTask.measure(state);
+      expect(state.scrollTop).to.equal(1777);
+      expect(state.scrollHeight).to.equal(2999);
+
+      viewportMock.expects('getScrollHeight').returns(3999).once();
+      viewportMock.expects('setScrollTop').withExactArgs(2777).once();
+      scrollAdjustTask.mutate(state);
+      expect(resource1.changeSize).to.be.calledOnce;
+      expect(resource1.changeSize).to.be.calledWith(undefined, undefined,
+          {top: 1});
+      expect(resources.relayoutTop_).to.equal(resource1.layoutBox_.top);
     });
 
     it('should reset pending change size when rescheduling', () => {
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resource1.getPendingChangeSize().height).to.equal(111);
       expect(resource1.getPendingChangeSize().width).to.equal(222);
 
-      resources.scheduleChangeSize_(resource1, 112, 223, false);
+      resources.scheduleChangeSize_(resource1, 112, 223, undefined, false);
       expect(resource1.getPendingChangeSize()).to.be.undefined;
     });
 
     it('should force resize after focus', () => {
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resource1.getPendingChangeSize()).to.jsonEqual(
           {height: 111, width: 222});
@@ -1383,14 +1542,14 @@ describe('Resources changeSize', () => {
 
     it('should NOT change size when far the bottom of the document', () => {
       viewportMock.expects('getScrollHeight').returns(10000).once();
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resource1.changeSize).to.not.been.called;
     });
 
     it('should change size when close to the bottom of the document', () => {
       viewportMock.expects('getScrollHeight').returns(110).once();
-      resources.scheduleChangeSize_(resource1, 111, 222, false);
+      resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resource1.changeSize).to.be.calledOnce;
     });


### PR DESCRIPTION
Allows the margins on an element to be changed via the attemptChangeSize function in resources-impl.js.

https://github.com/ampproject/amphtml/issues/6626