### PR TITLE
Normalize jank rate to a likelihood metric.

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -535,10 +535,10 @@ amp-fresh {
   position: fixed;
   background-color: rgba(232,72,95,.5);
   bottom: 0;
-  left: 0;
+  right: 0;
   color: #fff;
   font-size: 16px;
-  text-align: center;
+  width: 110px;
   z-index: 1000;
   padding: 5px;
 }

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -29,33 +29,34 @@ export class JankMeter {
     this.jankMeterDisplay_ = this.win_.document.createElement('div');
     this.jankMeterDisplay_.classList.add('i-amphtml-jank-meter');
     /** @private {number} */
-    this.jankCounter_ = 0;
+    this.jankCnt_ = 0;
     /** @private {number} */
-    this.bigJankCounter_ = 0;
+    this.totalCnt_ = 0;
     this.win_.document.body.appendChild(this.jankMeterDisplay_);
     this.updateMeterDisplay_(0);
-    /** @private {number} */
-    this.scheduledTime_ = -1;
+    /** @private {?number} */
+    this.scheduledTime_ = null;
   }
 
   onScheduled() {
     // only take the first schedule for the current frame.
-    if (this.scheduledTime_ == -1) {
-      this.scheduledTime_ = Date.now();
+    if (this.scheduledTime_ == null) {
+      this.scheduledTime_ = this.win_.Date.now();
     }
   }
 
   onRun() {
-    const paintLatency = Date.now() - this.scheduledTime_;
-    this.scheduledTime_ = -1;
+    if (this.scheduledTime_ == null) {
+      return;
+    }
+    const paintLatency = this.win_.Date.now() - this.scheduledTime_;
+    this.scheduledTime_ = null;
+    this.totalCnt_++;
     if (paintLatency > 16) {
-      this.jankCounter_++;
-      if (paintLatency > 100) {
-        this.bigJankCounter_++;
-      }
-      this.updateMeterDisplay_(paintLatency);
+      this.jankCnt_++;
       dev().info('JANK', 'Paint latency: ' + paintLatency + 'ms');
     }
+    this.updateMeterDisplay_(paintLatency);
   }
 
   /**
@@ -63,8 +64,10 @@ export class JankMeter {
    * @private
    */
   updateMeterDisplay_(paintLatency) {
+    // Calculate Good Frame Probability
+    const gfp = (this.totalCnt_ - this.jankCnt_) / this.totalCnt_;
     this.jankMeterDisplay_.textContent =
-        `${this.jankCounter_}|${this.bigJankCounter_}|${paintLatency}ms`;
+        `${gfp.toFixed(2)}|${this.totalCnt_}|${paintLatency}ms`;
   }
 }
 

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -65,9 +65,10 @@ export class JankMeter {
    */
   updateMeterDisplay_(paintLatency) {
     // Calculate Good Frame Probability
-    const gfp = (this.totalCnt_ - this.jankCnt_) / this.totalCnt_;
+    const gfp = this.win_.Math.floor(
+        (this.totalCnt_ - this.jankCnt_) / this.totalCnt_ * 100);
     this.jankMeterDisplay_.textContent =
-        `${gfp.toFixed(2)}|${this.totalCnt_}|${paintLatency}ms`;
+        `${gfp}%|${this.totalCnt_}|${paintLatency}ms`;
   }
 }
 


### PR DESCRIPTION
To make jank rate useful across documents, normalized it to a likelihood metric.
