### PR TITLE
Cache SW: Ensure any failure is always logged.

### DIFF
--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -624,7 +624,7 @@ export function handleFetch(request, maybeClientId) {
       // If not, let's fetch and cache the request.
       return fetchJsFile(cache, versionedRequest, pathname, version);
     });
-  }).catch((err) => {
+  }).catch(err => {
     // Throw error out of band.
     Promise.reject(err);
     throw err;

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -624,6 +624,10 @@ export function handleFetch(request, maybeClientId) {
       // If not, let's fetch and cache the request.
       return fetchJsFile(cache, versionedRequest, pathname, version);
     });
+  }).catch((err) => {
+    // Throw error out of band.
+    Promise.reject(err);
+    throw err;
   });
 }
 

--- a/src/service-worker/core.js
+++ b/src/service-worker/core.js
@@ -595,7 +595,7 @@ export function handleFetch(request, maybeClientId) {
 
   // Wait for the cachePromise to resolve. This is necessary
   // since the SW thread may be killed and restarted at any time.
-  return cachePromise.then(() => {
+  return /** @type {!Promise<!Response>} */ (cachePromise.then(() => {
     // If we already registered this client, we must always use the same
     // version.
     if (clientsVersion[clientId]) {
@@ -628,7 +628,7 @@ export function handleFetch(request, maybeClientId) {
     // Throw error out of band.
     Promise.reject(err);
     throw err;
-  });
+  }));
 }
 
 


### PR DESCRIPTION
If any failure happens in the promise chain, we want to hear about it. But unfortunately, the `event.respondWith` that we eventually pass the promise to will install a rejection handler, which means we won't get a `unhandledrejection` event.

This throws the error out-of-band with the promise chain.