### PR TITLE
Revert "Use max version on-demand loaded scripts in tests (#7110)"

### DIFF
--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -76,10 +76,7 @@ export function calculateEntryPointScriptUrl(location, entryPoint, isLocalDev,
  */
 function isMax(location) {
   const path = location.pathname;
-  //TODO(zhouyx, #6826): Remove as part of PR #6826
-  return path.indexOf('.max') >= 0 ||
-      path.substr(0, 5) == '/max/' ||
-      path.substr(0, 6) == '/test/'; // All test fixtures use max versions.
+  return path.indexOf('.max') >= 0 || path.substr(0, 5) == '/max/';
 }
 
 /**


### PR DESCRIPTION
This reverts commit bb2768b08c3ee1feaa22c0115ee9f4e3c026cb28.

#7110 was not the cause of failure and is actually wrong. gulp dist --fortesting rewrites those Urls to be the min version during integration tests anyway.