### PR TITLE
Add client check/formatting to AdSense Fast Fetch 

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -66,8 +66,9 @@ export const ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
  * @returns {boolean}
  */
 export function adsenseIsA4AEnabled(win, element) {
-  return googleAdsIsA4AEnabled(
-      win, element, ADSENSE_A4A_EXPERIMENT_NAME,
-      ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
-      ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES);
+  return !!element.getAttribute('data-ad-client') &&
+      googleAdsIsA4AEnabled(
+        win, element, ADSENSE_A4A_EXPERIMENT_NAME,
+        ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
+        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES);
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -105,7 +105,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   isValidElement() {
-    return isGoogleAdsA4AValidEnvironment(this.win) && this.isAmpAdElement();
+    return !!this.element.getAttribute('data-ad-client') &&
+        isGoogleAdsA4AValidEnvironment(this.win) && this.isAmpAdElement();
   }
 
   /** @override */
@@ -114,7 +115,12 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     // validateData, from 3p/3p/js, after moving it someplace common.
     const startTime = Date.now();
     const global = this.win;
-    const adClientId = this.element.getAttribute('data-ad-client');
+    let adClientId = this.element.getAttribute('data-ad-client');
+    // Ensure client id format: lower case with 'ca-' prefix.
+    adClientId = adClientId.toLowerCase();
+    if (adClientId.substring(0, 3) != 'ca-') {
+      adClientId = 'ca-' + adClientId;
+    }
     const slotRect = this.getIntersectionElementLayoutBox();
     const visibilityState = viewerForDoc(this.getAmpDoc())
         .getVisibilityState();

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -67,7 +67,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
           return ['google'];
         });
     element = createAdsenseImplElement({
-      'data-ad-client': 'adsense',
+      'data-ad-client': 'ca-adsense',
       'width': '320',
       'height': '50',
       'data-experiment-id': '8675309',
@@ -89,7 +89,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
     });
 
     const invariantParams = {
-      'client': 'adsense',
+      'client': 'ca-adsense',
       'format': '320x50',
       'w': '320',
       'h': '50',
@@ -114,7 +114,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
         upgradeOrRegisterElement(fixture.win, 'amp-a4a',
             AmpAdNetworkAdsenseImpl);
         const elem = createAdsenseImplElement({
-          'data-ad-client': 'adsense',
+          'data-ad-client': 'ca-adsense',
           'width': '320',
           'height': '50',
           'data-experiment-id': '8675309',
@@ -196,19 +196,19 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
         upgradeOrRegisterElement(fixture.win, 'amp-a4a',
             AmpAdNetworkAdsenseImpl);
         const elem1 = createAdsenseImplElement({
-          'data-ad-client': 'adsense',
+          'data-ad-client': 'ca-adsense',
           'width': '320',
           'height': '50',
           'data-experiment-id': '8675309',
         }, fixture.doc, 'amp-a4a');
         const elem2 = createAdsenseImplElement({
-          'data-ad-client': 'adsense',
+          'data-ad-client': 'ca-adsense',
           'width': '320',
           'height': '50',
           'data-experiment-id': '8675309',
         }, fixture.doc, 'amp-a4a');
         const elem3 = createAdsenseImplElement({
-          'data-ad-client': 'not-adsense',
+          'data-ad-client': 'ca-not-adsense',
           'width': '320',
           'height': '50',
           'data-experiment-id': '8675309',
@@ -250,19 +250,18 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
       expect(impl.isValidElement()).to.be.true;
     });
     it('should NOT be valid (impl tag name)', () => {
-      element = createAdsenseImplElement({'data-ad-client': 'adsense'},
+      element = createAdsenseImplElement({'data-ad-client': 'ca-adsense'},
           document, 'amp-ad-network-adsense-impl');
       impl = new AmpAdNetworkAdsenseImpl(element);
       expect(impl.isValidElement()).to.be.false;
     });
-    it.skip('should be NOT valid (missing ad client)', () => {
-      // TODO(taymonbeal): reenable this test after clarifying validation
+    it('should be NOT valid (missing ad client)', () => {
       element.setAttribute('data-ad-client', '');
       element.setAttribute('type', 'adsense');
       expect(impl.isValidElement()).to.be.false;
     });
     it('should be valid (amp-embed)', () => {
-      element = createAdsenseImplElement({'data-ad-client': 'adsense'},
+      element = createAdsenseImplElement({'data-ad-client': 'ca-adsense'},
           document, 'amp-embed');
       impl = new AmpAdNetworkAdsenseImpl(element);
       expect(impl.isValidElement()).to.be.true;
@@ -364,13 +363,21 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
   });
 
   describe('#getAdUrl', () => {
+    it('formats client properly', () => {
+      element.setAttribute('data-ad-client', 'SoMeClient');
+      new AmpAd(element).upgradeCallback();
+      impl.onLayoutMeasure();
+      return impl.getAdUrl().then(url => {
+        expect(url).to.match(/\\?client=ca-someclient/);
+      });
+    });
     it('returns the right URL', () => {
       new AmpAd(element).upgradeCallback();
       impl.onLayoutMeasure();
       return impl.getAdUrl().then(url => {
         expect(url).to.match(new RegExp(
           '^https://googleads\\.g\\.doubleclick\\.net/pagead/ads' +
-          '\\?client=adsense&format=0x0&w=0&h=0&adtest=false' +
+          '\\?client=ca-adsense&format=0x0&w=0&h=0&adtest=false' +
           '&adk=[0-9]+&bc=1&pv=1&vis=1&wgl=1' +
           '(&asnt=[0-9]+-[0-9]+)?' +
           '&prev_fmts=320x50(%2C[0-9]+x[0-9]+)*' +


### PR DESCRIPTION
Add existence check for data-ad-client as part of isValidElement otherwise request could be sent with missing id causing 400 response.  Ensure that client is properly formatted (lower case with ca- prefix).