### PR TITLE
Cache SW: Do not set Date header

### DIFF
--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -286,11 +286,6 @@ export function fetchAndCache(cache, request) {
                 `${response.status}.`);
           }
 
-          // Override the Date header, to avoid time skew between the server
-          // and the client (ie, a client with set to an incorrect date int the
-          // future).
-          response.headers.set('date', new Date().toUTCString());
-
           // You must clone to prevent double reading the body.
           cache.put(request, response.clone());
           return response;


### PR DESCRIPTION
Stupidly, ServiceWorkers do not allow mutations to the response
headers. Actually, only SWs do this, every other type of Response would
have allowed this.

Fixes #8318.