### PR TITLE
Make `<script custom-element=amp-facebook-comments>` unique

### DIFF
--- a/extensions/amp-facebook-comments/0.1/validator-amp-facebook-comments.protoascii
+++ b/extensions/amp-facebook-comments/0.1/validator-amp-facebook-comments.protoascii
@@ -19,7 +19,7 @@ tags: {  # amp-facebook-comments
   tag_name: "SCRIPT"
   spec_name: "amp-facebook-comments extension .js script"
   mandatory_parent: "HEAD"
-  unique_warning: true
+  unique: true
   satisfies: "amp-facebook-comments extension .js script"
   requires: "amp-facebook-comments"
   attrs: {


### PR DESCRIPTION
`<script custom-element=amp-facebook-comments>`should appear only once in a document. Since this is a new extension, we do not need to grandfather it in for this to only be a warning.