### PR TITLE
<amp-apester-media> out of experiment 

### DIFF
--- a/examples/apester-media.amp.html
+++ b/examples/apester-media.amp.html
@@ -15,14 +15,14 @@
 
     <!--Usage example of a simple unit-->
     <amp-apester-media
-            height="444"
+            height="404"
             data-apester-media-id="57a336dba187a2ca3005e826"
             layout="fixed-height">
     </amp-apester-media>
 
     <!--Usage example of a playlist unit-->
     <amp-apester-media
-            height="444"
+            height="404"
             data-apester-channel-token="57a36e1e96cd505a7f01ed12">
     </amp-apester-media>
 </article>

--- a/extensions/amp-apester-media/0.1/amp-apester-media.css
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.css
@@ -26,15 +26,8 @@
 }
 
 .amp-apester-loader {
-  height: 100px;
-  width: 100px;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  margin-top: -22px;
-}
-
-.amp-apester-loader-container {
+  height: 100%;
+  width: 100%;
   background-color: white;
 }
 
@@ -64,4 +57,68 @@
   font-weight: 700;
   outline: none;
   position: relative;
+}
+
+
+.amp-apester-loader-blobs {
+  filter: url("#amp-apester-goo");
+  position: absolute;
+  top:0;
+  left:0;
+  bottom:0;
+  right:0;
+}
+.amp-apester-loader-blob {
+  position: absolute;
+  margin: auto;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: #ee2e3d;
+}
+.amp-apester-loader-blob:nth-child(1) {
+  animation: amp-apester-blob-left-anim cubic-bezier(0.770, 0.000, 0.175, 1.000) 2s infinite;
+}
+.amp-apester-loader-blob:nth-child(2) {
+  animation: amp-apester-blob-right-anim cubic-bezier(0.770, 0.000, 0.175, 1.000) 2s infinite;
+}
+
+@keyframes amp-apester-blob-left-anim {
+  0% {transform:scale(1.0) translate(0, 0);}
+  33% {transform:scale(0.55, 0.5) translate(80px, 0);}
+  66% {transform:scale(0.8) translate(0, 0);}
+  100% {transform:scale(1.0) translate(0, 0);}
+}
+
+@keyframes amp-apester-blob-right-anim {
+  0% {transform:scale(1.0) translate(0, 0);}
+  33% {transform:scale(0.55, 0.5) translate(-80px, 0);}
+  66% {transform:scale(0.8) translate(0, 0);}
+  100% {transform:scale(1.0) translate(0, 0);}
+}
+
+@keyframes amp-apester-loader-logo {
+  0% {transform:scale(1.0); opacity:1;}
+  20% {transform:scale(1.0); opacity:0;}
+  40% {transform:scale(0.5); opacity:0;}
+  66% {transform:scale(0.8); opacity:1;}
+  100% {transform:scale(1.0); opacity:1;}
+}
+
+.amp-apester-loader-logo {
+  background: url("https://app.apester.com/assets/editor/3.4.10/dist/svg/ape-loader.svg") no-repeat center;
+  position: absolute;
+  height: 28px;
+  width: 28px;
+  left: calc(50% - 14px);
+  top: calc(50% - 14px);
+}
+
+.amp-apester-loader-logo svg {
+  height: 100%;
+  width: 100%;
 }

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 import {CSS} from '../../../build/amp-apester-media-0.1.css';
 import {user, dev} from '../../../src/log';
 import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
-import {isExperimentOn} from '../../../src/experiments';
 import {removeElement} from '../../../src/dom';
 import {vsyncFor} from '../../../src/vsync';
 import {xhrFor} from '../../../src/xhr';
@@ -58,9 +55,6 @@ class AmpApesterMedia extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-
-    // EXPERIMENT
-    user().assert(isExperimentOn(this.win, TAG), `Enable ${TAG} experiment`);
     const width = this.element.getAttribute('width');
     const height = this.element.getAttribute('height');
 
@@ -180,6 +174,29 @@ class AmpApesterMedia extends AMP.BaseElement {
   /**
    * @return {!Element}
    */
+  constructLoaderInnerHTML_() {
+    return `<div class="amp-apester-loader-blobs">
+    <div class="amp-apester-loader-blob"></div>
+    <div class="amp-apester-loader-blob"></div>
+    <div class="amp-apester-loader-logo"></div>
+</div>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <filter id="amp-apester-goo">
+            <feGaussianBlur in="SourceGraphic" result="blur" stdDeviation="10"/>
+            <feColorMatrix in="blur" mode="matrix"
+                           values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7"
+                           result="amp-apester-goo"/>
+            <feBlend in2="amp-apester-goo" in="SourceGraphic" result="mix"/>
+        </filter>
+    </defs>
+</svg>`;
+  }
+
+
+  /**
+   * @return {!Element}
+   */
   constructOverflow_() {
     const overflow = this.element.ownerDocument.createElement('div');
     overflow.setAttribute('overflow', '');
@@ -233,16 +250,14 @@ class AmpApesterMedia extends AMP.BaseElement {
 
   /** @override */
   createPlaceholderCallback() {
-    const img = this.element.ownerDocument.createElement('amp-img');
     const placeholder = this.element.ownerDocument.createElement('div');
     placeholder.setAttribute('placeholder', '');
+    placeholder.setAttribute('layout', 'fill');
     placeholder.className = 'amp-apester-loader';
-    img.setAttribute('src', this.loaderUrl_);
-    img.setAttribute('layout', 'fill');
-    img.setAttribute('noloading', '');
-    placeholder.appendChild(img);
+    placeholder.innerHTML = this.constructLoaderInnerHTML_();
     return placeholder;
   }
+
 
   /** @override */
   unlayoutOnPause() {

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -174,23 +174,53 @@ class AmpApesterMedia extends AMP.BaseElement {
   /**
    * @return {!Element}
    */
-  constructLoaderInnerHTML_() {
-    return `<div class="amp-apester-loader-blobs">
-    <div class="amp-apester-loader-blob"></div>
-    <div class="amp-apester-loader-blob"></div>
-    <div class="amp-apester-loader-logo"></div>
-</div>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <defs>
-        <filter id="amp-apester-goo">
-            <feGaussianBlur in="SourceGraphic" result="blur" stdDeviation="10"/>
-            <feColorMatrix in="blur" mode="matrix"
-                           values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7"
-                           result="amp-apester-goo"/>
-            <feBlend in2="amp-apester-goo" in="SourceGraphic" result="mix"/>
-        </filter>
-    </defs>
-</svg>`;
+  constructLoaderStructure_() {
+    const blobs = this.element.ownerDocument.createElement('div');
+    const blobLeft = this.element.ownerDocument.createElement('div');
+    const blobRight = this.element.ownerDocument.createElement('div');
+    const logo = this.element.ownerDocument.createElement('div');
+    blobs.classList.add('amp-apester-loader-blobs');
+    blobLeft.classList.add('amp-apester-loader-blob');
+    blobRight.classList.add('amp-apester-loader-blob');
+    logo.classList.add('amp-apester-loader-logo');
+    blobs.appendChild(blobLeft);
+    blobs.appendChild(blobRight);
+    blobs.appendChild(logo);
+    return blobs;
+  }
+
+  /**
+   * @return {!Element}
+   */
+  constructLoaderSVG_() {
+    const svg = this.element.ownerDocument.createElement('svg');
+    const defs = this.element.ownerDocument.createElement('defs');
+    const filter = this.element.ownerDocument.createElement('filter');
+    const feGaussianBlur = this.element.ownerDocument
+        .createElement('feGaussianBlur');
+    const feColorMatrix = this.element.ownerDocument
+        .createElement('feColorMatrix');
+    const feBlend = this.element.ownerDocument.createElement('feBlend');
+    svg.setAttribute('version', '1.1');
+    svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    filter.setAttribute('id', 'amp-apester-goo');
+    feGaussianBlur.setAttribute('in', 'SourceGraphic');
+    feGaussianBlur.setAttribute('results', 'blur');
+    feGaussianBlur.setAttribute('stdDeviation', '10');
+    feColorMatrix.setAttribute('in', 'blur');
+    feColorMatrix.setAttribute('mode', 'matrix');
+    feColorMatrix.setAttribute('values',
+        '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7');
+    feColorMatrix.setAttribute('result', 'amp-apester-goo');
+    feBlend.setAttribute('in2', 'amp-apester-goo');
+    feBlend.setAttribute('in', 'SourceGraphic');
+    feBlend.setAttribute('result', 'mix');
+    svg.appendChild(defs);
+    defs.appendChild(filter);
+    filter.appendChild(feGaussianBlur);
+    filter.appendChild(feColorMatrix);
+    filter.appendChild(feBlend);
+    return svg;
   }
 
   /**
@@ -253,7 +283,8 @@ class AmpApesterMedia extends AMP.BaseElement {
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('layout', 'fill');
     placeholder.className = 'amp-apester-loader';
-    placeholder.innerHTML = this.constructLoaderInnerHTML_();
+    placeholder.appendChild(this.constructLoaderStructure_());
+    placeholder.appendChild(this.constructLoaderSVG_());
     return placeholder;
   }
 

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -193,7 +193,6 @@ class AmpApesterMedia extends AMP.BaseElement {
 </svg>`;
   }
 
-
   /**
    * @return {!Element}
    */

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {
-    createIframePromise,
-    doNotLoadExternalResourcesInTest,
+  createIframePromise,
+  doNotLoadExternalResourcesInTest
 } from '../../../../testing/iframe';
 import '../amp-apester-media';
 import {adopt} from '../../../../src/runtime';
-import {toggleExperiment} from '../../../../src/experiments';
 import {xhrFor} from '../../../../src/xhr';
 import * as sinon from 'sinon';
 

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -15,7 +15,7 @@
  */
 import {
   createIframePromise,
-  doNotLoadExternalResourcesInTest
+  doNotLoadExternalResourcesInTest,
 } from '../../../../testing/iframe';
 import '../amp-apester-media';
 import {adopt} from '../../../../src/runtime';

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -33,7 +33,6 @@ describe('amp-apester-media', () => {
   let attemptChangeSizeSpy;
 
   beforeEach(() => {
-    toggleExperiment(window, 'amp-apester-media', true);
     sandbox = sinon.sandbox.create();
 
   });
@@ -55,7 +54,7 @@ describe('amp-apester-media', () => {
         'payload': {
           'interactionId': '57a336dba187a2ca3005e826',
           'data': {
-            'size': {'width': '600', 'height': '444'},
+            'size': {'width': '600', 'height': '404'},
           },
           'layout': {
             'id': '557d52c059081084b94845c3',
@@ -94,7 +93,7 @@ describe('amp-apester-media', () => {
       expect(iframe.src).to.equal(
           'https://renderer.qmerce.com/interaction/57a336dba187a2ca3005e826');
       expect(changeSizeSpy.callCount).to.equal(1);
-      expect(changeSizeSpy.args[0][0]).to.equal('444');
+      expect(changeSizeSpy.args[0][0]).to.equal('404');
     });
   });
 
@@ -107,7 +106,7 @@ describe('amp-apester-media', () => {
       expect(iframe.src).to.equal(
           'https://renderer.qmerce.com/interaction/57a336dba187a2ca3005e826');
       expect(attemptChangeSizeSpy.callCount).to.equal(1);
-      expect(attemptChangeSizeSpy.args[0][0]).to.equal('444');
+      expect(attemptChangeSizeSpy.args[0][0]).to.equal('404');
     });
   });
 

--- a/extensions/amp-apester-media/amp-apester-media.md
+++ b/extensions/amp-apester-media/amp-apester-media.md
@@ -23,7 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -60,12 +60,12 @@ Playlist Mode:
 ###Single Mode: 
 **data-apester-media-id**
 
-The ID of the media, an integer.
+The ID of the media, a string.
 
 ###Playlist Mode: 
 **data-apester-channel-token**
 
-The token of the channel, an integer.
+The token of the channel, a string.
 
 ## Validation
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -135,7 +135,7 @@ const EXPERIMENTS = [
   },
   {
     id: 'amp-apester-media',
-    name: 'AMP extension for Apester media',
+    name: 'AMP extension for Apester media (launched)',
     spec: 'https://github.com/ampproject/amphtml/issues/3233',
     cleanupIssue: 'https://github.com/ampproject/amphtml/pull/4291',
   },


### PR DESCRIPTION
Hi everybody, 

amp-apester-media tag was in experiment for a long time.
There is a growing demand for Apester tag to be out of experiment, therefore we submit this PR to change its status. 

This commit also improve apester custom loader and change it from a heavy gif file into a css animation with a tiny svg (just for the letter A on top of it of the blobs).

I hope we can push this PR as fast as possible so we can see our clients integrate apester-media tag into their websites.

Best,
Ori 

@OksanaSemenov
@OmriKeret
@dvoytenko  