### PR TITLE
Update amp-install-serviceworker.md

### DIFF
--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -96,7 +96,7 @@ attributes as following:
 ```html
 <amp-install-serviceworker layout="nodisplay"
     src="https://www.your-domain.com/serviceworker.js"
-    data-no-service-worker-fallback-url-match=".*\.amp.html"
+    data-no-service-worker-fallback-url-match=".*\.amp\.html"
     data-no-service-worker-fallback-shell-url="https://pub.com/shell">
 </amp-install-serviceworker>
 ```


### PR DESCRIPTION
Fully escape javascript regex (e.g. all `.` should be escaped otherwise it's meaning is different).