### PR TITLE
Enable decreasing height above viewport

### DIFF
--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -174,6 +174,16 @@
       </amp-anim>
     </amp-carousel>
   </p>
+  <h2 id="fakead3p_0">fake3pAd send no-content</h2>
+  <div>
+    <amp-ad width=300 height=250
+        type="_ping_"
+        data-id='0'
+        data-url='not-exist'
+        data-valid='false'>
+    </amp-ad>
+  </div>
+
   <p>
     <amp-carousel width=auto height=200>
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>

--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -174,16 +174,6 @@
       </amp-anim>
     </amp-carousel>
   </p>
-  <h2 id="fakead3p_0">fake3pAd send no-content</h2>
-  <div>
-    <amp-ad width=300 height=250
-        type="_ping_"
-        data-id='0'
-        data-url='not-exist'
-        data-valid='false'>
-    </amp-ad>
-  </div>
-
   <p>
     <amp-carousel width=auto height=200>
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1096,7 +1096,7 @@ export class Resources {
             }
             // Sync is necessary here to avoid UI jump in the next frame.
             const newScrollHeight = this.viewport_./*OK*/getScrollHeight();
-            if (newScrollHeight > state./*OK*/scrollHeight) {
+            if (newScrollHeight != state./*OK*/scrollHeight) {
               this.viewport_.setScrollTop(state./*OK*/scrollTop +
                   (newScrollHeight - state./*OK*/scrollHeight));
             }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -977,6 +977,7 @@ export class Resources {
       // Find minimum top position and run all mutates.
       let minTop = -1;
       const scrollAdjSet = [];
+      let aboveVpHeightChange = 0;
       for (let i = 0; i < requestsChangeSize.length; i++) {
         const request = requestsChangeSize[i];
         /** @const {!Resource} */
@@ -1026,11 +1027,20 @@ export class Resources {
           // resize.
           resize = true;
         } else if (bottomDisplacedBoundary <= viewportRect.top + topOffset) {
-          // 5. Elements above the viewport can only be resized when scrolling
-          // has stopped, otherwise defer util next cycle.
+          // 5. Elements above the viewport can only be resized if we are able
+          // to compensate the height change by setting scrollTop.
+          if (heightDiff < 0 &&
+              viewportRect.top + aboveVpHeightChange < -heightDiff) {
+            // Do nothing if height abobe viewport height can't compensate
+            // height decrease
+            continue;
+          }
+          // Can only resized when scrollinghas stopped,
+          // otherwise defer util next cycle.
           if (isScrollingStopped) {
             // These requests will be executed in the next animation cycle and
             // adjust the scroll position.
+            aboveVpHeightChange = aboveVpHeightChange + heightDiff;
             scrollAdjSet.push(request);
           } else {
             // Defer till next cycle.

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1466,6 +1466,7 @@ describe('Resources changeSize', () => {
       resource1.layoutBox_ = {top: 10, left: 0, right: 100, bottom: 50,
           height: 50};
       vsyncSpy = sandbox.stub(resources.vsync_, 'run');
+      resources.visible_ = true;
     });
 
     it('should NOT change size when height is unchanged', () => {
@@ -1606,6 +1607,66 @@ describe('Resources changeSize', () => {
       expect(resource1.changeSize).to.be.calledOnce;
       expect(resource1.changeSize).to.be.calledWith(111, 222);
       expect(resources.relayoutTop_).to.equal(resource1.layoutBox_.top);
+    });
+
+    it('should NOT resize when above vp but cannot adjust scrolling', () => {
+      resource1.layoutBox_ = {top: -1200, left: 0, right: 100, bottom: -1100,
+          height: 100};
+      resources.lastVelocity_ = 0;
+      clock.tick(5000);
+      resources.scheduleChangeSize_(resource1, 0, 222, undefined, false);
+      expect(vsyncSpy).to.be.calledOnce;
+      vsyncSpy.reset();
+      resources.mutateWork_();
+
+      expect(resources.requestsChangeSize_).to.be.empty;
+      expect(resource1.changeSize).to.not.be.called;
+      expect(vsyncSpy).to.not.be.called;
+    });
+
+    it('should resize if multi request above vp can adjust scroll', () => {
+      resource1.layoutBox_ = {top: -1200, left: 0, right: 100, bottom: -1100,
+          height: 100};
+      resource2.layoutBox_ = {top: -1300, left: 0, right: 100, bottom: -1200,
+          height: 100};
+      resources.lastVelocity_ = 0;
+      clock.tick(5000);
+      resources.scheduleChangeSize_(resource2, 200, 222, undefined, false);
+      resources.scheduleChangeSize_(resource1, 0, 222, undefined, false);
+      resources.mutateWork_();
+
+      const task = vsyncSpy.lastCall.args[0];
+      const state = {};
+      task.mutate(state);
+
+      expect(resource1.changeSize).to.be.calledOnce;
+      expect(resource2.changeSize).to.be.calledOnce;
+    });
+
+    it('should NOT resize if multi req above vp cannot adjust scroll', () => {
+      // Only to satisfy expectation in beforeEach
+      resources.viewport_.getRect();
+
+      // Force return here, because can't stub getRect fun twice.
+      resources.viewport_.getRect = () => {
+        return {top: 10, left: 0, right: 100, bottom: 210, height: 200};
+      };
+
+      resource1.layoutBox_ = {top: -1200, left: 0, right: 100, bottom: -1100,
+          height: 100};
+      resource2.layoutBox_ = {top: -1300, left: 0, right: 100, bottom: -1200,
+          height: 100};
+      resources.lastVelocity_ = 0;
+      clock.tick(5000);
+      resources.scheduleChangeSize_(resource1, 92, 222, undefined, false);
+      resources.scheduleChangeSize_(resource2, 92, 222, undefined, false);
+      resources.mutateWork_();
+      const task = vsyncSpy.lastCall.args[0];
+      const state = {};
+      task.mutate(state);
+
+      expect(resource1.changeSize).to.be.calledOnce;
+      expect(resource2.changeSize).to.not.be.called;
     });
 
     it('should NOT adjust scrolling if size did not increase', () => {

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1662,7 +1662,6 @@ describe('Resources changeSize', () => {
       const task = vsyncSpy.lastCall.args[0];
       const state = {};
       task.mutate(state);
-      console.log('success');
       expect(resource1.changeSize).to.be.calledOnce;
       expect(resource2.changeSize).to.not.be.called;
     });


### PR DESCRIPTION
We don't adjust scroll if element resize to a smaller height above viewport. This is a feature that we should support. 

Unlike increasing, it's possible that I cannot compensate height change through adjusting scroll, because there may not be enough height above. In this PR I only try to resize by best effort. Trying to see if I can reduce size based on already handled request in one mutate. 

The new feature will also fix #7481 