### PR TITLE
Turn on visibility-v2 in 1% canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -20,5 +20,6 @@
   "sentinel-name-change": 1,
   "chunked-amp": 1,
   "make-body-relative": 1,
+  "visibility-v2": 1,
   "amp-selector": 1
 }


### PR DESCRIPTION
@rudygalfi Regardless to the other experiment we're currently running with 3p publishers to check data integrity, this is to catch runtime exceptions if any. I think we can have them simultaneously.

Let me know if you have different opinion. 