### PR TITLE
Add update event to amp-live-list

### DIFF
--- a/examples/bind/live-list.amp.html
+++ b/examples/bind/live-list.amp.html
@@ -16,6 +16,7 @@
     <article>
       <div class="content-container">
         <div class="article-body" itemprop="articleBody">
+          <p>Updated <span [text]="numUpdates == 1 ? numUpdates + ' time' : numUpdates + ' times' ">0 times</span></p>
           <h2> Select your favorite food </h2>
           <button on="tap:AMP.setState({favoriteFood: 'pizza'})">Pizza</button>
           <button on="tap:AMP.setState({favoriteFood: 'pasta'})">Pasta</button>
@@ -24,7 +25,8 @@
             layout="container"
             data-poll-interval="15000"
             data-max-items-per-page="5"
-            id="live-blog-1">
+            id="live-blog-1"
+            on="update:live-blog-1.update;update:AMP.setState({numUpdates: (numUpdates ? numUpdates : 0) + 1})">
             <button id="live-list-update-button" update class="button"
                 on="tap:live-blog-1.update">You have updates</button>
             <div items>

--- a/examples/bind/live-list.amp.html
+++ b/examples/bind/live-list.amp.html
@@ -26,7 +26,7 @@
             data-poll-interval="15000"
             data-max-items-per-page="5"
             id="live-blog-1"
-            on="update:live-blog-1.update;update:AMP.setState({numUpdates: (numUpdates ? numUpdates : 0) + 1})">
+            on="update:AMP.setState({numUpdates: (numUpdates ? numUpdates : 0) + 1})">
             <button id="live-list-update-button" update class="button"
                 on="tap:live-blog-1.update">You have updates</button>
             <div items>

--- a/examples/bind/live-list.amp.html
+++ b/examples/bind/live-list.amp.html
@@ -26,7 +26,7 @@
             data-poll-interval="15000"
             data-max-items-per-page="5"
             id="live-blog-1"
-            on="update:AMP.setState({numUpdates: (numUpdates ? numUpdates : 0) + 1})">
+            on="update:AMP.setState({numUpdates: (numUpdates || 0) + 1})">
             <button id="live-list-update-button" update class="button"
                 on="tap:live-blog-1.update">You have updates</button>
             <div items>

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -15,8 +15,10 @@
  */
 
 
+import {actionServiceForDoc} from '../../../src/action';
 import {CSS} from '../../../build/amp-live-list-0.1.css';
 import {childElementByAttr} from '../../../src/dom';
+import {createCustomEvent} from '../../../src/event-helper';
 import {liveListManagerFor, LiveListManager} from './live-list-manager';
 import {isLayoutSizeDefined, Layout} from '../../../src/layout';
 import {user} from '../../../src/log';
@@ -169,6 +171,9 @@ export class AmpLiveList extends AMP.BaseElement {
 
     /** @private @const {function(!Element, !Element): number} */
     this.comparator_ = this.sortByDataSortTime_.bind(this);
+
+    /** @private {?../../../src/service/action-impl.ActionService} */
+    this.actions_ = null;
   }
 
   /** @override */
@@ -221,6 +226,8 @@ export class AmpLiveList extends AMP.BaseElement {
 
     this.curNumOfLiveItems_ = this.validateLiveListItems_(
         this.itemsSlot_, true);
+
+    this.actions_ = actionServiceForDoc(this.getAmpDoc());
 
     this.registerAction('update', this.updateAction_.bind(this));
   }
@@ -341,6 +348,7 @@ export class AmpLiveList extends AMP.BaseElement {
     if (shouldSendAmpDomUpdateEvent) {
       promise = promise.then(() => {
         this.sendAmpDomUpdateEvent_();
+        this.actions_.trigger(this.element, 'update', /* event */ null);
       });
     }
 

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -18,7 +18,6 @@
 import {actionServiceForDoc} from '../../../src/action';
 import {CSS} from '../../../build/amp-live-list-0.1.css';
 import {childElementByAttr} from '../../../src/dom';
-import {createCustomEvent} from '../../../src/event-helper';
 import {liveListManagerFor, LiveListManager} from './live-list-manager';
 import {isLayoutSizeDefined, Layout} from '../../../src/layout';
 import {user} from '../../../src/log';

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -17,6 +17,7 @@
 
 import {actionServiceForDoc} from '../../../src/action';
 import {CSS} from '../../../build/amp-live-list-0.1.css';
+import {createCustomEvent} from '../../../src/event-helper';
 import {childElementByAttr} from '../../../src/dom';
 import {liveListManagerFor, LiveListManager} from './live-list-manager';
 import {isLayoutSizeDefined, Layout} from '../../../src/layout';
@@ -293,8 +294,12 @@ export class AmpLiveList extends AMP.BaseElement {
     const hasInsertItems = this.pendingItemsInsert_.length > 0;
     const hasTombstoneItems = this.pendingItemsTombstone_.length > 0;
     const hasReplaceItems = this.pendingItemsReplace_.length > 0;
-
     const shouldSendAmpDomUpdateEvent = hasInsertItems || hasReplaceItems;
+
+    const insertItemIds = this.pendingItemsInsert_
+        .map(item => item.getAttribute('id'));
+    const replaceItemIds = this.pendingItemsReplace_
+        .map(item => item.getAttribute('id'));
 
     let promise = this.mutateElement(() => {
 
@@ -347,7 +352,11 @@ export class AmpLiveList extends AMP.BaseElement {
     if (shouldSendAmpDomUpdateEvent) {
       promise = promise.then(() => {
         this.sendAmpDomUpdateEvent_();
-        this.actions_.trigger(this.element, 'update', /* event */ null);
+        const event = createCustomEvent(
+          this.win,
+          'amp-live-list.update',
+          {insertItemIds, replaceItemIds});
+        this.actions_.trigger(this.element, 'update', event);
       });
     }
 

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -355,7 +355,7 @@ export class AmpLiveList extends AMP.BaseElement {
         const event = createCustomEvent(
           this.win,
           'amp-live-list.update',
-          {insertItemIds, replaceItemIds});
+          {insertedItemIds: insertItemIds, replacedItemIds: replaceItemIds});
         this.actions_.trigger(this.element, 'update', event);
       });
     }

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -292,9 +292,9 @@ export class AmpLiveList extends AMP.BaseElement {
   updateAction_() {
     const hasInsertItems = this.pendingItemsInsert_.length > 0;
     const hasTombstoneItems = this.pendingItemsTombstone_.length > 0;
+    const hasReplaceItems = this.pendingItemsReplace_.length > 0;
 
-    const shouldSendAmpDomUpdateEvent = this.pendingItemsInsert_.length > 0 ||
-        this.pendingItemsReplace_.length > 0;
+    const shouldSendAmpDomUpdateEvent = hasInsertItems || hasReplaceItems;
 
     let promise = this.mutateElement(() => {
 
@@ -312,12 +312,12 @@ export class AmpLiveList extends AMP.BaseElement {
         this.pendingItemsInsert_.length = 0;
       }
 
-      if (this.pendingItemsReplace_.length > 0) {
+      if (hasReplaceItems) {
         this.replace_(itemsSlot, this.pendingItemsReplace_);
         this.pendingItemsReplace_.length = 0;
       }
 
-      if (this.pendingItemsTombstone_.length > 0) {
+      if (hasTombstoneItems) {
         this.curNumOfLiveItems_ -= this.tombstone_(
             itemsSlot, this.pendingItemsTombstone_);
         this.pendingItemsTombstone_.length = 0;

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -17,7 +17,6 @@
 
 import {actionServiceForDoc} from '../../../src/action';
 import {CSS} from '../../../build/amp-live-list-0.1.css';
-import {createCustomEvent} from '../../../src/event-helper';
 import {childElementByAttr} from '../../../src/dom';
 import {liveListManagerFor, LiveListManager} from './live-list-manager';
 import {isLayoutSizeDefined, Layout} from '../../../src/layout';
@@ -296,11 +295,6 @@ export class AmpLiveList extends AMP.BaseElement {
     const hasReplaceItems = this.pendingItemsReplace_.length > 0;
     const shouldSendAmpDomUpdateEvent = hasInsertItems || hasReplaceItems;
 
-    const insertItemIds = this.pendingItemsInsert_
-        .map(item => item.getAttribute('id'));
-    const replaceItemIds = this.pendingItemsReplace_
-        .map(item => item.getAttribute('id'));
-
     let promise = this.mutateElement(() => {
 
       const itemsSlot = user().assertElement(this.itemsSlot_);
@@ -352,11 +346,7 @@ export class AmpLiveList extends AMP.BaseElement {
     if (shouldSendAmpDomUpdateEvent) {
       promise = promise.then(() => {
         this.sendAmpDomUpdateEvent_();
-        const event = createCustomEvent(
-          this.win,
-          'amp-live-list.update',
-          {insertedItemIds: insertItemIds, replacedItemIds: replaceItemIds});
-        this.actions_.trigger(this.element, 'update', event);
+        this.actions_.trigger(this.element, 'update', /* event */ null);
       });
     }
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -277,8 +277,8 @@ describe('amp-live-list', () => {
             'update',
             sinon.match({
               detail: {
-                insertItemIds: ['id0'],
-                replaceItemIds: [],
+                insertedItemIds: ['id0'],
+                replacedItemIds: [],
               },
             }));
       });
@@ -313,8 +313,8 @@ describe('amp-live-list', () => {
             'update',
             sinon.match({
               detail: {
-                insertItemIds: [],
-                replaceItemIds: ['id1'],
+                insertedItemIds: [],
+                replacedItemIds: ['id1'],
               },
             }));
       });

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -263,7 +263,7 @@ describe('amp-live-list', () => {
     });
 
     it('sends amp-dom-update and amp-live-list.update ' +
-        'events on new items', () => {
+       'events on new items', () => {
       buildElement(elem, dftAttrs);
       liveList.buildCallback();
       const domUpdateSpy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -273,14 +273,14 @@ describe('amp-live-list', () => {
       return liveList.updateAction_().then(() => {
         expect(domUpdateSpy).to.have.been.calledOnce;
         expect(triggerSpy).to.have.been.calledWith(
-          elem,
-          'update',
-          sinon.match({
-            detail: {
-              insertItemIds: ['id0'],
-              replaceItemIds: [],
-            },
-          }));
+            elem,
+            'update',
+            sinon.match({
+              detail: {
+                insertItemIds: ['id0'],
+                replaceItemIds: [],
+              },
+            }));
       });
     });
 
@@ -308,15 +308,15 @@ describe('amp-live-list', () => {
       stub./*OK*/restore();
       return liveList.updateAction_().then(() => {
         expect(domUpdateSpy).to.have.been.calledOnce;
-        expect(triggerSpy).to.have.been .calledWith(
-        elem,
-        'update',
-        sinon.match({
-          detail: {
-            insertItemIds: [],
-            replaceItemIds: ['id1'],
-          },
-        }));
+        expect(triggerSpy).to.have.been.calledWith(
+            elem,
+            'update',
+            sinon.match({
+              detail: {
+                insertItemIds: [],
+                replaceItemIds: ['id1'],
+              },
+            }));
       });
     });
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -262,18 +262,23 @@ describe('amp-live-list', () => {
       liveList.buildCallback();
     });
 
-    it('sends amp-dom-update event on new items', () => {
+    it('sends amp-dom-update and amp-live-list.update ' +
+        'events on new items', () => {
       buildElement(elem, dftAttrs);
       liveList.buildCallback();
-      const spy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+      const domUpdateSpy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+      const triggerSpy = sandbox.spy(liveList.actions_, 'trigger');
       const fromServer1 = createFromServer([{id: 'id0'}]);
       liveList.update(fromServer1);
       return liveList.updateAction_().then(() => {
-        expect(spy).to.have.been.calledOnce;
+        expect(domUpdateSpy).to.have.been.calledOnce;
+        expect(triggerSpy).to.have.been
+            .calledWith(elem, 'update', /* event */ null);
       });
     });
 
-    it('sends amp-dom-update event on replace items', () => {
+    it('sends amp-dom-update and amp-live-list.update ' +
+       'events on replace items', () => {
       const child1 = document.createElement('div');
       const child2 = document.createElement('div');
       child1.setAttribute('id', 'id1');
@@ -288,17 +293,21 @@ describe('amp-live-list', () => {
       const fromServer1 = createFromServer([
         {id: 'id1', updateTime: 125},
       ]);
-      const spy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+      const domUpdateSpy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+      const triggerSpy = sandbox.spy(liveList.actions_, 'trigger');
       // We stub and restore to not trigger `update` calling `updateAction_`.
       const stub = sinon./*OK*/stub(liveList, 'updateAction_');
       liveList.update(fromServer1);
       stub./*OK*/restore();
       return liveList.updateAction_().then(() => {
-        expect(spy).to.have.been.calledOnce;
+        expect(domUpdateSpy).to.have.been.calledOnce;
+        expect(triggerSpy).to.have.been
+            .calledWith(elem, 'update', /* event */ null);
       });
     });
 
-    it('sends amp-dom-update event on tombstone items', () => {
+    it('should NOT send amp-dom-update and amp-live-list.update ' +
+       'events on tombstone items', () => {
       const child1 = document.createElement('div');
       const child2 = document.createElement('div');
       child1.setAttribute('id', 'id1');
@@ -313,13 +322,15 @@ describe('amp-live-list', () => {
       const fromServer1 = createFromServer([
         {id: 'id1', tombstone: null},
       ]);
-      const spy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+      const domUpdateSpy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+      const triggerSpy = sandbox.spy(liveList.actions_, 'trigger');
       // We stub and restore to not trigger `update` calling `updateAction_`.
       const stub = sinon./*OK*/stub(liveList, 'updateAction_');
       liveList.update(fromServer1);
       stub./*OK*/restore();
       return liveList.updateAction_().then(() => {
-        expect(spy).to.not.have.been.called;
+        expect(domUpdateSpy).to.not.have.been.called;
+        expect(triggerSpy).to.not.have.been.called;
       });
     });
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -272,15 +272,7 @@ describe('amp-live-list', () => {
       liveList.update(fromServer1);
       return liveList.updateAction_().then(() => {
         expect(domUpdateSpy).to.have.been.calledOnce;
-        expect(triggerSpy).to.have.been.calledWith(
-            elem,
-            'update',
-            sinon.match({
-              detail: {
-                insertedItemIds: ['id0'],
-                replacedItemIds: [],
-              },
-            }));
+        expect(triggerSpy).to.have.been.calledWith(elem, 'update', null);
       });
     });
 
@@ -308,15 +300,7 @@ describe('amp-live-list', () => {
       stub./*OK*/restore();
       return liveList.updateAction_().then(() => {
         expect(domUpdateSpy).to.have.been.calledOnce;
-        expect(triggerSpy).to.have.been.calledWith(
-            elem,
-            'update',
-            sinon.match({
-              detail: {
-                insertedItemIds: [],
-                replacedItemIds: ['id1'],
-              },
-            }));
+        expect(triggerSpy).to.have.been.calledWith(elem, 'update', null);
       });
     });
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -272,8 +272,15 @@ describe('amp-live-list', () => {
       liveList.update(fromServer1);
       return liveList.updateAction_().then(() => {
         expect(domUpdateSpy).to.have.been.calledOnce;
-        expect(triggerSpy).to.have.been
-            .calledWith(elem, 'update', /* event */ null);
+        expect(triggerSpy).to.have.been.calledWith(
+          elem,
+          'update',
+          sinon.match({
+            detail: {
+              insertItemIds: ['id0'],
+              replaceItemIds: [],
+            },
+          }));
       });
     });
 
@@ -301,8 +308,15 @@ describe('amp-live-list', () => {
       stub./*OK*/restore();
       return liveList.updateAction_().then(() => {
         expect(domUpdateSpy).to.have.been.calledOnce;
-        expect(triggerSpy).to.have.been
-            .calledWith(elem, 'update', /* event */ null);
+        expect(triggerSpy).to.have.been .calledWith(
+        elem,
+        'update',
+        sinon.match({
+          detail: {
+            insertItemIds: [],
+            replaceItemIds: ['id1'],
+          },
+        }));
       });
     });
 

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -329,12 +329,10 @@ The `amp-live-list` also generates the following events for which you can use [A
   <tr>
     <th>Event</th>
     <th>Description</th>
-    <th>Data</th>
   </tr>
   <tr>
     <td>update</td>
     <td>Fired when the list's DOM items are inserted or replaced</td>
-    <td><code>event.insertedItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replacedItemIds</code> : the <code>id</code>s of replaced list items</td>
   </tr>
 </table>
 

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -334,7 +334,7 @@ The `amp-live-list` also generates the following events for which you can use [A
   <tr>
     <td>update</td>
     <td>Fired when the list's DOM items are inserted or replaced</td>
-    <td><code>event.insertItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replaceItemIds</code> : the <code>id</code>s of replaced list items</td>
+    <td><code>event.insertedItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replacedItemIds</code> : the <code>id</code>s of replaced list items</td>
   </tr>
 </table>
 

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -309,7 +309,7 @@ An `.amp-hidden` and `.amp-active` class is added to the `update`
 reference point, and you can hook into this class to add transitions.
 (see Examples below)
 
-## Actions
+## Actions and Events
 The `amp-live-list` exposes the following actions you can use [AMP on-syntax to trigger](../../../src/spec/amp-actions-and-events.md):
 
 <table>
@@ -320,6 +320,21 @@ The `amp-live-list` exposes the following actions you can use [AMP on-syntax to 
   <tr>
     <td>update (default)</td>
     <td>Updates DOM elements with new discovered updates</td>
+  </tr>
+</table>
+
+The `amp-live-list` also generates the following events for which you can use [AMP on-syntax to listen](../../../src/spec/amp-actions-and-events.md):
+
+<table>
+  <tr>
+    <th>Event</th>
+    <th>Description</th>
+    <th>Data</th>
+  </tr>
+  <tr>
+    <td>update</td>
+    <td>Fired when the list's DOM items are inserted or replaced</td>
+    <td><code>event.insertItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replaceItemIds</code> : the <code>id</code>s of replaced list items</td>
   </tr>
 </table>
 

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -133,7 +133,7 @@ Including: `input[type=radio]`, `input[type=checkbox]` and `select`.
   </tr>
   <tr>
     <td>update</td>
-    <td>Fired when the list's DOM items are inserted or replaced</td>
+    <td>Fired when the list's DOM items are inserted or replaced.</td>
     <td><code>event.insertItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replaceItemIds</code> : the <code>id</code>s of replaced list items</td>
   </tr>
 </table>

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -134,7 +134,7 @@ Including: `input[type=radio]`, `input[type=checkbox]` and `select`.
   <tr>
     <td>update</td>
     <td>Fired when the list's DOM items are inserted or replaced.</td>
-    <td><code>event.insertItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replaceItemIds</code> : the <code>id</code>s of replaced list items</td>
+    <td><code>event.insertedItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replacedItemIds</code> : the <code>id</code>s of replaced list items</td>
   </tr>
 </table>
 

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -124,6 +124,20 @@ Including: `input[type=radio]`, `input[type=checkbox]` and `select`.
   </tr>
 </table>
 
+### amp-live-list
+<table>
+  <tr>
+    <th>Event</th>
+    <th>Description</th>
+    <th>Data</th>
+  </tr>
+  <tr>
+    <td>update</td>
+    <td>Fired when the list's DOM items are inserted or replaced</td>
+    <td><code>event.insertItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replaceItemIds</code> : the <code>id</code>s of replaced list items</td>
+  </tr>
+</table>
+
 ### amp-selector
 <table>
   <tr>

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -129,12 +129,10 @@ Including: `input[type=radio]`, `input[type=checkbox]` and `select`.
   <tr>
     <th>Event</th>
     <th>Description</th>
-    <th>Data</th>
   </tr>
   <tr>
     <td>update</td>
     <td>Fired when the list's DOM items are inserted or replaced.</td>
-    <td><code>event.insertedItemIds</code> : the <code>id</code>s of inserted list items, <code>event.replacedItemIds</code> : the <code>id</code>s of replaced list items</td>
   </tr>
 </table>
 


### PR DESCRIPTION
- Adds an `update` event for amp-live-list. The event will fire when:

1. The user presses the update button and elements are inserted into/replaced in the list.
2. Replace items are swapped with their stale counterparts without user interaction


- Adds new tests for amp-live-list to verify the new event fires when expected
- Updated bind amp-live-list example to leverage the new event

I'm wondering what we want to put into the custom event for this. Right now I've left it empty. Would appreciate some input on this.

Fixes #7557 

/to @choumx @sebastianbenz @erwinmombay 

