### PR TITLE
Split up variable substitutions in forms for POST submits

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -180,6 +180,15 @@ export class AmpForm {
     /** @const @private {!./form-validators.FormValidator} */
     this.validator_ = getFormValidator(this.form_);
 
+    // Var-subs for POST will be launched soon. We're splitting this into
+    // two experiments to launch for POST separately.
+    const isVarSubExpOnForPost = isExperimentOn(
+        this.win_, 'amp-form-var-sub-for-post');
+    const isVarSubExpOn = isExperimentOn(this.win_, 'amp-form-var-sub');
+    /** @const @private {boolean} */
+    this.isVarSubsEnabled_ = (
+        (isVarSubExpOnForPost && this.method_ == 'POST') || isVarSubExpOn);
+
     this.actions_.installActionHandler(
         this.form_, this.actionHandler_.bind(this));
     this.installEventHandlers_();
@@ -277,24 +286,15 @@ export class AmpForm {
    * @private
    */
   submit_() {
-    const isVarSubExpOnForPost = isExperimentOn(
-        this.win_, 'amp-form-var-sub-for-post');
-    const isVarSubExpOn = isExperimentOn(this.win_, 'amp-form-var-sub');
     let varSubsFields = [];
     // Only allow variable substitutions for inputs if the form action origin
     // is the canonical origin.
     // TODO(mkhatib, #7168): Consider relaxing this.
-    if (this.isSubmittingToCanonical_()) {
-      // Var-subs for POST will be launched soon. We're splitting this into
-      // two experiments to launch for POST separately.
-      const isVarSubsEnabled = (
-          (isVarSubExpOnForPost && this.method_ == 'POST') ||
-          isVarSubExpOn);
-
+    if (this.isVarSubsEnabled_ && this.isSubmittingToCanonical_()) {
       // Fields that support var substitutions.
-      varSubsFields = isVarSubsEnabled ? this.form_.querySelectorAll(
-          '[type="hidden"][data-amp-replace]') : [];
-    } else {
+      varSubsFields = this.form_.querySelectorAll(
+          '[type="hidden"][data-amp-replace]');
+    } else if (this.isVarSubsEnabled_) {
       user().warn(TAG, 'Variable substitutions disabled for non-canonical ' +
           'origin submit action: %s', this.form_);
     }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -277,14 +277,22 @@ export class AmpForm {
    * @private
    */
   submit_() {
+    const isVarSubExpOnForPost = isExperimentOn(
+        this.win_, 'amp-form-var-sub-for-post');
     const isVarSubExpOn = isExperimentOn(this.win_, 'amp-form-var-sub');
     let varSubsFields = [];
     // Only allow variable substitutions for inputs if the form action origin
     // is the canonical origin.
     // TODO(mkhatib, #7168): Consider relaxing this.
     if (this.isSubmittingToCanonical_()) {
+      // Var-subs for POST will be launched soon. We're splitting this into
+      // two experiments to launch for POST separately.
+      const isVarSubsEnabled = (
+          (isVarSubExpOnForPost && this.method_ == 'POST') ||
+          isVarSubExpOn);
+
       // Fields that support var substitutions.
-      varSubsFields = isVarSubExpOn ? this.form_.querySelectorAll(
+      varSubsFields = isVarSubsEnabled ? this.form_.querySelectorAll(
           '[type="hidden"][data-amp-replace]') : [];
     } else {
       user().warn(TAG, 'Variable substitutions disabled for non-canonical ' +

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -104,7 +104,13 @@ const EXPERIMENTS = [
   },
   {
     id: 'amp-form-var-sub',
-    name: 'Variable Substitutions in AMP Form inputs',
+    name: 'Variable Substitutions in AMP Form inputs for POST/GET submits',
+    spec: 'https://github.com/ampproject/amphtml/issues/5654',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6377',
+  },
+  {
+    id: 'amp-form-var-sub-for-post',
+    name: 'Variable Substitutions in AMP Form inputs for POST submits only',
     spec: 'https://github.com/ampproject/amphtml/issues/5654',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6377',
   },


### PR DESCRIPTION
Var-subs for POST will be launched soon. We're splitting this into two experiments to launch for POST separately.