### PR TITLE
Form Proxy: Support null EventTarget class

### DIFF
--- a/extensions/amp-form/0.1/form-proxy.js
+++ b/extensions/amp-form/0.1/form-proxy.js
@@ -91,14 +91,15 @@ function createFormProxyConstr(win) {
   // Hierarchy:
   //   Node  <==  Element <== HTMLElement <== HTMLFormElement
   //   EventTarget  <==  HTMLFormElement
-  const prototypes = [
-    win.HTMLFormElement.prototype,
-    win.HTMLElement.prototype,
-    win.Element.prototype,
-    win.Node.prototype,
-    win.EventTarget.prototype,
+  const inheritance = [
+    win.HTMLFormElement,
+    win.HTMLElement,
+    win.Element,
+    win.Node,
+    win.EventTarget,
   ];
-  prototypes.forEach(function(prototype) {
+  inheritance.forEach(function(klass) {
+    const prototype = klass && klass.prototype;
     for (const name in prototype) {
       const property = win.Object.getOwnPropertyDescriptor(prototype, name);
       if (!property ||

--- a/extensions/amp-form/0.1/test/test-form-proxy.js
+++ b/extensions/amp-form/0.1/test/test-form-proxy.js
@@ -29,6 +29,7 @@ describes.repeated('installFormProxy', {
   'modern w/inputs': {inputs: true},
   'legacy w/o inputs': {blacklist: true},
   'legacy w/ inputs': {blacklist: true, inputs: true},
+  'no EventTarget': {eventTarget: true},
 }, (name, variant) => {
   let form;
   let inputs;
@@ -60,8 +61,17 @@ describes.repeated('installFormProxy', {
       setBlacklistedPropertiesForTesting(PROPS);
     }
 
+    const eventTarget = window.EventTarget;
+    if (variant.eventTarget) {
+      window.EventTarget = null;
+    }
+
     // Install proxy.
     installFormProxy(form);
+
+    if (eventTarget) {
+      window.EventTarget = eventTarget;
+    }
   });
 
   afterEach(() => {


### PR DESCRIPTION
In old Safari, the `EventTarget` methods are mixed into `Node`.

Fixes https://github.com/ampproject/amphtml/issues/7075.