### PR TITLE
Add caption support to amp-instagram

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -477,7 +477,7 @@ amp-pixel {
  * before the instagram implementation loads.
  */
 amp-instagram {
-  padding: 48px 8px !important;
+  padding: 64px 0px 0px 0px !important;
   background-color: white;
 }
 

--- a/examples/instagram.amp.html
+++ b/examples/instagram.amp.html
@@ -9,7 +9,17 @@
   <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
   <style amp-custom>
     body {
-      background-color: blue;
+      background-color: white;
+      padding: 20px;
+    }
+
+    amp-instagram [overflow] {
+      position: absolute;
+      bottom: 0;
+      text-align: center;
+      background: #444;
+      color: white;
+      padding: 5px;
     }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -28,32 +38,31 @@
       layout="responsive">
   </amp-instagram>
 
+  <h2>Instagram with Frame</h2>
   <amp-instagram
-      data-shortcode="6f8K16iZiK"
-      width="500"
-      height="500"
-      layout="responsive">
-  </amp-instagram>
-  
-  <amp-instagram
-      data-shortcode="6f8K16iZiK"
-      data-captioned
+      data-shortcode="BR3g5NDBvBu"
+      data-default-framing
       width="500"
       height="500"
       layout="responsive">
   </amp-instagram>
 
+  <h2>Instagram with Frame, Caption and Overflow Element</h2>
+  <amp-instagram
+      data-shortcode="BR3g5NDBvBu"
+      data-captioned
+      data-default-framing
+      width="500"
+      height="500"
+      layout="responsive">
+      <div overflow>Show Caption</div>
+  </amp-instagram>
+
+  <h2>Instagram Default Layout</h2> 
   <amp-instagram
       data-shortcode="fBwFP"
       width="381"
       height="381">
-  </amp-instagram>
-
-  <amp-instagram
-      data-shortcode="6f8K16iZiK"
-      width="500"
-      height="500"
-      layout="responsive">
   </amp-instagram>
 
   <h3>Instagram Video</h3>

--- a/examples/instagram.amp.html
+++ b/examples/instagram.amp.html
@@ -34,6 +34,14 @@
       height="500"
       layout="responsive">
   </amp-instagram>
+  
+  <amp-instagram
+      data-shortcode="6f8K16iZiK"
+      data-captioned
+      width="500"
+      height="500"
+      layout="responsive">
+  </amp-instagram>
 
   <amp-instagram
       data-shortcode="fBwFP"

--- a/extensions/amp-instagram/0.1/amp-instagram.css
+++ b/extensions/amp-instagram/0.1/amp-instagram.css
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Non-overridable properties */
+
+/* Adjust default spacing to allow for frame style */
+amp-instagram.amp-instagram-default-framing {
+  border: 1px solid #dbdbdb !important;
+}

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -93,7 +93,7 @@ class AmpInstagram extends AMP.BaseElement {
       'The data-shortcode attribute is required for <amp-instagram> %s',
       this.element);
     this.captioned_ = this.element.hasAttribute('data-captioned') ?
-      'captioned' : '';
+      'captioned/' : '';
   }
 
   /** @override */

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -35,13 +35,13 @@
  * the example above and will produce the correct aspect ratio.
  */
 
-import {isLayoutSizeDefined} from '../../../src/layout';
-import {setStyles} from '../../../src/style';
-import {removeElement} from '../../../src/dom';
-import {user} from '../../../src/log';
-import {tryParseJson} from '../../../src/json';
-import {isObject} from '../../../src/types';
-import {listen} from '../../../src/event-helper';
+import { isLayoutSizeDefined } from '../../../src/layout';
+import { setStyles } from '../../../src/style';
+import { removeElement } from '../../../src/dom';
+import { user } from '../../../src/log';
+import { tryParseJson } from '../../../src/json';
+import { isObject } from '../../../src/types';
+import { listen } from '../../../src/event-helper';
 
 const PADDING_LEFT = 8;
 const PADDING_RIGHT = 8;
@@ -52,24 +52,24 @@ class AmpInstagram extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
   constructor(element) {
-    super(element);
+      super(element);
 
-    /** @private {?Element} */
-    this.iframe_ = null;
+      /** @private {?Element} */
+      this.iframe_ = null;
 
-    /** @private {?Promise} */
-    this.iframePromise_ = null;
+      /** @private {?Promise} */
+      this.iframePromise_ = null;
 
-    /** @private {?string} */
-    this.shortcode_ = '';
+      /** @private {?string} */
+      this.shortcode_ = '';
 
-    /** @private {?Function} */
-    this.unlistenMessage_ = null;
-  }
- /**
-  * @param {boolean=} opt_onLayout
-  * @override
-  */
+      /** @private {?Function} */
+      this.unlistenMessage_ = null;
+    }
+    /**
+     * @param {boolean=} opt_onLayout
+     * @override
+     */
   preconnectCallback(opt_onLayout) {
     // See
     // https://instagram.com/developer/embedding/?hl=en
@@ -77,7 +77,7 @@ class AmpInstagram extends AMP.BaseElement {
     // Host instagram used for image serving. While the host name is
     // funky this appears to be stable in the post-domain sharding era.
     this.preconnect.url('https://instagram.fsnc1-1.fna.fbcdn.net',
-        opt_onLayout);
+      opt_onLayout);
   }
 
   /** @override */
@@ -88,10 +88,12 @@ class AmpInstagram extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.shortcode_ = user().assert(
-        (this.element.getAttribute('data-shortcode') ||
+      (this.element.getAttribute('data-shortcode') ||
         this.element.getAttribute('shortcode')),
-        'The data-shortcode attribute is required for <amp-instagram> %s',
-        this.element);
+      'The data-shortcode attribute is required for <amp-instagram> %s',
+      this.element);
+    this.captioned_ = this.element.hasAttribute('data-captioned') ?
+      'captioned' : '';
   }
 
   /** @override */
@@ -103,7 +105,7 @@ class AmpInstagram extends AMP.BaseElement {
     // This will redirect to the image URL. By experimentation this is
     // always the same URL that is actually used inside of the embed.
     image.setAttribute('src', 'https://www.instagram.com/p/' +
-        encodeURIComponent(this.shortcode_) + '/media/?size=l');
+      encodeURIComponent(this.shortcode_) + '/media/?size=l');
     image.setAttribute('layout', 'fill');
     image.setAttribute('referrerpolicy', 'origin');
 
@@ -141,9 +143,10 @@ class AmpInstagram extends AMP.BaseElement {
     iframe.setAttribute('allowtransparency', 'true');
     //Add title to the iframe for better accessibility.
     iframe.setAttribute('title', 'Instagram: ' +
-        this.element.getAttribute('alt'));
+      this.element.getAttribute('alt'));
     iframe.src = 'https://www.instagram.com/p/' +
-        encodeURIComponent(this.shortcode_) + '/embed/?v=4';
+      encodeURIComponent(this.shortcode_) + '/embed/' +
+      this.captioned_ + '?v=4';
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     setStyles(iframe, {
@@ -161,12 +164,12 @@ class AmpInstagram extends AMP.BaseElement {
   /** @private */
   handleInstagramMessages_(event) {
     if (event.origin != 'https://www.instagram.com' ||
-        event.source != this.iframe_.contentWindow) {
+      event.source != this.iframe_.contentWindow) {
       return;
     }
     if (!event.data ||
-        !(isObject(event.data) || event.data.indexOf('{') == 0)) {
-      return;  // Doesn't look like JSON.
+      !(isObject(event.data) || event.data.indexOf('{') == 0)) {
+      return; // Doesn't look like JSON.
     }
     const data = isObject(event.data) ? event.data : tryParseJson(event.data);
     if (data === undefined) {
@@ -175,7 +178,7 @@ class AmpInstagram extends AMP.BaseElement {
     if (data.type == 'MEASURE' && data.details) {
       const height = data.details.height;
       this.getVsync().measure(() => {
-        if (this.iframe_./*OK*/offsetHeight !== height) {
+        if (this.iframe_. /*OK*/ offsetHeight !== height) {
           // Height returned by Instagram includes header, so
           // subtract 48px top padding
           this.attemptChangeHeight(height - PADDING_TOP).catch(() => {});
@@ -199,7 +202,7 @@ class AmpInstagram extends AMP.BaseElement {
     if (this.unlistenMessage_) {
       this.unlistenMessage_();
     }
-    return true;  // Call layoutCallback again.
+    return true; // Call layoutCallback again.
   }
 };
 

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -65,6 +65,9 @@ class AmpInstagram extends AMP.BaseElement {
 
     /** @private {?Function} */
     this.unlistenMessage_ = null;
+
+    /** @private {string}  */
+    this.captioned_ = '';
   }
  /**
   * @param {boolean=} opt_onLayout

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -66,10 +66,10 @@ class AmpInstagram extends AMP.BaseElement {
     /** @private {?Function} */
     this.unlistenMessage_ = null;
   }
-  /**
-   * @param {boolean=} opt_onLayout
-   * @override
-   */
+ /**
+  * @param {boolean=} opt_onLayout
+  * @override
+  */
   preconnectCallback(opt_onLayout) {
     // See
     // https://instagram.com/developer/embedding/?hl=en

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -24,6 +24,7 @@
  * <amp-instagram
  *   data-shortcode="fBwFP"
  *   data-captioned
+ *   data-default-framing
  *   alt="Fastest page in the west."
  *   width="320"
  *   height="392"
@@ -37,8 +38,12 @@
  * frame. If captions are specified (data-captioned) then a resize will be
  * requested every time due to the fact that it's no possible to know the height
  * of the caption in advance.
+ *
+ * If data-default-framing is present will apply the default instagram frame
+ * style without changing the layout.
  */
 
+import {CSS} from '../../../build/amp-instagram-0.1.css';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {setStyles} from '../../../src/style';
 import {removeElement} from '../../../src/dom';
@@ -47,10 +52,15 @@ import {tryParseJson} from '../../../src/json';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';
 
-const PADDING_LEFT = 8;
-const PADDING_RIGHT = 8;
-const PADDING_BOTTOM = 48;
-const PADDING_TOP = 48;
+/*
+ * These padding values are specifc to intagram embeds with
+ * ?cr=1&v=7 if you change to a different version of the embed
+ * these will need to be recalculated.
+ */
+const PADDING_LEFT = 0;
+const PADDING_RIGHT = 0;
+const PADDING_BOTTOM = 0;
+const PADDING_TOP = 64;
 
 class AmpInstagram extends AMP.BaseElement {
 
@@ -117,6 +127,12 @@ class AmpInstagram extends AMP.BaseElement {
     image.setAttribute('referrerpolicy', 'origin');
 
     this.propagateAttributes(['alt'], image);
+    /*
+     * Add instagram default styling
+     */
+    if (this.element.hasAttribute('data-default-framing')) {
+      this.element.classList.add('amp-instagram-default-framing');
+    }
 
     // This makes the non-iframe image appear in the exact same spot
     // where it will be inside of the iframe.
@@ -146,6 +162,7 @@ class AmpInstagram extends AMP.BaseElement {
       this.handleInstagramMessages_.bind(this)
     );
 
+    iframe.setAttribute('scrolling', 'no');
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowtransparency', 'true');
     //Add title to the iframe for better accessibility.
@@ -153,7 +170,7 @@ class AmpInstagram extends AMP.BaseElement {
         this.element.getAttribute('alt'));
     iframe.src = 'https://www.instagram.com/p/' +
         encodeURIComponent(this.shortcode_) + '/embed/' +
-        this.captioned_ + '?v=4';
+        this.captioned_ + '?cr=1&v=7';
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     setStyles(iframe, {
@@ -188,7 +205,8 @@ class AmpInstagram extends AMP.BaseElement {
         if (this.iframe_./*OK*/offsetHeight !== height) {
           // Height returned by Instagram includes header, so
           // subtract 48px top padding
-          this.attemptChangeHeight(height - PADDING_TOP).catch(() => {});
+          this.attemptChangeHeight(height - (PADDING_TOP + PADDING_BOTTOM))
+              .catch(() => {});
         }
       });
     }
@@ -213,4 +231,4 @@ class AmpInstagram extends AMP.BaseElement {
   }
 };
 
-AMP.registerElement('amp-instagram', AmpInstagram);
+AMP.registerElement('amp-instagram', AmpInstagram, CSS);

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -36,11 +36,14 @@
  * the example above and should produce the correct aspect ratio. amp-instagram
  * will attempt to resize on load based on the height reported by the embedded
  * frame. If captions are specified (data-captioned) then a resize will be
- * requested every time due to the fact that it's no possible to know the height
+ * requested every time due to the fact that it's not possible to know the height
  * of the caption in advance.
  *
+ * If captions are included it is stringly reccomended that an overflow element
+ * is also included.  See description of overflow in amp-iframe.
+ *
  * If data-default-framing is present will apply the default instagram frame
- * style without changing the layout.
+ * style without changing the layout/size.
  */
 
 import {CSS} from '../../../build/amp-instagram-0.1.css';

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -35,13 +35,13 @@
  * the example above and will produce the correct aspect ratio.
  */
 
-import { isLayoutSizeDefined } from '../../../src/layout';
-import { setStyles } from '../../../src/style';
-import { removeElement } from '../../../src/dom';
-import { user } from '../../../src/log';
-import { tryParseJson } from '../../../src/json';
-import { isObject } from '../../../src/types';
-import { listen } from '../../../src/event-helper';
+import {isLayoutSizeDefined} from '../../../src/layout';
+import {setStyles} from '../../../src/style';
+import {removeElement} from '../../../src/dom';
+import {user} from '../../../src/log';
+import {tryParseJson} from '../../../src/json';
+import {isObject} from '../../../src/types';
+import {listen} from '../../../src/event-helper';
 
 const PADDING_LEFT = 8;
 const PADDING_RIGHT = 8;
@@ -52,24 +52,24 @@ class AmpInstagram extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
   constructor(element) {
-      super(element);
+    super(element);
 
-      /** @private {?Element} */
-      this.iframe_ = null;
+    /** @private {?Element} */
+    this.iframe_ = null;
 
-      /** @private {?Promise} */
-      this.iframePromise_ = null;
+    /** @private {?Promise} */
+    this.iframePromise_ = null;
 
-      /** @private {?string} */
-      this.shortcode_ = '';
+    /** @private {?string} */
+    this.shortcode_ = '';
 
-      /** @private {?Function} */
-      this.unlistenMessage_ = null;
-    }
-    /**
-     * @param {boolean=} opt_onLayout
-     * @override
-     */
+    /** @private {?Function} */
+    this.unlistenMessage_ = null;
+  }
+  /**
+   * @param {boolean=} opt_onLayout
+   * @override
+   */
   preconnectCallback(opt_onLayout) {
     // See
     // https://instagram.com/developer/embedding/?hl=en
@@ -77,7 +77,7 @@ class AmpInstagram extends AMP.BaseElement {
     // Host instagram used for image serving. While the host name is
     // funky this appears to be stable in the post-domain sharding era.
     this.preconnect.url('https://instagram.fsnc1-1.fna.fbcdn.net',
-      opt_onLayout);
+        opt_onLayout);
   }
 
   /** @override */
@@ -88,12 +88,12 @@ class AmpInstagram extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.shortcode_ = user().assert(
-      (this.element.getAttribute('data-shortcode') ||
+        (this.element.getAttribute('data-shortcode') ||
         this.element.getAttribute('shortcode')),
-      'The data-shortcode attribute is required for <amp-instagram> %s',
-      this.element);
+        'The data-shortcode attribute is required for <amp-instagram> %s',
+        this.element);
     this.captioned_ = this.element.hasAttribute('data-captioned') ?
-      'captioned/' : '';
+        'captioned/' : '';
   }
 
   /** @override */
@@ -105,7 +105,7 @@ class AmpInstagram extends AMP.BaseElement {
     // This will redirect to the image URL. By experimentation this is
     // always the same URL that is actually used inside of the embed.
     image.setAttribute('src', 'https://www.instagram.com/p/' +
-      encodeURIComponent(this.shortcode_) + '/media/?size=l');
+        encodeURIComponent(this.shortcode_) + '/media/?size=l');
     image.setAttribute('layout', 'fill');
     image.setAttribute('referrerpolicy', 'origin');
 
@@ -143,10 +143,10 @@ class AmpInstagram extends AMP.BaseElement {
     iframe.setAttribute('allowtransparency', 'true');
     //Add title to the iframe for better accessibility.
     iframe.setAttribute('title', 'Instagram: ' +
-      this.element.getAttribute('alt'));
+        this.element.getAttribute('alt'));
     iframe.src = 'https://www.instagram.com/p/' +
-      encodeURIComponent(this.shortcode_) + '/embed/' +
-      this.captioned_ + '?v=4';
+        encodeURIComponent(this.shortcode_) + '/embed/' +
+        this.captioned_ + '?v=4';
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     setStyles(iframe, {
@@ -164,12 +164,12 @@ class AmpInstagram extends AMP.BaseElement {
   /** @private */
   handleInstagramMessages_(event) {
     if (event.origin != 'https://www.instagram.com' ||
-      event.source != this.iframe_.contentWindow) {
+        event.source != this.iframe_.contentWindow) {
       return;
     }
     if (!event.data ||
-      !(isObject(event.data) || event.data.indexOf('{') == 0)) {
-      return; // Doesn't look like JSON.
+        !(isObject(event.data) || event.data.indexOf('{') == 0)) {
+      return;  // Doesn't look like JSON.
     }
     const data = isObject(event.data) ? event.data : tryParseJson(event.data);
     if (data === undefined) {
@@ -178,7 +178,7 @@ class AmpInstagram extends AMP.BaseElement {
     if (data.type == 'MEASURE' && data.details) {
       const height = data.details.height;
       this.getVsync().measure(() => {
-        if (this.iframe_. /*OK*/ offsetHeight !== height) {
+        if (this.iframe_./*OK*/offsetHeight !== height) {
           // Height returned by Instagram includes header, so
           // subtract 48px top padding
           this.attemptChangeHeight(height - PADDING_TOP).catch(() => {});
@@ -202,7 +202,7 @@ class AmpInstagram extends AMP.BaseElement {
     if (this.unlistenMessage_) {
       this.unlistenMessage_();
     }
-    return true; // Call layoutCallback again.
+    return true;  // Call layoutCallback again.
   }
 };
 

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -16,14 +16,14 @@
 
 
 /**
- * @fileoverview Embeds an instagram photo. Captions are currently
- * not supported.
+ * @fileoverview Embeds an instagram photo.
  * The data-shortcode attribute can be easily copied from a normal instagram
  * URL.
  * Example:
  * <code>
  * <amp-instagram
  *   data-shortcode="fBwFP"
+ *   data-captioned
  *   alt="Fastest page in the west."
  *   width="320"
  *   height="392"
@@ -32,7 +32,11 @@
  * </code>
  *
  * For responsive embedding the width and height can be left unchanged from
- * the example above and will produce the correct aspect ratio.
+ * the example above and should produce the correct aspect ratio. amp-instagram
+ * will attempt to resize on load based on the height reported by the embedded
+ * frame. If captions are specified (data-captioned) then a resize will be
+ * requested every time due to the fact that it's no possible to know the height
+ * of the caption in advance.
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -81,14 +81,14 @@ describe('amp-instagram', () => {
 
   function testIframe(iframe) {
     expect(iframe).to.not.be.null;
-    expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?v=4');
+    expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/?cr=1&v=7');
     expect(iframe.className).to.match(/i-amphtml-fill-content/);
     expect(iframe.getAttribute('title')).to.equal('Instagram: Testing');
   }
 
   function testIframeCaptioned(iframe) {
     expect(iframe).to.not.be.null;
-    expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/captioned/?v=4');
+    expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/captioned/?cr=1&v=7');
     expect(iframe.className).to.match(/i-amphtml-fill-content/);
     expect(iframe.getAttribute('title')).to.equal('Instagram: Testing');
   }
@@ -176,7 +176,7 @@ describe('amp-instagram', () => {
 
       expect(attemptChangeHeight).to.be.calledOnce;
       // Height minus padding
-      expect(attemptChangeHeight.firstCall.args[0]).to.equal(newHeight - 48);
+      expect(attemptChangeHeight.firstCall.args[0]).to.equal(newHeight - 64);
     });
   });
 

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -19,7 +19,7 @@ import {
   doNotLoadExternalResourcesInTest,
 } from '../../../../testing/iframe';
 import '../amp-instagram';
-import {adopt} from '../../../../src/runtime';
+import { adopt } from '../../../../src/runtime';
 import * as sinon from 'sinon';
 
 adopt(window);
@@ -36,7 +36,7 @@ describe('amp-instagram', () => {
     sandbox.restore();
   });
 
-  function getIns(shortcode, opt_responsive, opt_beforeLayoutCallback) {
+  function getIns(shortcode, opt_responsive, opt_beforeLayoutCallback, opt_captioned) {
     return createIframePromise(true, opt_beforeLayoutCallback).then(iframe => {
       doNotLoadExternalResourcesInTest(iframe.win);
       const ins = iframe.doc.createElement('amp-instagram');
@@ -46,6 +46,9 @@ describe('amp-instagram', () => {
       ins.setAttribute('alt', 'Testing');
       if (opt_responsive) {
         ins.setAttribute('layout', 'responsive');
+      }
+      if (opt_captioned) {
+        ins.setAttribute('data-captioned', '');
       }
       ins.implementation_.getVsync = () => {
         return {
@@ -69,7 +72,7 @@ describe('amp-instagram', () => {
   function testImage(image) {
     expect(image).to.not.be.null;
     expect(image.getAttribute('src')).to.equal(
-        'https://www.instagram.com/p/fBwFP/media/?size=l');
+      'https://www.instagram.com/p/fBwFP/media/?size=l');
     expect(image.getAttribute('layout')).to.equal('fill');
     expect(image.getAttribute('alt')).to.equal('Testing');
     expect(image.getAttribute('referrerpolicy')).to.equal('origin');
@@ -82,6 +85,13 @@ describe('amp-instagram', () => {
     expect(iframe.getAttribute('title')).to.equal('Instagram: Testing');
   }
 
+  function testIframeCaptioned(iframe) {
+    expect(iframe).to.not.be.null;
+    expect(iframe.src).to.equal('https://www.instagram.com/p/fBwFP/embed/captioned/?v=4');
+    expect(iframe.className).to.match(/i-amphtml-fill-content/);
+    expect(iframe.getAttribute('title')).to.equal('Instagram: Testing');
+  }
+
   it('renders', () => {
     return getIns('fBwFP').then(ins => {
       testIframe(ins.querySelector('iframe'));
@@ -89,10 +99,17 @@ describe('amp-instagram', () => {
     });
   });
 
+  it('renders captioned', () => {
+    return getIns('fBwFP', undefined, undefined, true).then(ins => {
+      testIframeCaptioned(ins.querySelector('iframe'));
+      testImage(ins.querySelector('amp-img'));
+    });
+  });
+
   it('sets noprerender on amp-img', () => {
     return getIns('fBwFP').then(ins => {
       expect(ins.querySelector('amp-img').hasAttribute('noprerender'))
-          .to.be.true;
+        .to.be.true;
     });
   });
 
@@ -140,7 +157,7 @@ describe('amp-instagram', () => {
 
   it('requires data-shortcode', () => {
     expect(getIns('')).to.be.rejectedWith(
-        /The data-shortcode attribute is required for/);
+      /The data-shortcode attribute is required for/);
   });
 
   it('resizes in response to messages from Instagram iframe', () => {

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -19,7 +19,7 @@ import {
   doNotLoadExternalResourcesInTest,
 } from '../../../../testing/iframe';
 import '../amp-instagram';
-import { adopt } from '../../../../src/runtime';
+import {adopt} from '../../../../src/runtime';
 import * as sinon from 'sinon';
 
 adopt(window);
@@ -36,7 +36,8 @@ describe('amp-instagram', () => {
     sandbox.restore();
   });
 
-  function getIns(shortcode, opt_responsive, opt_beforeLayoutCallback, opt_captioned) {
+  function getIns(shortcode, opt_responsive,
+      opt_beforeLayoutCallback, opt_captioned) {
     return createIframePromise(true, opt_beforeLayoutCallback).then(iframe => {
       doNotLoadExternalResourcesInTest(iframe.win);
       const ins = iframe.doc.createElement('amp-instagram');
@@ -72,7 +73,7 @@ describe('amp-instagram', () => {
   function testImage(image) {
     expect(image).to.not.be.null;
     expect(image.getAttribute('src')).to.equal(
-      'https://www.instagram.com/p/fBwFP/media/?size=l');
+        'https://www.instagram.com/p/fBwFP/media/?size=l');
     expect(image.getAttribute('layout')).to.equal('fill');
     expect(image.getAttribute('alt')).to.equal('Testing');
     expect(image.getAttribute('referrerpolicy')).to.equal('origin');
@@ -109,7 +110,7 @@ describe('amp-instagram', () => {
   it('sets noprerender on amp-img', () => {
     return getIns('fBwFP').then(ins => {
       expect(ins.querySelector('amp-img').hasAttribute('noprerender'))
-        .to.be.true;
+          .to.be.true;
     });
   });
 
@@ -157,7 +158,7 @@ describe('amp-instagram', () => {
 
   it('requires data-shortcode', () => {
     expect(getIns('')).to.be.rejectedWith(
-      /The data-shortcode attribute is required for/);
+        /The data-shortcode attribute is required for/);
   });
 
   it('resizes in response to messages from Instagram iframe', () => {

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -69,6 +69,10 @@ The instagram data-shortcode is found in every instagram photo URL.
 
 For example, in https://instagram.com/p/fBwFP, `fBwFP` is the data-shortcode.
 
+**data-captioned**
+
+Include the Instagram caption.  `amp-instagram` will attept to resize to the correct hight including the caption.
+
 **common attributes**
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,7 +85,7 @@ declareExtension('amp-gfycat', '0.1', false);
 declareExtension('amp-hulu', '0.1', false);
 declareExtension('amp-iframe', '0.1', false, 'NO_TYPE_CHECK');
 declareExtension('amp-image-lightbox', '0.1', true);
-declareExtension('amp-instagram', '0.1', false);
+declareExtension('amp-instagram', '0.1', true);
 declareExtension('amp-install-serviceworker', '0.1', false);
 declareExtension('amp-izlesene', '0.1', false);
 declareExtension('amp-jwplayer', '0.1', false, 'NO_TYPE_CHECK');


### PR DESCRIPTION
Add support for captions to `amp-instagram` via the `data-captioned` attribute

Fixes captions in issue #8242 


