### PR TITLE
Add overflow:hidden to disable scroll temporarily

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -225,6 +225,16 @@ i-amphtml-sizer {
   overflow: hidden !important;
 }
 
+.i-amphtml-scroll-disabled {
+  overflow-x: hidden !important;
+  overflow-y: hidden !important;
+}
+
+#i-amphtml-wrapper.i-amphtml-scroll-disabled {
+  overflow-x: hidden !important;
+  overflow-y: hidden !important;
+}
+
 /* "notbuild" classes are set as soon as an element is created and removed
    as soon as the element is built. */
 

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -173,6 +173,8 @@ export class ViewportBindingInabox {
   /** @override */ updatePaddingTop() {/* no-op */}
   /** @override */ hideViewerHeader() {/* no-op */}
   /** @override */ showViewerHeader() {/* no-op */}
+  /** @override */ disableScroll() {/* no-op */}
+  /** @override */ resetScroll() {/* no-op */}
   /** @override */ ensureReadyForElements() {/* no-op */}
   /** @override */ updateLightboxMode() {/* no-op */}
   /** @override */ setScrollTop() {/* no-op */}

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -457,14 +457,18 @@ export class Viewport {
    * Should only be used for temporarily disabling scroll.
    */
   disableScroll() {
-    this.binding_.disableScroll();
+    this.vsync_.mutate(() => {
+      this.binding_.disableScroll();
+    });
   }
 
   /*
    * Reset the scrolling by removing overflow: hidden.
    */
   resetScroll() {
-    this.binding_.resetScroll();
+    this.vsync_.mutate(() => {
+      this.binding_.resetScroll();
+    });
   }
 
   /**

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -437,6 +437,7 @@ export class Viewport {
     this.viewer_.sendMessage('requestFullOverlay', {}, /* cancelUnsent */true);
     this.disableTouchZoom();
     this.hideFixedLayer();
+    this.disableScroll();
     this.vsync_.mutate(() => this.binding_.updateLightboxMode(true));
   }
 
@@ -445,9 +446,25 @@ export class Viewport {
    */
   leaveLightboxMode() {
     this.viewer_.sendMessage('cancelFullOverlay', {}, /* cancelUnsent */true);
+    this.resetScroll();
     this.showFixedLayer();
     this.restoreOriginalTouchZoom();
     this.vsync_.mutate(() => this.binding_.updateLightboxMode(false));
+  }
+
+  /*
+   * Disable the scrolling by setting overflow: hidden.
+   * Should only be used for temporarily disabling scroll.
+   */
+  disableScroll() {
+    this.binding_.disableScroll();
+  }
+
+  /*
+   * Reset the scrolling by removing overflow: hidden.
+   */
+  resetScroll() {
+    this.binding_.resetScroll();
   }
 
   /**
@@ -812,6 +829,17 @@ export class ViewportBindingDef {
    */
   showViewerHeader(unusedTransient, unusedPaddingTop) {}
 
+  /*
+   * Disable the scrolling by setting overflow: hidden.
+   * Should only be used for temporarily disabling scroll.
+   */
+  disableScroll() {}
+
+  /*
+   * Reset the scrolling by removing overflow: hidden.
+   */
+  resetScroll() {}
+
   /**
    * Updates the viewport whether it's currently in the lightbox or a normal
    * mode.
@@ -991,6 +1019,18 @@ export class ViewportBindingNatural_ {
     if (!transient) {
       this.updatePaddingTop(paddingTop);
     }
+  }
+
+  /** @override */
+  disableScroll() {
+    this.win.document.documentElement.classList.add(
+        'i-amphtml-scroll-disabled');
+  }
+
+  /** @override */
+  resetScroll() {
+    this.win.document.documentElement.classList.remove(
+        'i-amphtml-scroll-disabled');
   }
 
   /** @override */
@@ -1263,6 +1303,16 @@ export class ViewportBindingNaturalIosEmbed_ {
     }
     // No need to adjust borderTop and paddingTop when the showing header
     // operation is transient
+  }
+
+  /** @override */
+  disableScroll() {
+    // This is not supported in ViewportBindingNaturalIosEmbed_
+  }
+
+  /** @override */
+  resetScroll() {
+    // This is not supported in ViewportBindingNaturalIosEmbed_
   }
 
   /** @override */
@@ -1547,6 +1597,16 @@ export class ViewportBindingIosEmbedWrapper_ {
     if (!transient) {
       this.updatePaddingTop(paddingTop);
     }
+  }
+
+  /** @override */
+  disableScroll() {
+    this.wrapper_.classList.add('i-amphtml-scroll-disabled');
+  }
+
+  /** @override */
+  resetScroll() {
+    this.wrapper_.classList.remove('i-amphtml-scroll-disabled');
   }
 
   /** @override */

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -990,7 +990,7 @@ describe('Viewport META', () => {
 });
 
 
-describes.realWin('ViewportBindingNatural', {}, env => {
+describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
   let binding;
   let win;
   let viewer;
@@ -1114,6 +1114,29 @@ describes.realWin('ViewportBindingNatural', {}, env => {
     expect(rect.top).to.equal(213);  // round(200 + 12.5)
     expect(rect.width).to.equal(14);  // round(13.5)
     expect(rect.height).to.equal(15);  // round(14.5)
+  });
+
+
+  it('should disable scroll temporarily and reset scroll', () => {
+    let htmlCss = win.getComputedStyle(win.document.documentElement);
+    expect(htmlCss.overflowX).to.equal('hidden');
+    expect(htmlCss.overflowY).to.equal('auto');
+
+    binding.disableScroll();
+
+    expect(win.document.documentElement).to.have.class(
+        'i-amphtml-scroll-disabled');
+    htmlCss = win.getComputedStyle(win.document.documentElement);
+    expect(htmlCss.overflowX).to.equal('hidden');
+    expect(htmlCss.overflowY).to.equal('hidden');
+
+    binding.resetScroll();
+
+    expect(win.document.documentElement).to.not.have.class(
+        'i-amphtml-scroll-disabled');
+    htmlCss = win.getComputedStyle(win.document.documentElement);
+    expect(htmlCss.overflowX).to.equal('hidden');
+    expect(htmlCss.overflowY).to.equal('auto');
   });
 });
 
@@ -1520,6 +1543,27 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
     }).then(() => {
       expect(binding.getScrollTop()).to.equal(11);
     });
+  });
+
+  it('should disable scroll temporarily and reset scroll', () => {
+    let wrapperCss = win.getComputedStyle(binding.wrapper_);
+    expect(wrapperCss.overflowX).to.equal('hidden');
+    expect(wrapperCss.overflowY).to.equal('auto');
+
+    binding.disableScroll();
+
+    expect(binding.wrapper_).to.have.class('i-amphtml-scroll-disabled');
+    wrapperCss = win.getComputedStyle(binding.wrapper_);
+    expect(wrapperCss.overflowX).to.equal('hidden');
+    expect(wrapperCss.overflowY).to.equal('hidden');
+
+    binding.resetScroll();
+
+    expect(binding.wrapper_).to.not.have.class(
+        'i-amphtml-scroll-disabled');
+    wrapperCss = win.getComputedStyle(binding.wrapper_);
+    expect(wrapperCss.overflowX).to.equal('hidden');
+    expect(wrapperCss.overflowY).to.equal('auto');
   });
 });
 


### PR DESCRIPTION
Partial of https://github.com/ampproject/amphtml/issues/6487
Fix lightbox scrolling issue: disable scrolling temporarily when opening lightbox

Manual tested in natural binding and ios wrapper binding.