### PR TITLE
Initial load analytics event

### DIFF
--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -193,6 +193,22 @@ describe('amp-ad-xorigin-iframe-handler', () => {
               .be.rejectedWith(/timeout/);
         });
       });
+
+      it('should not update "ini-load" signal implicitly', () => {
+        return initPromise.then(() => {
+          expect(signals.get('ini-load')).to.be.null;
+        });
+      });
+
+      it('should update "ini-load" signal on message', () => {
+        iframe.postMessageToParent({
+          sentinel: 'amp3ptest' + testIndex,
+          type: 'ini-load',
+        });
+        return initPromise.then(() => {
+          expect(signals.get('ini-load')).to.be.ok;
+        });
+      });
     });
 
     it('should trigger render-start on message "bootstrap-loaded" if' +
@@ -229,6 +245,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     it('should resolve directly if it is A4A', () => {
       return iframeHandler.init(iframe, true).then(() => {
         expect(iframe.style.visibility).to.equal('');
+        expect(iframe.readyState).to.equal('complete');
       });
     });
   });

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -21,6 +21,7 @@ import {
 } from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {map} from '../../../src/utils/object';
+import {whenContentIniLoad} from '../../../src/friendly-iframe-embed';
 
 const TAG = 'amp-analytics';
 
@@ -263,6 +264,14 @@ export class AnalyticsRoot {
       }
     };
   }
+
+  /**
+   * Returns the promise that will be resolved as soon as the elements within
+   * the root have been loaded inside the first viewport of the root.
+   * @return {!Promise}
+   * @abstract
+   */
+  whenIniLoaded() {}
 }
 
 
@@ -301,6 +310,11 @@ export class AmpdocAnalyticsRoot extends AnalyticsRoot {
   /** @override */
   getElementById(id) {
     return this.ampdoc.getElementById(id);
+  }
+
+  /** @override */
+  whenIniLoaded() {
+    return whenContentIniLoad(this.ampdoc, this.ampdoc.win);
   }
 }
 
@@ -343,6 +357,11 @@ export class EmbedAnalyticsRoot extends AnalyticsRoot {
   /** @override */
   getElementById(id) {
     return this.embed.win.document.getElementById(id);
+  }
+
+  /** @override */
+  whenIniLoaded() {
+    return this.embed.whenIniLoaded();
   }
 }
 

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CommonSignals} from '../../../src/common-signals';
 import {Observable} from '../../../src/observable';
 import {getDataParamsFromAttributes} from '../../../src/dom';
 import {user} from '../../../src/log';
@@ -249,6 +250,58 @@ export class SignalTracker extends EventTracker {
 
     // Wait for the target and the event signal.
     signalsPromise.then(signals => signals.whenSignal(eventType)).then(() => {
+      listener(new AnalyticsEvent(target, eventType));
+    });
+    return NO_UNLISTEN;
+  }
+}
+
+
+/**
+ * Tracks when the elements in the first viewport has been loaded - "ini-load".
+ */
+export class IniLoadTracker extends EventTracker {
+  /**
+   * @param {!./analytics-root.AnalyticsRoot} root
+   */
+  constructor(root) {
+    super(root);
+  }
+
+  /** @override */
+  dispose() {
+  }
+
+  /** @override */
+  add(context, eventType, config, listener) {
+    let target;
+    let promise;
+    const selector = config['selector'] || ':root';
+    if (selector == ':root' || selector == ':host') {
+      // Root selectors are delegated to analytics roots.
+      target = this.root.getRootElement();
+      promise = this.root.whenIniLoaded();
+    } else {
+      // An AMP-element. Wait for DOM to be fully parsed to avoid
+      // false missed searches.
+      promise = this.root.ampdoc.whenReady().then(() => {
+        const selectionMethod = config['selectionMethod'];
+        const element = user().assertElement(
+            this.root.getAmpElement(
+                (context.parentElement || context),
+                selector,
+                selectionMethod),
+            `Element "${selector}" not found`);
+        target = element;
+        const signals = element.signals();
+        return Promise.race([
+          signals.whenSignal(CommonSignals.INI_LOAD),
+          signals.whenSignal(CommonSignals.LOAD_END),
+        ]);
+      });
+    }
+    // Wait for the target and the event.
+    promise.then(() => {
       listener(new AnalyticsEvent(target, eventType));
     });
     return NO_UNLISTEN;

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -22,6 +22,7 @@ import {
   AnalyticsEvent,
   ClickEventTracker,
   CustomEventTracker,
+  IniLoadTracker,
   SignalTracker,
 } from './events';
 import {Observable} from '../../../src/observable';
@@ -87,6 +88,11 @@ const EVENT_TRACKERS = {
     name: 'render-start',
     allowedFor: ALLOWED_FOR_ALL,
     klass: SignalTracker,
+  },
+  'ini-load': {
+    name: 'ini-load',
+    allowedFor: ALLOWED_FOR_ALL,
+    klass: IniLoadTracker,
   },
 };
 

--- a/extensions/amp-analytics/0.1/test/test-analytics-root.js
+++ b/extensions/amp-analytics/0.1/test/test-analytics-root.js
@@ -84,6 +84,11 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
     expect(root.signals()).to.equal(ampdoc.signals());
   });
 
+  it('should resolve ini-load signal', () => {
+    ampdoc.signals().signal('ready-scan');
+    return root.whenIniLoaded();
+  });
+
 
   describe('getElement', () => {
 
@@ -385,6 +390,13 @@ describes.realWin('EmbedAnalyticsRoot', {
 
   it('should init with embed signals', () => {
     expect(root.signals()).to.equal(embed.signals());
+  });
+
+  it('should resolve ini-load signal', () => {
+    const stub = sandbox.stub(embed, 'whenIniLoaded', () => Promise.resolve());
+    return root.whenIniLoaded().then(() => {
+      expect(stub).to.be.calledOnce;
+    });
   });
 
 

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -19,6 +19,7 @@ import {
   AnalyticsEvent,
   ClickEventTracker,
   CustomEventTracker,
+  IniLoadTracker,
   SignalTracker,
 } from '../events';
 import {Signals} from '../../../../src/utils/signals';
@@ -301,6 +302,100 @@ describes.realWin('Events', {amp: 1}, env => {
       return promise.then(event => {
         expect(event.target).to.equal(target);
         expect(event.type).to.equal('sig1');
+      });
+    });
+  });
+
+
+  describe('IniLoadTracker', () => {
+    let tracker;
+    let targetSignals;
+
+    beforeEach(() => {
+      tracker = new IniLoadTracker(root);
+      target.classList.add('i-amphtml-element');
+      targetSignals = new Signals();
+      target.signals = () => targetSignals;
+    });
+
+    it('should initalize, add listeners and dispose', () => {
+      expect(tracker.root).to.equal(root);
+    });
+
+    it('should add doc listener', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      const iniLoadStub = sandbox.stub(root, 'whenIniLoaded',
+          () => Promise.resolve());
+      tracker.add(analyticsElement, 'ini-load', {}, resolver);
+      return promise.then(event => {
+        expect(event.target).to.equal(root.getRootElement());
+        expect(event.type).to.equal('ini-load');
+        expect(iniLoadStub).to.be.calledOnce;
+      });
+    });
+
+    it('should add root listener', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      const iniLoadStub = sandbox.stub(root, 'whenIniLoaded',
+          () => Promise.resolve());
+      tracker.add(analyticsElement, 'ini-load', {selector: ':root'}, resolver);
+      return promise.then(event => {
+        expect(event.target).to.equal(root.getRootElement());
+        expect(event.type).to.equal('ini-load');
+        expect(iniLoadStub).to.be.calledOnce;
+      });
+    });
+
+    it('should add host listener equal to root', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      const iniLoadStub = sandbox.stub(root, 'whenIniLoaded',
+          () => Promise.resolve());
+      tracker.add(analyticsElement, 'sig1', {selector: ':host'}, resolver);
+      return promise.then(event => {
+        expect(event.target).to.equal(root.getRootElement());
+        expect(event.type).to.equal('sig1');
+        expect(iniLoadStub).to.be.calledOnce;
+      });
+    });
+
+    it('should add target listener', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      const spy = sandbox.spy(targetSignals, 'whenSignal');
+      tracker.add(analyticsElement, 'ini-load', {selector: '.target'},
+          resolver);
+      targetSignals.signal('ini-load');
+      return promise.then(event => {
+        expect(event.target).to.equal(target);
+        expect(event.type).to.equal('ini-load');
+        expect(spy).to.be.calledWith('ini-load');
+      });
+    });
+
+    it('should trigger via load-end as well', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      const spy = sandbox.spy(targetSignals, 'whenSignal');
+      tracker.add(analyticsElement, 'ini-load', {selector: '.target'},
+          resolver);
+      targetSignals.signal('load-end');
+      return promise.then(event => {
+        expect(event.target).to.equal(target);
+        expect(event.type).to.equal('ini-load');
+        expect(spy).to.be.calledWith('load-end');
       });
     });
   });

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -21,6 +21,7 @@ import {
 import {
   ClickEventTracker,
   CustomEventTracker,
+  IniLoadTracker,
   SignalTracker,
 } from '../events';
 import {VisibilityState} from '../../../../src/visibility-state';
@@ -196,6 +197,21 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
       expect(stub).to.be.calledOnce;
       expect(stub).to.be.calledWith(
           analyticsElement, 'render-start', config, handler);
+    });
+
+    it('should add "ini-load" trigger', () => {
+      const config = {on: 'ini-load'};
+      group.addTrigger(config, handler);
+      const tracker = root.getTrackerOptional('ini-load');
+      expect(tracker).to.be.instanceOf(IniLoadTracker);
+
+      const unlisten = function() {};
+      const stub = sandbox.stub(tracker, 'add', () => unlisten);
+      const handler = function() {};
+      group.addTrigger(config, handler);
+      expect(stub).to.be.calledOnce;
+      expect(stub).to.be.calledWith(
+          analyticsElement, 'ini-load', config, handler);
     });
   });
 });

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -414,7 +414,7 @@ The trigger for the embed element has to include `selector` that points to the e
 "triggers": {
   "renderStart": {
     "on": "render-start",
-    "request": "render-start",
+    "request": "request",
     "selector": "#embed1"
   }
 }
@@ -425,7 +425,38 @@ This event is also emitted by the document itself and can be configured as:
 "triggers": {
   "renderStart": {
     "on": "render-start",
-    "request": "render-start"
+    "request": "request"
+  }
+}
+```
+
+#### Initial load trigger (`"on": "ini-load"`)
+This event is triggered when initial contents of an element or a document have been loaded.
+
+The "initial load" is defined in relationship to the container and its initial size.
+More specifically:
+ - For a document: all elements in the first viewport.
+ - For an embed element: all content elements in the embed document that are positiond within
+   the initial size of the embed element.
+ - For a simple AMP element (e.g. `amp-img`): the resources itself, such as an image or a video.
+
+The trigger for an embed or an AMP element has to include `selector` that points to the element:
+```javascript
+"triggers": {
+  "iniLoad": {
+    "on": "ini-load",
+    "request": "request",
+    "selector": "#embed1"
+  }
+}
+```
+
+This event is also emitted by the document itself and can be configured as:
+```javascript
+"triggers": {
+  "iniLoad": {
+    "on": "ini-load",
+    "request": "request"
   }
 }
 ```

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -431,7 +431,7 @@ This event is also emitted by the document itself and can be configured as:
 ```
 
 #### Initial load trigger (`"on": "ini-load"`)
-This event is triggered when initial contents of an element or a document have been loaded.
+This event is triggered when initial contents of an AMP element or an AMP document have been loaded.
 
 The "initial load" is defined in relationship to the container and its initial size.
 More specifically:

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -237,7 +237,7 @@ export class AmpAnimation extends AMP.BaseElement {
     }
 
     const vsync = this.getVsync();
-    const readyPromise = this.embed_ ? this.embed_.whenLoaded() :
+    const readyPromise = this.embed_ ? this.embed_.whenReady() :
         this.getAmpDoc().whenReady();
     return readyPromise.then(() => {
       const measurer = new MeasureScanner(this.win, {

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CommonSignals} from '../../../src/common-signals';
 import {CSS} from '../../../build/amp-sticky-ad-0.1.css';
 import {Layout} from '../../../src/layout';
 import {dev,user} from '../../../src/log';
@@ -140,7 +141,7 @@ class AmpStickyAd extends AMP.BaseElement {
   }
 
   /**
-   * Function that check if ad has been built.  If not, wait for the 'built'
+   * Function that check if ad has been built.  If not, wait for the "built"
    * signal. Otherwise schedule layout for ad.
    * @private
    */
@@ -165,8 +166,8 @@ class AmpStickyAd extends AMP.BaseElement {
     // all types of ads.
     const signals = ad.signals();
     return Promise.race([
-      signals.whenSignal('render-start'),
-      signals.whenSignal('load-end'),
+      signals.whenSignal(CommonSignals.RENDER_START),
+      signals.whenSignal(CommonSignals.LOAD_END),
     ]).then(() => {
       return this.vsync_.mutatePromise(() => {
         // Set sticky-ad to visible and change container style

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CommonSignals} from '../../../src/common-signals';
 import {CSS} from '../../../build/amp-sticky-ad-1.0.css';
 import {Layout} from '../../../src/layout';
 import {dev,user} from '../../../src/log';
@@ -157,7 +158,7 @@ class AmpStickyAd extends AMP.BaseElement {
   }
 
   /**
-   * Function that check if ad has been built.  If not, wait for the 'built'
+   * Function that check if ad has been built.  If not, wait for the "built"
    * signal. Otherwise schedule layout for ad.
    * @private
    */
@@ -183,8 +184,8 @@ class AmpStickyAd extends AMP.BaseElement {
     // all types of ads.
     const signals = ad.signals();
     return Promise.race([
-      signals.whenSignal('render-start'),
-      signals.whenSignal('load-end'),
+      signals.whenSignal(CommonSignals.RENDER_START),
+      signals.whenSignal(CommonSignals.LOAD_END),
     ]).then(() => {
       return this.vsync_.mutatePromise(() => {
         // Set sticky-ad to visible and change container style

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -697,8 +697,8 @@ export class BaseElement {
   }
 
   /**
-   * Returns the layout rectangle of the element used for reporting this
-   * element's intersection with the viewport.
+   * Returns the layout rectangle used for when calculating this element's
+   * intersection with the viewport.
    * @return {!./layout-rect.LayoutRectDef}
    */
   getIntersectionElementLayoutBox() {

--- a/src/common-signals.js
+++ b/src/common-signals.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Commonly used signals across different elements and documents.
+ * @enum {string}
+ */
+export const CommonSignals = {
+
+  /**
+   * The element has been built.
+   */
+  BUILT: 'built',
+
+  /**
+   * The initial contents of an element/document/embed have been loaded.
+   */
+  INI_LOAD: 'ini-load',
+
+  /**
+   * The element has been loaded.
+   */
+  LOAD_END: 'load-end',
+
+  /**
+   * The element has started loading.
+   */
+  LOAD_START: 'load-start',
+
+  /**
+   * Rendering has been confirmed to have been started.
+   */
+  RENDER_START: 'render-start',
+};

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CommonSignals} from './common-signals';
 import {Layout, getLayoutClass, getLengthNumeral, getLengthUnits,
     isInternalElement, isLayoutSizeDefined, isLoadingAllowed,
     parseLayout, parseLength, getNaturalDimensions,
@@ -673,7 +674,7 @@ function createBaseCustomElementClass(win) {
      * @return {!Promise}
      */
     whenBuilt() {
-      return this.signals_.whenSignal('built');
+      return this.signals_.whenSignal(CommonSignals.BUILT);
     }
 
     /**
@@ -706,9 +707,9 @@ function createBaseCustomElementClass(win) {
         this.built_ = true;
         this.classList.remove('i-amphtml-notbuilt');
         this.classList.remove('amp-notbuilt');
-        this.signals_.signal('built');
+        this.signals_.signal(CommonSignals.BUILT);
       } catch (e) {
-        this.signals_.rejectSignal('built', e);
+        this.signals_.rejectSignal(CommonSignals.BUILT, e);
         reportError(e, this);
         throw e;
       }
@@ -772,8 +773,6 @@ function createBaseCustomElementClass(win) {
       if (this.isUpgraded()) {
         this.implementation_.layoutWidth_ = this.layoutWidth_;
       }
-      // TODO(malteubl): Forward for stubbed elements.
-      // TODO(jridgewell): We should pass the layoutBox down.
       this.implementation_.onLayoutMeasure();
 
       if (this.isLoadingEnabled_()) {
@@ -1148,14 +1147,14 @@ function createBaseCustomElementClass(win) {
       this.dispatchCustomEventForTesting('amp:load:start');
       const isLoadEvent = (this.layoutCount_ == 0);  // First layout is "load".
       if (isLoadEvent) {
-        this.signals_.signal('load-start');
+        this.signals_.signal(CommonSignals.LOAD_START);
       }
       const promise = this.implementation_.layoutCallback();
       this.preconnect(/* onLayout */true);
       this.classList.add('i-amphtml-layout');
       return promise.then(() => {
         if (isLoadEvent) {
-          this.signals_.signal('load-end');
+          this.signals_.signal(CommonSignals.LOAD_END);
         }
         this.readyState = 'complete';
         this.layoutCount_++;
@@ -1173,7 +1172,7 @@ function createBaseCustomElementClass(win) {
         // add layoutCount_ by 1 despite load fails or not
         if (isLoadEvent) {
           this.signals_.rejectSignal(
-              'load-end', /** @type {!Error} */ (reason));
+              CommonSignals.LOAD_END, /** @type {!Error} */ (reason));
         }
         this.layoutCount_++;
         this.toggleLoading_(false, /* cleanup */ true);
@@ -1275,9 +1274,10 @@ function createBaseCustomElementClass(win) {
     reset_() {
       this.layoutCount_ = 0;
       this.isFirstLayoutCompleted_ = false;
-      this.signals_.reset('render-start');
-      this.signals_.reset('load-start');
-      this.signals_.reset('load-end');
+      this.signals_.reset(CommonSignals.RENDER_START);
+      this.signals_.reset(CommonSignals.LOAD_START);
+      this.signals_.reset(CommonSignals.LOAD_END);
+      this.signals_.reset(CommonSignals.INI_LOAD);
     }
 
     /**
@@ -1480,7 +1480,7 @@ function createBaseCustomElementClass(win) {
      * @package @final @this {!Element}
      */
     renderStarted() {
-      this.signals_.signal('render-start');
+      this.signals_.signal(CommonSignals.RENDER_START);
       this.toggleLoading_(false);
     }
 
@@ -1543,7 +1543,8 @@ function createBaseCustomElementClass(win) {
     toggleLoading_(state, opt_cleanup) {
       assertNotTemplate(this);
       if (state &&
-          (this.layoutCount_ > 0 || this.signals_.get('render-start'))) {
+          (this.layoutCount_ > 0 ||
+              this.signals_.get(CommonSignals.RENDER_START))) {
         // Loading has already been canceled. Ignore.
         return;
       }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -16,6 +16,7 @@
 
 import {BaseElement} from './base-element';
 import {BaseTemplate, registerExtendedTemplate} from './service/template-impl';
+import {CommonSignals} from './common-signals';
 import {VisibilityState} from './visibility-state';
 import {
   addDocFactoryToExtension,
@@ -654,7 +655,7 @@ class MultidocManager {
     // E.g. integrate with dynamic classes. In shadow case specifically, we have
     // to wait for stubbing to complete, which may take awhile due to importNode.
     setTimeout(() => {
-      ampdoc.signals().signal('render-start');
+      ampdoc.signals().signal(CommonSignals.RENDER_START);
       setStyle(hostElement, 'visibility', 'visible');
     }, 50);
 

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -35,9 +35,9 @@ import {installPixel} from '../../builtins/amp-pixel';
 import {installStyles} from '../style-installer';
 import {calculateExtensionScriptUrl} from './extension-location';
 
-
 const TAG = 'extensions';
 const UNKNOWN_EXTENSION = '_UNKNOWN_';
+const LEGACY_ELEMENTS = ['amp-ad', 'amp-embed', 'amp-video'];
 
 /**
  * The structure that contains the declaration of a custom element.
@@ -398,7 +398,9 @@ export class Extensions {
       // This will extend automatic upgrade of custom elements from top
       // window to the child window.
       stubElementIfNotKnown(topWin, extensionId);
-      stubElementInChildWindow(childWin, extensionId);
+      if (LEGACY_ELEMENTS.indexOf(extensionId) == -1) {
+        stubElementInChildWindow(childWin, extensionId);
+      }
 
       // Install CSS.
       const promise = this.loadExtension(extensionId).then(extension => {
@@ -590,9 +592,9 @@ function copyBuiltinElementsToChildWindow(parentWin, childWin) {
  * @param {!Window} win
  */
 export function stubLegacyElements(win) {
-  stubElementIfNotKnown(win, 'amp-ad');
-  stubElementIfNotKnown(win, 'amp-embed');
-  stubElementIfNotKnown(win, 'amp-video');
+  LEGACY_ELEMENTS.forEach(name => {
+    stubElementIfNotKnown(win, name);
+  });
 }
 
 

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -15,12 +15,15 @@
  */
 
 import {
+  FriendlyIframeEmbed,
   getFriendlyIframeEmbedOptional,
   installFriendlyIframeEmbed,
   mergeHtmlForTesting,
   setFriendlyIframeEmbedVisible,
   setSrcdocSupportedForTesting,
+  whenContentIniLoad,
 } from '../../src/friendly-iframe-embed';
+import {Signals} from '../../src/utils/signals';
 import {getStyle} from '../../src/style';
 import {extensionsFor} from '../../src/extensions';
 import {installServiceInEmbedScope} from '../../src/service';
@@ -80,6 +83,8 @@ describe('friendly-iframe-embed', () => {
       expect(embed.win).to.equal(iframe.contentWindow);
       expect(embed.iframe).to.equal(iframe);
       expect(embed.spec.url).to.equal('https://acme.org/url1');
+      expect(embed.host).to.be.null;
+      expect(embed.signals()).to.be.ok;
       expect(getFriendlyIframeEmbedOptional(embed.iframe)).to.equal(embed);
 
       // Iframe is rendered.
@@ -224,6 +229,92 @@ describe('friendly-iframe-embed', () => {
     });
   });
 
+  it('should support host', () => {
+    const host = document.createElement('amp-host');
+    const hostSignals = new Signals();
+    host.signals = () => hostSignals;
+    host.renderStarted = sandbox.spy();
+    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
+      url: 'https://acme.org/url1',
+      html: '<amp-test></amp-test>',
+      host,
+    });
+    return embedPromise.then(embed => {
+      expect(embed.host).to.equal(host);
+      expect(embed.signals()).to.equal(hostSignals);
+      expect(host.renderStarted).to.be.calledOnce;
+    });
+  });
+
+  it('should await initial load', () => {
+    resourcesMock
+        .expects('getResourcesInRect')
+        .withExactArgs(
+            sinon.match(arg => arg == iframe.contentWindow),
+            sinon.match(arg =>
+                arg.left == 0 &&
+                arg.top == 0 &&
+                arg.width == iframe.contentWindow.innerWidth &&
+                arg.height == iframe.contentWindow.innerHeight))
+        .returns(Promise.resolve([]))
+        .once();
+    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
+      url: 'https://acme.org/url1',
+      html: '<amp-test></amp-test>',
+    });
+    let embed;
+    return embedPromise.then(em => {
+      embed = em;
+      return embed.whenIniLoaded();
+    }).then(() => {
+      expect(embed.signals().get('ini-load')).to.be.ok;
+      return embed.whenReady();  // `whenReady` should also be complete.
+    });
+  });
+
+  it('should find and await all content elements', () => {
+    function resource(tagName) {
+      const res = {
+        element: {
+          tagName: tagName.toUpperCase(),
+        },
+        loadedComplete: false,
+      };
+      res.loadedOnce = () => Promise.resolve().then(() => {
+        res.loadedComplete = true;
+      });
+      return res;
+    }
+
+    let content1;
+    let content2;
+    let blacklistedAd;
+    let blacklistedAnalytics;
+    let blacklistedPixel;
+
+    const context = document.createElement('div');
+    document.body.appendChild(context);
+    resourcesMock
+        .expects('getResourcesInRect')
+        .withArgs(sinon.match(arg => arg == window))
+        .returns(Promise.resolve([
+          content1 = resource('amp-img', 0),
+          content2 = resource('amp-video', 0),
+          blacklistedAd = resource('amp-ad', 0),
+          blacklistedAnalytics = resource('amp-analytics', 0),
+          blacklistedPixel = resource('amp-pixel', 0),
+        ]))
+        .once();
+
+    return whenContentIniLoad(context, window).then(() => {
+      expect(content1.loadedComplete).to.be.true;
+      expect(content2.loadedComplete).to.be.true;
+      expect(blacklistedAd.loadedComplete).to.be.false;
+      expect(blacklistedAnalytics.loadedComplete).to.be.false;
+      expect(blacklistedPixel.loadedComplete).to.be.false;
+    });
+  });
+
   describe('mergeHtml', () => {
     let spec;
 
@@ -338,7 +429,7 @@ describe('friendly-iframe-embed', () => {
         html: '<a id="a1"></a>',
       });
       return embedPromise.then(embed => {
-        return embed.whenLoaded();
+        return embed.whenWindowLoaded();
       });
     });
 
@@ -349,7 +440,7 @@ describe('friendly-iframe-embed', () => {
         html: '<a id="a1"></a>',
       });
       return embedPromise.then(embed => {
-        return embed.whenLoaded();
+        return embed.whenWindowLoaded();
       });
     });
   });
@@ -364,6 +455,7 @@ describe('friendly-iframe-embed', () => {
     let container;
     let loadListener, errorListener;
     let polls;
+    let renderStartStub;
 
     beforeEach(() => {
       setSrcdocSupportedForTesting(true);
@@ -395,6 +487,7 @@ describe('friendly-iframe-embed', () => {
       loadListener = undefined;
       iframe = {
         tagName: 'IFRAME',
+        nodeType: 1,
         ownerDocument: {defaultView: win},
         style: {},
         setAttribute: () => {},
@@ -413,6 +506,8 @@ describe('friendly-iframe-embed', () => {
       container = {
         appendChild: () => {},
       };
+      renderStartStub = sandbox.stub(
+          FriendlyIframeEmbed.prototype, 'startRender_');
     });
 
     afterEach(() => {
@@ -496,6 +591,7 @@ describe('friendly-iframe-embed', () => {
       loadListener();
       return embedPromise.then(() => {
         expect(polls).to.have.length(0);
+        expect(renderStartStub).to.be.calledOnce;
       });
     });
 

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -791,43 +791,6 @@ describe('Resource', () => {
       resource.resume();
     });
   });
-
-  describe('getResourcesInViewport', () => {
-    let resource1;
-    let resource2;
-
-    beforeEach(() => {
-      resource1 = {
-        hasOwner: () => false,
-        isDisplayed: () => true,
-        isFixed: () => false,
-        prerenderAllowed: () => true,
-        overlaps: () => true,
-      };
-      resource2 = {
-        hasOwner: () => false,
-        isDisplayed: () => true,
-        isFixed: () => false,
-        prerenderAllowed: () => true,
-        overlaps: () => false,
-      };
-      resources.resources_ = [resource1, resource2];
-    });
-
-    it('should return a subset of resources that are currently ' +
-       'in the viewport', () => {
-      expect(resources.get().length).to.equal(2);
-      expect(resources.getResourcesInViewport().length).to.equal(1);
-    });
-
-    it('should not return resources that are not allowed to prerender if ' +
-       'in prerender mode', () => {
-      resource1.prerenderAllowed = () => false;
-      expect(resources.get().length).to.equal(2);
-      expect(resources.getResourcesInViewport(false).length).to.equal(1);
-      expect(resources.getResourcesInViewport(true).length).to.equal(0);
-    });
-  });
 });
 
 describe('Resource renderOutsideViewport', () => {


### PR DESCRIPTION
Closes #7452, #6413, #7522.

`ini-load` event is triggered for a document or an embed when the contents positioned within the first window have been loaded. This event is useful on its own and also will be eventually used for visibility events.