### PR TITLE
Revert "better update for document-register-element 1.4.1 (#7750)"

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -363,15 +363,8 @@ function patchRegisterElement() {
     if (argv.fortesting) {
       // Need to switch global to self since closure doesn't wrap the module
       // like CommonJS
-      file = file.replace(
-        /installCustomElements\(([^,)]+)\)/g,
-        function($0, $1) {
-          if ($1 == 'global') {
-            $1 = 'self';
-          }
-          return 'installCustomElements(' + $1 + ',\'auto\')';
-        }
-      );
+      file = file.replace('installCustomElements(global);',
+          'installCustomElements(self);');
     } else {
       // Get rid of the side effect the module has so we can tree shake it
       // better and control installation, unless --fortesting flag


### PR DESCRIPTION
This reverts commit 6af8a3b005e0c504e6f21f4e1af23a3c3dd58a86.

reverting for now since this causes master to be red

<img width="1028" alt="screen shot 2017-02-23 at 11 00 57 am" src="https://cloud.githubusercontent.com/assets/354746/23274429/8b8e4fac-f9b7-11e6-9a3c-fb74e8a8e77d.png">
