### PR TITLE
amp-pinterest: fix responsive widgets & cut off border

### DIFF
--- a/examples/pinterest.amp.html
+++ b/examples/pinterest.amp.html
@@ -8,6 +8,14 @@
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-pinterest" src="https://cdn.ampproject.org/v0/amp-pinterest-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+      body {
+        padding: 15px;
+      }
+      h1, h2, h3 {
+        clear: both;
+      }
+  </style>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
@@ -26,6 +34,41 @@
       data-width="medium"
       data-url="https://www.pinterest.com/pin/99360735500167749/">
     </amp-pinterest>
+
+  <h3>Embedded Pins - responsive</h3>
+
+    <div style="width: 320px; float: left;">
+      <amp-pinterest
+        width="11"
+        height="16"
+        layout="responsive"
+        data-do="embedPin"
+        data-width="medium"
+        data-url="https://www.pinterest.com/pin/494692340305120003/">
+      </amp-pinterest>
+    </div>
+
+    <div style="width: 240px; float: left;">
+      <amp-pinterest
+        width="10"
+        height="16"
+        layout="responsive"
+        data-do="embedPin"
+        data-width="medium"
+        data-url="https://www.pinterest.com/pin/494692340305120003/">
+      </amp-pinterest>
+    </div>
+
+    <div style="width: 180px; float: left;">
+      <amp-pinterest
+        width="9"
+        height="16"
+        layout="responsive"
+        data-do="embedPin"
+        data-width="medium"
+        data-url="https://www.pinterest.com/pin/494692340305120003/">
+      </amp-pinterest>
+    </div>
 
   <h2>Pin It Buttons</h2>
 

--- a/extensions/amp-pinterest/0.1/amp-pinterest.css
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.css
@@ -234,12 +234,21 @@
 
 .-amp-pinterest-embed-pin,
 .-amp-pinterest-embed-pin-medium {
+  box-sizing: border-box;
   padding: 5px;
   width: 237px;
 }
 
 .-amp-pinterest-embed-pin-medium {
   width: 345px;
+}
+
+.-amp-pinterest-embed-pin-responsive {
+  width: 100%;
+}
+
+.-amp-pinterest-embed-pin-responsive .-amp-pinterest-embed-pin-image {
+  max-width: 100%;
 }
 
 .-amp-pinterest-embed-pin-inner {

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -88,6 +88,11 @@ export class PinWidget {
       Util.log('&type=pidget&pin_count=1');
     }
 
+    // Apply a CSS class when the layout is responsive
+    if (this.layout === 'responsive') {
+      className += ' -amp-pinterest-embed-pin-responsive';
+    }
+
     const structure = Util.make(this.element.ownerDocument, {'span': {}});
     // TODO(dvoytenko, #6794): Remove old `-amp-fill-content` form after the new
     // form is in PROD for 1-2 weeks.
@@ -225,6 +230,7 @@ export class PinWidget {
   render() {
     this.pinUrl = this.element.getAttribute('data-url');
     this.width = this.element.getAttribute('data-width');
+    this.layout = this.element.getAttribute('layout');
 
     this.pinId = '';
     try {


### PR DESCRIPTION
Fixes #1816

 - Makes `amp-pinterest` components work in responsive mode
 - Fix the cut off right border

**Note**: only merge after @kentbrew has given a 👍  on this.

## Before
![screen shot 2017-02-02 at 3 33 45 pm](https://cloud.githubusercontent.com/assets/127199/22574325/2969df76-e963-11e6-953d-3e2c6dde7f32.png)

## After:
![screen shot 2017-02-02 at 4 13 25 pm](https://cloud.githubusercontent.com/assets/127199/22574333/2f161fde-e963-11e6-841a-2eacc9e62b98.png)
