### PR TITLE
InOb polyfill trigger new added element w/o tick

### DIFF
--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -298,6 +298,7 @@ export class Visibility {
       } else {
         this.intersectionObserver_ = new IntersectionObserverPolyfill(
             onIntersectionChanges, {threshold: DEFAULT_THRESHOLD});
+        this.intersectionObserver_.tick(viewport.getRect());
         //TODO: eventually this is go into the proposed layoutManager.
         const viewport = viewportForDoc(this.ampdoc);
         const ticker = () => {

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -298,9 +298,9 @@ export class Visibility {
       } else {
         this.intersectionObserver_ = new IntersectionObserverPolyfill(
             onIntersectionChanges, {threshold: DEFAULT_THRESHOLD});
-        this.intersectionObserver_.tick(viewport.getRect());
         //TODO: eventually this is go into the proposed layoutManager.
         const viewport = viewportForDoc(this.ampdoc);
+        this.intersectionObserver_.tick(viewport.getRect());
         const ticker = () => {
           this.intersectionObserver_.tick(viewport.getRect());
         };

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -206,7 +206,7 @@ export class IntersectionObserverPolyfill {
     this.lastViewportRect_ = null;
 
     /** @private {./layout-rect.LayoutRectDef|undefined} */
-    this.opt_lastIframeRect_ = undefined;
+    this.lastIframeRect_ = undefined;
 
     /**
      * Store a list of observed elements and their current threshold slot which
@@ -242,7 +242,7 @@ export class IntersectionObserverPolyfill {
     // Get the new observed element's first changeEntry based on last viewport
     if (this.lastViewportRect_) {
       const change = this.getValidIntersectionChangeEntry_(
-          newEntry, this.lastViewportRect_, this.opt_lastIframeRect_);
+          newEntry, this.lastViewportRect_, this.lastIframeRect_);
       if (change) {
         this.callback_([change]);
       }
@@ -286,7 +286,7 @@ export class IntersectionObserverPolyfill {
     }
 
     this.lastViewportRect_ = hostViewport;
-    this.opt_lastIframeRect_ = opt_iframe;
+    this.lastIframeRect_ = opt_iframe;
 
     const changes = [];
 

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -205,7 +205,7 @@ export class IntersectionObserverPolyfill {
     /** @private {?./layout-rect.LayoutRectDef} */
     this.lastViewportRect_ = null;
 
-    /** @private {./layout-rect.LayoutRectDef=} */
+    /** @private {./layout-rect.LayoutRectDef|undefined} */
     this.opt_lastIframeRect_ = undefined;
 
     /**
@@ -244,7 +244,7 @@ export class IntersectionObserverPolyfill {
       const change = this.getValidIntersectionChangeEntry_(
           newEntry, this.lastViewportRect_, this.opt_lastIframeRect_);
       if (change) {
-        this.callback_({change});
+        this.callback_([change]);
       }
     }
 

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -43,7 +43,7 @@ export const DEFAULT_THRESHOLD =
  *    currentThresholdSlot: number,
  *  }}
  */
-let IntersectionStateDef;
+let ElementIntersectionStateDef;
 
 /** @const @private */
 const TAG = 'INTERSECTION-OBSERVER';
@@ -211,7 +211,7 @@ export class IntersectionObserverPolyfill {
     /**
      * Store a list of observed elements and their current threshold slot which
      * their intersection ratio fills, range from [0, this.threshold_.length]
-     * @private {Array<!IntersectionStateDef>}
+     * @private {Array<!ElementIntersectionStateDef>}
      */
     this.observeEntries_ = [];
   }
@@ -234,7 +234,7 @@ export class IntersectionObserverPolyfill {
       }
     }
 
-    const newEntry = {
+    const newState = {
       element,
       currentThresholdSlot: 0,
     };
@@ -242,14 +242,14 @@ export class IntersectionObserverPolyfill {
     // Get the new observed element's first changeEntry based on last viewport
     if (this.lastViewportRect_) {
       const change = this.getValidIntersectionChangeEntry_(
-          newEntry, this.lastViewportRect_, this.lastIframeRect_);
+          newState, this.lastViewportRect_, this.lastIframeRect_);
       if (change) {
         this.callback_([change]);
       }
     }
 
     // push new observed element
-    this.observeEntries_.push(newEntry);
+    this.observeEntries_.push(newState);
   }
 
   /**
@@ -309,14 +309,14 @@ export class IntersectionObserverPolyfill {
    * When the new intersection ratio doesn't cross one of a threshold value,
    * the function will return null.
    *
-   * @param {!IntersectionStateDef} entry
+   * @param {!ElementIntersectionStateDef} state
    * @param {!./layout-rect.LayoutRectDef} hostViewport hostViewport's rect
    * @param {./layout-rect.LayoutRectDef=} opt_iframe. iframe container rect
    * @return {?IntersectionObserverEntry} A valid change entry or null if ratio
    * @private
    */
-  getValidIntersectionChangeEntry_(entry, hostViewport, opt_iframe) {
-    const element = entry.element;
+  getValidIntersectionChangeEntry_(state, hostViewport, opt_iframe) {
+    const element = state.element;
 
     // Normalize container LayoutRect to be relative to page
     let elementRect;
@@ -339,10 +339,10 @@ export class IntersectionObserverPolyfill {
     const ratio = intersectionRatio(intersectionRect, elementRect);
     const newThresholdSlot = getThresholdSlot(this.threshold_, ratio);
 
-    if (newThresholdSlot == entry.currentThresholdSlot) {
+    if (newThresholdSlot == state.currentThresholdSlot) {
       return null;
     }
-    entry.currentThresholdSlot = newThresholdSlot;
+    state.currentThresholdSlot = newThresholdSlot;
 
     // To get same behavior as native IntersectionObserver set hostViewport null
     // if inside an iframe

--- a/test/functional/test-intersection-observer-polyfill.js
+++ b/test/functional/test-intersection-observer-polyfill.js
@@ -307,6 +307,21 @@ describe('IntersectionObserverPolyfill', () => {
       expect(callbackSpy).to.not.be.called;
     });
 
+    it('should trigger for new observed element', () => {
+      io = new IntersectionObserverPolyfill(callbackSpy, {
+        threshold: [0, 1],
+      });
+      element.getLayoutBox = () => {
+        return layoutRectLtwh(0, 0, 100, 100);
+      };
+      io.tick(layoutRectLtwh(0, 90, 100, 100));
+
+      // Observe after tick.
+      io.observe(element);
+      expect(callbackSpy).to.be.calledOnce;
+    });
+
+
 
     describe('w/o container should get IntersectionChangeEntry when', () => {
       it('completely in viewport', () => {


### PR DESCRIPTION
fix #7992 
- Always store the last tick viewport position, and use it to calculate change entry to new added element w/o tick
- If last tick viewport position is not available, do nothing.
- IntersectionObserverPolyfill creator is responsible for the very first tick during initialization. 
 