### PR TITLE
amp-auto-ads: Adding 'ampa' tag origin for the AdSense AdNetworkConfig.

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -88,6 +88,10 @@ class AdSenseNetworkConfig {
         name: 'ad-client',
         value: this.autoAmpAdsElement_.getAttribute('data-ad-client'),
       },
+      {
+        name: 'tag-origin',
+        value: 'ampa',
+      },
     ];
   }
 }

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -51,6 +51,10 @@ describe('ad-network-config', () => {
           name: 'ad-client',
           value: 'ca-pub-1234',
         },
+        {
+          name: 'tag-origin',
+          value: 'ampa',
+        },
       ]);
     });
   });

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -131,6 +131,7 @@ describes.realWin('amp-auto-ads', {
     expect(adElement.tagName).to.equal('AMP-AD');
     expect(adElement.getAttribute('type')).to.equal('adsense');
     expect(adElement.getAttribute('data-ad-client')).to.equal(AD_CLIENT);
+    expect(adElement.getAttribute('data-tag-origin')).to.equal('ampa');
   }
 
   it('should insert three ads on page using config', () => {


### PR DESCRIPTION
Adding 'ampa' tag origin for the AdSense AdNetworkConfig. This is required in order to track traffic coming from amp-auto-ads.

https://github.com/ampproject/amphtml/issues/6196