### PR TITLE
amp-form: add 'amp-form-submit' analytics event

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -282,6 +282,8 @@ export class AmpForm {
   submit_() {
     let varSubsFields = [];
     const formData = {};
+    const formObject = this.getFormAsObject_();
+
     // Only allow variable substitutions for inputs if the form action origin
     // is the canonical origin.
     // TODO(mkhatib, #7168): Consider relaxing this.
@@ -294,9 +296,9 @@ export class AmpForm {
           'origin submit action: %s', this.form_);
     }
 
-    new FormData(this.form_).forEach((fieldValue, fieldName) => {
-      formData['formFields[' + fieldName + ']'] = fieldValue;
-    });
+    for (const k in formObject) {
+      formData['formFields[' + k + ']'] = formObject[k][0];
+    }
     formData['formId'] = this.form_.id;
 
     if (this.xhrAction_) {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -281,7 +281,7 @@ export class AmpForm {
    */
   submit_() {
     let varSubsFields = [];
-    let formData = {};
+    const formData = {};
     // Only allow variable substitutions for inputs if the form action origin
     // is the canonical origin.
     // TODO(mkhatib, #7168): Consider relaxing this.
@@ -294,9 +294,9 @@ export class AmpForm {
           'origin submit action: %s', this.form_);
     }
 
-    for (let p of new FormData(this.form_)) {
-      formData["formFields[" + p[0] + "]"] = p[1];
-    }
+    new FormData(this.form_).forEach((fieldValue, fieldName) => {
+      formData['formFields[' + fieldName + ']'] = fieldValue;
+    });
     formData['formId'] = this.form_.id;
 
     if (this.xhrAction_) {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -281,6 +281,7 @@ export class AmpForm {
    */
   submit_() {
     let varSubsFields = [];
+    let formData = {};
     // Only allow variable substitutions for inputs if the form action origin
     // is the canonical origin.
     // TODO(mkhatib, #7168): Consider relaxing this.
@@ -292,11 +293,19 @@ export class AmpForm {
       user().warn(TAG, 'Variable substitutions disabled for non-canonical ' +
           'origin submit action: %s', this.form_);
     }
+
+    for (let p of new FormData(this.form_)) {
+      formData["formFields[" + p[0] + "]"] = p[1];
+    }
+    formData['formId'] = this.form_.id;
+
     if (this.xhrAction_) {
+      this.analyticsEvent_('amp-form-submit', formData);
       this.handleXhrSubmit_(varSubsFields);
     } else if (this.method_ == 'POST') {
       this.handleNonXhrPost_();
     } else if (this.method_ == 'GET') {
+      this.analyticsEvent_('amp-form-submit', formData);
       this.handleNonXhrGet_(varSubsFields);
     }
   }

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -394,28 +394,35 @@ describes.realWin('amp-form', {
   });
 
   it('should trigger amp-form-submit analytics event with form data', () => {
-      return getAmpForm().then(ampForm => {
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
-          sandbox.stub(ampForm, 'analyticsEvent_');
-          const event = {
-              stopImmediatePropagation: sandbox.spy(),
-              target: ampForm.form_,
-              preventDefault: sandbox.spy(),
-          };
-          ampForm.handleSubmitEvent_(event);
-          expect(event.preventDefault).to.be.calledOnce;
-          expect(ampForm.analyticsEvent_).to.have.been.calledWith('amp-form-submit', {"formId": "", "formFields[name]": "John Miller"});
-          return timer.promise(1).then(() => {
-              expect(ampForm.xhr_.fetch).to.be.calledOnce;
-              expect(ampForm.xhr_.fetch).to.be.calledWith('https://example.com');
+    return getAmpForm().then(ampForm => {
+      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+      sandbox.stub(ampForm, 'analyticsEvent_');
+      const event = {
+        stopImmediatePropagation: sandbox.spy(),
+        target: ampForm.form_,
+        preventDefault: sandbox.spy(),
+      };
+      const expectedFormData = {
+        'formId': '',
+        'formFields[name]': 'John Miller',
+      };
+      ampForm.handleSubmitEvent_(event);
+      expect(event.preventDefault).to.be.calledOnce;
+      expect(ampForm.analyticsEvent_).to.be.calledWith(
+        'amp-form-submit',
+        expectedFormData
+      );
+      return timer.promise(1).then(() => {
+        expect(ampForm.xhr_.fetch).to.be.calledOnce;
+        expect(ampForm.xhr_.fetch).to.be.calledWith('https://example.com');
 
-              const xhrCall = ampForm.xhr_.fetch.getCall(0);
-              const config = xhrCall.args[1];
-              expect(config.body).to.not.be.null;
-              expect(config.method).to.equal('POST');
-              expect(config.credentials).to.equal('include');
-          });
+        const xhrCall = ampForm.xhr_.fetch.getCall(0);
+        const config = xhrCall.args[1];
+        expect(config.body).to.not.be.null;
+        expect(config.method).to.equal('POST');
+        expect(config.credentials).to.equal('include');
       });
+    });
   });
 
   it('should block multiple submissions and disable buttons', () => {
@@ -1412,7 +1419,7 @@ describes.realWin('amp-form', {
     it('should trigger amp-form-submit analytics event with form data', () => {
       return getAmpForm().then(ampForm => {
         const form = ampForm.form_;
-        form.id = "registration";
+        form.id = 'registration';
 
         const passwordInput = document.createElement('input');
         passwordInput.setAttribute('name', 'password');
@@ -1432,13 +1439,16 @@ describes.realWin('amp-form', {
         sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         sandbox.stub(ampForm, 'analyticsEvent_');
         ampForm.handleSubmitAction_();
-        let expectedFormData = {
-          "formId": "registration",
-          "formFields[name]": "John Miller",
-          "formFields[password]": "god"
+        const expectedFormData = {
+          'formId': 'registration',
+          'formFields[name]': 'John Miller',
+          'formFields[password]': 'god',
         };
         expect(form.submit).to.have.been.called;
-        expect(ampForm.analyticsEvent_).to.have.been.calledWith('amp-form-submit', expectedFormData);
+        expect(ampForm.analyticsEvent_).to.be.calledWith(
+          'amp-form-submit',
+          expectedFormData
+        );
       });
     });
   });

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -196,6 +196,27 @@ describes.realWin('amp-form', {
     document.body.removeChild(form);
   });
 
+  it('should not trigger amp-form-submit analytics event', () => {
+    const form = getForm();
+    document.body.appendChild(form);
+    form.removeAttribute('action-xhr');
+    document.body.appendChild(form);
+    const ampForm = new AmpForm(form);
+    const event = {
+      stopImmediatePropagation: sandbox.spy(),
+      target: form,
+      preventDefault: sandbox.spy(),
+    };
+    sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+    sandbox.stub(ampForm, 'analyticsEvent_');
+    sandbox.spy(form, 'checkValidity');
+    expect(() => ampForm.handleSubmitEvent_(event)).to.throw(
+        /Only XHR based \(via action-xhr attribute\) submissions are support/);
+    expect(event.preventDefault).to.be.called;
+    expect(ampForm.analyticsEvent_).to.have.not.been.called;
+    document.body.removeChild(form);
+  });
+
   it('should respect novalidate on a form', () => {
     setReportValiditySupportedForTesting(true);
     const form = getForm();

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -407,10 +407,6 @@ describes.realWin('amp-form', {
       };
       ampForm.handleSubmitEvent_(event);
       expect(event.preventDefault).to.be.calledOnce;
-      expect(ampForm.analyticsEvent_).to.be.calledWith(
-        'amp-form-submit',
-        expectedFormData
-      );
       return timer.promise(1).then(() => {
         expect(ampForm.xhr_.fetch).to.be.calledOnce;
         expect(ampForm.xhr_.fetch).to.be.calledWith('https://example.com');
@@ -420,6 +416,59 @@ describes.realWin('amp-form', {
         expect(config.body).to.not.be.null;
         expect(config.method).to.equal('POST');
         expect(config.credentials).to.equal('include');
+        expect(ampForm.analyticsEvent_).to.be.calledWith(
+            'amp-form-submit',
+            expectedFormData
+        );
+      });
+    });
+  });
+
+  it('should trigger amp-form-submit after variables substitution', () => {
+    return getAmpForm().then(ampForm => {
+      const form = ampForm.form_;
+      const clientIdField = document.createElement('input');
+      clientIdField.setAttribute('name', 'clientId');
+      clientIdField.setAttribute('type', 'hidden');
+      clientIdField.value = 'CLIENT_ID(form)';
+      clientIdField.setAttribute('data-amp-replace', 'CLIENT_ID');
+      form.appendChild(clientIdField);
+      const canonicalUrlField = document.createElement('input');
+      canonicalUrlField.setAttribute('name', 'canonicalUrl');
+      canonicalUrlField.setAttribute('type', 'hidden');
+      canonicalUrlField.value = 'CANONICAL_URL';
+      canonicalUrlField.setAttribute('data-amp-replace', 'CANONICAL_URL');
+      form.appendChild(canonicalUrlField);
+      sandbox.stub(form, 'checkValidity').returns(true);
+      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+      sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
+      sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
+      sandbox.stub(ampForm, 'analyticsEvent_');
+      ampForm.submit_();
+      const expectedFormData = {
+        'formId': '',
+        'formFields[name]': 'John Miller',
+        'formFields[clientId]': sinon.match(/amp-.+/),
+        'formFields[canonicalUrl]': 'https%3A%2F%2Fexample.com%2Famps.html',
+      };
+      expect(ampForm.xhr_.fetch).to.have.not.been.called;
+      expect(ampForm.urlReplacement_.expandInputValueSync)
+            .to.not.have.been.called;
+      expect(ampForm.urlReplacement_.expandInputValueAsync)
+            .to.have.been.calledTwice;
+      expect(ampForm.urlReplacement_.expandInputValueAsync)
+            .to.have.been.calledWith(clientIdField);
+      expect(ampForm.urlReplacement_.expandInputValueAsync)
+            .to.have.been.calledWith(canonicalUrlField);
+      return timer.promise(10).then(() => {
+        expect(ampForm.xhr_.fetch).to.be.called;
+        expect(clientIdField.value).to.match(/amp-.+/);
+        expect(canonicalUrlField.value).to.equal(
+                'https%3A%2F%2Fexample.com%2Famps.html');
+
+        expect(ampForm.analyticsEvent_).to.be.calledWithMatch(
+                'amp-form-submit',
+                expectedFormData);
       });
     });
   });
@@ -1448,6 +1497,58 @@ describes.realWin('amp-form', {
           'amp-form-submit',
           expectedFormData
         );
+      });
+    });
+
+    it('should trigger amp-form-submit after variables substitution', () => {
+      return getAmpForm().then(ampForm => {
+        const form = ampForm.form_;
+        form.id = 'registration';
+        ampForm.method_ = 'GET';
+        ampForm.xhrAction_ = null;
+        const clientIdField = document.createElement('input');
+        clientIdField.setAttribute('name', 'clientId');
+        clientIdField.setAttribute('type', 'hidden');
+        clientIdField.setAttribute('data-amp-replace', 'CLIENT_ID');
+        clientIdField.value = 'CLIENT_ID(form)';
+        form.appendChild(clientIdField);
+        const canonicalUrlField = document.createElement('input');
+        canonicalUrlField.setAttribute('name', 'canonicalUrl');
+        canonicalUrlField.setAttribute('type', 'hidden');
+        canonicalUrlField.setAttribute('data-amp-replace', 'CANONICAL_URL');
+        canonicalUrlField.value = 'CANONICAL_URL';
+        form.appendChild(canonicalUrlField);
+        sandbox.stub(form, 'submit');
+        sandbox.stub(form, 'checkValidity').returns(true);
+        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+        sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
+        sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
+        sandbox.stub(ampForm, 'analyticsEvent_');
+        ampForm.handleSubmitAction_();
+        const expectedFormData = {
+          'formId': 'registration',
+          'formFields[name]': 'John Miller',
+          'formFields[canonicalUrl]': 'https%3A%2F%2Fexample.com%2Famps.html',
+          'formFields[clientId]': '',
+        };
+        expect(ampForm.analyticsEvent_).to.be.calledWith(
+          'amp-form-submit',
+          expectedFormData
+        );
+        expect(ampForm.urlReplacement_.expandInputValueAsync)
+            .to.not.have.been.called;
+        expect(ampForm.urlReplacement_.expandInputValueSync)
+            .to.have.been.called;
+        expect(ampForm.urlReplacement_.expandInputValueSync)
+            .to.have.been.calledWith(clientIdField);
+        expect(ampForm.urlReplacement_.expandInputValueSync)
+            .to.have.been.calledWith(canonicalUrlField);
+        return timer.promise(10).then(() => {
+          expect(form.submit).to.have.been.called;
+          expect(clientIdField.value).to.equal('');
+          expect(canonicalUrlField.value).to.equal(
+              'https%3A%2F%2Fexample.com%2Famps.html');
+        });
       });
     });
   });

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -198,7 +198,6 @@ describes.realWin('amp-form', {
 
   it('should not trigger amp-form-submit analytics event', () => {
     const form = getForm();
-    document.body.appendChild(form);
     form.removeAttribute('action-xhr');
     document.body.appendChild(form);
     const ampForm = new AmpForm(form);

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -205,7 +205,7 @@ The `amp-form-submit` event fires when a form request is initiated. The `amp-for
 
 For example, the following form has two fields:
 
-```
+```html
 <form action-xhr="/register" method="POST" id="registration_form">
   <input type="text" name="user_name" />
   <input type="password" name="user_password" />

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -201,7 +201,9 @@ You can configure your analytics to send these events as in the example below.
 </amp-analytics>
 ```
 
-`amp-form-submit` is fired before a request is sent. For this event, a set of variables that reflects your form's fields is generated. For an example, consider the following form:
+The `amp-form-submit` event fires when a form request is initiated. The `amp-form-submit` event generates a set of variables that correspond to the specific form and the fields in the form. These variables can be used for analytics.
+
+For example, the following form has two fields:
 
 ```
 <form action-xhr="/register" method="POST" id="registration_form">
@@ -210,7 +212,11 @@ You can configure your analytics to send these events as in the example below.
   <input type="submit" value="Sign up" />
 </form>
 ```
-When `amp-form-submit` is fired, the following variables are generated for you to use in analytics: `formId`, `formFields[user_name]`, and `formFields[user_password]`, with each variable containing corresponding value.
+When the `amp-form-submit` event fires, it generates the following variables containing the values that were specified in the form:
+
+* formId
+* formFields[user_name]
+* formFields[user_password]
 
 ## Success/Error Response Rendering
 `amp-form` allows publishers to render the responses using [Extended Templates](../../spec/amp-html-format.md#extended-templates).

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -164,7 +164,7 @@ For example, a common use case is to submit a form on input change (selecting a 
 See the [full example here](../../examples/forms.amp.html).
 
 ### Analytics Triggers
-`amp-form` triggers two events you can track in your `amp-analytics` config: `amp-form-submit-success` and `amp-form-submit-error`.
+`amp-form` triggers three events you can track in your `amp-analytics` config: `amp-form-submit`, `amp-form-submit-success`, and `amp-form-submit-error`.
 
 You can configure your analytics to send these events as in the example below.
 
@@ -173,9 +173,14 @@ You can configure your analytics to send these events as in the example below.
   <script type="application/json">
     {
       "requests": {
-        "event": "https://www.example.com/analytics/event?eid=${eventId}"
+        "event": "https://www.example.com/analytics/event?eid=${eventId}",
+        "searchEvent": "https://www.example.com/analytics/search?formId=${formId}&query=${formFields[query]}"
       },
       "triggers": {
+        "formSubmit": {
+          "on": "amp-form-submit",
+          "request": "searchEvent"
+        },
         "formSubmitSuccess": {
           "on": "amp-form-submit-success",
           "request": "event",
@@ -195,6 +200,17 @@ You can configure your analytics to send these events as in the example below.
   </script>
 </amp-analytics>
 ```
+
+`amp-form-submit` is fired before a request is sent. For this event, a set of variables is generated that reflects your form's fields. For an example, consider the following form:
+
+```
+<form action-xhr="/register" method="POST" id="registration_form">
+  <input type="text" name="user_name" />
+  <input type="password" name="user_password" />
+  <input type="submit" value="Sign up" />
+</form>
+```
+When `amp-form-submit` is fired, the following variables are generated for you to use in analytics: `formId`, `formFields[user_name]`, and `formFields[user_password]`, with each variable containing corresponding value.
 
 ## Success/Error Response Rendering
 `amp-form` allows publishers to render the responses using [Extended Templates](../../spec/amp-html-format.md#extended-templates).

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -214,9 +214,9 @@ For example, the following form has two fields:
 ```
 When the `amp-form-submit` event fires, it generates the following variables containing the values that were specified in the form:
 
-* formId
-* formFields[user_name]
-* formFields[user_password]
+* `formId`
+* `formFields[user_name]`
+* `formFields[user_password]`
 
 ## Success/Error Response Rendering
 `amp-form` allows publishers to render the responses using [Extended Templates](../../spec/amp-html-format.md#extended-templates).

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -201,7 +201,7 @@ You can configure your analytics to send these events as in the example below.
 </amp-analytics>
 ```
 
-`amp-form-submit` is fired before a request is sent. For this event, a set of variables is generated that reflects your form's fields. For an example, consider the following form:
+`amp-form-submit` is fired before a request is sent. For this event, a set of variables that reflects your form's fields is generated. For an example, consider the following form:
 
 ```
 <form action-xhr="/register" method="POST" id="registration_form">


### PR DESCRIPTION
This PR adds `amp-form-submit` event to `amp-form`. The event is only accessible in `amp-analytics` and is intended to allow to track form submissions as well as form fields and values. Currently there are `amp-form-submit-success` and `amp-form-submit-error` events but they're triggered only after receiving a response, i.e. they won't be triggered in case of non-XHR GET request that reloads a page.

Fixes https://github.com/ampproject/amphtml/issues/8114