### PR TITLE
Force AMP pages to always paint once before installing extensions.

### DIFF
--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -61,7 +61,7 @@ export function waitForServices(win) {
  * @return {boolean}
  */
 export function hasRenderDelayingServices(win) {
-  return includedServices(win).length > 0
+  return includedServices(win).length > 0;
 }
 
 /**

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -56,12 +56,20 @@ export function waitForServices(win) {
 }
 
 /**
+ * Returns true if the page has a render delaying service.
+ * @param {!Window} win
+ * @return {boolean}
+ */
+export function hasRenderDelayingServices(win) {
+  return includedServices(win).length > 0
+}
+
+/**
  * Detects which, if any, render-delaying extensions are included on the page.
  * @param {!Window} win
  * @return {!Array<string>}
- * @private
  */
-function includedServices(win) {
+export function includedServices(win) {
   /** @const {!Document} */
   const doc = win.document;
   dev().assert(doc.body);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -45,6 +45,9 @@ import {
   installStylesForShadowRoot,
 } from './shadow-embed';
 import {getMode} from './mode';
+import {
+  hasRenderDelayingServices,
+} from './render-delaying-services';
 import {installActionServiceForDoc} from './service/action-impl';
 import {installCryptoService} from './service/crypto-impl';
 import {installDocumentInfoServiceForDoc} from './service/document-info-impl';
@@ -979,6 +982,10 @@ function maybePumpEarlyFrame(win, cb) {
   // There is definitely nothing to draw yet, so we might as well
   // proceed.
   if (!win.document.body) {
+    cb();
+    return;
+  }
+  if (hasRenderDelayingServices(win)) {
     cb();
     return;
   }

--- a/test/functional/test-render-delaying-services.js
+++ b/test/functional/test-render-delaying-services.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {waitForServices} from '../../src/render-delaying-services';
+import {
+  waitForServices,
+  hasRenderDelayingServices,
+} from '../../src/render-delaying-services';
 import {createIframePromise} from '../../testing/iframe';
 import * as service from '../../src/service';
 import * as sinon from 'sinon';
@@ -51,6 +54,7 @@ describe('waitForServices', () => {
   it('should resolve if no blocking services is presented', () => {
     // <script custom-element="amp-experiment"> should not block
     addExtensionScript(win, 'amp-experiment');
+    expect(hasRenderDelayingServices(win)).to.be.false;
     return expect(waitForServices(win)).to.eventually.have.lengthOf(0);
   });
 
@@ -58,6 +62,7 @@ describe('waitForServices', () => {
     addExtensionScript(win, 'amp-accordion');
     addExtensionScript(win, 'amp-dynamic-css-classes');
     win.document.body.appendChild(win.document.createElement('amp-experiment'));
+    expect(hasRenderDelayingServices(win)).to.be.true;
     addExtensionScript(win, 'non-blocking-extension');
 
     const promise = waitForServices(win);
@@ -72,6 +77,7 @@ describe('waitForServices', () => {
     addExtensionScript(win, 'amp-accordion');
     addExtensionScript(win, 'amp-dynamic-css-classes');
     win.document.body.appendChild(win.document.createElement('amp-experiment'));
+    expect(hasRenderDelayingServices(win)).to.be.true;
     addExtensionScript(win, 'non-blocking-extension');
 
     const promise = waitForServices(win);

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -30,7 +30,7 @@ import {
 } from '../../src/service';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
-import {installVsyncService} from '../../src/service/vsync-impl';
+import {vsyncForTesting} from '../../src/service/vsync-impl';
 import {platformFor} from '../../src/platform';
 import {runChunksForTesting} from '../../src/chunk';
 import {toggleExperiment} from '../../src/experiments';
@@ -41,13 +41,14 @@ import * as shadowembed from '../../src/shadow-embed';
 import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 
-describes.fakeWin('runtime', {
+describes.fakeWin.only('runtime', {
   location: 'https://cdn.ampproject.org/c/s/www.example.com/path',
 }, env => {
   let win;
   let ampdocService;
   let ampdocServiceMock;
   let extensionElementIndex;
+  let vsync;
 
   beforeEach(() => {
     win = env.win;
@@ -66,7 +67,7 @@ describes.fakeWin('runtime', {
     ampdocService.getAmpDoc = () => ampdoc;
     installPlatformService(win);
     installTimerService(win);
-    installVsyncService(win);
+    vsync = vsyncForTesting(win);
     installAmpdocServices(ampdoc);
   });
 
@@ -141,7 +142,7 @@ describes.fakeWin('runtime', {
     expect(win.document.documentElement.style.cursor).to.equal('pointer');
   });
 
-  it('should execute scheduled extensions & execute new extensions', () => {
+  const extensionRegistrationTest = () => {
     let progress = '';
     const queueExtensions = win.AMP;
     win.AMP.push(regularExtension(amp => {
@@ -165,6 +166,68 @@ describes.fakeWin('runtime', {
       expect(amp).to.equal(win.AMP);
       progress += '4';
     }));
+    runChunksForTesting(win.document);
+    expect(progress).to.equal('1234');
+    win.AMP.push(regularExtension(amp => {
+      expect(amp).to.equal(win.AMP);
+      progress += '5';
+    }));
+    runChunksForTesting(win.document);
+    expect(progress).to.equal('12345');
+    expect(queueExtensions).to.have.length(0);
+  };
+  it('should execute scheduled extensions & execute new extensions',
+      extensionRegistrationTest);
+
+  it('should not maybePumpEarlyFrame when body not yet present', () => {
+    toggleExperiment(win, 'pump-early-frame', true);
+    // Make document.body be null on first invocation to simulate
+    // JS executing before the rest of the doc has been parsed.
+    const body = win.document.body;
+    let accessedOnce = false;
+    Object.defineProperty(win.document, 'body', {
+      get: () => {
+        if (accessedOnce) {
+          return body;
+        }
+        accessedOnce = true;
+        return null;
+      },
+    });
+    extensionRegistrationTest();
+  });
+
+  it('should maybePumpEarlyFrame and delay extension execution', () => {
+    toggleExperiment(win, 'pump-early-frame', true);
+    let progress = '';
+    const queueExtensions = win.AMP;
+    win.AMP.push(regularExtension(amp => {
+      expect(amp).to.equal(win.AMP);
+      progress += '1';
+    }));
+    win.AMP.push(regularExtension(amp => {
+      expect(amp).to.equal(win.AMP);
+      progress += '2';
+    }));
+    win.AMP.push(regularExtension(amp => {
+      expect(amp).to.equal(win.AMP);
+      progress += '3';
+    }));
+    expect(queueExtensions).to.have.length(3);
+    adopt(win);
+    runChunksForTesting(win.document);
+    expect(queueExtensions).to.have.length(3);
+    vsync.runScheduledTasks_();
+    expect(queueExtensions).to.have.length(3);
+    expect(progress).to.equal('');
+    // New extension arrives before inital ran.
+    win.AMP.push(regularExtension(amp => {
+      expect(amp).to.equal(win.AMP);
+      progress += '4';
+    }));
+    expect(queueExtensions).to.have.length(4);
+    vsync.runScheduledTasks_();
+    expect(queueExtensions).to.have.length(0);
     runChunksForTesting(win.document);
     expect(progress).to.equal('1234');
     win.AMP.push(regularExtension(amp => {

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -41,7 +41,7 @@ import * as shadowembed from '../../src/shadow-embed';
 import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 
-describes.fakeWin.only('runtime', {
+describes.fakeWin('runtime', {
   location: 'https://cdn.ampproject.org/c/s/www.example.com/path',
 }, env => {
   let win;

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -197,6 +197,14 @@ describes.fakeWin('runtime', {
     extensionRegistrationTest();
   });
 
+  it('should not maybePumpEarlyFrame ' +
+      'when a renderDelayingExtension is present', () => {
+        toggleExperiment(win, 'pump-early-frame', true);
+        win.document.body.appendChild(
+            document.createElement('amp-experiment'));
+        extensionRegistrationTest();
+      });
+
   it('should maybePumpEarlyFrame and delay extension execution', () => {
     toggleExperiment(win, 'pump-early-frame', true);
     let progress = '';

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -199,11 +199,11 @@ describes.fakeWin('runtime', {
 
   it('should not maybePumpEarlyFrame ' +
       'when a renderDelayingExtension is present', () => {
-        toggleExperiment(win, 'pump-early-frame', true);
-        win.document.body.appendChild(
+    toggleExperiment(win, 'pump-early-frame', true);
+    win.document.body.appendChild(
             document.createElement('amp-experiment'));
-        extensionRegistrationTest();
-      });
+    extensionRegistrationTest();
+  });
 
   it('should maybePumpEarlyFrame and delay extension execution', () => {
     toggleExperiment(win, 'pump-early-frame', true);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -213,10 +213,16 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/2198',
   },
   {
+    id: 'pump-early-frame',
+    name: 'Force all extensions to have the same release ' +
+        'as the main JS binary',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8237',
+  },
+  {
     id: 'version-locking',
     name: 'Force all extensions to have the same release ' +
         'as the main JS binary',
-    cleanupIssue: 'DO_NOT_SUBMIT',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8236',
   },
   {
     id: 'amp-bind',


### PR DESCRIPTION
This makes AMP draw roughly half way into the JS initialization which is quite significant perceptual speedup. This comes at

- overall larger CPU usage (due to extra paint and more style recalc)
- and overall slightly longer start up (since waiting for frames to pass by).