### PR TITLE
amp-bind: Validate brightcove, youtube and iframe integrations

### DIFF
--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -38,10 +38,6 @@ const GLOBAL_PROPERTY_RULES = map({
   'class': {
     blacklistedValueRegex: '(^|\\W)i-amphtml-',
   },
-  // ARIA accessibility attributes.
-  'aria-describedby': null,
-  'aria-label': null,
-  'aria-labelledby': null,
 });
 
 /**
@@ -225,7 +221,7 @@ function createElementRules_() {
     },
     'AMP-IMG': {
       'alt': null,
-      'referrerpolicy': null,
+      'attribution': null,
       'src': {
         'allowedProtocols': {
           'data': true,
@@ -243,11 +239,8 @@ function createElementRules_() {
     'AMP-VIDEO': {
       'alt': null,
       'attribution': null,
-      'autoplay': null,
       'controls': null,
       'loop': null,
-      'muted': null,
-      'placeholder': null,
       'poster': null,
       'preload': null,
       'src': {
@@ -326,6 +319,7 @@ function createElementRules_() {
       'label': null,
     },
     'SELECT': {
+      'autofocus': null,
       'disabled': null,
       'multiple': null,
       'required': null,
@@ -350,6 +344,7 @@ function createElementRules_() {
     },
     'TEXTAREA': {
       'autocomplete': null,
+      'autofocus': null,
       'cols': null,
       'disabled': null,
       'maxlength': null,

--- a/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
@@ -36,6 +36,13 @@ tags: {  # <amp-brightcove>
     name: "data-account"
     mandatory: true
   }
+  # <amp-bind>
+  attrs: { "[data-account]" }
+  attrs: { "[data-embed]" }
+  attrs: { "[data-player]" }
+  attrs: { "[data-player-id]" }
+  attrs: { "[data-playlist-id]" }
+  attrs: { "[data-video-id]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-brightcove"
   amp_layout: {

--- a/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/0.1/validator-amp-brightcove.protoascii
@@ -37,12 +37,12 @@ tags: {  # <amp-brightcove>
     mandatory: true
   }
   # <amp-bind>
-  attrs: { "[data-account]" }
-  attrs: { "[data-embed]" }
-  attrs: { "[data-player]" }
-  attrs: { "[data-player-id]" }
-  attrs: { "[data-playlist-id]" }
-  attrs: { "[data-video-id]" }
+  attrs: { name: "[data-account]" }
+  attrs: { name: "[data-embed]" }
+  attrs: { name: "[data-player]" }
+  attrs: { name: "[data-player-id]" }
+  attrs: { name: "[data-playlist-id]" }
+  attrs: { name: "[data-video-id]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-brightcove"
   amp_layout: {

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -425,6 +425,8 @@ export class AmpIframe extends AMP.BaseElement {
         this.iframe_.src = this.assertSource(
             this.iframeSrc, window.location.href, this.sandbox_);
       }
+      // Per validator, src and srcdoc should be mutually exclusive.
+      this.element.removeAttribute('srcdoc');
     }
   }
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -425,8 +425,6 @@ export class AmpIframe extends AMP.BaseElement {
         this.iframe_.src = this.assertSource(
             this.iframeSrc, window.location.href, this.sandbox_);
       }
-      // Per validator, src and srcdoc should be mutually exclusive.
-      this.element.removeAttribute('srcdoc');
     }
   }
 

--- a/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
@@ -73,7 +73,12 @@ tags: {  # <amp-iframe>
     mandatory_oneof: "['src', 'srcdoc']"
   }
   # <amp-bind>
-  attrs: { name: "[src]" }
+  attrs: {
+    name: "[src]"
+    trigger: {
+      also_requires_attr: "src"
+    }
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-iframe"
   amp_layout: {

--- a/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/0.1/validator-amp-iframe.protoascii
@@ -72,6 +72,8 @@ tags: {  # <amp-iframe>
     name: "srcdoc"
     mandatory_oneof: "['src', 'srcdoc']"
   }
+  # <amp-bind>
+  attrs: { name: "[src]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-iframe"
   amp_layout: {

--- a/extensions/amp-video/0.1/validator-amp-video.protoascii
+++ b/extensions/amp-video/0.1/validator-amp-video.protoascii
@@ -62,9 +62,10 @@ tags: {  # <amp-video>
     blacklisted_value_regex: "__amp_source_origin"
   }
   # <amp-bind>
+  attrs: { name: "[alt]" }
+  attrs: { name: "[attribution]" }
   attrs: { name: "[controls]" }
   attrs: { name: "[loop]" }
-  attrs: { name: "[muted]" }
   attrs: { name: "[poster]" }
   attrs: { name: "[preload]" }
   attrs: { name: "[src]" }

--- a/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/0.1/validator-amp-youtube.protoascii
@@ -38,6 +38,8 @@ tags: {  # <amp-youtube>
     mandatory: true
     value_regex: "[^=/?:]+"
   }
+  # <amp-bind>
+  attrs: { name: "[data-videoid]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-youtube"
   amp_layout: {


### PR DESCRIPTION
Follow-up to #8056.

- Support bindable attributes in `amp-brightcove`, `amp-youtube`, and `amp-iframe`.
- Fix inconsistencies since we had to restore the `canBind()` method for security reasons (#8271) 🙁 

/to @Gregable @kmh287 