### PR TITLE
Send GFP (Good Frame Probability) on 200th frame.

### DIFF
--- a/src/performance.js
+++ b/src/performance.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {getExistingServiceForWindow} from './service';
+import {
+  getExistingServiceForWindow,
+  getExistingServiceForWindowOrNull,
+} from './service';
 
 /**
  * @param {!Window} window
@@ -23,4 +26,13 @@ import {getExistingServiceForWindow} from './service';
 export function performanceFor(window) {
   return /** @type {!./service/performance-impl.Performance}*/ (
       getExistingServiceForWindow(window, 'performance'));
-};
+}
+
+/**
+ * @param {!Window} window
+ * @return {!./service/performance-impl.Performance}
+ */
+export function performanceForOrNull(window) {
+  return /** @type {!./service/performance-impl.Performance}*/ (
+      getExistingServiceForWindowOrNull(window, 'performance'));
+}

--- a/src/service.js
+++ b/src/service.js
@@ -72,12 +72,21 @@ export class EmbeddableService {
  * @return {!Object} The service.
  */
 export function getExistingServiceForWindow(win, id) {
-  win = getTopWindow(win);
-  const exists = win.services && win.services[id] && win.services[id].obj;
+  const exists = getExistingServiceForWindowOrNull(win, id);
   return dev().assert(exists, `${id} service not found. Make sure it is ` +
       `installed.`);
 }
 
+/**
+ * Returns a service or null with the given id.
+ * @param {!Window} win
+ * @param {string} id
+ * @return {?Object} The service.
+ */
+export function getExistingServiceForWindowOrNull(win, id) {
+  win = getTopWindow(win);
+  return win.services && win.services[id] && win.services[id].obj;
+}
 
 /**
  * Returns a service with the given id. Assumes that it has been constructed

--- a/src/service.js
+++ b/src/service.js
@@ -73,8 +73,8 @@ export class EmbeddableService {
  */
 export function getExistingServiceForWindow(win, id) {
   const exists = getExistingServiceForWindowOrNull(win, id);
-  return dev().assert(exists, `${id} service not found. Make sure it is ` +
-      `installed.`);
+  return dev().assert(/** @type {!Object} */ (exists),
+      `${id} service not found. Make sure it is installed.`);
 }
 
 /**

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -15,7 +15,11 @@
  */
 
 import {isExperimentOn} from '../experiments';
+import {performanceFor} from '../performance';
 import {dev} from '../log';
+
+/** @const {number} */
+const NTH_FRAME = 200;
 
 export class JankMeter {
 
@@ -25,20 +29,28 @@ export class JankMeter {
   constructor(win) {
     /** @private {!Window} */
     this.win_ = win;
-    /** @private {!Element} */
-    this.jankMeterDisplay_ = this.win_.document.createElement('div');
-    this.jankMeterDisplay_.classList.add('i-amphtml-jank-meter');
     /** @private {number} */
     this.jankCnt_ = 0;
     /** @private {number} */
     this.totalCnt_ = 0;
-    this.win_.document.body.appendChild(this.jankMeterDisplay_);
-    this.updateMeterDisplay_(0);
     /** @private {?number} */
     this.scheduledTime_ = null;
+    /** @private {?./performance-impl.Performance} */
+    this.perf_ = performanceFor(win);
+
+    if (isJankMeterEnabled(win)) {
+      /** @private {!Element} */
+      this.jankMeterDisplay_ = this.win_.document.createElement('div');
+      this.jankMeterDisplay_.classList.add('i-amphtml-jank-meter');
+      this.win_.document.body.appendChild(this.jankMeterDisplay_);
+      this.updateMeterDisplay_(0);
+    }
   }
 
   onScheduled() {
+    if (!this.isEnabled_()) {
+      return;
+    }
     // only take the first schedule for the current frame.
     if (this.scheduledTime_ == null) {
       this.scheduledTime_ = this.win_.Date.now();
@@ -46,7 +58,7 @@ export class JankMeter {
   }
 
   onRun() {
-    if (this.scheduledTime_ == null) {
+    if (!this.isEnabled_() || this.scheduledTime_ == null) {
       return;
     }
     const paintLatency = this.win_.Date.now() - this.scheduledTime_;
@@ -56,7 +68,22 @@ export class JankMeter {
       this.jankCnt_++;
       dev().info('JANK', 'Paint latency: ' + paintLatency + 'ms');
     }
-    this.updateMeterDisplay_(paintLatency);
+
+    // Report Good Frame Probability on Nth frame.
+    if (this.perf_ && this.totalCnt_ == NTH_FRAME) {
+      this.perf_.tickDelta('gfp', this.calculateGfp_());
+      this.perf_.flush();
+    }
+    if (isJankMeterEnabled(this.win_)) {
+      this.updateMeterDisplay_(paintLatency);
+    }
+  }
+
+  isEnabled_() {
+    return isJankMeterEnabled(this.win_)
+        || (this.perf_
+            && this.perf_.isPerformanceTrackingOn()
+            && this.totalCnt_ < NTH_FRAME);
   }
 
   /**
@@ -64,14 +91,22 @@ export class JankMeter {
    * @private
    */
   updateMeterDisplay_(paintLatency) {
-    // Calculate Good Frame Probability
-    const gfp = this.win_.Math.floor(
-        (this.totalCnt_ - this.jankCnt_) / this.totalCnt_ * 100);
+    const gfp = this.calculateGfp_();
     this.jankMeterDisplay_.textContent =
         `${gfp}%|${this.totalCnt_}|${paintLatency}ms`;
   }
+
+  /**
+   * Calculate Good Frame Probability, which is a value range from 0 to 100.
+   * @returns {number}
+   * @private
+   */
+  calculateGfp_() {
+    return this.win_.Math.floor(
+        (this.totalCnt_ - this.jankCnt_) / this.totalCnt_ * 100);
+  }
 }
 
-export function isJankMeterEnabled(win) {
+function isJankMeterEnabled(win) {
   return isExperimentOn(win, 'jank-meter');
 }

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -15,7 +15,7 @@
  */
 
 import {isExperimentOn} from '../experiments';
-import {performanceFor} from '../performance';
+import {performanceForOrNull} from '../performance';
 import {dev} from '../log';
 
 /** @const {number} */
@@ -36,7 +36,7 @@ export class JankMeter {
     /** @private {?number} */
     this.scheduledTime_ = null;
     /** @private {?./performance-impl.Performance} */
-    this.perf_ = performanceFor(win);
+    this.perf_ = performanceForOrNull(win);
 
     if (isJankMeterEnabled(win)) {
       /** @private {!Element} */

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -23,8 +23,7 @@ import {documentStateFor} from './document-state';
 import {getService} from '../service';
 import {installTimerService} from './timer-impl';
 import {viewerForDoc, viewerPromiseForDoc} from '../viewer';
-import {JankMeter, isJankMeterEnabled} from './jank-meter';
-import {performanceFor} from '../performance';
+import {JankMeter} from './jank-meter';
 
 /** @const {time} */
 const FRAME_TIME = 16;
@@ -452,4 +451,4 @@ export function installVsyncService(window) {
     installTimerService(window);
     return new Vsync(window);
   }));
-};
+}

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -24,6 +24,7 @@ import {getService} from '../service';
 import {installTimerService} from './timer-impl';
 import {viewerForDoc, viewerPromiseForDoc} from '../viewer';
 import {JankMeter, isJankMeterEnabled} from './jank-meter';
+import {performanceFor} from '../performance';
 
 /** @const {time} */
 const FRAME_TIME = 16;
@@ -130,9 +131,8 @@ export class Vsync {
       this.docState_.onVisibilityChanged(boundOnVisibilityChanged);
     }
 
-    /** @private {?JankMeter} */
-    this.jankMeter_ =
-        isJankMeterEnabled(this.win) ? new JankMeter(this.win) : null;
+    /** @private {!JankMeter} */
+    this.jankMeter_ = new JankMeter(this.win);
   }
 
   /** @private */
@@ -350,9 +350,7 @@ export class Vsync {
     }
     // Schedule actual animation frame and then run tasks.
     this.scheduled_ = true;
-    if (this.jankMeter_) {
-      this.jankMeter_.onScheduled();
-    }
+    this.jankMeter_.onScheduled();
     this.forceSchedule_();
   }
 
@@ -373,9 +371,7 @@ export class Vsync {
    */
   runScheduledTasks_() {
     this.scheduled_ = false;
-    if (this.jankMeter_) {
-      this.jankMeter_.onRun();
-    }
+    this.jankMeter_.onRun();
 
     const tasks = this.tasks_;
     const states = this.states_;


### PR DESCRIPTION
As discussed, send on 200th frame is to normalize the number across page view. Since the first several frames is usually heavy. And once all content loaded, the browser turns into idle. 200 is a magic number that makes sure we're measuring same thing all the time.