### PR TITLE
Use getService instead of getExistingServiceForWindow for batched-xhr

### DIFF
--- a/src/batched-xhr.js
+++ b/src/batched-xhr.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getExistingServiceForWindow} from './service';
+import {getService} from './service';
 
 
 /**
@@ -23,5 +23,5 @@ import {getExistingServiceForWindow} from './service';
  */
 export function batchedXhrFor(window) {
   return /** @type {!./service/batched-xhr-impl.BatchedXhr} */ (
-      getExistingServiceForWindow(window, 'batched-xhr'));
+      getService(window, 'batched-xhr'));
 };


### PR DESCRIPTION
`getExistingServiceForWindow` doesn't build the service if it hasn't been built already. When I started on #7562 that was the method that `xhr.js` called, but now it uses `getService` after #7875 was merged, and I incompletely duplicated those changes into `batched-xhr.js`.