### PR TITLE
Separate render-start and loaded phases for Ads

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -207,14 +207,9 @@ export class AmpAdXOriginIframeHandler {
       iframeLoadPromise,
       noContentPromise,
     ]);
-    return adLoadPromise.then(() => {
-      // If ad loading has succeeded, so should either visibilityPromise or
-      // no-content. Return it here to ensure that rendering has been fully
-      // processed when layout promise is complete.
-      return Promise.race([visibilityPromise, noContentPromise]);
-    }, reason => {
+    return adLoadPromise.catch(reason => {
       this.noContent_();
-      user().warn('AMP-AD', reason);
+      user().warn('AMP-AD', 'Ad loading failed', reason);
     });
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -136,7 +136,7 @@ export class AmpAdXOriginIframeHandler {
     }
 
     // Calculate render-start and no-content signal. These signals are mutually
-    // exlcusive. Whichever arrives first wins.
+    // exclusive. Whichever arrives first wins.
     let renderStartResolve;
     const renderStartPromise = new Promise(resolve => {
       renderStartResolve = resolve;

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -189,7 +189,7 @@ export class AmpAdXOriginIframeHandler {
     // load, whichever is earlier.
     setStyle(this.iframe, 'visibility', 'hidden');
     this.element_.appendChild(this.iframe);
-    const visibilityPromise = Promise.race([
+    Promise.race([
       renderStartPromise,
       iframeLoadPromise,
       timer.promise(VISIBILITY_TIMEOUT),

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -126,7 +126,7 @@ export class AmpAdXOriginIframeHandler {
 
     // Iframe.onload normally called by the Ad after full load.
     const iframeLoadPromise = loadPromise(this.iframe).then(() => {
-      // Wait just a little to allow messages to arrive.
+      // Wait just a little to allow `no-content` message to arrive.
       return timer.promise(10);
     });
     if (this.baseInstance_.emitLifecycleEvent) {
@@ -226,13 +226,14 @@ export class AmpAdXOriginIframeHandler {
   renderStart_(opt_info) {
     this.uiHandler_.setDisplayState(AdDisplayState.LOADED_RENDER_START);
     this.baseInstance_.renderStarted();
-    if (opt_info) {
-      const data = opt_info.data;
-      this.updateSize_(data.height, data.width,
-                  opt_info.source, opt_info.origin);
-      if (this.baseInstance_.emitLifecycleEvent) {
-        this.baseInstance_.emitLifecycleEvent('renderCrossDomainStart');
-      }
+    if (!opt_info) {
+      return;
+    }
+    const data = opt_info.data;
+    this.updateSize_(data.height, data.width,
+                opt_info.source, opt_info.origin);
+    if (this.baseInstance_.emitLifecycleEvent) {
+      this.baseInstance_.emitLifecycleEvent('renderCrossDomainStart');
     }
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -203,14 +203,7 @@ export class AmpAdXOriginIframeHandler {
     });
 
     // The actual ad load is eariliest of iframe.onload event and no-content.
-    const adLoadPromise = Promise.race([
-      iframeLoadPromise,
-      noContentPromise,
-    ]);
-    return adLoadPromise.catch(reason => {
-      this.noContent_();
-      user().warn('AMP-AD', 'Ad loading failed', reason);
-    });
+    return Promise.race([iframeLoadPromise, noContentPromise]);
   }
 
   /**
@@ -225,8 +218,7 @@ export class AmpAdXOriginIframeHandler {
       return;
     }
     const data = opt_info.data;
-    this.updateSize_(data.height, data.width,
-                opt_info.source, opt_info.origin);
+    this.updateSize_(data.height, data.width, opt_info.source, opt_info.origin);
     if (this.baseInstance_.emitLifecycleEvent) {
       this.baseInstance_.emitLifecycleEvent('renderCrossDomainStart');
     }

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -25,7 +25,7 @@ import {
   IntersectionObserver,
 } from '../../../src/intersection-observer';
 import {viewerForDoc} from '../../../src/viewer';
-import {dev, user} from '../../../src/log';
+import {dev} from '../../../src/log';
 import {timerFor} from '../../../src/timer';
 import {setStyle} from '../../../src/style';
 import {loadPromise} from '../../../src/event-helper';

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -212,7 +212,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       };
     });
 
-    it('should trigger render-start on timeout', done => {
+    it('should trigger visibility on timeout', done => {
       const clock = sandbox.useFakeTimers();
       iframe.name = 'test_master';
       initPromise = iframeHandler.init(iframe);

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -195,6 +195,37 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       });
     });
 
+    it('should trigger render-start on message "bootstrap-loaded" if' +
+       ' render-start is NOT implemented', done => {
+      initPromise = iframeHandler.init(iframe);
+      iframe.onload = () => {
+        expect(iframe.style.visibility).to.equal('hidden');
+        iframe.postMessageToParent({
+          sentinel: 'amp3ptest' + testIndex,
+          type: 'bootstrap-loaded',
+        });
+        initPromise.then(() => {
+          expect(iframe.style.visibility).to.equal('');
+          expect(renderStartedSpy).to.be.calledOnce;
+          done();
+        });
+      };
+    });
+
+    it('should trigger render-start on timeout', done => {
+      const clock = sandbox.useFakeTimers();
+      iframe.name = 'test_master';
+      initPromise = iframeHandler.init(iframe);
+      iframe.onload = () => {
+        clock.tick(10000);
+        initPromise.then(() => {
+          expect(iframe.style.visibility).to.equal('');
+          expect(renderStartedSpy).to.not.be.called;
+          done();
+        });
+      };
+    });
+
     it('should resolve directly if it is A4A', () => {
       return iframeHandler.init(iframe, true).then(() => {
         expect(iframe.style.visibility).to.equal('');

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -30,6 +30,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
   let sandbox;
   let adImpl;
   let signals;
+  let renderStartedSpy;
   let iframeHandler;
   let iframe;
   let testIndex = 0;
@@ -45,6 +46,11 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     };
     signals = new Signals();
     adElement.signals = () => signals;
+    renderStartedSpy = sandbox.spy();
+    adElement.renderStarted = () => {
+      renderStartedSpy();
+      signals.signal('render-start');
+    };
     adImpl = new BaseElement(adElement);
     adImpl.getFallback = () => {
       return null;
@@ -84,24 +90,34 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         initPromise = iframeHandler.init(iframe);
       });
 
+      it('should resolve on iframe.onload', () => {
+        expect(iframe.style.visibility).to.equal('hidden');
+        return initPromise.then(() => {
+          expect(iframe.style.visibility).to.equal('');
+          expect(renderStartedSpy).to.not.be.called;
+          expect(signals.get('render-start')).to.be.null;
+        });
+      });
+
       it('should resolve on message "render-start"', () => {
         expect(iframe.style.visibility).to.equal('hidden');
         iframe.postMessageToParent({
           sentinel: 'amp3ptest' + testIndex,
           type: 'render-start',
         });
-        return initPromise.then(() => {
+        const renderStartPromise = signals.whenSignal('render-start');
+        return Promise.all([renderStartPromise, initPromise]).then(() => {
           expect(iframe.style.visibility).to.equal('');
-          expect(signals.get('render-start')).to.be.ok;
+          expect(renderStartedSpy).to.be.calledOnce;
         }).then(() => {
-          iframe.postMessageToParent({
+          const message = {
             sentinel: 'amp3ptest' + testIndex,
             type: 'no-content',
-          });
-          return expectPostMessage(iframe.contentWindow, window, {
-            sentinel: 'amp3ptest' + testIndex,
-            type: 'no-content',
-          }).then(() => {
+          };
+          const promise = expectPostMessage(
+              iframe.contentWindow, window, message);
+          iframe.postMessageToParent(message);
+          return promise.then(() => {
             expect(noContentSpy).to.not.been.called;
           });
         });
@@ -115,14 +131,19 @@ describe('amp-ad-xorigin-iframe-handler', () => {
           type: 'render-start',
           sentinel: 'amp3ptest' + testIndex,
         });
-        return initPromise.then(() => {
+        const expectResponsePromise = iframe.expectMessageFromParent(
+            'amp-' + JSON.stringify({
+              requestedWidth: 114,
+              requestedHeight: 217,
+              type: 'embed-size-changed',
+              sentinel: 'amp3ptest' + testIndex,
+            }));
+        const renderStartPromise = signals.whenSignal('render-start');
+        return Promise.all([renderStartPromise, initPromise]).then(() => {
+          return initPromise;
+        }).then(() => {
           expect(iframe.style.visibility).to.equal('');
-          return iframe.expectMessageFromParent('amp-' + JSON.stringify({
-            requestedWidth: 114,
-            requestedHeight: 217,
-            type: 'embed-size-changed',
-            sentinel: 'amp3ptest' + testIndex,
-          }));
+          return expectResponsePromise;
         });
       });
 
@@ -147,7 +168,6 @@ describe('amp-ad-xorigin-iframe-handler', () => {
           type: 'no-content',
         });
         return initPromise.then(() => {
-          expect(iframe.style.visibility).to.equal('');
           expect(noContentSpy).to.be.calledOnce;
           expect(noContentSpy).to.be.calledWith(true);
         });
@@ -172,41 +192,6 @@ describe('amp-ad-xorigin-iframe-handler', () => {
           return expect(timeoutPromise).to.eventually
               .be.rejectedWith(/timeout/);
         });
-      });
-    });
-
-    it('should resolve on message "bootstrap-loaded" if render-start is'
-        + 'NOT implemented', done => {
-
-      initPromise = iframeHandler.init(iframe);
-      iframe.onload = () => {
-        expect(iframe.style.visibility).to.equal('hidden');
-        iframe.postMessageToParent({
-          sentinel: 'amp3ptest' + testIndex,
-          type: 'bootstrap-loaded',
-        });
-        initPromise.then(() => {
-          expect(iframe.style.visibility).to.equal('');
-          done();
-        });
-      };
-    });
-
-    it('should resolve on timeout', done => {
-      const noContentSpy =
-          sandbox.spy/*OK*/(iframeHandler, 'freeXOriginIframe');
-      const clock = sandbox.useFakeTimers();
-
-      iframe.name = 'test_master';
-      initPromise = iframeHandler.init(iframe);
-      clock.tick(9999);
-      expect(noContentSpy).to.not.be.called;
-      clock.tick(1);
-      initPromise.then(() => {
-        expect(iframe.style.visibility).to.equal('');
-        expect(noContentSpy).to.be.calledOnce;
-        expect(noContentSpy).to.be.calledWith(true);
-        done();
       });
     });
 

--- a/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/amp-sticky-ad.js
@@ -19,7 +19,6 @@ import {Layout} from '../../../src/layout';
 import {dev,user} from '../../../src/log';
 import {removeElement} from '../../../src/dom';
 import {toggle} from '../../../src/style';
-import {listenOnce} from '../../../src/event-helper';
 
 class AmpStickyAd extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -141,18 +140,15 @@ class AmpStickyAd extends AMP.BaseElement {
   }
 
   /**
-   * Function that check if ad has been built
-   * If not, wait for the amp:built event
-   * otherwise schedule layout for ad.
+   * Function that check if ad has been built.  If not, wait for the 'built'
+   * signal. Otherwise schedule layout for ad.
    * @private
    */
   scheduleLayoutForAd_() {
     if (this.ad_.isBuilt()) {
       this.layoutAd_();
     } else {
-      listenOnce(dev().assertElement(this.ad_), 'amp:built', () => {
-        this.layoutAd_();
-      });
+      this.ad_.whenBuilt().then(this.layoutAd_.bind(this));
     }
   }
 
@@ -161,10 +157,18 @@ class AmpStickyAd extends AMP.BaseElement {
    * @private
    */
   layoutAd_() {
-    this.updateInViewport(dev().assertElement(this.ad_), true);
-    this.scheduleLayout(dev().assertElement(this.ad_));
-    listenOnce(dev().assertElement(this.ad_), 'amp:load:end', () => {
-      this.vsync_.mutate(() => {
+    const ad = dev().assertElement(this.ad_);
+    this.updateInViewport(ad, true);
+    this.scheduleLayout(ad);
+    // Wait for the earliest: `render-start` or `load-end` signals.
+    // `render-start` is expected to arrive first, but it's not emitted by
+    // all types of ads.
+    const signals = ad.signals();
+    return Promise.race([
+      signals.whenSignal('render-start'),
+      signals.whenSignal('load-end'),
+    ]).then(() => {
+      return this.vsync_.mutatePromise(() => {
         // Set sticky-ad to visible and change container style
         this.element.setAttribute('visible', '');
         this.element.classList.add('amp-sticky-ad-loaded');

--- a/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/0.1/test/test-amp-sticky-ad.js
@@ -16,6 +16,7 @@
 
 import '../amp-sticky-ad';
 import '../../../amp-ad/0.1/amp-ad';
+import {poll} from '../../../../testing/iframe';
 
 describes.realWin('amp-sticky-ad 0.1 version', {
   win: { /* window spec */
@@ -191,22 +192,48 @@ describes.realWin('amp-sticky-ad 0.1 version', {
       expect(impl.element.children[1].tagName).to.equal('BUTTON');
     });
 
-    it('should listen to amp:built, amp:load:end', () => {
-      impl.ad_.isBuilt = () => {
-        return false;
-      };
+    it('should wait for built and load-end signals', () => {
+      impl.ad_.isBuilt = () => false;
       impl.vsync_.mutate = function(callback) {
         callback();
       };
       const layoutAdSpy = sandbox.spy(impl, 'layoutAd_');
       impl.scheduleLayoutForAd_();
       expect(layoutAdSpy).to.not.been.called;
-      impl.ad_.dispatchEvent(new Event('amp:built'));
-      expect(layoutAdSpy).to.be.called;
-      impl.ad_.dispatchEvent(new Event('amp:load:end'));
-      expect(ampStickyAd).to.have.attribute('visible');
-      expect(ampStickyAd.classList.contains('amp-sticky-ad-loaded'))
-          .to.be.true;
+      impl.ad_.signals().signal('built');
+      return impl.ad_.signals().whenSignal('built').then(() => {
+        expect(layoutAdSpy).to.be.called;
+        expect(ampStickyAd).to.not.have.attribute('visible');
+        expect(ampStickyAd.classList.contains('amp-sticky-ad-loaded'))
+            .to.be.false;
+        impl.ad_.signals().signal('load-end');
+        return poll('visible attribute must be set', () => {
+          return (ampStickyAd.hasAttribute('visible') &&
+              ampStickyAd.classList.contains('amp-sticky-ad-loaded'));
+        });
+      });
+    });
+
+    it('should wait for built and render-start signals', () => {
+      impl.ad_.isBuilt = () => false;
+      impl.vsync_.mutate = function(callback) {
+        callback();
+      };
+      const layoutAdSpy = sandbox.spy(impl, 'layoutAd_');
+      impl.scheduleLayoutForAd_();
+      expect(layoutAdSpy).to.not.been.called;
+      impl.ad_.signals().signal('built');
+      return impl.ad_.signals().whenSignal('built').then(() => {
+        expect(layoutAdSpy).to.be.called;
+        expect(ampStickyAd).to.not.have.attribute('visible');
+        expect(ampStickyAd.classList.contains('amp-sticky-ad-loaded'))
+            .to.be.false;
+        impl.ad_.signals().signal('render-start');
+        return poll('visible attribute must be set', () => {
+          return (ampStickyAd.hasAttribute('visible') &&
+              ampStickyAd.classList.contains('amp-sticky-ad-loaded'));
+        });
+      });
     });
   });
 

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -19,7 +19,6 @@ import {Layout} from '../../../src/layout';
 import {dev,user} from '../../../src/log';
 import {removeElement} from '../../../src/dom';
 import {toggle} from '../../../src/style';
-import {listenOnce} from '../../../src/event-helper';
 import {
   setStyle,
   removeAlphaFromColor,
@@ -143,30 +142,37 @@ class AmpStickyAd extends AMP.BaseElement {
   }
 
   /**
-   * Function that check if ad has been built
-   * If not, wait for the amp:built event
-   * otherwise schedule layout for ad.
+   * Function that check if ad has been built.  If not, wait for the 'built'
+   * signal. Otherwise schedule layout for ad.
    * @private
    */
   scheduleLayoutForAd_() {
     if (this.ad_.isBuilt()) {
       this.layoutAd_();
     } else {
-      listenOnce(dev().assertElement(this.ad_), 'amp:built', () => {
-        this.layoutAd_();
-      });
+      this.ad_.whenBuilt().then(this.layoutAd_.bind(this));
     }
   }
 
   /**
    * Layout ad, and display sticky-ad container after layout complete.
+   * @return {!Promise}
    * @private
    */
   layoutAd_() {
-    this.updateInViewport(dev().assertElement(this.ad_), true);
-    this.scheduleLayout(dev().assertElement(this.ad_));
-    listenOnce(dev().assertElement(this.ad_), 'amp:load:end', () => {
-      this.vsync_.mutate(() => {
+    // QQQQ: sync up with 0.1 version.
+    const ad = dev().assertElement(this.ad_);
+    this.updateInViewport(ad, true);
+    this.scheduleLayout(ad);
+    // Wait for the earliest: `render-start` or `load-end` signals.
+    // `render-start` is expected to arrive first, but it's not emitted by
+    // all types of ads.
+    const signals = ad.signals();
+    return Promise.race([
+      signals.whenSignal('render-start'),
+      signals.whenSignal('load-end'),
+    ]).then(() => {
+      return this.vsync_.mutatePromise(() => {
         // Set sticky-ad to visible and change container style
         this.element.setAttribute('visible', '');
         // Add border-bottom to the body to compensate space that was taken

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -160,7 +160,6 @@ class AmpStickyAd extends AMP.BaseElement {
    * @private
    */
   layoutAd_() {
-    // QQQQ: sync up with 0.1 version.
     const ad = dev().assertElement(this.ad_);
     this.updateInViewport(ad, true);
     this.scheduleLayout(ad);

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -16,6 +16,7 @@
 
 import '../amp-sticky-ad';
 import '../../../amp-ad/0.1/amp-ad';
+import {poll} from '../../../../testing/iframe';
 
 describes.realWin('amp-sticky-ad 1.0 version', {
   win: { /* window spec */
@@ -157,20 +158,42 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       expect(impl.element.children[2].tagName).to.equal('BUTTON');
     });
 
-    it('should listen to amp:built, amp:load:end', () => {
-      impl.ad_.isBuilt = () => {
-        return false;
-      };
+    it('should wait for built and load-end signals', () => {
+      impl.ad_.isBuilt = () => false;
       impl.vsync_.mutate = function(callback) {
         callback();
       };
       const layoutAdSpy = sandbox.spy(impl, 'layoutAd_');
       impl.scheduleLayoutForAd_();
       expect(layoutAdSpy).to.not.been.called;
-      impl.ad_.dispatchEvent(new Event('amp:built'));
-      expect(layoutAdSpy).to.be.called;
-      impl.ad_.dispatchEvent(new Event('amp:load:end'));
-      expect(ampStickyAd).to.have.attribute('visible');
+      impl.ad_.signals().signal('built');
+      return impl.ad_.signals().whenSignal('built').then(() => {
+        expect(layoutAdSpy).to.be.called;
+        expect(ampStickyAd).to.not.have.attribute('visible');
+        impl.ad_.signals().signal('load-end');
+        return poll('visible attribute must be set', () => {
+          return ampStickyAd.hasAttribute('visible');
+        });
+      });
+    });
+
+    it('should wait for built and render-start signals', () => {
+      impl.ad_.isBuilt = () => false;
+      impl.vsync_.mutate = function(callback) {
+        callback();
+      };
+      const layoutAdSpy = sandbox.spy(impl, 'layoutAd_');
+      impl.scheduleLayoutForAd_();
+      expect(layoutAdSpy).to.not.been.called;
+      impl.ad_.signals().signal('built');
+      return impl.ad_.signals().whenSignal('built').then(() => {
+        expect(layoutAdSpy).to.be.called;
+        expect(ampStickyAd).to.not.have.attribute('visible');
+        impl.ad_.signals().signal('render-start');
+        return poll('visible attribute must be set', () => {
+          return ampStickyAd.hasAttribute('visible');
+        });
+      });
     });
 
     it('should not allow container to be set semi-transparent', () => {
@@ -179,10 +202,13 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       impl.vsync_.mutate = function(callback) {
         callback();
       };
-      impl.layoutAd_();
-      impl.ad_.dispatchEvent(new Event('amp:load:end'));
-      expect(window.getComputedStyle(ampStickyAd)
-          .getPropertyValue('background-color')).to.equal('rgb(55, 55, 55)');
+      const layoutPromise = impl.layoutAd_();
+      impl.ad_.signals().signal('render-start');
+      return layoutPromise.then(() => {
+        const bg = window.getComputedStyle(ampStickyAd)
+            .getPropertyValue('background-color');
+        return bg == 'rgb(55, 55, 55)';
+      });
     });
 
     it('should not allow container to be set to transparent', () => {
@@ -191,10 +217,13 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       impl.vsync_.mutate = function(callback) {
         callback();
       };
-      impl.layoutAd_();
-      impl.ad_.dispatchEvent(new Event('amp:load:end'));
-      expect(window.getComputedStyle(ampStickyAd)
-          .getPropertyValue('background-color')).to.equal('rgb(0, 0, 0)');
+      const layoutPromise = impl.layoutAd_();
+      impl.ad_.signals().signal('render-start');
+      return layoutPromise.then(() => {
+        const bg = window.getComputedStyle(ampStickyAd)
+            .getPropertyValue('background-color');
+        return bg == 'rgb(0, 0, 0)';
+      });
     });
   });
 
@@ -296,9 +325,10 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     };
 
     impl.displayAfterScroll_();
-    impl.layoutAd_();
-    impl.ad_.dispatchEvent(new Event('amp:load:end'));
-    return impl.viewport_.ampdoc.whenBodyAvailable().then(() => {
+    impl.ad_.signals().signal('load-end');
+    const layoutPromise = impl.layoutAd_();
+    const bodyPromise = impl.viewport_.ampdoc.whenBodyAvailable();
+    return Promise.all([layoutPromise, bodyPromise]).then(() => {
       let borderWidth = win.getComputedStyle(win.document.body, null)
           .getPropertyValue('border-bottom-width');
       expect(borderWidth).to.equal('54px');
@@ -333,9 +363,10 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     };
 
     impl.displayAfterScroll_();
-    impl.layoutAd_();
-    impl.ad_.dispatchEvent(new Event('amp:load:end'));
-    return impl.viewport_.ampdoc.whenBodyAvailable().then(() => {
+    impl.ad_.signals().signal('load-end');
+    const layoutPromise = impl.layoutAd_();
+    const bodyPromise = impl.viewport_.ampdoc.whenBodyAvailable();
+    return Promise.all([layoutPromise, bodyPromise]).then(() => {
       let borderWidth = win.getComputedStyle(win.document.body, null)
           .getPropertyValue('border-bottom-width');
       expect(borderWidth).to.equal('54px');

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -635,6 +635,14 @@ export class BaseElement {
   }
 
   /**
+   * An implementation can call this method to signal to the element that
+   * it has started rendering.
+   */
+  renderStarted() {
+    this.element.renderStarted();
+  }
+
+  /**
    * Returns the original nodes of the custom element without any service nodes
    * that could have been added for markup. These nodes can include Text,
    * Comment and other child nodes.

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -294,6 +294,8 @@ export class Resource {
     } else {
       this.state_ = ResourceState.NOT_LAID_OUT;
     }
+    // TODO(dvoytenko, #7389): cleanup once amp-sticky-ad signals are
+    // in PROD.
     this.element.dispatchCustomEvent('amp:built');
   }
 

--- a/src/utils/signals.js
+++ b/src/utils/signals.js
@@ -27,7 +27,7 @@ export class Signals {
     /**
      * A mapping from a signal name to the signal response: either time or
      * an error.
-     * @private @const {!Object<string, (time|!Error)>}
+     * @private {!Object<string, (time|!Error)>}
      */
     this.map_ = map();
 
@@ -126,6 +126,21 @@ export class Signals {
       promiseStruct.reject(error);
       promiseStruct.resolve = undefined;
       promiseStruct.reject = undefined;
+    }
+  }
+
+  /**
+   * Resets all signals.
+   * @param {string} name
+   */
+  reset(name) {
+    if (this.map_[name]) {
+      delete this.map_[name];
+    }
+    // Reset promise it has already been resolved.
+    const promiseStruct = this.promiseMap_ && this.promiseMap_[name];
+    if (promiseStruct && !promiseStruct.resolve) {
+      delete this.promiseMap_[name];
     }
   }
 }

--- a/src/utils/signals.js
+++ b/src/utils/signals.js
@@ -27,7 +27,7 @@ export class Signals {
     /**
      * A mapping from a signal name to the signal response: either time or
      * an error.
-     * @private {!Object<string, (time|!Error)>}
+     * @private @const {!Object<string, (time|!Error)>}
      */
     this.map_ = map();
 

--- a/test/functional/utils/test-signals.js
+++ b/test/functional/utils/test-signals.js
@@ -120,4 +120,54 @@ describes.sandboxed('Signals', {}, () => {
       expect(signals.whenSignal('sig')).to.equal(promise);  // Reuse promise.
     });
   });
+
+  it('should reset signal before it was triggered', () => {
+    signals.reset('sig');
+    expect(signals.get('sig')).to.be.null;
+    expect(signals.promiseMap_).to.be.null;
+  });
+
+  it('should reset signal after it was triggered', () => {
+    signals.signal('sig');
+    expect(signals.get('sig')).to.be.ok;
+
+    signals.reset('sig');
+    expect(signals.get('sig')).to.be.null;
+    expect(signals.promiseMap_).to.be.null;
+  });
+
+  it('should reset signal after it was requested', () => {
+    signals.whenSignal('sig');
+    const iniPromise = signals.promiseMap_['sig'].promise;
+    expect(iniPromise).to.be.ok;
+
+    signals.reset('sig');
+    // Promise has not changed.
+    expect(signals.promiseMap_['sig'].promise).to.equal(iniPromise);
+    expect(signals.promiseMap_['sig'].resolve).to.be.ok;
+  });
+
+  it('should reset signal after it was resolved', () => {
+    signals.whenSignal('sig');
+    signals.signal('sig');
+    const iniPromise = signals.promiseMap_['sig'].promise;
+    expect(iniPromise).to.be.ok;
+    expect(signals.promiseMap_['sig'].resolve).to.be.undefined;
+
+    signals.reset('sig');
+    // Promise has been reset completely.
+    expect(signals.promiseMap_['sig']).to.be.undefined;
+  });
+
+  it('should reset a pre-resolved signal', () => {
+    signals.signal('sig');
+    signals.whenSignal('sig');
+    const iniPromise = signals.promiseMap_['sig'].promise;
+    expect(iniPromise).to.be.ok;
+    expect(signals.promiseMap_['sig'].resolve).to.be.undefined;
+
+    signals.reset('sig');
+    // Promise has been reset completely.
+    expect(signals.promiseMap_['sig']).to.be.undefined;
+  });
 });


### PR DESCRIPTION
This is a significant overhaul for loading. The loading is split into two phases: render-start and load. Render-start is used to update UX for loading indicator and sticky ad functionality.

Some notes:
 1. Signals are now a more precise and asynchronous way to wait for particular element states, such as built and render-start.
 2. amp-sticky-ad:0.1 will be redone in *this* PR, after review of 1.0.
 3. Cleanup of events will have to be done *after* amp-sticky-ad changes in prod. See #7389.
 4. render-start will continue to be optional signal for now so we have to use both: render-start and load-end in most of cases.
