### PR TITLE
Fix fontloader polyfill by comparing against one default font at a time.

### DIFF
--- a/extensions/amp-font/0.1/fontloader.js
+++ b/extensions/amp-font/0.1/fontloader.js
@@ -55,10 +55,6 @@ export class FontLoader {
     this.document_ = win.document;
     /** @private {?Element} */
     this.container_ = null;
-    /** @private {?Array.<Element>} */
-    this.defaultFontElements_ = null;
-    /** @private {?Element} */
-    this.customFontElement_ = null;
     /** @private {boolean} */
     this.fontLoadResolved_ = false;
     /** @private {boolean} */
@@ -137,7 +133,7 @@ export class FontLoader {
 
 
   /**
-   * @returns {boolean} True when native font api is supported by the browser.
+   * @return {boolean} True when native font api is supported by the browser.
    * @private
    */
   canUseNativeApis_() {
@@ -155,8 +151,8 @@ export class FontLoader {
   loadWithPolyfill_() {
     return new Promise((resolve, reject) => {
       const vsync = vsyncFor(this.win_);
-      // Create DOM elements
-      this.createElements_();
+      // Create font comparators
+      const comparators = this.createFontComparators_();
       // Measure until timeout (or font load).
       const vsyncTask = vsync.createTask({
         measure: () => {
@@ -164,7 +160,7 @@ export class FontLoader {
             resolve();
           } else if (this.fontLoadRejected_) {
             reject(new Error('Font loading timed out.'));
-          } else if (this.compareMeasurements_()) {
+          } else if (comparators.some(comparator => comparator.compare())) {
             resolve();
           } else {
             vsyncTask();
@@ -177,12 +173,12 @@ export class FontLoader {
 
 
   /**
-   * Step 1 for loading font on browsers that don't support font loading events.
-   * Creates divs hidden from the viewport and measures dimensions for default
-   * fonts.
+   * Create hidden divs and measure dimensions for fonts.
+   * @return {!Array<!FontComparator>} An array of comparators, one for each
+   *     default font to compare against the font specified in fontConfig.
    * @private
    */
-  createElements_() {
+  createFontComparators_() {
     const containerElement = this.container_ =
         this.document_.createElement('div');
     style.setStyles(containerElement, {
@@ -199,58 +195,11 @@ export class FontLoader {
       top: '-999px',
       visibility: 'hidden',
     });
-    this.defaultFontElements_ = [];
-    DEFAULT_FONTS_.forEach(font => {
-      const defaultFontElement = this.document_.createElement('div');
-      this.defaultFontElements_.push(defaultFontElement);
-      defaultFontElement.textContent = TEST_STRING_;
-      style.setStyles(defaultFontElement, {
-        float: 'left',
-        fontFamily: font,
-        margin: 0,
-        padding: 0,
-        whiteSpace: 'nowrap',
-      });
-      containerElement.appendChild(defaultFontElement);
-    });
-    // Adding custom font family to the element to trigger load.
-    // The loading will begin after the container has been appended to the body.
-    const customFontElement = this.customFontElement_ =
-        this.document_.createElement('div');
-    style.setStyles(customFontElement, {
-      float: 'left',
-      fontFamily: this.fontConfig_.family + ',' + DEFAULT_FONTS_.join(),
-      margin: 0,
-      padding: 0,
-      whiteSpace: 'nowrap',
-    });
-    customFontElement.textContent = TEST_STRING_;
-    containerElement.appendChild(customFontElement);
+
+    const comparators = DEFAULT_FONTS_.map(defaultFont => new FontComparator(
+        containerElement, this.fontConfig_.family, defaultFont));
     this.document_.body.appendChild(containerElement);
-  }
-
-
-  /**
-   * Compare dimensions between elements styled with default fonts and custom
-   * font.
-   * @returns {boolean} Returns true if the dimensions are noticeably different
-   * else returns false.
-   * @private
-   */
-  compareMeasurements_() {
-    return this.defaultFontElements_.some(defaultElement => {
-      const hasWidthChanged = (
-          Math.abs(
-              defaultElement./*OK*/offsetWidth -
-              this.customFontElement_./*OK*/offsetWidth) >
-              TOLERANCE_);
-      const hasHeightChanged = (
-          Math.abs(
-              defaultElement./*OK*/offsetHeight -
-              this.customFontElement_./*OK*/offsetHeight) >
-              TOLERANCE_);
-      return (hasWidthChanged || hasHeightChanged);
-    });
+    return comparators;
   }
 
 
@@ -262,7 +211,69 @@ export class FontLoader {
       removeElement(this.container_);
     }
     this.container_ = null;
-    this.defaultFontElements_ = null;
-    this.customFontElement_ = null;
+  }
+}
+
+class FontComparator {
+
+  /**
+   * Create two elements to compare fonts and insert them into a container.
+   * @param {!Element} container Contains the backing font comparison elements
+   * @param {string} customFont A font name to detect if a font has loaded
+   * @param {string} defaultFont A fallback font family, like sans-serif
+   */
+  constructor(container, customFont, defaultFont) {
+    const doc = container.ownerDocument;
+    const testFontFamily = `${customFont},${defaultFont}`;
+
+    /** @private {!Element} */
+    this.defaultFontElement_ = this.getFontElement_(doc, defaultFont);
+
+    /** @private {!Element} */
+    this.testFontElement_ = this.getFontElement_(doc, testFontFamily);
+
+    container.appendChild(this.defaultFontElement_);
+    container.appendChild(this.testFontElement_);
+  }
+
+
+  /**
+   * Create and style a DOM element to use to compare two fonts.
+   * @param {!Document} doc
+   * @param {string} fontFamily
+   * @return {!Element}
+   * @private
+   */
+  getFontElement_(doc, fontFamily) {
+    const element = doc.createElement('div');
+    element.textContent = TEST_STRING_;
+    style.setStyles(element, {
+      float: 'left',
+      fontFamily,
+      margin: 0,
+      padding: 0,
+      whiteSpace: 'nowrap',
+    });
+    return element;
+  }
+
+
+  /**
+   * Compare dimensions between elements styled with default and custom fonts.
+   * If the divs are identical, the custom font has not loaded.
+   * @return {boolean} Returns true if the dimensions are noticeably different.
+   */
+  compare() {
+    const hasWidthChanged = (
+        Math.abs(
+            this.defaultFontElement_./*OK*/offsetWidth -
+            this.testFontElement_./*OK*/offsetWidth) >
+            TOLERANCE_);
+    const hasHeightChanged = (
+        Math.abs(
+            this.defaultFontElement_./*OK*/offsetHeight -
+            this.testFontElement_./*OK*/offsetHeight) >
+            TOLERANCE_);
+    return (hasWidthChanged || hasHeightChanged);
   }
 }

--- a/extensions/amp-font/0.1/test/test-fontloader.js
+++ b/extensions/amp-font/0.1/test/test-fontloader.js
@@ -15,11 +15,7 @@
  */
 
 import {FontLoader} from '../fontloader';
-import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
-import * as sinon from 'sinon';
-
-adopt(window);
 
 /** @private @const {string} */
 const FONT_FACE_ = `
@@ -55,7 +51,7 @@ const FAILURE_FONT_CONFIG = {
   family: 'Comic BLAH',
 };
 
-describe('FontLoader', () => {
+describes.sandboxed('FontLoader', {}, env => {
 
   let sandbox;
   let fontloader;
@@ -63,14 +59,14 @@ describe('FontLoader', () => {
   let setupFontLoadSpy;
   let setupLoadWithPolyfillSpy;
   let setupDisposeSpy;
-  let setupCreateElementsSpy;
+  let setupCreateFontComparatorsSpy;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = env.sandbox;
     setupLoadWithPolyfillSpy =
         sandbox.spy(FontLoader.prototype, 'loadWithPolyfill_');
-    setupCreateElementsSpy =
-        sandbox.spy(FontLoader.prototype, 'createElements_');
+    setupCreateFontComparatorsSpy =
+        sandbox.spy(FontLoader.prototype, 'createFontComparators_');
     setupDisposeSpy = sandbox.spy(FontLoader.prototype, 'dispose_');
   });
 
@@ -115,7 +111,7 @@ describe('FontLoader', () => {
         expect(setupFontCheckSpy).to.have.not.been.called;
         expect(setupFontLoadSpy).to.have.not.been.called;
         expect(setupLoadWithPolyfillSpy).to.be.calledOnce;
-        expect(setupCreateElementsSpy).to.be.calledOnce;
+        expect(setupCreateFontComparatorsSpy).to.be.calledOnce;
         expect(setupDisposeSpy).to.be.calledOnce;
       }).catch(() => {
         assert.fail('Font load failed');
@@ -145,7 +141,7 @@ describe('FontLoader', () => {
         expect(setupFontCheckSpy).to.have.not.been.called;
         expect(setupFontLoadSpy).to.have.not.been.called;
         expect(setupLoadWithPolyfillSpy).to.be.calledOnce;
-        expect(setupCreateElementsSpy).to.be.calledOnce;
+        expect(setupCreateFontComparatorsSpy).to.be.calledOnce;
         expect(setupDisposeSpy).to.be.calledOnce;
       });
     });
@@ -187,23 +183,10 @@ describe('FontLoader', () => {
   });
 
   it('should check compare elements', () => {
-    return getIframe().then(iframe => {
-      const defaultDiv = iframe.doc.createElement('div');
-      defaultDiv.style.fontFamily = 'serif';
-      defaultDiv.style.position = 'absolute';
-      defaultDiv.textContent = 'HelloWSSIENd2939Qq';
-      const fontDiv = iframe.doc.createElement('div');
-      fontDiv.style.fontFamily = 'Comic AMP';
-      fontDiv.style.position = 'absolute';
-      fontDiv.textContent = 'HelloWSSIENd2939Qq';
-      iframe.doc.body.appendChild(defaultDiv);
-      iframe.doc.body.appendChild(fontDiv);
-      fontloader.defaultFontElements_ = [defaultDiv];
-      fontloader.customFontElement_ = fontDiv;
+    return getIframe().then(() => {
       return fontloader.load(FONT_CONFIG, 3000).then(() => {
-        fontloader.defaultFontElements_ = [defaultDiv];
-        fontloader.customFontElement_ = fontDiv;
-        expect(fontloader.compareMeasurements_()).to.be.true;
+        const comparators = fontloader.createFontComparators_();
+        expect(comparators.some(c => c.compare())).to.be.true;
       }).catch(() => {
         assert.fail('Font load failed');
       });


### PR DESCRIPTION
Fixes #6219

The polyfill in `fontloader.js` wasn't working because `compareMeasurements_` checked if the test div's font was different than both a `sans-serif` and a `serif` font at the same time. `compareMeasurements_` works by comparing the dimensions of two divs containing the same special text string. If the two divs have different fonts, they should have different dimensions. The code assumes that if the dimensions are different, the font must have loaded.

Since the test div was given `font-family: "Comic AMP", sans-serif, serif`, it would be rendered with a `sans-serif` font before `"Comic AMP"` loaded or failed to load. Since `compareMeasurements_` compared against `serif` *and* `sans-serif`, and the test div rendered with `sans-serif`, the dimensions of the test div would be different than the dimensions of the `serif` div. This caused `amp-font` to behave as if the font had loaded when it really hadn't.

tl;dr Fixed the bug by giving the test div only one fallback font-family at a time.