### PR TITLE
Append CSA container to 'c' container

### DIFF
--- a/ads/google/csa.js
+++ b/ads/google/csa.js
@@ -61,8 +61,7 @@ export function csa(global, data) {
   const containerDiv = global.document.createElement('div');
   const containerId = 'csacontainer';
   containerDiv.id = containerId;
-  setStyle(containerDiv, 'position', 'absolute');
-  global.document.body.appendChild(containerDiv);
+  global.document.getElementById('c').appendChild(containerDiv);
 
   const pageOptions = {source: 'amp', referer: global.context.referrer};
   const adblockOptions = {container: containerId};
@@ -294,7 +293,7 @@ function createOverflow(global, container, height) {
   const overflow = getOverflowElement(global);
   // When overflow is clicked, resize to full height
   overflow.onclick = global.context.requestResize.bind(null, undefined, height);
-  global.document.body.appendChild(overflow);
+  global.document.getElementById('c').appendChild(overflow);
   // Resize the CSA container to not conflict with overflow
   resizeCsa(container, currentAmpHeight - overflowHeight);
 }
@@ -310,7 +309,6 @@ function getOverflowElement(global) {
   setStyles(overflow, {
     position: 'absolute',
     height: overflowHeight + 'px',
-    top: (currentAmpHeight - overflowHeight) + 'px',
     width: '100%',
   });
   overflow.appendChild(getOverflowLine(global));

--- a/ads/google/csa.js
+++ b/ads/google/csa.js
@@ -61,6 +61,7 @@ export function csa(global, data) {
   const containerDiv = global.document.createElement('div');
   const containerId = 'csacontainer';
   containerDiv.id = containerId;
+  setStyle(containerDiv, 'position', 'absolute');
   global.document.body.appendChild(containerDiv);
 
   const pageOptions = {source: 'amp', referer: global.context.referrer};
@@ -309,6 +310,7 @@ function getOverflowElement(global) {
   setStyles(overflow, {
     position: 'absolute',
     height: overflowHeight + 'px',
+    top: (currentAmpHeight - overflowHeight) + 'px',
     width: '100%',
   });
   overflow.appendChild(getOverflowLine(global));

--- a/test/functional/ads/test-csa.js
+++ b/test/functional/ads/test-csa.js
@@ -70,6 +70,9 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
         noContentAvailable() {},
         referrer: null,
       };
+      const div = win.document.createElement('div');
+      div.id = 'c';
+      win.document.body.appendChild(div);
     });
   });
 


### PR DESCRIPTION
This PR is in response to #7047 (the iframe isn't clickable).  This is happening because of a div that gets added above the CSA container div:

```
<div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">
  <script>draw3p()</script>
</div>
```

Because of the absolute positioning, none of the underlying elements in the iframe can be clickable.  @lannka do you know why this element needs to have absolute positioning?  If I set the CSA container to absolute positioning the problem is solved, however.

Fixes #7047.