### PR TITLE
Add OWNERS for amp-bind

### DIFF
--- a/extensions/amp-bind/OWNERS.yaml
+++ b/extensions/amp-bind/OWNERS.yaml
@@ -1,0 +1,2 @@
+- choumx
+- kmh287


### PR DESCRIPTION
Avoid sending every `amp-bind` PR to Malte and Dima.

/to @erwinmombay /cc @kmh287 