### PR TITLE
Fixes :root selector for inabox in Safari.

### DIFF
--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -492,7 +492,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
       return;
     }
     element.getLayoutBox = () => {
-      return this.viewport_.getRect();
+      return this.viewport_.getLayoutRect(element);
     };
     element.getOwner = () => null;
   }


### PR DESCRIPTION
@dvoytenko any reason why the root element polyfill is bound to viewport?

will add test if the fix looks right.

for #7830