### PR TITLE
Fixing attribute checking in amp-auto-ads tests

### DIFF
--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -84,9 +84,9 @@ describe('ad-strategy', () => {
           expect(anchor2.childNodes).to.have.lengthOf(0);
           const adElement = anchor1.childNodes[0];
           expect(adElement.tagName).to.equal('AMP-AD');
-          expect(adElement).to.have.attribute('type', 'adsense');
-          expect(adElement).to.have.attribute('data-custom-att-1', 'val-1');
-          expect(adElement).to.have.attribute('data-custom-att-2', 'val-2');
+          expect(adElement.getAttribute('type')).to.equal('adsense');
+          expect(adElement.getAttribute('data-custom-att-1')).to.equal('val-1');
+          expect(adElement.getAttribute('data-custom-att-2')).to.equal('val-2');
         });
       });
 
@@ -141,9 +141,9 @@ describe('ad-strategy', () => {
       expect(anchor2.childNodes).to.have.lengthOf(1);
       const adElement = anchor2.childNodes[0];
       expect(adElement.tagName).to.equal('AMP-AD');
-      expect(adElement).to.have.attribute('type', 'adsense');
-      expect(adElement).to.have.attribute('data-custom-att-1', 'val-1');
-      expect(adElement).to.have.attribute('data-custom-att-2', 'val-2');
+      expect(adElement.getAttribute('type')).to.equal('adsense');
+      expect(adElement.getAttribute('data-custom-att-1')).to.equal('val-1');
+      expect(adElement.getAttribute('data-custom-att-2')).to.equal('val-2');
     });
   });
 
@@ -203,9 +203,9 @@ describe('ad-strategy', () => {
       expect(anchor2.childNodes).to.have.lengthOf(0);
       const adElement = anchor1.childNodes[0];
       expect(adElement.tagName).to.equal('AMP-AD');
-      expect(adElement).to.have.attribute('type', 'adsense');
-      expect(adElement).to.have.attribute('data-custom-att-1', 'val-1');
-      expect(adElement).to.have.attribute('data-custom-att-2', 'val-2');
+      expect(adElement.getAttribute('type')).to.equal('adsense');
+      expect(adElement.getAttribute('data-custom-att-1')).to.equal('val-1');
+      expect(adElement.getAttribute('data-custom-att-2')).to.equal('val-2');
     });
   });
 
@@ -265,14 +265,14 @@ describe('ad-strategy', () => {
       expect(anchor2.childNodes).to.have.lengthOf(1);
       const adElement1 = anchor1.childNodes[0];
       expect(adElement1.tagName).to.equal('AMP-AD');
-      expect(adElement1).to.have.attribute('type', 'adsense');
-      expect(adElement1).to.have.attribute('data-custom-att-1', 'val-1');
-      expect(adElement1).to.have.attribute('data-custom-att-2', 'val-2');
+      expect(adElement1.getAttribute('type')).to.equal('adsense');
+      expect(adElement1.getAttribute('data-custom-att-1')).to.equal('val-1');
+      expect(adElement1.getAttribute('data-custom-att-2')).to.equal('val-2');
       const adElement2 = anchor2.childNodes[0];
       expect(adElement2.tagName).to.equal('AMP-AD');
-      expect(adElement2).to.have.attribute('type', 'adsense');
-      expect(adElement2).to.have.attribute('data-custom-att-1', 'val-1');
-      expect(adElement2).to.have.attribute('data-custom-att-2', 'val-2');
+      expect(adElement2.getAttribute('type')).to.equal('adsense');
+      expect(adElement2.getAttribute('data-custom-att-1')).to.equal('val-1');
+      expect(adElement2.getAttribute('data-custom-att-2')).to.equal('val-2');
     });
   });
 
@@ -335,9 +335,9 @@ describe('ad-strategy', () => {
       expect(anchor2.childNodes).to.have.lengthOf(0);
       const adElement1 = anchor1.childNodes[0];
       expect(adElement1.tagName).to.equal('AMP-AD');
-      expect(adElement1).to.have.attribute('type', 'adsense');
-      expect(adElement1).to.have.attribute('data-custom-att-1', 'val-1');
-      expect(adElement1).to.have.attribute('data-custom-att-2', 'val-2');
+      expect(adElement1.getAttribute('type')).to.equal('adsense');
+      expect(adElement1.getAttribute('data-custom-att-1')).to.equal('val-1');
+      expect(adElement1.getAttribute('data-custom-att-2')).to.equal('val-2');
     });
   });
 

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -219,12 +219,14 @@ describe('placement', () => {
       ], new AdTracker([], 0)).then(() => {
         const adElement = anchor.firstChild;
         expect(adElement.tagName).to.equal('AMP-AD');
-        expect(adElement).to.have.attribute('type', 'ad-network-type');
-        expect(adElement).to.have.attribute('layout', 'responsive');
-        expect(adElement).to.have.attribute('width', '320');
-        expect(adElement).to.have.attribute('height', '0');
-        expect(adElement).to.have.attribute('data-custom-att-1', 'val-1');
-        expect(adElement).to.have.attribute('data-custom-att-2', 'val-2');
+        expect(adElement.getAttribute('type')).to.equal('ad-network-type');
+        expect(adElement.getAttribute('layout')).to.equal('responsive');
+        expect(adElement.getAttribute('width')).to.equal('0');
+        expect(adElement.getAttribute('height')).to.equal('0');
+        expect(adElement.getAttribute('data-custom-att-1'))
+            .to.equal('val-1');
+        expect(adElement.getAttribute('data-custom-att-2'))
+            .to.equal('val-2');
       });
     });
 
@@ -254,10 +256,10 @@ describe('placement', () => {
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
-            expect(adElement).to.have.attribute('type', 'ad-network-type');
-            expect(adElement).to.have.attribute('layout', 'responsive');
-            expect(adElement).to.have.attribute('width', '320');
-            expect(adElement).to.have.attribute('height', '0');
+            expect(adElement.getAttribute('type')).to.equal('ad-network-type');
+            expect(adElement.getAttribute('layout')).to.equal('responsive');
+            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.style.marginTop).to.equal('5px');
             expect(adElement.style.marginBottom).to.equal('6px');
             expect(adElement.style.marginLeft).to.equal('');
@@ -290,10 +292,10 @@ describe('placement', () => {
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
-            expect(adElement).to.have.attribute('type', 'ad-network-type');
-            expect(adElement).to.have.attribute('layout', 'responsive');
-            expect(adElement).to.have.attribute('width', '320');
-            expect(adElement).to.have.attribute('height', '0');
+            expect(adElement.getAttribute('type')).to.equal('ad-network-type');
+            expect(adElement.getAttribute('layout')).to.equal('responsive');
+            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.style.marginTop).to.equal('5px');
             expect(adElement.style.marginBottom).to.equal('');
             expect(adElement.style.marginLeft).to.equal('');
@@ -326,10 +328,10 @@ describe('placement', () => {
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
-            expect(adElement).to.have.attribute('type', 'ad-network-type');
-            expect(adElement).to.have.attribute('layout', 'responsive');
-            expect(adElement).to.have.attribute('width', '320');
-            expect(adElement).to.have.attribute('height', '0');
+            expect(adElement.getAttribute('type')).to.equal('ad-network-type');
+            expect(adElement.getAttribute('layout')).to.equal('responsive');
+            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.style.marginTop).to.equal('');
             expect(adElement.style.marginBottom).to.equal('6px');
             expect(adElement.style.marginLeft).to.equal('');
@@ -360,10 +362,10 @@ describe('placement', () => {
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
-            expect(adElement).to.have.attribute('type', 'ad-network-type');
-            expect(adElement).to.have.attribute('layout', 'responsive');
-            expect(adElement).to.have.attribute('width', '320');
-            expect(adElement).to.have.attribute('height', '0');
+            expect(adElement.getAttribute('type')).to.equal('ad-network-type');
+            expect(adElement.getAttribute('layout')).to.equal('responsive');
+            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.style.marginTop).to.equal('');
             expect(adElement.style.marginBottom).to.equal('');
             expect(adElement.style.marginLeft).to.equal('');


### PR DESCRIPTION
Fixes the checking of attributes in tests. .to.have.attribute() only checks that the attribute exists and not what the value of it is.

https://github.com/ampproject/amphtml/issues/6196