### PR TITLE
A4A: log sampling of errors as dev-expected

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -57,7 +57,6 @@ import {
 } from '../../../src/service/url-replacements-impl';
 import {extensionsFor} from '../../../src/extensions';
 import {A4AVariableSource} from './a4a-variable-source';
-import {rethrowAsync} from '../../../src/log';
 // TODO(tdrl): Temporary.  Remove when we migrate to using amp-analytics.
 import {getTimingDataAsync} from '../../../src/service/variable-source';
 import {getContextMetadata} from '../../../src/iframe-attributes';

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -24,7 +24,7 @@ import {
   removeChildren,
   createElementWithAttributes,
 } from '../../../src/dom';
-import {cancellation} from '../../../src/error';
+import {cancellation, isCancellation} from '../../../src/error';
 import {
   installAnchorClickInterceptor,
 } from '../../../src/anchor-click-interceptor';
@@ -83,7 +83,7 @@ export const SAFEFRAME_IMPL_PATH =
 export const RENDERING_TYPE_HEADER = 'X-AmpAdRender';
 
 /** @type {string} */
-const TAG = 'AMP-A4A';
+const TAG = 'amp-a4a';
 
 /** @type {string} */
 const NO_CONTENT_RESPONSE = 'NO-CONTENT-RESPONSE';
@@ -625,7 +625,7 @@ export class AmpA4A extends AMP.BaseElement {
           // If error in chain occurs, report it and return null so that
           // layoutCallback can render via cross domain iframe assuming ad
           // url or creative exist.
-          rethrowAsync(this.promiseErrorHandler_(error));
+          this.promiseErrorHandler_(error);
           return null;
         });
   }
@@ -739,32 +739,38 @@ export class AmpA4A extends AMP.BaseElement {
   /**
    * Handles uncaught errors within promise flow.
    * @param {*} error
-   * @return {*}
    * @private
    */
   promiseErrorHandler_(error) {
-    if (error && error.message) {
-      if (error.message.indexOf(TAG) == 0) {
-        // caught previous call to promiseErrorHandler?  Infinite loop?
-        return error;
-      }
-      if (error.message == cancellation().message) {
-        // Rethrow if cancellation
-        throw error;
-      }
+    if (isCancellation(error)) {
+      // Rethrow if cancellation.
+      throw error;
     }
-    // Returning promise reject should trigger unhandledrejection which will
-    // trigger reporting via src/error.js
+
+    if (!error || !error.message) {
+      error = new Error('unknown error ' + error);
+    }
+
+    // Add `type` to the message. Ensure to preserve the original stack.
+    const type = this.element.getAttribute('type') || 'notype';
+    error.message = `${TAG}: ${type}: ${error.message}`;
+
+    // Additional arguments.
     const adQueryIdx = this.adUrl_ ? this.adUrl_.indexOf('?') : -1;
-    const state = {
-      'm': error instanceof Error ? error.message : error,
-      's': error instanceof Error ? error.stack : '',
-      'tag': this.element.tagName,
-      'type': this.element.getAttribute('type'),
+    error.args = {
       'au': adQueryIdx < 0 ? '' :
           this.adUrl_.substring(adQueryIdx + 1, adQueryIdx + 251),
     };
-    return new Error(TAG + ': ' + JSON.stringify(state));
+
+    if (getMode().development || getMode().localDev || getMode().log) {
+      user().error(TAG, error);
+    } else {
+      user().warn(TAG, error);
+      // Report with 1% sampling as an expected dev error.
+      if (Math.random() < 0.01) {
+        dev().expectedError(TAG, error);
+      }
+    }
   }
 
   /** @override */
@@ -805,11 +811,14 @@ export class AmpA4A extends AMP.BaseElement {
           // rendering within cross domain iframe.
           user().error(TAG, this.element.getAttribute('type'),
             'Error injecting creative in friendly frame', err);
-          rethrowAsync(this.promiseErrorHandler_(err));
+          this.promiseErrorHandler_(err);
           return this.renderNonAmpCreative_()
             .then(() => protectedOnCreativeRender(false));
         });
-    }).catch(error => this.promiseErrorHandler_(error));
+    }).catch(error => {
+      this.promiseErrorHandler_(error);
+      throw cancellation();
+    });
   }
 
   /** @override  */
@@ -1046,6 +1055,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   renderNonAmpCreative_() {
+    this.promiseErrorHandler_(new Error('fallback to 3p'));
     this.protectedEmitLifecycleEvent_('preAdThrottle');
     incrementLoadingAds(this.win);
     // Haven't rendered yet, so try rendering via one of our

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1087,7 +1087,8 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   renderAmpCreative_(creativeMetaData) {
-    dev().assert(creativeMetaData.minifiedCreative);
+    dev().assert(creativeMetaData.minifiedCreative,
+        'missing minified creative');
     dev().assert(!!this.element.ownerDocument, 'missing owner document?!');
     this.protectedEmitLifecycleEvent_('renderFriendlyStart');
     // Create and setup friendly iframe.

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -171,7 +171,7 @@ describe('integration test: a4a', () => {
     // rendered.  This should be fixed in a refactor, and we should change this
     // .catch to a .then.
     const forceCollapseStub =
-        sandbox.stub(MockA4AImpl.prototype, 'forceCollapse');
+        sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
     return fixture.addElement(a4aElement).catch(error => {
       expect(error.message).to.contain.string('Testing network error');
       expect(error.message).to.contain.string('AMP-A4A-');
@@ -247,8 +247,8 @@ describe('integration test: a4a', () => {
       credentials: 'include',
     }).onFirstCall().returns(Promise.resolve(mockResponse));
     const forceCollapseStub =
-        sandbox.stub(MockA4AImpl.prototype, 'forceCollapse');
-    return fixture.addElement(a4aElement).then(unusedElement => {
+        sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
+    return fixture.addElement(a4aElement).then(() => {
       expect(forceCollapseStub).to.be.calledOnce;
     });
   });
@@ -260,7 +260,7 @@ describe('integration test: a4a', () => {
       credentials: 'include',
     }).onFirstCall().returns(Promise.resolve(null));
     const forceCollapseStub =
-        sandbox.stub(MockA4AImpl.prototype, 'forceCollapse');
+        sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
     return fixture.addElement(a4aElement).then(unusedElement => {
       expect(forceCollapseStub).to.be.notCalled;
     });
@@ -285,8 +285,8 @@ describe('integration test: a4a', () => {
       credentials: 'include',
     }).onFirstCall().returns(Promise.resolve(mockResponse));
     const forceCollapseStub =
-        sandbox.stub(MockA4AImpl.prototype, 'forceCollapse');
-    return fixture.addElement(a4aElement).then(unusedElement => {
+        sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
+    return fixture.addElement(a4aElement).then(() => {
       expect(forceCollapseStub).to.be.calledOnce;
     });
   });
@@ -311,7 +311,7 @@ describe('integration test: a4a', () => {
           credentials: 'include',
         }).onFirstCall().returns(Promise.resolve(mockResponse));
         const forceCollapseStub =
-            sandbox.stub(MockA4AImpl.prototype, 'forceCollapse');
+            sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
         return fixture.addElement(a4aElement).then(unusedElement => {
           expect(forceCollapseStub).to.be.calledOnce;
         });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1369,7 +1369,7 @@ describe('amp-a4a', () => {
     });
   });
 
-  describe.only('error handler', () => {
+  describe('error handler', () => {
     let a4aElement;
     let a4a;
     let userErrorStub;
@@ -1380,7 +1380,8 @@ describe('amp-a4a', () => {
       userErrorStub = sandbox.stub(user(), 'error');
       userWarnStub = sandbox.stub(user(), 'warn');
       devExpectedErrorStub = sandbox.stub(dev(), 'expectedError');
-      return createAdTestingIframePromise().then(fixture => {
+      return createIframePromise().then(fixture => {
+        setupForAdTesting(fixture);
         const doc = fixture.doc;
         a4aElement = createA4aElement(doc);
         a4a = new MockA4AImpl(a4aElement);

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -46,7 +46,7 @@ import {urlReplacementsForDoc} from '../../../../src/url-replacements';
 import {incrementLoadingAds} from '../../../amp-ad/0.1/concurrent-load';
 import {platformFor} from '../../../../src/platform';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
-import {dev} from '../../../../src/log';
+import {dev, user} from '../../../../src/log';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {AmpContext} from '../../../../3p/ampcontext.js';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
@@ -1209,6 +1209,7 @@ describe('amp-a4a', () => {
         });
       });
     });
+
     it('verify cancelled promise', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
@@ -1220,6 +1221,7 @@ describe('amp-a4a', () => {
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+        const errorHandlerSpy = sandbox.spy(a4a, 'promiseErrorHandler_');
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         const adPromise = a4a.adPromise_;
@@ -1236,6 +1238,7 @@ describe('amp-a4a', () => {
           expect(getAdUrlSpy.called, 'getAdUrl never called')
               .to.be.false;
           expect(reason).to.deep.equal(cancellation());
+          expect(errorHandlerSpy).to.be.calledOnce;
         });
       });
     });
@@ -1363,6 +1366,80 @@ describe('amp-a4a', () => {
         // execute.
         setTimeout(() => {keyInfoResolver({}); }, 0);
       });
+    });
+  });
+
+  describe.only('error handler', () => {
+    let a4aElement;
+    let a4a;
+    let userErrorStub;
+    let userWarnStub;
+    let devExpectedErrorStub;
+
+    beforeEach(() => {
+      userErrorStub = sandbox.stub(user(), 'error');
+      userWarnStub = sandbox.stub(user(), 'warn');
+      devExpectedErrorStub = sandbox.stub(dev(), 'expectedError');
+      return createAdTestingIframePromise().then(fixture => {
+        const doc = fixture.doc;
+        a4aElement = createA4aElement(doc);
+        a4a = new MockA4AImpl(a4aElement);
+        a4a.adUrl_ = 'https://acme.org?query';
+      });
+    });
+
+    it('should rethrow cancellation', () => {
+      expect(() => {
+        a4a.promiseErrorHandler_(cancellation());
+      }).to.throw(/CANCELLED/);
+    });
+
+    it('should create an error if needed', () => {
+      window.AMP_MODE = {development: true};
+      a4a.promiseErrorHandler_('intentional');
+      expect(userErrorStub).to.be.calledOnce;
+      expect(userErrorStub.args[0][1]).to.be.instanceOf(Error);
+      expect(userErrorStub.args[0][1].message).to.be.match(/intentional/);
+    });
+
+    it('should route error to user.error in dev mode', () => {
+      const error = new Error('intentional');
+      window.AMP_MODE = {development: true};
+      a4a.promiseErrorHandler_(error);
+      expect(userErrorStub).to.be.calledOnce;
+      expect(userErrorStub.args[0][1]).to.be.equal(error);
+      expect(error.message).to.equal('amp-a4a: adsense: intentional');
+      expect(error.args).to.deep.equal({au: 'query'});
+      expect(devExpectedErrorStub).to.not.be.called;
+    });
+
+    it('should route error to user.warn in prod mode', () => {
+      const error = new Error('intentional');
+      window.AMP_MODE = {development: false};
+      a4a.promiseErrorHandler_(error);
+      expect(userWarnStub).to.be.calledOnce;
+      expect(userWarnStub.args[0][1]).to.be.equal(error);
+      expect(error.message).to.equal('amp-a4a: adsense: intentional');
+      expect(error.args).to.deep.equal({au: 'query'});
+    });
+
+    it('should send an expected error in prod mode with sampling', () => {
+      const error = new Error('intentional');
+      sandbox.stub(Math, 'random', () => 0.005);
+      window.AMP_MODE = {development: false};
+      a4a.promiseErrorHandler_(error);
+      expect(devExpectedErrorStub).to.be.calledOnce;
+      expect(devExpectedErrorStub.args[0][1]).to.be.equal(error);
+      expect(error.message).to.equal('amp-a4a: adsense: intentional');
+      expect(error.args).to.deep.equal({au: 'query'});
+    });
+
+    it('should NOT send an expected error in prod mode with sampling', () => {
+      const error = new Error('intentional');
+      sandbox.stub(Math, 'random', () => 0.011);
+      window.AMP_MODE = {development: false};
+      a4a.promiseErrorHandler_(error);
+      expect(devExpectedErrorStub).to.not.be.called;
     });
   });
 

--- a/src/error.js
+++ b/src/error.js
@@ -153,7 +153,7 @@ export function cancellation() {
 }
 
 /**
- * @param {?Error|string} errorOrMessage
+ * @param {*} errorOrMessage
  * @return {boolean}
  */
 export function isCancellation(errorOrMessage) {

--- a/src/error.js
+++ b/src/error.js
@@ -24,10 +24,11 @@ import {
   USER_ERROR_SENTINEL,
   isUserErrorMessage,
 } from './log';
-import {makeBodyVisible} from './style-installer';
-import {urls} from './config';
 import {isProxyOrigin} from './url';
 import {isCanary} from './experiments';
+import {makeBodyVisible} from './style-installer';
+import {startsWith} from './string';
+import {urls} from './config';
 
 
 /**
@@ -160,7 +161,13 @@ export function isCancellation(errorOrMessage) {
   if (!errorOrMessage) {
     return false;
   }
-  return errorOrMessage == CANCELLED || errorOrMessage.message == CANCELLED;
+  if (typeof errorOrMessage == 'string') {
+    return startsWith(errorOrMessage, CANCELLED);
+  }
+  if (typeof errorOrMessage.message == 'string') {
+    return startsWith(errorOrMessage.message, CANCELLED);
+  }
+  return false;
 }
 
 /**

--- a/src/error.js
+++ b/src/error.js
@@ -153,6 +153,17 @@ export function cancellation() {
 }
 
 /**
+ * @param {?Error|string} errorOrMessage
+ * @return {boolean}
+ */
+export function isCancellation(errorOrMessage) {
+  if (!errorOrMessage) {
+    return false;
+  }
+  return errorOrMessage == CANCELLED || errorOrMessage.message == CANCELLED;
+}
+
+/**
  * Install handling of global unhandled exceptions.
  * @param {!Window} win
  */
@@ -313,9 +324,12 @@ export function getErrorReportUrl(message, filename, line, col, error,
 
   if (error) {
     const tagName = error && error.associatedElement
-      ? error.associatedElement.tagName
-      : 'u';  // Unknown
+        ? error.associatedElement.tagName
+        : 'u';  // Unknown
     url += `&el=${encodeURIComponent(tagName)}`;
+    if (error.args) {
+      url += `&args=${encodeURIComponent(JSON.stringify(error.args))}`;
+    }
 
     if (!isUserError) {
       url += `&s=${encodeURIComponent(error.stack || '')}`;

--- a/src/log.js
+++ b/src/log.js
@@ -387,6 +387,8 @@ export class Log {
       } else if (error.message.indexOf(this.suffix_) == -1) {
         error.message += this.suffix_;
       }
+    } else if (isUserErrorMessage(error.message)) {
+      error.message = error.message.replace(USER_ERROR_SENTINEL, '');
     }
   }
 }

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -265,6 +265,17 @@ describe('reportErrorToServer', () => {
     const e = cancellation();
     expect(isCancellation(e)).to.be.true;
     expect(isCancellation(e.message)).to.be.true;
+
+    // Suffix is tollerated.
+    e.message += '___';
+    expect(isCancellation(e)).to.be.true;
+    expect(isCancellation(e.message)).to.be.true;
+
+    // Prefix is not tollerated.
+    e.message = '___' + e.message;
+    expect(isCancellation(e)).to.be.false;
+    expect(isCancellation(e.message)).to.be.false;
+
     expect(isCancellation('')).to.be.false;
     expect(isCancellation(null)).to.be.false;
     expect(isCancellation(1)).to.be.false;

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -19,6 +19,7 @@ import {
   detectNonAmpJs,
   getErrorReportUrl,
   installErrorReporting,
+  isCancellation,
   reportError,
 } from '../../src/error';
 import {parseUrl, parseQueryString} from '../../src/url';
@@ -115,6 +116,18 @@ describe('reportErrorToServer', () => {
     expect(query.ae).to.equal('');
     expect(query.r).to.contain('http://localhost');
     expect(query.noAmp).to.equal('1');
+    expect(query.args).to.be.undefined;
+  });
+
+  it('reportError with error object w/args', () => {
+    const e = new Error('XYZ');
+    e.args = {x: 1};
+    const url = parseUrl(
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e,
+          true));
+    const query = parseQueryString(url.search);
+
+    expect(query.args).to.equal(JSON.stringify({x: 1}));
   });
 
   it('reportError with a string instead of error', () => {
@@ -246,6 +259,16 @@ describe('reportErrorToServer', () => {
     const url =
         getErrorReportUrl(undefined, undefined, undefined, undefined, e);
     expect(url).to.be.undefined;
+  });
+
+  it('should construct cancellation', () => {
+    const e = cancellation();
+    expect(isCancellation(e)).to.be.true;
+    expect(isCancellation(e.message)).to.be.true;
+    expect(isCancellation('')).to.be.false;
+    expect(isCancellation(null)).to.be.false;
+    expect(isCancellation(1)).to.be.false;
+    expect(isCancellation({})).to.be.false;
   });
 
   it('reportError with error object', () => {

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -404,6 +404,15 @@ describe('Logging', () => {
       expect(message.indexOf(USER_ERROR_SENTINEL)).to.equal(-1);
     });
 
+    it('should strip suffix if not available', () => {
+      const error = log.createError(new Error('test'));
+      expect(isUserErrorMessage(error.message)).to.be.true;
+
+      const noSuffixLog = new Log(win, RETURNS_FINE);
+      noSuffixLog.createError(error);
+      expect(isUserErrorMessage(error.message)).to.be.false;
+    });
+
     it('should create other-suffixed errors', () => {
       log = new Log(win, RETURNS_FINE, '-other');
       const error = log.createError('test');


### PR DESCRIPTION
The end-goal is to be able for AMP monitoring to pick up code regressions in A4A delivery pipeline.

Closes #7489.

/cc @keithwrightbos @tdrl 
