### PR TITLE
Put back form-var-* experiment flags until code is in prod

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,6 +8,8 @@
   "pan-y": 1,
   "a4aProfilingRate": 1,
   "amp-form-custom-validations": 1,
+  "amp-form-var-sub": 1,
+  "amp-form-var-sub-for-post": 1,
   "ad-type-custom": 1,
   "amp-scrollable-carousel": 1,
   "amp-inabox": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,6 +8,8 @@
   "expDoubleclickA4A": 0.1,
   "a4aProfilingRate": 1,
   "amp-form-custom-validations": 1,
+  "amp-form-var-sub": 1,
+  "amp-form-var-sub-for-post": 1,
   "ad-type-custom": 1,
   "amp-scrollable-carousel": 1,
   "amp-inabox": 1,


### PR DESCRIPTION
The code that does not rely on the experiment flag is not in prod yet, can't ship the config until it makes it to prod.