### PR TITLE
DO NOT SUBMIT: Repro case for InOb not sending events for newly observed elements

### DIFF
--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -232,6 +232,11 @@ export class IntersectionObserverPolyfill {
       element,
       currentThresholdSlot: 0,
     });
+
+    // DO NOT SUBMIT: QQQ(lannka): shouldn't it tick somem time soon? Maybe
+    // just for this one element as optimization?
+    // Per spec:
+    // "Schedule an iteration of the event loop in the root's browsing context."
   }
 
   /**

--- a/test/functional/test-intersection-observer-polyfill.js
+++ b/test/functional/test-intersection-observer-polyfill.js
@@ -307,6 +307,20 @@ describe('IntersectionObserverPolyfill', () => {
       expect(callbackSpy).to.not.be.called;
     });
 
+    it('should trigger without scroll', () => {
+      io = new IntersectionObserverPolyfill(callbackSpy, {
+        threshold: [0, 1],
+      });
+      element.getLayoutBox = () => {
+        return layoutRectLtwh(0, 0, 100, 100);
+      };
+      io.tick(layoutRectLtwh(0, 90, 100, 100));
+
+      // Observe after tick.
+      io.observe(element);
+      expect(callbackSpy).to.be.calledOnce;
+    });
+
 
     describe('w/o container should get IntersectionChangeEntry when', () => {
       it('completely in viewport', () => {


### PR DESCRIPTION
This demonstrates the problem with InOb polyfill. See the associated bug for more details.