### PR TITLE
Delegate submit events until amp-form is loaded 

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -501,6 +501,20 @@ app.use(['/examples/*', '/extensions/*'], function (req, res, next) {
   next();
 });
 
+/**
+ * Append ?sleep=5 to any included JS file in examples to emulate delay in loading that
+ * file. This allows you to test issues with your extension being late to load
+ * and testing user interaction with your element before your code loads.
+ *
+ * Example delay loading amp-form script by 5 seconds:
+ * <script async custom-element="amp-form"
+ *    src="https://cdn.ampproject.org/v0/amp-form-0.1.js?sleep=5"></script>
+ */
+app.use(['/dist/v0/amp-*.js'], function(req, res, next) {
+  var sleep = parseInt(req.query.sleep || 0) * 1000;
+  setTimeout(next, sleep);
+});
+
 app.get(['/examples/*', '/test/manual/*'], function(req, res, next) {
   var filePath = req.path;
   var mode = getPathMode(filePath);

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -168,13 +168,14 @@ export class AmpForm {
    */
   actionHandler_(invocation) {
     if (invocation.method == 'submit') {
-      this.handleSubmit_();
+      this.handleSubmitAction_();
     }
   }
 
   /** @private */
   installEventHandlers_() {
-    this.form_.addEventListener('submit', e => this.handleSubmit_(e), true);
+    this.form_.addEventListener(
+        'submit', e => this.handleSubmitEvent_(e), true);
     this.form_.addEventListener('blur', e => {
       onInputInteraction_(e);
       this.validator_.onBlur(e);
@@ -186,35 +187,138 @@ export class AmpForm {
   }
 
   /**
+   * Handles submissions through action service invocations.
+   *   e.g. <img on=tap:form.submit>
+   * @private
+   */
+  handleSubmitAction_() {
+    if (this.state_ == FormState_.SUBMITTING || !this.checkValidity_()) {
+      return;
+    }
+    this.submit_();
+    if (this.method_ == 'GET' && !this.xhrAction_) {
+      // Trigger the actual submit of GET non-XHR.
+      this.form_.submit();
+    }
+  }
+
+  /**
    * Note on stopImmediatePropagation usage here, it is important to emulate native
    * browser submit event blocking. Otherwise any other submit listeners would get the
    * event.
    *
    * For example, action service shouldn't trigger 'submit' event if form is actually
-   * invalid. stopImmediatePropagation allows us to make sure we don't trigger it
+   * invalid. stopImmediatePropagation allows us to make sure we don't trigger it.
    *
-   *
-   * @param {?Event=} opt_event
+   * @param {Event} event
    * @private
    */
-  handleSubmit_(opt_event) {
-    if (this.state_ == FormState_.SUBMITTING) {
-      if (opt_event) {
-        opt_event.stopImmediatePropagation();
-        opt_event.preventDefault();
-      }
+  handleSubmitEvent_(event) {
+    if (this.state_ == FormState_.SUBMITTING || !this.checkValidity_()) {
+      event.stopImmediatePropagation();
+      event.preventDefault();
       return;
     }
+    if (this.xhrAction_ || this.method_ == 'POST') {
+      event.preventDefault();
+    }
+    this.submit_();
+  }
 
-    if (isCheckValiditySupported(this.win_.document)) {
+  /**
+   * A helper method that actual handles the for different cases (post, get, xhr...).
+   * @private
+   */
+  submit_() {
+    const isVarSubExpOn = isExperimentOn(this.win_, 'amp-form-var-sub');
+    // Fields that support var substitutions.
+    const varSubsFields = isVarSubExpOn ? this.form_.querySelectorAll(
+        '[type="hidden"][data-amp-replace]') : [];
+    if (this.xhrAction_) {
+      this.handleXhrSubmit_(varSubsFields);
+    } else if (this.method_ == 'POST') {
+      this.handleNonXhrPost_();
+    } else if (this.method_ == 'GET') {
+      this.handleNonXhrGet_(varSubsFields);
+    }
+  }
+
+  /**
+   * @param {IArrayLike<!HTMLInputElement>} varSubsFields
+   * @private
+   */
+  handleXhrSubmit_(varSubsFields) {
+    this.cleanupRenderedTemplate_();
+    this.setState_(FormState_.SUBMITTING);
+    const isHeadOrGet = this.method_ == 'GET' || this.method_ == 'HEAD';
+    const varSubPromises = [];
+    for (let i = 0; i < varSubsFields.length; i++) {
+      varSubPromises.push(
+          this.urlReplacement_.expandInputValueAsync(varSubsFields[i]));
+    }
+    // Wait until all variables have been substituted or 100ms timeout.
+    this.waitOnPromisesOrTimeout_(varSubPromises, 100).then(() => {
+      let xhrUrl, body;
+      if (isHeadOrGet) {
+        xhrUrl = addParamsToUrl(
+            dev().assertString(this.xhrAction_), this.getFormAsObject_());
+      } else {
+        xhrUrl = this.xhrAction_;
+        body = new FormData(this.form_);
+      }
+      return this.xhr_.fetchJson(dev().assertString(xhrUrl), {
+        body,
+        method: this.method_,
+        credentials: 'include',
+        requireAmpResponseSourceOrigin: true,
+      }).then(response => {
+        this.triggerAction_(/* success */ true, response);
+        // TODO(mkhatib, #6032): Update docs to reflect analytics events.
+        this.analyticsEvent_('amp-form-submit-success');
+        this.setState_(FormState_.SUBMIT_SUCCESS);
+        this.renderTemplate_(response || {});
+      }).catch(error => {
+        this.triggerAction_(
+            /* success */ false, error ? error.responseJson : null);
+        this.analyticsEvent_('amp-form-submit-error');
+        this.setState_(FormState_.SUBMIT_ERROR);
+        this.renderTemplate_(error.responseJson || {});
+        rethrowAsync('Form submission failed:', error);
+      });
+    });
+  }
+
+  /** @private */
+  handleNonXhrPost_() {
+    // non-XHR POST requests are not supported.
+    user().assert(false,
+        'Only XHR based (via action-xhr attribute) submissions are support ' +
+        'for POST requests. %s',
+        this.form_);
+  }
+
+  /**
+   * Executes variable substitutions on the passed fields.
+   * @param {IArrayLike<!HTMLInputElement>} varSubsFields
+   * @private
+   */
+  handleNonXhrGet_(varSubsFields) {
+    // Non-xhr GET requests replacement should happen synchronously.
+    for (let i = 0; i < varSubsFields.length; i++) {
+      this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
+    }
+  }
+
+  /**
+   * @private
+   * @return {boolean} False if the form is invalid.
+   */
+  checkValidity_() {
+     if (isCheckValiditySupported(this.win_.document)) {
       // Validity checking should always occur, novalidate only circumvent
       // reporting and blocking submission on non-valid forms.
       const isValid = checkUserValidityOnSubmission(this.form_);
       if (this.shouldValidate_ && !isValid) {
-        if (opt_event) {
-          opt_event.stopImmediatePropagation();
-          opt_event.preventDefault();
-        }
         // TODO(#3776): Use .mutate method when it supports passing state.
         this.vsync_.run({
           measure: undefined,
@@ -222,84 +326,10 @@ export class AmpForm {
         }, {
           validator: this.validator_,
         });
-        return;
+        return false;
       }
     }
-
-    const isVarSubExpOn = isExperimentOn(this.win_, 'amp-form-var-sub');
-    // Fields that support var substitutions.
-    const varSubsFields = isVarSubExpOn ? this.form_.querySelectorAll(
-        '[type="hidden"][data-amp-replace]') : [];
-    if (this.xhrAction_) {
-      if (opt_event) {
-        opt_event.preventDefault();
-      }
-      this.cleanupRenderedTemplate_();
-      this.setState_(FormState_.SUBMITTING);
-      const isHeadOrGet = this.method_ == 'GET' || this.method_ == 'HEAD';
-      const varSubPromises = [];
-      for (let i = 0; i < varSubsFields.length; i++) {
-        varSubPromises.push(
-            this.urlReplacement_.expandInputValueAsync(varSubsFields[i]));
-      }
-      // Wait until all variables have been substituted or 100ms timeout.
-      this.waitOnPromisesOrTimeout_(varSubPromises, 100).then(() => {
-        let xhrUrl, body;
-        if (isHeadOrGet) {
-          xhrUrl = addParamsToUrl(
-              dev().assertString(this.xhrAction_), this.getFormAsObject_());
-        } else {
-          xhrUrl = this.xhrAction_;
-          body = new FormData(this.form_);
-        }
-        return this.xhr_.fetch(dev().assertString(xhrUrl), {
-          body,
-          method: this.method_,
-          credentials: 'include',
-        }).then(response => {
-          return response.json().then(json => {
-            this.triggerAction_(/* success */ true, json);
-            this.analyticsEvent_('amp-form-submit-success');
-            this.setState_(FormState_.SUBMIT_SUCCESS);
-            this.renderTemplate_(json || {});
-            this.maybeHandleRedirect_(
-                /** @type {../../../src/service/xhr-impl.FetchResponse} */ (
-                    response));
-          }, error => {
-            rethrowAsync('Failed to parse response JSON:', error);
-          });
-        }, error => {
-          this.triggerAction_(
-              /* success */ false, error ? error.responseJson : null);
-          this.analyticsEvent_('amp-form-submit-error');
-          this.setState_(FormState_.SUBMIT_ERROR);
-          this.renderTemplate_(error.responseJson || {});
-          this.maybeHandleRedirect_(
-              /** @type {../../../src/service/xhr-impl.FetchResponse} */ (
-                  error));
-          rethrowAsync('Form submission failed:', error);
-        });
-      });
-    } else if (this.method_ == 'POST') {
-      // non-XHR POST requests are not supported.
-      if (opt_event) {
-        opt_event.preventDefault();
-      }
-      user().assert(false,
-          'Only XHR based (via action-xhr attribute) submissions are ' +
-          'support for POST requests. %s',
-          this.form_);
-    } else if (this.method_ == 'GET') {
-      // Non-xhr GET requests replacement should happen synchronously.
-      for (let i = 0; i < varSubsFields.length; i++) {
-        this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
-      }
-
-      // If this wasn't a submission event, trigger form submit.
-      if (!opt_event) {
-        this.form_.submit();
-      }
-    }
+    return true;
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -175,7 +175,7 @@ export class AmpForm {
   /** @private */
   installEventHandlers_() {
     this.form_.addEventListener(
-        'submit', e => this.handleSubmitEvent_(e), true);
+        'submit', this.handleSubmitEvent_.bind(this), true);
     this.form_.addEventListener('blur', e => {
       onInputInteraction_(e);
       this.validator_.onBlur(e);
@@ -210,7 +210,13 @@ export class AmpForm {
    * For example, action service shouldn't trigger 'submit' event if form is actually
    * invalid. stopImmediatePropagation allows us to make sure we don't trigger it.
    *
-   * @param {Event} event
+   * This prevents the default submission event in any of following cases:
+   *   - The form is still finishing a previous submission.
+   *   - The form is invalid.
+   *   - Handling an XHR submission.
+   *   - It's a non-XHR POST submission (unsupported).
+   * 
+   * @param {!Event} event
    * @private
    */
   handleSubmitEvent_(event) {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -155,6 +155,8 @@ export class AmpForm {
     /** @const @private {!./form-validators.FormValidator} */
     this.validator_ = getFormValidator(this.form_);
 
+    // TODO(mkhatib, #6927): Wait for amp-selector to finish loading if the current form
+    // is using it.
     this.actions_.installActionHandler(
         this.form_, this.actionHandler_.bind(this));
     this.installEventHandlers_();
@@ -291,6 +293,11 @@ export class AmpForm {
       // Non-xhr GET requests replacement should happen synchronously.
       for (let i = 0; i < varSubsFields.length; i++) {
         this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
+      }
+
+      // If this wasn't a submission event, trigger form submit.
+      if (!opt_event) {
+        this.form_.submit();
       }
     }
   }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -215,7 +215,7 @@ export class AmpForm {
    *   - The form is invalid.
    *   - Handling an XHR submission.
    *   - It's a non-XHR POST submission (unsupported).
-   * 
+   *
    * @param {!Event} event
    * @private
    */
@@ -328,11 +328,11 @@ export class AmpForm {
    * @return {boolean} False if the form is invalid.
    */
   checkValidity_() {
-     if (isCheckValiditySupported(this.win_.document)) {
+    if (isCheckValiditySupported(this.win_.document)) {
       // Validity checking should always occur, novalidate only circumvent
       // reporting and blocking submission on non-valid forms.
-      const isValid = checkUserValidityOnSubmission(this.form_);
-      if (this.shouldValidate_ && !isValid) {
+       const isValid = checkUserValidityOnSubmission(this.form_);
+       if (this.shouldValidate_ && !isValid) {
         // TODO(#3776): Use .mutate method when it supports passing state.
         this.vsync_.run({
           measure: undefined,
@@ -342,7 +342,7 @@ export class AmpForm {
         });
         return false;
       }
-    }
+     }
     return true;
   }
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -331,8 +331,8 @@ export class AmpForm {
     if (isCheckValiditySupported(this.win_.document)) {
       // Validity checking should always occur, novalidate only circumvent
       // reporting and blocking submission on non-valid forms.
-       const isValid = checkUserValidityOnSubmission(this.form_);
-       if (this.shouldValidate_ && !isValid) {
+      const isValid = checkUserValidityOnSubmission(this.form_);
+      if (this.shouldValidate_ && !isValid) {
         // TODO(#3776): Use .mutate method when it supports passing state.
         this.vsync_.run({
           measure: undefined,
@@ -342,7 +342,7 @@ export class AmpForm {
         });
         return false;
       }
-     }
+    }
     return true;
   }
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -358,7 +358,7 @@ describe('amp-form', () => {
         expect(config.body).to.not.be.null;
         expect(config.method).to.equal('POST');
         expect(config.credentials).to.equal('include');
-        expect(config.requireAmpResponseSourceOrigin).to.be.undefined;
+        expect(config.requireAmpResponseSourceOrigin).to.be.true;
       });
     });
   });
@@ -612,7 +612,7 @@ describe('amp-form', () => {
           expect(config.body).to.be.undefined;
           expect(config.method).to.equal('GET');
           expect(config.credentials).to.equal('include');
-          expect(config.requireAmpResponseSourceOrigin).to.be.undefined;
+          expect(config.requireAmpResponseSourceOrigin).to.be.true;
         });
       });
     });

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -358,7 +358,6 @@ describe('amp-form', () => {
         expect(config.body).to.not.be.null;
         expect(config.method).to.equal('POST');
         expect(config.credentials).to.equal('include');
-        expect(config.requireAmpResponseSourceOrigin).to.be.true;
       });
     });
   });
@@ -612,7 +611,6 @@ describe('amp-form', () => {
           expect(config.body).to.be.undefined;
           expect(config.method).to.equal('GET');
           expect(config.credentials).to.equal('include');
-          expect(config.requireAmpResponseSourceOrigin).to.be.true;
         });
       });
     });
@@ -1109,7 +1107,7 @@ describe('amp-form', () => {
       it('should redirect users if header is set', () => {
         sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
         redirectToValue = 'https://google.com/';
-        ampForm.handleSubmit_();
+        ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
           expect(env.win.top.location.href).to.be.equal(redirectToValue);
         });
@@ -1118,7 +1116,7 @@ describe('amp-form', () => {
       it('should fail to redirect to non-secure urls', () => {
         sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
         redirectToValue = 'http://google.com/';
-        ampForm.handleSubmit_();
+        ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
           expect(env.win.top.location.href).to.be.equal(
               'https://example-top.com/');
@@ -1128,7 +1126,7 @@ describe('amp-form', () => {
       it('should fail to redirect to non-absolute urls', () => {
         sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
         redirectToValue = '/hello';
-        ampForm.handleSubmit_();
+        ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
           expect(env.win.top.location.href).to.be.equal(
               'https://example-top.com/');
@@ -1139,7 +1137,7 @@ describe('amp-form', () => {
         ampForm.target_ = '_blank';
         sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
         redirectToValue = 'http://google.com/';
-        ampForm.handleSubmit_();
+        ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
           expect(env.win.top.location.href).to.be.equal(
               'https://example-top.com/');
@@ -1160,7 +1158,7 @@ describe('amp-form', () => {
             }
           }, delay);
         });
-        ampForm.handleSubmit_();
+        ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
           expect(errors.length).to.equal(1);
           expect(errors[0]).to.match(/Form submission failed/);
@@ -1178,7 +1176,7 @@ describe('amp-form', () => {
         ampForm.xhrAction_ = null;
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         ampForm.handleSubmitAction_();
         expect(form.submit).to.have.been.called;
       });
@@ -1191,7 +1189,7 @@ describe('amp-form', () => {
         ampForm.xhrAction_ = null;
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         const event = {
           stopImmediatePropagation: sandbox.spy(),
           target: form,

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -166,7 +166,7 @@ describe('amp-form', () => {
 
     sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
     sandbox.spy(form, 'checkValidity');
-    ampForm.handleSubmit_(event);
+    ampForm.handleSubmitEvent_(event);
     expect(event.stopImmediatePropagation).to.be.called;
     expect(form.checkValidity).to.not.be.called;
     expect(ampForm.xhr_.fetch).to.not.be.called;
@@ -183,7 +183,7 @@ describe('amp-form', () => {
     };
     sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
     sandbox.spy(form, 'checkValidity');
-    expect(() => ampForm.handleSubmit_(event)).to.throw(
+    expect(() => ampForm.handleSubmitEvent_(event)).to.throw(
         /Only XHR based \(via action-xhr attribute\) submissions are support/);
     expect(event.preventDefault).to.be.called;
   });
@@ -217,7 +217,7 @@ describe('amp-form', () => {
     sandbox.spy(form, 'checkValidity');
     sandbox.spy(emailInput, 'reportValidity');
 
-    ampForm.handleSubmit_(event);
+    ampForm.handleSubmitEvent_(event);
     // Check validity should always be called regardless of novalidate.
     expect(form.checkValidity).to.be.called;
 
@@ -260,7 +260,7 @@ describe('amp-form', () => {
       const validationBubble = bubbleEl['__BUBBLE_OBJ'];
       sandbox.spy(validationBubble, 'show');
       sandbox.spy(validationBubble, 'hide');
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       expect(event.stopImmediatePropagation).to.be.called;
       expect(form.checkValidity).to.be.called;
       expect(ampForm.xhr_.fetch).to.not.be.called;
@@ -294,7 +294,7 @@ describe('amp-form', () => {
 
       // Check xhr goes through when form is valid.
       emailInput.value = 'cool@bea.ns';
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       return timer.promise(10).then(() => {
         expect(ampForm.xhr_.fetch).to.have.been.called;
       });
@@ -330,7 +330,7 @@ describe('amp-form', () => {
         },
       };
 
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       return timer.promise(1).then(() => {
         expect(event.stopImmediatePropagation).to.not.be.called;
         expect(form.checkValidity).to.not.be.called;
@@ -347,7 +347,7 @@ describe('amp-form', () => {
         target: ampForm.form_,
         preventDefault: sandbox.spy(),
       };
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       expect(event.preventDefault).to.be.calledOnce;
       return timer.promise(1).then(() => {
         expect(ampForm.xhr_.fetch).to.be.calledOnce;
@@ -381,14 +381,14 @@ describe('amp-form', () => {
       expect(button1.hasAttribute('disabled')).to.be.false;
       expect(button2.hasAttribute('disabled')).to.be.false;
       expect(button3.hasAttribute('disabled')).to.be.false;
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       expect(ampForm.state_).to.equal('submitting');
       return timer.promise(1).then(() => {
         expect(ampForm.xhr_.fetch.calledOnce).to.be.true;
         expect(button1.hasAttribute('disabled')).to.be.true;
         expect(button2.hasAttribute('disabled')).to.be.true;
-        ampForm.handleSubmit_(event);
-        ampForm.handleSubmit_(event);
+        ampForm.handleSubmitEvent_(event);
+        ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault.called).to.be.true;
         expect(event.preventDefault.callCount).to.equal(3);
         expect(event.stopImmediatePropagation.callCount).to.equal(2);
@@ -423,7 +423,7 @@ describe('amp-form', () => {
         target: form,
         preventDefault: sandbox.spy(),
       };
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       expect(event.preventDefault).to.be.called;
       expect(ampForm.state_).to.equal('submitting');
       expect(form.className).to.contain('amp-form-submitting');
@@ -465,7 +465,7 @@ describe('amp-form', () => {
       const button2 = form.querySelectorAll('input[type=submit]')[1];
       expect(button1.hasAttribute('disabled')).to.be.false;
       expect(button2.hasAttribute('disabled')).to.be.false;
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       expect(button1.hasAttribute('disabled')).to.be.true;
       expect(button2.hasAttribute('disabled')).to.be.true;
       expect(event.preventDefault).to.be.called;
@@ -528,7 +528,7 @@ describe('amp-form', () => {
           }
         }, delay);
       });
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       const findTemplateStub = ampForm.templates_.findAndRenderTemplate;
       return timer.promise(5).then(() => {
         expect(findTemplateStub).to.be.called;
@@ -576,7 +576,7 @@ describe('amp-form', () => {
         target: form,
         preventDefault: sandbox.spy(),
       };
-      ampForm.handleSubmit_(event);
+      ampForm.handleSubmitEvent_(event);
       return timer.promise(5).then(() => {
         expect(ampForm.templates_.findAndRenderTemplate).to.be.called;
         expect(ampForm.templates_.findAndRenderTemplate.calledWith(
@@ -600,7 +600,7 @@ describe('amp-form', () => {
           target: ampForm.form_,
           preventDefault: sandbox.spy(),
         };
-        ampForm.handleSubmit_(event);
+        ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault).to.be.calledOnce;
         return timer.promise(1).then(() => {
           expect(ampForm.xhr_.fetch).to.be.calledOnce;
@@ -643,7 +643,7 @@ describe('amp-form', () => {
         usernameInput.disabled = true;
         usernameInput.value = 'coolbeans';
         emailInput.value = 'cool@bea.ns';
-        ampForm.handleSubmit_(event);
+        ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault).to.be.calledOnce;
         return timer.promise(1).then(() => {
           expect(ampForm.xhr_.fetch).to.be.calledOnce;
@@ -655,7 +655,7 @@ describe('amp-form', () => {
           usernameInput.removeAttribute('disabled');
           usernameInput.value = 'coolbeans';
           emailInput.value = 'cool@bea.ns';
-          ampForm.handleSubmit_(event);
+          ampForm.handleSubmitEvent_(event);
           return timer.promise(1).then(() => {
             expect(ampForm.xhr_.fetch).to.be.calledOnce;
             expect(ampForm.xhr_.fetch).to.be.calledWith(
@@ -665,7 +665,7 @@ describe('amp-form', () => {
             ampForm.setState_('submit-success');
             ampForm.xhr_.fetch.reset();
             fieldset.disabled = true;
-            ampForm.handleSubmit_(event);
+            ampForm.handleSubmitEvent_(event);
 
             return timer.promise(1).then(() => {
               expect(ampForm.xhr_.fetch).to.be.calledOnce;
@@ -678,7 +678,7 @@ describe('amp-form', () => {
               usernameInput.removeAttribute('name');
               emailInput.removeAttribute('required');
               emailInput.value = '';
-              ampForm.handleSubmit_(event);
+              ampForm.handleSubmitEvent_(event);
               return timer.promise(1).then(() => {
                 expect(ampForm.xhr_.fetch).to.be.calledOnce;
                 expect(ampForm.xhr_.fetch).to.be.calledWith(
@@ -760,7 +760,7 @@ describe('amp-form', () => {
           preventDefault: sandbox.spy(),
         };
 
-        ampForm.handleSubmit_(event);
+        ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault).to.be.calledOnce;
         return timer.promise(1).then(() => {
           expect(ampForm.xhr_.fetch).to.be.calledOnce;
@@ -772,7 +772,7 @@ describe('amp-form', () => {
           ampForm.xhr_.fetch.reset();
           foodCB.checked = true;
           footballCB.checked = true;
-          ampForm.handleSubmit_(event);
+          ampForm.handleSubmitEvent_(event);
           return timer.promise(1).then(() => {
             expect(ampForm.xhr_.fetch).to.be.calledOnce;
             expect(ampForm.xhr_.fetch).to.be.calledWith(
@@ -783,7 +783,7 @@ describe('amp-form', () => {
             femaleRadio.checked = true;
             otherName1Input.value = 'John Maller';
             ampForm.xhr_.fetch.reset();
-            ampForm.handleSubmit_(event);
+            ampForm.handleSubmitEvent_(event);
             return timer.promise(1).then(() => {
               expect(ampForm.xhr_.fetch).to.be.calledOnce;
               expect(ampForm.xhr_.fetch).to.be.calledWith(
@@ -819,7 +819,7 @@ describe('amp-form', () => {
           stopImmediatePropagation: sandbox.spy(),
           preventDefault: sandbox.spy(),
         };
-        ampForm.handleSubmit_(event);
+        ampForm.handleSubmitEvent_(event);
 
         expect(form.checkValidity).to.be.called;
         expect(emailInput.checkValidity).to.be.called;
@@ -830,7 +830,7 @@ describe('amp-form', () => {
         expect(event.stopImmediatePropagation).to.be.called;
 
         emailInput.value = 'cool@bea.ns';
-        ampForm.handleSubmit_(event);
+        ampForm.handleSubmitEvent_(event);
         expect(form.className).to.contain('user-valid');
         expect(emailInput.className).to.contain('user-valid');
       });
@@ -940,11 +940,11 @@ describe('amp-form', () => {
     const ampForm = new AmpForm(form);
     sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
     expect(actions.installActionHandler).to.be.calledWith(form);
-    sandbox.spy(ampForm, 'handleSubmit_');
+    sandbox.spy(ampForm, 'handleSubmitAction_');
     ampForm.actionHandler_({method: 'anything'});
-    expect(ampForm.handleSubmit_).to.have.not.been.called;
+    expect(ampForm.handleSubmitAction_).to.have.not.been.called;
     ampForm.actionHandler_({method: 'submit'});
-    expect(ampForm.handleSubmit_).to.have.been.called;
+    expect(ampForm.handleSubmitAction_).to.have.been.called;
   });
 
   describe('Var Substitution', () => {
@@ -968,7 +968,7 @@ describe('amp-form', () => {
         sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
-        ampForm.handleSubmit_();
+        ampForm.submit_();
         expect(ampForm.xhr_.fetch).to.have.not.been.called;
         expect(ampForm.urlReplacement_.expandInputValueSync)
             .to.not.have.been.called;
@@ -1009,7 +1009,7 @@ describe('amp-form', () => {
               expandAsyncStringResolvers.push(resolve);
             }));
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
-        ampForm.handleSubmit_();
+        ampForm.submit_();
         expect(ampForm.xhr_.fetch).to.have.not.been.called;
         expect(ampForm.urlReplacement_.expandInputValueSync)
             .to.not.have.been.called;
@@ -1049,7 +1049,7 @@ describe('amp-form', () => {
         sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
-        ampForm.handleSubmit_();
+        ampForm.handleSubmitAction_();
         expect(ampForm.urlReplacement_.expandInputValueAsync)
             .to.not.have.been.called;
         expect(ampForm.urlReplacement_.expandInputValueSync)
@@ -1179,7 +1179,7 @@ describe('amp-form', () => {
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
         sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
-        ampForm.handleSubmit_();
+        ampForm.handleSubmitAction_();
         expect(form.submit).to.have.been.called;
       });
     });
@@ -1197,7 +1197,7 @@ describe('amp-form', () => {
           target: form,
           preventDefault: sandbox.spy(),
         };
-        ampForm.handleSubmit_(event);
+        ampForm.handleSubmitEvent_(event);
         expect(form.submit).to.have.not.been.called;
       });
     });

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -118,12 +118,12 @@ export function onDocumentFormSubmit_(e) {
   // the actual submission. For non-XHR GET we let the submission go through
   // to allow _blank target to work.
   if (actionXhr) {
-    actionServiceForDoc(form).execute(form, 'submit', null, form, e);
     e.preventDefault();
 
     // It's important to stop propagation of the submission to avoid double
     // handling of the event in cases were we are delegating to action service
     // to deliver the submission event.
     e.stopImmediatePropagation();
+    actionServiceForDoc(form).execute(form, 'submit', /*args*/ null, form, e);
   }
 }

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {actionServiceForDoc} from './action';
 import {getServiceForDoc} from './service';
 import {dev, user} from './log';
 import {
@@ -46,7 +47,7 @@ export function onDocumentFormSubmit_(e) {
     return;
   }
 
-  const form = e.target;
+  const form = dev().assertElement(e.target);
   if (!form || form.tagName != 'FORM') {
     return;
   }
@@ -82,7 +83,7 @@ export function onDocumentFormSubmit_(e) {
     // TODO(#5670): Make action optional for method=GET when action-xhr is provided.
     user().assert(action,
         'form action attribute is required for method=GET: %s', form);
-    assertHttpsUrl(action, dev().assertElement(form), 'action');
+    assertHttpsUrl(action, form, 'action');
     user().assert(!isProxyOrigin(action),
         'form action should not be on AMP CDN: %s', form);
     checkCorsUrl(action);
@@ -110,5 +111,19 @@ export function onDocumentFormSubmit_(e) {
       'form target=%s is invalid can only be _blank or _top: %s', target, form);
   if (actionXhr) {
     checkCorsUrl(actionXhr);
+  }
+
+  // For xhr submissions relay the submission event through action service to
+  // allow us to wait for amp-form (and possibly its dependencies) to execute
+  // the actual submission. For non-XHR GET we let the submission go through
+  // to allow _blank target to work.
+  if (actionXhr) {
+    actionServiceForDoc(form).execute(form, 'submit', null, form, e);
+    e.preventDefault();
+
+    // It's important to stop propagation of the submission to avoid double
+    // handling of the event in cases were we are delegating to action service
+    // to deliver the submission event.
+    e.stopImmediatePropagation();
   }
 }

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {actionServiceForDoc} from '../../src/action';
 import {onDocumentFormSubmit_} from '../../src/document-submit';
 import * as sinon from 'sinon';
 
@@ -22,22 +23,27 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
   let evt;
   let tgt;
   let preventDefaultSpy;
+  let stopImmediatePropagationSpy;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     preventDefaultSpy = sandbox.spy();
+    stopImmediatePropagationSpy = sandbox.spy();
     tgt = document.createElement('form');
     tgt.action = 'https://www.google.com';
     tgt.target = '_blank';
-    tgt.checkValidity = sandbox.stub();
+    tgt.checkValidity = sandbox.stub().returns(true);
     evt = {
       target: tgt,
       preventDefault: preventDefaultSpy,
+      stopImmediatePropagation: stopImmediatePropagationSpy,
       defaultPrevented: false,
     };
+    document.body.appendChild(tgt);
   });
 
   afterEach(() => {
+    document.body.removeChild(tgt);
     sandbox.restore();
   });
 
@@ -155,5 +161,24 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
     onDocumentFormSubmit_(evt);
     expect(preventDefaultSpy.callCount).to.equal(0);
     expect(tgt.checkValidity.callCount).to.equal(1);
+  });
+
+  it('should delegate xhr submit through action service', () => {
+    evt.target.setAttribute('action-xhr', 'https://example.com');
+    const actionService = actionServiceForDoc(tgt);
+    sandbox.stub(actionService, 'execute');
+    onDocumentFormSubmit_(evt);
+    expect(actionService.execute).to.have.been.calledOnce;
+    expect(actionService.execute).to.have.been.calledWith(
+        tgt, 'submit', null, tgt, evt);
+    expect(preventDefaultSpy).to.have.been.calledOnce;
+    expect(stopImmediatePropagationSpy).to.have.been.calledOnce;
+  });
+
+  it('should not delegate non-XHR submit through action service', () => {
+    const actionService = actionServiceForDoc(tgt);
+    sandbox.stub(actionService, 'execute');
+    onDocumentFormSubmit_(evt);
+    expect(actionService.execute).to.have.not.been.called;
   });
 });

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -126,9 +126,9 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
     expect(tgt.checkValidity.callCount).to.equal(0);
   });
 
-  it('should do nothing of no target', () => {
+  it('should throw if no target', () => {
     evt.target = null;
-    onDocumentFormSubmit_(evt);
+    expect(() => onDocumentFormSubmit_(evt)).to.throw(/Element expected/);
     expect(preventDefaultSpy.callCount).to.equal(0);
     expect(tgt.checkValidity.callCount).to.equal(0);
   });


### PR DESCRIPTION
Fixes #6928 
Fixes #6916 

This also fixes non-xhr submit throguh the `on=action:form.submit` syntax.