### PR TITLE
Add copyright to managing user state doc

### DIFF
--- a/spec/amp-managing-user-state.md
+++ b/spec/amp-managing-user-state.md
@@ -1,3 +1,19 @@
+<!---
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Managing non-authenticated user state with AMP
 
 **Table of contents**


### PR DESCRIPTION
This PR is adding copyright information to the managing user state documentation, which was missed in the original submission.