### PR TITLE
Fix validator inconsistency for amp-call-tracking

### DIFF
--- a/extensions/amp-call-tracking/0.1/amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/amp-call-tracking.js
@@ -15,7 +15,7 @@
  */
 
 import {assertHttpsUrl} from '../../../src/url';
-import {isLayoutSizeDefined} from '../../../src/layout';
+import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {urlReplacementsForDoc} from '../../../src/url-replacements';
 import {user} from '../../../src/log';
 import {xhrFor} from '../../../src/xhr';
@@ -67,7 +67,7 @@ export class AmpCallTracking extends AMP.BaseElement {
 
   /** @override */
   isLayoutSupported(layout) {
-    return isLayoutSizeDefined(layout);
+    return isLayoutSizeDefined(layout) || layout == Layout.CONTAINER;
   }
 
   /** @override */

--- a/extensions/amp-call-tracking/0.1/validator-amp-call-tracking.protoascii
+++ b/extensions/amp-call-tracking/0.1/validator-amp-call-tracking.protoascii
@@ -76,7 +76,6 @@ tags: {  # <amp-call-tracking>
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
-    supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
 }


### PR DESCRIPTION
Updated validator proto to match the implementation of the extension which uses [`isLayoutSizeDefined`](https://github.com/ampproject/amphtml/blob/04d1d8e43eecbe43cfd1bf1c79ac8b2c36fc0b14/src/layout.js#L130).