### PR TITLE
Pixel re-implemented to trigger immediately on visibility

### DIFF
--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -81,7 +81,7 @@ export class AmpPixel extends BaseElement {
         /^(https\:\/\/|\/\/)/i.test(src),
         'The <amp-pixel> src attribute must start with ' +
         '"https://" or "//". Invalid value: ' + src);
-    return src;
+    return /** @type {string} */ (src);
   }
 }
 

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -15,7 +15,6 @@
  */
 
 import {BaseElement} from '../src/base-element';
-import {Layout} from '../src/layout';
 import {dev, user} from '../src/log';
 import {registerElement} from '../src/custom-element';
 import {timerFor} from '../src/timer';
@@ -39,7 +38,7 @@ export class AmpPixel extends BaseElement {
   }
 
   /** @override */
-  isLayoutSupported(layout) {
+  isLayoutSupported(unusedLayout) {
     // No matter what layout is: the pixel is always non-displayed.
     return true;
   }

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -18,7 +18,6 @@ import {BaseElement} from '../src/base-element';
 import {Layout} from '../src/layout';
 import {dev, user} from '../src/log';
 import {registerElement} from '../src/custom-element';
-import {toggle} from '../src/style';
 import {urlReplacementsForDoc} from '../src/url-replacements';
 import {viewerForDoc} from '../src/viewer';
 
@@ -34,7 +33,7 @@ export class AmpPixel extends BaseElement {
   constructor(element) {
     super(element);
 
-    /** @private {?Promise} */
+    /** @private {?Promise<!Image>} */
     this.triggerPromise_ = null;
   }
 
@@ -47,7 +46,6 @@ export class AmpPixel extends BaseElement {
   /** @override */
   buildCallback() {
     // Element is invisible.
-    toggle(this.element, false);
     this.element.setAttribute('aria-hidden', 'true');
 
     // Trigger, but only when visible.
@@ -67,8 +65,8 @@ export class AmpPixel extends BaseElement {
           .then(src => {
             const image = new Image();
             image.src = src;
-            this.element.appendChild(image);
             dev().info(TAG, 'pixel triggered: ', src);
+            return image;
           });
     });
   }

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -18,6 +18,7 @@ import {BaseElement} from '../src/base-element';
 import {Layout} from '../src/layout';
 import {dev, user} from '../src/log';
 import {registerElement} from '../src/custom-element';
+import {timerFor} from '../src/timer';
 import {urlReplacementsForDoc} from '../src/url-replacements';
 import {viewerForDoc} from '../src/viewer';
 
@@ -39,8 +40,8 @@ export class AmpPixel extends BaseElement {
 
   /** @override */
   isLayoutSupported(layout) {
-    // "fixed" layout is supported, but in reality it's always width/height = 0.
-    return layout == Layout.FIXED;
+    // No matter what layout is: the pixel is always non-displayed.
+    return true;
   }
 
   /** @override */
@@ -58,7 +59,9 @@ export class AmpPixel extends BaseElement {
    * @private
    */
   trigger_() {
-    this.triggerPromise_ = Promise.resolve().then(() => {
+    // Delay(1) provides a rudimentary "idle" signal.
+    // TODO(dvoytenko): use an improved idle signal when available.
+    this.triggerPromise_ = timerFor(this.win).promise(1).then(() => {
       const src = this.element.getAttribute('src');
       return urlReplacementsForDoc(this.getAmpDoc())
           .expandAsync(this.assertSource_(src))

--- a/css/amp.css
+++ b/css/amp.css
@@ -432,7 +432,7 @@ i-amp-scroll-container.amp-active {
 }
 
 
-/* Polyfill for IE and any other browser that don't understand templates . */
+/* Polyfill for IE and any other browser that don't understand templates. */
 template {
   display: none !important;
 }
@@ -448,14 +448,9 @@ template {
   box-sizing: border-box;
 }
 
+/* amp-pixel is always non-displayed. */
 amp-pixel {
-  /* Fixed to make position independent of page other elements. */
-  position: fixed !important;
-  top: 0 !important;
-  width: 1px !important;
-  height: 1px !important; /* Only things with height are ever loaded. */
-  overflow: hidden !important;
-  visibility: hidden;
+  display: none !important;
 }
 
 /**

--- a/src/layout.js
+++ b/src/layout.js
@@ -68,7 +68,7 @@ let DimensionsDef;
  * @private  Visible for testing only!
  */
 export const naturalDimensions_ = {
-  'AMP-PIXEL': {width: '1px', height: '1px'},
+  'AMP-PIXEL': {width: '0px', height: '0px'},
   'AMP-ANALYTICS': {width: '1px', height: '1px'},
   // TODO(dvoytenko): audio should have width:auto.
   'AMP-AUDIO': null,

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -18,67 +18,97 @@ import {createIframePromise} from '../../testing/iframe';
 import {installPixel} from '../../builtins/amp-pixel';
 
 
-describe('amp-pixel', () => {
+describes.realWin('amp-pixel', {amp: true}, env => {
+  let win;
+  let whenFirstVisiblePromise, whenFirstVisibleResolver;
+  let pixel;
+  let implementation;
 
-  function getPixel(src) {
-    return createIframePromise().then(iframe => {
-      installPixel(iframe.win);
-      const p = iframe.doc.createElement('amp-pixel');
-      p.setAttribute('src', src);
-      iframe.doc.title = 'Pixel Test';
-      const link = iframe.doc.createElement('link');
-      link.setAttribute('href', 'https://pinterest.com/pin1');
-      link.setAttribute('rel', 'canonical');
-      iframe.doc.head.appendChild(link);
-      expect(p.style.display).to.equal('');
-      return iframe.addElement(p);
+  beforeEach(() => {
+    win = env.win;
+    const viewer = win.services.viewer.obj;
+    whenFirstVisiblePromise = new Promise(resolve => {
+      whenFirstVisibleResolver = resolve;
+    });
+    sandbox.stub(viewer, 'whenFirstVisible', () => whenFirstVisiblePromise);
+    pixel = win.document.createElement('amp-pixel');
+    pixel.setAttribute('src',
+        'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?');
+    win.document.body.appendChild(pixel);
+    pixel.build();
+    implementation = pixel.implementation_;
+  });
+
+  /**
+   * @param {string=} opt_src
+   * @return {!Promise<?Image>}
+   */
+  function trigger(opt_src) {
+    if (opt_src) {
+      pixel.setAttribute('src', opt_src);
+    }
+    whenFirstVisibleResolver();
+    return whenFirstVisiblePromise.then(() => {
+      expect(implementation.triggerPromise_).to.be.not.null;
+      return implementation.triggerPromise_;
+    }).then(() => {
+      expect(pixel.children).to.have.length(1);
+      const img = pixel.children[0];
+      expect(img.tagName).to.equal('IMG');
+      return img;
     });
   }
 
-  it('should load a pixel', () => {
-    return getPixel(
-        'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?'
-        ).then(p => {
-          expect(p.style.display).to.equal('none');
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?');
-          expect(p.getAttribute('aria-hidden')).to.equal('true');
-        });
+  it('should be non-displayed', () => {
+    expect(pixel.style.display).to.equal('none');
+    expect(pixel.style.width).to.equal('0px');
+    expect(pixel.style.height).to.equal('0px');
+    expect(pixel.getAttribute('aria-hidden')).to.equal('true');
   });
 
-  it('should load a pixel with protocol relative URL', () => {
-    return getPixel(
-        '//pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?');
-        });
+  it('should trigger when doc becomes visible', () => {
+    expect(pixel.children).to.have.length(0);
+    expect(implementation.triggerPromise_).to.be.null;
+    return trigger().then(img => {
+      expect(implementation.triggerPromise_).to.be.ok;
+      expect(img.src).to.equal(
+          'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?');
+    });
   });
 
-  it('should replace RANDOM', () => {
-    return getPixel(
-        'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=RANDOM?'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.match(/ord=(\d\.\d+)\?$/);
-        });
+  it('should allow protocol-relative URLs', () => {
+    const url = '//pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2';
+    return trigger(url).then(img => {
+      // Protocol is resolved to `http:` relative to test server.
+      expect(img.src).to.equal(
+          'http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2');
+    });
   });
 
-  it('should replace CANONICAL_URL', () => {
-    return getPixel(
-        'https://foo.com?href=CANONICAL_URL'
-        ).then(p => {
-          expect(p.querySelector('img')).to.not.be.null;
-          expect(p.children[0].src).to.equal(
-              'https://foo.com/?href=https%3A%2F%2Fpinterest.com%2Fpin1');
-        });
+  it('should disallow http URLs', () => {
+    const url = 'http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2';
+    return expect(trigger(url)).to.eventually
+        .rejectedWith(/src attribute must start with/);
   });
 
-  it('should throw for invalid URL', () => {
-    return getPixel(
-        'http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=RANDOM?')
-        .should.be.rejectedWith(/src attribute must start with/);
+  it('should disallow relative URLs', () => {
+    const url = '/activity;dc_iu=1/abc;ord=2';
+    return expect(trigger(url)).to.eventually
+        .rejectedWith(/src attribute must start with/);
+  });
+
+  it('should disallow fake-protocol URLs', () => {
+    const url = 'https/activity;dc_iu=1/abc;ord=2';
+    return expect(trigger(url)).to.eventually
+        .rejectedWith(/src attribute must start with/);
+  });
+
+  it('should replace URL parameters', () => {
+    sandbox.stub(Math, 'random', () => 111);
+    const url = 'https://pubads.g.doubleclick.net/activity;r=RANDOM';
+    return trigger(url).then(img => {
+      expect(img.src).to.equal(
+          'https://pubads.g.doubleclick.net/activity;r=111');
+    });
   });
 });

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import {createIframePromise} from '../../testing/iframe';
-import {installPixel} from '../../builtins/amp-pixel';
-
 
 describes.realWin('amp-pixel', {amp: true}, env => {
   let win;
@@ -51,19 +48,14 @@ describes.realWin('amp-pixel', {amp: true}, env => {
     return whenFirstVisiblePromise.then(() => {
       expect(implementation.triggerPromise_).to.be.not.null;
       return implementation.triggerPromise_;
-    }).then(() => {
-      expect(pixel.children).to.have.length(1);
-      const img = pixel.children[0];
-      expect(img.tagName).to.equal('IMG');
-      return img;
     });
   }
 
   it('should be non-displayed', () => {
-    expect(pixel.style.display).to.equal('none');
     expect(pixel.style.width).to.equal('0px');
     expect(pixel.style.height).to.equal('0px');
     expect(pixel.getAttribute('aria-hidden')).to.equal('true');
+    expect(win.getComputedStyle(pixel).display).to.equal('none');
   });
 
   it('should trigger when doc becomes visible', () => {

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -317,8 +317,8 @@ describe('Layout', () => {
   it('should configure natural dimensions; default layout', () => {
     const pixel = document.createElement('amp-pixel');
     expect(applyLayout_(pixel)).to.equal(Layout.FIXED);
-    expect(pixel.style.width).to.equal('1px');
-    expect(pixel.style.height).to.equal('1px');
+    expect(pixel.style.width).to.equal('0px');
+    expect(pixel.style.height).to.equal('0px');
   });
 
   it('should configure natural dimensions; default layout; with width', () => {
@@ -326,14 +326,14 @@ describe('Layout', () => {
     pixel.setAttribute('width', '11');
     expect(applyLayout_(pixel)).to.equal(Layout.FIXED);
     expect(pixel.style.width).to.equal('11px');
-    expect(pixel.style.height).to.equal('1px');
+    expect(pixel.style.height).to.equal('0px');
   });
 
   it('should configure natural dimensions; default layout; with height', () => {
     const pixel = document.createElement('amp-pixel');
     pixel.setAttribute('height', '11');
     expect(applyLayout_(pixel)).to.equal(Layout.FIXED);
-    expect(pixel.style.width).to.equal('1px');
+    expect(pixel.style.width).to.equal('0px');
     expect(pixel.style.height).to.equal('11px');
   });
 
@@ -341,15 +341,15 @@ describe('Layout', () => {
     const pixel = document.createElement('amp-pixel');
     pixel.setAttribute('layout', 'fixed');
     expect(applyLayout_(pixel)).to.equal(Layout.FIXED);
-    expect(pixel.style.width).to.equal('1px');
-    expect(pixel.style.height).to.equal('1px');
+    expect(pixel.style.width).to.equal('0px');
+    expect(pixel.style.height).to.equal('0px');
   });
 
   it('should configure natural dimensions; layout=fixed-height', () => {
     const pixel = document.createElement('amp-pixel');
     pixel.setAttribute('layout', 'fixed-height');
     expect(applyLayout_(pixel)).to.equal(Layout.FIXED_HEIGHT);
-    expect(pixel.style.height).to.equal('1px');
+    expect(pixel.style.height).to.equal('0px');
     expect(pixel.style.width).to.equal('');
   });
 


### PR DESCRIPTION
This will make `amp-pixel` to be more inline with an impression signal. The cost of this is very small since it only creates a single low-weight image.

Closes #6984
/cc @keithwrightbos @tdrl 