### PR TITLE
Revert to the old prerenderComplete reporting to re-baseline monitoring

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -309,6 +309,27 @@ export class Resources {
     });
   }
 
+  /**
+   * Returns a subset of resources which is identified as being in the current
+   * viewport.
+   * @param {boolean=} opt_isInPrerender signifies if we are in prerender mode.
+   * @return {!Array<!Resource>}
+   * TODO(dvoytenko, #7815): remove once the reporting regression is confirmed.
+   */
+  getResourcesInViewportLegacy(opt_isInPrerender) {
+    opt_isInPrerender = opt_isInPrerender || false;
+    const viewportRect = this.viewport_.getRect();
+    return this.resources_.filter(r => {
+      if (r.hasOwner() || !r.isDisplayed() || !r.overlaps(viewportRect)) {
+        return false;
+      }
+      if (opt_isInPrerender && !r.prerenderAllowed()) {
+        return false;
+      }
+      return true;
+    });
+  }
+
   /** @private */
   monitorInput_() {
     const input = inputFor(this.win);

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -461,7 +461,9 @@ describe('performance', () => {
 
   });
 
-  it('should wait for visible resources', () => {
+  // TODO(dvoytenko, #7815): re-enable once the reporting regression is
+  // confirmed.
+  it.skip('should wait for visible resources', () => {
     function resource() {
       const res = {
         loadedComplete: false,
@@ -531,7 +533,9 @@ describe('performance', () => {
 
       sandbox.stub(viewer, 'whenFirstVisible')
           .returns(whenFirstVisiblePromise);
-      sandbox.stub(perf, 'whenViewportLayoutComplete_')
+      // TODO(dvoytenko, #7815): switch back to the non-legacy version once the
+      // reporting regression is confirmed.
+      sandbox.stub(perf, 'whenViewportLayoutCompleteLegacy_')
           .returns(whenViewportLayoutCompletePromise);
       return viewer.whenMessagingReady();
     });


### PR DESCRIPTION
Partial for #7815.

This is, in effect, a partial revert of #7312 w.r.t. CSI reporting of "prerenderComplete" signal. Once the baseline is confirmed, this PR can simply be reverted to switch back to the new approach which is more accurate.

Also related to #7961.

/cc @ericfs 