### PR TITLE
Updated the function annotations to use lower cased 'function' #1275

### DIFF
--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -354,7 +354,7 @@ export class InstrumentationService {
    * Register for a listener to be called when the boundaries specified in
    * config are reached.
    * @param {!JSONType} config the config that specifies the boundaries.
-   * @param {Function} listener
+   * @param {function(!AnalyticsEvent)} listener
    * @private
    */
   registerScrollTrigger_(config, listener) {
@@ -465,7 +465,7 @@ export class InstrumentationService {
   }
 
   /**
-   * @param {!Function} listener
+   * @param {!function(!AnalyticsEvent)} listener
    * @param {JSONType} timerSpec
    * @private
    */

--- a/extensions/amp-playbuzz/0.1/utils.js
+++ b/extensions/amp-playbuzz/0.1/utils.js
@@ -82,7 +82,7 @@ export function handleMessageByName(element, event, messageName, handler) {
 /**
  * @param {Object} event
  * @param {String} eventName
- * @param {Function} handler
+ * @param {function} handler
  */
 function handlePlaybuzzItemEvent(event, eventName, handler) {
   const data = parsePlaybuzzEventData(event.data);


### PR DESCRIPTION
Fixed issue #1275 to use 'function' instead of Function in the code base. Surprisingly, there were only 3 instances across 2 files that had upper case Function annotations.