### PR TITLE
amp-bind: Remove BindValidator.canBind

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -485,7 +485,6 @@ export class Bind {
   apply_(results) {
     const applyPromises = this.boundElements_.map(boundElement => {
       const {element, boundProperties} = boundElement;
-      const tagName = element.tagName;
 
       const applyPromise = this.resources_.mutateElement(element, () => {
         const mutations = {};
@@ -514,7 +513,7 @@ export class Bind {
             mutations[mutation.name] = mutation.value;
           }
 
-          switch (boundProperty.property) {
+          switch (property) {
             case 'width':
               width = isFiniteNumber(newValue) ? Number(newValue) : width;
               break;

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -393,7 +393,7 @@ export class Bind {
     const attrs = element.attributes;
     for (let i = 0, numberOfAttrs = attrs.length; i < numberOfAttrs; i++) {
       const attr = attrs[i];
-      const boundProperty = this.scanAttribute_(attr, element);
+      const boundProperty = this.scanAttribute_(attr);
       if (boundProperty) {
         boundProperties.push(boundProperty);
       }
@@ -405,11 +405,10 @@ export class Bind {
    * Returns the bound property and expression string within a given attribute,
    * if it exists. Otherwise, returns null.
    * @param {!Attr} attribute
-   * @param {!Element} element
    * @return {?{property: string, expressionString: string}}
    * @private
    */
-  scanAttribute_(attribute, element) {
+  scanAttribute_(attribute) {
     const name = attribute.name;
     if (name.length > 2 && name[0] === '[' && name[name.length - 1] === ']') {
       const property = name.substr(1, name.length - 2);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -495,13 +495,7 @@ export class Bind {
           const {property, expressionString, previousResult} =
               boundProperty;
 
-          // TODO(choumx): Perform in worker with URL API.
-          // Rewrite attribute value if necessary. This is not done in the
-          // worker since it relies on `url#parseUrl`, which uses DOM APIs.
-          let newValue = results[expressionString];
-          if (typeof newValue === 'string') {
-            newValue = rewriteAttributeValue(tagName, property, newValue);
-          }
+          const newValue = results[expressionString];
 
           // Don't apply if the result hasn't changed or is missing.
           if (newValue === undefined ||
@@ -594,7 +588,12 @@ export class Bind {
             attributeChanged = true;
           }
         } else if (newValue !== oldValue) {
-          element.setAttribute(property, String(newValue));
+          // TODO(choumx): Perform in worker with URL API.
+          // Rewrite attribute value if necessary. This is not done in the
+          // worker since it relies on `url#parseUrl`, which uses DOM APIs.
+          const rewrittenNewValue = rewriteAttributeValue(
+              element.tagName, property, String(newValue));
+          element.setAttribute(property, rewrittenNewValue);
           attributeChanged = true;
         }
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -16,7 +16,6 @@
 
 import {BindExpressionResultDef} from './bind-expression';
 import {BindingDef, BindEvaluator} from './bind-evaluator';
-import {BindValidator} from './bind-validator';
 import {chunk, ChunkPriority} from '../../../src/chunk';
 import {dev, user} from '../../../src/log';
 import {fromClassForDoc} from '../../../src/service';
@@ -96,9 +95,6 @@ export class Bind {
      * @private @const {!Object<string, !Array<!Element>>}
      */
     this.expressionToElements_ = Object.create(null);
-
-    /** @const @private {!./bind-validator.BindValidator} */
-    this.validator_ = new BindValidator();
 
     /** @const @private {!Object} */
     this.scope_ = Object.create(null);
@@ -417,12 +413,7 @@ export class Bind {
     const name = attribute.name;
     if (name.length > 2 && name[0] === '[' && name[name.length - 1] === ']') {
       const property = name.substr(1, name.length - 2);
-      if (this.validator_.canBind(element.tagName, property)) {
-        return {property, expressionString: attribute.value};
-      } else {
-        const err = user().createError(`Binding to [${property}] not allowed.`);
-        reportError(err, element);
-      }
+      return {property, expressionString: attribute.value};
     }
     return null;
   }

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -23,7 +23,6 @@ const TAG = 'amp-bind';
  * @typedef {{
  *   allowedProtocols: (!Object<string,boolean>|undefined),
  *   alternativeName: (string|undefined),
- *   blockedURLs: (Array<string>|undefined),
  * }}
  */
 let PropertyRulesDef;
@@ -142,22 +141,6 @@ export class BindValidator {
       }
     }
 
-    // @see validator/engine/validator.ParsedTagSpec.validateAttributes()
-    const blockedURLs = rules.blockedURLs;
-    if (blockedURLs && url) {
-      for (let i = 0; i < blockedURLs.length; i++) {
-        let decodedURL;
-        try {
-          decodedURL = decodeURIComponent(url);
-        } catch (e) {
-          decodedURL = unescape(url);
-        }
-        if (decodedURL.trim() === blockedURLs[i]) {
-          return false;
-        }
-      }
-    }
-
     return true;
   }
 
@@ -199,7 +182,6 @@ function createElementRules_() {
           http: true,
           https: true,
         },
-        blockedURLs: ['__amp_source_origin'],
       },
       srcset: {
         alternativeName: 'src',
@@ -210,7 +192,6 @@ function createElementRules_() {
         allowedProtocols: {
           https: true,
         },
-        blockedURLs: ['__amp_source_origin'],
       },
     },
     A: {
@@ -232,13 +213,9 @@ function createElementRules_() {
           viber: true,
           whatsapp: true,
         },
-        blockedURLs: ['__amp_source_origin'],
       },
     },
     INPUT: {
-      name: {
-        blockedURLs: ['__amp_source_origin'],
-      },
       type: {
         blacklistedValueRegex: '(^|\\s)(button|file|image|password|)(\\s|$)',
       },
@@ -248,7 +225,6 @@ function createElementRules_() {
         allowedProtocols: {
           https: true,
         },
-        blockedURLs: ['__amp_source_origin'],
       },
     },
     TRACK: {
@@ -256,7 +232,6 @@ function createElementRules_() {
         allowedProtocols: {
           https: true,
         },
-        blockedURLs: ['__amp_source_origin'],
       },
     },
   };

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -36,10 +36,6 @@ const GLOBAL_PROPERTY_RULES = {
   'class': {
     blacklistedValueRegex: '(^|\\W)i-amphtml-',
   },
-  // ARIA accessibility attributes.
-  'aria-describedby': null,
-  'aria-label': null,
-  'aria-labelledby': null,
 };
 
 /**
@@ -68,18 +64,6 @@ const URL_PROPERTIES = {
  */
 export class BindValidator {
   /**
-   * Returns true if (tag, property) binding is allowed.
-   * Otherwise, returns false.
-   * @note `tag` and `property` are case-sensitive.
-   * @param {!string} tag
-   * @param {!string} property
-   * @return {boolean}
-   */
-  canBind(tag, property) {
-    return (this.rulesForTagAndProperty_(tag, property) !== undefined);
-  }
-
-  /**
    * Returns true if `value` is a valid result for a (tag, property) binding.
    * Otherwise, returns false.
    * @param {!string} tag
@@ -95,13 +79,8 @@ export class BindValidator {
       rules = this.rulesForTagAndProperty_(tag, rules.alternativeName);
     }
 
-    // If binding to (tag, property) is not allowed, return false.
-    if (rules === undefined) {
-      return false;
-    }
-
-    // If binding is allowed but have no specific rules, return true.
-    if (rules === null) {
+    // If there are no rules governing this binding, return true.
+    if (!rules) {
       return true;
     }
 
@@ -213,12 +192,7 @@ export class BindValidator {
 function createElementRules_() {
   // Initialize `rules` with tag-specific constraints.
   const rules = {
-    'AMP-CAROUSEL': {
-      slide: null,
-    },
     'AMP-IMG': {
-      alt: null,
-      referrerpolicy: null,
       src: {
         allowedProtocols: {
           data: true,
@@ -231,19 +205,7 @@ function createElementRules_() {
         alternativeName: 'src',
       },
     },
-    'AMP-SELECTOR': {
-      selected: null,
-    },
     'AMP-VIDEO': {
-      alt: null,
-      attribution: null,
-      autoplay: null,
-      controls: null,
-      loop: null,
-      muted: null,
-      placeholder: null,
-      poster: null,
-      preload: null,
       src: {
         allowedProtocols: {
           https: true,
@@ -273,60 +235,13 @@ function createElementRules_() {
         blockedURLs: ['__amp_source_origin'],
       },
     },
-    BUTTON: {
-      disabled: null,
-      type: null,
-      value: null,
-    },
-    FIELDSET: {
-      disabled: null,
-    },
     INPUT: {
-      accept: null,
-      accesskey: null,
-      autocomplete: null,
-      checked: null,
-      disabled: null,
-      height: null,
-      inputmode: null,
-      max: null,
-      maxlength: null,
-      min: null,
-      minlength: null,
-      multiple: null,
       name: {
         blockedURLs: ['__amp_source_origin'],
       },
-      pattern: null,
-      placeholder: null,
-      readonly: null,
-      required: null,
-      selectiondirection: null,
-      size: null,
-      spellcheck: null,
-      step: null,
       type: {
         blacklistedValueRegex: '(^|\\s)(button|file|image|password|)(\\s|$)',
       },
-      value: null,
-      width: null,
-    },
-    OPTION: {
-      disabled: null,
-      label: null,
-      selected: null,
-      value: null,
-    },
-    OPTGROUP: {
-      disabled: null,
-      label: null,
-    },
-    SELECT: {
-      disabled: null,
-      multiple: null,
-      name: null,
-      required: null,
-      size: null,
     },
     SOURCE: {
       src: {
@@ -335,76 +250,16 @@ function createElementRules_() {
         },
         blockedURLs: ['__amp_source_origin'],
       },
-      type: null,
     },
     TRACK: {
-      label: null,
       src: {
         allowedProtocols: {
           https: true,
         },
         blockedURLs: ['__amp_source_origin'],
       },
-      srclang: null,
-    },
-    TEXTAREA: {
-      autocomplete: null,
-      cols: null,
-      disabled: null,
-      maxlength: null,
-      minlength: null,
-      name: null,
-      placeholder: null,
-      readonly: null,
-      required: null,
-      rows: null,
-      selectiondirection: null,
-      selectionend: null,
-      selectionstart: null,
-      spellcheck: null,
-      wrap: null,
     },
   };
-
-  // Collate all standard elements that should support [text] binding
-  // and add them to `rules` object.
-  // 4.3 Sections
-  const sectionTags = ['ASIDE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
-      'HEADER', 'FOOTER', 'ADDRESS'];
-  // 4.4 Grouping content
-  const groupingTags = ['P', 'PRE', 'BLOCKQUOTE', 'LI', 'DT', 'DD',
-      'FIGCAPTION', 'DIV'];
-  // 4.5 Text-level semantics
-  const textTags = ['A', 'EM', 'STRONG', 'SMALL', 'S', 'CITE', 'Q',
-      'DFN', 'ABBR', 'DATA', 'TIME', 'CODE', 'VAR', 'SAMP', 'KBD',
-      'SUB', 'SUP', 'I', 'B', 'U', 'MARK', 'RUBY', 'RB', 'RT', 'RTC',
-      'RP', 'BDI', 'BDO', 'SPAN'];
-  // 4.6 Edits
-  const editTags = ['INS', 'DEL'];
-  // 4.9 Tabular data
-  const tabularTags = ['CAPTION', 'THEAD', 'TFOOT', 'TD'];
-  // 4.10 Forms
-  const formTags = ['BUTTON', 'LABEL', 'LEGEND', 'OPTION',
-      'OUTPUT', 'PROGRESS', 'TEXTAREA'];
-  const allTextTags = sectionTags.concat(groupingTags).concat(textTags)
-      .concat(editTags).concat(tabularTags).concat(formTags);
-  allTextTags.forEach(tag => {
-    if (rules[tag] === undefined) {
-      rules[tag] = {};
-    }
-    rules[tag]['text'] = null;
-  });
-
-  // AMP extensions support additional properties.
-  const ampExtensions = ['AMP-IMG'];
-  ampExtensions.forEach(tag => {
-    if (rules[tag] === undefined) {
-      rules[tag] = {};
-    }
-    const tagRule = rules[tag];
-    tagRule['width'] = null;
-    tagRule['height'] = null;
-  });
 
   return rules;
 }

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -30,16 +30,11 @@ describes.realWin('amp-bind', {
 }, env => {
   let bind;
 
-  // BindValidator method stubs.
-  let canBindStub;
-
   beforeEach(() => {
     installTimerService(env.win);
     toggleExperiment(env.win, 'amp-bind', true);
 
     // Stub validator methods to return true for ease of testing.
-    canBindStub = env.sandbox.stub(
-        BindValidator.prototype, 'canBind').returns(true);
     env.sandbox.stub(
         BindValidator.prototype, 'isResultValid').returns(true);
 
@@ -54,12 +49,14 @@ describes.realWin('amp-bind', {
   });
 
   /**
-   * @param {!string} binding
+   * @param {string} binding
+   * @param {string=} opt_tagName
    * @return {!Element}
    */
-  function createElementWithBinding(binding) {
+  function createElementWithBinding(binding, opt_tagName) {
+    const tag = opt_tagName || 'p';
     const div = env.win.document.createElement('div');
-    div.innerHTML = '<p ' + binding + '></p>';
+    div.innerHTML = `<${tag} ${binding}></${tag}>`;
     const newElement = div.firstElementChild;
     const parent = env.win.document.getElementById('parent');
     parent.appendChild(newElement);
@@ -163,7 +160,7 @@ describes.realWin('amp-bind', {
 
     //TODO(kmh287): Move to integration test
     it('should NOT bind blacklisted attributes', () => {
-      // Restore real implementations of canBind and isResultValid
+      // Restore real implementation of isResultValid.
       sandbox.restore();
       const doc = env.win.document;
       const template = doc.createElement('template');
@@ -186,7 +183,7 @@ describes.realWin('amp-bind', {
 
     //TODO(kmh287): Move to integration test
     it('should NOT allow unsecure attribute values', () => {
-      // Restore real implementations of canBind and isResultValid
+      // Restore real implementation of isResultValid.
       sandbox.restore();
       const doc = env.win.document;
       const template = doc.createElement('template');
@@ -379,12 +376,15 @@ describes.realWin('amp-bind', {
     });
   });
 
-  it('should NOT evaluate expression if binding is NOT allowed', () => {
-    canBindStub.returns(false);
-    const element = createElementWithBinding(`[onePlusOne]="1+1"`);
-    return onBindReadyAndSetState({}).then(() => {
-      expect(canBindStub.calledOnce).to.be.true;
-      expect(element.getAttribute('oneplusone')).to.be.null;
+  it('should rewrite attribute values regardless of result type', () => {
+    const withString = createElementWithBinding(`[href]="foo"`, 'a');
+    const withArray = createElementWithBinding(`[href]="bar"`, 'a');
+    return onBindReadyAndSetState({
+      foo: '?__amp_source_origin',
+      bar: ['?__amp_source_origin'],
+    }).then(() => {
+      expect(withString.getAttribute('href')).to.equal(null);
+      expect(withArray.getAttribute('href')).to.equal(null);
     });
   });
 });

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -159,29 +159,6 @@ describes.realWin('amp-bind', {
     });
 
     //TODO(kmh287): Move to integration test
-    it('should NOT bind blacklisted attributes', () => {
-      // Restore real implementation of isResultValid.
-      sandbox.restore();
-      const doc = env.win.document;
-      const template = doc.createElement('template');
-      let textElement;
-      doc.getElementById('parent').appendChild(template);
-      return onBindReady().then(() => {
-        expect(bind.boundElements_.length).to.equal(0);
-        const binding = '[onclick]="\'alert(document.cookie)\'" ' +
-          '[onmouseover]="\'alert()\'" ' +
-          '[style]="\'background=color:black\'"';
-        textElement = createElementWithBinding(binding);
-        return bind.waitForAllMutationsForTesting();
-      }).then(() => {
-        expect(bind.boundElements_.length).to.equal(0);
-        expect(textElement.getAttribute('onclick')).to.be.null;
-        expect(textElement.getAttribute('onmouseover')).to.be.null;
-        expect(textElement.getAttribute('style')).to.be.null;
-      });
-    });
-
-    //TODO(kmh287): Move to integration test
     it('should NOT allow unsecure attribute values', () => {
       // Restore real implementation of isResultValid.
       sandbox.restore();

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -23,107 +23,6 @@ describe('BindValidator', () => {
     val = new BindValidator();
   });
 
-  describe('canBind()', () => {
-    it('should allow binding to "class" for any element', () => {
-      expect(val.canBind('DIV', 'class')).to.be.true;
-      expect(val.canBind('ANY-TAG-REAL-OR-FAKE', 'class')).to.be.true;
-    });
-
-    it('should allow binding to "text" for whitelisted elements', () => {
-      expect(val.canBind('H1', 'text')).to.be.true;
-      expect(val.canBind('P', 'text')).to.be.true;
-      expect(val.canBind('SPAN', 'text')).to.be.true;
-      expect(val.canBind('A', 'text')).to.be.true;
-      expect(val.canBind('BUTTON', 'text')).to.be.true;
-      expect(val.canBind('CAPTION', 'text')).to.be.true;
-
-      expect(val.canBind('HEAD', 'text')).to.be.false;
-      expect(val.canBind('FORM', 'text')).to.be.false;
-      expect(val.canBind('AMP-IMG', 'text')).to.be.false;
-    });
-
-    it('should NOT allow binding to "style"', () => {
-      expect(val.canBind('DIV', 'style')).to.be.false;
-      expect(val.canBind('P', 'style')).to.be.false;
-      expect(val.canBind('SPAN', 'style')).to.be.false;
-      expect(val.canBind('OL', 'style')).to.be.false;
-      expect(val.canBind('BODY', 'style')).to.be.false;
-    });
-
-    it('should NOT allow binding to "on" event handlers', () => {
-      expect(val.canBind('BODY', 'onafterprint')).to.be.false;
-      expect(val.canBind('BODY', 'onbeforeprint')).to.be.false;
-      expect(val.canBind('BODY', 'onbeforeunload')).to.be.false;
-      expect(val.canBind('BODY', 'onhashchange')).to.be.false;
-      expect(val.canBind('BODY', 'onload')).to.be.false;
-      expect(val.canBind('BODY', 'onmessage')).to.be.false;
-      expect(val.canBind('BODY', 'onoffline')).to.be.false;
-      expect(val.canBind('BODY', 'ononline')).to.be.false;
-      expect(val.canBind('BODY', 'onpagehide')).to.be.false;
-      expect(val.canBind('BODY', 'onpageshow')).to.be.false;
-      expect(val.canBind('BODY', 'onpopstate')).to.be.false;
-      expect(val.canBind('BODY', 'onresize')).to.be.false;
-      expect(val.canBind('BODY', 'onstorage')).to.be.false;
-      expect(val.canBind('BODY', 'onunload')).to.be.false;
-
-      expect(val.canBind('FORM', 'onblur')).to.be.false;
-      expect(val.canBind('FORM', 'onchange')).to.be.false;
-      expect(val.canBind('FORM', 'oncontextmenu')).to.be.false;
-      expect(val.canBind('FORM', 'onfocus')).to.be.false;
-      expect(val.canBind('FORM', 'oninput')).to.be.false;
-      expect(val.canBind('FORM', 'oninvalid')).to.be.false;
-      expect(val.canBind('FORM', 'onreset')).to.be.false;
-      expect(val.canBind('FORM', 'onsearch')).to.be.false;
-      expect(val.canBind('FORM', 'onselect')).to.be.false;
-      expect(val.canBind('FORM', 'onsubmit')).to.be.false;
-
-      expect(val.canBind('INPUT', 'onkeydown')).to.be.false;
-      expect(val.canBind('INPUT', 'onkeypress')).to.be.false;
-      expect(val.canBind('INPUT', 'onkeyup')).to.be.false;
-
-      expect(val.canBind('BUTTON', 'onclick')).to.be.false;
-      expect(val.canBind('BUTTON', 'ondblclick')).to.be.false;
-      expect(val.canBind('BUTTON', 'onmousedown')).to.be.false;
-      expect(val.canBind('BUTTON', 'onmousemove')).to.be.false;
-      expect(val.canBind('BUTTON', 'onmouseout')).to.be.false;
-      expect(val.canBind('BUTTON', 'onmouseover')).to.be.false;
-      expect(val.canBind('BUTTON', 'onmouseup')).to.be.false;
-      expect(val.canBind('BUTTON', 'onmousewheel')).to.be.false;
-      expect(val.canBind('BUTTON', 'onwheel')).to.be.false;
-
-      expect(val.canBind('DIV', 'ondrag')).to.be.false;
-      expect(val.canBind('DIV', 'ondragend')).to.be.false;
-      expect(val.canBind('DIV', 'ondragenter')).to.be.false;
-      expect(val.canBind('DIV', 'ondragleave')).to.be.false;
-      expect(val.canBind('DIV', 'ondragover')).to.be.false;
-      expect(val.canBind('DIV', 'ondragstart')).to.be.false;
-      expect(val.canBind('DIV', 'ondrop')).to.be.false;
-      expect(val.canBind('DIV', 'onscroll')).to.be.false;
-
-      expect(val.canBind('INPUT', 'oncopy')).to.be.false;
-      expect(val.canBind('INPUT', 'oncut')).to.be.false;
-      expect(val.canBind('INPUT', 'onpaste')).to.be.false;
-    });
-
-    it('should NOT allow binding to Object.prototype keys', () => {
-      expect(val.canBind('constructor', 'constructor')).to.be.false;
-      expect(val.canBind('toString', 'constructor')).to.be.false;
-      expect(val.canBind('hasOwnProperty', 'constructor')).to.be.false;
-      expect(val.canBind('isPrototypeOf', 'constructor')).to.be.false;
-      expect(val.canBind('__defineGetter__', 'constructor')).to.be.false;
-      expect(val.canBind('__defineSetter__', 'constructor')).to.be.false;
-      expect(val.canBind('__proto__', 'constructor')).to.be.false;
-
-      expect(val.canBind('P', 'constructor')).to.be.false;
-      expect(val.canBind('P', 'toString')).to.be.false;
-      expect(val.canBind('P', 'hasOwnProperty')).to.be.false;
-      expect(val.canBind('P', 'isPrototypeOf')).to.be.false;
-      expect(val.canBind('P', '__defineGetter__')).to.be.false;
-      expect(val.canBind('P', '__defineSetter__')).to.be.false;
-      expect(val.canBind('P', '__proto__')).to.be.false;
-    });
-  });
-
   describe('isResultValid()', () => {
     it('should NOT allow invalid "class" attribute values', () => {
       expect(val.isResultValid('DIV', 'class', 'foo')).to.be.true;
@@ -177,15 +76,7 @@ describe('BindValidator', () => {
   });
 
   describe('AMP extensions', () => {
-    it('should support <amp-carousel>', () => {
-      expect(val.canBind('AMP-CAROUSEL', 'slide')).to.be.true;
-    });
-
     it('should support <amp-img>', () => {
-      expect(val.canBind('AMP-IMG', 'src')).to.be.true;
-      expect(val.canBind('AMP-IMG', 'width')).to.be.true;
-      expect(val.canBind('AMP-IMG', 'height')).to.be.true;
-
       // src
       expect(val.isResultValid(
           'AMP-IMG', 'src', 'http://foo.com/bar.jpg')).to.be.true;
@@ -209,15 +100,7 @@ describe('BindValidator', () => {
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
     });
 
-    it('should support <amp-selector>', () => {
-      expect(val.canBind('AMP-SELECTOR', 'selected')).to.be.true;
-    });
-
     it('should support <amp-video>', () => {
-      expect(val.canBind('AMP-VIDEO', 'loop')).to.be.true;
-      expect(val.canBind('AMP-VIDEO', 'poster')).to.be.true;
-      expect(val.canBind('AMP-VIDEO', 'src')).to.be.true;
-
       // src
       expect(val.isResultValid(
           'AMP-VIDEO', 'src', 'https://foo.com/bar.mp4')).to.be.true;

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -46,22 +46,16 @@ describe('BindValidator', () => {
           /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
       expect(val.isResultValid('A', 'href',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
-      expect(val.isResultValid('A', 'href',
-        '__amp_source_origin')).to.be.false;
 
       expect(val.isResultValid('SOURCE', 'src',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
       expect(val.isResultValid('SOURCE', 'src',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
-      expect(val.isResultValid('SOURCE', 'src',
-          '__amp_source_origin')).to.be.false;
 
       expect(val.isResultValid('TRACK', 'src',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)')).to.be.false;
       expect(val.isResultValid('TRACK', 'src',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
-      expect(val.isResultValid('TRACK', 'src',
-          '__amp_source_origin')).to.be.false;
     });
 
     it('should NOT allow unsupported <input> "type" values', () => {
@@ -82,18 +76,12 @@ describe('BindValidator', () => {
           'AMP-IMG', 'src', 'http://foo.com/bar.jpg')).to.be.true;
       expect(val.isResultValid('AMP-IMG', 'src',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
-      expect(val.isResultValid(
-          'AMP-IMG', 'src', '__amp_source_origin')).to.be.false;
 
       // srcset
       expect(val.isResultValid(
           'AMP-IMG',
           'srcset',
           'http://a.com/b.jpg 1x, http://c.com/d.jpg 2x')).to.be.true;
-      expect(val.isResultValid(
-          'AMP-IMG',
-          'srcset',
-          'http://a.com/b.jpg 1x, __amp_source_origin 2x')).to.be.false;
       expect(val.isResultValid(
           'AMP-IMG',
           'srcset',
@@ -108,8 +96,6 @@ describe('BindValidator', () => {
           'AMP-VIDEO', 'src', 'http://foo.com/bar.mp4')).to.be.false;
       expect(val.isResultValid('AMP-VIDEO', 'src',
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
-      expect(val.isResultValid(
-          'AMP-VIDEO', 'src', '__amp_source_origin')).to.be.false;
     });
   });
 });

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -37,7 +37,7 @@
 
   <p>AMP-IMG TEST</p>
   <button on="tap:AMP.setState(imageSrc='http://www.google.com/image2')" id="changeImgSrcButton"></button>
-  <button on="tap:AMP.setState(imageSrc='__amp_source_origin')" id="invalidSrcButton"></button>
+  <button on="tap:AMP.setState(imageSrc='?__amp_source_origin')" id="invalidSrcButton"></button>
   <button on="tap:AMP.setState(imageSrc='ftp://foo:bar@192.168.1.1/lol.jpg')" id="ftpSrcButton"></button>
   <button on="tap:AMP.setState(imageSrc='tel:1-555-867-5309')" id="telSrcButton"></button>
   <button on="tap:AMP.setState(imageAlt='hello world')" id="changeImgAltButton"></button>


### PR DESCRIPTION
Partial for #7826.

- Remove check if a binding is valid to since it's checked statically by the AMP Validator
- Remove `__amp_source_origin` check since it's covered by `rewriteAttributeValue`
- Fix array workaround for `rewriteAttributeValue` 