### PR TITLE
Turning amp-auto-ads experiment on

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -24,5 +24,6 @@
   "make-body-relative": 1,
   "visibility-v2": 1,
   "amp-selector": 1,
-  "sticky-ad-early-load": 1
+  "sticky-ad-early-load": 1,
+  "amp-auto-ads": 1,
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -22,5 +22,6 @@
   "make-body-relative": 1,
   "chunked-amp": 1,
   "amp-selector": 1,
-  "sentinel-name-change": 1
+  "sentinel-name-change": 1,
+  "amp-auto-ads": 1,
 }


### PR DESCRIPTION
Turning amp-auto-ads experiment on to 100% for prod and canary. The presence of the <amp-auto-ads> tag on the page is the effective opt-in mechanism.

https://github.com/ampproject/amphtml/issues/6196
https://github.com/ampproject/amphtml/issues/6217