### PR TITLE
Validator rollup

### DIFF
--- a/extensions/amp-access/0.1/validator-amp-access.protoascii
+++ b/extensions/amp-access/0.1/validator-amp-access.protoascii
@@ -31,6 +31,7 @@ tags: {  # amp-access
     value: "amp-access"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true
@@ -62,6 +63,7 @@ tags: {  # amp-access (json)
     value: "amp-access"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "type"
     mandatory: true

--- a/extensions/amp-accordion/0.1/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/0.1/validator-amp-accordion.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-accordion
     value: "amp-accordion"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-ad/0.1/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/0.1/validator-amp-ad.protoascii
@@ -37,6 +37,7 @@ tags: {  # amp-ad
     value: "amp-ad"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-analytics/0.1/validator-amp-analytics.protoascii
+++ b/extensions/amp-analytics/0.1/validator-amp-analytics.protoascii
@@ -41,6 +41,7 @@ tags: {  # amp-analytics
     value: "amp-analytics"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true
@@ -64,6 +65,7 @@ tags: {  # amp-analytics (json)
   tag_name: "SCRIPT"
   spec_name: "amp-analytics extension .json script"
   mandatory_parent: "AMP-ANALYTICS"
+  attrs: { name: "nonce" }
   attrs: {
     name: "type"
     mandatory: true

--- a/extensions/amp-analytics/0.1/validator-amp-analytics.protoascii
+++ b/extensions/amp-analytics/0.1/validator-amp-analytics.protoascii
@@ -89,15 +89,16 @@ tags: {  # amp-ad-metadata (json)
   spec_name: "amp-ad-metadata .json script"
   mandatory_parent: "BODY"
   attrs: {
-    name: "type"
-    mandatory: true
-    value_casei: "application/json"
-  }
-  attrs: {
     name: "amp-ad-metadata"
     mandatory: true
     value: ""
     dispatch_key: true
+  }
+  attrs: { name: "nonce" }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "application/json"
   }
   cdata: {
     blacklisted_cdata_regex: {

--- a/extensions/amp-anim/0.1/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/0.1/validator-amp-anim.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-anim
     value: "amp-anim"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-apester-media/0.1/validator-amp-apester-media.protoascii
+++ b/extensions/amp-apester-media/0.1/validator-amp-apester-media.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-apester-media
     value: "amp-apester-media"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-app-banner/0.1/validator-amp-app-banner.protoascii
+++ b/extensions/amp-app-banner/0.1/validator-amp-app-banner.protoascii
@@ -31,6 +31,7 @@ tags: {  # <script custom-element="amp-sticky-ad">
     value: "amp-app-banner"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-app-banner/0.1/validator-amp-app-banner.protoascii
+++ b/extensions/amp-app-banner/0.1/validator-amp-app-banner.protoascii
@@ -54,15 +54,17 @@ tags: {  # <amp-app-banner>
   tag_name: "AMP-APP-BANNER"
   spec_name: "amp-app-banner"
   mandatory_parent: "BODY"
-
   requires: "amp-app-banner data source"
   also_requires_tag: "amp-app-banner extension .js script"
   # The "amp-app-banner button[open-button]" tag is in
   # validator-main.protoascii and in turn has an "AMP-APP-BANNER"
   # mandatory_parent.
   also_requires_tag: "amp-app-banner button[open-button]"
+  attrs: {
+    name: "id"
+    mandatory: true
+  }
   attr_lists: "extended-amp-global"
-  attrs: { name: "id" mandatory: true }
   unique: true
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-add-banner.html"
   amp_layout: {

--- a/extensions/amp-audio/0.1/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/0.1/validator-amp-audio.protoascii
@@ -51,7 +51,6 @@ tags: {  # amp-audio
 }
 attr_lists: { # amp-audio attributes that are common to both AMP and A4A format.
   name: "amp-audio-common"
-
   attrs: { name: "controls" }
   attrs: { name: "loop"  value: "" }
   attrs: { name: "muted" value: "" }

--- a/extensions/amp-audio/0.1/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/0.1/validator-amp-audio.protoascii
@@ -31,6 +31,7 @@ tags: {  # amp-audio
     value: "amp-audio"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
+++ b/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
@@ -55,8 +55,10 @@ tags: {  # <amp-auto-ads>
   disallowed_ancestor: "AMP-AUTO-ADS"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-auto-ads extension .js script"
-  attrs: { name: "type" mandatory: true }
+  attrs: {
+    name: "type"
+    mandatory: true
+  }
   attr_lists: "extended-amp-global"
-
   spec_url: "https://github.com/ampproject/amphtml/issues/6196"
 }

--- a/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
+++ b/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
@@ -31,6 +31,7 @@ tags: {  # amp-auto-ads
     value: "amp-auto-ads"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -31,6 +31,7 @@ tags: {  # amp-bind
     value: "amp-bind"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true
@@ -65,6 +66,7 @@ tags: {  # <amp-state> (json)
   tag_name: "SCRIPT"
   spec_name: "amp-bind extension .json script"
   mandatory_parent: "AMP-STATE"
+  attrs: { name: "nonce" }
   attrs: {
     name: "type"
     mandatory: true

--- a/extensions/amp-brid-player/0.1/validator-amp-brid-player.protoascii
+++ b/extensions/amp-brid-player/0.1/validator-amp-brid-player.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-brid-player
     value: "amp-brid-player"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-brightcove
     value: "amp-brightcove"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
@@ -57,7 +57,10 @@ tags: {  # <amp-brightcove>
   tag_name: "AMP-BRIGHTCOVE"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-brightcove extension .js script"
-  attrs: { name: "data-account" mandatory: true }
+  attrs: {
+    name: "data-account"
+    mandatory: true
+  }
   # If data-embed is missing, the default value is "default".
   attrs: { name: "data-embed" }
   # If data-player is missing, the default value is "default".

--- a/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-carousel
     value: "amp-carousel"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii
@@ -57,13 +57,31 @@ tags: {  # <amp-carousel>
   tag_name: "AMP-CAROUSEL"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-carousel extension .js script"
-  attrs: { name: "arrows" value: "" }
-  attrs: { name: "autoplay" value: "" }
+  attrs: {
+    name: "arrows"
+    value: ""
+  }
+  attrs: {
+    name: "autoplay"
+    value: ""
+  }
   attrs: { name: "controls" }
-  attrs: { name: "delay" value_regex: "[0-9]+" }
-  attrs: { name: "dots" value: "" }
-  attrs: { name: "loop" value: "" }
-  attrs: { name: "type" value_regex: "slides|carousel" }
+  attrs: {
+    name: "delay"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "dots"
+    value: ""
+  }
+  attrs: {
+    name: "loop"
+    value: ""
+  }
+  attrs: {
+    name: "type"
+    value_regex: "slides|carousel"
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-carousel.html"
   amp_layout: {

--- a/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-dailymotion
     value: "amp-dailymotion"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
@@ -56,13 +56,34 @@ tags: {  # <amp-dailymotion>
   tag_name: "AMP-DAILYMOTION"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-dailymotion extension .js script"
-  attrs: { name: "data-endscreen-enable" value_regex: "true|false" }
-  attrs: { name: "data-info" value_regex: "true|false" }
-  attrs: { name: "data-mute" value_regex: "true|false" }
-  attrs: { name: "data-sharing-enable" value_regex: "true|false" }
-  attrs: { name: "data-start" value_regex: "[0-9]+" }
-  attrs: { name: "data-ui-highlight" value_regex_casei: "([0-9a-f]{3}){1,2}" }
-  attrs: { name: "data-ui-logo" value_regex: "true|false" }
+  attrs: {
+    name: "data-endscreen-enable"
+    value_regex: "true|false"
+  }
+  attrs: {
+    name: "data-info"
+    value_regex: "true|false"
+  }
+  attrs: {
+    name: "data-mute"
+    value_regex: "true|false"
+  }
+  attrs: {
+    name: "data-sharing-enable"
+    value_regex: "true|false"
+  }
+  attrs: {
+    name: "data-start"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "data-ui-highlight"
+    value_regex_casei: "([0-9a-f]{3}){1,2}"
+  }
+  attrs: {
+    name: "data-ui-logo"
+    value_regex: "true|false"
+  }
   attrs: {
     name: "data-videoid"
     mandatory: true

--- a/extensions/amp-dynamic-css-classes/0.1/validator-amp-dynamic-css-classes.protoascii
+++ b/extensions/amp-dynamic-css-classes/0.1/validator-amp-dynamic-css-classes.protoascii
@@ -31,6 +31,7 @@ tags: {  # amp-dynamic-css-classes
     value: "amp-dynamic-css-classes"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-experiment/0.1/validator-amp-experiment.protoascii
+++ b/extensions/amp-experiment/0.1/validator-amp-experiment.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-experiment
     value: "amp-experiment"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true
@@ -55,6 +56,7 @@ tags: {  # amp-experiment (json)
   tag_name: "SCRIPT"
   spec_name: "amp-experiment extension .json script"
   mandatory_parent: "AMP-EXPERIMENT"
+  attrs: { name: "nonce" }
   attrs: {
     name: "type"
     mandatory: true

--- a/extensions/amp-facebook/0.1/validator-amp-facebook.protoascii
+++ b/extensions/amp-facebook/0.1/validator-amp-facebook.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-facebook
     value: "amp-facebook"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-facebook/0.1/validator-amp-facebook.protoascii
+++ b/extensions/amp-facebook/0.1/validator-amp-facebook.protoascii
@@ -58,7 +58,10 @@ tags: {  # <amp-facebook>
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-facebook extension .js script"
   # data-* is generally allowed, but it's not generally mandatory.
-  attrs: { name: "data-href" mandatory: true }
+  attrs: {
+    name: "data-href"
+    mandatory: true
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-facebook.html"
   amp_layout: {

--- a/extensions/amp-fit-text/0.1/validator-amp-fit-text.protoascii
+++ b/extensions/amp-fit-text/0.1/validator-amp-fit-text.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-fit-text
     value: "amp-fit-text"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-font/0.1/validator-amp-font.protoascii
+++ b/extensions/amp-font/0.1/validator-amp-font.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-font
     value: "amp-font"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-form/0.1/validator-amp-form.protoascii
+++ b/extensions/amp-form/0.1/validator-amp-form.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-form
     value: "amp-form"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-fx-flying-carpet/0.1/validator-amp-fx-flying-carpet.protoascii
+++ b/extensions/amp-fx-flying-carpet/0.1/validator-amp-fx-flying-carpet.protoascii
@@ -32,6 +32,7 @@ tags: {  # <script custom-element="amp-fx-flying-carpet">
     value: "amp-fx-flying-carpet"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-gfycat/0.1/validator-amp-gfycat.protoascii
+++ b/extensions/amp-gfycat/0.1/validator-amp-gfycat.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-gfycat
     value: "amp-gfycat"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-hulu/0.1/validator-amp-hulu.protoascii
+++ b/extensions/amp-hulu/0.1/validator-amp-hulu.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-hulu
     value: "amp-hulu"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-iframe
     value: "amp-iframe"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
@@ -55,13 +55,28 @@ tags: {  # <amp-iframe>
   tag_name: "AMP-IFRAME"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-iframe extension .js script"
-  attrs: { name: "allowfullscreen" value: "" }
-  attrs: { name: "allowtransparency" value: "" }
-  attrs: { name: "frameborder" value_regex: "0|1" }
+  attrs: {
+    name: "allowfullscreen"
+    value: ""
+  }
+  attrs: {
+    name: "allowtransparency"
+    value: ""
+  }
+  attrs: {
+    name: "frameborder"
+    value_regex: "0|1"
+  }
   attrs: { name: "referrerpolicy" }
-  attrs: { name: "resizable" value: "" }
+  attrs: {
+    name: "resizable"
+    value: ""
+  }
   attrs: { name: "sandbox" }
-  attrs: { name: "scrolling" value_regex: "auto|yes|no" }
+  attrs: {
+    name: "scrolling"
+    value_regex: "auto|yes|no"
+  }
   attrs: {
     name: "src"
     mandatory_oneof: "['src', 'srcdoc']"
@@ -72,7 +87,10 @@ tags: {  # <amp-iframe>
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
-  attrs: { name: "srcdoc" mandatory_oneof: "['src', 'srcdoc']" }
+  attrs: {
+    name: "srcdoc"
+    mandatory_oneof: "['src', 'srcdoc']"
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-iframe.html"
   amp_layout: {

--- a/extensions/amp-image-lightbox/0.1/validator-amp-image-lightbox.protoascii
+++ b/extensions/amp-image-lightbox/0.1/validator-amp-image-lightbox.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-image-lightbox
     value: "amp-image-lightbox"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-instagram/0.1/validator-amp-instagram.protoascii
+++ b/extensions/amp-instagram/0.1/validator-amp-instagram.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-instagram
     value: "amp-instagram"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-install-serviceworker/0.1/validator-amp-install-serviceworker.protoascii
+++ b/extensions/amp-install-serviceworker/0.1/validator-amp-install-serviceworker.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-install-serviceworker
     mandatory: true
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-jwplayer/0.1/validator-amp-jwplayer.protoascii
+++ b/extensions/amp-jwplayer/0.1/validator-amp-jwplayer.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-jwplayer
     mandatory: true
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-kaltura-player/0.1/validator-amp-kaltura-player.protoascii
+++ b/extensions/amp-kaltura-player/0.1/validator-amp-kaltura-player.protoascii
@@ -59,9 +59,10 @@ tags: {  # <amp-kaltura-player>
   tag_name: "AMP-KALTURA-PLAYER"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-kaltura-player extension .js script"
-
-  attrs: { name: "data-partner" mandatory: true }
-
+  attrs: {
+    name: "data-partner"
+    mandatory: true
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-kaltura-player.html"
   amp_layout: {

--- a/extensions/amp-kaltura-player/0.1/validator-amp-kaltura-player.protoascii
+++ b/extensions/amp-kaltura-player/0.1/validator-amp-kaltura-player.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-kaltura-player
     value: "amp-kaltura-player"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-lightbox/0.1/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/0.1/validator-amp-lightbox.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-lightbox
     value: "amp-lightbox"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-list/0.1/validator-amp-list.protoascii
+++ b/extensions/amp-list/0.1/validator-amp-list.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-list
     value: "amp-list"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-live-list/0.1/validator-amp-live-list.protoascii
+++ b/extensions/amp-live-list/0.1/validator-amp-live-list.protoascii
@@ -56,19 +56,22 @@ tags: {  # <amp-live-list>
   tag_name: "AMP-LIVE-LIST"
   also_requires_tag: "amp-live-list extension .js script"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-live-list.html"
-  attrs: { name: "id" mandatory: true }
-  attrs: {
-    name: "data-poll-interval"
-    value_regex: "\\d{5,}"
-  }
   attrs: {
     name: "data-max-items-per-page"
     mandatory: true
     value_regex: "\\d+"
   }
   attrs: {
+    name: "data-poll-interval"
+    value_regex: "\\d{5,}"
+  }
+  attrs: {
     name: "disabled"
     value: ""
+  }
+  attrs: {
+    name: "id"
+    mandatory: true
   }
   reference_points: {
     tag_spec_name: "AMP-LIVE-LIST [update]"

--- a/extensions/amp-live-list/0.1/validator-amp-live-list.protoascii
+++ b/extensions/amp-live-list/0.1/validator-amp-live-list.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-live-list
     value: "amp-live-list"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-mustache/0.1/validator-amp-mustache.protoascii
+++ b/extensions/amp-mustache/0.1/validator-amp-mustache.protoascii
@@ -36,6 +36,7 @@ tags: {  # amp-mustache
     value: "amp-mustache"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-o2-player/0.1/validator-amp-o2-player.protoascii
+++ b/extensions/amp-o2-player/0.1/validator-amp-o2-player.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-o2-player
     value: "amp-o2-player"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-o2-player/0.1/validator-amp-o2-player.protoascii
+++ b/extensions/amp-o2-player/0.1/validator-amp-o2-player.protoascii
@@ -57,9 +57,15 @@ tags: {  # <amp-o2-player>
   tag_name: "AMP-O2-PLAYER"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-o2-player extension .js script"
-  attrs: { name: "data-pid" mandatory: true }
-  attrs: { name: "data-bcid" mandatory: true }
+  attrs: {
+    name: "data-bcid"
+    mandatory: true
+  }
   attrs: { name: "data-bid" }
+  attrs: {
+    name: "data-pid"
+    mandatory: true
+  }
   attrs: { name: "data-vid" }
   # If data-embed is missing, the default value is "default".
   attr_lists: "extended-amp-global"

--- a/extensions/amp-ooyala-player/0.1/validator-amp-ooyala-player.protoascii
+++ b/extensions/amp-ooyala-player/0.1/validator-amp-ooyala-player.protoascii
@@ -54,6 +54,7 @@ tags: {  # <amp-ooyala-player>
   html_format: AMP
   html_format: AMP4ADS
   also_requires_tag: "amp-ooyala-player extension .js script"
+  attrs: { name: "data-config" }
   attrs: {
     name: "data-embedcode"
     mandatory: true
@@ -66,12 +67,7 @@ tags: {  # <amp-ooyala-player>
     name: "data-playerid"
     mandatory: true
   }
-  attrs: {
-    name: "data-playerversion"
-  }
-  attrs: {
-    name: "data-config"
-  }
+  attrs: { name: "data-playerversion" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-ooyala-player.html"
   amp_layout: {

--- a/extensions/amp-ooyala-player/0.1/validator-amp-ooyala-player.protoascii
+++ b/extensions/amp-ooyala-player/0.1/validator-amp-ooyala-player.protoascii
@@ -31,6 +31,7 @@ tags: {  # amp-ooyala-player
     value: "amp-ooyala-player"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-pinterest/0.1/validator-amp-pinterest.protoascii
+++ b/extensions/amp-pinterest/0.1/validator-amp-pinterest.protoascii
@@ -61,7 +61,10 @@ tags: {  # <amp-pinterest>
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-pinterest extension .js script"
   # data-* is generally allowed, but it's not generally mandatory.
-  attrs: { name: "data-do" mandatory: true }
+  attrs: {
+    name: "data-do"
+    mandatory: true
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-pinterest.html"
   amp_layout: {

--- a/extensions/amp-pinterest/0.1/validator-amp-pinterest.protoascii
+++ b/extensions/amp-pinterest/0.1/validator-amp-pinterest.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-pinterest
     value: "amp-pinterest"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-playbuzz/0.1/validator-amp-playbuzz.protoascii
+++ b/extensions/amp-playbuzz/0.1/validator-amp-playbuzz.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-playbuzz
     value: "amp-playbuzz"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-playbuzz/0.1/validator-amp-playbuzz.protoascii
+++ b/extensions/amp-playbuzz/0.1/validator-amp-playbuzz.protoascii
@@ -57,8 +57,8 @@ tags: {  # <amp-playbuzz>
   tag_name: "AMP-PLAYBUZZ"
   also_requires_tag: "amp-playbuzz extension .js script"
   attrs: {
-    name: "src"
-    mandatory: true
+    name: "data-comments"
+    value_regex_casei: "(false|true)"
   }
   attrs: {
     name: "data-item-info"
@@ -69,8 +69,8 @@ tags: {  # <amp-playbuzz>
     value_regex_casei: "(false|true)"
   }
   attrs: {
-    name: "data-comments"
-    value_regex_casei: "(false|true)"
+    name: "src"
+    mandatory: true
   }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-playbuzz"

--- a/extensions/amp-reach-player/0.1/validator-amp-reach-player.protoascii
+++ b/extensions/amp-reach-player/0.1/validator-amp-reach-player.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-reach-player
     value: "amp-reach-player"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     value_regex: "https://cdn\\.ampproject\\.org/v0/amp-reach-player-(latest|0\\.1).js"

--- a/extensions/amp-reddit/0.1/validator-amp-reddit.protoascii
+++ b/extensions/amp-reddit/0.1/validator-amp-reddit.protoascii
@@ -34,6 +34,7 @@ tags: {  # amp-reddit
     value: "amp-reddit"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-selector/0.1/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/0.1/validator-amp-selector.protoascii
@@ -33,6 +33,7 @@ tags: {
     value: "amp-selector"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-selector/0.1/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/0.1/validator-amp-selector.protoascii
@@ -58,9 +58,15 @@ tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
   disallowed_ancestor: "AMP-SELECTOR"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-selector extension .js script"
-  attrs: { name: "disabled" value: "" }
+  attrs: {
+    name: "disabled"
+    value: ""
+  }
   attrs: { name: "form" }
-  attrs: { name: "multiple" value: "" }
+  attrs: {
+    name: "multiple"
+    value: ""
+  }
   reference_points: {
     tag_spec_name: "AMP-SELECTOR option"
   }

--- a/extensions/amp-sidebar/0.1/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/0.1/validator-amp-sidebar.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-sidebar
     value: "amp-sidebar"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     value_regex: "https://cdn\\.ampproject\\.org/v0/amp-sidebar-(latest|0\\.1).js"

--- a/extensions/amp-slides/0.1/validator-amp-slides.protoascii
+++ b/extensions/amp-slides/0.1/validator-amp-slides.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-slides
     value: "amp-slides"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
+++ b/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-social-share
     value: "amp-social-share"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
+++ b/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
@@ -57,10 +57,6 @@ tags: {  # <amp-social-share>
   tag_name: "AMP-SOCIAL-SHARE"
   also_requires_tag: "amp-social-share extension .js script"
   attrs: {
-    name: "type"
-    mandatory: true
-  }
-  attrs: {
     name: "data-share-endpoint"
     value_url: {
       allowed_protocol: "ftp"
@@ -87,6 +83,10 @@ tags: {  # <amp-social-share>
       allow_relative: false
     }
     blacklisted_value_regex: "__amp_source_origin"
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
   }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-social-share.html"

--- a/extensions/amp-soundcloud/0.1/validator-amp-soundcloud.protoascii
+++ b/extensions/amp-soundcloud/0.1/validator-amp-soundcloud.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-soundcloud
     value: "amp-soundcloud"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-soundcloud/0.1/validator-amp-soundcloud.protoascii
+++ b/extensions/amp-soundcloud/0.1/validator-amp-soundcloud.protoascii
@@ -57,7 +57,10 @@ tags: {  # <amp-soundcloud>
   tag_name: "AMP-SOUNDCLOUD"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-soundcloud extension .js script"
-  attrs: { name: "data-color" value_regex_casei: "([0-9a-f]{3}){1,2}" }
+  attrs: {
+    name: "data-color"
+    value_regex_casei: "([0-9a-f]{3}){1,2}"
+  }
   attrs: {
     name: "data-secret-token"
     value_regex: "[A-Za-z0-9_-]+"
@@ -67,7 +70,10 @@ tags: {  # <amp-soundcloud>
     mandatory: true
     value_regex: "[0-9]+"
   }
-  attrs: { name: "data-visual" value_regex: "true|false" }
+  attrs: {
+    name: "data-visual"
+    value_regex: "true|false"
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-soundcloud.html"
   amp_layout: {

--- a/extensions/amp-springboard-player/0.1/validator-amp-springboard-player.protoascii
+++ b/extensions/amp-springboard-player/0.1/validator-amp-springboard-player.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-springboard-player
     value: "amp-springboard-player"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-sticky-ad/0.1/validator-amp-sticky-ad.protoascii
+++ b/extensions/amp-sticky-ad/0.1/validator-amp-sticky-ad.protoascii
@@ -31,6 +31,7 @@ tags: {  # <script custom-element="amp-sticky-ad">
     value: "amp-sticky-ad"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-twitter/0.1/validator-amp-twitter.protoascii
+++ b/extensions/amp-twitter/0.1/validator-amp-twitter.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-twitter
     value: "amp-twitter"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-user-notification/0.1/validator-amp-user-notification.protoascii
+++ b/extensions/amp-user-notification/0.1/validator-amp-user-notification.protoascii
@@ -64,14 +64,6 @@ tags: {  # <amp-user-notification>
   # These attributes are allowed implicitly as data-* attributes,
   # but we make additional constraints on validating URLs.
   attrs: {
-    name: "data-show-if-href"
-    value_url: {
-      allowed_protocol: "https"
-      allow_relative: false
-      allow_empty: false
-    }
-  }
-  attrs: {
     name: "data-dismiss-href"
     value_url: {
       allowed_protocol: "https"
@@ -79,5 +71,12 @@ tags: {  # <amp-user-notification>
       allow_empty: false
     }
   }
-
+  attrs: {
+    name: "data-show-if-href"
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: false
+      allow_empty: false
+    }
+  }
 }

--- a/extensions/amp-user-notification/0.1/validator-amp-user-notification.protoascii
+++ b/extensions/amp-user-notification/0.1/validator-amp-user-notification.protoascii
@@ -32,6 +32,7 @@ tags: {  # amp-user-notification
     value: "amp-user-notification"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-video/0.1/validator-amp-video.protoascii
+++ b/extensions/amp-video/0.1/validator-amp-video.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-video
      value: "amp-video"
      dispatch_key: true
    }
+   attrs: { name: "nonce" }
    attrs: {
      name: "src"
      mandatory: true

--- a/extensions/amp-video/0.1/validator-amp-video.protoascii
+++ b/extensions/amp-video/0.1/validator-amp-video.protoascii
@@ -59,13 +59,28 @@ tags: {  # <amp-video>
   also_requires_tag_warning: "amp-video extension .js script"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
-  attrs: { name: "autoplay" value: "" }
-  attrs: { name: "controls" value: "" }
-  attrs: { name: "loop"     value: "" }
-  attrs: { name: "muted"    value: "" }
+  attrs: {
+    name: "autoplay"
+    value: ""
+  }
+  attrs: {
+    name: "controls"
+    value: ""
+  }
+  attrs: {
+    name: "loop"
+    value: ""
+  }
+  attrs: {
+    name: "muted"
+    value: ""
+  }
   attrs: { name: "placeholder" }
   attrs: { name: "poster" }
-  attrs: { name: "preload" value_regex: "(none|metadata|auto|)" }
+  attrs: {
+    name: "preload"
+    value_regex: "(none|metadata|auto|)"
+  }
   attrs: {
     name: "src"
     value_url: {

--- a/extensions/amp-vimeo/0.1/validator-amp-vimeo.protoascii
+++ b/extensions/amp-vimeo/0.1/validator-amp-vimeo.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-vimeo
     value: "amp-vimeo"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-vine/0.1/validator-amp-vine.protoascii
+++ b/extensions/amp-vine/0.1/validator-amp-vine.protoascii
@@ -58,7 +58,10 @@ tags: {  # <amp-vine>
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-vine extension .js script"
   # data-* is generally allowed, but it's not generally mandatory.
-  attrs: { name: "data-vineid" mandatory: true }
+  attrs: {
+    name: "data-vineid"
+    mandatory: true
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-vine.html"
   amp_layout: {

--- a/extensions/amp-vine/0.1/validator-amp-vine.protoascii
+++ b/extensions/amp-vine/0.1/validator-amp-vine.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-vine
     value: "amp-vine"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii
@@ -33,6 +33,7 @@ tags: {  # amp-youtube
     value: "amp-youtube"
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -3665,11 +3665,12 @@ class ParsedValidatorRules {
    */
   constructor(htmlFormat) {
     /**
-     * ParsedTagSpecs in id order.
-     * @type {!Object<number, !ParsedTagSpec>}
+     * ParsedTagSpecs in id order, that is, the order in which the tagspecs
+     * appear in ValidatorRules::tags.
+     * @type {!Array<!ParsedTagSpec>}
      * @private
      */
-    this.tagSpecById_ = {};
+    this.tagSpecById_ = [];
     /**
      * ParsedTagSpecs keyed by name
      * @type {!Object<string, !TagSpecDispatch>}

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -1202,8 +1202,8 @@ class ReferencePointMatcher {
    * @param {!amp.validator.ValidationResult} result
    */
   exitParentTag(context, result) {
-    /** @type {!Object<number, number>} */
-    const referencePointByCount = {};
+    /** @type {!Array<number>} */
+    const referencePointByCount = [];
     for (const r of this.referencePointsMatched_) {
       referencePointByCount[r] = referencePointByCount.hasOwnProperty(r) ?
           (referencePointByCount[r] + 1) :
@@ -1883,10 +1883,10 @@ class Context {
 
     /**
      * Maps from the tagspec id to the tagspec id.
-     * @type {!Object<number, ?>}
+     * @type {!Array<?>}
      * @private
      */
-    this.tagspecsValidated_ = {};
+    this.tagspecsValidated_ = [];
 
     /**
      * Set of conditions that we've satisfied.
@@ -1965,7 +1965,7 @@ class Context {
   }
 
   /**
-   * @return {!Object<number, ?>}
+   * @return {!Object<string, ?>}
    */
   conditionsSatisfied() {
     return this.conditionsSatisfied_;
@@ -2013,7 +2013,7 @@ class Context {
   }
 
   /**
-   * @return {!Object<number, ?>}
+   * @return {!Array<?>}
    */
   getTagspecsValidated() {
     return this.tagspecsValidated_;
@@ -2716,7 +2716,7 @@ function CalculateLayout(inputLayout, width, height, sizesAttr, heightsAttr) {
  * - Unique tags
  * - Tags (identified by their TagSpecName() that are required by other tags.
  * @param {!amp.validator.TagSpec} tag
- * @param {!Object<number, boolean>} tagSpecIdsToTrack
+ * @param {!Array<boolean>} tagSpecIdsToTrack
  * @return {boolean}
  */
 function shouldRecordTagspecValidated(tag, tagSpecIdsToTrack) {
@@ -3204,11 +3204,12 @@ function validateAttributes(
   /** @type {!Object<string, ?>} */
   const mandatoryOneofsSeen = {};
   let parsedTriggerSpecs = [];
-  /** If a tag has implicit attributes, we then add these attributes as
+  /**
+   * If a tag has implicit attributes, we then add these attributes as
    * validated. E.g. tag 'a' has implicit attributes 'role' and 'tabindex'.
-   * @type {!Object<number, ?>}
+   * @type {!Array<?>}
    */
-  const attrspecsValidated = {};
+  const attrspecsValidated = [];
   for (const implicit of parsedTagSpec.getImplicitAttrspecs()) {
     attrspecsValidated[implicit] = 0;
   }
@@ -3696,9 +3697,8 @@ class ParsedValidatorRules {
      */
     this.parsedAttrSpecs_ = new ParsedAttrSpecs(this.rules_.attrLists);
 
-    /** @type {!Object<number, boolean>} */
-    const tagSpecIdsToTrack = {};
-    const extensionUnusedUnlessTagPresent = {};
+    /** @type {!Array<boolean>} */
+    const tagSpecIdsToTrack = [];
     for (const tag of this.rules_.tags) {
       const tagSpecName = getTagSpecName(tag);
       if (tag.alsoRequiresTag.length > 0) {

--- a/validator/testdata/feature_tests/minimum_valid_amp.html
+++ b/validator/testdata/feature_tests/minimum_valid_amp.html
@@ -25,7 +25,7 @@
   <link rel="canonical" href="./regular-html-version.html" />
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async nonce="cryptographic-nonce" src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
 Hello, world.

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 210
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 350
+spec_file_revision: 351
 
 # Validator extensions.
 # =====================
@@ -2910,7 +2910,7 @@ attr_lists: {
         "hasAttributes|"
         "hasChildNodes|"
         "hasPointerCapture|"
-        "i-amphtml-.*|"
+        "i-amphtml-\\S*|"
         "innerHTML|"
         "innerText|"
         "inputMode|"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 210
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 352
+spec_file_revision: 353
 
 # Validator extensions.
 # =====================
@@ -535,6 +535,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP
     # attribute and thus can't have a dispatch_key.
     # dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {  # This is a default, but it doesn't hurt.
     name: "type"
     value_casei: "text/css"
@@ -624,6 +625,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP4ADS
     # attribute and thus can't have a dispatch_key.
     # dispatch_key: true
   }
+  attrs: { name: "nonce" }
   attrs: {  # This is a default, but it doesn't hurt.
     name: "type"
     value_casei: "text/css"
@@ -707,6 +709,7 @@ tags: {
   mandatory_parent: "HEAD"
   deprecation: "head > style[amp-boilerplate]"
   deprecation_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
+  attrs: { name: "nonce" }
   cdata: {
     cdata_regex: "body ?{opacity: ?0}"
   }
@@ -721,6 +724,7 @@ tags: {
   mandatory_parent: "NOSCRIPT"
   deprecation: "noscript > style[amp-boilerplate]"
   deprecation_url: "https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md"
+  attrs: { name: "nonce" }
   cdata {
     cdata_regex: "body ?{opacity: ?1}"
   }
@@ -740,6 +744,7 @@ tags: {
     value: ""
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   cdata: {
     # This regex allows arbitrary whitespace whenever some whitespace
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
@@ -759,6 +764,7 @@ tags: {
     value: ""
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   cdata: {
     # This regex allows arbitrary whitespace around the body statement, but
     # not inside it. This is a compromise to keep things simple, but allow
@@ -781,6 +787,7 @@ tags: {
     value: ""
     dispatch_key: true
   }
+  attrs: { name: "nonce" }
   cdata {
     cdata_regex: "\\s*body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\\s*"
   }
@@ -2597,6 +2604,7 @@ tags: {
     mandatory: true
     value: ""
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true
@@ -2627,6 +2635,7 @@ tags: {
     mandatory: true
     value: ""
   }
+  attrs: { name: "nonce" }
   attrs: {
     name: "src"
     mandatory: true
@@ -2650,6 +2659,7 @@ tags: {
 tags: {
   tag_name: "SCRIPT"
   spec_name: "script type=application/ld+json"
+  attrs: { name: "nonce" }
   attrs: {
     name: "type"
     mandatory: true

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 210
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 351
+spec_file_revision: 352
 
 # Validator extensions.
 # =====================
@@ -2279,7 +2279,7 @@ attr_lists: {
   attrs: {
     name: "name"
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
-        "__amp_source_origin|"
+        "__amp_\\S*|"
         "__count__|"
         "__defineGetter__|"
         "__defineSetter__|"
@@ -2288,6 +2288,7 @@ attr_lists: {
         "__noSuchMethod__|"
         "__parent__|"
         "__proto__|"
+        "__AMP_\\S*|"
         "\\$p|"
         "\\$proxy|"
         "acceptCharset|"
@@ -2310,6 +2311,7 @@ attr_lists: {
         "computedRole|"
         "contentEditable|"
         "createShadowRoot|"
+        "enqueAction|"
         "firstChild|"
         "firstElementChild|"
         "getAnimations|"
@@ -2860,6 +2862,7 @@ attr_lists: {
   attrs: {
     name: "id"
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
+        "__amp_\\S*|"
         "__count__|"
         "__defineGetter__|"
         "__defineSetter__|"
@@ -2868,6 +2871,7 @@ attr_lists: {
         "__noSuchMethod__|"
         "__parent__|"
         "__proto__|"
+        "__AMP_\\S*|"
         "\\$p|"
         "\\$proxy|"
         "acceptCharset|"
@@ -2891,6 +2895,7 @@ attr_lists: {
         "computedRole|"
         "contentEditable|"
         "createShadowRoot|"
+        "enqueAction|"
         "firstChild|"
         "firstElementChild|"
         "getAnimations|"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 210
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 353
+spec_file_revision: 354
 
 # Validator extensions.
 # =====================

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 210
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 354
+spec_file_revision: 355
 
 # Validator extensions.
 # =====================
@@ -222,6 +222,7 @@ tags: {
   tag_name: "LINK"
   spec_name: "link rel=stylesheet for fonts"
   mandatory_parent: "HEAD"
+  attrs: { name: "async" }
   attrs: {
     name: "href"
     mandatory: true

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 210
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 355
+spec_file_revision: 356
 
 # Validator extensions.
 # =====================
@@ -497,6 +497,22 @@ tags: {
     name: "content"
     mandatory: true
     value_casei: "text/javascript"
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/spec.html#html-tags"
+}
+# http-equiv origin-trial tag
+tags: {
+  tag_name: "META"
+  spec_name: "meta http-equiv=origin-trial"
+  attrs: {
+    name: "http-equiv"
+    mandatory: true
+    value_casei: "origin-trial"
+    dispatch_key: true
+  }
+  attrs: {
+    name: "content"
+    mandatory: true
   }
   spec_url: "https://www.ampproject.org/docs/reference/spec.html#html-tags"
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 210
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 349
+spec_file_revision: 350
 
 # Validator extensions.
 # =====================
@@ -244,6 +244,10 @@ tags: {
     value_casei: "text/css"
   }
   attrs: { name: "media" }
+  # SRI attributes (https://www.w3.org/TR/SRI/)
+  attrs: { name: "crossorigin" }
+  attrs: { name: "integrity" }
+
   spec_url: "https://www.ampproject.org/docs/reference/spec.html#custom-fonts"
 }
 # itemprop=sameAs is allowed per schema.org, needs not be in head

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -356,6 +356,9 @@ def PrintClassFor(descriptor, msg_desc, out):
         out.Line('/**%s @type {%s} */' % (export_or_empty, type_name))
         out.Line('this.%s = %s;' % (UnderscoreToCamelCase(field.name),
                                     assigned_value))
+    if msg_desc.full_name == 'amp.validator.ValidatorRules':
+      out.Line('/** @type {Array<!string>} */')
+      out.Line('this.dispatchKeyByTagSpecId = Array(tags.length);')
     out.PopIndent()
     out.Line('};')
   out.Line('')
@@ -538,6 +541,25 @@ def PrintObject(descriptor, msg, out):
   return this_id
 
 
+def DispatchKeyForTagSpecOrNone(tag_spec):
+  """For a provided tag_spec, generates its dispatch key.
+
+  Args:
+    tag_spec: an instance of type validator_pb2.TagSpec.
+
+  Returns:
+    a string indicating the dispatch key, or None.
+  """
+  for attr in tag_spec.attrs:
+    if attr.dispatch_key:
+      mandatory_parent = tag_spec.mandatory_parent or ''
+      attr_name = attr.name
+      attr_value = attr.value_casei or attr.value.lower()
+      assert attr_value is not None
+      return '%s\\0%s\\0%s' % (attr_name, attr_value, mandatory_parent)
+  return None
+
+
 def GenerateValidatorGeneratedJs(specfile, validator_pb2, text_format,
                                  descriptor, out):
   """Main method for the code generator.
@@ -601,6 +623,13 @@ def GenerateValidatorGeneratedJs(specfile, validator_pb2, text_format,
   out.Line('amp.validator.createRules = function() {')
   out.PushIndent(2)
   PrintObject(descriptor, rules, out)
+  for tag_spec in rules.tags:
+    tag_spec_id = out.TagIdForTagName(TagSpecName(tag_spec))
+    dispatch_key = DispatchKeyForTagSpecOrNone(tag_spec)
+    if dispatch_key:
+      out.Line('obj_0.dispatchKeyByTagSpecId[%d]="%s"' % (
+          tag_spec_id, dispatch_key))
+
   out.Line('return obj_0;')
   out.PopIndent()
   out.Line('}')

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -605,6 +605,3 @@ def GenerateValidatorGeneratedJs(specfile, validator_pb2, text_format,
   out.PopIndent()
   out.Line('}')
   out.Line('')
-  out.Line('/**')
-  out.Line(' * @type {!%s}' % rules.DESCRIPTOR.full_name)
-  out.Line(' */')


### PR DESCRIPTION
Releasing to github, these are not released in PROD yet.

- Allow `<meta http-equiv=origin-trial ...>` Github #7122
- Allow async attr on font link tag. Github #7105
- Make validator protoascii usage more consistent.
- Allow `nonce` attribute on `<script>` and `<style>` tags. Github #6992
- More disallowed id and name attribute values.
- Reduce greediness of i-ampthml- blacklist regex.
- Make the ParsedTagSpec instantiation lazy.
- Generate a synthetic field ValidatorRules.dispatchKeyByTagSpecId and populate it.
- Construct ParsedAttrSpec objects lazily.
- Object -> Array and remove extensionUnusedUnless...
- Allow SRI attributes for stylesheets. Github #7060
- Make tagSpecById array; add comment about ids. Remove unused type decl.