### PR TITLE
Remove typo in Nokta amp-ad documentation

### DIFF
--- a/ads/nokta.md
+++ b/ads/nokta.md
@@ -34,7 +34,7 @@ limitations under the License.
 
 For semantics of configuration, please see ad network documentation.
 
-### Pubmine Required parameters
+### Required parameters
 
 | Parameter     | Description |
 |:------------- |:-------------|


### PR DESCRIPTION
- Removes a typo in the Nokta's amp-ad documentation.

Related-to #5550.