### PR TITLE
Set experiments cookies on explicit hostname.

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -70,10 +70,14 @@ function tryGetDocumentCookieNoInline(win) {
  * @param {string} name
  * @param {string} value
  * @param {time} expirationTime
- * @param {{highestAvailableDomain:boolean}=} opt_options
+ * @param {{
+ *   highestAvailableDomain:(boolean|undefined),
+ *   domain:(string|undefined)
+ * }=} opt_options
  *     - highestAvailableDomain: If true, set the cookie at the widest domain
  *       scope allowed by the browser. E.g. on example.com if we are currently
  *       on www.example.com.
+ *     - domain: Explicit domain to set.
  */
 export function setCookie(win, name, value, expirationTime, opt_options) {
   if (opt_options && opt_options.highestAvailableDomain) {
@@ -87,7 +91,11 @@ export function setCookie(win, name, value, expirationTime, opt_options) {
       }
     }
   }
-  trySetCookie(win, name, value, expirationTime, undefined);
+  let domain = undefined;
+  if (opt_options && opt_options.domain) {
+    domain = opt_options.domain;
+  }
+  trySetCookie(win, name, value, expirationTime, domain);
 }
 
 /**

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -192,7 +192,10 @@ function saveExperimentTogglesToCookie(win, toggles) {
   }
 
   setCookie(win, COOKIE_NAME, experimentIds.join(','),
-      Date.now() + COOKIE_EXPIRATION_INTERVAL);
+      Date.now() + COOKIE_EXPIRATION_INTERVAL, {
+        // Set explicit domain, so the cookie gets send to sub domains.
+        domain: win.location.hostname,
+      });
 }
 
 /**

--- a/test/functional/test-cookies.js
+++ b/test/functional/test-cookies.js
@@ -17,7 +17,7 @@
 import {getCookie, setCookie} from '../../src/cookies';
 
 
-describe('getCookie', () => {
+describe('cookies', () => {
 
   function expectCookie(cookiesString, cookieName) {
     return expect(getCookie({

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -210,11 +210,17 @@ describe('toggleExperiment', () => {
       cookie: cookiesString,
     };
     resetExperimentTogglesForTesting();
-    const on = toggleExperiment({document: doc}, experimentId, opt_on);
+    const on = toggleExperiment({
+      document: doc,
+      location: {
+        hostname: 'test.test',
+      },
+    }, experimentId, opt_on);
     const parts = doc.cookie.split(/\s*;\s*/g);
     if (parts.length > 1) {
       expect(parts[1]).to.equal('path=/');
-      expect(parts[2]).to.equal('expires=' + expTime);
+      expect(parts[2]).to.equal('domain=test.test');
+      expect(parts[3]).to.equal('expires=' + expTime);
     }
     return expect(`${on}; ${decodeURIComponent(parts[0])}`);
   }
@@ -281,6 +287,9 @@ describe('toggleExperiment', () => {
       document: {
         cookie: '',
       },
+      location: {
+        hostname: 'test.test',
+      },
     };
     toggleExperiment(win, 'transient', true, true);
     toggleExperiment(win, 'e1', true);
@@ -336,6 +345,9 @@ describe('toggleExperiment', () => {
       document: {
         cookie: '',
       },
+      location: {
+        hostname: 'test.test',
+      },
     };
     // Make sure some experiments are enabled in the cookie.
     toggleExperiment(win, 'e0', true);
@@ -387,6 +399,9 @@ describe('toggleExperiment', () => {
       },
       'AMP_CONFIG': {
         'e1': 1,
+      },
+      location: {
+        hostname: 'test.test',
       },
     };
 

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -1028,6 +1028,7 @@ describe('ViewportBindingNatural', () => {
       defaultView: windowApi,
     };
     windowApi.navigator = {userAgent: ''};
+    windowApi.location = {};
     windowMock = sandbox.mock(windowApi);
     installPlatformService(windowApi);
     viewer = {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -393,7 +393,11 @@ function toggleExperiment_(id, name, opt_on) {
     if (id == CANARY_EXPERIMENT_ID) {
       const validUntil = Date.now() +
           COOKIE_MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
-      setCookie(window, 'AMP_CANARY', (on ? '1' : '0'), (on ? validUntil : 0));
+      setCookie(window, 'AMP_CANARY',
+          (on ? '1' : '0'), (on ? validUntil : 0), {
+            // Set explicit domain, so the cookie gets send to sub domains.
+            domain: location.hostname,
+          });
     } else {
       toggleExperiment(window, id, on);
     }


### PR DESCRIPTION
This makes them available to sub domains which is important for the foo.cdn.ampproject.org style domains.
