### PR TITLE
Support generic chunking and chunk Bind's DOM scan

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -465,8 +465,8 @@ var forbiddenTerms = {
       'dist.3p/current/integration.js',  // Includes the previous.
     ],
   },
-  'chunk\\(': {
-    message: 'chunk( should only be used during startup',
+  'startupChunk\\(': {
+    message: 'startupChunk( should only be used during startup',
     whitelist: [
       'src/amp.js',
       'src/chunk.js',

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -53,6 +53,7 @@ export class BindEvaluator {
     this.validator_ = new BindValidator();
 
     // Create BindExpression objects from expression strings.
+    // TODO(choumx): Chunk creation of BindExpression or change to web worker.
     for (let i = 0; i < evaluatees.length; i++) {
       const e = evaluatees[i];
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -163,21 +163,16 @@ export class Bind {
 
     // TODO(choumx): Use TreeWalker if this is too slow.
     const elements = body.getElementsByTagName('*');
+    const numElements = elements.length;
 
     // Helper function for scanning a slice of elements.
     const scanFromTo = (start, end) => {
-      for (let i = start; i < end; i++) {
-        const el = elements[i];
-        if (!el) {
-          break;
-        }
+      for (let i = start; i < end && i < numElements; i++) {
         const bindings = [];
+        const el = elements[i];
         const attrs = el.attributes;
-        for (let j = 0;; j++) {
+        for (let j = 0, numAttrs = attrs.length; j < numAttrs; j++) {
           const attr = attrs[j];
-          if (!attr) {
-            break;
-          }
           const binding = this.bindingForAttribute_(attr, el);
           if (binding) {
             bindings.push(binding);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -147,7 +147,10 @@ export class Bind {
    * a tuple containing bound elements and binding data for the evaluator.
    * @param {!Element} body
    * @return {
-   *   !Promise<{boundElements: !Array<BoundElementDef>, evaluatees: !Array<./bind-evaluator.EvaluateeDef>}>
+   *   !Promise<{
+   *     boundElements: !Array<BoundElementDef>,
+   *     evaluatees: !Array<./bind-evaluator.EvaluateeDef>
+   *   }>
    * }
    * @private
    */

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -116,7 +116,7 @@ export class Bind {
 
     if (!opt_skipDigest) {
       // If scan hasn't completed yet, set `digestQueuedAfterScan_`.
-      if (this.boundElements_) {
+      if (this.evaluator_) {
         this.digest_();
       } else {
         this.digestQueuedAfterScan_ = true;
@@ -137,9 +137,8 @@ export class Bind {
       this.evaluator_ = new BindEvaluator(evaluatees);
 
       // Trigger verify-only digest in development.
-      const development = getMode().development;
-      if (development || this.digestQueuedAfterScan_) {
-        this.digest_(/* opt_verifyOnly */ development);
+      if (getMode().development || this.digestQueuedAfterScan_) {
+        this.digest_(/* opt_verifyOnly */ !this.digestQueuedAfterScan_);
       }
     });
   }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -168,23 +168,11 @@ export class Bind {
     // Helper function for scanning a slice of elements.
     const scanFromTo = (start, end) => {
       for (let i = start; i < end && i < numElements; i++) {
-        const bindings = [];
-        const el = elements[i];
-        const attrs = el.attributes;
-        for (let j = 0, numAttrs = attrs.length; j < numAttrs; j++) {
-          const attr = attrs[j];
-          const binding = this.bindingForAttribute_(attr, el);
-          if (binding) {
-            bindings.push(binding);
-            evaluatees.push({
-              tagName: el.tagName,
-              property: binding.property,
-              expressionString: binding.expressionString,
-            });
-          }
-        }
+        const element = elements[i];
+        // Note: bindingsForElement_() mutates `evaluatees`.
+        const bindings = this.bindingsForElement_(element, evaluatees);
         if (bindings.length > 0) {
-          boundElements.push({element: el, bindings});
+          boundElements.push({element, bindings});
         }
       }
     };
@@ -218,6 +206,32 @@ export class Bind {
       };
       chunk(this.ampdoc, chunktion, ChunkPriority.LOW);
     });
+  }
+
+  /**
+   * Returns array of bindings for given element. Also, creates an EvaluateeDef
+   * for each binding and appends it to `evaluatees` param.
+   * @param {!Element} element
+   * @param {!Array<./bind-evaluator.EvaluateeDef>} evaluatees
+   * @return {!Array<{property: string, expressionString: string}>}
+   * @private
+   */
+  bindingsForElement_(element, evaluatees) {
+    const bindings = [];
+    const attrs = element.attributes;
+    for (let i = 0, numberOfAttrs = attrs.length; i < numberOfAttrs; i++) {
+      const attr = attrs[i];
+      const binding = this.bindingForAttribute_(attr, element);
+      if (binding) {
+        bindings.push(binding);
+        evaluatees.push({
+          tagName: element.tagName,
+          property: binding.property,
+          expressionString: binding.expressionString,
+        });
+      }
+    }
+    return bindings;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -172,7 +172,12 @@ export class Bind {
           break;
         }
         const bindings = [];
-        for (const attr of el.attributes) {
+        const attrs = el.attributes;
+        for (let j = 0;; j++) {
+          const attr = attrs[j];
+          if (!attr) {
+            break;
+          }
           const binding = this.bindingForAttribute_(attr, el);
           if (binding) {
             bindings.push(binding);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -166,11 +166,14 @@ export class Bind {
 
     // Helper function for scanning a slice of elements.
     const scanFromTo = (start, end) => {
-      for (let i = start, el = elements[i]; i < end && el; i++) {
-        const attrs = el.attributes;
+      for (let i = start; i < end; i++) {
+        const el = elements[i];
+        if (!el) {
+          break;
+        }
         const bindings = [];
-        for (let j = 0; attrs[j]; j++) {
-          const binding = this.bindingForAttribute_(attrs[j], el);
+        for (const attr of el.attributes) {
+          const binding = this.bindingForAttribute_(attr, el);
           if (binding) {
             bindings.push(binding);
             evaluatees.push({

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -166,8 +166,7 @@ export class Bind {
 
     // Helper function for scanning a slice of elements.
     const scanFromTo = (start, end) => {
-      for (let i = start; i < end && elements[i]; i++) {
-        const el = elements[i];
+      for (let i = start, el = elements[i]; i < end && el; i++) {
         const attrs = el.attributes;
         const bindings = [];
         for (let j = 0; attrs[j]; j++) {
@@ -194,16 +193,10 @@ export class Bind {
       const chunktion = idleDeadline => {
         // If `requestIdleCallback` is available, scan elements until
         // idle time runs out.
-        if (idleDeadline) {
-          if (idleDeadline.didTimeout) {
-            // On timeout, scan the remaining elements immediately.
-            scanFromTo(position, Number.POSITIVE_INFINITY);
-            position = Number.POSITIVE_INFINITY;
-          } else {
-            while (idleDeadline.timeRemaining() > 1 && elements[position]) {
-              scanFromTo(position, position + 1);
-              position++;
-            }
+        if (idleDeadline && !idleDeadline.didTimeout) {
+          while (idleDeadline.timeRemaining() > 1 && elements[position]) {
+            scanFromTo(position, position + 1);
+            position++;
           }
         } else {
           // If `requestIdleCallback` isn't available, scan elements in buckets.

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -77,14 +77,16 @@ describes.realWin('amp-bind', {
    */
   function onBindReady(callback) {
     return env.ampdoc.whenReady().then(() => {
+      return bind.scanPromise_;
+    }).then(() => {
       if (bind.evaluatePromise_) {
-        return bind.evaluatePromise_.then(() => {
-          env.flushVsync();
-          callback();
-        });
+        return bind.evaluatePromise_;
       } else {
         callback();
       }
+    }).then(() => {
+      env.flushVsync();
+      callback();
     });
   }
 
@@ -96,11 +98,13 @@ describes.realWin('amp-bind', {
    */
   function onBindReadyAndSetState(state, callback) {
     return env.ampdoc.whenReady().then(() => {
+      return bind.scanPromise_;
+    }).then(() => {
       bind.setState(state);
-      return bind.evaluatePromise_.then(() => {
-        env.flushVsync();
-        callback();
-      });
+      return bind.evaluatePromise_;
+    }).then(() => {
+      env.flushVsync();
+      callback();
     });
   }
 

--- a/src/amp.js
+++ b/src/amp.js
@@ -19,7 +19,7 @@
  */
 
 import './polyfills';
-import {chunk} from './chunk';
+import {startupChunk} from './chunk';
 import {fontStylesheetTimeout} from './font-stylesheet-timeout';
 import {installPerformanceService} from './service/performance-impl';
 import {installPullToRefreshBlocker} from './pull-to-refresh';
@@ -62,14 +62,14 @@ try {
   makeBodyVisible(self.document);
   throw e;
 }
-chunk(self.document, function initial() {
+startupChunk(self.document, function initial() {
   /** @const {!./service/ampdoc-impl.AmpDoc} */
   const ampdoc = ampdocService.getAmpDoc(self.document);
   /** @const {!./service/performance-impl.Performance} */
   const perf = installPerformanceService(self);
   perf.tick('is');
   installStyles(self.document, cssText, () => {
-    chunk(self.document, function services() {
+    startupChunk(self.document, function services() {
       // Core services.
       installRuntimeServices(self);
       fontStylesheetTimeout(self);
@@ -78,17 +78,17 @@ chunk(self.document, function initial() {
       perf.coreServicesAvailable();
       maybeTrackImpression(self);
     });
-    chunk(self.document, function builtins() {
+    startupChunk(self.document, function builtins() {
       // Builtins.
       installBuiltins(self);
     });
-    chunk(self.document, function adoptWindow() {
+    startupChunk(self.document, function adoptWindow() {
       adopt(self);
     });
-    chunk(self.document, function stub() {
+    startupChunk(self.document, function stub() {
       stubElements(self);
     });
-    chunk(self.document, function final() {
+    startupChunk(self.document, function final() {
       installPullToRefreshBlocker(self);
       installGlobalClickListenerForDoc(ampdoc);
 
@@ -96,7 +96,7 @@ chunk(self.document, function initial() {
       makeBodyVisible(self.document, /* waitForServices */ true);
       installCacheServiceWorker(self);
     });
-    chunk(self.document, function finalTick() {
+    startupChunk(self.document, function finalTick() {
       perf.tick('e_is');
       // TODO(erwinm): move invocation of the `flush` method when we have the
       // new ticks in place to batch the ticks properly.

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -217,9 +217,9 @@ class StartupTask extends Task {
   /**
    * @param {!function(?IdleDeadline)} fn
    * @param {!Window} win
-   * @param {!Promise<./service/viewer-impl.Viewer>} viewerPromise
+   * @param {!Promise<!./service/viewer-impl.Viewer>} viewerPromise
    */
-  constructor(fn, win, viewerOrPromise) {
+  constructor(fn, win, viewerPromise) {
     super(fn);
 
     /** @private {!Window} */
@@ -234,7 +234,7 @@ class StartupTask extends Task {
     /** @private {?./service/viewer-impl.Viewer} */
     this.viewer_ = null;
 
-    viewerOrPromise.then(viewer => {
+    viewerPromise.then(viewer => {
       this.viewer_ = viewer;
 
       this.viewer_.onVisibilityChanged(() => {
@@ -389,7 +389,7 @@ class Chunks {
    * @param {?IdleDeadline} idleDeadline
    * @private
    */
-  executeASAP_(idleDeadline) {
+  executeAsap_(idleDeadline) {
     resolved.then(() => {
       this.boundExecute_(idleDeadline);
     });
@@ -405,7 +405,7 @@ class Chunks {
       return;
     }
     if (nextTask.immediateTriggerCondition_()) {
-      this.executeASAP_(/* idleDeadline */ null);
+      this.executeAsap_(/* idleDeadline */ null);
       return;
     }
     // If requestIdleCallback exists, schedule a task with it, but

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -215,6 +215,7 @@ class Task {
 
 /**
  * A task that's run as part of AMP's startup sequence.
+ * @private
  */
 class StartupTask extends Task {
   /**
@@ -358,6 +359,7 @@ class Chunks {
    * If `opt_dequeue` is true, remove the returned task from the queue.
    * @param {boolean=} opt_dequeue
    * @return {?Task}
+   * @private
    */
   nextTask_(opt_dequeue) {
     let t = this.tasks_.peek();

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import PriorityQueue from './utils/priority-queue';
 import {dev} from './log';
 import {fromClassForDoc} from './service';
 import {isExperimentOnAllowUrlOverride} from './experiments';
@@ -36,22 +37,29 @@ let deactivated = /nochunking=1/.test(self.location.hash);
 const resolved = Promise.resolve();
 
 /**
- * Run the given function. For visible documents the function will be
- * called in a micro task (Essentially ASAP). If the document is
- * not visible, tasks will yield to the event loop (to give the browser
- * time to do other things) and may even be further delayed until
- * there is time.
+ * Run the given function sometime in the future without blocking UI.
+ *
+ * Higher priority tasks are executed before lower priority tasks.
+ * Tasks with the same priority are executed in FIFO order.
+ *
+ * For ChunkPriority.STARTUP:
+ *   In visible documents, `fn` will be called in a micro task
+ *   (essentially ASAP). If the document is not visible, tasks will yield
+ *   to the event loop (to give the browser time to do other things)
+ *   and may even be further delayed until there is time.
  *
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrAmpDoc
  * @param {function()} fn Function that will be called as a "chunk".
+ * @param {ChunkPriority=} opt_priority
+ * @return {!Promise} Resolved when the task is executed.
  */
-export function chunk(nodeOrAmpDoc, fn) {
+export function chunk(nodeOrAmpDoc, fn, opt_priority) {
   if (deactivated) {
-    resolved.then(fn);
-    return;
+    return resolved.then(fn);
   }
   const service = fromClassForDoc(nodeOrAmpDoc, 'chunk', Chunks);
-  service.run_(fn);
+  const p = (opt_priority === undefined) ? ChunkPriority.STARTUP : opt_priority;
+  return service.run_(fn, p);
 };
 
 /**
@@ -99,114 +107,159 @@ export function runChunksForTesting(nodeOrAmpDoc) {
   }
 }
 
-class Chunks {
+/**
+ * The priority of a chunk task. Higher priority tasks have higher values.
+ * @enum {number}
+ */
+export const ChunkPriority = {
+  STARTUP: 100,
+  HIGH: 20,
+  LOW: 10,
+  BACKGROUND: 0,
+};
+
+/** @enum {string} */
+const TaskState = {
+  NOT_RUN: 'not_run',
+  RUN: 'run',
+};
+
+/**
+ * A default chunkable task.
+ */
+class Task {
   /**
+   * @param {!Function} fn
+   */
+  constructor(fn) {
+    /** @public {TaskState} */
+    this.state = TaskState.NOT_RUN;
+
+    /** @private @const {!Function} */
+    this.fn_ = fn;
+
+    /** @private {?Function} */
+    this.resolve_ = null;
+
+    /** @private {?Function} */
+    this.reject_ = null;
+
+    /** @public @const */
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve_ = resolve;
+      this.reject_ = reject;
+    });
+  }
+
+  /**
+   * Executes the wrapped function.
+   * @throws {Error}
+   */
+  runTask() {
+    this.state = TaskState.RUN;
+    try {
+      const result = this.fn_();
+      this.resolve_(result);
+    } catch (e) {
+      this.onTaskError_(e);
+      this.reject_(e);
+      throw e;
+    }
+  }
+
+  /**
+   * @return {string}
+   */
+  get name() {
+    return this.fn_.displayName || this.fn_.name;
+  }
+
+  /**
+   * Optional handling when a task run throws an error.
+   * @protected
+   * @param {Error} unusedError
+   */
+  onTaskError_(unusedError) {
+    // By default, no-op.
+  }
+
+  /**
+   * Returns true if this task should be run without delay.
+   * @protected
+   * @return {boolean}
+   */
+  immediateTriggerCondition_() {
+    // By default, there are no immediate trigger conditions.
+    return false;
+  }
+
+  /**
+   * Returns true if this task should be scheduled using `requestIdleCallback`.
+   * Otherwise, task is scheduled as macro-task on next event loop.
+   * @protected
+   * @return {boolean}
+   */
+  useRequestIdleCallback_() {
+    // By default, always use requestIdleCallback.
+    return true;
+  }
+}
+
+/**
+ * A task that's run as part of AMP's startup sequence.
+ */
+class StartupTask extends Task {
+  /**
+   * @param {!Function} fn
    * @param {!./service/ampdoc-impl.AmpDoc} ampDoc
    */
-  constructor(ampDoc) {
-    /** @private @const */
-    this.ampDoc_ = ampDoc;
-    /** @private @const {!Window} */
+  constructor(fn, ampDoc) {
+    super(fn);
+
+    /** @private {!Window} */
     this.win_ = ampDoc.win;
-    /** @private @const {!Array<function()>} */
-    this.tasks_ = [];
-    /** @private {?./service/viewer-impl.Viewer} */
-    this.viewer_ = null;
-    /** @private @const {function()} */
-    this.boundExecute_ = () => this.execute_();
+
     /** @private @const {boolean} */
     this.active_ = isExperimentOnAllowUrlOverride(this.win_, 'chunked-amp');
-
     if (!this.active_) {
       return;
     }
-    this.win_.addEventListener('message', e => {
-      if (e.data = 'amp-macro-task') {
-        this.execute_();
-      }
-    });
+
+    /** @private {?./service/viewer-impl.Viewer} */
+    this.viewer_ = null;
     viewerPromiseForDoc(ampDoc).then(viewer => {
       this.viewer_ = viewer;
       viewer.onVisibilityChanged(() => {
         if (viewer.isVisible()) {
-          this.execute_();
+          this.runTask();
         }
       });
       if (viewer.isVisible()) {
-        this.execute_();
+        this.runTask();
       }
     });
   }
 
-  /**
-   * Run fn as a "chunk". It'll run in a micro task when the doc is visible
-   * and otherwise run it after having yielded to the event queue once.
-   * @param {function()} fn
-   * @private
-   */
-  run_(fn) {
-    this.tasks_.push(fn);
-    this.schedule_();
+  /** @override */
+  onTaskError_(unusedError) {
+    // Startup tasks run early in init. All errors should show the doc.
+    makeBodyVisible(self.document);
   }
 
-  /**
-   * Run a task.
-   * Schedule the next round if there are more tasks.
-   * @return {boolean} Whether anything was executed.
-   * @private
-   */
-  execute_() {
-    const t = this.tasks_.shift();
-    if (!t) {
-      return false;
-    }
-    const before = Date.now();
-    try {
-      t();
-    } catch (e) {
-      // We run early in init. All errors should show the doc.
-      makeBodyVisible(self.document);
-      throw e;
-    } finally {
-      if (this.tasks_.length) {
-        this.schedule_();
-      }
-      dev().fine(TAG, t.displayName || t.name,
-          'Chunk duration', Date.now() - before);
-    }
-    return true;
+  /** @override */
+  immediateTriggerCondition_() {
+    // Run in a micro task when the doc is visible. Otherwise, run after
+    // having yielded to the event queue once.
+    return !this.active_ || this.isVisible_();
   }
 
-  /**
-   * Schedule running a task.
-   * @private
-   */
-  schedule_() {
-    if (!this.active_ || this.isVisible_()) {
-      resolved.then(this.boundExecute_);
-      return;
-    }
-    // If requestIdleCallback exists, schedule a task with it, but
-    // do not wait longer than one second.
+  /** @override */
+  useRequestIdleCallback_() {
     // We only start using requestIdleCallback when the viewer has
     // been initialized. Otherwise we risk starving ourselves
     // before we get into a state where the viewer can tell us
     // that we are visible.
-    if (this.viewer_ && this.win_.requestIdleCallback) {
-      onIdle(this.win_,
-          // Wait until we have a budget of at least 15ms.
-          // 15ms is a magic number. Budgets are higher when the user
-          // is completely idle (around 40), but that occurs too
-          // rarely to be usable. 15ms budgets can happen during scrolling
-          // but only if the device is doing super, super well, and no
-          // real processing is done between frames.
-          15 /* minimumTimeRemaining */ ,
-          2000 /* timeout */,
-          this.boundExecute_);
-      return;
-    }
-    // The message doesn't actually matter.
-    this.win_.postMessage/*OK*/('amp-macro-task', '*');
+    return !!this.viewer_;
   }
 
   /**
@@ -225,6 +278,110 @@ class Chunks {
     // Viewers send a URL param if we are not visible.
     return !(/visibilityState=(hidden|prerender)/.test(
         this.win_.location.hash));
+  }
+}
+
+/**
+ * Handles queueing, scheduling and executing tasks.
+ */
+class Chunks {
+  /**
+   * @param {!./service/ampdoc-impl.AmpDoc} ampDoc
+   */
+  constructor(ampDoc) {
+    /** @protected @const */
+    this.ampDoc_ = ampDoc;
+    /** @protected @const {!Window} */
+    this.win_ = ampDoc.win;
+    /** @protected @const {!PriorityQueue<Task>} */
+    this.tasks_ = new PriorityQueue();
+    /** @protected @const {function()} */
+    this.boundExecute_ = () => this.execute_();
+
+    this.win_.addEventListener('message', e => {
+      if (e.data = 'amp-macro-task') {
+        this.execute_();
+      }
+    });
+  }
+
+  /**
+   * Run fn as a "chunk".
+   * @param {function()} fn
+   * @param {ChunkPriority} priority
+   * @private
+   */
+  run_(fn, priority) {
+    // Use special subclass for startup tasks.
+    const t = (priority === ChunkPriority.STARTUP)
+        ? new StartupTask(fn, this.ampDoc_)
+        : new Task(fn);
+    this.tasks_.enqueue(t, priority);
+    // TODO(choumx): Fix this issue with tests.
+    Promise.resolve().then(() => this.schedule_());
+    return t.promise;
+  }
+
+  /**
+   * Run a task.
+   * Schedule the next round if there are more tasks.
+   * @return {boolean} Whether anything was executed.
+   * @private
+   */
+  execute_() {
+    let t = null;
+    do {
+      t = this.tasks_.dequeue();
+    } while (t && t.state !== TaskState.NOT_RUN);
+    if (!t) {
+      return false;
+    }
+    const before = Date.now();
+    try {
+      t.runTask();
+    } catch (e) {
+      throw e;
+    } finally {
+      if (this.tasks_.length) {
+        this.schedule_();
+      }
+      dev().fine(TAG, t.name, 'Chunk duration', Date.now() - before);
+    }
+    return true;
+  }
+
+  /**
+   * Schedule running a task.
+   * @protected
+   */
+  schedule_() {
+    let nextTask = null;
+    if (this.tasks_.length) {
+      nextTask = this.tasks_.peek();
+      if (nextTask.immediateTriggerCondition_()) {
+        resolved.then(this.boundExecute_);
+        return;
+      }
+    }
+
+    // If requestIdleCallback exists, schedule a task with it, but
+    // do not wait longer than one second.
+    const useRIC = !nextTask || nextTask.useRequestIdleCallback_();
+    if (useRIC && this.win_.requestIdleCallback) {
+      onIdle(this.win_,
+          // Wait until we have a budget of at least 15ms.
+          // 15ms is a magic number. Budgets are higher when the user
+          // is completely idle (around 40), but that occurs too
+          // rarely to be usable. 15ms budgets can happen during scrolling
+          // but only if the device is doing super, super well, and no
+          // real processing is done between frames.
+          15 /* minimumTimeRemaining */,
+          2000 /* timeout */,
+          this.boundExecute_);
+      return;
+    }
+    // The message doesn't actually matter.
+    this.win_.postMessage/*OK*/('amp-macro-task', '*');
   }
 }
 

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -65,7 +65,6 @@ export function startupChunk(nodeOrAmpDoc, fn) {
  * @param {ChunkPriority} priority
  * @return {!Promise} Resolved when the task is executed.
  */
-
 export function chunk(nodeOrAmpDoc, fn, priority) {
   const service = fromClassForDoc(nodeOrAmpDoc, 'chunk', Chunks);
   return service.run_(fn, priority);
@@ -220,7 +219,7 @@ class StartupTask extends Task {
   /**
    * @param {!Function} fn
    * @param {!Window} win
-   * @param {!./service/viewer-impl.Viewer|Promise} viewerOrPromise
+   * @param {!./service/viewer-impl.Viewer|!Promise} viewerOrPromise
    */
   constructor(fn, win, viewerOrPromise) {
     super(fn);

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -70,6 +70,10 @@ export function startupChunk(nodeOrAmpDoc, fn) {
  * @param {ChunkPriority} priority
  */
 export function chunk(nodeOrAmpDoc, fn, priority) {
+  if (deactivated) {
+    resolved.then(fn);
+    return;
+  }
   const service = fromClassForDoc(nodeOrAmpDoc, 'chunk', Chunks);
   service.run_(fn, priority);
 }
@@ -168,7 +172,7 @@ class Task {
   /**
    * @return {string}
    */
-  get name() {
+  getName() {
     return this.fn_.displayName || this.fn_.name;
   }
 
@@ -385,14 +389,9 @@ class Chunks {
       return false;
     }
     const before = Date.now();
-    try {
-      t.runTask(idleDeadline);
-    } catch (e) {
-      throw e;
-    } finally {
-      this.schedule_();
-      dev().fine(TAG, t.name, 'Chunk duration', Date.now() - before);
-    }
+    t.runTask(idleDeadline);
+    this.schedule_();
+    dev().fine(TAG, t.getName(), 'Chunk duration', Date.now() - before);
     return true;
   }
 

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -20,7 +20,7 @@
 
 import '../../third_party/babel/custom-babel-helpers';
 import '../polyfills';
-import {chunk} from '../chunk';
+import {startupChunk} from '../chunk';
 import {fontStylesheetTimeout} from '../font-stylesheet-timeout';
 import {installPerformanceService} from '../service/performance-impl';
 import {installPullToRefreshBlocker} from '../pull-to-refresh';
@@ -65,14 +65,14 @@ try {
   makeBodyVisible(self.document);
   throw e;
 }
-chunk(self.document, function initial() {
+startupChunk(self.document, function initial() {
   /** @const {!../service/ampdoc-impl.AmpDoc} */
   const ampdoc = ampdocService.getAmpDoc(self.document);
   /** @const {!../service/performance-impl.Performance} */
   const perf = installPerformanceService(self);
   perf.tick('is');
   installStyles(self.document, cssText, () => {
-    chunk(self.document, function services() {
+    startupChunk(self.document, function services() {
       // Core services.
       installRuntimeServices(self);
       fontStylesheetTimeout(self);
@@ -89,17 +89,17 @@ chunk(self.document, function initial() {
       perf.coreServicesAvailable();
       maybeTrackImpression(self);
     });
-    chunk(self.document, function builtins() {
+    startupChunk(self.document, function builtins() {
       // Builtins.
       installBuiltins(self);
     });
-    chunk(self.document, function adoptWindow() {
+    startupChunk(self.document, function adoptWindow() {
       adopt(self);
     });
-    chunk(self.document, function stub() {
+    startupChunk(self.document, function stub() {
       stubElements(self);
     });
-    chunk(self.document, function final() {
+    startupChunk(self.document, function final() {
       installPullToRefreshBlocker(self);
       installGlobalClickListenerForDoc(ampdoc);
 
@@ -107,7 +107,7 @@ chunk(self.document, function initial() {
       makeBodyVisible(self.document, /* waitForServices */ true);
       installCacheServiceWorker(self);
     });
-    chunk(self.document, function finalTick() {
+    startupChunk(self.document, function finalTick() {
       perf.tick('e_is');
       // TODO(erwinm): move invocation of the `flush` method when we have the
       // new ticks in place to batch the ticks properly.

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -28,7 +28,7 @@ import {
   stubLegacyElements,
 } from './service/extensions-impl';
 import {ampdocServiceFor} from './ampdoc';
-import {chunk} from './chunk';
+import {startupChunk} from './chunk';
 import {cssText} from '../build/css';
 import {dev, user, initLogConstructor} from './log';
 import {
@@ -285,7 +285,7 @@ function adoptShared(global, opts, callback) {
       Promise.resolve().then(register);
     } else {
       register.displayName = fnOrStruct.n;
-      chunk(global.document, register);
+      startupChunk(global.document, register);
     }
   }
 

--- a/src/utils/priority-queue.js
+++ b/src/utils/priority-queue.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * A simple priority queue.
+ * A priority queue backed with sorted array.
  * @template T
  */
 export default class PriorityQueue {

--- a/src/utils/priority-queue.js
+++ b/src/utils/priority-queue.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A simple priority queue.
+ * @template T
+ */
+export default class PriorityQueue {
+  constructor() {
+    /** @private @const {Array<{item: T, priority: number}>} */
+    this.queue_ = [];
+  }
+
+  /**
+   * Returns the max priority item without dequeueing it.
+   * @return {T}
+   */
+  peek() {
+    const l = this.queue_.length;
+    if (!l) {
+      return null;
+    }
+    return this.queue_[l - 1].item;
+  }
+
+  /**
+   * Enqueues an item with the given priority.
+   * @param {T} item
+   * @param {number} priority
+   */
+  enqueue(item, priority) {
+    if (isNaN(priority)) {
+      throw new Error('Priority must not be NaN.');
+    }
+    const i = this.binarySearch_(priority);
+    this.queue_.splice(i, 0, {item, priority});
+  }
+
+  /**
+   * Returns index at which item with `target` priority should be inserted.
+   * @param {number} target
+   * @return {number}
+   * @private
+   */
+  binarySearch_(target) {
+    let i = -1;
+    let lo = 0;
+    let hi = this.queue_.length;
+    while (lo <= hi) {
+      i = Math.floor((lo + hi) / 2);
+      // This means `target` is the new max priority in the queue.
+      if (i === this.queue_.length) {
+        break;
+      }
+      // Stop searching once p[i] >= target AND p[i-1] < target.
+      // This way, we'll return the index of the first occurence of `target`
+      // priority (if any), which preserves FIFO order of same-priority items.
+      if (this.queue_[i].priority < target) {
+        lo = i + 1;
+      } else if (i > 0 && this.queue_[i - 1].priority >= target) {
+        hi = i - 1;
+      } else {
+        break;
+      }
+    }
+    return i;
+  }
+
+  /**
+   * Dequeues the max priority item.
+   * Items with the same priority are dequeued in FIFO order.
+   * @return {T}
+   */
+  dequeue() {
+    if (!this.queue_.length) {
+      return null;
+    }
+    return this.queue_.pop().item;
+  }
+
+  /**
+   * The number of items in the queue.
+   * @return {number}
+   */
+  get length() {
+    return this.queue_.length;
+  }
+}

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -29,7 +29,6 @@ import * as sinon from 'sinon';
 
 describe('chunk', () => {
 
-  let resolved;
   let experimentOn;
   beforeEach(() => {
     experimentOn = true;
@@ -206,8 +205,8 @@ describe('chunk', () => {
         env.win.requestIdleCallback =
             resolvingIdleCallbackWithTimeRemaining(15);
         const chunks = chunkInstanceForTesting(env.win.document);
-        env.sandbox.stub(chunks, 'executeASAP_', () => {
-          throw new Error('No calls expected: executeASAP_');
+        env.sandbox.stub(chunks, 'executeAsap_', () => {
+          throw new Error('No calls expected: executeAsap_');
         });
         env.win.location.resetHref('test#visibilityState=hidden');
       });
@@ -240,8 +239,8 @@ describe('chunk', () => {
         env.win.requestIdleCallback =
             resolvingIdleCallbackWithTimeRemaining(15);
         const chunks = chunkInstanceForTesting(env.win.document);
-        env.sandbox.stub(chunks, 'executeASAP_', () => {
-          throw new Error('No calls expected: executeASAP_');
+        env.sandbox.stub(chunks, 'executeAsap_', () => {
+          throw new Error('No calls expected: executeAsap_');
         });
         env.win.document.hidden = true;
       });

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -21,6 +21,7 @@ import {
   deactivateChunking,
   onIdle,
   resolvedObjectforTesting,
+  startupChunk,
 } from '../../src/chunk';
 import {installDocService} from '../../src/service/ampdoc-impl';
 import {toggleExperiment} from '../../src/experiments';
@@ -62,7 +63,7 @@ describe('chunk', () => {
     });
 
     it('should execute a chunk', done => {
-      chunk(fakeWin.document, done);
+      startupChunk(fakeWin.document, done);
     });
 
     it('should execute chunks', done => {
@@ -77,14 +78,14 @@ describe('chunk', () => {
           }
         };
       }
-      chunk(fakeWin.document, complete('a'));
-      chunk(fakeWin.document, complete('b'));
-      chunk(fakeWin.document, function() {
+      startupChunk(fakeWin.document, complete('a'));
+      startupChunk(fakeWin.document, complete('b'));
+      startupChunk(fakeWin.document, function() {
         complete('c')();
-        chunk(fakeWin.document, function() {
+        startupChunk(fakeWin.document, function() {
           complete('d')();
-          chunk(fakeWin.document, complete('e'));
-          chunk(fakeWin.document, complete('f'));
+          startupChunk(fakeWin.document, complete('e'));
+          startupChunk(fakeWin.document, complete('f'));
         });
       });
     });
@@ -173,10 +174,10 @@ describe('chunk', () => {
       });
 
       it('should proceed on error and rethrowAsync', d => {
-        chunk(fakeWin.document, () => {
+        startupChunk(fakeWin.document, () => {
           throw new Error('test async');
         });
-        chunk(fakeWin.document, () => {
+        startupChunk(fakeWin.document, () => {
           done = d;
         });
       });

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -62,8 +62,6 @@ describe('chunk', () => {
     });
 
     it('should execute a chunk', done => {
-      expect(chunkInstanceForTesting(env.win.document).active_).to.equal(
-          experimentOn);
       chunk(fakeWin.document, done);
     });
 

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -16,7 +16,6 @@
 
 import {
   activateChunkingForTesting,
-  chunk,
   chunkInstanceForTesting,
   deactivateChunking,
   onIdle,

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -187,7 +187,7 @@ describes.fakeWin('runtime', {
     expect(progress).to.equal('');
     adopt(win);
     expect(queueExtensions).to.have.length(0);
-    return Promise.resolve().then(() => {
+    return setTimeout(() => {
       expect(progress).to.equal('1HIGH');
       win.AMP.push({
         n: 'ext1',
@@ -211,7 +211,7 @@ describes.fakeWin('runtime', {
           progress += 'B';
         },
       });
-      return Promise.resolve().then(() => {
+      return setTimeout(() => {
         expect(queueExtensions).to.have.length(0);
 
         expect(progress).to.equal('1HIGHAB2');
@@ -220,8 +220,8 @@ describes.fakeWin('runtime', {
         const ext1 = extensions.waitForExtension('ext1');
         const ext2 = extensions.waitForExtension('ext2');
         return Promise.all([ext1, ext2]);
-      });
-    });
+      }, 0);
+    }, 0);
   });
 
   it('should wait for body before processing extensions', () => {

--- a/test/functional/utils/test-priority-queue.js
+++ b/test/functional/utils/test-priority-queue.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PriorityQueue from '../../../src/utils/priority-queue';
+
+describe('PriorityQueue', function() {
+  let pq;
+
+  beforeEach(() => {
+    pq = new PriorityQueue();
+  });
+
+  /**
+   * @param {PriorityQueue<T>} pq
+   * @return {Array<T>}
+   */
+  function toArray(pq) {
+    const array = [];
+    while (pq.length) {
+      array.push(pq.dequeue());
+    }
+    return array;
+  }
+
+  it('should return the correct length of the queue', () => {
+    expect(pq.length).to.equal(0);
+    pq.enqueue('a', 0);
+    pq.enqueue('b', 1);
+    expect(pq.length).to.equal(2);
+    pq.dequeue();
+    expect(pq.length).to.equal(1);
+    pq.dequeue();
+    expect(pq.length).to.equal(0);
+  });
+
+  it('should support enqueueing arbitrary data types', () => {
+    pq.enqueue('abc', 0);
+    pq.enqueue(123, 0);
+    pq.enqueue(['x', 'y'], 0);
+    pq.enqueue({foo: 'bar'}, 0);
+    expect(toArray(pq)).to.deep.equal(['abc', 123, ['x', 'y'], {foo: 'bar'}]);
+  });
+
+  it('should support peeking at the max priority item', () => {
+    pq.enqueue('a', 0);
+    pq.enqueue('b', 10);
+    pq.enqueue('c', 5);
+    expect(pq.peek()).to.equal('b');
+  });
+
+  it('should dequeue items in descending priority order', () => {
+    pq.enqueue('c', 0);
+    pq.enqueue('a', Number.POSITIVE_INFINITY);
+    pq.enqueue('d', -4);
+    pq.enqueue('b', 200);
+    pq.enqueue('e', Number.NEGATIVE_INFINITY);
+    expect(toArray(pq)).to.deep.equal(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('should dequeue items with same priority in FIFO order', () => {
+    pq.enqueue('b', 1);
+    pq.enqueue('a', 2);
+    pq.enqueue('c', 1);
+    pq.enqueue('e', 0);
+    pq.enqueue('d', 1);
+    expect(toArray(pq)).to.deep.equal(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('should return null when dequeueing an empty queue', () => {
+    expect(pq.dequeue()).to.be.null;
+    expect(pq.length).to.equal(0);
+  });
+
+  it('should throw error when priority is NaN', () => {
+    expect(() => { pq.enqueue(NaN); }).to.throw(Error);
+  });
+});


### PR DESCRIPTION
Partial for #6199 and #6910.

- Add new `PriorityQueue` data structure 
- Extend `chunk.js` to support non-startup tasks
- Chunk Bind's DOM scan

This PR is on the larger side -- happy to split this into multiple PRs. PTAL!

/to @cramforce @dvoytenko