### PR TITLE
Use a higher-specificity CSS rule for amp-list overflow example

### DIFF
--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -90,7 +90,7 @@ Example: Using overflow
 ```
 
 ```css
-.list-overflow {
+.list-overflow[overflow] {
   position: absolute;
   bottom: 0;
 }


### PR DESCRIPTION
See https://github.com/ampproject/amphtml/issues/7689 for the reason.