### PR TITLE
Amp-bind: Cleanup removed bindings from bind evaluator

### DIFF
--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -80,12 +80,11 @@ export class BindEvaluator {
    */
   removeBindingsWithExpressionStrings(expressionStrings) {
     const expressionsToRemove = Object.create(null);
-    for (let i = 0; i < expressionStrings.length; i++) {
-      const expressionString = expressionStrings[i];
+
+    expressionStrings.forEach(expressionString => {
       delete this.expressions_[expressionString];
-      // Use a map instead of an array to make filtering bindings_ faster
       expressionsToRemove[expressionString] = true;
-    }
+    });
 
     filterSplice(this.bindings_, binding =>
         !expressionsToRemove[binding.expressionString]);
@@ -223,6 +222,15 @@ export class BindEvaluator {
    */
   bindingsForTesting() {
     return this.bindings_;
+  }
+
+  /**
+   * Returns the expression cache for testing.
+   * @return {!Object<string, !BindExpression>}
+   * @visibleForTesting
+   */
+  expressionsForTesting() {
+    return this.expressions_;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -82,7 +82,7 @@ export class BindEvaluator {
     const expressionsToRemove = Object.create(null);
     for (let i = 0; i < expressionStrings.length; i++) {
       const expressionString = expressionStrings[i];
-      delete this.expressionCache_[expressionString];
+      delete this.expressions_[expressionString];
       // Use a map instead of an array to make filtering bindings_ faster
       expressionsToRemove[expressionString] = true;
     }

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -81,7 +81,10 @@ export class BindEvaluator {
   removeBindingsWithExpressionStrings(expressionStrings) {
     const expressionsToRemove = Object.create(null);
     for (let i = 0; i < expressionStrings.length; i++) {
-      expressionsToRemove[expressionStrings[i]] = true;
+      const expressionString = expressionStrings[i];
+      delete this.expressionCache_[expressionString];
+      // Use a map instead of an array to make filtering bindings_ faster
+      expressionsToRemove[expressionString] = true;
     }
 
     filterSplice(this.bindings_, binding =>

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -69,7 +69,7 @@ describe('BindEvaluator', () => {
     expect(numberOfBindings()).to.equal(0);
   });
 
-  it('should NOT cache expressions that have been removed', () => {
+  it('should clean up removed expressions from its cache', () => {
     expect(numberOfCachedExpressions()).to.equal(0);
     evaluator.addBindings([{
       tagName: 'P',

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -28,6 +28,11 @@ describe('BindEvaluator', () => {
     return evaluator.bindingsForTesting().length;
   }
 
+  function numberOfCachedExpressions() {
+    const cache = evaluator.expressionsForTesting();
+    return Object.keys(cache).length;
+  }
+
   it('should allow callers to add bindings multiple times', () => {
     expect(numberOfBindings()).to.equal(0);
     evaluator.addBindings([{
@@ -64,12 +69,23 @@ describe('BindEvaluator', () => {
     expect(numberOfBindings()).to.equal(0);
   });
 
-  it('should evaluate expressions given a scope with needed bindings', () => {
-    const bindingDef = {
+  it('should NOT cache expressions that have been removed', () => {
+    expect(numberOfCachedExpressions()).to.equal(0);
+    evaluator.addBindings([{
       tagName: 'P',
       property: 'text',
       expressionString: 'oneplusone + 2',
-    };
+    }, {
+      tagName: 'A',
+      property: 'href',
+      expressionString: 'url',
+    }]);
+    expect(numberOfCachedExpressions()).to.equal(2);
+    evaluator.removeBindingsWithExpressionStrings(['url']);
+    expect(numberOfCachedExpressions()).to.equal(1);
+  });
+
+  it('should evaluate expressions given a scope with needed bindings', () => {
     expect(numberOfBindings()).to.equal(0);
     evaluator.addBindings([{
       tagName: 'P',


### PR DESCRIPTION
The bind evaluator doesn't currently delete expressions from its cache even when the expressions are no longer used for any bind attributes on the page. This PR clears the cache when bindings are removed. The caller should only call with expression strings that are no longer used to bind any attributes on the page. bind-impl already does this [here](https://github.com/ampproject/amphtml/blob/master/extensions/amp-bind/0.1/bind-impl.js#L275)

Detecting bindings in amp-live-lists introduces the potential for this cache to grow without bound.

/to @choumx 