### PR TITLE
Revert "Using `playing` instead of `play` event"

### DIFF
--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -61,6 +61,7 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
     const iframe = this.element.ownerDocument.createElement('iframe');
     this.iframe_ = iframe;
 
+    this.forwardEvents([VideoEvents.PLAY, VideoEvents.PAUSE], iframe);
     this.applyFillContent(iframe, true);
     this.element.appendChild(iframe);
 
@@ -147,7 +148,7 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
       return; // We only process valid JSON.
     }
     if (data.data == 'playing') {
-      this.element.dispatchCustomEvent(VideoEvents.PLAYING);
+      this.element.dispatchCustomEvent(VideoEvents.PLAY);
     } else if (data.data == 'paused') {
       this.element.dispatchCustomEvent(VideoEvents.PAUSE);
     } else if (data.data == 'muted') {

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -178,7 +178,7 @@ class AmpVideo extends AMP.BaseElement {
      */
     installEventHandlers_() {
       const video = dev().assertElement(this.video_);
-      this.forwardEvents([VideoEvents.PLAYING, VideoEvents.PAUSE], video);
+      this.forwardEvents([VideoEvents.PLAY, VideoEvents.PAUSE], video);
       listen(video, 'volumechange', () => {
         if (this.muted_ != this.video_.muted) {
           this.muted_ = this.video_.muted;

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -361,7 +361,7 @@ describe(TAG, () => {
 
   it('should forward certain events from video to the amp element', () => {
     return getVideo({
-      src: '/examples/av/ForBiggerJoyrides.mp4',
+      src: 'foo.mp4',
       width: 160,
       height: 90,
     }).then(v => {
@@ -373,7 +373,7 @@ describe(TAG, () => {
       })
       .then(() => {
         impl.play();
-        return listenOncePromise(v, VideoEvents.PLAYING);
+        return listenOncePromise(v, VideoEvents.PLAY);
       })
       .then(() => {
         impl.pause();

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -248,7 +248,7 @@ class AmpYoutube extends AMP.BaseElement {
       if (this.playerState_ == PlayerStates.PAUSED) {
         this.element.dispatchCustomEvent(VideoEvents.PAUSE);
       } else if (this.playerState_ == PlayerStates.PLAYING) {
-        this.element.dispatchCustomEvent(VideoEvents.PLAYING);
+        this.element.dispatchCustomEvent(VideoEvents.PLAY);
       }
     } else if (data.event == 'infoDelivery' &&
         data.info && data.info.muted !== undefined) {

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -266,7 +266,7 @@ describe('amp-youtube', function() {
         return p;
       })
       .then(() => {
-        const p = listenOncePromise(yt, VideoEvents.PLAYING);
+        const p = listenOncePromise(yt, VideoEvents.PLAY);
         sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 1});
         return p;
       })

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -280,7 +280,7 @@ class VideoEntry {
     const unlistenPause = listen(this.video.element, VideoEvents.PAUSE,
         toggleAnimation.bind(this, /*playing*/ false));
 
-    const unlistenPlay = listen(this.video.element, VideoEvents.PLAYING,
+    const unlistenPlay = listen(this.video.element, VideoEvents.PLAY,
         toggleAnimation.bind(this, /*playing*/ true));
 
     function onInteraction() {

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -165,16 +165,16 @@ export const VideoEvents = {
   /**
    * play
    *
-   * Fired when the video starts playing.
+   * Fired when the video plays.
    *
-   * @event playing
+   * @event play
    */
-  PLAYING: 'playing',
+  PLAY: 'play',
 
   /**
    * pause
    *
-   * Fired when the video is paused.
+   * Fired when the video pauses.
    *
    * @event pause
    */

--- a/test/functional/test-video-manager.js
+++ b/test/functional/test-video-manager.js
@@ -261,7 +261,7 @@ function createFakeVideoPlayerClass(win) {
      */
     play(unusedIsAutoplay) {
       Promise.resolve().then(() => {
-        this.element.dispatchCustomEvent(VideoEvents.PLAYING);
+        this.element.dispatchCustomEvent(VideoEvents.PLAY);
       });
     }
 

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -69,7 +69,7 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
         })
         .then(() => {
           playButton.click();
-          return listenOncePromise(r.video, VideoEvents.PLAYING);
+          return listenOncePromise(r.video, VideoEvents.PLAY);
         })
         .then(() => {
           pauseButton.click();
@@ -114,14 +114,14 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
     describe('play/pause', () => {
       it('should play when in view port initially', () => {
         return getVideoPlayer({outsideView: false, autoplay: true}).then(r => {
-          return listenOncePromise(r.video, VideoEvents.PLAYING);
+          return listenOncePromise(r.video, VideoEvents.PLAY);
         });
       });
 
       it('should not play when not in view port initially', () => {
         return getVideoPlayer({outsideView: true, autoplay: true}).then(r => {
           const timer = timerFor(r.video.implementation_.win);
-          const p = listenOncePromise(r.video, VideoEvents.PLAYING).then(() => {
+          const p = listenOncePromise(r.video, VideoEvents.PLAY).then(() => {
             return Promise.reject('should not have autoplayed');
           });
           // we have to wait to ensure play is NOT called.
@@ -137,7 +137,7 @@ export function runVideoPlayerIntegrationTests(createVideoElementFunc) {
           viewport = video.implementation_.getViewport();
 
           // scroll to the bottom, make video fully visible
-          const p = listenOncePromise(video, VideoEvents.PLAYING);
+          const p = listenOncePromise(video, VideoEvents.PLAY);
           viewport.scrollIntoView(video);
           return p;
         }).then(() => {

--- a/test/integration/test-video-players.js
+++ b/test/integration/test-video-players.js
@@ -31,7 +31,8 @@ import {runVideoPlayerIntegrationTests} from './test-video-players-helper';
 describe('amp-video', () => {
   runVideoPlayerIntegrationTests(fixture => {
     const video = fixture.doc.createElement('amp-video');
-    video.setAttribute('src', '/examples/av/ForBiggerJoyrides.mp4');
+    video.setAttribute('src', 'https://commondatastorage.googleapis.com' +
+      '/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4');
     return video;
   });
 });


### PR DESCRIPTION
Reverts ampproject/amphtml#7279

Reverting until I can figure out how to test this properly since SauceLabs VM can not play videos but `playable` event only fires when video actually really plays.