### PR TITLE
Fix various issues with error reporting integration tests

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -97,7 +97,7 @@ export function reportError(error, opt_associatedElement) {
       error = new Error('Unknown error');
     }
     // Report if error is not an expected type.
-    if (!isValidError && getMode().localDev) {
+    if (!isValidError && getMode().localDev && !getMode().test) {
       setTimeout(function() {
         const rethrow = new Error(
             '_reported_ Error reported incorrectly: ' + error);

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -87,7 +87,6 @@ describe('reportErrorToServer', () => {
   beforeEach(() => {
     onError = window.onerror;
     sandbox = sinon.sandbox.create();
-    sandbox.spy(window, 'Image');
   });
 
   afterEach(() => {
@@ -108,10 +107,12 @@ describe('reportErrorToServer', () => {
     expect(query.m).to.equal('XYZ');
     expect(query.el).to.equal('u');
     expect(query.a).to.equal('0');
-    expect(query.s).to.equal(e.stack);
+    expect(query.s).to.equal(e.stack.trim());
     expect(query['3p']).to.equal(undefined);
     expect(e.message).to.contain('_reported_');
-    expect(query.or).to.contain('http://localhost');
+    if (location.ancestorOrigins) {
+      expect(query.or).to.contain('http://localhost');
+    }
     expect(query.vs).to.be.undefined;
     expect(query.ae).to.equal('');
     expect(query.r).to.contain('http://localhost');

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -379,6 +379,7 @@ describes.sandboxed('reportError', {}, () => {
   });
 
   it('should accept string and report incorrect use', () => {
+    window.AMP_MODE = {localDev: true, test: false};
     const result = reportError('error');
     expect(result).to.be.instanceOf(Error);
     expect(result.message).to.be.equal('error');
@@ -390,6 +391,7 @@ describes.sandboxed('reportError', {}, () => {
   });
 
   it('should accept number and report incorrect use', () => {
+    window.AMP_MODE = {localDev: true, test: false};
     const result = reportError(101);
     expect(result).to.be.instanceOf(Error);
     expect(result.message).to.be.equal('101');
@@ -401,6 +403,7 @@ describes.sandboxed('reportError', {}, () => {
   });
 
   it('should accept null and report incorrect use', () => {
+    window.AMP_MODE = {localDev: true, test: false};
     const result = reportError(null);
     expect(result).to.be.instanceOf(Error);
     expect(result.message).to.be.equal('Unknown error');


### PR DESCRIPTION
- Spying (for some reason) on `Image` breaks Safari
- Firefox has a newline at the end of its stack, which is trimmed by `parseQueryString`
- Firefox and IE don't support `ancestorOrigins`, so no `or` param

Hopefully this'll get master back to green. I'm out tomorrow, so feel free to merge.

Fixes https://github.com/ampproject/amphtml/issues/7761.