### PR TITLE
Analytics: universal visibility helper

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-visibility-helper.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-helper.js
@@ -20,6 +20,13 @@ const NO_PARENT = null;
 const NO_SPEC = {};
 
 
+// QQQ
+// visiblePercentageMin: Number(spec['visiblePercentageMin']) / 100 || 0,
+// visiblePercentageMax: Number(spec['visiblePercentageMax']) / 100 || 1,
+// totalTimeMin: Number(spec['totalTimeMin']) || 0,
+// totalTimeMax: Number(spec['totalTimeMax']) || Infinity,
+// continuousTimeMin: Number(spec['continuousTimeMin']) || 0,
+// continuousTimeMax: Number(spec['continuousTimeMax']) || Infinity,
 describes.sandboxed('VisibilityHelper', {}, () => {
   let startTime;
   let clock;
@@ -34,114 +41,114 @@ describes.sandboxed('VisibilityHelper', {}, () => {
   describe('config', () => {
 
     function config(spec) {
-      return new VisibilityHelper(NO_PARENT, spec, 0);
+      return new VisibilityHelper(NO_PARENT, spec, 0).spec_;
     }
 
     it('should parse visiblePercentageMin', () => {
-      expect(config({}).visiblePercentageMin_).to.equal(0);
-      expect(config({visiblePercentageMin: ''}).visiblePercentageMin_)
+      expect(config({}).visiblePercentageMin).to.equal(0);
+      expect(config({visiblePercentageMin: ''}).visiblePercentageMin)
           .to.equal(0);
-      expect(config({visiblePercentageMin: 0}).visiblePercentageMin_)
+      expect(config({visiblePercentageMin: 0}).visiblePercentageMin)
           .to.equal(0);
-      expect(config({visiblePercentageMin: '0'}).visiblePercentageMin_)
+      expect(config({visiblePercentageMin: '0'}).visiblePercentageMin)
           .to.equal(0);
-      expect(config({visiblePercentageMin: 50}).visiblePercentageMin_)
+      expect(config({visiblePercentageMin: 50}).visiblePercentageMin)
           .to.equal(0.5);
-      expect(config({visiblePercentageMin: '50'}).visiblePercentageMin_)
+      expect(config({visiblePercentageMin: '50'}).visiblePercentageMin)
           .to.equal(0.5);
-      expect(config({visiblePercentageMin: 100}).visiblePercentageMin_)
+      expect(config({visiblePercentageMin: 100}).visiblePercentageMin)
           .to.equal(1);
-      expect(config({visiblePercentageMin: '100'}).visiblePercentageMin_)
+      expect(config({visiblePercentageMin: '100'}).visiblePercentageMin)
           .to.equal(1);
     });
 
     it('should parse visiblePercentageMax', () => {
-      expect(config({}).visiblePercentageMax_).to.equal(1);
-      expect(config({visiblePercentageMax: ''}).visiblePercentageMax_)
+      expect(config({}).visiblePercentageMax).to.equal(1);
+      expect(config({visiblePercentageMax: ''}).visiblePercentageMax)
           .to.equal(1);
-      expect(config({visiblePercentageMax: 0}).visiblePercentageMax_)
+      expect(config({visiblePercentageMax: 0}).visiblePercentageMax)
           .to.equal(1);
-      expect(config({visiblePercentageMax: '0'}).visiblePercentageMax_)
+      expect(config({visiblePercentageMax: '0'}).visiblePercentageMax)
           .to.equal(1);
-      expect(config({visiblePercentageMax: 50}).visiblePercentageMax_)
+      expect(config({visiblePercentageMax: 50}).visiblePercentageMax)
           .to.equal(0.5);
-      expect(config({visiblePercentageMax: '50'}).visiblePercentageMax_)
+      expect(config({visiblePercentageMax: '50'}).visiblePercentageMax)
           .to.equal(0.5);
-      expect(config({visiblePercentageMax: 100}).visiblePercentageMax_)
+      expect(config({visiblePercentageMax: 100}).visiblePercentageMax)
           .to.equal(1);
-      expect(config({visiblePercentageMax: '100'}).visiblePercentageMax_)
+      expect(config({visiblePercentageMax: '100'}).visiblePercentageMax)
           .to.equal(1);
     });
 
     it('should parse totalTimeMin', () => {
-      expect(config({}).totalTimeMin_).to.equal(0);
-      expect(config({totalTimeMin: ''}).totalTimeMin_)
+      expect(config({}).totalTimeMin).to.equal(0);
+      expect(config({totalTimeMin: ''}).totalTimeMin)
           .to.equal(0);
-      expect(config({totalTimeMin: 0}).totalTimeMin_)
+      expect(config({totalTimeMin: 0}).totalTimeMin)
           .to.equal(0);
-      expect(config({totalTimeMin: '0'}).totalTimeMin_)
+      expect(config({totalTimeMin: '0'}).totalTimeMin)
           .to.equal(0);
-      expect(config({totalTimeMin: 50}).totalTimeMin_)
+      expect(config({totalTimeMin: 50}).totalTimeMin)
           .to.equal(50);
-      expect(config({totalTimeMin: '50'}).totalTimeMin_)
+      expect(config({totalTimeMin: '50'}).totalTimeMin)
           .to.equal(50);
-      expect(config({totalTimeMin: 100}).totalTimeMin_)
+      expect(config({totalTimeMin: 100}).totalTimeMin)
           .to.equal(100);
-      expect(config({totalTimeMin: '100'}).totalTimeMin_)
+      expect(config({totalTimeMin: '100'}).totalTimeMin)
           .to.equal(100);
     });
 
     it('should parse totalTimeMax', () => {
-      expect(config({}).totalTimeMax_).to.equal(Infinity);
-      expect(config({totalTimeMax: ''}).totalTimeMax_)
+      expect(config({}).totalTimeMax).to.equal(Infinity);
+      expect(config({totalTimeMax: ''}).totalTimeMax)
           .to.equal(Infinity);
-      expect(config({totalTimeMax: 0}).totalTimeMax_)
+      expect(config({totalTimeMax: 0}).totalTimeMax)
           .to.equal(Infinity);
-      expect(config({totalTimeMax: '0'}).totalTimeMax_)
+      expect(config({totalTimeMax: '0'}).totalTimeMax)
           .to.equal(Infinity);
-      expect(config({totalTimeMax: 50}).totalTimeMax_)
+      expect(config({totalTimeMax: 50}).totalTimeMax)
           .to.equal(50);
-      expect(config({totalTimeMax: '50'}).totalTimeMax_)
+      expect(config({totalTimeMax: '50'}).totalTimeMax)
           .to.equal(50);
-      expect(config({totalTimeMax: 100}).totalTimeMax_)
+      expect(config({totalTimeMax: 100}).totalTimeMax)
           .to.equal(100);
-      expect(config({totalTimeMax: '100'}).totalTimeMax_)
+      expect(config({totalTimeMax: '100'}).totalTimeMax)
           .to.equal(100);
     });
 
     it('should parse continuousTimeMin', () => {
-      expect(config({}).continuousTimeMin_).to.equal(0);
-      expect(config({continuousTimeMin: ''}).continuousTimeMin_)
+      expect(config({}).continuousTimeMin).to.equal(0);
+      expect(config({continuousTimeMin: ''}).continuousTimeMin)
           .to.equal(0);
-      expect(config({continuousTimeMin: 0}).continuousTimeMin_)
+      expect(config({continuousTimeMin: 0}).continuousTimeMin)
           .to.equal(0);
-      expect(config({continuousTimeMin: '0'}).continuousTimeMin_)
+      expect(config({continuousTimeMin: '0'}).continuousTimeMin)
           .to.equal(0);
-      expect(config({continuousTimeMin: 50}).continuousTimeMin_)
+      expect(config({continuousTimeMin: 50}).continuousTimeMin)
           .to.equal(50);
-      expect(config({continuousTimeMin: '50'}).continuousTimeMin_)
+      expect(config({continuousTimeMin: '50'}).continuousTimeMin)
           .to.equal(50);
-      expect(config({continuousTimeMin: 100}).continuousTimeMin_)
+      expect(config({continuousTimeMin: 100}).continuousTimeMin)
           .to.equal(100);
-      expect(config({continuousTimeMin: '100'}).continuousTimeMin_)
+      expect(config({continuousTimeMin: '100'}).continuousTimeMin)
           .to.equal(100);
     });
 
     it('should parse continuousTimeMax', () => {
-      expect(config({}).continuousTimeMax_).to.equal(Infinity);
-      expect(config({continuousTimeMax: ''}).continuousTimeMax_)
+      expect(config({}).continuousTimeMax).to.equal(Infinity);
+      expect(config({continuousTimeMax: ''}).continuousTimeMax)
           .to.equal(Infinity);
-      expect(config({continuousTimeMax: 0}).continuousTimeMax_)
+      expect(config({continuousTimeMax: 0}).continuousTimeMax)
           .to.equal(Infinity);
-      expect(config({continuousTimeMax: '0'}).continuousTimeMax_)
+      expect(config({continuousTimeMax: '0'}).continuousTimeMax)
           .to.equal(Infinity);
-      expect(config({continuousTimeMax: 50}).continuousTimeMax_)
+      expect(config({continuousTimeMax: 50}).continuousTimeMax)
           .to.equal(50);
-      expect(config({continuousTimeMax: '50'}).continuousTimeMax_)
+      expect(config({continuousTimeMax: '50'}).continuousTimeMax)
           .to.equal(50);
-      expect(config({continuousTimeMax: 100}).continuousTimeMax_)
+      expect(config({continuousTimeMax: 100}).continuousTimeMax)
           .to.equal(100);
-      expect(config({continuousTimeMax: '100'}).continuousTimeMax_)
+      expect(config({continuousTimeMax: '100'}).continuousTimeMax)
           .to.equal(100);
     });
   });

--- a/extensions/amp-analytics/0.1/test/test-visibility-helper.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-helper.js
@@ -1,0 +1,894 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {VisibilityHelper} from '../visibility-helper';
+
+const NO_PARENT = null;
+const NO_SPEC = {};
+
+
+describes.sandboxed('VisibilityHelper', {}, () => {
+  let startTime;
+  let clock;
+
+  beforeEach(() => {
+    clock = sandbox.useFakeTimers();
+    startTime = 10000;
+    clock.tick(startTime + 1);
+  });
+
+
+  describe('config', () => {
+
+    function config(spec) {
+      return new VisibilityHelper(NO_PARENT, spec, 0);
+    }
+
+    it('should parse visiblePercentageMin', () => {
+      expect(config({}).visiblePercentageMin_).to.equal(0);
+      expect(config({visiblePercentageMin: ''}).visiblePercentageMin_)
+          .to.equal(0);
+      expect(config({visiblePercentageMin: 0}).visiblePercentageMin_)
+          .to.equal(0);
+      expect(config({visiblePercentageMin: '0'}).visiblePercentageMin_)
+          .to.equal(0);
+      expect(config({visiblePercentageMin: 50}).visiblePercentageMin_)
+          .to.equal(0.5);
+      expect(config({visiblePercentageMin: '50'}).visiblePercentageMin_)
+          .to.equal(0.5);
+      expect(config({visiblePercentageMin: 100}).visiblePercentageMin_)
+          .to.equal(1);
+      expect(config({visiblePercentageMin: '100'}).visiblePercentageMin_)
+          .to.equal(1);
+    });
+
+    it('should parse visiblePercentageMax', () => {
+      expect(config({}).visiblePercentageMax_).to.equal(1);
+      expect(config({visiblePercentageMax: ''}).visiblePercentageMax_)
+          .to.equal(1);
+      expect(config({visiblePercentageMax: 0}).visiblePercentageMax_)
+          .to.equal(1);
+      expect(config({visiblePercentageMax: '0'}).visiblePercentageMax_)
+          .to.equal(1);
+      expect(config({visiblePercentageMax: 50}).visiblePercentageMax_)
+          .to.equal(0.5);
+      expect(config({visiblePercentageMax: '50'}).visiblePercentageMax_)
+          .to.equal(0.5);
+      expect(config({visiblePercentageMax: 100}).visiblePercentageMax_)
+          .to.equal(1);
+      expect(config({visiblePercentageMax: '100'}).visiblePercentageMax_)
+          .to.equal(1);
+    });
+
+    it('should parse totalTimeMin', () => {
+      expect(config({}).totalTimeMin_).to.equal(0);
+      expect(config({totalTimeMin: ''}).totalTimeMin_)
+          .to.equal(0);
+      expect(config({totalTimeMin: 0}).totalTimeMin_)
+          .to.equal(0);
+      expect(config({totalTimeMin: '0'}).totalTimeMin_)
+          .to.equal(0);
+      expect(config({totalTimeMin: 50}).totalTimeMin_)
+          .to.equal(50);
+      expect(config({totalTimeMin: '50'}).totalTimeMin_)
+          .to.equal(50);
+      expect(config({totalTimeMin: 100}).totalTimeMin_)
+          .to.equal(100);
+      expect(config({totalTimeMin: '100'}).totalTimeMin_)
+          .to.equal(100);
+    });
+
+    it('should parse totalTimeMax', () => {
+      expect(config({}).totalTimeMax_).to.equal(Infinity);
+      expect(config({totalTimeMax: ''}).totalTimeMax_)
+          .to.equal(Infinity);
+      expect(config({totalTimeMax: 0}).totalTimeMax_)
+          .to.equal(Infinity);
+      expect(config({totalTimeMax: '0'}).totalTimeMax_)
+          .to.equal(Infinity);
+      expect(config({totalTimeMax: 50}).totalTimeMax_)
+          .to.equal(50);
+      expect(config({totalTimeMax: '50'}).totalTimeMax_)
+          .to.equal(50);
+      expect(config({totalTimeMax: 100}).totalTimeMax_)
+          .to.equal(100);
+      expect(config({totalTimeMax: '100'}).totalTimeMax_)
+          .to.equal(100);
+    });
+
+    it('should parse continuousTimeMin', () => {
+      expect(config({}).continuousTimeMin_).to.equal(0);
+      expect(config({continuousTimeMin: ''}).continuousTimeMin_)
+          .to.equal(0);
+      expect(config({continuousTimeMin: 0}).continuousTimeMin_)
+          .to.equal(0);
+      expect(config({continuousTimeMin: '0'}).continuousTimeMin_)
+          .to.equal(0);
+      expect(config({continuousTimeMin: 50}).continuousTimeMin_)
+          .to.equal(50);
+      expect(config({continuousTimeMin: '50'}).continuousTimeMin_)
+          .to.equal(50);
+      expect(config({continuousTimeMin: 100}).continuousTimeMin_)
+          .to.equal(100);
+      expect(config({continuousTimeMin: '100'}).continuousTimeMin_)
+          .to.equal(100);
+    });
+
+    it('should parse continuousTimeMax', () => {
+      expect(config({}).continuousTimeMax_).to.equal(Infinity);
+      expect(config({continuousTimeMax: ''}).continuousTimeMax_)
+          .to.equal(Infinity);
+      expect(config({continuousTimeMax: 0}).continuousTimeMax_)
+          .to.equal(Infinity);
+      expect(config({continuousTimeMax: '0'}).continuousTimeMax_)
+          .to.equal(Infinity);
+      expect(config({continuousTimeMax: 50}).continuousTimeMax_)
+          .to.equal(50);
+      expect(config({continuousTimeMax: '50'}).continuousTimeMax_)
+          .to.equal(50);
+      expect(config({continuousTimeMax: 100}).continuousTimeMax_)
+          .to.equal(100);
+      expect(config({continuousTimeMax: '100'}).continuousTimeMax_)
+          .to.equal(100);
+    });
+  });
+
+
+  describe('structure', () => {
+    beforeEach(() => {
+    });
+
+    it('should dispose fully', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      vh.scheduledRunId_ = 1;
+      const unsubscribeSpy = sandbox.spy();
+      vh.unsubscribe(unsubscribeSpy);
+
+      vh.dispose();
+      expect(vh.scheduledRunId_).to.be.null;
+      expect(unsubscribeSpy).to.be.calledOnce;
+      expect(vh.unsubscribe_).to.be.empty;
+      expect(vh.eventResolver_).to.be.null;
+    });
+
+    it('should update on any visibility event', () => {
+      const updateStub = sandbox.stub(VisibilityHelper.prototype, 'update');
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      vh.setVisibility(0);
+      vh.setVisibility(1);
+      vh.setBlocked(false);
+      vh.setBlocked(true);
+      expect(updateStub.callCount).to.equal(4);
+    });
+
+    it('should update when started visible', () => {
+      const updateStub = sandbox.stub(VisibilityHelper.prototype, 'update');
+      new VisibilityHelper(NO_PARENT, NO_SPEC, 1);
+      expect(updateStub).to.be.calledOnce;
+    });
+
+    it('should NOT update when started invisible', () => {
+      const updateStub = sandbox.stub(VisibilityHelper.prototype, 'update');
+      new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      expect(updateStub).to.not.be.called;
+    });
+
+    it('should work w/o parent', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      expect(vh.children_).to.be.null;  // Don't take extra memory.
+
+      vh.setVisibility(0.5);
+      expect(vh.getVisibility()).to.equal(0.5);
+
+      vh.setBlocked(true);
+      expect(vh.getVisibility()).to.equal(0);
+
+      vh.setBlocked(false);
+      expect(vh.getVisibility()).to.equal(0.5);
+    });
+
+    it('should work w/children', () => {
+      const parent = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      const child1 = new VisibilityHelper(parent, NO_SPEC, 0);
+      const child2 = new VisibilityHelper(parent, NO_SPEC, 0,
+          /* factorParent */ true);
+      expect(parent.children_).to.deep.equal([child1, child2]);
+      expect(child1.parent_).to.equal(parent);
+      expect(child2.parent_).to.equal(parent);
+
+      // Visibility blocked by parent.
+      child1.setVisibility(0.5);
+      child2.setVisibility(0.5);
+      expect(child1.getVisibility()).to.equal(0);
+      expect(child2.getVisibility()).to.equal(0);
+
+      // Visibility unblocked by parent.
+      parent.setVisibility(0.7);
+      expect(child1.getVisibility()).to.equal(0.5);
+      expect(child2.getVisibility()).to.equal(0.35);  // 0.5 * 0.7 = 0.35
+
+      // Block parent.
+      parent.setBlocked(true);
+      expect(child1.getVisibility()).to.equal(0);
+      expect(child2.getVisibility()).to.equal(0);
+
+      // Unlock parent.
+      parent.setBlocked(false);
+      expect(child1.getVisibility()).to.equal(0.5);
+      expect(child2.getVisibility()).to.equal(0.35);  // 0.5 * 0.7 = 0.35
+
+      // Block children.
+      child1.setBlocked(true);
+      child2.setBlocked(true);
+      expect(child1.getVisibility()).to.equal(0);
+      expect(child2.getVisibility()).to.equal(0);
+
+      // Unblock children.
+      child1.setBlocked(false);
+      child2.setBlocked(false);
+      expect(child1.getVisibility()).to.equal(0.5);
+      expect(child2.getVisibility()).to.equal(0.35);  // 0.5 * 0.7 = 0.35
+
+      // Invisible again.
+      parent.setVisibility(0);
+      expect(child1.getVisibility()).to.equal(0);
+      expect(child2.getVisibility()).to.equal(0);
+    });
+
+    it('should update on visibility change', () => {
+      const parent = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      const child1 = new VisibilityHelper(parent, NO_SPEC, 0);
+      const child2 = new VisibilityHelper(parent, NO_SPEC, 0);
+      child1.setVisibility(0.2);
+      sandbox.stub(parent, 'update_');
+      sandbox.stub(child1, 'update_');
+      sandbox.stub(child2, 'update_');
+
+      parent.setVisibility(0.1);
+      expect(parent.update_).to.be.calledOnce;
+      expect(child1.update_).to.be.calledOnce;
+      expect(child2.update_).to.be.calledOnce;
+      expect(parent.update_.args[0][0]).to.equal(0.1);
+      expect(child1.update_.args[0][0]).to.equal(0.2);
+      expect(child2.update_.args[0][0]).to.equal(0);
+
+      parent.update();
+      expect(parent.update_).to.be.calledTwice;
+      expect(child1.update_).to.be.calledTwice;
+      expect(child2.update_).to.be.calledTwice;
+      expect(parent.update_.args[1][0]).to.equal(0.1);
+      expect(child1.update_.args[1][0]).to.equal(0.2);
+      expect(child2.update_.args[1][0]).to.equal(0);
+    });
+
+    it('should default export var state', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      expect(vh.getState(0)).to.contains({
+        firstSeenTime: 0,
+        lastSeenTime: 0,
+        lastVisibleTime: 0,
+        fistVisibleTime: 0,
+        maxContinuousVisibleTime: 0,
+        totalVisibleTime: 0,
+        loadTimeVisibility: 0,
+        minVisiblePercentage: 0,
+        maxVisiblePercentage: 0,
+      });
+    });
+
+    it('should export full state', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      vh.firstSeenTime_ = 2;
+      vh.lastSeenTime_ = 3;
+      vh.lastVisibleTime_ = 4;
+      vh.fistVisibleTime_ = 5;
+      vh.maxContinuousVisibleTime_ = 10;
+      vh.totalVisibleTime_ = 11;
+      vh.loadTimeVisibility_ = 0.1;
+      vh.minVisiblePercentage_ = 0.2;
+      vh.maxVisiblePercentage_ = 0.3;
+      expect(vh.getState(1)).to.deep.equal({
+        // Base times:
+        firstSeenTime: 1,
+        lastSeenTime: 2,
+        lastVisibleTime: 3,
+        fistVisibleTime: 4,
+        // Durations:
+        maxContinuousVisibleTime: 10,
+        totalVisibleTime: 11,
+        // Percent:
+        loadTimeVisibility: 10,
+        minVisiblePercentage: 20,
+        maxVisiblePercentage: 30,
+      });
+    });
+  });
+
+
+  describe('update monitor', () => {
+    let vh;
+    let updateStub;
+    let eventSpy;
+
+    beforeEach(() => {
+      vh = new VisibilityHelper(NO_PARENT, {
+        minVisiblePercentage: 25,
+        totalTimeMin: 10,
+        continuousTimeMin: 10,
+      }, 0);
+      updateStub = sandbox.stub(vh, 'update');
+      eventSpy = vh.eventResolver_ = sandbox.spy();
+    });
+
+    it('conditions not met', () => {
+      vh.update_(0.1);
+      expect(vh.scheduledRunId_).to.be.ok;
+      expect(updateStub).to.not.be.called;
+
+      // Check schedule for 10 seconds.
+      clock.tick(9);
+      expect(updateStub).to.not.be.called;
+      clock.tick(1);
+      expect(updateStub).to.be.calledOnce;
+      expect(vh.scheduledRunId_).to.be.null;
+    });
+
+    it('conditions not met and cannot schedule', () => {
+      vh.continuousTime_ = vh.totalVisibleTime_ = 10;
+      vh.update_(0.1);
+      expect(vh.scheduledRunId_).to.be.null;
+    });
+
+    it('conditions not met, schedule for total time', () => {
+      vh.totalVisibleTime_ = 5;
+      vh.update_(0.1);
+      expect(vh.scheduledRunId_).to.be.ok;
+
+      // Check schedule for 5 seconds.
+      clock.tick(4);
+      expect(updateStub).to.not.be.called;
+      clock.tick(1);
+      expect(updateStub).to.be.calledOnce;
+      expect(vh.scheduledRunId_).to.be.null;
+    });
+
+    it('conditions not met, schedule for continuous time', () => {
+      vh.continuousTime_ = 4;
+      vh.update_(0.1);
+      expect(vh.scheduledRunId_).to.be.ok;
+
+      // Check schedule for 6 seconds.
+      clock.tick(5);
+      expect(updateStub).to.not.be.called;
+      clock.tick(1);
+      expect(updateStub).to.be.calledOnce;
+      expect(vh.scheduledRunId_).to.be.null;
+    });
+
+    it('conditions not met, schedule w/o total time', () => {
+      vh.totalVisibleTime_ = 10;
+      vh.continuousTime_ = 4;
+      vh.update_(0.1);
+      expect(vh.scheduledRunId_).to.be.ok;
+
+      // Check schedule for 6 seconds.
+      clock.tick(5);
+      expect(updateStub).to.not.be.called;
+      clock.tick(1);
+      expect(updateStub).to.be.calledOnce;
+      expect(vh.scheduledRunId_).to.be.null;
+    });
+
+    it('conditions not met, schedule w/o continuous time', () => {
+      vh.totalVisibleTime_ = 5;
+      vh.continuousTime_ = 10;
+      vh.update_(0.1);
+      expect(vh.scheduledRunId_).to.be.ok;
+
+      // Check schedule for 5 seconds.
+      clock.tick(4);
+      expect(updateStub).to.not.be.called;
+      clock.tick(1);
+      expect(updateStub).to.be.calledOnce;
+      expect(vh.scheduledRunId_).to.be.null;
+    });
+
+    it('conditions not met -> invisible', () => {
+      vh.update_(0.1);
+      expect(vh.scheduledRunId_).to.be.ok;
+
+      // Goes invisible.
+      vh.update_(0);
+      expect(vh.scheduledRunId_).to.be.null;
+      clock.tick(1000);
+      expect(updateStub).to.not.be.called;
+    });
+
+    it('conditions met', () => {
+      vh.update_(0.1);
+      expect(vh.scheduledRunId_).to.be.ok;
+
+      // Goes invisible.
+      vh.continuousTime_ = vh.totalVisibleTime_ = 10;
+      vh.update_(1);
+      expect(vh.scheduledRunId_).to.be.null;
+      expect(eventSpy).to.be.calledOnce;
+      clock.tick(1000);
+      expect(updateStub).to.not.be.called;
+    });
+  });
+
+
+  describe('tracking math', () => {
+
+    it('should register "seen" values', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC);
+
+      // Not yet visible: nothing is registered.
+      vh.updateCounters_(0);
+      expect(vh.getState(startTime)).to.contains({
+        firstSeenTime: 0,
+        lastSeenTime: 0,
+        loadTimeVisibility: 0,
+      });
+
+      // First-time visible: values updated.
+      clock.tick(100);
+      vh.updateCounters_(0.1);
+      expect(vh.getState(startTime)).to.contains({
+        firstSeenTime: 101,
+        lastSeenTime: 101,
+        loadTimeVisibility: 10,
+      });
+
+      // Repeat visible: most values do not change.
+      clock.tick(100);
+      vh.updateCounters_(0.2);
+      expect(vh.getState(startTime)).to.contains({
+        firstSeenTime: 101,
+        lastSeenTime: 201,
+        loadTimeVisibility: 10,
+      });
+    });
+
+    it('should ignore "load visibility" after timeout', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC);
+      clock.tick(500);
+      vh.updateCounters_(0.1);
+      expect(vh.getState(startTime)).to.contains({
+        firstSeenTime: 501,
+        lastSeenTime: 501,
+        loadTimeVisibility: 0,
+      });
+    });
+
+    it('should match default visibility position', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC);
+      vh.updateCounters_(0);
+      expect(vh.matchesVisibility_).to.be.false;
+
+      vh.updateCounters_(-1);
+      expect(vh.matchesVisibility_).to.be.false;
+
+      vh.updateCounters_(0.0001);
+      expect(vh.matchesVisibility_).to.be.true;
+
+      vh.updateCounters_(0.9999);
+      expect(vh.matchesVisibility_).to.be.true;
+
+      vh.updateCounters_(1);
+      expect(vh.matchesVisibility_).to.be.true;
+
+      vh.updateCounters_(1.00001);
+      expect(vh.matchesVisibility_).to.be.false;
+    });
+
+    it('should match custom visibility position', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        visiblePercentageMin: 10,
+        visiblePercentageMax: 90,
+      });
+      vh.updateCounters_(0);
+      expect(vh.matchesVisibility_).to.be.false;
+
+      vh.updateCounters_(-1);
+      expect(vh.matchesVisibility_).to.be.false;
+
+      vh.updateCounters_(0.1);
+      expect(vh.matchesVisibility_).to.be.false;
+
+      vh.updateCounters_(0.1001);
+      expect(vh.matchesVisibility_).to.be.true;
+
+      vh.updateCounters_(0.9);
+      expect(vh.matchesVisibility_).to.be.true;
+
+      vh.updateCounters_(0.90001);
+      expect(vh.matchesVisibility_).to.be.false;
+
+      vh.updateCounters_(1);
+      expect(vh.matchesVisibility_).to.be.false;
+
+      vh.updateCounters_(1.00001);
+      expect(vh.matchesVisibility_).to.be.false;
+    });
+
+    it('should transition to visible and stay visible', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC);
+      clock.tick(100);
+      vh.updateCounters_(0.1);
+      expect(vh.getState(startTime)).to.contains({
+        fistVisibleTime: 101,
+        lastVisibleTime: 101,
+        totalVisibleTime: 0,
+        maxContinuousVisibleTime: 0,
+        minVisiblePercentage: 10,
+        maxVisiblePercentage: 10,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(Date.now());
+
+      // Stay visible.
+      clock.tick(100);
+      vh.updateCounters_(0.05);
+      expect(vh.getState(startTime)).to.contains({
+        fistVisibleTime: 101,  // Doesn't change.
+        lastVisibleTime: 201,
+        totalVisibleTime: 100,
+        maxContinuousVisibleTime: 100,
+        minVisiblePercentage: 5,
+        maxVisiblePercentage: 10,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(Date.now());
+
+      // Continue visible.
+      clock.tick(100);
+      vh.updateCounters_(0.2);
+      expect(vh.getState(startTime)).to.contains({
+        fistVisibleTime: 101,  // Doesn't change.
+        lastVisibleTime: 301,
+        totalVisibleTime: 200,
+        maxContinuousVisibleTime: 200,
+        minVisiblePercentage: 5,
+        maxVisiblePercentage: 20,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(Date.now());
+    });
+
+    it('should transition to invisible and back to visible', () => {
+      const vh = new VisibilityHelper(NO_PARENT, NO_SPEC);
+      clock.tick(100);
+      vh.updateCounters_(0.1);
+      expect(vh.getState(startTime)).to.contains({
+        fistVisibleTime: 101,
+        lastVisibleTime: 101,
+        totalVisibleTime: 0,
+        maxContinuousVisibleTime: 0,
+        minVisiblePercentage: 10,
+        maxVisiblePercentage: 10,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(Date.now());
+
+      // Stay visible.
+      clock.tick(100);
+      vh.updateCounters_(0.05);
+      expect(vh.getState(startTime)).to.contains({
+        fistVisibleTime: 101,  // Doesn't change.
+        lastVisibleTime: 201,
+        totalVisibleTime: 100,
+        maxContinuousVisibleTime: 100,
+        minVisiblePercentage: 5,
+        maxVisiblePercentage: 10,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(Date.now());
+
+      // Go invisible.
+      clock.tick(100);
+      vh.updateCounters_(0);
+      expect(vh.getState(startTime)).to.contains({
+        // Last update.
+        totalVisibleTime: 200,
+        maxContinuousVisibleTime: 200,
+        lastVisibleTime: 301,
+        // No changes.
+        fistVisibleTime: 101,
+        minVisiblePercentage: 5,
+        maxVisiblePercentage: 10,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(0);
+
+      // Stay invisible.
+      clock.tick(100);
+      vh.updateCounters_(0);
+      expect(vh.getState(startTime)).to.contains({
+        // No changes.
+        totalVisibleTime: 200,
+        maxContinuousVisibleTime: 200,
+        lastVisibleTime: 301,
+        fistVisibleTime: 101,
+        minVisiblePercentage: 5,
+        maxVisiblePercentage: 10,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(0);
+
+      // Back to visible.
+      clock.tick(100);
+      vh.updateCounters_(0.6);
+      expect(vh.getState(startTime)).to.contains({
+        maxVisiblePercentage: 60,
+        lastVisibleTime: 501,
+        // No changes.
+        totalVisibleTime: 200,
+        maxContinuousVisibleTime: 200,
+        fistVisibleTime: 101,
+        minVisiblePercentage: 5,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(Date.now());
+
+      // Stay to visible.
+      clock.tick(100);
+      vh.updateCounters_(0.7);
+      expect(vh.getState(startTime)).to.contains({
+        maxVisiblePercentage: 70,
+        lastVisibleTime: 601,
+        totalVisibleTime: 300,
+        // No changes.
+        maxContinuousVisibleTime: 200,
+        fistVisibleTime: 101,
+        minVisiblePercentage: 5,
+      });
+      expect(vh.lastVisibleUpdateTime_).to.equal(Date.now());
+    });
+
+    it('should yield based on position only', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        visiblePercentageMin: 10,
+        visiblePercentageMax: 90,
+      });
+      clock.tick(100);
+      expect(vh.updateCounters_(0)).to.be.false;
+      expect(vh.updateCounters_(0.1)).to.be.false;
+      expect(vh.updateCounters_(0.9001)).to.be.false;
+      expect(vh.updateCounters_(0.1001)).to.be.true;
+      expect(vh.updateCounters_(0.9)).to.be.true;
+    });
+
+    it('should yield based on total time only', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        totalTimeMin: 10,
+        totalTimeMax: 90,
+      });
+      expect(vh.updateCounters_(0.1)).to.be.false;
+      clock.tick(5);
+      expect(vh.updateCounters_(0)).to.be.false;
+      clock.tick(100);
+      expect(vh.updateCounters_(0.1)).to.be.false;
+      clock.tick(5);
+      expect(vh.updateCounters_(0.1)).to.be.true;
+      clock.tick(90);
+      expect(vh.updateCounters_(0.1)).to.be.false;
+    });
+
+    it('should yield based on continuous time only', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        continuousTimeMin: 10,
+        continuousTimeMax: 90,
+      });
+      expect(vh.updateCounters_(0.1)).to.be.false;
+      clock.tick(5);
+      expect(vh.updateCounters_(0)).to.be.false;
+      clock.tick(100);
+      expect(vh.updateCounters_(0.1)).to.be.false;
+      clock.tick(5);
+      expect(vh.updateCounters_(0.1)).to.be.false;
+      clock.tick(5);
+      expect(vh.updateCounters_(0.1)).to.be.true;
+      clock.tick(90);
+      expect(vh.updateCounters_(0.1)).to.be.false;
+    });
+  });
+
+
+  describe('end-to-end events', () => {
+
+    it('should trigger for visibility percent only', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        visiblePercentageMin: 49,
+        visiblePercentageMax: 80,
+      }, 0);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+
+      vh.setVisibility(0.63);
+      expect(vh.getState(startTime)).to.contains({
+        minVisiblePercentage: 63,
+        maxVisiblePercentage: 63,
+        loadTimeVisibility: 63,
+      });
+      expect(eventSpy).to.be.calledOnce;
+    });
+
+    it('should only update load-time visibility once', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        visiblePercentageMin: 49,
+        visiblePercentageMax: 80,
+      }, 0);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+
+      vh.setVisibility(0.49);
+      vh.setVisibility(0.63);
+      expect(vh.getState(startTime)).to.contains({
+        minVisiblePercentage: 63,
+        maxVisiblePercentage: 63,
+        loadTimeVisibility: 49,
+      });
+      expect(eventSpy).to.be.calledOnce;
+    });
+
+    it('should fire with totalTimeMin condition', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        totalTimeMin: 1000,
+      }, 0);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+
+      vh.setVisibility(0.63);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 63});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(999);
+      vh.setVisibility(0);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 63});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1000);
+      vh.setVisibility(0.64);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 64});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1);
+      expect(vh.getState(startTime)).to.contains({
+        maxVisiblePercentage: 64,
+        totalVisibleTime: 1000,
+      });
+      expect(eventSpy).to.be.calledOnce;
+    });
+
+    it('should fire with continuousTimeMin condition', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        continuousTimeMin: 1000,
+      }, 0);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+
+      vh.setVisibility(0.63);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 63});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(999);
+      vh.setVisibility(0);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 63});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1000);
+      vh.setVisibility(0.64);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 64});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1);
+      vh.setVisibility(0.65);
+      expect(vh.getState(startTime)).to.contains({
+        maxVisiblePercentage: 65,
+        totalVisibleTime: 1000,
+      });
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(999);
+      expect(eventSpy).to.be.calledOnce;
+      expect(vh.getState(startTime)).to.contains({
+        maxVisiblePercentage: 65,
+        totalVisibleTime: 1999,
+      });
+    });
+
+    it('should fire with totalTimeMin and visiblePercentageMin', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        totalTimeMin: 1000,
+        visiblePercentageMin: 10,
+      }, 0);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+
+      vh.setVisibility(0.05);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 0});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1000);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 0});
+      expect(eventSpy).to.not.be.called;
+
+      vh.setVisibility(0.11);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 11});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1000);
+      expect(eventSpy).to.be.calledOnce;
+      expect(vh.getState(startTime)).to.contains({
+        maxVisiblePercentage: 11,
+        maxContinuousVisibleTime: 1000,
+        totalVisibleTime: 1000,
+        firstSeenTime: 1,
+        fistVisibleTime: 1001,
+        lastSeenTime: 2001,
+        lastVisibleTime: 2001,
+      });
+    });
+
+    it('should fire with continuousTimeMin=1k and totalTimeMin=2k', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        totalTimeMin: 2000,
+        continuousTimeMin: 1000,
+      }, 0);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+
+      vh.setVisibility(0.05);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 5});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1000);
+      vh.setVisibility(0.1);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 10});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1000);
+      expect(eventSpy).to.be.calledOnce;
+      expect(vh.getState(startTime)).to.contains({
+        maxVisiblePercentage: 10,
+        maxContinuousVisibleTime: 2000,
+        totalVisibleTime: 2000,
+        firstSeenTime: 1,
+        fistVisibleTime: 1,
+        lastSeenTime: 2001,
+        lastVisibleTime: 2001,
+      });
+    });
+
+    it('should fire with continuousTimeMin=1k and visPercentageMin=50', () => {
+      const vh = new VisibilityHelper(NO_PARENT, {
+        continuousTimeMin: 1000,
+        visiblePercentageMin: 49,
+      }, 0);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+
+      clock.tick(999);
+      vh.setVisibility(0);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 0});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1000);
+      vh.setVisibility(0.5);
+      expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 50});
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(999);
+      expect(eventSpy).to.not.be.called;
+
+      clock.tick(1);
+      expect(eventSpy).to.be.calledOnce;
+      expect(vh.getState(startTime)).to.contains({
+        maxContinuousVisibleTime: 1000,
+        minVisiblePercentage: 50,
+        maxVisiblePercentage: 50,
+        totalVisibleTime: 1000,
+      });
+    });
+  });
+});

--- a/extensions/amp-analytics/0.1/test/test-visibility-helper.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-helper.js
@@ -164,6 +164,16 @@ describes.sandboxed('VisibilityHelper', {}, () => {
       expect(vh.eventResolver_).to.be.null;
     });
 
+    it('should dispose with parent', () => {
+      const parent = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);
+      const vh = new VisibilityHelper(parent, NO_SPEC, 0);
+      expect(parent.children_).to.have.length(1);
+      expect(parent.children_[0]).to.equal(vh);
+
+      vh.dispose();
+      expect(parent.children_).to.have.length(0);
+    });
+
     it('should update on any visibility event', () => {
       const updateStub = sandbox.stub(VisibilityHelper.prototype, 'update');
       const vh = new VisibilityHelper(NO_PARENT, NO_SPEC, 0);

--- a/extensions/amp-analytics/0.1/visibility-helper.js
+++ b/extensions/amp-analytics/0.1/visibility-helper.js
@@ -27,9 +27,9 @@ export class VisibilityHelper {
    * @param {?VisibilityHelper} parent
    * @param {!Object<string, *>} spec
    * @param {number=} opt_iniVisibility
-   * @param {boolean=} opt_factorParent
+   * @param {boolean=} opt_shouldFactorParent
    */
-  constructor(parent, spec, opt_iniVisibility, opt_factorParent) {
+  constructor(parent, spec, opt_iniVisibility, opt_shouldFactorParent) {
     /** @const @private */
     this.parent_ = parent;
 
@@ -38,7 +38,7 @@ export class VisibilityHelper {
      * final visibility will be this visibility times parent.
      * @const @private {boolean}
      */
-    this.factorParent_ = opt_factorParent || false;
+    this.shouldFactorParent_ = opt_shouldFactorParent || false;
 
     /**
      * Spec parameters.
@@ -199,7 +199,7 @@ export class VisibilityHelper {
     if (!this.parent_) {
       return ownVisibility;
     }
-    if (this.factorParent_) {
+    if (this.shouldFactorParent_) {
       return ownVisibility * this.parent_.getVisibility();
     }
     return this.parent_.getVisibility() > 0 ? ownVisibility : 0;

--- a/extensions/amp-analytics/0.1/visibility-helper.js
+++ b/extensions/amp-analytics/0.1/visibility-helper.js
@@ -135,6 +135,9 @@ export class VisibilityHelper {
 
   /** @override */
   dispose() {
+    if (this.parent_) {
+      this.parent_.removeChild_(this);
+    }
     if (this.scheduledRunId_) {
       clearTimeout(this.scheduledRunId_);
       this.scheduledRunId_ = null;
@@ -366,6 +369,19 @@ export class VisibilityHelper {
       this.children_ = [];
     }
     this.children_.push(child);
+  }
+
+  /**
+   * @param {!VisibilityHelper} child
+   * @private
+   */
+  removeChild_(child) {
+    if (this.children_) {
+      const index = this.children_.indexOf(child);
+      if (index != -1) {
+        this.children_.splice(index, 1);
+      }
+    }
   }
 }
 

--- a/extensions/amp-analytics/0.1/visibility-helper.js
+++ b/extensions/amp-analytics/0.1/visibility-helper.js
@@ -1,0 +1,381 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {dev} from '../../../src/log';
+
+
+/**
+ * A helper class that implements visibility calculations based on the
+ * visibility ratio. It's used for documents, embeds and individual element.
+ * @implements {../../../src/service.Disposable}
+ */
+export class VisibilityHelper {
+  /**
+   * @param {?VisibilityHelper} parent
+   * @param {!Object<string, *>} spec
+   * @param {number=} opt_iniVisibility
+   * @param {boolean=} opt_factorParent
+   */
+  constructor(parent, spec, opt_iniVisibility, opt_factorParent) {
+    /** @const @private */
+    this.parent_ = parent;
+
+    /**
+     * Whether this visibility is in the intersection with parent. Thus the
+     * final visibility will be this visibility times parent.
+     * @const @private {boolean}
+     */
+    this.factorParent_ = opt_factorParent || false;
+
+    /** @const @private */
+    this.eventPromise_ = new Promise(resolve => {
+      /** @private {?function()} */
+      this.eventResolver_ = resolve;
+    });
+
+    /** @private {?Array<!VisibilityHelper>} */
+    this.children_ = null;
+
+    /** @private {!Array<!UnsubscribeDef>} */
+    this.unsubscribe_ = [];
+
+    // Spec.
+
+    /** @const @private {number} */
+    this.visiblePercentageMin_ =
+        Number(spec['visiblePercentageMin']) / 100 || 0;
+
+    /** @const @private {number} */
+    this.visiblePercentageMax_ =
+        Number(spec['visiblePercentageMax']) / 100 || 1;
+
+    /** @const @private {time} */
+    this.totalTimeMin_ = Number(spec['totalTimeMin']) || 0;
+
+    /** @const @private {time} */
+    this.totalTimeMax_ = Number(spec['totalTimeMax']) || Infinity;
+
+    /** @const @private {time} */
+    this.continuousTimeMin_ = Number(spec['continuousTimeMin']) || 0;
+
+    /** @const @private {time} */
+    this.continuousTimeMax_ = Number(spec['continuousTimeMax']) || Infinity;
+
+    // Runtime.
+
+    /** @const @private {time} */
+    this.createdTime_ = Date.now();
+
+    /** @private {number} */
+    this.ownVisibility_ = opt_iniVisibility || 0;
+
+    /** @private {boolean} */
+    this.blocked_ = false;
+
+    /** @private {?number} */
+    this.scheduledRunId_ = null;
+
+    /** @private {boolean} */
+    this.matchesVisibility_ = false;
+
+    /** @private {time} */
+    this.continuousTime_ = 0;
+
+    /** @private {time} */
+    this.maxContinuousVisibleTime_ = 0;
+
+    /** @private {time} */
+    this.totalVisibleTime_ = 0;
+
+    /** @private {time} */
+    this.firstSeenTime_ = 0;
+
+    /** @private {time} */
+    this.lastSeenTime_ = 0;
+
+    /** @private {time} */
+    this.fistVisibleTime_ = 0;
+
+    /** @private {time} */
+    this.lastVisibleTime_ = 0;
+
+    /** @private {time} */
+    this.loadTimeVisibility_ = 0;
+
+    /** @private {number} */
+    this.minVisiblePercentage_ = 0;
+
+    /** @private {number} */
+    this.maxVisiblePercentage_ = 0;
+
+    /** @private {time} */
+    this.lastVisibleUpdateTime_ = 0;
+
+    if (this.parent_) {
+      this.parent_.addChild_(this);
+    }
+
+    if (this.getVisibility() > 0) {
+      this.update();
+    }
+  }
+
+  /** @override */
+  dispose() {
+    if (this.scheduledRunId_) {
+      clearTimeout(this.scheduledRunId_);
+      this.scheduledRunId_ = null;
+    }
+    this.unsubscribe_.forEach(unsubscribe => {
+      unsubscribe();
+    });
+    this.unsubscribe_.length = 0;
+    this.eventResolver_ = null;
+  }
+
+  /**
+   * Adds the unsubscribe handler that will be called when this visibility
+   * helper is destroyed.
+   * @param {!UnsubscribeDef} handler
+   */
+  unsubscribe(handler) {
+    this.unsubscribe_.push(handler);
+  }
+
+  /**
+   * Adds the event handler that will be called when all visibility conditions
+   * have been met.
+   * @param {function()} handler
+   */
+  onEvent(handler) {
+    this.eventPromise_.then(handler);
+  }
+
+  /**
+   * Sets visibility of this object. See `getVisibility()` for the final
+   * visibility calculations.
+   * @param {number} visibility
+   */
+  setVisibility(visibility) {
+    this.ownVisibility_ = visibility;
+    this.update();
+  }
+
+  /**
+   * Sets whether this object is blocked. Blocking means that visibility is
+   * not ready to be calculated, e.g. because an element has not yet
+   * sufficiently rendered. See `getVisibility()` for the final
+   * visibility calculations.
+   * @param {boolean} blocked
+   */
+  setBlocked(blocked) {
+    this.blocked_ = blocked;
+    this.update();
+  }
+
+  /**
+   * Returns the final visibility. It depends on the following factors:
+   *  1. This object's visibility.
+   *  2. Whether the object is blocked.
+   *  3. The parent's visibility.
+   * @return {number}
+   */
+  getVisibility() {
+    const ownVisibility = this.ownVisibility_ * (this.blocked_ ? 0 : 1);
+    if (!this.parent_) {
+      return ownVisibility;
+    }
+    if (this.factorParent_) {
+      return ownVisibility * this.parent_.getVisibility();
+    }
+    return ownVisibility * (this.parent_.getVisibility() > 0 ? 1 : 0);
+  }
+
+  /**
+   * Runs the calculation cycle.
+   */
+  update() {
+    const visibility = this.getVisibility();
+    this.update_(visibility);
+    if (this.children_) {
+      for (let i = 0; i < this.children_.length; i++) {
+        this.children_[i].update();
+      }
+    }
+  }
+
+  /**
+   * Returns the calculated state of visibility.
+   * @param {time} startTime
+   * @return {!Object<string, string|number>}
+   */
+  getState(startTime) {
+    return {
+      // Observed times, relative to the `startTime`.
+      firstSeenTime: timeBase(this.firstSeenTime_, startTime),
+      lastSeenTime: timeBase(this.lastSeenTime_, startTime),
+      lastVisibleTime: timeBase(this.lastVisibleTime_, startTime),
+      fistVisibleTime: timeBase(this.fistVisibleTime_, startTime),
+
+      // Durations.
+      maxContinuousVisibleTime: this.maxContinuousVisibleTime_,
+      totalVisibleTime: this.totalVisibleTime_,
+
+      // Visibility percents.
+      loadTimeVisibility: this.loadTimeVisibility_ * 100 || 0,
+      minVisiblePercentage: this.minVisiblePercentage_ * 100,
+      maxVisiblePercentage: this.maxVisiblePercentage_ * 100,
+    };
+  }
+
+  /**
+   * @param {number} visibility
+   * @private
+   */
+  update_(visibility) {
+    if (!this.eventResolver_) {
+      return;
+    }
+    // Update state and check if all conditions are satisfied
+    const conditionsMet = this.updateCounters_(visibility);
+    if (conditionsMet) {
+      if (this.scheduledRunId_) {
+        clearTimeout(this.scheduledRunId_);
+        this.scheduledRunId_ = null;
+      }
+      this.eventResolver_();
+    } else if (this.matchesVisibility_ && !this.scheduledRunId_) {
+      // There is unmet duration condition, schedule a check
+      const timeToWait = this.computeTimeToWait_();
+      if (timeToWait > 0) {
+        this.scheduledRunId_ = setTimeout(() => {
+          this.scheduledRunId_ = null;
+          this.update();
+        }, timeToWait);
+      }
+    } else if (!this.matchesVisibility_ && this.scheduledRunId_) {
+      clearTimeout(this.scheduledRunId_);
+      this.scheduledRunId_ = null;
+    }
+  }
+
+  /**
+   * @param {number} visibility
+   * @return {boolean} true
+   * @private
+   */
+  updateCounters_(visibility) {
+    const now = Date.now();
+
+    if (visibility > 0) {
+      this.firstSeenTime_ = this.firstSeenTime_ || now;
+      this.lastSeenTime_ = now;
+      // Consider it as load time visibility if this happens within 300ms of
+      // page load.
+      if (!this.loadTimeVisibility_ && (now - this.createdTime_) < 300) {
+        this.loadTimeVisibility_ = visibility;
+      }
+    }
+
+    const prevMatchesVisibility = this.matchesVisibility_;
+    const timeSinceLastUpdate =
+        this.lastVisibleUpdateTime_ ? now - this.lastVisibleUpdateTime_ : 0;
+    this.matchesVisibility_ = (
+        visibility > this.visiblePercentageMin_ &&
+        visibility <= this.visiblePercentageMax_);
+
+    if (this.matchesVisibility_) {
+      if (!prevMatchesVisibility) {
+        // The resource came into view: start counting.
+        dev().assert(!this.lastVisibleUpdateTime_);
+        this.fistVisibleTime_ = this.fistVisibleTime_ || now;
+      } else {
+        // Keep counting.
+        this.totalVisibleTime_ += timeSinceLastUpdate;
+        this.continuousTime_ += timeSinceLastUpdate;
+        this.maxContinuousVisibleTime_ =
+            Math.max(this.maxContinuousVisibleTime_, this.continuousTime_);
+      }
+      this.lastVisibleUpdateTime_ = now;
+      this.minVisiblePercentage_ =
+          this.minVisiblePercentage_ > 0 ?
+          Math.min(this.minVisiblePercentage_, visibility) :
+          visibility;
+      this.maxVisiblePercentage_ =
+          Math.max(this.maxVisiblePercentage_, visibility);
+      this.lastVisibleTime_ = now;
+    } else if (!this.matchesVisibility_ && prevMatchesVisibility) {
+      // The resource went out of view. Do final calculations and reset state.
+      dev().assert(this.lastVisibleUpdateTime_ > 0);
+
+      this.maxContinuousVisibleTime_ = Math.max(
+          this.maxContinuousVisibleTime_,
+          this.continuousTime_ + timeSinceLastUpdate);
+
+      // Reset for next visibility event.
+      this.lastVisibleUpdateTime_ = 0;
+      this.totalVisibleTime_ += timeSinceLastUpdate;
+      this.continuousTime_ = 0;  // Clear only after max is calculated above.
+      this.lastVisibleTime_ = now;
+    }
+
+    return this.matchesVisibility_ &&
+        (this.totalVisibleTime_ >= this.totalTimeMin_) &&
+        (this.totalVisibleTime_ <= this.totalTimeMax_) &&
+        (this.maxContinuousVisibleTime_ >= this.continuousTimeMin_) &&
+        (this.maxContinuousVisibleTime_ <= this.continuousTimeMax_);
+  }
+
+  /**
+   * Computes time, assuming the object is currently visible, that it'd take
+   * it to match all timing requirements.
+   * @return {time}
+   * @private
+   */
+  computeTimeToWait_() {
+    const waitForContinuousTime = Math.max(
+        this.continuousTimeMin_ - this.continuousTime_, 0);
+    const waitForTotalTime = Math.max(
+        this.totalTimeMin_ - this.totalVisibleTime_, 0);
+    const maxWaitTime = Math.max(waitForContinuousTime, waitForTotalTime);
+    return Math.min(
+        maxWaitTime,
+        waitForContinuousTime || Infinity,
+        waitForTotalTime || Infinity);
+  }
+
+  /**
+   * @param {!VisibilityHelper} child
+   * @private
+   */
+  addChild_(child) {
+    if (!this.children_) {
+      this.children_ = [];
+    }
+    this.children_.push(child);
+  }
+}
+
+
+/**
+ * Calculates the specified time based on the given `baseTime`.
+ * @param {time} time
+ * @param {time} baseTime
+ * @return {time}
+ */
+function timeBase(time, baseTime) {
+  return time >= baseTime ? time - baseTime : 0;
+}


### PR DESCRIPTION
`VisibilityHelper` is a fairly straightforward refactoring of `onIntersectionChange_`, `updateCounters_` and all other all code related to a single trigger monitoring in `visibility-impl.js`.

The goal is to enable reuse of this code regardless whether it's used for the document, embed or an element.

The follow up PRs will use `VisibilityHelper` to create `VisiblityTracker` for roots and elements.

Partial for #7457.