### PR TITLE
Update amp-bind.md

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -98,7 +98,7 @@ For AMP components, only select attributes are bindable:
 | Component | Attributes |
 | --- | --- |
 | amp-carousel | slide |
-| amp-img | src, srcset, alt |
+| amp-img | src, srcset, alt, height, width |
 | amp-selector | selected |
 | amp-video | src, srcset, alt, controls, loop, poster |
 

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -93,12 +93,12 @@ In this example, `myState.foo` will evaluate to `"bar"`.
 
 For non-AMP elements, most attributes accepted by the [AMP Validator](https://validator.ampproject.org/) are bindable.
 
-For AMP components, only select attributes are bindable:
+For AMP components, the height and width attributes are bindable along with the following specific attributes:
 
 | Component | Attributes |
 | --- | --- |
 | amp-carousel | slide |
-| amp-img | src, srcset, alt, height, width |
+| amp-img | src, srcset, alt  |
 | amp-selector | selected |
 | amp-video | src, srcset, alt, controls, loop, poster |
 

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -98,7 +98,7 @@ For AMP components, the height and width attributes are bindable along with the 
 | Component | Attributes |
 | --- | --- |
 | amp-carousel | slide |
-| amp-img | src, srcset, alt  |
+| amp-img | src, srcset, alt |
 | amp-selector | selected |
 | amp-video | src, srcset, alt, controls, loop, poster |
 


### PR DESCRIPTION
Add `width` and `height` as attributes that support bindings on `amp-img`