### PR TITLE
Add Carousel and Selector to Bind validator

### DIFF
--- a/examples/bind.amp.html
+++ b/examples/bind.amp.html
@@ -38,7 +38,7 @@
 </head>
 
 <body>
-  <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle &lt;amp-bind&gt; experiment</button>
+  <button onclick="AMP.toggleExperiment('AMP-BIND');window.location.href=window.location.href;">Toggle &lt;AMP-BIND&gt; experiment</button>
   <button onclick="AMP.toggleExperiment('amp-selector');window.location.href=window.location.href;">Toggle &lt;amp-selector&gt; experiment</button>
 
   <h2>Basic example</h2>

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -311,6 +311,8 @@ export class Bind {
           element.className = ampClasses.concat(newValue).join(' ');
         } else if (typeof newValue === 'string') {
           element.className = ampClasses.join(' ') + ' ' + newValue;
+        } else if (newValue === null) {
+          element.className = ampClasses.join(' ');
         } else {
           user().error(TAG, 'Invalid result for [class]', newValue);
         }

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -30,6 +30,10 @@ const GLOBAL_PROPERTY_RULES = {
   'class': {
     blacklistedValueRegex: '(^|\\W)i-amphtml-',
   },
+  // ARIA accessibility attributes.
+  'aria-describedby': null,
+  'aria-label': null,
+  'aria-labelledby': null,
 };
 
 /**
@@ -153,11 +157,11 @@ export class BindValidator {
 function createElementRules_() {
   // Initialize `rules` with tag-specific constraints.
   const rules = {
+    'AMP-CAROUSEL': {
+      slide: null,
+    },
     'AMP-IMG': {
       alt: null,
-      'aria-describedby': null,
-      'aria-label': null,
-      'aria-labelledby': null,
       referrerpolicy: null,
       src: {
         allowedProtocols: {
@@ -167,14 +171,28 @@ function createElementRules_() {
         },
         blockedURLs: ['__amp_source_origin'],
       },
-      srcset: {
+      // TODO: Support `srcset`.
+    },
+    'AMP-SELECTOR': {
+      selected: null,
+    },
+    'AMP-VIDEO': {
+      alt: null,
+      attribution: null,
+      autoplay: null,
+      controls: null,
+      loop: null,
+      muted: null,
+      placeholder: null,
+      poster: null,
+      preload: null,
+      src: {
         allowedProtocols: {
-          data: true,
-          http: true,
           https: true,
         },
         blockedURLs: ['__amp_source_origin'],
       },
+      // TODO: Support `srcset`.
     },
     A: {
       href: {

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -177,22 +177,40 @@ describe('BindValidator', () => {
   });
 
   describe('AMP extensions', () => {
+    it('should support <amp-carousel>', () => {
+      expect(val.canBind('AMP-CAROUSEL', 'slide')).to.be.true;
+    });
+
     it('should support <amp-img>', () => {
       expect(val.canBind('AMP-IMG', 'src')).to.be.true;
-      expect(val.canBind('AMP-IMG', 'srcset')).to.be.true;
       expect(val.canBind('AMP-IMG', 'width')).to.be.true;
       expect(val.canBind('AMP-IMG', 'height')).to.be.true;
 
       expect(val.isResultValid(
           'AMP-IMG', 'src', 'http://foo.com/bar.jpg')).to.be.true;
       expect(val.isResultValid('AMP-IMG', 'src',
-          /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
       expect(val.isResultValid(
           'AMP-IMG', 'src', '__amp_source_origin')).to.be.false;
-      expect(val.isResultValid('AMP-IMG', 'srcset',
-          /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
+    });
+
+    it('should support <amp-selector>', () => {
+      expect(val.canBind('AMP-SELECTOR', 'selected')).to.be.true;
+    });
+
+    it('should support <amp-video>', () => {
+      expect(val.canBind('AMP-VIDEO', 'loop')).to.be.true;
+      expect(val.canBind('AMP-VIDEO', 'poster')).to.be.true;
+      expect(val.canBind('AMP-VIDEO', 'src')).to.be.true;
+
       expect(val.isResultValid(
-          'AMP-IMG', 'srcset', '__amp_source_origin')).to.be.false;
+          'AMP-VIDEO', 'src', 'https://foo.com/bar.mp4')).to.be.true;
+      expect(val.isResultValid(
+          'AMP-VIDEO', 'src', 'http://foo.com/bar.mp4')).to.be.false;
+      expect(val.isResultValid('AMP-VIDEO', 'src',
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-VIDEO', 'src', '__amp_source_origin')).to.be.false;
     });
   });
 });

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -95,11 +95,16 @@ export class AmpSelector extends AMP.BaseElement {
     if (!this.isMultiple_) {
       selectedArray = selectedArray.slice(0, 1);
     }
+    // Convert array values to strings and create map for fast lookup.
+    const selectedMap = selectedArray.reduce((map, value) => {
+      map[value] = true;
+      return map;
+    }, Object.create(null));
     // Iterate through elements and toggle selection as necessary.
     for (let i = 0; i < this.options_.length; i++) {
       const element = this.options_[i];
       const option = element.getAttribute('option');
-      if (selectedArray.indexOf(option) >= 0) {
+      if (selectedMap[option]) {
         this.setSelection_(element);
       } else {
         this.clearSelection_(element);

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -82,11 +82,11 @@ export class AmpSelector extends AMP.BaseElement {
 
   /**
    * Handles mutation of the `selected` attribute.
-   * @param {string|Array|null} newValue
+   * @param {null|boolean|string|number|Array|Object} newValue
    * @private
    */
   selectedAttributeMutated_(newValue) {
-    if (!newValue) {
+    if (newValue === null) {
       this.clearAllSelections_();
       return;
     }

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -534,7 +534,13 @@ describes.realWin('amp-selector', {
       expect(impl.options_[0].hasAttribute('selected')).to.be.false;
       expect(impl.options_[3].hasAttribute('selected')).to.be.true;
 
-      expect(setInputsSpy).calledOnce;
+      // Integers should be converted to strings.
+      impl.mutatedAttributesCallback({selected: 0});
+
+      expect(impl.options_[0].hasAttribute('selected')).to.be.true;
+      expect(impl.options_[3].hasAttribute('selected')).to.be.false;
+
+      expect(setInputsSpy).calledTwice;
     });
 
     it('should trigger `select` action when user selects an option', () => {


### PR DESCRIPTION
Partial for #6199.

Also:
- Convert amp-selector `[selected]` attr mutations to string
- Fix amp-bind experiment toggling
- Allow `null` result for `[class]` binding

/to @camelburrito 