### PR TITLE
Limit URL replacement to secure origins.

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -21,7 +21,7 @@ import {shareTrackingForOrNull} from '../share-tracking-service';
 import {dev, user, rethrowAsync} from '../log';
 import {documentInfoForDoc} from '../document-info';
 import {getServiceForDoc, installServiceInEmbedScope} from '../service';
-import {parseUrl, removeFragment, parseQueryString} from '../url';
+import {isSecureUrl, parseUrl, removeFragment, parseQueryString} from '../url';
 import {viewerForDoc} from '../viewer';
 import {viewportForDoc} from '../viewport';
 import {userNotificationManagerFor} from '../user-notification';
@@ -757,6 +757,11 @@ export class UrlReplacements {
       user().warn('URL', 'Ignoring link replacement', href,
           ' because the link does not go to the document\'s' +
           ' source or canonical origin.');
+      return;
+    }
+    if (!isSecureUrl(href)) {
+      user().warn('URL', 'Ignoring link replacement', href,
+          ' because it is only supported for secure links.');
       return;
     }
     if (element[ORIGINAL_HREF_PROPERTY] == null) {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -1041,6 +1041,14 @@ describes.sandboxed('UrlReplacements', {}, () => {
       expect(a.href).to.equal('https://example.com/link?out=RANDOM');
     });
 
+    it('should not replace in http (non-secure)', () => {
+      canonical = 'http://example.com/link';
+      a.href = 'http://example.com/link?out=QUERY_PARAM(foo)';
+      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+      urlReplacements.maybeExpandLink(a);
+      expect(a.href).to.equal('http://example.com/link?out=QUERY_PARAM(foo)');
+    });
+
     it('should replace with canonical origin', () => {
       a.href = 'https://canonical.com/link?out=QUERY_PARAM(foo)';
       a.setAttribute('data-amp-replace', 'QUERY_PARAM');


### PR DESCRIPTION
This is as designed and follows with web policy that powerful features are only available on HTTPS.

Related to #4078

CC @rudygalfi 