### PR TITLE
Adsense explicitly support responsive

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -271,6 +271,7 @@ function validateAllowedFields(data, allowedFields) {
     mode: true,
     consentNotificationId: true,
     ampSlotIndex: true,
+    layout: true,
   };
 
   for (const field in data) {

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -314,7 +314,6 @@ const defaultAllowedTypesInCustomFrame = [
  *     on this.
  */
 export function draw3p(win, data, configCallback) {
-  console.log(`draw3p: ${JSON.stringify(win.context)}`);
   const type = data.type;
 
   user().assert(isTagNameAllowed(data.type, win.context.tagName),

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -314,6 +314,7 @@ const defaultAllowedTypesInCustomFrame = [
  *     on this.
  */
 export function draw3p(win, data, configCallback) {
+  console.log(`draw3p: ${JSON.stringify(win.context)}`);
   const type = data.type;
 
   user().assert(isTagNameAllowed(data.type, win.context.tagName),

--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -15,6 +15,7 @@
  */
 
 import {validateData} from '../../3p/3p';
+import {Layout} from '../../src/layout';
 import {setStyles} from '../../src/style';
 
 /**
@@ -52,6 +53,11 @@ export function adsense(global, data) {
   }
   if (data['tagOrigin']) {
     i.setAttribute('data-tag-origin', data['tagOrigin']);
+  }
+  if (global.context['layout'] == Layout.RESPONSIVE) {
+    // Use fluid as it will fill the space which requires at least 250 width
+    // otherwise use auto.
+    i.setAttribute('data-ad-format', data.width >= 250 ? 'fluid' : 'auto');
   }
   i.setAttribute('data-page-url', global.context.canonicalUrl);
   i.setAttribute('class', 'adsbygoogle');

--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -15,7 +15,6 @@
  */
 
 import {validateData} from '../../3p/3p';
-import {Layout} from '../../src/layout';
 import {setStyles} from '../../src/style';
 
 /**
@@ -54,9 +53,9 @@ export function adsense(global, data) {
   if (data['tagOrigin']) {
     i.setAttribute('data-tag-origin', data['tagOrigin']);
   }
-  if (global.context['layout'] == Layout.RESPONSIVE) {
-    // Use fluid as it will fill the space which requires at least 250 width
-    // otherwise use auto.
+  if (global.context['layout'] == 'responsive') {
+    // Fluid will fill the space, so use it if eligible (slot width >= 250);
+    // otherwise use auto. Auto is likely to be much smaller than slot.
     i.setAttribute('data-ad-format', data.width >= 250 ? 'fluid' : 'auto');
   }
   i.setAttribute('data-page-url', global.context.canonicalUrl);

--- a/examples/adsense.amp.html
+++ b/examples/adsense.amp.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-custom>
     amp-ad {
-      max-width: 500px;
+      max-width: 550px;
     }
     .red {
       background-color: red;
@@ -51,31 +51,32 @@
 </head>
 <body>
 
-  <amp-user-notification
+  <!--amp-user-notification
       layout=nodisplay
       id="amp-user-notification">
     This site uses cookies to personalize content.
     <a href="#learn-more">Learn more.</a>
     <button on="tap:amp-user-notification.dismiss" role="button" tabindex="0">I accept</button>
-  </amp-user-notification>
+  </amp-user-notification-->
 
   <h2>AdSense</h2>
   <amp-ad width=300 height=250
       type="adsense"
       data-ad-client="ca-pub-2005682797531342"
-      data-ad-slot="7046626912">
+      data-ad-slot="7046626912"
+      layout="responsive">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
 
-  <amp-ad width=300 height=250
+  <!--amp-ad width=300 height=250
           type="adsense"
           data-ad-client="ca-pub-2005682797531342"
           data-ad-slot="7046626912"
           data-consent-notification-id="amp-user-notification">
     <div placeholder>should only show ad after notification get dismissed</div>
     <div fallback></div>
-  </amp-ad>
+  </amp-ad-->
 
   <div class=talldiv>
     <!-- Make the second ad below the fold. -->
@@ -86,8 +87,7 @@
   <amp-ad width=300 height=250
       type="adsense"
       data-ad-client="ca-pub-2005682797531342"
-      data-ad-slot="7046626912"
-      data-adtest="on">
+      layout="responsive">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>

--- a/examples/adsense.amp.html
+++ b/examples/adsense.amp.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-custom>
     amp-ad {
-      max-width: 550px;
+      max-width: 500px;
     }
     .red {
       background-color: red;
@@ -51,32 +51,31 @@
 </head>
 <body>
 
-  <!--amp-user-notification
+  <amp-user-notification
       layout=nodisplay
       id="amp-user-notification">
     This site uses cookies to personalize content.
     <a href="#learn-more">Learn more.</a>
     <button on="tap:amp-user-notification.dismiss" role="button" tabindex="0">I accept</button>
-  </amp-user-notification-->
+  </amp-user-notification>
 
   <h2>AdSense</h2>
   <amp-ad width=300 height=250
       type="adsense"
       data-ad-client="ca-pub-2005682797531342"
-      data-ad-slot="7046626912"
-      layout="responsive">
+      data-ad-slot="7046626912">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
 
-  <!--amp-ad width=300 height=250
+  <amp-ad width=300 height=250
           type="adsense"
           data-ad-client="ca-pub-2005682797531342"
           data-ad-slot="7046626912"
           data-consent-notification-id="amp-user-notification">
     <div placeholder>should only show ad after notification get dismissed</div>
     <div fallback></div>
-  </amp-ad-->
+  </amp-ad>
 
   <div class=talldiv>
     <!-- Make the second ad below the fold. -->
@@ -87,7 +86,19 @@
   <amp-ad width=300 height=250
       type="adsense"
       data-ad-client="ca-pub-2005682797531342"
-      layout="responsive">
+      data-ad-slot="7046626912"
+      data-adtest="on">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+  <h2>AdSense responsive</h2>
+  <amp-ad width=300 height=250
+      type="adsense"
+      data-ad-client="ca-pub-2005682797531342"
+      data-ad-slot="7046626912"
+      layout="responsive"
+      data-adtest="on">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -90,13 +90,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     this.uniqueSlotId_ = null;
 
     /**
-     * Whether element has responsive layout.
-     * @private {boolean}
-     */
-    this.isResponsive_ =
-        this.element.getAttribute('layout') == Layout.RESPONSIVE;
-
-    /**
      * Sizes for resize (width then height).
      * @private {?Array<number>}
      */
@@ -123,8 +116,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const width = slotRect.width;
     // If responsive, set height to value that is considered valid by
     // ad server.
+    const isResponsive = this.element.getLayout() == Layout.RESPONSIVE;
     const height =
-        this.isResponsive_ ? Math.ceil(width / 1.91 + 120) : slotRect.height;
+        isResponsive ? Math.ceil(width / 1.91 + 120) : slotRect.height;
     const format = `${width}x${height}`;
 
     const slotId = this.element.getAttribute('data-amp-slot-index');
@@ -162,7 +156,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       paramList.push({name: 'prev_fmts', value: sharedStateParams.prevFmts});
     }
 
-    if (this.isResponsive_ &&
+    if (isResponsive &&
         (height != slotRect.height || width != slotRect.width)) {
       // If responsive, attempt resize
       this.attemptChangeSize(height, width).catch(() => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -31,6 +31,7 @@ import {
   createElementWithAttributes,
   addAttributesToElement,
 } from '../../../../src/dom';
+import {parseQueryString} from '../../../../src/url';
 
 function createAdsenseImplElement(attributes, opt_doc, opt_tag) {
   const doc = opt_doc || document;
@@ -333,12 +334,8 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
             // Create AdsenseImpl instance.
             impl = new AmpAdNetworkAdsenseImpl(addedElem);
             return impl.getAdUrl().then(adUrl => {
-              const queryPairs = adUrl.split('?')[1].split('&');
-              const actualQueryParams = {};
-              queryPairs.forEach(pair => {
-                const pairArr = pair.split('=');
-                actualQueryParams[pairArr[0]] = pairArr[1];
-              });
+              const actualQueryParams = parseQueryString(
+                adUrl.substr(adUrl.indexOf('?') + 1));
               expect(actualQueryParams['format']).to.equal('300x278');
               expect(actualQueryParams['w']).to.equal('300');
               expect(actualQueryParams['h']).to.equal('278');
@@ -357,7 +354,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
           });
         });
       });
-      it('modifies format, initial resize failuer', () => {
+      it('modifies format, initial resize failure', () => {
         sandbox.stub(AmpAdNetworkAdsenseImpl.prototype, 'attemptChangeSize',
           () => {
             return Promise.reject('resize failure');

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -65,6 +65,11 @@ function getFrameAttributes(parentWindow, element, opt_type, opt_context) {
     domFingerprint: domFingerprint(element),
     experimentToggles: experimentToggles(parentWindow),
   };
+  const layout = element.getAttribute('layout');
+  if (layout) {
+    additionalContext.layout = layout;
+  }
+  console.log(`3p-frame: ${JSON.stringify(additionalContext)}`);
   Object.assign(attributes._context, opt_context);
   Object.assign(attributes._context, additionalContext);
   return attributes;

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -69,7 +69,6 @@ function getFrameAttributes(parentWindow, element, opt_type, opt_context) {
   if (layout) {
     additionalContext.layout = layout;
   }
-  console.log(`3p-frame: ${JSON.stringify(additionalContext)}`);
   Object.assign(attributes._context, opt_context);
   Object.assign(attributes._context, additionalContext);
   return attributes;

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -65,10 +65,7 @@ function getFrameAttributes(parentWindow, element, opt_type, opt_context) {
     domFingerprint: domFingerprint(element),
     experimentToggles: experimentToggles(parentWindow),
   };
-  const layout = element.getAttribute('layout');
-  if (layout) {
-    additionalContext.layout = layout;
-  }
+  additionalContext.layout = element.getLayout();
   Object.assign(attributes._context, opt_context);
   Object.assign(attributes._context, additionalContext);
   return attributes;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1079,6 +1079,14 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * @return {!Layout}
+     * @final @this {!Element}
+     */
+    getLayout() {
+      return this.implementation_.layout_;
+    }
+
+    /**
      * @return {!./layout-rect.LayoutRectDef}
      * @final @this {!Element}
      */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1083,7 +1083,7 @@ function createBaseCustomElementClass(win) {
      * @final @this {!Element}
      */
     getLayout() {
-      return this.implementation_.layout_;
+      return this.layout_;
     }
 
     /**

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -120,6 +120,7 @@ describe('3p-frame', () => {
       div.setAttribute('data-ping', 'pong');
       div.setAttribute('width', '50');
       div.setAttribute('height', '100');
+      div.setAttribute('layout', 'responsive');
 
       const width = window.innerWidth;
       const height = window.innerHeight;
@@ -185,6 +186,7 @@ describe('3p-frame', () => {
           // Note that DOM fingerprint will change if the document DOM changes
           // Note also that running it using --files uses different DOM.
           ',"domFingerprint":"1725030182"' +
+          ',"layout":"responsive"' +
           ',"startTime":1234567888' +
           ',"experimentToggles":{"exp-a":true,"exp-b":true' +
           (sentinelName == 'sentinel' ?
@@ -223,6 +225,7 @@ describe('3p-frame', () => {
         expect(win.context.noContentAvailable).to.be.a('function');
         expect(win.context.observeIntersection).to.be.a('function');
         expect(win.context.reportRenderedEntityIdentifier).to.be.a('function');
+        expect(win.context.layout).to.equal('responsive');
         const c = win.document.getElementById('c');
         expect(c).to.not.be.null;
         expect(c.textContent).to.contain('pong');

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -25,6 +25,7 @@ import {
   serializeMessage,
   deserializeMessage,
 } from '../../src/3p-frame';
+import {Layout} from '../../src/layout';
 import {dev} from '../../src/log';
 import {documentInfoForDoc} from '../../src/document-info';
 import {loadPromise} from '../../src/event-helper';
@@ -124,6 +125,9 @@ describe('3p-frame', () => {
 
       const width = window.innerWidth;
       const height = window.innerHeight;
+      div.getLayout = function() {
+        return Layout.RESPONSIVE;
+      };
       div.getIntersectionChangeEntry = function() {
         return {
           time: 1234567888,
@@ -338,6 +342,9 @@ describe('3p-frame', () => {
     div.setAttribute('type', '_ping_');
     div.setAttribute('width', 100);
     div.setAttribute('height', 200);
+    div.getLayout = function() {
+      return Layout.FILL;
+    };
     div.getIntersectionChangeEntry = function() {
       return {
         left: 0,


### PR DESCRIPTION
Adsense relies on a known, allowed set of format sizes based on the size of the slot however responsive layout can cause this to break resulting in a 400 response.  Change is to explicitly detect responsive layout for both delayed and fast fetch and modify the ad request accordingly.