### PR TITLE
Update spec URLs from github to ampproject.

### DIFF
--- a/extensions/amp-access-laterpay/0.1/validator-amp-access-laterpay.protoascii
+++ b/extensions/amp-access-laterpay/0.1/validator-amp-access-laterpay.protoascii
@@ -47,5 +47,5 @@ tags: {  # amp-access-laterpay
       error_message: "contents"
     }
   }
-  spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-access-laterpay/amp-access-laterpay.md"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-access-laterpay"
 }

--- a/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
+++ b/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
@@ -48,7 +48,7 @@ tags: {  # amp-auto-ads
       error_message: "contents"
     }
   }
-  spec_url: "https://github.com/ampproject/amphtml/issues/6196"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-auto-ads"
 }
 tags: {  # <amp-auto-ads>
   html_format: AMP
@@ -62,5 +62,5 @@ tags: {  # <amp-auto-ads>
     mandatory: true
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://github.com/ampproject/amphtml/issues/6196"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-auto-ads"
 }

--- a/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.out
+++ b/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.out
@@ -1,3 +1,3 @@
 FAIL
-amp-izlesene/0.1/test/validator-amp-izlesene.html:42:2 The attribute 'data-videoid' in tag 'amp-izlesene' is set to the invalid value 'something else'. (see https:///www.ampproject.org/docs/reference/components/amp-izlesene) [AMP_TAG_PROBLEM]
-amp-izlesene/0.1/test/validator-amp-izlesene.html:45:2 The mandatory attribute 'data-videoid' is missing in tag 'amp-izlesene'. (see https:///www.ampproject.org/docs/reference/components/amp-izlesene) [AMP_TAG_PROBLEM]
+amp-izlesene/0.1/test/validator-amp-izlesene.html:42:2 The attribute 'data-videoid' in tag 'amp-izlesene' is set to the invalid value 'something else'. (see https://www.ampproject.org/docs/reference/components/amp-izlesene) [AMP_TAG_PROBLEM]
+amp-izlesene/0.1/test/validator-amp-izlesene.html:45:2 The mandatory attribute 'data-videoid' is missing in tag 'amp-izlesene'. (see https://www.ampproject.org/docs/reference/components/amp-izlesene) [AMP_TAG_PROBLEM]

--- a/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.out
+++ b/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.out
@@ -1,3 +1,3 @@
 FAIL
-amp-izlesene/0.1/test/validator-amp-izlesene.html:42:2 The attribute 'data-videoid' in tag 'amp-izlesene' is set to the invalid value 'something else'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/amp-izlesene.md) [AMP_TAG_PROBLEM]
-amp-izlesene/0.1/test/validator-amp-izlesene.html:45:2 The mandatory attribute 'data-videoid' is missing in tag 'amp-izlesene'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/amp-izlesene.md) [AMP_TAG_PROBLEM]
+amp-izlesene/0.1/test/validator-amp-izlesene.html:42:2 The attribute 'data-videoid' in tag 'amp-izlesene' is set to the invalid value 'something else'. (see https:///www.ampproject.org/docs/reference/components/amp-izlesene) [AMP_TAG_PROBLEM]
+amp-izlesene/0.1/test/validator-amp-izlesene.html:45:2 The mandatory attribute 'data-videoid' is missing in tag 'amp-izlesene'. (see https:///www.ampproject.org/docs/reference/components/amp-izlesene) [AMP_TAG_PROBLEM]

--- a/extensions/amp-izlesene/0.1/validator-amp-izlesene.protoascii
+++ b/extensions/amp-izlesene/0.1/validator-amp-izlesene.protoascii
@@ -48,7 +48,7 @@ tags: {  # amp-izlesene
       error_message: "contents"
     }
   }
-  spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/amp-izlesene.md"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-izlesene"
 }
 tags: {  # <amp-izlesene>
   html_format: AMP
@@ -61,7 +61,7 @@ tags: {  # <amp-izlesene>
     value_regex: "[0-9]+"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-izlesene/amp-izlesene.md"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-izlesene"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-selector/0.1/test/validator-amp-selector.html
+++ b/extensions/amp-selector/0.1/test/validator-amp-selector.html
@@ -31,7 +31,7 @@
   <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
 </head>
 <body>
-  <!-- Example from https://github.com/ampproject/amphtml/blob/master/extensions/amp-selector/amp-selector.md -->
+  <!-- Valid -->
   <form action="/" method="get" target="_blank" id="form1">
   <!-- <amp-selector> with the options as list elements -->
   <amp-selector layout="container" name="single_image_select">


### PR DESCRIPTION
These URLs show up in error messages. It is preferred that ampproject be the destination of these URLs.