### PR TITLE
Ensure that critical vsync tasks run when rAF is disabled.

### DIFF
--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -43,7 +43,7 @@ let VsyncTaskSpecDef;
 
 
 /**
- * Abstraction over requestAnimationFrame that batches DOM read (measure)
+ * Abstraction over requestAnimationFrame (rAF) that batches DOM read (measure)
  * and write (mutate) tasks in a single frame, to eliminate layout thrashing.
  *
  * NOTE: If the document is invisible due to prerendering (this includes
@@ -108,8 +108,27 @@ export class Vsync {
     /** @const {!Function} */
     this.boundRunScheduledTasks_ = this.runScheduledTasks_.bind(this);
 
-    /** @const {!Pass} */
-    this.pass_ = new Pass(this.win, this.boundRunScheduledTasks_, FRAME_TIME);
+    /**
+     * If the doc is invisible we use this instead of rAF because rAF
+     * does not run in that scenario.
+     * However, we only do this for non-animation tasks as running
+     * animations doesn't make sense when not visible.
+     * @const {!Pass}
+     */
+    this.invisiblePass_ = new Pass(this.win, this.boundRunScheduledTasks_,
+        FRAME_TIME);
+
+    /**
+     * Similar to this.invisiblePass_, but backing up a real rAF call. If we
+     * somehow failed to know that we are throttled we use a timer (which
+     * may also be throttled but at least runs eventually) to make sure
+     * we continue to get work done.
+     * @const {!Pass}
+     */
+    this.backupPass_ = new Pass(this.win, this.boundRunScheduledTasks_,
+        // We cancel this when rAF fires and really only want it to fire
+        // if rAF doesn't work at all.
+        FRAME_TIME * 2.5);
 
     /** @private {?./viewer-impl.Viewer} */
     this.singleDocViewer_ = null;
@@ -360,8 +379,9 @@ export class Vsync {
   forceSchedule_() {
     if (this.canAnimate_()) {
       this.raf_(this.boundRunScheduledTasks_);
+      this.backupPass_.schedule();
     } else {
-      this.pass_.schedule();
+      this.invisiblePass_.schedule();
     }
   }
 
@@ -372,6 +392,7 @@ export class Vsync {
    * @private
    */
   runScheduledTasks_() {
+    this.backupPass_.cancel();
     this.scheduled_ = false;
     if (this.jankMeter_) {
       this.jankMeter_.onRun();

--- a/test/functional/test-vsync.js
+++ b/test/functional/test-vsync.js
@@ -41,7 +41,10 @@ describe('vsync', () => {
       },
       services: {},
       setTimeout: (fn, t) => {
-        window.setTimeout(fn, t);
+        return window.setTimeout(fn, t);
+      },
+      clearTimeout: (index) => {
+        window.clearTimeout(index);
       },
       requestAnimationFrame: window.requestAnimationFrame.bind(window),
     };
@@ -272,13 +275,15 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
       expect(rafHandler).to.exist;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
+      expect(vsync.backupPass_.isPending()).to.be.true;
 
       rafHandler();
       expect(result).to.equal('mu1');
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
+      expect(vsync.backupPass_.isPending()).to.be.false;
     });
 
     it('should schedule via timer frames when doc is not visible', () => {
@@ -296,13 +301,48 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
       expect(rafHandler).to.be.undefined;
-      expect(vsync.pass_.isPending()).to.be.true;
+      expect(vsync.invisiblePass_.isPending()).to.be.true;
 
       clock.tick(17);
       expect(result).to.equal('mu1');
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
+    });
+
+    it('should run via backup timer if rAF somehow doesnt fire', () => {
+      let rafHandler;
+      vsync.raf_ = function() {
+        // intentionally empty
+      };
+      viewer.isVisible = () => true;
+
+      let result = '';
+      vsync.run({
+        mutate: () => {
+          result += 'mu1';
+        },
+      });
+
+      expect(vsync.tasks_).to.have.length(1);
+      expect(vsync.scheduled_).to.be.true;
+      expect(rafHandler).to.be.undefined;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
+      expect(vsync.backupPass_.isPending()).to.be.true;
+
+      clock.tick(17);
+      expect(result).to.equal('');
+      expect(vsync.tasks_).to.have.length(1);
+      expect(vsync.scheduled_).to.be.true;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
+      expect(vsync.backupPass_.isPending()).to.be.true;
+
+      clock.tick(240);
+      expect(result).to.equal('mu1');
+      expect(vsync.tasks_).to.have.length(0);
+      expect(vsync.scheduled_).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
+      expect(vsync.backupPass_.isPending()).to.be.false;
     });
 
     it('should re-schedule when doc goes invisible', () => {
@@ -320,20 +360,20 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
       expect(rafHandler).to.exist;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
 
       viewer.isVisible = () => false;
       viewerVisibilityChangedHandler();
 
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
-      expect(vsync.pass_.isPending()).to.be.true;
+      expect(vsync.invisiblePass_.isPending()).to.be.true;
 
       clock.tick(17);
       expect(result).to.equal('mu1');
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
     });
 
     it('should re-schedule when doc goes visible', () => {
@@ -351,7 +391,7 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
       expect(rafHandler).to.be.undefined;
-      expect(vsync.pass_.isPending()).to.be.true;
+      expect(vsync.invisiblePass_.isPending()).to.be.true;
 
       viewer.isVisible = () => true;
       viewerVisibilityChangedHandler();
@@ -374,7 +414,7 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
       expect(rafHandler).to.be.undefined;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
 
       viewer.isVisible = () => false;
       viewerVisibilityChangedHandler();
@@ -382,7 +422,7 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
       expect(rafHandler).to.be.undefined;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
     });
 
     it('should run anim task when visible', () => {
@@ -549,7 +589,7 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
       expect(rafHandler).to.exist;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
 
       rafHandler();
       expect(result).to.equal('mu1');
@@ -572,13 +612,13 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
       expect(rafHandler).to.be.undefined;
-      expect(vsync.pass_.isPending()).to.be.true;
+      expect(vsync.invisiblePass_.isPending()).to.be.true;
 
       clock.tick(17);
       expect(result).to.equal('mu1');
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
     });
 
     it('should re-schedule when doc goes invisible', () => {
@@ -596,20 +636,20 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
       expect(rafHandler).to.exist;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
 
       docState.isHidden = () => true;
       docVisibilityHandler();
 
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
-      expect(vsync.pass_.isPending()).to.be.true;
+      expect(vsync.invisiblePass_.isPending()).to.be.true;
 
       clock.tick(17);
       expect(result).to.equal('mu1');
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
     });
 
     it('should re-schedule when doc goes visible', () => {
@@ -627,7 +667,7 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(1);
       expect(vsync.scheduled_).to.be.true;
       expect(rafHandler).to.be.undefined;
-      expect(vsync.pass_.isPending()).to.be.true;
+      expect(vsync.invisiblePass_.isPending()).to.be.true;
 
       docState.isHidden = () => false;
       docVisibilityHandler();
@@ -650,7 +690,7 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
       expect(rafHandler).to.be.undefined;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
 
       docState.isHidden = () => true;
       docVisibilityHandler();
@@ -658,7 +698,7 @@ describe('vsync', () => {
       expect(vsync.tasks_).to.have.length(0);
       expect(vsync.scheduled_).to.be.false;
       expect(rafHandler).to.be.undefined;
-      expect(vsync.pass_.isPending()).to.be.false;
+      expect(vsync.invisiblePass_.isPending()).to.be.false;
     });
 
     it('should run anim task when visible', () => {

--- a/test/functional/test-vsync.js
+++ b/test/functional/test-vsync.js
@@ -43,7 +43,7 @@ describe('vsync', () => {
       setTimeout: (fn, t) => {
         return window.setTimeout(fn, t);
       },
-      clearTimeout: (index) => {
+      clearTimeout: index => {
         window.clearTimeout(index);
       },
       requestAnimationFrame: window.requestAnimationFrame.bind(window),


### PR DESCRIPTION
Add a backup timer for non-animation vsync tasks. This ensures that non-animation tasks still eventually (timer at 2.5X normal rAF time) execute when we somehow failed to detect that we aren't visible.

Fixes #7589