### PR TITLE
amp-bind: Don't depend on template location to locate dynamic elements

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -149,6 +149,8 @@ function compile(entryModuleFilenames, outputDir,
       'extensions/amp-analytics/**/*.js',
       // For amp-bind in the web worker (ww.js).
       'extensions/amp-bind/**/*.js',
+      // Needed to access form impl from other extensions
+      'extensions/amp-form/**/*.js',
       'src/*.js',
       'src/!(inabox)*/**/*.js',
       '!third_party/babel/custom-babel-helpers.js',

--- a/examples/bind/forms.amp.html
+++ b/examples/bind/forms.amp.html
@@ -39,7 +39,14 @@
           <template type="amp-mustache">
               Success! Thanks {{name}} for entering your email: {{email}}
 
-              <p>You have selected: <span [text]="selected ? selected : 'No selection'">0</span></p>
+              <p>You have selected: <span [text]="selected ? selected : 'No selection'">No selection</span></p>
+          </template>
+      </div>
+      <div submit-error>
+        <template type="amp-mustache">
+              Error! Failure to register: {{name}} : {{email}}
+
+              <p>You have selected: <span [text]="selected ? selected : 'No selection'">No selection</span></p>
           </template>
       </div>
   </form>

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -15,7 +15,6 @@
  */
 
 import {BindExpressionResultDef} from './bind-expression';
-import {childElementByAttr} from '../../../src/dom';
 import {BindingDef, BindEvaluator} from './bind-evaluator';
 import {BindValidator} from './bind-validator';
 import {chunk, ChunkPriority} from '../../../src/chunk';
@@ -25,7 +24,6 @@ import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {invokeWebWorker} from '../../../src/web-worker/amp-worker';
 import {isFiniteNumber} from '../../../src/types';
-import {map} from '../../../src/utils/object';
 import {reportError} from '../../../src/error';
 import {resourcesForDoc} from '../../../src/resources';
 import {filterSplice} from '../../../src/utils/array';
@@ -382,7 +380,17 @@ export class Bind {
 
       let dynamicElements = [];
       if (typeof element.getDynamicElements === 'function') {
-        dynamicElements = element.getDynamicElements(mutations);
+        dynamicElements = element.getDynamicElements();
+      } else if (element.tagName === 'FORM') {
+        // FORM is not an amp element, so it doesn't have the getter.
+        const successDiv = element./*OK*/querySelector('[submit-success]');
+        if (successDiv) {
+          dynamicElements.push(successDiv);
+        }
+        const errorDiv = element./*OK*/querySelector('[submit-error]');
+        if (errorDiv) {
+          dynamicElements.push(errorDiv);
+        }
       }
       dynamicElements.forEach(elementToObserve => {
         this.mutationObserver_.observe(elementToObserve, {childList: true});

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -380,14 +380,13 @@ export class Bind {
       const tagName = element.tagName;
 
       let dynamicElements = [];
-      if (typeof element.getDynamicElements === 'function') {
-        dynamicElements = element.getDynamicElements();
+      if (typeof element.getDynamicElementContainers === 'function') {
+        dynamicElements = element.getDynamicElementContainers();
       } else if (element.tagName === 'FORM') {
         // FORM is not an amp element, so it doesn't have the getter directly.
         const form = formOrNullForElement(element);
-        if (form) {
-          dynamicElements = form.getDynamicElements();
-        }
+        dev().assert(form, 'could not find form implementation');
+        dynamicElements = form.getDynamicElementContainers();
       }
       dynamicElements.forEach(elementToObserve => {
         this.mutationObserver_.observe(elementToObserve, {childList: true});

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -20,6 +20,7 @@ import {BindValidator} from './bind-validator';
 import {chunk, ChunkPriority} from '../../../src/chunk';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
+import {formOrNullForElement} from '../../../src/form';
 import {isArray, toArray} from '../../../src/types';
 import {isExperimentOn} from '../../../src/experiments';
 import {invokeWebWorker} from '../../../src/web-worker/amp-worker';
@@ -382,14 +383,10 @@ export class Bind {
       if (typeof element.getDynamicElements === 'function') {
         dynamicElements = element.getDynamicElements();
       } else if (element.tagName === 'FORM') {
-        // FORM is not an amp element, so it doesn't have the getter.
-        const successDiv = element./*OK*/querySelector('[submit-success]');
-        if (successDiv) {
-          dynamicElements.push(successDiv);
-        }
-        const errorDiv = element./*OK*/querySelector('[submit-error]');
-        if (errorDiv) {
-          dynamicElements.push(errorDiv);
+        // FORM is not an amp element, so it doesn't have the getter directly.
+        const form = formOrNullForElement(element);
+        if (form) {
+          dynamicElements = form.getDynamicElements();
         }
       }
       dynamicElements.forEach(elementToObserve => {

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -15,14 +15,15 @@
  */
 
 import * as sinon from 'sinon';
+import {AmpForm} from '../../../amp-form/0.1/amp-form';
 import {Bind} from '../bind-impl';
 import {BindExpression} from '../bind-expression';
 import {BindValidator} from '../bind-validator';
 import {chunkInstanceForTesting} from '../../../../src/chunk';
+import {installTimerService} from '../../../../src/service/timer-impl';
 import {toArray} from '../../../../src/types';
 import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
-import {installTimerService} from '../../../../src/service/timer-impl';
 
 describes.realWin('Bind', {
   amp: {
@@ -173,6 +174,8 @@ describes.realWin('Bind', {
     const dynamicTag = doc.createElement('div');
     dynamicTag.setAttribute('submit-success', null);
     form.appendChild(dynamicTag);
+    // Wrap form in amp-form implementation so bind can access it
+    new AmpForm(form);
     return onBindReady().then(() => {
       expect(bind.boundElements_.length).to.equal(0);
       const elementWithBinding = createElementWithBinding('[onePlusOne]="1+1"');

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -168,13 +168,15 @@ describes.realWin('Bind', {
 
   it('should dynamically detect new bindings under dynamic tags', () => {
     const doc = env.win.document;
-    const template = doc.createElement('template');
-    doc.getElementById('parent').appendChild(template);
+    const form = doc.createElement('form');
+    doc.getElementById('parent').appendChild(form);
+    const dynamicTag = doc.createElement('div');
+    dynamicTag.setAttribute('submit-success', null);
+    form.appendChild(dynamicTag);
     return onBindReady().then(() => {
       expect(bind.boundElements_.length).to.equal(0);
-      // As a dynamic element, template adds rendered templates as siblings.
-      // Element is added as a sibling to the template
-      createElementWithBinding('[onePlusOne]="1+1"');
+      const elementWithBinding = createElementWithBinding('[onePlusOne]="1+1"');
+      dynamicTag.appendChild(elementWithBinding);
       return waitForEvent('amp:bind:mutated');
     }).then(() => {
       expect(bind.boundElements_.length).to.equal(1);

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -67,14 +67,20 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
 
   describe('detecting bindings under dynamic tags', () => {
     it('should NOT bind blacklisted attributes', () => {
-      const template = fixture.doc.getElementById('dynamicTemplate');
+      const dynamicTag = fixture.doc.getElementById('dynamicTag');
       const div = fixture.doc.createElement('div');
       div.innerHTML = '<p [onclick]="javascript:alert(document.cookie)" ' +
                          '[onmouseover]="javascript:alert()" ' +
                          '[style]="background=color:black"></p>';
       const textElement = div.firstElementChild;
-      template.parentElement.appendChild(textElement);
+      // for amp-live-list, dynamic element is <div items>, which is a child
+      // of the list.
+      dynamicTag.firstElementChild.appendChild(textElement);
       return waitForAllMutations().then(() => {
+        // Force bind to apply bindings
+        fixture.doc.getElementById('triggerBindApplicationButton').click();
+        return waitForBindApplication();
+      }).then(() => {
         expect(textElement.getAttribute('onclick')).to.be.null;
         expect(textElement.getAttribute('onmouseover')).to.be.null;
         expect(textElement.getAttribute('style')).to.be.null;
@@ -85,9 +91,13 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
       const div = fixture.doc.createElement('div');
       div.innerHTML = '<a [href]="javascript:alert(1)"></a>';
       const aElement = div.firstElementChild;
-      const template = fixture.doc.getElementById('dynamicTemplate');
-      template.parentElement.appendChild(aElement);
+      const dynamicTag = fixture.doc.getElementById('dynamicTag');
+      dynamicTag.firstElementChild.appendChild(aElement);
       return waitForAllMutations().then(() => {
+        // Force bind to apply bindings
+        fixture.doc.getElementById('triggerBindApplicationButton').click();
+        return waitForBindApplication();
+      }).then(() => {
         expect(aElement.getAttribute('href')).to.be.null;
       });
     });

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -594,14 +594,18 @@ export class AmpForm {
    * @return {Array<!Element>}
    * @public
    */
-  getDynamicElements() {
+  getDynamicElementContainers() {
     const dynamicElements = [];
     const successDiv =
         this.form_./*OK*/querySelector(`[${FormState_.SUBMIT_SUCCESS}]`);
     const errorDiv =
         this.form_./*OK*/querySelector(`[${FormState_.SUBMIT_ERROR}]`);
-    successDiv && dynamicElements.push(successDiv);
-    errorDiv && dynamicElements.push(errorDiv);
+    if (successDiv) {
+      dynamicElements.push(successDiv);
+    }
+    if (errorDiv) {
+      dynamicElements.push(errorDiv);
+    }
     return dynamicElements;
   }
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -18,6 +18,7 @@ import {installFormProxy} from './form-proxy';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 import {createCustomEvent} from '../../../src/event-helper';
 import {documentInfoForDoc} from '../../../src/document-info';
+import {setFormForElement} from '../../../src/form';
 import {getService} from '../../../src/service';
 import {
   assertAbsoluteHttpOrHttpsUrl,
@@ -101,6 +102,8 @@ export class AmpForm {
     } catch (e) {
       dev().error(TAG, 'form proxy failed to install', e);
     }
+
+    setFormForElement(element, this);
 
     /** @private @const {string} */
     this.id_ = id;
@@ -585,6 +588,21 @@ export class AmpForm {
     if (previousRender) {
       removeElement(previousRender);
     }
+  }
+
+  /**
+   * @return {Array<!Element>}
+   * @public
+   */
+  getDynamicElements() {
+    const dynamicElements = [];
+    const successDiv =
+        this.form_./*OK*/querySelector(`[${FormState_.SUBMIT_SUCCESS}]`);
+    const errorDiv =
+        this.form_./*OK*/querySelector(`[${FormState_.SUBMIT_ERROR}]`);
+    successDiv && dynamicElements.push(successDiv);
+    errorDiv && dynamicElements.push(errorDiv);
+    return dynamicElements;
   }
 
   /**

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -841,7 +841,7 @@ export class AmpLiveList extends AMP.BaseElement {
   }
 
   /** @override */
-  getDynamicElements() {
+  getDynamicElementContainers() {
     return this.itemsSlot_ ? [this.itemsSlot_] : [];
   }
 

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -840,6 +840,11 @@ export class AmpLiveList extends AMP.BaseElement {
     return this.updateTime_;
   }
 
+  /** @override */
+  getDynamicElements() {
+    return this.itemsSlot_ ? [this.itemsSlot_] : [];
+  }
+
   sendAmpDomUpdateEvent_() {
     const event = this.win.document.createEvent('Event');
     event.initEvent('amp:dom-update', true, true);

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -900,10 +900,10 @@ export class BaseElement {
    * element owns that could have children added or removed dynamically.
    * The array should not contain any ancestors of this element, but could
    * contain this element itself.
-   * @return {Array<!Element>}
+   * @return {!Array<!Element>}
    * @public
    */
-  getDynamicElements() {
+  getDynamicElementContainers() {
     return [];
   }
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -896,6 +896,17 @@ export class BaseElement {
   }
 
   /**
+   * Returns an array of nodes in this element's subtree that could have
+   * descendants added or removed dynamically. The array should not contain
+   * any ancestors of this element, but could contain this element itself.
+   * @return {Array<!Node>}
+   * @public
+   */
+  getDynamicElements() {
+    return [];
+  }
+
+  /**
    * Called when we just measured the layout rect of this element. Doing
    * more expensive style reads should now be cheap.
    * This may currently not work with extended elements. Please file

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -896,10 +896,11 @@ export class BaseElement {
   }
 
   /**
-   * Returns an array of nodes in this element's subtree that could have
-   * descendants added or removed dynamically. The array should not contain
-   * any ancestors of this element, but could contain this element itself.
-   * @return {Array<!Node>}
+   * Returns an array of elements in this element's subtree that this
+   * element owns that could have children added or removed dynamically.
+   * The array should not contain any ancestors of this element, but could
+   * contain this element itself.
+   * @return {Array<!Element>}
    * @public
    */
   getDynamicElements() {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1352,6 +1352,17 @@ function createBaseCustomElementClass(win) {
       this.implementation_.mutatedAttributesCallback(mutations);
     }
 
+        /**
+     * Returns an array of nodes in this element's subtree that could have
+     * descendants added or removed dynamically. The array should not contain
+     * any ancestors of this element, but could contain this element itself.
+     * @return {Array<!Node>}
+     * @public
+     */
+    getDynamicElements() {
+      return this.implementation_.getDynamicElements();
+    }
+
     /**
      * Enqueues the action with the element. If element has been upgraded and
      * built, the action is dispatched to the implementation right away.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1352,11 +1352,12 @@ function createBaseCustomElementClass(win) {
       this.implementation_.mutatedAttributesCallback(mutations);
     }
 
-        /**
-     * Returns an array of nodes in this element's subtree that could have
-     * descendants added or removed dynamically. The array should not contain
-     * any ancestors of this element, but could contain this element itself.
-     * @return {Array<!Node>}
+    /**
+     * Returns an array of elements in this element's subtree that this
+     * element owns that could have children added or removed dynamically.
+     * The array should not contain any ancestors of this element, but could
+     * contain this element itself.
+     * @return {Array<!Element>}
      * @public
      */
     getDynamicElements() {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1360,8 +1360,8 @@ function createBaseCustomElementClass(win) {
      * @return {Array<!Element>}
      * @public
      */
-    getDynamicElements() {
-      return this.implementation_.getDynamicElements();
+    getDynamicElementContainers() {
+      return this.implementation_.getDynamicElementContainers();
     }
 
     /**

--- a/src/form.js
+++ b/src/form.js
@@ -19,6 +19,7 @@ const FORM_PROP_ = '__AMP_FORM';
 
 /**
  * @param {!Element} element
+ * @return {../extensions/amp-form/0.1/amp-form.AmpForm}
  */
 export function formOrNullForElement(element) {
   return element[FORM_PROP_] || null;
@@ -26,6 +27,7 @@ export function formOrNullForElement(element) {
 
 /**
  * @param {!Element} element
+ * @param {!../extensions/amp-form/0.1/amp-form.AmpForm} form
  */
 export function setFormForElement(element, form) {
   element[FORM_PROP_] = form;

--- a/src/form.js
+++ b/src/form.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /** @const {string} */
+const FORM_PROP_ = '__AMP_FORM';
+
+/**
+ * @param {!Element} element
+ */
+export function formOrNullForElement(element) {
+  return element[FORM_PROP_] || null;
+}
+
+/**
+ * @param {!Element} element
+ */
+export function setFormForElement(element, form) {
+  element[FORM_PROP_] = form;
+}

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -86,10 +86,10 @@ export class Resource {
 
   /**
    * @param {!Element} element
-   * @return {?Resource}
+   * @return {Resource}
    */
   static forElementOptional(element) {
-    return /** @type {?Resource} */ (element[RESOURCE_PROP_]);
+    return /** @type {Resource} */ (element[RESOURCE_PROP_]);
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -89,7 +89,7 @@ export class Resource {
    * @return {?Resource}
    */
   static forElementOptional(element) {
-    return /** @type {!Resource} */ (element[RESOURCE_PROP_]);
+    return /** @type {?Resource} */ (element[RESOURCE_PROP_]);
   }
 
   /**

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -26,12 +26,17 @@
 </head>
 
 <body>
+
+  <button on="tap:AMP.setState({})" id="triggerBindApplicationButton"></button>
+
   <p>DYNAMIC TAGS</p>
-  <!-- For generic dynamic tag tests only. Template tag used as an example. -->
-  <div>
-    <template id="dynamicTemplate"></template>
-    <!-- Siblings added in test -->
-  </div>
+  <!-- Live list is used for generic dynamic tag testing  -->
+  <amp-live-list id="dynamicTag" data-poll-interval="15000" data-max-items-per-page="2">
+    <div items>
+      <!-- Children added in test -->
+    </div>
+    <button update></button>
+  </amp-live-list>
 
   <p>P TAG</p>
   <button on="tap:AMP.setState(boundText='hello world')" id="changeTextButton"></button>


### PR DESCRIPTION
Added a method to base-element for an element to report any elements it "owns" that are containers for dynamic contents. For instance, `<div items>` on an amp-live-list can have elements added/removed from its child list and so amp-live-list should return that div. The returned elements will be observed for mutations by bind. I'm not thrilled with the method name, `getDynamicElements` so I'm open to renaming.

I've also changed `bind-impl` to depend on this new method instead of the locations of templates. One caveat is forms; `amp-form` isn't an element, and so I've implemented custom behavior for the success/failure divs.

Fixes #8341 

/to @choumx @jridgewell 