### PR TITLE
Fix scrolling of scrollable iframes in iOS

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -311,6 +311,7 @@ i-amp-scroll-container {
  */
 i-amp-scroll-container.amp-active {
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .i-amphtml-loading-container {


### PR DESCRIPTION
Adds the magic `-webkit-overflow-scrolling: touch;`. It is actually very suprising that it works with this, while it is broken without. And I'm pretty sure it worked with an older version of iOS.

Without one can scroll the iframe when not touching the iframe (e.g. to the left or to the right). With the extra property it also works when touching the iframe.

Tested with http://output.jsbin.com/sopuji/quiet

Fixes #7400