### PR TITLE
Rename goToSlide event to slideChange

### DIFF
--- a/examples/bind/carousels.amp.html
+++ b/examples/bind/carousels.amp.html
@@ -34,7 +34,7 @@
     <p [text]="'Selected slide: ' + selectedSlide">Selected slide: None<p>
 
     <amp-carousel controls type=slides width=400 height=300
-        [slide]="selectedSlide" on="goToSlide:AMP.setState(selectedSlide=event.index)">
+        [slide]="selectedSlide" on="slideChange:AMP.setState(selectedSlide=event.index)">
       <amp-img src="https://ampbyexample.com/img/image1.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image2.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image3.jpg" width=400 height=300></amp-img>

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -534,14 +534,14 @@ export class AmpSlideScroll extends BaseSlides {
   }
 
   /**
-   * Shows the slide at the given index and triggers a `goToSlide` action.
+   * Shows the slide at the given index and triggers a `slideChange` event.
    * @param {number} newIndex
    * @private
    */
   showSlideAndTriggerAction_(newIndex) {
     this.showSlide_(newIndex);
 
-    const name = 'goToSlide';
+    const name = 'slideChange';
     const detail = {index: newIndex};
     const event = new CustomEvent(`slidescroll.${name}`, {detail});
     this.action_.trigger(this.element, name, event);

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -954,7 +954,7 @@ describe('SlideScroll', () => {
       });
     });
 
-    it('should trigger `slide` action when user changes slides', () => {
+    it('should trigger `slideChange` action when user changes slides', () => {
       return getAmpSlideScroll(true).then(obj => {
         const ampSlideScroll = obj.ampSlideScroll;
         const impl = ampSlideScroll.implementation_;
@@ -963,13 +963,13 @@ describe('SlideScroll', () => {
         impl.goCallback(-1, /* animate */ false);
         expect(triggerSpy).to.have.been.calledWith(
             ampSlideScroll,
-            'goToSlide',
+            'slideChange',
             /* CustomEvent */ sinon.match.has('detail', {index: 4}));
 
         impl.goCallback(1, /* animate */ false);
         expect(triggerSpy).to.have.been.calledWith(
             ampSlideScroll,
-            'goToSlide',
+            'slideChange',
             /* CustomEvent */ sinon.match.has('detail', {index: 0}));
       });
     });
@@ -980,7 +980,6 @@ describe('SlideScroll', () => {
         const impl = ampSlideScroll.implementation_;
         let args = {'index': '123'};
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
-
 
         impl.executeAction({method: 'goToSlide', args});
         expect(showSlideSpy).to.have.been.calledWith(123);

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -101,7 +101,7 @@ Including: `input[type=radio]`, `input[type=checkbox]` and `select`.
 </table>
 
 
-### amp-carousel
+### amp-carousel[type="slides"]
 <table>
   <tr>
     <th>Event</th>
@@ -109,9 +109,9 @@ Including: `input[type=radio]`, `input[type=checkbox]` and `select`.
     <th>Data</th>
   </tr>
   <tr>
-    <td>goToSlide</td>
-    <td>Fired when the user changes the carousel's current slide.</td>
-    <td><code>index</code> : slide number</td>
+    <td>slideChange</td>
+    <td>Fired when the user manually changes the carousel's current slide. Does not fire on autoplay or the <code>goToSlide</code> action.</td>
+    <td><code>event.index</code> : slide number</td>
   </tr>
 </table>
 
@@ -130,12 +130,12 @@ Including: `input[type=radio]`, `input[type=checkbox]` and `select`.
   <tr>
     <td>submit-success</td>
     <td>Fired when the form submission response is success.</td>
-    <td><code>response</code> : JSON response</td>
+    <td><code>event.response</code> : JSON response</td>
   </tr>
   <tr>
     <td>submit-error</td>
     <td>Fired when the form submission response is an error.</td>
-    <td><code>response</code> : JSON response</td>
+    <td><code>event.response</code> : JSON response</td>
   </tr>
 </table>
 
@@ -247,7 +247,7 @@ Including: `input[type=radio]`, `input[type=checkbox]` and `select`.
   </tr>
   <tr>
     <td>goToSlide(index=INTEGER)</td>
-    <td>Advances the carousel to a specified slide index</td>
+    <td>Advances the carousel to a specified slide index.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Fixes #7337 and #7298. 

- `slideChange` instead of `slidechanged` to have consistent tense, e.g. `change` and `submit` are not past tense
- Clarified documentation about when the event is not fired
- Q: Should we stick with camelCasing or dash-delimiting like `submit-success`?

/to @mkhatib @camelburrito /cc @ericlindley-g 