### PR TITLE
Move scheduling for font-stylesheet timeout to earlier in the process.

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -67,12 +67,12 @@ startupChunk(self.document, function initial() {
   const ampdoc = ampdocService.getAmpDoc(self.document);
   /** @const {!./service/performance-impl.Performance} */
   const perf = installPerformanceService(self);
+  fontStylesheetTimeout(self);
   perf.tick('is');
   installStyles(self.document, cssText, () => {
     startupChunk(self.document, function services() {
       // Core services.
       installRuntimeServices(self);
-      fontStylesheetTimeout(self);
       installAmpdocServices(ampdoc);
       // We need the core services (viewer/resources) to start instrumenting
       perf.coreServicesAvailable();

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -50,7 +50,7 @@ export function fontStylesheetTimeout(win) {
 
   timerFor(win).delay(() => {
     // We waited for the timeout period. There is no way to check whether
-    // the stylesheets actually loaded. For that reason we check whether
+    // the stylesheet actually loaded. For that reason we check whether
     // the document is ready instead. The link tags block the readiness
     // and they are the only external resource that does, so if the doc
     // isn't ready yet it is probably the stylesheet's fault.
@@ -78,9 +78,9 @@ export function fontStylesheetTimeout(win) {
       // Insert the stylesheet. We do it right before the existing one,
       // so that
       // - we pick up its HTTP request.
-      // - CSS evaluation order doen't change.
+      // - CSS evaluation order doesn't change.
       parent.insertBefore(newLink, existingLink);
-      // And remove the blocking stylsheet.
+      // And remove the blocking stylesheet.
       parent.removeChild(existingLink);
     }
   }, timeout);

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -15,7 +15,6 @@
  */
 
 import {isDocumentReady} from './document-ready';
-import {timerFor} from './timer';
 
 /**
  * While browsers put a timeout on font downloads (3s by default,
@@ -48,7 +47,8 @@ export function fontStylesheetTimeout(win) {
   }
   const timeout = Math.max(1, 1000 - timeSinceResponseStart);
 
-  timerFor(win).delay(() => {
+  // Avoid timer dependency since this runs very early in execution.
+  win.setTimeout(() => {
     // We waited for the timeout period. There is no way to check whether
     // the stylesheet actually loaded. For that reason we check whether
     // the document is ready instead. The link tags block the readiness


### PR DESCRIPTION
There is reason to believe that the link tag may sometimes block style installation, so we should install the timeout before installing our styles.