### PR TITLE
Quick fix to #6826

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -620,8 +620,8 @@ app.get('/dist/rtv/99*/*.js', function(req, res, next) {
 
 app.get('/dist/rtv/*/v0/*.js', function(req, res, next) {
   var mode = getPathMode(req.headers.referer);
-  var filePath = req.path;
-  filePath = filePath.replace(/\/rtv\/\d{13}/, '');
+  var fileName = path.basename(req.path);
+  var filePath = 'https://cdn.ampproject.org/v0/' + fileName;
   filePath = replaceUrls(mode, filePath);
   req.url = filePath;
   next();


### PR DESCRIPTION
I have a quick fix for #6826. The reason it didn't work before is we only replace xxx.js to xxx.max.js if it starts with `https://cdn.ampproject.org`. I replaced the filePath to fix it. 

I am fine with either reverting #6826 or merging the fix. The revert PR is #7467 