### PR TITLE
Flying carpet: make container full viewport and center content

### DIFF
--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.css
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.css
@@ -45,9 +45,21 @@ amp-fx-flying-carpet > .-amp-fx-flying-carpet-clip > .-amp-fx-flying-carpet-cont
   position: fixed !important;
   top: 0 !important;
   width: 100%;
+  height: 100%;
   /*
    * Included to force slow webkit browsers (Android) into rendering the
    * container using the GPU.
    */
   -webkit-transform: translateZ(0) !important;
+
+  /* Center contents in the container */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.-amp-fx-flying-carpet-container > .i-amphtml-layout-responsive,
+.-amp-fx-flying-carpet-container > .i-amphtml-layout-fixed-height {
+  align-self: stretch;
 }


### PR DESCRIPTION
Closes #8097.

The flying carpet's container has to be full screen and center its content.
