### PR TITLE
Force cloudflare amp-ad to use absolute src. 

### DIFF
--- a/extensions/amp-ad-network-cloudflare-impl/0.1/vendors.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/vendors.js
@@ -23,7 +23,7 @@ export const NETWORKS = /** @type {!JSONType} */ ({
   },
 
   adzerk: {
-    base: 'https://engine.adzerk.com',
+    base: 'https://engine.betazerk.com',
   },
 
   dianomi: {


### PR DESCRIPTION
The cloudflare extension wasn't properly ensuring that the src attribute was an absolute URL.  This changes the implementation to still check for vendor specific URLs, but ensures full URLs.

Fixes #7543