### PR TITLE
Docs: Update availability text to stable for amp-izlesene

### DIFF
--- a/extensions/amp-izlesene/amp-izlesene.md
+++ b/extensions/amp-izlesene/amp-izlesene.md
@@ -23,7 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>Coming Soon; Available on <a href="https://www.ampproject.org/docs/reference/experimental#opt-into-the-amp-dev-channel">Dev Channel</a></td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>


### PR DESCRIPTION
Change availability to "Stable" now that amp-izlesene is included in validator.



