### PR TITLE
Introduce a new attemptCollapse function

### DIFF
--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -71,6 +71,8 @@ export function _ping_(global, data) {
       });
     }
   } else {
-    global.context.noContentAvailable();
+    window.setTimeout(() => {
+      global.context.noContentAvailable();
+    }, 1000);
   }
 }

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -71,7 +71,7 @@ export function _ping_(global, data) {
       });
     }
   } else {
-    window.setTimeout(() => {
+    global.setTimeout(() => {
       global.context.noContentAvailable();
     }, 1000);
   }

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -566,6 +566,7 @@ var forbiddenTermsSrcInclusive = {
   // Functions
   '\\.changeHeight\\(': bannedTermsHelpString,
   '\\.changeSize\\(': bannedTermsHelpString,
+  '\\.attemptChangeHeight\\(0\\)': 'please consider using `attemptCollapse()`',
   '\\.collapse\\(': bannedTermsHelpString,
   '\\.focus\\(': bannedTermsHelpString,
   '\\.getBBox\\(': bannedTermsHelpString,

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -162,8 +162,7 @@ export class AmpAdUIHandler {
         this.state = AdDisplayState.LOADED_NO_CONTENT;
       });
     } else {
-      this.baseInstance_.attemptChangeHeight(0).then(() => {
-        this.baseInstance_./*OK*/collapse();
+      this.baseInstance_.attemptCollapse().then(() => {
         this.state = AdDisplayState.LOADED_NO_CONTENT;
       }, () => {
         // Apply default fallback when resize fail.

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -43,15 +43,15 @@ describe('amp-ad-ui handler', () => {
       sandbox.stub(adImpl, 'getFallback', () => {
         return false;
       });
-      sandbox.stub(adImpl, 'attemptChangeHeight', height => {
-        expect(height).to.equal(0);
+      const attemptCollapseSpy = sandbox.spy();
+      sandbox.stub(adImpl, 'attemptCollapse', () => {
+        attemptCollapseSpy();
         return Promise.resolve();
       });
-      const collapseSpy = sandbox.stub(adImpl, 'collapse', () => {});
       uiHandler.init();
       uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
       return Promise.resolve().then(() => {
-        expect(collapseSpy).to.be.calledOnce;
+        expect(attemptCollapseSpy).to.be.calledOnce;
         expect(uiHandler.state).to.equal(3);
       });
     });
@@ -60,7 +60,7 @@ describe('amp-ad-ui handler', () => {
       sandbox.stub(adImpl, 'getFallback', () => {
         return false;
       });
-      sandbox.stub(adImpl, 'attemptChangeHeight', () => {
+      sandbox.stub(adImpl, 'attemptCollapse', () => {
         return Promise.reject();
       });
       toggleExperiment(window, UX_EXPERIMENT, true);

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -162,9 +162,7 @@ class AmpFlyingCarpet extends AMP.BaseElement {
       this.children_.splice(index, 1);
       this.totalChildren_--;
       if (this.totalChildren_ == 0) {
-        return this.attemptChangeHeight(0).then(() => {
-          this./*OK*/collapse();
-        }, () => {});
+        return this.attemptCollapse().then(() => {}, () => {});
       }
     }
   }

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -162,7 +162,7 @@ class AmpFlyingCarpet extends AMP.BaseElement {
       this.children_.splice(index, 1);
       this.totalChildren_--;
       if (this.totalChildren_ == 0) {
-        return this.attemptCollapse().then(() => {}, () => {});
+        return this.attemptCollapse().catch(() => {});
       }
     }
   }

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -184,7 +184,7 @@ describe('amp-fx-flying-carpet', () => {
     });
   });
 
-  it('should attempt to change height to 0 when its children collapse', () => {
+  it('should attempt to collapse when its children collapse', () => {
     let img;
     return getAmpFlyingCarpet(iframe => {
       installImg(iframe.win);
@@ -198,21 +198,13 @@ describe('amp-fx-flying-carpet', () => {
       const posttext = iframe.doc.createTextNode('\n');
       return [pretext, img, posttext];
     }).then(flyingCarpet => {
-      const attemptChangeHeight = sandbox.stub(flyingCarpet.implementation_,
-          'attemptChangeHeight', height => {
-            flyingCarpet.style.height = height;
+      const attemptCollapse = sandbox.stub(flyingCarpet.implementation_,
+          'attemptCollapse', () => {
             return Promise.resolve();
           });
-      const collapse = sandbox.spy(flyingCarpet.implementation_, 'collapse');
       expect(flyingCarpet.getBoundingClientRect().height).to.be.gt(0);
       img.collapse();
-      expect(attemptChangeHeight).to.have.been.called;
-      expect(attemptChangeHeight.firstCall.args[0]).to.equal(0);
-      return attemptChangeHeight().then(() => {
-        expect(flyingCarpet.getBoundingClientRect().height).to.equal(0);
-        expect(collapse).to.have.been.called;
-        expect(flyingCarpet.style.display).to.equal('none');
-      });
+      expect(attemptCollapse).to.have.been.called;
     });
   });
 });

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -788,7 +788,6 @@ export class BaseElement {
   /**
    * Return a promise that request the runtime to collapse one element
    * @return {!Promise}
-   * @public
    */
   attemptCollapse() {
     return this.element.getResources().attemptCollapse(this.element);

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -777,6 +777,26 @@ export class BaseElement {
   }
 
   /**
+   * Collapses the element, setting it to `display: none`, and notifies its
+   * owner (if there is one) through {@link collapsedCallback} that the element
+   * is no longer visible.
+   */
+  collapse() {
+    this.element.getResources().collapseElement(this.element);
+  }
+
+  /**
+   * Return a promise that request the runtime to collapse one element
+   * @return {!Promise}
+   * @public
+   */
+  attemptCollapse() {
+    return this.element.getResources().attemptCollapse(
+      this.element, 0, /* newWidth */ undefined);
+  }
+
+
+  /**
    * Return a promise that requests the runtime to update
    * the height of this element to the specified value.
    * The runtime will schedule this request and attempt to process it
@@ -841,15 +861,6 @@ export class BaseElement {
    */
   deferMutate(callback) {
     this.element.getResources().deferMutate(this.element, callback);
-  }
-
-  /**
-   * Collapses the element, setting it to `display: none`, and notifies its
-   * owner (if there is one) through {@link collapsedCallback} that the element
-   * is no longer visible.
-   */
-  collapse() {
-    this.element.getResources().collapseElement(this.element);
   }
 
   /**

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -791,8 +791,7 @@ export class BaseElement {
    * @public
    */
   attemptCollapse() {
-    return this.element.getResources().attemptCollapse(
-      this.element, 0, /* newWidth */ undefined);
+    return this.element.getResources().attemptCollapse(this.element);
   }
 
 

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -315,6 +315,7 @@ export class Resource {
    */
   changeSize(newHeight, newWidth, opt_newMargins) {
     this.element./*OK*/changeSize(newHeight, newWidth, opt_newMargins);
+
     // Schedule for re-layout.
     if (this.state_ != ResourceState.NOT_BUILT) {
       this.state_ = ResourceState.NOT_LAID_OUT;
@@ -412,6 +413,10 @@ export class Resource {
 
     this.element.updateLayoutBox(box);
   }
+  /**
+   * Collapse on changing height/width to 0
+   */
+
 
   /**
    * Completes collapse: ensures that the element is `display:none` and
@@ -425,6 +430,10 @@ export class Resource {
         0, 0);
     this.isFixed_ = false;
     this.element.updateLayoutBox(this.layoutBox_);
+    const owner = this.getOwner();
+    if (owner) {
+      owner.colllapsedCallback(this.element);
+    }
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -432,7 +432,7 @@ export class Resource {
     this.element.updateLayoutBox(this.layoutBox_);
     const owner = this.getOwner();
     if (owner) {
-      owner.colllapsedCallback(this.element);
+      owner.collapsedCallback(this.element);
     }
   }
 

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -413,10 +413,6 @@ export class Resource {
 
     this.element.updateLayoutBox(box);
   }
-  /**
-   * Collapse on changing height/width to 0
-   */
-
 
   /**
    * Completes collapse: ensures that the element is `display:none` and

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -812,11 +812,6 @@ export class Resources {
       this.setRelayoutTop_(box.top);
     }
     resource.completeCollapse();
-    resource.layoutBox_ = layoutRectLtwh(
-        resource.layoutBox_.left,
-        resource.layoutBox_.top,
-        0, 0);
-    element.updateLayoutBox(this.layoutBox_);
     this.schedulePass(FOUR_FRAME_DELAY_);
   }
 
@@ -1056,11 +1051,7 @@ export class Resources {
             }
             // Sync is necessary here to avoid UI jump in the next frame.
             const newScrollHeight = this.viewport_./*OK*/getScrollHeight();
-            console.log('old scrollHeight', state.scrollHeight);
-            console.log('new scrollHeight', newScrollHeight);
-            console.log('old scrollTop', state.scrollTop);
-            console.log('new scrollTop', state./*OK*/scrollTop + newScrollHeight - state./*OK*/scrollHeight);
-            if (newScrollHeight != state./*OK*/scrollHeight) {
+            if (newScrollHeight > state./*OK*/scrollHeight) {
               this.viewport_.setScrollTop(state./*OK*/scrollTop +
                   (newScrollHeight - state./*OK*/scrollHeight));
             }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -33,7 +33,7 @@ import {dev} from '../log';
 import {reportError} from '../error';
 import {filterSplice} from '../utils/array';
 import {getSourceUrl} from '../url';
-import {areMarginsChanged, layoutRectLtwh} from '../layout-rect';
+import {areMarginsChanged} from '../layout-rect';
 import {documentInfoForDoc} from '../document-info';
 
 const TAG_ = 'Resources';

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -325,12 +325,18 @@ describe('Resource', () => {
           return data.width == 0 && data.height == 0;
         }))
         .once();
-
+    const owner = {
+      collapsedCallback: sandbox.spy(),
+    };
+    sandbox.stub(resource, 'getOwner', () => {
+      return owner;
+    });
     resource.completeCollapse();
     expect(resource.element.style.display).to.equal('none');
     expect(resource.getLayoutBox().width).to.equal(0);
     expect(resource.getLayoutBox().height).to.equal(0);
     expect(resource.isFixed()).to.be.false;
+    expect(owner.collapsedCallback).to.be.calledOnce;
   });
 
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1839,17 +1839,6 @@ describe('Resources mutateElement and collapse', () => {
     expect(resource1.completeCollapse).to.be.calledOnce;
     expect(relayoutTopStub).to.have.not.been.called;
   });
-
-  it('should notify owner', () => {
-    const owner = {
-      contains: () => true,
-      collapsedCallback: sandbox.spy(),
-    };
-    Resource.setOwner(resource1.element, owner);
-    Resource.completeCollapse();
-    expect(owner.collapsedCallback).to.be.calledOnce;
-    expect(owner.collapsedCallback.args[0][0]).to.equal(resource1.element);
-  });
 });
 
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1846,7 +1846,7 @@ describe('Resources mutateElement and collapse', () => {
       collapsedCallback: sandbox.spy(),
     };
     Resource.setOwner(resource1.element, owner);
-    resources.collapseElement(resource1.element);
+    Resource.completeCollapse();
     expect(owner.collapsedCallback).to.be.calledOnce;
     expect(owner.collapsedCallback.args[0][0]).to.equal(resource1.element);
   });

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1727,6 +1727,15 @@ describe('Resources mutateElement and collapse', () => {
         }
         return Promise.resolve();
       },
+      run: task => {
+        const state = {};
+        if (task.measure) {
+          task.measure(state);
+        }
+        if (task.mutate) {
+          task.mutate(state);
+        }
+      },
     };
     relayoutTopStub = sandbox.stub(resources, 'setRelayoutTop_');
     sandbox.stub(resources, 'schedulePass');
@@ -1822,6 +1831,67 @@ describe('Resources mutateElement and collapse', () => {
       expect(relayoutTopStub.getCall(0).args[0]).to.equal(10);
       expect(relayoutTopStub.getCall(1).args[0]).to.equal(1010);
     });
+  });
+
+  it('attemptCollapse should not call attemptChangeSize', () => {
+    // This test ensure that #attemptCollapse won't do any optimization or
+    // refactor by calling attemptChangeSize.
+    // This to support collapsing element above viewport
+    // When attemptChangeSize succeed, resources manager will measure the new
+    // scrollHeight, and we need to make sure the newScrollHeight is measured
+    // after setting element display:none
+    sandbox.stub(resources.viewport_, 'getRect', () => {
+      return {
+        top: 1500,
+        bottom: 1800,
+        left: 0,
+        right: 500,
+        width: 500,
+        height: 300,
+      };
+    });
+    let promiseResolve = null;
+    const promise = new Promise(resolve => {
+      promiseResolve = resolve;
+    });
+    let index = 0;
+    sandbox.stub(resources.viewport_, 'getScrollHeight', () => {
+      // In change element size above viewport path, getScrollHeight will be
+      // called three times. And we care that the last measurement is correct,
+      // which requires it to be measured after element dispaly set to none.
+      if (index == 2) {
+        expect(resource1.completeCollapse).to.be.calledOnce;
+        promiseResolve();
+        return;
+      }
+      expect(resource1.completeCollapse).to.not.been.called;
+      index++;
+    });
+
+    resource1.layoutBox_ = {top: 1000, left: 0, right: 100, bottom: 1050,
+        height: 50};
+    resources.lastVelocity_ = 0;
+    resources.attemptCollapse(resource1.element);
+    resources.mutateWork_();
+    return promise;
+  });
+
+  it('attemptCollapse should complete collapse if resize succeed', () => {
+    sandbox.stub(resources, 'scheduleChangeSize_', (resource, newHeight,
+        newWidth, newMargins, force, callback) => {
+      callback(true);
+    });
+    resources.attemptCollapse(resource1.element);
+    expect(resource1.completeCollapse).to.be.calledOnce;
+  });
+
+  it('attemptCollapse should NOT complete collapse if resize fail', () => {
+    sandbox.stub(resources, 'scheduleChangeSize_', (resource, newHeight,
+        newWidth, newMargins, force, callback) => {
+      callback(false);
+    });
+    resources.attemptCollapse(resource1.element);
+    expect(resource1.completeCollapse).to.not.been.called;
   });
 
   it('should complete collapse and trigger relayout', () => {

--- a/test/manual/fakead3p.amp.html
+++ b/test/manual/fakead3p.amp.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-custom>
     amp-ad {
-      border: 2px solid red;
+
       padding: 0;
       margin: 0;
     }
@@ -19,85 +19,57 @@
 </head>
 <body>
 
-  <h2 id="fakead3p_0">fake3pAd send no-content</h2>
   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='not-exist'
-        data-valid='false'
+        data-valid='false'>
     </amp-ad>
   </div>
 
-  <h2 id="fakead3p_0">fake3pAd send render-start w/ width & height</h2>
   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'
-        data-ad-width=50
-        data-ad-height=50
-        data-enable-io='true'
+        data-valid='true'>
     </amp-ad>
   </div>
 
-  <h2 id="fakead3p_0">fake3pAd send render-start w/o width or height</h2>
   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'
-        data-enable-io='true'
+        data-valid='true'>
     </amp-ad>
   </div>
-
-  <h2 id="fakead3p_0">fake3pAd send render-start w/ only width</h2>
-  <div>
+   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'
-        data-ad-width=50
-        data-enable-io='true'
+        data-valid='true'>
     </amp-ad>
   </div>
-
-  <h2 id="fakead3p_0">fake3pAd send render-start w/ only height</h2>
-  <div>
+   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'
-        data-ad-height=50
-        data-enable-io='true'
+        data-valid='true'>
     </amp-ad>
   </div>
 
-  <h2 id="fakead3p_0">Below viewport fake3pAd send render-start w/ width & height</h2>
-  <div>
-    <amp-ad width=300 height=250
-        type="_ping_"
-        data-id='0'
-        data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'
-        data-ad-width=50
-        data-ad-height=50
-        data-enable-io='true'
-    </amp-ad>
-  </div>
 
-  <h2 id="fakead3p_0">Below viewport fake3pAd send no-content</h2>
+
   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='not-exist'
-        data-valid='false'
-        data-enable-io='true'
+        data-valid='false'>
     </amp-ad>
   </div>
 

--- a/test/manual/fakead3p.amp.html
+++ b/test/manual/fakead3p.amp.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-custom>
     amp-ad {
-
+      border: 2px solid red;
       padding: 0;
       margin: 0;
     }
@@ -19,6 +19,7 @@
 </head>
 <body>
 
+  <h2 id="fakead3p_0">fake3pAd send no-content</h2>
   <div>
     <amp-ad width=300 height=250
         type="_ping_"
@@ -28,48 +29,75 @@
     </amp-ad>
   </div>
 
+  <h2 id="fakead3p_0">fake3pAd send render-start w/ width & height</h2>
   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'>
+        data-valid='true'
+        data-ad-width=50
+        data-ad-height=50
+        data-enable-io='true'>
     </amp-ad>
   </div>
 
+  <h2 id="fakead3p_0">fake3pAd send render-start w/o width or height</h2>
   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'>
+        data-valid='true'
+        data-enable-io='true'>
     </amp-ad>
   </div>
-   <div>
+
+  <h2 id="fakead3p_0">fake3pAd send render-start w/ only width</h2>
+  <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'>
+        data-valid='true'
+        data-ad-width=50
+        data-enable-io='true'>
     </amp-ad>
   </div>
-   <div>
+
+  <h2 id="fakead3p_0">fake3pAd send render-start w/ only height</h2>
+  <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
-        data-valid='true'>
+        data-valid='true'
+        data-ad-height=50
+        data-enable-io='true'>
     </amp-ad>
   </div>
 
+  <h2 id="fakead3p_0">Below viewport fake3pAd send render-start w/ width & height</h2>
+  <div>
+    <amp-ad width=300 height=250
+        type="_ping_"
+        data-id='0'
+        data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
+        data-valid='true'
+        data-ad-width=50
+        data-ad-height=50
+        data-enable-io='true'>
+    </amp-ad>
+  </div>
 
-
+  <h2 id="fakead3p_0">Below viewport fake3pAd send no-content</h2>
   <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-id='0'
         data-url='not-exist'
-        data-valid='false'>
+        data-valid='false'
+        data-enable-io='true'>
     </amp-ad>
   </div>
 


### PR DESCRIPTION
when we try to collapse an element we do things like:
```
element.attemptChangeHeight(0).then(() => {
  element.collapse();
})
```
We do some measurements after height is set to 0, and before we call `element.collapse()`; However with display:inline-block, it is still possible for layout to change from height = 0 to display: none. [[Looks like a well know CSS issue](https://css-tricks.com/fighting-the-space-between-inline-block-elements/)] Then the previous measure will give wrong result. https://github.com/ampproject/amphtml/blob/master/src/service/resources-impl.js#L1036

In this PR I am trying to introduce a new method call `attemptCollapse`, and it will call resources `scheduleChangeSize_` with a callback function to set display none.

Still need to work on adding test coverage.