### PR TITLE
Add id to amp-accordion element if not provided

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -104,7 +104,7 @@ class AmpAccordion extends AMP.BaseElement {
    * @private
    */
   getSessionStorageKey_() {
-    const id_ = this.element.id;
+    const id_ = this.element.id || this.element.getResourceId();
     const url = removeFragment(this.win.location.href);
     return `amp-${id_}-${url}`;
   }


### PR DESCRIPTION
Fix #7365 

The PR helps guarantee that we always have an id to map to the correct sessionState. 