### PR TITLE
Add ability to AB test Sortable <amp-ad> against Google (adsense/dfp).

### DIFF
--- a/ads/sortable.js
+++ b/ads/sortable.js
@@ -15,14 +15,30 @@
  */
 
 import {loadScript, validateData} from '../3p/3p';
+import {doubleclick} from './google/doubleclick';
+import {adsense} from './google/adsense';
 
 /**
  * @param {!Window} global
  * @param {!Object} data
  */
 export function sortable(global, data) {
-  validateData(data, ['site', 'name']);
+  /**
+   * For A/B testing our tags against doubleclick or adsense in AMP ads.
+   * See https://github.com/ampproject/amphtml/blob/master/ads/sortable.md for examples.
+   */
+  if (data.abType && data.abType === 'doubleclick' && data.abPct &&
+      Math.random() * 100 < parseInt(data.abPct, 10)) {
+    doubleclick(global, data);
+    return;
+  }
+  if (data.abType && data.abType === 'adsense' && data.abPct &&
+      Math.random() * 100 < parseInt(data.abPct, 10)) {
+    adsense(global, data);
+    return;
+  }
 
+  validateData(data, ['site', 'name']);
   const slot = global.document.getElementById('c');
   const ad = global.document.createElement('div');
   ad.className = 'ad-tag';

--- a/ads/sortable.md
+++ b/ads/sortable.md
@@ -31,6 +31,27 @@ limitations under the License.
       data-site="ampproject.org">
   </amp-ad>
 ```
+### A/B testing
+```html
+  <amp-ad width="300" height="250"
+      type="sortable"
+      data-name="medrec"
+      data-site="ampproject.org"
+      data-ab-type="doubleclick"
+      data-ab-pct="50"
+      data-slot="/4119129/mobile_ad_banner">
+  </amp-ad>
+
+  <amp-ad width="300" height="250"
+      type="sortable"
+      data-name="medrec"
+      data-site="ampproject.org"
+      data-ab-type="adsense"
+      data-ab-pct="50"
+      data-ad-client="ca-pub-2005682797531342"
+      data-ad-slot="7046626912">
+  </amp-ad>
+```
 
 ## Configuration
 
@@ -44,5 +65,10 @@ __Required:__
 
 `type` - always set to "sortable"
  
+__Optional:__
+
+`data-ab-type` - for A/B testing Sortable against other services. Either 'adsense' or 'doubleclick'.
+`data-ab-pct` - percent likelihood that the alternate tags will be run instead of Sortable's.
 
 No explicit configuration is needed for a given sortable amp-ad, though each site must be set up beforehand with [Sortable](http://sortable.com). The site name `ampproject.org` can be used for testing. Note that only the two examples above will show an ad properly.
+for A/B testing, ad slots must have attributes compliant with the services that are being tested against Sortable. See the examples above.


### PR DESCRIPTION
- Can now AB test sortable against doubleclick and adsense tags.
- Use data-ab-type to specify test type, and data-ab-pct to specify probability of using alternate tags.