### PR TITLE
Throttle "Script error." reports.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -32,10 +32,10 @@ const CANCELLED = 'CANCELLED';
 
 
 /**
- * The threshold for throttling load errors. Currently at 0.1%.
+ * The threshold for throttled errors. Currently at 0.1%.
  * @const {number}
  */
-const LOAD_ERROR_THRESHOLD = 1e-3;
+const THROTTLED_ERROR_THRESHOLD = 1e-3;
 
 
 /**
@@ -235,12 +235,16 @@ export function getErrorReportUrl(message, filename, line, col, error,
     return;
   }
 
-  // Load errors are always "expected".
-  if (isLoadErrorMessage(message)) {
+  // We throttle load errors and generic "Script error." errors
+  // that have no information and thus cannot be acted upon.
+  if (isLoadErrorMessage(message) ||
+    // See https://github.com/ampproject/amphtml/issues/7353
+    // for context.
+    message == 'Script error.') {
     expected = true;
 
     // Throttle load errors.
-    if (Math.random() > LOAD_ERROR_THRESHOLD) {
+    if (Math.random() > THROTTLED_ERROR_THRESHOLD) {
       return;
     }
   }

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -272,6 +272,24 @@ describe('reportErrorToServer', () => {
     expect(url).to.contain('&ex=1');
   });
 
+  it('should not report Script errors', () => {
+    sandbox.stub(Math, 'random', () => (1e-3 + 1e-4));
+    const e = new Error('Script error.');
+    const url =
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e);
+    expect(url).to.be.undefined;
+  });
+
+  it('should report throttled Script errors at threshold', () => {
+    sandbox.stub(Math, 'random', () => 1e-3);
+    const e = new Error('Script error.');
+    const url =
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e);
+    expect(url).to.be.ok;
+    expect(url).to.contain('&ex=1');
+  });
+
+
   it('should report throttled load errors under threshold', () => {
     sandbox.stub(Math, 'random', () => (1e-3 - 1e-4));
     const e = new Error('Failed to load:');


### PR DESCRIPTION
These contain zero information and so we only care about the count, but not about getting every single one.

See #7353 for context.