### PR TITLE
Update doubleclick.md

### DIFF
--- a/ads/google/doubleclick.md
+++ b/ads/google/doubleclick.md
@@ -105,7 +105,7 @@ Supported via `json` attribute:
 - `useSameDomainRenderingUntilDeprecated`
 
 ### Temporary use of useSameDomainRenderingUntilDeprecated
-An experiment to use the higher performance GPT Light tag in place of the DoubleClick GPT tag causes the ad to render in a second cross domain iframe within the outer AMP iframe. This prevents ads from accessing the iframe sandbox information and methods which are provided by the AMP runtime. Until this API is available to work in the second level iframe, publishers can opt out of this experiment by including "useSameDomainRenderingUntilDeprecated": 1 as a json attribute. This attribute will be deprecated by the end of August 2016, when the GPT Light tag will become the default, and all ads will always be rendered inside a second cross domain iframe
+An experiment to use the higher performance GPT Light tag in place of the DoubleClick GPT tag causes the ad to render in a second cross domain iframe within the outer AMP iframe. This prevents ads from accessing the iframe sandbox information and methods which are provided by the AMP runtime. Until this API is available to work in the second level iframe, publishers can opt out of this experiment by including "useSameDomainRenderingUntilDeprecated": 1 as a json attribute. This attribute will be deprecated once the [new window.context implementation](https://github.com/ampproject/amphtml/issues/6829) is complete. After that point, the GPT Light tag will become the default and all eligible ads will always be rendered inside a second cross domain iframe.
 
 Example:
 ```html


### PR DESCRIPTION
Update doubleclick.md to properly reflect the state of the "useSameDomainRenderingUntilDeprecated" feature.