### PR TITLE
Fix article-fixed-header example

### DIFF
--- a/examples/article-fixed-header.amp.html
+++ b/examples/article-fixed-header.amp.html
@@ -35,10 +35,9 @@
       top: 0;
       left: 0;
       right: 0;
-      height: 46px;
+      height: 20px;
       background: cyan;
       z-index: 10;
-      padding: 8px 15px;
       transform: translateX(20px);
     }
 
@@ -56,7 +55,7 @@
     }
 
     body {
-      padding-top: 46px;
+      padding-top: 50px;
     }
 
     /* In the shadow-doc mode, the parent shell already has header and nav. */


### PR DESCRIPTION
When tested in search viewer, this example page has wrong offset top for `position: fixed` element `.logo` because [the `auto` positioning coincided with a declared non-auto position in CSS](https://github.com/ampproject/amphtml/issues/5406#issuecomment-253385847)

The bug happens because the following coincidence happens:
* `body` has `padding-top: 46px`
* When embedded in viewer the document `html` has `padding-top: 54px` which makes space for the viewer header
* The position fixed element `.logo` has `top:100px`

46+54==100, the position fixed element is not offset correctly (should be `calc(100px)`) because of the coincidence.
This rarely happens so I changed the example file to avoid the extreme case for easy test when embedded in viewer.