### PR TITLE
Introduce field "runtime=inabox" in error reporting to differentiate errors generated from inabox JS.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -262,9 +262,16 @@ export function getErrorReportUrl(message, filename, line, col, error,
     // classify these errors as benchmarks and not exceptions.
     url += '&ex=1';
   }
+
+  let runtime = '1p';
   if (self.context && self.context.location) {
     url += '&3p=1';
+    runtime = '3p';
+  } else if (getMode().runtime) {
+    runtime = getMode().runtime;
   }
+  url += '&rt=' + runtime;
+
   if (isCanary(self)) {
     url += '&ca=1';
   }

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -42,6 +42,9 @@ import {maybeTrackImpression} from '../impression';
 import {isExperimentOn} from '../experiments';
 import {installViewerServiceForDoc} from '../service/viewer-impl';
 import {installInaboxViewportService} from './inabox-viewport';
+import {getMode} from '../mode';
+
+getMode(self).runtime = 'inabox';
 
 // TODO(lannka): only install the necessary services.
 

--- a/tools/errortracker/errortracker.go
+++ b/tools/errortracker/errortracker.go
@@ -125,11 +125,19 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		errorType += "-origin"
 	}
 	is3p := false
-	if r.URL.Query().Get("3p") == "1" {
-		is3p = true
-		errorType += "-3p"
+	runtime := r.URL.Query().Get("rt")
+	if runtime != "" {
+		errorType += "-" + runtime;
+		if runtime == "3p" {
+			is3p = true
+		}
 	} else {
-		errorType += "-1p"
+		if r.URL.Query().Get("3p") == "1" {
+			is3p = true
+			errorType += "-3p"
+		} else {
+			errorType += "-1p"
+		}
 	}
 	isCanary := false;
 	if r.URL.Query().Get("ca") == "1" {


### PR DESCRIPTION
This is to differentiate errors generated from amp-inabox runtime vs conventional runtime. #5700 

The PR introduces a new field `runtime=[1p|3p|inabox]`.
The stack driver service name will look like: `(default|assert)-cdn-(1p|3p|inabox)[-canary]`

@dvoytenko @cramforce
@jridgewell how would this go with SW?