### PR TITLE
Improve reporting of amp-bind user errors

### DIFF
--- a/examples/bind/errors.amp.html
+++ b/examples/bind/errors.amp.html
@@ -33,10 +33,15 @@
   <h3>2. Malformed expressions</h3>
   <p [text]="(">This expression is missing a closing parens.</p>
 
-  <h3>3. Mismatched initial state</h3>
+  <h3>3. Invalid function invocation</h3>
+  <p [text]="123.substring(2)">This expression calls `substring` on a number.</p>
+
+  <h3>4. Invalid expression result</h3>
+  <a [href]="'javascript:alert(1)'">This expression contains an invalid URL protocol.</a>
+
+  <h3>5. Mismatched initial state</h3>
   <h4>(Only with '#development=1')</h4>
   <p [text]="myState.foo">This paragraph's initial `text` state doesn't match the evaluated expression result.</p>
-  <p [text]="myState.foo">bar</p>
 
   <amp-state id="myState">
     <script type="application/json">

--- a/examples/bind/errors.amp.html
+++ b/examples/bind/errors.amp.html
@@ -36,10 +36,10 @@
   <h3>3. Invalid function invocation</h3>
   <p [text]="123.substring(2)">This expression calls `substring` on a number.</p>
 
-  <h3>4. Invalid expression result (validator)</h3>
+  <h3>4.a Invalid expression result (validator)</h3>
   <a [href]="'javascript:alert(1)'">This expression contains an invalid URL protocol.</a>
 
-  <h3>4. Invalid expression result (css)</h3>
+  <h3>4.b Invalid expression result (css)</h3>
   <a [class]="123">This expression contains an invalid [class] result (only string/array/null supported).</a>
 
   <h3>5. Mismatched initial state</h3>

--- a/examples/bind/errors.amp.html
+++ b/examples/bind/errors.amp.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind: Errors</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+
+  <style amp-custom>
+    .redBackground {
+      background-color: red;
+    }
+    button {
+      border: solid 1px black;
+    }
+  </style>
+</head>
+
+<body>
+  <button onclick="AMP.toggleExperiment('AMP-BIND');window.location.href=window.location.href;">Toggle &lt;AMP-BIND&gt; experiment</button>
+
+  <h2>Error examples</h2>
+  <p>This page lists the different types of runtime user errors that amp-bind can throw.</p>
+  <hr>
+
+  <h3>1. Binding to unsupported property</h3>
+  <p [asdf]="">This paragraph element attempts to bind to "asdf".</p>
+
+  <h3>2. Malformed expressions</h3>
+  <p [text]="(">This expression is missing a closing parens.</p>
+
+  <h3>3. Mismatched initial state</h3>
+  <h4>(Only with '#development=1')</h4>
+  <p [text]="myState.foo">This paragraph's initial `text` state doesn't match the evaluated expression result.</p>
+  <p [text]="myState.foo">bar</p>
+
+  <amp-state id="myState">
+    <script type="application/json">
+      { "foo": "bar" }
+    </script>
+  </amp-state>
+</body>
+</html>

--- a/examples/bind/errors.amp.html
+++ b/examples/bind/errors.amp.html
@@ -36,8 +36,11 @@
   <h3>3. Invalid function invocation</h3>
   <p [text]="123.substring(2)">This expression calls `substring` on a number.</p>
 
-  <h3>4. Invalid expression result</h3>
+  <h3>4. Invalid expression result (validator)</h3>
   <a [href]="'javascript:alert(1)'">This expression contains an invalid URL protocol.</a>
+
+  <h3>4. Invalid expression result (css)</h3>
+  <a [class]="123">This expression contains an invalid [class] result (only string/array/null supported).</a>
 
   <h3>5. Mismatched initial state</h3>
   <h4>(Only with '#development=1')</h4>

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -43,26 +43,34 @@ let ParsedBindingDef;
  * Asynchronously evaluates a set of Bind expressions.
  */
 export class BindEvaluator {
-  /**
-   * @param {!Array<BindingDef>} bindings
-   */
-  constructor(bindings) {
+  constructor() {
     /** @const {!Array<ParsedBindingDef>} */
     this.parsedBindings_ = [];
 
     /** @const {!./bind-validator.BindValidator} */
     this.validator_ = new BindValidator();
+  }
+
+  /**
+   * Parses and stores given bindings into expression objects and returns map
+   * of expression string to parse errors.
+   * @param {!Array<BindingDef>} bindings
+   * @return {Object<string,Error>}
+   */
+  setBindings(bindings) {
+    const errors = Object.create(null);
 
     // Create BindExpression objects from expression strings.
     // TODO(choumx): Chunk creation of BindExpression or change to web worker.
     for (let i = 0; i < bindings.length; i++) {
       const e = bindings[i];
+      const string = e.expressionString;
 
       let expression;
       try {
         expression = new BindExpression(e.expressionString);
       } catch (error) {
-        user().error(TAG, 'Malformed expression:', error);
+        errors[string] = user().createError('Malformed expression', error);
         continue;
       }
 
@@ -72,6 +80,8 @@ export class BindEvaluator {
         expression,
       });
     }
+
+    return errors;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -18,8 +18,6 @@ import {BindExpression} from './bind-expression';
 import {BindValidator} from './bind-validator';
 import {rewriteAttributeValue} from '../../../src/sanitizer';
 
-const TAG = 'amp-bind';
-
 /**
  * @typedef {{
  *   tagName: string,
@@ -54,11 +52,10 @@ export class BindEvaluator {
    * Parses and stores given bindings into expression objects and returns map
    * of expression string to parse errors.
    * @param {!Array<BindingDef>} bindings
-   * @return {Object<string,Error>}
+   * @return {!Object<string,!Error>}
    */
   setBindings(bindings) {
     const errors = Object.create(null);
-
     // Create BindExpression objects from expression strings.
     // TODO(choumx): Chunk creation of BindExpression or change to web worker.
     for (let i = 0; i < bindings.length; i++) {
@@ -79,7 +76,6 @@ export class BindEvaluator {
         expression,
       });
     }
-
     return errors;
   }
 
@@ -96,9 +92,9 @@ export class BindEvaluator {
    */
   evaluate(scope) {
     return new Promise(resolve => {
-      /** @type {!Object<string, BindEvaluationResultDef} */
+      /** @type {!Object<string, ./bind-expression.BindExpressionResultDef>} */
       const cache = {};
-      /** @type {!Object<string, Error>} */
+      /** @type {!Object<string, !Error>} */
       const errors = {};
 
       this.parsedBindings_.forEach(binding => {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -153,8 +153,7 @@ export class Bind {
       this.evaluator_ = new BindEvaluator();
       const parseErrors = this.evaluator_.setBindings(bindings);
 
-      // For each parse error, find elements that the malformed expressions
-      // belong to and report them.
+      // Report each parse error.
       Object.keys(parseErrors).forEach(expressionString => {
         const elements = this.expressionToElements_[expressionString];
         if (elements.length > 0) {
@@ -309,6 +308,7 @@ export class Bind {
         this.apply_(results);
       }
 
+      // Report evaluation errors.
       Object.keys(errors).forEach(expressionString => {
         const err = user().createError(errors[expressionString]);
         const elements = this.expressionToElements_[expressionString];

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -135,7 +135,7 @@ describes.realWin('amp-bind', {
     env.sandbox.stub(window, 'AMP_MODE', {development: true});
     // Only the initial value for [a] binding does not match.
     createElementWithBinding('[a]="a" [b]="b" b="b"');
-    const errorStub = env.sandbox.stub(user(), 'error').withArgs('amp-bind');
+    const errorStub = env.sandbox.stub(user(), 'createError');
     return onBindReady(() => {
       expect(errorStub.callCount).to.equal(1);
     });
@@ -145,7 +145,7 @@ describes.realWin('amp-bind', {
     env.sandbox.stub(window, 'AMP_MODE', {development: true});
     // Only the initial value for [c] binding does not match.
     createElementWithBinding(`a [a]="true" [b]="false" c="false" [c]="false"`);
-    const errorStub = env.sandbox.stub(user(), 'error').withArgs('amp-bind');
+    const errorStub = env.sandbox.stub(user(), 'createError');
     return onBindReady(() => {
       expect(errorStub.callCount).to.equal(1);
     });


### PR DESCRIPTION
Partial for #7257, related to #6199.

- Pass errors to `reportError()` instead of `user().error()` for native rendering in dev console and adding `i-amphtml-error` to affected elements
- Add `examples/bind/errors.amp.html` containing different types of errors

/to @aghassemi