### PR TITLE
Adds two new experiment IDs

### DIFF
--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -31,8 +31,8 @@ import * as sinon from 'sinon';
 
 const EXP_ID = 'EXP_ID';
 
-// Note: All branch IDs must be numeric so that they pass validateExperimentIds
-// and are preserved by addExperimentIdToElement.
+// Note: All branch IDs must be string formatted numbers so that they pass
+// validateExperimentIds and are preserved by addExperimentIdToElement.
 /** @type {!Branches} */
 const EXTERNAL_BRANCHES = {
   control: '1',

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -19,6 +19,8 @@ import {
     googleAdsIsA4AEnabled,
     isInExperiment,
     isInManualExperiment,
+    isExternallyTriggeredExperiment,
+    isInternallyTriggeredExperiment,
 } from '../traffic-experiments';
 import {toggleExperiment} from '../../../../src/experiments';
 import {installPlatformService} from '../../../../src/service/platform-impl';
@@ -28,16 +30,70 @@ import {documentStateFor} from '../../../../src/service/document-state';
 import * as sinon from 'sinon';
 
 const EXP_ID = 'EXP_ID';
+
+// Note: All branch IDs must be numeric so that they pass validateExperimentIds
+// and are preserved by addExperimentIdToElement.
 /** @type {!Branches} */
 const EXTERNAL_BRANCHES = {
-  control: 'EXT_CONTROL',
-  experiment: 'EXT_EXPERIMENT',
+  control: '1',
+  experiment: '2',
 };
 /** @type {!Branches} */
 const INTERNAL_BRANCHES = {
-  control: 'INT_CONTROL',
-  experiment: 'INT_EXPERIMENT',
+  control: '3',
+  experiment: '4',
 };
+
+/**
+ * Checks that element's data-experiment-id tag contains the specified id and
+ * that it does not contain any of the {EXTERNAL,INTERNAL} branches other than
+ * id.
+ *
+ * @param {!Element} element
+ * @param {string} id
+ */
+function expectThereCanBeOnlyOne(element, id) {
+  const notHave = [
+    EXTERNAL_BRANCHES.control,
+    EXTERNAL_BRANCHES.experiment,
+    INTERNAL_BRANCHES.control,
+    INTERNAL_BRANCHES.experiment,
+  ].filter(x => {
+    return x != id;
+  });
+  notHave.forEach(eid => {
+    expect(isInExperiment(element, eid),
+        `expected ${eid} not to be in ${element.getAttribute(
+            'data-experiment-id')}`).to.be.false;
+  });
+  expect(isInExperiment(element, id),
+      `expected ${id} to be in ${element.getAttribute(
+          'data-experiment-id')}`).to.be.true;
+}
+
+/**
+ * Checks that element's data-element-id contains the "is internally triggered"
+ * experiment ID and that it does not contain the "is externally triggered"
+ * eid.
+ *
+ * @param {!Element} element
+ */
+function expectInternallyTriggered(element) {
+  expect(isInternallyTriggeredExperiment(element)).to.be.true;
+  expect(isExternallyTriggeredExperiment(element)).to.be.false;
+}
+
+/**
+ * Checks that element's data-element-id contains the "is externally triggered"
+ * experiment ID and that it does not contain the "is internally triggered"
+ * eid.
+ *
+ * @param {!Element} element
+ */
+function expectExternallyTriggered(element) {
+  expect(isInternallyTriggeredExperiment(element)).to.be.false;
+  expect(isExternallyTriggeredExperiment(element)).to.be.true;
+}
 
 describe('a4a_config', () => {
   let sandbox;
@@ -98,8 +154,8 @@ describe('a4a_config', () => {
         EXTERNAL_BRANCHES, INTERNAL_BRANCHES),
            'googleAdsIsA4AEnabled').to.be.true;
     expect(win.document.cookie).to.be.null;
-    expect(element.getAttribute('data-experiment-id')).to.equal(
-        INTERNAL_BRANCHES.experiment);
+    expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
+    expectInternallyTriggered(element);
   });
 
   it('should attach control ID and return false when control is on', () => {
@@ -108,8 +164,8 @@ describe('a4a_config', () => {
         INTERNAL_BRANCHES),
            'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
-    expect(element.getAttribute('data-experiment-id')).to.equal(
-        INTERNAL_BRANCHES.control);
+    expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.control);
+    expectInternallyTriggered(element);
   });
 
   it('should not attach ID and return false when selected out', () => {
@@ -144,6 +200,7 @@ describe('a4a_config', () => {
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
         INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+    expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
   });
 
   it('should return true if only crypto.subtle is available', () => {
@@ -151,6 +208,7 @@ describe('a4a_config', () => {
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
         INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+    expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
   });
 
   const urlBaseConditions = ['?exp=PARAM',
@@ -184,8 +242,8 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(element.getAttribute('data-experiment-id')).to.equal(
-          INTERNAL_BRANCHES.experiment);
+      expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
+      expectInternallyTriggered(element);
     });
 
     it('should fall back to client-side eid when param is empty', () => {
@@ -194,8 +252,8 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(element.getAttribute('data-experiment-id')).to.equal(
-          INTERNAL_BRANCHES.experiment);
+      expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
+      expectInternallyTriggered(element);
     });
 
     it(`should force experiment param from URL when pattern=${urlBase}`,
@@ -204,8 +262,8 @@ describe('a4a_config', () => {
           expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
               INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
           expect(win.document.cookie).to.be.null;
-          expect(element.getAttribute('data-experiment-id')).to.equal(
-              EXTERNAL_BRANCHES.experiment);
+          expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
+          expectExternallyTriggered(element);
         });
 
     it(`should force control param from URL when pattern=${urlBase}`, () => {
@@ -215,8 +273,8 @@ describe('a4a_config', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
-      expect(element.getAttribute('data-experiment-id')).to.equal(
-          EXTERNAL_BRANCHES.control);
+      expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.control);
+      expectExternallyTriggered(element);
     });
 
     it(`should exclude all experiment IDs when pattern=${urlBase}`, () => {
@@ -343,8 +401,8 @@ describe('a4a_config hash param parsing', () => {
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
-      expect(element.getAttribute('data-experiment-id')).to.equal(
-          EXTERNAL_BRANCHES.experiment);
+      expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
+      expectExternallyTriggered(element);
     });
   });
 });

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -34,6 +34,12 @@ export let ExperimentInfo;
 /** @type {!string} @private */
 const MANUAL_EXPERIMENT_ID = '117152632';
 
+/** @type {!string} @private */
+const EXTERNALLY_SELECTED_ID = '2088461';
+
+/** @type {!string} @private */
+const INTERNALLY_SELECTED_ID = '2088462';
+
 /**
  * Check whether Google Ads supports the A4A rendering pathway for a given ad
  * Element on a given Window.  The tests we use are:
@@ -76,6 +82,14 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
       // Page is selected into the overall traffic experiment.
       const selectedBranch = getPageExperimentBranch(win, experimentName);
       addExperimentIdToElement(selectedBranch, element);
+      // Detect how page was selected into the overall experimentName.
+      if (selectedBranch == externalBranches.experiment ||
+          selectedBranch == externalBranches.control) {
+        addExperimentIdToElement(EXTERNALLY_SELECTED_ID, element);
+      } else if (selectedBranch == internalBranches.experiment ||
+          selectedBranch == internalBranches.control) {
+        addExperimentIdToElement(INTERNALLY_SELECTED_ID, element);
+      }
       // Detect whether page is on the "experiment" (i.e., use A4A rendering
       // pathway) branch of the overall traffic experiment or it's on the
       // "control" (i.e., use traditional, 3p iframe rendering pathway).
@@ -303,6 +317,30 @@ export function isInExperiment(element, id) {
  */
 export function isInManualExperiment(element) {
   return isInExperiment(element, MANUAL_EXPERIMENT_ID);
+}
+
+/**
+ * Checks whether the given element is in any of the branches triggered by
+ * the externally-provided experiment parameter (as decided by the
+ * #maybeSetExperimentFromUrl function).
+ *
+ * @param {!Element} element
+ * @return {boolean}
+ */
+export function isExternallyTriggeredExperiment(element) {
+  return isInExperiment(element, EXTERNALLY_SELECTED_ID);
+}
+
+/**
+ * Checks whether the given element is in any of the branches triggered by
+ * internal experiment selection (as set by
+ * #randomlySelectUnsetPageExperiments).
+ *
+ * @param {!Element} element
+ * @return {boolean}
+ */
+export function isInternallyTriggeredExperiment(element) {
+  return isInExperiment(element, INTERNALLY_SELECTED_ID);
 }
 
 /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -381,7 +381,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
           '&c=[0-9]+&output=html&nhd=1&eid=8675309&biw=[0-9]+&bih=[0-9]+' +
           '&adx=-?[0-9]+&ady=-?[0-9]+&u_aw=[0-9]+&u_ah=[0-9]+&u_cd=24' +
           '&u_w=[0-9]+&u_h=[0-9]+&u_tz=-?[0-9]+&u_his=[0-9]+' +
-          '&oid=2&brdim=[0-9]+(%2C[0-9]+){9}' +
+          '&oid=2&brdim=-?[0-9]+(%2C-?[0-9]+){9}' +
           '&isw=[0-9]+&ish=[0-9]+' +
           '&url=https?%3A%2F%2F[a-zA-Z0-9.:%]+' +
           '&top=https?%3A%2F%2Flocalhost%3A9876%2F%3Fid%3D[0-9]+' +

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -200,7 +200,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           '&c=[0-9]+&output=html&nhd=1&biw=[0-9]+&bih=[0-9]+' +
           '&adx=-?[0-9]+&ady=-?[0-9]+&u_aw=[0-9]+&u_ah=[0-9]+&u_cd=24' +
           '&u_w=[0-9]+&u_h=[0-9]+&u_tz=-?[0-9]+&u_his=[0-9]+' +
-          '&oid=2&brdim=[0-9]+(%2C[0-9]+){9}' +
+          '&oid=2&brdim=-?[0-9]+(%2C-?[0-9]+){9}' +
           '&isw=[0-9]+&ish=[0-9]+' +
           '&url=https?%3A%2F%2F[a-zA-Z0-9.:%]+' +
           '&top=https?%3A%2F%2Flocalhost%3A9876%2F%3Fid%3D[0-9]+' +

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -113,6 +113,10 @@ describe('doubleclick-a4a-config', () => {
           expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
         } else {
           expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.be.ok;
+          expect(isInExperiment(elem,
+              DOUBLECLICK_A4A_BETA_BRANCHES.experiment)).to.be.false;
+          expect(isInExperiment(elem,
+              DOUBLECLICK_A4A_BETA_BRANCHES.control)).to.be.false;
         }
       });
 
@@ -147,7 +151,7 @@ describe('doubleclick-a4a-config', () => {
       });
     });
 
-    it('manual experiment should win over force a4a attribute', () => {
+    it('manual experiment should win over beta force a4a attribute', () => {
       mockWin.location = parseUrl(
           'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:-1');
       const elem = testFixture.doc.createElement('div');
@@ -155,6 +159,10 @@ describe('doubleclick-a4a-config', () => {
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(isInManualExperiment(elem)).to.be.true;
+      expect(isInExperiment(elem, DOUBLECLICK_A4A_BETA_BRANCHES.experiment))
+          .to.be.false;
+      expect(isInExperiment(elem, DOUBLECLICK_A4A_BETA_BRANCHES.control))
+          .to.be.false;
     });
 
     it('should not switch on other slot on page', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -22,6 +22,7 @@ import {
 } from '../doubleclick-a4a-config';
 import {
   isInManualExperiment,
+  isInExperiment,
 } from '../../../../ads/google/a4a/traffic-experiments';
 import {EXPERIMENT_ATTRIBUTE} from '../../../../ads/google/a4a/utils';
 import {parseUrl} from '../../../../src/url';
@@ -185,8 +186,8 @@ describe('doubleclick-a4a-config', () => {
       expect(elem0.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
           DOUBLECLICK_A4A_BETA_BRANCHES.experiment);
       expect(doubleclickIsA4AEnabled(mockWin, elem1)).to.be.true;
-      expect(elem1.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES.experiment);
+      expect(isInExperiment(elem1,
+          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES.experiment)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
... to distinguish "any externally triggered" experiment from "any internally triggered".

Also updates tests to remove a number of assumptions that only a single eid will be populated.

