### PR TITLE
Limit the number of elements to build during prerender

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -282,9 +282,11 @@ export class Resource {
    * for details.
    */
   build() {
-    if (this.blacklisted_ || !this.element.isUpgraded()
-        || !this.resources_.shouldBuildNow()) {
+    if (this.blacklisted_ || !this.element.isUpgraded()) {
       return;
+    }
+    if (!this.resources_.grantBuildPermission()) {
+
     }
     try {
       this.element.build();

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -282,7 +282,8 @@ export class Resource {
    * for details.
    */
   build() {
-    if (this.blacklisted_ || !this.element.isUpgraded()) {
+    if (this.blacklisted_ || !this.element.isUpgraded()
+        || !this.resources_.shouldBuildNow()) {
       return;
     }
     try {

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -282,11 +282,9 @@ export class Resource {
    * for details.
    */
   build() {
-    if (this.blacklisted_ || !this.element.isUpgraded()) {
+    if (this.blacklisted_ || !this.element.isUpgraded()
+        || !this.resources_.grantBuildPermission()) {
       return;
-    }
-    if (!this.resources_.grantBuildPermission()) {
-
     }
     try {
       this.element.build();

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -103,6 +103,9 @@ export class Resources {
     /** @private {number} */
     this.addCount_ = 0;
 
+    /** @private {number} */
+    this.buildAttemptsCount_ = 0;
+
     /** @private {boolean} */
     this.visible_ = this.viewer_.isVisible();
 
@@ -471,6 +474,10 @@ export class Resources {
       dev().fine(TAG_, 'resource added:', resource.debugid);
     }
     this.resources_.push(resource);
+  }
+
+  shouldBuildNow() {
+    return this.buildAttemptsCount_++ < 20 || this.viewer_.hasBeenVisible();
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -476,7 +476,20 @@ export class Resources {
     this.resources_.push(resource);
   }
 
-  shouldBuildNow() {
+  /**
+   * Limits the number of elements being build in pre-render phase to
+   * a finite number. Returns false if the number has been reached.
+   * @return {boolean}
+   */
+  grantBuildPermission() {
+    // For pre-render we want to limit the amount of CPU used, so we limit
+    // the number of elements build. For pre-render to "seem complete"
+    // we only need to build elements in the first viewport. We can't know
+    // which are actually in the viewport (because the decision is pre-layout,
+    // so we use a heuristic instead.
+    // Most documents have 10 or less AMP tags. By building 20 we should not
+    // change the behavior for the vast majority of docs, and almost always
+    // catch everything in the first viewport.
     return this.buildAttemptsCount_++ < 20 || this.viewer_.hasBeenVisible();
   }
 

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -125,11 +125,15 @@ describe('Resource', () => {
   });
 
   it('should not build if permission is not granted', () => {
+    let permission = false;
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('build').never();
-    sandbox.stub(resources, 'grantBuildPermission', () => false);
+    sandbox.stub(resources, 'grantBuildPermission', () => permission);
     resource.build();
     expect(resource.getState()).to.equal(ResourceState.NOT_BUILT);
+
+    permission = true;
+    resource.build();
+    expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
   });
 
   it('should blacklist on build failure', () => {

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -124,6 +124,14 @@ describe('Resource', () => {
     expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
   });
 
+  it('should not build if permission is not granted', () => {
+    elementMock.expects('isUpgraded').returns(true).atLeast(1);
+    elementMock.expects('build').never();
+    sandbox.stub(resources, 'grantBuildPermission', () => false);
+    resource.build();
+    expect(resource.getState()).to.equal(ResourceState.NOT_BUILT);
+  });
+
   it('should blacklist on build failure', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     elementMock.expects('build').throws('Failed').once();

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1104,6 +1104,18 @@ describe('Resources discoverWork', () => {
     expect(setInViewport).to.have.been.calledBefore(schedule);
   });
 
+  it('should not grant permission to build when threshold reached', () => {
+    let hasBeenVisible = false;
+    sandbox.stub(resources.viewer_, 'hasBeenVisible', () => hasBeenVisible);
+
+    for (let i = 0; i < 20; i++) {
+      expect(resources.grantBuildPermission()).to.be.true;
+    }
+    expect(resources.grantBuildPermission()).to.be.false;
+    hasBeenVisible = true;
+    expect(resources.grantBuildPermission()).to.be.true;
+  });
+
   it('should build resource when not built', () => {
     const schedulePassStub = sandbox.stub(resources, 'schedulePass');
     sandbox.stub(resources, 'schedule_');


### PR DESCRIPTION
This significantly reduces the amount of CPU needed for very large documents during prerender. The count of elements to build was chosen arbitray as "big enough that it typically should be enough to render stuff in the first viewport".

This seems to work quite well and it suggests we do have quite the opportunity to optimize things with a chunking scheduler.

The document I was testing with (http://www.refinery29.com/amp/best-pizza-nyc) does get much better with this, although it doesn't get into good shape, since it is simply too big for a browser (let alone a mobile browser) to reasonably render.