### PR TITLE
Do not set hidden attribute on hide/collapse

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -420,7 +420,6 @@ export class Resource {
    */
   completeCollapse() {
     toggle(this.element, false);
-    this.element.setAttribute('hidden', '');
     this.layoutBox_ = layoutRectLtwh(
         this.layoutBox_.left,
         this.layoutBox_.top,

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -122,7 +122,6 @@ export class StandardActions {
         target./*OK*/collapse();
       } else {
         toggle(target, false);
-        target.setAttribute('hidden', '');
       }
     });
   }


### PR DESCRIPTION
Setting `hidden` on `hide` and `collapse` is not backward compatible (and also redundant) 

Closes #7863 

/to @dvoytenko @alanorozco 
/cc @muxin Also needs to get in before Canary cut.