### PR TITLE
Fix double drain bug

### DIFF
--- a/src/service/batched-xhr-impl.js
+++ b/src/service/batched-xhr-impl.js
@@ -61,7 +61,8 @@ export class BatchedXhr extends Xhr {
     const fetchPromise = super.fetch(input, opt_init);
 
     if (isBatchable) {
-      this.fetchPromises_[key] = fetchPromise.then(response => {
+      this.fetchPromises_[key] = fetchPromise;
+      return fetchPromise.then(response => {
         delete this.fetchPromises_[key];
         return response.clone();
       }, err => {


### PR DESCRIPTION
This should fix [the issue @jridgewell raised](https://github.com/ampproject/amphtml/pull/7562#pullrequestreview-28207531) since it temporarily caches the original response and only gives callers cloned responses. The previous implementation cached a cloned response and returned it, allowing a potential double drain.