### PR TITLE
Fix undefined reportError

### DIFF
--- a/3p/ampcontext-lib.js
+++ b/3p/ampcontext-lib.js
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 import {AmpContext} from './ampcontext.js';
-import {initLogConstructor} from '../src/log';
+import {initLogConstructor, setReportError} from '../src/log';
+import {reportError} from '../src/error';
 initLogConstructor();
+setReportError(reportError);
 
 
 /**

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +35,8 @@ import {
 import {urls} from '../src/config';
 import {endsWith} from '../src/string';
 import {parseUrl, getSourceUrl, isProxyOrigin} from '../src/url';
-import {dev, initLogConstructor, user} from '../src/log';
+import {dev, initLogConstructor, setReportError, user} from '../src/log';
+import {reportError} from '../src/error';
 import {getMode} from '../src/mode';
 
 // 3P - please keep in alphabetic order
@@ -180,6 +181,7 @@ try {
 
 // This should only be invoked after window.context is set
 initLogConstructor();
+setReportError(reportError);
 
 // Experiment toggles
 setExperimentToggles(window.context.experimentToggles);

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -36,7 +36,6 @@ import {urls} from '../src/config';
 import {endsWith} from '../src/string';
 import {parseUrl, getSourceUrl, isProxyOrigin} from '../src/url';
 import {dev, initLogConstructor, setReportError, user} from '../src/log';
-import {reportError} from '../src/error';
 import {getMode} from '../src/mode';
 
 // 3P - please keep in alphabetic order
@@ -181,7 +180,7 @@ try {
 
 // This should only be invoked after window.context is set
 initLogConstructor();
-setReportError(reportError);
+setReportError(console.error.bind(console));
 
 // Experiment toggles
 setExperimentToggles(window.context.experimentToggles);

--- a/ads/alp/install-alp.js
+++ b/ads/alp/install-alp.js
@@ -19,8 +19,10 @@
 import '../../third_party/babel/custom-babel-helpers';
 
 import {installAlpClickHandler, warmupStatic} from './handler';
-import {initLogConstructor} from '../../src/log';
+import {initLogConstructor, setReportError} from '../../src/log';
+import {reportError} from '../../src/error';
 
 initLogConstructor();
+setReportError(reportError);
 installAlpClickHandler(window);
 warmupStatic(window);

--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -20,7 +20,8 @@
  */
 
 import '../../third_party/babel/custom-babel-helpers';
-import {dev, initLogConstructor} from '../../src/log';
+import {dev, initLogConstructor, setReportError} from '../../src/log';
+import {reportError} from '../../src/error';
 import {InaboxMessagingHost} from './inabox-messaging-host';
 
 const TAG = 'inabox-host';
@@ -38,6 +39,7 @@ function run(win) {
 
   win['ampInaboxInitialized'] = true;
   initLogConstructor();
+  setReportError(reportError);
 
   const host = new InaboxMessagingHost(win, win['ampInaboxIframes']);
 

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -253,7 +253,7 @@ var forbiddenTerms = {
       'src/service/xhr-impl.js',
     ],
   },
-  'initLogConstructor': {
+  'initLogConstructor|setReportError': {
     message: 'Should only be called from JS binary entry files.',
     whitelist: [
       '3p/integration.js',
@@ -336,15 +336,6 @@ var forbiddenTerms = {
       'src/cookies.js',
       'src/experiments.js',
       'tools/experiments/experiments.js',
-    ],
-  },
-  'setReportError\\W': {
-    message: 'Should only be used in error.js and tests.',
-    whitelist: [
-      'dist.3p/current/integration.js',
-      'src/error.js',
-      'src/event-helper.js',
-      'src/log.js',
     ],
   },
   'isTrustedViewer': {

--- a/extensions/amp-access/0.1/amp-login-done.js
+++ b/extensions/amp-access/0.1/amp-login-done.js
@@ -22,10 +22,12 @@
 import '../../../third_party/babel/custom-babel-helpers';
 import '../../../src/polyfills';
 import {LoginDoneDialog} from './amp-login-done-dialog';
-import {initLogConstructor} from '../../../src/log';
+import {initLogConstructor, setReportError} from '../../../src/log';
+import {reportError} from '../../../src/error';
 import {onDocumentReady} from '../../../src/document-ready';
 
 initLogConstructor();
+setReportError(reportError);
 
 onDocumentReady(document, () => {
   new LoginDoneDialog(window).start();

--- a/src/error.js
+++ b/src/error.js
@@ -19,12 +19,10 @@ import {getMode} from './mode';
 import {exponentialBackoff} from './exponential-backoff';
 import {
   isLoadErrorMessage,
-  setReportError as setReportErrorEventHelper,
 } from './event-helper';
 import {
   USER_ERROR_SENTINEL,
   isUserErrorMessage,
-  setReportError as setReportErrorLog,
 } from './log';
 import {makeBodyVisible} from './style-installer';
 import {urls} from './config';
@@ -145,8 +143,6 @@ export function reportError(error, opt_associatedElement) {
   }
   return /** @type {!Error} */ (error);
 }
-setReportErrorEventHelper(reportError);
-setReportErrorLog(reportError);
 
 /**
  * Returns an error for a cancellation of a promise.

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -36,7 +36,7 @@ export function listen(element, eventType, listener, opt_capture) {
     try {
       return localListener.call(this, event);
     } catch (e) {
-      reportError(e);
+      self.reportError(e);
       throw e;
     }
   };
@@ -71,7 +71,7 @@ export function listenOnce(element, eventType, listener, opt_capture) {
     try {
       localListener(event);
     } catch (e) {
-      reportError(e);
+      self.reportError(e);
       throw e;
     } finally {
       unlisten();

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -36,6 +36,7 @@ export function listen(element, eventType, listener, opt_capture) {
     try {
       return localListener.call(this, event);
     } catch (e) {
+      // reportError is installed globally per window in the entry point.
       self.reportError(e);
       throw e;
     }
@@ -71,6 +72,7 @@ export function listenOnce(element, eventType, listener, opt_capture) {
     try {
       localListener(event);
     } catch (e) {
+      // reportError is installed globally per window in the entry point.
       self.reportError(e);
       throw e;
     } finally {

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -21,21 +21,6 @@ import {user} from './log';
 const LOAD_FAILURE_PREFIX = 'Failed to load:';
 
 /**
- * @type {function(*, !Element=)|undefined}
- */
-let reportError;
-
-/**
- * Sets reportError function. Called from error.js to break cyclic
- * dependency.
- * @param {function(*, !Element=)|undefined} fn
- */
-export function setReportError(fn) {
-  reportError = fn;
-}
-
-
-/**
  * Listens for the specified event on the element.
  * @param {!EventTarget} element
  * @param {string} eventType

--- a/src/log.js
+++ b/src/log.js
@@ -210,6 +210,7 @@ export class Log {
   error(tag, var_args) {
     const error = this.error_.apply(this, arguments);
     if (error) {
+      // reportError is installed globally per window in the entry point.
       self.reportError(error);
     }
   }
@@ -224,6 +225,7 @@ export class Log {
     const error = this.error_.apply(this, arguments);
     if (error) {
       error.expected = true;
+      // reportError is installed globally per window in the entry point.
       self.reportError(error);
     }
   }
@@ -295,6 +297,7 @@ export class Log {
       e.associatedElement = firstElement;
       e.messageArray = messageArray;
       this.prepareError_(e);
+      // reportError is installed globally per window in the entry point.
       self.reportError(e);
       throw e;
     }
@@ -448,6 +451,7 @@ function createErrorVargs(var_args) {
 export function rethrowAsync(var_args) {
   const error = createErrorVargs.apply(null, arguments);
   setTimeout(() => {
+    // reportError is installed globally per window in the entry point.
     self.reportError(error);
     throw error;
   });

--- a/src/log.js
+++ b/src/log.js
@@ -55,17 +55,12 @@ export const LogLevel = {
 };
 
 /**
- * @type {function(*, !Element=)|undefined}
- */
-let reportError;
-
-/**
  * Sets reportError function. Called from error.js to break cyclic
  * dependency.
  * @param {function(*, !Element=)|undefined} fn
  */
 export function setReportError(fn) {
-  reportError = fn;
+  self.reportError = fn;
 }
 
 /**
@@ -215,7 +210,7 @@ export class Log {
   error(tag, var_args) {
     const error = this.error_.apply(this, arguments);
     if (error) {
-      reportError(error);
+      self.reportError(error);
     }
   }
 
@@ -229,7 +224,7 @@ export class Log {
     const error = this.error_.apply(this, arguments);
     if (error) {
       error.expected = true;
-      reportError(error);
+      self.reportError(error);
     }
   }
 
@@ -300,7 +295,7 @@ export class Log {
       e.associatedElement = firstElement;
       e.messageArray = messageArray;
       this.prepareError_(e);
-      reportError(e);
+      self.reportError(e);
       throw e;
     }
     return shouldBeTrueish;
@@ -453,7 +448,7 @@ function createErrorVargs(var_args) {
 export function rethrowAsync(var_args) {
   const error = createErrorVargs.apply(null, arguments);
   setTimeout(() => {
-    reportError(error);
+    self.reportError(error);
     throw error;
   });
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -30,7 +30,8 @@ import {
 import {ampdocServiceFor} from './ampdoc';
 import {startupChunk} from './chunk';
 import {cssText} from '../build/css';
-import {dev, user, initLogConstructor} from './log';
+import {dev, user, initLogConstructor, setReportError} from './log';
+import {reportError} from './error';
 import {
   disposeServicesForDoc,
   fromClassForDoc,
@@ -83,6 +84,7 @@ import {waitForBody} from './dom';
 import * as config from './config';
 
 initLogConstructor();
+setReportError(reportError);
 
 /**
  * - n is the name.

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -16,7 +16,8 @@
 
 import '../../third_party/babel/custom-babel-helpers';
 import '../../src/polyfills';
-import {dev, initLogConstructor} from '../../src/log';
+import {dev, initLogConstructor, setReportError} from '../../src/log';
+import {reportError} from '../../src/error';
 import {getCookie, setCookie} from '../../src/cookies';
 import {getMode} from '../../src/mode';
 import {isExperimentOn, toggleExperiment} from '../../src/experiments';
@@ -26,6 +27,7 @@ import {onDocumentReady} from '../../src/document-ready';
 import '../../src/service/timer-impl';
 
 initLogConstructor();
+setReportError(reportError);
 
 const COOKIE_MAX_AGE_DAYS = 180;  // 6 month
 


### PR DESCRIPTION
Fixes a bug from #7363. Because the extensions never see a call to
`setReportError`, in their own bundles `reportError` is probably
`undefined`.

This fix makes `reportError` a global variable, so we get the same
requirements (entry-points must call `setReportError`). But now, the
extension bundles will use that global `reportError`.