### PR TITLE
Warn during expression soft-failures in amp-bind

### DIFF
--- a/examples/bind/errors.amp.html
+++ b/examples/bind/errors.amp.html
@@ -23,7 +23,7 @@
 <body>
   <button onclick="AMP.toggleExperiment('AMP-BIND');window.location.href=window.location.href;">Toggle &lt;AMP-BIND&gt; experiment</button>
 
-  <h2>Error examples</h2>
+  <h2>Error &amp; warning examples</h2>
   <p>This page lists the different types of runtime user errors that amp-bind can throw.</p>
   <hr>
 
@@ -40,9 +40,18 @@
   <a [href]="'javascript:alert(1)'">This expression contains an invalid URL protocol.</a>
 
   <h3>4.b Invalid expression result (css)</h3>
-  <a [class]="123">This expression contains an invalid [class] result (only string/array/null supported).</a>
+  <p [class]="123">This expression contains an invalid [class] result (only string/array/null supported).</p>
 
-  <h3>5. Mismatched initial state</h3>
+  <h3>5. (WARN) Undefined variables and members</h3>
+  <p [text]="foo">null</p><p>Expression above references an undefined variable `foo`.</p>
+  <p [text]="myState.qux">null</p><p>Expression above references an undefined member `myState.qux`.</p>
+
+  <h3>6. (WARN) Invalid member access</h3>
+  <p [text]="myState[true]">null</p><p>Expression above tries to access a boolean member.</p>
+  <p [text]="true[3]">null</p><p>Expression above tries to access a member of a boolean.</p>
+  <p [text]="true[3]">null</p><p>Expression above tries to access a member of null.</p>
+
+  <h3>7. Mismatched initial state</h3>
   <h4>(Only with '#development=1')</h4>
   <p [text]="myState.foo">This paragraph's initial `text` state doesn't match the evaluated expression result.</p>
 

--- a/examples/bind/errors.amp.html
+++ b/examples/bind/errors.amp.html
@@ -49,7 +49,8 @@
   <h3>6. (WARN) Invalid member access</h3>
   <p [text]="myState[true]">null</p><p>Expression above tries to access a boolean member.</p>
   <p [text]="true[3]">null</p><p>Expression above tries to access a member of a boolean.</p>
-  <p [text]="true[3]">null</p><p>Expression above tries to access a member of null.</p>
+  <p [text]="myState[null]">null</p><p>Expression above tries to access a null member.</p>
+  <p [text]="null[3]">null</p><p>Expression above tries to access a member of null.</p>
 
   <h3>7. Mismatched initial state</h3>
   <h4>(Only with '#development=1')</h4>

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -137,7 +137,7 @@ export class BindExpression {
             }
           }
         }
-        throw new Error(`${caller}.${method} is not a supported function.`);
+        throw new Error(`${callerType}.${method} is not a supported function.`);
 
       case AstNodeType.MEMBER_ACCESS:
         const target = this.eval_(args[0], scope);

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -271,8 +271,8 @@ export class BindExpression {
    * @param {*} member
    */
   memberAccessWarning_(target, member) {
-    user().warn(TAG, `Cannot read property ${member} of ${target}; ` +
-        `returning null.`);
+    user().warn(TAG, `Cannot read property ${JSON.stringify(member)} of ` +
+        `${JSON.stringify(target)}; returning null.`);
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -16,6 +16,9 @@
 
 import {AstNodeType} from './bind-expr-defines';
 import {parser} from './bind-expr-impl';
+import {user} from '../../../src/log';
+
+const TAG = 'amp-bind';
 
 /**
  * Possible types of a Bind expression evaluation.
@@ -134,27 +137,32 @@ export class BindExpression {
             }
           }
         }
-        throw new Error(`${method}() is not a supported function.`);
+        throw new Error(`${caller}.${method} is not a supported function.`);
 
       case AstNodeType.MEMBER_ACCESS:
         const target = this.eval_(args[0], scope);
         const member = this.eval_(args[1], scope);
 
         if (target === null || member === null) {
+          this.memberAccessWarning_(target, member);
           return null;
         }
         const targetType = typeof target;
         if (targetType !== 'string' && targetType !== 'object') {
+          this.memberAccessWarning_(target, member);
           return null;
         }
         const memberType = typeof member;
         if (memberType !== 'string' && memberType !== 'number') {
+          this.memberAccessWarning_(target, member);
           return null;
         }
         // Ignore Closure's type constraint for `hasOwnProperty`.
         if (Object.prototype.hasOwnProperty.call(
               /** @type {Object} */ (target), member)) {
           return target[member];
+        } else {
+          this.memberAccessWarning_(target, member);
         }
         return null;
 
@@ -165,6 +173,8 @@ export class BindExpression {
         const variable = value;
         if (Object.prototype.hasOwnProperty.call(scope, variable)) {
           return scope[variable];
+        } else {
+          user().warn(TAG, `${variable} is not defined; returning null.`);
         }
         return null;
 
@@ -254,6 +264,15 @@ export class BindExpression {
       default:
         throw new Error(`Unexpected AstNodeType: ${type}.`);
     }
+  }
+
+  /**
+   * @param {*} target
+   * @param {*} member
+   */
+  memberAccessWarning_(target, member) {
+    user().warn(TAG, `Cannot read property ${member} of ${target}; ` +
+        `returning null.`);
   }
 
   /**


### PR DESCRIPTION
Partial for #7257, related to #6199.

- Add warnings when soft-failing expressions to `null` 
- Make unsupported function error more specific