### PR TITLE
Using `playing` instead of `play` event

### DIFF
--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -149,7 +149,7 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
     if (data.data == 'playing') {
       this.element.dispatchCustomEvent(VideoEvents.PLAYING);
     } else if (data.data == 'paused') {
-      this.element.dispatchCustomEvent(VideoEvents.PAUSED);
+      this.element.dispatchCustomEvent(VideoEvents.PAUSE);
     } else if (data.data == 'muted') {
       this.element.dispatchCustomEvent('mute');
     } else if (data.data == 'unmuted') {

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -61,7 +61,6 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
     const iframe = this.element.ownerDocument.createElement('iframe');
     this.iframe_ = iframe;
 
-    this.forwardEvents([VideoEvents.PLAY, VideoEvents.PAUSE], iframe);
     this.applyFillContent(iframe, true);
     this.element.appendChild(iframe);
 
@@ -148,9 +147,9 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
       return; // We only process valid JSON.
     }
     if (data.data == 'playing') {
-      this.element.dispatchCustomEvent(VideoEvents.PLAY);
+      this.element.dispatchCustomEvent(VideoEvents.PLAYING);
     } else if (data.data == 'paused') {
-      this.element.dispatchCustomEvent(VideoEvents.PAUSE);
+      this.element.dispatchCustomEvent(VideoEvents.PAUSED);
     } else if (data.data == 'muted') {
       this.element.dispatchCustomEvent('mute');
     } else if (data.data == 'unmuted') {

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -178,7 +178,7 @@ class AmpVideo extends AMP.BaseElement {
      */
     installEventHandlers_() {
       const video = dev().assertElement(this.video_);
-      this.forwardEvents([VideoEvents.PLAY, VideoEvents.PAUSE], video);
+      this.forwardEvents([VideoEvents.PLAYING, VideoEvents.PAUSED], video);
       listen(video, 'volumechange', () => {
         if (this.muted_ != this.video_.muted) {
           this.muted_ = this.video_.muted;

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -59,9 +59,6 @@ class AmpVideo extends AMP.BaseElement {
 
       /** @private {?boolean}  */
       this.muted_ = false;
-
-      /** @private @const {!Promise} */
-      this.loadPromise_ = null;
     }
 
     /**
@@ -171,8 +168,7 @@ class AmpVideo extends AMP.BaseElement {
       });
 
       // loadPromise for media elements listens to `loadstart`
-      this.loadPromise_ = this.loadPromise(this.video_);
-      return this.loadPromise_.then(() => {
+      return this.loadPromise(this.video_).then(() => {
         this.element.dispatchCustomEvent(VideoEvents.LOAD);
       });
     }
@@ -224,24 +220,24 @@ class AmpVideo extends AMP.BaseElement {
      * @override
      */
     play(unusedIsAutoplay) {
-      this.loadPromise_.then(() => {
-        return this.video_.play();
-      }).catch(() => {
-        // Empty catch to prevent useless unhandled promise rejection logging.
-        // Play can fail for many reasons such as video getting paused before
-        // play() is finished.
-        // We use events to know the state of the video and do not care about
-        // the success or failure of the play()'s returned promise.
-      });
+      const ret = this.video_.play();
+
+      if (ret && ret.catch) {
+        ret.catch(() => {
+          // Empty catch to prevent useless unhandled promise rejection logging.
+          // Play can fail for many reasons such as video getting paused before
+          // play() is finished.
+          // We use events to know the state of the video and do not care about
+          // the success or failure of the play()'s returned promise.
+        });
+      }
     }
 
     /**
      * @override
      */
     pause() {
-      this.loadPromise_.then(() => {
-        this.video_.pause();
-      });
+      this.video_.pause();
     }
 
     /**

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -178,7 +178,7 @@ class AmpVideo extends AMP.BaseElement {
      */
     installEventHandlers_() {
       const video = dev().assertElement(this.video_);
-      this.forwardEvents([VideoEvents.PLAYING, VideoEvents.PAUSED], video);
+      this.forwardEvents([VideoEvents.PLAYING, VideoEvents.PAUSE], video);
       listen(video, 'volumechange', () => {
         if (this.muted_ != this.video_.muted) {
           this.muted_ = this.video_.muted;

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -373,11 +373,11 @@ describe(TAG, () => {
       })
       .then(() => {
         impl.play();
-        return listenOncePromise(v, VideoEvents.PLAY);
+        return listenOncePromise(v, VideoEvents.PLAYING);
       })
       .then(() => {
         impl.pause();
-        return listenOncePromise(v, VideoEvents.PAUSE);
+        return listenOncePromise(v, VideoEvents.PAUSED);
       })
       .then(() => {
         impl.unmute();

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -361,7 +361,7 @@ describe(TAG, () => {
 
   it('should forward certain events from video to the amp element', () => {
     return getVideo({
-      src: 'foo.mp4',
+      src: '/examples/av/ForBiggerJoyrides.mp4',
       width: 160,
       height: 90,
     }).then(v => {
@@ -377,7 +377,7 @@ describe(TAG, () => {
       })
       .then(() => {
         impl.pause();
-        return listenOncePromise(v, VideoEvents.PAUSED);
+        return listenOncePromise(v, VideoEvents.PAUSE);
       })
       .then(() => {
         impl.unmute();

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -246,7 +246,7 @@ class AmpYoutube extends AMP.BaseElement {
         data.info && data.info.playerState !== undefined) {
       this.playerState_ = data.info.playerState;
       if (this.playerState_ == PlayerStates.PAUSED) {
-        this.element.dispatchCustomEvent(VideoEvents.PAUSED);
+        this.element.dispatchCustomEvent(VideoEvents.PAUSE);
       } else if (this.playerState_ == PlayerStates.PLAYING) {
         this.element.dispatchCustomEvent(VideoEvents.PLAYING);
       }

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -246,9 +246,9 @@ class AmpYoutube extends AMP.BaseElement {
         data.info && data.info.playerState !== undefined) {
       this.playerState_ = data.info.playerState;
       if (this.playerState_ == PlayerStates.PAUSED) {
-        this.element.dispatchCustomEvent(VideoEvents.PAUSE);
+        this.element.dispatchCustomEvent(VideoEvents.PAUSED);
       } else if (this.playerState_ == PlayerStates.PLAYING) {
-        this.element.dispatchCustomEvent(VideoEvents.PLAY);
+        this.element.dispatchCustomEvent(VideoEvents.PLAYING);
       }
     } else if (data.event == 'infoDelivery' &&
         data.info && data.info.muted !== undefined) {

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -266,12 +266,12 @@ describe('amp-youtube', function() {
         return p;
       })
       .then(() => {
-        const p = listenOncePromise(yt, VideoEvents.PLAY);
+        const p = listenOncePromise(yt, VideoEvents.PLAYING);
         sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 1});
         return p;
       })
       .then(() => {
-        const p = listenOncePromise(yt, VideoEvents.PAUSE);
+        const p = listenOncePromise(yt, VideoEvents.PAUSED);
         sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 2});
         return p;
       })

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -271,7 +271,7 @@ describe('amp-youtube', function() {
         return p;
       })
       .then(() => {
-        const p = listenOncePromise(yt, VideoEvents.PAUSED);
+        const p = listenOncePromise(yt, VideoEvents.PAUSE);
         sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 2});
         return p;
       })

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -277,7 +277,7 @@ class VideoEntry {
     // Listen to pause, play and user interaction events.
     const unlistenInteraction = listen(mask, 'click', onInteraction.bind(this));
 
-    const unlistenPause = listen(this.video.element, VideoEvents.PAUSED,
+    const unlistenPause = listen(this.video.element, VideoEvents.PAUSE,
         toggleAnimation.bind(this, /*playing*/ false));
 
     const unlistenPlay = listen(this.video.element, VideoEvents.PLAYING,

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -277,10 +277,10 @@ class VideoEntry {
     // Listen to pause, play and user interaction events.
     const unlistenInteraction = listen(mask, 'click', onInteraction.bind(this));
 
-    const unlistenPause = listen(this.video.element, VideoEvents.PAUSE,
+    const unlistenPause = listen(this.video.element, VideoEvents.PAUSED,
         toggleAnimation.bind(this, /*playing*/ false));
 
-    const unlistenPlay = listen(this.video.element, VideoEvents.PLAY,
+    const unlistenPlay = listen(this.video.element, VideoEvents.PLAYING,
         toggleAnimation.bind(this, /*playing*/ true));
 
     function onInteraction() {

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -165,20 +165,20 @@ export const VideoEvents = {
   /**
    * play
    *
-   * Fired when the video plays.
+   * Fired when the video start playing.
    *
-   * @event play
+   * @event playing
    */
-  PLAY: 'play',
+  PLAYING: 'playing',
 
   /**
    * pause
    *
-   * Fired when the video pauses.
+   * Fired when the video is paused.
    *
-   * @event pause
+   * @event paused
    */
-  PAUSE: 'pause',
+  PAUSED: 'paused',
 
   /**
    * muted

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -176,9 +176,9 @@ export const VideoEvents = {
    *
    * Fired when the video is paused.
    *
-   * @event paused
+   * @event pause
    */
-  PAUSED: 'paused',
+  PAUSE: 'pause',
 
   /**
    * muted

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -165,7 +165,7 @@ export const VideoEvents = {
   /**
    * play
    *
-   * Fired when the video start playing.
+   * Fired when the video starts playing.
    *
    * @event playing
    */

--- a/test/functional/test-video-manager.js
+++ b/test/functional/test-video-manager.js
@@ -270,7 +270,7 @@ function createFakeVideoPlayerClass(win) {
      */
     pause() {
       Promise.resolve().then(() => {
-        this.element.dispatchCustomEvent(VideoEvents.PAUSED);
+        this.element.dispatchCustomEvent(VideoEvents.PAUSE);
       });
     }
 

--- a/test/functional/test-video-manager.js
+++ b/test/functional/test-video-manager.js
@@ -261,7 +261,7 @@ function createFakeVideoPlayerClass(win) {
      */
     play(unusedIsAutoplay) {
       Promise.resolve().then(() => {
-        this.element.dispatchCustomEvent(VideoEvents.PLAY);
+        this.element.dispatchCustomEvent(VideoEvents.PLAYING);
       });
     }
 
@@ -270,7 +270,7 @@ function createFakeVideoPlayerClass(win) {
      */
     pause() {
       Promise.resolve().then(() => {
-        this.element.dispatchCustomEvent(VideoEvents.PAUSE);
+        this.element.dispatchCustomEvent(VideoEvents.PAUSED);
       });
     }
 

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -54,8 +54,8 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
 
   describe.configure().retryOnSaucelabs()
   .run('Actions', function() {
-    this.timeout(900000);
-    it.only('should support mute, play, pause, unmute actions', function() {
+    this.timeout(TIMEOUT);
+    it('should support mute, play, pause, unmute actions', function() {
       return getVideoPlayer({outsideView: false, autoplay: false}).then(r => {
         // Create a action buttons
         const playButton = createButton(r, 'play');

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -54,8 +54,8 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
 
   describe.configure().retryOnSaucelabs()
   .run('Actions', function() {
-    this.timeout(TIMEOUT);
-    it('should support mute, play, pause, unmute actions', function() {
+    this.timeout(900000);
+    it.only('should support mute, play, pause, unmute actions', function() {
       return getVideoPlayer({outsideView: false, autoplay: false}).then(r => {
         // Create a action buttons
         const playButton = createButton(r, 'play');

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -73,7 +73,7 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
         })
         .then(() => {
           pauseButton.click();
-          return listenOncePromise(r.video, VideoEvents.PAUSED);
+          return listenOncePromise(r.video, VideoEvents.PAUSE);
         })
         .then(() => {
           unmuteButton.click();
@@ -142,7 +142,7 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
           return p;
         }).then(() => {
           // scroll back to top, make video not visible
-          const p = listenOncePromise(video, VideoEvents.PAUSED);
+          const p = listenOncePromise(video, VideoEvents.PAUSE);
           viewport.setScrollTop(0);
           return p;
         });

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -69,11 +69,11 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
         })
         .then(() => {
           playButton.click();
-          return listenOncePromise(r.video, VideoEvents.PLAY);
+          return listenOncePromise(r.video, VideoEvents.PLAYING);
         })
         .then(() => {
           pauseButton.click();
-          return listenOncePromise(r.video, VideoEvents.PAUSE);
+          return listenOncePromise(r.video, VideoEvents.PAUSED);
         })
         .then(() => {
           unmuteButton.click();
@@ -114,14 +114,14 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
     describe('play/pause', () => {
       it('should play when in view port initially', () => {
         return getVideoPlayer({outsideView: false, autoplay: true}).then(r => {
-          return listenOncePromise(r.video, VideoEvents.PLAY);
+          return listenOncePromise(r.video, VideoEvents.PLAYING);
         });
       });
 
       it('should not play when not in view port initially', () => {
         return getVideoPlayer({outsideView: true, autoplay: true}).then(r => {
           const timer = timerFor(r.video.implementation_.win);
-          const p = listenOncePromise(r.video, VideoEvents.PLAY).then(() => {
+          const p = listenOncePromise(r.video, VideoEvents.PLAYING).then(() => {
             return Promise.reject('should not have autoplayed');
           });
           // we have to wait to ensure play is NOT called.
@@ -137,12 +137,12 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
           viewport = video.implementation_.getViewport();
 
           // scroll to the bottom, make video fully visible
-          const p = listenOncePromise(video, VideoEvents.PLAY);
+          const p = listenOncePromise(video, VideoEvents.PLAYING);
           viewport.scrollIntoView(video);
           return p;
         }).then(() => {
           // scroll back to top, make video not visible
-          const p = listenOncePromise(video, VideoEvents.PAUSE);
+          const p = listenOncePromise(video, VideoEvents.PAUSED);
           viewport.setScrollTop(0);
           return p;
         });

--- a/test/integration/test-video-players.js
+++ b/test/integration/test-video-players.js
@@ -31,8 +31,7 @@ import {runVideoPlayerIntegrationTests} from './test-video-players-helper';
 describe('amp-video', () => {
   runVideoPlayerIntegrationTests(fixture => {
     const video = fixture.doc.createElement('amp-video');
-    video.setAttribute('src', 'https://commondatastorage.googleapis.com' +
-      '/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4');
+    video.setAttribute('src', '/examples/av/ForBiggerJoyrides.mp4');
     return video;
   });
 });

--- a/test/integration/test-video-players.js
+++ b/test/integration/test-video-players.js
@@ -31,17 +31,18 @@ import {runVideoPlayerIntegrationTests} from './test-video-players-helper';
 describe('amp-video', () => {
   runVideoPlayerIntegrationTests(fixture => {
     const video = fixture.doc.createElement('amp-video');
-    video.setAttribute('src', '/examples/av/ForBiggerJoyrides.mp4');
+    video.setAttribute('src', 'https://commondatastorage.googleapis.com' +
+      '/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4');
     return video;
   });
 });
 
 //TODO(aghassemi,#7160): We have to skip iOS for YouTube tests since YouTube
 //player does not work at all (not AMP related) on SauceLab's iOS simulator.
-// describe.configure().skipIos().run('amp-youtube', () => {
-//   runVideoPlayerIntegrationTests(fixture => {
-//     const video = fixture.doc.createElement('amp-youtube');
-//     video.setAttribute('data-videoid', 'lBTCB7yLs8Y');
-//     return video;
-//   });
-// });
+describe.configure().skipIos().run('amp-youtube', () => {
+  runVideoPlayerIntegrationTests(fixture => {
+    const video = fixture.doc.createElement('amp-youtube');
+    video.setAttribute('data-videoid', 'lBTCB7yLs8Y');
+    return video;
+  });
+});

--- a/test/integration/test-video-players.js
+++ b/test/integration/test-video-players.js
@@ -31,18 +31,17 @@ import {runVideoPlayerIntegrationTests} from './test-video-players-helper';
 describe('amp-video', () => {
   runVideoPlayerIntegrationTests(fixture => {
     const video = fixture.doc.createElement('amp-video');
-    video.setAttribute('src', 'https://commondatastorage.googleapis.com' +
-      '/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4');
+    video.setAttribute('src', '/examples/av/ForBiggerJoyrides.mp4');
     return video;
   });
 });
 
 //TODO(aghassemi,#7160): We have to skip iOS for YouTube tests since YouTube
 //player does not work at all (not AMP related) on SauceLab's iOS simulator.
-describe.configure().skipIos().run('amp-youtube', () => {
-  runVideoPlayerIntegrationTests(fixture => {
-    const video = fixture.doc.createElement('amp-youtube');
-    video.setAttribute('data-videoid', 'lBTCB7yLs8Y');
-    return video;
-  });
-});
+// describe.configure().skipIos().run('amp-youtube', () => {
+//   runVideoPlayerIntegrationTests(fixture => {
+//     const video = fixture.doc.createElement('amp-youtube');
+//     video.setAttribute('data-videoid', 'lBTCB7yLs8Y');
+//     return video;
+//   });
+// });


### PR DESCRIPTION
`play` event is dispatched when a video is requested to `play` but there is no guarantee is will `play` (e.g. if video has ended). Switching to `playing` event which is guaranteed to be correct.

Also removing an unnecessary event forwarding from ooyala.