### PR TITLE
Load sticky ad after first viewport scroll

### DIFF
--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -26,7 +26,7 @@ import {
 } from '../../../src/style';
 
 /** @const */
-const TAG = 'sticky-ad-early-load';
+const EARLY_LOAD_EXPERIMENT = 'sticky-ad-early-load';
 
 class AmpStickyAd extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -129,8 +129,8 @@ class AmpStickyAd extends AMP.BaseElement {
    * @private
    */
   onScroll_() {
-    if (isExperimentOn(this.win, TAG)) {
-      this.displayAfterScroll_();
+    if (isExperimentOn(this.win, EARLY_LOAD_EXPERIMENT)) {
+      this.display_();
       return;
     }
 
@@ -138,7 +138,7 @@ class AmpStickyAd extends AMP.BaseElement {
     const viewportHeight = this.viewport_.getSize().height;
     // Check user has scrolled at least one viewport from init position.
     if (scrollTop > viewportHeight) {
-      this.displayAfterScroll_();
+      this.display_();
     }
   }
 
@@ -146,7 +146,7 @@ class AmpStickyAd extends AMP.BaseElement {
    * Display and load sticky ad.
    * @private
    */
-  displayAfterScroll_() {
+  display_() {
     this.removeOnScrollListener_();
     this.deferMutate(() => {
       this.visible_ = true;

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -19,10 +19,14 @@ import {Layout} from '../../../src/layout';
 import {dev,user} from '../../../src/log';
 import {removeElement} from '../../../src/dom';
 import {toggle} from '../../../src/style';
+import {isExperimentOn} from '../../../src/experiments';
 import {
   setStyle,
   removeAlphaFromColor,
 } from '../../../src/style';
+
+/** @const */
+const TAG = 'sticky-ad-early-load';
 
 class AmpStickyAd extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -68,7 +72,7 @@ class AmpStickyAd extends AMP.BaseElement {
 
     // On viewport scroll, check requirements for amp-stick-ad to display.
     this.scrollUnlisten_ =
-        this.viewport_.onScroll(() => this.displayAfterScroll_());
+        this.viewport_.onScroll(() => this.onScroll_());
   }
 
   /** @override */
@@ -120,25 +124,36 @@ class AmpStickyAd extends AMP.BaseElement {
   }
 
   /**
-   * The listener function that listen on onScroll event and
-   * show sticky ad when user scroll at least one viewport and
-   * there is at least one more viewport available.
+   * The listener function that listen on viewport scroll event.
+   * And decide when to display the ad.
+   * @private
+   */
+  onScroll_() {
+    if (isExperimentOn(this.win, TAG)) {
+      this.displayAfterScroll_();
+      return;
+    }
+
+    const scrollTop = this.viewport_.getScrollTop();
+    const viewportHeight = this.viewport_.getSize().height;
+    // Check user has scrolled at least one viewport from init position.
+    if (scrollTop > viewportHeight) {
+      this.displayAfterScroll_();
+    }
+  }
+
+  /**
+   * Display and load sticky ad.
    * @private
    */
   displayAfterScroll_() {
-    const scrollTop = this.viewport_.getScrollTop();
-    const viewportHeight = this.viewport_.getSize().height;
-
-    // Check user has scrolled at least one viewport from init position.
-    if (scrollTop > viewportHeight) {
-      this.removeOnScrollListener_();
-      this.deferMutate(() => {
-        this.visible_ = true;
-        this.viewport_.addToFixedLayer(this.element);
-        this.addCloseButton_();
-        this.scheduleLayoutForAd_();
-      });
-    }
+    this.removeOnScrollListener_();
+    this.deferMutate(() => {
+      this.visible_ = true;
+      this.viewport_.addToFixedLayer(this.element);
+      this.addCloseButton_();
+      this.scheduleLayoutForAd_();
+    });
   }
 
   /**

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -180,7 +180,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
         callback();
       };
 
-      impl.displayAfterScroll_();
+      impl.display_();
       expect(addCloseButtonSpy).to.be.called;
       expect(impl.element.children[0]).to.be.not.null;
       expect(impl.element.children[0].tagName).to.equal(
@@ -355,7 +355,7 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
       return 20;
     };
 
-    impl.displayAfterScroll_();
+    impl.display_();
     impl.ad_.signals().signal('load-end');
     const layoutPromise = impl.layoutAd_();
     const bodyPromise = impl.viewport_.ampdoc.whenBodyAvailable();
@@ -393,7 +393,7 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
       return 20;
     };
 
-    impl.displayAfterScroll_();
+    impl.display_();
     impl.ad_.signals().signal('load-end');
     const layoutPromise = impl.layoutAd_();
     const bodyPromise = impl.viewport_.ampdoc.whenBodyAvailable();

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -124,7 +124,8 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       getSizeStub.returns({
         height: 50,
       });
-      const getScrollHeightStub = sandbox.stub(impl.viewport_, 'getScrollHeight');
+      const getScrollHeightStub =
+          sandbox.stub(impl.viewport_, 'getScrollHeight');
       getScrollHeightStub.returns(300);
 
       impl.deferMutate = function(callback) {

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -117,22 +117,16 @@ describes.realWin('amp-sticky-ad 1.0 version', {
           () => {});
       const removeOnScrollListenerSpy =
           sandbox.spy(impl, 'removeOnScrollListener_');
-      const getScrollTopSpy = sandbox.spy();
-      const getSizeSpy = sandbox.spy();
-      const getScrollHeightSpy = sandbox.spy();
 
-      impl.viewport_.getScrollTop = function() {
-        getScrollTopSpy();
-        return 1;
-      };
-      impl.viewport_.getSize = function() {
-        getSizeSpy();
-        return {height: 50};
-      };
-      impl.viewport_.getScrollHeight = function() {
-        getScrollHeightSpy();
-        return 300;
-      };
+      const getScrollTopStub = sandbox.stub(impl.viewport_, 'getScrollTop');
+      getScrollTopStub.returns(1);
+      const getSizeStub = sandbox.stub(impl.viewport_, 'getSize');
+      getSizeStub.returns({
+        height: 50,
+      });
+      const getScrollHeightStub = sandbox.stub(impl.viewport_, 'getScrollHeight');
+      getScrollHeightStub.returns(300);
+
       impl.deferMutate = function(callback) {
         callback();
       };

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -263,7 +263,7 @@ const EXPERIMENTS = [
     id: 'sticky-ad-early-load',
     name: 'Load sticky-ad early after user first scroll' +
         'Only apply to 1.0 version',
-    cleanupIssue: 'TODO: create issue',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7479',
   },
 ];
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -259,6 +259,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
          'amp-selector/amp-selector.md',
   },
+  {
+    id: 'sticky-ad-early-load',
+    name: 'Load sticky-ad early after user first scroll' +
+        'Only apply to 1.0 version',
+    cleanupIssue: 'TODO: create issue',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Closes #6597 
This PR introduces an experiment flag 'sticky-ad-early-load'
Now: load sticky ad after viewport scrolls down  1vp length
Experiment: load sticky ad after first viewport scroll