### PR TITLE
reinstate Amp-selector experiment to 100% on prod (the cleanup has no…

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -17,5 +17,6 @@
   "amp-apester-media": 1,
   "amp-accordion-session-state-optout": 1,
   "amp-playbuzz": 1,
-  "make-body-relative": 1
+  "make-body-relative": 1,
+  "amp-selector": 1
 }

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -252,6 +252,13 @@ const EXPERIMENTS = [
     id: 'jank-meter',
     name: 'Display jank meter',
   },
+  {
+    id: 'amp-selector',
+    name: 'Amp selector extension- [LAUNCHED]',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6168',
+    spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
+         'amp-selector/amp-selector.md',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
https://github.com/ampproject/amphtml/pull/7305 - unlaunched this experiment on prod.