### PR TITLE
Created new endpoint for loading test pages in an iframe.

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -460,7 +460,7 @@ app.use('/min/', function(req, res) {
 // Nest the response in an iframe.
 // Example:
 // http://localhost:8000/iframe/examples/ads.amp.max.html
-app.use('/iframe/', function(req, res) {
+app.get('/iframe/', function(req, res) {
   // Returns an html blob with an iframe pointing to the url after /iframe/.
   res.send(`<!doctype html>
           <html style="width:100%; height:100%;">

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -251,15 +251,6 @@ function proxyToAmpProxy(req, res, minify) {
   });
 }
 
-// Returns an html blob with an iframe pointing to the provided url.
-function nestResponseInIframe(url) {
-  return `<!doctype html>
-          <html style="width:100%; height:100%;">
-            <body style="width:98%; height:98%;">
-              <iframe src="${url}" style="width:100%; height:100%;"></iframe>
-            </body>
-          </html>`;
-}
 
 var liveListUpdateFile = '/examples/live-list-update.amp.html';
 var liveListCtr = 0;
@@ -470,7 +461,14 @@ app.use('/min/', function(req, res) {
 // Example:
 // http://localhost:8000/iframe/examples/ads.amp.max.html
 app.use('/iframe/', function(req, res) {
-  res.send(nestResponseInIframe(req.url));
+  // Returns an html blob with an iframe pointing to the url after /iframe/.
+  res.send(`<!doctype html>
+          <html style="width:100%; height:100%;">
+            <body style="width:98%; height:98%;">
+              <iframe src="${req.url}" style="width:100%; height:100%;">
+              </iframe>
+            </body>
+          </html>`);
 });
 
 // A4A envelope.

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -251,6 +251,16 @@ function proxyToAmpProxy(req, res, minify) {
   });
 }
 
+// Returns an html blob with an iframe pointing to the provided url.
+function nestResponseInIframe(url) {
+  return `<!doctype html>
+          <html style="width:100%; height:100%;">
+            <body style="width:98%; height:98%;">
+              <iframe src="${url}" style="width:100%; height:100%;"></iframe>
+            </body>
+          </html>`;
+}
+
 var liveListUpdateFile = '/examples/live-list-update.amp.html';
 var liveListCtr = 0;
 var itemCtr = 2;
@@ -454,6 +464,13 @@ app.use('/max/', function(req, res) {
 // http://localhost:8000/min/s/www.washingtonpost.com/amphtml/news/post-politics/wp/2016/02/21/bernie-sanders-says-lower-turnout-contributed-to-his-nevada-loss-to-hillary-clinton/
 app.use('/min/', function(req, res) {
   proxyToAmpProxy(req, res, /* minify */ true);
+});
+
+// Nest the response in an iframe.
+// Example:
+// http://localhost:8000/iframe/examples/ads.amp.max.html
+app.use('/iframe/', function(req, res) {
+  res.send(nestResponseInIframe(req.url));
 });
 
 // A4A envelope.


### PR DESCRIPTION
It is becoming increasingly common to want to run example pages within an iframe. Instead of redoing ever test and making N duplicates, I have added an endpoint to the test server, /iframe/, that allows you to load any page inside of an iframe. 