### PR TITLE
Shadow DOM v1

### DIFF
--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -21,6 +21,7 @@ import {closestNode, escapeCssSelectorIdent} from './dom';
 import {extensionsFor} from './extensions';
 import {insertStyleElement} from './style-installer';
 import {setStyle} from './style';
+import {isShadowDomSupported, getShadowDomMethod} from './web-components';
 
 /**
  * Used for non-composed root-node search. See `getRootNode`.
@@ -33,32 +34,6 @@ const CSS_SELECTOR_BEG_REGEX = /[^\.\-\_0-9a-zA-Z]/;
 
 /** @const {!RegExp} */
 const CSS_SELECTOR_END_REGEX = /[^\-\_0-9a-zA-Z]/;
-
-
-/**
- * @type {boolean|undefined}
- * @visibleForTesting
- */
-let shadowDomSupported;
-
-/**
- * @param {boolean|undefined} val
- * @visibleForTesting
- */
-export function setShadowDomSupportedForTesting(val) {
-  shadowDomSupported = val;
-}
-
-/**
- * Returns `true` if the Shadow DOM is supported.
- * @return {boolean}
- */
-export function isShadowDomSupported() {
-  if (shadowDomSupported === undefined) {
-    shadowDomSupported = !!Element.prototype.createShadowRoot;
-  }
-  return shadowDomSupported;
-}
 
 
 /**
@@ -76,7 +51,7 @@ export function createShadowRoot(hostElement) {
 
   // Native support.
   if (isShadowDomSupported()) {
-    return hostElement.createShadowRoot();
+    return getShadowDomMethod().call(hostElement, {mode: 'open'});
   }
 
   // Polyfill.

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -24,7 +24,7 @@ import {setStyle} from './style';
 import {
   isShadowDomSupported,
   getShadowDomSupportedVersion,
-  ShadowDomVersion
+  ShadowDomVersion,
 } from './web-components';
 
 /**

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -21,7 +21,11 @@ import {closestNode, escapeCssSelectorIdent} from './dom';
 import {extensionsFor} from './extensions';
 import {insertStyleElement} from './style-installer';
 import {setStyle} from './style';
-import {isShadowDomSupported, getShadowDomMethod} from './web-components';
+import {
+  isShadowDomSupported,
+  getShadowDomSupportedVersion,
+  ShadowDomVersion
+} from './web-components';
 
 /**
  * Used for non-composed root-node search. See `getRootNode`.
@@ -50,8 +54,11 @@ export function createShadowRoot(hostElement) {
   }
 
   // Native support.
-  if (isShadowDomSupported()) {
-    return getShadowDomMethod().call(hostElement, {mode: 'open'});
+  const shadowDomSupported = getShadowDomSupportedVersion();
+  if (shadowDomSupported == ShadowDomVersion.V1) {
+    return hostElement.attachShadow({mode: 'open'});
+  } else if (shadowDomSupported == ShadowDomVersion.V0) {
+    return hostElement.createShadowRoot();
   }
 
   // Polyfill.

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -26,13 +26,13 @@ export const ShadowDomVersion = {
 };
 
 /**
- * @type {string|undefined}
+ * @type {ShadowDomVersion|undefined}
  * @visibleForTesting
  */
 let shadowDomSupportedVersion;
 
 /**
- * @param {string|undefined} val
+ * @param {ShadowDomVersion|undefined} val
  * @visibleForTesting
  */
 export function setShadowDomSupportedVersionForTesting(val) {
@@ -49,17 +49,18 @@ export function isShadowDomSupported() {
 
 /**
  * Returns the supported version of Shadow DOM spec.
- * @param {function=} optional for testing
- * @return {string}
+ * @param {Function=} opt_elementClass optional for testing
+ * @return {ShadowDomVersion}
  */
-export function getShadowDomSupportedVersion(opt_element) {
+export function getShadowDomSupportedVersion(opt_elementClass) {
   if (shadowDomSupportedVersion === undefined) {
 
     //TODO: Remove native CE check once WebReflection/document-register-element#96 is fixed.
     if (!areNativeCustomElementsSupported()) {
       shadowDomSupportedVersion = ShadowDomVersion.NONE;
     } else {
-      shadowDomSupportedVersion = getShadowDomVersion(opt_element || Element);
+      shadowDomSupportedVersion =
+          getShadowDomVersion(opt_elementClass || Element);
     }
   }
 
@@ -77,7 +78,11 @@ function getShadowDomVersion(element) {
 }
 
 function areNativeCustomElementsSupported() {
-  return isNative(self.document.registerElement);
+  return isNative(self.document.registerElement) ||
+         isNative(self
+             .Object
+             .getOwnPropertyDescriptor(self, 'customElements')
+             .get);
 }
 
 /**

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * @type {boolean|undefined}
+ * @visibleForTesting
+ */
+let shadowDomSupported;
+
+/**
+ * @type {Function|undefined}
+ * @visibleForTesting
+ */
+let shadowDomMethod;
+
+let win = window;
+
+/**
+ * @param {boolean|undefined} val
+ * @visibleForTesting
+ */
+export function setWindowForTesting(val) {
+  win = val;
+}
+
+/**
+ * @param {boolean|undefined} val
+ * @visibleForTesting
+ */
+export function setShadowDomSupportedForTesting(val) {
+  shadowDomSupported = val;
+}
+
+/**
+ * @param {function|undefined} val
+ * @visibleForTesting
+ */
+export function setShadowDomMethodForTesting(val) {
+  shadowDomMethod = val;
+}
+
+/**
+ * Returns `true` if the Shadow DOM is supported.
+ * @return {boolean}
+ */
+export function isShadowDomSupported() {
+  if (shadowDomSupported === undefined) {
+    shadowDomSupported = !!getShadowDomMethod();// && areNativeCustomElementsSupported();
+  }
+
+  return shadowDomSupported;
+}
+
+/**
+ * Shadow DOM version method
+ * @return {function}
+ */
+export function getShadowDomMethod() {
+  if (shadowDomMethod === undefined) {
+    shadowDomMethod = win.Element.prototype.createShadowRoot || win.Element.prototype.attachShadow;
+  }
+
+  return shadowDomMethod;
+}
+
+function areNativeCustomElementsSupported() {
+  return isNative(win.document.registerElement) || isNative(win.customElements && win.customElements.define);
+}
+
+export function isNative(method) {
+  return !!method && method.toString().indexOf('[native code]') !== -1;
+}

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -88,7 +88,7 @@ function areNativeCustomElementsSupported() {
 /**
  * Returns `true` if the method is natively implemented by the browser
  * @visibleForTesting
- * @param {Function} method
+ * @param {Function=} method
  * @return {boolean}
  */
 export function isNative(method) {

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -22,7 +22,7 @@
 export const ShadowDomVersion = {
   NONE: 'none',
   V0: 'v0',
-  V1: 'v1'
+  V1: 'v1',
 };
 
 /**
@@ -69,7 +69,7 @@ export function getShadowDomSupportedVersion(opt_element) {
 function getShadowDomVersion(element) {
   if (!!element.prototype.attachShadow) {
     return ShadowDomVersion.V1;
-  } else if(!!element.prototype.createShadowRoot) {
+  } else if (!!element.prototype.createShadowRoot) {
     return ShadowDomVersion.V0;
   }
 
@@ -77,7 +77,7 @@ function getShadowDomVersion(element) {
 }
 
 function areNativeCustomElementsSupported() {
-  return isNative(document.registerElement);
+  return isNative(self.document.registerElement);
 }
 
 /**

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -59,7 +59,7 @@ export function setShadowDomMethodForTesting(val) {
  */
 export function isShadowDomSupported() {
   if (shadowDomSupported === undefined) {
-    shadowDomSupported = !!getShadowDomMethod();// && areNativeCustomElementsSupported();
+    shadowDomSupported = !!getShadowDomMethod() && areNativeCustomElementsSupported();
   }
 
   return shadowDomSupported;

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -28,7 +28,7 @@ import {
 } from '../../src/shadow-embed';
 import {
   setShadowDomSupportedVersionForTesting,
-  ShadowDomVersion
+  ShadowDomVersion,
 } from '../../src/web-components';
 import {extensionsFor} from '../../src/extensions';
 import * as sinon from 'sinon';
@@ -64,98 +64,102 @@ describe('shadow-embed', () => {
     expect(copy).to.not.equal(style);
   });
 
-  [ShadowDomVersion.NONE, ShadowDomVersion.V0, ShadowDomVersion.V1].forEach(scenario => {
-    describe('shadow APIs ' + scenario, () => {
-      let hostElement;
+  [ShadowDomVersion.NONE, ShadowDomVersion.V0, ShadowDomVersion.V1]
+      .forEach(scenario => {
+        describe('shadow APIs ' + scenario, () => {
+          let hostElement;
 
-      beforeEach(function() {
-        hostElement = document.createElement('div');
-        setShadowDomSupportedVersionForTesting(scenario);
+          beforeEach(() => {
+            hostElement = document.createElement('div');
+            setShadowDomSupportedVersionForTesting(scenario);
 
-        if (scenario == ShadowDomVersion.V0 && !Element.prototype.createShadowRoot) {
-          this.skip();
-        }
+            if (scenario == ShadowDomVersion.V0 &&
+                !Element.prototype.createShadowRoot) {
+              this.skip();
+            }
 
-        if (scenario == ShadowDomVersion.V1 && !Element.prototype.attachShadow) {
-          this.skip();
-        }
-      });
-
-      it('should transform CSS installStylesForShadowRoot', () => {
-        const shadowRoot = createShadowRoot(hostElement);
-        const style = installStylesForShadowRoot(shadowRoot, 'body {}', true);
-        expect(shadowRoot.contains(style)).to.be.true;
-        const css = style.textContent.replace(/\s/g, '');
-        if (scenario == ShadowDomVersion.NONE) {
-          expect(css).to.match(/amp-body/);
-        } else {
-          expect(css).to.equal('body{}');
-        }
-      });
-
-      describe('createShadowRoot', () => {
-        it('should clear duplicate root', () => {
-          const shadowRoot1 = createShadowRoot(hostElement);
-          const span = document.createElement('span');
-          shadowRoot1.appendChild(span);
-          expect(shadowRoot1.contains(span)).to.be.true;
-
-          const shadowRoot2 = createShadowRoot(hostElement);
-          expect(shadowRoot2).to.equal(shadowRoot1);
-          expect(shadowRoot2.contains(span)).to.be.false;
-        });
-
-        it('should have host', () => {
-          const shadowRoot = createShadowRoot(hostElement);
-          expect(shadowRoot.host).to.equal(hostElement);
-        });
-
-        it('should have getElementById', () => {
-          const shadowRoot = createShadowRoot(hostElement);
-          expect(shadowRoot.getElementById).to.be.ok;
-
-          const spanId = 'test' + Math.floor(Math.random() * 10000);
-          const span = document.createElement('span');
-          span.id = spanId;
-          shadowRoot.appendChild(span);
-          expect(shadowRoot.getElementById(spanId)).to.equal(span);
-        });
-
-        if (scenario == ShadowDomVersion.NONE) {
-          it('should add id for polyfill', () => {
-            const shadowRoot = createShadowRoot(hostElement);
-            expect(shadowRoot.tagName).to.equal('I-AMP-SHADOW-ROOT');
-            expect(shadowRoot.id).to.match(/i-amp-sd-\d+/);
+            if (scenario == ShadowDomVersion.V1 &&
+                !Element.prototype.attachShadow) {
+              this.skip();
+            }
           });
-        }
-      });
 
-      describe('importShadowBody', () => {
-        it('should import body with all children', () => {
-          const shadowRoot = createShadowRoot(hostElement);
-          const source = document.createElement('body');
-          const child1 = document.createElement('div');
-          child1.id = 'child1';
-          const child2 = document.createElement('div');
-          child2.id = 'child2';
-          source.appendChild(child1);
-          source.appendChild(child2);
+          it('should transform CSS installStylesForShadowRoot', () => {
+            const shadowRoot = createShadowRoot(hostElement);
+            const style = installStylesForShadowRoot(
+                shadowRoot, 'body {}', true);
+            expect(shadowRoot.contains(style)).to.be.true;
+            const css = style.textContent.replace(/\s/g, '');
+            if (scenario == ShadowDomVersion.NONE) {
+              expect(css).to.match(/amp-body/);
+            } else {
+              expect(css).to.equal('body{}');
+            }
+          });
 
-          const body = importShadowBody(shadowRoot, source);
-          expect(body.tagName).to.equal(
-              scenario == ShadowDomVersion.NONE ? 'AMP-BODY' : 'BODY');
-          expect(body.style.position).to.equal('relative');
-          if (scenario == ShadowDomVersion.NONE) {
-            expect(body.style.display).to.equal('block');
-          }
-          expect(shadowRoot.contains(body)).to.be.true;
-          expect(body.children).to.have.length(2);
-          expect(body.children[0].id).to.equal('child1');
-          expect(body.children[1].id).to.equal('child2');
+          describe('createShadowRoot', () => {
+            it('should clear duplicate root', () => {
+              const shadowRoot1 = createShadowRoot(hostElement);
+              const span = document.createElement('span');
+              shadowRoot1.appendChild(span);
+              expect(shadowRoot1.contains(span)).to.be.true;
+
+              const shadowRoot2 = createShadowRoot(hostElement);
+              expect(shadowRoot2).to.equal(shadowRoot1);
+              expect(shadowRoot2.contains(span)).to.be.false;
+            });
+
+            it('should have host', () => {
+              const shadowRoot = createShadowRoot(hostElement);
+              expect(shadowRoot.host).to.equal(hostElement);
+            });
+
+            it('should have getElementById', () => {
+              const shadowRoot = createShadowRoot(hostElement);
+              expect(shadowRoot.getElementById).to.be.ok;
+
+              const spanId = 'test' + Math.floor(Math.random() * 10000);
+              const span = document.createElement('span');
+              span.id = spanId;
+              shadowRoot.appendChild(span);
+              expect(shadowRoot.getElementById(spanId)).to.equal(span);
+            });
+
+            if (scenario == ShadowDomVersion.NONE) {
+              it('should add id for polyfill', () => {
+                const shadowRoot = createShadowRoot(hostElement);
+                expect(shadowRoot.tagName).to.equal('I-AMP-SHADOW-ROOT');
+                expect(shadowRoot.id).to.match(/i-amp-sd-\d+/);
+              });
+            }
+          });
+
+          describe('importShadowBody', () => {
+            it('should import body with all children', () => {
+              const shadowRoot = createShadowRoot(hostElement);
+              const source = document.createElement('body');
+              const child1 = document.createElement('div');
+              child1.id = 'child1';
+              const child2 = document.createElement('div');
+              child2.id = 'child2';
+              source.appendChild(child1);
+              source.appendChild(child2);
+
+              const body = importShadowBody(shadowRoot, source);
+              expect(body.tagName).to.equal(
+                  scenario == ShadowDomVersion.NONE ? 'AMP-BODY' : 'BODY');
+              expect(body.style.position).to.equal('relative');
+              if (scenario == ShadowDomVersion.NONE) {
+                expect(body.style.display).to.equal('block');
+              }
+              expect(shadowRoot.contains(body)).to.be.true;
+              expect(body.children).to.have.length(2);
+              expect(body.children[0].id).to.equal('child1');
+              expect(body.children[1].id).to.equal('child2');
+            });
+          });
         });
       });
-    });
-  });
 
   describe('isShadowRoot', () => {
 

--- a/test/functional/test-web-components.js
+++ b/test/functional/test-web-components.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {
+  setShadowDomMethodForTesting,
+  setWindowForTesting,
+  isShadowDomSupported,
+  getShadowDomMethod,
+  isNative
+} from '../../src/web-components';
+
+
+describe('web components', () => {
+  it("reports when a method is browser native", () => {
+    expect(isNative(document.getElementById)).to.be.true;
+    expect(isNative(() => {})).to.be.false;
+  })
+});
+
+['shadowDomV0', 'shadowDomV1'].forEach(shadowDomVersion => {
+  ['customElementsV0', 'customElementsV1'].forEach(customElementsVersion => {
+    describes.realWin('web components', {}, env => {
+      let win;
+      let shadowDomMethod;
+      let customElementsMethod;
+
+      beforeEach(() => {
+        win = env.win;
+        setWindowForTesting(win);
+
+        if (shadowDomVersion == 'shadowDomV0') {
+          shadowDomMethod = win.Element.prototype.createShadowRoot;
+          win.Element.prototype.attachShadow = undefined;
+        }
+
+        if (shadowDomVersion == 'shadowDomV1') {
+          shadowDomMethod = win.Element.prototype.attachShadow;
+          win.Element.prototype.createShadowRoot = undefined;
+        }
+
+        if (customElementsVersion == 'customElementsV0') {
+          customElementsMethod = win.document.registerElement;
+        }
+
+        if (customElementsVersion == 'customElementsV1') {
+          customElementsMethod = win.customElements && win.customElements.define;
+          win.document.registerElement = undefined;
+        }
+      });
+
+      afterEach(() => {
+        setShadowDomMethodForTesting(undefined);
+        setShadowDomMethodForTesting(undefined);
+        setWindowForTesting(window);
+      });
+
+      describe('shadow dom', () => {
+        it("should report support for shadow dom", () => {
+          expect(isShadowDomSupported()).to.equal(
+              !!shadowDomMethod && !!customElementsMethod);
+        });
+
+        it("should return available shadow dom method", () => {
+          expect(getShadowDomMethod()).to.equal(
+              shadowDomMethod);
+        });
+      });
+    });
+  });
+});

--- a/test/functional/test-web-components.js
+++ b/test/functional/test-web-components.js
@@ -29,7 +29,7 @@ describe('web components', () => {
     setShadowDomSupportedVersionForTesting(undefined);
   });
 
-  it("reports when a method is browser native", () => {
+  it('reports when a method is browser native', () => {
     expect(isNative(document.getElementById)).to.be.true;
     expect(isNative(() => {})).to.be.false;
   });
@@ -45,7 +45,7 @@ describe('web components', () => {
   });
 });
 
-describes.realWin("Web Components spec", {}, env => {
+describes.realWin('Web Components spec', {}, env => {
   let win;
 
   beforeEach(() => {
@@ -55,26 +55,29 @@ describes.realWin("Web Components spec", {}, env => {
 
   //TODO: Remove native CE check once WebReflection/document-register-element#96 is fixed.
   if (isNative(document.registerElement)) {
-    describe("Shadow DOM", () => {
-      it("reports NONE when no spec is available", () => {
+    describe('Shadow DOM', () => {
+      it('reports NONE when no spec is available', () => {
         win.Element.prototype.createShadowRoot = undefined;
         win.Element.prototype.attachShadow = undefined;
 
-        expect(getShadowDomSupportedVersion(win.Element)).to.equal(ShadowDomVersion.NONE);
+        expect(getShadowDomSupportedVersion(win.Element))
+            .to.equal(ShadowDomVersion.NONE);
       });
 
-      it("gives preference to v1 over v0 when both specs are available", () => {
+      it('gives preference to v1 over v0 when both specs are available', () => {
         if (!!win.Element.prototype.createShadowRoot &&
             !!win.Element.prototype.attachShadow) {
-          expect(getShadowDomSupportedVersion(win.Element)).to.equal(ShadowDomVersion.V1);
+          expect(getShadowDomSupportedVersion(win.Element))
+              .to.equal(ShadowDomVersion.V1);
         }
       });
 
-      it("reports v0 when available but v1 is not", () => {
+      it('reports v0 when available but v1 is not', () => {
         if (!!win.Element.prototype.createShadowRoot) {
           win.Element.prototype.attachShadow = undefined;
 
-          expect(getShadowDomSupportedVersion(win.Element)).to.equal(ShadowDomVersion.V0);
+          expect(getShadowDomSupportedVersion(win.Element))
+              .to.equal(ShadowDomVersion.V0);
         }
       });
     });

--- a/test/functional/test-web-components.js
+++ b/test/functional/test-web-components.js
@@ -30,18 +30,22 @@ describe('web components', () => {
   });
 
   it('reports when a method is browser native', () => {
-    expect(isNative(document.getElementById)).to.be.true;
+    expect(isNative(self.document.getElementById)).to.be.true;
     expect(isNative(() => {})).to.be.false;
   });
 
   it('should report whether native shadow dom supported', () => {
     const shadowDomV0 = !!Element.prototype.createShadowRoot;
     const shadowDomV1 = !!Element.prototype.attachShadow;
-    const nativeCEV0 = isNative(document.registerElement);
+    const nativeCEV0 = isNative(self.document.registerElement);
+    const nativeCEV1 = isNative(self
+        .Object
+        .getOwnPropertyDescriptor(self, 'customElements')
+        .get);
 
     //TODO: Remove native CE check once WebReflection/document-register-element#96 is fixed.
     expect(isShadowDomSupported()).to.equal(
-        (shadowDomV0 || shadowDomV1) && nativeCEV0);
+        (shadowDomV0 || shadowDomV1) && (nativeCEV0 || nativeCEV1));
   });
 });
 
@@ -54,7 +58,7 @@ describes.realWin('Web Components spec', {}, env => {
   });
 
   //TODO: Remove native CE check once WebReflection/document-register-element#96 is fixed.
-  if (isNative(document.registerElement)) {
+  if (isNative(self.document.registerElement)) {
     describe('Shadow DOM', () => {
       it('reports NONE when no spec is available', () => {
         win.Element.prototype.createShadowRoot = undefined;

--- a/third_party/closure-compiler/externs/shadow_dom.js
+++ b/third_party/closure-compiler/externs/shadow_dom.js
@@ -32,3 +32,18 @@ var GetRootNodeOptions;
  * @return {?Node}
  */
 Node.prototype.getRootNode = function(opt_options) {};
+
+/**
+ * @see https://www.w3.org/TR/shadow-dom/#idl-def-ShadowRootInit
+ * @typedef {{
+ *   mode: string
+ * }}
+ */
+var ShadowRootInit;
+
+/**
+ * @see https://www.w3.org/TR/shadow-dom/#h-extensions-to-element-interface
+ * @param {ShadowRootInit=} opt_init
+ * @return {!ShadowRoot}
+ */
+Element.prototype.attachShadow = function(opt_init) {};


### PR DESCRIPTION
Support for Shadow DOM v1 in AMP Shadow

To cover cases like Safari 10, where Shadow DOM is implemented but Custom Elements is not, native Shadow DOM is disabled because Custom Elements polyfill does not cover custom elements inside shadow roots

Related to #6893 

