### PR TITLE
amp-bind: Restore canBind()

### DIFF
--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -209,6 +209,14 @@ export class BindValidator {
 function createElementRules_() {
   // Initialize `rules` with tag-specific constraints.
   const rules = map({
+    'AMP-BRIGHTCOVE': {
+      'data-account': null,
+      'data-embed': null,
+      'data-player': null,
+      'data-player-id': null,
+      'data-playlist-id': null,
+      'data-video-id': null,
+    },
     'AMP-CAROUSEL': {
       'slide': null,
     },
@@ -244,6 +252,9 @@ function createElementRules_() {
           'https': true,
         },
       },
+    },
+    'AMP-YOUTUBE': {
+      'data-videoid': null,
     },
     'A': {
       'href': {

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -45,6 +45,15 @@ const GLOBAL_PROPERTY_RULES = map({
 });
 
 /**
+ * Property rules that apply to all AMP elements.
+ * @private {Object<string, Object<string, ?PropertyRulesDef>>}
+ */
+const AMP_PROPERTY_RULES = map({
+  'width': null,
+  'height': null,
+});
+
+/**
  * Maps tag names to property names to PropertyRulesDef.
  * If `ELEMENT_RULES[tag][property]` is null, then all values are valid
  * for that property in that tag.
@@ -60,15 +69,6 @@ const URL_PROPERTIES = map({
   'src': true,
   'srcset': true,
   'href': true,
-});
-
-/**
- * Map whose keys are attribute rules for AMP elements.
- * @private {Object<string, boolean>}
- */
-const AMP_ELEMENT_RULES = map({
-  'width': true,
-  'height': true,
 });
 
 /**
@@ -185,18 +185,18 @@ export class BindValidator {
    * @private
    */
   rulesForTagAndProperty_(tag, property) {
-    const globalRules = GLOBAL_PROPERTY_RULES[property];
-    if (globalRules) {
-      return globalRules;
+    const globalPropertyRules = GLOBAL_PROPERTY_RULES[property];
+    if (globalPropertyRules !== undefined) {
+      return globalPropertyRules;
     }
     const tagRules = ELEMENT_RULES[tag];
     // hasOwnProperty() needed since nested objects are not prototype-less.
     if (tagRules && tagRules.hasOwnProperty(property)) {
       return tagRules[property];
     }
-    const ampElementRules = AMP_ELEMENT_RULES[tag];
-    if (startsWith(tag, 'AMP-') && ampElementRules) {
-      return ampElementRules;
+    const ampPropertyRules = AMP_PROPERTY_RULES[property];
+    if (startsWith(tag, 'AMP-') && ampPropertyRules !== undefined) {
+      return ampPropertyRules;
     }
     return undefined;
   }

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -314,7 +314,6 @@ function createElementRules_() {
     'SELECT': {
       'disabled': null,
       'multiple': null,
-      'name': null,
       'required': null,
       'size': null,
     },
@@ -341,7 +340,6 @@ function createElementRules_() {
       'disabled': null,
       'maxlength': null,
       'minlength': null,
-      'name': null,
       'placeholder': null,
       'readonly': null,
       'required': null,

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -16,6 +16,7 @@
 
 import {map} from '../../../src/utils/object';
 import {parseSrcset} from '../../../src/srcset';
+import {startsWith} from '../../../src/string';
 import {user} from '../../../src/log';
 
 const TAG = 'amp-bind';
@@ -33,9 +34,14 @@ let PropertyRulesDef;
  * @private {Object<string, ?PropertyRulesDef>}
  */
 const GLOBAL_PROPERTY_RULES = map({
+  'text': null,
   'class': {
     blacklistedValueRegex: '(^|\\W)i-amphtml-',
   },
+  // ARIA accessibility attributes.
+  'aria-describedby': null,
+  'aria-label': null,
+  'aria-labelledby': null,
 });
 
 /**
@@ -57,12 +63,33 @@ const URL_PROPERTIES = map({
 });
 
 /**
+ * Map whose keys are attribute rules for AMP elements.
+ * @private {Object<string, boolean>}
+ */
+const AMP_ELEMENT_RULES = map({
+  'width': true,
+  'height': true,
+});
+
+/**
  * BindValidator performs runtime validation of Bind expression results.
  *
  * For performance reasons, the validation rules enforced are a subset
  * of the AMP validator's, selected with a focus on security and UX.
  */
 export class BindValidator {
+  /**
+   * Returns true if (tag, property) binding is allowed.
+   * Otherwise, returns false.
+   * @note `tag` and `property` are case-sensitive.
+   * @param {!string} tag
+   * @param {!string} property
+   * @return {boolean}
+   */
+  canBind(tag, property) {
+    return (this.rulesForTagAndProperty_(tag, property) !== undefined);
+  }
+
   /**
    * Returns true if `value` is a valid result for a (tag, property) binding.
    * Otherwise, returns false.
@@ -79,8 +106,13 @@ export class BindValidator {
       rules = this.rulesForTagAndProperty_(tag, rules.alternativeName);
     }
 
-    // If there are no rules governing this binding, return true.
-    if (!rules) {
+    // If binding to (tag, property) is not allowed, return false.
+    if (rules === undefined) {
+      return false;
+    }
+
+    // If binding is allowed but have no specific rules, return true.
+    if (rules === null) {
       return true;
     }
 
@@ -162,7 +194,10 @@ export class BindValidator {
     if (tagRules && tagRules.hasOwnProperty(property)) {
       return tagRules[property];
     }
-
+    const ampElementRules = AMP_ELEMENT_RULES[tag];
+    if (startsWith(tag, 'AMP-') && ampElementRules) {
+      return ampElementRules;
+    }
     return undefined;
   }
 }
@@ -174,7 +209,12 @@ export class BindValidator {
 function createElementRules_() {
   // Initialize `rules` with tag-specific constraints.
   const rules = map({
+    'AMP-CAROUSEL': {
+      'slide': null,
+    },
     'AMP-IMG': {
+      'alt': null,
+      'referrerpolicy': null,
       'src': {
         'allowedProtocols': {
           'data': true,
@@ -186,7 +226,19 @@ function createElementRules_() {
         'alternativeName': 'src',
       },
     },
+    'AMP-SELECTOR': {
+      'selected': null,
+    },
     'AMP-VIDEO': {
+      'alt': null,
+      'attribution': null,
+      'autoplay': null,
+      'controls': null,
+      'loop': null,
+      'muted': null,
+      'placeholder': null,
+      'poster': null,
+      'preload': null,
       'src': {
         'allowedProtocols': {
           'https': true,
@@ -214,10 +266,57 @@ function createElementRules_() {
         },
       },
     },
+    'BUTTON': {
+      'disabled': null,
+      'type': null,
+      'value': null,
+    },
+    'FIELDSET': {
+      'disabled': null,
+    },
     'INPUT': {
+      'accept': null,
+      'accesskey': null,
+      'autocomplete': null,
+      'checked': null,
+      'disabled': null,
+      'height': null,
+      'inputmode': null,
+      'max': null,
+      'maxlength': null,
+      'min': null,
+      'minlength': null,
+      'multiple': null,
+      'pattern': null,
+      'placeholder': null,
+      'readonly': null,
+      'required': null,
+      'selectiondirection': null,
+      'size': null,
+      'spellcheck': null,
+      'step': null,
       'type': {
-        'blacklistedValueRegex': '(^|\\s)(button|file|image|password|)(\\s|$)',
+        blacklistedValueRegex: '(^|\\s)(button|file|image|password|)(\\s|$)',
       },
+      'value': null,
+      'width': null,
+    },
+    'OPTION': {
+      'disabled': null,
+      'label': null,
+      'selected': null,
+      'value': null,
+    },
+    'OPTGROUP': {
+      'disabled': null,
+      'label': null,
+    },
+    'SELECT': {
+      'disabled': null,
+      'multiple': null,
+      'name': null,
+      'required': null,
+      'size': null,
     },
     'SOURCE': {
       'src': {
@@ -225,13 +324,33 @@ function createElementRules_() {
           'https': true,
         },
       },
+      'type': null,
     },
     'TRACK': {
+      'label': null,
       'src': {
         'allowedProtocols': {
           'https': true,
         },
       },
+      'srclang': null,
+    },
+    'TEXTAREA': {
+      'autocomplete': null,
+      'cols': null,
+      'disabled': null,
+      'maxlength': null,
+      'minlength': null,
+      'name': null,
+      'placeholder': null,
+      'readonly': null,
+      'required': null,
+      'rows': null,
+      'selectiondirection': null,
+      'selectionend': null,
+      'selectionstart': null,
+      'spellcheck': null,
+      'wrap': null,
     },
   });
   return rules;

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -30,11 +30,16 @@ describes.realWin('amp-bind', {
 }, env => {
   let bind;
 
+  // BindValidator method stubs.
+  let canBindStub;
+
   beforeEach(() => {
     installTimerService(env.win);
     toggleExperiment(env.win, 'amp-bind', true);
 
     // Stub validator methods to return true for ease of testing.
+    canBindStub = env.sandbox.stub(
+        BindValidator.prototype, 'canBind').returns(true);
     env.sandbox.stub(
         BindValidator.prototype, 'isResultValid').returns(true);
 
@@ -342,6 +347,15 @@ describes.realWin('amp-bind', {
     stub.returns('stubbed');
     return onBindReadyAndSetState({}).then(() => {
       expect(stub.calledOnce).to.be.true;
+    });
+  });
+
+  it('should NOT evaluate expression if binding is NOT allowed', () => {
+    canBindStub.returns(false);
+    const element = createElementWithBinding(`[onePlusOne]="1+1"`);
+    return onBindReadyAndSetState({}).then(() => {
+      expect(canBindStub.calledOnce).to.be.true;
+      expect(element.getAttribute('oneplusone')).to.be.null;
     });
   });
 

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -29,17 +29,9 @@ describe('BindValidator', () => {
       expect(val.canBind('ANY-TAG-REAL-OR-FAKE', 'class')).to.be.true;
     });
 
-    it('should allow binding to "text" for whitelisted elements', () => {
-      expect(val.canBind('H1', 'text')).to.be.true;
+    it('should allow binding to "text" for any elements', () => {
       expect(val.canBind('P', 'text')).to.be.true;
-      expect(val.canBind('SPAN', 'text')).to.be.true;
-      expect(val.canBind('A', 'text')).to.be.true;
-      expect(val.canBind('BUTTON', 'text')).to.be.true;
-      expect(val.canBind('CAPTION', 'text')).to.be.true;
-
-      expect(val.canBind('HEAD', 'text')).to.be.false;
-      expect(val.canBind('FORM', 'text')).to.be.false;
-      expect(val.canBind('AMP-IMG', 'text')).to.be.false;
+      expect(val.canBind('ANY-TAG-REAL-OR-FAKE', 'text')).to.be.true;
     });
 
     it('should NOT allow binding to "style"', () => {
@@ -171,14 +163,17 @@ describe('BindValidator', () => {
   });
 
   describe('AMP extensions', () => {
+    it('should support width/height for all AMP elements', () => {
+      expect(val.canBind('AMP-FOO', 'width')).to.be.true;
+      expect(val.canBind('AMP-FOO', 'height')).to.be.true;
+    });
+
     it('should support <amp-carousel>', () => {
       expect(val.canBind('AMP-CAROUSEL', 'slide')).to.be.true;
     });
 
     it('should support <amp-img>', () => {
       expect(val.canBind('AMP-IMG', 'src')).to.be.true;
-      expect(val.canBind('AMP-IMG', 'width')).to.be.true;
-      expect(val.canBind('AMP-IMG', 'height')).to.be.true;
 
       // src
       expect(val.isResultValid(

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -23,6 +23,107 @@ describe('BindValidator', () => {
     val = new BindValidator();
   });
 
+  describe('canBind()', () => {
+    it('should allow binding to "class" for any element', () => {
+      expect(val.canBind('DIV', 'class')).to.be.true;
+      expect(val.canBind('ANY-TAG-REAL-OR-FAKE', 'class')).to.be.true;
+    });
+
+    it('should allow binding to "text" for whitelisted elements', () => {
+      expect(val.canBind('H1', 'text')).to.be.true;
+      expect(val.canBind('P', 'text')).to.be.true;
+      expect(val.canBind('SPAN', 'text')).to.be.true;
+      expect(val.canBind('A', 'text')).to.be.true;
+      expect(val.canBind('BUTTON', 'text')).to.be.true;
+      expect(val.canBind('CAPTION', 'text')).to.be.true;
+
+      expect(val.canBind('HEAD', 'text')).to.be.false;
+      expect(val.canBind('FORM', 'text')).to.be.false;
+      expect(val.canBind('AMP-IMG', 'text')).to.be.false;
+    });
+
+    it('should NOT allow binding to "style"', () => {
+      expect(val.canBind('DIV', 'style')).to.be.false;
+      expect(val.canBind('P', 'style')).to.be.false;
+      expect(val.canBind('SPAN', 'style')).to.be.false;
+      expect(val.canBind('OL', 'style')).to.be.false;
+      expect(val.canBind('BODY', 'style')).to.be.false;
+    });
+
+    it('should NOT allow binding to "on" event handlers', () => {
+      expect(val.canBind('BODY', 'onafterprint')).to.be.false;
+      expect(val.canBind('BODY', 'onbeforeprint')).to.be.false;
+      expect(val.canBind('BODY', 'onbeforeunload')).to.be.false;
+      expect(val.canBind('BODY', 'onhashchange')).to.be.false;
+      expect(val.canBind('BODY', 'onload')).to.be.false;
+      expect(val.canBind('BODY', 'onmessage')).to.be.false;
+      expect(val.canBind('BODY', 'onoffline')).to.be.false;
+      expect(val.canBind('BODY', 'ononline')).to.be.false;
+      expect(val.canBind('BODY', 'onpagehide')).to.be.false;
+      expect(val.canBind('BODY', 'onpageshow')).to.be.false;
+      expect(val.canBind('BODY', 'onpopstate')).to.be.false;
+      expect(val.canBind('BODY', 'onresize')).to.be.false;
+      expect(val.canBind('BODY', 'onstorage')).to.be.false;
+      expect(val.canBind('BODY', 'onunload')).to.be.false;
+
+      expect(val.canBind('FORM', 'onblur')).to.be.false;
+      expect(val.canBind('FORM', 'onchange')).to.be.false;
+      expect(val.canBind('FORM', 'oncontextmenu')).to.be.false;
+      expect(val.canBind('FORM', 'onfocus')).to.be.false;
+      expect(val.canBind('FORM', 'oninput')).to.be.false;
+      expect(val.canBind('FORM', 'oninvalid')).to.be.false;
+      expect(val.canBind('FORM', 'onreset')).to.be.false;
+      expect(val.canBind('FORM', 'onsearch')).to.be.false;
+      expect(val.canBind('FORM', 'onselect')).to.be.false;
+      expect(val.canBind('FORM', 'onsubmit')).to.be.false;
+
+      expect(val.canBind('INPUT', 'onkeydown')).to.be.false;
+      expect(val.canBind('INPUT', 'onkeypress')).to.be.false;
+      expect(val.canBind('INPUT', 'onkeyup')).to.be.false;
+
+      expect(val.canBind('BUTTON', 'onclick')).to.be.false;
+      expect(val.canBind('BUTTON', 'ondblclick')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmousedown')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmousemove')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmouseout')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmouseover')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmouseup')).to.be.false;
+      expect(val.canBind('BUTTON', 'onmousewheel')).to.be.false;
+      expect(val.canBind('BUTTON', 'onwheel')).to.be.false;
+
+      expect(val.canBind('DIV', 'ondrag')).to.be.false;
+      expect(val.canBind('DIV', 'ondragend')).to.be.false;
+      expect(val.canBind('DIV', 'ondragenter')).to.be.false;
+      expect(val.canBind('DIV', 'ondragleave')).to.be.false;
+      expect(val.canBind('DIV', 'ondragover')).to.be.false;
+      expect(val.canBind('DIV', 'ondragstart')).to.be.false;
+      expect(val.canBind('DIV', 'ondrop')).to.be.false;
+      expect(val.canBind('DIV', 'onscroll')).to.be.false;
+
+      expect(val.canBind('INPUT', 'oncopy')).to.be.false;
+      expect(val.canBind('INPUT', 'oncut')).to.be.false;
+      expect(val.canBind('INPUT', 'onpaste')).to.be.false;
+    });
+
+    it('should NOT allow binding to Object.prototype keys', () => {
+      expect(val.canBind('constructor', 'constructor')).to.be.false;
+      expect(val.canBind('toString', 'constructor')).to.be.false;
+      expect(val.canBind('hasOwnProperty', 'constructor')).to.be.false;
+      expect(val.canBind('isPrototypeOf', 'constructor')).to.be.false;
+      expect(val.canBind('__defineGetter__', 'constructor')).to.be.false;
+      expect(val.canBind('__defineSetter__', 'constructor')).to.be.false;
+      expect(val.canBind('__proto__', 'constructor')).to.be.false;
+
+      expect(val.canBind('P', 'constructor')).to.be.false;
+      expect(val.canBind('P', 'toString')).to.be.false;
+      expect(val.canBind('P', 'hasOwnProperty')).to.be.false;
+      expect(val.canBind('P', 'isPrototypeOf')).to.be.false;
+      expect(val.canBind('P', '__defineGetter__')).to.be.false;
+      expect(val.canBind('P', '__defineSetter__')).to.be.false;
+      expect(val.canBind('P', '__proto__')).to.be.false;
+    });
+  });
+
   describe('isResultValid()', () => {
     it('should NOT allow invalid "class" attribute values', () => {
       expect(val.isResultValid('DIV', 'class', 'foo')).to.be.true;
@@ -70,7 +171,15 @@ describe('BindValidator', () => {
   });
 
   describe('AMP extensions', () => {
+    it('should support <amp-carousel>', () => {
+      expect(val.canBind('AMP-CAROUSEL', 'slide')).to.be.true;
+    });
+
     it('should support <amp-img>', () => {
+      expect(val.canBind('AMP-IMG', 'src')).to.be.true;
+      expect(val.canBind('AMP-IMG', 'width')).to.be.true;
+      expect(val.canBind('AMP-IMG', 'height')).to.be.true;
+
       // src
       expect(val.isResultValid(
           'AMP-IMG', 'src', 'http://foo.com/bar.jpg')).to.be.true;
@@ -88,7 +197,15 @@ describe('BindValidator', () => {
           /* eslint no-script-url: 0 */ 'javascript:alert(1)\n;')).to.be.false;
     });
 
+    it('should support <amp-selector>', () => {
+      expect(val.canBind('AMP-SELECTOR', 'selected')).to.be.true;
+    });
+
     it('should support <amp-video>', () => {
+      expect(val.canBind('AMP-VIDEO', 'loop')).to.be.true;
+      expect(val.canBind('AMP-VIDEO', 'poster')).to.be.true;
+      expect(val.canBind('AMP-VIDEO', 'src')).to.be.true;
+
       // src
       expect(val.isResultValid(
           'AMP-VIDEO', 'src', 'https://foo.com/bar.mp4')).to.be.true;


### PR DESCRIPTION
Fixes #8271.

- Partial revert of #8033.
- Restores `BindValidator.canBind()` with latest integrations.