### PR TITLE
Allow variable substitution for whitelisted origins

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -725,6 +725,34 @@ export class UrlReplacements {
   }
 
   /**
+    * Returns whether variable substitution is allowed for given url.
+    * @param {!Location} url.
+    * @return {boolean}
+    */
+  isAllowedOrigin_(url) {
+    const docInfo = documentInfoForDoc(this.ampdoc);
+
+    if (url.origin == parseUrl(docInfo.canonicalUrl).origin ||
+        url.origin == parseUrl(docInfo.sourceUrl).origin) {
+      return true;
+    }
+
+    const meta = this.ampdoc.getRootNode().querySelector(
+      'meta[name=amp-link-variable-allowed-origin]');
+
+    if (meta && meta.hasAttribute('content')) {
+      const whitelist = meta.getAttribute('content').trim().split(/\s+/);
+      for (let i = 0; i < whitelist.length; i++) {
+        if (url.origin == parseUrl(whitelist[i]).origin) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Replaces values in the link of an anchor tag if
    * - the link opts into it (via data-amp-replace argument)
    * - the destination is the source or canonical origin of this doc.
@@ -745,18 +773,16 @@ export class UrlReplacements {
     if (!whitelist) {
       return;
     }
-    const docInfo = documentInfoForDoc(this.ampdoc);
     // ORIGINAL_HREF_PROPERTY has the value of the href "pre-replacement".
     // We set this to the original value before doing any work and use it
     // on subsequent replacements, so that each run gets a fresh value.
     const href = dev().assertString(
         element[ORIGINAL_HREF_PROPERTY] || element.getAttribute('href'));
     const url = parseUrl(href);
-    if (url.origin != parseUrl(docInfo.canonicalUrl).origin &&
-        url.origin != parseUrl(docInfo.sourceUrl).origin) {
+    if (!this.isAllowedOrigin_(url)) {
       user().warn('URL', 'Ignoring link replacement', href,
           ' because the link does not go to the document\'s' +
-          ' source or canonical origin.');
+          ' source, canonical, or whitelisted origin.');
       return;
     }
     if (element[ORIGINAL_HREF_PROPERTY] == null) {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -120,7 +120,16 @@ describes.sandboxed('UrlReplacements', {}, () => {
       },
       document: {
         nodeType: /* document */ 9,
-        querySelector: () => {return {href: canonical};},
+        querySelector: selector => {
+          if (selector.startsWith('meta')) {
+            return {
+              getAttribute: () => {return 'https://whitelisted.com';},
+              hasAttribute: () => {return true;},
+            };
+          } else {
+            return {href: canonical};
+          }
+        },
         cookie: '',
       },
       Math: window.Math,
@@ -1046,6 +1055,13 @@ describes.sandboxed('UrlReplacements', {}, () => {
       a.setAttribute('data-amp-replace', 'QUERY_PARAM');
       urlReplacements.maybeExpandLink(a);
       expect(a.href).to.equal('https://canonical.com/link?out=bar');
+    });
+
+    it('should replace with whitelisted origin', () => {
+      a.href = 'https://whitelisted.com/link?out=QUERY_PARAM(foo)';
+      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+      urlReplacements.maybeExpandLink(a);
+      expect(a.href).to.equal('https://whitelisted.com/link?out=bar');
     });
 
     it('should not replace to different origin', () => {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -123,7 +123,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
         querySelector: selector => {
           if (selector.startsWith('meta')) {
             return {
-              getAttribute: () => {return 'https://whitelisted.com';},
+              getAttribute: () => {return 'https://whitelisted.com https://greylisted.com';},
               hasAttribute: () => {return true;},
             };
           } else {


### PR DESCRIPTION
Allow for an additional domain (or list of domains) for which variable substitution is allowed in links.

- list of domains is specified via meta tag with name=`amp-link-variable-allowed-origin`
- multiple whitelisted domains can be specified by using whitespace separated list
- allowed variables uses existing whitelist on the element (`data-amp-replace`)

Implements https://github.com/ampproject/amphtml/issues/6141
