### PR TITLE
New extension: amp-graphiq

### DIFF
--- a/examples/graphiq.amp.html
+++ b/examples/graphiq.amp.html
@@ -23,7 +23,7 @@
 
   <amp-graphiq
     data-widget-id="dUuriXJo2qx"
-    data-href="https://example.com/more/details/url" 
+    data-href="https://example.com/more/details/url"
     width="600"
     height="512"
     layout="responsive">
@@ -34,6 +34,13 @@
     width="300"
     height="300">
   </amp-graphiq>
+
+  <amp-graphiq
+    data-widget-id="20QHse7RHkp"
+    width="600"
+    height="668"
+    data-frozen="true">
+</amp-graphiq>
 
 </body>
 </html>

--- a/examples/graphiq.amp.html
+++ b/examples/graphiq.amp.html
@@ -39,7 +39,7 @@
     data-widget-id="20QHse7RHkp"
     width="600"
     height="668"
-    data-frozen="true">
+    data-frozen>
 </amp-graphiq>
 
 </body>

--- a/examples/graphiq.amp.html
+++ b/examples/graphiq.amp.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Graphiq examples</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-graphiq" src="https://cdn.ampproject.org/v0/amp-graphiq-0.1.js"></script>
+  <style amp-custom>
+    body {
+      background-color: blue;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+
+
+  <h2>Graphiq</h2>
+
+  <amp-graphiq
+    data-widget-id="dUuriXJo2qx"
+    data-href="https://example.com/more/details/url" 
+    width="600"
+    height="512"
+    layout="responsive">
+  </amp-graphiq>
+
+  <amp-graphiq
+    data-widget-id="dUuriXJo2qx"
+    width="300"
+    height="300">
+  </amp-graphiq>
+
+</body>
+</html>

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -52,6 +52,9 @@ class AmpGraphiq extends AMP.BaseElement {
     /** @private {!string} */
     this.href_ = '';
 
+    /** @private {!string} */
+    this.domain_ = '';
+
     /** @private {?Function} */
     this.unlistenMessage_ = null;
   }
@@ -60,7 +63,7 @@ class AmpGraphiq extends AMP.BaseElement {
   * @override
   */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://w.graphiq.com', opt_onLayout);
+    this.preconnect.url(this.domain_, opt_onLayout);
   }
 
   /** @override */
@@ -70,6 +73,8 @@ class AmpGraphiq extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    const isFrozen = this.element.getAttribute('data-frozen');
+    this.domain_ = isFrozen ? 'https://sw.graphiq.com' : 'https://w.graphiq.com';
     this.widgetId_ = user().assert(
         this.element.getAttribute('data-widget-id'),
         'The data-widget-id attribute is required for <amp-graphiq> %s',
@@ -103,7 +108,7 @@ class AmpGraphiq extends AMP.BaseElement {
         this.element.getAttribute('alt') || '');
     iframe.setAttribute('height', initialHeight);
     iframe.setAttribute('width', initialWidth);
-    iframe.src = 'https://w.graphiq.com/w/' + encodeURIComponent(this.widgetId_) +
+    iframe.src = this.domain_ + '/w/' + encodeURIComponent(this.widgetId_) +
         '?data-width=' + encodeURIComponent(initialWidth) +
         '&data-height=' + encodeURIComponent(initialHeight) +
         '&data-href=' + encodeURIComponent(this.href_) +
@@ -125,7 +130,7 @@ class AmpGraphiq extends AMP.BaseElement {
 
   /** @private */
   handleGraphiqMessages_(event) {
-    if (event.origin != 'https://w.graphiq.com' ||
+    if (event.origin != this.domain_ ||
         event.source != this.iframe_.contentWindow) {
       return;
     }

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -73,7 +73,7 @@ class AmpGraphiq extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const isFrozen = this.element.getAttribute('data-frozen');
+    const isFrozen = this.element.hasAttribute('data-frozen');
     this.domain_ = isFrozen ? 'https://sw.graphiq.com' : 'https://w.graphiq.com';
     this.widgetId_ = user().assert(
         this.element.getAttribute('data-widget-id'),

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -143,10 +143,7 @@ class AmpGraphiq extends AMP.BaseElement {
       return; // We only process valid JSON.
     }
     if (data.type === 'embed-size' && data.sentinel === 'amp') {
-      const height = data.height;
-      this.getVsync().measure(() => {
-        this.attemptChangeHeight(height).catch(() => {});
-      });
+      this.attemptChangeHeight(data.height).catch(() => {});
     }
   }
 

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -106,8 +106,6 @@ class AmpGraphiq extends AMP.BaseElement {
     //Add title to the iframe for better accessibility.
     iframe.setAttribute('title', 'Graphiq: ' +
         this.element.getAttribute('alt') || '');
-    iframe.setAttribute('height', initialHeight);
-    iframe.setAttribute('width', initialWidth);
     iframe.src = this.domain_ + '/w/' + encodeURIComponent(this.widgetId_) +
         '?data-width=' + encodeURIComponent(initialWidth) +
         '&data-height=' + encodeURIComponent(initialHeight) +
@@ -135,7 +133,8 @@ class AmpGraphiq extends AMP.BaseElement {
       return;
     }
     if (!event.data ||
-        !(isObject(event.data) || event.data.indexOf('{') == 0)) {
+        !(isObject(event.data) ||
+          (typeof event.data == 'string' && event.data.startsWith('{')))) {
       return;  // Doesn't look like JSON.
     }
     const data = isObject(event.data) ? event.data : tryParseJson(event.data);

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -106,7 +106,8 @@ class AmpGraphiq extends AMP.BaseElement {
     iframe.src = 'https://w.graphiq.com/w/' + encodeURIComponent(this.widgetId_) +
         '?data-width=' + encodeURIComponent(initialWidth) +
         '&data-height=' + encodeURIComponent(initialHeight) +
-        '&data-href=' + encodeURIComponent(this.href_);
+        '&data-href=' + encodeURIComponent(this.href_) +
+        '&data-amp-version=true';
 
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
@@ -136,7 +137,7 @@ class AmpGraphiq extends AMP.BaseElement {
     if (data === undefined) {
       return; // We only process valid JSON.
     }
-    if (data.method == 'resize') {
+    if (data.type === 'embed-size' && data.sentinel === 'amp') {
       const height = data.height;
       this.getVsync().measure(() => {
         this.attemptChangeHeight(height).catch(() => {});

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * @fileoverview Embeds a Graphiq embed.
+ * URL.
+ * Example:
+ * <code>
+ * <amp-graphiq
+ *   data-widget-id="ekkg7oSEwYZ"
+ *   width="320"
+ *   height="392"
+ *   data-href="https://www.graphiq.com/vlp/ekkg7oSEwYZ">
+ * </amp-graphiq>
+ * </code>
+ */
+
+import {isLayoutSizeDefined} from '../../../src/layout';
+import {setStyles} from '../../../src/style';
+import {removeElement} from '../../../src/dom';
+import {user} from '../../../src/log';
+import {tryParseJson} from '../../../src/json';
+import {isObject} from '../../../src/types';
+import {listen} from '../../../src/event-helper';
+
+class AmpGraphiq extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?Element} */
+    this.iframe_ = null;
+
+    /** @private {?Promise} */
+    this.iframePromise_ = null;
+
+    /** @private {!string} */
+    this.widgetId_ = '';
+
+    /** @private {!string} */
+    this.href_ = '';
+
+    /** @private {!string} */
+    this.initialHeight_ = '';
+
+    /** @private {!string} */
+    this.initialWidth_ = '';
+
+    /** @private {?Function} */
+    this.unlistenMessage_ = null;
+  }
+ /**
+  * @param {boolean=} opt_onLayout
+  * @override
+  */
+  preconnectCallback(opt_onLayout) {
+    this.preconnect.url('https://w.graphiq.com', opt_onLayout);
+  }
+
+  /** @override */
+  renderOutsideViewport() {
+    return false;
+  }
+
+  /** @override */
+  buildCallback() {
+    this.widgetId_ = user().assert(
+        this.element.getAttribute('data-widget-id'),
+        'The data-widget-id attribute is required for <amp-graphiq> %s',
+        this.element);
+    this.href_ = this.element.getAttribute('data-href') ||
+        'https://www.graphiq.com/vlp/' + this.widgetId_;
+    this.initialHeight_ = this.element.getAttribute('height');
+    this.initialWidth_ = this.element.getAttribute('width');
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
+  /** @override */
+  layoutCallback() {
+    const iframe = this.element.ownerDocument.createElement('iframe');
+    this.iframe_ = iframe;
+
+    this.unlistenMessage_ = listen(
+      this.win,
+      'message',
+      this.handleGraphiqMessages_.bind(this)
+    );
+
+    iframe.setAttribute('frameborder', '0');
+    iframe.setAttribute('allowtransparency', 'true');
+    //Add title to the iframe for better accessibility.
+    iframe.setAttribute('title', 'Graphiq: ' +
+        this.element.getAttribute('alt') || '');
+    if (this.initialHeight_) {
+      iframe.setAttribute('height', this.initialHeight_);
+    }
+    if (this.initialWidth_) {
+      iframe.setAttribute('width', this.initialWidth_);
+    }
+    iframe.src = 'https://w.graphiq.com/w/' + this.widgetId_ +
+        '?data-width=' + encodeURIComponent(this.initialWidth_) +
+        '&data-height=' + encodeURIComponent(this.initialHeight_) +
+        '&data-href=' + encodeURIComponent(this.href_);
+
+    this.applyFillContent(iframe);
+    this.element.appendChild(iframe);
+    setStyles(iframe, {
+      'opacity': 0,
+    });
+    return this.iframePromise_ = this.loadPromise(iframe).then(() => {
+      this.getVsync().mutate(() => {
+        setStyles(iframe, {
+          'opacity': 1,
+        });
+      });
+    });
+  }
+
+  /** @private */
+  handleGraphiqMessages_(event) {
+    if (event.origin != 'https://w.graphiq.com' ||
+        event.source != this.iframe_.contentWindow) {
+      return;
+    }
+    if (!event.data ||
+        !(isObject(event.data) || event.data.indexOf('{') == 0)) {
+      return;  // Doesn't look like JSON.
+    }
+    const data = isObject(event.data) ? event.data : tryParseJson(event.data);
+    if (data === undefined) {
+      return; // We only process valid JSON.
+    }
+    if (data.method == 'resize') {
+      const height = data.height;
+      this.getVsync().measure(() => {
+        if (this.iframe_./*OK*/offsetHeight !== height) {
+          this.attemptChangeHeight(height).catch(() => {});
+        }
+      });
+    }
+  }
+
+  /** @override */
+  unlayoutOnPause() {
+    return true;
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    if (this.iframe_) {
+      removeElement(this.iframe_);
+      this.iframe_ = null;
+      this.iframePromise_ = null;
+    }
+    if (this.unlistenMessage_) {
+      this.unlistenMessage_();
+    }
+    return true;  // Call layoutCallback again.
+  }
+};
+
+AMP.registerElement('amp-graphiq', AmpGraphiq);

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -55,12 +55,6 @@ class AmpGraphiq extends AMP.BaseElement {
     /** @private {!string} */
     this.href_ = '';
 
-    /** @private {!string} */
-    this.initialHeight_ = '';
-
-    /** @private {!string} */
-    this.initialWidth_ = '';
-
     /** @private {?Function} */
     this.unlistenMessage_ = null;
   }
@@ -84,9 +78,7 @@ class AmpGraphiq extends AMP.BaseElement {
         'The data-widget-id attribute is required for <amp-graphiq> %s',
         this.element);
     this.href_ = this.element.getAttribute('data-href') ||
-        'https://www.graphiq.com/vlp/' + this.widgetId_;
-    this.initialHeight_ = this.element.getAttribute('height');
-    this.initialWidth_ = this.element.getAttribute('width');
+        'https://www.graphiq.com/vlp/' + encodeURIComponent(this.widgetId_);
   }
 
   /** @override */
@@ -98,6 +90,8 @@ class AmpGraphiq extends AMP.BaseElement {
   layoutCallback() {
     const iframe = this.element.ownerDocument.createElement('iframe');
     this.iframe_ = iframe;
+    const initialHeight = this.element.getAttribute('height') || '';
+    const initialWidth = this.element.getAttribute('width') || '';
 
     this.unlistenMessage_ = listen(
       this.win,
@@ -110,15 +104,11 @@ class AmpGraphiq extends AMP.BaseElement {
     //Add title to the iframe for better accessibility.
     iframe.setAttribute('title', 'Graphiq: ' +
         this.element.getAttribute('alt') || '');
-    if (this.initialHeight_) {
-      iframe.setAttribute('height', this.initialHeight_);
-    }
-    if (this.initialWidth_) {
-      iframe.setAttribute('width', this.initialWidth_);
-    }
-    iframe.src = 'https://w.graphiq.com/w/' + this.widgetId_ +
-        '?data-width=' + encodeURIComponent(this.initialWidth_) +
-        '&data-height=' + encodeURIComponent(this.initialHeight_) +
+    iframe.setAttribute('height', initialHeight);
+    iframe.setAttribute('width', initialWidth);
+    iframe.src = 'https://w.graphiq.com/w/' + encodeURIComponent(this.widgetId_) +
+        '?data-width=' + encodeURIComponent(initialWidth) +
+        '&data-height=' + encodeURIComponent(initialHeight) +
         '&data-href=' + encodeURIComponent(this.href_);
 
     this.applyFillContent(iframe);
@@ -152,9 +142,7 @@ class AmpGraphiq extends AMP.BaseElement {
     if (data.method == 'resize') {
       const height = data.height;
       this.getVsync().measure(() => {
-        if (this.iframe_./*OK*/offsetHeight !== height) {
-          this.attemptChangeHeight(height).catch(() => {});
-        }
+        this.attemptChangeHeight(height).catch(() => {});
       });
     }
   }

--- a/extensions/amp-graphiq/0.1/amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/amp-graphiq.js
@@ -46,9 +46,6 @@ class AmpGraphiq extends AMP.BaseElement {
     /** @private {?Element} */
     this.iframe_ = null;
 
-    /** @private {?Promise} */
-    this.iframePromise_ = null;
-
     /** @private {!string} */
     this.widgetId_ = '';
 
@@ -116,7 +113,7 @@ class AmpGraphiq extends AMP.BaseElement {
     setStyles(iframe, {
       'opacity': 0,
     });
-    return this.iframePromise_ = this.loadPromise(iframe).then(() => {
+    return this.loadPromise(iframe).then(() => {
       this.getVsync().mutate(() => {
         setStyles(iframe, {
           'opacity': 1,
@@ -157,7 +154,6 @@ class AmpGraphiq extends AMP.BaseElement {
     if (this.iframe_) {
       removeElement(this.iframe_);
       this.iframe_ = null;
-      this.iframePromise_ = null;
     }
     if (this.unlistenMessage_) {
       this.unlistenMessage_();

--- a/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
@@ -48,7 +48,7 @@ describe('amp-graphiq', () => {
         graphiq.setAttribute('layout', 'responsive');
       }
       if (opt_isFrozen) {
-        graphiq.setAttribute('data-frozen', 'true');
+        graphiq.setAttribute('data-frozen', '');
       }
       // Placeholder
       const img = iframe.doc.createElement('amp-img');

--- a/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
@@ -36,7 +36,7 @@ describe('amp-graphiq', () => {
     sandbox.restore();
   });
 
-  function getGraphiq(widgetId, opt_responsive, opt_beforeLayoutCallback) {
+  function getGraphiq(widgetId, opt_responsive, opt_beforeLayoutCallback, opt_isFrozen) {
     return createIframePromise(true, opt_beforeLayoutCallback).then(iframe => {
       doNotLoadExternalResourcesInTest(iframe.win);
       const graphiq = iframe.doc.createElement('amp-graphiq');
@@ -46,6 +46,9 @@ describe('amp-graphiq', () => {
       graphiq.setAttribute('alt', 'Testing');
       if (opt_responsive) {
         graphiq.setAttribute('layout', 'responsive');
+      }
+      if (opt_isFrozen) {
+        graphiq.setAttribute('data-frozen', 'true');
       }
       // Placeholder
       const img = iframe.doc.createElement('amp-img');
@@ -82,27 +85,30 @@ describe('amp-graphiq', () => {
     // expect(image.getAttribute('referrerpolicy')).to.equal('origin');
   }
 
-  function testIframe(iframe) {
+  function testIframe(iframe, widgetId, opt_isFrozen = false) {
     expect(iframe).to.not.be.null;
-    expect(iframe.src).to.equal('https://w.graphiq.com/w/dUuriXJo2qx' +
+    expect(iframe.src).to.equal('https://' +
+      (opt_isFrozen ? 'sw' : 'w') + '.graphiq.com/w/' + widgetId +
       '?data-width=600&data-height=512' +
-      '&data-href=https%3A%2F%2Fwww.graphiq.com%2Fvlp%2FdUuriXJo2qx' +
+      '&data-href=https%3A%2F%2Fwww.graphiq.com%2Fvlp%2F' + widgetId +
       '&data-amp-version=true');
     expect(iframe.className).to.match(/i-amphtml-fill-content/);
     expect(iframe.getAttribute('title')).to.equal('Graphiq: Testing');
   }
 
   it('renders', () => {
-    return getGraphiq('dUuriXJo2qx').then(graphiq => {
-      testIframe(graphiq.querySelector('iframe'));
+    const widgetId = 'dUuriXJo2qx';
+    return getGraphiq(widgetId).then(graphiq => {
+      testIframe(graphiq.querySelector('iframe'), widgetId);
       testImage(graphiq.querySelector('amp-img'));
     });
   });
 
   it('removes iframe after unlayoutCallback', () => {
-    return getGraphiq('dUuriXJo2qx').then(graphiq => {
+    const widgetId = 'dUuriXJo2qx';
+    return getGraphiq(widgetId).then(graphiq => {
       const placeholder = graphiq.querySelector('[placeholder]');
-      testIframe(graphiq.querySelector('iframe'));
+      testIframe(graphiq.querySelector('iframe'), widgetId);
       const obj = graphiq.implementation_;
       obj.unlayoutCallback();
       expect(graphiq.querySelector('iframe')).to.be.null;
@@ -136,6 +142,14 @@ describe('amp-graphiq', () => {
 
       expect(attemptChangeHeight).to.be.calledOnce;
       expect(attemptChangeHeight.firstCall.args[0]).to.equal(newHeight);
+    });
+  });
+
+  it('support sw.graphiq.com domain', () => {
+    const widgetId = '20QHse7RHkp';
+    return getGraphiq(widgetId, false, false, true).then(graphiq => {
+      testIframe(graphiq.querySelector('iframe'), widgetId, true);
+      testImage(graphiq.querySelector('amp-img'));
     });
   });
 

--- a/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
@@ -106,7 +106,7 @@ describe('amp-graphiq', () => {
       obj.unlayoutCallback();
       expect(graphiq.querySelector('iframe')).to.be.null;
       expect(obj.iframe_).to.be.null;
-      expect(obj.iframePromise_).to.be.null;
+      expect(obj.iframePromise_).to.not.exist;
       expect(placeholder.style.display).to.be.equal('');
     });
   });

--- a/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
@@ -86,7 +86,8 @@ describe('amp-graphiq', () => {
     expect(iframe).to.not.be.null;
     expect(iframe.src).to.equal('https://w.graphiq.com/w/dUuriXJo2qx' +
       '?data-width=600&data-height=512' +
-      '&data-href=https%3A%2F%2Fwww.graphiq.com%2Fvlp%2FdUuriXJo2qx');
+      '&data-href=https%3A%2F%2Fwww.graphiq.com%2Fvlp%2FdUuriXJo2qx' +
+      '&data-amp-version=true');
     expect(iframe.className).to.match(/i-amphtml-fill-content/);
     expect(iframe.getAttribute('title')).to.equal('Graphiq: Testing');
   }
@@ -143,7 +144,8 @@ describe('amp-graphiq', () => {
       origin: 'https://w.graphiq.com',
       source: iframe.contentWindow,
       data: JSON.stringify({
-        method: 'resize',
+        sentinel: 'amp',
+        type: 'embed-size',
         height,
       }),
     });

--- a/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
@@ -113,7 +113,6 @@ describe('amp-graphiq', () => {
       obj.unlayoutCallback();
       expect(graphiq.querySelector('iframe')).to.be.null;
       expect(obj.iframe_).to.be.null;
-      expect(obj.iframePromise_).to.not.exist;
       expect(placeholder.style.display).to.be.equal('');
     });
   });

--- a/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
+++ b/extensions/amp-graphiq/0.1/test/test-amp-graphiq.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createIframePromise,
+  doNotLoadExternalResourcesInTest,
+} from '../../../../testing/iframe';
+import '../amp-graphiq';
+import {adopt} from '../../../../src/runtime';
+import * as sinon from 'sinon';
+
+adopt(window);
+
+describe('amp-graphiq', () => {
+
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function getGraphiq(widgetId, opt_responsive, opt_beforeLayoutCallback) {
+    return createIframePromise(true, opt_beforeLayoutCallback).then(iframe => {
+      doNotLoadExternalResourcesInTest(iframe.win);
+      const graphiq = iframe.doc.createElement('amp-graphiq');
+      graphiq.setAttribute('data-widget-id', widgetId);
+      graphiq.setAttribute('width', '600');
+      graphiq.setAttribute('height', '512');
+      graphiq.setAttribute('alt', 'Testing');
+      if (opt_responsive) {
+        graphiq.setAttribute('layout', 'responsive');
+      }
+      // Placeholder
+      const img = iframe.doc.createElement('amp-img');
+      img.setAttribute('layout', 'fill');
+      img.setAttribute('src', 'https://i.ytimg.com/vi/cMcCTVAFBWM/hqdefault.jpg');
+      img.setAttribute('placeholder', '');
+      graphiq.appendChild(img);
+
+      graphiq.implementation_.getVsync = () => {
+        return {
+          mutate(cb) { cb(); },
+          measure(cb) { cb(); },
+          runPromise(task, state = {}) {
+            if (task.measure) {
+              task.measure(state);
+            }
+            if (task.mutate) {
+              task.mutate(state);
+            }
+            return Promise.resolve();
+          },
+        };
+      };
+      return iframe.addElement(graphiq);
+    });
+  }
+
+  function testImage(image) {
+    expect(image).to.not.be.null;
+    expect(image.getAttribute('src')).to.equal(
+        'https://i.ytimg.com/vi/cMcCTVAFBWM/hqdefault.jpg');
+    expect(image.getAttribute('layout')).to.equal('fill');
+    // expect(image.getAttribute('alt')).to.equal('Testing');
+    // expect(image.getAttribute('referrerpolicy')).to.equal('origin');
+  }
+
+  function testIframe(iframe) {
+    expect(iframe).to.not.be.null;
+    expect(iframe.src).to.equal('https://w.graphiq.com/w/dUuriXJo2qx' +
+      '?data-width=600&data-height=512' +
+      '&data-href=https%3A%2F%2Fwww.graphiq.com%2Fvlp%2FdUuriXJo2qx');
+    expect(iframe.className).to.match(/i-amphtml-fill-content/);
+    expect(iframe.getAttribute('title')).to.equal('Graphiq: Testing');
+  }
+
+  it('renders', () => {
+    return getGraphiq('dUuriXJo2qx').then(graphiq => {
+      testIframe(graphiq.querySelector('iframe'));
+      testImage(graphiq.querySelector('amp-img'));
+    });
+  });
+
+  it('removes iframe after unlayoutCallback', () => {
+    return getGraphiq('dUuriXJo2qx').then(graphiq => {
+      const placeholder = graphiq.querySelector('[placeholder]');
+      testIframe(graphiq.querySelector('iframe'));
+      const obj = graphiq.implementation_;
+      obj.unlayoutCallback();
+      expect(graphiq.querySelector('iframe')).to.be.null;
+      expect(obj.iframe_).to.be.null;
+      expect(obj.iframePromise_).to.be.null;
+      expect(placeholder.style.display).to.be.equal('');
+    });
+  });
+
+  it('renders responsively', () => {
+    return getGraphiq('dUuriXJo2qx', true).then(graphiq => {
+      expect(graphiq.className).to.match(/i-amphtml-layout-responsive/);
+    });
+  });
+
+  it('requires data-widget-id', () => {
+    expect(getGraphiq('')).to.be.rejectedWith(
+        /The data-widget-id attribute is required for/);
+  });
+
+  it('resizes in response to messages from Graphiq iframe', () => {
+    return getGraphiq('dUuriXJo2qx', true).then(graphiq => {
+      const impl = graphiq.implementation_;
+      const iframe = graphiq.querySelector('iframe');
+      const attemptChangeHeight = sandbox.spy(impl, 'attemptChangeHeight');
+      const newHeight = 977;
+
+      expect(iframe).to.not.be.null;
+
+      sendFakeHeightMessage(graphiq, iframe, newHeight);
+
+      expect(attemptChangeHeight).to.be.calledOnce;
+      expect(attemptChangeHeight.firstCall.args[0]).to.equal(newHeight);
+    });
+  });
+
+  function sendFakeHeightMessage(graphiq, iframe, height) {
+    graphiq.implementation_.handleGraphiqMessages_({
+      origin: 'https://w.graphiq.com',
+      source: iframe.contentWindow,
+      data: JSON.stringify({
+        method: 'resize',
+        height,
+      }),
+    });
+  }
+});

--- a/extensions/amp-graphiq/0.1/validator-amp-graphiq.protoascii
+++ b/extensions/amp-graphiq/0.1/validator-amp-graphiq.protoascii
@@ -17,39 +17,14 @@
 tags: {  # amp-graphiq
   html_format: AMP
   tag_name: "SCRIPT"
-  spec_name: "amp-graphiq extension .js script"
   satisfies: "amp-graphiq extension .js script"
-  mandatory_parent: "HEAD"
-  unique: true
-  extension_unused_unless_tag_present: "amp-graphiq"
-  attrs: {
-    name: "async"
-    mandatory: true
-    value: ""
+  requires: "amp-graphiq"
+  extension_spec: {
+    name: "amp-graphiq"
+    allowed_versions: "0.1"
+    allowed_versions: "latest"
   }
-  attrs: {
-    name: "custom-element"
-    mandatory: true
-    value: "amp-graphiq"
-    dispatch_key: true
-  }
-  attrs: { name: "nonce" }
-  attrs: {
-    name: "src"
-    mandatory: true
-    value_regex: "https://cdn\\.ampproject\\.org/v0/amp-graphiq-(latest|0\\.1).js"
-  }
-  attrs: {
-    name: "type"
-    value_casei: "text/javascript"
-  }
-  cdata: {
-    blacklisted_cdata_regex: {
-      regex: "."
-      error_message: "contents"
-    }
-  }
-  spec_url: "https://www.ampproject.org/docs/reference/components/media/amp-graphiq"
+  attr_lists: "common-extension-attrs"
 }
 tags: {  # <amp-graphiq>
   html_format: AMP
@@ -65,6 +40,7 @@ tags: {  # <amp-graphiq>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
+      allow_relative: false
     }
   }
   attr_lists: "extended-amp-global"

--- a/extensions/amp-graphiq/0.1/validator-amp-graphiq.protoascii
+++ b/extensions/amp-graphiq/0.1/validator-amp-graphiq.protoascii
@@ -1,0 +1,81 @@
+#
+# Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-graphiq
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amp-graphiq extension .js script"
+  satisfies: "amp-graphiq extension .js script"
+  mandatory_parent: "HEAD"
+  unique_warning: true
+  extension_unused_unless_tag_present: "amp-graphiq"
+  attrs: {
+    name: "async"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "custom-element"
+    mandatory: true
+    value: "amp-graphiq"
+    dispatch_key: true
+  }
+  attrs: { name: "nonce" }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_regex: "https://cdn\\.ampproject\\.org/v0/amp-graphiq-(latest|0\\.1).js"
+  }
+  attrs: {
+    name: "type"
+    value_casei: "text/javascript"
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "."
+      error_message: "contents"
+    }
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/extended/amp-graphiq.html"
+}
+tags: {  # <amp-graphiq>
+  html_format: AMP
+  tag_name: "AMP-GRAPHIQ"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires: "amp-graphiq extension .js script"
+  attrs: { name: "alt" }
+  attrs: {
+    name: "data-widget-id"
+    mandatory: true
+  }
+  attrs: {
+    name: "data-href"
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://www.ampproject.org/docs/reference/extended/amp-graphiq.html"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}

--- a/extensions/amp-graphiq/0.1/validator-amp-graphiq.protoascii
+++ b/extensions/amp-graphiq/0.1/validator-amp-graphiq.protoascii
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+# Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ tags: {  # amp-graphiq
   spec_name: "amp-graphiq extension .js script"
   satisfies: "amp-graphiq extension .js script"
   mandatory_parent: "HEAD"
-  unique_warning: true
+  unique: true
   extension_unused_unless_tag_present: "amp-graphiq"
   attrs: {
     name: "async"
@@ -49,14 +49,13 @@ tags: {  # amp-graphiq
       error_message: "contents"
     }
   }
-  spec_url: "https://www.ampproject.org/docs/reference/extended/amp-graphiq.html"
+  spec_url: "https://www.ampproject.org/docs/reference/components/media/amp-graphiq"
 }
 tags: {  # <amp-graphiq>
   html_format: AMP
   tag_name: "AMP-GRAPHIQ"
   disallowed_ancestor: "AMP-SIDEBAR"
   requires: "amp-graphiq extension .js script"
-  attrs: { name: "alt" }
   attrs: {
     name: "data-widget-id"
     mandatory: true
@@ -69,7 +68,7 @@ tags: {  # <amp-graphiq>
     }
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://www.ampproject.org/docs/reference/extended/amp-graphiq.html"
+  spec_url: "https://www.ampproject.org/docs/reference/components/media/amp-graphiq"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-graphiq/OWNERS.yaml
+++ b/extensions/amp-graphiq/OWNERS.yaml
@@ -1,0 +1,1 @@
+- src-code

--- a/extensions/amp-graphiq/amp-graphiq.md
+++ b/extensions/amp-graphiq/amp-graphiq.md
@@ -63,6 +63,10 @@ The Graphiq widget id.
 
 The `data-href` attribute can optionally be defined to override the default href used for the "See more details" link which appears in the widget. The default behavior is to link to an expanded view of the widget on Graphiq's site.
 
+**data-frozen** (optional)
+
+The existence of the `data-frozen` attribute will set the subdomain of the widget to `sw.graphiq.com`, indicating that the widget was frozen. A frozen widget's data does not update - it reflects whatever the data was at the time of freezing. `data-frozen` only changes the subdomain, **it does not freeze the visualization**. Thus, it can only be set for an already frozen widget, usually provided directly from Graphiq (which executes the freezing).
+
 **common attributes**
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/extensions/amp-graphiq/amp-graphiq.md
+++ b/extensions/amp-graphiq/amp-graphiq.md
@@ -1,0 +1,72 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# <a name="amp-graphiq"></a> `amp-graphiq`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Displays a [Graphiq embed](https://www.graphiq.com/).</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td>Experimental</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-graphiq" src="https://cdn.ampproject.org/v0/amp-graphiq-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
+  </tr>
+  <!-- <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td><a href="https://ampbyexample.com/components/amp-graphiq/">Annotated code example for amp-graphiq</a></td>
+  </tr> -->
+</table>
+
+## Behavior
+
+The `width` and `height` attributes are passed to the Graphiq embed in order to set its initial render dimension, however the component will resize itself as necessary once rendered.
+
+Example:
+```html
+<amp-graphiq
+    data-widget-id="dUuriXJo2qx"
+    width="600"
+    height="512"
+    layout="responsive">
+</amp-graphiq>
+```
+
+## Attributes
+
+**data-widget-id**
+
+The Graphiq widget id.
+
+**data-href**
+
+The `data-href` attribute can optionally be defined to override the default href used for the "See more details" link which appears in the widget. The default behavior is to link to an expanded view of the widget on Graphiq's site.
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
+## Validation
+
+See [amp-graphiq rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-graphiq/0.1/validator-amp-graphiq.protoascii) in the AMP validator specification.

--- a/extensions/amp-graphiq/amp-graphiq.md
+++ b/extensions/amp-graphiq/amp-graphiq.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -55,11 +55,11 @@ Example:
 
 ## Attributes
 
-**data-widget-id**
+**data-widget-id** (required)
 
 The Graphiq widget id.
 
-**data-href**
+**data-href** (optional)
 
 The `data-href` attribute can optionally be defined to override the default href used for the "See more details" link which appears in the widget. The default behavior is to link to an expanded view of the widget on Graphiq's site.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,6 +79,7 @@ declareExtension('amp-form', '0.1', true);
 declareExtension('amp-fresh', '0.1', true);
 declareExtension('amp-fx-flying-carpet', '0.1', true);
 declareExtension('amp-gfycat', '0.1', false);
+declareExtension('amp-graphiq', '0.1', false);
 declareExtension('amp-hulu', '0.1', false);
 declareExtension('amp-iframe', '0.1', false, 'NO_TYPE_CHECK');
 declareExtension('amp-image-lightbox', '0.1', true);

--- a/test/manual/amp-graphiq.amp.html
+++ b/test/manual/amp-graphiq.amp.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-graphiq" src="../../dist/v0/amp-graphiq-0.1.max.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+
+    amp-graphiq iframe {
+      margin: 30px;
+      padding: 30px;
+      border: 10px solid red;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="../../dist/amp.js"></script>
+</head>
+<body>
+  <h1>amp #0</h1>
+  <amp-graphiq
+    data-widget-id="dUuriXJo2qx"
+    data-href="https://example.com/more/details/url" 
+    width="600"
+    height="512"
+    layout="responsive">
+  </amp-graphiq>
+</body>
+</html>


### PR DESCRIPTION
Introduces a new component for supporting Graphiq data viz embeds.  Closes #7787.

I'm not sure I've got all the validation stuff set up right, so would appreciate eyes on that in particular.  Also, not clear to me which examples are necessary, but I added a couple based on what I found for other components.  Also, does this need to be added to experiments initially?