### PR TITLE
add yarn to installation requirements

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -33,9 +33,10 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 ### Installation
 
 1. Install [NodeJS](https://nodejs.org).
-2. In the repo directory, run `npm i` command to install the required npm packages.
-3. Run `npm i -g gulp` command to install gulp system-wide (on Mac or Linux you may need to prefix this with `sudo`, depending on how Node was installed).
-4. Edit your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows) and map `ads.localhost` and `iframe.localhost` to `127.0.0.1`.
+2. Install [yarn](https://yarnpkg.com/en/docs/install) (yarn is faster than `npm install` and gives us deterministic builds)
+3. In the repo directory, run `yarn` command to install the required npm packages.
+4. Run `yarn global add gulp` command to install gulp system-wide (on Mac or Linux you may need to prefix this with `sudo`, depending on how Node was installed).
+5. Edit your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows) and map `ads.localhost` and `iframe.localhost` to `127.0.0.1`.
 <pre>
   127.0.0.1               ads.localhost iframe.localhost
 </pre>

--- a/validator/gulpjs/README.md
+++ b/validator/gulpjs/README.md
@@ -7,7 +7,7 @@ A Gulp plugin for validating [AMPHTML files](https://ampproject.org) using the o
 Install package with NPM and add it to your development dependencies:
 
 ```
-npm install --save-dev gulp-amphtml-validator
+yarn add gulp-amphtml-validator
 ```
 
 ## Usage


### PR DESCRIPTION
switching to yarn for package.json installation. when using `npm install` sub dependencies of top level dependencies can vary in range while yarn will pin it to a specific version. this has caused us build failures in the past and allows cloudflare as well to be more confident that theyre js binary build is the same as what google is serving.

let me know if there are other spots i need to add this documentation to

Closes https://github.com/ampproject/amphtml/issues/7511