### PR TITLE
Add scopedQuerySelector helper

### DIFF
--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -20,6 +20,7 @@ import {
 } from '../performance';
 import {createIframePromise} from '../../../../testing/iframe';
 import {viewerForDoc} from '../../../../src/viewer';
+import {toArray} from '../../../../src/types';
 import * as sinon from 'sinon';
 
 /**
@@ -42,7 +43,7 @@ function expectMatchesAll(address, matchList) {
  * @param {!Array<!RegExp>} matchList
  */
 function expectHasSiblingImgMatchingAll(element, matchList) {
-  const imgSiblings = element.parentElement.querySelectorAll('img');
+  const imgSiblings = toArray(element.parentElement.querySelectorAll('img'));
   expect(imgSiblings).to.not.be.empty;
   const result = imgSiblings.some(e => {
     const src = e.getAttribute('src');

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -36,15 +36,6 @@ function expectMatchesAll(address, matchList) {
 }
 
 /**
- * Whether `element` is an `img` DOM node.
- * @param {!Element} element
- * @returns {boolean}
- */
-function isImgNode(element) {
-  return element.tagName == 'IMG';
-}
-
-/**
  * Verify that `element` has at least one sibling DOM node that is an
  * `img` tag whose `src` matches all of the patterns in `matchList`.
  *
@@ -52,8 +43,7 @@ function isImgNode(element) {
  * @param {!Array<!RegExp>} matchList
  */
 function expectHasSiblingImgMatchingAll(element, matchList) {
-  const imgSiblings = childElements(
-      element.parentElement, e => isImgNode(e));
+  const imgSiblings = scopedQuerySelectorAll(element.parentElement, 'img');
   expect(imgSiblings).to.not.be.empty;
   const result = imgSiblings.some(e => {
     const src = e.getAttribute('src');
@@ -229,7 +219,7 @@ describe('GoogleAdLifecycleReporter', () => {
           }
         });
         expect(emitPingSpy.callCount).to.equal(nSlots * nStages);
-        const allImgNodes = childElements(doc.body, x => isImgNode(x));
+        const allImgNodes = doc.querySelectorAll('img');
         expect(allImgNodes.length).to.equal(nSlots * nStages);
         let commonCorrelator;
         const slotCounts = {};

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -18,7 +18,6 @@ import {
   GoogleAdLifecycleReporter,
   BaseLifecycleReporter,
 } from '../performance';
-import {childElements} from '../../../../src/dom';
 import {createIframePromise} from '../../../../testing/iframe';
 import {viewerForDoc} from '../../../../src/viewer';
 import * as sinon from 'sinon';
@@ -43,7 +42,7 @@ function expectMatchesAll(address, matchList) {
  * @param {!Array<!RegExp>} matchList
  */
 function expectHasSiblingImgMatchingAll(element, matchList) {
-  const imgSiblings = scopedQuerySelectorAll(element.parentElement, 'img');
+  const imgSiblings = element.parentElement.querySelectorAll('img');
   expect(imgSiblings).to.not.be.empty;
   const result = imgSiblings.some(e => {
     const src = e.getAttribute('src');

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -344,7 +344,7 @@ function liveListTombstone(liveList) {
   // We can tombstone any list item except item-1 since we always do a
   // replace example on item-1.
   if (tombstoneId != 1) {
-    var item = liveList.querySelector(`#list-item-${tombstoneId}`);
+    var item = liveList./*OK*/querySelector(`#list-item-${tombstoneId}`);
     if (item) {
       item.setAttribute('data-tombstone', '');
     }

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -571,6 +571,15 @@ var forbiddenTermsSrcInclusive = {
   '\\.webkitConvertPointFromNodeToPage\\(': bannedTermsHelpString,
   '\\.webkitConvertPointFromPageToNode\\(': bannedTermsHelpString,
   '\\.scheduleUnlayout\\(': bannedTermsHelpString,
+  // Super complicated regex that says "find any querySelector method call that
+  // is passed as a variable anything that is not a string, or a string that
+  // contains a space.
+  '\\b(?:(?!\\w*[dD]oc\\w*)\\w)+\\.querySelector(?:All)?\\((?=\\s*([^\'"\\s]|[^\\s)]+\\s))[^)]*\\)': {
+    message: 'querySelector is not scoped to the element, but globally and ' +
+      'filtered to just the elements inside the element. This leads to ' +
+      'obscure bugs if you attempt to match a descendant of a descendant (ie ' +
+      '"div div"). Instead, use the scopedQuerySelector helper in dom.js',
+  },
   'loadExtension': {
     message: bannedTermsHelpString,
     whitelist: [

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -159,15 +159,15 @@ export class AccessServerAdapter {
             },
             requireAmpResponseSourceOrigin: false,
           }));
-    }).then(response => {
-      dev().fine(TAG, 'Authorization response: ', response);
+    }).then(responseDoc => {
+      dev().fine(TAG, 'Authorization response: ', responseDoc);
       const accessDataString = dev().assert(
-          response.querySelector('script[id="amp-access-data"]'),
+          responseDoc.querySelector('script[id="amp-access-data"]'),
           'No authorization data available').textContent;
       const accessData = JSON.parse(accessDataString);
       dev().fine(TAG, '- access data: ', accessData);
 
-      return this.replaceSections_(response).then(() => {
+      return this.replaceSections_(responseDoc).then(() => {
         return accessData;
       });
     });

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -170,12 +170,9 @@ describe('A4A loader', () => {
           ampAd = new AmpAd(ampAdElement);
           ampAd.upgradeCallback().then(element => {
             expect(element).to.not.be.null;
-            expect(childElement(fixture.doc.head,
-                c => {
-                  return c.tagName == 'SCRIPT' &&
-                      c.getAttribute('custom-element') ===
-                      'amp-ad-network-zort-impl';
-                })).to.not.be.null;
+            expect(fixture.doc.head.querySelector(
+                'script[custom-element="amp-ad-network-zort-impl"]'))
+                .to.not.be.null;
           });
         });
       });

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -18,7 +18,6 @@ import {createIframePromise} from '../../../../testing/iframe';
 import {a4aRegistry} from '../../../../ads/_a4a-config';
 import {AmpAd} from '../amp-ad';
 import {AmpAd3PImpl} from '../amp-ad-3p-impl';
-import {childElement} from '../../../../src/dom';
 import {extensionsFor} from '../../../../src/extensions';
 import {stubService} from '../../../../testing/test-helper';
 import * as sinon from 'sinon';

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {closestBySelector, matches} from '../../../src/dom';
+import {
+  closestBySelector,
+  matches,
+  scopedQuerySelector
+} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {map} from '../../../src/utils/object';
 
@@ -155,7 +159,7 @@ export class AnalyticsRoot {
     // Query search based on the selection method.
     let found;
     if (selectionMethod == 'scope') {
-      found = context.querySelector(selector);
+      found = scopedQuerySelector(context, selector);
     } else if (selectionMethod == 'closest') {
       found = closestBySelector(context, selector);
     } else {

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -17,7 +17,7 @@
 import {
   closestBySelector,
   matches,
-  scopedQuerySelector
+  scopedQuerySelector,
 } from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {map} from '../../../src/utils/object';

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {closestByTag, closestBySelector} from '../../../src/dom';
+import {
+  closestByTag,
+  closestBySelector,
+  scopedQuerySelector
+} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {resourcesForDoc} from '../../../src/resources';
 import {getParentWindowFrameElement} from '../../../src/service';
@@ -177,7 +181,7 @@ export function getElement(ampdoc, selector, analyticsEl, selectionMethod) {
     // Only tag names are supported currently.
     foundEl = closestByTag(analyticsEl, selector);
   } else if (selectionMethod == 'scope') {
-    foundEl = analyticsEl.parentElement.querySelector(selector);
+    foundEl = scopedQuerySelector(analyticsEl.parentElement, selector);
   } else if (selector[0] == '#') {
     const containerDoc = friendlyFrame ? analyticsEl.ownerDocument : ampdoc;
     foundEl = containerDoc.getElementById(selector.slice(1));

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -181,7 +181,8 @@ export function getElement(ampdoc, selector, analyticsEl, selectionMethod) {
     // Only tag names are supported currently.
     foundEl = closestByTag(analyticsEl, selector);
   } else if (selectionMethod == 'scope') {
-    foundEl = scopedQuerySelector(analyticsEl.parentElement, selector);
+    foundEl = scopedQuerySelector(
+        dev().assertElement(analyticsEl.parentElement), selector);
   } else if (selector[0] == '#') {
     const containerDoc = friendlyFrame ? analyticsEl.ownerDocument : ampdoc;
     foundEl = containerDoc.getElementById(selector.slice(1));

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -17,7 +17,7 @@
 import {
   closestByTag,
   closestBySelector,
-  scopedQuerySelector
+  scopedQuerySelector,
 } from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {resourcesForDoc} from '../../../src/resources';

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -205,7 +205,8 @@ export class AmpForm {
     if (this.dependenciesPromise_) {
       return this.dependenciesPromise_;
     }
-    const depElements = this.form_.querySelectorAll(EXTERNAL_DEPS.join(','));
+    const depElements = this.form_./*OK*/querySelectorAll(
+        EXTERNAL_DEPS.join(','));
     // Wait for an element to be built to make sure it is ready.
     const depPromises = toArray(depElements).map(el => el.whenBuilt());
     return this.dependenciesPromise_ = Promise.race(

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -524,7 +524,7 @@ export class AmpForm {
    * @private
    */
   renderTemplate_(data) {
-    const container = this.form_.querySelector(`[${this.state_}]`);
+    const container = this.form_./*OK*/querySelector(`[${this.state_}]`);
     if (container) {
       const messageId = `rendered-message-${this.id_}`;
       container.setAttribute('role', 'alert');
@@ -543,7 +543,7 @@ export class AmpForm {
    * @private
    */
   cleanupRenderedTemplate_() {
-    const container = this.form_.querySelector(`[${this.state_}]`);
+    const container = this.form_./*OK*/querySelector(`[${this.state_}]`);
     if (!container) {
       return;
     }

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -392,7 +392,7 @@ export class AmpLiveList extends AMP.BaseElement {
     let count = 0;
     orphans.forEach(orphan => {
       const orphanId = orphan.getAttribute('id');
-      const liveElement = parent.querySelector(`#${orphanId}`);
+      const liveElement = parent./*OK*/querySelector(`#${orphanId}`);
       // Don't bother updating if live element is tombstoned or
       // if we can't find it.
       if (!liveElement) {
@@ -419,7 +419,7 @@ export class AmpLiveList extends AMP.BaseElement {
     let count = 0;
     orphans.forEach(orphan => {
       const orphanId = orphan.getAttribute('id');
-      const liveElement = parent.querySelector(`#${orphanId}`);
+      const liveElement = parent./*OK*/querySelector(`#${orphanId}`);
       if (!liveElement) {
         return;
       }

--- a/src/dom.js
+++ b/src/dom.js
@@ -16,7 +16,6 @@
 
 import {dev} from './log';
 import {cssEscape} from '../third_party/css-escape/css-escape';
-import {toArray} from './types';
 
 const HTML_ESCAPE_CHARS = {
   '&': '&amp;',
@@ -385,7 +384,7 @@ export function lastChildElementByAttr(parent, attr) {
  * Finds all child elements that has the specified attribute.
  * @param {!Element} parent
  * @param {string} attr
- * @return {!Array<!Element>}
+ * @return {!NodeList<!Element>}
  */
 export function childElementsByAttr(parent, attr) {
   return scopedQuerySelectorAll(parent, `> [${attr}]`);
@@ -407,7 +406,7 @@ export function childElementByTag(parent, tagName) {
  * Finds all child elements with the specified tag name.
  * @param {!Element} parent
  * @param {string} tagName
- * @return {!Array<!Element>}
+ * @return {!NodeList<!Element>}
  */
 export function childElementsByTag(parent, tagName) {
   return scopedQuerySelectorAll(parent, `> ${tagName}`);
@@ -443,14 +442,14 @@ export function scopedQuerySelector(root, selector) {
  * Note: in IE, this causes a quick mutation of the element's class list.
  * @param {!Element} root
  * @param {string} selector
- * @return {!Array<!Element>}
+ * @return {!NodeList<!Element>}
  */
 export function scopedQuerySelectorAll(root, selector) {
   if (scopeSelectorSupported == null) {
     scopeSelectorSupported = isScopeSelectorSupported(root);
   }
   if (scopeSelectorSupported) {
-    return toArray(root./*OK*/querySelectorAll(`:scope ${selector}`));
+    return root./*OK*/querySelectorAll(`:scope ${selector}`);
   }
 
   // Only IE.
@@ -458,7 +457,7 @@ export function scopedQuerySelectorAll(root, selector) {
   root.classList.add(unique);
   const elements = root./*OK*/querySelectorAll(`.${unique} ${selector}`);
   root.classList.remove(unique);
-  return toArray(elements);
+  return elements;
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -364,15 +364,7 @@ function isScopeSelectorSupported(parent) {
  * @return {?Element}
  */
 export function childElementByAttr(parent, attr) {
-  if (scopeSelectorSupported == null) {
-    scopeSelectorSupported = isScopeSelectorSupported(parent);
-  }
-  if (scopeSelectorSupported) {
-    return parent.querySelector(':scope > [' + attr + ']');
-  }
-  return childElement(parent, el => {
-    return el.hasAttribute(attr);
-  });
+  return scopedQuerySelector(parent, `> [${attr}]`);
 }
 
 
@@ -396,15 +388,7 @@ export function lastChildElementByAttr(parent, attr) {
  * @return {!Array<!Element>}
  */
 export function childElementsByAttr(parent, attr) {
-  if (scopeSelectorSupported == null) {
-    scopeSelectorSupported = isScopeSelectorSupported(parent);
-  }
-  if (scopeSelectorSupported) {
-    return toArray(parent.querySelectorAll(':scope > [' + attr + ']'));
-  }
-  return childElements(parent, el => {
-    return el.hasAttribute(attr);
-  });
+  return scopedQuerySelectorAll(parent, `> [${attr}]`);
 }
 
 
@@ -415,16 +399,7 @@ export function childElementsByAttr(parent, attr) {
  * @return {?Element}
  */
 export function childElementByTag(parent, tagName) {
-  if (scopeSelectorSupported == null) {
-    scopeSelectorSupported = isScopeSelectorSupported(parent);
-  }
-  if (scopeSelectorSupported) {
-    return parent.querySelector(':scope > ' + tagName);
-  }
-  tagName = tagName.toUpperCase();
-  return childElement(parent, el => {
-    return el.tagName == tagName;
-  });
+  return scopedQuerySelector(parent, `> ${tagName}`);
 }
 
 
@@ -435,16 +410,55 @@ export function childElementByTag(parent, tagName) {
  * @return {!Array<!Element>}
  */
 export function childElementsByTag(parent, tagName) {
+  return scopedQuerySelectorAll(parent, `> ${tagName}`);
+}
+
+
+/**
+ * Finds the first element that matches `selector`, scoped inside `root`.
+ * Note: in IE, this causes a quick mutation of the element's class list.
+ * @param {!Element} root
+ * @param {string} selector
+ * @return {?Element}
+ */
+export function scopedQuerySelector(root, selector) {
   if (scopeSelectorSupported == null) {
-    scopeSelectorSupported = isScopeSelectorSupported(parent);
+    scopeSelectorSupported = isScopeSelectorSupported(root);
   }
   if (scopeSelectorSupported) {
-    return toArray(parent.querySelectorAll(':scope > ' + tagName));
+    return root./*OK*/querySelector(`:scope ${selector}`);
   }
-  tagName = tagName.toUpperCase();
-  return childElements(parent, el => {
-    return el.tagName == tagName;
-  });
+
+  // Only IE.
+  const unique = `i-amphtml-scoped-${Math.random()}`;
+  root.classList.add(unique);
+  const elements = root./*OK*/querySelector(`.${unique} ${selector}`);
+  root.classList.remove(unique);
+  return elements;
+}
+
+
+/**
+ * Finds the every element that matches `selector`, scoped inside `root`.
+ * Note: in IE, this causes a quick mutation of the element's class list.
+ * @param {!Element} root
+ * @param {string} selector
+ * @return {!Array<!Element>}
+ */
+export function scopedQuerySelectorAll(root, selector) {
+  if (scopeSelectorSupported == null) {
+    scopeSelectorSupported = isScopeSelectorSupported(root);
+  }
+  if (scopeSelectorSupported) {
+    return toArray(root./*OK*/querySelectorAll(`:scope ${selector}`));
+  }
+
+  // Only IE.
+  const unique = `i-amphtml-scoped-${Math.random()}`;
+  root.classList.add(unique);
+  const elements = toArray(root./*OK*/querySelectorAll(`.${unique} ${selector}`));
+  root.classList.remove(unique);
+  return elements;
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -429,7 +429,7 @@ export function scopedQuerySelector(root, selector) {
   }
 
   // Only IE.
-  const unique = `i-amphtml-scoped-${Date.now()}`;
+  const unique = `i-amphtml-scoped`;
   root.classList.add(unique);
   const element = root./*OK*/querySelector(`.${unique} ${selector}`);
   root.classList.remove(unique);
@@ -453,7 +453,7 @@ export function scopedQuerySelectorAll(root, selector) {
   }
 
   // Only IE.
-  const unique = `i-amphtml-scoped-${Date.now()}`;
+  const unique = `i-amphtml-scoped`;
   root.classList.add(unique);
   const elements = root./*OK*/querySelectorAll(`.${unique} ${selector}`);
   root.classList.remove(unique);

--- a/src/dom.js
+++ b/src/dom.js
@@ -430,7 +430,7 @@ export function scopedQuerySelector(root, selector) {
   }
 
   // Only IE.
-  const unique = `i-amphtml-scoped-${Math.random()}`;
+  const unique = `i-amphtml-scoped-${Date.now()}`;
   root.classList.add(unique);
   const elements = root./*OK*/querySelector(`.${unique} ${selector}`);
   root.classList.remove(unique);
@@ -454,7 +454,7 @@ export function scopedQuerySelectorAll(root, selector) {
   }
 
   // Only IE.
-  const unique = `i-amphtml-scoped-${Math.random()}`;
+  const unique = `i-amphtml-scoped-${Date.now()}`;
   root.classList.add(unique);
   const elements = toArray(root./*OK*/querySelectorAll(`.${unique} ${selector}`));
   root.classList.remove(unique);

--- a/src/dom.js
+++ b/src/dom.js
@@ -432,9 +432,9 @@ export function scopedQuerySelector(root, selector) {
   // Only IE.
   const unique = `i-amphtml-scoped-${Date.now()}`;
   root.classList.add(unique);
-  const elements = root./*OK*/querySelector(`.${unique} ${selector}`);
+  const element = root./*OK*/querySelector(`.${unique} ${selector}`);
   root.classList.remove(unique);
-  return elements;
+  return element;
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -456,9 +456,9 @@ export function scopedQuerySelectorAll(root, selector) {
   // Only IE.
   const unique = `i-amphtml-scoped-${Date.now()}`;
   root.classList.add(unique);
-  const elements = toArray(root./*OK*/querySelectorAll(`.${unique} ${selector}`));
+  const elements = root./*OK*/querySelectorAll(`.${unique} ${selector}`);
   root.classList.remove(unique);
-  return elements;
+  return toArray(elements);
 }
 
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -927,7 +927,7 @@ function maybeLoadCorrectVersion(win, fnOrStruct) {
   }
   // The :not is an extra prevention of recursion because it will be
   // added to script tags that go into the code path below.
-  const scriptInHead = win.document.head.querySelector(
+  const scriptInHead = win.document.head./*OK*/querySelector(
           `[custom-element="${fnOrStruct.n}"]:not([i-amphtml-inserted])`);
   dev().assert(scriptInHead, 'Expected to find script for extension: %s',
       fnOrStruct.n);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -675,13 +675,14 @@ class MultidocManager {
     const extensionIds = [];
     if (doc.head) {
       const parentLinks = {};
-      childElementsByTag(dev().assertElement(this.win.document.head), 'link')
-          .forEach(link => {
-            const href = link.getAttribute('href');
-            if (href) {
-              parentLinks[href] = true;
-            }
-          });
+      const links = childElementsByTag(
+          dev().assertElement(this.win.document.head), 'link');
+      for (let i = 0; i < links.length; i++) {
+        const href = links[i].getAttribute('href');
+        if (href) {
+          parentLinks[href] = true;
+        }
+      }
 
       for (let n = doc.head.firstElementChild; n; n = n.nextElementSibling) {
         const tagName = n.tagName;

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -523,7 +523,7 @@ export class Extensions {
       return false;
     }
     if (holder.scriptPresent === undefined) {
-      const scriptInHead = this.win.document.head.querySelector(
+      const scriptInHead = this.win.document.head./*OK*/querySelector(
           `[custom-element="${extensionId}"]`);
       holder.scriptPresent = !!scriptInHead;
     }

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -90,7 +90,7 @@ function createShadowRootPolyfill(hostElement) {
   shadowRoot.getElementById = function(id) {
     const escapedId = escapeCssSelectorIdent(win, id);
     return /** @type {HTMLElement|null} */ (
-        shadowRoot.querySelector(`#${escapedId}`));
+        shadowRoot./*OK*/querySelector(`#${escapedId}`));
   };
 
   return shadowRoot;

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -92,7 +92,7 @@ export function insertStyleElement(doc, cssRoot, cssText, isRuntimeCss, ext) {
     const existing =
         isRuntimeCss ?
         cssRoot.querySelector('style[amp-runtime]') :
-        cssRoot.querySelector(`style[amp-extension=${ext}]`);
+        cssRoot./*OK*/querySelector(`style[amp-extension=${ext}]`);
     if (existing) {
       if (isRuntimeCss) {
         cssRoot.runtimeStyleElement = existing;

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -17,6 +17,7 @@
 import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 import {loadPromise} from '../../src/event-helper';
+import {toArray} from '../../src/types';
 
 
 
@@ -268,11 +269,11 @@ describe('DOM', () => {
     const element3 = document.createElement('element23');
     parent.appendChild(element3);
 
-    expect(dom.childElementsByTag(parent, 'element1'))
+    expect(toArray(dom.childElementsByTag(parent, 'element1')))
         .to.deep.equal([element1]);
-    expect(dom.childElementsByTag(parent, 'element23'))
+    expect(toArray(dom.childElementsByTag(parent, 'element23')))
         .to.deep.equal([element2, element3]);
-    expect(dom.childElementsByTag(parent, 'element3'))
+    expect(toArray(dom.childElementsByTag(parent, 'element3')))
         .to.deep.equal([]);
   }
 
@@ -402,13 +403,13 @@ describe('DOM', () => {
     const grandparent = document.createElement('div');
 
     const parent = document.createElement('div');
-    grandparent.appendChild('div');
+    grandparent.appendChild(parent);
 
     const element1 = document.createElement('div');
     parent.appendChild(element1);
 
-    expect(dom.scopedQuerySelector(parent, 'div')).to.equal(parent);
-    expect(dom.scopedQuerySelector(parent, 'div div')).to.equal(element1);
+    expect(dom.scopedQuerySelector(parent, 'div')).to.equal(element1);
+    expect(dom.scopedQuerySelector(grandparent, 'div div')).to.equal(element1);
   }
 
   it('scopedQuerySelector should find first match', testScopedQuerySelector);
@@ -422,7 +423,7 @@ describe('DOM', () => {
     const grandparent = document.createElement('div');
 
     const parent = document.createElement('div');
-    grandparent.appendChild('div');
+    grandparent.appendChild(parent);
 
     const element1 = document.createElement('div');
     parent.appendChild(element1);
@@ -431,10 +432,10 @@ describe('DOM', () => {
     parent.appendChild(element2);
 
 
-    expect(dom.scopedQuerySelectorAll(parent, 'div')).to.deep.equal(
-        [parent, element1, element2]);
-    expect(dom.scopedQuerySelectorAll(parent, 'div div')).to.deep.equal(
-        [element1, element2]);
+    expect(toArray(dom.scopedQuerySelectorAll(parent, 'div')))
+      .to.deep.equal([element1, element2]);
+    expect(toArray(dom.scopedQuerySelectorAll(grandparent, 'div div')))
+      .to.deep.equal([element1, element2]);
   }
 
   it('scopedQuerySelectorAll should find all matches',

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -437,9 +437,10 @@ describe('DOM', () => {
         [element1, element2]);
   }
 
-  it('scopedQuerySelectorAll should find first match', testScopedQuerySelectorAll);
+  it('scopedQuerySelectorAll should find all matches',
+      testScopedQuerySelectorAll);
 
-  it('scopedQuerySelectorAll should find first match (polyfill)', () => {
+  it('scopedQuerySelectorAll should find all matches (polyfill)', () => {
     dom.setScopeSelectorSupportedForTesting(false);
     testScopedQuerySelectorAll();
   });

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -398,6 +398,52 @@ describe('DOM', () => {
         .to.be.equal(0);
   });
 
+  function testScopedQuerySelector() {
+    const grandparent = document.createElement('div');
+
+    const parent = document.createElement('div');
+    grandparent.appendChild('div');
+
+    const element1 = document.createElement('div');
+    parent.appendChild(element1);
+
+    expect(dom.scopedQuerySelector(parent, 'div')).to.equal(parent);
+    expect(dom.scopedQuerySelector(parent, 'div div')).to.equal(element1);
+  }
+
+  it('scopedQuerySelector should find first match', testScopedQuerySelector);
+
+  it('scopedQuerySelector should find first match (polyfill)', () => {
+    dom.setScopeSelectorSupportedForTesting(false);
+    testScopedQuerySelector();
+  });
+
+  function testScopedQuerySelectorAll() {
+    const grandparent = document.createElement('div');
+
+    const parent = document.createElement('div');
+    grandparent.appendChild('div');
+
+    const element1 = document.createElement('div');
+    parent.appendChild(element1);
+
+    const element2 = document.createElement('div');
+    parent.appendChild(element2);
+
+
+    expect(dom.scopedQuerySelectorAll(parent, 'div')).to.deep.equal(
+        [parent, element1, element2]);
+    expect(dom.scopedQuerySelectorAll(parent, 'div div')).to.deep.equal(
+        [element1, element2]);
+  }
+
+  it('scopedQuerySelectorAll should find first match', testScopedQuerySelectorAll);
+
+  it('scopedQuerySelectorAll should find first match (polyfill)', () => {
+    dom.setScopeSelectorSupportedForTesting(false);
+    testScopedQuerySelectorAll();
+  });
+
   describe('waitFor', () => {
     let parent;
     let child;


### PR DESCRIPTION
This fixes (and forbids future) element scoped `#querySelector` calls.  Anytime you select a descendant of a descendant (`div div`, or, really, `* *`), your matching against the entire document then filtering to elements inside the scope. This is **not** what you'd expect.

```js
var parent = document.createElement('div');

var element = document.createElement('span');
parent.appendChild(element);

var a = document.createElement('a');
element.appendChild(a);

// WHAT!?
element.querySelector('div a'); // => a
```

Instead, we'll use the `:scope` CSS selector where supported ([everywhere but IE](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope#Browser_compatibility)), and will quickly mutate and un-mutate the element in IE to accomplish a global, unique scope selector.

```js
scopedQuerySelector(element, 'div a'); // => null
```

Fixes a selector bug in `<amp-analytics>`. /cc @avimehta 
/cc @tlong2 