### PR TITLE
Remove 'experimental' from docs for custom validation as it's now launched

### DIFF
--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -23,12 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>Stable with the following Experimental features:
-       <ul>
-          <li><a href="#custom-validations">Custom Validation</a></li>
-          <li><a href="#variable-substitutions">Variable Substitutions</a></li>
-       </ul>
-    </td>
+    <td>Stable with the following Experimental feature: <a href="#variable-substitutions">Variable Substitutions</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -108,7 +103,7 @@ See [Security Considerations](#security-considerations) for notes on how to secu
 
 All other [form attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) are optional.
 
-**custom-validation-reporting** (optional) (experimental)
+**custom-validation-reporting** (optional) 
 
 Enables and selects a custom validation reporting strategy, valid values are one of: `show-first-on-submit`, `show-all-on-submit` or `as-you-go`.
 
@@ -267,13 +262,14 @@ See the [full example here](../../examples/forms.amp.html) on using these.
 
 ## Custom Validations
 
-**<a href="https://www.ampproject.org/docs/reference/experimental.html">experimental</a>**
+The `amp-form` extension allows you to build your own custom validation UI by using the `custom-validation-reporting` attribute along with one the following reporting strategies: `show-first-on-submit`, `show-all-on-submit` or `as-you-go`.
 
-`amp-form` provides a way for you to build your own custom validation UI with few validation reporting strategies available to choose from `show-first-on-submit`, `show-all-on-submit` or `as-you-go`.
+To specify custom validation on your form:
 
-The general usage of this is you first set `custom-validation-reporting` attribute on your `form` to one of the validation reporting strategies and then provide your own validation UI marked up with special attributes, AMP will discover these and report them at the right time depending on the strategy selected.
+1. Set the `custom-validation-reporting` attribute on your `form` to one of the [validation reporting strategies](#reporting-strategies).
+2. Provide your own validation UI marked up with special attributes. AMP will discover the special attributes and report them at the right time depending on the reporting strategy you specified.
 
-Here's an example (for more examples, see [examples/forms.amp.html](../../examples/forms.amp.html)):
+Here's an example:
 ```html
 <h4>Show All Invalid Messages On Submit</h4>
 <form method="post"
@@ -299,18 +295,22 @@ Here's an example (for more examples, see [examples/forms.amp.html](../../exampl
   </fieldset>
 </form>
 ```
+For more examples, see [examples/forms.amp.html](../../examples/forms.amp.html).
 
-For validation messages, if your element contains no text content inside, AMP will fill it out with the browser's default validation message. In the example above, when `name5` input is empty and validation kicked off (i.e. user tried to submit the form) AMP will fill `<span visible-when-invalid="valueMissing" validation-for="name5"></span>` with the browser validation message and show that `span` to the user.
+For validation messages, if your element contains no text content inside, AMP will fill it out with the browser's default validation message. In the example above, when the `name5` input is empty and validation is kicked off (i.e., user tried to submit the form) AMP will fill `<span visible-when-invalid="valueMissing" validation-for="name5"></span>` with the browser's validation message and show that `span` to the user.
 
 ### Reporting Strategies
+
+Specify one of the following reporting options for the `custom-validation-reporting` attribute: 
+
 #### Show First on Submit
-This mimics the browser default behavior when default validation kicks in. It shows the first validation error it finds and stops there.
+The `show-first-on-submit` reporting option mimics the browser's default behavior when default validation kicks in. It shows the first validation error it finds and stops there.
 
 #### Show All on Submit
-This shows all validation errors on all invalid inputs when the form is submitted. This is useful if you'd like to show a summary of validations for example.
+The `show-all-on-submit` reporting option shows all validation errors on all invalid inputs when the form is submitted. This is useful if you'd like to show a summary of validations.
 
 #### As You Go
-This allows your user to see validation messages as they're interacting with the input, if the email they typed is invalid they'll see the error right away and once fixed the error goes away.
+The `as-you-go` reporting option allows your user to see validation messages as they're interacting with the input. For example, if the user types an invalid email address, the user will see the error right away.  Once they correct the value, the error goes away.
 
 ## Variable Substitutions
 __(<a href="https://www.ampproject.org/docs/reference/experimental.html">experimental</a>)__


### PR DESCRIPTION
amp-form custom validation is now launched, so remove "experimental" from associated docs.
Fixes #7186 
