### PR TITLE
amp-bind: Support amp-iframe

### DIFF
--- a/examples/bind/iframe.amp.html
+++ b/examples/bind/iframe.amp.html
@@ -28,10 +28,11 @@
   <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle &lt;amp-bind&gt; experiment</button>
 
   <h2>amp-iframe (scroll down)</h2>
+  <button on="tap:AMP.setState(bling='https://giphy.com/embed/DKG1OhBUmxL4Q')">Change iframe src</button>
+
   <amp-iframe width="500" height="281"
       sandbox="allow-scripts allow-same-origin allow-popups" allowfullscreen frameborder="0"
       src="https://player.vimeo.com/video/140261016" [src]="bling">
   </amp-iframe>
-  <button on="tap:AMP.setState(bling='https://giphy.com/embed/DKG1OhBUmxL4Q')">Change iframe src</button>
 </body>
 </html>

--- a/examples/bind/iframe.amp.html
+++ b/examples/bind/iframe.amp.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind: iframe</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+
+  <style amp-custom>
+    .redBackground {
+      background-color: red;
+    }
+    button {
+      border: solid 1px black;
+    }
+    amp-iframe {
+      margin-top: 600px; /* iframes must not be in initial viewport as a rule */
+    }
+  </style>
+</head>
+
+<body>
+  <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle &lt;amp-bind&gt; experiment</button>
+
+  <h2>amp-iframe (scroll down)</h2>
+  <amp-iframe width="500" height="281"
+      sandbox="allow-scripts allow-same-origin allow-popups" allowfullscreen frameborder="0"
+      src="https://player.vimeo.com/video/140261016" [src]="bling">
+  </amp-iframe>
+  <button on="tap:AMP.setState(bling='https://giphy.com/embed/DKG1OhBUmxL4Q')">Change iframe src</button>
+</body>
+</html>

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -220,6 +220,9 @@ function createElementRules_() {
     'AMP-CAROUSEL': {
       'slide': null,
     },
+    'AMP-IFRAME': {
+      'src': null,
+    },
     'AMP-IMG': {
       'alt': null,
       'referrerpolicy': null,

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -20,25 +20,20 @@ import {bindForDoc} from '../../../../src/bind';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 
 describe.configure().retryOnSaucelabs().run('amp-bind', function() {
+  const fixtureLocation = 'test/fixtures/amp-bind-integrations.html';
+
   let fixture;
   let ampdoc;
-  const fixtureLocation = 'test/fixtures/amp-bind-integrations.html';
 
   this.timeout(5000);
 
   beforeEach(() => {
-    let bindInitPromise;
     return createFixtureIframe(fixtureLocation).then(f => {
       fixture = f;
-      bindInitPromise = waitForEvent('amp:bind:initialize');
-      const numberOfExtensionElements = 4;
-      return fixture.awaitEvent('amp:load:start', numberOfExtensionElements);
+      return waitForEvent('amp:bind:initialize');
     }).then(() => {
       const ampdocService = ampdocServiceFor(fixture.win);
       ampdoc = ampdocService.getAmpDoc(fixture.doc);
-      return bindForDoc(ampdoc);
-    }).then(unusedBind => {
-      return bindInitPromise;
     });
   });
 
@@ -394,16 +389,18 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   describe('amp-iframe', () => {
     it('should support binding to src', () => {
       const button = fixture.doc.getElementById('iframeButton');
-      const ampIframe = fixture.doc.getElementById('iframe');
+      const ampIframe = fixture.doc.getElementById('ampIframe');
       // Force layout in case element is not in viewport.
       ampIframe.implementation_.layoutCallback();
       const iframe = ampIframe.querySelector('iframe');
-      expect(ampIframe.src).to.not.contain('bound');
-      expect(iframe.src).to.not.contain('bound');
+
+      const newSrc = 'https://giphy.com/embed/DKG1OhBUmxL4Q';
+      expect(ampIframe.getAttribute('src')).to.not.contain(newSrc);
+      expect(iframe.src).to.not.contain(newSrc);
       button.click();
       return waitForBindApplication().then(() => {
-        expect(ampIframe.src).to.contain('bound');
-        expect(iframe.src).to.contain('bound');
+        expect(ampIframe.getAttribute('src')).to.contain(newSrc);
+        expect(iframe.src).to.contain(newSrc);
       });
     });
   });

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -390,4 +390,19 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
       });
     });
   });
+
+  describe('amp-iframe', () => {
+    it('should support binding to src', () => {
+      const button = fixture.doc.getElementById('iframeButton');
+      const ampIframe = fixture.doc.getElementById('iframe');
+      // Force layout in case element is not in viewport.
+      ampIframe.implementation_.layoutCallback();
+      const iframe = ampIframe.querySelector('iframe');
+      expect(iframe.src).to.not.contain('bound');
+      button.click();
+      return waitForBindApplication().then(() => {
+        expect(iframe.src).to.contain('bound');
+      });
+    });
+  });
 });

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -398,9 +398,11 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
       // Force layout in case element is not in viewport.
       ampIframe.implementation_.layoutCallback();
       const iframe = ampIframe.querySelector('iframe');
+      expect(ampIframe.src).to.not.contain('bound');
       expect(iframe.src).to.not.contain('bound');
       button.click();
       return waitForBindApplication().then(() => {
+        expect(ampIframe.src).to.contain('bound');
         expect(iframe.src).to.contain('bound');
       });
     });

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -416,6 +416,20 @@ export class AmpIframe extends AMP.BaseElement {
     return super.getPriority();
   }
 
+  /** @override */
+  mutatedAttributesCallback(mutations) {
+    const src = mutations['src'];
+    if (src !== undefined) {
+      const iframeSrc = this.transformSrc_(src);
+      if (this.iframe_) {
+        this.iframe_.src = this.assertSource(
+            iframeSrc, window.location.href, this.sandbox_);
+      } else {
+        this.iframeSrc = iframeSrc;
+      }
+    }
+  }
+
   /**
    * Makes the iframe visible.
    * @private

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -420,12 +420,10 @@ export class AmpIframe extends AMP.BaseElement {
   mutatedAttributesCallback(mutations) {
     const src = mutations['src'];
     if (src !== undefined) {
-      const iframeSrc = this.transformSrc_(src);
+      this.iframeSrc = this.transformSrc_(src);
       if (this.iframe_) {
         this.iframe_.src = this.assertSource(
-            iframeSrc, window.location.href, this.sandbox_);
-      } else {
-        this.iframeSrc = iframeSrc;
+            this.iframeSrc, window.location.href, this.sandbox_);
       }
     }
   }

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -659,6 +659,7 @@ describe('amp-iframe', () => {
       const newSrc = 'https://foo.bar';
       container.setAttribute('src', newSrc);
       impl.mutatedAttributesCallback({src: newSrc});
+      expect(impl.iframeSrc).to.contain(newSrc);
       expect(iframe.getAttribute('src')).to.contain(newSrc);
     });
   });

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -645,4 +645,21 @@ describe('amp-iframe', () => {
       expect(newIntersection.height).to.equal(250);
     });
   });
+
+  it('should propagate `src` when container attribute is mutated', () => {
+    return getAmpIframe({
+      src: iframeSrc,
+      width: 100,
+      height: 100,
+    }).then(amp => {
+      const container = amp.container;
+      const impl = container.implementation_;
+      const iframe = amp.iframe;
+
+      const newSrc = 'https://foo.bar';
+      container.setAttribute('src', newSrc);
+      impl.mutatedAttributesCallback({src: newSrc});
+      expect(iframe.getAttribute('src')).to.contain(newSrc);
+    });
+  });
 });

--- a/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
@@ -72,6 +72,8 @@ tags: {  # <amp-iframe>
     name: "srcdoc"
     mandatory_oneof: "['src', 'srcdoc']"
   }
+  # <amp-bind>
+  attrs: { name: "[src]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-iframe"
   amp_layout: {

--- a/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
@@ -72,8 +72,6 @@ tags: {  # <amp-iframe>
     name: "srcdoc"
     mandatory_oneof: "['src', 'srcdoc']"
   }
-  # <amp-bind>
-  attrs: { name: "[src]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-iframe"
   amp_layout: {

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -111,8 +111,8 @@
   </amp-brightcove>
 
   <p>AMP-IFRAME</p>
-  <button id="iframeButton" on="tap:AMP.setState(iframe='bound')">Change amp-iframe</button>
-  <amp-iframe width=100 height=100 id="iframe" sandbox="allow-scripts allow-same-origin allow-popups"
+  <button id="iframeButton" on="tap:AMP.setState(iframe='https://giphy.com/embed/DKG1OhBUmxL4Q')">Change amp-iframe</button>
+  <amp-iframe width=100 height=100 id="ampIframe" sandbox="allow-scripts allow-same-origin allow-popups"
       src="https://player.vimeo.com/video/140261016" [src]="iframe">
   </amp-iframe>
 </body>

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -19,6 +19,7 @@
   <script custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
   <script custom-element="amp-brightcove" src="/dist/v0/amp-brightcove-0.1.max.js"></script>
   <script custom-element="amp-carousel" src="/dist/v0/amp-carousel-0.1.max.js"></script>
+  <script custom-element="amp-iframe" src="/dist/v0/amp-iframe-0.1.max.js"></script>
   <script custom-element="amp-live-list" src="/dist/v0/amp-live-list-0.1.max.js"></script>
   <script custom-element="amp-selector" src="/dist/v0/amp-selector-0.1.max.js"></script>
   <script custom-element="amp-youtube" src="/dist/v0/amp-youtube-0.1.max.js"></script>
@@ -109,5 +110,10 @@
       data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c">
   </amp-brightcove>
 
+  <p>AMP-IFRAME</p>
+  <button id="iframeButton" on="tap:AMP.setState(iframe='bound')">Change amp-iframe</button>
+  <amp-iframe width=100 height=100 id="iframe" sandbox="allow-scripts allow-same-origin allow-popups"
+      src="https://player.vimeo.com/video/140261016" [src]="iframe">
+  </amp-iframe>
 </body>
 </html>


### PR DESCRIPTION
Fixes #7837.

- Support binding to `src` attribute of `amp-iframe`.

/to @aghassemi @kmh287 PTAL