### PR TITLE
Proxying the form to call the prototype methods/properties, incl Chrome 45

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {installFormProxy} from './form-proxy';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 import {isExperimentOn} from '../../../src/experiments';
 import {getService} from '../../../src/service';
@@ -77,6 +78,8 @@ export class AmpForm {
    * @param {string} id
    */
   constructor(element, id) {
+    installFormProxy(element);
+
     /** @private @const {string} */
     this.id_ = id;
 

--- a/extensions/amp-form/0.1/form-proxy.js
+++ b/extensions/amp-form/0.1/form-proxy.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Creates a proxy object `form.$p` that proxies all of the methods and
+ * properties to the original DOM APIs. This is to work around the problematic
+ * forms feature where inputs mask DOM APIs.
+ *
+ * E.g. a `<input id="id">` will override `form.id` from the original DOM API.
+ * Form proxy will give access to the original `id` value via `form.$p.id`.
+ *
+ * See https://medium.com/@dvoytenko/solving-conflicts-between-form-inputs-and-dom-api-535c45333ae4
+ *
+ * @param {!HTMLFormElement} form
+ * @return {!Object}
+ */
+export function installFormProxy(form) {
+  const constr = getFormProxyConstr(form.ownerDocument.defaultView);
+  const proxy = new constr(form);
+  form['$p'] = proxy;
+  return proxy;
+}
+
+
+/**
+ * @param {!Window} win
+ * @return {function(new:Object, !HTMLFormElement)}
+ */
+function getFormProxyConstr(win) {
+  if (!win.FormProxy) {
+    win.FormProxy = createFormProxyConstr(win);
+  }
+  return win.FormProxy;
+}
+
+
+/**
+ * @param {!Window} win
+ * @return {function(new:Object, !HTMLFormElement)}
+ */
+function createFormProxyConstr(win) {
+
+  /**
+   * @param {!HTMLFormElement} form
+   * @constructor
+   */
+  function FormProxy(form) {
+    /** @private @const {!HTMLFormElement} */
+    this.form_ = form;
+  }
+
+  const FormProxyProto = FormProxy.prototype;
+
+  // Hierarchy:
+  //   Node  <==  Element <== HTMLElement <== HTMLFormElement
+  //   EventTarget  <==  HTMLFormElement
+  const prototypes = [
+    win.HTMLFormElement.prototype,
+    win.HTMLElement.prototype,
+    win.Element.prototype,
+    win.Node.prototype,
+    win.EventTarget.prototype,
+  ];
+  prototypes.forEach(function(prototype) {
+    for (const name in prototype) {
+      const property = win.Object.getOwnPropertyDescriptor(prototype, name);
+      if (!property ||
+          name.substring(0, 2) == 'on' ||
+          win.Object.prototype.hasOwnProperty.call(FormProxyProto, name)) {
+        continue;
+      }
+      if (typeof property.value == 'function') {
+        // A method call. Call the original prototype method via `call`.
+        const method = property.value;
+        FormProxyProto[name] = function() {
+          return method.apply(this.form_, arguments);
+        };
+      } else {
+        // A read/write property. Call the original prototype getter/setter.
+        const spec = {};
+        if (property.get) {
+          spec.get = function() {
+            return property.get.call(this.form_);
+          };
+        }
+        if (property.set) {
+          spec.set = function(value) {
+            return property.set.call(this.form_, value);
+          };
+        }
+        win.Object.defineProperty(FormProxyProto, name, spec);
+      }
+    }
+  });
+
+  return FormProxy;
+}

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -146,6 +146,14 @@ describe('amp-form', () => {
     expect(form.className).to.contain('-amp-form');
   });
 
+  it('should install proxy', () => {
+    const form = getForm();
+    form.setAttribute('action-xhr', 'https://example.com');
+    new AmpForm(form);
+    expect(form.$p).to.be.ok;
+    expect(form.$p.getAttribute('action-xhr')).to.equal('https://example.com');
+  });
+
   it('should do nothing if already submitted', () => {
     const form = getForm();
     const ampForm = new AmpForm(form);

--- a/extensions/amp-form/0.1/test/test-form-proxy.js
+++ b/extensions/amp-form/0.1/test/test-form-proxy.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {installFormProxy} from '../form-proxy';
+
+
+describes.sandboxed('installFormProxy', {}, () => {
+  let form;
+
+  beforeEach(() => {
+    form = document.createElement('form');
+    form.id = 'form1';
+    form.action = 'https://example.org/submit';
+    form.method = 'post';
+    installFormProxy(form);
+  });
+
+  describe('w/o masking inputs', () => {
+    it('should initialize correctly', () => {
+      expect(form.$p).to.be.ok;
+      expect(form.$p.form_).to.equal(form);
+    });
+
+    it('should proxy properties', () => {
+      expect(form.id).to.equal('form1');
+      expect(form.$p.id).to.equal('form1');
+
+      expect(form.action).to.equal('https://example.org/submit');
+      expect(form.$p.action).to.equal('https://example.org/submit');
+
+      expect(form.method).to.equal('post');
+      expect(form.$p.method).to.equal('post');
+    });
+
+    it('should proxy methods', () => {
+      expect(form.getAttribute('id')).to.equal('form1');
+      expect(form.$p.getAttribute('id')).to.equal('form1');
+    });
+
+    it('should proxy property writes', () => {
+      form.$p.id = 'form2';
+
+      expect(form.id).to.equal('form2');
+      expect(form.$p.id).to.equal('form2');
+      expect(form.getAttribute('id')).to.equal('form2');
+      expect(form.$p.getAttribute('id')).to.equal('form2');
+    });
+  });
+
+  describe('with masking inputs', () => {
+    let idInput, actionInput, methodInput, getAttrInput;
+
+    beforeEach(() => {
+      idInput = document.createElement('input');
+      idInput.id = 'id';
+      form.appendChild(idInput);
+
+      actionInput = document.createElement('input');
+      actionInput.id = 'action';
+      form.appendChild(actionInput);
+
+      methodInput = document.createElement('input');
+      methodInput.id = 'method';
+      form.appendChild(methodInput);
+
+      getAttrInput = document.createElement('input');
+      getAttrInput.id = 'getAttribute';
+      form.appendChild(getAttrInput);
+    });
+
+    it('should proxy properties', () => {
+      expect(form.$p.id).to.equal('form1');
+      expect(form.id).to.equal(idInput);
+
+      expect(form.$p.action).to.equal('https://example.org/submit');
+      expect(form.action).to.equal(actionInput);
+
+      expect(form.$p.method).to.equal('post');
+      expect(form.method).to.equal(methodInput);
+    });
+
+    it('should proxy methods', () => {
+      expect(form.$p.getAttribute('id')).to.equal('form1');
+      expect(form.getAttribute).to.equal(getAttrInput);
+    });
+
+    it('should proxy property writes', () => {
+      form.$p.id = 'form2';
+
+      expect(form.$p.id).to.equal('form2');
+      expect(form.id).to.equal(idInput);
+      expect(form.$p.getAttribute('id')).to.equal('form2');
+      expect(form.getAttribute).to.equal(getAttrInput);
+    });
+  });
+});

--- a/extensions/amp-form/0.1/test/test-form-proxy.js
+++ b/extensions/amp-form/0.1/test/test-form-proxy.js
@@ -14,96 +14,258 @@
  * limitations under the License.
  */
 
-import {installFormProxy} from '../form-proxy';
+import {
+  installFormProxy,
+  setBlacklistedPropertiesForTesting,
+} from '../form-proxy';
+
+const PROPS = ['id', 'action', 'method', 'style', 'acceptCharset',
+    'attributes', 'elements', 'children', 'draggable', 'hidden',
+    'autocomplete'];
 
 
-describes.sandboxed('installFormProxy', {}, () => {
+describes.repeated('installFormProxy', {
+  'modern w/o inputs': {},
+  'modern w/inputs': {inputs: true},
+  'legacy w/o inputs': {blacklist: true},
+  'legacy w/ inputs': {blacklist: true, inputs: true},
+}, (name, variant) => {
   let form;
+  let inputs;
 
   beforeEach(() => {
     form = document.createElement('form');
     form.id = 'form1';
     form.action = 'https://example.org/submit';
     form.method = 'post';
+    form.setAttribute('accept-charset', 'OTHER');
+
+    // Inputs.
+    if (variant.inputs) {
+      const inputNames = PROPS.slice(0);
+      // Also, add some methods, which are never blacklisted.
+      inputNames.push('getAttribute');
+      inputNames.push('submit');
+      inputs = {};
+      inputNames.forEach(name => {
+        const input = document.createElement('input');
+        input.id = name;
+        form.appendChild(input);
+        inputs[name] = input;
+      });
+    }
+
+    // Test blacklist.
+    if (variant.blacklist) {
+      setBlacklistedPropertiesForTesting(PROPS);
+    }
+
+    // Install proxy.
     installFormProxy(form);
   });
 
-  describe('w/o masking inputs', () => {
-    it('should initialize correctly', () => {
-      expect(form.$p).to.be.ok;
-      expect(form.$p.form_).to.equal(form);
-    });
-
-    it('should proxy properties', () => {
-      expect(form.id).to.equal('form1');
-      expect(form.$p.id).to.equal('form1');
-
-      expect(form.action).to.equal('https://example.org/submit');
-      expect(form.$p.action).to.equal('https://example.org/submit');
-
-      expect(form.method).to.equal('post');
-      expect(form.$p.method).to.equal('post');
-    });
-
-    it('should proxy methods', () => {
-      expect(form.getAttribute('id')).to.equal('form1');
-      expect(form.$p.getAttribute('id')).to.equal('form1');
-    });
-
-    it('should proxy property writes', () => {
-      form.$p.id = 'form2';
-
-      expect(form.id).to.equal('form2');
-      expect(form.$p.id).to.equal('form2');
-      expect(form.getAttribute('id')).to.equal('form2');
-      expect(form.$p.getAttribute('id')).to.equal('form2');
-    });
+  afterEach(() => {
+    delete window.FormProxy;
+    setBlacklistedPropertiesForTesting(null);
   });
 
-  describe('with masking inputs', () => {
-    let idInput, actionInput, methodInput, getAttrInput;
+  it('should initialize correctly', () => {
+    expect(form.$p).to.be.ok;
+    expect(form.$p.form_).to.equal(form);
+  });
 
-    beforeEach(() => {
-      idInput = document.createElement('input');
-      idInput.id = 'id';
-      form.appendChild(idInput);
+  it('should NOT proxy consts', () => {
+    expect(form.ELEMENT_NODE).to.equal(1);
+    expect(form.$p.ELEMENT_NODE).to.be.undefined;
+  });
 
-      actionInput = document.createElement('input');
-      actionInput.id = 'action';
-      form.appendChild(actionInput);
+  it('should proxy methods', () => {
+    expect(form.$p.getAttribute('id')).to.equal('form1');
+    expect(form.$p.submit).to.be.function;
+    if (inputs) {
+      expect(form.getAttribute).to.equal(inputs.getAttribute);
+      expect(form.submit).to.equal(inputs.submit);
+    } else {
+      expect(form.getAttribute).to.be.function;
+      expect(form.getAttribute('id')).to.equal('form1');
+      expect(form.submit).to.be.function;
+    }
+  });
 
-      methodInput = document.createElement('input');
-      methodInput.id = 'method';
-      form.appendChild(methodInput);
+  it('should proxy attribute-based properties', () => {
+    expect(form.$p.id).to.equal('form1');
+    expect(form.$p.method).to.equal('post');
+    expect(form.$p.acceptCharset).to.equal('OTHER');
+    if (inputs) {
+      expect(form.id).to.equal(inputs.id);
+      expect(form.method).to.equal(inputs.method);
+      expect(form.acceptCharset).to.equal(inputs.acceptCharset);
+    } else {
+      expect(form.id).to.equal('form1');
+      expect(form.method).to.equal('post');
+      expect(form.acceptCharset).to.equal('OTHER');
+    }
+  });
 
-      getAttrInput = document.createElement('input');
-      getAttrInput.id = 'getAttribute';
-      form.appendChild(getAttrInput);
-    });
+  it('should proxy attribute-based property writes', () => {
+    form.$p.id = 'form2';
+    expect(form.$p.id).to.equal('form2');
+    expect(form.$p.getAttribute('id')).to.equal('form2');
+    if (inputs) {
+      expect(form.id).to.equal(inputs.id);
+      expect(form.getAttribute).to.equal(inputs.getAttribute);
+    } else {
+      expect(form.id).to.equal('form2');
+      expect(form.getAttribute('id')).to.equal('form2');
+    }
+  });
 
-    it('should proxy properties', () => {
-      expect(form.$p.id).to.equal('form1');
-      expect(form.id).to.equal(idInput);
+  it('should proxy draggable attribute', () => {
+    expect(form.$p.draggable).to.be.false;
 
-      expect(form.$p.action).to.equal('https://example.org/submit');
-      expect(form.action).to.equal(actionInput);
+    form.$p.setAttribute('draggable', 'true');
+    expect(form.$p.draggable).to.be.true;
 
-      expect(form.$p.method).to.equal('post');
-      expect(form.method).to.equal(methodInput);
-    });
+    form.$p.setAttribute('draggable', 'false');
+    expect(form.$p.draggable).to.be.false;
 
-    it('should proxy methods', () => {
-      expect(form.$p.getAttribute('id')).to.equal('form1');
-      expect(form.getAttribute).to.equal(getAttrInput);
-    });
+    form.$p.draggable = true;
+    expect(form.$p.getAttribute('draggable')).to.equal('true');
 
-    it('should proxy property writes', () => {
-      form.$p.id = 'form2';
+    form.$p.draggable = false;
+    expect(form.$p.getAttribute('draggable')).to.equal('false');
+  });
 
-      expect(form.$p.id).to.equal('form2');
-      expect(form.id).to.equal(idInput);
-      expect(form.$p.getAttribute('id')).to.equal('form2');
-      expect(form.getAttribute).to.equal(getAttrInput);
-    });
+  it('should proxy hidden attribute', () => {
+    expect(form.$p.hidden).to.be.false;
+
+    form.$p.setAttribute('hidden', '');
+    expect(form.$p.hidden).to.be.true;
+
+    form.$p.setAttribute('hidden', 'true');
+    expect(form.$p.hidden).to.be.true;
+
+    form.$p.setAttribute('hidden', 'false');
+    expect(form.$p.hidden).to.be.true;
+
+    form.$p.removeAttribute('hidden');
+    expect(form.$p.hidden).to.be.false;
+
+    form.$p.hidden = true;
+    expect(form.$p.getAttribute('hidden')).to.equal('');
+
+    form.$p.hidden = false;
+    expect(form.$p.getAttribute('hidden')).to.be.null;
+  });
+
+  it('should proxy novalidate attribute', () => {
+    expect(form.$p.noValidate).to.be.false;
+
+    form.$p.setAttribute('novalidate', '');
+    expect(form.$p.noValidate).to.be.true;
+
+    form.$p.setAttribute('novalidate', 'true');
+    expect(form.$p.noValidate).to.be.true;
+
+    form.$p.setAttribute('novalidate', 'false');
+    expect(form.$p.noValidate).to.be.true;
+
+    form.$p.removeAttribute('novalidate');
+    expect(form.$p.noValidate).to.be.false;
+
+    form.$p.noValidate = true;
+    expect(form.$p.getAttribute('novalidate')).to.equal('');
+
+    form.$p.noValidate = false;
+    expect(form.$p.getAttribute('novalidate')).to.be.null;
+  });
+
+  it('should proxy autocomplete attribute', () => {
+    // "on" by default.
+    expect(form.$p.autocomplete).to.equal('on');
+
+    form.$p.setAttribute('autocomplete', 'off');
+    expect(form.$p.autocomplete).to.equal('off');
+
+    form.$p.autocomplete = 'on';
+    expect(form.$p.getAttribute('autocomplete')).to.equal('on');
+  });
+
+  it('should proxy action', () => {
+    expect(form.$p.action).to.equal('https://example.org/submit');
+    if (inputs) {
+      expect(form.action).to.equal(inputs.action);
+    } else {
+      expect(form.action).to.equal('https://example.org/submit');
+    }
+
+    // Relative URLs should also work.
+    form.$p.setAttribute('action', 'submit2');
+    expect(form.$p.action).to.match(/http?\:\/\/.*\/submit2/);
+    if (inputs) {
+      expect(form.action).to.equal(inputs.action);
+    } else {
+      expect(form.action).to.match(/http?\:\/\/.*\/submit2/);
+    }
+  });
+
+  it('should proxy style', () => {
+    expect(form.$p.style.display).to.equal('');
+    if (inputs) {
+      expect(form.style).to.equal(inputs.style);
+    } else {
+      expect(form.style.display).to.equal('');
+    }
+
+    form.$p.style.display = 'none';
+    expect(form.$p.style.display).to.equal('none');
+    if (inputs) {
+      expect(form.style).to.equal(inputs.style);
+    } else {
+      expect(form.style.display).to.equal('none');
+    }
+  });
+
+  it('should proxy elements and children', () => {
+    const allInputs = [];
+    if (inputs) {
+      for (const k in inputs) {
+        allInputs.push(inputs[k]);
+      }
+    }
+    const allChildren = allInputs.slice(0);
+    expect(form.$p.elements.length).to.equal(allInputs.length);
+    expect(form.$p.children.length).to.equal(allChildren.length);
+
+    // Create one input and one non-input.
+    const input1 = document.createElement('input');
+    form.$p.appendChild(input1);
+    allInputs.push(input1);
+    allChildren.push(input1);
+    const div1 = document.createElement('div');
+    form.$p.appendChild(div1);
+    allChildren.push(div1);
+
+    expect(form.$p.elements.length).to.equal(allInputs.length);
+    for (let i = 0; i < form.$p.elements.length; i++) {
+      expect(allInputs).to.contain(form.$p.elements[i]);
+    }
+    expect(form.$p.children.length).to.equal(allChildren.length);
+    for (let i = 0; i < form.$p.children.length; i++) {
+      expect(allChildren).to.contain(form.$p.children[i]);
+    }
+  });
+
+  it('should proxy attributes', () => {
+    const iniCount = form.$p.attributes.length;
+    form.$p.setAttribute('other', '');
+    expect(form.$p.attributes.length).to.equal(iniCount + 1);
+    expect(form.$p.attributes['other']).to.be.ok;
+  });
+
+  it('should proxy dataset', () => {
+    expect(form.$p.dataset['other']).to.not.exist;
+    form.$p.setAttribute('data-other', '');
+    expect(form.$p.dataset['other']).to.exist;
   });
 });

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -149,6 +149,51 @@ export const realWin = describeEnv(spec => [
 
 
 /**
+ * A repeating test.
+ * @param {string} name
+ * @param {!Object<string, *>} variants
+ * @param {function(string, *)} fn
+ */
+export const repeated = (function() {
+  /**
+   * @param {string} name
+   * @param {!Object<string, *>} variants
+   * @param {function(string, *)} fn
+   * @param {function(string, function())} describeFunc
+   */
+  const templateFunc = function(name, variants, fn, describeFunc) {
+    return describeFunc(name, function() {
+      for (const name in variants) {
+        describe(name ? ` ${name} ` : SUB, function() {
+          fn.call(this, name, variants[name]);
+        });
+      }
+    });
+  };
+
+  /**
+   * @param {string} name
+   * @param {!Object<string, *>} variants
+   * @param {function(string, *)} fn
+   */
+  const mainFunc = function(name, variants, fn) {
+    return templateFunc(name, variants, fn, describe);
+  };
+
+  /**
+   * @param {string} name
+   * @param {!Object<string, *>} variants
+   * @param {function(string, *)} fn
+   */
+  mainFunc.only = function(name, variants, fn) {
+    return templateFunc(name, variants, fn, describe./*OK*/only);
+  };
+
+  return mainFunc;
+})();
+
+
+/**
  * A test within a described environment.
  * @param {function(!Object):!Array<?Fixture>} factory
  */


### PR DESCRIPTION
Rollforward of #6720 including changes necessary for Chrome 45 and below.

The only difference from the previously rolled back #6720 is concentrated in the `setupLegacyProxy` method.