### PR TITLE
Avoid amp-img srcset selecting a smaller image if it will look unacceptably distorted

### DIFF
--- a/src/srcset.js
+++ b/src/srcset.js
@@ -209,7 +209,12 @@ export class Srcset {
         // that is closer with a slight preference toward higher numbers.
         const delta = sourceWidth - width;
         const prevDelta = (width - prevWidth) * 1.1;
-        return (delta < prevDelta) ? i : i + 1;
+        // If smaller size is closer, enfore minimum ratio between
+        // requested width and prevWidth to ensure image isn't too distorted.
+        if (prevDelta < delta && width / prevWidth <= 1.2) {
+          return i + 1;
+        }
+        return i;
       }
       prevWidth = sourceWidth;
     }

--- a/test/functional/test-srcset.js
+++ b/test/functional/test-srcset.js
@@ -337,13 +337,14 @@ describe('Srcset select', () => {
     expect(srcset.select(1000, 1).url).to.equal('image-1000');
     expect(srcset.select(900, 1).url).to.equal('image-1000');
     expect(srcset.select(800, 1).url).to.equal('image-1000');
-    expect(srcset.select(700, 1).url).to.equal('image-500');
+    // select image-1000
+    expect(srcset.select(700, 1).url).to.equal('image-1000');
     expect(srcset.select(600, 1).url).to.equal('image-500');
     expect(srcset.select(500, 1).url).to.equal('image-500');
     expect(srcset.select(400, 1).url).to.equal('image-500');
     expect(srcset.select(300, 1).url).to.equal('image-250');
     expect(srcset.select(200, 1).url).to.equal('image-250');
-    expect(srcset.select(100, 1).url).to.equal('image');
+    expect(srcset.select(100, 1).url).to.equal('image-250');
     expect(srcset.select(50, 1).url).to.equal('image');
     expect(srcset.select(1, 1).url).to.equal('image');
 
@@ -360,7 +361,7 @@ describe('Srcset select', () => {
     expect(srcset.select(300, 2).url).to.equal('image-500');
     expect(srcset.select(200, 2).url).to.equal('image-500');
     expect(srcset.select(100, 2).url).to.equal('image-250');
-    expect(srcset.select(50, 2).url).to.equal('image');
+    expect(srcset.select(50, 2).url).to.equal('image-250');
     expect(srcset.select(1, 2).url).to.equal('image');
   });
 
@@ -390,9 +391,13 @@ describe('Srcset select', () => {
     expect(srcset.select(740, 1).url).to.equal('image-1000');
     expect(srcset.select(370, 2).url).to.equal('image-1000');
 
-    // Lower than threshold: 730 -> go for lower value.
-    expect(srcset.select(730, 1).url).to.equal('image-500');
-    expect(srcset.select(365, 2).url).to.equal('image-500');
+    // Lower than threshold but difference ratio (730/500 = 1.46) too high -> higher value
+    expect(srcset.select(730, 1).url).to.equal('image-1000');
+    expect(srcset.select(365, 2).url).to.equal('image-1000');
+
+    // Lower than threshold and difference ratio (600/500 = 1.2) is low enough -> lower value
+    expect(srcset.select(600, 1).url).to.equal('image-500');
+    expect(srcset.select(300, 2).url).to.equal('image-500');
   });
 
   it('select by dpr', () => {


### PR DESCRIPTION
# Account for proportionality ratio to `srcset` select calculation when choosing a smaller image over a larger one

Currently the `srcset` selection chooses the closest size, favoring the larger size by 10%. So if you have a 400px wide and 800px wide version of an image in the srcset, and the current `<amp-img>` element width is 590px (`590 - 400 = 190 * 1.1 = 209`; `800 - 590 = 210`), amp selects the 400px version and you wind up getting a highly distorted image rendering. However, if you had 1400px and 1800px wide versions of an image, and the current element width is 1590px, choosing the 1400px version is a good call. The selection algorithm needs to account for proportionality to predict how distorted the image will wind up looking.

In this PR, I chose to make 1.2 the maximum acceptable ratio of element width to image width for choosing a smaller image. In specific terms, my first example: `590 / 400 = 1.475`, which would be above the max ratio, so `srcset` selects the larger image. In the 2nd example: `1590 / 1400 = 1.136`, ratio is below 1.2, so `<amp-img>` goes with the smaller image.

This also scales down well to smaller image sizes. I recently had an instance where we had a `30px` and `120px` wide image version in the `srcset`. The element was being rendered at 70px, and `<amp-img>` was choosing the 30px version, which of course looks unacceptable. The ratio makes it obvious: `70 / 30 = 2.33`.

Related-to #1280
