### PR TITLE
Fix accidental null of amp-image-lightbox keyboard listener

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -834,7 +834,6 @@ class AmpImageLightbox extends AMP.BaseElement {
     }
     this.win.document.documentElement.removeEventListener(
         'keydown', this.boundCloseOnEscape_);
-    this.boundCloseOnEscape_ = null;
   }
 
   /**

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -146,6 +146,9 @@ describe('amp-image-lightbox component', () => {
     return getImageLightbox().then(lightbox => {
       const impl = lightbox.implementation_;
       const setupCloseSpy = sandbox.spy(impl, 'close');
+      const nullAddEventListenerSpy = sandbox.spy(
+          impl.win.document.documentElement, 'addEventListener')
+          .withArgs('keydown', null);
       const viewportOnChanged = sandbox.spy();
       const enterLightboxMode = sandbox.spy();
       const leaveLightboxMode = sandbox.spy();
@@ -171,6 +174,11 @@ describe('amp-image-lightbox component', () => {
       impl.activate({source: ampImage});
       impl.closeOnEscape_({keyCode: 27});
       expect(setupCloseSpy.callCount).to.equal(1);
+
+      // Regression test: ensure escape event listener is bound properly
+      expect(nullAddEventListenerSpy.callCount).to.equal(0);
+      impl.activate({source: ampImage});
+      expect(nullAddEventListenerSpy.callCount).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
Fixes #7050.  See there for more details, but the gist is that if you open then close a lightbox, the internal event listener was previously set to `null`, which prevented the escape key from closing the lightbox on any future opens.