### PR TITLE
amp-bind: Support amp-brightcove

### DIFF
--- a/examples/bind/video.amp.html
+++ b/examples/bind/video.amp.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind: Video</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
+
+  <style amp-custom>
+    button {
+      border: solid 1px black;
+    }
+  </style>
+</head>
+
+<body>
+  <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle &lt;amp-bind&gt; experiment</button>
+
+  <h2>amp-video</h2>
+
+  <amp-video width=480 height=270 autoplay src="https://ampbyexample.com/video/tokyo.mp4"
+      [src]="videoSrc || 'https://ampbyexample.com/video/tokyo.mp4'"
+      [controls]="videoControls || false">
+  </amp-video>
+  <p>
+    <button on="tap:AMP.setState({
+        videoSrc: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4',
+        videoControls: true
+    })">Change amp-video</button>
+  </p>
+
+  <h2>amp-brightcove</h2>
+
+  <amp-brightcove width=480 height=270
+    data-account="906043040001" data-player-id="180a5658-8be8-4f33-8eba-d562ab41b40c" data-video-id="1401169490001"
+    [data-account]="brightcoveAccountId" [data-player-id]="brightcovePlayerId">
+  </amp-brightcove>
+  <p>
+    <button on="tap:AMP.setState({
+        brightcoveAccountId: '3441935391001',
+        brightcovePlayerId: 'ced36921-fd10-4944-bd78-1582084edd85'
+    })">Change amp-brightcove</button>
+  </p>
+
+  <!-- TODO: Add other video players -->
+</body>
+</html>

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -33,7 +33,8 @@ describe.configure().retryOnSaucelabs().run('integration amp-bind', function() {
     return createFixtureIframe(fixtureLocation).then(f => {
       fixture = f;
       toggleExperiment(fixture, 'amp-bind', true, true);
-      return fixture.awaitEvent('amp:load:start', 1);
+      const numberOfExtensionElements = 4;
+      return fixture.awaitEvent('amp:load:start', numberOfExtensionElements);
     }).then(() => {
       const ampdocService = ampdocServiceFor(fixture.win);
       ampdoc = ampdocService.getAmpDoc(fixture.doc);
@@ -268,4 +269,18 @@ describe.configure().retryOnSaucelabs().run('integration amp-bind', function() {
     });
   });
 
+  describe('amp-brightcove', () => {
+    it('should support binding to data-account', () => {
+      const button = fixture.doc.getElementById('brightcoveButton');
+      const bc = fixture.doc.getElementById('brightcove');
+      // Force layout in case element is not in viewport.
+      bc.implementation_.layoutCallback();
+      const iframe = bc.querySelector('iframe');
+      expect(iframe.src).to.not.contain('bound');
+      button.click();
+      return waitForBindApplication().then(() => {
+        expect(iframe.src).to.contain('bound');
+      });
+    });
+  });
 });

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -96,4 +96,26 @@ describe('amp-brightcove', () => {
       expect(params).to.contain('myParam=hello%20world');
     });
   });
+
+  it('should propagate mutated attributes', () => {
+    return getBrightcove({
+      'data-account': '906043040001',
+      'data-video-id': 'ref:ampdemo',
+    }).then(bc => {
+      const iframe = bc.querySelector('iframe');
+
+      expect(iframe.src).to.equal('https://players.brightcove.net/' +
+          '906043040001/default_default/index.html?videoId=ref:ampdemo');
+
+      bc.setAttribute('data-account', '12345');
+      bc.setAttribute('data-video-id', 'abcdef');
+      bc.mutatedAttributesCallback({
+        'data-account': '12345',
+        'data-video-id': 'abcdef',
+      });
+
+      expect(iframe.src).to.equal('https://players.brightcove.net/' +
+          '12345/default_default/index.html?videoId=abcdef');
+    });
+  });
 });

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -16,6 +16,7 @@
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script src="/dist/amp.js"></script>
+  <script custom-element="amp-brightcove" src="/dist/v0/amp-brightcove-0.1.js"></script>
   <script custom-element="amp-carousel" src="/dist/v0/amp-carousel-0.1.js"></script>
   <script custom-element="amp-selector" src="/dist/v0/amp-selector-0.1.js"></script>
 </head>
@@ -81,5 +82,10 @@
     [controls]="videoControls">
   </amp-video>
 
+  <p>AMP-BRIGHTCOVE</p>
+  <button id="brightcoveButton" on="tap:AMP.setState(brightcove='bound')">Change amp-brightcove</button>
+  <amp-brightcove width=480 height=270 id="brightcove" [data-account]="brightcove"
+      data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c">
+  </amp-brightcove>
 </body>
 </html>


### PR DESCRIPTION
Partial for #7825.

- Support binding to `amp-brightcove`'s video source attributes.

/to @mister-ben @aghassemi