### PR TITLE
Create srcset in #layoutCallback

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -67,8 +67,6 @@ export class AmpImg extends BaseElement {
   /** @override */
   buildCallback() {
     this.isPrerenderAllowed_ = !this.element.hasAttribute('noprerender');
-
-    this.srcset_ = srcsetFromElement(this.element);
   }
 
   /** @override */
@@ -83,6 +81,9 @@ export class AmpImg extends BaseElement {
   initialize_() {
     if (this.img_) {
       return;
+    }
+    if (!this.srcset_) {
+      this.srcset_ = srcsetFromElement(this.element);
     }
     this.allowImgLoadFallback_ = true;
     // If this amp-img IS the fallback then don't allow it to have its own

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -60,8 +60,6 @@ export class AmpAnim extends AMP.BaseElement {
     st.toggle(this.img_, !this.getPlaceholder());
 
     this.element.appendChild(this.img_);
-
-    this.srcset_ = srcsetFromElement(this.element);
   }
 
   /** @override */
@@ -71,6 +69,9 @@ export class AmpAnim extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    if (!this.srcset_) {
+      this.srcset_ = srcsetFromElement(this.element);
+    }
     return this.updateImageSrc_();
   }
 


### PR DESCRIPTION
Each srcset takes ~.2ms (for 2 possibles selections) to parse and
create. Moving this into `#layoutCallback` saves us from doing that when
we parse _every_ image in the DOM.

Fixes https://github.com/ampproject/amphtml/issues/8359.