### PR TITLE
Allow multiple action handlers for the same event

### DIFF
--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -58,6 +58,13 @@ You can listen to multiple events on an element by separating the two events wit
 
 Example: `on="submit-success:lightbox1;submit-error:lightbox2"`
 
+
+## Multiple Actions For One Event
+You can execute multiple actions in sequence for the same event by separating the two actions with a comma ','.
+
+Example: `on="tap:target1.actionA,target2.actionB"`
+
+
 ## Globally defined Events and Actions
 Currently AMP defines `tap` event globally that you can listen to on any HTML element (including amp-elements).
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -342,16 +342,15 @@ export class ActionService {
   /**
    * @param {!Element} target
    * @param {string} actionEventType
-   * @return {?{node: !Element, actionInfos: Array<!ActionInfoDef>}}
+   * @return {?{node: !Element, actionInfos: !Array<!ActionInfoDef>}}
    */
   findAction_(target, actionEventType) {
     // Go from target up the DOM tree and find the applicable action.
     let n = target;
-    let actionInfos = null;
     while (n) {
-      actionInfos = this.matchActionInfos_(n, actionEventType);
+      const actionInfos = this.matchActionInfos_(n, actionEventType);
       if (actionInfos) {
-        return {node: n, actionInfos};
+        return {node: n, actionInfos: dev().assert(actionInfos)};
       }
       n = n.parentElement;
     }
@@ -361,7 +360,7 @@ export class ActionService {
   /**
    * @param {!Element} node
    * @param {string} actionEventType
-   * @return {?Array<ActionInfoDef>}
+   * @return {?Array<!ActionInfoDef>}
    */
   matchActionInfos_(node, actionEventType) {
     const actionMap = this.getActionMap_(node);
@@ -373,7 +372,7 @@ export class ActionService {
 
   /**
    * @param {!Element} node
-   * @return {?Object<string, Array<ActionInfoDef>>}
+   * @return {?Object<string, !Array<!ActionInfoDef>>}
    */
   getActionMap_(node) {
     let actionMap = node[ACTION_MAP_];
@@ -392,7 +391,7 @@ export class ActionService {
 /**
  * @param {string} s
  * @param {!Element} context
- * @return {?Object<string, Array<ActionInfoDef>>}
+ * @return {?Object<string, !Array<!ActionInfoDef>>}
  * @private Visible for testing only.
  */
 export function parseActionMap(s, context) {

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -247,31 +247,31 @@ export class ActionService {
       return;
     }
 
-    const actionInfo = action.actionInfo;
+    for (let i = 0; i < action.actionInfos.length; i++) {
+      const actionInfo = action.actionInfos[i];
+      // Replace any variables in args with data in `event`.
+      const args = applyActionInfoArgs(actionInfo.args, event);
 
-    // Replace any variables in args with data in `event`.
-    const args = applyActionInfoArgs(actionInfo.args, event);
-
-    // Global target, e.g. `AMP`.
-    const globalTarget = this.globalTargets_[actionInfo.target];
-    if (globalTarget) {
-      const invocation = new ActionInvocation(
-          this.root_,
-          actionInfo.method,
-          args,
-          action.node,
-          event);
-      globalTarget(invocation);
-      return;
+      // Global target, e.g. `AMP`.
+      const globalTarget = this.globalTargets_[actionInfo.target];
+      if (globalTarget) {
+        const invocation = new ActionInvocation(
+            this.root_,
+            actionInfo.method,
+            args,
+            action.node,
+            event);
+        globalTarget(invocation);
+      } else {
+        const target = this.root_.getElementById(actionInfo.target);
+        if (target) {
+          this.invoke_(target, actionInfo.method, args,
+              action.node, event, actionInfo);
+        } else {
+          this.actionInfoError_('target not found', actionInfo, target);
+        }
+      }
     }
-
-    const target = this.root_.getElementById(actionInfo.target);
-    if (!target) {
-      this.actionInfoError_('target not found', actionInfo, target);
-      return;
-    }
-    this.invoke_(target, actionInfo.method, args,
-        action.node, event, actionInfo);
   }
 
   /**
@@ -342,16 +342,16 @@ export class ActionService {
   /**
    * @param {!Element} target
    * @param {string} actionEventType
-   * @return {?{node: !Element, actionInfo: !ActionInfoDef}}
+   * @return {?{node: !Element, actionInfos: Array<!ActionInfoDef>}}
    */
   findAction_(target, actionEventType) {
     // Go from target up the DOM tree and find the applicable action.
     let n = target;
-    let actionInfo = null;
+    let actionInfos = null;
     while (n) {
-      actionInfo = this.matchActionInfo_(n, actionEventType);
-      if (actionInfo) {
-        return {node: n, actionInfo};
+      actionInfos = this.matchActionInfos_(n, actionEventType);
+      if (actionInfos) {
+        return {node: n, actionInfos};
       }
       n = n.parentElement;
     }
@@ -361,9 +361,9 @@ export class ActionService {
   /**
    * @param {!Element} node
    * @param {string} actionEventType
-   * @return {?ActionInfoDef}
+   * @return {?Array<ActionInfoDef>}
    */
-  matchActionInfo_(node, actionEventType) {
+  matchActionInfos_(node, actionEventType) {
     const actionMap = this.getActionMap_(node);
     if (!actionMap) {
       return null;
@@ -373,7 +373,7 @@ export class ActionService {
 
   /**
    * @param {!Element} node
-   * @return {?Object<string, ActionInfoDef>}
+   * @return {?Object<string, Array<ActionInfoDef>>}
    */
   getActionMap_(node) {
     let actionMap = node[ACTION_MAP_];
@@ -392,7 +392,7 @@ export class ActionService {
 /**
  * @param {string} s
  * @param {!Element} context
- * @return {?Object<string, ActionInfoDef>}
+ * @return {?Object<string, Array<ActionInfoDef>>}
  * @private Visible for testing only.
  */
 export function parseActionMap(s, context) {
@@ -416,80 +416,92 @@ export function parseActionMap(s, context) {
       // Event: "event:"
       const event = tok.value;
 
-      // Target: ":target."
+      // Target: ":target." separator
       assertToken(toks.next(), [TokenType.SEPARATOR], ':');
-      const target = assertToken(
-          toks.next(), [TokenType.LITERAL, TokenType.ID]).value;
 
-      // Method: ".method". Method is optional.
-      let method = DEFAULT_METHOD_;
-      let args = null;
-      peek = toks.peek();
-      if (peek.type == TokenType.SEPARATOR && peek.value == '.') {
-        toks.next();  // Skip '.'
-        method = assertToken(
-            toks.next(), [TokenType.LITERAL, TokenType.ID]).value || method;
+      const actions = [];
 
-        // Optionally, there may be arguments: "(key = value, key = value)".
+      // Handlers for event
+      do {
+        const target = assertToken(
+            toks.next(), [TokenType.LITERAL, TokenType.ID]).value;
+
+        // Method: ".method". Method is optional.
+        let method = DEFAULT_METHOD_;
+        let args = null;
         peek = toks.peek();
-        if (peek.type == TokenType.SEPARATOR && peek.value == '(') {
-          toks.next();  // Skip '('.
-          do {
-            tok = toks.next();
+        if (peek.type == TokenType.SEPARATOR && peek.value == '.') {
+          toks.next();  // Skip '.'
+          method = assertToken(
+              toks.next(), [TokenType.LITERAL, TokenType.ID]).value || method;
 
-            // Format: key = value, ....
-            if (tok.type == TokenType.SEPARATOR &&
-                    (tok.value == ',' || tok.value == ')')) {
-              // Expected: ignore.
-            } else if (tok.type == TokenType.LITERAL ||
-                tok.type == TokenType.ID) {
-              // Key: "key = "
-              const argKey = tok.value;
-              assertToken(toks.next(), [TokenType.SEPARATOR], '=');
-              // Value is either a literal or a variable: "foo.bar.baz"
-              tok = assertToken(toks.next(/* convertValue */ true),
-                  [TokenType.LITERAL, TokenType.ID]);
-              const argValueTokens = [tok];
-              // Variables have one or more dereferences: ".identifier"
-              if (tok.type == TokenType.ID) {
-                for (peek = toks.peek();
-                    peek.type == TokenType.SEPARATOR && peek.value == '.';
-                    peek = toks.peek()) {
-                  tok = toks.next(); // Skip '.'.
-                  tok = assertToken(toks.next(false), [TokenType.ID]);
-                  argValueTokens.push(tok);
+          // Optionally, there may be arguments: "(key = value, key = value)".
+          peek = toks.peek();
+          if (peek.type == TokenType.SEPARATOR && peek.value == '(') {
+            toks.next();  // Skip '('.
+            do {
+              tok = toks.next();
+
+              // Format: key = value, ....
+              if (tok.type == TokenType.SEPARATOR &&
+                      (tok.value == ',' || tok.value == ')')) {
+                // Expected: ignore.
+              } else if (tok.type == TokenType.LITERAL ||
+                  tok.type == TokenType.ID) {
+                // Key: "key = "
+                const argKey = tok.value;
+                assertToken(toks.next(), [TokenType.SEPARATOR], '=');
+                // Value is either a literal or a variable: "foo.bar.baz"
+                tok = assertToken(toks.next(/* convertValue */ true),
+                    [TokenType.LITERAL, TokenType.ID]);
+                const argValueTokens = [tok];
+                // Variables have one or more dereferences: ".identifier"
+                if (tok.type == TokenType.ID) {
+                  for (peek = toks.peek();
+                      peek.type == TokenType.SEPARATOR && peek.value == '.';
+                      peek = toks.peek()) {
+                    tok = toks.next(); // Skip '.'.
+                    tok = assertToken(toks.next(false), [TokenType.ID]);
+                    argValueTokens.push(tok);
+                  }
                 }
+                const argValue = getActionInfoArgValue(argValueTokens);
+                if (!args) {
+                  args = map();
+                }
+                args[argKey] = argValue;
+                peek = toks.peek();
+                assertAction(
+                    peek.type == TokenType.SEPARATOR &&
+                    (peek.value == ',' || peek.value == ')'),
+                    'Expected either [,] or [)]');
+              } else {
+                // Unexpected token.
+                assertAction(false, `; unexpected token [${tok.value || ''}]`);
               }
-              const argValue = getActionInfoArgValue(argValueTokens);
-              if (!args) {
-                args = map();
-              }
-              args[argKey] = argValue;
-              peek = toks.peek();
-              assertAction(
-                  peek.type == TokenType.SEPARATOR &&
-                  (peek.value == ',' || peek.value == ')'),
-                  'Expected either [,] or [)]');
-            } else {
-              // Unexpected token.
-              assertAction(false, `; unexpected token [${tok.value || ''}]`);
-            }
-          } while (!(tok.type == TokenType.SEPARATOR && tok.value == ')'));
+            } while (!(tok.type == TokenType.SEPARATOR && tok.value == ')'));
+          }
         }
-      }
 
-      const action = {
-        event,
-        target,
-        method,
-        args: (args && getMode().test && Object.freeze) ?
-            Object.freeze(args) : args,
-        str: s,
-      };
+        actions.push({
+          event,
+          target,
+          method,
+          args: (args && getMode().test && Object.freeze) ?
+              Object.freeze(args) : args,
+          str: s,
+        });
+
+        peek = toks.peek();
+
+      } while (peek.type == TokenType.SEPARATOR && peek.value == ','
+          && toks.next()); // skip "," when found
+
       if (!actionMap) {
         actionMap = map();
       }
-      actionMap[action.event] = action;
+
+      actionMap[event] = actions;
     } else {
       // Unexpected token.
       assertAction(false, `; unexpected token [${tok.value || ''}]`);

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -138,6 +138,49 @@ describe('ActionService parseAction', () => {
     expect(a[1].args['keyA']()).to.equal('valueA');
   });
 
+  it('should parse multiple event types with multiple actions', () => {
+    const a = parseActionMap(
+        'event1:target1, target2.methodA, target3.methodB(keyA=valueA);' +
+        'event2:target4, target5.methodC, target6.methodD(keyB=valueB)');
+
+    expect(Object.keys(a)).to.have.length(2);
+
+    expect(a['event1']).to.have.length(3);
+    expect(a['event2']).to.have.length(3);
+
+    // action definitions for event1
+    expect(a['event1'][0].event).to.equal('event1');
+    expect(a['event1'][0].target).to.equal('target1');
+    expect(a['event1'][0].method).to.equal('activate');
+    expect(a['event1'][0].args).to.be.null;
+
+    expect(a['event1'][1].event).to.equal('event1');
+    expect(a['event1'][1].target).to.equal('target2');
+    expect(a['event1'][1].method).to.equal('methodA');
+    expect(a['event1'][1].args).to.be.null;
+
+    expect(a['event1'][2].event).to.equal('event1');
+    expect(a['event1'][2].target).to.equal('target3');
+    expect(a['event1'][2].method).to.equal('methodB');
+    expect(a['event1'][2].args['keyA']()).to.equal('valueA');
+
+    // action definitions for event2
+    expect(a['event2'][0].event).to.equal('event2');
+    expect(a['event2'][0].target).to.equal('target4');
+    expect(a['event2'][0].method).to.equal('activate');
+    expect(a['event2'][0].args).to.be.null;
+
+    expect(a['event2'][1].event).to.equal('event2');
+    expect(a['event2'][1].target).to.equal('target5');
+    expect(a['event2'][1].method).to.equal('methodC');
+    expect(a['event2'][1].args).to.be.null;
+
+    expect(a['event2'][2].event).to.equal('event2');
+    expect(a['event2'][2].target).to.equal('target6');
+    expect(a['event2'][2].method).to.equal('methodD');
+    expect(a['event2'][2].args['keyB']()).to.equal('valueB');
+  })
+
   it('should parse with multiple args', () => {
     const a = parseAction('event1:target1.method1(key1=value1, key2 = value2)');
     expect(a.event).to.equal('event1');

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -24,6 +24,14 @@ import {setParentWindow} from '../../src/service';
 import * as sinon from 'sinon';
 
 
+function createExecElement(id, enqueAction) {
+  const execElement = document.createElement('amp-element');
+  execElement.setAttribute('id', id);
+  execElement.enqueAction = enqueAction;
+  return execElement;
+}
+
+
 function assertInvocation(inv, target, method, source, opt_event, opt_args) {
   expect(inv.target).to.equal(target);
   expect(inv.method).to.equal(method);
@@ -140,8 +148,8 @@ describe('ActionService parseAction', () => {
 
   it('should parse multiple event types with multiple actions', () => {
     const a = parseActionMap(
-        'event1:target1, target2.methodA, target3.methodB(keyA=valueA);' +
-        'event2:target4, target5.methodC, target6.methodD(keyB=valueB)');
+        'event1:foo, baz.firstMethod, corge.secondMethod(keyA=valueA);' +
+        'event2:bar, qux.thirdMethod, grault.fourthMethod(keyB=valueB)');
 
     expect(Object.keys(a)).to.have.length(2);
 
@@ -150,36 +158,36 @@ describe('ActionService parseAction', () => {
 
     // action definitions for event1
     expect(a['event1'][0].event).to.equal('event1');
-    expect(a['event1'][0].target).to.equal('target1');
+    expect(a['event1'][0].target).to.equal('foo');
     expect(a['event1'][0].method).to.equal('activate');
     expect(a['event1'][0].args).to.be.null;
 
     expect(a['event1'][1].event).to.equal('event1');
-    expect(a['event1'][1].target).to.equal('target2');
-    expect(a['event1'][1].method).to.equal('methodA');
+    expect(a['event1'][1].target).to.equal('baz');
+    expect(a['event1'][1].method).to.equal('firstMethod');
     expect(a['event1'][1].args).to.be.null;
 
     expect(a['event1'][2].event).to.equal('event1');
-    expect(a['event1'][2].target).to.equal('target3');
-    expect(a['event1'][2].method).to.equal('methodB');
+    expect(a['event1'][2].target).to.equal('corge');
+    expect(a['event1'][2].method).to.equal('secondMethod');
     expect(a['event1'][2].args['keyA']()).to.equal('valueA');
 
     // action definitions for event2
     expect(a['event2'][0].event).to.equal('event2');
-    expect(a['event2'][0].target).to.equal('target4');
+    expect(a['event2'][0].target).to.equal('bar');
     expect(a['event2'][0].method).to.equal('activate');
     expect(a['event2'][0].args).to.be.null;
 
     expect(a['event2'][1].event).to.equal('event2');
-    expect(a['event2'][1].target).to.equal('target5');
-    expect(a['event2'][1].method).to.equal('methodC');
+    expect(a['event2'][1].target).to.equal('qux');
+    expect(a['event2'][1].method).to.equal('thirdMethod');
     expect(a['event2'][1].args).to.be.null;
 
     expect(a['event2'][2].event).to.equal('event2');
-    expect(a['event2'][2].target).to.equal('target6');
-    expect(a['event2'][2].method).to.equal('methodD');
+    expect(a['event2'][2].target).to.equal('grault');
+    expect(a['event2'][2].method).to.equal('fourthMethod');
     expect(a['event2'][2].args['keyB']()).to.equal('valueB');
-  })
+  });
 
   it('should parse with multiple args', () => {
     const a = parseAction('event1:target1.method1(key1=value1, key2 = value2)');
@@ -575,9 +583,7 @@ describe('Action method', () => {
     targetElement.appendChild(child);
     document.body.appendChild(parent);
 
-    execElement = document.createElement('amp-element');
-    execElement.setAttribute('id', id);
-    execElement.enqueAction = onEnqueue;
+    execElement = createExecElement(id, onEnqueue);
     parent.appendChild(execElement);
   });
 
@@ -670,13 +676,6 @@ describe('Multiple handlers action method', () => {
   let onEnqueue1, onEnqueue2;
   let targetElement, parent, child, execElement1, execElement2;
 
-  function createExecElement(id, enqueAction) {
-    const execElement = document.createElement('amp-element');
-    execElement.setAttribute('id', id);
-    execElement.enqueAction = enqueAction;
-    return execElement;
-  }
-
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     win = {
@@ -689,8 +688,8 @@ describe('Multiple handlers action method', () => {
     onEnqueue1 = sandbox.spy();
     onEnqueue2 = sandbox.spy();
     targetElement = document.createElement('target');
-    const id1 = ('Ea' + Math.random()).replace('.', '');
-    const id2 = ('Eb' + Math.random()).replace('.', '');
+    const id1 = 'elementFoo';
+    const id2 = 'elementBar';
     targetElement.setAttribute('on', `tap:${id1}.method1,${id2}.method2`);
     parent = document.createElement('parent');
     child = document.createElement('child');

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -24,8 +24,23 @@ import {setParentWindow} from '../../src/service';
 import * as sinon from 'sinon';
 
 
+function assertInvocation(inv, target, method, source, opt_event, opt_args) {
+  expect(inv.target).to.equal(target);
+  expect(inv.method).to.equal(method);
+  expect(inv.source).to.equal(source);
+
+  if (opt_event !== undefined) {
+    expect(inv.event).to.equal(opt_event);
+  }
+
+  if (opt_args !== undefined) {
+    expect(inv.args).to.deep.equal(opt_args);
+  }
+}
+
+
 describe('ActionService parseAction', () => {
-  function parseAction(s) {
+  function parseMultipleActions(s) {
     const actionMap = parseActionMap(s);
     if (actionMap == null) {
       return null;
@@ -35,11 +50,30 @@ describe('ActionService parseAction', () => {
     return actionMap[keys[0]];
   }
 
+  function parseAction(s) {
+    const actions = parseMultipleActions(s);
+    if (actions == null) {
+      return null;
+    }
+    expect(actions).to.have.length(1);
+    return actions[0];
+  }
+
   it('should parse full form', () => {
     const a = parseAction('event1:target1.method1');
     expect(a.event).to.equal('event1');
     expect(a.target).to.equal('target1');
     expect(a.method).to.equal('method1');
+  });
+
+  it('should parse full form with two actions', () => {
+    const a = parseMultipleActions('event1:target1.methodA,target2.methodB');
+    expect(a[0].event).to.equal('event1');
+    expect(a[0].target).to.equal('target1');
+    expect(a[0].method).to.equal('methodA');
+    expect(a[1].event).to.equal('event1');
+    expect(a[1].target).to.equal('target2');
+    expect(a[1].method).to.equal('methodB');
   });
 
   it('should parse with default method', () => {
@@ -49,11 +83,31 @@ describe('ActionService parseAction', () => {
     expect(a.method).to.equal('activate');
   });
 
+  it('should parse with default method for two different targets', () => {
+    const a = parseMultipleActions('event1:target1,target2');
+    expect(a[0].event).to.equal('event1');
+    expect(a[0].target).to.equal('target1');
+    expect(a[0].method).to.equal('activate');
+    expect(a[1].event).to.equal('event1');
+    expect(a[1].target).to.equal('target2');
+    expect(a[1].method).to.equal('activate');
+  });
+
   it('should parse with numeric target', () => {
     const a = parseAction('event1:1234.method1');
     expect(a.event).to.equal('event1');
     expect(a.target).to.equal('1234');
     expect(a.method).to.equal('method1');
+  });
+
+  it('should parse with two numeric targets', () => {
+    const a = parseMultipleActions('event1:1234.method1,9876.method2');
+    expect(a[0].event).to.equal('event1');
+    expect(a[0].target).to.equal('1234');
+    expect(a[0].method).to.equal('method1');
+    expect(a[1].event).to.equal('event1');
+    expect(a[1].target).to.equal('9876');
+    expect(a[1].method).to.equal('method2');
   });
 
   it('should parse with lots of whitespace', () => {
@@ -69,6 +123,19 @@ describe('ActionService parseAction', () => {
     expect(a.target).to.equal('target1');
     expect(a.method).to.equal('method1');
     expect(a.args['key1']()).to.equal('value1');
+  });
+
+  it('should parse args in more than one action', () => {
+    const a = parseMultipleActions(
+      'event1:target1.methodA(key1=value1),target2.methodB(keyA=valueA)');
+    expect(a[0].event).to.equal('event1');
+    expect(a[0].target).to.equal('target1');
+    expect(a[0].method).to.equal('methodA');
+    expect(a[0].args['key1']()).to.equal('value1');
+    expect(a[1].event).to.equal('event1');
+    expect(a[1].target).to.equal('target2');
+    expect(a[1].method).to.equal('methodB');
+    expect(a[1].args['keyA']()).to.equal('valueA');
   });
 
   it('should parse with multiple args', () => {
@@ -303,6 +370,10 @@ describe('ActionService parseAction', () => {
     expect(() => {
       parseAction('event:target1.method(key = value key2 = value2)');
     }).to.throw(/Invalid action/);
+    // Empty (2...n)nd target
+    expect(() => {
+      parseAction('event:target1,');
+    }).to.throw(/Invalid action/);
   });
 });
 
@@ -310,19 +381,20 @@ describe('Action parseActionMap', () => {
 
   it('should parse with a single action', () => {
     const m = parseActionMap('event1:action1');
-    expect(m['event1'].target).to.equal('action1');
+    expect(m['event1'][0].target).to.equal('action1');
   });
 
   it('should parse with two actions', () => {
     const m = parseActionMap('event1:action1; event2: action2');
-    expect(m['event1'].target).to.equal('action1');
-    expect(m['event2'].target).to.equal('action2');
+    expect(m['event1'][0].target).to.equal('action1');
+    expect(m['event2'][0].target).to.equal('action2');
   });
 
   it('should parse with dupe actions by overriding with last', () => {
     const m = parseActionMap('event1:action1; event1: action2');
+    expect(m['event1']).to.have.length(1);
     // Currently, we overwrite the events.
-    expect(m['event1'].target).to.equal('action2');
+    expect(m['event1'][0].target).to.equal('action2');
   });
 
   it('should parse empty forms to null', () => {
@@ -388,7 +460,8 @@ describe('Action findAction', () => {
     const element = document.createElement('div');
     element.setAttribute('on', 'event1:action1');
     const m = action.getActionMap_(element);
-    expect(m['event1'].target).to.equal('action1');
+    expect(m['event1']).to.have.length(1);
+    expect(m['event1'][0].target).to.equal('action1');
   });
 
   it('should cache action map', () => {
@@ -405,7 +478,8 @@ describe('Action findAction', () => {
     element.setAttribute('on', 'event1:action1');
     const a = action.findAction_(element, 'event1');
     expect(a.node).to.equal(element);
-    expect(a.actionInfo.target).to.equal('action1');
+    expect(a.actionInfos).to.have.length(1);
+    expect(a.actionInfos[0].target).to.equal('action1');
 
     expect(action.findAction_(element, 'event3')).to.equal(null);
   });
@@ -419,11 +493,13 @@ describe('Action findAction', () => {
 
     let a = action.findAction_(element, 'event1');
     expect(a.node).to.equal(parent);
-    expect(a.actionInfo.target).to.equal('action1');
+    expect(a.actionInfos).to.have.length(1);
+    expect(a.actionInfos[0].target).to.equal('action1');
 
     a = action.findAction_(element, 'event2');
     expect(a.node).to.equal(element);
-    expect(a.actionInfo.target).to.equal('action2');
+    expect(a.actionInfos).to.have.length(1);
+    expect(a.actionInfos[0].target).to.equal('action2');
 
     expect(action.findAction_(element, 'event3')).to.equal(null);
   });
@@ -540,6 +616,64 @@ describe('Action method', () => {
     expect(inv.method).to.equal('method1');
     expect(inv.args['key1']).to.equal(11);
     expect(inv.source).to.equal(child);
+  });
+});
+
+
+describe('Multiple handlers action method', () => {
+  let sandbox;
+  let win;
+  let action;
+  let onEnqueue1, onEnqueue2;
+  let targetElement, parent, child, execElement1, execElement2;
+
+  function createExecElement(id, enqueAction) {
+    const execElement = document.createElement('amp-element');
+    execElement.setAttribute('id', id);
+    execElement.enqueAction = enqueAction;
+    return execElement;
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    win = {
+      document: {body: {}},
+      services: {
+        vsync: {obj: {}},
+      },
+    };
+    action = new ActionService(new AmpDocSingle(win), document);
+    onEnqueue1 = sandbox.spy();
+    onEnqueue2 = sandbox.spy();
+    targetElement = document.createElement('target');
+    const id1 = ('Ea' + Math.random()).replace('.', '');
+    const id2 = ('Eb' + Math.random()).replace('.', '');
+    targetElement.setAttribute('on', `tap:${id1}.method1,${id2}.method2`);
+    parent = document.createElement('parent');
+    child = document.createElement('child');
+    parent.appendChild(targetElement);
+    targetElement.appendChild(child);
+    document.body.appendChild(parent);
+
+    execElement1 = createExecElement(id1, onEnqueue1);
+    execElement2 = createExecElement(id2, onEnqueue2);
+
+    parent.appendChild(execElement1);
+    parent.appendChild(execElement2);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(parent);
+    sandbox.restore();
+  });
+
+  it('should trigger event', () => {
+    action.trigger(child, 'tap', null);
+    expect(onEnqueue1).to.be.calledOnce;
+    assertInvocation(onEnqueue1.getCall(0).args[0], execElement1, 'method1',
+        targetElement);
+    assertInvocation(onEnqueue2.getCall(0).args[0], execElement2, 'method2',
+        targetElement);
   });
 });
 
@@ -708,18 +842,28 @@ describes.sandboxed('Action global target', {}, () => {
     action.trigger(element, 'tap', event);
     expect(target2).to.not.be.called;
     expect(target1).to.be.calledOnce;
-    const inv = target1.args[0][0];
-    expect(inv.target).to.equal(document);
-    expect(inv.method).to.equal('action1');
-    expect(inv.source).to.equal(element);
-    expect(inv.event).to.equal(event);
-    expect(inv.args['a']).to.equal('b');
+    assertInvocation(target1.args[0][0], document, 'action1', element, event,
+        {a: 'b'});
 
     const element2 = document.createElement('div');
     element2.setAttribute('on', 'tap:target2.action1');
     action.trigger(element2, 'tap', event);
     expect(target2).to.be.calledOnce;
     expect(target1).to.be.calledOnce;
+
+    const element3 = document.createElement('div');
+    element3.setAttribute('on', 'tap:target1.action1,target2.action1');
+    action.trigger(element3, 'tap', event);
+    expect(target2).to.be.calledTwice;
+    expect(target1).to.be.calledTwice;
+
+    const element4 = document.createElement('div');
+    element4.setAttribute('on', 'tap:target1.action1,target2.action2(x=y)');
+    action.trigger(element4, 'tap', event);
+    expect(target2).to.be.calledThrice;
+    expect(target1).to.be.calledThrice;
+    assertInvocation(target2.args[2][0], document, 'action2', element4, event,
+        {x: 'y'});
   });
 });
 


### PR DESCRIPTION
Fixes #649.

- Changes internal structure for action maps from `string → ActionDef` to `string → Array<ActionDef>`

- Updates parser to read new format (reference issue for syntax).

- Executes all actions defined in result array

- Modifies tests that expected the single item structure so that they compare against the first item from each array

- Adds several tests for the new use case