### PR TITLE
Update Getting Started guides with release info

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ See our [docs and reference](https://www.ampproject.org/docs/get_started/about-a
 
 We push a new release of AMP to all AMP pages every week on Thursday. The more detailed schedule is as follows:
 
-- Every Thursday we cut a green release from our `master` branch.
-- This is then pushed to users of AMP who opted into the [AMP Dev Channel](#amp-dev-channel).
+- Every Wednesday we cut a green release from our `master` branch.
+- On Thursday this is pushed to users of AMP who opted into the [AMP Dev Channel](#amp-dev-channel).
 - On Monday we check error rates for opt-in users and bug reports and if everything looks fine, we push this new release to 1% of AMP pages.
 - We then continue to monitor error rates and bug reports throughout the week.
 - On Thursday the "Dev Channel" release from last Thursday is then pushed to all users.

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -423,14 +423,23 @@ git push origin --delete <branch name>
 
 # See your changes in production
 
-⚡⚡⚡Congratulations⚡⚡⚡ on making your first change to AMP!
+**Congratulations on making your first change to AMP!**
 
 Once your changes are merged in, you won't have to wait long to see them live on AMP pages across the web!
 
-The [Releases](../README.md#releases) section of our README.md has details on the release process and how you can opt in to seeing your changes live even faster via the [AMP Dev Channel](../README.md#amp-dev-channel).
-In general we cut a release on Thursdays during working hours (Pacific time) and push it to the AMP Dev Channel that day.  The following Monday we will start rolling it out across the web slowly with a full rollout expected a few days later on Thursday.  That is:  if your change is merged in on Wednesday, you should generally be able to opt-in to see it the next day and then see it live everywhere a week later.
+In general we cut a release of AMP JS on Thursdays during working hours (Pacific time) and push it to the AMP Dev Channel that day.  After verifying there are no issues, we start rolling that build out the following Monday and complete the push that Thursday.
 
-Now that you know the process for making changes to the AMP Project and you already have most of the heavy lifting done we look forward to seeing your future contributions to the project. :)
+You can see whether your change made it into the Dev Channel or production build on the [amphtml Releases page](https://github.com/ampproject/amphtml/releases).  The build marked `Draft` is the version on the Dev Channel and the build marked `Latest Release` is what is running in production.  Your Pull Request will be listed in the first build that includes it; if you don't see your Pull Request listed it will likely be in the next build.
+
+You can opt-in to using the Dev Channel in a browser by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.  (Note that this only affects the browser in which you enable the experiment.)
+
+You can verify the AMP version your browser is using for a given page by looking at your browser's developer console.  After loading an AMP page (e.g. [https://ampproject.org](https://ampproject.org)) the console will have a message like `Powered by AMP ⚡ HTML – Version <build number>`).  The `<build number>` will match one of the build numbers on the [amphtml Releases page](https://github.com/ampproject/amphtml/releases).
+
+The [Releases section of README.md](../README.md#releases) has more details on the release process.
+
+# ⚡⚡⚡...
+
+Now that you know the process for making changes to the AMP Project you already have most of the heavy lifting done.  **We look forward to seeing your future contributions to the project.** :)
 
 # Other resources
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -425,9 +425,9 @@ git push origin --delete <branch name>
 
 **Congratulations on making your first change to AMP!**
 
-Once your changes are merged in, you won't have to wait long to see them live on AMP pages across the web!
+If your change affected internal documentation, tests, the build process, etc. you can generally see your changes right after they're merged.  If your change was to the code that runs on AMP pages across the web, you'll have to wait for them to be included in a release.
 
-In general we cut a release of AMP JS on Thursdays during working hours (Pacific time) and push it to the AMP Dev Channel that day.  After verifying there are no issues, we start rolling that build out the following Monday and complete the push that Thursday.
+In general we cut a release of amphtml on Thursdays during working hours (Pacific time) and push it to the AMP Dev Channel that day.  After verifying there are no issues, we start rolling that build out the following Monday and complete the push that Thursday.
 
 You can see whether your change made it into the Dev Channel or production build on the [amphtml Releases page](https://github.com/ampproject/amphtml/releases).  The build marked `Draft` is the version on the Dev Channel and the build marked `Latest Release` is what is running in production.  Your Pull Request will be listed in the first build that includes it; if you don't see your Pull Request listed it will likely be in the next build.
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -427,11 +427,13 @@ git push origin --delete <branch name>
 
 If your change affected internal documentation, tests, the build process, etc. you can generally see your changes right after they're merged.  If your change was to the code that runs on AMP pages across the web you'll have to wait for the change to be included in a release.
 
-In general we cut a release of amphtml on Thursdays during working hours (Pacific time) and push it to the AMP Dev Channel that day.  After verifying there are no issues, we start rolling that build out the following Monday and complete the push that Thursday.
+In general we cut a release of amphtml on Wednesdays during working hours (Pacific time) and push it to the AMP Dev Channel the next day.  After verifying there are no issues, we push that build to 1% of AMP pages the following Monday and complete the push to all AMP pages a few days later on Thursday.  That is:  on Thursday we will typically push last week's build to all AMP pages and this week's build to the Dev Channel.
 
-You can see whether your change made it into the Dev Channel or production build on the [amphtml Releases page](https://github.com/ampproject/amphtml/releases).  The build marked `Draft` is the version on the Dev Channel and the build marked `Latest Release` is what is running in production.  Your Pull Request will be listed in the first build that includes it; if you don't see your Pull Request listed it will likely be in the next build.
+**Once the push of the build that includes your change is complete all users of AMP will be using the code you contributed!**
 
-You can opt-in to using the Dev Channel in a browser by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.  (Note that this only affects the browser in which you enable the experiment.)
+You can see whether your change made it into a given build on the [amphtml Releases page](https://github.com/ampproject/amphtml/releases).  The build marked `Pre-release` is the version on the Dev Channel and the build marked `Latest Release` is what is running in production.  Your Pull Request will be listed in the first build that includes it; if you don't see your Pull Request listed it will likely be in the next build.
+
+You can set your browser to use the Dev Channel build by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.  This will let you see how your changes will affect any AMP page before your changes are rolled out to all AMP pages.  Note that this only affects the browser in which you enable the experiment.
 
 You can verify the AMP version your browser is using for a given page by looking at your browser's developer console.  After loading an AMP page (e.g. [https://ampproject.org](https://ampproject.org)) the console will have a message like `Powered by AMP ⚡ HTML – Version <build number>`).  The `<build number>` will match one of the build numbers on the [amphtml Releases page](https://github.com/ampproject/amphtml/releases).
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -425,7 +425,7 @@ git push origin --delete <branch name>
 
 **Congratulations on making your first change to AMP!**
 
-If your change affected internal documentation, tests, the build process, etc. you can generally see your changes right after they're merged.  If your change was to the code that runs on AMP pages across the web, you'll have to wait for them to be included in a release.
+If your change affected internal documentation, tests, the build process, etc. you can generally see your changes right after they're merged.  If your change was to the code that runs on AMP pages across the web you'll have to wait for the change to be included in a release.
 
 In general we cut a release of amphtml on Thursdays during working hours (Pacific time) and push it to the AMP Dev Channel that day.  After verifying there are no issues, we start rolling that build out the following Monday and complete the push that Thursday.
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -216,7 +216,7 @@ In the workflow we will be using you'll go to the master branch on your local re
 git checkout master
 
 # pull in the latest changes from the remote amphtml repository
-git pull upstream master 
+git pull upstream master
 ```
 If there have been any changes you'll see the details of what changed, otherwise you'll see a message like `Already up-to-date`.
 
@@ -224,7 +224,7 @@ After running that `git pull` command your local master branch has the latest fi
 
 ```
 # go to the branch you want to sync
-git checkout <branch name> 
+git checkout <branch name>
 
 # bring the latest changes from your master branch into this branch
 git rebase master
@@ -412,21 +412,25 @@ GitHub offers a convenient "Delete branch" button on the PR page after the chang
 
 ```
 # go back to the master branch
-git checkout master 
+git checkout master
 
 # delete the branch in your local repository
 git branch -D <branch name>
 
 # delete the branch in your GitHub fork (if you didn't use the UI)
-git push origin --delete <branch name> 
+git push origin --delete <branch name>
 ```
 
-# Celebrate
+# See your changes in production
 
-If you've gone through the steps above and had your first pull request approved and merged--or even if you just got the amphtml code built and played around with some local changes--congratulations!
+⚡⚡⚡Congratulations⚡⚡⚡ on making your first change to AMP!
 
-Now that you know the process for making changes to the AMP Project and you already have most of the heavy lifting done we look forward to seeing your future contributions to the project. :) 
+Once your changes are merged in, you won't have to wait long to see them live on AMP pages across the web!
 
+The [Releases](../README.md#releases) section of our README.md has details on the release process and how you can opt in to seeing your changes live even faster via the [AMP Dev Channel](../README.md#amp-dev-channel).
+In general we cut a release on Thursdays during working hours (Pacific time) and push it to the AMP Dev Channel that day.  The following Monday we will start rolling it out across the web slowly with a full rollout expected a few days later on Thursday.  That is:  if your change is merged in on Wednesday, you should generally be able to opt-in to see it the next day and then see it live everywhere a week later.
+
+Now that you know the process for making changes to the AMP Project and you already have most of the heavy lifting done we look forward to seeing your future contributions to the project. :)
 
 # Other resources
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -94,7 +94,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 # See your changes in production
 
-* Barring any issues, releases are cut Thursday, pushed to Dev Channel immediately, pushed to 1% on Monday and pushed to all of prod on Thursday.
+* Barring any issues releases are cut Thursday, pushed to Dev Channel immediately, pushed to 1% on Monday and pushed to all of prod on Thursday.
 * The [amphtml Releases page](https://github.com/ampproject/amphtml/releases) will list your PR in the first build that contains it.  `Draft` is the build on the Dev Channel, `Latest Release` is the build in production.
 * Opt-in to using the Dev Channel in a browser by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.
 * Find the AMP version being used on a page in the developer console, i.e. `Powered by AMP ⚡ HTML – Version <build number>`).

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -94,7 +94,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 # See your changes in production
 
-* Barring any issues releases are cut Thursday, pushed to Dev Channel immediately, pushed to 1% on Monday and pushed to all of prod on Thursday.
-* The [amphtml Releases page](https://github.com/ampproject/amphtml/releases) will list your PR in the first build that contains it.  `Draft` is the build on the Dev Channel, `Latest Release` is the build in production.
+* Barring any issues releases are cut on Wednesdays, pushed to Dev Channel Thursday, pushed to 1% of AMP pages on Monday and pushed to all pages a few days later on Thursday.
+* The [amphtml Releases page](https://github.com/ampproject/amphtml/releases) will list your PR in the first build that contains it.  `Pre-release` is the build on the Dev Channel, `Latest Release` is the build in production.
 * Opt-in to using the Dev Channel in a browser by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.
 * Find the AMP version being used on a page in the developer console, i.e. `Powered by AMP ⚡ HTML – Version <build number>`).

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -91,3 +91,10 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 * Go to the master branch: `git checkout master`
 * Delete your local branch: `git branch -D <branch name>`
 * Delete the GitHub fork branch: `git push origin --delete <branch name>`
+
+# See your changes in production
+
+* Barring any issues, releases are cut Thursday, pushed to Dev Channel immediately, pushed to 1% on Monday and pushed to all of prod on Thursday.
+* The [amphtml Releases page](https://github.com/ampproject/amphtml/releases) will list your PR in the first build that contains it.  `Draft` is the build on the Dev Channel, `Latest Release` is the build in production.
+* Opt-in to using the Dev Channel in a browser by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.
+* Find the AMP version being used on a page in the developer console, i.e. `Powered by AMP ⚡ HTML – Version <build number>`).


### PR DESCRIPTION
Added a section to the E2E and Quick Start Getting Started guides on how a changes gets to production and how the contributor can track where it is/test on Dev Channel.

cc @cramforce @bpaduch 