### PR TITLE
Add Facebook comments support (#5219)

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -40,12 +40,19 @@ function getFacebookSdk(global, cb) {
  */
 export function facebook(global, data) {
   const embedAs = data.embedAs || 'post';
-  user().assert(['post', 'video'].indexOf(embedAs) !== -1,
+  user().assert(['post', 'video', 'comments'].indexOf(embedAs) !== -1,
       'Attribute data-embed-as  for <amp-facebook> value is wrong, should be' +
-      ' "post" or "video" was: %s', embedAs);
+      ' "post", "comments" or "video" was: %s', embedAs);
   const fbPost = global.document.createElement('div');
   fbPost.className = 'fb-' + embedAs;
   fbPost.setAttribute('data-href', data.href);
+
+  if (embedAs === 'comments') {
+    fbPost.setAttribute('data-numposts', data.numposts);
+    fbPost.setAttribute('data-order-by', data.orderBy);
+    fbPost.setAttribute('data-width', '100%');
+  }
+
   global.document.getElementById('c').appendChild(fbPost);
   getFacebookSdk(global, FB => {
     // Dimensions are given by the parent frame.
@@ -54,7 +61,7 @@ export function facebook(global, data) {
 
     // Only need to listen to post resizing as FB videos have a fixed ratio
     // and can automatically resize correctly given the initial width/height.
-    if (embedAs === 'post') {
+    if (embedAs === 'post' || embedAs === 'comments') {
       FB.Event.subscribe('xfbml.resize', event => {
         context.updateDimensions(
             parseInt(event.width, 10),

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -104,6 +104,8 @@ data.pageHidden;
 data.changes;
 data._context;
 data.inViewport;
+data.numposts;
+data.orderBy;
 
 
 // 3p code

--- a/examples/facebook.amp.html
+++ b/examples/facebook.amp.html
@@ -21,7 +21,7 @@
     data-href="https://www.facebook.com/zuck/posts/10102593740125791">
 </amp-facebook>
 
-<h1>More Posts</h1>
+<h1>Posts</h1>
 
 <amp-facebook width=552 height=350
     layout="responsive"
@@ -38,10 +38,23 @@
     data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&set=a.529237706231.2034669.4&type=3&theater">
 </amp-facebook>
 
+<h1>Video</h1>
+
+
 <amp-facebook width=552 height=310
     layout="responsive"
     data-embed-as="video"
     data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+</amp-facebook>
+
+<h1>Comments</h1>
+
+<amp-facebook width=552 height=310
+    layout="responsive"
+    data-embed-as="comments"
+    data-numposts="5"
+    data-order-by="social"
+    data-href="https://developers.facebook.com/docs/plugins/comments">
 </amp-facebook>
 
 </body>

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -34,6 +34,7 @@ describe('amp-facebook', function() {
 
   const fbPostHref = 'https://www.facebook.com/zuck/posts/10102593740125791';
   const fbVideoHref = 'https://www.facebook.com/zuck/videos/10102509264909801/';
+  const fbCommentsHref = 'https://developers.facebook.com/docs/plugins/comments/';
 
   function getAmpFacebook(href, opt_embedAs, opt_noFakeResources) {
     return createIframePromise(/*opt_runtimeOff*/ true).then(iframe => {
@@ -78,6 +79,15 @@ describe('amp-facebook', function() {
     });
   });
 
+  it('renders iframe in amp-facebook with comments', () => {
+    return getAmpFacebook(fbCommentsHref, 'comments').then(ampFB => {
+      const iframe = ampFB.firstChild;
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      expect(iframe.className).to.match(/i-amphtml-fill-content/);
+    });
+  });
+
   it('adds fb-post element correctly', () => {
     return createIframePromise().then(iframe => {
       const div = document.createElement('div');
@@ -110,6 +120,24 @@ describe('amp-facebook', function() {
       const fbVideo = iframe.doc.body.getElementsByClassName('fb-video')[0];
       expect(fbVideo).not.to.be.undefined;
       expect(fbVideo.getAttribute('data-href')).to.equal(fbVideoHref);
+    });
+  });
+
+  it('adds fb-comments element correctly', () => {
+    return createIframePromise().then(iframe => {
+      const div = document.createElement('div');
+      div.setAttribute('id', 'c');
+      iframe.doc.body.appendChild(div);
+
+      facebook(iframe.win, {
+        href: fbCommentsHref,
+        width: 111,
+        height: 222,
+        embedAs: 'comments',
+      });
+      const fbComments = iframe.doc.body.getElementsByClassName('fb-comments')[0];
+      expect(fbComments).not.to.be.undefined;
+      expect(fbComments.getAttribute('data-href')).to.equal(fbCommentsHref);
     });
   });
 

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -135,7 +135,8 @@ describe('amp-facebook', function() {
         height: 222,
         embedAs: 'comments',
       });
-      const fbComments = iframe.doc.body.getElementsByClassName('fb-comments')[0];
+      const fbComments = iframe.doc.body
+        .getElementsByClassName('fb-comments')[0];
       expect(fbComments).not.to.be.undefined;
       expect(fbComments.getAttribute('data-href')).to.equal(fbCommentsHref);
     });

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Displays a Facebook post or video. </td>
+    <td>Displays a Facebook post, video or comments.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
@@ -38,9 +38,9 @@ limitations under the License.
     <td><a href="https://ampbyexample.com/components/amp-facebook/">Annotated code example for amp-facebook</a></td>
   </tr>
 </table>
-## Overview 
+## Overview
 
-You can use the `amp-facebook` component to embed a Facebook post or a Facebook video.
+You can use the `amp-facebook` component to embed a Facebook post, Facebook video or Facebook comments.
 
 **Example: Embedding a post**
 
@@ -61,19 +61,34 @@ You can use the `amp-facebook` component to embed a Facebook post or a Facebook 
 </amp-facebook>
 ```
 
+**Example: Embedding comments**
+
+```html
+<amp-facebook width=486 height=657
+    layout="responsive"
+    data-embed-as="comments"
+    data-href="https://www.ampproject.org/">
+</amp-facebook>
+```
 ## Attributes
 
 **data-href** (required)
 
-The URL of the Facebook post/video. For example: https://www.facebook.com/zuck/posts/10102593740125791.
+The URL of the Facebook post, video or comments page. For example: https://www.facebook.com/zuck/posts/10102593740125791.
 
 **data-embed-as** (optional)
 
-The value is either `post` or `video`.  The default is `post`.
+The value is either `post`, `video` or `comments`. The default is `post`.
 
 Both posts and videos can be embedded as a post. Setting `data-embed-as="video"` for Facebook videos only embeds the player of the video, and ignores the accompanying post card with it. This is recommended if you'd like a better aspect ratio management for the video to be responsive.  
 
 Check out the documentation for differences between [post embeds](https://developers.facebook.com/docs/plugins/embedded-posts) and [video embeds](https://developers.facebook.com/docs/plugins/embedded-video-player).
+
+**data-numposts** (optional)
+Only when `data-embed-as` is `comments`. See Facebook [documentation](https://developers.facebook.com/docs/plugins/comments/) for usage.
+
+**data-order-by** (optional)
+Only when `data-embed-as` is `comments`. See Facebook [documentation](https://developers.facebook.com/docs/plugins/comments/) for usage.
 
 **common attributes**
 


### PR DESCRIPTION
Added a new feature to `amp-facebook` which allows support for the [Facebook Comments](https://developers.facebook.com/docs/plugins/comments/) plugin.

As requested in #5219.

On my localhost I have a functional issue when trying to save a comment, where Facebook tries to open a popup window which is blocked by Chrome. Expect it to be caused by localhost environment. When loading the Facebook Comment plugin without AMP, it shows the same issue. Was hoping someone could help test there.

