### PR TITLE
Remove meta name=amp-access-state tag.

### DIFF
--- a/extensions/amp-access-laterpay/0.1/test/validator-amp-access-laterpay.html
+++ b/extensions/amp-access-laterpay/0.1/test/validator-amp-access-laterpay.html
@@ -35,7 +35,6 @@
       "laterpay": {},
     }
   </script>
-  <meta name="amp-access-state" content="lemur">
 </head>
 <body>
 Hello, world.

--- a/extensions/amp-access/0.1/test/validator-amp-access.html
+++ b/extensions/amp-access/0.1/test/validator-amp-access.html
@@ -33,7 +33,6 @@
       "contents": "currently untested"
     }
   </script>
-  <meta name="amp-access-state" content="lemur">
 </head>
 <body>
 Hello, world.

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -420,25 +420,6 @@ tags: {
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/ads/amp-ad"
 }
-# AMP metadata, name=amp-access-state
-# https://www.ampproject.org/docs/reference/components/dynamic/amp-access
-tags: {
-  html_format: AMP
-  tag_name: "META"
-  spec_name: "meta name=amp-access-state"
-  mandatory_parent: "HEAD"
-  attrs: {
-    name: "name"
-    mandatory: true
-    value_casei: "amp-access-state"
-    dispatch_key: true
-  }
-  attrs: {
-    name: "content"
-    mandatory: true
-  }
-  spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/amp-access"
-}
 # AMP metadata, name=amp-link-variable-allowed-origin
 # https://github.com/ampproject/amphtml/issues/8132
 tags: {


### PR DESCRIPTION
This tag isn't used by amp-access, so remove it from the test files and validator.