### PR TITLE
Reuse resource when reparented for some extensions

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -122,6 +122,11 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override */
+  reconstructWhenReparented() {
+    return false;
+  }
+
+  /** @override */
   layoutCallback() {
     this.initialize_();
     let promise = this.updateImageSrc_();

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -49,6 +49,11 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /** @override */
+  reconstructWhenReparented() {
+    return false;
+  }
+
+  /** @override */
   layoutCallback() {
     return this.urlReplacements_.expandAsync(assertHttpsUrl(
         this.element.getAttribute('src'), this.element)).then(src => {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -447,6 +447,16 @@ export class BaseElement {
   }
 
   /**
+   * Whether the element needs to be reconstructed after it has been
+   * re-parented. Many elements cannot survive fully the reparenting and
+   * are better to be reconstructed from scratch.
+   * @return {boolean}
+   */
+  reconstructWhenReparented() {
+    return true;
+  }
+
+  /**
    * Instructs the element that its activation is requested based on some
    * user event. Intended to be implemented by actual components.
    * @param {!./service/action-impl.ActionInvocation} unusedInvocation
@@ -468,6 +478,7 @@ export class BaseElement {
     return loadPromise(element, opt_timeout);
   }
 
+  /** @private */
   initActionMap_() {
     if (!this.actionMap_) {
       this.actionMap_ = this.win.Object.create(null);

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -450,6 +450,14 @@ export class BaseElement {
    * Whether the element needs to be reconstructed after it has been
    * re-parented. Many elements cannot survive fully the reparenting and
    * are better to be reconstructed from scratch.
+   *
+   * An example of an element that should be reconstructed in a iframe-based
+   * element. Reparenting such an element will cause the iframe to reload and
+   * will lost the previously established connection. It's safer to reconstruct
+   * such an element. An image or the other hand does not need to be
+   * reconstructed since image itself is not reloaded by the browser and thus
+   * there's no need to use additional resources for reconstruction.
+   *
    * @return {boolean}
    */
   reconstructWhenReparented() {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1250,6 +1250,18 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * Whether the element needs to be reconstructed after it has been
+     * re-parented. Many elements cannot survive fully the reparenting and
+     * are better to be reconstructed from scratch.
+     *
+     * @return {boolean}
+     * @package @final @this {!Element}
+     */
+    reconstructWhenReparented() {
+      return this.implementation_.reconstructWhenReparented();
+    }
+
+    /**
      * Collapses the element, and notifies its owner (if there is one) that the
      * element is no longer present.
      * @suppress {missingProperties}

--- a/src/element-stub.js
+++ b/src/element-stub.js
@@ -48,6 +48,12 @@ export class ElementStub extends BaseElement {
     // element.
     return true;
   }
+
+  /** @override */
+  reconstructWhenReparented() {
+    // No real state so no reason to reconstruct.
+    return false;
+  }
 }
 
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -362,11 +362,21 @@ export class Resources {
       this.viewport_.ensureReadyForElements();
     }
 
-    // Create and add the resource.
-    const resource = new Resource((++this.resourceIdCounter_), element, this);
+    // First check if the resource is being reparented and if it requires
+    // reconstruction. Only already built elements are eligible.
+    let resource = Resource.forElementOptional(element);
+    if (resource &&
+        resource.getState() != ResourceState.NOT_BUILT &&
+        !element.reconstructWhenReparented()) {
+      resource.requestMeasure();
+      dev().fine(TAG_, 'resource reused:', resource.debugid);
+    } else {
+      // Create and add a new resource.
+      resource = new Resource((++this.resourceIdCounter_), element, this);
+      this.buildOrScheduleBuildForResource_(resource);
+      dev().fine(TAG_, 'resource added:', resource.debugid);
+    }
     this.resources_.push(resource);
-    this.buildOrScheduleBuildForResource_(resource);
-    dev().fine(TAG_, 'element added:', resource.debugid);
   }
 
   /**


### PR DESCRIPTION
Closes #6987.

Notice that `reconstructWhenReparented` is the current behavior. This PR enables a non-reconstructing mode. Follow up PRs will update this flag for other AMP elements.