### PR TITLE
Web worker for amp-bind

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -39,7 +39,7 @@ exports.rules = [
     mustNotDependOn: 'src/sanitizer.js',
     whitelist: [
       'extensions/amp-mustache/0.1/amp-mustache.js->src/sanitizer.js',
-      'extensions/amp-bind/0.1/bind-evaluator.js->src/sanitizer.js',
+      'extensions/amp-bind/0.1/bind-impl.js->src/sanitizer.js',
     ],
   },
   {

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -147,6 +147,8 @@ function compile(entryModuleFilenames, outputDir,
       // Currently needed for crypto.js and visibility.js.
       // Should consider refactoring.
       'extensions/amp-analytics/**/*.js',
+      // For amp-bind in the web worker (ww.js).
+      'extensions/amp-bind/**/*.js',
       'src/*.js',
       'src/!(inabox)*/**/*.js',
       '!third_party/babel/custom-babel-helpers.js',

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -16,7 +16,6 @@
 
 import {BindExpression} from './bind-expression';
 import {BindValidator} from './bind-validator';
-import {rewriteAttributeValue} from '../../../src/sanitizer';
 
 /**
  * @typedef {{
@@ -113,11 +112,6 @@ export class BindEvaluator {
 
       const resultString = this.stringValueOf_(property, result);
       if (this.validator_.isResultValid(tagName, property, resultString)) {
-        // Rewrite URL attributes for CDN if necessary.
-        // TODO(willchou)
-        // cache[expr] = typeof result === 'string'
-        //     ? rewriteAttributeValue(tagName, property, result)
-        //     : result;
         cache[expr] = result;
       } else {
         errors[expr] = new Error(

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -80,53 +80,51 @@ export class BindEvaluator {
   }
 
   /**
-   * Evaluates all expressions with the given `scope` data and resolves
-   * the returned Promise with a map of expression strings to results.
+   * Evaluates all expressions with the given `scope` data returns two maps:
+   * expression strings to results and expression strings to errors.
    * @param {!Object} scope
-   * @return {
-   *   !Promise<{
-   *     results: !Object<string, ./bind-expression.BindExpressionResultDef>,
-   *     errors: !Object<string, !Error>,
-   *   }>
-   * }
+   * @return {{
+   *   results: !Object<string, ./bind-expression.BindExpressionResultDef>,
+   *   errors: !Object<string, !Error>,
+   * }}
    */
   evaluate(scope) {
-    return new Promise(resolve => {
-      /** @type {!Object<string, ./bind-expression.BindExpressionResultDef>} */
-      const cache = {};
-      /** @type {!Object<string, !Error>} */
-      const errors = {};
+    /** @type {!Object<string, ./bind-expression.BindExpressionResultDef>} */
+    const cache = {};
+    /** @type {!Object<string, !Error>} */
+    const errors = {};
 
-      this.parsedBindings_.forEach(binding => {
-        const {tagName, property, expression} = binding;
-        const expr = expression.expressionString;
+    this.parsedBindings_.forEach(binding => {
+      const {tagName, property, expression} = binding;
+      const expr = expression.expressionString;
 
-        // Skip if we've already evaluated this expression string.
-        if (cache[expr] !== undefined || errors[expr]) {
-          return;
-        }
+      // Skip if we've already evaluated this expression string.
+      if (cache[expr] !== undefined || errors[expr]) {
+        return;
+      }
 
-        let result;
-        try {
-          result = binding.expression.evaluate(scope);
-        } catch (error) {
-          errors[expr] = error;
-          return;
-        }
+      let result;
+      try {
+        result = binding.expression.evaluate(scope);
+      } catch (error) {
+        errors[expr] = error;
+        return;
+      }
 
-        const resultString = this.stringValueOf_(property, result);
-        if (this.validator_.isResultValid(tagName, property, resultString)) {
-          // Rewrite URL attributes for CDN if necessary.
-          cache[expr] = typeof result === 'string'
-              ? rewriteAttributeValue(tagName, property, result)
-              : result;
-        } else {
-          errors[expr] = new Error(
-              `"${result}" is not a valid result for [${property}].`);
-        }
-      });
-      resolve({results: cache, errors});
+      const resultString = this.stringValueOf_(property, result);
+      if (this.validator_.isResultValid(tagName, property, resultString)) {
+        // Rewrite URL attributes for CDN if necessary.
+        // TODO(willchou)
+        // cache[expr] = typeof result === 'string'
+        //     ? rewriteAttributeValue(tagName, property, result)
+        //     : result;
+        cache[expr] = result;
+      } else {
+        errors[expr] = new Error(
+            `"${result}" is not a valid result for [${property}].`);
+      }
     });
+    return {results: cache, errors};
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -161,9 +161,7 @@ export class Bind {
     this.scanPromise_ = this.scanBody_(this.ampdoc.getBody());
     this.scanPromise_.then(results => {
       const {boundElements, bindings, expressionToElements} = results;
-
       this.boundElements_ = boundElements;
-
       Object.assign(this.expressionToElements_, expressionToElements);
       dev().fine(TAG, `Scanned ${bindings.length} bindings from ` +
           `${boundElements.length} elements.`);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -179,13 +179,11 @@ export class Bind {
       this.initialized_ = true;
 
       // Report each parse error.
-      let numberOfParseErrors = 0;
       Object.keys(parseErrors).forEach(expressionString => {
         const elements = this.expressionToElements_[expressionString];
         if (elements.length > 0) {
           const err = user().createError(parseErrors[expressionString]);
           reportError(err, elements[0]);
-          numberOfParseErrors++;
         }
       });
 
@@ -195,7 +193,7 @@ export class Bind {
       }
 
       dev().fine(TAG, `Worker finished parsing expressions with ` +
-          `${numberOfParseErrors} errors.`);
+          `${Object.keys(parseErrors).length} errors.`);
     });
   }
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -173,7 +173,7 @@ export class Bind {
       } else {
         this.evaluator_ = new BindEvaluator();
         const parseErrors = this.evaluator_.setBindings(bindings);
-        return Promise.resolve(parseErrors);
+        return parseErrors;
       }
     }).then(parseErrors => {
       this.initialized_ = true;
@@ -192,7 +192,7 @@ export class Bind {
         this.digest_(/* opt_verifyOnly */ !this.digestQueuedAfterScan_);
       }
 
-      dev().fine(TAG, `Worker finished parsing expressions with ` +
+      dev().fine(TAG, `Finished parsing expressions with ` +
           `${Object.keys(parseErrors).length} errors.`);
     });
   }
@@ -387,9 +387,9 @@ export class Bind {
           const {property, expressionString, previousResult} =
               boundProperty;
 
-          // Rewrite attribute value if necessary.
-          // This is not done in the worker since it relies on `url#parseUrl`,
-          // which uses DOM APIs.
+          // TODO(choumx): Perform in worker with URL API.
+          // Rewrite attribute value if necessary. This is not done in the
+          // worker since it relies on `url#parseUrl`, which uses DOM APIs.
           let newValue = results[expressionString];
           if (typeof newValue === 'string') {
             newValue = rewriteAttributeValue(tagName, property, newValue);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -328,7 +328,8 @@ export class Bind {
       this.evaluatePromise_ =
           invokeWebWorker(this.win_, 'bind.evaluate', [this.scope_]);
     } else {
-      this.evaluatePromise_ = this.evaluator_.evaluate(this.scope_);
+      const evaluation = this.evaluator_.evaluate(this.scope_);
+      this.evaluatePromise_ = Promise.resolve(evaluation);
     }
 
     this.evaluatePromise_.then(returnValue => {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -71,7 +71,7 @@ export class Bind {
     this.enabled_ = isExperimentOn(ampdoc.win, TAG);
     user().assert(this.enabled_, `Experiment "${TAG}" is disabled.`);
 
-    /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc} */
+    /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc = ampdoc;
 
     /** @const @private {!Window} */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -526,6 +526,7 @@ function checkTypes() {
     './src/service-worker/shell.js',
     './src/service-worker/core.js',
     './src/service-worker/kill.js',
+    './src/web-worker/web-worker.js',
   ];
   var extensionSrcs = Object.values(extensions).filter(function(extension) {
     return !extension.noTypeCheck;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -475,6 +475,7 @@ function build() {
     polyfillsForTests(),
     buildAlp(),
     buildSw(),
+    buildWebWorker(),
     buildExtensions({bundleOnlyIfListedInFiles: true}),
     compile(),
   ]);
@@ -494,6 +495,7 @@ function dist() {
     // and whether you need to init logging (initLogConstructor).
     buildAlp({minify: true, watch: false, preventRemoveAndMakeDir: true}),
     buildSw({minify: true, watch: false, preventRemoveAndMakeDir: true}),
+    buildWebWorker({minify: true, watch: false, preventRemoveAndMakeDir: true}),
     buildExtensions({minify: true, preventRemoveAndMakeDir: true}),
     buildExperiments({minify: true, watch: false, preventRemoveAndMakeDir: true}),
     buildLoginDone({minify: true, watch: false, preventRemoveAndMakeDir: true}),
@@ -837,7 +839,7 @@ function buildLoginDoneVersion(version, options) {
 }
 
 /**
- * Build ALP JS
+ * Build ALP JS.
  *
  * @param {!Object} options
  */
@@ -856,12 +858,12 @@ function buildAlp(options) {
 }
 
 /**
- * Build ALP JS
+ * Build service worker JS.
  *
  * @param {!Object} options
  */
 function buildSw(options) {
-  $$.util.log('Bundling service-worker.js');
+  $$.util.log('Bundling sw.js');
   var opts = Object.assign({}, options);
 
   return Promise.all([
@@ -885,6 +887,24 @@ function buildSw(options) {
     buildExtensionJs('./src/service-worker', 'cache-service-worker', '0.1',
         Object.assign({}, opts, {noWrapper: true, filename: 'core.js'})),
   ]);
+}
+
+/**
+ * Build web worker JS.
+ *
+ * @param {!Object} options
+ */
+function buildWebWorker(options) {
+  $$.util.log('Bundling ww.js');
+  var opts = Object.assign({}, options);
+
+  return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {
+    toName: 'ww.max.js',
+    minifiedName: 'ww.js',
+    watch: opts.watch,
+    minify: opts.minify || argv.minify,
+    preventRemoveAndMakeDir: opts.preventRemoveAndMakeDir,
+  });
 }
 
 /**

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -42,7 +42,7 @@ export function invokeWebWorker(win, method, opt_args) {
     return Promise.reject(`Experiment "${TAG}" is disabled.`);
   }
   if (!win.Worker) {
-    return Promise.reject('Worker not supported in window: ' + win);
+    return Promise.reject('Worker not supported in window.');
   }
   const worker = fromClass(win, 'amp-worker', AmpWorker);
   return worker.sendMessage_(method, opt_args || []);
@@ -77,7 +77,7 @@ class AmpWorker {
 
     /**
      * Array of in-flight messages pending response from worker.
-     * @private {!Array<(PendingMessageDef|undefined)>}
+     * @const @private {!Array<(PendingMessageDef|undefined)>}
      */
     this.messages_ = [];
   }
@@ -90,7 +90,7 @@ class AmpWorker {
    * @private
    */
   sendMessage_(method, args) {
-    const promise = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const index = this.messages_.length;
       this.messages_[index] = {method, resolve, reject};
 
@@ -98,7 +98,6 @@ class AmpWorker {
       const message = {method, args, id: index};
       this.worker_./*OK*/postMessage(message);
     });
-    return promise;
   }
 
   /**
@@ -131,7 +130,7 @@ class AmpWorker {
       }
     }
     if (empty) {
-      this.messages_ = [];
+      this.messages_.length = 0;
     }
   }
 

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {FromWorkerMessageDef, ToWorkerMessageDef} from './web-worker-defines';
 import {calculateEntryPointScriptUrl} from '../service/extension-location';
 import {dev} from '../log';
 import {fromClass} from '../service';
@@ -21,24 +22,6 @@ import {isExperimentOn} from '../experiments';
 import {getMode} from '../mode';
 
 const TAG = 'web-worker';
-
-/**
- * @typedef {{
- *   method: string,
- *   args: !Array,
- *   id: number,
- * }}
- */
-export let ToWorkerMessageDef;
-
-/**
- * @typedef {{
- *   method: string,
- *   returnValue: *,
- *   id: number,
- * }}
- */
-export let FromWorkerMessageDef;
 
 /**
  * @typedef {{method: string, resolve: !Function, reject: !Function}}

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -77,7 +77,7 @@ class AmpWorker {
 
     /**
      * Array of in-flight messages pending response from worker.
-     * @const @private {!Array<(PendingMessageDef|undefined)>}
+     * @const @private {!Object<number, (PendingMessageDef|undefined)>}
      */
     this.messages_ = {};
 
@@ -97,13 +97,12 @@ class AmpWorker {
    */
   sendMessage_(method, args) {
     return new Promise((resolve, reject) => {
-      this.messages_[this.counter_] = {method, resolve, reject};
+      const id = this.counter_++;
+      this.messages_[id] = {method, resolve, reject};
 
       /** @type {ToWorkerMessageDef} */
-      const message = {method, args, id: this.counter_};
+      const message = {method, args, id};
       this.worker_./*OK*/postMessage(message);
-
-      this.counter_++;
     });
   }
 

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -77,7 +77,7 @@ class AmpWorker {
 
     /**
      * Array of in-flight messages pending response from worker.
-     * @const @private {!Object<number, (PendingMessageDef|undefined)>}
+     * @const @private {!Object<number, PendingMessageDef>}
      */
     this.messages_ = {};
 

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -93,6 +93,7 @@ class AmpWorker {
   }
 
   /**
+   * Sends a method invocation request to the worker and returns a Promise.
    * @param {string} method
    * @param {!Array} args
    * @return {!Promise}
@@ -114,6 +115,8 @@ class AmpWorker {
   }
 
   /**
+   * Receives the result of a method invocation from the worker and resolves
+   * the Promise returned from the corresponding `sendMessage_()` call.
    * @param {!MessageEvent} event
    * @private
    */

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -77,7 +77,7 @@ class AmpWorker {
 
     /**
      * Array of in-flight messages pending response from worker.
-     * @const @private {!Array<(PendingMessageDef|undefined)>}
+     * @private {!Array<(PendingMessageDef|undefined)>}
      */
     this.messages_ = [];
   }

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -109,7 +109,7 @@ class AmpWorker {
 
       /** @type {ToWorkerMessageDef} */
       const message = {method, args, id: index};
-      this.worker_.postMessage(message);
+      this.worker_./*OK*/postMessage(message);
     });
     return promise;
   }

--- a/src/web-worker/install.js
+++ b/src/web-worker/install.js
@@ -25,24 +25,92 @@ const TAG = 'web-worker';
 let worker;
 
 /**
- * TODO
+ * @param {!Window} win
+ * @param {string} method
+ * @param {!Array=} opt_args
+ * @return {!Promise}
  */
-export function getWebWorker(win) {
-  if (worker) {
-    return worker;
+export function callWorkerMethod(win, method, args) {
+  if (!worker) {
+    // if (!isExperimentOn(win, TAG)) {
+    //   return;
+    // }
+    if (!('Worker' in win)) {
+      return null;
+    }
+    if (!getMode().localDev &&
+        win.location.hostname !== parseUrl(urls.cdn).hostname) {
+      return;
+    }
+    const url =
+        calculateEntryPointScriptUrl(location, 'ww', getMode().localDev);
+    worker = new AmpWorker(win, url);
   }
-  // if (!isExperimentOn(win, TAG)) {
-  //   return;
-  // }
-  if (!('Worker' in win)) {
-    return null;
+  return worker.sendMessage_(method, args || []);
+}
+
+class AmpWorker {
+  /**
+   * @param {!Window} win
+   * @param {string} url
+   */
+  constructor(win, url) {
+    /** @const @private {!Window} */
+    this.win_ = win;
+
+    /** @const @private {!Worker} */
+    this.worker_ = new win.Worker(url);
+    this.worker_.onmessage = this.receiveMessage_.bind(this);
+
+    /** @const @private {!Object<string, !Array<!Function>>} */
+    this.messages_ = Object.create(null);
   }
-  if (!getMode().localDev &&
-      win.location.hostname !== parseUrl(urls.cdn).hostname) {
-    return;
+
+  /**
+   * @param {string} method
+   * @param {Array} args
+   * @return {!Promise}
+   * @private
+   */
+  sendMessage_(method, args) {
+    const promise = new Promise(resolve => {
+      if (!this.messages_[method]) {
+        this.messages_[method] = [];
+      }
+      const index = this.messages_[method].length;
+      this.messages_[method][index] = resolve;
+
+      this.worker_.postMessage({method, args, index});
+    });
+    return promise;
   }
-  const url =
-      calculateEntryPointScriptUrl(location, 'ww', getMode().localDev);
-  worker = new win.Worker(url);
-  return worker;
+
+  /**
+   * @param {!MessageEvent} event
+   * @private
+   */
+  receiveMessage_(event) {
+    const {method, returnValue, index} = event.data;
+
+    // TODO(willchou): Add errors.
+    const invocations = this.messages_[method];
+    if (invocations) {
+      const resolve = invocations[index];
+      if (resolve) {
+        resolve(returnValue);
+        invocations[index] = undefined;
+      }
+    }
+
+    // Clean up array if there are no more messages in flight for this method.
+    let empty = true;
+    for (let i = 0; i < invocations.length && empty; i++) {
+      if (invocations[i] !== undefined) {
+        empty = false;
+      }
+    }
+    if (empty) {
+      delete this.messages_[method];
+    }
+  }
 }

--- a/src/web-worker/install.js
+++ b/src/web-worker/install.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {calculateEntryPointScriptUrl} from '../service/extension-location';
+import {isExperimentOn} from '../experiments';
+import {getMode} from '../mode';
+import {parseUrl} from '../url';
+import {urls} from '../config';
+
+const TAG = 'web-worker';
+
+let worker;
+
+/**
+ * TODO
+ */
+export function getWebWorker(win) {
+  if (worker) {
+    return worker;
+  }
+  // if (!isExperimentOn(win, TAG)) {
+  //   return;
+  // }
+  if (!('Worker' in win)) {
+    return null;
+  }
+  if (!getMode().localDev &&
+      win.location.hostname !== parseUrl(urls.cdn).hostname) {
+    return;
+  }
+  const url =
+      calculateEntryPointScriptUrl(location, 'ww', getMode().localDev);
+  worker = new win.Worker(url);
+  return worker;
+}

--- a/src/web-worker/web-worker-defines.js
+++ b/src/web-worker/web-worker-defines.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @typedef {{
+ *   method: string,
+ *   args: !Array,
+ *   id: number,
+ * }}
+ */
+export let ToWorkerMessageDef;
+
+/**
+ * @typedef {{
+ *   method: string,
+ *   returnValue: *,
+ *   id: number,
+ * }}
+ */
+export let FromWorkerMessageDef;

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -23,7 +23,7 @@
 
 import '../../third_party/babel/custom-babel-helpers';
 import {BindEvaluator} from '../../extensions/amp-bind/0.1/bind-evaluator';
-import {FromWorkerMessageDef, ToWorkerMessageDef} from './amp-worker';
+import {FromWorkerMessageDef, ToWorkerMessageDef} from './web-worker-defines';
 
 /** @private {BindEvaluator} */
 let evaluator_;

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -33,6 +33,7 @@ self.addEventListener('message', function(event) {
 
   let returnValue;
 
+  // TODO(choumx): Add error reporting.
   switch (method) {
     case 'bind.initialize':
       evaluator_ = new BindEvaluator();
@@ -46,6 +47,9 @@ self.addEventListener('message', function(event) {
         throw new Error(`${method}: BindEvaluator is not initialized.`);
       }
       break;
+
+    default:
+      throw new Error(`Unrecognized method: ${method}`);
   }
 
   /** @type {FromWorkerMessageDef} */

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../../third_party/babel/custom-babel-helpers';
+import {BindEvaluator} from '../../extensions/amp-bind/0.1/bind-evaluator';
+
+let evaluator;
+
+self.addEventListener('message', function(event) {
+  const data = event.data;
+  switch (data.method) {
+    case 'initialize':
+      evaluator = new BindEvaluator();
+      const parseErrors = evaluator.setBindings(data.args);
+      self.postMessage({method: data.method, parseErrors});
+      break;
+
+    case 'evaluate':
+      const scope = data.args;
+      const {results, errors} = evaluator.evaluate(scope);
+      self.postMessage({method: data.method, results, errors});
+      break;
+  }
+});

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -50,5 +50,5 @@ self.addEventListener('message', function(event) {
 
   /** @type {FromWorkerMessageDef} */
   const message = {method, returnValue, id};
-  self.postMessage(message);
+  self./*OK*/postMessage(message);
 });

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview Web worker entry point. Currently only used by a single
+ *   extension (amp-bind), so dependencies are directly imported.
+ *   Eventually, each extension that uses this worker will bundle its own
+ *   "lib" JS files and loaded at runtime via `importScripts()`.
+ */
+
 import '../../third_party/babel/custom-babel-helpers';
 import {BindEvaluator} from '../../extensions/amp-bind/0.1/bind-evaluator';
 import {FromWorkerMessageDef, ToWorkerMessageDef} from './amp-worker';

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -17,21 +17,23 @@
 import '../../third_party/babel/custom-babel-helpers';
 import {BindEvaluator} from '../../extensions/amp-bind/0.1/bind-evaluator';
 
-let evaluator;
+let evaluator; // TODO(willchou)
 
 self.addEventListener('message', function(event) {
-  const data = event.data;
-  switch (data.method) {
+  const {method, args, index} = event.data;
+
+  let returnValue;
+
+  switch (method) {
     case 'initialize':
       evaluator = new BindEvaluator();
-      const parseErrors = evaluator.setBindings(data.args);
-      self.postMessage({method: data.method, parseErrors});
+      returnValue = evaluator.setBindings.apply(evaluator, args);
       break;
 
     case 'evaluate':
-      const scope = data.args;
-      const {results, errors} = evaluator.evaluate(scope);
-      self.postMessage({method: data.method, results, errors});
+      returnValue = evaluator.evaluate.apply(evaluator, args);
       break;
   }
+
+  self.postMessage({method, returnValue, index});
 });

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -19,7 +19,7 @@ import {
   invokeWebWorker,
   ampWorkerForTesting,
 } from '../../../src/web-worker/amp-worker';
-import {toggleExperiment} from '../../../src/experiments';
+import * as experiments from '../../../src/experiments';
 import * as sinon from 'sinon';
 
 describe('invokeWebWorker', () => {
@@ -27,6 +27,7 @@ describe('invokeWebWorker', () => {
   let fakeWin;
   let postMessageStub;
   let fakeWorker;
+  let isExperimentOnStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -39,7 +40,8 @@ describe('invokeWebWorker', () => {
     const fakeWorkerClass = () => fakeWorker;
     fakeWin = {Worker: fakeWorkerClass};
 
-    toggleExperiment(fakeWin, 'web-worker', true);
+    isExperimentOnStub = sandbox.stub(experiments, 'isExperimentOn');
+    isExperimentOnStub.returns(true);
   });
 
   afterEach(() => {
@@ -47,7 +49,7 @@ describe('invokeWebWorker', () => {
   });
 
   it('should check if experiment is enabled', () => {
-    toggleExperiment(fakeWin, 'web-worker', false);
+    isExperimentOnStub.returns(false);
     return expect(invokeWebWorker(fakeWin, 'foo'))
         .to.eventually.be.rejectedWith('disabled');
   });

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  invokeWebWorker, ampWorkerForTesting
+} from '../../../src/web-worker/amp-worker';
+import {toggleExperiment} from '../../../src/experiments';
+import * as sinon from 'sinon';
+
+describe('invokeWebWorker', () => {
+  let sandbox;
+  let fakeWin;
+  let postMessageStub;
+  let fakeWorker;
+
+  beforeEach(() => {
+    toggleExperiment(fakeWin, 'web-worker', true);
+
+    sandbox = sinon.sandbox.create();
+
+    postMessageStub = sandbox.stub();
+
+    fakeWorker = {};
+    fakeWorker.postMessage = postMessageStub;
+
+    const fakeWorkerClass = () => fakeWorker;
+    fakeWin = {Worker: fakeWorkerClass};
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should check if experiment is enabled', () => {
+    toggleExperiment(fakeWin, 'web-worker', false);
+    return expect(invokeWebWorker(fakeWin, 'foo'))
+        .to.eventually.be.rejectedWith('disabled');
+  });
+
+  it('should check if Worker is supported', () => {
+    fakeWin.Worker = undefined;
+    return expect(invokeWebWorker(fakeWin, 'foo'))
+        .to.eventually.be.rejectedWith('not supported');
+  });
+
+  it('should send and receive a message', () => {
+    // Sending.
+    const promise = invokeWebWorker(fakeWin, 'foo', ['bar', 123]);
+    expect(postMessageStub).to.have.been.calledWithMatch({
+      method: 'foo',
+      args: sinon.match(['bar', 123]),
+      id: 0,
+    });
+    // Receiving.
+    const data = {
+      method: 'foo',
+      returnValue: {'qux': 456},
+      id: 0,
+    };
+    fakeWorker.onmessage({data});
+    return promise.then(returnValue => {
+      expect(returnValue).to.deep.equals({'qux': 456});
+    });
+  });
+
+  it('should differentiate messages of different methods', () => {
+    const foo = invokeWebWorker(fakeWin, 'foo', ['foo-arg']);
+    const bar = invokeWebWorker(fakeWin, 'bar', ['bar-arg']);
+    const qux = invokeWebWorker(fakeWin, 'qux', ['qux-arg']);
+
+    fakeWorker.onmessage({data: {
+      method: 'bar',
+      returnValue: 'bar-retVal',
+      id: 0,
+    }});
+    fakeWorker.onmessage({data: {
+      method: 'qux',
+      returnValue: 'qux-retVal',
+      id: 0,
+    }});
+    fakeWorker.onmessage({data: {
+      method: 'foo',
+      returnValue: 'foo-retVal',
+      id: 0,
+    }});
+
+    return Promise.all([foo, bar, qux]).then(values => {
+      expect(values[0]).to.equal('foo-retVal');
+      expect(values[1]).to.equal('bar-retVal');
+      expect(values[2]).to.equal('qux-retVal');
+    });
+  });
+
+  it('should differentiate messages of same method with different ids', () => {
+    const one = invokeWebWorker(fakeWin, 'foo', ['one']);
+    expect(postMessageStub).to.have.been.calledWithMatch({
+      method: 'foo',
+      id: 0,
+    });
+    const two = invokeWebWorker(fakeWin, 'foo', ['two']);
+    expect(postMessageStub).to.have.been.calledWithMatch({
+      method: 'foo',
+      id: 1,
+    });
+    const three = invokeWebWorker(fakeWin, 'foo', ['three']);
+    expect(postMessageStub).to.have.been.calledWithMatch({
+      method: 'foo',
+      id: 2,
+    });
+
+    fakeWorker.onmessage({data: {
+      method: 'foo',
+      returnValue: 'three',
+      id: 2,
+    }});
+    fakeWorker.onmessage({data: {
+      method: 'foo',
+      returnValue: 'one',
+      id: 0,
+    }});
+    fakeWorker.onmessage({data: {
+      method: 'foo',
+      returnValue: 'two',
+      id: 1,
+    }});
+
+    return Promise.all([one, two, three]).then(values => {
+      expect(values[0]).to.equal('one');
+      expect(values[1]).to.equal('two');
+      expect(values[2]).to.equal('three');
+    });
+  });
+
+  it('should clean up storage after message completion', () => {
+    const ampWorker = ampWorkerForTesting(fakeWin);
+
+    const foo = invokeWebWorker(fakeWin, 'foo');
+
+    expect(ampWorker.hasPendingMessagesFor('foo')).to.be.true;
+
+    fakeWorker.onmessage({data: {
+      method: 'foo',
+      returnValue: 'abc',
+      id: 0,
+    }});
+
+    expect(ampWorker.hasPendingMessagesFor('foo')).to.be.false;
+  });
+});

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -19,7 +19,7 @@ import {
   invokeWebWorker,
   ampWorkerForTesting,
 } from '../../../src/web-worker/amp-worker';
-import * as experiments from '../../../src/experiments';
+import {toggleExperiment} from '../../../src/experiments';
 import * as sinon from 'sinon';
 
 describe('invokeWebWorker', () => {
@@ -27,7 +27,6 @@ describe('invokeWebWorker', () => {
   let fakeWin;
   let postMessageStub;
   let fakeWorker;
-  let isExperimentOnStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -40,8 +39,11 @@ describe('invokeWebWorker', () => {
     const fakeWorkerClass = () => fakeWorker;
     fakeWin = {Worker: fakeWorkerClass};
 
-    isExperimentOnStub = sandbox.stub(experiments, 'isExperimentOn');
-    isExperimentOnStub.returns(true);
+    toggleExperiment(
+        fakeWin,
+        'web-worker',
+        /* opt_on */ true,
+        /* opt_transientExperiment */ true);
   });
 
   afterEach(() => {
@@ -49,7 +51,11 @@ describe('invokeWebWorker', () => {
   });
 
   it('should check if experiment is enabled', () => {
-    isExperimentOnStub.returns(false);
+    toggleExperiment(
+        fakeWin,
+        'web-worker',
+        /* opt_on */ false,
+        /* opt_transientExperiment */ true);
     return expect(invokeWebWorker(fakeWin, 'foo'))
         .to.eventually.be.rejectedWith('disabled');
   });

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -29,8 +29,6 @@ describe('invokeWebWorker', () => {
   let fakeWorker;
 
   beforeEach(() => {
-    toggleExperiment(fakeWin, 'web-worker', true);
-
     sandbox = sinon.sandbox.create();
 
     postMessageStub = sandbox.stub();
@@ -40,6 +38,8 @@ describe('invokeWebWorker', () => {
 
     const fakeWorkerClass = () => fakeWorker;
     fakeWin = {Worker: fakeWorkerClass};
+
+    toggleExperiment(fakeWin, 'web-worker', true);
   });
 
   afterEach(() => {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -249,6 +249,11 @@ const EXPERIMENTS = [
         'amp-bind/amp-bind.md',
   },
   {
+    id: 'web-worker',
+    name: 'Web worker for background processing',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7156',
+  },
+  {
     id: 'jank-meter',
     name: 'Display jank meter',
   },


### PR DESCRIPTION
Fixes #6910, partial for #6199.

- Implements a `Worker` in a new entry point compiled to `dist/ww.js`
- Adds `AmpWorker` class that wraps the `Worker` with a Promise-based API
- Use in `amp-bind` to parse and evaluate expressions on background thread
- Flagged under new "web-worker" experiment