### PR TITLE
Specify a z-index for autoplay animation

### DIFF
--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -1,35 +1,39 @@
-selector                                    |   z-index      |   file
----                                         |   ---          |   ---
-.-amp-image-lightbox-container              |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-loading-container                |   1            |   css/amp.css
-.i-amphtml-layout-size-defined > [fallback] |   1            |   css/amp.css
-.-amp-image-lightbox-viewer-image           |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.-amp-image-lightbox-viewer                 |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-layout-size-defined > [placeholder] |   1            |   css/amp.css
-.-amp-image-lightbox-caption                |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-element > [overflow]             |   2            |   css/amp.css
-.i-amphtml-loader-moving-line               |   2            |   css/amp.css
-.amp-carousel-button                        |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
-amp-sticky-ad                               |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
-amp-sticky-ad                               |   11           |   extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
-amp-sticky-ad-top-padding                   |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
-amp-app-banner                              |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-.amp-app-banner-dismiss-button              |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-i-amp-app-banner-top-padding                |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-amp-image-lightbox                          |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-amp-user-notification                       |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
-amp-live-list > [update]                    |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
-amp-lightbox                                |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
-.-amp-lightboxed-ancestor                   |   auto         |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.-amp-image-lightbox-trans                  |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.-amp-lbv-mask                              |   2147483642   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.amp-lightboxed                             |   2147483643   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.amp-lbv-desc-box                           |   2147483644   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.-amp-lbv-gallery                           |   2147483645   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.-amp-sidebar-mask                          |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
-.amp-lbv-button-prev                        |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.amp-lbv-button-next                        |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.amp-lbv-button-gallery                     |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.amp-lbv-button-back                        |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-.amp-lbv-button-close                       |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-amp-sidebar                                 |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+selector                                         |   z-index      |   file
+---                                              |   ---          |   ---
+.-amp-image-lightbox-container                   |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.amp-video-eq                                    |   1            |   css/amp.css
+.i-amphtml-layout-size-defined > [placeholder]   |   1            |   css/amp.css
+.i-amphtml-loading-container                     |   1            |   css/amp.css
+.-amp-image-lightbox-viewer-image                |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.-amp-image-lightbox-viewer                      |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-layout-size-defined > [fallback]      |   1            |   css/amp.css
+.i-amphtml-loader-moving-line                    |   2            |   css/amp.css
+.i-amphtml-element > [overflow]                  |   2            |   css/amp.css
+.-amp-image-lightbox-caption                     |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.amp-carousel-button                             |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
+amp-sticky-ad                                    |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+amp-sticky-ad                                    |   11           |   extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
+amp-sticky-ad-top-padding                        |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+amp-app-banner                                   |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+.amp-app-banner-dismiss-button                   |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+i-amp-app-banner-top-padding                     |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+amp-image-lightbox                               |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+amp-user-notification                            |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
+amp-live-list > [update]                         |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
+amp-lightbox                                     |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
+.-amp-lightboxed-ancestor                        |   auto         |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+.-amp-image-lightbox-trans                       |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.-amp-lbv-mask                                   |   2147483642   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+.amp-lightboxed                                  |   2147483643   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+.amp-lbv-desc-box                                |   2147483644   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+.-amp-lbv-gallery                                |   2147483645   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+.-amp-sidebar-mask                               |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+.amp-lbv-button-prev                             |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+.amp-lbv-button-next                             |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+
+.amp-lbv-button-gallery                         |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+
+.amp-lbv-button-back                            |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+
+.amp-lbv-button-close                           |   2147483646   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+amp-sidebar                                      |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css

--- a/css/amp.css
+++ b/css/amp.css
@@ -543,6 +543,7 @@ amp-fresh {
   opacity: 0.8;
   overflow: hidden;
   position: absolute;
+  z-index: 1;
   right: 7px;
   width: 20px;
 }

--- a/css/amp.css
+++ b/css/amp.css
@@ -543,9 +543,9 @@ amp-fresh {
   opacity: 0.8;
   overflow: hidden;
   position: absolute;
-  z-index: 1;
   right: 7px;
   width: 20px;
+  z-index: 1;
 }
 .amp-video-eq .amp-video-eq-col {
   flex: 1;


### PR DESCRIPTION
Fixes a race condition:
When video-manager adds the element for the animation icon, there is no guarantee that the icon is inserted before or after the actual video tag (or iframe in the case of youtube). Without an explicit z-index and if icon is inserted before the iframe, then iframe will cover the animation icon.