### PR TITLE
Measure document height when necessary and send to viewer

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -87,10 +87,11 @@ html.i-amphtml-ios-embed {
   /* Make sure position:absolute elements are positioned relative to the body,
      not i-amp-html-wrapper */
   position: relative !important;
-  /* Use overflow hidden to avoid margin collapsing outside body.
-     This will also give the correct value for body's scrollHeight including
-     margins of body's first and last child */
-  overflow: hidden;
+  /* `body` must have a 1px transparent border for two purposes:
+      (1) to cancel out margin collapse in body's children so that position
+          absolute element is positioned correctly
+      (2) to offset scroll adjustment to 1 to avoid scroll freeze problem. */
+  border-top: 1px solid transparent !important;
 }
 
 

--- a/css/amp.css
+++ b/css/amp.css
@@ -84,10 +84,13 @@ html.i-amphtml-ios-embed {
 }
 
 #i-amphtml-wrapper > body {
+  /* Make sure position:absolute elements are positioned relative to the body,
+     not i-amp-html-wrapper */
   position: relative !important;
-  /* Border is necessary to avoid margins collapsing outside body.
-     Alternatively we can also set overflow to hidden. */
-  border-top: 1px solid transparent !important;
+  /* Use overflow hidden to avoid margin collapsing outside body.
+     This will also give the correct value for body's scrollHeight including
+     margins of body's first and last child */
+  overflow: hidden;
 }
 
 

--- a/examples/article-fixed-header.amp.html
+++ b/examples/article-fixed-header.amp.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>
-  <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
+  <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <style amp-custom>
@@ -167,6 +167,7 @@
       justify-content: center;
       height: 226px;
       background: #f4f4f4;
+      margin-bottom: 20px;
     }
 
     hr {

--- a/examples/article-super-short.amp.html
+++ b/examples/article-super-short.amp.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Lorem Ipsum</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp-custom>
+    body {
+      font-family: 'Georgia', Serif;
+    }
+    h1 {
+      padding: 10px;
+    }
+    p {
+      padding: 15px;
+    }
+  </style>
+</head>
+<body>
+<h1>Lorem Ipsum</h1>
+<amp-img
+  src="img/sea@1x.jpg"
+  srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
+  alt="Fusce pretium tempor justo, vitae consequat dolor maximus eget."
+  placeholder
+  width="360" height="216" layout="responsive">
+</amp-img>
+<p>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+  luctus nunc ut elit cursus, et imperdiet diam vehicula.
+  Duis et nisi sed urna blandit bibendum et sit amet erat.
+</p>
+</body>
+</html>

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -140,6 +140,7 @@
       justify-content: center;
       height: 226px;
       background: #f4f4f4;
+      margin-bottom: 20px;
     }
 
     hr {

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -466,6 +466,9 @@
         log('unloaded');
         return this.handleUnload_();
       }
+      if (type == 'documentHeight') {
+        return;
+      }
       return Promise.reject('request not supported: ' + type);
     };
 

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -178,6 +178,7 @@ export class ViewportBindingInabox {
   /** @override */ setScrollTop() {/* no-op */}
   /** @override */ getScrollWidth() {return 0;}
   /** @override */ getScrollHeight() {return 0;}
+  /** @override */ getContentHeight() {return 0;}
   /** @override */ requiresFixedLayerTransfer() {return false;}
 }
 

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -178,7 +178,6 @@ export class ViewportBindingInabox {
   /** @override */ setScrollTop() {/* no-op */}
   /** @override */ getScrollWidth() {return 0;}
   /** @override */ getScrollHeight() {return 0;}
-  /** @override */ getContentHeight() {return 0;}
   /** @override */ requiresFixedLayerTransfer() {return false;}
 }
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -175,7 +175,7 @@ export class Resources {
     this.vsyncScheduled_ = false;
 
     /** @private {number} */
-    this.scrollHeight_ = 0;
+    this.contentHeight_ = 0;
 
     /** @private {boolean} */
     this.maybeChangeHeight_ = false;
@@ -908,10 +908,10 @@ export class Resources {
         linkRels: documentInfoForDoc(this.ampdoc).linkRels,
       }, /* cancelUnsent */true);
 
-      this.scrollHeight_ = this.viewport_.getScrollHeight();
+      this.contentHeight_ = this.viewport_.getContentHeight();
       this.viewer_.sendMessage('documentHeight',
-          {height: this.scrollHeight_}, /* cancelUnsent */true);
-      dev().fine(TAG_, 'document height on load: ' + this.scrollHeight_);
+          {height: this.contentHeight_}, /* cancelUnsent */true);
+      dev().fine(TAG_, 'document height on load: ' + this.contentHeight_);
     }
 
     const viewportSize = this.viewport_.getSize();
@@ -934,18 +934,18 @@ export class Resources {
       this.ampdoc.signals().signal(READY_SCAN_SIGNAL_);
     }
 
-    this.vsync_.measure(() => {
-      if (this.maybeChangeHeight_) {
-        const measuredScrollHeight = this.viewport_.getScrollHeight();
-        if (measuredScrollHeight != this.scrollHeight_) {
+    if (this.maybeChangeHeight_) {
+      this.vsync_.measure(() => {
+        const measuredContentHeight = this.viewport_.getContentHeight();
+        if (measuredContentHeight != this.contentHeight_) {
           this.viewer_.sendMessage('documentHeight',
-              {height: measuredScrollHeight}, /* cancelUnsent */true);
-          this.scrollHeight_ = measuredScrollHeight;
-          dev().fine(TAG_, 'document height changed: ' + this.scrollHeight_);
+              {height: measuredContentHeight}, /* cancelUnsent */true);
+          this.contentHeight_ = measuredContentHeight;
+          dev().fine(TAG_, 'document height changed: ' + this.contentHeight_);
         }
         this.maybeChangeHeight_ = false;
-      }
-    });
+      });
+    }
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -174,6 +174,12 @@ export class Resources {
     /** @private {boolean} */
     this.vsyncScheduled_ = false;
 
+    /** @private {number} */
+    this.scrollHeight_ = 0;
+
+    /** @private {boolean} */
+    this.maybeChangeHeight_ = false;
+
     /** @private @const {!FiniteStateMachine<!VisibilityState>} */
     this.visibilityStateMachine_ = new FiniteStateMachine(
       this.viewer_.getVisibilityState()
@@ -812,6 +818,7 @@ export class Resources {
             this.setRelayoutTop_(updatedRelayoutTop);
             this.schedulePass(FOUR_FRAME_DELAY_);
           }
+          this.maybeChangeHeight_ = true;
         });
       },
     });
@@ -900,6 +907,11 @@ export class Resources {
         serverLayout: doc.documentElement.hasAttribute('i-amphtml-element'),
         linkRels: documentInfoForDoc(this.ampdoc).linkRels,
       }, /* cancelUnsent */true);
+
+      this.scrollHeight_ = this.viewport_.getScrollHeight();
+      this.viewer_.sendMessage('documentHeight',
+          {height: this.scrollHeight_}, /* cancelUnsent */true);
+      dev().fine(TAG_, 'document height on load: ' + this.scrollHeight_);
     }
 
     const viewportSize = this.viewport_.getSize();
@@ -921,6 +933,19 @@ export class Resources {
       // "layer measured".
       this.ampdoc.signals().signal(READY_SCAN_SIGNAL_);
     }
+
+    this.vsync_.measure(() => {
+      if (this.maybeChangeHeight_) {
+        const measuredScrollHeight = this.viewport_.getScrollHeight();
+        if (measuredScrollHeight != this.scrollHeight_) {
+          this.viewer_.sendMessage('documentHeight',
+              {height: measuredScrollHeight}, /* cancelUnsent */true);
+          this.scrollHeight_ = measuredScrollHeight;
+          dev().fine(TAG_, 'document height changed: ' + this.scrollHeight_);
+        }
+        this.maybeChangeHeight_ = false;
+      }
+    });
   }
 
   /**
@@ -967,6 +992,7 @@ export class Resources {
       for (let i = 0; i < deferredMutates.length; i++) {
         deferredMutates[i]();
       }
+      this.maybeChangeHeight_ = true;
     }
     if (this.requestsChangeSize_.length > 0) {
       dev().fine(TAG_, 'change size requests:',
@@ -1061,6 +1087,7 @@ export class Resources {
               request.newHeight, request.newWidth, newMargins);
           request.resource.overflowCallback(/* overflown */ false,
               request.newHeight, request.newWidth, newMargins);
+          this.maybeChangeHeight_ = true;
         }
 
         if (request.callback) {
@@ -1100,6 +1127,7 @@ export class Resources {
               this.viewport_.setScrollTop(state./*OK*/scrollTop +
                   (newScrollHeight - state./*OK*/scrollHeight));
             }
+            this.maybeChangeHeight_ = true;
           },
         }, {});
       }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -175,7 +175,7 @@ export class Resources {
     this.vsyncScheduled_ = false;
 
     /** @private {number} */
-    this.contentHeight_ = 0;
+    this.scrollHeight_ = 0;
 
     /** @private {boolean} */
     this.maybeChangeHeight_ = false;
@@ -908,10 +908,10 @@ export class Resources {
         linkRels: documentInfoForDoc(this.ampdoc).linkRels,
       }, /* cancelUnsent */true);
 
-      this.contentHeight_ = this.viewport_.getContentHeight();
+      this.scrollHeight_ = this.viewport_.getScrollHeight();
       this.viewer_.sendMessage('documentHeight',
-          {height: this.contentHeight_}, /* cancelUnsent */true);
-      dev().fine(TAG_, 'document height on load: ' + this.contentHeight_);
+          {height: this.scrollHeight_}, /* cancelUnsent */true);
+      dev().fine(TAG_, 'document height on load: ' + this.scrollHeight_);
     }
 
     const viewportSize = this.viewport_.getSize();
@@ -936,12 +936,12 @@ export class Resources {
 
     if (this.maybeChangeHeight_) {
       this.vsync_.measure(() => {
-        const measuredContentHeight = this.viewport_.getContentHeight();
-        if (measuredContentHeight != this.contentHeight_) {
+        const measuredScrollHeight = this.viewport_.getScrollHeight();
+        if (measuredScrollHeight != this.scrollHeight_) {
           this.viewer_.sendMessage('documentHeight',
-              {height: measuredContentHeight}, /* cancelUnsent */true);
-          this.contentHeight_ = measuredContentHeight;
-          dev().fine(TAG_, 'document height changed: ' + this.contentHeight_);
+              {height: measuredScrollHeight}, /* cancelUnsent */true);
+          this.scrollHeight_ = measuredScrollHeight;
+          dev().fine(TAG_, 'document height changed: ' + this.scrollHeight_);
         }
         this.maybeChangeHeight_ = false;
       });

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -935,6 +935,7 @@ export class Resources {
     }
 
     if (this.maybeChangeHeight_) {
+      this.maybeChangeHeight_ = false;
       this.vsync_.measure(() => {
         const measuredScrollHeight = this.viewport_.getScrollHeight();
         if (measuredScrollHeight != this.scrollHeight_) {
@@ -943,7 +944,6 @@ export class Resources {
           this.scrollHeight_ = measuredScrollHeight;
           dev().fine(TAG_, 'document height changed: ' + this.scrollHeight_);
         }
-        this.maybeChangeHeight_ = false;
       });
     }
   }

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -308,7 +308,8 @@ export class Viewport {
   }
 
   /**
-   * Returns the scroll height of the content of the document.
+   * Returns the scroll height of the content of the document, including the
+   * padding top for the viewer header.
    * The scrollHeight will be the viewport height if there's not enough content
    * to fill up the viewport.
    * Note that this method is not cached since we there's no indication when
@@ -317,18 +318,6 @@ export class Viewport {
    */
   getScrollHeight() {
     return this.binding_.getScrollHeight();
-  }
-
-  /**
-   * Returns the scroll height of the content of the document.
-   * The scrollHeight will be the exact content height if there's not enough
-   * content to fill up the viewport.
-   * Note that this method is not cached since we there's no indication when
-   * it might change.
-   * @return {number}
-   */
-  getContentHeight() {
-    return this.binding_.getContentHeight();
   }
 
   /**
@@ -861,20 +850,13 @@ export class ViewportBindingDef {
   getScrollWidth() {}
 
   /**
-   * Returns the scroll height of the content of the document.
+   * Returns the scroll height of the content of the document, including the
+   * padding top for the viewer header.
    * The scrollHeight will be the viewport height if there's not enough content
    * to fill up the viewport.
    * @return {number}
    */
   getScrollHeight() {}
-
-  /**
-   * Returns the scroll height of the content of the document.
-   * The scrollHeight will be the exact content height if there's not enough
-   * content to fill up the viewport.
-   * @return {number}
-   */
-  getContentHeight() {}
 
   /**
    * Returns the rect of the element within the document.
@@ -1052,11 +1034,6 @@ export class ViewportBindingNatural_ {
   /** @override */
   getScrollHeight() {
     return this.getScrollingElement_()./*OK*/scrollHeight;
-  }
-
-  /** @override */
-  getContentHeight() {
-    return this.win.document.documentElement./*OK*/scrollHeight;
   }
 
   /** @override */
@@ -1345,11 +1322,6 @@ export class ViewportBindingNaturalIosEmbed_ {
 
   /** @override */
   getScrollHeight() {
-    return this.getContentHeight();
-  }
-
-  /** @override */
-  getContentHeight() {
     // We have to use a special "tail" element on iOS due to the issues outlined
     // in the {@link onScrolled_} method. Because we are forced to layout BODY
     // with position:absolute, we can no longer use BODY's scrollHeight to
@@ -1517,7 +1489,6 @@ export class ViewportBindingIosEmbedWrapper_ {
     // - https://bugs.webkit.org/show_bug.cgi?id=149264
     const doc = this.win.document;
     const body = dev().assertElement(doc.body, 'body is not available');
-
     doc.documentElement.appendChild(this.wrapper_);
     this.wrapper_.appendChild(body);
     // Redefine `document.body`, otherwise it'd be `null`.
@@ -1609,21 +1580,7 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   getScrollHeight() {
-    // The scroll height include the padding top for the viewer header.
     return this.wrapper_./*OK*/scrollHeight;
-  }
-
-  /** @override */
-  getContentHeight() {
-    const body = this.win.document.body;
-    if (!body) {
-      return 0;
-    }
-    // The reparented body inside wrapper will have the correct content height.
-    // Body is overflow: hidden so that the scrollHeight include the margins of
-    // body's first and last child.
-    // This height does not include the padding top for the viewer header.
-    return body./*OK*/scrollHeight;
   }
 
   /** @override */

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1251,6 +1251,59 @@ describe('Resources discoverWork', () => {
   });
 });
 
+describes.realWin('Resources scrollHeight', {
+  amp: {
+    runtimeOn: true,
+  },
+}, env => {
+  let win;
+  let resources;
+  let viewerSendMessageStub;
+
+  beforeEach(() => {
+    win = env.win;
+    resources = win.services.resources.obj;
+    viewerSendMessageStub = sandbox.stub(resources.viewer_, 'sendMessage');
+    sandbox.stub(resources.vsync_, 'run', task => {
+      task.measure({});
+    });
+  });
+
+  it('should measure initial scrollHeight', () => {
+    const scrollHeight = resources.viewport_.getScrollHeight();
+    expect(resources.maybeChangeHeight_).to.equal(false);
+    expect(resources.documentReady_).to.equal(true);
+    expect(resources.scrollHeight_).to.equal(scrollHeight);
+  });
+
+  it('should send scrollHeight to viewer if height was changed', () => {
+    sandbox.stub(resources.viewport_, 'getScrollHeight', () => {
+      return 200;
+    });
+    resources.maybeChangeHeight_ = true;
+
+    resources.doPass_();
+
+    expect(resources.maybeChangeHeight_).to.equal(false);
+    expect(resources.scrollHeight_).to.equal(200);
+    expect(viewerSendMessageStub).to.be.calledOnce;
+    expect(viewerSendMessageStub).to.be.calledWith(
+        'documentHeight', {height: 200}, true);
+  });
+
+  it('should not send scrollHeight to viewer if height is not changed', () => {
+    const scrollHeight = resources.viewport_.getScrollHeight();
+    resources.maybeChangeHeight_ = true;
+
+    resources.doPass_();
+
+    expect(resources.maybeChangeHeight_).to.equal(false);
+    expect(resources.scrollHeight_).to.equal(scrollHeight);
+    expect(viewerSendMessageStub).to.not.be.called;
+  });
+
+
+});
 
 describe('Resources changeSize', () => {
 

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -32,7 +32,6 @@ import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
 import {platformFor} from '../../src/platform';
 import {runChunksForTesting} from '../../src/chunk';
-import {timerFor} from '../../src/timer';
 import {toggleExperiment} from '../../src/experiments';
 import * as ext from '../../src/service/extensions-impl';
 import * as extel from '../../src/extended-element';
@@ -959,11 +958,9 @@ describes.realWin('runtime multidoc', {
 
 
   describe('messaging', () => {
-    let timer;
     let doc1, doc2, doc3;
 
     beforeEach(() => {
-      timer = timerFor(win);
       doc1 = attach('https://example.org/doc1');
       doc2 = attach('https://example.org/doc2');
       doc3 = attach('https://example.org/doc3');
@@ -993,7 +990,7 @@ describes.realWin('runtime multidoc', {
       viewer.onBroadcast(broadcastReceived);
       const onMessage = sandbox.stub();
       amp.onMessage(function(eventType, data) {
-        if (eventType == 'ignore' || eventType == 'documentLoaded') {
+        if (eventType == 'ignore') {
           return Promise.resolve();
         }
         return onMessage(eventType, data);
@@ -1004,8 +1001,6 @@ describes.realWin('runtime multidoc', {
     it('should broadcast to all but sender', () => {
       doc1.viewer.broadcast({test: 1});
       return doc1.viewer.sendMessageAwaitResponse('ignore', {}).then(() => {
-        return timer.promise(0);
-      }).then(() => {
         // Sender is not called.
         expect(doc1.broadcastReceived).to.not.be.called;
 
@@ -1026,8 +1021,6 @@ describes.realWin('runtime multidoc', {
       doc3.amp.close();
       doc1.viewer.broadcast({test: 1});
       return doc1.viewer.sendMessageAwaitResponse('ignore', {}).then(() => {
-        return timer.promise(0);
-      }).then(() => {
         // Sender is not called, closed is not called.
         expect(doc1.broadcastReceived).to.not.be.called;
         expect(doc3.broadcastReceived).to.not.be.called;
@@ -1042,8 +1035,6 @@ describes.realWin('runtime multidoc', {
       doc3.hostElement.parentNode.removeChild(doc3.hostElement);
       doc1.viewer.broadcast({test: 1});
       return doc1.viewer.sendMessageAwaitResponse('ignore', {}).then(() => {
-        return timer.promise(0);
-      }).then(() => {
         // Sender is not called, closed is not called.
         expect(doc1.broadcastReceived).to.not.be.called;
         expect(doc3.broadcastReceived).to.not.be.called;
@@ -1059,8 +1050,6 @@ describes.realWin('runtime multidoc', {
       doc1.onMessage.returns(Promise.resolve());
       return doc1.viewer.sendMessageAwaitResponse('test3', {test: 3}).then(
           () => {
-            return timer.promise(0);
-          }).then(() => {
             expect(doc1.onMessage).to.be.calledOnce;
             expect(doc1.onMessage.args[0][0]).to.equal('test3');
             expect(doc1.onMessage.args[0][1]).to.deep.equal({test: 3});

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -1537,8 +1537,8 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     expect(htmlCss.overflowX).to.equal('hidden');
     expect(wrapperCss.overflowY).to.equal('auto');
     expect(wrapperCss.overflowX).to.equal('hidden');
-    expect(bodyCss.overflowY).to.equal('hidden');
-    expect(bodyCss.overflowX).to.equal('hidden');
+    expect(bodyCss.overflowY).to.equal('visible');
+    expect(bodyCss.overflowX).to.equal('visible');
 
     // Wrapper must be a block and positioned absolute at 0/0/0/0.
     expect(wrapperCss.display).to.equal('block');
@@ -1554,6 +1554,11 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     // Preserve the customized `display` value.
     expect(bodyCss.display).to.equal('table');
 
+    // `body` must have a 1px transparent border for two purposes:
+    // (1) to cancel out margin collapse in body's children;
+    // (2) to offset scroll adjustment to 1 to avoid scroll freeze problem.
+    expect(bodyCss.borderTop.replace('rgba(0, 0, 0, 0)', 'transparent'))
+        .to.equal('1px solid transparent');
     expect(bodyCss.margin).to.equal('0px');
   });
 
@@ -1597,11 +1602,11 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
   });
 
   it('should calculate scrollWidth from wrapper', () => {
-    expect(binding.getScrollWidth()).to.equal(100);
+    expect(binding.getScrollWidth()).to.equal(200);
   });
 
   it('should calculate scrollHeight from wrapper', () => {
-    expect(binding.getScrollHeight()).to.equal(300);
+    expect(binding.getScrollHeight()).to.equal(301); // +1px for border-top.
   });
 
   it('should update scrollTop on wrapper', () => {

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -1537,8 +1537,8 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     expect(htmlCss.overflowX).to.equal('hidden');
     expect(wrapperCss.overflowY).to.equal('auto');
     expect(wrapperCss.overflowX).to.equal('hidden');
-    expect(bodyCss.overflowY).to.equal('visible');
-    expect(bodyCss.overflowX).to.equal('visible');
+    expect(bodyCss.overflowY).to.equal('hidden');
+    expect(bodyCss.overflowX).to.equal('hidden');
 
     // Wrapper must be a block and positioned absolute at 0/0/0/0.
     expect(wrapperCss.display).to.equal('block');
@@ -1554,11 +1554,6 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     // Preserve the customized `display` value.
     expect(bodyCss.display).to.equal('table');
 
-    // `body` must have a 1px transparent body for two purposes:
-    // (1) to cancel out margin collapse in body's children;
-    // (2) to offset scroll adjustment to 1 to avoid scroll freeze problem.
-    expect(bodyCss.borderTop.replace('rgba(0, 0, 0, 0)', 'transparent'))
-        .to.equal('1px solid transparent');
     expect(bodyCss.margin).to.equal('0px');
   });
 
@@ -1596,20 +1591,20 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     expect(size.height).to.equal(100);
   });
 
-  it('should calculate scrollTop from scrollElement', () => {
+  it('should calculate scrollTop from wrapper', () => {
     binding.wrapper_.scrollTop = 17;
     expect(binding.getScrollTop()).to.equal(17);
   });
 
-  it('should calculate scrollWidth from scrollElement', () => {
-    expect(binding.getScrollWidth()).to.equal(200);
+  it('should calculate scrollWidth from wrapper', () => {
+    expect(binding.getScrollWidth()).to.equal(100);
   });
 
-  it('should calculate scrollHeight from scrollElement', () => {
-    expect(binding.getScrollHeight()).to.equal(301); // +1px for border-top.
+  it('should calculate scrollHeight from wrapper', () => {
+    expect(binding.getScrollHeight()).to.equal(300);
   });
 
-  it('should update scrollTop on scrollElement', () => {
+  it('should update scrollTop on wrapper', () => {
     binding.setScrollTop(21);
     expect(binding.wrapper_.scrollTop).to.equal(21);
   });


### PR DESCRIPTION
Implements https://github.com/ampproject/amphtml/issues/6530
* Measure document height when necessary
  * deferMutate
  * mutateElement
  * resize
* Manual tested in three types of viewport.