### PR TITLE
Make viewport getScrollLeft return 0

### DIFF
--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1014,8 +1014,9 @@ export class ViewportBindingNatural_ {
 
   /** @override */
   getScrollLeft() {
-    return this.getScrollingElement_()./*OK*/scrollLeft ||
-        this.win./*OK*/pageXOffset;
+    // The html is set to overflow-x: hidden so the document cannot be
+    // scrolled horizontally. The scrollLeft will always be 0.
+    return 0;
   }
 
   /** @override */
@@ -1301,7 +1302,9 @@ export class ViewportBindingNaturalIosEmbed_ {
 
   /** @override */
   getScrollLeft() {
-    return Math.round(this.pos_.x);
+    // The html is set to overflow-x: hidden so the document cannot be
+    // scrolled horizontally. The scrollLeft will always be 0.
+    return 0;
   }
 
   /** @override */
@@ -1558,7 +1561,9 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   getScrollLeft() {
-    return this.wrapper_./*OK*/scrollLeft;
+    // The wrapper is set to overflow-x: hidden so the document cannot be
+    // scrolled horizontally. The scrollLeft will always be 0.
+    return 0;
   }
 
   /** @override */

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -1168,7 +1168,7 @@ describe('ViewportBindingNatural', () => {
   });
 
   it('should offset client rect for layout', () => {
-    windowApi.pageXOffset = 100;
+    windowApi.pageXOffset = 0;
     windowApi.pageYOffset = 200;
     windowApi.document = {scrollingElement: {}};
     const el = {
@@ -1177,14 +1177,14 @@ describe('ViewportBindingNatural', () => {
       },
     };
     const rect = binding.getLayoutRect(el);
-    expect(rect.left).to.equal(112);  // round(100 + 11.5)
+    expect(rect.left).to.equal(12);  // round(0 + 11.5)
     expect(rect.top).to.equal(213);  // round(200 + 12.5)
     expect(rect.width).to.equal(14);  // round(13.5)
     expect(rect.height).to.equal(15);  // round(14.5)
   });
 
   it('should offset client rect for layout and position passed in', () => {
-    windowApi.pageXOffset = 1000;
+    windowApi.pageXOffset = 0;
     windowApi.pageYOffset = 2000;
     windowApi.document = {scrollingElement: {}};
     const el = {


### PR DESCRIPTION
Fix #7355 
Since we have `overflow-x: hidden` on `html` (in natural and ios-embed binding) and `#i-amphtml-wrapper` (in ios-embed-wrapper binding), the scrollLeft will always be 0.
Also modified test cases that return non-zero value for getScrollLeft which couldn't happen in reality.