### PR TITLE
preventing overflow:hidden for un-expanded amp-ads

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -151,6 +151,12 @@ html.i-amphtml-ios-embed {
   overflow: hidden !important;
 }
 
+.i-amphtml-layout-awaiting-size {
+  position: absolute !important;
+  top: auto !important;
+  bottom: auto !important;
+}
+
 i-amphtml-sizer {
   display: block !important;
 }

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -202,6 +202,7 @@ export class Placement {
     const attributes = Object.assign({
       'layout': 'fixed-height',
       'height': '0',
+      'class': 'i-amphtml-layout-awaiting-size',
     }, baseAttributes, this.attributes_);
     return createElementWithAttributes(
         this.win_.document, 'amp-ad', attributes);

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -298,6 +298,45 @@ describes.realWin('placement', {
           });
     });
 
+    it('should place an ad with i-amphtml-layout-awaiting-size class', () => {
+      const anchor = document.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(env.win, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      const baseAttributes = {
+        'type': 'ad-network-type',
+      };
+
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(baseAttributes, adTracker)
+          .then(() => {
+            const adElement = anchor.firstChild;
+            expect(adElement.tagName).to.equal('AMP-AD');
+            expect(adElement.getAttribute('type')).to.equal('ad-network-type');
+            expect(adElement.getAttribute('layout')).to.equal('fixed-height');
+            expect(adElement.getAttribute('height')).to.equal('0');
+            expect(adElement.classList.contains(
+                'i-amphtml-layout-awaiting-size')).to.equal.true;
+          });
+    });
+
     it('should place an ad with the correct margins', () => {
       const anchor = document.createElement('div');
       anchor.id = 'anId';

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -904,6 +904,9 @@ function createBaseCustomElementClass(win) {
           setStyle(this, 'marginLeft', opt_newMargins.left, 'px');
         }
       }
+      if (this.isAwaitingSize_()) {
+        this.sizeProvided_();
+      }
     }
 
     /**
@@ -965,6 +968,21 @@ function createBaseCustomElementClass(win) {
           this.dispatchCustomEventForTesting('amp:stubbed');
         }
       }
+    }
+
+    /**
+     * @return {boolean}
+     * @private
+     */
+    isAwaitingSize_() {
+      return this.classList.contains('i-amphtml-layout-awaiting-size');
+    }
+
+    /**
+     * @private
+     */
+    sizeProvided_() {
+      this.classList.remove('i-amphtml-layout-awaiting-size');
     }
 
     /** The Custom Elements V0 sibling to `connectedCallback`. */

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1040,6 +1040,16 @@ describe('CustomElement', () => {
     expect(element.style.width).to.equal('0px');
   });
 
+  it('should remove i-amphtml-layout-awaiting-size class when ' +
+      'size changed', () => {
+    const element = new StubElementClass();
+    expect(element.isUpgraded()).to.equal(false);
+    element.classList.add('i-amphtml-layout-awaiting-size');
+
+    expect(element).to.have.class('i-amphtml-layout-awaiting-size');
+    element.changeSize(100, 100);
+    expect(element).not.to.have.class('i-amphtml-layout-awaiting-size');
+  });
 
   describe('unlayoutCallback', () => {
 


### PR DESCRIPTION
Introduces a new i-amphtml-layout-awaiting-size state, which prevents upgrade from happening until changeSize has been called on the element. Requires various carve outs to the CSS rules in amp.css to ensure element with i-amphtml-layout-awaiting-size have overflow:visible and also that anything inside them has display:none (ensuring nothing spills outside the element).

This is to solve: https://github.com/ampproject/amphtml/issues/8219