### PR TITLE
Correct <amp-social-share> docs

### DIFF
--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -164,7 +164,7 @@ The `amp-social-share` component provides [some pre-configured providers](0.1/am
     <td>
       <ul>
         <li><code>text</code>: optional, defaults to: "Current page title"</li>
-        <li><code>data-mode</code>: optional, if set to <code>override</code>, all other share options are removed.</li>
+        <li><code>data-mode</code>: optional, if set to <code>replace</code>, all other share options are removed.</li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
The docs don't match [the code](https://github.com/ampproject/amphtml/blob/master/extensions/amp-social-share/0.1/amp-social-share.js#L72).