### PR TITLE
Update amp-bind.md

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -202,6 +202,7 @@ key_value:
 
 ```text
 Array.concat()
+Array.includes()
 Array.indexOf()
 Array.join()
 Array.lastIndexOf()


### PR DESCRIPTION
Adds Array.includes() to the amp-bind documentation, as part of #7401
@kmh287