### PR TITLE
Ensuring amp-auto-ads are centered and/or use full-width

### DIFF
--- a/extensions/amp-auto-ads/0.1/attributes.js
+++ b/extensions/amp-auto-ads/0.1/attributes.js
@@ -26,7 +26,6 @@ const TAG = 'amp-auto-ads';
  */
 const NON_DATA_ATTRIBUTE_WHITELIST = {
   'type': true,
-  'layout': true,
 };
 
 /**

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -30,12 +30,6 @@ const TAG = 'amp-auto-ads';
  * TODO: Specify this via the configuration.
  * @const
  */
-const TARGET_AD_WIDTH_PX = 320;
-
-/**
- * TODO: Specify this via the configuration.
- * @const
- */
 const TARGET_AD_HEIGHT_PX = 100;
 
 /**
@@ -187,7 +181,7 @@ export class Placement {
         this.adElement_ = this.createAdElement_(baseAttributes);
         this.injector_(this.anchorElement_, this.adElement_);
         return this.resources_.attemptChangeSize(this.adElement_,
-            TARGET_AD_HEIGHT_PX, TARGET_AD_WIDTH_PX, this.margins_)
+            TARGET_AD_HEIGHT_PX, undefined, this.margins_)
                 .then(() => {
                   this.state_ = PlacementState.PLACED;
                   return this.state_;
@@ -206,8 +200,7 @@ export class Placement {
    */
   createAdElement_(baseAttributes) {
     const attributes = Object.assign({
-      'layout': 'responsive',
-      'width': '0',
+      'layout': 'fixed-height',
       'height': '0',
     }, baseAttributes, this.attributes_);
     return createElementWithAttributes(

--- a/extensions/amp-auto-ads/0.1/test/test-attributes.js
+++ b/extensions/amp-auto-ads/0.1/test/test-attributes.js
@@ -43,7 +43,6 @@ describe('attributes', () => {
 
     expect(getAttributesFromConfigObj(configObj)).to.deep.equal({
       'type': 'val2',
-      'layout': 'val3',
       'data-something': 'val5',
       'data-1234': 'val6',
     });

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -229,8 +229,7 @@ describes.realWin('placement', {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
             expect(adElement.getAttribute('type')).to.equal('ad-network-type');
-            expect(adElement.getAttribute('layout')).to.equal('responsive');
-            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('layout')).to.equal('fixed-height');
             expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.getAttribute('data-custom-att-1'))
                 .to.equal('val-1');
@@ -254,7 +253,6 @@ describes.realWin('placement', {
             type: 1,
             attributes: {
               'type': 'ad-network-type2',
-              'layout': 'fixed',
               'data-custom-att-1': 'val-1',
               'data-custom-att-2': 'val-2',
             },
@@ -265,7 +263,6 @@ describes.realWin('placement', {
 
       const baseAttributes = {
         'type': 'ad-network-type',
-        'layout': 'fill',
         'data-custom-att-2': 'val-3',
         'data-custom-att-3': 'val-4',
       };
@@ -275,8 +272,7 @@ describes.realWin('placement', {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
             expect(adElement.getAttribute('type')).to.equal('ad-network-type2');
-            expect(adElement.getAttribute('layout')).to.equal('fixed');
-            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('layout')).to.equal('fixed-height');
             expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.getAttribute('data-custom-att-1'))
                 .to.equal('val-1');
@@ -318,8 +314,7 @@ describes.realWin('placement', {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
             expect(adElement.getAttribute('type')).to.equal('ad-network-type');
-            expect(adElement.getAttribute('layout')).to.equal('responsive');
-            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('layout')).to.equal('fixed-height');
             expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.style.marginTop).to.equal('5px');
             expect(adElement.style.marginBottom).to.equal('6px');
@@ -358,8 +353,7 @@ describes.realWin('placement', {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
             expect(adElement.getAttribute('type')).to.equal('ad-network-type');
-            expect(adElement.getAttribute('layout')).to.equal('responsive');
-            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('layout')).to.equal('fixed-height');
             expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.style.marginTop).to.equal('5px');
             expect(adElement.style.marginBottom).to.equal('');
@@ -398,8 +392,7 @@ describes.realWin('placement', {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
             expect(adElement.getAttribute('type')).to.equal('ad-network-type');
-            expect(adElement.getAttribute('layout')).to.equal('responsive');
-            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('layout')).to.equal('fixed-height');
             expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.style.marginTop).to.equal('');
             expect(adElement.style.marginBottom).to.equal('6px');
@@ -436,8 +429,7 @@ describes.realWin('placement', {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
             expect(adElement.getAttribute('type')).to.equal('ad-network-type');
-            expect(adElement.getAttribute('layout')).to.equal('responsive');
-            expect(adElement.getAttribute('width')).to.equal('0');
+            expect(adElement.getAttribute('layout')).to.equal('fixed-height');
             expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.style.marginTop).to.equal('');
             expect(adElement.style.marginBottom).to.equal('');
@@ -476,7 +468,7 @@ describes.realWin('placement', {
       return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
-                anchor.firstChild, 100, 320);
+                anchor.firstChild, 100, undefined);
             expect(placementState).to.equal(PlacementState.PLACED);
           });
     });
@@ -511,7 +503,7 @@ describes.realWin('placement', {
       return placements[0].placeAd(attributes, new AdTracker([], 0))
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
-                anchor.firstChild, 100, 320);
+                anchor.firstChild, 100, undefined);
             expect(placementState).to.equal(PlacementState.RESIZE_FAILED);
           });
     });


### PR DESCRIPTION
Changes amp-auto-ads to inject `<amp-ad>`s with `layout='fixed-height'` to ensure that they are full-width and there that any ad within them can be full-width, or else be centered in the ad slot.

https://github.com/ampproject/amphtml/issues/6196