### PR TITLE
Rename messaging request string in history

### DIFF
--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -791,7 +791,7 @@ export class HistoryBindingVirtual_ {
     if (!this.viewer_.hasCapability('fragment')) {
       return Promise.resolve('');
     }
-    return this.viewer_.sendMessageAwaitResponse('fragment', undefined,
+    return this.viewer_.sendMessageAwaitResponse('getFragment', undefined,
         /* cancelUnsent */true).then(
         hash => {
           if (!hash) {
@@ -810,7 +810,7 @@ export class HistoryBindingVirtual_ {
       return Promise.resolve();
     }
     return /** @type {!Promise} */ (this.viewer_.sendMessageAwaitResponse(
-        'fragment', {fragment}, /* cancelUnsent */true));
+        'replaceHistory', {fragment}, /* cancelUnsent */true));
   }
 }
 

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -580,7 +580,7 @@ describes.fakeWin('Get and update fragment', {}, env => {
         new HistoryBindingVirtual_(env.win, viewer));
     viewerMock.expects('hasCapability').withExactArgs('fragment').once()
         .returns(true);
-    viewerMock.expects('sendMessageAwaitResponse').withExactArgs('fragment',
+    viewerMock.expects('sendMessageAwaitResponse').withExactArgs('getFragment',
         undefined, true).once().returns(Promise.resolve('#from-viewer'));
     return history.getFragment().then(fragment => {
       expect(fragment).to.equal('from-viewer');
@@ -594,7 +594,7 @@ describes.fakeWin('Get and update fragment', {}, env => {
         new HistoryBindingVirtual_(env.win, viewer));
     viewerMock.expects('hasCapability').withExactArgs('fragment').once()
         .returns(true);
-    viewerMock.expects('sendMessageAwaitResponse').withExactArgs('fragment',
+    viewerMock.expects('sendMessageAwaitResponse').withExactArgs('getFragment',
         undefined, true).once().returns(Promise.resolve('from-viewer'));
     return history.getFragment().then(() => {
       throw new Error('should not happen');
@@ -620,7 +620,7 @@ describes.fakeWin('Get and update fragment', {}, env => {
         new HistoryBindingVirtual_(env.win, viewer));
     viewerMock.expects('hasCapability').withExactArgs('fragment').once()
         .returns(true);
-    viewerMock.expects('sendMessageAwaitResponse').withExactArgs('fragment',
+    viewerMock.expects('sendMessageAwaitResponse').withExactArgs('getFragment',
         undefined, true).once().returns(Promise.resolve());
     return history.getFragment().then(fragment => {
       expect(fragment).to.equal('');
@@ -633,8 +633,9 @@ describes.fakeWin('Get and update fragment', {}, env => {
         new HistoryBindingVirtual_(env.win, viewer));
     viewerMock.expects('hasCapability').withExactArgs('fragment').once()
         .returns(true);
-    viewerMock.expects('sendMessageAwaitResponse').withExactArgs('fragment',
-        {fragment: '#fragment'}, true).once().returns(Promise.resolve());
+    viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
+        'replaceHistory', {fragment: '#fragment'}, true).once()
+        .returns(Promise.resolve());
     return history.updateFragment('#fragment').then(() => {});
   });
 
@@ -644,8 +645,8 @@ describes.fakeWin('Get and update fragment', {}, env => {
         new HistoryBindingVirtual_(env.win, viewer));
     viewerMock.expects('hasCapability').withExactArgs('fragment').once()
         .returns(false);
-    viewerMock.expects('sendMessageAwaitResponse').withExactArgs('fragment',
-        {fragment: '#fragment'}, true).never();
+    viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
+        'replaceHistory', {fragment: '#fragment'}, true).never();
     return history.updateFragment('#fragment').then(() => {});
   });
 });


### PR DESCRIPTION
According to new spec, the naming of the message string should be changed.