### PR TITLE
Add code language for codeblocks so render correctly

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -103,7 +103,7 @@ Note that the set of bindable attributes will grow over time as development prog
 
 #### BNF-like grammar
 
-```
+```text
 expr:
     operation
   | invocation
@@ -182,7 +182,7 @@ key_value:
 
 #### Whitelisted functions
 
-```
+```text
 Array.concat
 Array.indexOf
 Array.join


### PR DESCRIPTION
Fixing issue - https://github.com/ampproject/docs/issues/301.
Codeblocks need a specified language otherwise they do not render correctly on ampproject.org.