### PR TITLE
amp-auto-ads: implements more versatile constraints around ad placement

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -141,7 +141,7 @@ function compile(entryModuleFilenames, outputDir,
       // Strange access/login related files.
       'build/all/v0/*.js',
       // A4A has these cross extension deps.
-      'extensions/**/*-config.js',
+      'extensions/amp-ad-network*/**/*-config.js',
       'extensions/amp-ad/**/*.js',
       'extensions/amp-a4a/**/*.js',
       // Currently needed for crypto.js and visibility.js.

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -17,6 +17,8 @@
 import {buildUrl} from '../../../ads/google/a4a/url-builder';
 import {documentInfoForDoc} from '../../../src/document-info';
 import {parseUrl} from '../../../src/url';
+import {viewportForDoc} from '../../../src/viewport';
+
 
 /**
  * An interface intended to be implemented by any ad-networks wishing to support
@@ -36,6 +38,12 @@ class AdNetworkConfigDef {
    * @return {!Object<string, string>}
    */
   getAttributes() {}
+
+  /**
+   * Network specific constraints on the placement of ads on the page.
+   * @return {!./ad-tracker.AdConstraints}
+   */
+  getAdConstraints() {}
 }
 
 /**
@@ -83,6 +91,20 @@ class AdSenseNetworkConfig {
     return {
       'type': 'adsense',
       'data-ad-client': this.autoAmpAdsElement_.getAttribute('data-ad-client'),
+    };
+  }
+
+  /** @override */
+  getAdConstraints() {
+    const viewportHeight =
+        viewportForDoc(this.autoAmpAdsElement_).getSize().height;
+    return {
+      initialMinSpacing: viewportHeight,
+      subsequentMinSpacing: [
+        {adCount: 3, spacing: viewportHeight * 2},
+        {adCount: 6, spacing: viewportHeight * 3},
+      ],
+      maxAdCount: 8,
     };
   }
 }

--- a/extensions/amp-auto-ads/0.1/ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/ad-strategy.js
@@ -20,6 +20,14 @@ import {dev} from '../../../src/log';
 /** @const */
 const TAG = 'amp-auto-ads';
 
+/**
+ * @typedef {{
+ *   adsPlaced: number,
+ *   totalAdsOnPage: number
+ * }}
+ */
+export let StrategyResult;
+
 export class AdStrategy {
 
   /**
@@ -28,9 +36,8 @@ export class AdStrategy {
    *     be added to any inserted ads. These will be combined with any
    *     additional data atrributes specified by the placement.
    * @param {!./ad-tracker.AdTracker} adTracker
-   * @param {number} targetAdCount
    */
-  constructor(placements, baseAttributes, adTracker, targetAdCount) {
+  constructor(placements, baseAttributes, adTracker) {
     this.availablePlacements_ = placements.slice(0);
 
     this.baseAttributes_ = baseAttributes;
@@ -39,22 +46,33 @@ export class AdStrategy {
     this.adTracker_ = adTracker;
 
     /** @type {number} */
-    this.targetAdCount_ = targetAdCount;
+    this.adsPlaced_ = 0;
   }
 
   /**
-   * @return {!Promise<boolean>} True if strategy succeeds false otherwise.
+   * @return {!Promise<StrategyResult>} Resolves when the strategy is complete.
    */
   run() {
-    if (this.adTracker_.getAdCount() >= this.targetAdCount_) {
-      return Promise.resolve(true);
+    if (this.adTracker_.isMaxAdCountReached()) {
+      return Promise.resolve(this.getStrategyResult_());
     }
     return this.placeNextAd_().then(success => {
       if (success) {
         return this.run();
       }
-      return false;
+      return this.getStrategyResult_();
     });
+  }
+
+  /**
+   * @return {!StrategyResult}
+   * @private
+   */
+  getStrategyResult_() {
+    return {
+      adsPlaced: this.adsPlaced_,
+      totalAdsOnPage: this.adTracker_.getAdCount(),
+    };
   }
 
   /**
@@ -74,6 +92,7 @@ export class AdStrategy {
         .then(state => {
           if (state == PlacementState.PLACED) {
             this.adTracker_.addAd(nextPlacement.getAdElement());
+            this.adsPlaced_++;
             return true;
           } else {
             return this.placeNextAd_();

--- a/extensions/amp-auto-ads/0.1/ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/ad-tracker.js
@@ -16,18 +16,58 @@
 
 import {resourcesForDoc} from '../../../src/resources';
 
+/**
+ * Structure for defining contraints about the placement of ads.
+ *
+ * initialMinSpacing - gives the minimum vertical spacing (in pixels) that
+ *                     should be between any two ads on the page. This is used
+ *                     up to the point where a rule in subsequentMinSpacing
+ *                     matches the number of ads on the page.
+ *
+ * subsequentMinSpacing - an array of rules that change the minimum vertical
+ *                        spacing required between ads as a function of how
+ *                        many ads are on the page. adCount matches the number
+ *                        of ads on the page (both hard-coded and those inserted
+ *                        by amp-auto-ads), and spacing defines the vertical
+ *                        spacing for the matching condition.
+ *
+ * maxAdCount - specifies the maximum number of ads that should be on the page.
+ *              Both hard-coded ads and those inserted by amp-auto-ads count
+ *              towards this. Once this limit is reached, amp-auto-ads will
+ *              stop trying to insert additional ads.
+ *
+ * @typedef {{
+ *   initialMinSpacing: number,
+ *   subsequentMinSpacing: !Array<!{adCount: number, spacing: number}>,
+ *   maxAdCount: number
+ * }}
+ */
+export let AdConstraints;
+
 export class AdTracker {
 
   /**
    * @param {!Array<!Element>} ads
-   * @param {number} minAdSpacing
+   * @param {!AdConstraints} adConstraints
    */
-  constructor(ads, minAdSpacing) {
+  constructor(ads, adConstraints) {
     /** @type {!Array<!Element>} */
     this.ads_ = ads;
 
     /** @type {number} */
-    this.minAdSpacing_ = minAdSpacing;
+    this.initialMinSpacing_ = adConstraints.initialMinSpacing;
+
+    /** @type {!Array<!{adCount: number, spacing: number}>} */
+    this.subsequentMinSpacing_ = adConstraints.subsequentMinSpacing.slice(0)
+        .sort((a, b) => {
+          return a.adCount - b.adCount;
+        });
+
+    /** @type {number} */
+    this.maxAdCount_ = adConstraints.maxAdCount;
+
+    /** @type {number} */
+    this.minAdSpacing_ = this.getMinAdSpacing_();
   }
 
   /**
@@ -35,6 +75,7 @@ export class AdTracker {
    */
   addAd(ad) {
     this.ads_.push(ad);
+    this.minAdSpacing_ = this.getMinAdSpacing_();
   }
 
   /**
@@ -42,6 +83,13 @@ export class AdTracker {
    */
   getAdCount() {
     return this.ads_.length;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isMaxAdCountReached() {
+    return this.getAdCount() >= this.maxAdCount_;
   }
 
   /**
@@ -89,6 +137,22 @@ export class AdTracker {
             Math.abs(yPosition - box.bottom));
       }
     });
+  }
+
+  /**
+   * @private
+   * @return {number}
+   */
+  getMinAdSpacing_() {
+    const adCount = this.getAdCount();
+    let spacing = this.initialMinSpacing_;
+    for (let i = 0; i < this.subsequentMinSpacing_.length; i++) {
+      const item = this.subsequentMinSpacing_[i];
+      if (item.adCount <= adCount) {
+        spacing = item.spacing;
+      }
+    }
+    return spacing;
   }
 }
 

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -26,23 +26,6 @@ import {getPlacementsFromConfigObj} from './placement';
 /** @const */
 const TAG = 'amp-auto-ads';
 
-/**
- * The target number of ads for the page. Both existing ads and any inserted by
- * amp-auto-ads count towards this.
- * TODO: Make this configurable via the JSON config returned by the ad network.
- * @const {number}
- */
-const TARGET_AD_COUNT = 3;
-
-/**
- * The minimum distance between any two ads in pixels. Auto ads will only be
- * inserted in positions where they are estimated to be a vertical distance of
- * this or more from any other ads.
- * TODO: Make this configurable via the JSON config returned by the ad network.
- * @const {number}
- */
-const MIN_AD_SPACING = 500;
-
 
 export class AmpAutoAds extends AMP.BaseElement {
 
@@ -60,8 +43,9 @@ export class AmpAutoAds extends AMP.BaseElement {
       const placements = getPlacementsFromConfigObj(this.win, configObj);
       const attributes = Object.assign(adNetwork.getAttributes(),
           getAttributesFromConfigObj(configObj));
-      const adTracker = new AdTracker(getExistingAds(this.win), MIN_AD_SPACING);
-      new AdStrategy(placements, attributes, adTracker, TARGET_AD_COUNT).run();
+      const adTracker =
+          new AdTracker(getExistingAds(this.win), adNetwork.getAdConstraints());
+      new AdStrategy(placements, attributes, adTracker).run();
     });
   }
 

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -15,10 +15,13 @@
  */
 
 import {getAdNetworkConfig} from '../ad-network-config';
+import {viewportForDoc} from '../../../../src/viewport';
 
 describes.realWin('ad-network-config', {
   amp: {
     canonicalUrl: 'https://foo.bar/baz',
+    runtimeOn: true,
+    ampdoc: 'single',
   },
 }, env => {
 
@@ -28,11 +31,11 @@ describes.realWin('ad-network-config', {
   beforeEach(() => {
     document = env.win.document;
     ampAutoAdsElem = document.createElement('amp-auto-ads');
-    document.body.appendChild(ampAutoAdsElem);
+    env.win.document.body.appendChild(ampAutoAdsElem);
   });
 
   afterEach(() => {
-    document.body.removeChild(ampAutoAdsElem);
+    env.win.document.body.removeChild(ampAutoAdsElem);
   });
 
   describe('AdSense', () => {
@@ -55,6 +58,22 @@ describes.realWin('ad-network-config', {
       expect(adNetwork.getAttributes()).to.deep.equal({
         'type': 'adsense',
         'data-ad-client': 'ca-pub-1234',
+      });
+    });
+
+    it('should get the ad constraints', () => {
+      const viewportMock = sandbox.mock(viewportForDoc(env.win.document));
+      viewportMock.expects('getSize').returns(
+          {width: 320, height: 500}).atLeast(1);
+
+      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      expect(adNetwork.getAdConstraints()).to.deep.equal({
+        initialMinSpacing: 500,
+        subsequentMinSpacing: [
+          {adCount: 3, spacing: 1000},
+          {adCount: 6, spacing: 1500},
+        ],
+        maxAdCount: 8,
       });
     });
   });

--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -80,11 +80,15 @@ describes.realWin('amp-strategy', {
           'data-custom-att-2': 'val-2',
         };
 
-        const adStrategy =
-            new AdStrategy(placements, attributes, new AdTracker([], 0), 1);
+        const adTracker = new AdTracker([], {
+          initialMinSpacing: 0,
+          subsequentMinSpacing: [],
+          maxAdCount: 1,
+        });
+        const adStrategy = new AdStrategy(placements, attributes, adTracker);
 
-        return adStrategy.run().then(success => {
-          expect(success).to.equal(true);
+        return adStrategy.run().then(result => {
+          expect(result).to.deep.equal({adsPlaced: 1, totalAdsOnPage: 1});
           expect(anchor1.childNodes).to.have.lengthOf(1);
           expect(anchor2.childNodes).to.have.lengthOf(0);
           const adElement = anchor1.childNodes[0];
@@ -135,11 +139,15 @@ describes.realWin('amp-strategy', {
       'data-custom-att-2': 'val-2',
     };
 
-    const adStrategy =
-        new AdStrategy(placements, attributes, new AdTracker([], 0), 1);
+    const adTracker = new AdTracker([], {
+      initialMinSpacing: 0,
+      subsequentMinSpacing: [],
+      maxAdCount: 1,
+    });
+    const adStrategy = new AdStrategy(placements, attributes, adTracker);
 
-    return adStrategy.run().then(success => {
-      expect(success).to.equal(true);
+    return adStrategy.run().then(result => {
+      expect(result).to.deep.equal({adsPlaced: 1, totalAdsOnPage: 1});
       expect(anchor1.childNodes).to.have.lengthOf(0);
       expect(anchor2.childNodes).to.have.lengthOf(1);
       const adElement = anchor2.childNodes[0];
@@ -195,11 +203,15 @@ describes.realWin('amp-strategy', {
       'data-custom-att-2': 'val-2',
     };
 
-    const adStrategy =
-        new AdStrategy(placements, attributes, new AdTracker([], 200), 2);
+    const adTracker = new AdTracker([], {
+      initialMinSpacing: 200,
+      subsequentMinSpacing: [],
+      maxAdCount: 2,
+    });
+    const adStrategy = new AdStrategy(placements, attributes, adTracker);
 
-    return adStrategy.run().then(success => {
-      expect(success).to.equal(false);
+    return adStrategy.run().then(result => {
+      expect(result).to.deep.equal({adsPlaced: 1, totalAdsOnPage: 1});
       expect(anchor1.childNodes).to.have.lengthOf(1);
       expect(anchor2.childNodes).to.have.lengthOf(0);
       const adElement = anchor1.childNodes[0];
@@ -255,11 +267,15 @@ describes.realWin('amp-strategy', {
       'data-custom-att-2': 'val-2',
     };
 
-    const adStrategy =
-        new AdStrategy(placements, attributes, new AdTracker([], 200), 2);
+    const adTracker = new AdTracker([], {
+      initialMinSpacing: 200,
+      subsequentMinSpacing: [],
+      maxAdCount: 2,
+    });
+    const adStrategy = new AdStrategy(placements, attributes, adTracker);
 
-    return adStrategy.run().then(success => {
-      expect(success).to.equal(true);
+    return adStrategy.run().then(result => {
+      expect(result).to.deep.equal({adsPlaced: 2, totalAdsOnPage: 2});
       expect(anchor1.childNodes).to.have.lengthOf(1);
       expect(anchor2.childNodes).to.have.lengthOf(1);
       const adElement1 = anchor1.childNodes[0];
@@ -323,11 +339,15 @@ describes.realWin('amp-strategy', {
       'data-custom-att-2': 'val-2',
     };
 
-    const adStrategy = new AdStrategy(placements, attributes,
-        new AdTracker([fakeExistingAd], 200), 2);
+    const adTracker = new AdTracker([fakeExistingAd], {
+      initialMinSpacing: 200,
+      subsequentMinSpacing: [],
+      maxAdCount: 2,
+    });
+    const adStrategy = new AdStrategy(placements, attributes, adTracker);
 
-    return adStrategy.run().then(success => {
-      expect(success).to.equal(true);
+    return adStrategy.run().then(result => {
+      expect(result).to.deep.equal({adsPlaced: 1, totalAdsOnPage: 2});
       expect(anchor1.childNodes).to.have.lengthOf(1);
       expect(anchor2.childNodes).to.have.lengthOf(0);
       const adElement1 = anchor1.childNodes[0];
@@ -338,55 +358,58 @@ describes.realWin('amp-strategy', {
     });
   });
 
-  it('should report strategy as unsuccessful when unable to place either ad',
-      () => {
-        const anchor1 = document.createElement('div');
-        anchor1.id = 'anchor1Id';
-        container.appendChild(anchor1);
+  it('should report unable to place either ad', () => {
+    const anchor1 = document.createElement('div');
+    anchor1.id = 'anchor1Id';
+    container.appendChild(anchor1);
 
-        const anchor2 = document.createElement('div');
-        anchor2.id = 'anchor2Id';
-        container.appendChild(anchor2);
+    const anchor2 = document.createElement('div');
+    anchor2.id = 'anchor2Id';
+    container.appendChild(anchor2);
 
-        const configObj = {
-          placements: [
-            {
-              anchor: {
-                selector: 'DIV#anchor1Id',
-              },
-              pos: 2,
-              type: 1,
-            },
-            {
-              anchor: {
-                selector: 'DIV#anchor2Id',
-              },
-              pos: 2,
-              type: 1,
-            },
-          ],
-        };
-        const placements = getPlacementsFromConfigObj(env.win, configObj);
+    const configObj = {
+      placements: [
+        {
+          anchor: {
+            selector: 'DIV#anchor1Id',
+          },
+          pos: 2,
+          type: 1,
+        },
+        {
+          anchor: {
+            selector: 'DIV#anchor2Id',
+          },
+          pos: 2,
+          type: 1,
+        },
+      ],
+    };
+    const placements = getPlacementsFromConfigObj(env.win, configObj);
 
-        expect(placements).to.have.lengthOf(2);
-        sandbox.stub(placements[0], 'placeAd', () => {
-          return Promise.resolve(PlacementState.REIZE_FAILED);
-        });
-        sandbox.stub(placements[1], 'placeAd', () => {
-          return Promise.resolve(PlacementState.REIZE_FAILED);
-        });
+    expect(placements).to.have.lengthOf(2);
+    sandbox.stub(placements[0], 'placeAd', () => {
+      return Promise.resolve(PlacementState.REIZE_FAILED);
+    });
+    sandbox.stub(placements[1], 'placeAd', () => {
+      return Promise.resolve(PlacementState.REIZE_FAILED);
+    });
 
-        const attributes = {
-          'type': 'adsense',
-        };
+    const attributes = {
+      'type': 'adsense',
+    };
 
-        const adStrategy =
-            new AdStrategy(placements, attributes, new AdTracker([], 0), 1);
+    const adTracker = new AdTracker([], {
+      initialMinSpacing: 0,
+      subsequentMinSpacing: [],
+      maxAdCount: 1,
+    });
+    const adStrategy = new AdStrategy(placements, attributes, adTracker);
 
-        return adStrategy.run().then(success => {
-          expect(success).to.equal(false);
-          expect(anchor1.childNodes).to.have.lengthOf(0);
-          expect(anchor2.childNodes).to.have.lengthOf(0);
-        });
-      });
+    return adStrategy.run().then(result => {
+      expect(result).to.deep.equal({adsPlaced: 0, totalAdsOnPage: 0});
+      expect(anchor1.childNodes).to.have.lengthOf(0);
+      expect(anchor2.childNodes).to.have.lengthOf(0);
+    });
+  });
 });

--- a/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
@@ -55,10 +55,25 @@ describe('ad-tracker', () => {
     return ad;
   }
 
+  function checkMinSpacing(adTracker, tooNearPos, okPos) {
+    return adTracker.isTooNearAnAd(tooNearPos).then(tooNear => {
+      expect(tooNear).to.equal(true);
+      return adTracker.isTooNearAnAd(okPos).then(tooNear => {
+        expect(tooNear).to.equal(false);
+      });
+    });
+  }
+
   it('should return the correct ad count', () => {
+    const adConstraints = {
+      initialMinSpacing: 100,
+      subsequentMinSpacing: [],
+      maxAdCount: 10,
+    };
+
     const adTracker = new AdTracker([
       addAd(layoutRectLtwh(0, 0, 300, 50)),
-    ], 100);
+    ], adConstraints);
     expect(adTracker.getAdCount()).to.equal(1);
 
     adTracker.addAd(addAd(layoutRectLtwh(0, 100, 300, 50)));
@@ -66,46 +81,147 @@ describe('ad-tracker', () => {
   });
 
   it('should find position is too near when close to ad above', () => {
+    const adConstraints = {
+      initialMinSpacing: 100,
+      subsequentMinSpacing: [],
+      maxAdCount: 10,
+    };
+
     const adTracker = new AdTracker([
       addAd(layoutRectLtwh(0, 0, 300, 50)),
-    ], 100);
+    ], adConstraints);
     return adTracker.isTooNearAnAd(149).then(tooNear => {
       expect(tooNear).to.equal(true);
     });
   });
 
   it('should find position is too near when close to ad below', () => {
+    const adConstraints = {
+      initialMinSpacing: 100,
+      subsequentMinSpacing: [],
+      maxAdCount: 10,
+    };
+
     const adTracker = new AdTracker([
       addAd(layoutRectLtwh(0, 100, 300, 50)),
-    ], 100);
+    ], adConstraints);
     return adTracker.isTooNearAnAd(1).then(tooNear => {
       expect(tooNear).to.equal(true);
     });
   });
 
   it('should find position is too near when inside ad', () => {
+    const adConstraints = {
+      initialMinSpacing: 100,
+      subsequentMinSpacing: [],
+      maxAdCount: 10,
+    };
+
     const adTracker = new AdTracker([
       addAd(layoutRectLtwh(0, 0, 300, 50)),
-    ], 1);
+    ], adConstraints);
     return adTracker.isTooNearAnAd(25).then(tooNear => {
       expect(tooNear).to.equal(true);
     });
   });
 
   it('should find position is not too near an ad', () => {
+    const adConstraints = {
+      initialMinSpacing: 100,
+      subsequentMinSpacing: [],
+      maxAdCount: 10,
+    };
+
     const adTracker = new AdTracker([
       addAd(layoutRectLtwh(0, 0, 300, 50)),
       addAd(layoutRectLtwh(0, 250, 300, 50)),
-    ], 100);
+    ], adConstraints);
     return adTracker.isTooNearAnAd(150).then(tooNear => {
       expect(tooNear).to.equal(false);
     });
   });
 
-  it('should add an ad to the tracker', () => {
+  it('should use the initial min ad spacing', () => {
+    const adConstraints = {
+      initialMinSpacing: 500,
+      subsequentMinSpacing: [],
+      maxAdCount: 10,
+    };
+
     const adTracker = new AdTracker([
       addAd(layoutRectLtwh(0, 0, 300, 50)),
-    ], 100);
+    ], adConstraints);
+    return checkMinSpacing(adTracker, 549, 550);
+  });
+
+  it('should use a subsequent ad spacing when an existing ad present', () => {
+    const adConstraints = {
+      initialMinSpacing: 500,
+      subsequentMinSpacing: [
+        {adCount: 1, spacing: 600},
+      ],
+      maxAdCount: 10,
+    };
+
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+    ], adConstraints);
+    return checkMinSpacing(adTracker, 649, 650);
+  });
+
+  it('should use a subsequent ad spacing when two existing ads present', () => {
+    const adConstraints = {
+      initialMinSpacing: 500,
+      subsequentMinSpacing: [
+        {adCount: 1, spacing: 600},
+        {adCount: 2, spacing: 700},
+      ],
+      maxAdCount: 10,
+    };
+
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+    ], adConstraints);
+    return checkMinSpacing(adTracker, 749, 750);
+  });
+
+  it('should change min spacing as ads added', () => {
+    const adConstraints = {
+      initialMinSpacing: 500,
+      subsequentMinSpacing: [
+        {adCount: 1, spacing: 600},
+        {adCount: 3, spacing: 700},
+        {adCount: 4, spacing: 800},
+      ],
+      maxAdCount: 10,
+    };
+
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+    ], adConstraints);
+    return checkMinSpacing(adTracker, 649, 650).then(() => {
+      adTracker.addAd(addAd(layoutRectLtwh(0, 0, 300, 50)));
+      return checkMinSpacing(adTracker, 649, 650).then(() => {
+        adTracker.addAd(addAd(layoutRectLtwh(0, 0, 300, 50)));
+        return checkMinSpacing(adTracker, 749, 750).then(() => {
+          adTracker.addAd(addAd(layoutRectLtwh(0, 0, 300, 50)));
+          return checkMinSpacing(adTracker, 849, 850);
+        });
+      });
+    });
+  });
+
+  it('should add an ad to the tracker', () => {
+    const adConstraints = {
+      initialMinSpacing: 100,
+      subsequentMinSpacing: [],
+      maxAdCount: 10,
+    };
+
+    const adTracker = new AdTracker([
+      addAd(layoutRectLtwh(0, 0, 300, 50)),
+    ], adConstraints);
     adTracker.addAd(addAd(layoutRectLtwh(0, 100, 300, 50)));
     return adTracker.isTooNearAnAd(150).then(tooNear => {
       expect(tooNear).to.equal(true);

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -18,6 +18,7 @@ import {AmpAutoAds} from '../amp-auto-ads';
 import {toggleExperiment} from '../../../../src/experiments';
 import {xhrFor} from '../../../../src/xhr';
 import {waitForChild} from '../../../../src/dom';
+import {viewportForDoc} from '../../../../src/viewport';
 
 describes.realWin('amp-auto-ads', {
   amp: {
@@ -53,6 +54,10 @@ describes.realWin('amp-auto-ads', {
 
     toggleExperiment(env.win, 'amp-auto-ads', true);
     sandbox = env.sandbox;
+
+    const viewportMock = sandbox.mock(viewportForDoc(env.win.document));
+    viewportMock.expects('getSize').returns(
+        {width: 320, height: 500}).atLeast(1);
 
     container = env.win.document.createElement('div');
     env.win.document.body.appendChild(container);

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -65,7 +65,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(() => {
             expect(placements[0].getAdElement()).to.equal(anchor.childNodes[0]);
           });
@@ -224,7 +229,12 @@ describes.realWin('placement', {
         'data-custom-att-2': 'val-2',
       };
 
-      return placements[0].placeAd(baseAttributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(baseAttributes, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -270,7 +280,12 @@ describes.realWin('placement', {
         'data-custom-att-3': 'val-4',
       };
 
-      return placements[0].placeAd(baseAttributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(baseAttributes, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -313,7 +328,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -353,7 +373,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -393,7 +418,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -431,7 +461,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -473,7 +508,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });;
+      return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
                 anchor.firstChild, 100, 320);
@@ -508,7 +548,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
                 anchor.firstChild, 100, 320);
@@ -537,7 +582,11 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      const adTracker = new AdTracker([fakeAd], 100);
+      const adTracker = new AdTracker([fakeAd], {
+        initialMinSpacing: 100,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
 
       const attributes = {
         'type': 'ad-network-type',
@@ -574,7 +623,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(2);
@@ -604,7 +658,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(2);
@@ -635,7 +694,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(1);
@@ -666,7 +730,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(1);
@@ -701,7 +770,12 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, new AdTracker([], 0))
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(anchor1.childNodes).to.have.lengthOf(0);


### PR DESCRIPTION
Allows networks to specify the ad density and also define a variable spacing strategy, where ads get further spaced as more are added to the page.