### PR TITLE
Fix for Index Exchange ad tags to render creative in 'c' div

### DIFF
--- a/ads/ix.js
+++ b/ads/ix.js
@@ -102,8 +102,9 @@ function indexAmpRender(doc, targetID, global) {
     const ad = global._IndexRequestData.targetIDToBid[targetID].pop();
     if (ad != null) {
       const admDiv = document.createElement('div');
+      admDiv.setAttribute('style', 'position: absolute; top: 0; left: 0;');
       admDiv./*OK*/innerHTML = ad;
-      doc.body.appendChild(admDiv);
+      document.getElementById('c').appendChild(admDiv);
     } else {
       global.context.noContentAvailable();
     }


### PR DESCRIPTION
"ix" ad tags were incorrectly rendering creatives in the body of the amp-ad tag instead of appending to the "c" div, causing issues for clicks. This pull fixes this to correctly append to "c".