### PR TITLE
Fix test failures

### DIFF
--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -62,7 +62,7 @@
   <p> AMP-VIDEO TEST</p>
   <button on="tap:AMP.setState(videoSrc='https://www.google.com/bound.webm')" id="changeVidSrcButton"></button>
   <button on="tap:AMP.setState(videoSrc='http://www.google.com/justhttp.ogg')" id="httpVidSrcButton"></button>
-  <button on="tap:AMP.setState(videoSrc='__amp_source_origin')" id="disallowedVidUrlButton"></button>
+  <button on="tap:AMP.setState(videoSrc='?__amp_source_origin')" id="disallowedVidUrlButton"></button>
   <button on="tap:AMP.setState(videoAlt='hello world')" id="changeVidAltButton"></button>
   <button on="tap:AMP.setState(videoWidth=300, videoHeight=300)" id="changeVidDimensButton"></button>
   <button on="tap:AMP.setState(videoControls=true)" id="showVidControlsButton"></button>

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -326,19 +326,24 @@ describe('cid', () => {
   });
 
   it('should work without mocking', () => {
+    // Can't stub Window's readonly properties nor access properties via
+    // __proto__ (as of Chrome 57), so we must wrap individual props like so.
     const win = {
+      crypto: window.crypto,
+      document: {
+        body: {},
+      },
       location: {
         href: 'https://cdn.ampproject.org/v/www.origin.com/',
         search: '',
       },
+      name: window.name,
+      navigator: window.navigator,
       services: {},
-      document: {
-        body: {},
-      },
     };
+
     const ampdocService = installDocService(win, /* isSingleDoc */ true);
     const ampdoc2 = ampdocService.getAmpDoc();
-    win.__proto__ = window;
     expect(win.location.href).to.equal('https://cdn.ampproject.org/v/www.origin.com/');
     installTimerService(win);
     installPlatformService(win);


### PR DESCRIPTION
Fix test failures at HEAD.

1. `test-bind-integration.js` failure caused by #8033 on stale base.
2. `test-cid.js` failure caused by behavior change between Chrome 56 to 57.