### PR TITLE
Apply opacity to the loading line.

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -349,7 +349,7 @@ i-amp-scroll-container.amp-active {
   position: absolute;
   width: 100%;
   height: 100% !important;
-  background-color: #979797;
+  background-color: rgba(0, 0, 0, 0.5);
   z-index: 2;
 }
 

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -38,7 +38,7 @@ amp-ad iframe {
 
 .-amp-ad-default-holder:after {
   content: "Ad";
-  background-color: rgba(50, 50, 50, 0.7);
+  background-color: rgba(0, 0, 0, 0.5);
   border-radius: 2px;
   color: #fff;
   font-size: 16px;


### PR DESCRIPTION
Tried `background-blend-mode`, it doesn't really make a difference for non-image background. 
#5918


![g9ykd8bpqsp](https://cloud.githubusercontent.com/assets/8496897/22271984/6c68b4aa-e24c-11e6-978f-3d99e8b4083b.png)

![6836omzyuip](https://cloud.githubusercontent.com/assets/8496897/22272019/906813fa-e24c-11e6-8ff4-3207e612bf63.png)

@abeck000 @jasti 