### PR TITLE
Fixed Carousel Arrow SVGs - Added IE11 Compatible Charset for SVGs

### DIFF
--- a/extensions/amp-app-banner/0.1/amp-app-banner.css
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.css
@@ -43,7 +43,7 @@ i-amp-app-banner-top-padding {
   height: 28px;
   top: -28px;
   right: 0;
-  background-image: url('data:image/svg+xml;utf8,%3Csvg%20width%3D%2213px%22%20height%3D%2213px%22%20viewBox%3D%22341%208%2013%2013%22%20version%3D%221.1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%3E%3Cg%20id%3D%22ic_close_black_24dp%22%20stroke%3D%22none%22%20stroke-width%3D%221%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%20transform%3D%22translate%28341.000000%2C%208.000000%29%22%3E%3Cpolygon%20id%3D%22Shape%22%20fill%3D%22%234F4F4F%22%20points%3D%2213%201.30928571%2011.6907143%200%206.5%205.19071429%201.30928571%200%200%201.30928571%205.19071429%206.5%200%2011.6907143%201.30928571%2013%206.5%207.80928571%2011.6907143%2013%2013%2011.6907143%207.80928571%206.5%22%3E%3C/polygon%3E%3C/g%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20width%3D%2213px%22%20height%3D%2213px%22%20viewBox%3D%22341%208%2013%2013%22%20version%3D%221.1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%3E%3Cg%20id%3D%22ic_close_black_24dp%22%20stroke%3D%22none%22%20stroke-width%3D%221%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%20transform%3D%22translate%28341.000000%2C%208.000000%29%22%3E%3Cpolygon%20id%3D%22Shape%22%20fill%3D%22%234F4F4F%22%20points%3D%2213%201.30928571%2011.6907143%200%206.5%205.19071429%201.30928571%200%200%201.30928571%205.19071429%206.5%200%2011.6907143%201.30928571%2013%206.5%207.80928571%2011.6907143%2013%2013%2011.6907143%207.80928571%206.5%22%3E%3C/polygon%3E%3C/g%3E%3C/svg%3E');
   background-size: 13px 13px;
   background-position: 9px center;
   background-color: #fff;

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -58,13 +58,13 @@ amp-carousel[controls] .amp-carousel-button,
 
 .amp-carousel-button-prev {
   left: 16px;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23fff" viewBox="0 0 18 18"><path d="M15 8.25H5.87l4.19-4.19L9 3 3 9l6 6 1.06-1.06-4.19-4.19H15v-1.5z" /></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23fff" viewBox="0 0 18 18"><path d="M15 8.25H5.87l4.19-4.19L9 3 3 9l6 6 1.06-1.06-4.19-4.19H15v-1.5z" /></svg>');
   background-size: 18px 18px;
 }
 
 .amp-carousel-button-next {
   right: 16px;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23fff" viewBox="0 0 18 18"><path d="M9 3L7.94 4.06l4.19 4.19H3v1.5h9.13l-4.19 4.19L9 15l6-6z" /></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23fff" viewBox="0 0 18 18"><path d="M9 3L7.94 4.06l4.19 4.19H3v1.5h9.13l-4.19 4.19L9 15l6-6z" /></svg>');
   background-size: 18px 18px;
 }
 

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -116,7 +116,7 @@ This element includes [common attributes](https://www.ampproject.org/docs/refere
 ```css
 .amp-carousel-button-prev {
   left: 16px;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M15 8.25H5.87l4.19-4.19L9 3 3 9l6 6 1.06-1.06-4.19-4.19H15v-1.5z" fill="#fff" /></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M15 8.25H5.87l4.19-4.19L9 3 3 9l6 6 1.06-1.06-4.19-4.19H15v-1.5z" fill="#fff" /></svg>');
 }
 ```
 
@@ -125,7 +125,7 @@ This element includes [common attributes](https://www.ampproject.org/docs/refere
 ```css
 .amp-carousel-button-prev {
   left: 5%;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M11.56 5.56L10.5 4.5 6 9l4.5 4.5 1.06-1.06L8.12 9z" fill="#fff" /></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M11.56 5.56L10.5 4.5 6 9l4.5 4.5 1.06-1.06L8.12 9z" fill="#fff" /></svg>');
 }
 ```
 

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -162,31 +162,31 @@
 
 .amp-lbv-button-next {
   right: 0;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23fff" viewBox="0 0 18 18"><path d="M9 3L7.94 4.06l4.19 4.19H3v1.5h9.13l-4.19 4.19L9 15l6-6z" /></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23fff" viewBox="0 0 18 18"><path d="M9 3L7.94 4.06l4.19 4.19H3v1.5h9.13l-4.19 4.19L9 15l6-6z" /></svg>');
 }
 
 .amp-lbv-button-prev {
   left: 0;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23fff" viewBox="0 0 18 18"><path d="M15 8.25H5.87l4.19-4.19L9 3 3 9l6 6 1.06-1.06-4.19-4.19H15v-1.5z" /></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23fff" viewBox="0 0 18 18"><path d="M15 8.25H5.87l4.19-4.19L9 3 3 9l6 6 1.06-1.06-4.19-4.19H15v-1.5z" /></svg>');
 }
 
 .amp-lbv-button-close {
   top: 0;
   left: 0;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="%23fff" height="24" viewBox="0 0 24 24" width="24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" fill="%23fff" height="24" viewBox="0 0 24 24" width="24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }
 
 .amp-lbv-button-gallery {
   top: 0;
   right: 0;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="%23fff" width="24" height="24" viewBox="0 0 24 24"><path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM8 20H4v-4h4v4zm0-6H4v-4h4v4zm0-6H4V4h4v4zm6 12h-4v-4h4v4zm0-6h-4v-4h4v4zm0-6h-4V4h4v4zm6 12h-4v-4h4v4zm0-6h-4v-4h4v4zm0-6h-4V4h4v4z"/></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" fill="%23fff" width="24" height="24" viewBox="0 0 24 24"><path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM8 20H4v-4h4v4zm0-6H4v-4h4v4zm0-6H4V4h4v4zm6 12h-4v-4h4v4zm0-6h-4v-4h4v4zm0-6h-4V4h4v4zm6 12h-4v-4h4v4zm0-6h-4v-4h4v4zm0-6h-4V4h4v4z"/></svg>');
 }
 
 .amp-lbv-button-back {
   top: 0;
   display: none;
   left: 0;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="%23fff" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" fill="%23fff" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>');
 }
 
 .-amp-lbv[no-next] .amp-lbv-button-next {

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
@@ -55,7 +55,7 @@ amp-sticky-ad[visible] {
   height: 32px;
   top: -32px;
   right: 0;
-  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22%23000000%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%2224%22%3E%3Cpath%20d%3D%22M19%206.41L17.59%205%2012%2010.59%206.41%205%205%206.41%2010.59%2012%205%2017.59%206.41%2019%2012%2013.41%2017.59%2019%2019%2017.59%2013.41%2012z%22%2F%3E%3Cpath%20d%3D%22M0%200h24v24H0z%22%20fill%3D%22none%22%2F%3E%3C%2Fsvg%3E');
+  background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22%23000000%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%2224%22%3E%3Cpath%20d%3D%22M19%206.41L17.59%205%2012%2010.59%206.41%205%205%206.41%2010.59%2012%205%2017.59%206.41%2019%2012%2013.41%2017.59%2019%2019%2017.59%2013.41%2012z%22%2F%3E%3Cpath%20d%3D%22M0%200h24v24H0z%22%20fill%3D%22none%22%2F%3E%3C%2Fsvg%3E');
   background-size: 26px 26px;
   background-position: center;
   background-color: #fff;

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
@@ -65,7 +65,7 @@ amp-sticky-ad[visible] {
   height: 28px;
   top: -28px;
   right: 0;
-  background-image: url('data:image/svg+xml;utf8,%3Csvg%20width%3D%2213px%22%20height%3D%2213px%22%20viewBox%3D%22341%208%2013%2013%22%20version%3D%221.1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%3E%3Cg%20id%3D%22ic_close_black_24dp%22%20stroke%3D%22none%22%20stroke-width%3D%221%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%20transform%3D%22translate%28341.000000%2C%208.000000%29%22%3E%3Cpolygon%20id%3D%22Shape%22%20fill%3D%22%234F4F4F%22%20points%3D%2213%201.30928571%2011.6907143%200%206.5%205.19071429%201.30928571%200%200%201.30928571%205.19071429%206.5%200%2011.6907143%201.30928571%2013%206.5%207.80928571%2011.6907143%2013%2013%2011.6907143%207.80928571%206.5%22%3E%3C/polygon%3E%3C/g%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20width%3D%2213px%22%20height%3D%2213px%22%20viewBox%3D%22341%208%2013%2013%22%20version%3D%221.1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%3E%3Cg%20id%3D%22ic_close_black_24dp%22%20stroke%3D%22none%22%20stroke-width%3D%221%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%20transform%3D%22translate%28341.000000%2C%208.000000%29%22%3E%3Cpolygon%20id%3D%22Shape%22%20fill%3D%22%234F4F4F%22%20points%3D%2213%201.30928571%2011.6907143%200%206.5%205.19071429%201.30928571%200%200%201.30928571%205.19071429%206.5%200%2011.6907143%201.30928571%2013%206.5%207.80928571%2011.6907143%2013%2013%2011.6907143%207.80928571%206.5%22%3E%3C/polygon%3E%3C/g%3E%3C/svg%3E');
   background-size: 13px 13px;
   background-position: 9px center;
   background-color: #fff;


### PR DESCRIPTION
closes #6591 

Added IE11 compatible charset for CSS SVGs for amp-carousel. I discovered shorthands will break SVG support in IE 11. And possbily, but NOT in this case, may need to be URL encoded.

Tested using the [http://localhost:8000/examples/carousel.amp.max.html](http://localhost:8000/examples/carousel.amp.max.html), url meant for testing extensions, and tested in IE11, Edge, Google Chrome, and Firefox. See Below for no Safari testing, or if you are interested in testing on Safari for me :)

Supporting Research/Docs:
[RFC Docs](https://tools.ietf.org/html/rfc2397)
[CSS Tricks Comment 1](https://css-tricks.com/probably-dont-base64-svg/#comment-1586108)
[CSS Tricks Comment 2](https://css-tricks.com/probably-dont-base64-svg/#comment-1586152)


## Testing Browser Screenshots:

**IE11**
![aaronampbugfixie11](https://cloud.githubusercontent.com/assets/1448289/21716000/92c7d2f0-d3bc-11e6-82fe-27dfc59c9f89.png)

**Edge**
![aaronampbugfixedge](https://cloud.githubusercontent.com/assets/1448289/21716013/9f917946-d3bc-11e6-81b5-672288e1a70f.png)


**FireFox**
![screenshot from 2017-01-06 02-35-49](https://cloud.githubusercontent.com/assets/1448289/21716038/cfd2de38-d3bc-11e6-80c4-7a340de33108.png)


**Google Chrome**
![screenshot from 2017-01-06 02-35-05](https://cloud.githubusercontent.com/assets/1448289/21716017/ae640650-d3bc-11e6-9bda-498e87860619.png)

**Safari**
Unfortunately, I do not have any apple hardware, it would be much appreciated if someone tested in recent Safari versions for me!