### PR TITLE
Add URL rewriting and `srcset` support to amp-bind

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -37,8 +37,10 @@ exports.rules = [
   {
     filesMatching: '**/*.js',
     mustNotDependOn: 'src/sanitizer.js',
-    whitelist: 'extensions/amp-mustache/0.1/amp-mustache.js->' +
-        'src/sanitizer.js',
+    whitelist: [
+      'extensions/amp-mustache/0.1/amp-mustache.js->src/sanitizer.js',
+      'extensions/amp-bind/0.1/bind-evaluator.js->src/sanitizer.js',
+    ],
   },
   {
     filesMatching: '**/*.js',

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -261,6 +261,7 @@ function compile(entryModuleFilenames, outputDir,
         jscomp_off: ['unknownDefines'],
         define: [],
         hide_warnings_for: [
+          'third_party/caja/',
           'third_party/closure-library/sha384-generated.js',
           'third_party/d3/',
           'third_party/vega/',

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -16,6 +16,7 @@
 
 import {BindExpression} from './bind-expression';
 import {BindValidator} from './bind-validator';
+import {rewriteAttributeValue} from '../../../src/sanitizer';
 import {user} from '../../../src/log';
 
 const TAG = 'AMP-BIND';
@@ -107,7 +108,10 @@ export class BindEvaluator {
 
         const resultString = this.stringValueOf_(property, result);
         if (this.validator_.isResultValid(tagName, property, resultString)) {
-          cache[expr] = result;
+          // Rewrite URL attributes for CDN if necessary.
+          cache[expr] = typeof result === 'string'
+              ? rewriteAttributeValue(tagName, property, result)
+              : result;
         } else {
           invalid[expr] = true;
         }

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -250,9 +250,6 @@ function createElementRules_() {
         },
         blockedURLs: ['__amp_source_origin'],
       },
-      srcset: {
-        alternativeName: 'src',
-      },
     },
     A: {
       href: {

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -227,24 +227,6 @@ describe('BindValidator', () => {
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
       expect(val.isResultValid(
           'AMP-VIDEO', 'src', '__amp_source_origin')).to.be.false;
-
-      // srcset
-      expect(val.isResultValid(
-          'AMP-VIDEO',
-          'srcset',
-          'https://a.com/b.mp4 1x, https://c.com/d.mp4 2x')).to.be.true;
-      expect(val.isResultValid(
-          'AMP-VIDEO',
-          'srcset',
-          'https://a.com/b.mp4 1x, http://c.com/d.mp4 2x')).to.be.false;
-      expect(val.isResultValid(
-          'AMP-VIDEO',
-          'srcset',
-          'https://a.com/b.mp4 1x, __amp_source_origin 2x')).to.be.false;
-      expect(val.isResultValid(
-          'AMP-VIDEO',
-          'srcset',
-          /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
     });
   });
 });

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -186,12 +186,27 @@ describe('BindValidator', () => {
       expect(val.canBind('AMP-IMG', 'width')).to.be.true;
       expect(val.canBind('AMP-IMG', 'height')).to.be.true;
 
+      // src
       expect(val.isResultValid(
           'AMP-IMG', 'src', 'http://foo.com/bar.jpg')).to.be.true;
       expect(val.isResultValid('AMP-IMG', 'src',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
       expect(val.isResultValid(
           'AMP-IMG', 'src', '__amp_source_origin')).to.be.false;
+
+      // srcset
+      expect(val.isResultValid(
+          'AMP-IMG',
+          'srcset',
+          'http://a.com/b.jpg 1x, http://c.com/d.jpg 2x')).to.be.true;
+      expect(val.isResultValid(
+          'AMP-IMG',
+          'srcset',
+          'http://a.com/b.jpg 1x, __amp_source_origin 2x')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-IMG',
+          'srcset',
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
     });
 
     it('should support <amp-selector>', () => {
@@ -203,6 +218,7 @@ describe('BindValidator', () => {
       expect(val.canBind('AMP-VIDEO', 'poster')).to.be.true;
       expect(val.canBind('AMP-VIDEO', 'src')).to.be.true;
 
+      // src
       expect(val.isResultValid(
           'AMP-VIDEO', 'src', 'https://foo.com/bar.mp4')).to.be.true;
       expect(val.isResultValid(
@@ -211,6 +227,24 @@ describe('BindValidator', () => {
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
       expect(val.isResultValid(
           'AMP-VIDEO', 'src', '__amp_source_origin')).to.be.false;
+
+      // srcset
+      expect(val.isResultValid(
+          'AMP-VIDEO',
+          'srcset',
+          'https://a.com/b.mp4 1x, https://c.com/d.mp4 2x')).to.be.true;
+      expect(val.isResultValid(
+          'AMP-VIDEO',
+          'srcset',
+          'https://a.com/b.mp4 1x, http://c.com/d.mp4 2x')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-VIDEO',
+          'srcset',
+          'https://a.com/b.mp4 1x, __amp_source_origin 2x')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-VIDEO',
+          'srcset',
+          /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
     });
   });
 });

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -254,7 +254,7 @@ export function sanitizeHtml(html) {
         emit(attrName);
         emit('="');
         if (attrValue) {
-          emit(htmlSanitizer.escapeAttrib(resolveAttrValue(
+          emit(htmlSanitizer.escapeAttrib(rewriteAttributeValue(
               tagName, attrName, attrValue)));
         }
         emit('"');
@@ -350,14 +350,15 @@ export function isValidAttr(tagName, attrName, attrValue) {
 }
 
 /**
- * Resolves the attribute value. The main purpose is to rewrite URLs as
- * described in `resolveUrlAttr`.
+ * If (tagName, attrName) is a CDN-rewritable URL attribute, returns the
+ * rewritten URL value. Otherwise, returns the unchanged `attrValue`.
+ * @see resolveUrlAttr for rewriting rules.
  * @param {string} tagName
  * @param {string} attrName
  * @param {string} attrValue
  * @return {string}
  */
-function resolveAttrValue(tagName, attrName, attrValue) {
+export function rewriteAttributeValue(tagName, attrName, attrValue) {
   if (attrName == 'src' || attrName == 'href' || attrName == 'srcset') {
     return resolveUrlAttr(tagName, attrName, attrValue, self.location);
   }


### PR DESCRIPTION
Partial for #6199.

- Rewrite image URLs on CDN-served AMP pages
- Support `srcset` attribute in `BindValidator`