### PR TITLE
Extract signals into its own class

### DIFF
--- a/src/base-element.js
+++ b/src/base-element.js
@@ -153,6 +153,14 @@ export class BaseElement {
   }
 
   /**
+   * The element's signal tracker.
+   * @return {!./utils/signals.Signals}
+   */
+  signals() {
+    return this.element.signals();
+  }
+
+  /**
   * This is the priority of loading elements (layoutCallback).
   * The lower the number, the higher the priority.
   * The default priority for base elements is 0.
@@ -866,25 +874,4 @@ export class BaseElement {
    * @public
    */
   onLayoutMeasure() {}
-
-  /**
-   * Triggers the signal with the specified name on the element. The time is
-   * optional; if not provided, the current time is used. The associated
-   * promise is resolved with the resulting time.
-   * @param {string} name
-   * @param {time=} opt_time
-   */
-  signal(name, opt_time) {
-    this.element.signal(name, opt_time);
-  }
-
-  /**
-   * Rejects the signal. Indicates that the signal will never succeed. The
-   * associated signal is rejected.
-   * @param {string} name
-   * @param {!Error} error
-   */
-  rejectSignal(name, error) {
-    this.element.rejectSignal(name, error);
-  }
-};
+}

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -15,6 +15,7 @@
  */
 
 import {Observable} from './observable';
+import {Signals} from './utils/signals';
 import {dev, rethrowAsync} from './log';
 import {disposeServicesForEmbed, getTopWindow} from './service';
 import {escapeHtml} from './dom';
@@ -321,6 +322,9 @@ export class FriendlyIframeEmbed {
 
     /** @private {!Observable<boolean>} */
     this.visibilityObservable_ = new Observable();
+
+    /** @private @const */
+    this.signals_ = new Signals();
   }
 
   /**
@@ -329,6 +333,11 @@ export class FriendlyIframeEmbed {
   destroy() {
     resourcesForDoc(this.iframe).removeForChildWindow(this.win);
     disposeServicesForEmbed(this.win);
+  }
+
+  /** @return {!Signals} */
+  signals() {
+    return this.signals_;
   }
 
   /**

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Signals} from '../utils/signals';
 import {dev} from '../log';
 import {
   getParentWindowFrameElement,
@@ -183,6 +184,9 @@ export class AmpDoc {
   constructor(win) {
     /** @public @const {!Window} */
     this.win = win;
+
+    /** @private @const */
+    this.signals_ = new Signals();
   }
 
   /**
@@ -201,6 +205,11 @@ export class AmpDoc {
    */
   getWin() {
     return this.win;
+  }
+
+  /** @return {!Signals} */
+  signals() {
+    return this.signals_;
   }
 
   /**

--- a/src/utils/signals.js
+++ b/src/utils/signals.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {map} from './object';
+
+
+/**
+ * This object tracts signals and allows blocking until a signal has been
+ * received.
+ */
+export class Signals {
+
+  constructor() {
+    /**
+     * A mapping from a signal name to the signal response: either time or
+     * an error.
+     * @private @const {!Object<string, (time|!Error)>}
+     */
+    this.map_ = map();
+
+    /**
+     * A mapping from a signal name to the signal promise, resolve and reject.
+     * Only allocated when promise has been requested.
+     * @private {?Object<string, {
+     *   promise: !Promise,
+     *   resolve: (function(time)|undefined),
+     *   reject: (function(!Error)|undefined)
+     * }>}
+     */
+    this.promiseMap_ = null;
+  }
+
+  /**
+   * Returns the current known value of the signal. If signal is not yet
+   * available, `null` is returned.
+   * @param {string} name
+   * @return {number|!Error|null}
+   */
+  get(name) {
+    return this.map_[name] || null;
+  }
+
+  /**
+   * Returns the promise that's resolved when the signal is triggered. The
+   * resolved value is the time of the signal.
+   * @param {string} name
+   * @return {!Promise<time>}
+   */
+  whenSignal(name) {
+    let promiseStruct = this.promiseMap_ && this.promiseMap_[name];
+    if (!promiseStruct) {
+      const result = this.map_[name];
+      if (result != null) {
+        // Immediately resolve signal.
+        const promise = typeof result == 'number' ?
+            Promise.resolve(result) :
+            Promise.reject(result);
+        promiseStruct = {promise};
+      } else {
+        // Allocate the promise/resolver for when the signal arrives in the
+        // future.
+        let resolve, reject;
+        const promise = new Promise((aResolve, aReject) => {
+          resolve = aResolve;
+          reject = aReject;
+        });
+        promiseStruct = {promise, resolve, reject};
+      }
+      if (!this.promiseMap_) {
+        this.promiseMap_ = map();
+      }
+      this.promiseMap_[name] = promiseStruct;
+    }
+    return promiseStruct.promise;
+  }
+
+  /**
+   * Triggers the signal with the specified name on the element. The time is
+   * optional; if not provided, the current time is used. The associated
+   * promise is resolved with the resulting time.
+   * @param {string} name
+   * @param {time=} opt_time
+   */
+  signal(name, opt_time) {
+    if (this.map_[name] != null) {
+      // Do not duplicate signals.
+      return;
+    }
+    const time = opt_time || Date.now();
+    this.map_[name] = time;
+    const promiseStruct = this.promiseMap_ && this.promiseMap_[name];
+    if (promiseStruct && promiseStruct.resolve) {
+      promiseStruct.resolve(time);
+      promiseStruct.resolve = undefined;
+      promiseStruct.reject = undefined;
+    }
+  }
+
+  /**
+   * Rejects the signal. Indicates that the signal will never succeed. The
+   * associated signal is rejected.
+   * @param {string} name
+   * @param {!Error} error
+   */
+  rejectSignal(name, error) {
+    if (this.map_[name] != null) {
+      // Do not duplicate signals.
+      return;
+    }
+    this.map_[name] = error;
+    const promiseStruct = this.promiseMap_ && this.promiseMap_[name];
+    if (promiseStruct && promiseStruct.reject) {
+      promiseStruct.reject(error);
+      promiseStruct.resolve = undefined;
+      promiseStruct.reject = undefined;
+    }
+  }
+}

--- a/test/functional/utils/test-signals.js
+++ b/test/functional/utils/test-signals.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Signals} from '../../../src/utils/signals';
+
+
+describes.sandboxed('Signals', {}, () => {
+  let clock;
+  let signals;
+
+  beforeEach(() => {
+    clock = sandbox.useFakeTimers();
+    clock.tick(1);
+    signals = new Signals();
+  });
+
+  it('should register signal without promise', () => {
+    signals.signal('sig');
+    expect(signals.get('sig')).to.equal(1);
+    expect(signals.promiseMap_).to.be.null;
+  });
+
+  it('should reject signal without promise', () => {
+    const error = new Error();
+    signals.rejectSignal('sig', error);
+    expect(signals.get('sig')).to.equal(error);
+    expect(signals.promiseMap_).to.be.null;
+  });
+
+  it('should not duplicate signal', () => {
+    signals.signal('sig', 11);
+    expect(signals.map_['sig']).to.equal(11);
+
+    signals.signal('sig', 12);
+    expect(signals.map_['sig']).to.equal(11);  // Did not change.
+
+    signals.rejectSignal('sig', new Error());
+    expect(signals.map_['sig']).to.equal(11);  // Did not change.
+  });
+
+  it('should override signal time', () => {
+    signals.signal('sig', 11);
+    expect(signals.map_['sig']).to.equal(11);
+    expect(signals.promiseMap_).to.be.null;
+  });
+
+  it('should resolve signal after it was requested', () => {
+    const promise = signals.whenSignal('sig');
+    expect(signals.promiseMap_['sig'].promise).to.equal(promise);
+    expect(signals.promiseMap_['sig'].resolve).to.be.ok;
+    expect(signals.promiseMap_['sig'].reject).to.be.ok;
+    expect(signals.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+    signals.signal('sig', 11);
+    return promise.then(time => {
+      expect(time).to.equal(11);
+      expect(signals.promiseMap_['sig'].promise).to.equal(promise);
+      expect(signals.promiseMap_['sig'].resolve).to.be.undefined;
+      expect(signals.promiseMap_['sig'].reject).to.be.undefined;
+      expect(signals.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+    });
+  });
+
+  it('should resolve signal before it was requested', () => {
+    signals.signal('sig', 11);
+    const promise = signals.whenSignal('sig');
+    expect(signals.promiseMap_['sig'].promise).to.equal(promise);
+    expect(signals.promiseMap_['sig'].resolve).to.be.undefined;
+    expect(signals.promiseMap_['sig'].reject).to.be.undefined;
+    expect(signals.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+    return promise.then(time => {
+      expect(time).to.equal(11);
+      expect(signals.promiseMap_['sig'].promise).to.equal(promise);
+      expect(signals.promiseMap_['sig'].resolve).to.be.undefined;
+      expect(signals.promiseMap_['sig'].reject).to.be.undefined;
+      expect(signals.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+    });
+  });
+
+  it('should reject signal after it was requested', () => {
+    const promise = signals.whenSignal('sig');
+    expect(signals.promiseMap_['sig'].promise).to.equal(promise);
+    const error = new Error();
+    signals.rejectSignal('sig', error);
+    return promise.then(() => {
+      throw new Error('should have failed');
+    }, reason => {
+      expect(reason).to.equal(error);
+      expect(signals.promiseMap_['sig'].promise).to.equal(promise);
+      expect(signals.promiseMap_['sig'].resolve).to.be.undefined;
+      expect(signals.promiseMap_['sig'].reject).to.be.undefined;
+      expect(signals.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+    });
+  });
+
+  it('should reject signal before it was requested', () => {
+    const error = new Error();
+    signals.rejectSignal('sig', error);
+    const promise = signals.whenSignal('sig');
+    expect(signals.promiseMap_['sig'].promise).to.equal(promise);
+    return promise.then(() => {
+      throw new Error('should have failed');
+    }, reason => {
+      expect(reason).to.equal(error);
+      expect(signals.promiseMap_['sig'].promise).to.equal(promise);
+      expect(signals.promiseMap_['sig'].resolve).to.be.undefined;
+      expect(signals.promiseMap_['sig'].reject).to.be.undefined;
+      expect(signals.whenSignal('sig')).to.equal(promise);  // Reuse promise.
+    });
+  });
+});


### PR DESCRIPTION
The `Signals` object is used across AMP elements, ampdoc and friendly embeds and potentially more in the future. Signals can be used for analytics or other dependent functions.

This PR is a straightforward refactoring that extracts `Signals` class and its tests into a separate module. No functional code changes.