### PR TITLE
Switched from vid to cid for adsense and doubleclick integration with Google Analytics

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -31,7 +31,7 @@ export function adsense(global, data) {
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.
     global.gaGlobal = {
-      vid: global.context.clientId,
+      cid: global.context.clientId,
       hid: global.context.pageViewId,
     };
   }

--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -49,7 +49,7 @@ export function doubleclick(global, data) {
   if (global.context.clientId) {
     // Read by GPT/Glade for GA/Doubleclick integration.
     global.gaGlobal = {
-      vid: global.context.clientId,
+      cid: global.context.clientId,
       hid: global.context.pageViewId,
     };
   }


### PR DESCRIPTION
The backend expects `vid` to be of a particular format: `nnnn.nnnn.`
Whereas `cid` can be of arbitrary format (as is the case for AMP).

Fixes #6379