### PR TITLE
amp-selector: Clean up `amp-selector` experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -17,7 +17,6 @@
   "amp-apester-media": 1,
   "amp-accordion-session-state-optout": 1,
   "amp-playbuzz": 1,
-  "amp-selector": 1,
   "sentinel-name-change": 1,
   "chunked-amp": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -15,6 +15,5 @@
   "ios-embed-wrapper": 1,
   "amp-apester-media": 1,
   "amp-accordion-session-state-optout": 1,
-  "amp-playbuzz": 1,
-  "amp-selector": 1
+  "amp-playbuzz": 1
 }

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -17,8 +17,7 @@
 import {CSS} from '../../../build/amp-selector-0.1.css';
 import {actionServiceForDoc} from '../../../src/action';
 import {closest} from '../../../src/dom';
-import {dev, user} from '../../../src/log';
-import {isExperimentOn} from '../../../src/experiments';
+import {dev} from '../../../src/log';
 
 export class AmpSelector extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -51,8 +50,6 @@ export class AmpSelector extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    user().assert(isExperimentOn(this.win, 'amp-selector'),
-        `Experiment amp-selector is disabled.`);
     this.isMultiple_ = this.element.hasAttribute('multiple');
     this.isDisabled_ = this.element.hasAttribute('disabled');
 

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -15,7 +15,6 @@
  */
 
 import '../amp-selector';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('amp-selector', {
   win: { /* window spec */
@@ -29,14 +28,6 @@ describes.realWin('amp-selector', {
 }, env => {
   let win;
   describe('test extension', () => {
-
-    beforeEach(() => {
-      toggleExperiment(window, 'amp-selector', true);
-    });
-
-    afterEach(() => {
-      toggleExperiment(window, 'amp-selector', false);
-    });
 
     function getSelector(options) {
       win = env.win;

--- a/test/manual/amp-selector.amp.html
+++ b/test/manual/amp-selector.amp.html
@@ -25,7 +25,6 @@
   <script async src="../../dist/amp.js"></script>
 </head>
 <body>
-  <button onclick="AMP.toggleExperiment('amp-selector');window.location.href=window.location.href;">Toggle Experiment</button>
   <form action="/test/manual/amp-selector.amp.html" method="get" target="_blank" id="form1">
   <amp-selector layout="container" name="single_image_select">
     <div option="xyz" selected>Select me</div>

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -220,13 +220,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6254',
   },
   {
-    id: 'amp-selector',
-    name: 'Amp selector extension',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6168',
-    spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
-        'amp-selector/amp-selector.md',
-  },
-  {
     id: 'amp-accordion-session-state-optout',
     name: 'AMP Accordion attribute to opt out of preserved state.',
     Spec: 'https://github.com/ampproject/amphtml/issues/3813',


### PR DESCRIPTION
Amp selector is launched 100% on prod, so cleaning up the experiment.

- Removes experiment entry from experiments list
- Removes the experiment from prod and canary JSON.
- Removes experiment checks in the code base.
- Remove usage of experiments in the unit test.
- Updates manual test file

really help with making this more readable.

Fixes #6168