### PR TITLE
Render associated element in error console

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -109,19 +109,16 @@ export function reportError(error, opt_associatedElement) {
 
   // Report to console.
   if (self.console) {
+    const output = (console.error || console.log);
     if (error.messageArray) {
-      (console.error || console.log).apply(console,
-          error.messageArray);
+      output.apply(console, error.messageArray);
     } else {
       if (element) {
-        (console.error || console.log).call(console,
-            element.tagName.toLowerCase() +
-                (element.id ? ' with id ' + element.id : '') + ':',
-            error.message);
+        output.call(console, error.message, element);
       } else if (!getMode().minified) {
-        (console.error || console.log).call(console, error.stack);
+        output.call(console, error.stack);
       } else {
-        (console.error || console.log).call(console, error.message);
+        output.call(console, error.message);
       }
     }
   }


### PR DESCRIPTION
- Improves error messaging by rendering the associated element natively with mouse-over highlighting, consistent with errors reported by `assert()`
- Tested on Chrome 55 and Safari 10

/to @cramforce /cc @jridgewell