### PR TITLE
Configure validator.ampproject.org to not set cookie on ampproject.org

### DIFF
--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -47,7 +47,7 @@ if (location.href.match(/^https:\/\/validator.ampproject.org\/.*/)) {
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-79737099-1', 'auto');
+  ga('create', 'UA-79737099-1', 'none');
   ga('send', 'pageview');
 }
 </script>


### PR DESCRIPTION
This was by accident, sorry.

Looks like this is the way to set the cookie domain to none, as opposed to
auto which is probablly what's setting it to ampproject.org.

https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#cookieDomain