### PR TITLE
Clarify that amp-ad script is required for sticky ad

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["visibility-v2"],
+  "allow-doc-opt-in": ["visibility-v2", "visibility-v3"],
 
   "canary": 1,
   "amp-experiment": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["visibility-v2"],
+  "allow-doc-opt-in": ["visibility-v2", "visibility-v3"],
 
   "canary": 0,
   "amp-experiment": 1,

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -688,6 +688,7 @@ var forbiddenTermsSrcInclusive = {
       'tools/errortracker/errortracker.go',
       'validator/nodejs/index.js',
       'validator/webui/serve-standalone.go',
+      'build-system/tasks/extension-generator/index.js',
     ],
   },
 };

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -41,6 +41,7 @@ import {
   registerServiceBuilderForDoc,
 } from '../../../src/service';
 import {isEnumValue} from '../../../src/types';
+import {isExperimentOn} from '../../../src/experiments';
 import {timerFor} from '../../../src/timer';
 import {viewerForDoc} from '../../../src/viewer';
 import {viewportForDoc} from '../../../src/viewport';
@@ -531,6 +532,10 @@ export class AnalyticsGroup {
 
     /** @private @const {!Array<!UnlistenDef>} */
     this.listeners_ = [];
+
+    // TODO(dvoytenko, #8121): Cleanup visibility-v3 experiment.
+    /** @private @const {boolean} */
+    this.visibilityV3_ = isExperimentOn(root.ampdoc.win, 'visibility-v3');
   }
 
   /** @override */
@@ -551,7 +556,11 @@ export class AnalyticsGroup {
    * @param {function(!AnalyticsEvent)} handler
    */
   addTrigger(config, handler) {
-    const eventType = dev().assertString(config['on']);
+    let eventType = dev().assertString(config['on']);
+    // TODO(dvoytenko, #8121): Cleanup visibility-v3 experiment.
+    if (eventType == 'visible' && this.visibilityV3_) {
+      eventType = 'visible-v3';
+    }
     let trackerProfile = EVENT_TRACKERS[eventType];
     if (!trackerProfile && !isEnumValue(AnalyticsEventType, eventType)) {
       trackerProfile = EVENT_TRACKERS['custom'];

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -35,6 +35,7 @@ import {
     installResourcesServiceForDoc,
 } from '../../../../src/service/resources-impl';
 import {documentStateFor} from '../../../../src/service/document-state';
+import {toggleExperiment} from '../../../../src/experiments';
 
 
 describes.realWin('InstrumentationService', {amp: 1}, env => {
@@ -100,6 +101,10 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
     beforeEach(() => {
       group = service.createAnalyticsGroup(analyticsElement);
       insStub = sandbox.stub(service, 'addListenerDepr_');
+    });
+
+    afterEach(() => {
+      toggleExperiment(win, 'visibility-v3', false);
     });
 
     it('should create group for the ampdoc root', () => {
@@ -217,6 +222,24 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
 
     it('should add "visible-v3" trigger', () => {
       const config = {on: 'visible-v3'};
+      group.addTrigger(config, handler);
+      const tracker = root.getTrackerOptional('visible-v3');
+      expect(tracker).to.be.instanceOf(VisibilityTracker);
+
+      const unlisten = function() {};
+      const stub = sandbox.stub(tracker, 'add', () => unlisten);
+      const handler = function() {};
+      group.addTrigger(config, handler);
+      expect(stub).to.be.calledOnce;
+      expect(stub).to.be.calledWith(
+          analyticsElement, 'visible-v3', config, handler);
+    });
+
+    it('should use "visible-v3" for "visible" w/experiment', () => {
+      // TODO(dvoytenko, #8121): Cleanup visibility-v3 experiment.
+      toggleExperiment(win, 'visibility-v3', true);
+      group = service.createAnalyticsGroup(analyticsElement);
+      const config = {on: 'visible'};
       group.addTrigger(config, handler);
       const tracker = root.getTrackerOptional('visible-v3');
       expect(tracker).to.be.instanceOf(VisibilityTracker);

--- a/extensions/amp-bind/OWNERS.yaml
+++ b/extensions/amp-bind/OWNERS.yaml
@@ -1,0 +1,2 @@
+- choumx
+- kmh287

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -526,29 +526,16 @@ describes.realWin('amp-form', {
         target: form,
         preventDefault: sandbox.spy(),
       };
-
-      const errors = [];
-      const realSetTimeout = window.setTimeout;
-      sandbox.stub(window, 'setTimeout', (callback, delay) => {
-        realSetTimeout(() => {
-          try {
-            callback();
-          } catch (e) {
-            errors.push(e);
-          }
-        }, delay);
-      });
       ampForm.handleSubmitEvent_(event);
       const findTemplateStub = ampForm.templates_.findAndRenderTemplate;
-      return timer.promise(5).then(() => {
+      return ampForm.xhrSubmitPromiseForTesting().then(() => {
         expect(findTemplateStub).to.be.called;
+        // Template should have rendered an error
         expect(findTemplateStub).to.have.been.calledWith(
             errorContainer, {message: 'hello there'});
         // Check that form has a rendered div with class .submit-error-message.
         renderedTemplate = form.querySelector('[i-amp-rendered]');
         expect(renderedTemplate).to.not.be.null;
-        expect(errors.length).to.be.equal(1);
-        expect(errors[0].message).to.match(/Form submission failed/);
       });
     });
   });

--- a/extensions/amp-nexxtv-player/amp-nexxtv-player.md
+++ b/extensions/amp-nexxtv-player/amp-nexxtv-player.md
@@ -55,17 +55,17 @@ With the responsive layout, the width and height from the example should yield c
 
 ## Attributes
 
-**mediaid**
+**data-mediaid**
 
 * Required
 * ID of your media you want to play
 
-**client**
+**data-client**
 
 * Required
 * your domain ID
 
-**streamtype**
+**data-streamtype**
 
 * optional
 * default: video
@@ -73,20 +73,20 @@ With the responsive layout, the width and height from the example should yield c
 * playlist-masked: playlist without possibility to skip or choose video
 * album: is an audio playlist
 
-**seek-to**
+**data-seek-to**
 
 Starting point of your media in seconds e.g. video starting 1:30min
 
 * optional
 
-**mode**
+**data-mode**
 
 * optional
 * default: static
 * possible values: [static | api]
 
 
-**origin**
+**data-origin**
 
 Source from which embed domain media is played.
 

--- a/extensions/amp-sticky-ad/amp-sticky-ad.md
+++ b/extensions/amp-sticky-ad/amp-sticky-ad.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 ## Behavior
 
-- There can be only one `<amp-sticky-ad>` in an AMP document. The `<amp-sticky-ad>` should only have one direct child of `<amp-ad>`.
+- There can be only one `<amp-sticky-ad>` in an AMP document. The `<amp-sticky-ad>` should only have one direct child: `<amp-ad>`. **Note**: Make sure you include any required scripts for the `<amp-ad>` component.
 - The sticky ad appears at the bottom of a page.
 - The sticky ad introduces a full-width blank container and then fills the sticky ad based on the width and height of the `<amp-ad>`.
 - The height of the sticky-ad is whatever its child needs up to its max-height.

--- a/spec/amp-cache-modifications.md
+++ b/spec/amp-cache-modifications.md
@@ -310,7 +310,7 @@ If the document is using `amp-access` type of `server` then the AMP Cache remove
 #### Remove attribute `nonce`
 
 *Condition*:
-Remove `nonce` from every tag except for those that are only inserted by the AMP cache `<meta content=NONCE name=i-amphtml-access-state>` and `<meta content=NONCE name=i-amp-access-state>`
+Remove `nonce` attribute from every tag.
 
 <details>
 <summary>example</summary>

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -21,6 +21,7 @@ import {viewerForDoc} from '../viewer';
 import {viewportForDoc} from '../viewport';
 import {whenDocumentComplete, whenDocumentReady} from '../document-ready';
 import {urls} from '../config';
+import {getMode} from '../mode';
 
 
 /**
@@ -302,6 +303,10 @@ export class Performance {
       return this.enabledExperiments_;
     }
     const experiments = [];
+    // Add RTV version as experiment ID, so we can slice the data by version.
+    if (getMode(this.win).rtvVersion) {
+      experiments.push(getMode(this.win).rtvVersion);
+    }
     // Check if it's the legacy CDN domain.
     if (this.getHostname_() == urls.cdn.split('://')[1]) {
       experiments.push('legacy-cdn-domain');

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -399,17 +399,20 @@ describe('performance', () => {
       });
 
       it('should call the flush callback', () => {
-        expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+        const payload = {
+          ampexp: '$internalRuntimeVersion$',
+        };
+        expect(viewerSendMessageStub.withArgs('sendCsi', payload,
             /* cancelUnsent */true)).to.have.callCount(0);
         // coreServicesAvailable calls flush once.
         return perf.coreServicesAvailable().then(() => {
-          expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+          expect(viewerSendMessageStub.withArgs('sendCsi', payload,
               /* cancelUnsent */true)).to.have.callCount(1);
           perf.flush();
-          expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+          expect(viewerSendMessageStub.withArgs('sendCsi', payload,
               /* cancelUnsent */true)).to.have.callCount(2);
           perf.flush();
-          expect(viewerSendMessageStub.withArgs('sendCsi', undefined,
+          expect(viewerSendMessageStub.withArgs('sendCsi', payload,
               /* cancelUnsent */true)).to.have.callCount(3);
         });
       });
@@ -625,8 +628,9 @@ describes.fakeWin('performance with experiment', {amp: true}, env => {
     sandbox.stub(perf, 'getHostname_', () => 'cdn.ampproject.org');
     return perf.coreServicesAvailable().then(() => {
       perf.flush();
-      expect(viewerSendMessageStub)
-          .to.be.calledWith('sendCsi', {ampexp: 'legacy-cdn-domain'});
+      expect(viewerSendMessageStub).to.be.calledWith('sendCsi', {
+        ampexp: '$internalRuntimeVersion$,legacy-cdn-domain',
+      });
     });
   });
 
@@ -634,7 +638,9 @@ describes.fakeWin('performance with experiment', {amp: true}, env => {
     sandbox.stub(perf, 'getHostname_', () => 'curls.cdn.ampproject.org');
     return perf.coreServicesAvailable().then(() => {
       perf.flush();
-      expect(viewerSendMessageStub).to.be.calledWith('sendCsi', undefined);
+      expect(viewerSendMessageStub).to.be.calledWith('sendCsi', {
+        ampexp: '$internalRuntimeVersion$',
+      });
     });
   });
 });

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -198,6 +198,11 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6254',
   },
   {
+    id: 'visibility-v3',
+    name: 'Visibility tracking with FIE and in-a-box support',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8121',
+  },
+  {
     id: 'amp-accordion-session-state-optout',
     name: 'AMP Accordion attribute to opt out of preserved state.',
     Spec: 'https://github.com/ampproject/amphtml/issues/3813',


### PR DESCRIPTION
Clarify wording so that the reader knows to include the `amp-ad` required scripts when creating a sticky ad.

Fixes: https://github.com/ampproject/docs/issues/347

to: @zhouyx
cc: @SidVal
