### PR TITLE
Always collapse sticky-ad

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -84,8 +84,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     /** @private {IntersectionObserver} */
     this.intersectionObserver_ = null;
 
-    /** @private {?string|undefined} */
-    this.container_ = undefined;
+    /** {?string|undefined} */
+    this.container = undefined;
 
     /** @private {?Promise} */
     this.layoutPromise_ = null;
@@ -172,8 +172,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   onLayoutMeasure() {
     this.isInFixedContainer_ = !isAdPositionAllowed(this.element, this.win);
     /** detect ad containers, add the list to element as a new attribute */
-    if (this.container_ === undefined) {
-      this.container_ = getAdContainer(this.element);
+    if (this.container === undefined) {
+      this.container = getAdContainer(this.element);
     }
     // We remeasured this tag, let's also remeasure the iframe. Should be
     // free now and it might have changed.
@@ -232,7 +232,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.uiHandler.setDisplayState(AdDisplayState.LOADING);
       const opt_context = {
         clientId: cid || null,
-        container: this.container_,
+        container: this.container,
       };
 
       // In this path, the request and render start events are entangled,

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -84,8 +84,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     /** @private {IntersectionObserver} */
     this.intersectionObserver_ = null;
 
-    /** {?string|undefined} */
-    this.container = undefined;
+    /** @private {?string|undefined} */
+    this.container_ = undefined;
 
     /** @private {?Promise} */
     this.layoutPromise_ = null;
@@ -172,8 +172,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   onLayoutMeasure() {
     this.isInFixedContainer_ = !isAdPositionAllowed(this.element, this.win);
     /** detect ad containers, add the list to element as a new attribute */
-    if (this.container === undefined) {
-      this.container = getAdContainer(this.element);
+    if (this.container_ === undefined) {
+      this.container_ = getAdContainer(this.element);
     }
     // We remeasured this tag, let's also remeasure the iframe. Should be
     // free now and it might have changed.
@@ -232,7 +232,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.uiHandler.setDisplayState(AdDisplayState.LOADING);
       const opt_context = {
         clientId: cid || null,
-        container: this.container,
+        container: this.container_,
       };
 
       // In this path, the request and render start events are entangled,

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -141,6 +141,12 @@ export class AmpAdUIHandler {
    * @private
    */
   displayNoContentUI_() {
+    if (this.baseInstance_.container == 'AMP-STICKY-AD') {
+      // force collapse the sticky-ad
+      this.baseInstance_.collapse();
+      this.state = AdDisplayState.LOADED_NO_CONTENT;
+      return;
+    }
     // The order here is collapse > user provided fallback > default fallback
     this.baseInstance_.attemptCollapse().then(() => {
       this.state = AdDisplayState.LOADED_NO_CONTENT;

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -15,6 +15,7 @@
  */
 
 import {dev} from '../../../src/log';
+import {getAdContainer} from '../../../src/ad-helper';
 
 const TAG = 'AmpAdUIHandler';
 
@@ -141,9 +142,10 @@ export class AmpAdUIHandler {
    * @private
    */
   displayNoContentUI_() {
-    if (this.baseInstance_.container == 'AMP-STICKY-AD') {
+    const adContainer = getAdContainer(this.baseInstance_.element);
+    if (adContainer == 'AMP-STICKY-AD') {
       // force collapse the sticky-ad
-      this.baseInstance_.collapse();
+      this.baseInstance_./*OK*/collapse();
       this.state = AdDisplayState.LOADED_NO_CONTENT;
       return;
     }

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -142,9 +142,8 @@ export class AmpAdUIHandler {
    * @private
    */
   displayNoContentUI_() {
-    const adContainer = getAdContainer(this.baseInstance_.element);
-    if (adContainer == 'AMP-STICKY-AD') {
-      // force collapse the sticky-ad
+    if (getAdContainer(this.baseInstance_.element) == 'AMP-STICKY-AD') {
+      // Special case: force collapse sticky-ad if no content.
       this.baseInstance_./*OK*/collapse();
       this.state = AdDisplayState.LOADED_NO_CONTENT;
       return;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -16,6 +16,7 @@
 
 import {AdDisplayState, AmpAdUIHandler} from '../amp-ad-ui';
 import {BaseElement} from '../../../../src/base-element';
+import * as adHelper from '../../../../src/ad-helper';
 
 describes.realWin('amp-ad-ui handler', {
   amp: {
@@ -25,6 +26,7 @@ describes.realWin('amp-ad-ui handler', {
   let sandbox;
   let adImpl;
   let uiHandler;
+  let adContainer;
 
   beforeEach(() => {
     sandbox = env.sandbox;
@@ -32,13 +34,17 @@ describes.realWin('amp-ad-ui handler', {
     adImpl = new BaseElement(adElement);
     uiHandler = new AmpAdUIHandler(adImpl);
     uiHandler.setDisplayState(AdDisplayState.LOADING);
+    sandbox.stub(adHelper, 'getAdContainer', () => {
+      return adContainer;
+    });
+    adContainer = null;
   });
 
   describe('with state LOADED_NO_CONTENT', () => {
     it('should force collapse ad in special container', () => {
-      adImpl.container = 'AMP-STICKY-AD';
+      adContainer = 'AMP-STICKY-AD';
       const attemptCollapseSpy = sandbox.spy(adImpl, 'attemptCollapse');
-      const collapseSpy = sandbox.spy(adImpl, 'collapse');
+      const collapseSpy = sandbox.stub(adImpl, 'collapse', () => {});
       uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
       expect(collapseSpy).to.be.calledOnce;
       expect(attemptCollapseSpy).to.not.be.called;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -35,6 +35,15 @@ describes.realWin('amp-ad-ui handler', {
   });
 
   describe('with state LOADED_NO_CONTENT', () => {
+    it('should force collapse ad in special container', () => {
+      adImpl.container = 'AMP-STICKY-AD';
+      const attemptCollapseSpy = sandbox.spy(adImpl, 'attemptCollapse');
+      const collapseSpy = sandbox.spy(adImpl, 'collapse');
+      uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+      expect(collapseSpy).to.be.calledOnce;
+      expect(attemptCollapseSpy).to.not.be.called;
+    });
+
     it('should try to collapse element first', () => {
       sandbox.stub(adImpl, 'getFallback', () => {
         return true;

--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -17,6 +17,8 @@
 import {dev} from './log';
 import {computedStyle} from './style';
 
+const AD_CONTAINER_PROP = '__AMP__AD_CONTAINER';
+
 /**
  * Tags that are allowed to have fixed positioning
  * @const {!Object<string, boolean>}
@@ -75,12 +77,15 @@ export function isAdPositionAllowed(element, win) {
  * @return {?string}
  */
 export function getAdContainer(element) {
-  let el = element;
-  do {
-    el = el.parentElement;
-    if (CONTAINERS[el.tagName]) {
-      return el.tagName;
-    }
-  } while (el && el.tagName != 'BODY');
-  return null;
+  if (element[AD_CONTAINER_PROP] === undefined) {
+    let el = element;
+    do {
+      el = el.parentElement;
+      if (CONTAINERS[el.tagName]) {
+        return element[AD_CONTAINER_PROP] = el.tagName;
+      }
+    } while (el && el.tagName != 'BODY');
+    element[AD_CONTAINER_PROP] = null;
+  }
+  return element[AD_CONTAINER_PROP];
 }

--- a/test/functional/test-ad-helper.js
+++ b/test/functional/test-ad-helper.js
@@ -14,55 +14,91 @@
  * limitations under the License.
  */
 
-import {isAdPositionAllowed} from '../../src/ad-helper';
+import {isAdPositionAllowed, getAdContainer} from '../../src/ad-helper';
 import {createIframePromise} from '../../testing/iframe';
 
 describe('ad-helper', () => {
-  it('should allow position fixed element that is whitelisted element', () => {
-    return createIframePromise().then(iframe => {
-      const whitelistedElement = iframe.doc.createElement('amp-lightbox');
-      whitelistedElement.style.position = 'fixed';
-      iframe.doc.body.appendChild(whitelistedElement);
-      expect(isAdPositionAllowed(whitelistedElement, iframe.win)).to.be.true;
+  describe('isAdPositionAllowed function', () => {
+    it('should allow position fixed element that is whitelisted element', () => {
+      return createIframePromise().then(iframe => {
+        const whitelistedElement = iframe.doc.createElement('amp-lightbox');
+        whitelistedElement.style.position = 'fixed';
+        iframe.doc.body.appendChild(whitelistedElement);
+        expect(isAdPositionAllowed(whitelistedElement, iframe.win)).to.be.true;
+      });
+    });
+
+    it('should allow position fixed element inside whitelisted element', () => {
+      return createIframePromise().then(iframe => {
+        const whitelistedElement = iframe.doc.createElement('amp-lightbox');
+        whitelistedElement.style.position = 'fixed';
+        const childElement = iframe.doc.createElement('div');
+        const childChildElement = iframe.doc.createElement('div');
+        childElement.appendChild(childChildElement);
+        whitelistedElement.appendChild(childElement);
+        iframe.doc.body.appendChild(whitelistedElement);
+        expect(isAdPositionAllowed(childChildElement, iframe.win)).to.be.true;
+      });
+    });
+
+    it('should not allow position fixed element that is non-whitelisted ' +
+        'element', () => {
+      return createIframePromise().then(iframe => {
+        const nonWhitelistedElement = iframe.doc.createElement('foo-bar');
+        nonWhitelistedElement.style.position = 'fixed';
+        iframe.doc.body.appendChild(nonWhitelistedElement);
+        expect(isAdPositionAllowed(nonWhitelistedElement, iframe.win))
+            .to.be.false;
+      });
+    });
+
+    it('should not allow position fixed element inside non-whitelisted ' +
+        'element', () => {
+      return createIframePromise().then(iframe => {
+        const nonWhitelistedElement = iframe.doc.createElement('foo-bar');
+        nonWhitelistedElement.style.position = 'fixed';
+        const childElement = iframe.doc.createElement('div');
+        const childChildElement = iframe.doc.createElement('div');
+        childElement.appendChild(childChildElement);
+        nonWhitelistedElement.appendChild(childElement);
+        iframe.doc.body.appendChild(nonWhitelistedElement);
+        expect(isAdPositionAllowed(childChildElement, iframe.win)).to.be.false;
+      });
     });
   });
 
-  it('should allow position fixed element inside whitelisted element', () => {
-    return createIframePromise().then(iframe => {
-      const whitelistedElement = iframe.doc.createElement('amp-lightbox');
-      whitelistedElement.style.position = 'fixed';
-      const childElement = iframe.doc.createElement('div');
-      const childChildElement = iframe.doc.createElement('div');
-      childElement.appendChild(childChildElement);
-      whitelistedElement.appendChild(childElement);
-      iframe.doc.body.appendChild(whitelistedElement);
-      expect(isAdPositionAllowed(childChildElement, iframe.win)).to.be.true;
+  describe('getAdContainer function', () => {
+    it('should return null if no container', () => {
+      return createIframePromise().then(iframe => {
+        const parentElement = iframe.doc.createElement('div');
+        const childElement = iframe.doc.createElement('div');
+        parentElement.appendChild(childElement);
+        iframe.doc.body.appendChild(parentElement);
+        expect(getAdContainer(childElement)).to.be.null;
+      });
+    });
+
+    it('should return the closest container', () => {
+      return createIframePromise().then(iframe => {
+        const parentElement = iframe.doc.createElement('amp-lightbox');
+        const childElement = iframe.doc.createElement('amp-sticky-ad');
+        const childChildElement = iframe.doc.createElement('div');
+        iframe.doc.body.appendChild(parentElement);
+        parentElement.appendChild(childElement);
+        childElement.appendChild(childChildElement);
+        expect(getAdContainer(childChildElement)).to.equal(childElement.tagName);
+      });
+    });
+
+    it('should return pre-calculated value', () => {
+      return createIframePromise().then(iframe => {
+        const parentElement = iframe.doc.createElement('amp-fx-flying-carpet');
+        const childElement = iframe.doc.createElement('amp-sticky-ad');
+        parentElement.appendChild(childElement);
+        iframe.doc.body.appendChild(parentElement);
+        childElement['__AMP__AD_CONTAINER'] = 'AMP-LIGHTBOX';
+        expect(getAdContainer(childElement)).to.equal('AMP-LIGHTBOX');
+      });
     });
   });
-
-  it('should not allow position fixed element that is non-whitelisted ' +
-      'element', () => {
-    return createIframePromise().then(iframe => {
-      const nonWhitelistedElement = iframe.doc.createElement('foo-bar');
-      nonWhitelistedElement.style.position = 'fixed';
-      iframe.doc.body.appendChild(nonWhitelistedElement);
-      expect(isAdPositionAllowed(nonWhitelistedElement, iframe.win))
-          .to.be.false;
-    });
-  });
-
-  it('should not allow position fixed element inside non-whitelisted ' +
-      'element', () => {
-    return createIframePromise().then(iframe => {
-      const nonWhitelistedElement = iframe.doc.createElement('foo-bar');
-      nonWhitelistedElement.style.position = 'fixed';
-      const childElement = iframe.doc.createElement('div');
-      const childChildElement = iframe.doc.createElement('div');
-      childElement.appendChild(childChildElement);
-      nonWhitelistedElement.appendChild(childElement);
-      iframe.doc.body.appendChild(nonWhitelistedElement);
-      expect(isAdPositionAllowed(childChildElement, iframe.win)).to.be.false;
-    });
-  });
-
 });

--- a/test/functional/test-ad-helper.js
+++ b/test/functional/test-ad-helper.js
@@ -19,7 +19,7 @@ import {createIframePromise} from '../../testing/iframe';
 
 describe('ad-helper', () => {
   describe('isAdPositionAllowed function', () => {
-    it('should allow position fixed element that is whitelisted element', () => {
+    it('should allow position fixed element that is whitelisted', () => {
       return createIframePromise().then(iframe => {
         const whitelistedElement = iframe.doc.createElement('amp-lightbox');
         whitelistedElement.style.position = 'fixed';
@@ -86,7 +86,8 @@ describe('ad-helper', () => {
         iframe.doc.body.appendChild(parentElement);
         parentElement.appendChild(childElement);
         childElement.appendChild(childChildElement);
-        expect(getAdContainer(childChildElement)).to.equal(childElement.tagName);
+        expect(getAdContainer(childChildElement)).to.equal(
+            childElement.tagName);
       });
     });
 


### PR DESCRIPTION
closes #6184 

Only ad rendered in cross domain iframe has ad container value calculated before.  Thus I decided to keep the code cleaner by always calculating container again.
I can also use the pre-calculate container value from `baseInstance` If anyone thinks the call of `#getAdContainer` is expensive https://github.com/ampproject/amphtml/blob/master/src/ad-helper.js#L77

@jridgewell I believe we will not force collapse an ad in flying-carpet?  