### PR TITLE
Adding margin support to placement.js for <amp-auto-ads>

### DIFF
--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -85,8 +85,9 @@ export class Placement {
    * @param {!Element} anchorElement
    * @param {!Position} position
    * @param {!function(!Element, !Element)} injector
+   * @param {!../../../src/layout-rect.LayoutMarginsChangeDef=} opt_margins
    */
-  constructor(win, resources, anchorElement, position, injector) {
+  constructor(win, resources, anchorElement, position, injector, opt_margins) {
     /** @const @private {!Window} */
     this.win_ = win;
 
@@ -101,6 +102,12 @@ export class Placement {
 
     /** @const @private {!function(!Element, !Element)} */
     this.injector_ = injector;
+
+    /**
+     * @const
+     * @private {!../../../src/layout-rect.LayoutMarginsChangeDef|undefined}
+     */
+    this.margins_ = opt_margins;
 
     /** @private {?Element} */
     this.adElement_ = null;
@@ -163,8 +170,8 @@ export class Placement {
         }
         this.adElement_ = this.createAdElement_(type, dataAttributes);
         this.injector_(this.anchorElement_, this.adElement_);
-        return this.resources_.attemptChangeSize(
-            this.adElement_, TARGET_AD_HEIGHT_PX, TARGET_AD_WIDTH_PX)
+        return this.resources_.attemptChangeSize(this.adElement_,
+            TARGET_AD_HEIGHT_PX, TARGET_AD_WIDTH_PX, this.margins_)
                 .then(() => {
                   this.state_ = PlacementState.PLACED;
                   return this.state_;
@@ -247,8 +254,19 @@ function getPlacementFromObject(win, placementObj) {
     dev().warn(TAG, 'Parentless anchor with BEFORE/AFTER position.');
     return null;
   }
+  let margins = undefined;
+  if (placementObj['style']) {
+    const marginTop = parseInt(placementObj['style']['top_m'], 10);
+    const marginBottom = parseInt(placementObj['style']['bot_m'], 10);
+    if (marginTop || marginBottom) {
+      margins = {
+        top: marginTop || undefined,
+        bottom: marginBottom || undefined,
+      };
+    }
+  }
   return new Placement(win, resourcesForDoc(anchorElement), anchorElement,
-      placementObj['pos'], injector);
+      placementObj['pos'], injector, margins);
 }
 
 /**

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -228,6 +228,149 @@ describe('placement', () => {
       });
     });
 
+    it('should place an ad with the correct margins', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+            style: {
+              'top_m': 5,
+              'bot_m': 6,
+            },
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(() => {
+            const adElement = anchor.firstChild;
+            expect(adElement.tagName).to.equal('AMP-AD');
+            expect(adElement).to.have.attribute('type', 'ad-network-type');
+            expect(adElement).to.have.attribute('layout', 'responsive');
+            expect(adElement).to.have.attribute('width', '320');
+            expect(adElement).to.have.attribute('height', '0');
+            expect(adElement.style.marginTop).to.equal('5px');
+            expect(adElement.style.marginBottom).to.equal('6px');
+            expect(adElement.style.marginLeft).to.equal('');
+            expect(adElement.style.marginRight).to.equal('');
+          });
+    });
+
+    it('should place an ad with top margin only', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+            style: {
+              'top_m': 5,
+            },
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(() => {
+            const adElement = anchor.firstChild;
+            expect(adElement.tagName).to.equal('AMP-AD');
+            expect(adElement).to.have.attribute('type', 'ad-network-type');
+            expect(adElement).to.have.attribute('layout', 'responsive');
+            expect(adElement).to.have.attribute('width', '320');
+            expect(adElement).to.have.attribute('height', '0');
+            expect(adElement.style.marginTop).to.equal('5px');
+            expect(adElement.style.marginBottom).to.equal('');
+            expect(adElement.style.marginLeft).to.equal('');
+            expect(adElement.style.marginRight).to.equal('');
+          });
+    });
+
+    it('should place an ad with bottom margin only', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+            style: {
+              'bot_m': 6,
+            },
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(() => {
+            const adElement = anchor.firstChild;
+            expect(adElement.tagName).to.equal('AMP-AD');
+            expect(adElement).to.have.attribute('type', 'ad-network-type');
+            expect(adElement).to.have.attribute('layout', 'responsive');
+            expect(adElement).to.have.attribute('width', '320');
+            expect(adElement).to.have.attribute('height', '0');
+            expect(adElement.style.marginTop).to.equal('');
+            expect(adElement.style.marginBottom).to.equal('6px');
+            expect(adElement.style.marginLeft).to.equal('');
+            expect(adElement.style.marginRight).to.equal('');
+          });
+    });
+
+    it('should place an ad with no margins', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+            style: {},
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+          .then(() => {
+            const adElement = anchor.firstChild;
+            expect(adElement.tagName).to.equal('AMP-AD');
+            expect(adElement).to.have.attribute('type', 'ad-network-type');
+            expect(adElement).to.have.attribute('layout', 'responsive');
+            expect(adElement).to.have.attribute('width', '320');
+            expect(adElement).to.have.attribute('height', '0');
+            expect(adElement.style.marginTop).to.equal('');
+            expect(adElement.style.marginBottom).to.equal('');
+            expect(adElement.style.marginLeft).to.equal('');
+            expect(adElement.style.marginRight).to.equal('');
+          });
+    });
+
     it('should report placement placed when resize allowed', () => {
       const anchor = document.createElement('div');
       anchor.id = 'anId';


### PR DESCRIPTION
Margins are specified in the placement object within the JSON config using:

```js
style: {
  top_m: 4,
  bot_m: 5
}
```