### PR TITLE
Fix an amp-instagram race condition

### DIFF
--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -175,7 +175,7 @@ class AmpInstagram extends AMP.BaseElement {
     if (data.type == 'MEASURE' && data.details) {
       const height = data.details.height;
       this.getVsync().measure(() => {
-        if (this.iframe_./*OK*/offsetHeight !== height) {
+        if (this.iframe_ && this.iframe_./*OK*/offsetHeight !== height) {
           // Height returned by Instagram includes header, so
           // subtract 48px top padding
           this.attemptChangeHeight(height - PADDING_TOP).catch(() => {});


### PR DESCRIPTION
Fixing a small race condition where vsync ran after component was unlayedout (setting `this.iframe_` to null)

