### PR TITLE
Calculate scroll length.

### DIFF
--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -120,7 +120,7 @@ export class Viewport {
     this.scrollTracking_ = false;
 
     /** @private {number} */
-    this.scrollCount_ = 0;
+    this.scrollLength_ = 0;
 
     /** @private @const {!Observable<!ViewportChangedEventDef>} */
     this.changeObservable_ = new Observable();
@@ -498,11 +498,11 @@ export class Viewport {
   }
 
   /**
-   * Returns whether the user has scrolled yet.
-   * @return {boolean}
+   * Returns total scrolled length in pixel.
+   * @return {number}
    */
-  hasScrolled() {
-    return this.scrollCount_ > 0;
+  getTotalScrollLength() {
+    return this.scrollLength_;
   }
 
   /**
@@ -665,7 +665,6 @@ export class Viewport {
   /** @private */
   scroll_() {
     this.rect_ = null;
-    this.scrollCount_++;
     this.scrollLeft_ = this.binding_.getScrollLeft();
     const newScrollTop = this.binding_.getScrollTop();
     if (newScrollTop < 0) {
@@ -674,6 +673,7 @@ export class Viewport {
       // be ignored here.
       return;
     }
+    this.scrollLength_ += Math.abs(newScrollTop - this.scrollTop_);
     this.scrollTop_ = newScrollTop;
     if (!this.scrollTracking_) {
       this.scrollTracking_ = true;


### PR DESCRIPTION
Scroll length is the number of pixels that the user has scrolled so far. 

Usages: 
- used to normalize the page jank rate.
- as an analytics metric for publisher to understand how much user has interacted with the page.