### PR TITLE
Adding sub-anchor support to <amp-auto-ads>

### DIFF
--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -16,7 +16,10 @@
 
 import {dev} from '../../../src/log';
 import {resourcesForDoc} from '../../../src/resources';
-import {createElementWithAttributes} from '../../../src/dom';
+import {
+  createElementWithAttributes,
+  scopedQuerySelectorAll,
+} from '../../../src/dom';
 
 /** @const */
 const TAG = 'amp-auto-ads';
@@ -216,12 +219,9 @@ export function getPlacementsFromConfigObj(win, configObj) {
     return [];
   }
   const placements = [];
-  for (let i = 0; i < placementObjs.length; ++i) {
-    const placement = getPlacementFromObject(win, placementObjs[i]);
-    if (placement) {
-      placements.push(placement);
-    }
-  }
+  placementObjs.forEach(placementObj => {
+    getPlacementsFromObject(win, placementObj, placements);
+  });
   return placements;
 }
 
@@ -230,29 +230,24 @@ export function getPlacementsFromConfigObj(win, configObj) {
  * constructs and returns an instance of the Placement class for it.
  * @param {!Window} win
  * @param {!Object} placementObj
- * @return {?Placement}
+ * @param {!Array<!Placement>} placements
  */
-function getPlacementFromObject(win, placementObj) {
+function getPlacementsFromObject(win, placementObj, placements) {
   const injector = INJECTORS[placementObj['pos']];
   if (!injector) {
     dev().warn(TAG, 'No injector for position');
-    return null;
+    return;
   }
   const anchor = placementObj['anchor'];
   if (!anchor) {
     dev().warn(TAG, 'No anchor in placement');
-    return null;
+    return;
   }
-  const anchorElement = getAnchorElement(win, anchor);
-  if (!anchorElement) {
+  const anchorElements =
+      getAnchorElements(win.document.documentElement, anchor);
+  if (!anchorElements.length) {
     dev().warn(TAG, 'No anchor element found');
-    return null;
-  }
-  if ((placementObj['pos'] == Position.BEFORE ||
-       placementObj['pos'] == Position.AFTER) &&
-      !anchorElement.parentNode) {
-    dev().warn(TAG, 'Parentless anchor with BEFORE/AFTER position.');
-    return null;
+    return;
   }
   let margins = undefined;
   if (placementObj['style']) {
@@ -265,24 +260,55 @@ function getPlacementFromObject(win, placementObj) {
       };
     }
   }
-  return new Placement(win, resourcesForDoc(anchorElement), anchorElement,
-      placementObj['pos'], injector, margins);
+  anchorElements.forEach(anchorElement => {
+    if ((placementObj['pos'] == Position.BEFORE ||
+         placementObj['pos'] == Position.AFTER) &&
+        !anchorElement.parentNode) {
+      dev().warn(TAG, 'Parentless anchor with BEFORE/AFTER position.');
+      return;
+    }
+    placements.push(new Placement(win, resourcesForDoc(anchorElement),
+        anchorElement, placementObj['pos'], injector, margins));
+  });
 }
 
 /**
- * @param {!Window} win
+ * Looks up the element(s) addresses by the anchorObj.
+ *
+ * @param {!Element} rootElement
  * @param {!Object} anchorObj
- * @return {?Element}
+ * @return {!Array<!Element>}
  */
-function getAnchorElement(win, anchorObj) {
+function getAnchorElements(rootElement, anchorObj) {
   const selector = anchorObj['selector'];
   if (!selector) {
     dev().warn(TAG, 'No selector in anchor');
-    return null;
+    return [];
   }
-  const index = anchorObj['index'] || 0;
-  if (index == 0) {
-    return win.document.querySelector(selector);
+  let elements = [].slice.call(scopedQuerySelectorAll(rootElement, selector));
+
+  const minChars = anchorObj['min_c'] || 0;
+  if (minChars > 0) {
+    elements = elements.filter(el => {
+      return el.textContent.length >= minChars;
+    });
   }
-  return win.document.querySelectorAll(selector)[index] || null;
+
+  if (typeof anchorObj['index'] == 'number' || !anchorObj['all']) {
+    const element = elements[anchorObj['index'] || 0];
+    elements = element ? [element] : [];
+  }
+
+  if (elements.length == 0) {
+    return [];
+  }
+
+  if (anchorObj['sub']) {
+    let subElements = [];
+    elements.forEach(el => {
+      subElements = subElements.concat(getAnchorElements(el, anchorObj['sub']));
+    });
+    return subElements;
+  }
+  return elements;
 }

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -696,5 +696,392 @@ describe('placement', () => {
           });
           expect(placements).to.be.empty;
         });
+
+    it('should get a placement for the 2nd anchor with class name', () => {
+      const anchor1 = document.createElement('div');
+      anchor1.className = 'aClass';
+      container.appendChild(anchor1);
+
+      const anchor2 = document.createElement('div');
+      anchor2.className = 'aClass';
+      container.appendChild(anchor2);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV.aClass',
+              index: 1,
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      expect(placements[0].anchorElement_).to.eql(anchor2);
+    });
+
+    it('should get a placement for all the anchors with class name', () => {
+      const anchor1 = document.createElement('div');
+      anchor1.className = 'aClass';
+      container.appendChild(anchor1);
+
+      const anchor2 = document.createElement('div');
+      anchor2.className = 'aClass';
+      container.appendChild(anchor2);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV.aClass',
+              all: true,
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(2);
+
+      expect(placements[0].anchorElement_).to.eql(anchor1);
+      expect(placements[1].anchorElement_).to.eql(anchor2);
+    });
+
+    it('should get a placement for the 2nd anchor with class name when ' +
+        'index and all both specified.', () => {
+      const anchor1 = document.createElement('div');
+      anchor1.className = 'aClass';
+      container.appendChild(anchor1);
+
+      const anchor2 = document.createElement('div');
+      anchor2.className = 'aClass';
+      container.appendChild(anchor2);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV.aClass',
+              index: 0,
+              all: true,
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      expect(placements[0].anchorElement_).to.eql(anchor1);
+    });
+
+    it('should only get placement for element with sufficient textContent',
+        () => {
+          const nonAnchor = document.createElement('div');
+          nonAnchor.className = 'class1';
+          container.appendChild(nonAnchor);
+          nonAnchor.appendChild(document.createTextNode('abc'));
+
+          const anchor = document.createElement('div');
+          anchor.className = 'class1';
+          container.appendChild(anchor);
+          anchor.appendChild(document.createTextNode('abcd'));
+
+          const placements = getPlacementsFromConfigObj(window, {
+            placements: [
+              {
+                anchor: {
+                  selector: '.class1',
+                  'min_c': 4,
+                },
+                pos: 1,
+                type: 1,
+              },
+            ],
+          });
+          expect(placements).to.have.lengthOf(1);
+          expect(placements[0].anchorElement_).to.eql(anchor);
+        });
+  });
+
+  describe('getPlacementsFromConfigObj, sub-anchors', () => {
+    it('should get placements using the sub anchor', () => {
+      const nonAnchor = document.createElement('div');
+      nonAnchor.id = 'anId';
+      container.appendChild(nonAnchor);
+
+      const nonSubAnchor1 = document.createElement('div');
+      nonSubAnchor1.className = 'sub-class';
+      nonAnchor.appendChild(nonSubAnchor1);
+
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const subAnchor1 = document.createElement('div');
+      subAnchor1.className = 'sub-class';
+      anchor.appendChild(subAnchor1);
+
+      const nonSubAnchor2 = document.createElement('div');
+      nonSubAnchor2.className = 'non-sub-class';
+      anchor.appendChild(nonSubAnchor2);
+
+      const subAnchor2 = document.createElement('div');
+      subAnchor2.className = 'sub-class';
+      anchor.appendChild(subAnchor2);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+              index: 1,
+              sub: {
+                selector: '.sub-class',
+                all: true,
+              },
+            },
+            pos: 1,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(2);
+      expect(placements[0].anchorElement_).to.eql(subAnchor1);
+      expect(placements[1].anchorElement_).to.eql(subAnchor2);
+    });
+
+    it('should get placement only for anchor indexed in sub-anchor', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const subAnchor1 = document.createElement('div');
+      subAnchor1.className = 'sub-class';
+      anchor.appendChild(subAnchor1);
+
+      const subAnchor2 = document.createElement('div');
+      subAnchor2.className = 'sub-class';
+      anchor.appendChild(subAnchor2);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+              sub: {
+                selector: '.sub-class',
+                index: 1,
+              },
+            },
+            pos: 1,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+      expect(placements[0].anchorElement_).to.eql(subAnchor2);
+    });
+
+    it('should get placements using recursive sub anchors', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const subAnchor1 = document.createElement('div');
+      subAnchor1.className = 'sub-class1';
+      anchor.appendChild(subAnchor1);
+
+      const subSubAnchor1 = document.createElement('div');
+      subSubAnchor1.className = 'sub-class2';
+      subAnchor1.appendChild(subSubAnchor1);
+
+      const nonSubSubAnchor = document.createElement('div');
+      nonSubSubAnchor.className = 'sub-class3';
+      subAnchor1.appendChild(nonSubSubAnchor);
+
+      const subAnchor2 = document.createElement('div');
+      subAnchor2.className = 'sub-class1';
+      anchor.appendChild(subAnchor2);
+
+      const subSubAnchor2 = document.createElement('div');
+      subSubAnchor2.className = 'sub-class2';
+      subAnchor2.appendChild(subSubAnchor2);
+
+      const nonSubAnchor = document.createElement('div');
+      nonSubAnchor.className = 'sub-class1';
+      anchor.appendChild(nonSubAnchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+              sub: {
+                selector: '.sub-class1',
+                all: true,
+                sub: {
+                  selector: '.sub-class2',
+                  all: true,
+                },
+              },
+            },
+            pos: 1,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(2);
+      expect(placements[0].anchorElement_).to.eql(subSubAnchor1);
+      expect(placements[1].anchorElement_).to.eql(subSubAnchor2);
+    });
+
+    it('should not return placement when no element matches sub anchor', () => {
+      const nonAnchor = document.createElement('div');
+      nonAnchor.id = 'anId';
+      container.appendChild(nonAnchor);
+
+      const nonSubAnchor1 = document.createElement('div');
+      nonSubAnchor1.className = 'sub-class';
+      nonAnchor.appendChild(nonSubAnchor1);
+
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const nonSubAnchor2 = document.createElement('div');
+      nonSubAnchor2.className = 'non-sub-class';
+      anchor.appendChild(nonSubAnchor2);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+              index: 1,
+              sub: {
+                selector: '.sub-class',
+              },
+            },
+            pos: 1,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(0);
+    });
+
+    it('sub anchor query selector matching should be scoped to within parent ' +
+        'anchor element', () => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'class1';
+      container.appendChild(wrapper);
+
+      const anchor = document.createElement('div');
+      anchor.className = 'class2';
+      wrapper.appendChild(anchor);
+
+      const subAnchor = document.createElement('div');
+      subAnchor.className = 'class3';
+      anchor.appendChild(subAnchor);
+
+      const placements = getPlacementsFromConfigObj(window, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV.class2',
+              sub: {
+                selector: 'DIV.class1 DIV.class3',
+                all: true,
+              },
+            },
+            pos: 1,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(0);
+    });
+
+    it('should only get placements for elements with sufficient textContent',
+        () => {
+          const anchor = document.createElement('div');
+          anchor.id = 'anId';
+          container.appendChild(anchor);
+
+          const subAnchor1 = document.createElement('div');
+          subAnchor1.className = 'sub-class';
+          anchor.appendChild(subAnchor1);
+          subAnchor1.appendChild(document.createTextNode('abc'));
+
+          const subAnchor2 = document.createElement('div');
+          subAnchor2.className = 'sub-class';
+          anchor.appendChild(subAnchor2);
+          subAnchor2.appendChild(document.createTextNode('abcd'));
+
+          const subAnchor3 = document.createElement('div');
+          subAnchor3.className = 'sub-class';
+          anchor.appendChild(subAnchor3);
+          subAnchor3.appendChild(document.createTextNode('abcd'));
+
+          const placements = getPlacementsFromConfigObj(window, {
+            placements: [
+              {
+                anchor: {
+                  selector: 'DIV#anId',
+                  sub: {
+                    selector: '.sub-class',
+                    'min_c': 4,
+                    all: true,
+                  },
+                },
+                pos: 1,
+                type: 1,
+              },
+            ],
+          });
+          expect(placements).to.have.lengthOf(2);
+          expect(placements[0].anchorElement_).to.eql(subAnchor2);
+          expect(placements[1].anchorElement_).to.eql(subAnchor3);
+        });
+
+    it('should only get placement for element with sufficient textContent',
+        () => {
+          const anchor = document.createElement('div');
+          anchor.id = 'anId';
+          container.appendChild(anchor);
+
+          const subAnchor1 = document.createElement('div');
+          subAnchor1.className = 'sub-class';
+          anchor.appendChild(subAnchor1);
+          subAnchor1.appendChild(document.createTextNode('abc'));
+
+          const subAnchor2 = document.createElement('div');
+          subAnchor2.className = 'sub-class';
+          anchor.appendChild(subAnchor2);
+          subAnchor2.appendChild(document.createTextNode('abcd'));
+
+          const placements = getPlacementsFromConfigObj(window, {
+            placements: [
+              {
+                anchor: {
+                  selector: 'DIV#anId',
+                  sub: {
+                    selector: '.sub-class',
+                    'min_c': 4,
+                    index: 0,
+                  },
+                },
+                pos: 1,
+                type: 1,
+              },
+            ],
+          });
+          expect(placements).to.have.lengthOf(1);
+          expect(placements[0].anchorElement_).to.eql(subAnchor2);
+        });
   });
 });


### PR DESCRIPTION
Adds sub-anchor support to placement.js in amp-auto-ads.

The point in sub-anchors is to allow placements to be generated from anchors that appear in variable numbers on a page. The main usage case for this is paragraphs within the main content area of a page.

E.g. a page has:
```html
<div class='main-content'>
  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
</div>
```

The ad network can supply a config with the following placementObj:
```json
{
  "anchor": {
    "selector": "DIV.main-content",
    "sub": {
      "selector": "P"
    },
  },
  "pos": 1
}
```
This will generate a placement for a position before each `<P>` element within main-content.

The reason not to just wrap this all into one query selector e.g. "DIV.main-content>P", is that the primary anchor selector might not be unique on the page, requiring the use of an index. For example it maybe be necessary to do:
```json
  "anchor": {
    "selector": "DIV.non-unique-class",
    "index": 1,
    "sub": {
      "selector": "P"
    }
  }
```
Which cannot be achieved with a single query selector.

Also supports filtering sub-anchors based on how much text they contain as this allows, for example, `<P>` elements containing very little text to be ignored.

https://github.com/ampproject/amphtml/issues/6196