### PR TITLE
Removes typography.com from amp-html-format.md.

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -300,7 +300,6 @@ Example:
 
 Font providers can be whitelisted if they support CSS-only integrations and serve over HTTPS. The following origins are currently allowed for font serving via link tags:
 
-- Typography.com: https://cloud.typography.com
 - Fonts.com: https://fast.fonts.net
 - Google Fonts: https://fonts.googleapis.com
 - Font Awesome: https://maxcdn.bootstrapcdn.com


### PR DESCRIPTION
Closes #5844