### PR TITLE
actually generate ampcontext-v0.js

### DIFF
--- a/build-system/tasks/size.js
+++ b/build-system/tasks/size.js
@@ -97,7 +97,7 @@ function normalizeRows(rows) {
   // normalize integration.js
   normalizeRow(rows, 'current-min/f.js', 'current/integration.js', true);
 
-  normalizeRow(rows, 'current-min/ampcontext-lib.js',
+  normalizeRow(rows, 'current-min/ampcontext-v0.js',
       'current/ampcontext-lib.js', true);
 
   // normalize alp.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -197,10 +197,11 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     minifiedName: 'ampcontext-v0.js',
     checkTypes: opt_checkTypes,
     watch: watch,
-    minify: false,
+    minify: shouldMinify,
     preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
     externs: ['ads/ads.extern.js',],
-    includeBasicPolyfills: false,
+    include3pDirectories: true,
+    includePolyfills: false,
   });
 
   // For compilation with babel we start with the amp-babel entry point,


### PR DESCRIPTION
ampcontext-v0.js was never getting generated when we run `dist` only `build` (non closure binary)