### PR TITLE
Throw user error when upgrading to unknown amp-ad

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -18,10 +18,12 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {AmpAd3PImpl} from './amp-ad-3p-impl';
 import {AmpAdCustom} from './amp-ad-custom';
 import {a4aRegistry} from '../../../ads/_a4a-config';
+import {adConfig} from '../../../ads/_config';
 import {dev, user} from '../../../src/log';
 import {extensionsFor} from '../../../src/extensions';
 import {userNotificationManagerFor} from '../../../src/user-notification';
 import {isExperimentOn} from '../../../src/experiments';
+import {hasOwn} from '../../../src/utils/object';
 
 
 /**
@@ -51,17 +53,20 @@ export class AmpAd extends AMP.BaseElement {
 
     return consent.then(() => {
       const type = this.element.getAttribute('type');
-      if (!type) {
-        // Unspecified or empty type.  Nothing to do here except bail out.
-        return null;
-      }
+      const isCustom = type === 'custom' && isExperimentOn(this.win,
+          'ad-type-custom');
+      user().assert(isCustom || hasOwn(adConfig, type)
+          || hasOwn(a4aRegistry, type), `Unknown ad type "${type}"`);
+
       // Check for the custom ad type (no ad network, self-service)
-      if (type === 'custom' && isExperimentOn(this.win, 'ad-type-custom')) {
+      if (isCustom) {
         return new AmpAdCustom(this.element);
       }
+
       window.ampAdSlotIdCounter = window.ampAdSlotIdCounter || 0;
       const slotId = window.ampAdSlotIdCounter++;
       this.element.setAttribute('data-amp-slot-index', slotId);
+
       // TODO(tdrl): Check amp-ad registry to see if they have this already.
       if (!a4aRegistry[type] ||
           !a4aRegistry[type](this.win, this.element)) {
@@ -70,6 +75,7 @@ export class AmpAd extends AMP.BaseElement {
         // tag as A4A.  Fall back to the 3p implementation.
         return new AmpAd3PImpl(this.element);
       }
+
       const extensionTagName = networkImplementationTag(type);
       this.element.setAttribute('data-a4a-upgrade-type', extensionTagName);
       return extensionsFor(this.win).loadElementClass(extensionTagName)
@@ -83,18 +89,6 @@ export class AmpAd extends AMP.BaseElement {
           return new AmpAd3PImpl(this.element);
         });
     });
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return isLayoutSizeDefined(layout);
-  }
-
-  /** @override */
-  buildCallback() {
-    // This is only called when no type was set on the element and thus
-    // upgrade element fell through.
-    dev().assert(this.element.getAttribute('type'), 'Required attribute type');
   }
 }
 

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -19,7 +19,7 @@ import {AmpAd3PImpl} from './amp-ad-3p-impl';
 import {AmpAdCustom} from './amp-ad-custom';
 import {a4aRegistry} from '../../../ads/_a4a-config';
 import {adConfig} from '../../../ads/_config';
-import {dev, user} from '../../../src/log';
+import {user} from '../../../src/log';
 import {extensionsFor} from '../../../src/extensions';
 import {userNotificationManagerFor} from '../../../src/user-notification';
 import {isExperimentOn} from '../../../src/experiments';

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -75,7 +75,7 @@ describe('Ad loader', () => {
 
       describe('with consent-notification-id, upgradeCallback', () => {
         it('should block for notification dismissal', () => {
-          return iframePromise.then((fixture) => {
+          return iframePromise.then(fixture => {
             ampAdElement.setAttribute('data-consent-notification-id', 'notif');
 
             return Promise.race([
@@ -83,9 +83,9 @@ describe('Ad loader', () => {
                 throw new Error('upgradeCallback should not resolve without ' +
                   'notification dismissal');
               }),
-              timerFor(fixture.win).promise(25)
+              timerFor(fixture.win).promise(25),
             ]);
-         });
+          });
         });
 
         it('should resolve once notification is dismissed', () => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -20,9 +20,10 @@ import {AmpAd} from '../amp-ad';
 import {AmpAd3PImpl} from '../amp-ad-3p-impl';
 import {extensionsFor} from '../../../../src/extensions';
 import {stubService} from '../../../../testing/test-helper';
+import {timerFor} from '../../../../src/timer';
 import * as sinon from 'sinon';
 
-describe('A4A loader', () => {
+describe('Ad loader', () => {
   let sandbox;
   let registryBackup;
   const tagNames = ['amp-ad', 'amp-embed'];
@@ -63,7 +64,7 @@ describe('A4A loader', () => {
               }));
 
           ampAdElement = doc.createElement(tag);
-          ampAdElement.setAttribute('type', 'nonexistent-tag-type');
+          ampAdElement.setAttribute('type', '_ping_');
           ampAdElement.setAttribute('width', '300');
           ampAdElement.setAttribute('height', '200');
           doc.body.appendChild(ampAdElement);
@@ -73,26 +74,26 @@ describe('A4A loader', () => {
       });
 
       describe('with consent-notification-id, upgradeCallback', () => {
-        it('should block for notification dismissal', done => {
-          iframePromise.then(() => {
+        it('should block for notification dismissal', () => {
+          return iframePromise.then((fixture) => {
             ampAdElement.setAttribute('data-consent-notification-id', 'notif');
 
-            ampAd.upgradeCallback().then(() => {
-              done('upgradeCallback should not resolve without ' +
+            return Promise.race([
+              ampAd.upgradeCallback().then(() => {
+                throw new Error('upgradeCallback should not resolve without ' +
                   'notification dismissal');
-            });
-            setTimeout(() => done(), 0);
-          });
+              }),
+              timerFor(fixture.win).promise(25)
+            ]);
+         });
         });
 
-        it('should resolve once notification is dismissed', done => {
-          iframePromise.then(() => {
+        it('should resolve once notification is dismissed', () => {
+          return iframePromise.then(() => {
             ampAdElement.setAttribute('data-consent-notification-id', 'notif');
 
-            ampAd.upgradeCallback().then(() => {
-              done();
-            });
-            userNotificationResolver();
+            setTimeout(userNotificationResolver, 25);
+            return ampAd.upgradeCallback();
           });
         });
       });
@@ -100,13 +101,13 @@ describe('A4A loader', () => {
       describe('#upgradeCallback', () => {
         it('fails upgrade on unregistered type', () => {
           return iframePromise.then(() => {
+            ampAdElement.setAttribute('type', 'zort');
             return expect(ampAd.upgradeCallback()).to.eventually.be.rejected;
           });
         });
 
         it('falls back to 3p for registered, non-A4A type', () => {
           return iframePromise.then(() => {
-            ampAdElement.setAttribute('type', '_ping_');
             ampAd = new AmpAd(ampAdElement);
             return expect(ampAd.upgradeCallback())
                 .to.eventually.be.instanceof(AmpAd3PImpl);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -991,7 +991,9 @@ function createBaseCustomElementClass(win) {
         this.completeUpgrade_(impl);
       } else if (typeof res.then == 'function') {
         // It's a promise: wait until it's done.
-        res.then(impl => this.completeUpgrade_(impl)).catch(reason => {
+        res.then(upgrade => {
+          this.completeUpgrade_(upgrade || impl)
+        }).catch(reason => {
           this.upgradeState_ = UpgradeState.UPGRADE_FAILED;
           rethrowAsync(reason);
         });

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -992,7 +992,7 @@ function createBaseCustomElementClass(win) {
       } else if (typeof res.then == 'function') {
         // It's a promise: wait until it's done.
         res.then(upgrade => {
-          this.completeUpgrade_(upgrade || impl)
+          this.completeUpgrade_(upgrade || impl);
         }).catch(reason => {
           this.upgradeState_ = UpgradeState.UPGRADE_FAILED;
           rethrowAsync(reason);

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -427,6 +427,27 @@ describe('CustomElement', () => {
     });
   });
 
+  it('Element - re-upgrade to new promised null', () => {
+    const element = new ElementClass();
+    expect(element.isUpgraded()).to.equal(false);
+    const oldImpl = element.implementation_;
+    const promise = Promise.resolve(null);
+    oldImpl.upgradeCallback = () => promise;
+
+    container.appendChild(element);
+    element.attachedCallback();
+    expect(element.implementation_).to.equal(oldImpl);
+    expect(element.isUpgraded()).to.equal(false);
+    expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
+    return promise.then(() => {
+      // Skip a microtask.
+    }).then(() => {
+      expect(element.implementation_).to.equal(oldImpl);
+      expect(element.isUpgraded()).to.equal(true);
+      expect(element.upgradeState_).to.equal(/* UPGRADED */ 2);
+    });
+  });
+
   it('Element - re-upgrade with a failed promised', () => {
     const element = new ElementClass();
     expect(element.isUpgraded()).to.equal(false);


### PR DESCRIPTION
This does two things:

1. When upgrading to an unknown `<amp-ad>` type, we throw an error. This is essentially a failed element upgrade.
2. We now allow upgrade promises to resolve to `null`, in which case the upgrade falls back to the original implementation. This mirrors the sync case.

Fixes #7652.