### PR TITLE
Support dot syntax in action arg keys

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -117,7 +117,7 @@ export class Bind {
 
   /**
    * Same as `setState()` except this method supports keys nested with '.'.
-   * E.g. `{'foo.bar': '123'}` will be "unwrapped" into `{foo: {bar: 123}}`.
+   * E.g. `{'foo.bar': '123'}` will be transformed into `{foo: {bar: 123}}`.
    * @param {!Object} state
    */
   setStateWithNestedKeys(state) {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -22,6 +22,7 @@ import {getMode} from '../../../src/mode';
 import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber} from '../../../src/types';
+import {map} from '../../../src/utils/object';
 import {reportError} from '../../../src/error';
 import {resourcesForDoc} from '../../../src/resources';
 
@@ -78,7 +79,7 @@ export class Bind {
     this.validator_ = new BindValidator();
 
     /** @const @private {!Object} */
-    this.scope_ = Object.create(null);
+    this.scope_ = map();
 
     /** @private {?./bind-evaluator.BindEvaluator} */
     this.evaluator_ = null;
@@ -90,7 +91,7 @@ export class Bind {
      * Maps expression string to the element(s) that contain it.
      * @private @const {!Object<string, !Array<!Element>>}
      */
-    this.expressionToElements_ = Object.create(null);
+    this.expressionToElements_ = map();
 
     /** @visibleForTesting {?Promise} */
     this.scanPromise_ = null;
@@ -112,6 +113,30 @@ export class Bind {
     if (getMode().localDev) {
       AMP.reinitializeBind = this.initialize_.bind(this);
     }
+  }
+
+  /**
+   * Same as `setState()` except this method supports keys nested with '.'.
+   * E.g. `{'foo.bar': '123'}` will be "unwrapped" into `{foo: {bar: 123}}`.
+   * @param {!Object} state
+   */
+  setStateWithNestedKeys(state) {
+    const unnestedState = map();
+
+    Object.keys(state).forEach(key => {
+      let value = state[key];
+      const fragments = key.split('.');
+      // Create a wrapping object for each '.' in key, starting from inside.
+      // Stop before the first fragment, which is the top-most key.
+      for (let i = fragments.length - 1; i >= 1; i--) {
+        const wrapper = map();
+        wrapper[fragments[i]] = value;
+        value = wrapper;
+      }
+      unnestedState[fragments[0]] = value;
+    });
+
+    this.setState(unnestedState);
   }
 
   /**
@@ -191,7 +216,7 @@ export class Bind {
     /** @type {!Array<./bind-evaluator.BindingDef>} */
     const bindings = [];
     /** @type {!Object<string, !Array<!Element>>} */
-    const expressionToElements = Object.create(null);
+    const expressionToElements = map();
 
     const doc = dev().assert(body.ownerDocument, 'ownerDocument is null.');
     const walker = doc.createTreeWalker(body, NodeFilter.SHOW_ELEMENT);

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -112,6 +112,23 @@ describes.realWin('amp-bind', {
     });
   }
 
+  /**
+   * Similar to `onBindReadyAndSetState` but calls `setStateWithNestedKeys()`
+   * instead of `setState()`.
+   * @param {!Object} state
+   * @return {!Promise}
+   */
+  function onBindReadyAndSetStateWithNestedKeys(state) {
+    return env.ampdoc.whenReady().then(() => {
+      return bind.scanPromise_;
+    }).then(() => {
+      bind.setStateWithNestedKeys(state);
+      return bind.evaluatePromise_;
+    }).then(() => {
+      env.flushVsync();
+    });
+  }
+
   it('should throw error if experiment is not enabled', () => {
     toggleExperiment(env.win, 'amp-bind', false);
     expect(() => {
@@ -293,6 +310,14 @@ describes.realWin('amp-bind', {
     return onBindReadyAndSetState({}, () => {
       expect(canBindStub.calledOnce).to.be.true;
       expect(element.getAttribute('oneplusone')).to.be.null;
+    });
+  });
+
+  it('should support nested keys in setStateWithNestedKeys()', () => {
+    const element = createElementWithBinding('[text]="foo.bar"');
+    const state = {'foo.bar': 'baz'};
+    return onBindReadyAndSetStateWithNestedKeys(state).then(() => {
+      expect(element.textContent).to.equal('baz');
     });
   });
 });

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -71,7 +71,7 @@ export class StandardActions {
     switch (invocation.method) {
       case 'setState':
         bindForDoc(this.ampdoc).then(bind => {
-          bind.setState(invocation.args);
+          bind.setStateWithNestedKeys(invocation.args);
         });
         return;
       case 'goBack':

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -163,6 +163,11 @@ describe('ActionService parseAction', () => {
     expect(parseAction('e:t.m(01=1)').args['01']()).to.equal(1);
   });
 
+  it('should parse with arg keys containing "." chars', () => {
+    const a = parseAction('e:t.m(foo.bar.baz=value)');
+     expect(a.args['foo.bar.baz']()).to.equal('value');
+  });
+
   it('should dereference vars in arg value identifiers', () => {
     const data = {foo: {bar: 'baz'}};
     const a = parseAction('e:t.m(key1=foo.bar)');

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -165,7 +165,7 @@ describe('ActionService parseAction', () => {
 
   it('should parse with arg keys containing "." chars', () => {
     const a = parseAction('e:t.m(foo.bar.baz=value)');
-     expect(a.args['foo.bar.baz']()).to.equal('value');
+    expect(a.args['foo.bar.baz']()).to.equal('value');
   });
 
   it('should dereference vars in arg value identifiers', () => {

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -66,8 +66,8 @@ describes.sandboxed('StandardActions', {}, () => {
 
     it('should implement setState', () => {
       const setStateSpy = sandbox.spy();
-      const bind = {setState: setStateSpy};
-      window.services.bind = {obj: bind};
+      const fakeBind = {setStateWithNestedKeys: setStateSpy};
+      window.services.bind = {obj: fakeBind};
       const args = {};
       standardActions.handleAmpTarget({method: 'setState', args});
       return bindForDoc(standardActions.ampdoc).then(() => {


### PR DESCRIPTION
Fixes #7399, partial for #6199.

Adds support for nested keys in action method args, e.g. `AMP.setState(foo.bar.baz='qux')`.