### PR TITLE
Make Array `includes()` polyfill not enumerable

### DIFF
--- a/src/polyfills/array-includes.js
+++ b/src/polyfills/array-includes.js
@@ -44,6 +44,9 @@ function includes(value, opt_fromIndex) {
 */
 export function install(win) {
   if (!win.Array.prototype.includes) {
-    win.Array.prototype.includes = includes;
+    win.Object.defineProperty(Array.prototype, 'includes', {
+        enumerable: false,
+        value: includes,
+    });
   }
 }

--- a/src/polyfills/array-includes.js
+++ b/src/polyfills/array-includes.js
@@ -45,8 +45,10 @@ function includes(value, opt_fromIndex) {
 export function install(win) {
   if (!win.Array.prototype.includes) {
     win.Object.defineProperty(Array.prototype, 'includes', {
-        enumerable: false,
-        value: includes,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: includes,
     });
   }
 }

--- a/src/polyfills/document-contains.js
+++ b/src/polyfills/document-contains.js
@@ -37,6 +37,11 @@ function documentContainsPolyfill(node) {
  */
 export function install(win) {
   if (!win.HTMLDocument.prototype.contains) {
-    win.HTMLDocument.prototype.contains = documentContainsPolyfill;
+    win.Object.defineProperty(win.HTMLDocument.prototype, 'contains', {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: documentContainsPolyfill,
+    });
   }
 }

--- a/src/polyfills/domtokenlist-toggle.js
+++ b/src/polyfills/domtokenlist-toggle.js
@@ -42,7 +42,12 @@ function domTokenListTogglePolyfill(token, opt_force) {
  */
 export function install(win) {
   if (isIe(win) && win.DOMTokenList) {
-    win.DOMTokenList.prototype.toggle = domTokenListTogglePolyfill;
+    win.Object.defineProperty(win.DOMTokenList.prototype, 'toggle', {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: domTokenListTogglePolyfill,
+    });
   }
 }
 

--- a/src/polyfills/math-sign.js
+++ b/src/polyfills/math-sign.js
@@ -40,6 +40,11 @@ export function sign(x) {
  */
 export function install(win) {
   if (!win.Math.sign) {
-    win.Math.sign = sign;
+    win.Object.defineProperty(win.Math, 'sign', {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: sign,
+    });
   }
 }

--- a/src/polyfills/object-assign.js
+++ b/src/polyfills/object-assign.js
@@ -50,6 +50,11 @@ export function assign(target, var_args) {
  */
 export function install(win) {
   if (!win.Object.assign) {
-    win.Object.assign = assign;
+    win.Object.defineProperty(win.Object, 'assign', {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: assign,
+    });
   }
 }

--- a/test/functional/test-polyfill-document-contains.js
+++ b/test/functional/test-polyfill-document-contains.js
@@ -37,12 +37,14 @@ describe('HTMLDocument.contains', () => {
       HTMLDocument: class {
         contains() {}
       },
+      Object: window.Object,
     };
     nativeContains = fakeWinWithContains.HTMLDocument.prototype.contains;
 
     fakeWinWithoutContains = {
       HTMLDocument: class {
       },
+      Object: window.Object,
     };
     install(fakeWinWithoutContains);
     polyfillContains = fakeWinWithoutContains.HTMLDocument.prototype.contains;


### PR DESCRIPTION
All the `for var in arr` code that did not check `hasOwnProperty` has been broken since the polyfill did not make `includes` not enumerable.

Fixes Chrome 45 tests failures on Master as well.

/to @jridgewell 