### PR TITLE
Omit the stack trace for user errors.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -264,6 +264,8 @@ export function getErrorReportUrl(message, filename, line, col, error,
     }
   }
 
+  const isUserError = isUserErrorMessage(message);
+
   // This is the App Engine app in
   // ../tools/errortracker
   // It stores error reports via https://cloud.google.com/error-reporting/
@@ -272,7 +274,7 @@ export function getErrorReportUrl(message, filename, line, col, error,
       '?v=' + encodeURIComponent('$internalRuntimeVersion$') +
       '&noAmp=' + (hasNonAmpJs ? 1 : 0) +
       '&m=' + encodeURIComponent(message.replace(USER_ERROR_SENTINEL, '')) +
-      '&a=' + (isUserErrorMessage(message) ? 1 : 0);
+      '&a=' + (isUserError ? 1 : 0);
   if (expected) {
     // Errors are tagged with "ex" ("expected") label to allow loggers to
     // classify these errors as benchmarks and not exceptions.
@@ -317,8 +319,12 @@ export function getErrorReportUrl(message, filename, line, col, error,
     const tagName = error && error.associatedElement
       ? error.associatedElement.tagName
       : 'u';  // Unknown
-    url += '&el=' + encodeURIComponent(tagName) +
-        '&s=' + encodeURIComponent(error.stack || '');
+    url += `&el=${encodeURIComponent(tagName)}`;
+
+    if (!isUserError) {
+      url += `&s=${encodeURIComponent(error.stack || '')}`;
+    }
+
     error.message += ' _reported_';
   } else {
     url += '&f=' + encodeURIComponent(filename || '') +

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -299,6 +299,15 @@ describe('reportErrorToServer', () => {
     expect(url).to.contain('&ex=1');
   });
 
+  it('should omit the error stack for user errors', () => {
+    const e = user().createError('123');
+    const url = parseUrl(
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e,
+          true));
+    const query = parseQueryString(url.search);
+    expect(query.s).to.be.undefined;
+  });
+
   describe('detectNonAmpJs', () => {
     let win;
     let scripts;


### PR DESCRIPTION
- The stack trace is not important for user errors
- This should improve performance since accessing the stack trace is expensive

Implements #4949
