### PR TITLE
TreeWalker in Bind & better variable names

### DIFF
--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -28,7 +28,7 @@ const TAG = 'AMP-BIND';
  *   expressionString: string,
  * }}
  */
-export let EvaluateeDef;
+export let BindingDef;
 
 /**
  * @typedef {{
@@ -37,26 +37,26 @@ export let EvaluateeDef;
  *   expression: !BindExpression,
  * }}
  */
-let ParsedEvaluateeDef;
+let ParsedBindingDef;
 
 /**
  * Asynchronously evaluates a set of Bind expressions.
  */
 export class BindEvaluator {
   /**
-   * @param {!Array<EvaluateeDef>} evaluatees
+   * @param {!Array<BindingDef>} bindings
    */
-  constructor(evaluatees) {
-    /** @const {!Array<ParsedEvaluateeDef>} */
-    this.parsedEvaluatees_ = [];
+  constructor(bindings) {
+    /** @const {!Array<ParsedBindingDef>} */
+    this.parsedBindings_ = [];
 
     /** @const {!./bind-validator.BindValidator} */
     this.validator_ = new BindValidator();
 
     // Create BindExpression objects from expression strings.
     // TODO(choumx): Chunk creation of BindExpression or change to web worker.
-    for (let i = 0; i < evaluatees.length; i++) {
-      const e = evaluatees[i];
+    for (let i = 0; i < bindings.length; i++) {
+      const e = bindings[i];
 
       let expression;
       try {
@@ -66,7 +66,7 @@ export class BindEvaluator {
         continue;
       }
 
-      this.parsedEvaluatees_.push({
+      this.parsedBindings_.push({
         tagName: e.tagName,
         property: e.property,
         expression,
@@ -89,8 +89,8 @@ export class BindEvaluator {
       /** @type {!Object<string, boolean>} */
       const invalid = {};
 
-      this.parsedEvaluatees_.forEach(evaluatee => {
-        const {tagName, property, expression} = evaluatee;
+      this.parsedBindings_.forEach(binding => {
+        const {tagName, property, expression} = binding;
         const expr = expression.expressionString;
 
         // Skip if we've already evaluated this expression string.
@@ -100,7 +100,7 @@ export class BindEvaluator {
 
         let result;
         try {
-          result = evaluatee.expression.evaluate(scope);
+          result = binding.expression.evaluate(scope);
         } catch (error) {
           user().error(TAG, error);
           return;

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -17,12 +17,12 @@
 import {BindEvaluator} from './bind-evaluator';
 import {BindValidator} from './bind-validator';
 import {chunk, ChunkPriority} from '../../../src/chunk';
+import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber} from '../../../src/types';
 import {resourcesForDoc} from '../../../src/resources';
-import {user} from '../../../src/log';
 
 const TAG = 'amp-bind';
 
@@ -166,8 +166,7 @@ export class Bind {
     /** @type {!Array<./bind-evaluator.BindingDef>} */
     const bindings = [];
 
-    // TODO(choumx): Use TreeWalker if this is too slow.
-    const elements = body.getElementsByTagName('*');
+    const elements = this.elementsInNode_(body);
     const numElements = elements.length;
 
     // Helper function for scanning a slice of elements.
@@ -259,6 +258,24 @@ export class Bind {
       }
     }
     return null;
+  }
+
+  /**
+   * Returns all descendant elements in a given node.
+   * @param {!Node} node
+   * @return {!Array<Element>}
+   * @private
+   */
+  elementsInNode_(node) {
+    const doc = dev().assert(node.ownerDocument, 'ownerDocument is null.');
+    const treeWalker = doc.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
+
+    const elements = [];
+    let currentElement;
+    while (currentElement = treeWalker.nextNode()) {
+      elements.push(currentElement);
+    }
+    return elements;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -178,13 +178,12 @@ export class Bind {
         const boundProperties = this.scanElement_(element, bindings);
         if (boundProperties.length > 0) {
           boundElements.push({element, boundProperties});
-
-          // Append (element, property, expressionString) tuples to `bindings`.
-          boundProperties.forEach(boundProperty => {
-            const {property, expressionString} = boundProperty;
-            bindings.push({tagName, property, expressionString});
-          });
         }
+        // Append (element, property, expressionString) tuples to `bindings`.
+        boundProperties.forEach(boundProperty => {
+          const {property, expressionString} = boundProperty;
+          bindings.push({tagName, property, expressionString});
+        });
       }
     };
 


### PR DESCRIPTION
Partial for #7230, related to #6199.

- Replace `getElementsByTagName` with `TreeWalker` for DOM scan
- Rename `BindingDef` -> `BoundPropertyDef` and `evaluatee` -> `binding`

/to @jridgewell 