### PR TITLE
Added a special param to measure activity on amp-hulu

### DIFF
--- a/extensions/amp-hulu/0.1/amp-hulu.js
+++ b/extensions/amp-hulu/0.1/amp-hulu.js
@@ -79,7 +79,7 @@ class AmpHulu extends AMP.BaseElement {
   /** @return {string} */
   getVideoIframeSrc_() {
     dev().assert(this.eid_);
-    return `https://secure.hulu.com/dash/mobile_embed.html?eid=${encodeURIComponent(this.eid_ || '')}`;
+    return `https://secure.hulu.com/dash/mobile_embed.html?amp=1&eid=${encodeURIComponent(this.eid_ || '')}`;
   }
 
 };

--- a/extensions/amp-hulu/0.1/test/test-amp-hulu.js
+++ b/extensions/amp-hulu/0.1/test/test-amp-hulu.js
@@ -44,7 +44,7 @@ describe('amp-hulu', () => {
       const iframe = hulu.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
-      expect(iframe.src).to.equal('https://secure.hulu.com/dash/mobile_embed.html?eid=4Dk5F2PYTtrgciuvloH3UA');
+      expect(iframe.src).to.equal('https://secure.hulu.com/dash/mobile_embed.html?amp=1&eid=4Dk5F2PYTtrgciuvloH3UA');
     });
   });
 


### PR DESCRIPTION
For now we don't have a endpoint to track traffic from amp-hulu, add a param to the embed url helps embed player and hulu server to identify the request.
1. Add "amp=1" to the umbed url.
https://secure.hulu.com/dash/mobile_embed.html?amp=1