### PR TITLE
Put back link-url-replace on Canary config as well

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,6 +8,7 @@
   "pan-y": 1,
   "a4aProfilingRate": 1,
   "amp-form-custom-validations": 1,
+  "link-url-replace": 1,
   "amp-form-var-sub": 1,
   "amp-form-var-sub-for-post": 1,
   "ad-type-custom": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,6 +8,7 @@
   "expDoubleclickA4A": 0.1,
   "a4aProfilingRate": 1,
   "amp-form-custom-validations": 1,
+  "link-url-replace": 1,
   "amp-form-var-sub": 1,
   "amp-form-var-sub-for-post": 1,
   "ad-type-custom": 1,


### PR DESCRIPTION
This should not matter since Canary already has the removal code, but trying to keep canary and prod configs the same for now.