### PR TITLE
Classify new domain scheme traffic as coming from CDN.

### DIFF
--- a/tools/errortracker/app.yaml
+++ b/tools/errortracker/app.yaml
@@ -1,5 +1,5 @@
 application: amp-error-reporting
-version: 12
+version: 13
 runtime: go
 api_version: go1
 

--- a/tools/errortracker/errortracker.go
+++ b/tools/errortracker/errortracker.go
@@ -116,6 +116,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	// docs) we log as "ERROR".
 	isCdn := false
 	if strings.HasPrefix(r.Referer(), "https://cdn.ampproject.org/") ||
+			strings.Contains(r.Referer(), ".cdn.ampproject.org/") ||
 			strings.Contains(r.Referer(), ".ampproject.net/") {
 		severity = "ERROR"
 		level = logging.Error


### PR DESCRIPTION
Adds support for the new domain scheme: https://domain-com.cdn.ampproject.org

Fixes #7019