### PR TITLE
Doc cleanup: formatting, grammar, consistency, minor fixes

### DIFF
--- a/builtins/amp-pixel.md
+++ b/builtins/amp-pixel.md
@@ -17,15 +17,19 @@ limitations under the License.
 # <a name="amp-pixel"></a> `amp-pixel`
 
 <table>
-   <tr>
+  <tr>
     <td class="col-fourty"><strong>Description</strong></td>
     <td>The <code>amp-pixel</code> element is meant to be used as a typical tracking pixel - to count page views.</td>
   </tr>
-   <tr>
+  <tr>
     <td class="col-fourty"><strong>Availability</strong></td>
     <td>Stable</td>
   </tr>
-   <tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>fixed, nodisplay</td>
+  </tr>
+  <tr>
     <td class="col-fourty"><strong>Examples</strong></td>
     <td><a href="https://github.com/ampproject/amphtml/blob/master/examples/everything.amp.html">everything.amp.html</a></td>
   </tr>
@@ -37,7 +41,7 @@ The `amp-pixel` component behaves like a simple tracking pixel `img`. It takes a
 
 ## Attributes
 
-**src**
+**src** (required)
 
 A simple URL to send a GET request to when the tracking pixel is loaded.
 

--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -124,15 +124,48 @@ All of the endpoints are configured in the AMP document as a JSON object in the 
 
 The following properties are defined in this configuration:
 
-|Property       | Values               | Description |
---------------  | -------------------- | --------------------------------- |
-| authorization | &lt;URL&gt;          | The HTTPS URL for the Authorization endpoint. |
-| pingback      | &lt;URL&gt;          | The HTTPS URL for the Pingback endpoint. |
-| noPingback    | true/false           | When true, disables pingback. |
-| login         | &lt;URL&gt; or &lt;Map[string, URL]&gt; | The HTTPS URL for the Login Page or a set of URLs for different types of login pages. |
-| authorizationFallbackResponse | &lt;object&gt;          | The JSON object to be used in place of the authorization response if it fails. |
-| authorizationTimeout          | &lt;number&gt;          | Timeout (in milliseconds) after which authorization request is considered as failed. Default is 3000. Values greater than 3000 are allowed only in dev environment. |
-| type          | "client" or "server" | Default is “client”. The "server" option is under design discussion and these docs will be updated when it is ready. |
+<table>
+  <tr>
+    <th>Property</th>
+    <th>Values</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>authorization</code></td>
+    <td>&lt;URL&gt;</td>
+    <td>The HTTPS URL for the Authorization endpoint.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>pingback</code></td>
+    <td>&lt;URL&gt;</td>
+    <td>The HTTPS URL for the Pingback endpoint.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>noPingback</code></td>
+    <td>true/false</td>
+    <td>When true, disables pingback.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>login</code></td>
+    <td class="col-twenty">&lt;URL&gt; or<br>&lt;Map[string, URL]&gt;</td>
+    <td>The HTTPS URL for the Login Page or a set of URLs for different types of login pages.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>authorizationFallbackResponse</code></td>
+    <td>&lt;object&gt;</td>
+    <td>The JSON object to be used in place of the authorization response if it fails.</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>authorizationTimeout</code></td>
+    <td>&lt;number&gt;</td>
+    <td>Timeout (in milliseconds) after which the authorization request is considered as failed. Default is 3000. Values greater than 3000 are allowed only in dev environment. </td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><code>type</code></td>
+    <td>"client" or "server"</td>
+    <td>Default is “client”. The "server" option is under design discussion and these docs will be updated when it is ready.</td>
+  </tr>
+</table>
 
 *&lt;URL&gt;* values specify HTTPS URLs with substitution variables. The substitution variables are covered in more detail in the [Access URL Variables][7] section below.
 
@@ -155,17 +188,48 @@ Here’s an example of the AMP Access configuration:
 
 When configuring the URLs for various endpoints, the Publisher can use substitution variables. The full list of these variables are defined in the [AMP Var Spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md). In addition, this spec adds a few access-specific variables such as `READER_ID` and `AUTHDATA`. Some of the most relevant variables are described in the table below:
 
-| Var               | Description |
-| ----------------- | ----------- |
-| READER_ID         | The AMP Reader ID. |
-| AUTHDATA(field)   | The value of the field in the authorization response. |
-| RETURN_URL        | The placeholder for the return URL specified by the AMP runtime for a Login Dialog to return to. |
-| SOURCE_URL        | The Source URL of this AMP Document. If document is served from CDN, AMPDOC_URL will be a CDN URL, while SOURCE_URL will be the original source URL. |
-| AMPDOC_URL        | The URL of this AMP Document. |
-| CANONICAL_URL     | The canonical URL of this AMP Document. |
-| DOCUMENT_REFERRER | The Referrer URL. |
-| VIEWER            | The URL of the AMP Viewer. |
-| RANDOM            | A random number. Helpful to avoid browser caching. |
+<table>
+  <tr>
+    <th>Var</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>READER_ID</code></td>
+    <td>The AMP Reader ID.</td>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>AUTHDATA(field)</code></td>
+    <td>The value of the field in the authorization response.</td>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>RETURN_URL</code></td>
+    <td>The placeholder for the return URL specified by the AMP runtime for a Login Dialog to return to.</td>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>SOURCE_URL</code></td>
+    <td>The Source URL of this AMP document. If the document is served from a CDN, the AMPDOC_URL will be a CDN URL, while SOURCE_URL will be the original source URL.</td>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>AMPDOC_URL</code></td>
+    <td>The URL of this AMP document.</td>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>CANONICAL_URL</code></td>
+    <td>The canonical URL of this AMP document.</td>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>DOCUMENT_REFERRER</code></td>
+    <td>The Referrer URL.</td>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>VIEWER</code></td>
+    <td>The URL of the AMP Viewer.</td>
+  </tr>
+  <tr>
+    <td class="col-thirty"><code>RANDOM</code></td>
+    <td>A random number. Helpful to avoid browser caching.</td>
+  </tr>
+</table>
 
 Here’s an example of the URL extended with Reader ID, Canonical URL, Referrer information and random cachebuster:
 ```text

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -1,6 +1,8 @@
 # <a name="amp-ad"></a> `amp-ad` / `amp-embed`
 
-NOTE: The specification of `amp-ad` / `amp-embed` is likely to significantly evolve over time. The current approach is designed to bootstrap the format to be able to show ads.
+{% call callout('Note', type='note') %}
+The specification of `amp-ad` / `amp-embed` is likely to significantly evolve over time. The current approach is designed to bootstrap the format to be able to show ads.
+{% endcall %}
 
 <!---
 Copyright 2015 The AMP HTML Authors. All Rights Reserved.
@@ -182,33 +184,38 @@ This is due to the UX implications of full page overlay ads. It may be considere
 
 ## Attributes
 
-### type
+**type**
 
-Identifier for the ad network. This selects the template that is used for the ad tag.
+An identifier for the ad network. This selects the template that is used for the ad tag.
 
-### src
+**src**
 
-Optional src value for a script tag loaded for this ad network. This can be used with ad networks that require exactly a single script tag to be inserted in the page. The src value must have a prefix that is whitelisted for this ad network.
+An optional src value for a script tag loaded for this ad network. This can be used with ad networks that require exactly a single script tag to be inserted in the page. The src value must have a prefix that is white-listed for this ad network.
 
-### data-foo-bar
+**data-foo-bar**
 
-Most ad networks require further configuration. This can be passed to the network using HTML `data-` attributes. The parameter names are subject to standard data attribute dash to camel case conversion. E.g. "data-foo-bar" is send to the ad for configuration as "fooBar".
+Most ad networks require further configuration. This can be passed to the network using HTML `data-` attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar".
 
-### json
+**json**
 
-Optional attribute to pass configuration to the ad as an arbitrarily complex JSON object. The object is passed to the ad as-is with no mangling done on the names.
+An optional attribute to pass a configuration to the ad as an arbitrarily complex JSON object. The object is passed to the ad as-is with no mangling done on the names.
 
-### data-consent-notification-id
+**data-consent-notification-id**
 
-Optional attribute. If provided will require confirming the [amp-user-notification](../amp-user-notification/amp-user-notification.md) with the given HTML-id until the "AMP client id" for the user (similar to a cookie) is passed to the ad. The means ad rendering is delayed until the user confirmed the notification.
+An optional attribute. If provided, will require confirming the [amp-user-notification](../amp-user-notification/amp-user-notification.md) with the given HTML-id until the "AMP client id" for the user (similar to a cookie) is passed to the ad. The means ad rendering is delayed until the user confirmed the notification.
 
-### data-loading-strategy
+**data-loading-strategy**
 
-Supported value: `prefer-viewability-over-views`. Instructs AMP to load ads in a way that prefers a high degree of viewability, while sometimes loading too late to generate a view.
+Instructs AMP to load ads in a way that prefers a high degree of viewability, while sometimes loading too late to generate a view. Supported value: `prefer-viewability-over-views`. 
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Placeholder
 
-Optionally `amp-ad` supports a child element with the `placeholder` attribute. If supported by the ad network, this element is shown until the ad is available for viewing.
+Optionally, `amp-ad` supports a child element with the `placeholder` attribute. If supported by the ad network, this element is shown until the ad is available for viewing.
+
 ```html
 <amp-ad width=300 height=250
     type="foo">
@@ -218,18 +225,18 @@ Optionally `amp-ad` supports a child element with the `placeholder` attribute. I
 
 ## No Ad available
 - `amp-ad` supports a child element with the `fallback` attribute. If supported by the ad network, this element is shown if no ad is available for this slot.
+- If there is no fallback element available, the amp-ad tag will be collapsed (set to display: none) if the ad sends a message that the ad slot cannot be filled and AMP determines that this operation can be performed without affecting the user's scroll position.
+
+Example with fallback:
+
 ```html
-<amp-ad width=300 height=250
-    type="foo">
+<amp-ad width=300 height=250 type="foo">
   <div fallback>Have a great day!</div>
 </amp-ad>
 ```
 
-- If there is no fallback element available, the amp-ad tag will be collapsed (set to display: none) if the ad sends a message that the ad slot cannot be filled and AMP determines that this operation can be performed without affecting the user's scroll position.
-
-
 ## Serving video ads
-AMP natively supports a number video players like BrightCove, DailyMotion etc that can monetize ads. For a full list, see [here] (../README.md#audiovideo).
+AMP natively supports a number video players like BrightCove, DailyMotion etc that can monetize ads. For a full list, see [here](https://www.ampproject.org/docs/reference/components#audio-video).
 
 If you use a player that is not supported in AMP, you can serve your custom player using [amp-iframe](https://ampbyexample.com/components/amp-iframe/).
 
@@ -248,7 +255,7 @@ To enable this, copy the file [remote.html](../../3p/remote.html) to your web se
 <meta name="amp-3p-iframe-src" content="https://assets.your-domain.com/path/to/remote.html">
 ```
 
-The `content` attribute of the meta tag is the absolute URL to your copy of the remote.html file on your web server. This URL must use a "https" schema. It is not allowed to reside on the same origin as your AMP files. E.g. if you host AMP files on `www.example.com`, this URL must not be on `www.example.com` but e.g. `something-else.example.com` is OK. See the doc ["Iframe origin policy"](../../spec/amp-iframe-origin-policy.md) for further details on allowed origins for iframes.
+The `content` attribute of the meta tag is the absolute URL to your copy of the remote.html file on your web server. This URL must use a "https" schema. It cannot reside on the same origin as your AMP files. For example, if you host AMP files on `www.example.com`, this URL must not be on `www.example.com` but `something-else.example.com` is OK. See ["Iframe origin policy"](../../spec/amp-iframe-origin-policy.md) for further details on allowed origins for iframes.
 
 ### Security
 
@@ -284,8 +291,8 @@ draw3p(function(config, done) {
 
 ## Validation
 
-See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii) in the AMP validator specification.
+See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad/0.1/validator-amp-ad.protoascii) in the AMP validator specification.
 
 ## Notes
 
-To use `<amp-ad>` or `<amp-embed>`, the script to the `amp-ad` library is needed. It is recommended to add the script manually but currently it will be automatically fetched when `amp-ad` is used.
+To use `<amp-ad>` or `<amp-embed>`, the script to the `amp-ad` library is needed. It's recommended that you add the script manually; however, currently, it will be automatically fetched when `amp-ad` is used.

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -225,7 +225,7 @@ Optionally, `amp-ad` supports a child element with the `placeholder` attribute. 
 
 ## No Ad available
 - `amp-ad` supports a child element with the `fallback` attribute. If supported by the ad network, this element is shown if no ad is available for this slot.
-- If there is no fallback element available, the amp-ad tag will be collapsed (set to display: none) if the ad sends a message that the ad slot cannot be filled and AMP determines that this operation can be performed without affecting the user's scroll position.
+- If there is no fallback element available, the amp-ad tag will be collapsed (set to `display: none`) if the ad sends a message that the ad slot cannot be filled and AMP determines that this operation can be performed without affecting the user's scroll position.
 
 Example with fallback:
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -117,7 +117,7 @@ Adds support for Chartbeat. More details for adding Chartbeat support can be fou
 
 Type attribute value: `colanalytics`
 
-Adds support for ColAnalytics. Additionally, need the value for `id`.
+Adds support for ColAnalytics. Additionally, you must specify a value for `id`.
 
 ### Clicky Web Analytics
 
@@ -263,17 +263,29 @@ Type attribute value: `metrika`
 
 Adds support for Yandex Metrica.
 
-## <a name="attributes"></a>Attributes
+## Attributes
 
-  - `type` See [Analytics vendors](#analytics-vendors)
-  - `config` Optional attribute. This attribute can be used to load a configuration from a specified remote URL. The URL specified here should use https scheme. See also `data-include-credentials` attribute below. The URL may include [AMP URL vars](../../spec/amp-var-substitutions.md).
+**type**
 
-    `<amp-analytics config="https://example.com/analytics.config.json"></amp-analytics>`
+Specifies the type of vendor.  For details, see the [Analytics vendors](#analytics-vendors) section above.
 
-    The response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
-  - `data-credentials` Optional attribute. If set to `include` turns on the ability to read and write cookies on the request specified via `config` above.
-  - `data-consent-notification-id` Optional attribute. If provided, the page will not process analytics requests until an [amp-user-notification](../../extensions/amp-user-notification/amp-user-notification.md) with
-    the given HTML element id is confirmed (accepted) by the user.
+**config**
+
+This is an optional attribute that can be used to load a configuration from a specified remote URL. The URL specified should use the HTTPS scheme. See also the `data-include-credentials` attribute below. The URL may include [AMP URL vars](../../spec/amp-var-substitutions.md). The response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
+
+Example:
+
+```html
+<amp-analytics config="https://example.com/analytics.config.json"></amp-analytics>
+```
+
+**data-credentials**
+
+If set to `include`, this turns on the ability to read and write cookies on the request specified via the `config` attribute. This is an optional attribute.
+
+**data-consent-notification-id**
+
+If provided, the page will not process analytics requests until an [amp-user-notification](../../extensions/amp-user-notification/amp-user-notification.md) with the given HTML element id is confirmed (accepted) by the user. This is an optional attribute.
 
 ## Configuration
 
@@ -308,6 +320,7 @@ The `<amp-analytics>` configuration object uses the following format:
   }
 }
 ```
+
 ### Requests
 The `requests` attribute specifies the URLs used to transmit data to an analytics platform. The `request-name` is used
 in the trigger configuration to specify what request should be sent in response to a particular event. The `request-value`
@@ -351,27 +364,28 @@ The `triggers` attribute describes when an analytics request should be sent. It 
     - `sampleOn` This string template is expanded by filling in the platform variables and then hashed to generate a number for the purposes of the sampling logic described under threshold below.
     - `threshold` This configuration is used to filter out requests that do not meet particular criteria: For a request to go through to the analytics vendor, the following logic should be true `HASH(sampleOn) < threshold`.
 
-  As an example, following configuration can be used to sample 50% of the requests based on random input or at 1% based on client id.
-  ```javascript
-  'triggers': {
-    'sampledOnRandom': {
-      'on': 'visible',
-      'request': 'request',
-      'sampleSpec': {
-        'sampleOn': '${random}',
-        'threshold': 50,
-      },
-    },
-    'sampledOnClientId': {
-      'on': 'visible',
-      'request': 'request',
-      'sampleSpec': {
-        'sampleOn': '${clientId(cookieName)}',
-        'threshold': 1,
-      },
+As an example, the following configuration can be used to sample 50% of the requests based on random input or at 1% based on client id.
+
+```javascript
+'triggers': {
+  'sampledOnRandom': {
+    'on': 'visible',
+    'request': 'request',
+    'sampleSpec': {
+      'sampleOn': '${random}',
+      'threshold': 50,
     },
   },
-  ```
+  'sampledOnClientId': {
+    'on': 'visible',
+    'request': 'request',
+    'sampleSpec': {
+      'sampleOn': '${clientId(cookieName)}',
+      'threshold': 1,
+    },
+  },
+},
+```
 
 #### Page visible trigger (`"on": "visible"`)
 Use this configuration to fire a request when the page becomes visible. The firing of this trigger can be configured using `visibilitySpec`.
@@ -422,22 +436,23 @@ In addition to the variables provided as part of triggers you can also specify a
 Use this configuration to fire a request when a specified element is clicked. Use `selector` to control which elements will cause this request to fire:
   - `selector` A CSS selector used to refine which elements should be tracked. Use value `*` to track all elements. The value of `selector` can include variables that are defined in inline or remote config. The variables will be expanded to determine the elements to be tracked.
 
-    ```javascript
+```javascript
+"vars": {
+  "id1": "#socialButtonId",
+  "id2": ".shareButtonClass"
+},
+"triggers": {
+  "anchorClicks": {
+    "on": "click",
+    "selector": "a, ${id1}, ${id2}",
+    "request": "event",
     "vars": {
-      "id1": "#socialButtonId",
-      "id2": ".shareButtonClass"
-    },
-    "triggers": {
-      "anchorClicks": {
-        "on": "click",
-        "selector": "a, ${id1}, ${id2}",
-        "request": "event",
-        "vars": {
-          "eventId": 128
-        }
-      }
+      "eventId": 128
     }
-    ```
+  }
+}
+```
+
 In addition to the variables provided as part of triggers you can also specify additional / overrides for [variables as data attribute](./analytics-vars.md#variables-as-data-attribute). If used, these data attributes have to be part of element specified as the `selector`
 
 #### Scroll trigger (`"on": "scroll"`)
@@ -445,18 +460,18 @@ Use this configuration to fire a request under certain conditions when the page 
   - `scrollSpec` This object can contain `verticalBoundaries` and `horizontalBoundaries`. At least one of the two properties is required for a scroll event to fire. The values for both of the properties should be arrays of numbers containing the boundaries on which a scroll event is generated. For instance, in the following code snippet, the scroll event will be fired when page is scrolled vertically by 25%, 50% and 90%. Additionally, the event will also fire when the page is horizontally scrolled to 90% of scroll width. To keep the page performant, the scroll boundaries are rounded to the nearest multiple of `5`.
 
 
-    ```javascript
-    "triggers": {
-      "scrollPings": {
-        "on": "scroll",
-        "scrollSpec": {
-          "verticalBoundaries": [25, 50, 90],
-          "horizontalBoundaries": [90]
-        },
-        "request": "event"
-      }
-    }
-    ```
+```javascript
+"triggers": {
+  "scrollPings": {
+    "on": "scroll",
+    "scrollSpec": {
+      "verticalBoundaries": [25, 50, 90],
+      "horizontalBoundaries": [90]
+    },
+    "request": "event"
+  }
+}
+```
 
 #### Timer trigger (`"on": "timer"`)
 Use this configuration to fire a request on a regular time interval. Use `timerSpec` to control when this will fire:
@@ -465,18 +480,18 @@ Use this configuration to fire a request on a regular time interval. Use `timerS
     - `maxTimerLength` Maximum duration for which the timer will fire, in seconds.
     - `immediate` trigger timer immediately or not. Boolean, defaults to true
 
-    ```javascript
-    "triggers": {
-      "pageTimer": {
-        "on": "timer",
-        "timerSpec": {
-          "interval": 10,
-          "maxTimerLength": 600
-        },
-        "request": "pagetime"
-      }
-    }
-    ```
+```javascript
+"triggers": {
+  "pageTimer": {
+    "on": "timer",
+    "timerSpec": {
+      "interval": 10,
+      "maxTimerLength": 600
+    },
+    "request": "pagetime"
+  }
+}
+```
 
 #### Hidden trigger (`"on": "hidden"`)
 Use this configuration to fire a request when the page becomes is hidden.  The firing of this trigger can be configured using [`visibilitySpec`](#visibility-spec).

--- a/extensions/amp-anim/amp-anim.md
+++ b/extensions/amp-anim/amp-anim.md
@@ -41,9 +41,10 @@ limitations under the License.
 
 ## Behavior
 
-The `amp-anim` component is very similar to the `amp-image` element, and provides additional functionality to manage loading and playing of animated images such as GIFs.
+The `amp-anim` component is very similar to the `amp-img` element, and provides additional functionality to manage loading and playing of animated images such as GIFs.
 
 The `amp-anim` component can also have an optional placeholder child, to display while the `src` file is loading. The placeholder is specified via the `placeholder` attribute:
+
 ```html
 <amp-anim width=400 height=300 src="my-gif.gif">
   <amp-img placeholder width=400 height=300 src="my-gif-screencap.jpg">
@@ -68,7 +69,15 @@ A string of alternate text, similar to the `alt` attribute on `img`.
 
 **attribution**
 
-A string that indicates the attribution of the image. E.g. `attribution="CC courtesy of Cats on Flicker"`
+A string that indicates the attribution of the image. For example, `attribution="CC courtesy of Cats on Flicker"`.
+
+**height** and **width**
+
+An explicit size of the image, which is used by the AMP runtime to determine the aspect ratio without fetching the image. 
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 
 ## Styling

--- a/extensions/amp-animation/amp-animation.md
+++ b/extensions/amp-animation/amp-animation.md
@@ -105,16 +105,63 @@ media query will match the current environment.
 Top-level animation and animation components may contain timing properties. These properties are defined in detail in the
 [AnimationEffectTimingProperties](https://www.w3.org/TR/web-animations/#dictdef-animationeffecttimingproperties) of the Web Animation spec. The set of properties allowed here includes:
 
-Property | Type | Default | Description
--------- | ---- | ------- | -----------
-`duration` | number | 0 | The animation duration in milliseconds
-`delay` | number | 0 | The delay in milliseconds before animation starts executing
-`endDelay` | number | 0 | The delay in milliseconds after animation completes and before it's actually considered to be complete
-`iterations` | number or "Infinity" | 1 | The number of times to the animation effect repeats
-`iterationStart` | number | 0 | The time offset at which the effect begins animating
-`easing` | string | "linear" | The [timing function](https://www.w3.org/TR/web-animations/#timing-function) used to scale the time to produce easing effects
-`direction` | string | "normal" | One of "normal", "reverse", "alternate" or "alternate-reverse"
-`fill` | string | "none" | One of "none", "forwards", "backwards", "both", "auto"
+
+<table>
+  <tr>
+    <th class="col-twenty">Property</th>
+    <th class="col-twenty">Type</th>
+    <th class="col-twenty">Default</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>duration</code></td>
+    <td>number</td>
+    <td>0</td>
+    <td>The animation duration in milliseconds.</td>
+  </tr>
+  <tr>
+    <td><code>delay</code></td>
+    <td>number</td>
+    <td>0</td>
+    <td>The delay in milliseconds before animation starts executing.</td>
+  </tr>
+  <tr>
+    <td><code>endDelay</code></td>
+    <td>number</td>
+    <td>0</td>
+    <td>The delay in milliseconds after the animation completes and before it's actually considered to be complete.</td>
+  </tr>
+  <tr>
+    <td><code>iterations</code></td>
+    <td>number or<br>"Infinity"</td>
+    <td>1</td>
+    <td>The number of times the animation effect repeats.</td>
+  </tr>
+  <tr>
+    <td><code>iterationStart</code></td>
+    <td>number</td>
+    <td>0</td>
+    <td>The time offset at which the effect begins animating.</td>
+  </tr>
+  <tr>
+    <td><code>easing</code></td>
+    <td>string</td>
+    <td>"linear"</td>
+    <td>The <a href="https://www.w3.org/TR/web-animations/#timing-function">timing function</a> used to scale the time to produce easing effects.</td>
+  </tr>
+  <tr>
+    <td><code>direction</code></td>
+    <td>string</td>
+    <td>"normal" </td>
+    <td>One of "normal", "reverse", "alternate" or "alternate-reverse".</td>
+  </tr>
+  <tr>
+    <td><code>fill</code></td>
+    <td>string</td>
+    <td>"none"</td>
+    <td>One of "none", "forwards", "backwards", "both", "auto".</td>
+  </tr>
+</table>
 
 An example of timing properties in JSON:
 ```text

--- a/extensions/amp-app-banner/amp-app-banner.md
+++ b/extensions/amp-app-banner/amp-app-banner.md
@@ -54,12 +54,13 @@ To extend and promote the usage of the natively supported app banners on <a href
 
 The AMP runtime parses the meta tag content attribute on iOS extracting the App ID and `app-argument` (usually used for deep-linking URIs - app-protocols like `whatsapp://` or `medium://`). On Android, the AMP runtimes makes an XHR request to fetch the `manifest.json` file, and parses its content to extract `app_id` from `related_applications` and it calculates the app store URL as well as open-in-app URL:
 
-```
+```text
 android-app://${appId}/${protocol}/${host}${pathname}
 ```
-Note that the protocol/host/pathname are calculated from the canonical URL of the AMP document, and that your native app needs to register the links in their manifest as <a href="https://developer.android.com/training/app-indexing/deep-linking.html">documented here</a>.
+**Note**: The protocol/host/pathname are calculated from the canonical URL of the AMP document, and your native app needs to register the links in their manifest as <a href="https://developer.android.com/training/app-indexing/deep-linking.html">documented here</a>.
 
 ### App manifest example
+
 ```java
 <activity
     android:name="com.example.android.GizmosActivity"
@@ -89,11 +90,9 @@ Note that the protocol/host/pathname are calculated from the canonical URL of th
 }
 ```
 
-
-
-
 ##Appearance Behavior
-amp-app-banner provides no default UI and leave the UI to the developer. The developer can build any kind of UI inside the banner and style it accordingly. There is one UI element that has limits to the amount of customization—the "X" button that dismisses the banner. This button can be styled with the `.amp-app-banner-dismiss-button` class. It should be kept visible and easily accessible on mobile devices, to avoid blocking content.
+
+`amp-app-banner` provides no default UI and leaves the UI to the developer. The developer can build any kind of UI inside the banner and style it accordingly. There is one UI element that has limits to the amount of customization--the "X" button that dismisses the banner. This button can be styled with the `.amp-app-banner-dismiss-button` class. It should be kept visible and easily accessible on mobile devices, to avoid blocking content.
 
 One required UI element is the `button[open-button]` button, which is the click target for the banner to install the app, or open the deep-link if the app is already installed.
 
@@ -103,15 +102,15 @@ Because native app banners currently are not shown in the viewer context, `<amp-
 
 <table>
   <tr>
-    <td></td>
-    <td>Android + Chrome</td>
-    <td>iOS + Safari</td>
-    <td>Other OS + browser</td>
+    <th>Context</th>
+    <th>Android + Chrome</th>
+    <th>iOS + Safari</th>
+    <th>Other OS + browser</th>
   </tr>
   <tr>
     <td>In AMP viewer</td>
     <td>Show amp-app-banner</td>
-    <td>Currently, will not show anything due to #6454</td>
+    <td>Currently, will not show anything due to <a href="https://github.com/ampproject/amphtml/issues/6454">#6454</a></td>
     <td>Show amp-app-banner</td>
   </tr>
   <tr>
@@ -124,15 +123,16 @@ Because native app banners currently are not shown in the viewer context, `<amp-
 
 
 ##Dismissal Persistence
-The banner currently will be displayed always unless it was dismissed. Once dismissed the banner will never be displayed on that domain unless user visits on a different browser or clears their local storage.
+Currently, the banner will be displayed always unless it was dismissed. Once dismissed, the banner will never be displayed on that domain unless the user visits on a different browser or clears their local storage.
 
 
 ## Tags
 
-**At least one of `meta[name="apple-itunes-app"]` or `link[rel=manifest]`**
-* `<meta>` tag must have "name" attribute and "content" attribute
-* The value of the "content" attribute must contain "app-id=" 
-* `<link>` tag must have "rel='manifest'" attribute and value, as well as "href" attribute
+**At least one of**: `meta[name="apple-itunes-app"]` or `link[rel=manifest]`
+
+* The `<meta>` tag must have the `name` and `content` attributes.
+* The value of the `content` attribute must contain `app-id=`.
+* The `<link>` tag must have the `"rel='manifest'"` attribute and value, as well as the `href` attribute.
 
 
 ## Attributes
@@ -142,27 +142,33 @@ The banner currently will be displayed always unless it was dismissed. Once dism
 
 **id** (Required)
 
-To uniquely identify an amp-app-banner - for persistence logic
+A unique identifier for an amp-app-banner; used for persistence logic.
 
-**layout="nodisplay"** (Required)
+**layout** (Required)
 
-### Attributes on 'button' descendent element
+The value must be `nodisplay`. 
+
+### Attributes on `button` descendant element
 
 **open-button** (Required)
+
+The click target for the banner to install the app, or open the deep-link if the app is already installed.
 
 Not permitted: **disabled**
 
 
 ## Additional Validations
 
-* Cannot have `<amp-ad>`, `<amp-sticky-ad>`, `<amp-embed>`, or `<amp-iframe>` as descendents
+* Cannot have `<amp-ad>`, `<amp-sticky-ad>`, `<amp-embed>`, or `<amp-iframe>` as descendants
 * Height cannot exceed 100px
 * Must be a direct child of `<body>`
 * Android manifest `href` must be served over `https`
 * Cannot have more than one `<amp-app-banner>` on a single page
 
 
-## Example ([link to full page example](https://github.com/ampproject/amphtml/blob/master/examples/article.amp.html))
+## Example
+
+([link to full page example](https://github.com/ampproject/amphtml/blob/master/examples/article.amp.html))
 ```html
 <head>
   <meta name="apple-itunes-app"
@@ -185,3 +191,7 @@ Not permitted: **disabled**
   </amp-app-banner>
 </body>
 ```
+
+## Validation
+
+See [amp-app-banner rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-app-banner/0.1/validator-amp-app-banner.protoascii) in the AMP validator specification.

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -79,6 +79,10 @@ If present, will automatically loop the audio back to the start upon reaching th
 
 If present, will mute the audio by default.
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
 ## Validation
 
 See [amp-audio rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-audio/0.1/validator-amp-audio.protoascii) in the AMP validator specification.

--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -73,6 +73,10 @@ The Brid.tv video ID.
 
 The Brid.tv playlist ID. Embed must either have video or playlist attribute.
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
 ## Validation
 
 See [amp-brid-player rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-brid-player/0.1/validator-amp-brid-player.protoascii) in the AMP validator specification.

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -93,9 +93,13 @@ Keys and values will be URI encoded. Keys will be camel cased.
 - `data-param-language="de"` becomes `&language=de`
 - `data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
 ## Player configuration
 
-This script should be added to the configuration of Brightcove Players used with this component. This allows the AMP document to pause the player. Only the script need be added, no plugin name or JSON are needed.
+The followings script should be added to the configuration of Brightcove Players used with this component. This allows the AMP document to pause the player. Only the script need be added, no plugin name or JSON are needed.
 
 * http://players.brightcove.net/906043040001/plugins/postmessage_pause.js
 

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -47,7 +47,7 @@ The carousel consists of an arbitrary number of items, as well as optional navig
 
 The carousel advances between items if the user swipes, uses arrow keys, or clicks an optional navigation arrow.
 
-**Example**: While the example shows a carousel of images, `amp-carousel` supports arbitrary children.
+**Example**: While the example shows a carousel of images, `amp-carousel` supports arbitrary HTML children.
 
 ```html
 <amp-carousel width=300 height=400>
@@ -95,6 +95,14 @@ By default, `autoplay` advances a slide in 5000 millisecond intervals (5 seconds
 By default, a slide will advance in 5000 millisecond intervals (5 seconds)
 when `autoplay` is specified and will use the value of the `delay`
 attribute if present (minimum of 1000 ms; an error will be thrown if it's any lower). The value of `delay` must be a number of milliseconds, e.g. `delay=5000`.
+
+**height** (required)
+
+The height of the carousel, in pixels.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Styling
 - You may use the `amp-carousel` element selector to style it freely.

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -50,69 +50,63 @@ With responsive layout, the width and height from the example should yield corre
     width="480" height="270"></amp-dailymotion>
 ```
 
-## Required attributes
+## Attributes
 
-**data-videoid**
+**data-videoid** (required)
 
-The Dailymotion video id found in every video page URL.
+The Dailymotion video id found in every video page URL. For example, `"x2m8jpp"` is the video id for `https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation`. 
 
-E.g. in https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation `"x2m8jpp"` is the video id.
+**data-mute** (optional)
 
-## Optional attributes
+Indicates whether to mute the video.
 
-**data-mute**
+* Value: `"true"` or `"false"`
+* Default value: `"false"`
 
-Whether to mute the video or not.
+**data-endscreen-enable** (optional)
 
-Value: `"true"` or `"false"`
+Indicates whether to enable the end screen.
 
-Default value: `"false"`
+* Value: `"true"` or `"false"`
+* Default value: `"true"`
 
-**data-endscreen-enable**
+**data-sharing-enable** (optional)
 
-Whether to enable the end screen or not.
+Indicates whether to display the sharing button.
 
-Value: `"true"` or `"false"`
+* Value: `"true"` or `"false"`
+* Default value: `"true"`
 
-Default value: `"true"`
-
-**data-sharing-enable**
-
-Whether to display the sharing button or not.
-
-Value: `"true"` or `"false"`
-
-Default value: `"true"`
-
-**data-start**
+**data-start** (optional)
 
 Specifies the time (in seconds) from which the video should start playing. 
 
-Value: integer (number of seconds). E.g. `data-start=45`
+* Value: integer (number of seconds). For example, `data-start=45`.
+* Default value: `0`
 
-Default value: `0`
-
-**data-ui-highlight**
+**data-ui-highlight** (optional)
 
 Change the default highlight color used in the controls.
 
-Value: Hexadecimal color value (without the leading #). E.g. `data-ui-highlight="e540ff"`
+* Value: Hexadecimal color value (without the leading #). For example, `data-ui-highlight="e540ff"`.
 
-**data-ui-logo**
+**data-ui-logo** (optional)
 
-Whether to display the Dailymotion logo or not.
+Indicates whether to display the Dailymotion logo.
 
-Value: `"true"` or `"false"`
+* Value: `"true"` or `"false"`
+* Default value: `"true"`
 
-Default value: `"true"`
+**data-info** (optional)
 
-**data-info**
+Indicates whether to show video information (title and owner) on the start screen.
 
-Whether to show video information (title and owner) on the start screen.
+* Value: `"true"` or `"false"`
+* Default value: `"true"`
 
-Value: `"true"` or `"false"`
+**common attributes**
 
-Default value: `"true"`
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-experiment/amp-experiment.md
+++ b/extensions/amp-experiment/amp-experiment.md
@@ -120,4 +120,4 @@ An experiment can be forced to a variant via URL fragment. This is useful in dev
 Notice the same `amp-x-` prefix used as in body attributes.
 
 ## Validation
-One AMP document can have at most one `amp-experiment` element.
+One AMP document can have at most one `amp-experiment` element. See [amp-experiment rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-experiment/0.1/validator-amp-experiment.protoascii) in the AMP validator specification.

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -19,11 +19,11 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays a Facebook Post or Video. </td>
+    <td>Displays a Facebook post or video. </td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>Stable.</td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -38,10 +38,12 @@ limitations under the License.
     <td><a href="https://ampbyexample.com/components/amp-facebook/">Annotated code example for amp-facebook</a></td>
   </tr>
 </table>
+## Overview 
 
-## Examples
+You can use the `amp-facebook` component to embed a Facebook post or a Facebook video.
 
-Example - Embedding a post:
+**Example: Embedding a post**
+
 ```html
 <amp-facebook width=486 height=657
     layout="responsive"
@@ -49,7 +51,8 @@ Example - Embedding a post:
 </amp-facebook>
 ```
 
-Example - Embedding a video:
+**Example: Embedding a video**
+
 ```html
 <amp-facebook width=552 height=574
     layout="responsive"
@@ -60,17 +63,21 @@ Example - Embedding a video:
 
 ## Attributes
 
-**data-href**
+**data-href** (required)
 
-The URL of the facebook post/video. For example: https://www.facebook.com/zuck/posts/10102593740125791.
+The URL of the Facebook post/video. For example: https://www.facebook.com/zuck/posts/10102593740125791.
 
-**data-embed-as**
-_Optional_
-Either `post` or `video` (default: `post`).
+**data-embed-as** (optional)
 
-Both posts and videos can be embedded as a post. Setting `data-embed-as="video"` for Facebook videos only embed the player of the video ignoring the accompanying post card with it. This is recommended if you'd like a better aspect ratio management for the video to be responsive.  
+The value is either `post` or `video`.  The default is `post`.
 
-Checkout the documentation for differences between [post embeds](https://developers.facebook.com/docs/plugins/embedded-posts) and [video embeds](https://developers.facebook.com/docs/plugins/embedded-video-player).
+Both posts and videos can be embedded as a post. Setting `data-embed-as="video"` for Facebook videos only embeds the player of the video, and ignores the accompanying post card with it. This is recommended if you'd like a better aspect ratio management for the video to be responsive.  
+
+Check out the documentation for differences between [post embeds](https://developers.facebook.com/docs/plugins/embedded-posts) and [video embeds](https://developers.facebook.com/docs/plugins/embedded-video-player).
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -73,6 +73,9 @@ The minimum font size as an integer that the `amp-fit-text` can use.
 
 The maximum font size as an integer that the `amp-fit-text` can use.
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Styling
 

--- a/extensions/amp-font/amp-font.md
+++ b/extensions/amp-font/amp-font.md
@@ -43,7 +43,7 @@ limitations under the License.
 
 The `amp-font` extension should be used for controlling timeouts on font loading.
 
-The `amp-font` extension allows adding and removing CSS classes from document.documentElement based on whether a font was loaded or is in error-state.
+The `amp-font` extension allows adding and removing CSS classes from `document.documentElement` based on whether a font was loaded or is in error-state.
 
 Example:
 ```html
@@ -101,6 +101,10 @@ CSS class that would be removed from the `document.documentElement` and `documen
 **font-weight, font-style, font-variant**
 
 The attributes above should all behave like they do on standard elements.
+
+**layout**
+
+Must be `nodisplay`.
 
 ## Validation
 

--- a/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
+++ b/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
@@ -51,7 +51,11 @@ Example:
 
 **height**
 
-The height of the flying carpets "window".
+The height of the flying carpet's "window".
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Styling
 

--- a/extensions/amp-gfycat/amp-gfycat.md
+++ b/extensions/amp-gfycat/amp-gfycat.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays a Gfycat video GIF.</td>
+    <td>Displays a <a href="https://gfycat.com/">Gfycat</a> video GIF.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
@@ -31,35 +31,38 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
+    <td>fill, fixed, fixed-height, flex-item, responsive</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Examples</strong></td>
+    <td class="col-fourty"><strong>Examples</strong></td>
     <td>
-      <a href="https://github.com/ampproject/amphtml/blob/master/examples/gfycat.amp.html">Source</a>
-      <a href="https://cdn.rawgit.com/ampproject/amphtml/master/examples/gfycat.amp.html">Rendered</a>
+      <ul>
+      <li><a href="https://ampbyexample.com/components/amp-gfycat/">Annotated code example for amp-gfycat</a></li>
+      <li>Other example: <a href="https://github.com/ampproject/amphtml/blob/master/examples/gfycat.amp.html">Source</a>,
+      <a href="https://cdn.rawgit.com/ampproject/amphtml/master/examples/gfycat.amp.html">Rendered</a></li>
+    </ul>
     </td>
   </tr>
 </table>
 
 ## Example
 
-Gfycat embed with responsive layout:
+The `width` and `height` attributes determine the aspect ratio of the Gfycat embedded in responsive layouts.
 
 ```html
-  <amp-gfycat
-          data-gfyid="TautWhoppingCougar"
-          width="640"
-          height="360"
-          layout="responsive">
-  </amp-gfycat>
+<amp-gfycat
+    data-gfyid="TautWhoppingCougar"
+    width="640"
+    height="360"
+    layout="responsive">
+</amp-gfycat>
 ```
 
 ## Attributes
 
 **data-gfyid**
 
-In the url https://gfycat.com/TautWhoppingCougar gfyid is `TautWhoppingCougar`, can be found in any Gfycat url.
+The Gfycat ID found in any Gfycat url. For example, `TautWhoppingCougar` is the id in the following url: https://gfycat.com/TautWhoppingCougar.
 
 **width** and **height**
 
@@ -67,20 +70,25 @@ The width and height attributes are special for the Gfycat embed. These should b
 
 Gfycat allows many aspect ratios.
 
-To specify the width and height in the code, please copy it from the embed URL. You can see these values by going to:
-https://gfycat.com/name
-Click on the embed link </>. Copy the width and height specified in the fixed IFRAME field.
+To specify the width and height in the code, copy it from the embed URL:
 
-**Example:**
+1. Go to https://gfycat.com/name, where name is the Gfycat ID.
+2. Click the embed link icon (</>).
+3. Copy the width and height specified in the "Fixed iFRAME" field.
+
+Example: Finding the actual width and height
 
 ```html
-<iframe src='https://gfycat.com/ifr/TautWhoppingCougar' frameborder='0' scrolling='no' width='640' height='360' allowfullscreen></iframe>
+<iframe src='https://gfycat.com/ifr/TautWhoppingCougar'
+        frameborder='0' scrolling='no' width='640'
+        height='360' allowfullscreen>
+</iframe>
 ```
 **noautoplay**
 
-By default video is autoplaying. It's possible to turn it off by setting `noautoplay` attribute.
+By default, a video autoplays. You can turn off autoplay by setting the  `noautoplay` attribute.
 
-**Example:**
+Example: Turning off autoplay
 
 ```html
   <amp-gfycat
@@ -90,3 +98,11 @@ By default video is autoplaying. It's possible to turn it off by setting `noauto
           noautoplay>
   </amp-gfycat>
 ```
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
+## Validation
+
+See [amp-gfycat rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-gfycat/0.1/validator-amp-gfycat.protoascii) in the AMP validator specification.

--- a/extensions/amp-hulu/amp-hulu.md
+++ b/extensions/amp-hulu/amp-hulu.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays a Hulu simple embed.</td>
+    <td>Displays a simple embedded <a href="http://www.hulu.com">Hulu</a> video.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
@@ -51,5 +51,12 @@ limitations under the License.
 
 **data-eid**
 
-In a URL like https://secure.hulu.com/embed.html?eid=4Dk5F2PYTtrgciuvloH3UA `4Dk5F2PYTtrgciuvloH3UA` is the eid.
+The ID of the video. For example, `4Dk5F2PYTtrgciuvloH3UA` is the eid in the following URL: https://secure.hulu.com/embed.html?eid=4Dk5F2PYTtrgciuvloH3UA.
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
+## Validation
+
+See [amp-hulu rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-hulu/0.1/validator-amp-hulu.protoascii) in the AMP validator specification.

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -44,7 +44,7 @@ limitations under the License.
 `amp-iframe` has several important differences from vanilla iframes that are designed to make it more secure and avoid AMP files that are dominated by a single iframe:
 
 - `amp-iframe` may not appear close to the top of the document (except for iframes that use `placeholder` as described below). They must be either 600px away from the top or not within the first 75% of the viewport when scrolled to the top – whichever is smaller. NOTE: We are currently looking for feedback as to how well this restriction works in practice.
-- They are sandboxed by default. [Details](#sandbox)
+- By default, an amp-iframe is sandboxed ([details](#sandbox)).
 - They must only request resources via HTTPS or from a data-URI or via the srcdoc attribute.
 - They must not be in the same origin as the container unless they do not allow `allow-same-origin` in the sandbox attribute. See the doc ["Iframe origin policy"](../../spec/amp-iframe-origin-policy.md) for further details on allowed origins for iframes.
 
@@ -73,21 +73,21 @@ The reasons for this policy are that:
 
 ## Attributes
 
-### src
+**src**
 
 The `src` attribute behaves mainly like on a standard iframe with one exception: the `#amp=1` fragment is added to the URL to allow
 source documents to know that they are embedded in the AMP context. This fragment is only added if the URL specified by `src` does
 not already have a fragment.
 
-### srcdoc, frameborder, allowfullscreen, allowtransparency, referrerpolicy
+**srcdoc, frameborder, allowfullscreen, allowtransparency, referrerpolicy**
 
 The attributes above should all behave like they do on standard iframes.
 
-If `frameborder` is not specified, it will be set to `0` by default.
+If `frameborder` is not specified, by default, it will be set to `0`.
 
-### sandbox
+<a id="sandbox"></a>**sandbox**
 
-Iframes created by `amp-iframe` always have the `sandbox` attribute defined on them. By default the value is empty. That means that they are "maximum sandboxed" by default. By setting sandbox values, one can opt the iframe into being less sandboxed. All values supported by browsers are allowed. E.g. setting `sandbox="allow-scripts"` allows the iframe to run JavaScript, or `sandbox="allow-scripts allow-same-origin"` allows the iframe to run JavaScript, make non-CORS XHRs, and read/write cookies.
+Iframes created by `amp-iframe` always have the `sandbox` attribute defined on them. By default, the value is empty, which means that they are "maximum sandboxed" by default. By setting sandbox values, one can opt the iframe into being less sandboxed. All values supported by browsers are allowed. For example, setting `sandbox="allow-scripts"` allows the iframe to run JavaScript, or `sandbox="allow-scripts allow-same-origin"` allows the iframe to run JavaScript, make non-CORS XHRs, and read/write cookies.
 
 If you are iframing a document that was not specifically created with sandboxing in mind, you will most likely need to add `allow-scripts allow-same-origin` to the `sandbox` attribute and you mights need to allow additional capabilities.
 
@@ -95,19 +95,23 @@ Note also, that the sandbox applies to all windows opened from a sandboxed ifram
 
 See the [the docs on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) for further details on the sandbox attribute.
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
 ## Iframe Resizing
 
 An `amp-iframe` must have static layout defined as is the case with any other AMP element. However,
 it's possible to resize an `amp-iframe` in runtime. To do so:
 
-1. The `amp-iframe` must be defined with `resizable` attribute;
-2. The `amp-iframe` must have `overflow` child element;
-3. The iframe document has to send a `embed-size` request as a window message.
-4. The `embed-size` request will be denied if the request height is less than certain threshold (100px).
+1. The `amp-iframe` must be defined with the `resizable` attribute.
+2. The `amp-iframe` must have an `overflow` child element.
+3. The iframe document must send an `embed-size` request as a window message.
+4. The `embed-size` request will be denied if the request height is less than a certain threshold (100px).
 
 Notice that `resizable` overrides `scrolling` value to `no`.
 
-Example of `amp-iframe` with `overflow` element:
+Example: `amp-iframe` with `overflow` element
 ```html
 <amp-iframe width=300 height=300
     layout="responsive"
@@ -118,7 +122,8 @@ Example of `amp-iframe` with `overflow` element:
 </amp-iframe>
 ```
 
-Example of iframe resize request:
+Example: iframe resize request
+
 ```javascript
 window.parent.postMessage({
   sentinel: 'amp',
@@ -127,16 +132,13 @@ window.parent.postMessage({
 }, '*');
 ```
 
-Once this message is received the AMP runtime will try to accommodate this request as soon as
-possible, but it will take into account where the reader is currently reading, whether the scrolling
-is ongoing and any other UX or performance factors. If the runtime cannot satisfy the resize events
-the `amp-iframe` will show an `overflow` element. Clicking on the `overflow` element will immediately
-resize the `amp-iframe` since it's triggered by a user action.
+Once this message is received, the AMP runtime tries to accommodate this request as soon as possible, but it takes into account where the reader is currently reading, whether the scrolling is ongoing and any other UX or performance factors. If the runtime cannot satisfy the resize events,
+the `amp-iframe` will show an `overflow` element. Clicking on the `overflow` element will immediately resize the `amp-iframe` since it's triggered by a user action.
 
 Here are some factors that affect how fast the resize will be executed:
 
-- Whether the resize is triggered by the user action;
-- Whether the resize is requested for a currently active iframe;
+- Whether the resize is triggered by the user action.
+- Whether the resize is requested for a currently active iframe.
 - Whether the resize is requested for an iframe below the viewport or above the viewport.
 
 ## Iframe with Placeholder
@@ -153,7 +155,7 @@ It is possible to have an `amp-iframe` appear on the top of a document when the 
 - The `amp-iframe` must contain an element with the `placeholder` attribute, (for instance an `amp-img` element) which would be rendered as a placeholder till the iframe is ready to be displayed.
 - Iframe readiness can be known by listening to `onload` of the iframe or an `embed-ready` postMessage which would be sent by the iframe document, whichever comes first.
 
-Example of Iframe embed-ready request:
+Example: Iframe embed-ready request
 ```javascript
 window.parent.postMessage({
   sentinel: 'amp',
@@ -165,7 +167,7 @@ window.parent.postMessage({
 
 Iframes can send a  `send-intersections` message to its parent to start receiving IntersectionObserver style [change records](http://rawgit.com/slightlyoff/IntersectionObserver/master/index.html#intersectionobserverentry) of the iframe's intersection with the parent viewport.
 
-Example of iframe `send-intersections` request:
+Example: iframe `send-intersections` request
 ```javascript
 window.parent.postMessage({
   sentinel: 'amp',
@@ -175,7 +177,7 @@ window.parent.postMessage({
 
 The iframe can listen to an `intersection` message from the parent window to receive the intersection data.
 
-Example of iframe `send-intersections` request:
+Example: iframe `send-intersections` request
 ```javascript
 window.addEventListener('message', function(event) {
   const listener = function(event) {
@@ -196,9 +198,9 @@ The intersection message would be sent by the parent to the iframe when the ifra
 
 ## Tracking/Analytics iframes
 
-We strongly recommend using [`amp-analytics`](../amp-analytics/amp-analytics.md) for analytics purposes, because it is significantly more robust, complete and efficient solution and can be configured for a wide range of analytics vendors.
+We strongly recommend using [`amp-analytics`](../amp-analytics/amp-analytics.md) for analytics purposes, because it is significantly more robust, complete and an efficient solution which can be configured for a wide range of analytics vendors.
 
-AMP only allows a single iframe, that is used for analytics and tracking purposes, per page. To conserve resources these iframes will be removed from the DOM 5 seconds after they loaded, which should be sufficient time to complete whatever work is needed to be done.
+AMP only allows a single iframe, that is used for analytics and tracking purposes, per page. To conserve resources, these iframes will be removed from the DOM 5 seconds after they loaded, which should be sufficient time to complete whatever work is needed to be done.
 
 Iframes are identified as tracking/analytics iframes if they appear to serve no direct user purpose such as being invisible or small.
 

--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -51,7 +51,7 @@ The typical scenario looks like this:
 <amp-image-lightbox id="lightbox1" layout="nodisplay"></amp-image-lightbox>
 ```
 
-The `amp-image-lightbox` is activated using `on` action on the `amp-img` element
+The `amp-image-lightbox` is activated using [`on`](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#on) action on the `amp-img` element
 by referencing the lightbox element's ID. When activated, it places the image in
 the center of the full-viewport lightbox. Notice that any number of images in
 the article can use the same `amp-image-lightbox`. The `amp-image-lightbox`
@@ -95,6 +95,12 @@ The `amp-image-lightbox` exposes the following actions you can use [AMP on-synta
 <amp-img on="tap:lightbox1" role="button" tabindex="0" src="image1" width=200 height=100></amp-img>
 <amp-image-lightbox id="lightbox1" layout="nodisplay"></amp-image-lightbox>
 ```
+
+## Attributes
+
+**layout**
+
+Must be set to `nodisplay`.
 
 ## Validation
 

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays an instagram embed.</td>
+    <td>Displays an Instagram embed.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
@@ -41,11 +41,11 @@ limitations under the License.
 
 ## Behavior
 
-The `width` and `height` attributes are special for the instagram embed.
-These should be the actual width and height of the instagram image.
-The system automatically adds space for the "chrome" that instagram adds around the image.
+The `width` and `height` attributes are special for the Instagram embed.
+These should be the actual width and height of the Instagram image.
+The system automatically adds space for the "chrome" that Instagram adds around the image.
 
-Many instagrams are square. When you set `layout="responsive"` any value where `width` and `height` are the same will work.
+Many Instagrams are square. When you set `layout="responsive"` any value where `width` and `height` are the same will work.
 
 Example:
 ```html
@@ -57,22 +57,21 @@ Example:
 </amp-instagram>
 ```
 
-If the instagram is not square you will need to enter the actual dimensions of the image.
+If the Instagram is not square you will need to enter the actual dimensions of the image.
 
 When using non-responsive layout you will need to account for the extra space added for the "instagram chrome" around the image. This is currently 48px above and below the image and 8px on the sides.
 
 ## Attributes
 
-<!---
-`src` attribute hasn't been documented. Should it be?
-Also, can the tag include both data-shortcode and src or are they mutually exclusive?
--->
-
 **data-shortcode**
 
-The instagram data-shortcode found in every instagram photo URL.
+The instagram data-shortcode is found in every instagram photo URL.
 
-E.g. in https://instagram.com/p/fBwFP fBwFP is the data-shortcode.
+For example, in https://instagram.com/p/fBwFP, `fBwFP` is the data-shortcode.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -47,52 +47,45 @@ This ServiceWorker runs whenever the AMP file is served from the origin where yo
 
 See [this article](https://medium.com/@cramforce/amps-and-websites-in-the-age-of-the-service-worker-8369841dc962) for how ServiceWorkers can help with making the AMP experience awesome with ServiceWorkers.
 
-Example
+Example:
 
 ```html
-  <amp-install-serviceworker
-      src="https://www.your-domain.com/serviceworker.js"
-      data-iframe-src="https://www.your-domain.com/install-serviceworker.html"
-      layout="nodisplay">
-  </amp-install-serviceworker>
+<amp-install-serviceworker
+  src="https://www.your-domain.com/serviceworker.js"
+  data-iframe-src="https://www.your-domain.com/install-serviceworker.html"
+  layout="nodisplay">
+</amp-install-serviceworker>
 ```
 
 ## Attributes
 
-### `src`
+**src** (required)
 
-URL of the ServiceWorker to register.
+The URL of the ServiceWorker to register.
 
-### `data-iframe-src` (optional)
+**data-iframe-src** (optional)
 
-URL of a HTML document that install a ServiceWorker.
+The URL of an HTML document that installs a ServiceWorker.
 
-### `layout`
+**layout**
 
 Must have the value `nodisplay`.
 
-### `data-no-service-worker-fallback-url-match`
+**data-no-service-worker-fallback-url-match**
 
-A regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback.
-See [Shell URL rewrite](#shell-url-rewrite) section for more details.
-
-The value must be a valid JavaScript RegExp string, for instance:
+The is a regular expression that matches URLs to be rewritten to navigate via shell for no-service-worker fallback. See [Shell URL rewrite](#shell-url-rewrite) section for more details. The value must be a valid JavaScript RegExp string. For example:
  - `amp.html`
  - `.*amp`
  - `.*\.amp\.html`
  - `.*\/amp$`
 
-### `data-no-service-worker-fallback-shell-url`
+**data-no-service-worker-fallback-shell-url**
 
-The URL to the shell to use to rewrite URL navigations for no-service-worker fallback.
-See [Shell URL rewrite](#shell-url-rewrite) section for more details.
-
-The value must be an URL on the same origin as the AMP document itself.
+The URL to the shell to use to rewrite URL navigations for no-service-worker fallback. See [Shell URL rewrite](#shell-url-rewrite) section for more details. The value must be an URL on the same origin as the AMP document itself.
 
 ## Shell URL rewrite
 
-When service workers are not available or not yet active, it's possible to configure URL rewrite to direct
-navigations to the shell. This way, e.g. AMP Runtime can redirect navigation to the "shell" instead of
+When service workers are not available or not yet active, it's possible to configure URL rewrite to direct navigations to the shell. This way, for example, AMP Runtime can redirect navigation to the "shell" instead of
 a "leaf" AMP document.
 
 This fallback is only used when the document is opened on the source origin, and NOT on proxy origin.
@@ -102,13 +95,13 @@ attributes as following:
 
 ```html
 <amp-install-serviceworker layout="nodisplay"
-      src="https://www.your-domain.com/serviceworker.js"
-      data-no-service-worker-fallback-url-match=".*\.amp.html"
-      data-no-service-worker-fallback-shell-url="https://pub.com/shell">
+    src="https://www.your-domain.com/serviceworker.js"
+    data-no-service-worker-fallback-url-match=".*\.amp.html"
+    data-no-service-worker-fallback-shell-url="https://pub.com/shell">
 </amp-install-serviceworker>
 ```
 
-Here:
+Where:
  - `data-no-service-worker-fallback-shell-url` specifies the link for AMP+PWA shell. It's required to be on the source origin as the AMP document.
  - `data-no-service-worker-fallback-url-match` is a JavaScript regular expression that describes how to match “in-shell” links vs non-in-shell links.
  - Both of these attributes must be present to trigger URL rewrite.
@@ -120,12 +113,10 @@ URL rewrite works as following:
  4. AMP Runtime will intercept the “in-shell” navigations (which will often be AMP-to-AMP navigations) and if the service worker is not running, rewrite the navigation URL to proceed to the “shell”-based URL.
  5. The shell will startup and run the requested navigation via its router. Typically the shell will immediately execute history.replaceState(href).
 
-A URL is rewritten in the form `shell-url#href={encodeURIComponent(href)}`. E.g.:
+A URL is rewritten in the form `shell-url#href={encodeURIComponent(href)}`. For example:
 ```text
 https://pub.com/doc.amp.html
-
 -->
-
 https://pub.com/shell#href=%2Fdoc.amp.html
 ```
 

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>An <code>amp-jwplayer</code> component displays a cloud-hosted JW Player.</td>
+    <td>Displays a cloud-hosted <a href="https://www.jwplayer.com/">JW Player</a>.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
@@ -79,6 +79,10 @@ The JW Platform media id. This is an 8-digit alphanumeric sequence that can be f
 **data-playlist-id**
 
 The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the [Playlists](https://dashboard.jwplayer.com/#/content/playlists) section in your JW Player Dashboard.  If both `data-playlist-id` and `data-media-id` are specified, `data-playlist-id` takes precedence.  (**Required if `data-media-id` is not defined.**)
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 See [amp-jwplayer rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-jwplayer/0.1/validator-amp-jwplayer.protoascii) in the AMP validator specification.

--- a/extensions/amp-kaltura-player/amp-kaltura-player.md
+++ b/extensions/amp-kaltura-player/amp-kaltura-player.md
@@ -78,6 +78,10 @@ Keys and values will be URI encoded. Keys will be camel cased.
 
 - `data-param-streamerType="auto"` becomes `&flashvars[streamerType]=auto`
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
 ## Validation
 
 See [amp-kaltura-player rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-kaltura-player/0.1/validator-amp-kaltura-player.protoascii) in the AMP validator specification.

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -63,7 +63,7 @@ Example:
 The `amp-lightbox` component can be styled with standard CSS.
 
 ## Actions
-The `amp-lightbox` exposes the following actions you can use [AMP on-syntax to trigger](../../../src/spec/amp-actions-and-events.md):
+The `amp-lightbox` exposes the following actions you can use [AMP on-syntax to trigger](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md):
 
 <table>
   <tr>
@@ -83,12 +83,22 @@ The `amp-lightbox` exposes the following actions you can use [AMP on-syntax to t
 ### Examples
 
 ```html
-<button on="tap:tweets-lb.open">See Quote</button>
+<button on="tap:tweets-lb">See Quote</button>
 <amp-lightbox id="tweets-lb" layout="nodisplay">
     <blockquote>"Don't talk to me about JavaScript fatigue" - Horse JS</blockquote>
     <button on="tap:tweets-lb.close">Nice!</button>
 </amp-lightbox>
 ```
+
+## Attributes
+
+**id** (required)
+
+A unique identifer for the lightbox.
+
+**layout**
+
+Must be set to `nodisplay`.
 
 ## Validation
 

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -57,7 +57,7 @@ response and accessed using, e.g. `items="field1.field2"` expression.
 
 Thus, when `items="items"` is specified (the default) the response must be a JSON object that
 contains an array property "items":
-```json
+```text
 {
   "items": [...]
 }
@@ -68,12 +68,12 @@ The template can be specified using either of the following two ways:
 - `template` attribute that references an ID of an existing `template` element.
 - `template` element nested directly inside of this `amp-list` element.
 
-For more details on templates see [AMP HTML Templates](../../spec/amp-html-templates.md).
+For more details on templates, see [AMP HTML Templates](../../spec/amp-html-templates.md).
 
 Optionally, `amp-list` element can contain an element with `overflow` attribute. This
 element will be shown if AMP Runtime cannot resize the `amp-list` element as requested.
 
-An example:
+Example: Using overflow
 ```html
 <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
     width=300 height=200 layout=responsive>
@@ -96,16 +96,12 @@ An example:
 }
 ```
 
-The `amp-list` supports the following layouts: `fixed`, `fixed-height`,
-`responsive`, `fill`. See [AMP HTML Layout System](../../spec/amp-html-layout.md)
-for details.
-
 ## Substitutions
 
 The `amp-list` allows all standard URL variable substitutions.
 See [Substitutions Guide](../../spec/amp-var-substitutions.md) for more info.
 
-For instance:
+For example:
 ```html
 <amp-list src="https://foo.com/list.json?RANDOM"></amp-list>
 ```
@@ -128,12 +124,12 @@ elements rendered via the template.
 
 ## Attributes
 
-**src**
+**src** (required)
 
 The URL location of the remote endpoint that will return the JSON that will be rendered
 within this `amp-list`. This must be a CORS HTTP service.
 
-**credentials**
+**credentials** (optional)
 
 Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
 To send credentials, pass the value of "include". If this is set, the response must follow
@@ -148,7 +144,11 @@ expression that navigates via fields of the JSON response. Notice:
 
 - The default value is "items". The expected response: `{items: [...]}`.
 - If the response itself is the desired array, use the value of ".". The expected response is: `[...]`.
-- Nest navigation is permitted, e.g. "field1.field2". The expected response is: `{field1: {field2: [...]}}`.
+- Nest navigation is permitted (e.g., "field1.field2"). The expected response is: `{field1: {field2: [...]}}`.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -116,7 +116,7 @@ operation.
 
 {% call callout('Note', type='note') %}
 When using `position: fixed` we highly recommend that you use an id selector or a css selector with no other css combinators, because complex combinators cannot be moved into the fixed layer (fixed layer is an iOS workaround
-for webkit's fixed position bug **TODO: add webkit bug id here**).
+for webkit's fixed position [bug](https://bugs.webkit.org/show_bug.cgi?id=154399).
 {% endcall %}
 
 The actual action handler may be at a descendant and does not have to be at the

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -56,15 +56,20 @@ is live blogs: coverage for breaking news or live events where the user can stay
 on or keep returning to the same page to see new updates as they come in. Common
 examples are award shows, sporting events, and elections.
 
+To learn how to use `amp-live-list` in a blog, see the [Create a Live Blog](https://www.ampproject.org/docs/get_started/live_blog) tutorial.
+
 ## How it works
 
 In the background, while an AMP page using `<amp-live-list>` is displayed on the client, the AMP runtime polls the origin document on the host for updates. When the client receives a response, it then [filters](#server-side-filtering) and dynamically inserts those updates back into the page on the client. Publishers can customize the polling rate in order to control the number of incoming requests, and AMP caches like the Google AMP Cache can perform optimizations to reduce the server response payload, saving client bandwidth and CPU cycles.
 
 The `amp-live-list` component has 3 sections. We'll refer to these sections as
-"reference points" and they are denoted by an attribute. The 3 reference points are
-`update`, `items` and `pagination` and must be a direct child of the `amp-live-list`
-component. `update` and `items` are mandatory while `pagination` is optional.
-See "Reference Points" section below for further details.
+"reference points" and they are denoted by an attribute. These reference points must be a direct child of the `amp-live-list` component. The 3 reference points are:
+
+* `update`  (mandatory)
+* `items`  (mandatory)
+* `pagination` (optional)
+
+For more details, see the ["Reference Points"](#reference-points) section below.
 
 Example:
 
@@ -109,10 +114,10 @@ point is not shown for either updates (using `data-update-time`) or tombstone
 (using `data-tombstone`) operations without an insert (newly discovered id's)
 operation.
 
-**NOTE**: When using `position: fixed` we highly recommend
-to use an id selector or a css selector with no other css combinators, as complex
-combinators cannot be moved into the fixed layer (fixed layer  is an iOS workaround
+{% call callout('Note', type='note') %}
+When using `position: fixed` we highly recommend that you use an id selector or a css selector with no other css combinators, because complex combinators cannot be moved into the fixed layer (fixed layer is an iOS workaround
 for webkit's fixed position bug **TODO: add webkit bug id here**).
+{% endcall %}
 
 The actual action handler may be at a descendant and does not have to be at the
 `update` reference point. the `amp-live-list` component then has an internal
@@ -146,7 +151,7 @@ We recommend having a small subtree underneath this reference point as the
 the server in case the page count had increased. We don't do any special
 diffing and just outright replace the contents.
 
-## Update Behavior and User Experience (Work in Progress)
+## Update Behavior and User Experience
 
 When updates are discovered by the client from polling the server document, any
 newly discovered `id`'s from children of the `items` reference point will turn
@@ -195,7 +200,7 @@ See the documentation for [Server side filtering](../amp-live-list/amp-live-list
 
 ## Attributes
 
-Usuaully attribute requirements are only enforced on the actual component but
+Usually attribute requirements are only enforced on the actual component but
 because we need to anchor and make decisions on the client, we will also need
 to require an `items` and `update` attribute on a direct child of
 `amp-live-list`.  Children of the `items` reference point will also have
@@ -355,7 +360,7 @@ the lowest one.
     max-height: 0;
   }
 
-  // We need to override the `display: none` to be able to see
+  // We need to override "display: none" to be able to see
   // the transition effect on the 2nd live list.
   #live-list-2 > .amp-hidden[update] {
     display: block;
@@ -398,3 +403,6 @@ the lowest one.
   </div>
 </amp-live-list>
 ```
+
+## Validation
+See [amp-live-list rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-live-list/0.1/validator-amp-live-list.protoascii) in the AMP validator specification.

--- a/extensions/amp-mustache/amp-mustache.md
+++ b/extensions/amp-mustache/amp-mustache.md
@@ -26,6 +26,14 @@ limitations under the License.
     <td>Stable</td>
   </tr>
   <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td>
+      <div>
+        <code>&lt;script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js">&lt;/script></code>
+      </div>
+    </td>
+  </tr>
+  <tr>
     <td width="40%"><strong>Examples</strong></td>
     <td>None</td>
   </tr>

--- a/extensions/amp-o2-player/amp-o2-player.md
+++ b/extensions/amp-o2-player/amp-o2-player.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td class="col-fourty"><strong>Description</strong></td>
-    <td>An <code>amp-o2-player</code> component displays the AOL O2Player.</td>
+    <td>Displays the AOL O2Player.</td>
   </tr>
   <tr>
     <td class="col-fourty"><strong>Availability</strong></td>
@@ -28,6 +28,10 @@ limitations under the License.
   <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-o2-player" src="https://cdn.ampproject.org/v0/amp-o2-player-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+   <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
   </tr>
   <tr>
     <td class="col-fourty"><strong>Examples</strong></td>
@@ -54,30 +58,36 @@ Example:
 
 ## Attributes
 
-**data-pid**
+**data-pid** (required)
 
-The O2Player player id.
+The Player ID for the O2Player.
 
-**data-bcid**
+**data-bcid** (required)
 
-The O2Player bcid.
+The Buyer Company ID (bcid) for the O2Player.
 
 **data-bid**
 
-The O2Player bid.
+The Playlist ID (bid) for the O2Player.
 
-**data-vid**
+**data-vid** 
 
-The O2Player video id.
+The Video ID (vid) for the O2Player.
 
 **data-macros**
 
-The O2Player macros.
+The macros for the O2Player.
 
-## Validation errors
+**common attributes**
 
-The following lists validation errors specific to the `amp-o2-player` tag
-(see also `amp-o2-player` in the [AMP validator specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-o2-player/0.1/validator-amp-o2-player.protoascii)):
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
+## Validation 
+
+See [amp-o2-player rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-o2-player/0.1/validator-amp-o2-player.protoascii) in the AMP validator specification.
+
+The following lists validation errors specific to the `amp-o2-player` tag:
+
 
 <table>
   <tr>

--- a/extensions/amp-ooyala-player/amp-ooyala-player.md
+++ b/extensions/amp-ooyala-player/amp-ooyala-player.md
@@ -31,11 +31,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>FILL, FIXED, FLEX_ITEM, RESPONSIVE</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>Examples</strong></td>
-    <td></td>
+    <td>fill, fixed, flex-item, responsive</td>
   </tr>
 </table>
 
@@ -51,25 +47,29 @@ limitations under the License.
 
 ## Attributes
 
-**data-embedcode**
+**data-embedcode** (required)
 
 The video embed code from [Backlot](https://backlot.ooyala.com).
 
-**data-playerid**
+**data-playerid** (required)
 
 The ID of the player to load from [Backlot](https://backlot.ooyala.com).
 
-**data-pcode**
+**data-pcode** (required)
 
 The provider code for the account owning the embed code and player.
 
-**data-playerversion**
+**data-playerversion** (optional)
 
-An optional attribute to specify which version of the Ooyala player to use, V3 or V4. Defaults to V3.
+Specifies which version of the Ooyala player to use, V3 or V4. Defaults to V3.
 
-**data-config**
+**data-config** (optional)
 
-An optional attribute to specify a skin.json config file URL for player V4.
+Specifies a skin.json config file URL for player V4.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-pinterest/amp-pinterest.md
+++ b/extensions/amp-pinterest/amp-pinterest.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays a Pinterest widget or Pin It button.</td>
+    <td>Displays a Pinterest widget, Pin It button, or Follow button.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
@@ -39,12 +39,16 @@ limitations under the License.
   </tr>
 </table>
 
-## Examples:
+## Examples
 
-Pin It button: `data-do="buttonPin"`
+Use the `amp-pinterest` component to display a Pin It button, Pin widget, or Follow button.
+
+**Example: Pin It button**
 
 ```html
-<amp-pinterest height=20 width=40
+<amp-pinterest
+  height=20
+  width=40
   data-do="buttonPin"
   data-url="http://www.flickr.com/photos/kentbrew/6851755809/"
   data-media="http://farm8.staticflickr.com/7027/6851755809_df5b2051c9_z.jpg"
@@ -52,30 +56,49 @@ Pin It button: `data-do="buttonPin"`
 </amp-pinterest>
 ```
 
-Embedded pin widget: `data-do="embedPin"`
+**Example: Pin widget**
 
 ```html
-<amp-pinterest width=245 height=330
+<amp-pinterest
+  width=245
+  height=330
   data-do="embedPin"
   data-url="https://www.pinterest.com/pin/99360735500167749/">
 </amp-pinterest>
 ```
 
+**Example: Follow button**
+
+```html
+<amp-pinterest
+    height=20
+    width=94
+    data-do="buttonFollow"
+    data-href="https://www.pinterest.com/kentbrew/"
+    data-label="Kent Brewster">
+</amp-pinterest>
+```
+
+
 ## Pin It Button
 
-**data-url**
+**data-do** (required)
 
-Required when `data-do` is `buttonPin`.  Contains the fully-qualified URL intended to be pinned or re-made into a widget.
+Must be set to `buttonPin`.
 
-**data-media**
+**data-url** (required)
 
-Required when `data-do` is `buttonPin`.  Contains the fully-qualified URL of the image intended to be pinned. If the pin will eventually contain multimedia (such as YouTube), should point to a high-resolution thumbnail.
+Contains the fully-qualified URL intended to be pinned or re-made into a widget.
 
-**data-description**
+**data-media** (required)
 
-Required when `data-do` is `buttonPin`.  Contains the default description that appears in the pin create form; please choose carefully, since many Pinners will close the form without pinning if it doesn't make sense.
+Contains the fully-qualified URL of the image intended to be pinned. If the pin will eventually contain multimedia (such as YouTube), it should point to a high-resolution thumbnail.
 
-### Sizing the Pin It Button
+**data-description** (required)
+
+Contains the default description that appears in the pin create form; please choose carefully, since many Pinners will close the form without pinning if it doesn't make sense.
+
+### Sizing the Pin It button
 
 Default small rectangular button:
 
@@ -83,43 +106,43 @@ Default small rectangular button:
 height=20 width=40
 ```
 
-Small rectangular button with pin count to the right, using `data-count="beside"`
+Small rectangular button with pin count to the right, using `data-count="beside"`:
 
 ```html
 height=28 width=85
 ```
 
-Small rectangular button with pin count on top, using `data-count="above"`
+Small rectangular button with pin count on top, using `data-count="above"`:
 
 ```html
 height=50 width=40
 ```
 
-Large rectangular button using `data-height="tall"`
+Large rectangular button using `data-height="tall"`:
 
 ```html
 height=28 width=56
 ```
 
-Large rectangular button with pin count to the right, using `data-tall="true"` and `data-count="beside"`
+Large rectangular button with pin count to the right, using `data-tall="true"` and `data-count="beside"`:
 
 ```html
 height=28 width=107
 ```
 
-Large rectangular button with pin count on top, using `data-height="tall"` and `data-count="above"`
+Large rectangular button with pin count on top, using `data-height="tall"` and `data-count="above"`:
 
 ```html
 height=66 width=56
 ```
 
-Small circular button using `data-round="true"`
+Small circular button using `data-round="true"`:
 
 ```html
 height=16 width=16
 ```
 
-Large circular button using `data-round="true"` and `data-height="tall"`
+Large circular button using `data-round="true"` and `data-height="tall"`:
 
 ```html
 height=32 width=32
@@ -127,22 +150,29 @@ height=32 width=32
 
 ## Follow Button
 
-**data-href**
+**data-do** (required)
 
-Required when `data-do` is `buttonFollow`.  Contains the fully qualified Pinterest user profile url to follow.
+Must be set to `buttonFollow`.
 
-**data-label**
+**data-href** (required)
 
-Required when `data-do` is `buttonFollow`.  Contains the text to display on the follow button.
+Contains the fully qualified Pinterest user profile url to follow.
+
+**data-label** (required)
+
+Contains the text to display on the follow button.
 
 ## Embedded Pin Widget
 
-**data-url**
+**data-do** (required)
 
-When building the Embedded Pin widget, `data-url` is required and must contain the fully-qualified URL of the Pinterest resource to be shown as a widget.
+Must be set to `embedPin`.
+
+**data-url** (required)
+
+Must contain the fully-qualified URL of the Pinterest resource to be shown as a widget.
 
 ```html
-data-do="embedPin"
 data-url="https://www.pinterest.com/pin/99360735500167749/"
 ```
 

--- a/extensions/amp-reach-player/amp-reach-player.md
+++ b/extensions/amp-reach-player/amp-reach-player.md
@@ -20,13 +20,12 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>
-    An <code>amp-reach-player</code> component displays the Reach Player configured in the <a href="http://beachfrontreach.com">Beachfront Reach</a> platform.
+    <td>Displays the Reach Player configured in the <a href="http://beachfrontreach.com">Beachfront Reach</a> platform.
     </td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>Beta</td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -64,6 +63,10 @@ Example:
 **data-embed-id**
 
 The Reach player embed id found in the "players" section or in the generated embed itself.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-reddit/amp-reddit.md
+++ b/extensions/amp-reddit/amp-reddit.md
@@ -35,13 +35,15 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-reddit/">amp-reddit.html</a><br /><a href="https://github.com/ampproject/amphtml/blob/master/examples/reddit.amp.html">reddit.amp.html</a></td>
+    <td><a href="https://github.com/ampproject/amphtml/blob/master/examples/reddit.amp.html">reddit.amp.html</a></td>
   </tr>
 </table>
 
-## Example
+## Examples
 
-Post: `data-embedtype="post"`
+Use the `amp-reddit` component to embed a Reddit post or comment.
+
+**Example: Embedding a Reddit post**
 
 ```html
 <amp-reddit
@@ -49,11 +51,11 @@ Post: `data-embedtype="post"`
   width="300"
   height="400"
   data-embedtype="post"
-  data-src="https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed"
-></amp-reddit>
+  data-src="https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed">
+</amp-reddit>
 ```
 
-Comment: `data-embedtype="comment"`
+**Example: Embedding a Reddit comment**
 
 ```html
 <amp-reddit
@@ -65,35 +67,39 @@ Comment: `data-embedtype="comment"`
   data-uuid="b1246282-bd7b-4778-8c5b-5b08ac0e175e"
   data-embedcreated="2016-09-26T21:26:17.823Z"
   data-embedparent="true"
-  data-embedlive="true"
-></amp-reddit>
+  data-embedlive="true">
+</amp-reddit>
 ```
 
 ## Attributes
 
-**data-embedtype**
+**data-embedtype** (required)
 
-Required. The type of embed, either `post` or `comment`.
+The type of embed, either `post` or `comment`.
 
-**data-src**
+**data-src** (required)
 
-Required. The permamlink uri for the post or comment.
+The permamlink uri for the post or comment.
 
 **data-uuid**
 
-Supported when `data-embedtype` is `comment`. The provided UUID for the comment embed.
+The provided UUID for the comment embed. Supported when `data-embedtype` is `comment`. 
 
 **data-embedcreated**
 
-Supported when `data-embedtype` is `comment`. The datetime string for the comment embed.
+The datetime string for the comment embed. Supported when `data-embedtype` is `comment`. 
 
 **data-embedparent**
 
-Supported when `data-embedtype` is `comment`. Flag if the parent comment should be included in the embed.
+ Indicates whether the parent comment should be included in the embed. Supported when `data-embedtype` is `comment`.
 
 **data-embedlive**
 
-Supported when `data-embedtype` is `comment`. Flag if the embedded comment should update if the original comment is updated.
+ Indicates whether the embedded comment should update if the original comment is updated. Supported when `data-embedtype` is `comment`.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -102,6 +102,10 @@ The `open` attribute is present on the sidebar when it is open.
 
 The only permissible value for the `layout` attribute in `amp-sidebar` is `nodisplay`.
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
 ## Styling
 
 The `amp-sidebar` component can be styled with standard CSS.

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -23,8 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong>Availability</strong></td>
-    <td>
-      Stable
+    <td> Stable
     </td>
   </tr>
   <tr>
@@ -46,25 +45,19 @@ limitations under the License.
   </tr>
 </table>
 
+## Examples
 
-## Attributes
-**type** (__required__)
-Selects pre-configured type. This is required for both pre-configured and external providers.
+**Example: Basic social share button**
 
-**data-share-endpoint** (__required__ for non-configured providers)
-`amp-social-share` has some pre-configured share endpoints for popular providers, see section about [Pre-configured Providers](#pre-configured-providers). 
+The share button guesses some defaults for you for some pre-configured providers. It assumes that the current document canonical url is the URL you want to share and the page title is the text you want to share.
 
-**data-param-\***
-All `data-param-*` prefixed attributes will be turned into URL parameters and passed to the share endpoint.  
-
-#### The simplest example:
-The share button guesses some defaults for you for some already configured providers. It assumes that the current document canonical url is the URL you want to share and the page title is the text you want to share.
 ```html
 <amp-social-share type="twitter"></amp-social-share>
 ```
 
-#### Simple Examples:
-When you want to pass params to the share endpoint, you can specify ```data-param-<attribute>``` that will be appended to the share endpoint.
+**Example: Passing parameters**
+
+When you want to pass parameters to the share endpoint, you can specify `data-param-<attribute>` that will be appended to the share endpoint.
 ```html
 <amp-social-share type="linkedin" width="60" height="44"
   data-param-text="Hello world"
@@ -72,14 +65,120 @@ When you want to pass params to the share endpoint, you can specify ```data-para
 </amp-social-share>
 ```
 
-Linkedin is one of the configured providers so no need to provide `data-share-endpoint` attribute.
+Linkedin is one of the pre-configured providers, so you do not need to provide the `data-share-endpoint` attribute.
 
-#### Default Styles:
-By default `amp-social-share` comes with few pre-configured popular social share providers. These are styled with the provider official color and logo.
-__width__: default 60px
-__height__: default 44px
+## Attributes
 
-#### Custom Styles:
+**type** (__required__)
+
+Selects a provider type. This is required for both pre-configured and non-configured providers.
+
+**data-share-endpoint** (__required__ for non-configured providers)
+
+Some popular providers have pre-configured share endpoints. For details, see the [Pre-configured Providers](#pre-configured-providers) section.  For non-configured providers, you'll need to specify the share endpoint.
+
+**data-param-***
+
+All `data-param-*` prefixed attributes are turned into URL parameters and passed to the share endpoint.  
+
+
+## Pre-configured Providers
+The `amp-social-share` component provides [some pre-configured providers](0.1/amp-social-share-config.js) that know their sharing endpoints as well as some default parameters. 
+
+<table>
+  <tr>
+    <th class="col-twenty">Provider</th>
+    <th>Parameters</th>
+  </tr>
+  <tr>
+    <td>Email</td>
+    <td>
+      <ul>
+        <li><code>subject</code>: optional, defaults to: Current page title</li>
+        <li><code>body</code>: optional, defaults to: <code>rel=canonical</code> URL</li></ul>
+    </td>
+  </tr>
+  <tr>
+    <td>Facebook</td>
+    <td>
+      <ul>
+        <li><code>href</code>: optional, defaults to: <code>rel=canonical</code> URL</li>
+        <li><code>text</code>: optional, defaults to: none</li>
+        <li><code>app_id</code>: required, defaults to: none. This parameter is required for the <a href="https://developers.facebook.com/docs/sharing/reference/share-dialog">Facebook Share dialog</a>.</li></ul>
+    </td>
+  </tr>
+  <tr>
+    <td>LinkedIn</td>
+    <td>
+      <ul>
+        <li><code>url</code>: optional, defaults to: <code>rel=canonical</code> URL</li>
+      </ul>
+    </td>
+  </tr>
+  </tr>
+  <tr>
+    <td>Pinterest</td>
+    <td>
+      <ul>
+        <li><code>url</code>: optional, defaults to: <code>rel=canonical</code> URL</li>
+      </ul>
+    </td>
+  </tr>
+  </tr>
+  <tr>
+    <td>G+</td>
+    <td>
+      <ul>
+        <li><code>url</code>: optional, defaults to: <code>rel=canonical</code> URL</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>Tumblr</td>
+    <td>
+      <ul>
+        <li><code>url</code>: optional, defaults to: <code>rel=canonical</code> URL</li>
+        <li><code>text</code>: optional, defaults to: Current page title</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>Twitter</td>
+    <td>
+      <ul>
+        <li><code>url</code>: optional, defaults to: <code>rel=canonical</code> URL</li>
+        <li><code>text</code>: optional, defaults to: Current page title</li>
+      </ul>
+    </td>
+  </tr>
+</table>
+
+
+### Non-configured Providers
+
+In addition to pre-configured providers, you can use non-configured providers by specifying additional attributes in the `amp-social-share` component.
+
+**Example: Creating a share button for a non-configured provider**
+
+The following example creates a share button through WhatsApp by setting the `data-share-endpoint` attribute to the correct endpoint for the WhatsApp custom protocol.
+
+```html
+<amp-social-share type="whatsapp"
+    layout="container"
+    data-share-endpoint="whatsapp://send"
+    data-param-text="Check out this article: TITLE - CANONICAL_URL">
+    Share on Whatsapp
+</amp-social-share>
+```
+
+## Styles
+
+### Default Styles
+
+By default, `amp-social-share` includes some popular pre-configured providers. Buttons for these providers are styled with the provider's official color and logo. The default width is 60px, and the default height is 44px.
+
+### Custom Styles
+
 Sometimes you want to provide your own style. You can simply override the provided styles like the following: 
 ```css
 amp-social-share[type="twitter"] {
@@ -88,42 +187,19 @@ amp-social-share[type="twitter"] {
 }
 ```
 
-### Pre-configured Providers
-The element provides [some pre-configured providers](0.1/amp-social-share-config.js) that knows its sharing endpoint as well as some default parameters. 
+## Variable Substitution
+You can use [global AMP variables substitution](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md) in the `<amp-social-share>` element. In the example below, `TITLE` is substituted with the page title and `CANONICAL_URL` with the document's canonical URL.
 
-- twitter
-    - url `optional` (defaults: `rel=canonical` URL)
-    - text `optional` (defaults: Current page title)
-- facebook
-    - href `optional` (defaults: `rel=canonical` URL)
-    - text `optional` (defaults: none)
-    - app_id `required` (defaults: none) Required by [Facebook share dialog](https://developers.facebook.com/docs/sharing/reference/share-dialog).
-- pinterest
-    - url `optional` (defaults: `rel=canonical` URL)
-- linkedin
-    - url `optional` (defaults: `rel=canonical` URL)
-- gplus
-    - url `optional` (defaults: `rel=canonical` URL)
-- tumblr
-    - url `optional` (defaults: `rel=canonical` URL)
-    - name `optional` (defaults: Current page title)
-- email
-    - subject `optional` (defaults: Current page title)
-    - body `optional` (defaults: `rel=canonical` URL)
-
-### Un-configured Providers
-`amp-social-share` allows you to use any provider you'd like that is not pre-configured by configuring the element with more attributes.
-
-#### Example
-The following example will create a share button through whatsapp, by setting `data-share-endpoint` attribute to the correct endpoint for whatsapp custom protocol.
 ```html
 <amp-social-share type="whatsapp"
-                layout="container"
-                data-share-endpoint="whatsapp://send"
-                data-param-text="Check out this article: TITLE - CANONICAL_URL">
+    layout="container"
+    data-share-endpoint="whatsapp://send"
+    data-param-text="Check out this article: TITLE - CANONICAL_URL">
     Share on Whatsapp
 </amp-social-share>
 ```
 
-##### Var Substitution
-You can use the [global AMP variables substitution](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md) in the `<amp-social-share>` element. For exmaple, the above example will substitute `TITLE` with the page title and `CANONICAL_URL` with the document canonical URL.
+
+## Validation
+
+See [amp-social-share rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii) in the AMP validator specification.

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -57,36 +57,28 @@ Classic Mode:
     data-color="ff5500"></amp-soundcloud>
 ```
 
-## Required attributes
+## Attributes
 
-**data-trackid**
+**data-trackid** (required)
 
 The ID of the track, an integer.
 
-## Optional attributes
-
-**data-secret-token**
+**data-secret-token** (optional)
 
 The secret token of the track, if it is private.
 
-**data-visual**
+**data-visual** (optional)
 
-Value: `"true"` or `"false"`
+If set to `true`, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is `false`.
 
-Default value: `"false"`
+**data-color** (optional)
 
-If set to true, displays full width "Visual" mode. Otherwise, displays "Classic"
-mode.
+This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., `data-color="e540ff"`).
 
-**data-color**
 
-Value: Hexadecimal color value (without the leading #).
-E.g. `data-color="e540ff"`
+**width** and **height**
 
-Custom color override for the "Classic" mode. Ignored in "Visual" mode.
-
-**width and height**
-Layout is `fixed-height` and will fill all the available horizontal space. This is ideal for "Classic" mode, but for "Visual", height is recommended to be 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.
+The layout for `amp-soundcloud` is set to `fixed-height` and it fills all of the available horizontal space. This is ideal for the "Classic" mode, but for "Visual" mode, it's recommended that the height is 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.
 
 ## Validation
 

--- a/extensions/amp-springboard-player/amp-springboard-player.md
+++ b/extensions/amp-springboard-player/amp-springboard-player.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>An <code>amp-springboard-player</code> displays the Springboard Player used in <a href="http://publishers.springboardplatform.com">Springboard</a> Video Platform.
+    <td>Displays the Springboard Player used in the <a href="http://publishers.springboardplatform.com">Springboard</a> Video Platform.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
@@ -35,15 +35,14 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://github.com/ampproject/amphtml/blob/master/examples/springboard-player.amp.html">springboard-player.amp.html</a></td>
+    <td><a href="https://ampbyexample.com/components/amp-springboard-player/">Annotated code example for amp-springboard-player</a></td>
+  </tr>
   </tr>
 </table>
 
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
-
-Examples:
 
 ```html
 <amp-springboard-player
@@ -59,29 +58,33 @@ Examples:
 
 ## Attributes
 
-**data-site-id**
+**data-site-id** (required)
 
-The SpringBoard site id. Specific to every partner.
+The SpringBoard site ID. Specific to every partner.
 
-**data-mode**
+**data-mode** (required)
 
-The SpringBoard player mode (video|playlist).
+The SpringBoard player mode: `video` or `playlist`.
 
-**data-content-id**
+**data-content-id** (required)
 
-The SpringBoard player content id (video or playlist id).
+The SpringBoard player content ID (video or playlist ID).
 
-**data-player-id**
+**data-player-id** (required)
 
 The Springboard player ID.
 
-**data-domain**
+**data-domain** (required)
 
 The Springboard partner domain.
 
-**data-items**
+**data-items** (required)
 
-The number of videos in playlist
+The number of videos in the playlist.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-sticky-ad/amp-sticky-ad.md
+++ b/extensions/amp-sticky-ad/amp-sticky-ad.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>A stickyAd provides a way to fix ad at bottom of a page. The stickyAs serves as a container and the ad as its child will display as sticky-ad</td>
+    <td>Provides a way to fix an ad to the bottom of a page. The sticky-ad serves as a container, with the ad as its child.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -38,38 +38,42 @@ limitations under the License.
 ## Behavior
 
 - There can be only one `<amp-sticky-ad>` in an AMP document. The `<amp-sticky-ad>` should only have one direct child of `<amp-ad>`.
-- The sticky ad will appear on the bottom of a page.
-- The sticky ad introduces a full width blank container and then fills the sticky ad based on the width and height of the amp-ad.
+- The sticky ad appears at the bottom of a page.
+- The sticky ad introduces a full-width blank container and then fills the sticky ad based on the width and height of the `<amp-ad>`.
 - The height of the sticky-ad is whatever its child needs up to its max-height.
 - The max-height of the sticky-ad is 100px, if the height exceeds 100px then the height would be 100px and overflow content will be hidden.
 - The width of the sticky-ad is set to 100% using CSS and cannot be overridden.
 - The opacity of the sticky-ad is set to 1 using CSS and cannot be overridden.
-- The background color of the sticky-ad can be customized to match page style. However any semi-transparent or transparent background will not be allowed and will be changed to a non-transparent color.
-- The sticky ad will display after scroll one viewport height from top provided there is at least one more viewport of content available.
+- The background color of the sticky-ad can be customized to match the page style. However, any semi-transparent or transparent background will not be allowed and will be changed to a non-transparent color.
+- The sticky ad display after scrolling one viewport height from the top, provided there is at least one more viewport of content available.
 - When scrolled to the bottom of the page, the viewport is automatically padded with the additional height of the sticky ad, so that no content is ever hidden.
-- When in landscape mode, the sticky ad will be center aligned.
+- When in landscape mode, the sticky ad is center-aligned.
 - The sticky ad can be dismissed and removed by a close button.
 
 Example:
 ```html
 <amp-sticky-ad layout="nodisplay">
   <amp-ad width="320"
-        height="50"
-        type="doubleclick"
-        data-slot="/35096353/amptesting/formats/sticky">
+      height="50"
+      type="doubleclick"
+      data-slot="/35096353/amptesting/formats/sticky">
   </amp-ad>
 </amp-sticky-ad>
 ```
 
 ## Attributes
 
-**layout**
+**layout** (required)
 
-The only permissible value for the `layout` attribute in `amp-sticky-ad` is `nodisplay`.
+Must be set to `nodisplay`.
 
 ## Styling
 
 The `amp-sticky-ad` component can be styled with standard CSS.
 
-- Sticky ad container style can be set through css class `amp-sticky-ad`.
-- Close button style can be set through css class `amp-sticky-ad-close-button`.
+- The sticky ad container style can be set through the `amp-sticky-ad` CSS class.
+- The close button style can be set through the `amp-sticky-ad-close-button` CSS class.
+
+## Validation
+
+See [amp-sticky-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-sticky-ad/0.1/validator-amp-sticky-ad.protoascii) in the AMP validator specification.

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -60,13 +60,17 @@ Copy the placeholder from Twitter's embed dialog, but remove the `script`. Then 
 
 ## Attributes
 
-**data-tweetid**
+**data-tweetid** (required)
 
-The ID of the tweet. In a URL like https://twitter.com/joemccann/status/640300967154597888 `640300967154597888` is the tweetID.
+The ID of the tweet. In a URL like https://twitter.com/joemccann/status/640300967154597888,  `640300967154597888` is the tweetID.
 
-**data-nameofoption**
+**data-*** (optional)
 
-Options for the Tweet appearance can be set using `data-` attributes. E.g. `data-cards="hidden"` deactivates Twitter cards. For documentation of the available options, see [Twitter's docs](https://dev.twitter.com/web/javascript/creating-widgets#create-tweet).
+You can specify options for the Tweet appearance by setting `data-` attributes. For example, `data-cards="hidden"` deactivates Twitter cards. For details on the available options, see [Twitter's docs](https://dev.twitter.com/web/javascript/creating-widgets#create-tweet).
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-user-notification/amp-user-notification.md
+++ b/extensions/amp-user-notification/amp-user-notification.md
@@ -43,43 +43,45 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-user-notification/">Annotated code example for amp-user-notification (with local storage)</a><br /><a href="https://ampbyexample.com/advanced/amp-user-notification_with_server_endpoint/">Annotated code example for amp-user-notification (with Server Endpoint)</a></td>
+    <td>
+      <ul>
+        <li><a href="https://ampbyexample.com/components/amp-user-notification/">Annotated code example for amp-user-notification (with local storage)</a></li>
+        <li><a href="https://ampbyexample.com/advanced/amp-user-notification_with_server_endpoint/">Annotated code example for amp-user-notification (with Server Endpoint)</a></li>
+      </ul>
+    </td>
   </tr>
 </table>
 
 ## Usage
 
-An `id` is required
-as multiple `amp-user-notification` elements are allowed and the
-`id` is used to differentiate them.
+An `id` is required because multiple `amp-user-notification` elements are allowed and the `id` is used to differentiate them.
 
 By supplying two URLs that
 get called before the notification is shown and after it is dismissed,
 it is possible to control per user as to whether the notification should
 be shown (using the `ampUserId` value).
-For example, it could only be shown to users in certain geo locations or
+For example, it could only be shown to users in certain geolocations or
 prevent showing it again to the user when they've dismissed it before.
-If these URLs are not specified, dismissal state will be queried
+If these URLs are not specified, the dismissal state will be queried
 and/or stored locally to determine whether to show the notification to
 the user.
 
-To close `amp-user-notification`, add a `on` attribute to a button with the
+To close `amp-user-notification`, add an `on` attribute to a button with the
 following value scheme `on="event:idOfUserNotificationElement.dismiss"`
 (see example below). This user action also triggers the `GET` to the
-`data-dismiss-href` URL. Be very mindful of the browser caching the `GET` response
-and see details below in the `data-show-if-href` section. (We recommend
-adding a unique value to the `GET` url like a timestamp as a query string field)
+`data-dismiss-href` URL. Be very mindful of the browser caching the `GET` response; see details below in the `data-show-if-href` section. (We recommend
+adding a unique value to the `GET` url like a timestamp as a query string field).
 
 When multiple `amp-user-notification` elements are on a page, only one is shown
 at a single time (Once one is dismissed the next one is shown).
 The order of the notifications being shown is currently not deterministic. (TODO:
-follow up task #1229 to fix this).
+follow up task [#1229](https://github.com/ampproject/amphtml/issues/1229) to fix this).
 
 Example:
 
 ```html
 <amp-user-notification
-    layout=nodisplay
+    layout="nodisplay"
     id="amp-user-notification1"
     data-show-if-href="https://foo.com/api/show-api?timestamp=TIMESTAMP"
     data-dismiss-href="https://foo.com/api/dismissed">
@@ -89,73 +91,57 @@ Example:
 </amp-user-notification>
 ```
 
----
-
 ## Attributes
 
-**data-show-if-href** (Optional)
+**data-show-if-href** (optional)
 
-When specified, AMP will make a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
-GET request with credentials to this URL to determine whether the notification should be shown.
-We will append the `elementId` and `ampUserId` query string fields to the href provided
-on the `data-show-if-href` attribute. (see [#1228](https://github.com/ampproject/amphtml/issues/1228) on why this is a GET instead of a POST)
+When specified, AMP will make a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) GET request with credentials to this URL to determine whether the notification should be shown. AMP appends the `elementId` and `ampUserId` query string fields to the href provided
+on the `data-show-if-href` attribute (see [#1228](https://github.com/ampproject/amphtml/issues/1228) on why this is a GET instead of a POST).
 
-For best practice to not let the browser cache the GET response values you should add
+As a best practice to not let the browser cache the GET response values, you should add
 a [`TIMESTAMP` url replacement](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md) value to the `data-show-if-href` attribute value.
-You can add it as a query string field. (ex.
-`data-show-if-href="https://foo.com/api/show-api?timestamp=TIMESTAMP"`)
+You can add it as a query string field (e.g., 
+`data-show-if-href="https://foo.com/api/show-api?timestamp=TIMESTAMP"`).
 
- - `CORS GET request` query string fields
-    - `elementId`
-    - `ampUserId`
+ - **CORS GET request** query string fields: `elementId`, `ampUserId`
 
-  Example:
+    Example:
   ```text
   https://foo.com/api/show-api?timestamp=1234567890&elementId=notification1&ampUserId=cid-value
   ```
 
- - `CORS GET response` json fields
-    The response must contain a single JSON object with a field
-    "showNotification" of type boolean. If this field is `true` the
-    notification will be shown, otherwise it will not be shown.
-
-    - `showNotification`
+ - **CORS GET response** JSON fields: `showNotification`. The response must contain a single JSON object with a `showNotification` field of type boolean. If this field is `true`, the notification will be shown, otherwise it will not be shown.
 
     Example:
     ```json
     { "showNotification": true }
     ```
 
-If not specified, AMP will only check if the notification with the specified ID has been "dismissed"
-by the user locally. If not, the notification will be shown.
+If not specified, AMP will only check if the notification with the specified ID has been "dismissed" by the user locally. If not, the notification will be shown.
 
-**data-dismiss-href** (Optional)
+**data-dismiss-href** (optional)
 
-When specified, AMP will make a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
+When specified, AMP will make a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) 
 POST request to this URL transmitting the `elementId` and
 `ampUserId` only when the user has explicitly agreed.
 
-Use the `ampUserId` field to store that the user has seen the notification before
-if you want to avoid showing it in the future. (It is the same value that
-will be passed in future requests to data-show-if-href)
+Use the `ampUserId` field to store that the user has seen the notification before, if you want to avoid showing it in the future. It's the same value that
+will be passed in future requests to `data-show-if-href`.
 
-  - `POST request` json fields
-
-    - `elementId`
-    - `ampUserId`
+  - **POST request** JSON fields: `elementId`, `ampUserId`
 
     Example:
     ```json
     { "elementId": "id-of-amp-user-notification", "ampUserId": "ampUserIdString" }
     ```
-  - `POST response` should be a 200 HTTP code and no data is expected back.
 
-If not specified, AMP will not send a request upon dismissal and will only store "dismissed"
-flag for the specified ID locally.
+  - **POST response** should be a 200 HTTP code and no data is expected back.
 
-**data-persist-dismissal** (Optional)
-__Default: true__
-If set  to `false` AMP will not remember the user's dismissal of the notification. The notification
+If not specified, AMP will not send a request upon dismissal, and will only store the "dismissed" flag for the specified ID locally.
+
+**data-persist-dismissal** (optional)
+
+By default, this is set to `true`. If set to `false`, AMP will not remember the user's dismissal of the notification. The notification
 will always show if the `data-show-if-href` result is show notification. If no `data-show-if-href` is provided
 the notification will always show.
 
@@ -185,28 +171,23 @@ This notification should ALWAYS show on every page visit.
 </amp-user-notification>
 ```
 
-
----
-
 ## JSON Fields
 
-- `elementId` (string) - The HTML id used on `amp-user-notification` element.
-- `ampUserId` (string) - This id is passed to both the `data-show-if-href` GET request
+- `elementId` (string): The HTML ID used on the `amp-user-notification` element.
+- `ampUserId` (string): This ID is passed to both the `data-show-if-href` GET request
     (as a query string field) and the `data-dismiss-href` POST request (as a json field).
-    The id will be the same for this user going forward, but no other requests
-    in AMP send the same id.
-    You can use the id on your side to lookup/store whether the user has
+    The ID will be the same for this user going forward, but no other requests
+    in AMP send the same ID.
+    You can use the ID on your side to lookup/store whether the user has
     dismissed the notification before.
-- `showNotification` (boolean) - Boolean value indicating whether or not the notification should be shown.
-    If `false` the promise associated to the element is resolved right away.
+- `showNotification` (boolean): Indicates whether the notification should be shown. If `false`, the promise associated to the element is resolved right away.
 
----
 
 ## Behavior
 
 A notification is shown when:
 
-1. There's no record locally that the user has dismissed the notification with the
+1. There's no record locally that the user has dismissed the notification with the 
 specified ID.
 2. When specified, `data-show-if-href` endpoint returns `{ "showNotification": true }`.
 
@@ -217,37 +198,35 @@ notification from being shown again.
 2. When specified, `data-dismiss-href` is invoked and can be used to make the "dismiss"
 record remotely.
 
----
 
 ## Styling
 
 The `amp-user-notification` component should always have `layout=nodisplay`
 and will be `position: fixed` after layout (default is bottom: 0, which can be overridden).
-If a page has more than 1 `amp-user-notification` element then the notifications
+If a page has more than one `amp-user-notification` element, then the notifications
 are queued up and only shown when the previous notification has been dismissed.
 
-The `amp-active` (visibility: visible) class is added when the notification is displayed and
-and removed when the notification has been dismissed.
+The `amp-active` (visibility: visible) class is added when the notification is displayed and removed when the notification has been dismissed.
 `amp-hidden` (visibility: hidden) is added when the notification has been dismissed.
 
-You can for example hook into these classes for a "fade in" transition.
+For example, you can hook into these classes for a "fade in" transition.
 
-ex. (w/o vendor prefixes)
+Example: w/o vendor prefixes
 
 ```css
-  @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
 
-  amp-user-notification.amp-active {
-    opacity: 0;
-    animation: fadeIn ease-in 1s 1 forwards;
-  }
+amp-user-notification.amp-active {
+  opacity: 0;
+  animation: fadeIn ease-in 1s 1 forwards;
+}
 ```
 
 ## Actions
-The `amp-user-notification` exposes the following actions you can use [AMP on-syntax to trigger](../../../src/spec/amp-actions-and-events.md):
+The `amp-user-notification` exposes the following actions that you can use [AMP on-syntax to trigger](../../../src/spec/amp-actions-and-events.md):
 
 <table>
   <tr>
@@ -256,16 +235,16 @@ The `amp-user-notification` exposes the following actions you can use [AMP on-sy
   </tr>
   <tr>
     <td>dismiss (default)</td>
-    <td>Closes the user notification - see [Usage](#usage) for more details</td>
+    <td>Closes the user notification; see <a href="#usage">usage</a> for more details.</td>
   </tr>
 </table>
 
 ## Delaying Client ID generation until the notification is acknowledged
 
-Optionally one can delay generation of Client IDs used for analytics and similar purposes until an `amp-user-notification` is confirmed by the user. See these docs for how to implement this:
+Optionally, you can delay generation of Client IDs used for analytics and similar purposes until an `amp-user-notification` is confirmed by the user. See these docs for how to implement this:
 
-- [CLIENT_ID URL substitution.](../../spec/amp-var-substitutions.md#client-id)
-- [`amp-ad`](../../builtins/amp-ad.md)
+- [CLIENT_ID URL substitution](../../spec/amp-var-substitutions.md#client-id)
+- [`amp-ad`](../amp-ad/amp-ad.md)
 - [`amp-analytics`](../amp-analytics/amp-analytics.md)
 
 ## Validation

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -101,6 +101,10 @@ If present, will automatically loop the video back to the start upon reaching th
 `muted` attribute is deprecated and no longer has any effect.
 `autoplay` attribute automatically controls the mute behavior.
 
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
 ## Validation
 
 See [amp-video rules](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii) in the AMP validator specification.

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -52,11 +52,13 @@ With responsive layout, the width and height from the example should yield corre
 
 ## Attributes
 
-**data-videoid**
+**data-videoid** (required)
 
-The Vimeo video id found in every Vimeo video page URL
+The Vimeo video id found in every Vimeo video page URL For example, `27246366` is the video id for the following url: https://vimeo.com/27246366.
 
-E.g. in https://vimeo.com/27246366 27246366 is the video id.
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-vine/amp-vine.md
+++ b/extensions/amp-vine/amp-vine.md
@@ -51,9 +51,13 @@ A Vine simple embed has equal width and height:
 
 ## Attributes
 
-**data-vineid**
+**data-vineid** (required)
 
-The ID of the Vine. In a URL like https://vine.co/v/MdKjXez002d `MdKjXez002d` is the vineID.
+The ID of the Vine. In a URL like https://vine.co/v/MdKjXez002d, `MdKjXez002d` is the vineID.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -41,7 +41,7 @@ limitations under the License.
 
 ## Example
 
-With responsive layout the width and height from the example should yield correct layouts for 16:9 aspect ratio videos:
+With the responsive layout, the width and height from the example should yield correct layouts for 16:9 aspect ratio videos:
 
 ```html
 <amp-youtube
@@ -64,19 +64,23 @@ If this attribute is present, and the browser supports autoplay:
 
 **data-videoid**
 
-The Youtube video id found in every Youtube video page URL.
+The YouTube video id found in every YouTube video page URL.
 
 For example, in this URL: https://www.youtube.com/watch?v=Z1q71gFeRqM, `Z1q71gFeRqM` is the video id.
 
 **data-param-***
 
-All `data-param-*` attributes will be added as query parameter to the youtube iframe src. This may be used to pass custom values through to youtube plugins, such as whether to show controls.
+All `data-param-*` attributes will be added as query parameter to the YouTube iframe src. This may be used to pass custom values through to YouTube plugins, such as whether to show controls.
 
 Keys and values will be URI encoded. Keys will be camel cased.
 
 - `data-param-controls=1` becomes `&controls=1`
 
-See [Youtube Embedded Player Parameters](https://developers.google.com/youtube/player_parameters) for more parameter options for youtube.
+See [YouTube Embedded Player Parameters](https://developers.google.com/youtube/player_parameters) for more parameter options for YouTube.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 


### PR DESCRIPTION
Clean up of reference docs, particularly: adding reference to common attributes (when appropriate), fix formatting, grammar, links, and overall consistency.

to: @pbakaus 