### PR TITLE
Add fake cookie support to FakeWin

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -318,6 +318,7 @@ var forbiddenTerms = {
       'build-system/test-server.js',
       'src/cookies.js',
       'extensions/amp-analytics/0.1/cid-impl.js',
+      'testing/fake-dom.js',
     ],
   },
   'getCookie\\W': {

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -98,6 +98,35 @@ export class FakeWindow {
       },
     });
 
+    /** @private {!Array<string>} */
+    this.cookie_ = [];
+    Object.defineProperty(this.document, 'cookie', {
+      get: () => {
+        let cookie = [];
+        for (let i = 0; i < this.cookie_.length; i += 2) {
+          cookie.push(`${this.cookie_[i]}=${this.cookie_[i + 1]}`);
+        }
+        return cookie.join(';');
+      },
+      set: value => {
+        const semi = value.indexOf(';');
+        const cookie = value.match(/^([^=]*)=([^;]*)/);
+        const expiresMatch = value.match(/expires=([^;]*)(;|$)/);
+        const expires = expiresMatch ? Date.parse(expiresMatch[1]) : Infinity;
+        let i = 0;
+        for (; i < this.cookie_.length; i += 2) {
+          if (this.cookie_[i] == cookie[1]) {
+            break;
+          }
+        }
+        if (Date.now() >= expires) {
+          this.cookie_.splice(i, 2);
+        } else {
+          this.cookie_.splice(i, 2, cookie[1], cookie[2]);
+        }
+      }
+    });
+
     // Create element to enhance test elements.
     const nativeDocumentCreate = this.document.createElement;
     /** @this {HTMLDocument} */


### PR DESCRIPTION
Needed for me to complete #8108.

Do we have tests for our testing infrastructure? If not, test with:

```js
document.cookie = 'test=value';
document.cookie; // => 'test=value'

document.cookie = 'test2=value2';
document.cookie; // => 'test=value;test2=value2'

document.cookie = 'test=value3';
document.cookie; // => 'test=value3;test2=value2'

document.cookie = 'test2=value4';
document.cookie; // => 'test=value3;test2=value4'

document.cookie = 'test2=value5;expires=' new Date(0).toUTCString();
document.cookie; // => 'test=value3'

document.cookie = 'test=value6';
document.cookie; // => 'test=value6'

document.cookie = 'test3=value7'
document.cookie; // => 'test=value3;test3=value7'

document.cookie = 'test=value8;expires=' new Date(0).toUTCString();
document.cookie; // => 'test3=value7'

document.cookie = 'test3=value8;expires=' new Date(0).toUTCString();
document.cookie; // => ''
