### PR TITLE
amp-instagram: Resizing in response to messages posted by iframe

### DIFF
--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -168,7 +168,7 @@ class AmpInstagram extends AMP.BaseElement {
     if (data.type == 'MEASURE') {
       const height = data.details.height;
       if (this.iframe_./*OK*/offsetHeight !== height) {
-        // Height returned by Instagram includes header, so 
+        // Height returned by Instagram includes header, so
         // subtract 48px top padding
         this.attemptChangeHeight(height - PADDING_TOP).catch(() => {});
       }

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -63,7 +63,7 @@ class AmpInstagram extends AMP.BaseElement {
     /** @private {?string} */
     this.shortcode_ = '';
 
-    /** @private {?function} */
+    /** @private {?Function} */
     this.unlistenMessage_ = null;
   }
  /**

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -47,6 +47,21 @@ describe('amp-instagram', () => {
       if (opt_responsive) {
         ins.setAttribute('layout', 'responsive');
       }
+      ins.implementation_.getVsync = () => {
+        return {
+          mutate(cb) { cb(); },
+          measure(cb) { cb(); },
+          runPromise(task, state = {}) {
+            if (task.measure) {
+              task.measure(state);
+            }
+            if (task.mutate) {
+              task.mutate(state);
+            }
+            return Promise.resolve();
+          },
+        };
+      };
       return iframe.addElement(ins);
     });
   }

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -134,16 +134,16 @@ describe('amp-instagram', () => {
       const iframe = ins.querySelector('iframe');
       const attemptChangeHeight = sandbox.spy(impl, 'attemptChangeHeight');
       const newHeight = 977;
-      
+
       expect(iframe).to.not.be.null;
 
       sendFakeMessage(ins, iframe, 'MEASURE', {
-        height: newHeight
+        height: newHeight,
       });
 
       expect(attemptChangeHeight).to.be.calledOnce;
       // Height minus padding
-      expect(attemptChangeHeight.firstCall.args[0]).to.equal(newHeight - 48);      
+      expect(attemptChangeHeight.firstCall.args[0]).to.equal(newHeight - 48);
     });
   });
 
@@ -152,8 +152,8 @@ describe('amp-instagram', () => {
       origin: 'https://www.instagram.com',
       source: iframe.contentWindow,
       data: JSON.stringify({
-        type: type,
-        details: details
+        type,
+        details,
       }),
     });
   }

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -20,10 +20,21 @@ import {
 } from '../../../../testing/iframe';
 import '../amp-instagram';
 import {adopt} from '../../../../src/runtime';
+import * as sinon from 'sinon';
 
 adopt(window);
 
 describe('amp-instagram', () => {
+
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   function getIns(shortcode, opt_responsive, opt_beforeLayoutCallback) {
     return createIframePromise(true, opt_beforeLayoutCallback).then(iframe => {
@@ -116,4 +127,34 @@ describe('amp-instagram', () => {
     expect(getIns('')).to.be.rejectedWith(
         /The data-shortcode attribute is required for/);
   });
+
+  it('resizes in response to messages from Instagram iframe', () => {
+    return getIns('fBwFP', true).then(ins => {
+      const impl = ins.implementation_;
+      const iframe = ins.querySelector('iframe');
+      const attemptChangeHeight = sandbox.spy(impl, 'attemptChangeHeight');
+      const newHeight = 977;
+      
+      expect(iframe).to.not.be.null;
+
+      sendFakeMessage(ins, iframe, 'MEASURE', {
+        height: newHeight
+      });
+
+      expect(attemptChangeHeight).to.be.calledOnce;
+      // Height minus padding
+      expect(attemptChangeHeight.firstCall.args[0]).to.equal(newHeight - 48);      
+    });
+  });
+
+  function sendFakeMessage(ins, iframe, type, details) {
+    ins.implementation_.handleInstagramMessages_({
+      origin: 'https://www.instagram.com',
+      source: iframe.contentWindow,
+      data: JSON.stringify({
+        type: type,
+        details: details
+      }),
+    });
+  }
 });


### PR DESCRIPTION
Enabling the automatic resize of the `amp-instagram` component in response to messages received from the Instagram iframe.  Instagram posts messages with the following data property:

```json
"data": {
  "type": "MEASURE",
  "details": {
    "height": 123
  }
}
```

Fixes issue #5032.