### PR TITLE
Turn on amp-inabox to 100% on both canary and prod.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -11,6 +11,7 @@
   "ad-type-custom": 1,
   "amp-scrollable-carousel": 1,
   "amp-app-banner": 1,
+  "amp-inabox": 1,
   "ios-embed-wrapper": 1,
   "amp-apester-media": 1,
   "3p-frame-context-in-name": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -11,6 +11,7 @@
   "ad-type-custom": 1,
   "amp-scrollable-carousel": 1,
   "amp-app-banner": 1,
+  "amp-inabox": 1,
   "ios-embed-wrapper": 1,
   "amp-apester-media": 1
 }


### PR DESCRIPTION
We can turn this on to 100% in prod, as ad server is controlling the overall experiment right now.