### PR TITLE
Remove a redundant CSI ping

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1055,7 +1055,6 @@ export class AmpA4A extends AMP.BaseElement {
    */
   renderNonAmpCreative_() {
     this.promiseErrorHandler_(new Error('fallback to 3p'));
-    this.protectedEmitLifecycleEvent_('preAdThrottle');
     incrementLoadingAds(this.win);
     // Haven't rendered yet, so try rendering via one of our
     // cross-domain iframe solutions.


### PR DESCRIPTION
Removes a CSI ping that is being issued twice: once at the beginning of `layoutCallback` and once in `renderNonAmpCreative_`.