### PR TITLE
Sticky ad behavior changes

### DIFF
--- a/extensions/amp-sticky-ad/amp-sticky-ad.md
+++ b/extensions/amp-sticky-ad/amp-sticky-ad.md
@@ -45,10 +45,10 @@ limitations under the License.
 - The width of the sticky-ad is set to 100% using CSS and cannot be overridden.
 - The opacity of the sticky-ad is set to 1 using CSS and cannot be overridden.
 - The background color of the sticky-ad can be customized to match the page style. However, any semi-transparent or transparent background will not be allowed and will be changed to a non-transparent color.
-- The sticky ad display after scrolling one viewport height from the top.
 - When scrolled to the bottom of the page, the viewport is automatically padded with the additional height of the sticky ad, so that no content is ever hidden.
 - When in landscape mode, the sticky ad is center-aligned.
 - The sticky ad can be dismissed and removed by a close button.
+- If no ad is filled, the sticky ad container will collapse and will no longer be visible.
 
 Example:
 ```html


### PR DESCRIPTION
- Remove item about how sticky ad will only load after 1 viewport is scrolled (no longer true)
- Add item to reflect that container collapses if no ad is filled
