### PR TITLE
amp-auto-ads: Allows attributes for the <amp-ad>s to be specified in the config

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -31,14 +31,11 @@ class AdNetworkConfigDef {
   getConfigUrl() {}
 
   /**
-   * Any data attributes derived from either the page or the auto-amp-ads tag
-   * that should be applied to any ads inserted.
-   * @return {!Array<!{name: string, value: (boolean|number|string)}>} The array
-   *     contains the type: {!./placement.DataAttributeDef}, but for some reason
-   *     'gulp check-types' throws a warning if we try to reference the typedef
-   *     here.
+   * Any attributes derived from either the page or the auto-amp-ads tag that
+   * should be applied to any ads inserted.
+   * @return {!Object<string, string>}
    */
-  getDataAttributes() {}
+  getAttributes() {}
 }
 
 /**
@@ -82,12 +79,10 @@ class AdSenseNetworkConfig {
   }
 
   /** @override */
-  getDataAttributes() {
-    return [
-      {
-        name: 'ad-client',
-        value: this.autoAmpAdsElement_.getAttribute('data-ad-client'),
-      },
-    ];
+  getAttributes() {
+    return {
+      'type': 'adsense',
+      'data-ad-client': this.autoAmpAdsElement_.getAttribute('data-ad-client'),
+    };
   }
 }

--- a/extensions/amp-auto-ads/0.1/ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/ad-strategy.js
@@ -23,20 +23,17 @@ const TAG = 'amp-auto-ads';
 export class AdStrategy {
 
   /**
-   * @param {string} type
    * @param {!Array<!./placement.Placement>} placements
-   * @param {!Array<!DataAttributeDef>} baseDataAttributes Any data attributes
-   *     that should be added to any inserted ads. These will be combined with
-   *     any additional data atrributes specified by the configuration.
+   * @param {!Object<string, string>} baseAttributes Any attributes that should
+   *     be added to any inserted ads. These will be combined with any
+   *     additional data atrributes specified by the placement.
    * @param {!./ad-tracker.AdTracker} adTracker
    * @param {number} targetAdCount
    */
-  constructor(type, placements, baseDataAttributes, adTracker, targetAdCount) {
-    this.type_ = type;
-
+  constructor(placements, baseAttributes, adTracker, targetAdCount) {
     this.availablePlacements_ = placements.slice(0);
 
-    this.baseDataAttributes_ = baseDataAttributes;
+    this.baseAttributes_ = baseAttributes;
 
     /** @type {!./ad-tracker.AdTracker} */
     this.adTracker_ = adTracker;
@@ -73,8 +70,8 @@ export class AdStrategy {
       dev().warn(TAG, 'unable to fulfill ad strategy');
       return Promise.resolve(false);
     }
-    return nextPlacement.placeAd(this.type_, this.baseDataAttributes_,
-        this.adTracker_).then(state => {
+    return nextPlacement.placeAd(this.baseAttributes_, this.adTracker_)
+        .then(state => {
           if (state == PlacementState.PLACED) {
             this.adTracker_.addAd(nextPlacement.getAdElement());
             return true;

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -20,6 +20,7 @@ import {dev, user} from '../../../src/log';
 import {xhrFor} from '../../../src/xhr';
 import {getAdNetworkConfig} from './ad-network-config';
 import {isExperimentOn} from '../../../src/experiments';
+import {getAttributesFromConfigObj} from './attributes';
 import {getPlacementsFromConfigObj} from './placement';
 
 /** @const */
@@ -57,9 +58,10 @@ export class AmpAutoAds extends AMP.BaseElement {
 
     this.getConfig_(adNetwork.getConfigUrl()).then(configObj => {
       const placements = getPlacementsFromConfigObj(this.win, configObj);
+      const attributes = Object.assign(adNetwork.getAttributes(),
+          getAttributesFromConfigObj(configObj));
       const adTracker = new AdTracker(getExistingAds(this.win), MIN_AD_SPACING);
-      new AdStrategy(type, placements, adNetwork.getDataAttributes(),
-          adTracker, TARGET_AD_COUNT).run();
+      new AdStrategy(placements, attributes, adTracker, TARGET_AD_COUNT).run();
     });
   }
 

--- a/extensions/amp-auto-ads/0.1/attributes.js
+++ b/extensions/amp-auto-ads/0.1/attributes.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {user} from '../../../src/log';
+import {startsWith} from '../../../src/string';
+import {isArray, isObject} from '../../../src/types';
+
+/** @const */
+const TAG = 'amp-auto-ads';
+
+/**
+ * @const {!Object<string, boolean>}
+ */
+const NON_DATA_ATTRIBUTE_WHITELIST = {
+  'type': true,
+  'layout': true,
+};
+
+/**
+ * @param {!Object} configObj
+ * @return {!Object<string, string>}
+ */
+export function getAttributesFromConfigObj(configObj) {
+  if (!configObj['attributes']) {
+    return {};
+  }
+  if (!isObject(configObj['attributes']) || isArray(configObj['attributes'])) {
+    user().warn(TAG, 'attributes property not an object');
+    return {};
+  }
+  return parseAttributes(configObj['attributes']);
+}
+
+/**
+ * @param {!Object} attributeObject
+ * @return {!Object<string, string>}
+ */
+function parseAttributes(attributeObject) {
+  const attributes = {};
+  for (const key in attributeObject) {
+    if (!NON_DATA_ATTRIBUTE_WHITELIST[key] && !startsWith(key, 'data-')) {
+      user().warn(TAG, 'Attribute not whitlisted: ' + key);
+      continue;
+    }
+    const valueType = (typeof attributeObject[key]);
+    if (valueType != 'number' && valueType != 'string' &&
+        valueType != 'boolean') {
+      user().warn(TAG, 'Attribute type not supported: ' + valueType);
+      continue;
+    }
+    attributes[key] = String(attributeObject[key]);
+  }
+  return attributes;
+};

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -15,6 +15,7 @@
  */
 
 import {dev} from '../../../src/log';
+import {getAttributesFromConfigObj} from './attributes';
 import {resourcesForDoc} from '../../../src/resources';
 import {
   createElementWithAttributes,
@@ -35,12 +36,6 @@ const TARGET_AD_WIDTH_PX = 320;
  * @const
  */
 const TARGET_AD_HEIGHT_PX = 100;
-
-/**
- * @export
- * @typedef {{name: string, value: (boolean|number|string)}}
- */
-export let DataAttributeDef;
 
 /**
  * @enum {number}
@@ -88,9 +83,11 @@ export class Placement {
    * @param {!Element} anchorElement
    * @param {!Position} position
    * @param {!function(!Element, !Element)} injector
+   * @param {!Object<string, string>} attributes
    * @param {!../../../src/layout-rect.LayoutMarginsChangeDef=} opt_margins
    */
-  constructor(win, resources, anchorElement, position, injector, opt_margins) {
+  constructor(win, resources, anchorElement, position, injector, attributes,
+      opt_margins) {
     /** @const @private {!Window} */
     this.win_ = win;
 
@@ -105,6 +102,9 @@ export class Placement {
 
     /** @const @private {!function(!Element, !Element)} */
     this.injector_ = injector;
+
+    /** @const @private {!Object<string, string>} */
+    this.attributes_ = attributes;
 
     /**
      * @const
@@ -159,19 +159,21 @@ export class Placement {
   }
 
   /**
-   * @param {string} type
-   * @param {!Array<!DataAttributeDef>} dataAttributes
+   * @param {!Object<string, string>} baseAttributes Any attributes to add to
+   *     injected <amp-ad>. Specific attributes will override defaults, but be
+   *     overridden by placement specific attributes defined in the
+   *     configuration.
    * @param {!./ad-tracker.AdTracker} adTracker
    * @return {!Promise<!PlacementState>}
    */
-  placeAd(type, dataAttributes, adTracker) {
+  placeAd(baseAttributes, adTracker) {
     return this.getEstimatedPosition().then(yPosition => {
       return adTracker.isTooNearAnAd(yPosition).then(tooNear => {
         if (tooNear) {
           this.state_ = PlacementState.TOO_NEAR_EXISTING_AD;
           return this.state_;
         }
-        this.adElement_ = this.createAdElement_(type, dataAttributes);
+        this.adElement_ = this.createAdElement_(baseAttributes);
         this.injector_(this.anchorElement_, this.adElement_);
         return this.resources_.attemptChangeSize(this.adElement_,
             TARGET_AD_HEIGHT_PX, TARGET_AD_WIDTH_PX, this.margins_)
@@ -187,21 +189,16 @@ export class Placement {
   }
 
   /**
-   * @param {string} type
-   * @param {!Array<!DataAttributeDef>} dataAttributes
+   * @param {!Object<string, string>} baseAttributes
    * @return {!Element}
    * @private
    */
-  createAdElement_(type, dataAttributes) {
-    const attributes = {
-      type,
+  createAdElement_(baseAttributes) {
+    const attributes = Object.assign({
       'layout': 'responsive',
       'width': '0',
       'height': '0',
-    };
-    for (let i = 0; i < dataAttributes.length; ++i) {
-      attributes['data-' + dataAttributes[i].name] = dataAttributes[i].value;
-    }
+    }, baseAttributes, this.attributes_);
     return createElementWithAttributes(
         this.win_.document, 'amp-ad', attributes);
   }
@@ -267,8 +264,9 @@ function getPlacementsFromObject(win, placementObj, placements) {
       dev().warn(TAG, 'Parentless anchor with BEFORE/AFTER position.');
       return;
     }
+    const attributes = getAttributesFromConfigObj(placementObj);
     placements.push(new Placement(win, resourcesForDoc(anchorElement),
-        anchorElement, placementObj['pos'], injector, margins));
+        anchorElement, placementObj['pos'], injector, attributes, margins));
   });
 }
 

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -44,14 +44,12 @@ describe('ad-network-config', () => {
           AD_CLIENT + '&plah=foo.bar&ama_t=amp');
     });
 
-    it('should generate the data attributes', () => {
+    it('should generate the attributes', () => {
       const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
-      expect(adNetwork.getDataAttributes()).to.deep.equal([
-        {
-          name: 'ad-client',
-          value: 'ca-pub-1234',
-        },
-      ]);
+      expect(adNetwork.getAttributes()).to.deep.equal({
+        'type': 'adsense',
+        'data-ad-client': 'ca-pub-1234',
+      });
     });
   });
 

--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -68,16 +68,14 @@ describes.realWin('amp-strategy', {
         const placements = getPlacementsFromConfigObj(env.win, configObj);
         expect(placements).to.have.lengthOf(2);
 
-        const adStrategy = new AdStrategy('adsense', placements, [
-          {
-            name: 'custom-att-1',
-            value: 'val-1',
-          },
-          {
-            name: 'custom-att-2',
-            value: 'val-2',
-          },
-        ], new AdTracker([], 0), 1);
+        const attributes = {
+          'type': 'adsense',
+          'data-custom-att-1': 'val-1',
+          'data-custom-att-2': 'val-2',
+        };
+
+        const adStrategy =
+            new AdStrategy(placements, attributes, new AdTracker([], 0), 1);
 
         return adStrategy.run().then(success => {
           expect(success).to.equal(true);
@@ -125,16 +123,14 @@ describes.realWin('amp-strategy', {
       return Promise.resolve(PlacementState.REIZE_FAILED);
     });
 
-    const adStrategy = new AdStrategy('adsense', placements, [
-      {
-        name: 'custom-att-1',
-        value: 'val-1',
-      },
-      {
-        name: 'custom-att-2',
-        value: 'val-2',
-      },
-    ], new AdTracker([], 0), 1);
+    const attributes = {
+      'type': 'adsense',
+      'data-custom-att-1': 'val-1',
+      'data-custom-att-2': 'val-2',
+    };
+
+    const adStrategy =
+        new AdStrategy(placements, attributes, new AdTracker([], 0), 1);
 
     return adStrategy.run().then(success => {
       expect(success).to.equal(true);
@@ -187,16 +183,14 @@ describes.realWin('amp-strategy', {
     const placements = getPlacementsFromConfigObj(env.win, configObj);
     expect(placements).to.have.lengthOf(2);
 
-    const adStrategy = new AdStrategy('adsense', placements, [
-      {
-        name: 'custom-att-1',
-        value: 'val-1',
-      },
-      {
-        name: 'custom-att-2',
-        value: 'val-2',
-      },
-    ], new AdTracker([], 200), 2);
+    const attributes = {
+      'type': 'adsense',
+      'data-custom-att-1': 'val-1',
+      'data-custom-att-2': 'val-2',
+    };
+
+    const adStrategy =
+        new AdStrategy(placements, attributes, new AdTracker([], 200), 2);
 
     return adStrategy.run().then(success => {
       expect(success).to.equal(false);
@@ -249,16 +243,14 @@ describes.realWin('amp-strategy', {
     const placements = getPlacementsFromConfigObj(env.win, configObj);
     expect(placements).to.have.lengthOf(2);
 
-    const adStrategy = new AdStrategy('adsense', placements, [
-      {
-        name: 'custom-att-1',
-        value: 'val-1',
-      },
-      {
-        name: 'custom-att-2',
-        value: 'val-2',
-      },
-    ], new AdTracker([], 200), 2);
+    const attributes = {
+      'type': 'adsense',
+      'data-custom-att-1': 'val-1',
+      'data-custom-att-2': 'val-2',
+    };
+
+    const adStrategy =
+        new AdStrategy(placements, attributes, new AdTracker([], 200), 2);
 
     return adStrategy.run().then(success => {
       expect(success).to.equal(true);
@@ -319,16 +311,14 @@ describes.realWin('amp-strategy', {
     const placements = getPlacementsFromConfigObj(env.win, configObj);
     expect(placements).to.have.lengthOf(2);
 
-    const adStrategy = new AdStrategy('adsense', placements, [
-      {
-        name: 'custom-att-1',
-        value: 'val-1',
-      },
-      {
-        name: 'custom-att-2',
-        value: 'val-2',
-      },
-    ], new AdTracker([fakeExistingAd], 200), 2);
+    const attributes = {
+      'type': 'adsense',
+      'data-custom-att-1': 'val-1',
+      'data-custom-att-2': 'val-2',
+    };
+
+    const adStrategy = new AdStrategy(placements, attributes,
+        new AdTracker([fakeExistingAd], 200), 2);
 
     return adStrategy.run().then(success => {
       expect(success).to.equal(true);
@@ -380,16 +370,12 @@ describes.realWin('amp-strategy', {
           return Promise.resolve(PlacementState.REIZE_FAILED);
         });
 
-        const adStrategy = new AdStrategy('adsense', placements, [
-          {
-            name: 'custom-att-1',
-            value: 'val-1',
-          },
-          {
-            name: 'custom-att-2',
-            value: 'val-2',
-          },
-        ], new AdTracker([], 0), 1);
+        const attributes = {
+          'type': 'adsense',
+        };
+
+        const adStrategy =
+            new AdStrategy(placements, attributes, new AdTracker([], 0), 1);
 
         return adStrategy.run().then(success => {
           expect(success).to.equal(false);

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -38,6 +38,7 @@ describes.realWin('amp-auto-ads', {
   let ampAutoAds;
   let ampAutoAdsElem;
   let xhr;
+  let configObj;
 
   beforeEach(() => {
     // There seem to be a lot of tests that don't clean up after themselves,
@@ -87,40 +88,42 @@ describes.realWin('amp-auto-ads', {
     ampAutoAdsElem = env.win.document.createElement('amp-auto-ads');
     env.win.document.body.appendChild(ampAutoAdsElem);
 
+    configObj = {
+      placements: [
+        {
+          anchor: {
+            selector: 'DIV#anId1',
+          },
+          pos: 2,
+          type: 1,
+        },
+        {
+          anchor: {
+            selector: 'DIV#anId2',
+          },
+          pos: 2,
+          type: 1,
+        },
+        {
+          anchor: {
+            selector: 'DIV#anId3',
+          },
+          pos: 2,
+          type: 1,
+        },
+        {
+          anchor: {
+            selector: 'DIV#anId4',
+          },
+          pos: 2,
+          type: 1,
+        },
+      ],
+    };
+
     xhr = xhrFor(env.win);
     xhr.fetchJson = () => {
-      return Promise.resolve({
-        placements: [
-          {
-            anchor: {
-              selector: 'DIV#anId1',
-            },
-            pos: 2,
-            type: 1,
-          },
-          {
-            anchor: {
-              selector: 'DIV#anId2',
-            },
-            pos: 2,
-            type: 1,
-          },
-          {
-            anchor: {
-              selector: 'DIV#anId3',
-            },
-            pos: 2,
-            type: 1,
-          },
-          {
-            anchor: {
-              selector: 'DIV#anId4',
-            },
-            pos: 2,
-            type: 1,
-          },
-        ],
-      });
+      return Promise.resolve(configObj);
     };
     sandbox.spy(xhr, 'fetchJson');
 
@@ -149,6 +152,72 @@ describes.realWin('amp-auto-ads', {
         verifyAdElement(anchor1.childNodes[0]);
         verifyAdElement(anchor2.childNodes[0]);
         verifyAdElement(anchor4.childNodes[0]);
+        resolve();
+      });
+    });
+  });
+
+  it('should insert ads with the config provided attributes', () => {
+    configObj.attributes = {
+      'bad-name': 'should be filtered',
+      'data-custom-att-1': 'val-1',
+      'data-custom-att-2': 'val-2',
+    };
+
+    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+    ampAutoAdsElem.setAttribute('type', 'adsense');
+    ampAutoAds.buildCallback();
+
+    return new Promise(resolve => {
+      waitForChild(anchor4, parent => {
+        return parent.childNodes.length > 0;
+      }, () => {
+        expect(anchor1.childNodes).to.have.lengthOf(1);
+        expect(anchor1.childNodes[0].getAttribute('data-custom-att-1'))
+            .to.equal('val-1');
+        expect(anchor1.childNodes[0].getAttribute('data-custom-att-2'))
+            .to.equal('val-2');
+
+        expect(anchor2.childNodes).to.have.lengthOf(1);
+        expect(anchor2.childNodes[0].getAttribute('data-custom-att-1'))
+            .to.equal('val-1');
+        expect(anchor2.childNodes[0].getAttribute('data-custom-att-2'))
+            .to.equal('val-2');
+
+        expect(anchor4.childNodes).to.have.lengthOf(1);
+        expect(anchor4.childNodes[0].getAttribute('data-custom-att-1'))
+            .to.equal('val-1');
+        expect(anchor4.childNodes[0].getAttribute('data-custom-att-2'))
+            .to.equal('val-2');
+        resolve();
+      });
+    });
+  });
+
+  it('should override ad network type with config provided attribute', () => {
+    configObj.attributes = {
+      'type': 'doubleclick',
+    };
+
+    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+    ampAutoAdsElem.setAttribute('type', 'adsense');
+    ampAutoAds.buildCallback();
+
+    return new Promise(resolve => {
+      waitForChild(anchor4, parent => {
+        return parent.childNodes.length > 0;
+      }, () => {
+        expect(anchor1.childNodes).to.have.lengthOf(1);
+        expect(anchor1.childNodes[0].getAttribute('type'))
+            .to.equal('doubleclick');
+
+        expect(anchor2.childNodes).to.have.lengthOf(1);
+        expect(anchor2.childNodes[0].getAttribute('type'))
+            .to.equal('doubleclick');
+
+        expect(anchor4.childNodes).to.have.lengthOf(1);
+        expect(anchor4.childNodes[0].getAttribute('type'))
+            .to.equal('doubleclick');
         resolve();
       });
     });

--- a/extensions/amp-auto-ads/0.1/test/test-attributes.js
+++ b/extensions/amp-auto-ads/0.1/test/test-attributes.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getAttributesFromConfigObj} from '../attributes';
+
+describe('attributes', () => {
+
+  it('should ignore attributes field if an array', () => {
+    const configObj = {
+      attributes: [
+        'val1',
+        'val2',
+      ],
+    };
+
+    expect(getAttributesFromConfigObj(configObj)).to.deep.equal({});
+  });
+
+  it('should get only whitelisted attributes', () => {
+    const configObj = {
+      attributes: {
+        'not-allowed': 'val1',
+        'type': 'val2',
+        'layout': 'val3',
+        '-key': 'val4',
+        'data-something': 'val5',
+        'data-1234': 'val6',
+      },
+    };
+
+    expect(getAttributesFromConfigObj(configObj)).to.deep.equal({
+      'type': 'val2',
+      'layout': 'val3',
+      'data-something': 'val5',
+      'data-1234': 'val6',
+    });
+  });
+
+  it('should accept number values', () => {
+    const configObj = {
+      attributes: {
+        'data-key': 1,
+      },
+    };
+    expect(getAttributesFromConfigObj(configObj)).to.deep.equal({
+      'data-key': '1',
+    });
+  });
+
+  it('should accept string values', () => {
+    const configObj = {
+      attributes: {
+        'data-key': 'one',
+      },
+    };
+    expect(getAttributesFromConfigObj(configObj)).to.deep.equal({
+      'data-key': 'one',
+    });
+  });
+
+  it('should accept boolean values', () => {
+    const configObj = {
+      attributes: {
+        'data-key1': true,
+        'data-key2': false,
+      },
+    };
+    expect(getAttributesFromConfigObj(configObj)).to.deep.equal({
+      'data-key1': 'true',
+      'data-key2': 'false',
+    });
+  });
+
+  it('should not accept non-(number, string or boolean values)', () => {
+    const configObj = {
+      attributes: {
+        'data-key1': {},
+        'data-key2': [],
+      },
+    };
+    expect(getAttributesFromConfigObj(configObj)).to.deep.equal({});
+  });
+});

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -54,7 +54,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(() => {
             expect(placements[0].getAdElement()).to.equal(anchor.childNodes[0]);
           });
@@ -189,7 +193,7 @@ describes.realWin('placement', {
   });
 
   describe('placeAd', () => {
-    it('should place an ad with the correct attributes', () => {
+    it('should place an ad with the correct base attributes', () => {
       const anchor = document.createElement('div');
       anchor.id = 'anId';
       container.appendChild(anchor);
@@ -207,27 +211,73 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [
-        {
-          name: 'custom-att-1',
-          value: 'val-1',
-        },
-        {
-          name: 'custom-att-2',
-          value: 'val-2',
-        },
-      ], new AdTracker([], 0)).then(() => {
-        const adElement = anchor.firstChild;
-        expect(adElement.tagName).to.equal('AMP-AD');
-        expect(adElement.getAttribute('type')).to.equal('ad-network-type');
-        expect(adElement.getAttribute('layout')).to.equal('responsive');
-        expect(adElement.getAttribute('width')).to.equal('0');
-        expect(adElement.getAttribute('height')).to.equal('0');
-        expect(adElement.getAttribute('data-custom-att-1'))
-            .to.equal('val-1');
-        expect(adElement.getAttribute('data-custom-att-2'))
-            .to.equal('val-2');
+      const baseAttributes = {
+        'type': 'ad-network-type',
+        'data-custom-att-1': 'val-1',
+        'data-custom-att-2': 'val-2',
+      };
+
+      return placements[0].placeAd(baseAttributes, new AdTracker([], 0))
+          .then(() => {
+            const adElement = anchor.firstChild;
+            expect(adElement.tagName).to.equal('AMP-AD');
+            expect(adElement.getAttribute('type')).to.equal('ad-network-type');
+            expect(adElement.getAttribute('layout')).to.equal('responsive');
+            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('height')).to.equal('0');
+            expect(adElement.getAttribute('data-custom-att-1'))
+                .to.equal('val-1');
+            expect(adElement.getAttribute('data-custom-att-2'))
+                .to.equal('val-2');
+          });
+    });
+
+    it('should place an ad with the correct placement attributes', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(env.win, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+            attributes: {
+              'type': 'ad-network-type2',
+              'layout': 'fixed',
+              'data-custom-att-1': 'val-1',
+              'data-custom-att-2': 'val-2',
+            },
+          },
+        ],
       });
+      expect(placements).to.have.lengthOf(1);
+
+      const baseAttributes = {
+        'type': 'ad-network-type',
+        'layout': 'fill',
+        'data-custom-att-2': 'val-3',
+        'data-custom-att-3': 'val-4',
+      };
+
+      return placements[0].placeAd(baseAttributes, new AdTracker([], 0))
+          .then(() => {
+            const adElement = anchor.firstChild;
+            expect(adElement.tagName).to.equal('AMP-AD');
+            expect(adElement.getAttribute('type')).to.equal('ad-network-type2');
+            expect(adElement.getAttribute('layout')).to.equal('fixed');
+            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('height')).to.equal('0');
+            expect(adElement.getAttribute('data-custom-att-1'))
+                .to.equal('val-1');
+            expect(adElement.getAttribute('data-custom-att-2'))
+                .to.equal('val-2');
+            expect(adElement.getAttribute('data-custom-att-3'))
+                .to.equal('val-4');
+          });
     });
 
     it('should place an ad with the correct margins', () => {
@@ -252,7 +302,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -288,7 +342,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -324,7 +382,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -358,7 +420,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -396,7 +462,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
                 anchor.firstChild, 100, 320);
@@ -427,7 +497,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
                 anchor.firstChild, 100, 320);
@@ -458,7 +532,11 @@ describes.realWin('placement', {
 
       const adTracker = new AdTracker([fakeAd], 100);
 
-      return placements[0].placeAd('ad-network-type', [], adTracker)
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(
                 PlacementState.TOO_NEAR_EXISTING_AD);
@@ -485,7 +563,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(2);
@@ -511,7 +593,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(2);
@@ -538,7 +624,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(1);
@@ -565,7 +655,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(1);
@@ -596,7 +690,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      return placements[0].placeAd('ad-network-type', [], new AdTracker([], 0))
+      const attributes = {
+        'type': 'ad-network-type',
+      };
+
+      return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(anchor1.childNodes).to.have.lengthOf(0);


### PR DESCRIPTION
Attributes can be specified at the config level and will be applied to all `<amp-ad>`s inserted. Attributes can also be specified at the placement level and will only be applied to `<amp-ad>`s inserted using that placement.

Example:
```json
 {
  "placements": [
    {
      "anchor": {
        "selector": "DIV#anId",
      },
      "pos": 2,
      "type": 1,
      "attributes": {
        "data-att-1": "val1",
        "data-att-2": "val2",
      },
    },
  ],
  "attributes": {
    "data-att-2": "val3",
    "data-att-4": "val4",
  },
}
```
Would result in the following amp-ad being inserted:
`<amp-ad "data-att-1="val1" data-att-2="val2" data-att-4="val4">`

FYI: I'm working on an MD file for amp-auto-ads that will document the API with examples. Will send in a PR soon.

Incorporates the fix in https://github.com/ampproject/amphtml/pull/7427, since testing attributes is important to this change.

https://github.com/ampproject/amphtml/issues/6196