### PR TITLE
Detect JS Engine when reporting errors

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -57,6 +57,7 @@ var testPaths = commonTestPaths.concat([
 
 var integrationTestPaths = commonTestPaths.concat([
   'test/integration/**/*.js',
+  'test/functional/test-error.js',
   'extensions/**/test/integration/**/*.js',
 ]);
 

--- a/src/error.js
+++ b/src/error.js
@@ -412,7 +412,7 @@ export function detectJsEngineFromStack() {
     if (stack.indexOf('message') > -1) {
       return 'Chrome';
     }
-
-    return 'unknown';
   }
+
+  return 'unknown';
 }

--- a/src/error.js
+++ b/src/error.js
@@ -352,6 +352,7 @@ export function getErrorReportUrl(message, filename, line, col, error,
  * Returns true if it appears like there is non-AMP JS on the
  * current page.
  * @param {!Window} win
+ * @return {boolean}
  * @visibleForTesting
  */
 export function detectNonAmpJs(win) {
@@ -368,13 +369,21 @@ export function resetAccumulatedErrorMessagesForTesting() {
   accumulatedErrorMessages = [];
 }
 
+/**
+ * Does a series of checks on the stack of an thrown error to determine the
+ * JS engine that is currently running. This gives a bit more information than
+ * just the UserAgent, since browsers often allow overriding it to "emulate"
+ * mobile.
+ * @return {string}
+ * @visibleForTesting
+ */
 export function detectJsEngineFromStack() {
   const object = Object.create({
     // DO NOT rename this property.
     // DO NOT transform into shorthand method syntax.
     t: function() {
       throw new Error('message');
-    }
+    },
   });
   try {
     object.t();

--- a/src/error.js
+++ b/src/error.js
@@ -380,18 +380,26 @@ export function detectJsEngineFromStack() {
     object.t();
   } catch (e) {
     const stack = e.stack;
+    // Firefox uses a "<." to show prototype method.
     if (stack.indexOf('<.t@') > -1) {
       return 'Firefox';
     }
 
+    // Safari does not show the context ("object."), just the function name.
     if (stack.indexOf('t@') === 0) {
       return 'Safari';
     }
 
-    if (stack.indexOf('at Global code') > -1) {
+    // IE looks like Chrome, but includes a context for the base stack line.
+    // Explicitly, we're looking for something like:
+    // "    at Global code https://example.com/app.js:1:200" or
+    // "    at Anonymous function https://example.com/app.js:1:200"
+    const last = stack.split('\n').pop();
+    if (/\bat \w+ /i.test(last)) {
       return 'IE';
     }
 
+    // Finally, chrome includes the error message in the stack.
     if (stack.indexOf('message') > -1) {
       return 'Chrome';
     }

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -411,7 +411,7 @@ describes.sandboxed('reportError', {}, () => {
   });
 });
 
-describe.only('detectJsEngineFromStack', () => {
+describe('detectJsEngineFromStack', () => {
   // Note that these are not true of every case. You can emulate iOS Safari
   // on Desktop Chrome and break this. These tests are explicitly for
   // SauceLabs, which runs does not masquerade with UserAgent.

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -23,7 +23,6 @@ import {
   detectJsEngineFromStack,
 } from '../../src/error';
 import {parseUrl, parseQueryString} from '../../src/url';
-import {platformFor} from '../../src/platform';
 import {user} from '../../src/log';
 import * as sinon from 'sinon';
 
@@ -418,33 +417,33 @@ describe.only('detectJsEngineFromStack', () => {
   // SauceLabs, which runs does not masquerade with UserAgent.
   describe.configure().ifIos().run('on iOS', () => {
     it.configure().ifSafari().run('detects safari as safari', () => {
-          expect(detectJsEngineFromStack()).to.equal('Safari');
-        });
+      expect(detectJsEngineFromStack()).to.equal('Safari');
+    });
 
     it.configure().ifChrome().run('detects chrome as safari', () => {
-          expect(detectJsEngineFromStack()).to.equal('Safari');
-        });
+      expect(detectJsEngineFromStack()).to.equal('Safari');
+    });
 
     it.configure().ifFirefox().run('detects firefox as safari', () => {
-          expect(detectJsEngineFromStack()).to.equal('Safari');
-        });
+      expect(detectJsEngineFromStack()).to.equal('Safari');
+    });
   });
 
   describe.configure().skipIos().run('on other OSs', () => {
     it.configure().ifSafari().run('detects safari as safari', () => {
-          expect(detectJsEngineFromStack()).to.equal('Safari');
-        });
+      expect(detectJsEngineFromStack()).to.equal('Safari');
+    });
 
     it.configure().ifChrome().run('detects chrome as chrome', () => {
-          expect(detectJsEngineFromStack()).to.equal('Chrome');
-        });
+      expect(detectJsEngineFromStack()).to.equal('Chrome');
+    });
 
     it.configure().ifFirefox().run('detects firefox as firefox', () => {
-          expect(detectJsEngineFromStack()).to.equal('Firefox');
-        });
+      expect(detectJsEngineFromStack()).to.equal('Firefox');
+    });
 
     it.configure().ifEdge().run('detects edge as IE', () => {
-          expect(detectJsEngineFromStack()).to.equal('IE');
-        });
+      expect(detectJsEngineFromStack()).to.equal('IE');
+    });
   });
 });

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -20,8 +20,10 @@ import {
   getErrorReportUrl,
   installErrorReporting,
   reportError,
+  detectJsEngineFromStack,
 } from '../../src/error';
 import {parseUrl, parseQueryString} from '../../src/url';
+import {platformFor} from '../../src/platform';
 import {user} from '../../src/log';
 import * as sinon from 'sinon';
 
@@ -407,5 +409,42 @@ describes.sandboxed('reportError', {}, () => {
     expect(() => {
       clock.tick();
     }).to.throw(/_reported_ Error reported incorrectly/);
+  });
+});
+
+describe.only('detectJsEngineFromStack', () => {
+  // Note that these are not true of every case. You can emulate iOS Safari
+  // on Desktop Chrome and break this. These tests are explicitly for
+  // SauceLabs, which runs does not masquerade with UserAgent.
+  describe.configure().ifIos().run('on iOS', () => {
+    it.configure().ifSafari().run('detects safari as safari', () => {
+          expect(detectJsEngineFromStack()).to.equal('Safari');
+        });
+
+    it.configure().ifChrome().run('detects chrome as safari', () => {
+          expect(detectJsEngineFromStack()).to.equal('Safari');
+        });
+
+    it.configure().ifFirefox().run('detects firefox as safari', () => {
+          expect(detectJsEngineFromStack()).to.equal('Safari');
+        });
+  });
+
+  describe.configure().skipIos().run('on other OSs', () => {
+    it.configure().ifSafari().run('detects safari as safari', () => {
+          expect(detectJsEngineFromStack()).to.equal('Safari');
+        });
+
+    it.configure().ifChrome().run('detects chrome as chrome', () => {
+          expect(detectJsEngineFromStack()).to.equal('Chrome');
+        });
+
+    it.configure().ifFirefox().run('detects firefox as firefox', () => {
+          expect(detectJsEngineFromStack()).to.equal('Firefox');
+        });
+
+    it.configure().ifEdge().run('detects edge as IE', () => {
+          expect(detectJsEngineFromStack()).to.equal('IE');
+        });
   });
 });


### PR DESCRIPTION
This should save us some time trying to determine what the real browser
is, not what the UserAgent is masquerading as.