### PR TITLE
Directly report logged errors instead of relying on rethrowing

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -338,6 +338,14 @@ var forbiddenTerms = {
       'tools/experiments/experiments.js',
     ],
   },
+  'setReportError\\W': {
+    message: 'Should only be used in error.js and tests.',
+    whitelist: [
+      'dist.3p/current/integration.js',
+      'src/error.js',
+      'src/log.js',
+    ],
+  },
   'isTrustedViewer': {
     message: requiresReviewPrivacy,
     whitelist: [

--- a/src/log.js
+++ b/src/log.js
@@ -55,14 +55,14 @@ export const LogLevel = {
 };
 
 /**
- * @type {function(*,!Element=)|undefined}
+ * @type {function(*, !Element=)|undefined}
  */
 let reportError;
 
 /**
  * Sets reportError function. Called from error.js to break cyclic
  * dependency.
- * @param {function(*,!Element=)|undefined}
+ * @param {function(*, !Element=)|undefined} fn
  */
 export function setReportError(fn) {
   reportError = fn;

--- a/src/log.js
+++ b/src/log.js
@@ -54,6 +54,19 @@ export const LogLevel = {
   FINE: 4,
 };
 
+/**
+ * @type {function(*,!Element=)|undefined}
+ */
+let reportError;
+
+/**
+ * Sets reportError function. Called from error.js to break cyclic
+ * dependency.
+ * @param {function(*,!Element=)|undefined}
+ */
+export function setReportError(fn) {
+  reportError = fn;
+}
 
 /**
  * Logging class.
@@ -202,7 +215,7 @@ export class Log {
   error(tag, var_args) {
     const error = this.error_.apply(this, arguments);
     if (error) {
-      this.win.setTimeout(() => {throw /** @type {!Error} */ (error);});
+      reportError(error);
     }
   }
 
@@ -216,7 +229,7 @@ export class Log {
     const error = this.error_.apply(this, arguments);
     if (error) {
       error.expected = true;
-      this.win.setTimeout(() => {throw /** @type {!Error} */ (error);});
+      reportError(error);
     }
   }
 
@@ -287,6 +300,7 @@ export class Log {
       e.associatedElement = firstElement;
       e.messageArray = messageArray;
       this.prepareError_(e);
+      reportError(e);
       throw e;
     }
     return shouldBeTrueish;
@@ -438,7 +452,10 @@ function createErrorVargs(var_args) {
  */
 export function rethrowAsync(var_args) {
   const error = createErrorVargs.apply(null, arguments);
-  setTimeout(() => {throw error;});
+  setTimeout(() => {
+    reportError(error);
+    throw error;
+  });
 }
 
 

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -18,6 +18,7 @@
 import '../third_party/babel/custom-babel-helpers';
 import '../src/polyfills';
 import {removeElement} from '../src/dom';
+import {setReportError} from '../src/log';
 import {
   adopt,
   installAmpdocServices,
@@ -27,7 +28,10 @@ import {activateChunkingForTesting} from '../src/chunk';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {platformFor} from '../src/platform';
 import {setDefaultBootstrapBaseUrlForTesting} from '../src/3p-frame';
-import {resetAccumulatedErrorMessagesForTesting} from '../src/error';
+import {
+  resetAccumulatedErrorMessagesForTesting,
+  reportError,
+} from '../src/error';
 import {resetExperimentTogglesForTesting} from '../src/experiments';
 import * as describes from '../testing/describes';
 
@@ -233,6 +237,7 @@ afterEach(function() {
   setDefaultBootstrapBaseUrlForTesting(null);
   resetAccumulatedErrorMessagesForTesting();
   resetExperimentTogglesForTesting();
+  setReportError(reportError);
 });
 
 chai.Assertion.addMethod('attribute', function(attr) {

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -21,6 +21,7 @@ import {
   dev,
   isUserErrorMessage,
   rethrowAsync,
+  setReportError,
   user,
 } from '../../src/log';
 import * as sinon from 'sinon';
@@ -161,97 +162,62 @@ describe('Logging', () => {
     it('should report ERROR even when OFF and coallesce messages', () => {
       const log = new Log(win, RETURNS_OFF);
       expect(log.level_).to.equal(LogLevel.OFF);
-      win.setTimeout = () => {};
-      let timeoutCallback;
-      const timeoutStub = sandbox.stub(win, 'setTimeout', callback => {
-        timeoutCallback = callback;
+      let reportedError;
+      setReportError(function(e) {
+        reportedError = e;
       });
 
       log.error('TAG', 'intended', new Error('test'));
 
-      expect(logSpy.callCount).to.equal(0);
-      expect(timeoutStub.callCount).to.equal(1);
-      expect(timeoutCallback).to.exist;
-      try {
-        timeoutCallback();
-        throw new Error('must not be here');
-      } catch (e) {
-        expect(e).to.be.instanceof(Error);
-        expect(e.message).to.match(/intended\: test/);
-        expect(e.expected).to.be.undefined;
-        expect(isUserErrorMessage(e.message)).to.be.false;
-      }
+      expect(reportedError).to.be.instanceof(Error);
+      expect(reportedError.message).to.match(/intended\: test/);
+      expect(reportedError.expected).to.be.undefined;
+      expect(isUserErrorMessage(reportedError.message)).to.be.false;
     });
 
     it('should report ERROR and mark with expected flag', () => {
       const log = new Log(win, RETURNS_OFF);
       expect(log.level_).to.equal(LogLevel.OFF);
-      win.setTimeout = () => {};
-      let timeoutCallback;
-      const timeoutStub = sandbox.stub(win, 'setTimeout', callback => {
-        timeoutCallback = callback;
+      let reportedError;
+      setReportError(function(e) {
+        reportedError = e;
       });
 
       log.expectedError('TAG', 'intended', new Error('test'));
 
-      expect(logSpy.callCount).to.equal(0);
-      expect(timeoutStub.callCount).to.equal(1);
-      expect(timeoutCallback).to.exist;
-      try {
-        timeoutCallback();
-      } catch (e) {
-        expect(e).to.be.instanceof(Error);
-        expect(e.message).to.match(/intended\: test/);
-        expect(e.expected).to.be.true;
-      }
+      expect(reportedError).to.be.instanceof(Error);
+      expect(reportedError.message).to.match(/intended\: test/);
+      expect(reportedError.expected).to.be.true;
     });
 
     it('should report ERROR when OFF from a single message', () => {
       const log = new Log(win, RETURNS_OFF);
       expect(log.level_).to.equal(LogLevel.OFF);
-      win.setTimeout = () => {};
-      let timeoutCallback;
-      const timeoutStub = sandbox.stub(win, 'setTimeout', callback => {
-        timeoutCallback = callback;
+      let reportedError;
+      setReportError(function(e) {
+        reportedError = e;
       });
 
       log.error('TAG', 'intended');
 
-      expect(logSpy.callCount).to.equal(0);
-      expect(timeoutStub.callCount).to.equal(1);
-      expect(timeoutCallback).to.exist;
-      try {
-        timeoutCallback();
-        throw new Error('must not be here');
-      } catch (e) {
-        expect(e).to.be.instanceof(Error);
-        expect(e.message).to.match(/intended/);
-        expect(isUserErrorMessage(e.message)).to.be.false;
-      }
+      expect(reportedError).to.be.instanceof(Error);
+      expect(reportedError.message).to.match(/intended/);
+      expect(isUserErrorMessage(reportedError.message)).to.be.false;
     });
 
     it('should report ERROR when OFF from a single error object', () => {
       const log = new Log(win, RETURNS_OFF);
       expect(log.level_).to.equal(LogLevel.OFF);
-      win.setTimeout = () => {};
-      let timeoutCallback;
-      const timeoutStub = sandbox.stub(win, 'setTimeout', callback => {
-        timeoutCallback = callback;
+      let reportedError;
+      setReportError(function(e) {
+        reportedError = e;
       });
 
       log.error('TAG', new Error('test'));
 
-      expect(logSpy.callCount).to.equal(0);
-      expect(timeoutStub.callCount).to.equal(1);
-      expect(timeoutCallback).to.exist;
-      try {
-        timeoutCallback();
-        throw new Error('must not be here');
-      } catch (e) {
-        expect(e).to.be.instanceof(Error);
-        expect(e.message).to.match(/test/);
-        expect(isUserErrorMessage(e.message)).to.be.false;
-      }
+      expect(reportedError).to.be.instanceof(Error);
+      expect(reportedError.message).to.match(/test/);
+      expect(isUserErrorMessage(reportedError.message)).to.be.false;
     });
   });
 


### PR DESCRIPTION
…and then catching the `error` event.

Part of #7353

