### PR TITLE
Make fetch "normal"

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -337,7 +337,7 @@ export class AmpForm {
         xhrUrl = this.xhrAction_;
         body = new FormData(this.form_);
       }
-      return this.xhr_.fetchJsonResponse(dev().assertString(xhrUrl), {
+      return this.xhr_.fetch(dev().assertString(xhrUrl), {
         body,
         method: this.method_,
         credentials: 'include',

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -981,7 +981,7 @@ describe('amp-form', () => {
       form.appendChild(selector);
       sandbox.stub(selector, 'whenBuilt')
           .returns(new Promise(unusedResolve => {}));
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
+      sandbox.stub(ampForm.xhr_, 'fetch')
           .returns(Promise.resolve());
       sandbox.spy(ampForm, 'handleSubmitAction_');
       ampForm.actionHandler_({method: 'submit'});
@@ -1005,7 +1005,7 @@ describe('amp-form', () => {
       sandbox.stub(selector, 'whenBuilt').returns(new Promise(resolve => {
         builtPromiseResolver_ = resolve;
       }));
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
+      sandbox.stub(ampForm.xhr_, 'fetch')
           .returns(Promise.resolve());
       sandbox.spy(ampForm, 'handleSubmitAction_');
       ampForm.actionHandler_({method: 'submit'});
@@ -1161,7 +1161,7 @@ describe('amp-form', () => {
         form.appendChild(canonicalUrlField);
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
+        sandbox.stub(ampForm.xhr_, 'fetch')
             .returns(Promise.resolve());
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
@@ -1196,7 +1196,7 @@ describe('amp-form', () => {
         form.appendChild(canonicalUrlField);
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
+        sandbox.stub(ampForm.xhr_, 'fetch')
             .returns(Promise.resolve());
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
@@ -1233,7 +1233,7 @@ describe('amp-form', () => {
         form.appendChild(canonicalUrlField);
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
+        sandbox.stub(ampForm.xhr_, 'fetch')
             .returns(Promise.resolve());
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -181,13 +181,12 @@ describe('amp-form', () => {
       preventDefault: sandbox.spy(),
     };
 
-    sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-        .returns(Promise.resolve());
+    sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
     sandbox.spy(form, 'checkValidity');
     ampForm.handleSubmitEvent_(event);
     expect(event.stopImmediatePropagation).to.be.called;
     expect(form.checkValidity).to.not.be.called;
-    expect(ampForm.xhr_.fetchJsonResponse).to.not.be.called;
+    expect(ampForm.xhr_.fetch).to.not.be.called;
     document.body.removeChild(form);
   });
 
@@ -202,8 +201,7 @@ describe('amp-form', () => {
       target: form,
       preventDefault: sandbox.spy(),
     };
-    sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-        .returns(Promise.resolve());
+    sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
     sandbox.spy(form, 'checkValidity');
     expect(() => ampForm.handleSubmitEvent_(event)).to.throw(
         /Only XHR based \(via action-xhr attribute\) submissions are support/);
@@ -222,8 +220,7 @@ describe('amp-form', () => {
     emailInput.setAttribute('required', '');
     form.appendChild(emailInput);
     const ampForm = new AmpForm(form);
-    sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-        .returns(Promise.resolve());
+    sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
     const event = {
       stopImmediatePropagation: sandbox.spy(),
       target: form,
@@ -262,8 +259,7 @@ describe('amp-form', () => {
       emailInput.setAttribute('required', '');
       form.appendChild(emailInput);
       sandbox.spy(form, 'checkValidity');
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-          .returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
 
       const event = {
         stopImmediatePropagation: sandbox.spy(),
@@ -290,7 +286,7 @@ describe('amp-form', () => {
       ampForm.handleSubmitEvent_(event);
       expect(event.stopImmediatePropagation).to.be.called;
       expect(form.checkValidity).to.be.called;
-      expect(ampForm.xhr_.fetchJsonResponse).to.not.be.called;
+      expect(ampForm.xhr_.fetch).to.not.be.called;
 
       const showCall1 = validationBubble.show.getCall(0);
       expect(showCall1.args[0]).to.equal(emailInput);
@@ -304,7 +300,7 @@ describe('amp-form', () => {
       expect(showCall2.args[0]).to.equal(emailInput);
       expect(showCall2.args[1]).to.not.be.null;
       expect(showCall2.args[1]).to.not.equal(showCall1.args[0]);
-      expect(ampForm.xhr_.fetchJsonResponse).to.not.be.called;
+      expect(ampForm.xhr_.fetch).to.not.be.called;
 
       // Check bubble would hide when input becomes valid.
       emailInput.value = 'cool@bea.ns';
@@ -323,7 +319,7 @@ describe('amp-form', () => {
       emailInput.value = 'cool@bea.ns';
       ampForm.handleSubmitEvent_(event);
       return timer.promise(10).then(() => {
-        expect(ampForm.xhr_.fetchJsonResponse).to.have.been.called;
+        expect(ampForm.xhr_.fetch).to.have.been.called;
       });
     });
   });
@@ -338,8 +334,7 @@ describe('amp-form', () => {
       emailInput.setAttribute('required', '');
       form.appendChild(emailInput);
       sandbox.spy(form, 'checkValidity');
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-          .returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
 
       const event = {
         stopImmediatePropagation: sandbox.spy(),
@@ -362,15 +357,14 @@ describe('amp-form', () => {
       return timer.promise(1).then(() => {
         expect(event.stopImmediatePropagation).to.not.be.called;
         expect(form.checkValidity).to.not.be.called;
-        expect(ampForm.xhr_.fetchJsonResponse).to.be.called;
+        expect(ampForm.xhr_.fetch).to.be.called;
       });
     });
   });
 
   it('should call fetch with the xhr action and form data', () => {
     return getAmpForm().then(ampForm => {
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-          .returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
       const event = {
         stopImmediatePropagation: sandbox.spy(),
         target: ampForm.form_,
@@ -379,11 +373,10 @@ describe('amp-form', () => {
       ampForm.handleSubmitEvent_(event);
       expect(event.preventDefault).to.be.calledOnce;
       return timer.promise(1).then(() => {
-        expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-        expect(ampForm.xhr_.fetchJsonResponse)
-            .to.be.calledWith('https://example.com');
+        expect(ampForm.xhr_.fetch).to.be.calledOnce;
+        expect(ampForm.xhr_.fetch).to.be.calledWith('https://example.com');
 
-        const xhrCall = ampForm.xhr_.fetchJsonResponse.getCall(0);
+        const xhrCall = ampForm.xhr_.fetch.getCall(0);
         const config = xhrCall.args[1];
         expect(config.body).to.not.be.null;
         expect(config.method).to.equal('POST');
@@ -395,10 +388,9 @@ describe('amp-form', () => {
   it('should block multiple submissions and disable buttons', () => {
     return getAmpForm(true, true, true).then(ampForm => {
       let fetchResolver;
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-          .returns(new Promise(resolve => {
-            fetchResolver = resolve;
-          }));
+      sandbox.stub(ampForm.xhr_, 'fetch').returns(new Promise(resolve => {
+        fetchResolver = resolve;
+      }));
       const form = ampForm.form_;
       const event = {
         stopImmediatePropagation: sandbox.spy(),
@@ -414,7 +406,7 @@ describe('amp-form', () => {
       ampForm.handleSubmitEvent_(event);
       expect(ampForm.state_).to.equal('submitting');
       return timer.promise(1).then(() => {
-        expect(ampForm.xhr_.fetchJsonResponse.calledOnce).to.be.true;
+        expect(ampForm.xhr_.fetch.calledOnce).to.be.true;
         expect(button1.hasAttribute('disabled')).to.be.true;
         expect(button2.hasAttribute('disabled')).to.be.true;
         ampForm.handleSubmitEvent_(event);
@@ -422,7 +414,7 @@ describe('amp-form', () => {
         expect(event.preventDefault.called).to.be.true;
         expect(event.preventDefault.callCount).to.equal(3);
         expect(event.stopImmediatePropagation.callCount).to.equal(2);
-        expect(ampForm.xhr_.fetchJsonResponse.calledOnce).to.be.true;
+        expect(ampForm.xhr_.fetch.calledOnce).to.be.true;
         expect(form.className).to.contain('amp-form-submitting');
         expect(form.className).to.not.contain('amp-form-submit-error');
         expect(form.className).to.not.contain('amp-form-submit-success');
@@ -442,10 +434,9 @@ describe('amp-form', () => {
   it('should manage form state classes (submitting, success)', () => {
     return getAmpForm().then(ampForm => {
       let fetchResolver;
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-          .returns(new Promise(resolve => {
-            fetchResolver = resolve;
-          }));
+      sandbox.stub(ampForm.xhr_, 'fetch').returns(new Promise(resolve => {
+        fetchResolver = resolve;
+      }));
       sandbox.stub(ampForm, 'analyticsEvent_');
       sandbox.stub(ampForm.actions_, 'trigger');
       const form = ampForm.form_;
@@ -481,7 +472,7 @@ describe('amp-form', () => {
     return getAmpForm(true, true).then(ampForm => {
       let fetchRejecter;
       sandbox.stub(ampForm, 'analyticsEvent_');
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
+      sandbox.stub(ampForm.xhr_, 'fetch')
           .returns(new Promise((unusedResolve, reject) => {
             fetchRejecter = reject;
           }));
@@ -538,7 +529,7 @@ describe('amp-form', () => {
       errorContainer.appendChild(errorTemplate);
       let renderedTemplate = document.createElement('div');
       renderedTemplate.innerText = 'Error: hello there';
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
+      sandbox.stub(ampForm.xhr_, 'fetch')
           .returns(Promise.reject({responseJson: {message: 'hello there'}}));
       sandbox.stub(ampForm.templates_, 'findAndRenderTemplate')
           .returns(Promise.resolve(renderedTemplate));
@@ -594,7 +585,7 @@ describe('amp-form', () => {
       const newRender = document.createElement('div');
       newRender.innerText = 'New Success: What What';
 
-      sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
+      sandbox.stub(ampForm.xhr_, 'fetch')
           .returns(Promise.resolve({
             json: () => {
               return Promise.resolve({'message': 'What What'});
@@ -625,8 +616,7 @@ describe('amp-form', () => {
       return getAmpForm().then(ampForm => {
         ampForm.method_ = 'GET';
         ampForm.form_.setAttribute('method', 'GET');
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         const event = {
           stopImmediatePropagation: sandbox.spy(),
           target: ampForm.form_,
@@ -635,11 +625,11 @@ describe('amp-form', () => {
         ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault).to.be.calledOnce;
         return timer.promise(1).then(() => {
-          expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-          expect(ampForm.xhr_.fetchJsonResponse).to.be.calledWith(
+          expect(ampForm.xhr_.fetch).to.be.calledOnce;
+          expect(ampForm.xhr_.fetch).to.be.calledWith(
               'https://example.com?name=John%20Miller');
 
-          const xhrCall = ampForm.xhr_.fetchJsonResponse.getCall(0);
+          const xhrCall = ampForm.xhr_.fetch.getCall(0);
           const config = xhrCall.args[1];
           expect(config.body).to.be.undefined;
           expect(config.method).to.equal('GET');
@@ -653,8 +643,7 @@ describe('amp-form', () => {
         const form = ampForm.form_;
         ampForm.method_ = 'GET';
         form.setAttribute('method', 'GET');
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         const fieldset = document.createElement('fieldset');
         const emailInput = document.createElement('input');
         emailInput.setAttribute('name', 'email');
@@ -678,42 +667,42 @@ describe('amp-form', () => {
         ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault).to.be.calledOnce;
         return timer.promise(1).then(() => {
-          expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-          expect(ampForm.xhr_.fetchJsonResponse).to.be.calledWith(
+          expect(ampForm.xhr_.fetch).to.be.calledOnce;
+          expect(ampForm.xhr_.fetch).to.be.calledWith(
               'https://example.com?name=John%20Miller&email=cool%40bea.ns');
 
           ampForm.setState_('submit-success');
-          ampForm.xhr_.fetchJsonResponse.reset();
+          ampForm.xhr_.fetch.reset();
           usernameInput.removeAttribute('disabled');
           usernameInput.value = 'coolbeans';
           emailInput.value = 'cool@bea.ns';
           ampForm.handleSubmitEvent_(event);
           return timer.promise(1).then(() => {
-            expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-            expect(ampForm.xhr_.fetchJsonResponse).to.be.calledWith(
+            expect(ampForm.xhr_.fetch).to.be.calledOnce;
+            expect(ampForm.xhr_.fetch).to.be.calledWith(
                 'https://example.com?name=John%20Miller&email=cool%40bea.ns&' +
                 'nickname=coolbeans');
 
             ampForm.setState_('submit-success');
-            ampForm.xhr_.fetchJsonResponse.reset();
+            ampForm.xhr_.fetch.reset();
             fieldset.disabled = true;
             ampForm.handleSubmitEvent_(event);
 
             return timer.promise(1).then(() => {
-              expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-              expect(ampForm.xhr_.fetchJsonResponse).to.be.calledWith(
+              expect(ampForm.xhr_.fetch).to.be.calledOnce;
+              expect(ampForm.xhr_.fetch).to.be.calledWith(
                   'https://example.com?name=John%20Miller');
 
               ampForm.setState_('submit-success');
-              ampForm.xhr_.fetchJsonResponse.reset();
+              ampForm.xhr_.fetch.reset();
               fieldset.removeAttribute('disabled');
               usernameInput.removeAttribute('name');
               emailInput.removeAttribute('required');
               emailInput.value = '';
               ampForm.handleSubmitEvent_(event);
               return timer.promise(1).then(() => {
-                expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-                expect(ampForm.xhr_.fetchJsonResponse).to.be.calledWith(
+                expect(ampForm.xhr_.fetch).to.be.calledOnce;
+                expect(ampForm.xhr_.fetch).to.be.calledWith(
                     'https://example.com?name=John%20Miller&email=');
               });
             });
@@ -728,8 +717,7 @@ describe('amp-form', () => {
         const form = ampForm.form_;
         ampForm.method_ = 'GET';
         form.setAttribute('method', 'GET');
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
 
         const otherNamesFS = document.createElement('fieldset');
         const otherName1Input = document.createElement('input');
@@ -796,30 +784,30 @@ describe('amp-form', () => {
         ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault).to.be.calledOnce;
         return timer.promise(1).then(() => {
-          expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-          expect(ampForm.xhr_.fetchJsonResponse).to.be.calledWith(
+          expect(ampForm.xhr_.fetch).to.be.calledOnce;
+          expect(ampForm.xhr_.fetch).to.be.calledWith(
               'https://example.com?name=John%20Miller&name=&name=&' +
               'city=San%20Francisco');
 
           ampForm.setState_('submit-success');
-          ampForm.xhr_.fetchJsonResponse.reset();
+          ampForm.xhr_.fetch.reset();
           foodCB.checked = true;
           footballCB.checked = true;
           ampForm.handleSubmitEvent_(event);
           return timer.promise(1).then(() => {
-            expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-            expect(ampForm.xhr_.fetchJsonResponse).to.be.calledWith(
+            expect(ampForm.xhr_.fetch).to.be.calledOnce;
+            expect(ampForm.xhr_.fetch).to.be.calledWith(
                 'https://example.com?name=John%20Miller&name=&name=' +
                 '&interests=Football&interests=Food&city=San%20Francisco');
 
             ampForm.setState_('submit-success');
             femaleRadio.checked = true;
             otherName1Input.value = 'John Maller';
-            ampForm.xhr_.fetchJsonResponse.reset();
+            ampForm.xhr_.fetch.reset();
             ampForm.handleSubmitEvent_(event);
             return timer.promise(1).then(() => {
-              expect(ampForm.xhr_.fetchJsonResponse).to.be.calledOnce;
-              expect(ampForm.xhr_.fetchJsonResponse).to.be.calledWith(
+              expect(ampForm.xhr_.fetch).to.be.calledOnce;
+              expect(ampForm.xhr_.fetch).to.be.calledWith(
                   'https://example.com?name=John%20Miller&name=John%20Maller' +
                   '&name=&gender=Female&interests=Football&interests=Food&' +
                   'city=San%20Francisco');
@@ -845,8 +833,7 @@ describe('amp-form', () => {
         sandbox.spy(form, 'checkValidity');
         sandbox.spy(emailInput, 'checkValidity');
         sandbox.spy(fieldset, 'checkValidity');
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
 
         const event = {
           target: ampForm.form_,
@@ -888,8 +875,7 @@ describe('amp-form', () => {
         sandbox.spy(form, 'checkValidity');
         sandbox.spy(emailInput, 'checkValidity');
         sandbox.spy(fieldset, 'checkValidity');
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
 
         onInputInteraction_({target: emailInput});
         expect(form.checkValidity).to.be.called;
@@ -953,8 +939,7 @@ describe('amp-form', () => {
         sandbox.spy(form, 'checkValidity');
         sandbox.spy(emailInput, 'checkValidity');
         sandbox.spy(fieldset, 'checkValidity');
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
 
         emailInput.value = 'cool@bea.ns';
         const event = {target: emailInput};
@@ -975,8 +960,7 @@ describe('amp-form', () => {
     const actions = actionServiceForDoc(form.ownerDocument);
     sandbox.stub(actions, 'installActionHandler');
     const ampForm = new AmpForm(form);
-    sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-        .returns(Promise.resolve());
+    sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
     expect(actions.installActionHandler).to.be.calledWith(form);
     sandbox.spy(ampForm, 'handleSubmitAction_');
     ampForm.actionHandler_({method: 'anything'});
@@ -1056,12 +1040,11 @@ describe('amp-form', () => {
         canonicalUrlField.setAttribute('data-amp-replace', 'CANONICAL_URL');
         form.appendChild(canonicalUrlField);
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
         ampForm.submit_();
-        expect(ampForm.xhr_.fetchJsonResponse).to.have.not.been.called;
+        expect(ampForm.xhr_.fetch).to.have.not.been.called;
         expect(ampForm.urlReplacement_.expandInputValueSync)
             .to.not.have.been.called;
         expect(ampForm.urlReplacement_.expandInputValueAsync)
@@ -1071,7 +1054,7 @@ describe('amp-form', () => {
         expect(ampForm.urlReplacement_.expandInputValueAsync)
             .to.have.been.calledWith(canonicalUrlField);
         return timer.promise(10).then(() => {
-          expect(ampForm.xhr_.fetchJsonResponse).to.be.called;
+          expect(ampForm.xhr_.fetch).to.be.called;
           expect(clientIdField.value).to.match(/amp-\w+/);
           expect(canonicalUrlField.value).to.equal(
               'https%3A%2F%2Fexample.com%2Famps.html');
@@ -1096,15 +1079,14 @@ describe('amp-form', () => {
         canonicalUrlField.value = 'CANONICAL_URL';
         form.appendChild(canonicalUrlField);
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync')
             .returns(new Promise(resolve => {
               expandAsyncStringResolvers.push(resolve);
             }));
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
         ampForm.submit_();
-        expect(ampForm.xhr_.fetchJsonResponse).to.have.not.been.called;
+        expect(ampForm.xhr_.fetch).to.have.not.been.called;
         expect(ampForm.urlReplacement_.expandInputValueSync)
             .to.not.have.been.called;
         expect(ampForm.urlReplacement_.expandInputValueAsync)
@@ -1114,7 +1096,7 @@ describe('amp-form', () => {
         expect(ampForm.urlReplacement_.expandInputValueAsync)
             .to.have.been.calledWith(canonicalUrlField);
         return timer.promise(210).then(() => {
-          expect(ampForm.xhr_.fetchJsonResponse).to.be.called;
+          expect(ampForm.xhr_.fetch).to.be.called;
           expect(clientIdField.value).to.equal('CLIENT_ID(form)');
           expect(canonicalUrlField.value).to.equal('CANONICAL_URL');
         });
@@ -1140,8 +1122,7 @@ describe('amp-form', () => {
         form.appendChild(canonicalUrlField);
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
         ampForm.handleSubmitAction_();
@@ -1309,8 +1290,7 @@ describe('amp-form', () => {
 
     describe('AMP-Redirect-To', () => {
       it('should redirect users if header is set', () => {
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(fetchResolvePromise);
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
         redirectToValue = 'https://google.com/';
         ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
@@ -1319,8 +1299,7 @@ describe('amp-form', () => {
       });
 
       it('should fail to redirect to non-secure urls', () => {
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(fetchResolvePromise);
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
         redirectToValue = 'http://google.com/';
         ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
@@ -1330,8 +1309,7 @@ describe('amp-form', () => {
       });
 
       it('should fail to redirect to non-absolute urls', () => {
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(fetchResolvePromise);
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
         redirectToValue = '/hello';
         ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
@@ -1342,8 +1320,7 @@ describe('amp-form', () => {
 
       it('should fail to redirect to when target != _top', () => {
         ampForm.target_ = '_blank';
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(fetchResolvePromise);
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
         redirectToValue = 'http://google.com/';
         ampForm.handleSubmitAction_();
         return timer.promise(10).then(() => {
@@ -1353,8 +1330,7 @@ describe('amp-form', () => {
       });
 
       it('should redirect on error and header is set', () => {
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(fetchRejectPromise);
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchRejectPromise);
         redirectToValue = 'https://example2.com/hello';
         const errors = [];
         const realSetTimeout = window.setTimeout;
@@ -1385,8 +1361,7 @@ describe('amp-form', () => {
         ampForm.xhrAction_ = null;
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         ampForm.handleSubmitAction_();
         expect(form.submit).to.have.been.called;
       });
@@ -1399,8 +1374,7 @@ describe('amp-form', () => {
         ampForm.xhrAction_ = null;
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetchJsonResponse')
-            .returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         const event = {
           stopImmediatePropagation: sandbox.spy(),
           target: form,

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -177,28 +177,12 @@ export class Xhr {
    * @return {!Promise<!JSONType>}
    */
   fetchJson(input, opt_init) {
-    return this.fetchJsonResponse(input, opt_init)
-        .then(response => response.json());
-  }
-
-  /**
-   * Makes a request to fetch JSON response, based on the fetch polyfill.
-   *
-   * See https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
-   *
-   * See `fetchAmpCors_` for more detail.
-   *
-   * @param {string} input
-   * @param {?FetchInitDef=} opt_init
-   * @return {!Promise<!FetchResponse>}
-   */
-  fetchJsonResponse(input, opt_init) {
     const init = opt_init || {};
     init.method = normalizeMethod_(init.method);
     setupJson_(init);
     return this.fetchAmpCors_(input, init).then(response => {
       return assertSuccess(response);
-    });
+    }).then(response => response.json());
   }
 
   /**

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -529,7 +529,7 @@ describe('XHR', function() {
     });
 
     describe('#fetch ' + test.desc, () => {
-      const creative = '<html><body>This is a creative</body></html>';
+      const creative = '<html><body>This is a creative简</body></html>';
 
       // Using the Native fetch, we can't mock the XHR request, so an actual
       // HTTP request would be sent to the server.  Only execute this test


### PR DESCRIPTION
Makes fetch a normal implementation. We implement `#arrayBuffer` by way
of `utf8EncodeSync`, like it should have been.

Part 1 to fixing #7119.