### PR TITLE
Element-level signals for lifecycle events

### DIFF
--- a/src/base-element.js
+++ b/src/base-element.js
@@ -866,4 +866,25 @@ export class BaseElement {
    * @public
    */
   onLayoutMeasure() {}
+
+  /**
+   * Triggers the signal with the specified name on the element. The time is
+   * optional; if not provided, the current time is used. The associated
+   * promise is resolved with the resulting time.
+   * @param {string} name
+   * @param {time=} opt_time
+   */
+  signal(name, opt_time) {
+    this.element.signal(name, opt_time);
+  }
+
+  /**
+   * Rejects the signal. Indicates that the signal will never succeed. The
+   * associated signal is rejected.
+   * @param {string} name
+   * @param {!Error} error
+   */
+  rejectSignal(name, error) {
+    this.element.rejectSignal(name, error);
+  }
 };

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -27,6 +27,7 @@ import {
   getIntersectionChangeEntry,
 } from '../src/intersection-observer-polyfill';
 import {getMode} from './mode';
+import {map} from './utils/object';
 import {parseSizeList} from './size-list';
 import {reportError} from './error';
 import {resourcesForDoc} from './resources';
@@ -58,6 +59,17 @@ const PREPARE_LOADING_THRESHOLD_ = 1000;
 
 
 /**
+ * @enum {number}
+ */
+const UpgradeState = {
+  NOT_UPGRADED: 1,
+  UPGRADED: 2,
+  UPGRADE_FAILED: 3,
+  UPGRADE_IN_PROGRESS: 4,
+};
+
+
+/**
  * Caches whether the template tag is supported to avoid memory allocations.
  * @type {boolean|undefined}
  */
@@ -74,17 +86,6 @@ function isTemplateTagSupported() {
   }
   return templateTagSupported;
 }
-
-
-/**
- * @enum {number}
- */
-const UpgradeState = {
-  NOT_UPGRADED: 1,
-  UPGRADED: 2,
-  UPGRADE_FAILED: 3,
-  UPGRADE_IN_PROGRESS: 4,
-};
 
 
 /**
@@ -541,6 +542,24 @@ function createBaseCustomElementClass(win) {
        * @private {boolean|undefined}
        */
       this.isInTemplate_ = undefined;
+
+      /**
+       * A mapping from a signal name to the signal response: either time or
+       * an error.
+       * @private @const {!Object<string, (time|!Error)>}
+       */
+      this.signalMap_ = map();
+
+      /**
+       * A mapping from a signal name to the signal promise, resolve and reject.
+       * Only allocated when promise has been requested.
+       * @private {?Object<string, {
+       *   promise: !Promise,
+       *   resolve: (function(time)|undefined),
+       *   reject: (function(!Error)|undefined)
+       * }>}
+       */
+      this.signalPromiseMap_ = null;
     }
 
     /**
@@ -659,6 +678,15 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * Returns the promise that's resolved when the element has been built. If
+     * the build fails, the resulting promise is rejected.
+     * @return {!Promise}
+     */
+    whenBuilt() {
+      return this.whenSignal('built');
+    }
+
+    /**
      * Get the priority to load the element.
      * @return {number} @this {!Element}
      */
@@ -688,7 +716,9 @@ function createBaseCustomElementClass(win) {
         this.built_ = true;
         this.classList.remove('i-amphtml-notbuilt');
         this.classList.remove('amp-notbuilt');
+        this.signal('built');
       } catch (e) {
+        this.rejectSignal('built', e);
         reportError(e, this);
         throw e;
       }
@@ -710,6 +740,98 @@ function createBaseCustomElementClass(win) {
         if (placeholder) {
           this.appendChild(placeholder);
         }
+      }
+    }
+
+    /**
+     * Returns the promise that's resolved when the signal is triggered. The
+     * resolved value is the time of the signal.
+     * @param {string} name
+     * @return {!Promise<time>}
+     */
+    whenSignal(name) {
+      let promiseStruct = this.signalPromiseMap_ &&
+          this.signalPromiseMap_[name];
+      if (!promiseStruct) {
+        const result = this.signalMap_[name];
+        if (result != null) {
+          // Immediately resolve signal.
+          const promise = typeof result == 'number' ?
+              Promise.resolve(result) :
+              Promise.reject(result);
+          promiseStruct = {promise};
+        } else {
+          // Allocate the promise/resolver for when the signal arrives in the
+          // future.
+          let resolve, reject;
+          const promise = new Promise((aResolve, aReject) => {
+            resolve = aResolve;
+            reject = aReject;
+          });
+          promiseStruct = {promise, resolve, reject};
+        }
+        if (!this.signalPromiseMap_) {
+          this.signalPromiseMap_ = map();
+        }
+        this.signalPromiseMap_[name] = promiseStruct;
+      }
+      return promiseStruct.promise;
+    }
+
+    /**
+     * Returns a promise that's resolved when both signals are triggered with
+     * the delta of time between them.
+     * @param {string} fromSignal
+     * @param {string} toSignal
+     * @return {!Promise<number>}
+     */
+    signalDelta(fromSignal, toSignal) {
+      const fromPromise = this.whenSignal(fromSignal);
+      const toPromise = this.whenSignal(toSignal);
+      return Promise.all([fromPromise, toPromise]).then(times => {
+        const fromValue = times[0];
+        const toValue = times[1];
+        return toValue - fromValue;
+      });
+    }
+
+    /**
+     * Triggers the signal with the specified name on the element. The time is
+     * optional; if not provided, the current time is used. The associated
+     * promise is resolved with the resulting time.
+     * @param {string} name
+     * @param {time=} opt_time
+     */
+    signal(name, opt_time) {
+      dev().assert(this.signalMap_[name] == null,
+          'Duplicate signal: %s', name);
+      const time = opt_time || Date.now();
+      this.signalMap_[name] = time;
+      const promiseStruct = this.signalPromiseMap_ &&
+          this.signalPromiseMap_[name];
+      if (promiseStruct && promiseStruct.resolve) {
+        promiseStruct.resolve(time);
+        promiseStruct.resolve = undefined;
+        promiseStruct.reject = undefined;
+      }
+    }
+
+    /**
+     * Rejects the signal. Indicates that the signal will never succeed. The
+     * associated signal is rejected.
+     * @param {string} name
+     * @param {!Error} error
+     */
+    rejectSignal(name, error) {
+      dev().assert(this.signalMap_[name] == null,
+          'Duplicate signal: %s', name);
+      this.signalMap_[name] = error;
+      const promiseStruct = this.signalPromiseMap_ &&
+          this.signalPromiseMap_[name];
+      if (promiseStruct && promiseStruct.reject) {
+        promiseStruct.reject(error);
+        promiseStruct.resolve = undefined;
+        promiseStruct.reject = undefined;
       }
     }
 
@@ -1124,10 +1246,17 @@ function createBaseCustomElementClass(win) {
       dev().assert(this.isBuilt(),
         'Must be built to receive viewport events');
       this.dispatchCustomEventForTesting('amp:load:start');
+      const isLoadEvent = (this.layoutCount_ == 0);  // First layout is "load".
+      if (isLoadEvent) {
+        this.signal('load-start');
+      }
       const promise = this.implementation_.layoutCallback();
       this.preconnect(/* onLayout */true);
       this.classList.add('i-amphtml-layout');
       return promise.then(() => {
+        if (isLoadEvent) {
+          this.signal('load-end');
+        }
         this.readyState = 'complete';
         this.layoutCount_++;
         this.toggleLoading_(false, /* cleanup */ true);
@@ -1140,6 +1269,9 @@ function createBaseCustomElementClass(win) {
         }
       }, reason => {
         // add layoutCount_ by 1 despite load fails or not
+        if (isLoadEvent) {
+          this.rejectSignal('load-end', reason);
+        }
         this.layoutCount_++;
         this.toggleLoading_(false, /* cleanup */ true);
         throw reason;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -803,8 +803,10 @@ function createBaseCustomElementClass(win) {
      * @param {time=} opt_time
      */
     signal(name, opt_time) {
-      dev().assert(this.signalMap_[name] == null,
-          'Duplicate signal: %s', name);
+      if (this.signalMap_[name] != null) {
+        // Do not duplicate signals.
+        return;
+      }
       const time = opt_time || Date.now();
       this.signalMap_[name] = time;
       const promiseStruct = this.signalPromiseMap_ &&
@@ -823,8 +825,10 @@ function createBaseCustomElementClass(win) {
      * @param {!Error} error
      */
     rejectSignal(name, error) {
-      dev().assert(this.signalMap_[name] == null,
-          'Duplicate signal: %s', name);
+      if (this.signalMap_[name] != null) {
+        // Do not duplicate signals.
+        return;
+      }
       this.signalMap_[name] = error;
       const promiseStruct = this.signalPromiseMap_ &&
           this.signalPromiseMap_[name];

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -464,12 +464,34 @@ describe('CustomElement', () => {
 
     expect(element.isBuilt()).to.equal(false);
     expect(testElementBuildCallback.callCount).to.equal(0);
+    expect(element.signalMap_['built']).to.not.be.ok;
 
+    clock.tick(1);
     element.build();
     expect(element.isBuilt()).to.equal(true);
     expect(element).to.not.have.class('i-amphtml-notbuilt');
     expect(element).to.not.have.class('amp-notbuilt');
     expect(testElementBuildCallback.callCount).to.equal(1);
+    expect(element.signalMap_['built']).to.equal(1);
+    return element.whenBuilt();  // Should eventually resolve.
+  });
+
+  it('should anticipate build errors', () => {
+    const element = new ElementClass();
+    element.tryUpgrade_();
+
+    sandbox.stub(element.implementation_, 'buildCallback', () => {
+      throw new Error('intentional');
+    });
+
+    expect(() => {
+      element.build();
+    }).to.throw(/intentional/);
+    expect(element.isBuilt()).to.be.false;
+    expect(element).to.not.have.class('i-amphtml-notbuilt');
+    expect(element).to.not.have.class('amp-notbuilt');
+    return expect(element.whenBuilt())
+        .to.be.eventually.rejectedWith(/intentional/);
   });
 
   it('Element - build creates a placeholder if one does not exist' , () => {
@@ -692,8 +714,11 @@ describe('CustomElement', () => {
     expect(testElementLayoutCallback.callCount).to.equal(1);
     expect(testElementPreconnectCallback.callCount).to.equal(2);
     expect(testElementPreconnectCallback.getCall(1).args[0]).to.be.true;
+    expect(element.signalMap_['load-start']).to.equal(1);
+    expect(element.signalMap_['load-end']).to.be.undefined;
     return p.then(() => {
       expect(element.readyState).to.equal('complete');
+      expect(element.signalMap_['load-end']).to.equal(1);
     });
   });
 
@@ -1225,6 +1250,124 @@ describe('CustomElement', () => {
       expect(() => {
         element.viewportCallback(true);
       }).to.throw(/Must never be called in template/);
+    });
+  });
+
+
+  describe('signals', () => {
+    let element;
+
+    beforeEach(() => {
+      element = new ElementClass();
+      clock.tick(1);
+    });
+
+    it('should register signal without promise', () => {
+      element.signal('sig');
+      expect(element.signalMap_['sig']).to.equal(1);
+      expect(element.signalPromiseMap_).to.be.null;
+    });
+
+    it('should reject signal without promise', () => {
+      const error = new Error();
+      element.rejectSignal('sig', error);
+      expect(element.signalMap_['sig']).to.equal(error);
+      expect(element.signalPromiseMap_).to.be.null;
+    });
+
+    it('should disallow duplicate signal', () => {
+      element.signal('sig');
+      expect(() => {
+        element.signal('sig');
+      }).to.throw(/Duplicate/);
+      expect(() => {
+        element.rejectSignal('sig', new Error());
+      }).to.throw(/Duplicate/);
+    });
+
+    it('should override signal time', () => {
+      element.signal('sig', 11);
+      expect(element.signalMap_['sig']).to.equal(11);
+      expect(element.signalPromiseMap_).to.be.null;
+    });
+
+    it('should resolve signal after it was requested', () => {
+      const promise = element.whenSignal('sig');
+      expect(element.signalPromiseMap_['sig'].promise).to.equal(promise);
+      expect(element.signalPromiseMap_['sig'].resolve).to.be.ok;
+      expect(element.signalPromiseMap_['sig'].reject).to.be.ok;
+      expect(element.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+      element.signal('sig', 11);
+      return promise.then(time => {
+        expect(time).to.equal(11);
+        expect(element.signalPromiseMap_['sig'].promise).to.equal(promise);
+        expect(element.signalPromiseMap_['sig'].resolve).to.be.undefined;
+        expect(element.signalPromiseMap_['sig'].reject).to.be.undefined;
+        expect(element.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+      });
+    });
+
+    it('should resolve signal before it was requested', () => {
+      element.signal('sig', 11);
+      const promise = element.whenSignal('sig');
+      expect(element.signalPromiseMap_['sig'].promise).to.equal(promise);
+      expect(element.signalPromiseMap_['sig'].resolve).to.be.undefined;
+      expect(element.signalPromiseMap_['sig'].reject).to.be.undefined;
+      expect(element.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+      return promise.then(time => {
+        expect(time).to.equal(11);
+        expect(element.signalPromiseMap_['sig'].promise).to.equal(promise);
+        expect(element.signalPromiseMap_['sig'].resolve).to.be.undefined;
+        expect(element.signalPromiseMap_['sig'].reject).to.be.undefined;
+        expect(element.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+      });
+    });
+
+    it('should reject signal after it was requested', () => {
+      const promise = element.whenSignal('sig');
+      expect(element.signalPromiseMap_['sig'].promise).to.equal(promise);
+      const error = new Error();
+      element.rejectSignal('sig', error);
+      return promise.then(() => {
+        throw new Error('should have failed');
+      }, reason => {
+        expect(reason).to.equal(error);
+        expect(element.signalPromiseMap_['sig'].promise).to.equal(promise);
+        expect(element.signalPromiseMap_['sig'].resolve).to.be.undefined;
+        expect(element.signalPromiseMap_['sig'].reject).to.be.undefined;
+        expect(element.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+      });
+    });
+
+    it('should reject signal before it was requested', () => {
+      const error = new Error();
+      element.rejectSignal('sig', error);
+      const promise = element.whenSignal('sig');
+      expect(element.signalPromiseMap_['sig'].promise).to.equal(promise);
+      return promise.then(() => {
+        throw new Error('should have failed');
+      }, reason => {
+        expect(reason).to.equal(error);
+        expect(element.signalPromiseMap_['sig'].promise).to.equal(promise);
+        expect(element.signalPromiseMap_['sig'].resolve).to.be.undefined;
+        expect(element.signalPromiseMap_['sig'].reject).to.be.undefined;
+        expect(element.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+      });
+    });
+
+    it('should wait for two signal to calculate delta', () => {
+      const promise = element.signalDelta('sig1', 'sig2');
+      element.signal('sig1', 11);
+      element.signal('sig2', 21);
+      return expect(promise).to.eventually.equal(10);
+    });
+
+    it('should fail to calculate delta if one signal fails', () => {
+      const error = new Error();
+      const promise = element.signalDelta('sig1', 'sig2');
+      element.signal('sig1', 11);
+      element.rejectSignal('sig2', error);
+      return expect(promise).to.eventually.be.rejectedWith(error);
     });
   });
 });

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1275,14 +1275,15 @@ describe('CustomElement', () => {
       expect(element.signalPromiseMap_).to.be.null;
     });
 
-    it('should disallow duplicate signal', () => {
-      element.signal('sig');
-      expect(() => {
-        element.signal('sig');
-      }).to.throw(/Duplicate/);
-      expect(() => {
-        element.rejectSignal('sig', new Error());
-      }).to.throw(/Duplicate/);
+    it('should not duplicate signal', () => {
+      element.signal('sig', 11);
+      expect(element.signalMap_['sig']).to.equal(11);
+
+      element.signal('sig', 12);
+      expect(element.signalMap_['sig']).to.equal(11);  // Did not change.
+
+      element.rejectSignal('sig', new Error());
+      expect(element.signalMap_['sig']).to.equal(11);  // Did not change.
     });
 
     it('should override signal time', () => {


### PR DESCRIPTION
We have more and more use cases that need major lifecycle signals produced by standard AMP element and extensions. We can implement each separately, but there are some issues:
 1. Most of signals will not be used. Thus we want minimal CPU/memory until they are requested.
 2. Most of life-cycle events can be split into two signals: start and end.
 3. Individual code is a mess: it needs time, error, promise, resolver and rejector for all needs.

This PR:
 1. Creates a minimally filled struct per signal and adds three methods to support it: `whenSignal`, `signal` and `rejectSignal`. 
 2. The initial set of signals demonstrated here is small, but extensions can supply their own. That's why these methods are public.
 3. `signal` is the only "always use" method and thus it fills it only minimal parts of the struct and does minimal work. The rest is done lazily.
 4. `whenBuilt` is an example of API-level usage. Some lifecycle signals can be easily exposed via special API. This is currently in work for another PR. (/cc @mkhatib #7190)
 5. `signalDelta` is an example of how many metrics can be calculated between two signals. This will be (already is) very common in many analytics needs.
