### PR TITLE
Support LCD amp-ad in multi-size

### DIFF
--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {user} from '../../src/log';
-
 /**
  * Given the amp-ad data attribute containing the multi-size dimensions, and a
  * set of primary dimensions, this function will return all valid multi-size
@@ -63,12 +61,10 @@ export function getMultiSizeDimensions(
           `Invalid ${badDim} of ${badVal} given for secondary size.`)) {
       return;
     }
-
-   /*   
+   /*
 This check renders makes it only possible to do a GCD size for the primary unit. Without the ability to put a creative wrapper on AdX demand we cannot resize the container back down to 300x250.
 By removing this requirement we set the defaut size to 300x250 for AdX support and allow the amp-ad comtainer to resize up to accomadate our direct sold sponsorhip larger ad sizes. The container will only resize downward when BTF so there is no negative effect on user experience that I've seen.
 Perhaps the better way to solve this is to include a new attribute in the amp-ad tag that allows for this option as an override. Thanks Sam smansour@hearst
-
      // Check that secondary size is not larger than primary size.
     if (!validateDimensions(width, height,
           w => w > primaryWidth,
@@ -77,7 +73,6 @@ Perhaps the better way to solve this is to include a new attribute in the amp-ad
          `can't be larger than the primary ${badDim}.`)) {
      return;
    }*/
-
     // Check that if multi-size-validation is on, that the secondary sizes
     // are at least minRatio of the primary size.
     if (multiSizeValidation) {
@@ -94,14 +89,12 @@ Perhaps the better way to solve this is to include a new attribute in the amp-ad
         return;
       }
     }
-
     // Passed all checks! Push additional size to dimensions.
     dimensions.push([width, height]);
   });
 
   return dimensions;
 }
-
 /**
  * A helper function for determining whether a given width or height violates
  * some condition.

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -64,14 +64,19 @@ export function getMultiSizeDimensions(
       return;
     }
 
-    // Check that secondary size is not larger than primary size.
+   /*   
+This check renders makes it only possible to do a GCD size for the primary unit. Without the ability to put a creative wrapper on AdX demand we cannot resize the container back down to 300x250.
+By removing this requirement we set the defaut size to 300x250 for AdX support and allow the amp-ad comtainer to resize up to accomadate our direct sold sponsorhip larger ad sizes. The container will only resize downward when BTF so there is no negative effect on user experience that I've seen.
+Perhaps the better way to solve this is to include a new attribute in the amp-ad tag that allows for this option as an override. Thanks Sam smansour@hearst
+
+     // Check that secondary size is not larger than primary size.
     if (!validateDimensions(width, height,
           w => w > primaryWidth,
-          h => h > primaryHeight,
-          ({badDim, badVal}) => `Secondary ${badDim} ${badVal} ` +
-          `can't be larger than the primary ${badDim}.`)) {
-      return;
-    }
+         h => h > primaryHeight,
+         ({badDim, badVal}) => `Secondary ${badDim} ${badVal} ` +
+         `can't be larger than the primary ${badDim}.`)) {
+     return;
+   }*/
 
     // Check that if multi-size-validation is on, that the secondary sizes
     // are at least minRatio of the primary size.

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {user} from '../../src/log';
+
 /**
  * Given the amp-ad data attribute containing the multi-size dimensions, and a
  * set of primary dimensions, this function will return all valid multi-size
@@ -61,6 +62,7 @@ export function getMultiSizeDimensions(
           `Invalid ${badDim} of ${badVal} given for secondary size.`)) {
       return;
     }
+
    /*
 This check renders makes it only possible to do a GCD size for the primary unit. Without the ability to put a creative wrapper on AdX demand we cannot resize the container back down to 300x250.
 By removing this requirement we set the defaut size to 300x250 for AdX support and allow the amp-ad comtainer to resize up to accomadate our direct sold sponsorhip larger ad sizes. The container will only resize downward when BTF so there is no negative effect on user experience that I've seen.
@@ -75,6 +77,7 @@ Perhaps the better way to solve this is to include a new attribute in the amp-ad
    }*/
     // Check that if multi-size-validation is on, that the secondary sizes
     // are at least minRatio of the primary size.
+
     if (multiSizeValidation) {
       // The minimum ratio of each secondary dimension to its corresponding
       // primary dimension.
@@ -95,6 +98,7 @@ Perhaps the better way to solve this is to include a new attribute in the amp-ad
 
   return dimensions;
 }
+
 /**
  * A helper function for determining whether a given width or height violates
  * some condition.
@@ -113,6 +117,7 @@ Perhaps the better way to solve this is to include a new attribute in the amp-ad
  *    errorBuilder A function that will produce an informative error message.
  * @return {boolean}
  */
+
 function validateDimensions(width, height, widthCond, heightCond,
     errorBuilder) {
   let badParams = null;

--- a/examples/HDM-Superhero.html
+++ b/examples/HDM-Superhero.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html ⚡>
+  <head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="hello-world.html" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-custom>
+    
+   //  amp-ad {border: 1px solid #ccc; width: 100%; height:100%;} 
+	
+    </style>
+	
+    <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+		
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+	  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+  </head>
+  <body>
+	 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam bibendum hendrerit massa, eget tristique risus fringilla in. Quisque id velit porta, malesuada risus sit amet, aliquet felis. Donec finibus, nisl et sollicitudin ornare, tellus augue feugiat nibh, eu tristique massa lacus et turpis. Donec molestie, justo vel tempus porttitor, turpis arcu euismod purus, et auctor nisi elit eget sapien. Etiam tristique, arcu eu ornare ultrices, enim eros interdum magna, consequat porttitor turpis turpis eget augue. Aenean condimentum, purus et egestas pretium, quam orci tristique leo, nec aliquet massa orci eu mauris. Mauris dui diam, sodales a enim vitae, elementum varius urna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec ante nisl, tincidunt vitae fermentum in, tempor ac elit. Phasellus lacinia lorem ullamcorper tortor lobortis scelerisque. Suspendisse lacinia ultricies iaculis. Proin id lobortis mi. Praesent fringilla turpis a erat rutrum sodales.</p>
+    <div>
+	<amp-ad width=300 height=250
+    type="doubleclick"
+    data-slot="/36117602/hdm-esquire"
+    json='{"targeting":
+	{ 
+		"token":["ampsuperhero"]
+	} 
+	}'
+	data-multi-size="320x450,320x480,300x450,300x250,300x300"
+	data-multi-size-validation="false" 
+
+	>
+    </amp-ad>
+</div>
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam bibendum hendrerit massa, eget tristique risus fringilla in. Quisque id velit porta, malesuada risus sit amet, aliquet felis. Donec finibus, nisl et sollicitudin ornare, tellus augue feugiat nibh, eu tristique massa lacus et turpis. Donec molestie, justo vel tempus porttitor, turpis arcu euismod purus, et auctor nisi elit eget sapien. Etiam tristique, arcu eu ornare ultrices, enim eros interdum magna, consequat porttitor turpis turpis eget augue. Aenean condimentum, purus et egestas pretium, quam orci tristique leo, nec aliquet massa orci eu mauris. Mauris dui diam, sodales a enim vitae, elementum varius urna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec ante nisl, tincidunt vitae fermentum in, tempor ac elit. Phasellus lacinia lorem ullamcorper tortor lobortis scelerisque. Suspendisse lacinia ultricies iaculis. Proin id lobortis mi. Praesent fringilla turpis a erat rutrum sodales.</p>
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam bibendum hendrerit massa, eget tristique risus fringilla in. Quisque id velit porta, malesuada risus sit amet, aliquet felis. Donec finibus, nisl et sollicitudin ornare, tellus augue feugiat nibh, eu tristique massa lacus et turpis. Donec molestie, justo vel tempus porttitor, turpis arcu euismod purus, et auctor nisi elit eget sapien. Etiam tristique, arcu eu ornare ultrices, enim eros interdum magna, consequat porttitor turpis turpis eget augue. Aenean condimentum, purus et egestas pretium, quam orci tristique leo, nec aliquet massa orci eu mauris. Mauris dui diam, sodales a enim vitae, elementum varius urna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec ante nisl, tincidunt vitae fermentum in, tempor ac elit. Phasellus lacinia lorem ullamcorper tortor lobortis scelerisque. Suspendisse lacinia ultricies iaculis. Proin id lobortis mi. Praesent fringilla turpis a erat rutrum sodales.</p>
+  </body>
+</html>


### PR DESCRIPTION
This check makes it only possible to do a GCD size for the primary
unit. Without the ability to put a creative wrapper on AdX we cannot
resize the container back down to 300x250.
By removing this requirement we can set the default size to 300x250 for
AdX support and allow the amp-ad container to resize up for direct sold
sponsorship larger ad sizes. The container will only resize downward
when BTF so there is no negative effect on user experience that I've
seen.
Perhaps a better way to solve this is to include a new attribute in the
amp-ad tag that allows for this option as an override. Thanks Sam
smansour@hearst

http://localhost:8000/examples/HDM-Superhero.max.html

Please pick a meaningful title for your pull request using sentence case.

Do not overuse punctuation in the title like `(chore):`. If it is helpful feel free to start with a project name, though, like `ProjectX: Implement some feature`.

# Title instructions above.

Enter a succinct description of what is achieved by the PR. Ideally describe why the change is being made.

Bullet points like

- Implements aspect X
- Leaves out feature Y because of A
- Improves performance by B
- Improves accessibility by C

really help with making this more readable.

Fixes/Closes/Related-to #1 (enter issue number, except in rare cases where none exists).
