### PR TITLE
Change the frame.html container div z-index to -1.

### DIFF
--- a/3p/frame.max.html
+++ b/3p/frame.max.html
@@ -5,7 +5,7 @@
 <script src="./integration.js"></script>
 </head>
 <body style="margin:0">
-<div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">
+<div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;z-index:-1;">
   <script>draw3p()</script>
 </div>
 <script>if (window.docEndCallback) window.docEndCallback()</script>


### PR DESCRIPTION
@cramforce  do you think this is a good idea?
I'm hesitant because If we really want the content to be child of the container (for any Safari resizing issue), this change will make the problem harder to be noticed.

For #7047