### PR TITLE
Defer Layout Assertions till Upgrade

### DIFF
--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -88,20 +88,20 @@ describe('amp-social-share', () => {
     return createIframePromise().then(iframe => {
       const share = iframe.doc.createElement('amp-social-share');
       share.setAttribute('type', 'unknown-provider');
-      expect(() => {
-        share.tryUpgrade_();
-        share.build(true);
-      }).to.throw('data-share-endpoint attribute is required');
+      iframe.doc.body.appendChild(share);
+      return expect(share.whenBuilt())
+          .to.be.eventually.rejectedWith(
+            /data-share-endpoint attribute is required/
+          );
     });
   });
 
   it('errors if type is missing', () => {
     return createIframePromise().then(iframe => {
       const share = iframe.doc.createElement('amp-social-share');
-      expect(() => {
-        share.tryUpgrade_();
-        share.build(true);
-      }).to.throw('type attribute is required');
+      iframe.doc.body.appendChild(share);
+      return expect(share.whenBuilt())
+          .to.be.eventually.rejectedWith(/type attribute is required/);
     });
   });
 
@@ -109,10 +109,11 @@ describe('amp-social-share', () => {
     return createIframePromise().then(iframe => {
       const share = iframe.doc.createElement('amp-social-share');
       share.setAttribute('type', 'hello world');
-      expect(() => {
-        share.tryUpgrade_();
-        share.build(true);
-      }).to.throw('Space characters are not allowed in type attribute value');
+      iframe.doc.body.appendChild(share);
+      return expect(share.whenBuilt())
+          .to.be.eventually.rejectedWith(
+            /Space characters are not allowed in type attribute value/
+          );
     });
   });
 

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -67,7 +67,7 @@ describe('amp-user-notification', () => {
     button.setAttribute('on', 'tap:' + elem.getAttribute('id') + 'dismiss');
     elem.appendChild(button);
 
-    elem.tryUpgrade_();
+    doc.body.appendChild(elem);
     const impl = elem.implementation_;
     impl.storagePromise_ = Promise.resolve(storage);
     impl.userNotificationManager_ = {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -936,11 +936,16 @@ function createBaseCustomElementClass(win) {
       this.getResources().add(this);
 
       if (this.everAttached) {
-        if (this.reconstructWhenReparented()) {
+        const reconstruct = this.reconstructWhenReparented();
+        if (reconstruct) {
           this.reset_();
-          this.getResources().upgraded(this);
         }
-        this.dispatchCustomEventForTesting('amp:attached');
+        if (this.isUpgraded()) {
+          if (reconstruct) {
+            this.getResources().upgraded(this);
+          }
+          this.dispatchCustomEventForTesting('amp:attached');
+        }
       } else {
         this.everAttached = true;
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -938,8 +938,6 @@ function createBaseCustomElementClass(win) {
 
         try {
           this.layout_ = applyLayout_(this);
-          this.assertLayout_();
-          this.implementation_.layout_ = this.layout_;
         } catch (e) {
           reportError(e, this);
         }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -619,6 +619,10 @@ function createBaseCustomElementClass(win) {
       }
       this.implementation_ = new newImplClass(this);
       if (this.everAttached) {
+        // Usually, we do an implementation upgrade when the element is
+        // attached to the DOM. But, if it hadn't yet upgraded from
+        // ElementStub, we couldn't. Now that it's upgraded from a stub, go
+        // ahead and do the full upgrade.
         this.tryUpgrade_();
       }
     }
@@ -637,13 +641,9 @@ function createBaseCustomElementClass(win) {
       this.assertLayout_();
       this.implementation_.layout_ = this.layout_;
       this.implementation_.layoutWidth_ = this.layoutWidth_;
-      if (this.everAttached) {
-        this.implementation_.firstAttachedCallback();
-        this.dispatchCustomEventForTesting('amp:attached');
-        // For a never-added resource, the build will be done automatically
-        // via `resources.add` on the first attach.
-        this.getResources().upgraded(this);
-      }
+      this.implementation_.firstAttachedCallback();
+      this.dispatchCustomEventForTesting('amp:attached');
+      this.getResources().upgraded(this);
     }
 
     /* @private */
@@ -934,32 +934,26 @@ function createBaseCustomElementClass(win) {
         this.resources_ = resourcesForDoc(this.ampdoc_);
       }
       if (!this.everAttached) {
+        this.everAttached = true;
+
+        try {
+          this.layout_ = applyLayout_(this);
+          this.assertLayout_();
+          this.implementation_.layout_ = this.layout_;
+          this.implementation_.firstAttachedCallback();
+        } catch (e) {
+          reportError(e, this);
+        }
         if (!isStub(this.implementation_)) {
           this.tryUpgrade_();
         }
         if (!this.isUpgraded()) {
           this.classList.add('amp-unresolved');
           this.classList.add('i-amphtml-unresolved');
+          // amp:attached is dispatched from the ElementStub class when it
+          // replayed the firstAttachedCallback call.
+          this.dispatchCustomEventForTesting('amp:stubbed');
         }
-        try {
-          this.layout_ = applyLayout_(this);
-          this.assertLayout_();
-          this.implementation_.layout_ = this.layout_;
-          this.implementation_.firstAttachedCallback();
-          if (!this.isUpgraded()) {
-            // amp:attached is dispatched from the ElementStub class when it
-            // replayed the firstAttachedCallback call.
-            this.dispatchCustomEventForTesting('amp:stubbed');
-          } else {
-            this.dispatchCustomEventForTesting('amp:attached');
-          }
-        } catch (e) {
-          reportError(e, this);
-        }
-
-        // It's important to have this flag set in the end to avoid
-        // `resources.add` called twice if upgrade happens immediately.
-        this.everAttached = true;
       } else if (this.reconstructWhenReparented()) {
         this.reset_();
       }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -940,7 +940,6 @@ function createBaseCustomElementClass(win) {
           this.layout_ = applyLayout_(this);
           this.assertLayout_();
           this.implementation_.layout_ = this.layout_;
-          this.implementation_.firstAttachedCallback();
         } catch (e) {
           reportError(e, this);
         }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -933,6 +933,8 @@ function createBaseCustomElementClass(win) {
         // Resources can now be initialized since the ampdoc is now available.
         this.resources_ = resourcesForDoc(this.ampdoc_);
       }
+      this.getResources().add(this);
+
       if (!this.everAttached) {
         this.everAttached = true;
 
@@ -954,7 +956,6 @@ function createBaseCustomElementClass(win) {
       } else if (this.reconstructWhenReparented()) {
         this.reset_();
       }
-      this.getResources().add(this);
     }
 
     /** The Custom Elements V0 sibling to `connectedCallback`. */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -935,7 +935,13 @@ function createBaseCustomElementClass(win) {
       }
       this.getResources().add(this);
 
-      if (!this.everAttached) {
+      if (this.everAttached) {
+        if (this.reconstructWhenReparented()) {
+          this.reset_();
+          this.getResources().upgraded(this);
+        }
+        this.dispatchCustomEventForTesting('amp:attached');
+      } else {
         this.everAttached = true;
 
         try {
@@ -953,8 +959,6 @@ function createBaseCustomElementClass(win) {
           // replayed the firstAttachedCallback call.
           this.dispatchCustomEventForTesting('amp:stubbed');
         }
-      } else if (this.reconstructWhenReparented()) {
-        this.reset_();
       }
     }
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -468,7 +468,6 @@ export class Resources {
     } else {
       // Create and add a new resource.
       resource = new Resource((++this.resourceIdCounter_), element, this);
-      this.buildOrScheduleBuildForResource_(resource);
       dev().fine(TAG_, 'resource added:', resource.debugid);
     }
     this.resources_.push(resource);

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -199,7 +199,6 @@ describe('CustomElement', () => {
 
     // Resources available after attachment.
     container.appendChild(element);
-    element.attachedCallback();
     expect(element.ampdoc_).to.be.ok;
     expect(element.getAmpDoc()).to.be.ok;
     expect(element.resources_).to.be.ok;
@@ -220,7 +219,6 @@ describe('CustomElement', () => {
     expect(testElementCreatedCallback).to.have.not.been.called;
 
     container.appendChild(element);
-    element.attachedCallback();
     expect(element).to.have.class('i-amphtml-element');
     expect(element).to.have.class('i-amphtml-notbuilt');
     expect(element).to.have.class('amp-notbuilt');
@@ -246,7 +244,6 @@ describe('CustomElement', () => {
     expect(testElementCreatedCallback).to.have.not.been.called;
 
     container.appendChild(element);
-    element.attachedCallback();
     expect(element).to.have.class('i-amphtml-element');
     expect(element).to.have.class('i-amphtml-notbuilt');
     expect(element).to.have.class('amp-notbuilt');
@@ -265,7 +262,6 @@ describe('CustomElement', () => {
     expect(element).to.not.have.class('amp-notbuilt');
 
     container.appendChild(element);
-    element.attachedCallback();
 
     expect(element).to.have.class('i-amphtml-element');
     expect(element).to.have.class('i-amphtml-notbuilt');
@@ -286,7 +282,6 @@ describe('CustomElement', () => {
     const element = new ElementClass();
     sandbox.stub(element, 'build');
     container.appendChild(element);
-    element.attachedCallback();
 
     sandbox.stub(element, 'reconstructWhenReparented', () => true);
     element.layoutCount_ = 10;
@@ -305,7 +300,6 @@ describe('CustomElement', () => {
     const element = new ElementClass();
     sandbox.stub(element, 'build');
     container.appendChild(element);
-    element.attachedCallback();
 
     sandbox.stub(element, 'reconstructWhenReparented', () => false);
     element.layoutCount_ = 10;
@@ -323,7 +317,6 @@ describe('CustomElement', () => {
   it('Element - getIntersectionChangeEntry', () => {
     const element = new ElementClass();
     container.appendChild(element);
-    element.attachedCallback();
     element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
     element.getIntersectionChangeEntry();
     expect(testElementGetInsersectionElementLayoutBox).to.be.calledOnce;
@@ -332,7 +325,6 @@ describe('CustomElement', () => {
   it('Element - updateLayoutBox', () => {
     const element = new ElementClass();
     container.appendChild(element);
-    element.attachedCallback();
     expect(element.layoutWidth_).to.equal(-1);
     expect(element.implementation_.layoutWidth_).to.equal(-1);
 
@@ -349,7 +341,6 @@ describe('CustomElement', () => {
     element.setAttribute('layout', 'fill');
     element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
     container.appendChild(element);
-    element.attachedCallback();
     resourcesMock.expects('upgraded').withExactArgs(element).once();
 
     element.upgrade(TestElement);
@@ -400,7 +391,6 @@ describe('CustomElement', () => {
     element.implementation_.upgradeCallback = () => newImpl;
 
     container.appendChild(element);
-    element.attachedCallback();
     expect(element.isUpgraded()).to.equal(true);
     expect(element.implementation_).to.equal(newImpl);
   });
@@ -414,7 +404,6 @@ describe('CustomElement', () => {
     oldImpl.upgradeCallback = () => promise;
 
     container.appendChild(element);
-    element.attachedCallback();
     expect(element.implementation_).to.equal(oldImpl);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
@@ -435,7 +424,6 @@ describe('CustomElement', () => {
     oldImpl.upgradeCallback = () => promise;
 
     container.appendChild(element);
-    element.attachedCallback();
     expect(element.implementation_).to.equal(oldImpl);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
@@ -456,7 +444,6 @@ describe('CustomElement', () => {
     oldImpl.upgradeCallback = () => promise;
 
     container.appendChild(element);
-    element.attachedCallback();
     expect(element.implementation_).to.equal(oldImpl);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
@@ -479,13 +466,12 @@ describe('CustomElement', () => {
     oldImpl.upgradeCallback = () => promise;
 
     container.appendChild(element);
-    element.attachedCallback();
     expect(element.implementation_).to.equal(oldImpl);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
 
     oldImpl.upgradeCallback = () => newImpl2;
-    element.tryUpgrade_();
+    container.appendChild(element);
     expect(element.implementation_).to.equal(oldImpl);
     expect(element.isUpgraded()).to.equal(false);
     expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
@@ -520,14 +506,14 @@ describe('CustomElement', () => {
 
   it('Element - build allowed', () => {
     const element = new ElementClass();
-    element.tryUpgrade_();
 
     expect(element.isBuilt()).to.equal(false);
     expect(testElementBuildCallback).to.have.not.been.called;
     expect(element.signals().get('built')).to.not.be.ok;
 
     clock.tick(1);
-    element.build();
+    container.appendChild(element);
+
     expect(element.isBuilt()).to.equal(true);
     expect(element).to.not.have.class('i-amphtml-notbuilt');
     expect(element).to.not.have.class('amp-notbuilt');
@@ -538,50 +524,46 @@ describe('CustomElement', () => {
 
   it('should anticipate build errors', () => {
     const element = new ElementClass();
-    element.tryUpgrade_();
     sandbox.stub(element.implementation_, 'buildCallback', () => {
       throw new Error('intentional');
     });
-    expect(() => {
-      element.build();
-    }).to.throw(/intentional/);
+    container.appendChild(element);
     expect(element.isBuilt()).to.be.false;
-    expect(element).to.not.have.class('i-amphtml-notbuilt');
-    expect(element).to.not.have.class('amp-notbuilt');
+    expect(element).to.have.class('i-amphtml-notbuilt');
+    expect(element).to.have.class('amp-notbuilt');
     return expect(element.whenBuilt())
         .to.be.eventually.rejectedWith(/intentional/);
   });
 
   it('Element - build creates a placeholder if one does not exist' , () => {
     const element = new ElementClass();
-    element.tryUpgrade_();
     expect(testElementCreatePlaceholderCallback).to.have.not.been.called;
 
-    element.build();
+    container.appendChild(element);
+
     expect(element.isBuilt()).to.equal(true);
     expect(testElementCreatePlaceholderCallback).to.be.calledOnce;
   });
 
   it('Element - build does not create a placeholder when one exists' , () => {
     const element = new ElementClass();
-    element.tryUpgrade_();
     const placeholder = document.createElement('div');
     placeholder.setAttribute('placeholder', '');
     element.appendChild(placeholder);
     expect(testElementCreatePlaceholderCallback).to.have.not.been.called;
 
-    element.build();
+    container.appendChild(element);
     expect(element.isBuilt()).to.equal(true);
     expect(testElementCreatePlaceholderCallback).to.have.not.been.called;
   });
 
   it('Element - buildCallback cannot be called twice', () => {
     const element = new ElementClass();
-    element.tryUpgrade_();
     expect(element.isBuilt()).to.equal(false);
     expect(testElementBuildCallback).to.have.not.been.called;
 
-    element.build();
+    container.appendChild(element);
+
     expect(element.isBuilt()).to.equal(true);
     expect(testElementBuildCallback).to.be.calledOnce;
     expect(testElementPreconnectCallback).to.have.not.been.called;
@@ -636,8 +618,8 @@ describe('CustomElement', () => {
     expect(element.layout_).to.equal(Layout.NODISPLAY);
 
     resourcesMock.expects('add').withExactArgs(element).atLeast(1);
+    resourcesMock.expects('upgraded').withExactArgs(element).atLeast(1);
     container.appendChild(element);
-    element.attachedCallback();
 
     expect(element.everAttached).to.equal(true);
     expect(element.layout_).to.equal(Layout.FILL);
@@ -654,11 +636,9 @@ describe('CustomElement', () => {
 
     resourcesMock.expects('add').withExactArgs(element).atLeast(1);
     container.appendChild(element);
-    element.attachedCallback();
 
     expect(element.everAttached).to.equal(true);
     expect(element.layout_).to.equal(Layout.FILL);
-    expect(element.implementation_.layout_).to.equal(Layout.FILL);
     // Not upgraded yet!
     expect(testElementCreatedCallback).to.have.not.been.called;
     expect(testElementFirstAttachedCallback).to.have.not.been.called;
@@ -686,8 +666,8 @@ describe('CustomElement', () => {
     expect(element.layout_).to.equal(Layout.NODISPLAY);
 
     resourcesMock.expects('add').withExactArgs(element).atLeast(1);
+    resourcesMock.expects('upgraded').withExactArgs(element).atLeast(1);
     container.appendChild(element);
-    element.attachedCallback();
 
     resourcesMock.expects('remove').withExactArgs(element).once();
     element.detachedCallback();
@@ -702,10 +682,9 @@ describe('CustomElement', () => {
   it('Element - layoutCallback before build', () => {
     const element = new ElementClass();
     element.setAttribute('layout', 'fill');
-    element.tryUpgrade_();
     expect(testElementLayoutCallback).to.have.not.been.called;
-
     expect(element.isBuilt()).to.equal(false);
+
     expect(() => {
       element.layoutCallback();
     }).to.throw(/Must be built to receive viewport events/);
@@ -736,31 +715,10 @@ describe('CustomElement', () => {
     expect(testElementLayoutCallback).to.have.not.been.called;
   });
 
-  it('StubElement - layoutCallback after upgrade but before build', () => {
-    const element = new StubElementClass();
-    element.setAttribute('layout', 'fill');
-    expect(testElementLayoutCallback).to.have.not.been.called;
-    expect(element.isUpgraded()).to.equal(false);
-    expect(element.isBuilt()).to.equal(false);
-
-    resourcesMock.expects('upgraded').withExactArgs(element).once();
-    container.appendChild(element);
-    element.attachedCallback();
-    element.upgrade(TestElement);
-
-    expect(element.isUpgraded()).to.equal(true);
-    expect(element.isBuilt()).to.equal(false);
-    expect(() => {
-      element.layoutCallback();
-    }).to.throw(/Must be built to receive viewport events/);
-
-    expect(testElementLayoutCallback).to.have.not.been.called;
-  });
-
   it('Element - layoutCallback', () => {
     const element = new ElementClass();
     element.setAttribute('layout', 'fill');
-    element.tryUpgrade_();
+    container.appendChild(element);
     element.build();
     expect(element.isBuilt()).to.equal(true);
     expect(testElementLayoutCallback).to.have.not.been.called;
@@ -784,8 +742,7 @@ describe('CustomElement', () => {
       () => {
         const element = new ElementClass();
         element.setAttribute('layout', 'fill');
-        element.tryUpgrade_();
-        element.build();
+        container.appendChild(element);
 
         const p = element.layoutCallback();
         expect(testElementLayoutCallback).to.be.calledOnce;
@@ -806,7 +763,7 @@ describe('CustomElement', () => {
   it('Element - layoutCallback is NOT allowed in template', () => {
     const element = new ElementClass();
     element.setAttribute('layout', 'fill');
-    element.tryUpgrade_();
+    container.appendChild(element);
     element.build();
     expect(element.isBuilt()).to.equal(true);
     expect(testElementLayoutCallback).to.have.not.been.called;
@@ -865,7 +822,7 @@ describe('CustomElement', () => {
     const element = new ElementClass();
     const handler = sandbox.spy();
     element.implementation_.executeAction = handler;
-    element.tryUpgrade_();
+    container.appendChild(element);
     element.build();
 
     const inv = {};
@@ -877,7 +834,6 @@ describe('CustomElement', () => {
 
   it('should dequeue all actions after build', () => {
     const element = new ElementClass();
-    element.tryUpgrade_();
     const handler = sandbox.spy();
     element.implementation_.executeAction = handler;
 
@@ -890,7 +846,7 @@ describe('CustomElement', () => {
     expect(element.actionQueue_[1]).to.equal(inv2);
     expect(handler).to.have.not.been.called;
 
-    element.build();
+    container.appendChild(element);
     clock.tick(10);
     expect(handler).to.have.callCount(2);
     expect(handler.getCall(0).args[0]).to.equal(inv1);
@@ -946,7 +902,6 @@ describe('CustomElement', () => {
     element1.setAttribute('height', '200px');
     element1.setAttribute('heights', '(min-width: 1px) 99%, 1%');
     container.appendChild(element1);
-    element1.attachedCallback();
     element1.applySizesAndMediaQuery();
     expect(element1.sizerElement_.style.paddingTop).to.equal('99%');
 
@@ -957,7 +912,6 @@ describe('CustomElement', () => {
     element2.setAttribute('height', '200px');
     element2.setAttribute('heights', '(min-width: 1111111px) 99%, 1%');
     container.appendChild(element2);
-    element2.attachedCallback();
     element2.applySizesAndMediaQuery();
     expect(element2.sizerElement_.style.paddingTop).to.equal('1%');
   });
@@ -972,9 +926,8 @@ describe('CustomElement', () => {
     container.appendChild(element1);
 
     const sizer = document.createElement('i-amphtml-sizer');
-    element1.appendChild(sizer);
     expect(element1.sizerElement_).to.be.undefined;
-    element1.attachedCallback();
+    element1.appendChild(sizer);
     element1.applySizesAndMediaQuery();
     expect(element1.sizerElement_).to.equal(sizer);
     expect(sizer.style.paddingTop).to.equal('99%');
@@ -991,7 +944,6 @@ describe('CustomElement', () => {
 
     const sizer = document.createElement('i-amphtml-sizer');
     element1.appendChild(sizer);
-    element1.attachedCallback();
     element1.sizerElement_ = null;
     element1.applySizesAndMediaQuery();
     expect(element1.sizerElement_).to.be.null;
@@ -1093,7 +1045,6 @@ describe('CustomElement', () => {
 
     it('should unlayout built element and reset layoutCount', () => {
       const element = new ElementClass();
-      element.tryUpgrade_();
       // Non-built element doesn't receive unlayoutCallback.
       element.unlayoutCallback();
       expect(testElementUnlayoutCallback).to.have.not.been.called;
@@ -1108,8 +1059,9 @@ describe('CustomElement', () => {
         testElementUnlayoutCallback();
         return true;
       };
+
       // Built element receives unlayoutCallback.
-      element.build();
+      container.appendChild(element);
       element.unlayoutCallback();
       expect(testElementUnlayoutCallback).to.be.calledOnce;
       expect(element.layoutCount_).to.equal(0);
@@ -1117,8 +1069,7 @@ describe('CustomElement', () => {
 
     it('should not reset layoutCount if relayout not requested', () => {
       const element = new ElementClass();
-      element.tryUpgrade_();
-      element.build();
+      container.appendChild(element);
       element.implementation_.layoutCallback = () => {
         testElementLayoutCallback();
         element.layoutCount_++;
@@ -1147,14 +1098,13 @@ describe('CustomElement', () => {
   describe('pauseCallback', () => {
     it('Element', () => {
       const element = new ElementClass();
-      element.tryUpgrade_();
 
       // Non-built element doesn't receive pauseCallback.
       element.pauseCallback();
       expect(testElementPauseCallback).to.have.not.been.called;
 
       // Built element receives pauseCallback.
-      element.build();
+      container.appendChild(element);
       element.pauseCallback();
       expect(testElementPauseCallback).to.be.calledOnce;
     });
@@ -1171,14 +1121,13 @@ describe('CustomElement', () => {
   describe('resumeCallback', () => {
     it('Element', () => {
       const element = new ElementClass();
-      element.tryUpgrade_();
 
       // Non-built element doesn't receive resumeCallback.
       element.resumeCallback();
       expect(testElementResumeCallback).to.have.not.been.called;
 
       // Built element receives resumeCallback.
-      element.build();
+      container.appendChild(element);
       element.resumeCallback();
       expect(testElementResumeCallback).to.be.calledOnce;
     });
@@ -1228,8 +1177,7 @@ describe('CustomElement', () => {
     it('Element - should be called once built', () => {
       const element = new ElementClass();
       element.setAttribute('layout', 'fill');
-      element.tryUpgrade_();
-      element.build();
+      container.appendChild(element);
       expect(element.isBuilt()).to.equal(true);
       expect(testElementViewportCallback).to.have.not.been.called;
 
@@ -1241,16 +1189,15 @@ describe('CustomElement', () => {
     it('StubElement - should be called once upgraded', () => {
       const element = new StubElementClass();
       element.setAttribute('layout', 'fill');
-      resourcesMock.expects('upgraded').withExactArgs(element).once();
       container.appendChild(element);
-      element.attachedCallback();
-      element.upgrade(TestElement);
-      element.build();
-      expect(element.isUpgraded()).to.equal(true);
-      expect(element.isBuilt()).to.equal(true);
-      expect(testElementViewportCallback).to.have.not.been.called;
+      expect(element.isUpgraded()).to.equal(false);
+      expect(element.isBuilt()).to.equal(false);
 
       element.viewportCallback(true);
+      expect(element.implementation_.inViewport_).to.equal(false);
+      expect(testElementViewportCallback).to.not.have.been.called;
+
+      element.upgrade(TestElement);
       expect(element.implementation_.inViewport_).to.equal(true);
       expect(testElementViewportCallback).to.be.calledOnce;
     });
@@ -1266,40 +1213,22 @@ describe('CustomElement', () => {
       expect(testElementViewportCallback).to.have.not.been.called;
     });
 
-    it('StubElement - should be called once upgraded, attached', () => {
-      const element = new StubElementClass();
-      element.setAttribute('layout', 'fill');
-      element.everAttached = true;
-      element.resources_ = resources;
-      resourcesMock.expects('upgraded').withExactArgs(element).once();
-      element.upgrade(TestElement);
-      element.build();
-      expect(element.isUpgraded()).to.equal(true);
-      expect(element.isBuilt()).to.equal(true);
-      expect(testElementViewportCallback).to.have.not.been.called;
-
-      element.viewportCallback(true);
-      expect(element.implementation_.inViewport_).to.equal(true);
-      expect(testElementViewportCallback).to.be.calledOnce;
-    });
-
     it('Element - should be called on built if in viewport', () => {
       const element = new ElementClass();
       element.setAttribute('layout', 'fill');
-      element.tryUpgrade_();
       element.viewportCallback(true);
       expect(element.isInViewport_).to.equal(true);
       expect(testElementViewportCallback).to.have.not.been.called;
 
-      element.build();
-      expect(element.isBuilt()).to.equal(true);
+      container.appendChild(element);
+      expect(element.isInViewport_).to.equal(true);
       expect(testElementViewportCallback).to.be.calledOnce;
     });
 
     it('Element - should NOT be called in template', () => {
       const element = new ElementClass();
       element.setAttribute('layout', 'fill');
-      element.tryUpgrade_();
+      container.appendChild(element);
       element.build();
       expect(element.isBuilt()).to.equal(true);
       expect(testElementViewportCallback).to.have.not.been.called;
@@ -1442,6 +1371,7 @@ describe('CustomElement Loading Indicator', () => {
   let vsync;
   let vsyncTasks;
   let resourcesMock;
+  let container;
 
   beforeEach(() => {
     LOADING_ELEMENTS_['amp-test-loader'.toUpperCase()] = true;
@@ -1451,6 +1381,7 @@ describe('CustomElement Loading Indicator', () => {
     element = new ElementClass();
     element.layoutWidth_ = 300;
     element.layout_ = Layout.FIXED;
+    element.setAttribute('layout', 'fixed');
     element.resources_ = resources;
     vsync = vsyncFor(window);
     savedMutate = vsync.mutate;
@@ -1458,12 +1389,17 @@ describe('CustomElement Loading Indicator', () => {
     vsync.mutate = mutator => {
       vsyncTasks.push(mutator);
     };
+    container = document.createElement('div');
+    document.body.appendChild(container);
   });
 
   afterEach(() => {
     vsync.mutate = savedMutate;
     resourcesMock.verify();
     sandbox.restore();
+    if (container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
   });
 
 
@@ -1653,8 +1589,7 @@ describe('CustomElement Loading Indicator', () => {
 
   it('should toggle loading off after layout complete', () => {
     const toggle = sandbox.spy(element, 'toggleLoading_');
-    element.tryUpgrade_();
-    element.build();
+    container.appendChild(element);
     return element.layoutCallback().then(() => {
       expect(toggle).to.be.calledOnce;
       expect(toggle.firstCall.args[0]).to.equal(false);
@@ -1666,10 +1601,10 @@ describe('CustomElement Loading Indicator', () => {
 
   it('should toggle loading off after layout failed', () => {
     const toggle = sandbox.spy(element, 'toggleLoading_');
-    const implMock = sandbox.mock(element.implementation_);
-    implMock.expects('layoutCallback').returns(Promise.reject());
-    element.tryUpgrade_();
-    element.build();
+    sandbox.stub(element.implementation_, 'layoutCallback', () => {
+      return Promise.reject();
+    });
+    container.appendChild(element);
     return element.layoutCallback().then(() => {
       throw new Error('Should never happen.');
     }, () => {
@@ -1681,10 +1616,10 @@ describe('CustomElement Loading Indicator', () => {
 
   it('should disable toggle loading on after layout failed', () => {
     const prepareLoading = sandbox.spy(element, 'prepareLoading_');
-    const implMock = sandbox.mock(element.implementation_);
-    implMock.expects('layoutCallback').returns(Promise.reject());
-    element.tryUpgrade_();
-    element.build();
+    sandbox.stub(element.implementation_, 'layoutCallback', () => {
+      return Promise.reject();
+    });
+    container.appendChild(element);
     expect(element.layoutCount_).to.equal(0);
     expect(element.isLoadingEnabled_()).to.equal(true);
     return element.layoutCallback().then(() => {
@@ -1699,7 +1634,7 @@ describe('CustomElement Loading Indicator', () => {
 
   it('should ignore loading "on" if layout completed before vsync', () => {
     resourcesMock.expects('deferMutate').once();
-    element.tryUpgrade_();
+    container.appendChild(element);
     element.prepareLoading_();
     element.toggleLoading_(true);
     element.build();

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -2268,7 +2268,7 @@ describe('Resources mutateElement and collapse', () => {
 });
 
 
-describe('Resources.add/remove', () => {
+describe('Resources.add/upgrade/remove', () => {
   let sandbox;
   let resources;
   let parent;
@@ -2348,9 +2348,11 @@ describe('Resources.add/remove', () => {
     child2.isBuilt = () => false;
     resources.documentReady_ = false;
     resources.add(child1);
+    resources.upgraded(child1);
     expect(child1.build.called).to.be.false;
     resources.documentReady_ = true;
     resources.add(child2);
+    resources.upgraded(child2);
     expect(child2.build.calledOnce).to.be.true;
     expect(schedulePassStub).to.be.calledOnce;
   });
@@ -2366,6 +2368,7 @@ describe('Resources.add/remove', () => {
     };
     resources.documentReady_ = true;
     resources.add(child1);
+    resources.upgraded(child1);
     expect(child1BuildSpy.calledOnce).to.be.true;
     expect(schedulePassStub).to.not.be.called;
   });
@@ -2376,9 +2379,11 @@ describe('Resources.add/remove', () => {
     resources.buildReadyResources_ = sandbox.spy();
     resources.documentReady_ = false;
     resources.add(child1);
+    resources.upgraded(child1);
     expect(child1.build.called).to.be.false;
     expect(resources.pendingBuildResources_.length).to.be.equal(1);
     resources.add(child2);
+    resources.upgraded(child2);
     expect(child2.build.called).to.be.false;
     expect(resources.pendingBuildResources_.length).to.be.equal(2);
     expect(resources.buildReadyResources_.calledTwice).to.be.true;
@@ -2521,6 +2526,7 @@ describe('Resources.add/remove', () => {
           resources, 'buildOrScheduleBuildForResource_');
       child1.isBuilt = () => true;
       resources.add(child1);
+      resources.upgraded(child1);
       resource = Resource.forElementOptional(child1);
       resources.remove(child1);
     });
@@ -2531,39 +2537,6 @@ describe('Resources.add/remove', () => {
       expect(resources.resources_).to.not.contain(resource);
       expect(scheduleBuildStub).to.be.calledOnce;
       expect(resource.isMeasureRequested()).to.be.false;
-    });
-
-    it('should reconstruct w/reconstructWhenReparented=true', () => {
-      resources.add(child1);
-      const resource2 = Resource.forElementOptional(child1);
-      expect(resource2).to.not.equal(resource);
-      expect(scheduleBuildStub).to.be.calledTwice;  // +1 call
-      expect(resources.resources_).to.contain(resource2);
-      expect(resources.resources_).to.not.contain(resource);
-      expect(resource.isMeasureRequested()).to.be.false;
-    });
-
-    it('should reconstruct unbuilt w/reconstructWhenReparented=false', () => {
-      child1.reconstructWhenReparented = () => false;
-      resource.state_ = ResourceState.NOT_BUILT;  // Not built.
-      resources.add(child1);
-      const resource2 = Resource.forElementOptional(child1);
-      expect(resource2).to.not.equal(resource);
-      expect(scheduleBuildStub).to.be.calledTwice;  // +1 call
-      expect(resources.resources_).to.contain(resource2);
-      expect(resources.resources_).to.not.contain(resource);
-      expect(resource.isMeasureRequested()).to.be.false;
-    });
-
-    it('should NOT reconstruct built w/reconstructWhenReparented=false', () => {
-      child1.reconstructWhenReparented = () => false;
-      resource.state_ = ResourceState.NOT_LAID_OUT;  // Built.
-      resources.add(child1);
-      const resource2 = Resource.forElementOptional(child1);
-      expect(resource2).to.equal(resource);
-      expect(scheduleBuildStub).to.be.calledOnce;  // No new calls.
-      expect(resources.resources_).to.contain(resource);
-      expect(resource.isMeasureRequested()).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Ooo man, there was a tangle of crap between the `#upgradeComplete` and `#connectedCallback`.

First some info.

- `#connectedCallback` is always called first.
- It calls `#tryUpgrade`
  - if it can upgrade sync, it calls `#upgradeComplete` 
  - Else, it defers calling `#upgradeComplete` until the upgrade is complete (shocking)
- `#connectedCallback` has a ton of code that's written specifically for the sync upgrade case
- `#upgradeComplete` has a ton of code that's written specifically for the async upgrade case

Basically, `#connectedCallback` did `#upgradeComplete`'s job half the time. And that's screwed up. Especially because `#upgradeComplete` is called sync if upgrade is sync, or async or upgrade is async. So we can just move all that code from `#connectedCallback` and still have exactly the same behavior.

Oh, then we remove the layout assertions from the sync case. That fixes #5980.

And we remove a bogus call to `#firstAttachedCallback`. It'll always be called by `#upgradeCallback`, regardless of whether the upgrade is sync or async. Worse, it'll be called twice if the upgrade is sync. Even more worse, we call it on un-upgraded elements if the element is still a StubElement or it's async upgraded.