### PR TITLE
amp-youtube: Remove the layout wait, issue seems to have been fixed by YT

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -24,7 +24,6 @@ import {
 } from '../../../src/service/video-manager-impl';
 import {setStyles} from '../../../src/style';
 import {addParamsToUrl} from '../../../src/url';
-import {timerFor} from '../../../src/timer';
 import {isObject} from '../../../src/types';
 import {VideoEvents} from '../../../src/video-interface';
 import {videoManagerForDoc} from '../../../src/video-manager';

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -195,13 +195,6 @@ class AmpYoutube extends AMP.BaseElement {
     videoManagerForDoc(this.win.document).register(this);
 
     return this.loadPromise(iframe)
-        .then(() => {
-          // Make sure the YT player is ready for this. For some reason YT player
-          // would send couple of messages but then stop. Waiting for a bit before
-          // sending the 'listening' event seems to fix that and allow YT
-          // Player to send messages continuously.
-          return timerFor(this.win).promise(300);
-        })
         .then(() => this.listenToFrame_())
         .then(() => this.playerReadyPromise_);
   }


### PR DESCRIPTION
Fixes #6888

Tested on real iOS/Android with autoplay which constantly sends/receives messages from YT. Also tested with throttled network, all seems fine.