### PR TITLE
Avoid false-positive amp- messages in 3p

### DIFF
--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -380,10 +380,7 @@ export function deserializeMessage(message) {
     return null;
   }
   const startPos = message.indexOf('{');
-  if (startPos == -1) {
-    dev().error('MESSAGING', 'Failed to parse message: ' + message);
-    return null;
-  }
+  dev().assert(startPos != -1, 'JSON missing in %s', message);
   try {
     return /** @type {!JSONType} */ (JSON.parse(message.substr(startPos)));
   } catch (e) {
@@ -394,10 +391,11 @@ export function deserializeMessage(message) {
 
 /**
  *  Returns true if message looks like it is an AMP postMessage
- *  @param message {*}
+ *  @param {*} message
  *  @return {!boolean}
  */
 export function isAmpMessage(message) {
   return (typeof message == 'string' &&
-      message.indexOf(AMP_MESSAGE_PREFIX) == 0);
+      message.indexOf(AMP_MESSAGE_PREFIX) == 0 &&
+      message.indexOf('{') != -1);
 }

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -372,7 +372,7 @@ export function serializeMessage(type, sentinel, data = {}, rtvVersion = null) {
  * Deserialize an AMP post message.
  * Returns null if it's not valid AMP message format.
  *
- * @param message {*}
+ * @param {*} message
  * @returns {?JSONType}
  */
 export function deserializeMessage(message) {

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -378,12 +378,13 @@ function getSentinel_(iframe, opt_is3P) {
 
 /**
  * JSON parses event.data if it needs to be
+ * @param {*} data
  * @returns {?Object} object message
  * @private
  */
 function parseIfNeeded(data) {
-  if (typeof data === 'string') {
-    if (data.charAt(0) === '{') {
+  if (typeof data == 'string') {
+    if (data.charAt(0) == '{') {
       data = tryParseJson(data, e => {
         dev().warn('IFRAME-HELPER',
             'Postmessage could not be parsed. ' +

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
+import {deserializeMessage, isAmpMessage} from './3p-frame';
 import {dev} from './log';
-import {parseUrl} from './url';
 import {filterSplice} from './utils/array';
-import {
-  deserializeMessage,
-  isAmpMessage,
-} from './3p-frame';
+import {parseUrl} from './url';
+import {tryParseJson} from './json';
 
 /**
  * Sentinel used to force unlistening after a iframe is detached.
@@ -199,10 +197,8 @@ function registerGlobalListenerIfNeeded(parentWin) {
     if (!event.data) {
       return;
     }
-    // TODO(bradfrizzell): just directly use deserialize function
-    //    and update all affected tests
     const data = parseIfNeeded(event.data);
-    if (!data.sentinel) {
+    if (!data || !data.sentinel) {
       return;
     }
 
@@ -381,22 +377,25 @@ function getSentinel_(iframe, opt_is3P) {
 }
 
 /**
- * Json parses event.data if it needs to be
- * @returns {!Object|!String} object message
+ * JSON parses event.data if it needs to be
+ * @returns {?Object} object message
  * @private
  */
 function parseIfNeeded(data) {
-  if (typeof data === 'string' && data.charAt(0) === '{') {
-    try {
-      data = JSON.parse(data);
-    } catch (e) {
-      dev().warn('IFRAME-HELPER', 'Postmessage could not be parsed. ' +
-          'Is it in a valid JSON format?', e);
+  if (typeof data === 'string') {
+    if (data.charAt(0) === '{') {
+      data = tryParseJson(data, e => {
+        dev().warn('IFRAME-HELPER',
+            'Postmessage could not be parsed. ' +
+            'Is it in a valid JSON format?', e);
+      }) || null;
+    } else if (isAmpMessage(data)) {
+      data = deserializeMessage(data);
+    } else {
+      data = null;
     }
-  } else if (isAmpMessage(data)) {
-    data = deserializeMessage(data);
   }
-  return /** @type {!Object} */ (data) ;
+  return /** @type {?Object} */ (data);
 }
 
 

--- a/test/fixtures/served/iframe-intersection.html
+++ b/test/fixtures/served/iframe-intersection.html
@@ -52,5 +52,8 @@ function sendPostMessage() {
 sendPostMessage();
 sendPostMessage(); // send twice to test no double registration
 
+// Send foreign message.
+ampWindow./*OK*/postMessage('amp-other', '*');
+
 </script>
 </body>

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -25,6 +25,7 @@ import {
   serializeMessage,
   deserializeMessage,
 } from '../../src/3p-frame';
+import {dev} from '../../src/log';
 import {documentInfoForDoc} from '../../src/document-info';
 import {loadPromise} from '../../src/event-helper';
 import {toggleExperiment} from '../../src/experiments';
@@ -435,12 +436,21 @@ describe('3p-frame', () => {
           'noamp-{"type":"msgtype","sentinel":"msgsentinel"}')).to.be.null;
     });
 
+    it('should return null if the input is not a json', () => {
+      const errorStub = sandbox.stub(dev(), 'error');
+      expect(deserializeMessage('amp-other')).to.be.null;
+      expect(errorStub).to.not.be.called;
+    });
+
     it('should return null if failed to parse the input', () => {
+      const errorStub = sandbox.stub(dev(), 'error');
       expect(deserializeMessage(
-          'amp-"type":"msgtype","sentinel":"msgsentinel"}')).to.be.null;
+          'amp-{"type","sentinel":"msgsentinel"}')).to.be.null;
+      expect(errorStub).to.be.calledOnce;
 
       expect(deserializeMessage(
           'amp-{"type":"msgtype"|"sentinel":"msgsentinel"}')).to.be.null;
+      expect(errorStub).to.be.calledTwice;
     });
   });
 });


### PR DESCRIPTION
The main fix is that `amp-` messages are now required to contain `{`. Absent JSON is considered to be an error anyway and thus it's best to filter these messages higher in the stack.

Partial for #7402.
/cc @bradfrizzell
