### PR TITLE
Reduce URL entropy for preconnect polyfill.

### DIFF
--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -137,6 +137,7 @@ describe('preconnect', () => {
   it('should preconnect with polyfill', () => {
     isSafari = true;
     return getPreconnectIframe().then(iframe => {
+      clock.tick(1485531293690);
       const open = sandbox.spy(XMLHttpRequest.prototype, 'open');
       const send = sandbox.spy(XMLHttpRequest.prototype, 'send');
       preconnect.url('https://s.preconnect.com/foo/bar');
@@ -156,9 +157,10 @@ describe('preconnect', () => {
       return visible.then(() => {
         expect(open.callCount).to.equal(1);
         expect(send.callCount).to.equal(1);
-        expect(open.args[0][1]).to.include(
+        expect(open.args[0][1]).to.equal(
             'https://s.preconnect.com/amp_preconnect_polyfill_404_or' +
-            '_other_error_expected._Do_not_worry_about_it');
+            '_other_error_expected._Do_not_worry_about_it' +
+            '?1485531180000');
       });
     });
   });


### PR DESCRIPTION
A single AMP page would already only connect to a given origin once ever 180 seconds. With this change the URL for doing this will not change within that time interval. That means that all AMP pages that run on computers with roughly correct clocks will request the same URL within a 180 seconds interval, which should make it easier for CDNs to respond efficiently.