### PR TITLE
Add Dianomi as supported ad tag

### DIFF
--- a/ads/dianomi.md
+++ b/ads/dianomi.md
@@ -1,0 +1,44 @@
+<!---
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Dianomi Exchange
+
+## Example
+
+```html
+<amp-ad width=320 height=300
+  data-cf-network="dianomi"
+  type="cloudflare"
+</amp-ad>
+```
+
+## Configuration
+
+For semantics of configuration and to learn more about how we can help you deliver AMP Ads, please contact [contact dianomi](http://www.dianomi.com/).
+
+__Supported Parameters__
+
+- `data-id`
+- `width`
+- `height`
+- `data-cf-a4a`
+- `src`
+
+
+__Required:__
+
+- `data-cf-network`
+- `type`

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -115,6 +115,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [Criteo](../../ads/criteo.md)
 - [CSA](../../ads/google/csa.md)
 - [CxenseDisplay](../../ads/eas.md)
+- [Dianomi](../../ads/dianomi.md)
 - [DistroScale](../../ads/distroscale.md)
 - [Dot and Media](../../ads/dotandads.md)
 - [Doubleclick](../../ads/google/doubleclick.md)
@@ -220,7 +221,7 @@ An optional attribute. If provided, will require confirming the [amp-user-notifi
 
 **data-loading-strategy**
 
-Instructs AMP to load ads in a way that prefers a high degree of viewability, while sometimes loading too late to generate a view. Supported value: `prefer-viewability-over-views`. 
+Instructs AMP to load ads in a way that prefers a high degree of viewability, while sometimes loading too late to generate a view. Supported value: `prefer-viewability-over-views`.
 
 **common attributes**
 


### PR DESCRIPTION
Add [Dianomi](http://www.dianomi.com) as a supported ad tag.

- Dianomi is using Cloudflare's Generic ad-tag implementation.
- [This](https://github.com/ampproject/amphtml/pull/7352) is the PR that implemented the aforementioned Cloudflare tag.

Related-to #7352.
