### PR TITLE
Page-level visibility time for embed performance reporting

### DIFF
--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -160,6 +160,10 @@ export function googleLifecycleReporterFactory(a4aElement) {
         'AD_SLOT_EVENT_NAME.AD_SLOT_TIME_TO_EVENT',
     'e.AD_SLOT_ID': a4aElement.element.getAttribute(EXPERIMENT_ATTRIBUTE),
     'adt.AD_SLOT_ID': a4aElement.element.getAttribute('type'),
+    // Page-level visibility times: `firstVisibleTime.T,.lastVisibleTime.T`.
+    'met.AD_SLOT_NAMESPACE':
+        'firstVisibleTime.AD_PAGE_FIRST_VISIBLE_TIME' +
+        ',lastVisibleTime.AD_PAGE_LAST_VISIBLE_TIME',
   });
   return reporter;
 }

--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -18,8 +18,9 @@ import {getCorrelator} from './utils';
 import {LIFECYCLE_STAGES} from '../../../extensions/amp-a4a/0.1/amp-a4a';
 import {dev} from '../../../src/log';
 import {serializeQueryString} from '../../../src/url';
-import {urlReplacementsForDoc} from '../../../src/url-replacements';
 import {getTimingDataSync} from '../../../src/service/variable-source';
+import {urlReplacementsForDoc} from '../../../src/url-replacements';
+import {viewerForDoc} from '../../../src/viewer';
 
 /**
  * This module provides a fairly crude form of performance monitoring (or
@@ -138,7 +139,7 @@ export class GoogleAdLifecycleReporter extends BaseLifecycleReporter {
     } else {
       initTime = Number(scratch);
     }
-    /** @private {number} @const */
+    /** @private {time} @const */
     this.initTime_ = initTime;
 
     /** @private {!function():number} @const */
@@ -153,6 +154,9 @@ export class GoogleAdLifecycleReporter extends BaseLifecycleReporter {
      * @const
      */
     this.urlReplacer_ = urlReplacementsForDoc(element);
+
+    /** @const @private {!../../../src/service/viewer-impl.Viewer} */
+    this.viewer_ = viewerForDoc(element);
   }
 
   /**
@@ -213,6 +217,11 @@ export class GoogleAdLifecycleReporter extends BaseLifecycleReporter {
         AD_SLOT_EVENT_NAME: name,
         AD_SLOT_EVENT_ID: stageId,
         AD_PAGE_CORRELATOR: this.correlator_,
+        AD_PAGE_VISIBLE: this.viewer_.isVisible() ? 1 : 0,
+        AD_PAGE_FIRST_VISIBLE_TIME:
+            Math.round(this.viewer_.getFirstVisibleTime() - this.initTime_),
+        AD_PAGE_LAST_VISIBLE_TIME:
+            Math.round(this.viewer_.getLastVisibleTime() - this.initTime_),
       });
     }
     return extraParams ? `${this.pingbackAddress_}?${extraParams}` : '';

--- a/ads/google/a4a/test/test-google-data-reporter.js
+++ b/ads/google/a4a/test/test-google-data-reporter.js
@@ -205,6 +205,8 @@ describe('#getLifecycleReporter', () => {
       });
 
       it('should generate a ping with known parameters', () => {
+        const viewer = env.win.services.viewer.obj;
+        viewer.firstVisibleTime_ = viewer.lastVisibleTime_ = Date.now();
         mockReporter.sendPing('renderFriendlyStart');
         const pingElements = env.win.document.querySelectorAll('img');
         expect(pingElements.length).to.equal(1);
@@ -222,6 +224,7 @@ describe('#getLifecycleReporter', () => {
           'met.a4a.22=renderFriendlyStart.[0-9]+',
           `e.22=${DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES.experiment}`,
           'adt.22=doubleclick',
+          'met.a4a=firstVisibleTime.[0-9]+%2ClastVisibleTime.[0-9]+',
         ];
         expectedParams.forEach(p => {
           expect(pingUrl, p).to.match(new RegExp(`[?&]${p}(&|$)`));

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -728,6 +728,9 @@ export class AmpA4A extends AMP.BaseElement {
     if (!this.adPromise_) {
       return Promise.resolve();
     }
+    // There's no real throttling with A4A, but this is the signal that is
+    // most comparable with the layout callback for 3p ads.
+    this.protectedEmitLifecycleEvent_('preAdThrottle');
     const layoutCallbackStart = this.getNow_();
     // Promise chain will have determined if creative is valid AMP.
     return this.adPromise_.then(creativeMetaData => {

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -149,6 +149,9 @@ export class Viewer {
     /** @private {?time} */
     this.firstVisibleTime_ = null;
 
+    /** @private {?time} */
+    this.lastVisibleTime_ = null;
+
     /** @private {?Function} */
     this.messagingReadyResolver_ = null;
 
@@ -386,9 +389,11 @@ export class Viewer {
    */
   onVisibilityChange_() {
     if (this.isVisible()) {
+      const now = Date.now();
       if (!this.firstVisibleTime_) {
-        this.firstVisibleTime_ = Date.now();
+        this.firstVisibleTime_ = now;
       }
+      this.lastVisibleTime_ = now;
       this.hasBeenVisible_ = true;
       this.whenFirstVisibleResolve_();
     }
@@ -574,6 +579,15 @@ export class Viewer {
    */
   getFirstVisibleTime() {
     return this.firstVisibleTime_;
+  }
+
+  /**
+   * Returns the time when the document has become visible for the last time.
+   * If document has not yet become visible, the returned value is `null`.
+   * @return {?time}
+   */
+  getLastVisibleTime() {
+    return this.lastVisibleTime_;
   }
 
   /**

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -160,6 +160,7 @@ describe('Viewer', () => {
     expect(viewer.isVisible()).to.equal(true);
     expect(viewer.getPrerenderSize()).to.equal(1);
     expect(viewer.getFirstVisibleTime()).to.equal(0);
+    expect(viewer.getLastVisibleTime()).to.equal(0);
   });
 
   it('should initialize firstVisibleTime for initially visible doc', () => {
@@ -167,6 +168,7 @@ describe('Viewer', () => {
     const viewer = new Viewer(ampdoc);
     expect(viewer.isVisible()).to.be.true;
     expect(viewer.getFirstVisibleTime()).to.equal(1);
+    expect(viewer.getLastVisibleTime()).to.equal(1);
   });
 
   it('should initialize firstVisibleTime when doc becomes visible', () => {
@@ -175,12 +177,33 @@ describe('Viewer', () => {
     const viewer = new Viewer(ampdoc);
     expect(viewer.isVisible()).to.be.false;
     expect(viewer.getFirstVisibleTime()).to.be.null;
+    expect(viewer.getLastVisibleTime()).to.be.null;
 
+    // Becomes visible.
     viewer.receiveMessage('visibilitychange', {
       state: 'visible',
     });
     expect(viewer.isVisible()).to.be.true;
     expect(viewer.getFirstVisibleTime()).to.equal(1);
+    expect(viewer.getLastVisibleTime()).to.equal(1);
+
+    // Back to invisible.
+    clock.tick(1);
+    viewer.receiveMessage('visibilitychange', {
+      state: 'hidden',
+    });
+    expect(viewer.isVisible()).to.be.false;
+    expect(viewer.getFirstVisibleTime()).to.equal(1);
+    expect(viewer.getLastVisibleTime()).to.equal(1);
+
+    // Back to visible again.
+    clock.tick(1);
+    viewer.receiveMessage('visibilitychange', {
+      state: 'visible',
+    });
+    expect(viewer.isVisible()).to.be.true;
+    expect(viewer.getFirstVisibleTime()).to.equal(1);
+    expect(viewer.getLastVisibleTime()).to.equal(3);
   });
 
   it('should configure visibilityState and prerender', () => {


### PR DESCRIPTION
Classical performance reporting against the `navigationStart` time has issues in AMP since AMP pauses all processing while document is invisible. I propose here to also report first/last visibility times.

@tdrl Please guide me what other steps are needed to proceed with these three new metrics?