### PR TITLE
move #updateSize function to uiHandler

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -230,18 +230,18 @@ export class AmpAdUIHandler {
     };
 
     if (!newHeight && !newWidth) {
-      return Promise.reject(sizes);
+      return Promise.resolve(sizes);
     }
 
     if (getAdContainer(this.element_) == 'AMP-STICKY-AD') {
       // Special case: force collapse sticky-ad if no content.
-      return Promise.reject(sizes);
+      return Promise.reject(Error('Cannot resize ad in AMP-STICKY-AD'));
     }
     return this.baseInstance_.attemptChangeSize(
         newHeight, newWidth).then(() => {
           return Promise.resolve(sizes);
         }, () => {
-          return Promise.reject(sizes);
+          return Promise.reject();
         });
   }
 }

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -232,7 +232,7 @@ export class AmpAdUIHandler {
     };
 
     if (!newHeight && !newWidth) {
-      return Promise.reject('undefined width and height');
+      return Promise.reject(new Error('undefined width and height'));
     }
 
     if (getAdContainer(this.element_) == 'AMP-STICKY-AD') {

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -207,7 +207,7 @@ export class AmpAdUIHandler {
    * @param {number|string|undefined} width
    * @param {number} iframeHeight
    * @param {number} iframeWidth
-   * @return {!Promise<Object>}
+   * @return {!Promise<!Object>}
    */
   updateSize(height, width, iframeHeight, iframeWidth) {
     // Calculate new width and height of the container to include the padding.
@@ -224,24 +224,28 @@ export class AmpAdUIHandler {
           width - iframeWidth, width);
     }
 
-    const sizes = {
+    /** @type {!Object<!boolean, number|undefined, number|undefined>} */
+    const resizeInfo = {
+      success: true,
       newWidth,
       newHeight,
     };
 
     if (!newHeight && !newWidth) {
-      return Promise.resolve(sizes);
+      return Promise.reject('undefined width and height');
     }
 
     if (getAdContainer(this.element_) == 'AMP-STICKY-AD') {
       // Special case: force collapse sticky-ad if no content.
-      return Promise.reject(Error('Cannot resize ad in AMP-STICKY-AD'));
+      resizeInfo.success = false;
+      return Promise.resolve(resizeInfo);
     }
     return this.baseInstance_.attemptChangeSize(
         newHeight, newWidth).then(() => {
-          return Promise.resolve(sizes);
+          return resizeInfo;
         }, () => {
-          return Promise.reject();
+          resizeInfo.success = false;
+          return resizeInfo;
         });
   }
 }

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -58,6 +58,9 @@ export class AmpAdUIHandler {
     /** @private {!AMP.BaseElement} */
     this.baseInstance_ = baseInstance;
 
+    /** @private {!Element} */
+    this.element_ = baseInstance.element;
+
     /** @private @const {!Document} */
     this.doc_ = baseInstance.win.document;
 
@@ -142,7 +145,7 @@ export class AmpAdUIHandler {
    * @private
    */
   displayNoContentUI_() {
-    if (getAdContainer(this.baseInstance_.element) == 'AMP-STICKY-AD') {
+    if (getAdContainer(this.element_) == 'AMP-STICKY-AD') {
       // Special case: force collapse sticky-ad if no content.
       this.baseInstance_./*OK*/collapse();
       this.state = AdDisplayState.LOADED_NO_CONTENT;
@@ -197,6 +200,49 @@ export class AmpAdUIHandler {
 
     this.baseInstance_.element.appendChild(uiComponent);
     return uiComponent;
+  }
+
+  /**
+   * @param {number|string|undefined} height
+   * @param {number|string|undefined} width
+   * @param {number} iframeHeight
+   * @param {number} iframeWidth
+   * @return {!Promise<Object>}
+   */
+  updateSize(height, width, iframeHeight, iframeWidth) {
+    // Calculate new width and height of the container to include the padding.
+    // If padding is negative, just use the requested width and height directly.
+    let newHeight, newWidth;
+    height = parseInt(height, 10);
+    if (!isNaN(height)) {
+      newHeight = Math.max(this.element_./*OK*/offsetHeight +
+          height - iframeHeight, height);
+    }
+    width = parseInt(width, 10);
+    if (!isNaN(width)) {
+      newWidth = Math.max(this.element_./*OK*/offsetWidth +
+          width - iframeWidth, width);
+    }
+
+    const sizes = {
+      newWidth,
+      newHeight,
+    };
+
+    if (!newHeight && !newWidth) {
+      return Promise.reject(sizes);
+    }
+
+    if (getAdContainer(this.element_) == 'AMP-STICKY-AD') {
+      // Special case: force collapse sticky-ad if no content.
+      return Promise.reject(sizes);
+    }
+    return this.baseInstance_.attemptChangeSize(
+        newHeight, newWidth).then(() => {
+          return Promise.resolve(sizes);
+        }, () => {
+          return Promise.reject(sizes);
+        });
   }
 }
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -301,18 +301,14 @@ export class AmpAdXOriginIframeHandler {
    * @private
    */
   handleResize_(height, width, source, origin) {
-    this.baseInstance_.vsyn(() => {
-      this.uiHandler_.updateSize(height, width, this.iframe./*OK*/offsetHeight,
-        this.iframe./*OK*/offsetWidth).then(sizes => {
-          if (sizes.newWidth === undefined && sizes.newHeight === undefined) {
-            return;
-          }
-          this.sendEmbedSizeResponse_(true /* success */,
-              sizes.newWidth, sizes.newHeight, source, origin);
-        }, sizes => {
-          this.sendEmbedSizeResponse_(false /* success */,
-              sizes.newWidth, sizes.newHeight, source, origin);
-        });
+    this.baseInstance_.getVsync().mutate(() => {
+      const iframeHeight = this.iframe./*OK*/offsetHeight;
+      const iframeWidth = this.iframe./*OK*/offsetWidth;
+      this.uiHandler_.updateSize(height, width, iframeHeight,
+        iframeWidth).then(info => {
+          this.sendEmbedSizeResponse_(info.success,
+              info.newWidth, info.newHeight, source, origin);
+        }, () => {});
     });
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -118,7 +118,7 @@ export class AmpAdXOriginIframeHandler {
     // Install iframe resize API.
     this.unlisteners_.push(listenFor(this.iframe, 'embed-size',
         (data, source, origin) => {
-          this.updateSize_(data.height, data.width, source, origin);
+          this.handleResize_(data.height, data.width, source, origin);
         }, true, true));
 
     this.unlisteners_.push(this.viewer_.onVisibilityChanged(() => {
@@ -235,7 +235,8 @@ export class AmpAdXOriginIframeHandler {
       return;
     }
     const data = opt_info.data;
-    this.updateSize_(data.height, data.width, opt_info.source, opt_info.origin);
+    this.handleResize_(
+        data.height, data.width, opt_info.source, opt_info.origin);
     if (this.baseInstance_.emitLifecycleEvent) {
       this.baseInstance_.emitLifecycleEvent('renderCrossDomainStart');
     }
@@ -299,27 +300,18 @@ export class AmpAdXOriginIframeHandler {
    * @param {string} origin
    * @private
    */
-  updateSize_(height, width, source, origin) {
-    // Calculate new width and height of the container to include the padding.
-    // If padding is negative, just use the requested width and height directly.
-    let newHeight, newWidth;
-    height = parseInt(height, 10);
-    if (!isNaN(height)) {
-      newHeight = Math.max(this.element_./*OK*/offsetHeight +
-          height - this.iframe./*OK*/offsetHeight, height);
-    }
-    width = parseInt(width, 10);
-    if (!isNaN(width)) {
-      newWidth = Math.max(this.element_./*OK*/offsetWidth +
-          width - this.iframe./*OK*/offsetWidth, width);
-    }
-    if (newHeight !== undefined || newWidth !== undefined) {
-      this.baseInstance_.attemptChangeSize(newHeight, newWidth).then(() => {
-        this.sendEmbedSizeResponse_(
-          true /* success */, newWidth, newHeight, source, origin);
-      }, () => this.sendEmbedSizeResponse_(
-          false /* success */, newWidth, newHeight, source, origin));
-    }
+  handleResize_(height, width, source, origin) {
+    this.uiHandler_.updateSize(height, width, this.iframe./*OK*/offsetHeight,
+        this.iframe./*OK*/offsetWidth).then(sizes => {
+          this.sendEmbedSizeResponse_(true /* success */,
+              sizes.newWidth, sizes.newHeight, source, origin);
+        }, sizes => {
+          if (sizes.newWidth === undefined && sizes.newHeight === undefined) {
+            return;
+          }
+          this.sendEmbedSizeResponse_(false /* success */,
+              sizes.newWidth, sizes.newHeight, source, origin);
+        });
   }
 
   /**

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -301,17 +301,19 @@ export class AmpAdXOriginIframeHandler {
    * @private
    */
   handleResize_(height, width, source, origin) {
-    this.uiHandler_.updateSize(height, width, this.iframe./*OK*/offsetHeight,
+    this.baseInstance_.vsyn(() => {
+      this.uiHandler_.updateSize(height, width, this.iframe./*OK*/offsetHeight,
         this.iframe./*OK*/offsetWidth).then(sizes => {
-          this.sendEmbedSizeResponse_(true /* success */,
-              sizes.newWidth, sizes.newHeight, source, origin);
-        }, sizes => {
           if (sizes.newWidth === undefined && sizes.newHeight === undefined) {
             return;
           }
+          this.sendEmbedSizeResponse_(true /* success */,
+              sizes.newWidth, sizes.newHeight, source, origin);
+        }, sizes => {
           this.sendEmbedSizeResponse_(false /* success */,
               sizes.newWidth, sizes.newHeight, source, origin);
         });
+    });
   }
 
   /**

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -151,6 +151,7 @@ describes.realWin('amp-ad-ui handler', {
         });
         return uiHandler.updateSize(100, 400, 50, 300).then(sizes => {
           expect(sizes).to.deep.equal({
+            success: true,
             newWidth: 450,
             newHeight: 100,
           });
@@ -165,6 +166,7 @@ describes.realWin('amp-ad-ui handler', {
         });
         return uiHandler.updateSize('100', 400, 0, 0).then(sizes => {
           expect(sizes).to.deep.equal({
+            success: true,
             newWidth: 400,
             newHeight: 100,
           });
@@ -173,11 +175,8 @@ describes.realWin('amp-ad-ui handler', {
 
       it('should reject on special case undefined sizes', () => {
         const attemptChangeSizeSpy = sandbox.spy(adImpl, 'attemptChangeSize');
-        return uiHandler.updateSize(undefined, undefined, 0, 0).catch(sizes => {
-          expect(sizes).to.deep.equal({
-            newWidth: undefined,
-            newHeight: undefined,
-          });
+        return uiHandler.updateSize(undefined, undefined, 0, 0).catch(e => {
+          expect(e).to.equal('undefined width and height');
           expect(attemptChangeSizeSpy).to.not.be.called;
         });
       });
@@ -185,8 +184,9 @@ describes.realWin('amp-ad-ui handler', {
       it('should reject on special case inside sticky ad', () => {
         adContainer = 'AMP-STICKY-AD';
         const attemptChangeSizeSpy = sandbox.spy(adImpl, 'attemptChangeSize');
-        return uiHandler.updateSize(100, 400, 0, 0).catch(sizes => {
+        return uiHandler.updateSize(100, 400, 0, 0).then(sizes => {
           expect(sizes).to.deep.equal({
+            success: false,
             newWidth: 400,
             newHeight: 100,
           });
@@ -198,8 +198,9 @@ describes.realWin('amp-ad-ui handler', {
         sandbox.stub(adImpl, 'attemptChangeSize', () => {
           return Promise.reject();
         });
-        return uiHandler.updateSize(100, 400, 0, 0).catch(sizes => {
+        return uiHandler.updateSize(100, 400, 0, 0).then(sizes => {
           expect(sizes).to.deep.equal({
+            success: false,
             newWidth: 400,
             newHeight: 100,
           });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -176,7 +176,7 @@ describes.realWin('amp-ad-ui handler', {
       it('should reject on special case undefined sizes', () => {
         const attemptChangeSizeSpy = sandbox.spy(adImpl, 'attemptChangeSize');
         return uiHandler.updateSize(undefined, undefined, 0, 0).catch(e => {
-          expect(e).to.equal('undefined width and height');
+          expect(e.message).to.equal('undefined width and height');
           expect(attemptChangeSizeSpy).to.not.be.called;
         });
       });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {setStyles} from '../../../../src/style';
 import {AdDisplayState, AmpAdUIHandler} from '../amp-ad-ui';
 import {BaseElement} from '../../../../src/base-element';
 import * as adHelper from '../../../../src/ad-helper';
@@ -27,10 +28,11 @@ describes.realWin('amp-ad-ui handler', {
   let adImpl;
   let uiHandler;
   let adContainer;
+  let adElement;
 
   beforeEach(() => {
     sandbox = env.sandbox;
-    const adElement = env.win.document.createElement('amp-ad');
+    adElement = env.win.document.createElement('amp-ad');
     adImpl = new BaseElement(adElement);
     uiHandler = new AmpAdUIHandler(adImpl);
     uiHandler.setDisplayState(AdDisplayState.LOADING);
@@ -132,6 +134,76 @@ describes.realWin('amp-ad-ui handler', {
       return promise.then(() => {
         expect(fallbackSpy).to.not.be.called;
         expect(uiHandler.state).to.equal(AdDisplayState.NOT_LAID_OUT);
+      });
+    });
+
+    describe('updateSize function', () => {
+      it('should calculate take consideration of padding', () => {
+        setStyles(adImpl.element, {
+          width: '350px',
+          height: '50px',
+        });
+        env.win.document.body.appendChild(adElement);
+        sandbox.stub(adImpl, 'attemptChangeSize', (height, width) => {
+          expect(height).to.equal(100);
+          expect(width).to.equal(450);
+          return Promise.resolve();
+        });
+        return uiHandler.updateSize(100, 400, 50, 300).then(sizes => {
+          expect(sizes).to.deep.equal({
+            newWidth: 450,
+            newHeight: 100,
+          });
+        });
+      });
+
+      it('should tolerate string input', () => {
+        sandbox.stub(adImpl, 'attemptChangeSize', (height, width) => {
+          expect(height).to.equal(100);
+          expect(width).to.equal(400);
+          return Promise.resolve();
+        });
+        return uiHandler.updateSize('100', 400, 0, 0).then(sizes => {
+          expect(sizes).to.deep.equal({
+            newWidth: 400,
+            newHeight: 100,
+          });
+        });
+      });
+
+      it('should reject on special case undefined sizes', () => {
+        const attemptChangeSizeSpy = sandbox.spy(adImpl, 'attemptChangeSize');
+        return uiHandler.updateSize(undefined, undefined, 0, 0).catch(sizes => {
+          expect(sizes).to.deep.equal({
+            newWidth: undefined,
+            newHeight: undefined,
+          });
+          expect(attemptChangeSizeSpy).to.not.be.called;
+        });
+      });
+
+      it('should reject on special case inside sticky ad', () => {
+        adContainer = 'AMP-STICKY-AD';
+        const attemptChangeSizeSpy = sandbox.spy(adImpl, 'attemptChangeSize');
+        return uiHandler.updateSize(100, 400, 0, 0).catch(sizes => {
+          expect(sizes).to.deep.equal({
+            newWidth: 400,
+            newHeight: 100,
+          });
+          expect(attemptChangeSizeSpy).to.not.be.called;
+        });
+      });
+
+      it('should reject on attemptChangeSize reject', () => {
+        sandbox.stub(adImpl, 'attemptChangeSize', () => {
+          return Promise.reject();
+        });
+        return uiHandler.updateSize(100, 400, 0, 0).catch(sizes => {
+          expect(sizes).to.deep.equal({
+            newWidth: 400,
+            newHeight: 100,
+          });
+        });
       });
     });
   });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -79,10 +79,11 @@ describe('amp-ad-xorigin-iframe-handler', () => {
 
       beforeEach(() => {
         adImpl.config = {renderStartImplemented: true};
-        sandbox.stub(adImpl, 'attemptChangeSize', (height, width) => {
-          expect(height).to.equal(217);
-          expect(width).to.equal(114);
-          return Promise.resolve();
+        sandbox.stub(adImpl.uiHandler, 'updateSize', () => {
+          return Promise.resolve({
+            newWidth: 114,
+            newHeight: 217,
+          });
         });
         noContentSpy =
             sandbox.spy/*OK*/(iframeHandler, 'freeXOriginIframe');
@@ -270,10 +271,11 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should be able to use embed-size API, change size deny', () => {
-      sandbox.stub(adImpl, 'attemptChangeSize', (height, width) => {
-        expect(height).to.equal(217);
-        expect(width).to.equal(114);
-        return Promise.reject(new Error('for testing'));
+      sandbox.stub(adImpl.uiHandler, 'updateSize', () => {
+        return Promise.reject({
+          newWidth: 114,
+          newHeight: 217,
+        });
       });
       iframe.postMessageToParent({
         width: 114,
@@ -290,10 +292,11 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should be able to use embed-size API, change size succeed', () => {
-      sandbox.stub(adImpl, 'attemptChangeSize', (height, width) => {
-        expect(height).to.equal(217);
-        expect(width).to.equal(114);
-        return Promise.resolve();
+      sandbox.stub(adImpl.uiHandler, 'updateSize', () => {
+        return Promise.resolve({
+          newWidth: 114,
+          newHeight: 217,
+        });
       });
       iframe.postMessageToParent({
         width: 114,
@@ -310,10 +313,11 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should be able to use embed-size API to resize height only', () => {
-      sandbox.stub(adImpl, 'attemptChangeSize', (height, width) => {
-        expect(height).to.equal(217);
-        expect(width).to.be.undefined;
-        return Promise.resolve();
+      sandbox.stub(adImpl.uiHandler, 'updateSize', () => {
+        return Promise.resolve({
+          newWidth: undefined,
+          newHeight: 217,
+        });
       });
       iframe.postMessageToParent({
         height: 217,

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -81,6 +81,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         adImpl.config = {renderStartImplemented: true};
         sandbox.stub(adImpl.uiHandler, 'updateSize', () => {
           return Promise.resolve({
+            success: true,
             newWidth: 114,
             newHeight: 217,
           });
@@ -272,7 +273,8 @@ describe('amp-ad-xorigin-iframe-handler', () => {
 
     it('should be able to use embed-size API, change size deny', () => {
       sandbox.stub(adImpl.uiHandler, 'updateSize', () => {
-        return Promise.reject({
+        return Promise.resolve({
+          success: false,
           newWidth: 114,
           newHeight: 217,
         });
@@ -294,6 +296,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     it('should be able to use embed-size API, change size succeed', () => {
       sandbox.stub(adImpl.uiHandler, 'updateSize', () => {
         return Promise.resolve({
+          success: true,
           newWidth: 114,
           newHeight: 217,
         });
@@ -315,6 +318,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     it('should be able to use embed-size API to resize height only', () => {
       sandbox.stub(adImpl.uiHandler, 'updateSize', () => {
         return Promise.resolve({
+          success: true,
           newWidth: undefined,
           newHeight: 217,
         });


### PR DESCRIPTION
This PR does two things:
Refactor the `#updateSize` method of `AmpAdXoriginIframeHandler` to `AmpAdUIHandler`.
Add restriction to the `#updateSize` method, so that an ad placed in sticky-ad never gets resized.
