### PR TITLE
Remove Safari 8 config

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -54,10 +54,10 @@ function getConfig() {
             'SL_Chrome_latest',
             'SL_Chrome_45',
             'SL_Firefox_latest',
-            //'SL_Safari_8' // Disabled to due flakiness and low market share
+            //'SL_Safari_8' // Disabled due to flakiness and low market share
             'SL_Safari_9',
             'SL_Edge_latest',
-            //'SL_iOS_8_4', // Disabled to due flakiness and low market share
+            //'SL_iOS_8_4', // Disabled due to flakiness and low market share
             'SL_iOS_9_1',
             'SL_iOS_10_0',
             //'SL_IE_11',

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -54,10 +54,10 @@ function getConfig() {
             'SL_Chrome_latest',
             'SL_Chrome_45',
             'SL_Firefox_latest',
-            'SL_Safari_8',
+            //'SL_Safari_8' // Disabled to due flakiness and low market share
             'SL_Safari_9',
             'SL_Edge_latest',
-            'SL_iOS_8_4',
+            //'SL_iOS_8_4', // Disabled to due flakiness and low market share
             'SL_iOS_9_1',
             'SL_iOS_10_0',
             //'SL_IE_11',


### PR DESCRIPTION
Safari 8 integration tests have been flaky for a few weeks now and I have spent more than a day trying to figure out what's happening without any luck. Given the small market share of Safari 8 (iOS < 9 is only 6% which also includes 7) and the value of keeping the build green to capture breakage in more important browsers. I am removing Safari 8 from SauceLabs. 

If you object, speak now or forever hold your peace :)
/to @dvoytenko @cramforce @jridgewell @erwinmombay 