### PR TITLE
Implementing a more comprehensive strategy for amp-auto-ads.

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/ad-tracker.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {resourcesForDoc} from '../../../src/resources';
+
+export class AdTracker {
+
+  /**
+   * @param {!Array<!Element>} ads
+   * @param {number} minAdSpacing
+   */
+  constructor(ads, minAdSpacing) {
+    /** @type {!Array<!Element>} */
+    this.ads_ = ads;
+
+    /** @type {number} */
+    this.minAdSpacing_ = minAdSpacing;
+  }
+
+  /**
+   * @param {!Element} ad
+   */
+  addAd(ad) {
+    this.ads_.push(ad);
+  }
+
+  /**
+   * @return {number}
+   */
+  getAdCount() {
+    return this.ads_.length;
+  }
+
+  /**
+   * Indicates if the given yPosition would be within the specifiec minDistance,
+   * vertically, of an ad that the AdTracker is aware of.
+   * @param {number} yPosition
+   * @return {!Promise<boolean>}
+   */
+  isTooNearAnAd(yPosition) {
+    return this.isWithinMinDistanceOfAd_(yPosition, 0);
+  }
+
+  /**
+   * @param {number} yPosition
+   * @param {number} adIndex
+   * @return {!Promise<boolean>}
+   * @private
+   */
+  isWithinMinDistanceOfAd_(yPosition, adIndex) {
+    if (adIndex >= this.ads_.length) {
+      return Promise.resolve(false);
+    }
+    return this.getDistanceFromAd_(yPosition, this.ads_[adIndex])
+        .then(distance => {
+          if (distance < this.minAdSpacing_) {
+            return true;
+          }
+          return this.isWithinMinDistanceOfAd_(yPosition, adIndex + 1);
+        });
+  }
+
+  /**
+   * @param {number} yPosition
+   * @param {!Element} ad
+   * @return {!Promise<number>} The absolute value of the minimum vertical
+   *     distance from the yPosition to the ad.
+   * @private
+   */
+  getDistanceFromAd_(yPosition, ad) {
+    return resourcesForDoc(ad).getElementLayoutBox(ad).then(box => {
+      if (yPosition >= box.top && yPosition <= box.bottom) {
+        return 0;
+      } else {
+        return Math.min(Math.abs(yPosition - box.top),
+            Math.abs(yPosition - box.bottom));
+      }
+    });
+  }
+}
+
+/**
+ * @param {!Window} win
+ * @return {!Array<!Element>}
+ */
+export function getExistingAds(win) {
+  return [].slice.call(win.document.getElementsByTagName('AMP-AD')).concat(
+      [].slice.call(win.document.getElementsByTagName('AMP-A4A')));
+}

--- a/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {AdTracker, getExistingAds} from '../ad-tracker';
+import {layoutRectLtwh} from '../../../../src/layout-rect';
+import {resourcesForDoc} from '../../../../src/resources';
+import * as sinon from 'sinon';
+
+describe('ad-tracker', () => {
+  let doc;
+  let resources;
+  let sandbox;
+  let container;
+
+  beforeEach(() => {
+    doc = window.document;
+    sandbox = sinon.sandbox.create();
+
+    resources = resourcesForDoc(doc);
+    sandbox.stub(resources, 'getElementLayoutBox', element => {
+      return Promise.resolve(element.layoutBox);
+    });
+
+    container = doc.createElement('div');
+    doc.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    doc.body.removeChild(container);
+  });
+
+  function addAd(layoutBox) {
+    const ad = doc.createElement('amp-ad');
+    ad.setAttribute('type', 'adsense');
+    ad.setAttribute('layout', 'responsive');
+    ad.setAttribute('width', '300');
+    ad.setAttribute('height', '100');
+    ad.layoutBox = layoutBox;
+    container.appendChild(ad);
+    return ad;
+  }
+
+  it('should return the correct ad count', () => {
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+    ], 100);
+    expect(adTracker.getAdCount()).to.equal(1);
+
+    adTracker.addAd(addAd(layoutRectLtwh(0, 100, 300, 50)));
+    expect(adTracker.getAdCount()).to.equal(2);
+  });
+
+  it('should find position is too near when close to ad above', () => {
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+    ], 100);
+    return adTracker.isTooNearAnAd(149).then(tooNear => {
+      expect(tooNear).to.equal(true);
+    });
+  });
+
+  it('should find position is too near when close to ad below', () => {
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 100, 300, 50)),
+    ], 100);
+    return adTracker.isTooNearAnAd(1).then(tooNear => {
+      expect(tooNear).to.equal(true);
+    });
+  });
+
+  it('should find position is too near when inside ad', () => {
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+    ], 1);
+    return adTracker.isTooNearAnAd(25).then(tooNear => {
+      expect(tooNear).to.equal(true);
+    });
+  });
+
+  it('should find position is not too near an ad', () => {
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+      addAd(layoutRectLtwh(0, 250, 300, 50)),
+    ], 100);
+    return adTracker.isTooNearAnAd(150).then(tooNear => {
+      expect(tooNear).to.equal(false);
+    });
+  });
+
+  it('should add an ad to the tracker', () => {
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+    ], 100);
+    adTracker.addAd(addAd(layoutRectLtwh(0, 100, 300, 50)));
+    return adTracker.isTooNearAnAd(150).then(tooNear => {
+      expect(tooNear).to.equal(true);
+    });
+  });
+});
+
+describes.realWin('getExistingAds', {}, env => {
+  let win;
+  let doc;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+  });
+
+  it('should find all the amp-ads in the DOM', () => {
+    const ad1 = doc.createElement('amp-ad');
+    doc.body.appendChild(ad1);
+    const ad2 = doc.createElement('amp-ad');
+    doc.body.appendChild(ad2);
+    const ad3 = doc.createElement('amp-a4a');
+    doc.body.appendChild(ad3);
+
+    const ads = getExistingAds(win);
+    expect(ads).to.have.lengthOf(3);
+    expect(ads[0]).to.equal(ad1);
+    expect(ads[1]).to.equal(ad2);
+    expect(ads[2]).to.equal(ad3);
+  });
+});

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -28,11 +28,23 @@ describe('amp-auto-ads', () => {
   let container;
   let anchor1;
   let anchor2;
+  let anchor3;
+  let anchor4;
   let ampAutoAds;
   let ampAutoAdsElem;
   let xhr;
 
   beforeEach(() => {
+    // There seem to be a lot of tests that don't clean up after themselves,
+    // meaning there are a lot of <AMP-AD>s left over in the DOM.
+    // An alternative to doing this clean up would be for this test to do all
+    // its DOM stuff in a dedicated window, but trying that seems to result in a
+    // lot of errors.
+    const ampAds = document.getElementsByTagName('AMP-AD');
+    while (ampAds.length) {
+      ampAds[0].parentNode.removeChild(ampAds[0]);
+    }
+
     toggleExperiment(window, 'amp-auto-ads', true);
     sandbox = sinon.sandbox.create();
 
@@ -43,9 +55,29 @@ describe('amp-auto-ads', () => {
     anchor1.id = 'anId1';
     container.appendChild(anchor1);
 
+    const spacer = document.createElement('div');
+    spacer.style.height = '1000px';
+    container.appendChild(spacer);
+
     anchor2 = document.createElement('div');
     anchor2.id = 'anId2';
     container.appendChild(anchor2);
+
+    const spacer2 = document.createElement('div');
+    spacer2.style.height = '499px';
+    container.appendChild(spacer2);
+
+    anchor3 = document.createElement('div');
+    anchor3.id = 'anId3';
+    container.appendChild(anchor3);
+
+    const spacer3 = document.createElement('div');
+    spacer3.style.height = '500px';
+    container.appendChild(spacer3);
+
+    anchor4 = document.createElement('div');
+    anchor4.id = 'anId4';
+    container.appendChild(anchor4);
 
     ampAutoAdsElem = document.createElement('amp-auto-ads');
     document.body.appendChild(ampAutoAdsElem);
@@ -68,6 +100,20 @@ describe('amp-auto-ads', () => {
             pos: 2,
             type: 1,
           },
+          {
+            anchor: {
+              selector: 'DIV#anId3',
+            },
+            pos: 2,
+            type: 1,
+          },
+          {
+            anchor: {
+              selector: 'DIV#anId4',
+            },
+            pos: 2,
+            type: 1,
+          },
         ],
       });
     };
@@ -82,21 +128,30 @@ describe('amp-auto-ads', () => {
     document.body.removeChild(ampAutoAdsElem);
   });
 
-  it('should insert a single ad on page using config', done => {
+  function verifyAdElement(adElement) {
+    expect(adElement.tagName).to.equal('AMP-AD');
+    expect(adElement.getAttribute('type')).to.equal('adsense');
+    expect(adElement.getAttribute('data-ad-client')).to.equal(AD_CLIENT);
+  }
+
+  it('should insert three ads on page using config', () => {
     ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
     ampAutoAdsElem.setAttribute('type', 'adsense');
     ampAutoAds.buildCallback();
 
-    waitForChild(anchor1, parent => {
-      return parent.childNodes.length > 0;
-    }, () => {
-      expect(anchor1.childNodes.length).to.equal(1);
-      expect(anchor2.childNodes.length).to.equal(0);
-      const adElement = anchor1.childNodes[0];
-      expect(adElement.tagName).to.equal('AMP-AD');
-      expect(adElement.getAttribute('type')).to.equal('adsense');
-      expect(adElement.getAttribute('data-ad-client')).to.equal(AD_CLIENT);
-      done();
+    return new Promise(resolve => {
+      waitForChild(anchor4, parent => {
+        return parent.childNodes.length > 0;
+      }, () => {
+        expect(anchor1.childNodes).to.have.lengthOf(1);
+        expect(anchor2.childNodes).to.have.lengthOf(1);
+        expect(anchor3.childNodes).to.have.lengthOf(0);
+        expect(anchor4.childNodes).to.have.lengthOf(1);
+        verifyAdElement(anchor1.childNodes[0]);
+        verifyAdElement(anchor2.childNodes[0]);
+        verifyAdElement(anchor4.childNodes[0]);
+        resolve();
+      });
     });
   });
 

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AdTracker} from '../ad-tracker';
 import {resourcesForDoc} from '../../../../src/resources';
 import {PlacementState, getPlacementsFromConfigObj} from '../placement';
 import * as sinon from 'sinon';
@@ -32,6 +33,159 @@ describe('placement', () => {
   afterEach(() => {
     sandbox.restore();
     document.body.removeChild(container);
+  });
+
+  describe('getAdElement', () => {
+    it('should get ad Element when ad placed', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(() => {
+            expect(placements[0].getAdElement()).to.equal(anchor.childNodes[0]);
+          });
+    });
+
+    it('should throw an error if ad not placed', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      expect(() => placements[0].getAdElement()).to.throw(/No ad element/);
+    });
+  });
+
+  describe('getEstimatedPosition', () => {
+    it('should estimate the position when before anchor', () => {
+      const anchor = document.createElement('div');
+      anchor.style.position = 'absolute';
+      anchor.style.top = '15px';
+      anchor.style.height = '100px';
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 1,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].getEstimatedPosition(yPosition => {
+        expect(yPosition).to.equal(15);
+      });
+    });
+
+    it('should estimate the position when first child of anchor', () => {
+      const anchor = document.createElement('div');
+      anchor.style.position = 'absolute';
+      anchor.style.top = '15px';
+      anchor.style.height = '100px';
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].getEstimatedPosition(yPosition => {
+        expect(yPosition).to.equal(15);
+      });
+    });
+
+    it('should estimate the position when last child of anchor', () => {
+      const anchor = document.createElement('div');
+      anchor.style.position = 'absolute';
+      anchor.style.top = '15px';
+      anchor.style.height = '100px';
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 3,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].getEstimatedPosition(yPosition => {
+        expect(yPosition).to.equal(115);
+      });
+    });
+
+    it('should estimate the position when after anchor', () => {
+      const anchor = document.createElement('div');
+      anchor.style.position = 'absolute';
+      anchor.style.top = '15px';
+      anchor.style.height = '100px';
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 4,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].getEstimatedPosition(yPosition => {
+        expect(yPosition).to.equal(115);
+      });
+    });
   });
 
   describe('placeAd', () => {
@@ -62,7 +216,7 @@ describe('placement', () => {
           name: 'custom-att-2',
           value: 'val-2',
         },
-      ]).then(() => {
+      ], new AdTracker([], 0)).then(() => {
         const adElement = anchor.firstChild;
         expect(adElement.tagName).to.equal('AMP-AD');
         expect(adElement).to.have.attribute('type', 'ad-network-type');
@@ -97,8 +251,8 @@ describe('placement', () => {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', []).then(
-          placementState => {
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
                 anchor.firstChild, 100, 320);
             expect(placementState).to.equal(PlacementState.PLACED);
@@ -128,11 +282,41 @@ describe('placement', () => {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', []).then(
-          placementState => {
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
                 anchor.firstChild, 100, 320);
             expect(placementState).to.equal(PlacementState.RESIZE_FAILED);
+          });
+    });
+
+    it('should report too near existing ad', () => {
+      const fakeAd = document.createElement('div');
+      container.appendChild(fakeAd);
+
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      const adTracker = new AdTracker([fakeAd], 100);
+
+      return placements[0].placeAd('ad-network-type', [], adTracker)
+          .then(placementState => {
+            expect(placementState).to.equal(
+                PlacementState.TOO_NEAR_EXISTING_AD);
           });
     });
   });
@@ -156,8 +340,8 @@ describe('placement', () => {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', []).then(
-          placementState => {
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(2);
             expect(container.childNodes[0].tagName).to.equal('AMP-AD');
@@ -182,8 +366,8 @@ describe('placement', () => {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', []).then(
-          placementState => {
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(2);
             expect(container.childNodes[1].tagName).to.equal('AMP-AD');
@@ -209,8 +393,8 @@ describe('placement', () => {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', []).then(
-          placementState => {
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(1);
             expect(anchor.childNodes[0].tagName).to.equal('AMP-AD');
@@ -236,8 +420,8 @@ describe('placement', () => {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', []).then(
-          placementState => {
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(1);
             expect(anchor.childNodes[1].tagName).to.equal('AMP-AD');
@@ -267,8 +451,8 @@ describe('placement', () => {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', []).then(
-          placementState => {
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(anchor1.childNodes).to.have.lengthOf(0);
             expect(anchor2.childNodes).to.have.lengthOf(1);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -332,6 +332,27 @@ export class Resources {
   }
 
   /**
+   * Returns a promise to the layoutBox for the element. If the element is
+   * resource-backed then makes use of the resource layoutBox, otherwise
+   * measures the element directly.
+   * @param {!Element} element
+   * @return {!Promise<!../layout-rect.LayoutRectDef>}
+   */
+  getElementLayoutBox(element) {
+    const resource = this.getResourceForElementOptional(element);
+    if (resource && resource.hasBeenMeasured()) {
+      return Promise.resolve(resource.getLayoutBox());
+    }
+    return this.vsync_.measurePromise(() => {
+      if (resource) {
+        resource.measure();
+        return resource.getLayoutBox();
+      }
+      return this.getViewport().getLayoutRect(element);
+    });
+  }
+
+  /**
    * Returns the viewport instance
    * @return {!./viewport-impl.Viewport}
    */


### PR DESCRIPTION
Implements a more comprehensive strategy for amp-auto-ads. Strategy tries to ensure that there are 3 ads on the page and that no ads are within 500px of one another. The 3 ads and 500px are hard coded for now, but in a future change these will be configurable based on the configuration served by the ad network.

https://github.com/ampproject/amphtml/issues/6196