### PR TITLE
Allow hidden attribute globally.

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2945,6 +2945,10 @@ attr_lists: {
   attrs: { name: "dir" }
   attrs: { name: "draggable" }
   attrs: {
+    name: "hidden"
+    value: ""
+  }
+  attrs: {
     name: "id"
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
         "__amp_\\S*|"


### PR DESCRIPTION
For #7753, allow `hidden` attribute globally. Can have no value other than empty string.

Valid:
`<element hidden>`
`<element hidden="">`

Invalid:
`<element hidden="hidden">`
