### PR TITLE
html_format unnecessary for both AMP and AMP4ADS extensions

### DIFF
--- a/extensions/amp-accordion/0.1/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/0.1/validator-amp-accordion.protoascii
@@ -14,8 +14,6 @@
 # limitations under the license.
 #
 tags: {  # amp-accordion
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-accordion extension .js script"
   mandatory_parent: "HEAD"
@@ -51,8 +49,6 @@ tags: {  # amp-accordion
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-accordion.html"
 }
 tags: {  # <amp-accordion>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-ACCORDION"
   also_requires_tag: "amp-accordion extension .js script"
   attrs: { name: "disable-session-states" value: "" }
@@ -65,8 +61,6 @@ tags: {  # <amp-accordion>
   }
 }
 tags: {  # <amp-accordion> > <section>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SECTION"
   spec_name: "amp-accordion > section"
   mandatory_parent: "AMP-ACCORDION"

--- a/extensions/amp-analytics/0.1/validator-amp-analytics.protoascii
+++ b/extensions/amp-analytics/0.1/validator-amp-analytics.protoascii
@@ -16,8 +16,6 @@
 
 # Specific script tags for custom elements and runtime imports.
 tags: {  # amp-analytics
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-analytics extension .js script"
   mandatory_parent: "HEAD"
@@ -60,8 +58,6 @@ tags: {  # amp-analytics
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-analytics.html"
 }
 tags: {  # amp-analytics (json)
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-analytics extension .json script"
   mandatory_parent: "AMP-ANALYTICS"
@@ -83,8 +79,6 @@ tags: {  # amp-analytics (json)
 # This tag isn't intended to be used by publishers directly, but may be
 # emitted by the AMP cache.
 tags: {  # amp-ad-metadata (json)
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-ad-metadata .json script"
   mandatory_parent: "BODY"
@@ -109,8 +103,6 @@ tags: {  # amp-ad-metadata (json)
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-analytics.html"
 }
 tags: {  # <amp-analytics>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-ANALYTICS"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-analytics extension .js script"

--- a/extensions/amp-anim/0.1/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/0.1/validator-amp-anim.protoascii
@@ -15,8 +15,6 @@
 #
 
 tags: {  # amp-anim
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-anim extension .js script"
   mandatory_parent: "HEAD"
@@ -52,8 +50,6 @@ tags: {  # amp-anim
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-anim.html"
 }
 tags: {  # <amp-anim>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-ANIM"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-anim extension .js script"

--- a/extensions/amp-audio/0.1/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/0.1/validator-amp-audio.protoascii
@@ -14,8 +14,6 @@
 # limitations under the license.
 #
 tags: {  # amp-audio
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-audio extension .js script"
   mandatory_parent: "HEAD"

--- a/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii
@@ -15,8 +15,6 @@
 #
 
 tags: {  # amp-carousel
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-carousel extension .js script"
   mandatory_parent: "HEAD"
@@ -52,8 +50,6 @@ tags: {  # amp-carousel
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-carousel.html"
 }
 tags: {  # <amp-carousel>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-CAROUSEL"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-carousel extension .js script"

--- a/extensions/amp-fit-text/0.1/validator-amp-fit-text.protoascii
+++ b/extensions/amp-fit-text/0.1/validator-amp-fit-text.protoascii
@@ -15,8 +15,6 @@
 #
 
 tags: {  # amp-fit-text
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-fit-text extension .js script"
   mandatory_parent: "HEAD"
@@ -54,8 +52,6 @@ tags: {  # amp-fit-text
 # TODO(greggrothaus): amp-fit-text's attribute spec need flushing
 # out now that the spec is available.
 tags: {  # <amp-fit-text>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-FIT-TEXT"
   # <amp-fit-text> is whitelisted for <amp-sidebar>, otherwise:
   # disallowed_ancestor: "AMP-SIDEBAR"

--- a/extensions/amp-font/0.1/validator-amp-font.protoascii
+++ b/extensions/amp-font/0.1/validator-amp-font.protoascii
@@ -15,8 +15,6 @@
 #
 
 tags: {  # amp-font
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-font extension .js script"
   mandatory_parent: "HEAD"
@@ -52,8 +50,6 @@ tags: {  # amp-font
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-font.html"
 }
 tags: {  # <amp-font>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-FONT"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag: "amp-font extension .js script"

--- a/extensions/amp-form/0.1/validator-amp-form.protoascii
+++ b/extensions/amp-form/0.1/validator-amp-form.protoascii
@@ -14,8 +14,6 @@
 # limitations under the license.
 #
 tags: {  # amp-form
-  html_format: AMP
-  html_format: AMP4ADS
   # Accepted form elements can be found in validator-main.protoascii
   # under section "4.10 Forms"
   tag_name: "SCRIPT"

--- a/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
+++ b/extensions/amp-social-share/0.1/validator-amp-social-share.protoascii
@@ -15,8 +15,6 @@
 #
 
 tags: {  # amp-social-share
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp-social-share extension .js script"
   mandatory_parent: "HEAD"
@@ -52,8 +50,6 @@ tags: {  # amp-social-share
   spec_url: "https://www.ampproject.org/docs/reference/extended/amp-social-share.html"
 }
 tags: {  # <amp-social-share>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-SOCIAL-SHARE"
   also_requires_tag: "amp-social-share extension .js script"
   attrs: {

--- a/extensions/amp-video/0.1/validator-amp-video.protoascii
+++ b/extensions/amp-video/0.1/validator-amp-video.protoascii
@@ -15,8 +15,6 @@
 #
 
 tags: {  # amp-video
-   html_format: AMP
-   html_format: AMP4ADS
    tag_name: "SCRIPT"
    spec_name: "amp-video extension .js script"
    mandatory_parent: "HEAD"
@@ -52,8 +50,6 @@ tags: {  # amp-video
    spec_url: "https://www.ampproject.org/docs/reference/extended/amp-video.html"
  }
 tags: {  # <amp-video>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-VIDEO"
   disallowed_ancestor: "AMP-SIDEBAR"
   also_requires_tag_warning: "amp-video extension .js script"

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -494,9 +494,29 @@ describe('ValidatorRulesMakeSense', () => {
         tagWithoutSpecNameIsUnique[tagSpec.tagName] = 0;
       }
     });
-    if (tagSpec.tagName./*OK*/ startsWith('AMP-')) {
-      it('AMP- tags have html_format', () => {
-        expect(tagSpec.htmlFormat.length).toBeGreaterThan(0);
+    if (tagSpec.tagName./*OK*/ startsWith('AMP-') &&
+        ((tagSpec.htmlFormat.length === 0) ||
+         (tagSpec.htmlFormat.indexOf(
+              amp.validator.TagSpec.HtmlFormat.AMP4ADS) !== -1))) {
+      // AMP4ADS Creative Format document is the source of this whitelist.
+      // https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#amp-extensions-and-builtins
+      const whitelistedAmp4AdsExtensions = {
+        'AMP-ACCORDION': 0,
+        'AMP-ANALYTICS': 0,
+        'AMP-ANIM': 0,
+        'AMP-AUDIO': 0,
+        'AMP-CAROUSEL': 0,
+        'AMP-FIT-TEXT': 0,
+        'AMP-FONT': 0,
+        'AMP-FORM': 0,
+        'AMP-IMG': 0,
+        'AMP-PIXEL': 0,
+        'AMP-SOCIAL-SHARE': 0,
+        'AMP-VIDEO': 0
+      };
+      it(tagSpec.tagName + ' must be whitelisted for AMP4ADS', () => {
+        expect(whitelistedAmp4AdsExtensions.hasOwnProperty(tagSpec.tagName))
+            .toBe(true);
       });
     }
     // mandatory_parent

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2802,8 +2802,6 @@ attr_lists: {
   attrs: { name: "noloading" value: "" }
 }
 tags: {  # <amp-img>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-IMG"
   # <amp-img> is whitelisted for <amp-sidebar>, otherwise:
   # disallowed_ancestor: "AMP-SIDEBAR"
@@ -2823,8 +2821,6 @@ tags: {  # <amp-img>
   }
 }
 tags: {  # <amp-pixel>
-  html_format: AMP
-  html_format: AMP4ADS
   tag_name: "AMP-PIXEL"
   disallowed_ancestor: "AMP-SIDEBAR"
   attrs: {


### PR DESCRIPTION
When wanting a tagspec for both AMP and AMP4ADS, do not specify any html_format.