### PR TITLE
amp-bind: small fix in integration test

### DIFF
--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -50,7 +50,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     return new Promise(resolve => {
       function callback() {
         resolve();
-        fixture.win.removeEventListener(callback);
+        fixture.win.removeEventListener(name, callback);
       };
       fixture.win.addEventListener(name, callback);
     });


### PR DESCRIPTION
Provide event name and callback when removijng event listener in bind integration tests.

/to @choumx 