### PR TITLE
amp-bind: Use binary in test fixture

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -49,6 +49,7 @@ export class AmpState extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    // Allow integration test to access this class in testing mode.
     if (!getMode().test) {
       user().assert(isExperimentOn(this.win, 'amp-bind'),
           `Experiment "amp-bind" is disabled.`);

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -15,6 +15,7 @@
  */
 
 import {bindForDoc} from '../../../src/bind';
+import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
 import {isJsonScriptTag} from '../../../src/dom';
 import {toggle} from '../../../src/style';
@@ -48,8 +49,10 @@ export class AmpState extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    user().assert(isExperimentOn(this.win, 'amp-bind'),
-        `Experiment "amp-bind" is disabled.`);
+    if (!getMode().test) {
+      user().assert(isExperimentOn(this.win, 'amp-bind'),
+          `Experiment "amp-bind" is disabled.`);
+    }
 
     const TAG = this.getName_();
 

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -50,10 +50,8 @@ export class AmpState extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     // Allow integration test to access this class in testing mode.
-    if (!getMode().test) {
-      user().assert(isExperimentOn(this.win, 'amp-bind'),
-          `Experiment "amp-bind" is disabled.`);
-    }
+    user().assert(getMode().test || isExperimentOn(this.win, 'amp-bind'),
+        `Experiment "amp-bind" is disabled.`);
 
     const TAG = this.getName_();
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -68,6 +68,7 @@ export class Bind {
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
+    // Allow integration test to access this class in testing mode.
     /** @const @private {boolean} */
     this.enabled_ = getMode().test || isExperimentOn(ampdoc.win, TAG);
     user().assert(this.enabled_, `Experiment "${TAG}" is disabled.`);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -146,6 +146,8 @@ export class Bind {
       this.setStatePromise_ = this.initializePromise_.then(() => {
         user().fine(TAG, 'State updated; re-evaluating expressions...');
         return this.digest_();
+      }).then(() => {
+        this.dispatchEventForTesting_('amp:bind:setState');
       });
       return this.setStatePromise_;
     } else {
@@ -191,7 +193,9 @@ export class Bind {
    */
   initialize_() {
     dev().fine(TAG, 'Scanning DOM for bindings...');
-    return this.addBindingsForNode_(this.ampdoc.getBody());
+    return this.addBindingsForNode_(this.ampdoc.getBody()).then(() => {
+      this.dispatchEventForTesting_('amp:bind:initialize');
+    });
   }
 
   /**
@@ -808,7 +812,6 @@ export class Bind {
     return this.initializePromise_;
   }
 
-
   /**
    * Wait for bindings to evaluate and apply for testing. Should
    * be called once for each event that changes bindings.
@@ -838,4 +841,13 @@ export class Bind {
     });
   }
 
+  /**
+   * @param {string} name
+   * @private
+   */
+  dispatchEventForTesting_(name) {
+    if (getMode().test) {
+      this.win_.dispatchEvent(new Event(name));
+    }
+  }
 }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -147,9 +147,12 @@ export class Bind {
       this.setStatePromise_ = this.initializePromise_.then(() => {
         user().fine(TAG, 'State updated; re-evaluating expressions...');
         return this.digest_();
-      }).then(() => {
-        this.dispatchEventForTesting_('amp:bind:setState');
       });
+      if (getMode().test) {
+        this.setStatePromise_.then(() => {
+          this.dispatchEventForTesting_('amp:bind:setState');
+        });
+      }
       return this.setStatePromise_;
     } else {
       return Promise.resolve();
@@ -194,9 +197,13 @@ export class Bind {
    */
   initialize_() {
     dev().fine(TAG, 'Scanning DOM for bindings...');
-    return this.addBindingsForNode_(this.ampdoc.getBody()).then(() => {
-      this.dispatchEventForTesting_('amp:bind:initialize');
-    });
+    const promise = this.addBindingsForNode_(this.ampdoc.getBody());
+    if (getMode().test) {
+      promise.then(() => {
+        this.dispatchEventForTesting_('amp:bind:initialize');
+      });
+    }
+    return promise;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -66,14 +66,10 @@ let BoundElementDef;
 export class Bind {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   * @param {Object=} opt_mode
    */
-  constructor(ampdoc, opt_mode) {
-    /** @private {!Object} */
-    this.mode_ = opt_mode || getMode(ampdoc.win);
-
+  constructor(ampdoc) {
     /** @const @private {boolean} */
-    this.enabled_ = this.mode_.test || isExperimentOn(ampdoc.win, TAG);
+    this.enabled_ = getMode().test || isExperimentOn(ampdoc.win, TAG);
     user().assert(this.enabled_, `Experiment "${TAG}" is disabled.`);
 
     /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
@@ -128,7 +124,7 @@ export class Bind {
     this.setStatePromise_ = null;
 
     // Expose for testing on dev.
-    if (this.mode_.localDev) {
+    if (getMode().localDev) {
       AMP.reinitializeBind = this.initialize_.bind(this);
     }
   }
@@ -243,7 +239,7 @@ export class Bind {
           `${Object.keys(parseErrors).length} errors.`);
 
       // Trigger verify-only digest in development.
-      if (this.mode_.development) {
+      if (getMode().development) {
         this.digest_(/* opt_verifyOnly */ true);
       }
     });
@@ -725,7 +721,7 @@ export class Bind {
       }).then(() => {
         return this.digest_();
       });
-      if (this.mode_.test) {
+      if (getMode().test) {
         this.mutationPromises_.push(mutationPromise);
       }
     });
@@ -822,14 +818,6 @@ export class Bind {
    */
   setStatePromiseForTesting() {
     return this.setStatePromise_;
-  }
-
-  /**
-   * @param {!Object} mode
-   * @visibleForTesting
-   */
-  setModeForTesting(mode) {
-    this.mode_ = mode;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -18,7 +18,6 @@ import {BindExpressionResultDef} from './bind-expression';
 import {BindingDef, BindEvaluator} from './bind-evaluator';
 import {chunk, ChunkPriority} from '../../../src/chunk';
 import {dev, user} from '../../../src/log';
-import {fromClassForDoc} from '../../../src/service';
 import {getMode} from '../../../src/mode';
 import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
@@ -70,7 +69,7 @@ export class Bind {
    * @param {Object=} opt_mode
    */
   constructor(ampdoc, opt_mode) {
-    /** @const @private {!Object} */
+    /** @private {!Object} */
     this.mode_ = opt_mode || getMode(ampdoc.win);
 
     /** @const @private {boolean} */

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -41,7 +41,7 @@ describes.realWin('amp-bind', {
     // Make sure we have a chunk instance for testing.
     chunkInstanceForTesting(env.ampdoc);
 
-    bind = new Bind(env.ampdoc);
+    bind = new Bind(env.ampdoc, {test: true});
   });
 
   afterEach(() => {
@@ -115,7 +115,7 @@ describes.realWin('amp-bind', {
   it('should throw error if experiment is not enabled', () => {
     toggleExperiment(env.win, 'amp-bind', false);
     expect(() => {
-      new Bind(env.ampdoc);
+      new Bind(env.ampdoc, {test: false});
     }).to.throw('Experiment "amp-bind" is disabled.');
   });
 
@@ -192,7 +192,7 @@ describes.realWin('amp-bind', {
   });
 
   it('should verify string attribute bindings in dev mode', () => {
-    env.sandbox.stub(window, 'AMP_MODE', {development: true});
+    bind.setModeForTesting({development: true});
     // Only the initial value for [a] binding does not match.
     createElementWithBinding('[a]="a" [b]="b" b="b"');
     const errorStub = env.sandbox.stub(user(), 'createError');
@@ -202,7 +202,7 @@ describes.realWin('amp-bind', {
   });
 
   it('should verify boolean attribute bindings in dev mode', () => {
-    env.sandbox.stub(window, 'AMP_MODE', {development: true});
+    bind.setModeForTesting({development: true});
     // Only the initial value for [c] binding does not match.
     createElementWithBinding(`a [a]="true" [b]="false" c="false" [c]="false"`);
     const errorStub = env.sandbox.stub(user(), 'createError');

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -18,7 +18,6 @@ import {Bind} from '../bind-impl';
 import {BindExpression} from '../bind-expression';
 import {BindValidator} from '../bind-validator';
 import {chunkInstanceForTesting} from '../../../../src/chunk';
-import {getMode} from '../../../../src/mode';
 import {toArray} from '../../../../src/types';
 import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
@@ -116,7 +115,7 @@ describes.realWin('amp-bind', {
   it('should throw error if experiment is not enabled', () => {
     toggleExperiment(env.win, 'amp-bind', false);
     // Experiment check is bypassed on test mode -- make sure it isn't.
-    env.sandbox.stub(getMode(), 'test', false);
+    window.AMP_MODE = {test: false};
     expect(() => {
       new Bind(env.ampdoc);
     }).to.throw('Experiment "amp-bind" is disabled.');
@@ -195,7 +194,7 @@ describes.realWin('amp-bind', {
   });
 
   it('should verify string attribute bindings in dev mode', () => {
-    env.sandbox.stub(getMode(), 'development', true);
+    window.AMP_MODE = {development: true};
     // Only the initial value for [a] binding does not match.
     createElementWithBinding('[a]="a" [b]="b" b="b"');
     const errorStub = env.sandbox.stub(user(), 'createError');
@@ -205,7 +204,7 @@ describes.realWin('amp-bind', {
   });
 
   it('should verify boolean attribute bindings in dev mode', () => {
-    env.sandbox.stub(getMode(), 'development', true);
+    window.AMP_MODE = {development: true};
     // Only the initial value for [c] binding does not match.
     createElementWithBinding(`a [a]="true" [b]="false" c="false" [c]="false"`);
     const errorStub = env.sandbox.stub(user(), 'createError');

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -115,6 +115,7 @@ describes.realWin('amp-bind', {
 
   it('should throw error if experiment is not enabled', () => {
     toggleExperiment(env.win, 'amp-bind', false);
+    // Experiment check is bypassed on test mode -- make sure it isn't.
     env.sandbox.stub(getMode(), 'test', false);
     expect(() => {
       new Bind(env.ampdoc);

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -18,6 +18,7 @@ import {Bind} from '../bind-impl';
 import {BindExpression} from '../bind-expression';
 import {BindValidator} from '../bind-validator';
 import {chunkInstanceForTesting} from '../../../../src/chunk';
+import {getMode} from '../../../../src/mode';
 import {toArray} from '../../../../src/types';
 import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
@@ -41,7 +42,7 @@ describes.realWin('amp-bind', {
     // Make sure we have a chunk instance for testing.
     chunkInstanceForTesting(env.ampdoc);
 
-    bind = new Bind(env.ampdoc, {test: true});
+    bind = new Bind(env.ampdoc);
   });
 
   afterEach(() => {
@@ -114,8 +115,9 @@ describes.realWin('amp-bind', {
 
   it('should throw error if experiment is not enabled', () => {
     toggleExperiment(env.win, 'amp-bind', false);
+    env.sandbox.stub(getMode(), 'test', false);
     expect(() => {
-      new Bind(env.ampdoc, {test: false});
+      new Bind(env.ampdoc);
     }).to.throw('Experiment "amp-bind" is disabled.');
   });
 
@@ -192,7 +194,7 @@ describes.realWin('amp-bind', {
   });
 
   it('should verify string attribute bindings in dev mode', () => {
-    bind.setModeForTesting({development: true});
+    env.sandbox.stub(getMode(), 'development', true);
     // Only the initial value for [a] binding does not match.
     createElementWithBinding('[a]="a" [b]="b" b="b"');
     const errorStub = env.sandbox.stub(user(), 'createError');
@@ -202,7 +204,7 @@ describes.realWin('amp-bind', {
   });
 
   it('should verify boolean attribute bindings in dev mode', () => {
-    bind.setModeForTesting({development: true});
+    env.sandbox.stub(getMode(), 'development', true);
     // Only the initial value for [c] binding does not match.
     createElementWithBinding(`a [a]="true" [b]="false" c="false" [c]="false"`);
     const errorStub = env.sandbox.stub(user(), 'createError');

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -15,16 +15,13 @@
  */
 
 import '../../../amp-carousel/0.1/amp-carousel';
-import {installBindForTesting} from '../bind-impl';
-import {toggleExperiment} from '../../../../src/experiments';
 import {createFixtureIframe} from '../../../../testing/iframe';
 import {bindForDoc} from '../../../../src/bind';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 
-describe.configure().retryOnSaucelabs().run('integration amp-bind', function() {
+describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   let fixture;
   let ampdoc;
-  let bind;
   const fixtureLocation = 'test/fixtures/amp-bind-integrations.html';
 
   this.timeout(5000);
@@ -32,25 +29,21 @@ describe.configure().retryOnSaucelabs().run('integration amp-bind', function() {
   beforeEach(() => {
     return createFixtureIframe(fixtureLocation).then(f => {
       fixture = f;
-      toggleExperiment(fixture, 'amp-bind', true, true);
       const numberOfExtensionElements = 4;
       return fixture.awaitEvent('amp:load:start', numberOfExtensionElements);
     }).then(() => {
       const ampdocService = ampdocServiceFor(fixture.win);
       ampdoc = ampdocService.getAmpDoc(fixture.doc);
-      // Bind is installed manually here to get around an issue
-      // toggling experiments on the fixture iframe.
-      bind = installBindForTesting(ampdoc);
+      return bindForDoc(ampdoc);
+    }).then(bind => {
       return bind.initializePromiseForTesting();
     });
   });
 
   function waitForBindApplication() {
     // Bind should be available, but need to wait for actions to resolve
-    // service promise for bind and call setState
-    return bindForDoc(ampdoc).then(() => {
-      return bind.setStatePromiseForTesting();
-    });
+    // service promise for bind and call setState.
+    return bindForDoc(ampdoc).then(bind => bind.setStatePromiseForTesting());
   }
 
   describe('text integration', () => {

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -16,19 +16,20 @@
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script src="/dist/amp.js"></script>
-  <script custom-element="amp-brightcove" src="/dist/v0/amp-brightcove-0.1.js"></script>
-  <script custom-element="amp-carousel" src="/dist/v0/amp-carousel-0.1.js"></script>
-  <script custom-element="amp-selector" src="/dist/v0/amp-selector-0.1.js"></script>
-  <script custom-element="amp-youtube" src="/dist/v0/amp-youtube-0.1.js"></script>
+  <script custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
+  <script custom-element="amp-brightcove" src="/dist/v0/amp-brightcove-0.1.max.js"></script>
+  <script custom-element="amp-carousel" src="/dist/v0/amp-carousel-0.1.max.js"></script>
+  <script custom-element="amp-selector" src="/dist/v0/amp-selector-0.1.max.js"></script>
+  <script custom-element="amp-youtube" src="/dist/v0/amp-youtube-0.1.max.js"></script>
 </head>
 
 <body>
-  <p>P TAG TEST</p>
+  <p>P TAG</p>
   <button on="tap:AMP.setState(boundText='hello world')" id="changeTextButton"></button>
   <button on="tap:AMP.setState(boundClass='new')" id="changeTextClassButton"></button>
   <p id="textElement" class="original" [class]="boundClass" [text]="boundText">unbound</p>
 
-  <p>CAROUSEL TEST</p>
+  <p>CAROUSEL</p>
   <button on="tap:AMP.setState(selectedSlide=1)" id="goToSlide1Button">slide 1!</button>
   <p id="slideNum" [text]="selectedSlide">0</p>
   <amp-carousel width="300" height="100" type="slides"  id="carousel" on="slideChange:AMP.setState(selectedSlide=event.index)" [slide]="selectedSlide">
@@ -37,7 +38,7 @@
     <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
   </amp-carousel>
 
-  <p>AMP-IMG TEST</p>
+  <p>AMP-IMG</p>
   <button on="tap:AMP.setState(imageSrc='http://www.google.com/image2')" id="changeImgSrcButton"></button>
   <button on="tap:AMP.setState(imageSrc='?__amp_source_origin')" id="invalidSrcButton"></button>
   <button on="tap:AMP.setState(imageSrc='ftp://foo:bar@192.168.1.1/lol.jpg')" id="ftpSrcButton"></button>
@@ -52,7 +53,7 @@
     height="200" [height]="imageHeight"
     layout="responsive"></amp-img>
 
-  <p> AMP-SELECTOR TEST</p>
+  <p>AMP-SELECTOR</p>
   <button on="tap:AMP.setState(selected=2)" id="changeSelectionButton">Change selection to 2!</button>
   <p id=selectionText [text]="selected">None</p>
   <amp-selector layout="container" [selected]="selected" on="select:AMP.setState(selected=event.targetOption)">
@@ -61,7 +62,7 @@
     <amp-img src="/image2.jpg" width="60" height="40" option="3" id="selectorImg3"></amp-img>
   </amp-selector>
 
-  <p> AMP-VIDEO TEST</p>
+  <p>AMP-VIDEO</p>
   <button on="tap:AMP.setState(videoSrc='https://www.google.com/bound.webm')" id="changeVidSrcButton"></button>
   <button on="tap:AMP.setState(videoSrc='http://www.google.com/justhttp.ogg')" id="httpVidSrcButton"></button>
   <button on="tap:AMP.setState(videoSrc='?__amp_source_origin')" id="disallowedVidUrlButton"></button>
@@ -69,17 +70,11 @@
   <button on="tap:AMP.setState(videoWidth=300, videoHeight=300)" id="changeVidDimensButton"></button>
   <button on="tap:AMP.setState(videoControls=true)" id="showVidControlsButton"></button>
   <button on="tap:AMP.setState(videoControls=false)" id="hideVidControlsButton"></button>
-  <amp-video
-    layout="responsive"
-    id="video"
-    src="https://www.google.com/unbound.webm"
-    [src]="videoSrc"
-    alt="unbound"
-    [alt]="videoAlt"
-    width="200"
-    [width]="videoWidth"
-    height="200"
-    [height]="videoHeight"
+  <amp-video layout="responsive" id="video"
+    src="https://www.google.com/unbound.webm" [src]="videoSrc"
+    alt="unbound" [alt]="videoAlt"
+    width="200" [width]="videoWidth"
+    height="200" [height]="videoHeight"
     [controls]="videoControls">
   </amp-video>
 


### PR DESCRIPTION
Partial for #8159.

- Use `amp-bind` binary in test fixture so integration test can be run against production code.

Aside: I noticed that each `it` in the unit test reload the test fixture. We should consolidate tests to make it run faster.

/to @kmh287 
