### PR TITLE
Apply unpausable animation work-around to all of iOS not just Safari

### DIFF
--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -323,8 +323,8 @@ class VideoEntry {
       anim.appendChild(column);
     }
     const platform = platformFor(this.ampdoc_.win);
-    if (platform.isSafari() && platform.isIos()) {
-      // iOS Safari can not pause hardware accelerated animations.
+    if (platform.isIos()) {
+      // iOS can not pause hardware accelerated animations.
       anim.setAttribute('unpausable', '');
     }
     return anim;


### PR DESCRIPTION
Both Safari and Chrome in iOS can not pause hardware accelerated animations.