### PR TITLE
Only use local storage if the API is declared and does not throw an exception

### DIFF
--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -311,7 +311,7 @@ export class LocalStorageBinding {
       // any arbitrary key.
       this.win.localStorage.getItem('test');
       return true;
-    } catch(e) {
+    } catch (e) {
       return false;
     }
   }

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -286,11 +286,33 @@ export class LocalStorageBinding {
     this.win = win;
 
     /** @private @const {boolean} */
-    this.isLocalStorageSupported_ = 'localStorage' in this.win;
+    this.isLocalStorageSupported_ = this.checkIsLocalStorageSupported_();
 
     if (!this.isLocalStorageSupported_) {
       const error = new Error('localStorage not supported.');
       dev().expectedError(TAG, error);
+    }
+  }
+
+  /**
+   * Determines whether localStorage API is supported by ensuring it is declared
+   * and does not throw an exception when used.
+   * @return {boolean}
+   * @private
+   */
+  checkIsLocalStorageSupported_() {
+    try {
+      if (!('localStorage' in this.win)) {
+        return false;
+      }
+
+      // We do not care about the value fetched from local storage; we only care
+      // whether the call throws an exception or not.  As such, we can look up
+      // any arbitrary key.
+      this.win.localStorage.getItem('test');
+      return true;
+    } catch(e) {
+      return false;
     }
   }
 

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -286,33 +286,11 @@ export class LocalStorageBinding {
     this.win = win;
 
     /** @private @const {boolean} */
-    this.isLocalStorageSupported_ = this.checkIsLocalStorageSupported_();
+    this.isLocalStorageSupported_ = 'localStorage' in this.win;
 
     if (!this.isLocalStorageSupported_) {
       const error = new Error('localStorage not supported.');
       dev().expectedError(TAG, error);
-    }
-  }
-
-  /**
-   * Determines whether localStorage API is supported by ensuring it is declared
-   * and does not throw an exception when used.
-   * @return {boolean}
-   * @private
-   */
-  checkIsLocalStorageSupported_() {
-    try {
-      if (!('localStorage' in this.win)) {
-        return false;
-      }
-
-      // We do not care about the value fetched from local storage; we only care
-      // whether the call throws an exception or not.  As such, we can look up
-      // any arbitrary key.
-      this.win.localStorage.getItem('test');
-      return true;
-    } catch(e) {
-      return false;
     }
   }
 

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -508,6 +508,7 @@ describe('LocalStorageBinding', () => {
         .throws(new Error('unknown'))
         .once();
     binding = new LocalStorageBinding(windowApi);
+    localStorageMock.expects('getItem').never();
     return binding.loadBlob('https://acme.com')
         .then(() => 'SUCCESS', () => 'ERROR').then(res => {
           expect(res).to.equal('SUCCESS');

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -478,7 +478,8 @@ describe('LocalStorageBinding', () => {
     });
   });
 
-  it('should reject on local storage failure', () => {
+  it('should reject on local storage failure w/ localStorage support', () => {
+    binding.isLocalStorageSupported_ = true;
     localStorageMock.expects('getItem')
         .withExactArgs('amp-store:https://acme.com')
         .throws(new Error('unknown'))
@@ -499,6 +500,17 @@ describe('LocalStorageBinding', () => {
         .then(res => `SUCCESS ${res}`, () => 'ERROR').then(res => {
           // Resolves with null
           expect(res).to.equal('SUCCESS null');
+        });
+  });
+
+  it('should bypass loading from localStorage if getItem throws', () => {
+    localStorageMock.expects('getItem')
+        .throws(new Error('unknown'))
+        .once();
+    binding = new LocalStorageBinding(windowApi);
+    return binding.loadBlob('https://acme.com')
+        .then(() => 'SUCCESS', () => 'ERROR').then(res => {
+          expect(res).to.equal('SUCCESS');
         });
   });
 
@@ -529,6 +541,21 @@ describe('LocalStorageBinding', () => {
     // Never reaches setItem
     return binding.saveBlob('https://acme.com', 'BLOB1')
         .then(() => 'SUCCESS', () => `ERROR`).then(res => {
+          expect(res).to.equal('SUCCESS');
+        });
+  });
+
+  it('should bypass saving to localStorage if getItem throws', () => {
+    const setItemSpy = sandbox.spy(windowApi.localStorage, 'setItem');
+
+    localStorageMock.expects('getItem')
+        .throws(new Error('unknown'))
+        .once();
+    binding = new LocalStorageBinding(windowApi);
+    // Never reaches setItem
+    return binding.saveBlob('https://acme.com', 'BLOB1')
+        .then(() => 'SUCCESS', () => `ERROR`).then(res => {
+          expect(setItemSpy).to.have.not.been.called;
           expect(res).to.equal('SUCCESS');
         });
   });

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -478,8 +478,7 @@ describe('LocalStorageBinding', () => {
     });
   });
 
-  it('should reject on local storage failure w/ localStorage support', () => {
-    binding.isLocalStorageSupported_ = true;
+  it('should reject on local storage failure', () => {
     localStorageMock.expects('getItem')
         .withExactArgs('amp-store:https://acme.com')
         .throws(new Error('unknown'))
@@ -500,17 +499,6 @@ describe('LocalStorageBinding', () => {
         .then(res => `SUCCESS ${res}`, () => 'ERROR').then(res => {
           // Resolves with null
           expect(res).to.equal('SUCCESS null');
-        });
-  });
-
-  it('should bypass loading from localStorage if getItem throws', () => {
-    localStorageMock.expects('getItem')
-        .throws(new Error('unknown'))
-        .once();
-    binding = new LocalStorageBinding(windowApi);
-    return binding.loadBlob('https://acme.com')
-        .then(() => 'SUCCESS', () => 'ERROR').then(res => {
-          expect(res).to.equal('SUCCESS');
         });
   });
 
@@ -541,21 +529,6 @@ describe('LocalStorageBinding', () => {
     // Never reaches setItem
     return binding.saveBlob('https://acme.com', 'BLOB1')
         .then(() => 'SUCCESS', () => `ERROR`).then(res => {
-          expect(res).to.equal('SUCCESS');
-        });
-  });
-
-  it('should bypass saving to localStorage if getItem throws', () => {
-    const setItemSpy = sandbox.spy(windowApi.localStorage, 'setItem');
-
-    localStorageMock.expects('getItem')
-        .throws(new Error('unknown'))
-        .once();
-    binding = new LocalStorageBinding(windowApi);
-    // Never reaches setItem
-    return binding.saveBlob('https://acme.com', 'BLOB1')
-        .then(() => 'SUCCESS', () => `ERROR`).then(res => {
-          expect(setItemSpy).to.have.not.been.called;
           expect(res).to.equal('SUCCESS');
         });
   });


### PR DESCRIPTION
Fix for #6633 

FYI: There's still the possibility of this error surfacing if access to local storage is somehow revoked after the binding is constructed.