### PR TITLE
Throw an error if a required attribute is missing.

### DIFF
--- a/ads/google/csa.js
+++ b/ads/google/csa.js
@@ -212,15 +212,24 @@ function requestCsaAds(global, data, afsP, afsA, afshP, afshA) {
  */
 function getAdType(data) {
   if (data['afsPageOptions'] != null && data['afshPageOptions'] == null) {
+    validateData(data, ['afsPageOptions', 'afsAdblockOptions'], []);
     return AD_TYPE.AFS;
   }
   if (data['afsPageOptions'] == null && data['afshPageOptions'] != null) {
+    validateData(data, ['afshPageOptions', 'afshAdblockOptions'], []);
     return AD_TYPE.AFSH;
   }
   if (data['afsPageOptions'] != null && data['afshPageOptions'] != null) {
+    validateData(data, [
+      'afsPageOptions',
+      'afsAdblockOptions',
+      'afshPageOptions',
+      'afshAdblockOptions',
+    ], []);
     return AD_TYPE.AFSH_BACKFILL;
   }
   else {
+    validateData(data, ['afsPageOptions'], []);
     return AD_TYPE.UNSUPPORTED;
   }
 }

--- a/test/functional/ads/test-csa.js
+++ b/test/functional/ads/test-csa.js
@@ -115,6 +115,42 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
       csa(win, getAds(AD_TYPE.AFSH_BACKFILL));
       expect(googCsaSpy.args[0][0]).to.equal('plas');
     });
+
+    it('should throw an error: missing afsAdblockOptions', () => {
+      let error = null;
+      const missingAdblock = {
+        ampSlotIndex: '0',
+        height: 300,
+        type: 'csa',
+        afsPageOptions: '{"pubId": "gtech-codegen", "query": "flowers"}',
+      };
+      try {
+        csa(win, missingAdblock);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.not.be.null;
+      const message = 'Missing attribute for csa: afsAdblockOptions.​​​';
+      expect(error.message).to.equal(message);
+    });
+
+    it('should throw an error: missing afsPageOptions', () => {
+      let error = null;
+      const missingPage = {
+        ampSlotIndex: '0',
+        height: 300,
+        type: 'csa',
+        afsAdblockOptions: '{"width": "auto", "maxTop": 1}',
+      };
+      try {
+        csa(win, missingPage);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.not.be.null;
+      const message = 'Missing attribute for csa: afsPageOptions.​​​';
+      expect(error.message).to.equal(message);
+    });
   });
 
   describe('callback', () => {


### PR DESCRIPTION
Implement better error checking for CSA ad integration. Currently, if
the tag is missing a necessary attribute a request still gets made.
This change ensure that they are including the right attributes for the
correct product.  We can’t do this earlier in the code because we
aren’t sure which product to call until this point.