### PR TITLE
Add responsive attribute to Sortable AMP ad slots.

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -521,6 +521,7 @@ export const adConfig = {
       'https://securepubads.g.doubleclick.net',
       'https://tpc.googlesyndication.com',
     ],
+    renderStartImplemented: true,
   },
 
   sovrn: {

--- a/ads/sortable.js
+++ b/ads/sortable.js
@@ -21,13 +21,16 @@ import {loadScript, validateData} from '../3p/3p';
  * @param {!Object} data
  */
 export function sortable(global, data) {
-  validateData(data, ['site', 'name']);
+  validateData(data, ['site', 'name'], ['responsive']);
 
   const slot = global.document.getElementById('c');
   const ad = global.document.createElement('div');
+  const size = (data.responsive === 'true') ?
+    'auto'
+    : data.width + 'x' + data.height;
   ad.className = 'ad-tag';
   ad.setAttribute('data-ad-name', data.name);
-  ad.setAttribute('data-ad-size', data.width + 'x' + data.height);
+  ad.setAttribute('data-ad-size', size);
   slot.appendChild(ad);
   loadScript(global, 'https://tags-cdn.deployads.com/a/'
       + encodeURIComponent(data.site) + '.js');

--- a/ads/sortable.md
+++ b/ads/sortable.md
@@ -30,6 +30,15 @@ limitations under the License.
       data-name="medrec"
       data-site="ampproject.org">
   </amp-ad>
+
+  <!-- Responsive Ad -->
+
+  <amp-ad width=300 height=250
+      type="sortable"
+      data-name="medrec"
+      data-site="ampproject.org"
+      data-responsive="true">
+  </amp-ad>
 ```
 
 ## Configuration
@@ -43,6 +52,10 @@ __Required:__
 `width` + `height` - Required for all `<amp-ad>` units. Specifies the ad size.
 
 `type` - always set to "sortable"
+
+__Optional:__
+
+`data-reponsive` - when set to true indicates that the ad slot has multiple potential sizes.
  
 
 No explicit configuration is needed for a given sortable amp-ad, though each site must be set up beforehand with [Sortable](http://sortable.com). The site name `ampproject.org` can be used for testing. Note that only the two examples above will show an ad properly.


### PR DESCRIPTION
When data-responsive = 'true', this slot will be treated by Sortable
as a responsive ad unit.

This PR also set renderStartImplemented for Sortable.
