### PR TITLE
Update amp-cache-modifications.md

### DIFF
--- a/spec/amp-cache-modifications.md
+++ b/spec/amp-cache-modifications.md
@@ -310,7 +310,7 @@ If the document is using `amp-access` type of `server` then the AMP Cache remove
 #### Remove attribute `nonce`
 
 *Condition*:
-Remove `nonce` from every tag except for those that are only inserted by the AMP cache `<meta content=NONCE name=i-amphtml-access-state>` and `<meta content=NONCE name=i-amp-access-state>`
+Remove `nonce` attribute from every tag.
 
 <details>
 <summary>example</summary>


### PR DESCRIPTION
Clarify that removing `nonce` is only the attribute `nonce` and remove the confusion around the inserted `meta` tag for nonce.
