### PR TITLE
Fix visibility test failed on browsers without IntersectionObserver

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-visibility-impl.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-impl.js
@@ -493,7 +493,6 @@ describe('amp-analytics.visibility', () => {
   });
 
   describe('listenOnceV2', () => {
-
     let inObCallback;
     let observeSpy;
     let unobserveSpy;
@@ -505,15 +504,7 @@ describe('amp-analytics.visibility', () => {
       unobserveSpy = sandbox.stub();
       callbackSpy1 = sandbox.stub();
       callbackSpy2 = sandbox.stub();
-    });
-
-    afterEach(() => {
-      inObCallback = null;
-    });
-
-    describe('using native IntersectionObserver', () => {
-      beforeEach(() => {
-        sandbox.stub(inob, 'nativeIntersectionObserverSupported').returns(true);
+      if (inob.nativeIntersectionObserverSupported(ampdoc.win)) {
         sandbox.stub(ampdoc.win, 'IntersectionObserver', callback => {
           inObCallback = callback;
           return {
@@ -521,15 +512,7 @@ describe('amp-analytics.visibility', () => {
             unobserve: unobserveSpy,
           };
         });
-      });
-
-      testSuite();
-    });
-
-    describe('using polyfill IntersectionObserver', () => {
-      beforeEach(() => {
-        sandbox.stub(inob, 'nativeIntersectionObserverSupported')
-            .returns(false);
+      } else {
         sandbox.stub(inob, 'IntersectionObserverPolyfill', callback => {
           inObCallback = callback;
           return {
@@ -537,205 +520,205 @@ describe('amp-analytics.visibility', () => {
             unobserve: unobserveSpy,
           };
         });
-      });
-
-      testSuite();
+      }
     });
 
-    function testSuite() {
-      it('"visible" trigger should work with no duration condition', () => {
+    afterEach(() => {
+      inObCallback = null;
+    });
 
-        visibility.listenOnceV2({
-          selector: '#abc',
-          visiblePercentageMin: 20,
-        }, callbackSpy1, true, ampElement);
+    it('"visible" trigger should work with no duration condition', () => {
 
-        // add multiple triggers on the same element
-        visibility.listenOnceV2({
-          selector: '#abc',
-          visiblePercentageMin: 30,
-        }, callbackSpy2, true, ampElement);
+      visibility.listenOnceV2({
+        selector: '#abc',
+        visiblePercentageMin: 20,
+      }, callbackSpy1, true, ampElement);
 
-        // "observe" should not have been called since resource not loaded yet.
-        expect(observeSpy).to.be.not.called;
-        resourceLoadedResolver();
-        return Promise.resolve().then(() => {
-          expect(observeSpy).to.be.calledWith(ampElement);
+      // add multiple triggers on the same element
+      visibility.listenOnceV2({
+        selector: '#abc',
+        visiblePercentageMin: 30,
+      }, callbackSpy2, true, ampElement);
 
-          clock.tick(135);
-          fireIntersect(5); // below visiblePercentageMin, no trigger
-          expect(callbackSpy1).to.not.be.called;
-          expect(callbackSpy2).to.not.be.called;
-          expect(unobserveSpy).to.not.be.called;
+      // "observe" should not have been called since resource not loaded yet.
+      expect(observeSpy).to.be.not.called;
+      resourceLoadedResolver();
+      return Promise.resolve().then(() => {
+        expect(observeSpy).to.be.calledWith(ampElement);
 
-          clock.tick(100);
-          fireIntersect(25); // above spec 1 min visible, trigger callback 1
-          expect(callbackSpy1).to.be.calledWith({
-            backgrounded: '0',
-            backgroundedAtStart: '0',
-            elementHeight: '100',
-            elementWidth: '100',
-            elementX: '0',
-            elementY: '75',
-            firstSeenTime: '135',
-            fistVisibleTime: '235', // 135 + 100
-            lastSeenTime: '235',
-            lastVisibleTime: '235',
-            loadTimeVisibility: '5',
-            maxVisiblePercentage: '25',
-            minVisiblePercentage: '25',
-            totalVisibleTime: '0',         // duration metrics are always 0
-            maxContinuousVisibleTime: '0', // as it triggers immediately
-            totalTime: '1234',
-          });
-          expect(callbackSpy2).to.not.be.called;
-          expect(unobserveSpy).to.not.be.called;
-          callbackSpy1.reset();
+        clock.tick(135);
+        fireIntersect(5); // below visiblePercentageMin, no trigger
+        expect(callbackSpy1).to.not.be.called;
+        expect(callbackSpy2).to.not.be.called;
+        expect(unobserveSpy).to.not.be.called;
 
-          clock.tick(100);
-          fireIntersect(35); // above spec 2 min visible, trigger callback 2
-          expect(callbackSpy2).to.be.calledWith(sinon.match({
-            backgrounded: '0',
-            backgroundedAtStart: '0',
-            elementHeight: '100',
-            elementWidth: '100',
-            elementX: '0',
-            elementY: '65',
-            firstSeenTime: '135',
-            fistVisibleTime: '335', // 235 + 100
-            lastSeenTime: '335',
-            lastVisibleTime: '335',
-            loadTimeVisibility: '5',
-            maxVisiblePercentage: '35',
-            minVisiblePercentage: '35',
-            totalVisibleTime: '0',         // duration metrics is always 0
-            maxContinuousVisibleTime: '0', // as it triggers immediately
-            // totalTime is not testable because no way to stub performance API
-          }));
-          expect(callbackSpy1).to.not.be.called; // callback 1 not called again
-          expect(unobserveSpy).to.be.called; // unobserve when all callback fired
+        clock.tick(100);
+        fireIntersect(25); // above spec 1 min visible, trigger callback 1
+        expect(callbackSpy1).to.be.calledWith({
+          backgrounded: '0',
+          backgroundedAtStart: '0',
+          elementHeight: '100',
+          elementWidth: '100',
+          elementX: '0',
+          elementY: '75',
+          firstSeenTime: '135',
+          fistVisibleTime: '235', // 135 + 100
+          lastSeenTime: '235',
+          lastVisibleTime: '235',
+          loadTimeVisibility: '5',
+          maxVisiblePercentage: '25',
+          minVisiblePercentage: '25',
+          totalVisibleTime: '0',         // duration metrics are always 0
+          maxContinuousVisibleTime: '0', // as it triggers immediately
+          totalTime: '1234',
+        });
+        expect(callbackSpy2).to.not.be.called;
+        expect(unobserveSpy).to.not.be.called;
+        callbackSpy1.reset();
+
+        clock.tick(100);
+        fireIntersect(35); // above spec 2 min visible, trigger callback 2
+        expect(callbackSpy2).to.be.calledWith(sinon.match({
+          backgrounded: '0',
+          backgroundedAtStart: '0',
+          elementHeight: '100',
+          elementWidth: '100',
+          elementX: '0',
+          elementY: '65',
+          firstSeenTime: '135',
+          fistVisibleTime: '335', // 235 + 100
+          lastSeenTime: '335',
+          lastVisibleTime: '335',
+          loadTimeVisibility: '5',
+          maxVisiblePercentage: '35',
+          minVisiblePercentage: '35',
+          totalVisibleTime: '0',         // duration metrics is always 0
+          maxContinuousVisibleTime: '0', // as it triggers immediately
+          // totalTime is not testable because no way to stub performance API
+        }));
+        expect(callbackSpy1).to.not.be.called; // callback 1 not called again
+        expect(unobserveSpy).to.be.called; // unobserve when all callback fired
+      });
+    });
+
+    it('"visible" trigger should work with duration condition', () => {
+      visibility.listenOnceV2({
+        selector: '#abc',
+        continuousTimeMin: 1000,
+        visiblePercentageMin: 0,
+      }, callbackSpy1, true, ampElement);
+
+      resourceLoadedResolver();
+      return Promise.resolve().then(() => {
+        expect(observeSpy).to.be.calledWith(ampElement);
+
+        clock.tick(100);
+        fireIntersect(25); // visible
+        expect(callbackSpy1).to.not.be.called;
+
+        clock.tick(999);
+        fireIntersect(0); // this will reset the timer for continuous time
+        expect(callbackSpy1).to.not.be.called;
+
+        clock.tick(100);
+        fireIntersect(5); // visible again.
+        clock.tick(100);
+        fireIntersect(35); // keep being visible
+        expect(callbackSpy1).to.not.be.called;
+        clock.tick(899); // not yet!
+        expect(callbackSpy1).to.not.be.called;
+        clock.tick(1);  // now fire
+        expect(callbackSpy1).to.be.calledWith({
+          backgrounded: '0',
+          backgroundedAtStart: '0',
+          elementHeight: '100',
+          elementWidth: '100',
+          elementX: '0',
+          elementY: '65',
+          firstSeenTime: '100',
+          fistVisibleTime: '100',
+          lastSeenTime: '2199',
+          lastVisibleTime: '2199',
+          loadTimeVisibility: '25',
+          maxVisiblePercentage: '35',
+          minVisiblePercentage: '5',
+          totalVisibleTime: '1999',
+          maxContinuousVisibleTime: '1000',
+          totalTime: '1234',
         });
       });
+    });
 
-      it('"visible" trigger should work with duration condition', () => {
-        visibility.listenOnceV2({
-          selector: '#abc',
-          continuousTimeMin: 1000,
-          visiblePercentageMin: 0,
-        }, callbackSpy1, true, ampElement);
+    it('"hidden" trigger should work with duration condition', () => {
+      const viewer = viewerForDoc(ampdoc);
+      visibility.listenOnceV2({
+        selector: '#abc',
+        continuousTimeMin: 1000,
+        visiblePercentageMin: 10,
+      }, callbackSpy1, false /* hidden trigger */, ampElement);
 
-        resourceLoadedResolver();
-        return Promise.resolve().then(() => {
-          expect(observeSpy).to.be.calledWith(ampElement);
+      resourceLoadedResolver();
+      return Promise.resolve().then(() => {
+        expect(observeSpy).to.be.calledWith(ampElement);
 
-          clock.tick(100);
-          fireIntersect(25); // visible
-          expect(callbackSpy1).to.not.be.called;
+        clock.tick(100);
+        fireIntersect(5); // invisible
+        expect(callbackSpy1).to.not.be.called;
 
-          clock.tick(999);
-          fireIntersect(0); // this will reset the timer for continuous time
-          expect(callbackSpy1).to.not.be.called;
+        clock.tick(100);
+        fireIntersect(25); // visible
+        expect(callbackSpy1).to.not.be.called;
 
-          clock.tick(100);
-          fireIntersect(5); // visible again.
-          clock.tick(100);
-          fireIntersect(35); // keep being visible
-          expect(callbackSpy1).to.not.be.called;
-          clock.tick(899); // not yet!
-          expect(callbackSpy1).to.not.be.called;
-          clock.tick(1);  // now fire
-          expect(callbackSpy1).to.be.calledWith({
-            backgrounded: '0',
-            backgroundedAtStart: '0',
-            elementHeight: '100',
-            elementWidth: '100',
-            elementX: '0',
-            elementY: '65',
-            firstSeenTime: '100',
-            fistVisibleTime: '100',
-            lastSeenTime: '2199',
-            lastVisibleTime: '2199',
-            loadTimeVisibility: '25',
-            maxVisiblePercentage: '35',
-            minVisiblePercentage: '5',
-            totalVisibleTime: '1999',
-            maxContinuousVisibleTime: '1000',
-            totalTime: '1234',
-          });
+        clock.tick(100);
+        fireIntersect(5); // invisible
+        expect(callbackSpy1).to.not.be.called;
+
+        clock.tick(1000);
+        fireIntersect(15); // visible
+        expect(callbackSpy1).to.not.be.called;
+
+        clock.tick(1000); // continuous visible
+        expect(callbackSpy1).to.not.be.called;
+
+        clock.tick(100);
+        fireIntersect(5); // invisible
+        expect(callbackSpy1).to.not.be.called;
+
+        clock.tick(100);
+        fireIntersect(1); // invisible
+        expect(callbackSpy1).to.not.be.called;
+
+        viewer.setVisibilityState_(VisibilityState.HIDDEN);
+        expect(callbackSpy1).to.be.called;
+
+        expect(callbackSpy1).to.be.calledWith({
+          backgrounded: '0',
+          backgroundedAtStart: '0',
+          elementHeight: '100',
+          elementWidth: '100',
+          elementX: '0',
+          elementY: '99',
+          firstSeenTime: '100',
+          fistVisibleTime: '200',
+          lastSeenTime: '2500',
+          lastVisibleTime: '2400',
+          loadTimeVisibility: '5',
+          maxVisiblePercentage: '25',
+          minVisiblePercentage: '15',
+          totalVisibleTime: '1200',
+          maxContinuousVisibleTime: '1100',
+          totalTime: '1234',
         });
+
+        // This line is to remove side effect this test brought to others.
+        // Notice that this test installs everything to global window instead
+        // of an iframe. Some other tests that are not well isolated too get
+        // affected by the change of Viewer visibility here, so we need to
+        // restore.
+        // TODO: refactor this whole test file to enforce good isolation.
+        viewer.setVisibilityState_(VisibilityState.VISIBLE);
       });
-
-      it('"hidden" trigger should work with duration condition', () => {
-        const viewer = viewerForDoc(ampdoc);
-        visibility.listenOnceV2({
-          selector: '#abc',
-          continuousTimeMin: 1000,
-          visiblePercentageMin: 10,
-        }, callbackSpy1, false /* hidden trigger */, ampElement);
-
-        resourceLoadedResolver();
-        return Promise.resolve().then(() => {
-          expect(observeSpy).to.be.calledWith(ampElement);
-
-          clock.tick(100);
-          fireIntersect(5); // invisible
-          expect(callbackSpy1).to.not.be.called;
-
-          clock.tick(100);
-          fireIntersect(25); // visible
-          expect(callbackSpy1).to.not.be.called;
-
-          clock.tick(100);
-          fireIntersect(5); // invisible
-          expect(callbackSpy1).to.not.be.called;
-
-          clock.tick(1000);
-          fireIntersect(15); // visible
-          expect(callbackSpy1).to.not.be.called;
-
-          clock.tick(1000); // continuous visible
-          expect(callbackSpy1).to.not.be.called;
-
-          clock.tick(100);
-          fireIntersect(5); // invisible
-          expect(callbackSpy1).to.not.be.called;
-
-          clock.tick(100);
-          fireIntersect(1); // invisible
-          expect(callbackSpy1).to.not.be.called;
-
-          viewer.setVisibilityState_(VisibilityState.HIDDEN);
-          expect(callbackSpy1).to.be.called;
-
-          expect(callbackSpy1).to.be.calledWith({
-            backgrounded: '0',
-            backgroundedAtStart: '0',
-            elementHeight: '100',
-            elementWidth: '100',
-            elementX: '0',
-            elementY: '99',
-            firstSeenTime: '100',
-            fistVisibleTime: '200',
-            lastSeenTime: '2500',
-            lastVisibleTime: '2400',
-            loadTimeVisibility: '5',
-            maxVisiblePercentage: '25',
-            minVisiblePercentage: '15',
-            totalVisibleTime: '1200',
-            maxContinuousVisibleTime: '1100',
-            totalTime: '1234',
-          });
-
-          // This line is to remove side effect this test brought to others.
-          // Notice that this test installs everything to global window instead
-          // of an iframe. Some other tests that are not well isolated too get
-          // affected by the change of Viewer visibility here, so we need to
-          // restore.
-          // TODO: refactor this whole test file to enforce good isolation.
-          viewer.setVisibilityState_(VisibilityState.VISIBLE);
-        });
-      });
-    }
+    });
 
     function fireIntersect(intersectPercent) {
       scrollTop = 100 - intersectPercent;


### PR DESCRIPTION
Fixes #7416

/cc @zhouyx seems we did turned on saucelabs for the test. so no need to run twice in one browser.