### PR TITLE
Reconcile/clarify contribution & development docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,68 +14,68 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-## Contributing to AMP HTML
+# Contributing to AMP HTML
 
 The AMP HTML project strongly encourages technical [contributions](https://www.ampproject.org/contribute/)!
 
 We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about.
 
-### Filing Issues
+## Filing issues
 
-**Suggestions**
+### Suggestions
 
-The AMP HTML project is meant to evolve with feedback - the project and its users greatly appreciate any thoughts on ways to improve the design or features. Please use the `enhancement` tag to specifically denote issues that are suggestions - this helps us triage and respond appropriately.
+The AMP Project is meant to evolve with feedback.  The project and its users appreciate your thoughts on ways to improve the design or features.
 
-**Bugs**
+To make a suggestion [file an issue](https://github.com/ampproject/amphtml/issues/new) and add the [Type: Feature Request](https://github.com/ampproject/amphtml/labels/Type%3A%20Feature%20Request) label.
 
-As with all pieces of software, you may end up running into bugs. Please submit bugs as regular issues on GitHub - AMP HTML developers are regularly monitoring issues and will try to fix open bugs quickly.
+If you are suggesting a feature that you are intending to implement, please see the [Contributing features](#contributing-features) section below for next steps.
 
-The best bug reports include a detailed way to predictably reproduce the issue, and possibly even a working example that demonstrates the issue.
+### Bugs
 
-### Ongoing Participation
+If you find a bug in AMP, please [file an issue](https://github.com/ampproject/amphtml/issues/new).  Members of the community are regularly monitoring issues and will try to fix open bugs quickly.
 
-We actively encourage ongoing participation by community members.
+The best bug reports provide a detailed description of the issue (including screenshots if possible), step-by-step instructions for predictably reproducing the issue, and possibly even a working example that demonstrates the issue.
 
-* **Discussions** for implementations, designs, etc. often happen in the [amphtml-discuss Google Group](https://groups.google.com/forum/#!forum/amphtml-discuss) and the [amphtml Slack](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877).
-* **Weekly status updates** from individual community members are posted as GitHub issues labeled [Type: Weekly Status](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Weekly+Status%22).  If you have a weekly status update related to your work on AMP that you'd like to share with the community please add it as a comment on the relevant Weekly Status issue.
-* **Weekly design reviews** are held as video conferences via Google Hangouts on Wednesdays at [1pm Pacific](https://www.google.com/?#q=1pm+pacific+in+local+time).  Design reviews are used to discuss/refine engineering designs after an initial draft of the design has been created and shared with the community.  The design reviews are meant as an *optional* venue for concentrated feedback and discussion.  **Going through this design review is *not* required to make a contribution to AMP.**
-  * We use GitHub issues labeled [Type: Design Review](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Design+Review%22) to track design reviews.  The Design Review issue for a given week will have a link to the design docs being discussed that week as well as a link to the Hangout.
-  * When you attend a design review please read through the design docs before the review starts.
-  * If you have an engineering design you would like to discuss at a design review:
-    * Create a software design document in a shared Google Document open to public comments.  A short design doc is fine as long as it covers your design in sufficient detail to allow for a review by other members of the community.  Take a look at [Design docs - A design doc](https://medium.com/@cramforce/design-docs-a-design-doc-a152f4484c6b) for tips on putting together a good design doc.  Some examples:
-      * [Phone call tracking in AMP](https://docs.google.com/document/d/1UDMYv0f2R9CvMUSBQhxjtkSnC4984t9dJeqwm_8WiAM/edit)
-      * [New AMP Boilerplate](https://docs.google.com/document/d/1gZFaKvcDffceJNaI3bYfuYPtYU5u2y6UhE5wBPTsJ9w/edit)
-    * Perform a design pre-review with at least one [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md); you can request a pre-review in the [#design-review Slack channel](https://amphtml.slack.com/messages/design-review/).  It is fine to request a pre-review before your design doc is complete.
-    * When your design is ready to be discussed at a design review add a comment on the appropriate Design Review GitHub issue.  Post a link to the design doc and a brief summary by **1pm Pacific Monday** on the week of your design review.
+## Contributing code
 
-### Contributing Code
+The AMP Project accepts and greatly appreciates code contributions!
 
-The AMP HTML project accepts and greatly appreciates contributions. The project follows the [fork & pull](https://help.github.com/articles/using-pull-requests/#fork--pull) model for accepting contributions.
+### Tips for new open source contributors
 
-When contributing code, please also include appropriate tests as part of the pull request, and follow the same comment and coding style as the rest of the project. Take a look through the existing code for examples of the testing and style practices the project follows.
+If you are new to contributing to an open source project, Git/GitHub, etc. welcome!  We are glad you're interested in contributing to the AMP Project.
 
-A key feature of the AMP HTML project is performance - all pull requests will be analyzed for any performance impact, and the project greatly appreciates ways it can get even faster. Please include any measured performance impact with substantial pull requests.
+The [Getting Started End-to-End Guide](contributing/getting-started-e2e.md) provides step-by-step instructions for everything from creating a GitHub account to getting your code reviewed and merged.  Even if you've never contributed to an open source project before you'll soon be building AMP, making improvements and seeing your code live across the web.
 
-* We follow [Google's JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html).
+The community has created a list of [Great First Issues](https://github.com/ampproject/amphtml/labels/Great%20First%20Issues) specifically for new contributors to the project.  Feel free to find one that interests you and jump in!  Make sure to comment on the issue first so others know you are starting on it.
 
-**Google Individual Contributor License**
+If you run into any problems we have plenty of people who are willing to help; see the [How to get help](contributing/getting-started-e2e.md#how-to-get-help) section of the Getting Started guide. 
 
-Code contributors to the AMP HTML project must sign a Contributor License Agreement, either for an [individual](https://developers.google.com/open-source/cla/individual) or [corporation](https://developers.google.com/open-source/cla/corporate). The CLA is meant to protect contributors, users of the AMP HTML runtime, and Google in issues of intellectual property.
+### How to contribute code
 
-### Contributing Features
+The [Getting Started Quick Start Guide](contributing/getting-started-quick.md) has installation steps and instructions for building/testing AMP.
 
-All pull requests for new features must go through the following process:
-* Please familiarize yourself with the [AMP Design Principles](DESIGN_PRINCIPLES.md)
-* Start an Intent-to-implement GitHub issue for discussion of the new feature.
-* LGTM from Tech Lead and one other core committer is required
-* Development occurs on a separate branch of a separate fork, noted in the intent-to-implement issue
-* A pull request is created, referencing the issue.
-* AMP HTML developers will provide feedback on pull requests, looking at code quality, style, tests, performance, and directional alignment with the goals of the project. That feedback should be discussed and incorporated
-* LGTM from Tech Lead and one other core committer, who confirm engineering quality and direction.
+[DEVELOPING.md](DEVELOPING.md) has some more advanced instructions that may be necessary depending on the complexity of the changes you are making.
 
-#### Contributing Extended Components
+A few things to note:
 
-A key feature of the AMP HTML project is its extensibility - it is meant to support “Extended Components” that provide first-class support for additional rich features. The project currently accepts pull requests to include these types of extended components.
+* The AMP Project follows the [fork & pull](https://help.github.com/articles/using-pull-requests/#fork--pull) model for accepting contributions.
+* Familiarize yourself with our [Design Principles](DESIGN_PRINCIPLES.md).
+* We follow [Google's JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html).  More generally make sure to follow the same comment and coding style as the rest of the project.
+* Include tests when contributing code.  There are plenty of tests that you can use as examples.
+* A key feature of AMP is performance.  All changes will be analyzed for any performance impact; we particularly appreciate changes that make things even faster.  Please include any measured performance impact with substantial pull requests.
+
+## Contributing features
+
+Follow this process for contributing new features:
+* Familiarize yourself with the [AMP Design Principles](DESIGN_PRINCIPLES.md)
+* [Create a new GitHub issue](https://github.com/ampproject/amphtml/issues/new) with the [Intent to Implement label](https://github.com/ampproject/amphtml/labels/INTENT%20TO%20IMPLEMENT) to start discussion of the new feature.
+* Consider bringing the eng design for your feature to our [weekly design review](#weekly-design-review).
+* Before starting on the code for your feature, get approval from the [Tech Lead and a core contributor](GOVERNANCE.md).
+* Follow the guidelines for [Contributing code](#contributing-code) described above.
+
+## Contributing extended components
+
+A key feature of the AMP HTML project is its extensibility - it is meant to support “Extended Components” that provide first-class support for additional rich features.
 
 Because Extended Components may have significant impact on AMP HTML performance, security, and usage, Extended Component contributions will be very carefully analyzed and scrutinized.
 
@@ -83,9 +83,58 @@ In particular we strive to design the overall component set, so that a large num
 
 For further detail on integrating third party services, fonts, embeds, etc. see our [3p contribution guidelines](https://github.com/ampproject/amphtml/tree/master/3p).
 
+
+## Contributor License Agreement
+
+The AMP Project hosted at GitHub requires all contributors to sign a Contributor License Agreement ([individual](https://developers.google.com/open-source/cla/individual) or [corporation](https://developers.google.com/open-source/cla/corporate)) in order to protect contributors, users and Google in issues of intellectual property.
+
+When you create a Pull Request a check will be run to ensure that you have signed the CLA.  Make sure that you sign the CLA with the same email address you associate with your commits (likely via the `user.email` Git config as described on GitHub's [Set up Git](https://help.github.com/articles/set-up-git/) page).
+
+## Ongoing Participation
+
+We actively encourage ongoing participation by community members.
+
+### Discussion channels
+
+Technical issues, designs, etc. are discussed on [GitHub issues](https://github.com/ampproject/amphtml/issues) and [pull requests](https://github.com/ampproject/amphtml/pulls),
+ the [amphtml-discuss Google Group](https://groups.google.com/forum/#!forum/amphtml-discuss) and the [amphtml Slack](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877).
+
+### Weekly status updates
+
+GitHub issues labeled [Type: Weekly Status](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Weekly+Status%22) are used to track weekly updates from members of the community.  We encourage everyone who is actively contributing to AMP to add a comment to the relevant Weekly Status issue.
+
+### Weekly design reviews
+
+The community holds weekly design reviews as video conferences via Google Hangouts on Wednesdays at [1pm Pacific](https://www.google.com/?#q=1pm+pacific+in+local+time).
+
+We use GitHub issues labeled [Type: Design Review](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Design+Review%22) to track design reviews.  The Design Review issue for a given week will have a link to the design docs being discussed that week as well as a link to the Hangout.  **When attending a design review please read through the design docs _before_ the review starts.**
+
+If the design for an issue/feature you are working on has a scope larger than you can cover in a discussion in the GitHub issue or one of the other discussion channels, consider bringing it to a design review:
+
+* Create a software design document in a shared Google Document open to public comments.
+  * A short design doc is fine as long as it covers your design in sufficient detail to allow for a review by other members of the community.
+  * Take a look at [Design docs - A design doc](https://medium.com/@cramforce/design-docs-a-design-doc-a152f4484c6b) for tips on putting together a good design doc.  [Phone call tracking in AMP](https://docs.google.com/document/d/1UDMYv0f2R9CvMUSBQhxjtkSnC4984t9dJeqwm_8WiAM/edit) and [New AMP Boilerplate](https://docs.google.com/document/d/1gZFaKvcDffceJNaI3bYfuYPtYU5u2y6UhE5wBPTsJ9w/edit) are examples of past AMP Project design docs.
+  * Add this license text to the top of your design doc before sharing it with anyone else in the community (updating the year if necessary):
+      ```
+      Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+      Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+      See the License for the specific language governing permissions and limitations under the License.
+      ```
+
+* Perform a design pre-review with at least one [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md); you can request a pre-review in the [#design-review Slack channel](https://amphtml.slack.com/messages/design-review/).  It is fine to request a pre-review before your design doc is complete.
+
+* When your design is ready to be discussed at a design review add a comment on the appropriate Design Review GitHub issue.  Post a link to the design doc and a brief summary by **1pm Pacific Monday** on the week of your design review.
+
+* Update your design based on the feedback in the design review and any followup conversations in other channels.  Once your design is finalized, please provide a brief update at the start of a future design review (if you are able to attend) and submit a PDF version of your design doc in the [ampproject design-doc](https://github.com/ampproject/design-docs) repository.
+
 ### See Also
 
 * [Code of conduct](CODE_OF_CONDUCT.md)
-* [DEVELOPING](DEVELOPING.md) resources
 * [3p contribution guidelines](https://github.com/ampproject/amphtml/tree/master/3p)
 * The [GOVERNANCE](GOVERNANCE.md) model

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The [Getting Started End-to-End Guide](contributing/getting-started-e2e.md) prov
 
 The community has created a list of [Great First Issues](https://github.com/ampproject/amphtml/labels/Great%20First%20Issues) specifically for new contributors to the project.  Feel free to find one that interests you and jump in!  Make sure to comment on the issue first so others know you are starting on it.
 
-If you run into any problems we have plenty of people who are willing to help; see the [How to get help](contributing/getting-started-e2e.md#how-to-get-help) section of the Getting Started guide. 
+If you run into any problems we have plenty of people who are willing to help; see the [How to get help](contributing/getting-started-e2e.md#how-to-get-help) section of the Getting Started guide.
 
 ### How to contribute code
 
@@ -90,7 +90,7 @@ The AMP Project hosted at GitHub requires all contributors to sign a Contributor
 
 When you create a Pull Request a check will be run to ensure that you have signed the CLA.  Make sure that you sign the CLA with the same email address you associate with your commits (likely via the `user.email` Git config as described on GitHub's [Set up Git](https://help.github.com/articles/set-up-git/) page).
 
-## Ongoing Participation
+## Ongoing participation
 
 We actively encourage ongoing participation by community members.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,9 @@ A few things to note:
 
 Follow this process for contributing new features:
 * Familiarize yourself with the [AMP Design Principles](DESIGN_PRINCIPLES.md)
-* [Create a new GitHub issue](https://github.com/ampproject/amphtml/issues/new) with the [Intent to Implement label](https://github.com/ampproject/amphtml/labels/INTENT%20TO%20IMPLEMENT) to start discussion of the new feature.
+* [Create a new GitHub issue](https://github.com/ampproject/amphtml/issues/new) to start discussion of the new feature.
+* Before starting on the code get approval for your feature from an [OWNER](https://github.com/ampproject/amphtml/search?utf8=%E2%9C%93&q=filename%3AOWNERS.yaml&type=Code) of your feature's area and a [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md#core-committers).  In most cases the people who can give this approval and are most familiar with your feature's area will get involved proactively or someone else in the community will add them.  If you are having trouble finding the right people add a comment on the issue or reach out on one of the channels in [How to get help](contributing/getting-started-e2e.md#how-to-get-help).
 * Consider bringing the eng design for your feature to our [weekly design review](#weekly-design-review).
-* Before starting on the code for your feature, get approval from the [Tech Lead and a core contributor](GOVERNANCE.md).
 * Follow the guidelines for [Contributing code](#contributing-code) described above.
 
 ## Contributing extended components

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -14,33 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-## Development on AMP HTML
+# Development on AMP HTML
 
-### Slack and mailing list
+## How to get started
 
-Please join our [announcements mailing list](https://groups.google.com/forum/#!forum/amphtml-announce). This is a curated, low volume list for announcements about breaking changes and similar issues in AMP.
+Before you start developing in AMP, check out these resources:
+* [CONTRIBUTING.md](CONTRIBUTING.md) has details on various ways you can contribute to the AMP Project.
+  * If you're developing in AMP, you should read the [Contributing code](CONTRIBUTING.md#contributing-code) and [Contributing features](CONTRIBUTING.md#contributing-features) sections..
+  * The [Ongoing participation](CONTRIBUTING.md#ongoing-participation) section has details on various ways of getting in touch with others in the community including email and Slack.
+  * **If you are new to open source projects, Git/GitHub, etc.**, check out the [Tips for new open source contributors](CONTRIBUTING.md#tips-for-new-open-source-contributors) which includes information on getting help and finding your first bug to work on. 
+* The [Getting Started Quick Start Guide](contributing/getting-started-quick.md) has installation steps and basic instructions for [one-time setup](contributing/getting-started-quick.md#one-time-setup), how to [build AMP & run a local server](contributing/getting-started-quick.md#build-amp--run-a-local-server) and how to [test AMP](contributing/getting-started-quick.md#test-amp). 
 
-We discuss implementation issues on [amphtml-discuss@googlegroups.com](https://groups.google.com/forum/#!forum/amphtml-discuss).
 
-For more immediate feedback, [sign up for our Slack](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877).
+## Build & Test
 
-### Great First Issues
+For most developers the instructions in the [Getting Started Quick Start Guide](contributing/getting-started-quick.md) will be sufficient for building/running/testing during development.  This section provides a more detailed reference.
 
-We're curating a [list of GitHub "great first issues"](https://github.com/ampproject/amphtml/labels/Great%20First%20Issues) of small to medium complexity that are great to jump into development on AMP.
-
-If you have any questions, feel free to ask on the issue or join us on [Slack](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877)!
-
-### Installation
-
-1. Install [NodeJS](https://nodejs.org).
-2. In the repo directory, run `npm i` command to install the required npm packages.
-3. Run `npm i -g gulp` command to install gulp system-wide (on Mac or Linux you may need to prefix this with `sudo`, depending on how Node was installed).
-4. Edit your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows) and map `ads.localhost` and `iframe.localhost` to `127.0.0.1`.
-<pre>
-  127.0.0.1               ads.localhost iframe.localhost
-</pre>
-
-### Build & Test
+The Quick Start Guide's  [One-time setup](contributing/getting-started-quick.md#one-time-setup) has instructions for installing Node.js, Yarn, and Gulp which you'll need before running these commands.
 
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
@@ -71,26 +61,11 @@ If you have any questions, feel free to ask on the issue or join us on [Slack](h
 
 <a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.
 
-#### Saucelabs
+## Manual testing
 
-Running tests on Sauce Labs requires an account. You can get one by signing up for [Open Sauce](https://saucelabs.com/opensauce/). This will provide you with a user name and access code that you need to add to your `.bashrc` or equivalent like this:
+For manual testing build AMP and start the Node.js server by running `gulp`.
 
-```
-export SAUCE_USERNAME=sauce-labs-user-name
-export SAUCE_ACCESS_KEY=access-key
-```
-
-Also for local testing, download [saucelabs connect](https://docs.saucelabs.com/reference/sauce-connect/) (If you are having trouble, downgrade to 4.3.10) and establish a tunnel by running the `sc` before running tests.
-
-If your pull request contains JS or CSS changes and it does not change the build system, it will be automatically built and tested on [Travis](https://travis-ci.org/ampproject/amphtml/builds). After the travis run completes, the result will be logged to your PR.
-
-If a test flaked on a pull request you can ask a project owner to restart the tests for you. Use [`this.retries(x)`](https://mochajs.org/#retry-tests) as the last resort.
-
-### Manual testing
-
-The below assume you ran `gulp` in a terminal.
-
-#### Examples
+### Examples
 
 The content in the `examples` directory can be reached at: http://localhost:8000/examples/
 
@@ -101,7 +76,7 @@ For each example there are 3 modes:
 - `/examples/abc.min.html` points to a local minified AMP. This is closer to the prod setup. Only available after running `gulp dist --fortesting`.
 
 
-#### Document proxy
+### Document proxy
 
 AMP ships with a local proxy for testing production AMP documents with the local JS version.
 
@@ -119,9 +94,9 @@ code elimination to trim down the file size for the file we deploy to production
 If the origin resource is on HTTPS, the URLs are http://localhost:8000/max/s/output.jsbin.com/pegizoq/quiet and http://localhost:8000/min/s/output.jsbin.com/pegizoq/quiet
 
 
-#### A4A envelope
+### A4A envelope
 
-AMP ships with a local A4A envelope for testing local and production AMP documents with the local JS version.
+If you are working on AMP 4 Ads (A4A), you can use the local A4A envelope for testing local and production AMP documents with the local JS version.
 
 A4A can be run either of these two modes:
 
@@ -149,15 +124,41 @@ Additionally, the following query parameters can be provided:
 - `height` - the height of the `amp-ad` (default "250")
 
 
-#### Chrome extension
+### Chrome extension
 
 For testing documents on arbitrary URLs with your current local version of the AMP runtime we created a [Chrome extension](testing/local-amp-chrome-extension/README.md).
 
-#### Deploying AMP on Cloud for testing on devices
+## Testing on Sauce Labs
+
+In general local testing (i.e. `gulp test`) and the automatic test run on [Travis](https://travis-ci.org/ampproject/amphtml/pull_requests) that happens when you send a pull request are sufficient.  If you want to run your tests across multiple environments/browsers before sending your PR you can use Sauce Labs.
+
+To run the tests on Sauce Labs:
+
+* Create a Sauce Labs account.  If you are only going to use your account for open source projects like this one you can sign up for a free [Open Sauce](https://saucelabs.com/opensauce/) account.  (If you create an account through the normal account creation mechanism you'll be signing up for a free trial that expires; you can contact Sauce Labs customer service to switch your account to Open Sauce if you did this accidentally.)
+* Set the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables.  On Linux add this to your `.bashrc`:
+
+   ```
+   export SAUCE_USERNAME=<Sauce Labs username>
+   export SAUCE_ACCESS_KEY=<Sauce Labs access key>
+   ```
+
+  You can find your Sauce Labs access key on the [User Settings](https://saucelabs.com/beta/user-settings) page.
+* Install the [Sauce Connect Proxy](https://wiki.saucelabs.com/display/DOCS/Setting+Up+Sauce+Connect+Proxy).
+* Run the proxy and then run the tests:
+   ```
+   # start the proxy
+   sc
+
+   # after seeing the "Sauce Connect is up" msg, run the tests
+   gulp test --saucelabs
+   ``` 
+* It may take a few minutes for the tests to start.  You can see the status of your tests on the Sauce Labs [Automated Tests](https://saucelabs.com/beta/dashboard/tests) dashboard.  (You can also see the status of your proxy on the [Tunnels](https://saucelabs.com/beta/tunnels) dashboard. 
+
+## Deploying AMP on Cloud for testing on devices
 
 For deploying and testing local AMP builds on [HEROKU](https://www.heroku.com/) , please follow the steps outlined in this [document](https://docs.google.com/document/d/1LOr8SEBEpLkqnFjzTNIZGi2VA8AC8_aKmDVux6co63U/edit?usp=sharing).
 
-Meantime, you can also use our automatic build on Heroku [link](http://amphtml-nightly.herokuapp.com/), which is normally built with latest head on master branch (please allow delay). The first time load is normally slow due to Heroku's free account throttling policy.
+In the meantime you can also use our automatic build on Heroku [link](http://amphtml-nightly.herokuapp.com/), which is normally built with latest head on master branch (please allow delay). The first time load is normally slow due to Heroku's free account throttling policy.
 
 To correctly get ads and third party working when testing on hosted services
 you will need set the `AMP_TESTING_HOST` environment variable. (On heroku this
@@ -173,12 +174,13 @@ is done through
   builtins/       - tags built into the core AMP runtime
       *.md        - documentation for use of the builtin
       *.js        - source code for builtin tag
+  contributing/   - docs for people contributing to the AMP Project
   css/            - default css
   dist/           - (generated) main JS binaries are created here. This is what
                     gets deployed to cdn.ampproject.org.
   dist.3p/        - (generated) JS binaries and HTML files for 3p embeds and ads.
                     This is what gets deployed to 3p.ampproject.net.
-  docs/           - documentation
+  docs/           - documentation about AMP
   examples/       - example AMP HTML files and corresponding assets
   extensions/     - plugins which extend the AMP HTML runtime's core set of tags
   spec/           - The AMP HTML Specification files
@@ -197,7 +199,6 @@ In particular, we try to maintain "it might not be perfect but isn't broken"-sup
 
 ## Eng docs
 
-- [Design Principles](DESIGN_PRINCIPLES.md)
 - [Life of an AMP *](https://docs.google.com/document/d/1WdNj3qNFDmtI--c2PqyRYrPrxSg2a-93z5iX0SzoQS0/edit#)
 - [AMP Layout system](spec/amp-html-layout.md)
 - [Building an AMP Extension](https://docs.google.com/document/d/19o7eDta6oqPGF4RQ17LvZ9CHVQN53whN-mCIeIMM8Qk/edit#)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ under the [Apache License, Version 2.0](LICENSE).
 
 ## Contributing
 
-Please see [the CONTRIBUTING file](CONTRIBUTING.md) for information on contributing to the AMP Project, and [the DEVELOPING file](DEVELOPING.md) for documentation on the AMP library internals and [hints how to get started](DEVELOPING.md#starter-issues).
+We strongly encourage contributions from the community, whether it's reporting bugs, suggesting features or diving in and implementing changes to the AMP Project.  Please see [the CONTRIBUTING file](CONTRIBUTING.md) for information on contributing to the AMP Project.
 
 ### Security disclosures
 


### PR DESCRIPTION
Makes a few changes to reconcile various contribution/development docs.

- CONTRIBUTING.md
  - reorganized the doc to flow more naturally
  - added a new section for new contributors, pointing them to the other resources (e2e guide, Great First Issues, how to get help)
  - clarified that the CLA should be signed by the same address used in Git commits
  - added additional details to design review section (e.g. license text + followup)

- DEVELOPING.md
  - clarified that this doc is a reference and serves more advanced cases
  - added an intro section that points to other docs instead of repeating them
  - added additional details to the Sauce Labs section

- README.md
  - minor change to point only to CONTRIBUTING.md (removing reference to DEVELOPING.md) since CONTRIBUTING is a better entry point for new contributors

This fixes Issue #7569.

cc @bpaduch @pbakaus @camelburrito 