### PR TITLE
Workaround Chrome top=auto bug for position:sticky

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -309,7 +309,11 @@ export class FixedLayer {
           let top = styles.top;
           const currentOffsetTop = element./*OK*/offsetTop;
           const isImplicitAuto = currentOffsetTop == autoTopMap[fe.id];
-          if ((top == 'auto' || isImplicitAuto) && top != '0px') {
+          if ((top == 'auto' || isImplicitAuto) && top != '0px' ||
+              // This is workaround for http://crbug.com/703816 in Chrome where
+              // `getComputedStyle().top` returns `0px` instead of `auto`.
+              (isSticky && top == '0px' && isImplicitAuto &&
+                  currentOffsetTop != 0)) {
             top = '';
             if (currentOffsetTop == this.committedPaddingTop_) {
               top = '0px';

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -231,6 +231,9 @@ describe('FixedLayer', () => {
     };
     Object.defineProperty(elem, 'offsetTop', {
       get: () => {
+        if (elem.overrideOffsetTop != null) {
+          return elem.overrideOffsetTop;
+        }
         if (elem.style.top == 'auto' || elem.computedStyle.top == 'auto' ||
                 elem.computedStyle.top == '') {
           return elem.autoOffsetTop;
@@ -548,6 +551,51 @@ describe('FixedLayer', () => {
       expect(state['F4'].fixed).to.be.false;
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('');
+    });
+
+    it('should work around top=0 for sticky', () => {
+      // See http://crbug.com/703816.
+      element5.computedStyle['position'] = 'sticky';
+      element5.computedStyle['top'] = '0px';
+      element5.autoOffsetTop = 12;
+      element5.overrideOffsetTop = 12;
+
+      expect(vsyncTasks).to.have.length(1);
+      const state = {};
+      vsyncTasks[0].measure(state);
+
+      expect(state['F4'].sticky).to.be.true;
+      expect(state['F4'].top).to.equal('');
+    });
+
+    it('should NOT work around top=0 for sticky when offset = 0', () => {
+      // See http://crbug.com/703816.
+      element5.computedStyle['position'] = 'sticky';
+      element5.computedStyle['top'] = '0px';
+      element5.autoOffsetTop = 0;
+      element5.overrideOffsetTop = 0;
+
+      expect(vsyncTasks).to.have.length(1);
+      const state = {};
+      vsyncTasks[0].measure(state);
+
+      expect(state['F4'].sticky).to.be.true;
+      expect(state['F4'].top).to.equal('0px');
+    });
+
+    it('should NOT work around top=0 for sticky for non-implicit top', () => {
+      // See http://crbug.com/703816.
+      element5.computedStyle['position'] = 'sticky';
+      element5.computedStyle['top'] = '0px';
+      element5.autoOffsetTop = 12;
+      element5.overrideOffsetTop = 11;
+
+      expect(vsyncTasks).to.have.length(1);
+      const state = {};
+      vsyncTasks[0].measure(state);
+
+      expect(state['F4'].sticky).to.be.true;
+      expect(state['F4'].top).to.equal('0px');
     });
 
     it('should collect for implicit top = auto, but not update top', () => {


### PR DESCRIPTION
Closes #8149.

This is a workaround against http://crbug.com/703816 that returns `top = 0px` for implicit `top:auto` sticky elements.