### PR TITLE
Enable "sticky-ad-early-load" flag in canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -21,5 +21,6 @@
   "chunked-amp": 1,
   "make-body-relative": 1,
   "visibility-v2": 1,
-  "amp-selector": 1
+  "amp-selector": 1,
+  "sticky-ad-early-load": 1
 }


### PR DESCRIPTION
Test with 1% on the sticky-ad earlier load behavior.
cc @jasti 

