### PR TITLE
Splitting re-usable page-level experiment functionality out of google/ads/traffic-experiments.js

### DIFF
--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -17,12 +17,15 @@
 import {EXPERIMENT_ATTRIBUTE, QQID_HEADER} from './utils';
 import {BaseLifecycleReporter, GoogleAdLifecycleReporter} from './performance';
 import {getMode} from '../../../src/mode';
-import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
+import {
+  isExperimentOn,
+  toggleExperiment,
+  randomlySelectUnsetExperiments,
+} from '../../../src/experiments';
 
 import {
     parseExperimentIds,
     isInManualExperiment,
-    randomlySelectUnsetPageExperiments,
 } from './traffic-experiments';
 import {
     ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
@@ -41,16 +44,16 @@ import {
  * general traffic-experiments mechanism and is configured via the
  * a4aProfilingRate property of the global config(s),
  * build-system/global-configs/{canary,prod}-config.js.  This object is just
- * necessary for the traffic-experiments.js API, which expects a branch list
+ * necessary for the page-level-experiments.js API, which expects a branch list
  * for each experiment.  We assign all pages to the "control" branch
  * arbitrarily.
  *
- * @const {!Object<string,!./traffic-experiments.ExperimentInfo>}
+ * @const {!Object<string,!../../../src/experiments.ExperimentInfo>}
  */
 export const PROFILING_BRANCHES = {
   a4aProfilingRate: {
-    control: 'unused',
-    experiment: 'unused',
+    isTrafficEligible: () => true,
+    branches: ['unused', 'unused'],
   },
 };
 
@@ -130,7 +133,7 @@ export function getLifecycleReporter(ampElement, namespace, slotId) {
   if (getMode().localDev) {
     toggleExperiment(win, experimentName, true, true);
   }
-  randomlySelectUnsetPageExperiments(win, PROFILING_BRANCHES);
+  randomlySelectUnsetExperiments(win, PROFILING_BRANCHES);
   if ((type == 'doubleclick' || type == 'adsense') &&
       isInReportableBranch(ampElement, namespace) &&
       isExperimentOn(win, experimentName)) {

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -17,19 +17,18 @@
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {
-  RANDOM_NUMBER_GENERATORS,
   addExperimentIdToElement,
-  getPageExperimentBranch,
   mergeExperimentIds,
   isInExperiment,
-  randomlySelectUnsetPageExperiments,
+  isExternallyTriggeredExperiment,
+  isInternallyTriggeredExperiment,
   validateExperimentIds,
   googleAdsIsA4AEnabled,
-  forceExperimentBranch,
 } from '../traffic-experiments';
 import {
-  isExperimentOn,
+  RANDOM_NUMBER_GENERATORS,
   toggleExperiment,
+  forceExperimentBranch,
 } from '../../../../src/experiments';
 import {installPlatformService} from '../../../../src/service/platform-impl';
 import {installViewerServiceForDoc} from '../../../../src/service/viewer-impl';
@@ -44,28 +43,24 @@ import {
   DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
 } from '../../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js'; // eslint-disable-line
 import {EXPERIMENT_ATTRIBUTE} from '../utils';
-import {dev} from '../../../../src/log';
 import * as sinon from 'sinon';
-
-/** @private @const Tag used in dev log messages */
-const TAG_ = 'test-amp-ad';
 
 describe('all-traffic-experiments-tests', () => {
 
-  describe('#randomlySelectUnsetPageExperiments', () => {
+  describes.realWin('#googleAdsIsA4AEnabled', {
+    amp: {
+      runtimeOn: true,
+      ampdoc: 'single',
+    },
+  }, env => {
     let sandbox;
     let accurateRandomStub;
     let cachedAccuratePrng;
-    let testExperimentSet;
+    let element;
+
     beforeEach(() => {
       const experimentFrequency = 1.0;
-      testExperimentSet = {
-        testExperimentId: {
-          control: 'control_branch_id',
-          experiment: 'experiment_branch_id',
-        },
-      };
-      sandbox = sinon.sandbox.create();
+      sandbox = env.sandbox;
       sandbox.win = {
         location: {
           hostname: 'test.server.name.com',
@@ -77,186 +72,91 @@ describe('all-traffic-experiments-tests', () => {
           cookie: null,
           querySelector: () => {},
         },
+        crypto: {
+          subtle: {},
+        },
       };
       accurateRandomStub = sandbox.stub().returns(-1);
       cachedAccuratePrng = RANDOM_NUMBER_GENERATORS.accuratePrng;
       RANDOM_NUMBER_GENERATORS.accuratePrng = accurateRandomStub;
+
+      element = document.createElement('div');
+      env.win.document.body.appendChild(element);
     });
+
     afterEach(() => {
       sandbox.restore();
       RANDOM_NUMBER_GENERATORS.accuratePrng = cachedAccuratePrng;
     });
 
-    it('handles empty experiments list', () => {
-      // Opt out of experiment.
-      toggleExperiment(sandbox.win, 'testExperimentId', false, true);
-      randomlySelectUnsetPageExperiments(sandbox.win, {});
-      expect(isExperimentOn(sandbox.win, 'testExperimentId'),
-          'experiment is on').to.be.false;
-      expect(sandbox.win.pageExperimentBranches).to.be.empty;
+    it('should enable the external A4A experiment from the URL', () => {
+      const externalBranches = {control: '12', experiment: '34'};
+      const internalBranches = {control: '56', experiment: '78'};
+
+      sandbox.win.location.search = '?exp=a4a:2';
+
+      const renderViaA4a = googleAdsIsA4AEnabled(
+          sandbox.win, element, 'exp_name', externalBranches, internalBranches);
+      expect(renderViaA4a).to.be.true;
+      expect(isInExperiment(element, '12')).to.be.false;
+      expect(isInExperiment(element, '34')).to.be.true;
+      expect(isInExperiment(element, '56')).to.be.false;
+      expect(isInExperiment(element, '78')).to.be.false;
+      expect(isExternallyTriggeredExperiment(element)).to.be.true;
+      expect(isInternallyTriggeredExperiment(element)).to.be.false;
     });
-    it('handles experiment not diverted path', () => {
-      // Opt out of experiment.
-      toggleExperiment(sandbox.win, 'testExperimentId', false, true);
-      randomlySelectUnsetPageExperiments(sandbox.win, testExperimentSet);
-      expect(isExperimentOn(sandbox.win, 'testExperimentId'),
-          'experiment is on').to.be.false;
-      expect(getPageExperimentBranch(sandbox.win,
-          'testExperimentId')).to.not.be.ok;
+
+    it('should enable the external A4A control from the URL', () => {
+      const externalBranches = {control: '12', experiment: '34'};
+      const internalBranches = {control: '56', experiment: '78'};
+
+      sandbox.win.location.search = '?exp=a4a:1';
+
+      const renderViaA4a = googleAdsIsA4AEnabled(
+          sandbox.win, element, 'exp_name', externalBranches, internalBranches);
+      expect(renderViaA4a).to.be.false;
+      expect(isInExperiment(element, '12')).to.be.true;
+      expect(isInExperiment(element, '34')).to.be.false;
+      expect(isInExperiment(element, '56')).to.be.false;
+      expect(isInExperiment(element, '78')).to.be.false;
+      expect(isExternallyTriggeredExperiment(element)).to.be.true;
+      expect(isInternallyTriggeredExperiment(element)).to.be.false;
     });
-    it('handles experiment diverted path: control', () => {
-      // Force experiment on.
-      toggleExperiment(sandbox.win, 'testExperimentId', true, true);
-      // force the control branch to be chosen by making the accurate PRNG
-      // return a value < 0.5.
-      RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.3);
-      randomlySelectUnsetPageExperiments(sandbox.win, testExperimentSet);
-      expect(isExperimentOn(sandbox.win, 'testExperimentId'),
-          'experiment is on').to.be.true;
-      expect(getPageExperimentBranch(sandbox.win, 'testExperimentId')).to.equal(
-          testExperimentSet['testExperimentId'].control);
-    });
-    it('handles experiment diverted path: experiment', () => {
-      // Force experiment on.
-      toggleExperiment(sandbox.win, 'testExperimentId', true, true);
-      // Force the experiment branch to be chosen by making the accurate PRNG
-      // return a value > 0.5.
+
+    it('should enable the internal A4A experiment', () => {
+      toggleExperiment(sandbox.win, 'exp_name', true, true);
+      const externalBranches = {control: '12', experiment: '34'};
+      const internalBranches = {control: '56', experiment: '78'};
+
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.6);
-      randomlySelectUnsetPageExperiments(sandbox.win, testExperimentSet);
-      expect(isExperimentOn(sandbox.win, 'testExperimentId'),
-          'experiment is on').to.be.true;
-      expect(getPageExperimentBranch(sandbox.win, 'testExperimentId')).to.equal(
-          testExperimentSet['testExperimentId'].experiment);
-    });
-    it('handles multiple experiments', () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
-      toggleExperiment(sandbox.win, 'expt_1', false, true);
-      toggleExperiment(sandbox.win, 'expt_2', true, true);
-      toggleExperiment(sandbox.win, 'expt_3', true, true);
 
-      const experimentInfo = {
-        'expt_0': {
-          control: '0_c',
-          experiment: '0_e',
-        },
-        'expt_1': {
-          control: '1_c',
-          experiment: '1_e',
-        },
-        'expt_2': {
-          control: '2_c',
-          experiment: '2_e',
-        },
-        // expt_3 omitted.
-      };
-      RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.6);
-      randomlySelectUnsetPageExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0'),
-          'expt_0 is on').to.be.true;
-      expect(isExperimentOn(sandbox.win, 'expt_1'),
-          'expt_1 is on').to.be.false;
-      expect(isExperimentOn(sandbox.win, 'expt_2'),
-          'expt_2 is on').to.be.true;
-      // Note: calling isExperimentOn('expt_3') would actually evaluate the
-      // frequency for expt_3, possibly enabling it.  Since we wanted it to be
-      // omitted altogether, we'll evaluate it only via its branch.
-      expect(getPageExperimentBranch(sandbox.win, 'expt_0')).to.equal(
-          '0_e');
-      expect(getPageExperimentBranch(sandbox.win, 'expt_1')).to.not.be.ok;
-      expect(getPageExperimentBranch(sandbox.win, 'expt_2')).to.equal(
-          '2_e');
-      expect(getPageExperimentBranch(sandbox.win, 'expt_3')).to.not.be.ok;
-    });
-    it('handles multi-way branches', () => {
-      dev().info(TAG_, 'Testing multi-way branches');
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
-      const experimentInfo = {
-        'expt_0': {
-          b0: '0_0',
-          b1: '0_1',
-          b2: '0_2',
-          b3: '0_3',
-          b4: '0_4',
-        },
-      };
-      RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.7);
-      randomlySelectUnsetPageExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0'),
-          'expt_0 is on').to.be.true;
-      expect(getPageExperimentBranch(sandbox.win, 'expt_0')).to.equal(
-          '0_3');
-    });
-    it('handles multiple experiments with multi-way branches', () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
-      toggleExperiment(sandbox.win, 'expt_1', false, true);
-      toggleExperiment(sandbox.win, 'expt_2', true, true);
-      toggleExperiment(sandbox.win, 'expt_3', true, true);
-
-      const experimentInfo = {
-        'expt_0': {
-          b0: '0_0',
-          b1: '0_1',
-          b2: '0_2',
-          b3: '0_3',
-          b4: '0_4',
-        },
-        'expt_1': {
-          b0: '1_0',
-          b1: '1_1',
-          b2: '1_2',
-          b3: '1_3',
-          b4: '1_4',
-        },
-        'expt_2': {
-          b0: '2_0',
-          b1: '2_1',
-          b2: '2_2',
-          b3: '2_3',
-          b4: '2_4',
-        },
-      };
-      RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.7);
-      RANDOM_NUMBER_GENERATORS.accuratePrng.onSecondCall().returns(0.3);
-      randomlySelectUnsetPageExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0'),
-          'expt_0 is on').to.be.true;
-      expect(isExperimentOn(sandbox.win, 'expt_1'),
-          'expt_1 is on').to.be.false;
-      expect(isExperimentOn(sandbox.win, 'expt_2'),
-          'expt_2 is on').to.be.true;
-      // Note: calling isExperimentOn('expt_3') would actually evaluate the
-      // frequency for expt_3, possibly enabling it.  Since we wanted it to be
-      // omitted altogether, we'll evaluate it only via its branch.
-      expect(getPageExperimentBranch(sandbox.win, 'expt_0')).to.equal(
-          '0_3');
-      expect(getPageExperimentBranch(sandbox.win, 'expt_1')).to.not.be.ok;
-      expect(getPageExperimentBranch(sandbox.win, 'expt_2')).to.equal(
-          '2_1');
-      expect(getPageExperimentBranch(sandbox.win, 'expt_3')).to.not.be.ok;
+      const renderViaA4a = googleAdsIsA4AEnabled(
+          sandbox.win, element, 'exp_name', externalBranches, internalBranches);
+      expect(renderViaA4a).to.be.true;
+      expect(isInExperiment(element, '12')).to.be.false;
+      expect(isInExperiment(element, '34')).to.be.false;
+      expect(isInExperiment(element, '56')).to.be.false;
+      expect(isInExperiment(element, '78')).to.be.true;
+      expect(isExternallyTriggeredExperiment(element)).to.be.false;
+      expect(isInternallyTriggeredExperiment(element)).to.be.true;
     });
 
-    it('should not process the same experiment twice', () => {
-      const exptAInfo = {
-        'fooExpt': {
-          control: '012345',
-          experiment: '987654',
-        },
-      };
-      const exptBInfo = {
-        'fooExpt': {
-          control: '246810',
-          experiment: '108642',
-        },
-      };
-      toggleExperiment(sandbox.win, 'fooExpt', false, true);
-      randomlySelectUnsetPageExperiments(sandbox.win, exptAInfo);
-      randomlySelectUnsetPageExperiments(sandbox.win, exptBInfo);
-      // Even though we tried to set up a second time, using a config
-      // parameter that should ensure that the experiment was activated, the
-      // experiment framework should evaluate each experiment only once per
-      // page and should not enable it.
-      expect(isExperimentOn(sandbox.win, 'fooExpt')).to.be.false;
-      expect(getPageExperimentBranch(sandbox.win, 'fooExpt')).to.not.be.ok;
+    it('should enable the internal A4A control', () => {
+      toggleExperiment(sandbox.win, 'exp_name', true, true);
+      const externalBranches = {control: '12', experiment: '34'};
+      const internalBranches = {control: '56', experiment: '78'};
+
+      RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.3);
+
+      const renderViaA4a = googleAdsIsA4AEnabled(
+          sandbox.win, element, 'exp_name', externalBranches, internalBranches);
+      expect(renderViaA4a).to.be.false;
+      expect(isInExperiment(element, '12')).to.be.false;
+      expect(isInExperiment(element, '34')).to.be.false;
+      expect(isInExperiment(element, '56')).to.be.true;
+      expect(isInExperiment(element, '78')).to.be.false;
+      expect(isExternallyTriggeredExperiment(element)).to.be.false;
+      expect(isInternallyTriggeredExperiment(element)).to.be.true;
     });
   });
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -48,18 +48,21 @@ const ADSENSE_A4A_EXPERIMENT_NAME = 'expAdsenseA4A';
 // debug traffic profiling.  Once we have debugged the a4a implementation and
 // can disable profiling again, we can return these constants to being
 // private to this file.
-/** const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo}  */
+/**
+ * const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
+ */
 export const ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152650',
   experiment: '117152651',
   controlMeasureOnRender: '2093326',
 };
 
-/** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo}  */
+/**
+ * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
+ */
 export const ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152670',
   experiment: '117152671',
-  controlMeasureOnRender: null,
 };
 
 /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -53,39 +53,44 @@ const DOUBLECLICK_A4A_EXPERIMENT_NAME = 'expDoubleclickA4A';
 // debug traffic profiling.  Once we have debugged the a4a implementation and
 // can disable profiling again, we can return these constants to being
 // private to this file.
-/** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
+/** @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches} */
 export const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH = {
   control: '117152660',
   experiment: '117152661',
   controlMeasureOnRender: '2093327',
 };
 
-/** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
+/**
+ * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
+ */
 export const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH = {
   control: '2092619',
   experiment: '2092620',
   controlMeasureOnRender: '2093327',
 };
 
-/** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
+/**
+ * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
+ */
 export const DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH = {
   control: '117152680',
   experiment: '117152681',
-  controlMeasureOnRender: null,
 };
 
-/** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
+/**
+ * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
+ */
 export const DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH = {
   control: '2092613',
   experiment: '2092614',
-  controlMeasureOnRender: null,
 };
 
-/** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
+/**
+ * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
+ */
 export const DOUBLECLICK_A4A_BETA_BRANCHES = {
   control: '2077830',
   experiment: '2077831',
-  controlMeasureOnRender: null,
 };
 
 export const BETA_ATTRIBUTE = 'data-use-beta-a4a-implementation';

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -21,6 +21,9 @@ import {
   toggleExperiment,
   resetExperimentTogglesForTesting,
   getExperimentToglesFromCookieForTesting,
+  RANDOM_NUMBER_GENERATORS,
+  getExperimentBranch,
+  randomlySelectUnsetExperiments,
 } from '../../src/experiments';
 import {createElementWithAttributes} from '../../src/dom';
 import * as sinon from 'sinon';
@@ -514,6 +517,279 @@ describe('isCanary', () => {
     expect(isCanary(win)).to.be.false;
     win.AMP_CONFIG.canary = 1;
     expect(isCanary(win)).to.be.true;
+  });
+});
+
+describe('experiment branch tests', () => {
+
+  describe('#randomlySelectUnsetExperiments', () => {
+    let sandbox;
+    let accurateRandomStub;
+    let cachedAccuratePrng;
+    let testExperimentSet;
+
+    beforeEach(() => {
+      const experimentFrequency = 1.0;
+      testExperimentSet = {
+        testExperimentId: {
+          isTrafficEligible: () => true,
+          branches: ['branch1_id', 'branch2_id'],
+        },
+      };
+      sandbox = sinon.sandbox.create();
+      sandbox.win = {
+        location: {
+          hostname: 'test.server.name.com',
+        },
+        AMP_CONFIG: {
+          testExperimentId: experimentFrequency,
+        },
+        document: {
+          cookie: null,
+          querySelector: () => {},
+        },
+      };
+      accurateRandomStub = sandbox.stub().returns(-1);
+      cachedAccuratePrng = RANDOM_NUMBER_GENERATORS.accuratePrng;
+      RANDOM_NUMBER_GENERATORS.accuratePrng = accurateRandomStub;
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      RANDOM_NUMBER_GENERATORS.accuratePrng = cachedAccuratePrng;
+    });
+
+    it('handles empty experiments list', () => {
+      // Opt out of experiment.
+      toggleExperiment(sandbox.win, 'testExperimentId', false, true);
+      randomlySelectUnsetExperiments(sandbox.win, {});
+      expect(isExperimentOn(sandbox.win, 'testExperimentId'),
+          'experiment is on').to.be.false;
+      expect(sandbox.win.experimentBranches).to.be.empty;
+    });
+
+    it('handles experiment not diverted path', () => {
+      // Opt out of experiment.
+      toggleExperiment(sandbox.win, 'testExperimentId', false, true);
+      randomlySelectUnsetExperiments(sandbox.win, testExperimentSet);
+      expect(isExperimentOn(sandbox.win, 'testExperimentId'),
+          'experiment is on').to.be.false;
+      expect(getExperimentBranch(sandbox.win,
+          'testExperimentId')).to.not.be.ok;
+    });
+
+    it('handles experiment diverted path 1', () => {
+      // Force experiment on.
+      toggleExperiment(sandbox.win, 'testExperimentId', true, true);
+      // force the control branch to be chosen by making the accurate PRNG
+      // return a value < 0.5.
+      RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.3);
+      randomlySelectUnsetExperiments(sandbox.win, testExperimentSet);
+      expect(isExperimentOn(sandbox.win, 'testExperimentId'),
+          'experiment is on').to.be.true;
+      expect(getExperimentBranch(sandbox.win, 'testExperimentId')).to.equal(
+          'branch1_id');
+    });
+
+    it('handles experiment diverted path 2', () => {
+      // Force experiment on.
+      toggleExperiment(sandbox.win, 'testExperimentId', true, true);
+      // Force the experiment branch to be chosen by making the accurate PRNG
+      // return a value > 0.5.
+      RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.6);
+      randomlySelectUnsetExperiments(sandbox.win, testExperimentSet);
+      expect(isExperimentOn(sandbox.win, 'testExperimentId'),
+          'experiment is on').to.be.true;
+      expect(getExperimentBranch(sandbox.win, 'testExperimentId')).to.equal(
+          'branch2_id');
+    });
+
+    it('picks a branch if traffic eligible', () => {
+      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      sandbox.win.trafficEligible = true;
+      const experimentInfo = {
+        'expt_0': {
+          isTrafficEligible: win => { return win.trafficEligible; },
+          branches: ['0_0', '0_1'],
+        },
+      };
+      RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
+      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
+      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.equal('0_0');
+    });
+
+    it('doesn\'t pick a branch if traffic ineligible', () => {
+      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      sandbox.win.trafficEligible = false;
+      const experimentInfo = {
+        'expt_0': {
+          isTrafficEligible: win => { return win.trafficEligible; },
+          branches: ['0_0', '0_1'],
+        },
+      };
+      RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
+      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
+      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.be.null;
+    });
+
+    it('doesn\'t pick a branch if no traffic eligibility function', () => {
+      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      const experimentInfo = {
+        'expt_0': {
+          isTrafficEligible: undefined,
+          branches: ['0_0', '0_1'],
+        },
+      };
+      RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
+      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
+      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.be.null;
+    });
+
+    it('doesn\'t pick a branch if traffic becomes eligible after first ' +
+        'diversion', () => {
+      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      sandbox.win.trafficEligible = false;
+      const experimentInfo = {
+        'expt_0': {
+          isTrafficEligible: win => { return win.trafficEligible; },
+          branches: ['0_0', '0_1'],
+        },
+      };
+      RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
+
+      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
+      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.be.null;
+
+      sandbox.win.trafficEligible = true;
+
+      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
+      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.be.null;
+    });
+
+    it('handles multiple experiments', () => {
+      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      toggleExperiment(sandbox.win, 'expt_1', false, true);
+      toggleExperiment(sandbox.win, 'expt_2', true, true);
+      toggleExperiment(sandbox.win, 'expt_3', true, true);
+
+      const experimentInfo = {
+        'expt_0': {
+          isTrafficEligible: () => true,
+          branches: ['0_c', '0_e'],
+        },
+        'expt_1': {
+          isTrafficEligible: () => true,
+          branches: ['1_c', '1_e'],
+        },
+        'expt_2': {
+          isTrafficEligible: () => true,
+          branches: ['2_c', '2_e'],
+        },
+        // expt_3 omitted.
+      };
+      RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.6);
+      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      expect(isExperimentOn(sandbox.win, 'expt_0'),
+          'expt_0 is on').to.be.true;
+      expect(isExperimentOn(sandbox.win, 'expt_1'),
+          'expt_1 is on').to.be.false;
+      expect(isExperimentOn(sandbox.win, 'expt_2'),
+          'expt_2 is on').to.be.true;
+      // Note: calling isExperimentOn('expt_3') would actually evaluate the
+      // frequency for expt_3, possibly enabling it.  Since we wanted it to be
+      // omitted altogether, we'll evaluate it only via its branch.
+      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.equal(
+          '0_e');
+      expect(getExperimentBranch(sandbox.win, 'expt_1')).to.not.be.ok;
+      expect(getExperimentBranch(sandbox.win, 'expt_2')).to.equal(
+          '2_e');
+      expect(getExperimentBranch(sandbox.win, 'expt_3')).to.not.be.ok;
+    });
+
+    it('handles multi-way branches', () => {
+      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      const experimentInfo = {
+        'expt_0': {
+          isTrafficEligible: () => true,
+          branches: ['0_0', '0_1', '0_2', '0_3', '0_4'],
+        },
+      };
+      RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.7);
+      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      expect(isExperimentOn(sandbox.win, 'expt_0'),
+          'expt_0 is on').to.be.true;
+      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.equal(
+          '0_3');
+    });
+
+    it('handles multiple experiments with multi-way branches', () => {
+      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      toggleExperiment(sandbox.win, 'expt_1', false, true);
+      toggleExperiment(sandbox.win, 'expt_2', true, true);
+      toggleExperiment(sandbox.win, 'expt_3', true, true);
+
+      const experimentInfo = {
+        'expt_0': {
+          isTrafficEligible: () => true,
+          branches: ['0_0', '0_1', '0_2', '0_3', '0_4'],
+        },
+        'expt_1': {
+          isTrafficEligible: () => true,
+          branches: ['1_0', '1_1', '1_2', '1_3', '1_4'],
+        },
+        'expt_2': {
+          isTrafficEligible: () => true,
+          branches: ['2_0', '2_1', '2_2', '2_3', '2_4'],
+        },
+      };
+      RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.7);
+      RANDOM_NUMBER_GENERATORS.accuratePrng.onSecondCall().returns(0.3);
+      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      expect(isExperimentOn(sandbox.win, 'expt_0'),
+          'expt_0 is on').to.be.true;
+      expect(isExperimentOn(sandbox.win, 'expt_1'),
+          'expt_1 is on').to.be.false;
+      expect(isExperimentOn(sandbox.win, 'expt_2'),
+          'expt_2 is on').to.be.true;
+      // Note: calling isExperimentOn('expt_3') would actually evaluate the
+      // frequency for expt_3, possibly enabling it.  Since we wanted it to be
+      // omitted altogether, we'll evaluate it only via its branch.
+      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.equal(
+          '0_3');
+      expect(getExperimentBranch(sandbox.win, 'expt_1')).to.not.be.ok;
+      expect(getExperimentBranch(sandbox.win, 'expt_2')).to.equal(
+          '2_1');
+      expect(getExperimentBranch(sandbox.win, 'expt_3')).to.not.be.ok;
+    });
+
+    it('should not process the same experiment twice', () => {
+      const exptAInfo = {
+        'fooExpt': {
+          isTrafficEligible: () => true,
+          branches: ['012345', '987654'],
+        },
+      };
+      const exptBInfo = {
+        'fooExpt': {
+          isTrafficEligible: () => true,
+          branches: ['246810', '108642'],
+        },
+      };
+      toggleExperiment(sandbox.win, 'fooExpt', false, true);
+      randomlySelectUnsetExperiments(sandbox.win, exptAInfo);
+      randomlySelectUnsetExperiments(sandbox.win, exptBInfo);
+      // Even though we tried to set up a second time, using a config
+      // parameter that should ensure that the experiment was activated, the
+      // experiment framework should evaluate each experiment only once per
+      // page and should not enable it.
+      expect(isExperimentOn(sandbox.win, 'fooExpt')).to.be.false;
+      expect(getExperimentBranch(sandbox.win, 'fooExpt')).to.not.be.ok;
+    });
   });
 });
 


### PR DESCRIPTION
For testing amp-auto-ads for Google ad users we'd like to have page-level experiments that divert client-side.

This CL splits the generic page-level experiment selection logic out of google/ads/traffic-experiments.js, so that it can be re-used for other things.

Other details:
- introduces an isTrafficEligible function in ExperimentInfo, so experiments can be easily limited to certain slices of traffic (e.g. only those tagged with amp-auto-ads)
- adds unit tests for googleAdsIsA4AEnabled in traffic-experiments.js
- changes the list of experiment branches in ExperimentInfo to an array, so that the types aren't being violated when more than 2 branches are defined. This also protects against random other properties that may get inserted onto the ExperimentInfo object by the compiler.