### PR TITLE
Remove from test owners

### DIFF
--- a/test/OWNERS.yaml
+++ b/test/OWNERS.yaml
@@ -2,7 +2,6 @@
 - cvializ
 - chenshay
 - honeybadgerdontcare
-- dvoytenko
 - ericlindley-g
 - erwinmombay
 - gregable
@@ -12,7 +11,6 @@
 - newmuis
 - jridgewell
 - kmh287
-- cramforce
 - mkhatib
 - camelburrito
 - choumx


### PR DESCRIPTION
this is so that @dvoytenko and @cramforce don't get pinged just for test files reviews