### PR TITLE
loading indicator animation: translateX instead of left

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -346,7 +346,6 @@ i-amp-scroll-container.amp-active {
 .i-amphtml-loader-moving-line {
   display: block;
   position: absolute;
-  left: -100%;
   width: 100%;
   height: 100% !important;
   background-color: #979797;
@@ -354,8 +353,8 @@ i-amp-scroll-container.amp-active {
 }
 
 @keyframes i-amphtml-loader-line-moving {
-  0% {left: -100%;}
-  100% {left: 100%;}
+  0% {transform: translateX(-100%);}
+  100% {transform: translateX(100%);}
 }
 
 .i-amphtml-loader-line.amp-active .i-amphtml-loader-moving-line {


### PR DESCRIPTION
Small change with nice performance improvement:  I tested with both `translateX` and `left`. `translateX` does not layout every time, while `left` does. 