### PR TITLE
Make the gulp size task run after gulp dist.

### DIFF
--- a/build-system/tasks/size.js
+++ b/build-system/tasks/size.js
@@ -226,4 +226,4 @@ function sizeTask() {
     .on('end', del.bind(null, [tempFolderName]));
 }
 
-gulp.task('size', 'Runs a report on artifact size', sizeTask);
+gulp.task('size', 'Runs a report on artifact size', ['dist'], sizeTask);


### PR DESCRIPTION
Size depends on data generated by dist.

This could help other new contributors to the project avoid forgetting to run `gulp dist` before running `gulp size`, a mistake I made in [#7562](https://github.com/ampproject/amphtml/pull/7562#discussion_r105487670)