### PR TITLE
Better npm post-install for virtual machines

### DIFF
--- a/validator/nodejs/README.md
+++ b/validator/nodejs/README.md
@@ -79,3 +79,6 @@ As expected, this emits errors because the provided string in the example, `<htm
 
 ### 1.0.19
 * Set correct process exit status for old versions of Node.js (v0.10.25).
+
+### 1.0.20
+* Better npm post-install for virtual machines, running debian over windows with SMB shared folder

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -24,6 +24,6 @@
     "jasmine": "2.3.2"
   },
   "scripts": {
-    "postinstall": "/bin/sh -c \"exit 0\" 2> NUL && rm NUL || node postinstall-windows.js"
+    "postinstall": "/bin/sh -c \"exit 0\" 2> postinstall.DELETEME && rm postinstall.DELETEME || node postinstall-windows.js"
   }
 }

--- a/validator/nodejs/postinstall-windows.js
+++ b/validator/nodejs/postinstall-windows.js
@@ -20,10 +20,8 @@
 var path = require('path');
 var fs = require('fs');
 
-if (process.env.OS !== 'Windows_NT') {
-  console./*OK*/ error(
-      'postinstall-windows.js: This script is for Windows only.');
-  process.exit(1);
+if (fs.existsSync('postinstall.DELETEME')) {
+	fs.unlinkSync('postinstall.DELETEME');
 }
 
 // We only want to modify the .cmd shim - this is what would run on a


### PR DESCRIPTION
This pull requests resolves a bug in npm postinstall.

## Environment
- Virtual machine: Debian 8
- Hypervisor: Virtualbox 5.1.14
- Host OS: Windows 10
- Shared folders: SMB via vagrant

## Steps to reproduce
When you have a running environment, go to the shared folders where you cloned amphtml-validator. Then run `npm run postinstall`.

## Actual output

```
[08:18:43]-[/var/www/test-amp] $ npm i amphtml-validator

> amphtml-validator@1.0.19 postinstall /var/www/test-amp/node_modules/amphtml-va                                           lidator
> /bin/sh -c "exit 0" 2> NUL && rm NUL || node postinstall-windows.js

sh: 1: cannot create NUL: Permission denied
postinstall-windows.js: This script is for Windows only.
npm WARN enoent ENOENT: no such file or directory, open '/var/www/test-amp/packa                                           ge.json'
npm WARN test-amp No description
npm WARN test-amp No repository field.
npm WARN test-amp No README data
npm WARN test-amp No license field.
npm ERR! Linux 3.16.0-4-amd64
npm ERR! argv "/usr/local/node-v6.9.5-linux-x64/bin/node" "/usr/local/bin/npm" "                                           i" "amphtml-validator"
npm ERR! node v6.9.5
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE

npm ERR! amphtml-validator@1.0.19 postinstall: `/bin/sh -c "exit 0" 2> NUL && rm                                            NUL || node postinstall-windows.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the amphtml-validator@1.0.19 postinstall script '/bin/sh -c "                                           exit 0" 2> NUL && rm NUL || node postinstall-windows.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the amphtml-validator pac                                           kage,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     /bin/sh -c "exit 0" 2> NUL && rm NUL || node postinstall-windows.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs amphtml-validator
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls amphtml-validator
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /var/www/test-amp/npm-debug.log
```

## Expected output
Installation does not fails.

```
[08:40:28]-[/var/www/test-amp/node_modules/amphtml-validator] $ npm i

> amphtml-validator@1.0.19 postinstall /var/www/test-amp/node_modules/amphtml-validator
> node postinstall-windows.js

postinstall-windows.js: This script is for Windows only.
amphtml-validator@1.0.19 /var/www/test-amp/node_modules/amphtml-validator
âââ colors@1.1.2
âââ¬ commander@2.9.0
â âââ graceful-readlink@1.0.1
âââ¬ jasmine@2.3.2
â âââ exit@0.1.2
â âââ¬ glob@3.2.11
â â âââ inherits@2.0.3
â â âââ¬ minimatch@0.3.0
â â   âââ lru-cache@2.7.3
â â   âââ sigmund@1.0.1
â âââ jasmine-core@2.3.4
âââ¬ promise@7.1.1
  âââ asap@2.0.5
```

In this pull request we will run the `postinstall-windows.js` for every os and will exit without error when the current os is not Windows.