### PR TITLE
Add amp-bind support to amp-video

### DIFF
--- a/examples/bind.amp.html
+++ b/examples/bind.amp.html
@@ -49,11 +49,9 @@
   <p [class]="textClass">This text will have have a red background color</p>
   <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" [src]="imgSrc" width=100 [width]="imgSize" height=100 [height]="imgSize" alt="asdf" [alt]="imgAlt"></amp-img>
   <p>The image above will increase in size and change its src</p>
-  <!--
-  <amp-video src="https://ampbyexample.com/video/tokyo.mp4" [src]="videoSrc" width=480 height=270 controls></amp-video>
-  -->
+  <amp-video src="https://ampbyexample.com/video/tokyo.mp4" [src]="videoSrc" width=480 height=270 autoplay [controls]="videoControls"></amp-video>
   <div>
-    <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog', videoSrc='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4')">Click me</button>
+    <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog', videoSrc='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4', videoControls=true)">Click me</button>
   </div>
 
   <div>

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -183,21 +183,6 @@ class AmpVideo extends AMP.BaseElement {
       return !!this.video_.play;
     }
 
-    /**
-     * @param {string} attributeName
-     * @return {boolean}
-     * @private
-     */
-    shouldPropagateAttributeOnMutation_(attributeName) {
-      if (ATTRS_TO_PROPAGATE_ON_BUILD.indexOf(attributeName) >= 0) {
-        return true;
-      }
-      if (ATTRS_TO_PROPAGATE_ON_LAYOUT.indexOf(attributeName) >= 0) {
-        return true;
-      }
-      return false;
-    }
-
     // VideoInterface Implementation. See ../src/video-interface.VideoInterface
 
     /**

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -126,7 +126,9 @@ class AmpVideo extends AMP.BaseElement {
         }
         if (this.shouldPropagateAttributeOnMutation_(name)) {
           this.propagateAttributes(
-              name, this.video_, /* opt_removeMissingAttrs */ true);
+              name,
+              /** @type {!Element} */ (this.video_),
+              /* opt_removeMissingAttrs */ true);
         }
       }, this);
     }

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -28,16 +28,20 @@ import {assertHttpsUrl} from '../../../src/url';
 
 const TAG = 'amp-video';
 
-/** @type {!Array<string>} */
+/** @private {!Array<string>} */
 const ATTRS_TO_PROPAGATE_ON_BUILD = ['poster', 'controls', 'aria-label',
   'aria-describedby', 'aria-labelledby'];
 
 /**
  * @note Do not propagate `autoplay`. Autoplay behaviour is managed by
  *       video manager since amp-video implements the VideoInterface.
- * @type {!Array<string>}
+ * @private {!Array<string>}
  */
 const ATTRS_TO_PROPAGATE_ON_LAYOUT = ['src', 'loop', 'preload'];
+
+/** @private {!Array<string>} */
+const ATTRS_TO_PROPAGATE =
+    ATTRS_TO_PROPAGATE_ON_BUILD.concat(ATTRS_TO_PROPAGATE_ON_LAYOUT);
 
 /**
  * @implements {../../../src/video-interface.VideoInterface}
@@ -117,20 +121,15 @@ class AmpVideo extends AMP.BaseElement {
       if (!this.video_) {
         return;
       }
-      mutations.forEach(mutation => {
-        const name = mutation.name;
-        switch (name) {
-          case 'src':
-            assertHttpsUrl(this.element.getAttribute('src'), this.element);
-            break;
-        }
-        if (this.shouldPropagateAttributeOnMutation_(name)) {
-          this.propagateAttributes(
-              name,
-              /** @type {!Element} */ (this.video_),
-              /* opt_removeMissingAttrs */ true);
-        }
-      }, this);
+      if (mutations['src']) {
+        assertHttpsUrl(this.element.getAttribute('src'), this.element);
+      }
+      const attrs = ATTRS_TO_PROPAGATE.filter(
+          value => mutations[value] !== undefined);
+      this.propagateAttributes(
+          attrs,
+          dev().assertElement(this.video_),
+          /* opt_removeMissingAttrs */ true);
     }
 
     /** @override */

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -336,23 +336,16 @@ describe(TAG, () => {
       height: 90,
       controls: '',
     }).then(v => {
-      const mutations = [
-        {
-          name: 'src',
-          oldValue: 'foo.mp4',
-          newValue: 'bar.mp4',
-        },
-        {
-          name: 'controls',
-          oldValue: '',
-          newValue: null,
-        },
-      ];
-      mutations.forEach(m => {
-        if (m.newValue === null) {
-          v.removeAttribute(m.name);
+      const mutations = {
+        src: 'bar.mp4',
+        controls: null,
+      };
+      Object.keys(mutations).forEach(property => {
+        const value = mutations[property];
+        if (value === null) {
+          v.removeAttribute(property);
         } else {
-          v.setAttribute(m.name, m.newValue);
+          v.setAttribute(property, value);
         }
       });
       v.mutatedAttributesCallback(mutations);

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -328,4 +328,37 @@ describe(TAG, () => {
       expect(video.getAttribute('aria-describedby')).to.equal('id3');
     });
   });
+
+  it('should propagate attribute mutations', () => {
+    return getVideo({
+      src: 'foo.mp4',
+      width: 160,
+      height: 90,
+      controls: '',
+    }).then(v => {
+      const mutations = [
+        {
+          name: 'src',
+          oldValue: 'foo.mp4',
+          newValue: 'bar.mp4',
+        },
+        {
+          name: 'controls',
+          oldValue: '',
+          newValue: null,
+        },
+      ];
+      mutations.forEach(m => {
+        if (m.newValue === null) {
+          v.removeAttribute(m.name);
+        } else {
+          v.setAttribute(m.name, m.newValue);
+        }
+      });
+      v.mutatedAttributesCallback(mutations);
+      const video = v.querySelector('video');
+      expect(video.getAttribute('src')).to.equal('bar.mp4');
+      expect(video.controls).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
Partial for #6199.

- Simply propagates select attributes to inner video element.
- Requires #6779 to be merged first.

@aghassemi You mentioned in an old PR that `controls` can't be simply propagated, but I tested it and looked at `VideoManager` and couldn't see an obvious problem. Would you mind elaborating?