### PR TITLE
Allowing resize for fully below the fold elements even when top margin changed

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1049,6 +1049,7 @@ export class Resources {
 
         let topMarginDiff = 0;
         let bottomMarginDiff = 0;
+        let topUnchangedBoundary = box.top;
         let bottomDisplacedBoundary = box.bottom;
         let newMargins = undefined;
         if (request.marginChange) {
@@ -1059,6 +1060,9 @@ export class Resources {
           }
           if (newMargins.bottom != undefined) {
             bottomMarginDiff = newMargins.bottom - margins.bottom;
+          }
+          if (topMarginDiff) {
+            topUnchangedBoundary = box.top - margins.top;
           }
           if (bottomMarginDiff) {
             // The lowest boundary of the element that would appear to be
@@ -1082,8 +1086,9 @@ export class Resources {
           // 3. Active elements are immediately resized. The assumption is that
           // the resize is triggered by the user action or soon after.
           resize = true;
-        } else if (topMarginDiff == 0 && box.bottom + Math.min(heightDiff, 0) >=
-              viewportRect.bottom - bottomOffset) {
+        } else if (topUnchangedBoundary >= viewportRect.bottom - bottomOffset ||
+            (topMarginDiff == 0 && box.bottom + Math.min(heightDiff, 0) >=
+             viewportRect.bottom - bottomOffset)) {
           // 4. Elements under viewport are resized immediately, but only if
           // an element's boundary is not changed above the viewport after
           // resize.

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1633,6 +1633,65 @@ describe('Resources changeSize', () => {
       expect(overflowCallbackSpy.firstCall.args[0]).to.equal(false);
     });
 
+    it('should change size when below the viewport and top margin also changed',
+        () => {
+          resource1.layoutBox_ = {top: 200, left: 0, right: 100, bottom: 300,
+              height: 100};
+          resources.scheduleChangeSize_(resource1, 111, 222, {top: 20}, false);
+
+          expect(vsyncSpy).to.be.calledOnce;
+          const marginsTask = vsyncSpy.lastCall.args[0];
+          marginsTask.measure({});
+
+          resources.mutateWork_();
+          expect(resources.requestsChangeSize_).to.be.empty;
+          expect(resource1.changeSize).to.be.calledOnce;
+          expect(overflowCallbackSpy).to.be.calledOnce;
+          expect(overflowCallbackSpy.firstCall.args[0]).to.equal(false);
+        });
+
+    it('should change size when box top below the viewport but top margin ' +
+        'boundary is above viewport but top margin in unchanged', () => {
+      resource1.layoutBox_ = {top: 200, left: 0, right: 100, bottom: 300,
+          height: 100};
+      resource1.element.fakeComputedStyle = {
+        marginTop: '100px',
+        marginRight: '0px',
+        marginBottom: '0px',
+        marginLeft: '0px',
+      };
+      resources.scheduleChangeSize_(resource1, 111, 222, {top: 100}, false);
+
+      expect(vsyncSpy).to.be.calledOnce;
+      const marginsTask = vsyncSpy.lastCall.args[0];
+      marginsTask.measure({});
+
+      resources.mutateWork_();
+      expect(resources.requestsChangeSize_).to.be.empty;
+      expect(resource1.changeSize).to.be.calledOnce;
+      expect(overflowCallbackSpy).to.be.calledOnce;
+      expect(overflowCallbackSpy.firstCall.args[0]).to.equal(false);
+    });
+
+    it('should NOT change size when top margin boundary within viewport ' +
+        'and top margin changed', () => {
+      const callback = sandbox.spy();
+      resource1.layoutBox_ = {top: 100, left: 0, right: 100, bottom: 300,
+          height: 200};
+      resources.scheduleChangeSize_(
+          resource1, 111, 222, {top: 20}, false, callback);
+
+      expect(vsyncSpy).to.be.calledOnce;
+      const task = vsyncSpy.lastCall.args[0];
+      task.measure({});
+
+      resources.mutateWork_();
+      expect(resource1.changeSize).to.not.been.called;
+      expect(overflowCallbackSpy).to.not.been.called;
+      expect(callback).to.be.calledOnce;
+      expect(callback.args[0][0]).to.be.false;
+    });
+
     it('should defer when above the viewport and scrolling on', () => {
       resource1.layoutBox_ = {top: -1200, left: 0, right: 100, bottom: -1050,
           height: 50};


### PR DESCRIPTION
Fixes something that was missed in https://github.com/ampproject/amphtml/pull/6824. If an element is fully below the fold, then resize should be allowed even when top margin is being changed, since changes to the top boundary won't be visible to the user.