### PR TITLE
Remove the check of 2 viewport requirement for sticky-ad

### DIFF
--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -129,11 +129,6 @@ class AmpStickyAd extends AMP.BaseElement {
   displayAfterScroll_() {
     const scrollTop = this.viewport_.getScrollTop();
     const viewportHeight = this.viewport_.getSize().height;
-    const scrollHeight = this.viewport_.getScrollHeight();
-    if (scrollHeight < viewportHeight * 2) {
-      this.removeOnScrollListener_();
-      return;
-    }
 
     // Check user has scrolled at least one viewport from init position.
     if (scrollTop > viewportHeight) {

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -69,7 +69,6 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       impl.displayAfterScroll_();
       expect(getScrollTopSpy).to.have.been.called;
       expect(getSizeSpy).to.have.been.called;
-      expect(getScrollHeightSpy).to.have.been.called;
       expect(scheduleLayoutSpy).to.not.have.been.called;
       expect(removeOnScrollListenerSpy).to.not.have.been.called;
       done();
@@ -106,43 +105,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       impl.displayAfterScroll_();
       expect(getScrollTopSpy).to.have.been.called;
       expect(getSizeSpy).to.have.been.called;
-      expect(getScrollHeightSpy).to.have.been.called;
       expect(scheduleLayoutSpy).to.have.been.called;
-      expect(removeOnScrollListenerSpy).to.have.been.called;
-    });
-
-    it('should not build if less than one viewport height ahead', () => {
-      const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
-      const removeOnScrollListenerSpy =
-          sandbox.spy(impl, 'removeOnScrollListener_');
-      const getScrollTopSpy = sandbox.spy();
-      const getSizeSpy = sandbox.spy();
-      const getScrollHeightSpy = sandbox.spy();
-
-      impl.viewport_.getScrollTop = function() {
-        getScrollTopSpy();
-        return 150;
-      };
-      impl.viewport_.getSize = function() {
-        getSizeSpy();
-        return {height: 100};
-      };
-      impl.viewport_.getScrollHeight = function() {
-        getScrollHeightSpy();
-        return 180;
-      };
-      impl.deferMutate = function(callback) {
-        callback();
-      };
-      impl.vsync_.mutate = function(callback) {
-        callback();
-      };
-
-      impl.displayAfterScroll_();
-      expect(getScrollTopSpy).to.have.been.called;
-      expect(getSizeSpy).to.have.been.called;
-      expect(getScrollHeightSpy).to.have.been.called;
-      expect(scheduleLayoutSpy).to.not.have.been.called;
       expect(removeOnScrollListenerSpy).to.have.been.called;
     });
 


### PR DESCRIPTION
Fix #6597. this helps with the case that the ad should be displayed in landscape mode. 