### PR TITLE
Call #onLayoutMeasure after build

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -772,7 +772,9 @@ function createBaseCustomElementClass(win) {
       if (this.isUpgraded()) {
         this.implementation_.layoutWidth_ = this.layoutWidth_;
       }
-      this.implementation_.onLayoutMeasure();
+      if (this.isBuilt()) {
+        this.implementation_.onLayoutMeasure();
+      }
 
       if (this.isLoadingEnabled_()) {
         if (this.isInViewport_) {


### PR DESCRIPTION
element's `onLayoutMeasure()` should only be called if it is built.
fix #7759 
