### PR TITLE
Update ad loading UX.

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -21,10 +21,7 @@ import {UX_EXPERIMENT} from '../../../src/layout';
 const TAG = 'AmpAdUIHandler';
 
 /** @const */
-const HOLDER_HTML =
-    `<div class='-amp-ad-default-holder'>
-    <div class='-amp-ad-tag'>Ad</div>
-    </div>`;
+const HOLDER_HTML = `<div class='-amp-ad-default-holder'></div>`;
 
 /**
  * Ad display state.
@@ -90,7 +87,6 @@ export class AmpAdUIHandler {
     // Apply default fallback div when there's no default one
     const fallback = this.doc_.createElement('div');
     fallback.setAttribute('fallback', '');
-    fallback.classList.add('amp-ad-default-display');
     fallback./*OK*/innerHTML = HOLDER_HTML;
 
     this.baseInstance_.element.appendChild(fallback);

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -20,9 +20,6 @@ import {UX_EXPERIMENT} from '../../../src/layout';
 
 const TAG = 'AmpAdUIHandler';
 
-/** @const */
-const HOLDER_HTML = `<div class='-amp-ad-default-holder'></div>`;
-
 /**
  * Ad display state.
  * @enum {number}
@@ -66,7 +63,7 @@ export class AmpAdUIHandler {
     this.doc_ = baseInstance.win.document;
 
     /** {number} */
-    this.state = AdDisplayState.NOT_LAID_OUT;;
+    this.state = AdDisplayState.NOT_LAID_OUT;
 
     /** {!boolean} */
     this.hasPageProvidedFallback_ = !!baseInstance.getFallback();
@@ -85,11 +82,7 @@ export class AmpAdUIHandler {
     }
 
     // Apply default fallback div when there's no default one
-    const fallback = this.doc_.createElement('div');
-    fallback.setAttribute('fallback', '');
-    fallback./*OK*/innerHTML = HOLDER_HTML;
-
-    this.baseInstance_.element.appendChild(fallback);
+    this.addDefaultUiComponent_('fallback');
   }
 
   /**
@@ -128,11 +121,7 @@ export class AmpAdUIHandler {
     if (!isExperimentOn(this.baseInstance_.win, UX_EXPERIMENT)) {
       return null;
     }
-    const placeholder = this.doc_.createElement('div');
-    placeholder.setAttribute('placeholder', '');
-    placeholder./*OK*/innerHTML = HOLDER_HTML;
-    this.baseInstance_.element.appendChild(placeholder);
-    return placeholder;
+    return this.addDefaultUiComponent_('placeholder');
   }
 
   /**
@@ -201,6 +190,23 @@ export class AmpAdUIHandler {
       this.baseInstance_.togglePlaceholder(true);
       this.baseInstance_.toggleFallback(false);
     });
+  }
+
+  /**
+   * @param {string} name
+   * @return {!Element}
+   * @private
+   */
+  addDefaultUiComponent_(name) {
+    const uiComponent = this.doc_.createElement('div');
+    uiComponent.setAttribute(name, '');
+
+    const content = this.doc_.createElement('div');
+    content.classList.add('-amp-ad-default-holder');
+    uiComponent.appendChild(content);
+
+    this.baseInstance_.element.appendChild(uiComponent);
+    return uiComponent;
   }
 }
 

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -33,12 +33,12 @@ amp-ad iframe {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(200, 200, 200, 0.3);
+  background-color: rgba(200, 200, 200, 0.5);
 }
 
 .-amp-ad-default-holder:after {
   content: "Ad";
-  background-color: #696969;
+  background-color: rgba(50, 50, 50, 0.7);
   border-radius: 2px;
   color: #fff;
   font-size: 16px;

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -24,10 +24,6 @@ amp-ad iframe {
   padding: 0 !important;
 }
 
-.amp-ad-default-display {
-  background-color: #f5f5f5;
-}
-
 .-amp-ad-default-holder {
   position: absolute;
   left: 0;
@@ -37,20 +33,16 @@ amp-ad iframe {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #f5f5f5;
+  background-color: rgba(200, 200, 200, 0.3);
 }
 
-.-amp-ad-tag {
-  /* TODO(zhouyx): Confirm on tag style */
+.-amp-ad-default-holder:after {
+  content: "Ad";
   background-color: #696969;
   border-radius: 2px;
   color: #fff;
-  display: inline-block;
-  padding: 0 2px;
-  height: 18px;
-  width: 23px;
-  text-align: center;
-  vertical-align: middle;
-  line-height: 18px;
   font-size: 16px;
+  line-height: 16px;
+  font-family: Arial, sans-serif;
+  padding: 2px 4px;
 }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -67,9 +67,7 @@ describe('amp-ad-ui handler', () => {
       uiHandler.init();
       uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
       return Promise.resolve().then(() => {
-        const holder = adImpl.element.querySelector('.amp-ad-default-display');
-        expect(holder).to.not.be.null;
-        expect(holder).to.have.attribute('fallback');
+        expect(adImpl.element.querySelector('[fallback]')).to.be.ok;
       });
     });
 


### PR DESCRIPTION
- Add opacity to ad placeholder background so that it's visible in both white and dark pages.
- Use CSS :after selector to display the ad logo, so that is easily overriddable by pub for i18n.
- Fix a CSS bug caused by hard coded width/height of the ad logo.

For #5918

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/8496897/22227830/4022b26c-e182-11e6-9253-6e43468be61f.gif)

_________________
**Contrast under different background colors:**

![image](https://cloud.githubusercontent.com/assets/8496897/22229027/031063bc-e18a-11e6-99d0-2b8a7a1b45a7.png)

![image](https://cloud.githubusercontent.com/assets/8496897/22229030/0627989a-e18a-11e6-9686-0b55f270074b.png)

![image](https://cloud.githubusercontent.com/assets/8496897/22229025/ffdc01d8-e189-11e6-8e47-44e1c7cb47b8.png)


![image](https://cloud.githubusercontent.com/assets/8496897/22229021/f450a7ce-e189-11e6-93da-ac4c05a0320d.png)
