### PR TITLE
DistroScale enhancement: Use source URL instead of window.context.location for site identification.

### DIFF
--- a/ads/distroscale.js
+++ b/ads/distroscale.js
@@ -22,17 +22,24 @@ import {loadScript, validateData} from '../3p/3p';
  */
 export function distroscale(global, data) {
   validateData(data, ['pid'], ['zid', 'tid']);
-  let src = '//c.jsrdn.com/s/cs.js?p=' + encodeURIComponent(data.pid) +
-      '&f=' + encodeURIComponent(global.context.location.href);
-  if (data.tid) {
-    src += '&t=' + encodeURIComponent(data.tid);
-  }
+  let src = '//c.jsrdn.com/s/cs.js?p=' + encodeURIComponent(data.pid);
 
   if (data.zid) {
     src += '&z=' + encodeURIComponent(data.zid);
   } else {
     src += '&z=amp';
   }
+
+  if (data.tid) {
+    src += '&t=' + encodeURIComponent(data.tid);
+  }
+
+  let srcUrl = global.context.sourceUrl;
+
+  srcUrl = srcUrl.replace(/#.+/, '').replace(/\?.+/, '');
+
+  src += '&f=' + encodeURIComponent(srcUrl);
+
 
   global.dsAMPCallbacks = {
     renderStart: global.context.renderStart,


### PR DESCRIPTION
The purpose of this PR is to get the site URL in the form of //www.example.com/article/amp/ instead of //cdn.ampproject.org/v/s/www.example.com/article/amp/ for reporting and Ad-call.

How would #6829 impact getting the sourceUrl? I'm not seeing it in the backwards compatibility chart.

Fixes #7303