### PR TITLE
amp-bind: Support amp-youtube

### DIFF
--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -8,7 +8,6 @@
   <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
 
   <style amp-custom>
@@ -32,10 +31,9 @@
   <p [class]="textClass">This text will have have a red background color</p>
   <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" [src]="imgSrc" width=100 [width]="imgSize" height=100 [height]="imgSize" alt="asdf" [alt]="imgAlt"></amp-img>
   <p>The image above will increase in size and change its src</p>
-  <amp-video src="https://ampbyexample.com/video/tokyo.mp4" [src]="videoSrc" width=480 height=270 autoplay [controls]="videoControls"></amp-video>
   <div>
-    <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog', videoSrc='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4', videoControls=true)">Click me (key-value args)</button>
-    <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog', 'videoSrc': 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4', 'videoControls': true})">Click me (object args)</button>
+    <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog')">Click me (key-value args)</button>
+    <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog'})">Click me (object args)</button>
   </div>
 
   <amp-state id="myState">

--- a/examples/bind/video.amp.html
+++ b/examples/bind/video.amp.html
@@ -12,6 +12,7 @@
 
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
 
   <style amp-custom>
     button {
@@ -24,7 +25,6 @@
   <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle &lt;amp-bind&gt; experiment</button>
 
   <h2>amp-video</h2>
-
   <amp-video width=480 height=270 autoplay src="https://ampbyexample.com/video/tokyo.mp4"
       [src]="videoSrc || 'https://ampbyexample.com/video/tokyo.mp4'"
       [controls]="videoControls || false">
@@ -36,8 +36,17 @@
     })">Change amp-video</button>
   </p>
 
-  <h2>amp-brightcove</h2>
+  <h2>amp-youtube</h2>
+  <amp-youtube width=480 height=270 data-videoid="lBTCB7yLs8Y"
+      [data-videoid]="youtubeId || 'lBTCB7yLs8Y'">
+  </amp-youtube>
+  <p>
+    <button on="tap:AMP.setState({
+        youtubeId: 'WrpkFROqR0Q'
+    })">Change amp-youtube</button>
+  </p>
 
+  <h2>amp-brightcove</h2>
   <amp-brightcove width=480 height=270
     data-account="906043040001" data-player-id="180a5658-8be8-4f33-8eba-d562ab41b40c" data-video-id="1401169490001"
     [data-account]="brightcoveAccountId" [data-player-id]="brightcovePlayerId">

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -269,6 +269,18 @@ describe.configure().retryOnSaucelabs().run('integration amp-bind', function() {
     });
   });
 
+  describe('amp-youtube', () => {
+    it('should support binding to data-video-id', () => {
+      const button = fixture.doc.getElementById('youtubeButton');
+      const yt = fixture.doc.getElementById('youtube');
+      expect(yt.getAttribute('data-videoid')).to.equal('unbound');
+      button.click();
+      return waitForBindApplication().then(() => {
+        expect(yt.getAttribute('data-videoid')).to.equal('bound');
+      });
+    });
+  });
+
   describe('amp-brightcove', () => {
     it('should support binding to data-account', () => {
       const button = fixture.doc.getElementById('brightcoveButton');

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -210,8 +210,7 @@ class AmpYoutube extends AMP.BaseElement {
     if (mutations['data-videoid'] !== undefined) {
       this.videoid_ = this.getVideoId_();
       if (this.iframe_) { // `null` if element hasn't been laid out yet.
-        this.videoIframeSrc_ = null;
-        this.iframe_.src = this.getVideoIframeSrc_();
+        this.sendCommand_('loadVideoById', [this.videoid_]);
       }
     }
   }
@@ -230,15 +229,18 @@ class AmpYoutube extends AMP.BaseElement {
   /**
    * Sends a command to the player through postMessage.
    * @param {string} command
-   * @param {Object=} opt_args
+   * @param {Array=} opt_args
    * @private
    * */
   sendCommand_(command, opt_args) {
-    this.iframe_.contentWindow./*OK*/postMessage(JSON.stringify({
-      'event': 'command',
-      'func': command,
-      'args': opt_args || '',
-    }), '*');
+    this.playerReadyPromise_.then(() => {
+      const message = JSON.stringify({
+        'event': 'command',
+        'func': command,
+        'args': opt_args || '',
+      });
+      this.iframe_.contentWindow./*OK*/postMessage(message, '*');
+    });
   }
 
   /** @private */
@@ -354,36 +356,28 @@ class AmpYoutube extends AMP.BaseElement {
    * @override
    */
   play(unusedIsAutoplay) {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('playVideo');
-    });
+    this.sendCommand_('playVideo');
   }
 
   /**
    * @override
    */
   pause() {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('pauseVideo');
-    });
+    this.sendCommand_('pauseVideo');
   }
 
   /**
    * @override
    */
   mute() {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('mute');
-    });
+    this.sendCommand_('mute');
   }
 
   /**
    * @override
    */
   unmute() {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('unMute');
-    });
+    this.sendCommand_('unMute');
   }
 
   /**

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -112,10 +112,7 @@ class AmpYoutube extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.videoid_ = user().assert(
-        this.element.getAttribute('data-videoid'),
-        'The data-videoid attribute is required for <amp-youtube> %s',
-        this.element);
+    this.videoid_ = this.getVideoId_();
 
     this.playerReadyPromise_ = new Promise(resolve => {
       this.playerReadyResolver_ = resolve;
@@ -177,8 +174,7 @@ class AmpYoutube extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    // See
-    // https://developers.google.com/youtube/iframe_api_reference
+    // See https://developers.google.com/youtube/iframe_api_reference
     const iframe = this.element.ownerDocument.createElement('iframe');
     const src = this.getVideoIframeSrc_();
 
@@ -189,8 +185,6 @@ class AmpYoutube extends AMP.BaseElement {
     this.element.appendChild(iframe);
 
     this.iframe_ = iframe;
-
-
 
     this.win.addEventListener(
         'message', event => this.handleYoutubeMessages_(event));
@@ -209,6 +203,28 @@ class AmpYoutube extends AMP.BaseElement {
         this.playerState_ == PlayerStates.PLAYING) {
       this.pause();
     }
+  }
+
+  /** @override */
+  mutatedAttributesCallback(mutations) {
+    if (mutations['data-videoid'] !== undefined) {
+      this.videoid_ = this.getVideoId_();
+      if (this.iframe_) { // `null` if element hasn't been laid out yet.
+        this.videoIframeSrc_ = null;
+        this.iframe_.src = this.getVideoIframeSrc_();
+      }
+    }
+  }
+
+  /**
+   * @return {string}
+   * @private
+   */
+  getVideoId_() {
+    return user().assert(
+        this.element.getAttribute('data-videoid'),
+        'The data-videoid attribute is required for <amp-youtube> %s',
+        this.element);
   }
 
   /**

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -294,14 +294,11 @@ describe('amp-youtube', function() {
   it('should propagate attribute mutations', () => {
     return getYt({'data-videoid': 'mGENRKrdoGY'}).then(yt => {
       const iframe = yt.querySelector('iframe');
-
-      expect(iframe.src).to.contain('mGENRKrdoGY');
-
+      const spy = sandbox.spy(yt.implementation_, 'sendCommand_');
       yt.setAttribute('data-videoid', 'lBTCB7yLs8Y');
       yt.mutatedAttributesCallback({'data-videoid': 'lBTCB7yLs8Y'});
-
-      expect(iframe.src).to.not.contain('mGENRKrdoGY');
-      expect(iframe.src).to.contain('lBTCB7yLs8Y');
+      expect(spy).to.be.calledWith('loadVideoById',
+          sinon.match(['lBTCB7yLs8Y']));
     });
   });
 

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -293,7 +293,6 @@ describe('amp-youtube', function() {
 
   it('should propagate attribute mutations', () => {
     return getYt({'data-videoid': 'mGENRKrdoGY'}).then(yt => {
-      const iframe = yt.querySelector('iframe');
       const spy = sandbox.spy(yt.implementation_, 'sendCommand_');
       yt.setAttribute('data-videoid', 'lBTCB7yLs8Y');
       yt.mutatedAttributesCallback({'data-videoid': 'lBTCB7yLs8Y'});

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -291,6 +291,20 @@ describe('amp-youtube', function() {
     });
   });
 
+  it('should propagate attribute mutations', () => {
+    return getYt({'data-videoid': 'mGENRKrdoGY'}).then(yt => {
+      const iframe = yt.querySelector('iframe');
+
+      expect(iframe.src).to.contain('mGENRKrdoGY');
+
+      yt.setAttribute('data-videoid', 'lBTCB7yLs8Y');
+      yt.mutatedAttributesCallback({'data-videoid': 'lBTCB7yLs8Y'});
+
+      expect(iframe.src).to.not.contain('mGENRKrdoGY');
+      expect(iframe.src).to.contain('lBTCB7yLs8Y');
+    });
+  });
+
   function sendFakeInfoDeliveryMessage(yt, iframe, info) {
     yt.implementation_.handleYoutubeMessages_({
       origin: 'https://www.youtube.com',

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -19,6 +19,7 @@
   <script custom-element="amp-brightcove" src="/dist/v0/amp-brightcove-0.1.js"></script>
   <script custom-element="amp-carousel" src="/dist/v0/amp-carousel-0.1.js"></script>
   <script custom-element="amp-selector" src="/dist/v0/amp-selector-0.1.js"></script>
+  <script custom-element="amp-youtube" src="/dist/v0/amp-youtube-0.1.js"></script>
 </head>
 
 <body>
@@ -81,6 +82,12 @@
     [height]="videoHeight"
     [controls]="videoControls">
   </amp-video>
+
+  <p>AMP-YOUTUBE</p>
+  <button on="tap:AMP.setState(youtube='bound')" id="youtubeButton"></button>
+  <amp-youtube width=480 height=270 id="youtube" data-videoid="unbound"
+      [data-videoid]="youtube">
+  </amp-youtube>
 
   <p>AMP-BRIGHTCOVE</p>
   <button id="brightcoveButton" on="tap:AMP.setState(brightcove='bound')">Change amp-brightcove</button>


### PR DESCRIPTION
Partial for #7825.

- Support binding to `amp-youtube`'s `data-videoid` attribute.

/to @aghassemi 