### PR TITLE
Amp-bind Clarify bind expression errors

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -147,7 +147,7 @@ export class BindExpression {
         let unsupportedError;
 
         if (isBuiltIn) {
-          unsupportedError = `${method} is not a supported function.`
+          unsupportedError = `${method} is not a supported function.`;
           validFunction = FUNCTION_WHITELIST[BUILT_IN_FUNCTIONS][method];
         } else {
           unsupportedError =

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -146,8 +146,10 @@ export class BindExpression {
         let unsupportedError;
 
         if (isBuiltIn) {
-          unsupportedError = `${method} is not a supported function.`;
           validFunction = FUNCTION_WHITELIST[BUILT_IN_FUNCTIONS][method];
+          if (!validFunction) {
+            unsupportedError = `${method} is not a supported function.`;
+          }
         } else {
           const callerType = Object.prototype.toString.call(caller);
           const whitelist = FUNCTION_WHITELIST[callerType];

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -139,7 +139,6 @@ export class BindExpression {
         const isBuiltIn = (args[0] === null);
 
         const caller = this.eval_(args[0], scope);
-        const callerType = Object.prototype.toString.call(caller);
         const params = this.eval_(args[1], scope);
         const method = String(value);
 
@@ -150,14 +149,17 @@ export class BindExpression {
           unsupportedError = `${method} is not a supported function.`;
           validFunction = FUNCTION_WHITELIST[BUILT_IN_FUNCTIONS][method];
         } else {
-          unsupportedError =
-              `${callerType}.${method} is not a supported function.`;
+          const callerType = Object.prototype.toString.call(caller);
           const whitelist = FUNCTION_WHITELIST[callerType];
           if (whitelist) {
             const f = caller[method];
             if (f && f === whitelist[method]) {
               validFunction = f;
             }
+          }
+          if (!validFunction) {
+            unsupportedError =
+                `${callerType}.${method} is not a supported function.`;
           }
         }
 

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -139,23 +139,24 @@ export class BindExpression {
         const isBuiltIn = (args[0] === null);
 
         const caller = this.eval_(args[0], scope);
+        const callerType = Object.prototype.toString.call(caller);
         const params = this.eval_(args[1], scope);
         const method = String(value);
 
-        let validFunction = null;
-        let unsupportedError = `${method} is not a supported function.`;
+        let validFunction;
+        let unsupportedError;
 
         if (isBuiltIn) {
+          unsupportedError = `${method} is not a supported function.`
           validFunction = FUNCTION_WHITELIST[BUILT_IN_FUNCTIONS][method];
         } else {
-          const callerType = Object.prototype.toString.call(caller);
+          unsupportedError =
+              `${callerType}.${method} is not a supported function.`;
           const whitelist = FUNCTION_WHITELIST[callerType];
           if (whitelist) {
             const f = caller[method];
             if (f && f === whitelist[method]) {
               validFunction = f;
-            } else {
-              unsupportedError = `${callerType}.` + unsupportedError;
             }
           }
         }


### PR DESCRIPTION
If we don't have any functions whitelisted for a particular type, the type information isn't included in an error message. Since we don't whitelist any methods on Object, any attempt to call a method on an object provides an error message without statign the caller type. This caused the confusion behind #8251 

This PR ensures that any call to a non-built in function will include the caller type (even if it's null) to make debugging easier. For example, the issue from #8251 will show the error:

`[object Object].includes is not a supported function.`

instead of

`  includes is not a supported function.`

Fixes #8251 

/to @choumx 
