### PR TITLE
Fix bug in rendering caused by minification

### DIFF
--- a/ads/ix.js
+++ b/ads/ix.js
@@ -70,7 +70,7 @@ export function ix(global, data) {
         event.data.substring(0,11) !== 'ix-message-') {
         return;
       }
-      indexAmpRender(document, event.data.substring(11));
+      indexAmpRender(document, event.data.substring(11), global);
     });
 
     writeScript(global, 'https://js-sec.indexww.com/apl/apl6.js');
@@ -84,7 +84,7 @@ function callDoubleclick(global, data) {
   doubleclick(global, data);
 }
 
-function indexAmpRender(doc, targetID) {
+function indexAmpRender(doc, targetID, global) {
   try {
     const ad = global._IndexRequestData.targetIDToBid[targetID].pop();
     if (ad != null) {


### PR DESCRIPTION
'global' object in indexAmpRender() was not defined in compiled minified code. This fix passes global as an argument into the function explicitly so all references are minified correctly.