### PR TITLE
Restrict margin-bottom for sticky-ad

### DIFF
--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
@@ -27,6 +27,7 @@ amp-sticky-ad {
   background-image: none !important;
   background-color: #fff;
   box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2) !important;
+  margin-bottom: 0 !important;
 }
 
 amp-sticky-ad-top-padding {


### PR DESCRIPTION
fix for #8240
cc @jasti 

Since we add `margin-bottom` I am thinking should we also add `margin-left` `margin-right` since we ask stickyAd to always take 100% width.