### PR TITLE
Amp-Ad upgrade: move remote.html existence check before network predicate execution

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -76,8 +76,8 @@ export class AmpAd extends AMP.BaseElement {
 
       // TODO(tdrl): Check amp-ad registry to see if they have this already.
       if (!a4aRegistry[type] ||
-          !a4aRegistry[type](this.win, this.element) ||
-          this.win.document.querySelector('meta[name=amp-3p-iframe-src]')) {
+          this.win.document.querySelector('meta[name=amp-3p-iframe-src]') ||
+          !a4aRegistry[type](this.win, this.element)) {
         // Either this ad network doesn't support Fast Fetch, its Fast Fetch
         // implementation has explicitly opted not to handle this tag, or this
         // page uses remote.html which is inherently incompatible with Fast

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -141,7 +141,9 @@ describe('Ad loader', () => {
           meta.setAttribute('name', 'amp-3p-iframe-src');
           meta.setAttribute('content', 'https://example.com/remote.html');
           doc.head.appendChild(meta);
-          a4aRegistry['zort'] = () => true;
+          a4aRegistry['zort'] = () => {
+            throw new Error('predicate should not execute if remote.html!');
+          };
           ampAdElement.setAttribute('type', 'zort');
           const upgraded = new AmpAd(ampAdElement).upgradeCallback();
           return expect(upgraded).to.eventually.be.instanceof(AmpAd3PImpl);


### PR DESCRIPTION
For Fast Fetch network support selection within AmpAd element, a predicate is registered within the network config that when executed returns whether Fast Fetch flow should be used.  In the case of AdSense & Doubleclick, the function execution includes selection into control or experiment to isolate the impact of Fast vs Delayed Fetch.  Currently Fast Fetch does not support remote.html usage due to its nature of being custom JS and as such should be carved out of valid traffic for Fast Fetch selection.  This check was moved out of Doubleclick specific predicate to general AmpAd upgrade within #8248 when it was discovered that publishers were also using remote.html for AdSense.  However, when it was moved, it was placed AFTER the predicate execution causing selection into the Fast Fetch experiment to not actually result in a Fast Fetch request.

cc @ampproject/a4a 