### PR TITLE
 Scan used extension in HTML head, instead whole document.

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -155,7 +155,7 @@ function tryUpgradeElementNoInline(element, toClass) {
  */
 export function stubElements(win) {
   const knownElements = getExtendedElements(win);
-  const list = win.document.querySelectorAll('[custom-element]');
+  const list = win.document.head.querySelectorAll('script[custom-element]');
   for (let i = 0; i < list.length; i++) {
     const name = list[i].getAttribute('custom-element');
     if (knownElements[name]) {

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1663,15 +1663,17 @@ describe('CustomElement Overflow Element', () => {
       elements = [];
 
       doc = {
-        querySelectorAll: selector => {
-          if (selector == '[custom-element]') {
-            return elements;
-          }
-          return [];
-        },
         registerElement: sandbox.spy(),
         documentElement: {
           ownerDocument: doc,
+        },
+        head: {
+          querySelectorAll: selector => {
+            if (selector == 'script[custom-element]') {
+              return elements;
+            }
+            return [];
+          },
         },
         body: {},
       };


### PR DESCRIPTION
Fixes #6253