### PR TITLE
amp-auto-ads: preventing ad injection inside disallowed ancestors

### DIFF
--- a/extensions/amp-ad/0.1/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/0.1/validator-amp-ad.protoascii
@@ -62,6 +62,8 @@ tags: {  # <amp-ad>
   # many pages don't have it, so it ends up late loaded and we warn, instead
   # of making this a validation error.
   also_requires_tag_warning: "amp-ad extension .js script"
+  # If modifying disallowed_ancestors, then please also edit
+  # extensions/amp-auto-ads/*/ancestor-blacklist.js
   disallowed_ancestor: "AMP-APP-BANNER"
   disallowed_ancestor: "AMP-SIDEBAR"
   attrs: { name: "alt" }

--- a/extensions/amp-auto-ads/0.1/ancestor-blacklist.js
+++ b/extensions/amp-auto-ads/0.1/ancestor-blacklist.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {resourcesForDoc} from '../../../src/resources';
+
+/**
+ * Should be kept in sync with the disallowed_ancestors in
+ * extensions/amp-ad/.../validator-amp-ad.protoascii.
+ * @const {!Array<string>}
+ */
+const BLACKLISTED_ANCESTOR_TAGS = [
+  'AMP-SIDEBAR',
+  'AMP-APP-BANNER',
+];
+
+
+export class AncestorBlacklist {
+  /**
+   * @param {!../../../src/service/resources-impl.Resources} resources
+   * @param {!Array<number>} blacklistedAnchorUids
+   */
+  constructor(resources, blacklistedAnchorUids) {
+    /** @const @private {!../../../src/service/resources-impl.Resources} */
+    this.resources_ = resources;
+
+    /** @const @private {!Object<number, boolean>} */
+    this.blacklistedAnchorUids_ = getBlacklistMap(blacklistedAnchorUids);
+  }
+
+  /**
+   * @param {!Node} node
+   */
+  isOrDescendantOfBlacklistedElement(node) {
+    const uid = this.resources_.getNodeUid(node);
+    if (uid in this.blacklistedAnchorUids_) {
+      return this.blacklistedAnchorUids_[uid];
+    }
+    const parent = node.parentNode;
+    if (!parent) {
+      return (this.blacklistedAnchorUids_[uid] = false);
+    }
+    return (this.blacklistedAnchorUids_[uid] =
+        this.isOrDescendantOfBlacklistedElement(parent));
+  }
+}
+
+/**
+ * @param {!Window} win
+ * @return {!AncestorBlacklist}
+ */
+export function getAncestorBlacklist(win) {
+  const resources = resourcesForDoc(win.document);
+  const blacklistUids = [];
+  BLACKLISTED_ANCESTOR_TAGS.forEach(tagName => {
+    const elements = [].slice.call(win.document.getElementsByTagName(tagName));
+    elements.forEach(element => {
+      blacklistUids.push(resources.getNodeUid(element));
+    });
+  });
+  return new AncestorBlacklist(resources, blacklistUids);
+}
+
+/**
+ * @param {!Array<number>} blacklistedAnchorUids
+ * @return {!Object<number, boolean>}
+ */
+function getBlacklistMap(blacklistedAnchorUids) {
+  const map = {};
+  blacklistedAnchorUids.forEach(uid => {
+    map[uid] = true;
+  });
+  return map;
+}

--- a/extensions/amp-auto-ads/0.1/test/test-ancestor-blacklist.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ancestor-blacklist.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {getAncestorBlacklist} from '../ancestor-blacklist';
+
+describes.realWin('getAncestorBlacklist', {
+  amp: {
+    runtimeOn: true,
+    ampdoc: 'single',
+    extensions: ['amp-ad'],
+  },
+}, env => {
+  let win;
+  let doc;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+  });
+
+  it('should disallow blacklisted element.', () => {
+    const node = doc.createElement('amp-sidebar');
+    doc.body.appendChild(node);
+
+    const blacklist = getAncestorBlacklist(win);
+    expect(blacklist.isOrDescendantOfBlacklistedElement(node)).to.equal(true);
+  });
+
+  it('should disallow child of blacklisted element.', () => {
+    const parent = doc.createElement('amp-sidebar');
+    doc.body.appendChild(parent);
+
+    const node = doc.createElement('div');
+    parent.appendChild(node);
+
+    const blacklist = getAncestorBlacklist(win);
+    expect(blacklist.isOrDescendantOfBlacklistedElement(node)).to.equal(true);
+  });
+
+  it('should allow parent of blacklisted element.', () => {
+    const node = doc.createElement('div');
+    doc.body.appendChild(node);
+
+    const child = doc.createElement('amp-sidebar');
+    node.appendChild(child);
+
+    const blacklist = getAncestorBlacklist(win);
+    expect(blacklist.isOrDescendantOfBlacklistedElement(node)).to.equal(false);
+  });
+
+  it('should allow sibling of blacklisted element.', () => {
+    const node = doc.createElement('div');
+    doc.body.appendChild(node);
+
+    const sibling = doc.createElement('amp-sidebar');
+    doc.body.appendChild(sibling);
+
+    const blacklist = getAncestorBlacklist(win);
+    expect(blacklist.isOrDescendantOfBlacklistedElement(node)).to.equal(false);
+  });
+
+  it('should work with parentless node.', () => {
+    const node = doc.createElement('div');
+
+    const blacklist = getAncestorBlacklist(win);
+    expect(blacklist.isOrDescendantOfBlacklistedElement(node)).to.equal(false);
+  });
+
+  it('should work with text node.', () => {
+    const node = doc.createTextNode('hello');
+
+    const blacklist = getAncestorBlacklist(win);
+    expect(blacklist.isOrDescendantOfBlacklistedElement(node)).to.equal(false);
+  });
+
+  it('should disallow amp-sidebar.', () => {
+    const node = doc.createElement('amp-sidebar');
+    doc.body.appendChild(node);
+
+    const blacklist = getAncestorBlacklist(win);
+    expect(blacklist.isOrDescendantOfBlacklistedElement(node)).to.equal(true);
+  });
+
+  it('should disallow amp-app-banner.', () => {
+    const node = doc.createElement('amp-app-banner');
+    doc.body.appendChild(node);
+
+    const blacklist = getAncestorBlacklist(win);
+    expect(blacklist.isOrDescendantOfBlacklistedElement(node)).to.equal(true);
+  });
+});

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -912,6 +912,44 @@ describes.realWin('placement', {
           expect(placements).to.have.lengthOf(1);
           expect(placements[0].anchorElement_).to.eql(anchor);
         });
+
+    it('should not return a placement that\'s inside an amp-sidebar', () => {
+      const anchor = document.createElement('amp-sidebar');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(env.win, {
+        placements: [
+          {
+            anchor: {
+              selector: 'AMP-SIDEBAR#anId',
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.be.empty;
+    });
+
+    it('should get a placement when outside amp-sidebar', () => {
+      const anchor = document.createElement('amp-sidebar');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(env.win, {
+        placements: [
+          {
+            anchor: {
+              selector: 'AMP-SIDEBAR#anId',
+            },
+            pos: 1,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+    });
   });
 
   describe('getPlacementsFromConfigObj, sub-anchors', () => {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -50,6 +50,7 @@ const POST_TASK_PASS_DELAY_ = 1000;
 const MUTATE_DEFER_DELAY_ = 500;
 const FOCUS_HISTORY_TIMEOUT_ = 1000 * 60;  // 1min
 const FOUR_FRAME_DELAY_ = 70;
+const DOM_NODE_UID_PROPERTY = '__AMP__NODE_UID';
 
 
 /**
@@ -102,6 +103,9 @@ export class Resources {
 
     /** @private {number} */
     this.addCount_ = 0;
+
+    /** @private {number} */
+    this.nodeUidCount_ = 1;
 
     /** @private {boolean} */
     this.visible_ = this.viewer_.isVisible();
@@ -390,6 +394,15 @@ export class Resources {
     return this.vsync_.measurePromise(() => {
       return this.getViewport().getLayoutRect(element);
     });
+  }
+
+  /**
+   * @param {!Node} node
+   * @return {number}
+   */
+  getNodeUid(node) {
+    return node[DOM_NODE_UID_PROPERTY] ||
+        (node[DOM_NODE_UID_PROPERTY] = this.nodeUidCount_++);
   }
 
   /**

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1879,7 +1879,7 @@ describe('Resources changeSize', () => {
       viewportMock.expects('setScrollTop').withExactArgs(2777).once();
       scrollAdjustTask.mutate(state);
       expect(resource1.changeSize).to.be.calledOnce;
-      expect(resource1.changeSize).to.be.calledWith(undefined, undefined, 
+      expect(resource1.changeSize).to.be.calledWith(undefined, undefined,
           {top: 1});
       expect(resources.relayoutTop_).to.equal(resource1.layoutBox_.top);
     });

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1879,7 +1879,7 @@ describe('Resources changeSize', () => {
       viewportMock.expects('setScrollTop').withExactArgs(2777).once();
       scrollAdjustTask.mutate(state);
       expect(resource1.changeSize).to.be.calledOnce;
-      expect(resource1.changeSize).to.be.calledWith(undefined, undefined,
+      expect(resource1.changeSize).to.be.calledWith(undefined, undefined, 
           {top: 1});
       expect(resources.relayoutTop_).to.equal(resource1.layoutBox_.top);
     });


### PR DESCRIPTION
Achieved via a new class that finds the disallowed ancestors and then provides a function for checking if a node is an ancestor of any of them. Caches results so each node in the DOM only has to be visited a maximum of once for the lifetime of the class.

https://github.com/ampproject/amphtml/issues/7633
https://github.com/ampproject/amphtml/issues/6196