### PR TITLE
Scope event trigger for scoped analytics element

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -104,6 +104,9 @@ export class AmpAnalytics extends AMP.BaseElement {
 
     /** @private {!../../../src/service/crypto-impl.Crypto} */
     this.cryptoService_ = cryptoFor(this.win);
+
+    /** @private {boolean} */
+    this.isScoped_ = !!this.element.getAttribute('scope');
   }
 
   /** @override */
@@ -237,6 +240,9 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @private
    */
   addTriggerNoInline_(config) {
+    if (this.isScoped_) {
+      config['isScoped'] = 'true';
+    }
     try {
       this.analyticsGroup_.addTrigger(
           config, this.handleEvent_.bind(this, config));
@@ -293,7 +299,8 @@ export class AmpAnalytics extends AMP.BaseElement {
    */
   fetchRemoteConfig_() {
     let remoteConfigUrl = this.element.getAttribute('config');
-    if (!remoteConfigUrl) {
+    if (!remoteConfigUrl || this.isScoped_) {
+      // Remote config is not supported for inserted scoped analytics element
       return Promise.resolve();
     }
     assertHttpsUrl(remoteConfigUrl, this.element);

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -177,6 +177,9 @@ export class AnalyticsRoot {
     if (selector == ':host') {
       return this.getHostElement();
     }
+    if (selector == ':scope') {
+      return context;
+    }
 
     // Query search based on the selection method.
     let found;
@@ -241,12 +244,17 @@ export class AnalyticsRoot {
       const rootElement = this.getRootElement();
       const isSelectAny = (selector == '*');
       const isSelectRoot = (selector == ':root');
+      const isSelectScope = (selector == ':scope');
       let target = event.target;
       while (target) {
 
         // Target must be contained by this root.
         if (!this.contains(target)) {
           break;
+        }
+        // `:scope` selector should be the context itself.
+        if (isSelectScope && target != context) {
+          continue;
         }
         // `:scope` context must contain the target.
         if (selectionMethod == 'scope' &&
@@ -263,6 +271,7 @@ export class AnalyticsRoot {
         // Check if the target matches the selector.
         if (isSelectAny ||
             isSelectRoot && target == rootElement ||
+            isSelectScope && target == context ||
             matchesNoInline(target, selector)) {
           listener(target, event);
           // Don't fire the event multiple times even if the more than one

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -163,10 +163,11 @@ export function isVisibilitySpecValid(config) {
  * @return {?Element} Element corresponding to the selector if found.
  */
 export function getElement(ampdoc, selector, analyticsEl, selectionMethod) {
+  const isScoped = analyticsEl.getAttribute('scope');
   if (!analyticsEl) {
     return null;
   }
-
+  selectionMethod = isScoped ? 'scope' : selectionMethod;
   let foundEl;
   const friendlyFrame = getParentWindowFrameElement(analyticsEl, ampdoc.win);
   // Special case for root selector.
@@ -174,6 +175,9 @@ export function getElement(ampdoc, selector, analyticsEl, selectionMethod) {
     foundEl = friendlyFrame ?
         closestBySelector(
             friendlyFrame, '.i-amphtml-element') : null;
+    if (isScoped) {
+      foundEl = analyticsEl.parentElement.contains(foundEl) ? foundEl : null;
+    }
   } else if (selectionMethod == 'closest') {
     // Only tag names are supported currently.
     foundEl = closestByTag(analyticsEl, selector);


### PR DESCRIPTION
This PR blacklist `scroll` `timer` `hidden` event at this point.  
replace `selectionMethod` value with `scope` for scoped analytics element.
point to `element.parentElement` when `:root` is use.

WIP. Tests not added yet. Early feedback would be great. 
