### PR TITLE
Cleanup chunked-amp experiment.

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -17,7 +17,6 @@
 import PriorityQueue from './utils/priority-queue';
 import {dev} from './log';
 import {fromClassForDoc, getExistingServiceForDoc} from './service';
-import {isExperimentOnAllowUrlOverride} from './experiments';
 import {makeBodyVisible} from './style-installer';
 import {viewerPromiseForDoc} from './viewer';
 
@@ -229,12 +228,6 @@ class StartupTask extends Task {
     /** @private {!Window} */
     this.win_ = win;
 
-    /** @private @const {boolean} */
-    this.active_ = isExperimentOnAllowUrlOverride(this.win_, 'chunked-amp');
-    if (!this.active_) {
-      return;
-    }
-
     /** @private {?./service/viewer-impl.Viewer} */
     this.viewer_ = null;
 
@@ -262,7 +255,7 @@ class StartupTask extends Task {
   immediateTriggerCondition_() {
     // Run in a micro task when the doc is visible. Otherwise, run after
     // having yielded to the event queue once.
-    return !this.active_ || this.isVisible_();
+    return this.isVisible_();
   }
 
   /** @override */

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -22,16 +22,13 @@ import {
   startupChunk,
 } from '../../src/chunk';
 import {installDocService} from '../../src/service/ampdoc-impl';
-import {toggleExperiment} from '../../src/experiments';
 import {viewerForDoc, viewerPromiseForDoc} from '../../src/viewer';
 import * as sinon from 'sinon';
 
 
 describe('chunk', () => {
 
-  let experimentOn;
   beforeEach(() => {
-    experimentOn = true;
     activateChunkingForTesting();
   });
 
@@ -45,7 +42,6 @@ describe('chunk', () => {
     let fakeWin;
 
     beforeEach(() => {
-      toggleExperiment(env.win, 'chunked-amp', experimentOn);
       fakeWin = env.win;
       // If there is a viewer, wait for it, so we run with it being
       // installed.
@@ -158,7 +154,6 @@ describe('chunk', () => {
       }
 
       beforeEach(() => {
-        toggleExperiment(env.win, 'chunked-amp', experimentOn);
         fakeWin = env.win;
         const viewer = viewerForDoc(env.win.document);
         env.sandbox.stub(viewer, 'isVisible', () => {
@@ -179,21 +174,6 @@ describe('chunk', () => {
           done = d;
         });
       });
-    });
-
-    describe('invisible experiment off', () => {
-      beforeEach(() => {
-        experimentOn = false;
-        env.win.postMessage = () => {
-          throw new Error('No calls expected: postMessage');
-        };
-        env.win.requestIdleCallback = () => {
-          throw new Error('No calls expected: requestIdleCallback');
-        };
-        env.win.location.resetHref('test#visibilityState=hidden');
-      });
-
-      basicTests(env);
     });
 
     describe('invisible', () => {


### PR DESCRIPTION
Only deletes the guards. Leaves configs intact.

Part 1 of #5535

