### PR TITLE
Do not remove `meta` tags with `amp4ads-` prefix

### DIFF
--- a/spec/amp-cache-modifications.md
+++ b/spec/amp-cache-modifications.md
@@ -265,6 +265,7 @@ Remove any `<meta>` tags except for those that:
  - do not have attributes `content`, `itemprop`, `name` and `property`
  - have attribute `http-equiv`
  - have attribute `name` with prefix `amp-`
+ - have attribute `name` with prefix `amp4ads-`
  - have attribute `name` with prefix `dc.`
  - have attribute `name` with prefix `i-amp-` [temporary, will be removed at a future date]
  - have attribute `name` with prefix `i-amphtml-`


### PR DESCRIPTION
This is for issue #7730 which will introduce `<meta name=amp4ads-id vendor=doubleclick type=impression-id value=12345>`.