### PR TITLE
Change the spec for amp-audio[autoplay]

### DIFF
--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -67,9 +67,8 @@ For example:
 
 **autoplay**
 
-The `autoplay` attribute allows the author to specify when - if ever - the animated image will autoplay.
-
-The presence of the attribute alone implies that the animated image will always autoplay. The author may specify values to limit when the animations will autoplay. Allowable values are `desktop`, `tablet`, or `mobile`, with multiple values separated by a space. The runtime makes a best-guess approximation to the device type to apply this value.
+If present, the attribute alone implies that the animated image will always
+autoplay.
 
 **loop**
 

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -67,8 +67,8 @@ For example:
 
 **autoplay**
 
-If present, the attribute alone implies that the animated image will always
-autoplay.
+If present, the attribute implies that the audio start playing as soon as it is
+ready.
 
 **loop**
 


### PR DESCRIPTION
Change the spec for `amp-audio[autoplay]` to correctly indicate that this is a boolean attribute, rather than the enum mentioned today.