### PR TITLE
An additional required file was added for Rambler&Co ad network

### DIFF
--- a/ads/capirs.js
+++ b/ads/capirs.js
@@ -51,5 +51,6 @@ export function capirs(global, data) {
     },
   };
 
+  writeScript(global, '//ssp.rambler.ru/lpdid.js');
   writeScript(global, '//ssp.rambler.ru/capirs_async.js');
 }

--- a/ads/capirs.js
+++ b/ads/capirs.js
@@ -15,7 +15,7 @@
  */
 
 import {validateData} from '../3p/3p';
-import {writeScript} from '../3p/3p';
+import {loadScript} from '../3p/3p';
 
 /**
  * @param {!Window} global
@@ -51,6 +51,6 @@ export function capirs(global, data) {
     },
   };
 
-  writeScript(global, '//ssp.rambler.ru/lpdid.js');
-  writeScript(global, '//ssp.rambler.ru/capirs_async.js');
+  loadScript(global, '//ssp.rambler.ru/lpdid.js');
+  loadScript(global, '//ssp.rambler.ru/capirs_async.js');
 }


### PR DESCRIPTION
An additional required js file was added to amp-ad tag type capirs. It is necessary for some ad types in Rambler&Co ad network.