### PR TITLE
Migrating performance monitoring pings to amp-analytics

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -410,3 +410,80 @@ export function injectActiveViewAmpAnalyticsElement(
   ampAnalyticsElem.appendChild(scriptElem);
   a4a.element.appendChild(ampAnalyticsElem);
 }
+
+/**
+ * @param {string} urlBase Base URL to which monitoring pings will be directed.
+ * @param {string} type  Ad tag type (e.g., 'adsense')
+ * @param {?string} adSlotId  Unique (within page) ID for this ad slot.
+ * @param {?string} eids  List of eids attached to tag.
+ * @return {!JSONType}  Data structure containing analytics config.  Note:
+ *   returned as an object, not as a string.
+ */
+export function getGoogleAnalyticsConfig(urlBase, type, adSlotId, eids) {
+  const eventNamesToIds = {
+    urlBuilt: '1',
+    adRequestStart: '2',
+    adRequestEnd: '3',
+    extractCreativeAndSignature: '4',
+    adResponseValidateStart: '5',
+    renderFriendlyStart: '6',  // TODO(dvoytenko): this signal and similar are actually "embed-create", not "render-start".
+    renderCrossDomainStart: '7',
+    renderFriendlyEnd: '8',
+    renderCrossDomainEnd: '9',
+    preAdThrottle: '10',
+    renderSafeFrameStart: '11',
+    throttled3p: '12',
+    adResponseValidateEnd: '13',
+    xDomIframeLoaded: '14',
+    friendlyIframeLoaded: '15',
+    adSlotCollapsed: '16',
+    adSlotUnhidden: '17',
+    layoutAdPromiseDelay: '18',
+    signatureVerifySuccess: '19',
+    networkError: '20',
+    friendlyIframeIniLoad: '21',
+  };
+  const urlParams = ['n=${namespace}',
+    'v=${csiVersion}',
+    'rls=${ampVersion}',
+    't=${tagType}',
+    'slotId=${slotId}',
+    'stageId=${stageId}',
+    'stageName=${stageName}',
+    'vx=${viewportWidth}',
+    'vy=${viewportHeight}',
+    'dx=${scrollLeft}',
+    'dy=${scrollTop}',
+  ];
+  if (eids) {
+    urlParams.push('e=${exptIds}');
+  }
+  const config = {
+    'requests': {
+      'event': urlBase + '?' + urlParams.join('&'),
+    },
+    'vars': {
+      'tagType': type,
+      'slotId': adSlotId,
+      'exptIds': eids,
+      'namespace': 'a4a',
+      'csiVersion': '2',
+    },
+    'triggers': {},  // Filled in below.
+  };
+  for (const eventName in eventNamesToIds) {
+    if (eventNamesToIds.hasOwnProperty(eventName)) {
+      config.triggers[eventName] = {
+        'on': eventName,
+        'request': 'event',
+        'selector': 'amp-ad',
+        'selectionMethod': 'closest',
+        'vars': {
+          'stageName': eventName,
+          'stageId': eventNamesToIds[eventName],
+        },
+      };
+    }
+  }
+  return config;
+}

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -60,6 +60,7 @@ import {A4AVariableSource} from './a4a-variable-source';
 // TODO(tdrl): Temporary.  Remove when we migrate to using amp-analytics.
 import {getTimingDataAsync} from '../../../src/service/variable-source';
 import {getContextMetadata} from '../../../src/iframe-attributes';
+import {triggerAnalyticsEvent} from '../../../src/analytics';
 
 /** @type {string} */
 const METADATA_STRING = '<script type="application/json" amp-ad-metadata>';
@@ -308,6 +309,9 @@ export class AmpA4A extends AMP.BaseElement {
      * @private {boolean}
      */
     this.isCollapsed_ = false;
+
+    /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampDoc_ = this.getAmpDoc();
   }
 
   /** @override */
@@ -1382,8 +1386,14 @@ export class AmpA4A extends AMP.BaseElement {
    * variables of the form { name: val }.  It is up to the subclass what to
    * do with those variables.
    *
-   * @param {string} unusedEventName
+   * TODO(tdrl): This method and its instantiations should go away once
+   * we've verified that analytics is working correctly for performance
+   * monitoring and we can deprecate the direct CSI ping mechanism.
+   *
+   * @param {string} eventName
    * @param {!Object<string, string|number>=} opt_extraVariables
    */
-  emitLifecycleEvent(unusedEventName, opt_extraVariables) {}
+  emitLifecycleEvent(eventName, opt_extraVariables) {
+    triggerAnalyticsEvent(this.ampDoc_, eventName, opt_extraVariables);
+  }
 }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -311,7 +311,7 @@ describe('amp-a4a', () => {
           'whenIniLoaded',
           () => iniLoadPromise);
       const lifecycleEventStub = sandbox.stub(
-          a4a, 'protectedEmitLifecycleEvent_');
+          a4a, 'emitLifecycleEvent_');
       a4a.onLayoutMeasure();
       const layoutPromise = a4a.layoutCallback();
       return Promise.resolve().then(() => {
@@ -892,7 +892,7 @@ describe('amp-a4a', () => {
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         const lifecycleEventStub = sandbox.stub(
-            a4a, 'protectedEmitLifecycleEvent_');
+            a4a, 'emitLifecycleEvent_');
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.instanceof(Promise);

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -24,7 +24,6 @@ import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
-// import {dev} from '../../../src/log';
 import {
   extractGoogleAdCreativeAndSignature,
   googleAdUrl,
@@ -32,6 +31,8 @@ import {
   AmpAnalyticsConfigDef,
   extractAmpAnalyticsConfig,
   injectActiveViewAmpAnalyticsElement,
+  EXPERIMENT_ATTRIBUTE,
+  getGoogleAnalyticsConfig,
 } from '../../../ads/google/a4a/utils';
 import {
   googleLifecycleReporterFactory,
@@ -43,6 +44,11 @@ import {extensionsFor} from '../../../src/extensions';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {viewerForDoc} from '../../../src/viewer';
 import {AdsenseSharedState} from './adsense-shared-state';
+// TODO(tdrl): Update to using insertAnalyticsElement when PR#7940 is
+// merged.
+import {getAmpDoc} from '../../../src/ampdoc';
+import {getServiceForDoc} from '../../../src/service';
+import {createElementWithAttributes} from '../../../src/dom';
 
 /** @const {string} */
 const ADSENSE_BASE_URL = 'https://googleads.g.doubleclick.net/pagead/ads';
@@ -101,6 +107,38 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
     /** @private {!../../../src/service/extensions-impl.Extensions} */
     this.extensions_ = extensionsFor(this.win);
+  }
+
+  /**
+   * Returns the URL base address for performance monitor pings.  Exists
+   * to be stubbed out during testing.
+   *
+   * @return {string}
+   */
+  getPerformanceReportingUrlBase() {
+    return 'http://localhost:8000/nowhere';
+  }
+
+  buildCallback() {
+    super.buildCallback();
+    // TODO(tdrl): Update to using insertAnalyticsElement when PR#7940 is
+    // merged.
+    // Force load of amp-analytics.
+    const parentDoc = getAmpDoc(this.element);
+    getServiceForDoc(parentDoc, 'amp-analytics-instrumentation');
+    // Configure and insert it.  Note: use the 'config' attribute here to
+    // set a remote config, if we decide that it's useful to do so.
+    const analyticsElement = createElementWithAttributes(
+        parentDoc.win.document, 'amp-analytics', null);
+    const config = createElementWithAttributes(
+        parentDoc.win.document, 'script', {type: 'application/json'});
+    config.textContent = JSON.stringify(
+        getGoogleAnalyticsConfig(this.getPerformanceReportingUrlBase(),
+            'adsense',
+            this.element.getAttribute('data-amp-slot-index'),
+            this.element.getAttribute(EXPERIMENT_ATTRIBUTE)));
+    analyticsElement.appendChild(config);
+    this.element.appendChild(analyticsElement);
   }
 
   /** @override */
@@ -206,6 +244,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   emitLifecycleEvent(eventName, opt_extraVariables) {
+    super.emitLifecycleEvent(eventName, opt_extraVariables);
     if (opt_extraVariables) {
       this.lifecycleReporter_.setPingParameters(opt_extraVariables);
     }
@@ -222,6 +261,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       sharedState.removeSlot(this.uniqueSlotId_);
     }
     this.ampAnalyticsConfig = null;
+    // TODO(tdrl): Should we delete the performance analytics config here as
+    // well?  If yes, will #buildCallback be invoked again to recreate it,
+    // or will we need to insert something else to recreate it?
   }
 
   /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -129,7 +129,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     // Configure and insert it.  Note: use the 'config' attribute here to
     // set a remote config, if we decide that it's useful to do so.
     const analyticsElement = createElementWithAttributes(
-        parentDoc.win.document, 'amp-analytics', null);
+        parentDoc.win.document, 'amp-analytics', {});
     const config = createElementWithAttributes(
         parentDoc.win.document, 'script', {type: 'application/json'});
     config.textContent = JSON.stringify(

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -97,7 +97,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     // Configure and insert it.  Note: use the 'config' attribute here to
     // set a remote config, if we decide that it's useful to do so.
     const analyticsElement = createElementWithAttributes(
-        parentDoc.win.document, 'amp-analytics', null);
+        parentDoc.win.document, 'amp-analytics', {});
     const config = createElementWithAttributes(
         parentDoc.win.document, 'script', {type: 'application/json'});
     config.textContent = JSON.stringify(

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -31,6 +31,8 @@ import {
   AmpAnalyticsConfigDef,
   extractAmpAnalyticsConfig,
   injectActiveViewAmpAnalyticsElement,
+  EXPERIMENT_ATTRIBUTE,
+  getGoogleAnalyticsConfig,
 } from '../../../ads/google/a4a/utils';
 import {getMultiSizeDimensions} from '../../../ads/google/utils';
 import {
@@ -40,6 +42,11 @@ import {
 import {stringHash32} from '../../../src/crypto';
 import {extensionsFor} from '../../../src/extensions';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
+// TODO(tdrl): Update to using insertAnalyticsElement when PR#7940 is
+// merged.
+import {getAmpDoc} from '../../../src/ampdoc';
+import {getServiceForDoc} from '../../../src/service';
+import {createElementWithAttributes} from '../../../src/dom';
 
 /** @const {string} */
 const DOUBLECLICK_BASE_URL =
@@ -68,6 +75,38 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     /** @private {!../../../src/service/extensions-impl.Extensions} */
     this.extensions_ = extensionsFor(this.win);
+  }
+
+  /**
+   * Returns the URL base address for performance monitor pings.  Exists
+   * to be stubbed out during testing.
+   *
+   * @return {string}
+   */
+  getPerformanceReportingUrlBase() {
+    return 'http://localhost:8000/nowhere';
+  }
+
+  buildCallback() {
+    super.buildCallback();
+    // TODO(tdrl): Update to using insertAnalyticsElement when PR#7940 is
+    // merged.
+    // Force load of amp-analytics.
+    const parentDoc = getAmpDoc(this.element);
+    getServiceForDoc(parentDoc, 'amp-analytics-instrumentation');
+    // Configure and insert it.  Note: use the 'config' attribute here to
+    // set a remote config, if we decide that it's useful to do so.
+    const analyticsElement = createElementWithAttributes(
+        parentDoc.win.document, 'amp-analytics', null);
+    const config = createElementWithAttributes(
+        parentDoc.win.document, 'script', {type: 'application/json'});
+    config.textContent = JSON.stringify(
+        getGoogleAnalyticsConfig(this.getPerformanceReportingUrlBase(),
+            'doubleclick',
+            this.element.getAttribute('data-amp-slot-index'),
+            this.element.getAttribute(EXPERIMENT_ATTRIBUTE)));
+    analyticsElement.appendChild(config);
+    this.element.appendChild(analyticsElement);
   }
 
   /** @override */
@@ -156,6 +195,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   emitLifecycleEvent(eventName, opt_extraVariables) {
+    super.emitLifecycleEvent(eventName, opt_extraVariables);
     if (opt_extraVariables) {
       this.lifecycleReporter_.setPingParameters(opt_extraVariables);
     }
@@ -169,6 +209,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
     this.ampAnalyticsConfig = null;
+    // TODO(tdrl): Should we delete the performance analytics config here as
+    // well?  If yes, will #buildCallback be invoked again to recreate it,
+    // or will we need to insert something else to recreate it?
   }
 
   /**


### PR DESCRIPTION
First draft of migration code.  Not finished yet, but looking for early feedback.

I plan to run analytics-based pings in parallel with CSI-based pings for a while so that we can double-check for consistency between them.  Once we're happy with the analytics-based pings, we can go back and deprecate the CSI-style pings.

Still to do: Pick up and propagate the A4A-specific header variables and fill out rest of ping variables.  Plus tests.

