### PR TITLE
Cache SW: Support Precent Diversions

### DIFF
--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -326,8 +326,9 @@ export function expired(response) {
  *
  * @param {!Cache} cache
  * @return {!Promise<!Array<!RtvVersion>>}
+ * @visibleForTesting
  */
-function diversions(cache) {
+export function diversions(cache) {
   const request = new Request(`${urls.cdn}/diversions`);
 
   return fetchAndCache(cache, request).then(response => {
@@ -395,7 +396,12 @@ export function fetchJsFile(cache, request, requestPath, requestVersion) {
       if (!diversions) {
         return;
       }
-      let p = Promise.resolve();
+      let p = new Promise((resolve) => {
+        // Delay initial diversions requests by 10 seconds.
+        // This is because diversions are low priority compared to page
+        // content.
+        setTimeout(resolve, 10000)
+      });
       for (let i = 0; i < diversions.length; i++) {
         p = p.then(() => {
           const diversionRequest = normalizedRequest(request, diversions[i]);

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -273,7 +273,8 @@ export function fetchAndCache(cache, request) {
 
           // Did we receive a invalid response?
           if (!response.ok) {
-            throw new Error(`failed fetching ${url}`);
+            throw new Error(`fetching ${url} failed with statusCode ` +
+                `${response.status}.`);
           }
 
           // You must clone to prevent double reading the body.

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -299,7 +299,7 @@ export function expired(response) {
   let age = 0;
 
   if (headers.has('date') && headers.has('cache-control')) {
-    const maxAge = /max-age=(\d+)/gi.exec(headers.get('cache-control'));
+    const maxAge = /max-age=(\d+)/i.exec(headers.get('cache-control'));
     date = headers.get('date');
     age = maxAge ? maxAge[1] * 1000 : -Infinity;
   } else {

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -29,6 +29,12 @@ export let AmpVersion;
  */
 export let RtvVersion;
 
+/**
+ * An environment of the RTV version.
+ * @typedef {string}
+ */
+export let RtvEnvironment;
+
 /** @const */
 const TAG = 'cache-service-worker';
 
@@ -50,7 +56,7 @@ const BASE_RTV_VERSION = self.AMP_CONFIG.v;
 /**
  * The SW's current environment.
  * @const
- * @type {RtvVersion}
+ * @type {RtvEnvironment}
  */
 const BASE_RTV_ENVIRONMENT = BASE_RTV_VERSION.substr(0, 2);
 
@@ -65,7 +71,7 @@ let cache;
  * A mapping from a Client's (unique per tab _and_ refresh) ID to the AMP
  * release version we are serving it.
  *
- * @type {!Object<string, !Promise<RtvVersion>>}
+ * @type {!Object<string, !Promise<!RtvVersion>>}
  */
 const clientsVersion = Object.create(null);
 
@@ -136,10 +142,10 @@ export function isCdnJsFile(url) {
  * Extracts the data from the request URL.
  * @param {string} url
  * @return {{
- *   environment: string,
- *   explicitRtv: RtvVersion,
+ *   environment: !RtvEnvironment,
+ *   explicitRtv: !RtvVersion,
  *   pathname: string,
- *   rtv: RtvVersion,
+ *   rtv: !RtvVersion,
  * }}
  * @visibleForTesting
  */
@@ -157,7 +163,7 @@ export function requestData(url) {
  * Returns the URL with the requested version changed to `version`.
  *
  * @param {string} url
- * @param {RtvVersion} version
+ * @param {!RtvVersion} version
  * @return {string}
  * @visibleForTesting
  */
@@ -175,7 +181,7 @@ export function urlWithVersion(url, version) {
  * a versioned.
  *
  * @param {!Request} request
- * @param {RtvVersion} version
+ * @param {!RtvVersion} version
  * @return {!Request}
  */
 function normalizedRequest(request, version) {
@@ -201,7 +207,7 @@ function normalizedRequest(request, version) {
 
 /**
  * Determines if a AMP version is blacklisted.
- * @param {RtvVersion} version
+ * @param {!RtvVersion} version
  * @return {boolean}
  * @visibleForTesting
  */
@@ -243,7 +249,7 @@ export function generateFallbackClientId(referrer) {
  * the first is still fetching.
  *
  * @param {!Cache} cache
- * @param {!Request} requestOrUrl
+ * @param {!Request} request
  * @return {!Promise<!Response>}
  * @visibleForTesting
  */
@@ -307,7 +313,7 @@ export function expired(response) {
  * Returns the active percent diversions.
  *
  * @param {!Cache} cache
- * @return {!Promise<!Array<RtvVersion>>}
+ * @return {!Promise<!Array<!RtvVersion>>}
  */
 function diversions(cache) {
   const request = new Request(`${urls.cdn}/diversions`);
@@ -357,7 +363,7 @@ const cachePromise = self.caches.open('cdn-js').then(result => {
  * @param {!Cache} cache
  * @param {!Request} request
  * @param {string} requestPath the pathname of the request
- * @param {RtvVersion} requestVersion the version of the request
+ * @param {!RtvVersion} requestVersion the version of the request
  * @return {!Promise<!Response>}
  * @visibleForTesting
  */
@@ -399,7 +405,7 @@ export function fetchJsFile(cache, request, requestPath, requestVersion) {
  * @param {!Cache} cache
  * @param {string} path
  * @param {string} version
- * @param {?Array<RtvVersion>} diversions
+ * @param {?Array<!RtvVersion>} diversions
  * @return {!Promise<undefined>}
  */
 function purge(cache, path, version, diversions) {
@@ -461,8 +467,9 @@ function purge(cache, path, version, diversions) {
  *
  * @param {!Cache} cache
  * @param {string} requestPath
- * @param {RtvVersion} requestVersion
- * @return {!Promise<RtvVersion>}
+ * @param {!RtvVersion} requestVersion
+ * @param {!RtvEnvironment} requestEnv
+ * @return {!Promise<!RtvVersion>}
  * @visibleForTesting
  */
 export function getCachedVersion(cache, requestPath, requestVersion,

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -322,7 +322,10 @@ function diversions(cache) {
       return null;
     }
 
-    return diversions;
+    return diversions.filter(diversion => {
+      // Diversions cannot use the production environment.
+      return requestData(diversion).environment != BASE_RTV_VERSION;
+    });
   }, () => null);
 }
 

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -396,11 +396,11 @@ export function fetchJsFile(cache, request, requestPath, requestVersion) {
       if (!diversions) {
         return;
       }
-      let p = new Promise((resolve) => {
+      let p = new Promise(resolve => {
         // Delay initial diversions requests by 10 seconds.
         // This is because diversions are low priority compared to page
         // content.
-        setTimeout(resolve, 10000)
+        setTimeout(resolve, 10000);
       });
       for (let i = 0; i < diversions.length; i++) {
         p = p.then(() => {

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -295,17 +295,14 @@ export function fetchAndCache(cache, request) {
  */
 export function expired(response) {
   const {headers} = response;
-  let date;
-  let age = 0;
 
-  if (headers.has('date') && headers.has('cache-control')) {
-    const maxAge = /max-age=(\d+)/i.exec(headers.get('cache-control'));
-    date = headers.get('date');
-    age = maxAge ? maxAge[1] * 1000 : -Infinity;
-  } else {
-    date = headers.get('expires');
+  if (!headers.has('date') || !headers.has('cache-control')) {
+    return false;
   }
 
+  const maxAge = /max-age=(\d+)/i.exec(headers.get('cache-control'));
+  const date = headers.get('date');
+  const age = maxAge ? maxAge[1] * 1000 : -Infinity;
   return Date.now() >= Number(new Date(date)) + age;
 }
 

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -265,7 +265,9 @@ export function fetchAndCache(cache, request) {
 
   // Batch fetches. Mainly for the /diversions endpoint.
   if (fetchPromises[url]) {
-    return fetchPromises[url];
+    return fetchPromises[url].then(() => {
+      return cache.match(request);
+    });
   }
 
   return fetchPromises[url] = cache.match(request)

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -277,6 +277,11 @@ export function fetchAndCache(cache, request) {
                 `${response.status}.`);
           }
 
+          // Override the Date header, to avoid time skew between the server
+          // and the client (ie, a client with set to an incorrect date int the
+          // future).
+          response.headers.set('date', new Date().toUTCString());
+
           // You must clone to prevent double reading the body.
           cache.put(request, response.clone());
           return response;

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -48,6 +48,13 @@ const BLACKLIST = self.AMP_CONFIG[`${TAG}-blacklist`] || [];
 const BASE_RTV_VERSION = self.AMP_CONFIG.v;
 
 /**
+ * The SW's current environment.
+ * @const
+ * @type {RtvVersion}
+ */
+const BASE_RTV_ENVIRONMENT = BASE_RTV_VERSION.substr(0, 2);
+
+/**
  * Our cache of CDN JS files.
  *
  * @type {!Cache}
@@ -105,7 +112,7 @@ const CDN_JS_REGEX = new RegExp(
     // Require the CDN URL origin at the beginning.
     `^${urls.cdn.replace(/\./g, '\\.')}` +
     // Allow, but don't require, RTV.
-    `(?:/rtv/(\\d{2}\\d{13,}))?` +
+    `(?:/rtv/((\\d{2})\\d{13,}))?` +
     // Require text "/v0"
     `(/v0` +
       // Allow, but don't require, an extension under the v0 directory.
@@ -129,17 +136,19 @@ export function isCdnJsFile(url) {
  * Extracts the data from the request URL.
  * @param {string} url
  * @return {{
- *   explicitRtv: string
- *   pathname: string
- *   rtv: string
+ *   environment: string,
+ *   explicitRtv: RtvVersion,
+ *   pathname: string,
+ *   rtv: RtvVersion,
  * }}
  * @visibleForTesting
  */
 export function requestData(url) {
   const match = CDN_JS_REGEX.exec(url);
   return {
+    environment: match[2] || BASE_RTV_ENVIRONMENT,
     explicitRtv: match[1] || '',
-    pathname: match[2],
+    pathname: match[3],
     rtv: match[1] || BASE_RTV_VERSION,
   };
 }
@@ -241,6 +250,11 @@ export function generateFallbackClientId(referrer) {
 export function fetchAndCache(cache, request) {
   const url = request.url;
 
+  // Batch fetches. Mainly for the /diversions endpoint.
+  if (fetchPromises[url]) {
+    return fetchPromises[url];
+  }
+
   return fetchPromises[url] = cache.match(request)
       .then(response => {
         if (response && !expired(response)) {
@@ -289,6 +303,26 @@ export function expired(response) {
   return Date.now() >= Number(new Date(date)) + age;
 }
 
+/**
+ * Returns the active percent diversions.
+ *
+ * @param {!Cache} cache
+ * @return {!Promise<!Array<RtvVersion>>}
+ */
+function diversions(cache) {
+  const request = new Request(`${urls.cdn}/diversions`);
+
+  return fetchAndCache(cache, request).then(response => {
+    return response.json();
+  }).then(diversions => {
+    if (!Array.isArray(diversions)) {
+      return null;
+    }
+
+    return diversions;
+  }, () => null);
+}
+
 /*
  * Resets clientsVersion, referrersLastRequestTime, and fetchPromises.
  * @visibleForTesting
@@ -331,8 +365,26 @@ export function fetchJsFile(cache, request, requestPath, requestVersion) {
   // TODO(jridgewell): we should also fetch this requestVersion for all files
   // we know about.
   return fetchAndCache(cache, request).then(response => {
-    // Prune old versions from the cache.
-    purge(cache, requestPath, requestVersion);
+    // Fetch all diversions of this file.
+    // This intentionally does not block the request resolution to speed
+    // things up.
+    diversions(cache).then(diversions => {
+      // Prune old versions from the cache.
+      // This also prunes old diversions of other scripts, see purge for
+      // detailed information.
+      purge(cache, requestPath, requestVersion, diversions);
+
+      if (!diversions) {
+        return;
+      }
+      let p = Promise.resolve();
+      for (let i = 0; i < diversions.length; i++) {
+        p = p.then(() => {
+          const diversionRequest = normalizedRequest(request, diversions[i]);
+          return fetchAndCache(cache, diversionRequest);
+        });
+      }
+    });
 
     return response;
   });
@@ -340,26 +392,63 @@ export function fetchJsFile(cache, request, requestPath, requestVersion) {
 
 /**
  * Purges our cache of old files.
+ * - If path and version are given, then we will only delete files that match
+ *   path but are not version. I.e., we we clean up old versions of path.
+ * - Else, we cleanup any non-production script that's not a current diversion.
  *
  * @param {!Cache} cache
  * @param {string} path
  * @param {string} version
+ * @param {?Array<RtvVersion>} diversions
  * @return {!Promise<undefined>}
  */
-function purge(cache, path, version) {
+function purge(cache, path, version, diversions) {
   return cache.keys().then(requests => {
     for (let i = 0; i < requests.length; i++) {
       const request = requests[i];
       const url = request.url;
       const cachedData = requestData(url);
 
-      if (path !== cachedData.pathname) {
-        continue;
-      }
-      if (version === cachedData.rtv) {
-        continue;
+      if (path === cachedData.pathname) {
+        // This is case 1.
+        if (version === cachedData.rtv) {
+          continue;
+        }
+      } else {
+        // This is case 2.
+        if (BASE_RTV_ENVIRONMENT === cachedData.environment) {
+          continue;
+        }
       }
 
+      if (diversions) {
+        // This is case 3.
+        if (diversions.indexOf(cachedData.rtv) > -1) {
+          continue;
+        }
+      } else {
+        // This is case 4.
+        if (BASE_RTV_ENVIRONMENT !== cachedData.environment) {
+          continue;
+        }
+      }
+
+      // At this point, we know the cached file is either:
+      // - An old production env of newly fetched script (falls through case
+      //   1 and 3).
+      // - An old diversion of newly fetched script (falls through case 1 and
+      //   3).
+      // - An old diversion of any other script (falls through case 2 and  3).
+      // Importantly, it CANNOT be one of the following:
+      // - The newly fetched version script (case 1)
+      // - Any production env of any other script (case 2)
+      // - A current diversion the newly fetched script (case 3)
+      // - A current diversion of any other script (case 3)
+      // - Any suspected diversion of the newly fetched script (case 4)
+      // - Any suspected diversion of any other script (case 4)
+      //
+      // Note case 2 and 4 guarantee truthiness, so other scripts won't be
+      // deleted unless they're guaranteed old diversions.
       cache.delete(request);
     }
   });
@@ -376,7 +465,15 @@ function purge(cache, path, version) {
  * @return {!Promise<RtvVersion>}
  * @visibleForTesting
  */
-export function getCachedVersion(cache, requestPath, requestVersion) {
+export function getCachedVersion(cache, requestPath, requestVersion,
+    requestEnv) {
+
+  // If a request comes in for a version that does not match the SW's
+  // environment (eg, a percent diversion when the SW is using the production
+  // env), we must serve with the requested version.
+  if (requestEnv !== BASE_RTV_ENVIRONMENT) {
+    return Promise.resolve(requestVersion);
+  }
 
   // TODO(jridgewell): Maybe we should add a very short delay (~5ms) to collect
   // several requests. Then, use all requests to determine what to serve.
@@ -390,7 +487,14 @@ export function getCachedVersion(cache, requestPath, requestVersion) {
     // it is, and increment the number of files we have for that version.
     for (let i = 0; i < requests.length; i++) {
       const url = requests[i].url;
-      const {pathname, rtv} = requestData(url);
+      const {pathname, rtv, environment} = requestData(url);
+
+      // We will not stale serve a version that does not match the request's
+      // environment. This is so cached percent diversions will not be "stale"
+      // served when requesting a production script.
+      if (requestEnv !== environment) {
+        continue;
+      }
 
       // We do not want to stale serve blacklisted files. If nothing else is
       // cached, we will end up serving whatever version is requested.
@@ -450,7 +554,7 @@ export function handleFetch(request, maybeClientId) {
   // Closure Compiler!
   const clientId = /** @type {string} */(maybeClientId);
 
-  const {pathname, rtv} = requestData(url);
+  const {pathname, rtv, environment} = requestData(url);
   // Rewrite unversioned requests to the versioned RTV URL. This is a noop if
   // it's already versioned.
   request = normalizedRequest(request, rtv);
@@ -465,7 +569,8 @@ export function handleFetch(request, maybeClientId) {
     }
 
     // If not, let's find the version to serve up.
-    return clientsVersion[clientId] = getCachedVersion(cache, pathname, rtv);
+    return clientsVersion[clientId] = getCachedVersion(cache, pathname, rtv,
+        environment);
   }).then(version => {
     const versionedRequest = normalizedRequest(request, version);
 

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -339,33 +339,6 @@ runner.run('Cache SW', () => {
       });
     });
 
-    describe('with expires', () => {
-      it('expires in the past', () => {
-        response.headers.set('expires', new Date(Date.now() - 1000)
-            .toUTCString());
-        expect(sw.expired(response)).to.be.true;
-      });
-
-      it('expires now', () => {
-        response.headers.set('expires', new Date(Date.now()).toUTCString());
-        expect(sw.expired(response)).to.be.true;
-      });
-
-      it('expires in the future', () => {
-        response.headers.set('expires', new Date(Date.now() + 1000)
-            .toUTCString());
-        expect(sw.expired(response)).to.be.false;
-      });
-
-      it('is overridden by cache-control and date', () => {
-        response.headers.set('expires', new Date(Date.now() - 1000)
-            .toUTCString());
-        response.headers.set('date', new Date(Date.now()).toUTCString());
-        response.headers.set('cache-control', 'public, max-age=31536000');
-        expect(sw.expired(response)).to.be.false;
-      });
-    });
-
     describe('with no cache information', () => {
       it('is expired', () => {
         expect(sw.expired(response)).to.be.true;

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -254,15 +254,14 @@ runner.run('Cache SW', () => {
 
     beforeEach(() => {
       clock = sandbox.useFakeTimers();
-      clock.tick();
+      clock.setSystemTime(Date.parse('Mon, 06 Mar 2017 00:00:00 GMT'));
       response = new Response('');
     });
 
     describe('with cache-control and date', () => {
       describe('date in the past', () => {
         beforeEach(() => {
-          response.headers.set('date', new Date(Date.now() - 1000)
-              .toUTCString());
+          response.headers.set('date', 'Sun, 05 Mar 2017 00:00:00 GMT');
         });
 
         it('cache-control no-cache', () => {
@@ -288,7 +287,7 @@ runner.run('Cache SW', () => {
 
       describe('date is now', () => {
         beforeEach(() => {
-          response.headers.set('date', new Date().toUTCString());
+          response.headers.set('date', 'Mon, 06 Mar 2017 00:00:00 GMT');
         });
 
         it('cache-control no-cache', () => {
@@ -314,8 +313,7 @@ runner.run('Cache SW', () => {
 
       describe('date in the future', () => {
         beforeEach(() => {
-          response.headers.set('date', new Date(Date.now() + 1000)
-              .toUTCString());
+          response.headers.set('date', 'Tue, 07 Mar 2017 00:00:00 GMT');
         });
 
         it('cache-control no-cache', () => {

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -87,6 +87,11 @@ runner.run('Cache SW', () => {
   const url = `https://cdn.ampproject.org/rtv/${rtv}/v0.js`;
   let sandbox;
 
+  function rtvVersion(url) {
+    const data = sw.requestData(url);
+    return data && data.explicitRtv;
+  }
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
   });
@@ -443,7 +448,7 @@ runner.run('Cache SW', () => {
         return sw.handleFetch(rtvless, clientId).then(() => {
           return sw.handleFetch(compRequest, clientId);
         }).then(resp => {
-          expect(sw.rtvVersion(resp.url)).to.equal(sw.rtvVersion(prodUrl));
+          expect(rtvVersion(resp.url)).to.equal(rtvVersion(prodUrl));
         });
       });
     });
@@ -461,7 +466,7 @@ runner.run('Cache SW', () => {
         return sw.handleFetch(request, clientId).then(() => {
           return sw.handleFetch(prevRequest, clientId);
         }).then(resp => {
-          expect(sw.rtvVersion(resp.url)).to.equal(sw.rtvVersion(request.url));
+          expect(rtvVersion(resp.url)).to.equal(rtvVersion(request.url));
         });
       });
 
@@ -476,10 +481,10 @@ runner.run('Cache SW', () => {
               sw.handleFetch(request, clientId),
               sw.handleFetch(compRequest, clientId),
             ]).then(responses => {
-              expect(sw.rtvVersion(responses[0].url)).to.equal(
-                sw.rtvVersion(prevRequest.url));
-              expect(sw.rtvVersion(responses[1].url)).to.equal(
-                sw.rtvVersion(prevRequest.url));
+              expect(rtvVersion(responses[0].url)).to.equal(
+                rtvVersion(prevRequest.url));
+              expect(rtvVersion(responses[1].url)).to.equal(
+                rtvVersion(prevRequest.url));
             });
           });
         });
@@ -494,8 +499,8 @@ runner.run('Cache SW', () => {
           return sw.handleFetch(compRequest, clientId).then(() => {
             return sw.handleFetch(request, clientId);
           }).then(resp => {
-            expect(sw.rtvVersion(resp.url)).to.equal(
-                sw.rtvVersion(prevRequest.url));
+            expect(rtvVersion(resp.url)).to.equal(
+                rtvVersion(prevRequest.url));
           });
         });
 
@@ -552,10 +557,10 @@ runner.run('Cache SW', () => {
               sw.handleFetch(request, clientId),
               sw.handleFetch(prevRequest, clientId),
             ]).then(responses => {
-              expect(sw.rtvVersion(responses[0].url)).to.equal(
-                sw.rtvVersion(request.url));
-              expect(sw.rtvVersion(responses[1].url)).to.equal(
-                sw.rtvVersion(request.url));
+              expect(rtvVersion(responses[0].url)).to.equal(
+                rtvVersion(request.url));
+              expect(rtvVersion(responses[1].url)).to.equal(
+                rtvVersion(request.url));
             });
           });
         });

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -354,7 +354,7 @@ runner.run('Cache SW', () => {
 
     beforeEach(() => {
       calls = 0;
-      sandbox.stub(response, 'clone', () => response)
+      sandbox.stub(response, 'clone', () => response);
       fetch = sandbox.stub(window, 'fetch', () => {
         calls++;
         if (calls == 1) {
@@ -550,8 +550,8 @@ runner.run('Cache SW', () => {
 
         function waitForDiversions() {
           return sw.fetchJsFile(cache, request, '/v0.js', rtv).then(() => {
-            const stub = sandbox.stub(window, 'setTimeout', (callback) => {
-              stub.restore();
+            const setTimeout = sandbox.stub(window, 'setTimeout', callback => {
+              setTimeout.restore();
               callback();
             });
             return sw.diversions(cache);


### PR DESCRIPTION
This introduces the concept of RTV environments and the `/diversions` endpoint to the Cache SW.

The Cache SW now understands the "production" environment, and arbitrary diversion environments. The production env is whatever the env of the SW's version (the RTV is part of the Sw's bundled code). Any other env is considered a diversion.

Diversions are treated specially inside the stale-while-revalidate logic. Firstly, a diversion will never be served in place of (a "stale" serve) a request to a production env. Only cached scripts in the production environment can be stale served for a production request. Secondly, any request for a diversion will _always_ be served with that version (hopefully from cache). That is, diversion requests are never stale served an older version. This is because stale serving a 3 week old diversion is useless for our data collection.

Now for the `/diversions` endpoint. The SW will maintain a cached request to the endpoint, and the endpoint returns a JSON encoded array of diversion RTVs (note, they must not be production ENV). Whenever the SW "revalidates" (grabs a newer copy of a production script in the background), we will issue requests for the current diversions of the script as well. This allows us to eagerly cache our diversions, making sure they will be served as speedily as our normal production scripts (and we don't see any false-negative stats).

The `/diversions` endpoint will be live soon. 🤞