### PR TITLE
Fix locally failing tests.

### DIFF
--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -18,75 +18,74 @@ import {AdDisplayState, AmpAdUIHandler} from '../amp-ad-ui';
 import {BaseElement} from '../../../../src/base-element';
 import {toggleExperiment} from '../../../../src/experiments';
 import {UX_EXPERIMENT} from '../../../../src/layout';
-import * as sinon from 'sinon';
 
-describe('amp-ad-ui handler', () => {
+describes.realWin('amp-ad-ui handler', {
+  amp: {
+    ampdoc: 'single',
+    extensions: ['amp-ad'],
+  },
+}, env => {
   let sandbox;
   let adImpl;
   let uiHandler;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-    const adElement = document.createElement('amp-ad');
+    sandbox = env.sandbox;
+    const adElement = env.win.document.createElement('amp-ad');
     adImpl = new BaseElement(adElement);
     uiHandler = new AmpAdUIHandler(adImpl);
     uiHandler.setDisplayState(AdDisplayState.LOADING);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-    uiHandler = null;
-  });
-
   describe('with state LOADED_NO_CONTENT', () => {
     it('should try to collapse element', () => {
-      sandbox.stub(adImpl, 'getFallback', () => {
+        sandbox.stub(adImpl, 'getFallback', () => {
         return false;
       });
-      sandbox.stub(adImpl, 'attemptChangeHeight', height => {
+        sandbox.stub(adImpl, 'attemptChangeHeight', height => {
         expect(height).to.equal(0);
         return Promise.resolve();
       });
-      const collapseSpy = sandbox.stub(adImpl, 'collapse', () => {});
-      uiHandler.init();
-      uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
-      return Promise.resolve().then(() => {
+        const collapseSpy = sandbox.stub(adImpl, 'collapse', () => {});
+        uiHandler.init();
+        uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+        return Promise.resolve().then(() => {
         expect(collapseSpy).to.be.calledOnce;
         expect(uiHandler.state).to.equal(3);
       });
-    });
+      });
 
     it('should apply default holder when collapse fail', () => {
-      sandbox.stub(adImpl, 'getFallback', () => {
+        sandbox.stub(adImpl, 'getFallback', () => {
         return false;
       });
-      sandbox.stub(adImpl, 'attemptChangeHeight', () => {
+        sandbox.stub(adImpl, 'attemptChangeHeight', () => {
         return Promise.reject();
       });
-      toggleExperiment(window, UX_EXPERIMENT, true);
-      uiHandler.init();
-      uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
-      return Promise.resolve().then(() => {
+        toggleExperiment(window, UX_EXPERIMENT, true);
+        uiHandler.init();
+        uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+        return Promise.resolve().then(() => {
         expect(adImpl.element.querySelector('[fallback]')).to.be.ok;
       });
-    });
+      });
 
     it('should NOT continue with display state UN_LAID_OUT', () => {
-      sandbox.stub(adImpl, 'getFallback', () => {
+        sandbox.stub(adImpl, 'getFallback', () => {
         return document.createElement('div');
       });
-      uiHandler = new AmpAdUIHandler(adImpl);
-      uiHandler.setDisplayState(AdDisplayState.LOADING);
-      const spy = sandbox.stub(adImpl, 'deferMutate', callback => {
+        uiHandler = new AmpAdUIHandler(adImpl);
+        uiHandler.setDisplayState(AdDisplayState.LOADING);
+        const spy = sandbox.stub(adImpl, 'deferMutate', callback => {
         uiHandler.state = AdDisplayState.NOT_LAID_OUT;
         callback();
       });
-      const placeHolderSpy = sandbox.stub(adImpl, 'togglePlaceholder');
-      uiHandler.init();
-      uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
-      expect(spy).to.be.called;
-      expect(placeHolderSpy).to.not.be.called;
-      expect(uiHandler.state).to.equal(AdDisplayState.NOT_LAID_OUT);
-    });
+        const placeHolderSpy = sandbox.stub(adImpl, 'togglePlaceholder');
+        uiHandler.init();
+        uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+        expect(spy).to.be.called;
+        expect(placeHolderSpy).to.not.be.called;
+        expect(uiHandler.state).to.equal(AdDisplayState.NOT_LAID_OUT);
+      });
   });
 });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -39,53 +39,53 @@ describes.realWin('amp-ad-ui handler', {
 
   describe('with state LOADED_NO_CONTENT', () => {
     it('should try to collapse element', () => {
-        sandbox.stub(adImpl, 'getFallback', () => {
+      sandbox.stub(adImpl, 'getFallback', () => {
         return false;
       });
-        sandbox.stub(adImpl, 'attemptChangeHeight', height => {
+      sandbox.stub(adImpl, 'attemptChangeHeight', height => {
         expect(height).to.equal(0);
         return Promise.resolve();
       });
-        const collapseSpy = sandbox.stub(adImpl, 'collapse', () => {});
-        uiHandler.init();
-        uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
-        return Promise.resolve().then(() => {
+      const collapseSpy = sandbox.stub(adImpl, 'collapse', () => {});
+      uiHandler.init();
+      uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+      return Promise.resolve().then(() => {
         expect(collapseSpy).to.be.calledOnce;
         expect(uiHandler.state).to.equal(3);
       });
-      });
+    });
 
     it('should apply default holder when collapse fail', () => {
-        sandbox.stub(adImpl, 'getFallback', () => {
+      sandbox.stub(adImpl, 'getFallback', () => {
         return false;
       });
-        sandbox.stub(adImpl, 'attemptChangeHeight', () => {
+      sandbox.stub(adImpl, 'attemptChangeHeight', () => {
         return Promise.reject();
       });
-        toggleExperiment(window, UX_EXPERIMENT, true);
-        uiHandler.init();
-        uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
-        return Promise.resolve().then(() => {
+      toggleExperiment(window, UX_EXPERIMENT, true);
+      uiHandler.init();
+      uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+      return Promise.resolve().then(() => {
         expect(adImpl.element.querySelector('[fallback]')).to.be.ok;
       });
-      });
+    });
 
     it('should NOT continue with display state UN_LAID_OUT', () => {
-        sandbox.stub(adImpl, 'getFallback', () => {
+      sandbox.stub(adImpl, 'getFallback', () => {
         return document.createElement('div');
       });
-        uiHandler = new AmpAdUIHandler(adImpl);
-        uiHandler.setDisplayState(AdDisplayState.LOADING);
-        const spy = sandbox.stub(adImpl, 'deferMutate', callback => {
+      uiHandler = new AmpAdUIHandler(adImpl);
+      uiHandler.setDisplayState(AdDisplayState.LOADING);
+      const spy = sandbox.stub(adImpl, 'deferMutate', callback => {
         uiHandler.state = AdDisplayState.NOT_LAID_OUT;
         callback();
       });
-        const placeHolderSpy = sandbox.stub(adImpl, 'togglePlaceholder');
-        uiHandler.init();
-        uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
-        expect(spy).to.be.called;
-        expect(placeHolderSpy).to.not.be.called;
-        expect(uiHandler.state).to.equal(AdDisplayState.NOT_LAID_OUT);
-      });
+      const placeHolderSpy = sandbox.stub(adImpl, 'togglePlaceholder');
+      uiHandler.init();
+      uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+      expect(spy).to.be.called;
+      expect(placeHolderSpy).to.not.be.called;
+      expect(uiHandler.state).to.equal(AdDisplayState.NOT_LAID_OUT);
+    });
   });
 });

--- a/extensions/amp-anim/0.1/test/test-amp-anim.js
+++ b/extensions/amp-anim/0.1/test/test-amp-anim.js
@@ -16,12 +16,17 @@
 
 import {AmpAnim} from '../amp-anim';
 
-describe('amp-anim', () => {
+describes.realWin('amp-anim', {
+  amp: {
+    ampdoc: 'single',
+    extensions: ['amp-anim'],
+  },
+}, env => {
 
   // TODO(#5589): Add more tests for amp-anim.
 
   it('should propagate ARIA attributes', () => {
-    const el = document.createElement('amp-anim');
+    const el = env.win.document.createElement('amp-anim');
     el.setAttribute('src', 'test.jpg');
     el.setAttribute('width', 100);
     el.setAttribute('height', 100);

--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -18,22 +18,23 @@
 import {AdStrategy} from '../ad-strategy';
 import {PlacementState, getPlacementsFromConfigObj} from '../placement';
 import {AdTracker} from '../ad-tracker';
-import * as sinon from 'sinon';
 
-describe('ad-strategy', () => {
+describes.realWin('amp-strategy', {
+  amp: {
+    runtimeOn: true,
+    ampdoc: 'single',
+    extensions: ['amp-ad'],
+  },
+}, env => {
 
   let sandbox;
   let container;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-    container = document.createElement('div');
-    document.body.appendChild(container);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-    document.body.removeChild(container);
+    sandbox = env.sandbox;
+    container = env.win.document.createElement('div');
+    env.win.frameElement.style.height = '1000px';
+    env.win.document.body.appendChild(container);
   });
 
   it('should place an ad in the first placement only with correct attributes',
@@ -64,7 +65,7 @@ describe('ad-strategy', () => {
             },
           ],
         };
-        const placements = getPlacementsFromConfigObj(window, configObj);
+        const placements = getPlacementsFromConfigObj(env.win, configObj);
         expect(placements).to.have.lengthOf(2);
 
         const adStrategy = new AdStrategy('adsense', placements, [
@@ -117,7 +118,7 @@ describe('ad-strategy', () => {
         },
       ],
     };
-    const placements = getPlacementsFromConfigObj(window, configObj);
+    const placements = getPlacementsFromConfigObj(env.win, configObj);
 
     expect(placements).to.have.lengthOf(2);
     sandbox.stub(placements[0], 'placeAd', () => {
@@ -183,7 +184,7 @@ describe('ad-strategy', () => {
         },
       ],
     };
-    const placements = getPlacementsFromConfigObj(window, configObj);
+    const placements = getPlacementsFromConfigObj(env.win, configObj);
     expect(placements).to.have.lengthOf(2);
 
     const adStrategy = new AdStrategy('adsense', placements, [
@@ -245,7 +246,7 @@ describe('ad-strategy', () => {
         },
       ],
     };
-    const placements = getPlacementsFromConfigObj(window, configObj);
+    const placements = getPlacementsFromConfigObj(env.win, configObj);
     expect(placements).to.have.lengthOf(2);
 
     const adStrategy = new AdStrategy('adsense', placements, [
@@ -315,7 +316,7 @@ describe('ad-strategy', () => {
         },
       ],
     };
-    const placements = getPlacementsFromConfigObj(window, configObj);
+    const placements = getPlacementsFromConfigObj(env.win, configObj);
     expect(placements).to.have.lengthOf(2);
 
     const adStrategy = new AdStrategy('adsense', placements, [
@@ -369,7 +370,7 @@ describe('ad-strategy', () => {
             },
           ],
         };
-        const placements = getPlacementsFromConfigObj(window, configObj);
+        const placements = getPlacementsFromConfigObj(env.win, configObj);
 
         expect(placements).to.have.lengthOf(2);
         sandbox.stub(placements[0], 'placeAd', () => {

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -18,9 +18,14 @@ import {AmpAutoAds} from '../amp-auto-ads';
 import {toggleExperiment} from '../../../../src/experiments';
 import {xhrFor} from '../../../../src/xhr';
 import {waitForChild} from '../../../../src/dom';
-import * as sinon from 'sinon';
 
-describe('amp-auto-ads', () => {
+describes.realWin('amp-auto-ads', {
+  amp: {
+    runtimeOn: true,
+    ampdoc: 'single',
+    extensions: ['amp-ad', 'amp-auto-ads'],
+  },
+}, env => {
 
   const AD_CLIENT = 'ca-pub-1234';
 
@@ -40,49 +45,49 @@ describe('amp-auto-ads', () => {
     // An alternative to doing this clean up would be for this test to do all
     // its DOM stuff in a dedicated window, but trying that seems to result in a
     // lot of errors.
-    const ampAds = document.getElementsByTagName('AMP-AD');
+    const ampAds = env.win.document.getElementsByTagName('AMP-AD');
     while (ampAds.length) {
       ampAds[0].parentNode.removeChild(ampAds[0]);
     }
 
-    toggleExperiment(window, 'amp-auto-ads', true);
-    sandbox = sinon.sandbox.create();
+    toggleExperiment(env.win, 'amp-auto-ads', true);
+    sandbox = env.sandbox;
 
-    container = document.createElement('div');
-    document.body.appendChild(container);
+    container = env.win.document.createElement('div');
+    env.win.document.body.appendChild(container);
 
-    anchor1 = document.createElement('div');
+    anchor1 = env.win.document.createElement('div');
     anchor1.id = 'anId1';
     container.appendChild(anchor1);
 
-    const spacer = document.createElement('div');
+    const spacer = env.win.document.createElement('div');
     spacer.style.height = '1000px';
     container.appendChild(spacer);
 
-    anchor2 = document.createElement('div');
+    anchor2 = env.win.document.createElement('div');
     anchor2.id = 'anId2';
     container.appendChild(anchor2);
 
-    const spacer2 = document.createElement('div');
+    const spacer2 = env.win.document.createElement('div');
     spacer2.style.height = '499px';
     container.appendChild(spacer2);
 
-    anchor3 = document.createElement('div');
+    anchor3 = env.win.document.createElement('div');
     anchor3.id = 'anId3';
     container.appendChild(anchor3);
 
-    const spacer3 = document.createElement('div');
+    const spacer3 = env.win.document.createElement('div');
     spacer3.style.height = '500px';
     container.appendChild(spacer3);
 
-    anchor4 = document.createElement('div');
+    anchor4 = env.win.document.createElement('div');
     anchor4.id = 'anId4';
     container.appendChild(anchor4);
 
-    ampAutoAdsElem = document.createElement('amp-auto-ads');
-    document.body.appendChild(ampAutoAdsElem);
+    ampAutoAdsElem = env.win.document.createElement('amp-auto-ads');
+    env.win.document.body.appendChild(ampAutoAdsElem);
 
-    xhr = xhrFor(window);
+    xhr = xhrFor(env.win);
     xhr.fetchJson = () => {
       return Promise.resolve({
         placements: [
@@ -122,12 +127,6 @@ describe('amp-auto-ads', () => {
     ampAutoAds = new AmpAutoAds(ampAutoAdsElem);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-    document.body.removeChild(container);
-    document.body.removeChild(ampAutoAdsElem);
-  });
-
   function verifyAdElement(adElement) {
     expect(adElement.tagName).to.equal('AMP-AD');
     expect(adElement.getAttribute('type')).to.equal('adsense');
@@ -163,7 +162,7 @@ describe('amp-auto-ads', () => {
     return ampAutoAds.layoutCallback().then(() => {
       expect(xhr.fetchJson).to.have.been.calledWith(
           '//pagead2.googlesyndication.com/getconfig/ama?client=' +
-          AD_CLIENT + '&plah=foo.bar&ama_t=amp', {
+          AD_CLIENT + '&plah=localhost&ama_t=amp', {
             mode: 'cors',
             method: 'GET',
             credentials: 'omit',
@@ -191,7 +190,7 @@ describe('amp-auto-ads', () => {
   });
 
   it('should not try and fetch config if experiment off', () => {
-    toggleExperiment(window, 'amp-auto-ads', false);
+    toggleExperiment(env.win, 'amp-auto-ads', false);
     ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
     ampAutoAdsElem.setAttribute('type', 'adsense');
 

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -17,22 +17,22 @@
 import {AdTracker} from '../ad-tracker';
 import {resourcesForDoc} from '../../../../src/resources';
 import {PlacementState, getPlacementsFromConfigObj} from '../placement';
-import * as sinon from 'sinon';
 
-describe('placement', () => {
+describes.realWin('placement', {
+  amp: {
+    runtimeOn: true,
+    ampdoc: 'single',
+    extensions: ['amp-ad'],
+  },
+}, env => {
 
   let sandbox;
   let container;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-    container = document.createElement('div');
-    document.body.appendChild(container);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-    document.body.removeChild(container);
+    sandbox = env.sandbox.create();
+    container = env.win.document.createElement('div');
+    env.win.document.body.appendChild(container);
   });
 
   describe('getAdElement', () => {
@@ -41,7 +41,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -65,7 +65,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -91,7 +91,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -117,7 +117,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -143,7 +143,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -169,7 +169,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -194,7 +194,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -233,7 +233,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -270,7 +270,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -306,7 +306,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -342,7 +342,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -381,7 +381,7 @@ describe('placement', () => {
         return Promise.resolve();
       });
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -412,7 +412,7 @@ describe('placement', () => {
         return Promise.reject(new Error('Resize failed'));
       });
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -441,7 +441,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -470,7 +470,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -496,7 +496,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -523,7 +523,7 @@ describe('placement', () => {
       container.appendChild(anchor);
       anchor.appendChild(document.createElement('div'));
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -550,7 +550,7 @@ describe('placement', () => {
       container.appendChild(anchor);
       anchor.appendChild(document.createElement('div'));
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -580,7 +580,7 @@ describe('placement', () => {
       anchor2.className = 'aClass';
       container.appendChild(anchor2);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -610,7 +610,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -625,12 +625,12 @@ describe('placement', () => {
     });
 
     it('should return empty array when no placements array', () => {
-      const placements = getPlacementsFromConfigObj(window, {});
+      const placements = getPlacementsFromConfigObj(env.win, {});
       expect(placements).to.be.empty;
     });
 
     it('should not return a placement with no anchor property', () => {
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             pos: 1,
@@ -646,7 +646,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {},
@@ -663,7 +663,7 @@ describe('placement', () => {
       anchor.id = 'anId';
       container.appendChild(anchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -683,7 +683,7 @@ describe('placement', () => {
           anchor.id = 'wrongId';
           container.appendChild(anchor);
 
-          const placements = getPlacementsFromConfigObj(window, {
+          const placements = getPlacementsFromConfigObj(env.win, {
             placements: [
               {
                 anchor: {
@@ -706,7 +706,7 @@ describe('placement', () => {
       anchor2.className = 'aClass';
       container.appendChild(anchor2);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -732,7 +732,7 @@ describe('placement', () => {
       anchor2.className = 'aClass';
       container.appendChild(anchor2);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -760,7 +760,7 @@ describe('placement', () => {
       anchor2.className = 'aClass';
       container.appendChild(anchor2);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -790,7 +790,7 @@ describe('placement', () => {
           container.appendChild(anchor);
           anchor.appendChild(document.createTextNode('abcd'));
 
-          const placements = getPlacementsFromConfigObj(window, {
+          const placements = getPlacementsFromConfigObj(env.win, {
             placements: [
               {
                 anchor: {
@@ -833,7 +833,7 @@ describe('placement', () => {
       subAnchor2.className = 'sub-class';
       anchor.appendChild(subAnchor2);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -867,7 +867,7 @@ describe('placement', () => {
       subAnchor2.className = 'sub-class';
       anchor.appendChild(subAnchor2);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -915,7 +915,7 @@ describe('placement', () => {
       nonSubAnchor.className = 'sub-class1';
       anchor.appendChild(nonSubAnchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -956,7 +956,7 @@ describe('placement', () => {
       nonSubAnchor2.className = 'non-sub-class';
       anchor.appendChild(nonSubAnchor2);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -988,7 +988,7 @@ describe('placement', () => {
       subAnchor.className = 'class3';
       anchor.appendChild(subAnchor);
 
-      const placements = getPlacementsFromConfigObj(window, {
+      const placements = getPlacementsFromConfigObj(env.win, {
         placements: [
           {
             anchor: {
@@ -1027,7 +1027,7 @@ describe('placement', () => {
           anchor.appendChild(subAnchor3);
           subAnchor3.appendChild(document.createTextNode('abcd'));
 
-          const placements = getPlacementsFromConfigObj(window, {
+          const placements = getPlacementsFromConfigObj(env.win, {
             placements: [
               {
                 anchor: {
@@ -1064,7 +1064,7 @@ describe('placement', () => {
           anchor.appendChild(subAnchor2);
           subAnchor2.appendChild(document.createTextNode('abcd'));
 
-          const placements = getPlacementsFromConfigObj(window, {
+          const placements = getPlacementsFromConfigObj(env.win, {
             placements: [
               {
                 anchor: {

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -23,11 +23,17 @@ import {
 } from '../../../../src/service';
 import {loadPromise} from '../../../../src/event-helper';
 import {installTimerService} from '../../../../src/service/timer-impl';
-import * as sinon from 'sinon';
 
 
-describe('amp-install-serviceworker', () => {
+describes.realWin('amp-install-serviceworker', {
+  amp: {
+    runtimeOn: false,
+    ampdoc: 'single',
+    extensions: ['amp-install-serviceworker'],
+  },
+}, env => {
 
+  let doc;
   let clock;
   let sandbox;
   let container;
@@ -35,25 +41,19 @@ describe('amp-install-serviceworker', () => {
   let maybeInstallUrlRewriteStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    doc = env.win.document;
+    sandbox = env.sandbox;
     clock = sandbox.useFakeTimers();
-    ampdoc = ampdocServiceFor(window).getAmpDoc();
-    container = document.createElement('div');
-    document.body.appendChild(container);
+    ampdoc = ampdocServiceFor(env.win).getAmpDoc();
+    container = doc.createElement('div');
+    env.win.document.body.appendChild(container);
     maybeInstallUrlRewriteStub = sandbox.stub(
         AmpInstallServiceWorker.prototype,
         'maybeInstallUrlRewrite_');
   });
 
-  afterEach(() => {
-    sandbox.restore();
-    if (container.parentNode) {
-      container.parentNode.removeChild(container);
-    }
-  });
-
   it('should install for same origin', () => {
-    const install = document.createElement('div');
+    const install = doc.createElement('div');
     container.appendChild(install);
     install.setAttribute('src', 'https://example.com/sw.js');
     const implementation = new AmpInstallServiceWorker(install);
@@ -84,7 +84,7 @@ describe('amp-install-serviceworker', () => {
   });
 
   it('should be ok without service worker.', () => {
-    const install = document.createElement('amp-install-serviceworker');
+    const install = doc.createElement('amp-install-serviceworker');
     const implementation = install.implementation_;
     expect(implementation).to.be.defined;
     install.setAttribute('src', 'https://example.com/sw.js');
@@ -100,7 +100,7 @@ describe('amp-install-serviceworker', () => {
   });
 
   it('should do nothing with non-matching origins', () => {
-    const install = document.createElement('amp-install-serviceworker');
+    const install = doc.createElement('amp-install-serviceworker');
     const implementation = install.implementation_;
     expect(implementation).to.be.defined;
     install.setAttribute('src', 'https://other-origin.com/sw.js');
@@ -122,7 +122,7 @@ describe('amp-install-serviceworker', () => {
   });
 
   it('should do nothing on proxy without iframe URL', () => {
-    const install = document.createElement('amp-install-serviceworker');
+    const install = doc.createElement('amp-install-serviceworker');
     const implementation = install.implementation_;
     expect(implementation).to.be.defined;
     install.setAttribute('src', 'https://cdn.ampproject.org/sw.js');
@@ -146,9 +146,10 @@ describe('amp-install-serviceworker', () => {
     expect(install.children).to.have.length(0);
   });
 
+  // Rewrite as proper mock window test.
   describe('proxy iframe injection', () => {
 
-    let documentInfo;
+    let docInfo;
     let install;
     let implementation;
     let whenVisible;
@@ -177,21 +178,21 @@ describe('amp-install-serviceworker', () => {
         setTimeout: window.setTimeout,
         clearTimeout: window.clearTimeout,
         document: {
-          nodeType: /* document */ 9,
-          createElement: document.createElement.bind(document),
+          nodeType: /* doc */ 9,
+          createElement: doc.createElement.bind(doc),
         },
       };
       installTimerService(win);
       win.document.defaultView = win;
       implementation.win = win;
-      documentInfo = {
+      docInfo = {
         canonicalUrl: 'https://www.example.com/path',
         sourceUrl: 'https://source.example.com/path',
       };
-      resetServiceForTesting(window, 'documentInfo');
-      getServiceForDoc(document, 'documentInfo', () => {
+      resetServiceForTesting(env.win, 'documentInfo');
+      getServiceForDoc(doc, 'documentInfo', () => {
         return {
-          get: () => documentInfo,
+          get: () => docInfo,
         };
       });
       whenVisible = Promise.resolve();
@@ -242,7 +243,7 @@ describe('amp-install-serviceworker', () => {
         testIframe);
 
     it('should inject iframe on proxy if provided (valid source)', () => {
-      documentInfo = {
+      docInfo = {
         canonicalUrl: 'https://canonical.example.com/path',
         sourceUrl: 'https://www.example.com/path',
       };

--- a/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
@@ -14,58 +14,50 @@
  * limitations under the License.
  */
 
-    import '../amp-pinterest';
-    import {adopt} from '../../../../src/runtime';
-    import {timerFor} from '../../../../src/timer';
+import '../amp-pinterest';
+import {adopt} from '../../../../src/runtime';
 
-    adopt(window);
+adopt(window);
 
-    describe('amp-pinterest', () => {
+describes.realWin('amp-pinterest', {
+  amp: {
+    runtimeOn: false,
+    ampdoc: 'single',
+    extensions: ['amp-pinterest'],
+  },
+}, env => {
 
-      function createDivPromise() {
-        return new Promise(function(resolve) {
-          const div = document.createElement('div');
-          resolve({
-            div,
-            addElement: function(element) {
-              div.appendChild(element);
-              return timerFor(window).promise(16).then(() => {
-                element.implementation_.layoutCallback();
-                return element;
-              });
-            },
-          });
-          document.body.appendChild(div);
-        });
-      };
+  function getPin(pinDo, pinUrl, pinMedia, pinDescription) {
+    const div = document.createElement('div');
+    env.win.document.body.appendChild(div);
 
-      function getPin(pinDo, pinUrl, pinMedia, pinDescription) {
-        return createDivPromise().then(div => {
-          const pin = document.createElement('amp-pinterest');
-          pin.setAttribute('data-do', pinDo);
-          pin.setAttribute('data-url', pinUrl);
-          pin.setAttribute('data-media', pinMedia);
-          pin.setAttribute('data-description', pinDescription);
-          return div.addElement(pin);
-        });
-      };
-
-      it('renders', () => {
-        return getPin('buttonPin',
-          'http://www.flickr.com/photos/kentbrew/6851755809/',
-          'http://c2.staticflickr.com/8/7027/6851755809_df5b2051c9_b.jpg',
-          'Next stop: Pinterest'
-        ).then(pin => {
-          const a = pin.querySelector('a');
-          const href = a.href.replace(/&guid=\w+/, '');
-          expect(a).to.not.be.null;
-          expect(a.tagName).to.equal('A');
-          expect(href).to.equal('https://www.pinterest.com/pin/create/' +
-            'button/?amp=1&url=http%3A%2F%2Fwww.flickr.com%' +
-            '2Fphotos%2Fkentbrew%2F6851755809%2F&media=http%3A%2F%2Fc2.s' +
-            'taticflickr.com%2F8%2F7027%2F6851755809_df5b2051c9_b.jpg&de' +
-            'scription=Next%20stop%3A%20Pinterest');
-        });
-      });
-
+    const pin = env.win.document.createElement('amp-pinterest');
+    pin.setAttribute('data-do', pinDo);
+    pin.setAttribute('data-url', pinUrl);
+    pin.setAttribute('data-media', pinMedia);
+    pin.setAttribute('data-description', pinDescription);
+    div.appendChild(pin);
+    return pin.implementation_.layoutCallback().then(() => {
+      return pin;
     });
+  };
+
+  it('renders', () => {
+    return getPin('buttonPin',
+      'http://www.flickr.com/photos/kentbrew/6851755809/',
+      'http://c2.staticflickr.com/8/7027/6851755809_df5b2051c9_b.jpg',
+      'Next stop: Pinterest'
+    ).then(pin => {
+      const a = pin.querySelector('a');
+      const href = a.href.replace(/&guid=\w+/, '');
+      expect(a).to.not.be.null;
+      expect(a.tagName).to.equal('A');
+      expect(href).to.equal('https://www.pinterest.com/pin/create/' +
+        'button/?amp=1&url=http%3A%2F%2Fwww.flickr.com%' +
+        '2Fphotos%2Fkentbrew%2F6851755809%2F&media=http%3A%2F%2Fc2.s' +
+        'taticflickr.com%2F8%2F7027%2F6851755809_df5b2051c9_b.jpg&de' +
+        'scription=Next%20stop%3A%20Pinterest');
+    });
+  });
+
+});

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -16,7 +16,7 @@
 
 import '../amp-selector';
 
-describes.realWin('amp-selector', {
+describes.realWin.only('amp-selector', {
   win: { /* window spec */
     location: '...',
     historyOff: false,

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -16,7 +16,7 @@
 
 import '../amp-selector';
 
-describes.realWin.only('amp-selector', {
+describes.realWin('amp-selector', {
   win: { /* window spec */
     location: '...',
     historyOff: false,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "gzip-size": "3.0.0",
     "jison": "0.4.15",
     "jsdom": "9.2.1",
-    "json-stable-stringify": "^1.0.1",
+    "json-stable-stringify": "1.0.1",
     "karma": "0.13.21",
     "karma-browserify": "5.1.1",
     "karma-chai": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "gzip-size": "3.0.0",
     "jison": "0.4.15",
     "jsdom": "9.2.1",
+    "json-stable-stringify": "^1.0.1",
     "karma": "0.13.21",
     "karma-browserify": "5.1.1",
     "karma-chai": "0.1.0",

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -894,7 +894,8 @@ export function registerForUnitTest(win) {
 export function registerElementForTesting(win, elementName) {
   const element = elementsForTesting[elementName];
   if (!element) {
-    throw new Error('test element not found: ' + elementName);
+    throw new Error('test element not found: ' + elementName +
+      '\nKnown elements ' + Object.keys(elementsForTesting).sort());
   }
   win.AMP.registerElement(element.name, element.implementationClass,
       element.css);

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -34,6 +34,7 @@ import {
 } from '../src/error';
 import {resetExperimentTogglesForTesting} from '../src/experiments';
 import * as describes from '../testing/describes';
+import stringify from 'json-stable-stringify';
 
 
 // All exposed describes.
@@ -315,8 +316,8 @@ chai.Assertion.addMethod('display', function(display) {
 
 chai.Assertion.addMethod('jsonEqual', function(compare) {
   const obj = this._obj;
-  const a = JSON.stringify(compare);
-  const b = JSON.stringify(obj);
+  const a = stringify(compare);
+  const b = stringify(obj);
   this.assert(
     a == b,
     'expected JSON to be equal.\nExp: #{exp}\nAct: #{act}',

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -206,7 +206,12 @@ describe('3p-frame', () => {
       expect(name.attributes._context.domFingerprint).to.exist;
       delete name.attributes._context.domFingerprint;
       delete parsedFragment._context.domFingerprint;
-      expect(name.attributes).to.deep.equal(parsedFragment);
+      // Value changes between tests.
+      // TODO: Switch test to isolated window.
+      expect(name.attributes._context.experimentToggles).to.exist;
+      delete name.attributes._context.experimentToggles;
+      delete parsedFragment._context.experimentToggles;
+      expect(name.attributes).to.deep.jsonEqual(parsedFragment);
 
       // Switch to same origin for inner tests.
       iframe.src = '/dist.3p/current/frame.max.html';

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,6 +42,16 @@ acorn-globals@^1.0.4:
   dependencies:
     acorn "^2.1.0"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@4.0.4, acorn@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
+
 acorn@^1.0.3:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-1.2.2.tgz#c8ce27de0acc76d896d2b1fad3df588d9e82f014"
@@ -50,13 +60,9 @@ acorn@^2.1.0, acorn@^2.4.0, acorn@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
 
-acorn@^3.1.0:
+acorn@^3.0.4, acorn@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-acorn@^4.0.0:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
 adm-zip@~0.4.3:
   version "0.4.7"
@@ -72,6 +78,17 @@ agent-base@2:
   dependencies:
     extend "~3.0.0"
     semver "~5.0.1"
+
+ajv-keywords@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+
+ajv@^4.7.0:
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.3.tgz#ce30bdb90d1254f762c75af915fb3a63e7183d22"
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -270,9 +287,9 @@ assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-1.3.0.tgz#03939a622582a812cc202320a0b9a56c9b815849"
+assert@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
     util "0.10.3"
 
@@ -288,10 +305,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.4:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.4.tgz#410d1f81890aeb8e0a38621558ba5869ae53c91b"
@@ -306,13 +319,9 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@1.4.0:
+async@1.4.0, async@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/async/-/async-1.4.0.tgz#35f86f83c59e0421d099cd9a91d8278fb578c00d"
-
-async@^1.4.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.0.1:
   version "2.1.4"
@@ -336,7 +345,18 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-autoprefixer@6.6.1, autoprefixer@^6.0.3:
+autoprefixer@6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.0.tgz#88992cf04df141e7b8293550f2ee716c565d1cae"
+  dependencies:
+    browserslist "~1.6.0"
+    caniuse-db "^1.0.30000613"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^5.2.11"
+    postcss-value-parser "^3.2.3"
+
+autoprefixer@^6.0.3:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.6.1.tgz#11a4077abb4b313253ec2f6e1adb91ad84253519"
   dependencies:
@@ -448,7 +468,7 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
-babel-code-frame@^6.20.0, babel-code-frame@^6.7.5:
+babel-code-frame@^6.16.0, babel-code-frame@^6.20.0, babel-code-frame@^6.7.5:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
   dependencies:
@@ -1390,16 +1410,17 @@ browserify-zlib@~0.1.2:
   dependencies:
     pako "~0.2.0"
 
-browserify@13.0.0, browserify@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/browserify/-/browserify-13.0.0.tgz#8f223bb24ff4ee4335e6bea9671de294e43ba6a3"
+browserify@14.0.0, browserify@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/browserify/-/browserify-14.0.0.tgz#67e6cfe7acb2fb1a1908e8a763452306de0bcf38"
   dependencies:
     JSONStream "^1.0.3"
-    assert "~1.3.0"
+    assert "^1.4.0"
     browser-pack "^6.0.1"
     browser-resolve "^1.11.0"
     browserify-zlib "~0.1.2"
-    buffer "^4.1.0"
+    buffer "^5.0.2"
+    cached-path-relative "^1.0.0"
     concat-stream "~1.5.1"
     console-browserify "^1.1.0"
     constants-browserify "~1.0.0"
@@ -1409,15 +1430,14 @@ browserify@13.0.0, browserify@^13.0.0:
     domain-browser "~1.1.0"
     duplexer2 "~0.1.2"
     events "~1.1.0"
-    glob "^5.0.15"
+    glob "^7.1.0"
     has "^1.0.0"
     htmlescape "^1.1.0"
     https-browserify "~0.0.0"
     inherits "~2.0.1"
     insert-module-globals "^7.0.0"
-    isarray "0.0.1"
     labeled-stream-splicer "^2.0.0"
-    module-deps "^4.0.2"
+    module-deps "^4.0.8"
     os-browserify "~0.1.1"
     parents "^1.0.1"
     path-browserify "~0.0.0"
@@ -1428,7 +1448,7 @@ browserify@13.0.0, browserify@^13.0.0:
     readable-stream "^2.0.2"
     resolve "^1.1.4"
     shasum "^1.0.0"
-    shell-quote "^1.4.3"
+    shell-quote "^1.6.1"
     stream-browserify "^2.0.0"
     stream-http "^2.0.0"
     string_decoder "~0.10.0"
@@ -1447,6 +1467,13 @@ browserslist@^1.0.1, browserslist@^1.5.2, browserslist@~1.5.1:
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.5.2.tgz#1c82fde0ee8693e6d15c49b7bff209dc06298c56"
   dependencies:
     caniuse-db "^1.0.30000604"
+
+browserslist@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.6.0.tgz#85fb7c993540d3fda31c282baf7f5aee698ac9ee"
+  dependencies:
+    caniuse-db "^1.0.30000613"
+    electron-to-chromium "^1.2.0"
 
 buf-compare@^1.0.0:
   version "1.0.1"
@@ -1468,13 +1495,12 @@ buffer-xor@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
 
-buffer@^4.1.0:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+buffer@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.5.tgz#35c9393244a90aff83581063d16f0882cecc9418"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
-    isarray "^1.0.0"
 
 bufferstreams@1.0.1:
   version "1.0.1"
@@ -1533,9 +1559,19 @@ call-signature@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/call-signature/-/call-signature-0.0.2.tgz#a84abc825a55ef4cb2b028bd74e205a65b9a4996"
 
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
 callsite@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -1562,7 +1598,7 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.3.0"
     shelljs "^0.7.0"
 
-caniuse-db@^1.0.30000346, caniuse-db@^1.0.30000604:
+caniuse-db@^1.0.30000346, caniuse-db@^1.0.30000604, caniuse-db@^1.0.30000613:
   version "1.0.30000613"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000613.tgz#639133b7a5380c1416f9701d23d54d093dd68299"
 
@@ -1695,6 +1731,10 @@ cli-width@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-1.1.1.tgz#a4d293ef67ebb7b88d4a4d42c0ccf00c4d1e366d"
 
+cli-width@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -1720,6 +1760,10 @@ co-with-promise@^4.6.0:
   resolved "https://registry.yarnpkg.com/co-with-promise/-/co-with-promise-4.6.0.tgz#413e7db6f5893a60b942cf492c4bec93db415ab7"
   dependencies:
     pinkie-promise "^1.0.0"
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 coa@~1.0.1:
   version "1.0.1"
@@ -2121,10 +2165,6 @@ dateformat@^1.0.11, dateformat@^1.0.7-1.2.3:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-deap@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/deap/-/deap-1.0.0.tgz#b148bf82430a27699b7483a03eb6b67585bfc888"
-
 debug@2, debug@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
@@ -2298,6 +2338,13 @@ doctrine@^0.7.1:
     esutils "^1.1.6"
     isarray "0.0.1"
 
+doctrine@^1.2.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
 document-register-element@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/document-register-element/-/document-register-element-1.1.1.tgz#dd39d88814fdd14671aed85b9a5f0266e3aa9b1e"
@@ -2367,6 +2414,10 @@ ee-first@1.0.5:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+electron-to-chromium@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.2.tgz#e41bc9488c88e3cfa1e94bde28e8420d7d47c47c"
 
 elliptic@^6.0.0:
   version "6.3.2"
@@ -2510,11 +2561,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@1.0.2:
+escape-string-regexp@1.0.2, escape-string-regexp@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2539,7 +2590,7 @@ escodegen@^1.6.1:
   optionalDependencies:
     source-map "~0.2.0"
 
-escope@^3.3.0:
+escope@^3.3.0, escope@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
   dependencies:
@@ -2552,7 +2603,46 @@ eslint-plugin-google-camelcase@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-google-camelcase/-/eslint-plugin-google-camelcase-0.0.2.tgz#0c27555e4782073442d034a3db1f214ee0b37401"
 
-eslint@1.10.3, eslint@^1.4.0:
+eslint@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.14.1.tgz#8a62175f2255109494747a1b25128d97b8eb3d97"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.4.6"
+    debug "^2.1.1"
+    doctrine "^1.2.2"
+    escope "^3.6.0"
+    espree "^3.3.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
+eslint@^1.4.0:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-1.10.3.tgz#fb19a91b13c158082bbca294b17d979bc8353a0a"
   dependencies:
@@ -2602,6 +2692,13 @@ espower-location-detector@^1.0.0:
 espree@^2.2.4:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/espree/-/espree-2.2.5.tgz#df691b9310889402aeb29cc066708c56690b854b"
+
+espree@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
+  dependencies:
+    acorn "4.0.4"
+    acorn-jsx "^3.0.0"
 
 esprima-fb@~15001.1001.0-dev-harmony-fb:
   version "15001.1001.0-dev-harmony-fb"
@@ -2771,7 +2868,7 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
-fancy-log@^1.0.0, fancy-log@^1.1.0:
+fancy-log@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.0.tgz#45be17d02bb9917d60ccffd4995c999e6c8c9948"
   dependencies:
@@ -2802,6 +2899,13 @@ figures@^1.3.5, figures@^1.4.0:
 file-entry-cache@^1.1.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-1.3.1.tgz#44c61ea607ae4be9c1402f41f44270cbfe334ff8"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
@@ -3140,7 +3244,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.5:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3183,7 +3287,7 @@ globals@^8.11.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-8.18.0.tgz#93d4a62bdcac38cfafafc47d6b034768cb0ffcb4"
 
-globals@^9.0.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
 
@@ -3361,16 +3465,16 @@ gulp-sourcemaps@1.5.2:
     through2 "^0.6.3"
     vinyl "^0.4.6"
 
-gulp-uglify@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/gulp-uglify/-/gulp-uglify-1.5.1.tgz#9e13294247354c91e15ace116b1630789366206a"
+gulp-uglify@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/gulp-uglify/-/gulp-uglify-2.0.1.tgz#e8cfb831014fc9ff2e055e33785861830d499365"
   dependencies:
-    deap "^1.0.0"
-    fancy-log "^1.0.0"
-    gulp-util "^3.0.0"
-    isobject "^2.0.0"
+    gulplog "^1.0.0"
+    has-gulplog "^0.1.0"
+    lodash "^4.13.1"
+    make-error-cause "^1.1.1"
     through2 "^2.0.0"
-    uglify-js "2.6.0"
+    uglify-js "2.7.5"
     uglify-save-license "^0.4.1"
     vinyl-sourcemaps-apply "^0.2.0"
 
@@ -3694,6 +3798,10 @@ ignore-by-default@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
 
+ignore@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.2.tgz#1c51e1ef53bab6ddc15db4d9ac4ec139eceb3410"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -3752,6 +3860,24 @@ inquirer@^0.11.0:
     cli-width "^1.0.1"
     figures "^1.3.5"
     lodash "^3.3.1"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
+
+inquirer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
     readline2 "^1.0.1"
     run-async "^0.1.0"
     rx-lite "^3.1.2"
@@ -3864,6 +3990,10 @@ is-fullwidth-code-point@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
   dependencies:
     number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -4099,7 +4229,7 @@ js-yaml@3.4.5:
     argparse "^1.0.2"
     esprima "^2.6.0"
 
-js-yaml@^3.2.6:
+js-yaml@^3.2.6, js-yaml@^3.5.1:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -4151,7 +4281,7 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stable-stringify@^1.0.0:
+json-stable-stringify@1.0.1, json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -4212,9 +4342,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-karma-browserify@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/karma-browserify/-/karma-browserify-5.0.2.tgz#e425f1d7d2d24a2e639821d79bda58b3ff4f1e75"
+karma-browserify@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/karma-browserify/-/karma-browserify-5.1.1.tgz#f642d70d776d9ab3b73526c5732abcfea2400319"
   dependencies:
     convert-source-map "^1.1.3"
     hat "^0.0.3"
@@ -4361,19 +4491,19 @@ leven@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/leven/-/leven-1.0.2.tgz#9144b6eebca5f1d0680169f1a6770dcea60b75c3"
 
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 levn@~0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.2.5.tgz#ba8d339d0ca4a610e3a3f145b9caf48807155054"
   dependencies:
     prelude-ls "~1.1.0"
     type-check "~0.3.1"
-
-levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
 
 lex-parser@0.1.x, lex-parser@~0.1.3:
   version "0.1.4"
@@ -4795,7 +4925,7 @@ lodash@3.10.1, lodash@^3.1.0, lodash@^3.10.0, lodash@^3.10.1, lodash@^3.3.1, lod
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.14.0, lodash@^4.2.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4847,11 +4977,7 @@ lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
-lru-cache@2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
-
-lru-cache@2.2.x:
+lru-cache@2, lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
 
@@ -4865,6 +4991,16 @@ lru-cache@^4.0.1:
 macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
+
+make-error-cause@^1.1.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/make-error-cause/-/make-error-cause-1.2.2.tgz#df0388fcd0b37816dff0a5fb8108939777dcbc9d"
+  dependencies:
+    make-error "^1.2.0"
+
+make-error@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.2.1.tgz#9a6dfb4844423b9f145806728d05c6e935670e75"
 
 map-cache@^0.2.0:
   version "0.2.2"
@@ -4993,13 +5129,13 @@ minimatch@0.3:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@3.0.0:
+minimatch@3.0.0, minimatch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.0.tgz#5236157a51e4f004c177fb3c527ff7dd78f0ef83"
   dependencies:
@@ -5055,9 +5191,9 @@ mocha@2.5.3:
     supports-color "1.2.0"
     to-iso-string "0.0.2"
 
-module-deps@^4.0.2:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-4.0.8.tgz#55fd70623399706c3288bef7a609ff1e8c0ed2bb"
+module-deps@^4.0.8:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-4.1.0.tgz#ade2d5f58fda642f9a2c2d7a036b342f9a0df647"
   dependencies:
     JSONStream "^1.0.3"
     browser-resolve "^1.7.0"
@@ -5127,6 +5263,10 @@ nan@^2.3.0:
 natives@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -5342,7 +5482,7 @@ optionator@^0.6.0:
     type-check "~0.3.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -5618,6 +5758,10 @@ plur@^2.0.0:
   dependencies:
     irregular-plurals "^1.0.0"
 
+pluralize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
 postcss-calc@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-5.3.1.tgz#77bae7ca928ad85716e2fda42f261bf7c1d65b5e"
@@ -5821,6 +5965,15 @@ postcss@5.2.10, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.13, postcss@^5.0.
     source-map "^0.5.6"
     supports-color "^3.1.2"
 
+postcss@^5.2.11:
+  version "5.2.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.12.tgz#6a2b15e35dd65634441bb0961fa796904c7890e0"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
 power-assert-context-formatter@^1.0.7:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz#edba352d3ed8a603114d667265acce60d689ccdf"
@@ -5965,6 +6118,10 @@ process-nextick-args@~1.0.6:
 process@^0.11.1, process@~0.11.0:
   version "0.11.9"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
+
+progress@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
 promise-each@^2.2.0:
   version "2.2.0"
@@ -6125,9 +6282,18 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@^1.0.33, readable-stream@~1.0.17, readable-stream@~1.0.2, readable-stream@~1.0.24, readable-stream@~1.0.26, readable-stream@~1.0.33:
+"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17, readable-stream@~1.0.2, readable-stream@~1.0.24, readable-stream@~1.0.26, readable-stream@~1.0.33:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@^1.0.33, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -6145,15 +6311,6 @@ readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
-
-readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-stream@~2.0.0, readable-stream@~2.0.5:
   version "2.0.6"
@@ -6195,20 +6352,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"
@@ -6441,6 +6589,13 @@ require-precompiled@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/require-precompiled/-/require-precompiled-0.1.0.tgz#5a1b52eb70ebed43eb982e974c85ab59571e56fa"
 
+require-uncached@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
 requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -6457,6 +6612,10 @@ resolve-dir@^0.1.0:
   dependencies:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
 resolve-from@^2.0.0:
   version "2.0.0"
@@ -6628,7 +6787,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shell-quote@^1.4.2, shell-quote@^1.4.3:
+shell-quote@^1.4.2, shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
   dependencies:
@@ -6641,7 +6800,7 @@ shelljs@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.5.3.tgz#c54982b996c76ef0c1e6b59fbdc5825f5b713113"
 
-shelljs@^0.7.0:
+shelljs@^0.7.0, shelljs@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
   dependencies:
@@ -6893,6 +7052,13 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^3.0.0"
+
 string_decoder@~0.10.0, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -6953,6 +7119,10 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -6962,6 +7132,10 @@ strip-indent@^1.0.1:
 strip-json-comments@~1.0.1, strip-json-comments@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 subarg@^1.0.0:
   version "1.0.0"
@@ -6981,7 +7155,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -7016,6 +7190,17 @@ syntax-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.1.6.tgz#b4549706d386cc1c1dc7c2423f18579b6cade710"
   dependencies:
     acorn "^2.7.0"
+
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
 
 tar-pack@~3.3.0:
   version "3.3.0"
@@ -7263,7 +7448,16 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-uglify-js@2.6.0, uglify-js@^2.6:
+uglify-js@2.7.5:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
+  dependencies:
+    async "~0.2.6"
+    source-map "~0.5.1"
+    uglify-to-browserify "~1.0.0"
+    yargs "~3.10.0"
+
+uglify-js@^2.6:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.6.0.tgz#25eaa1cc3550e39410ceefafd1cfbb6b6d15f001"
   dependencies:
@@ -7528,12 +7722,12 @@ watch@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.11.0.tgz#e8dba091b7456799a3af57978b986e77e1320406"
 
-watchify@3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/watchify/-/watchify-3.7.0.tgz#ee2f2c5c8c37312303f998b818b2b3450eefe648"
+watchify@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/watchify/-/watchify-3.9.0.tgz#f075fd2e8a86acde84cedba6e5c2a0bedd523d9e"
   dependencies:
     anymatch "^1.3.0"
-    browserify "^13.0.0"
+    browserify "^14.0.0"
     chokidar "^1.0.0"
     defined "^1.0.0"
     outpipe "^1.1.0"


### PR DESCRIPTION
Most tests failed when executed together with other tests, because they relied on custom elements being installed in the main test window instead of a per test iframe. This was fixed by using `describes.realWin` instead of ad hoc code in tests.

Made the `jsonEqual` chai method more robust by switching to a JSON stringify that is stable. Fixed one cause of side effects making the 3p-frame test flaky.