### PR TITLE
amp-bind: Catch exceptions in mutatedAttributesCallback

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -557,8 +557,8 @@ export class Bind {
     const applyPromises = this.boundElements_.map(boundElement => {
       const {element, boundProperties} = boundElement;
 
-      // TODO(choumx): We should avoid triggering a mutation if there are the
-      // expression results don't affect this element.
+      // TODO(choumx): We should avoid triggering a mutation if the expression
+      // results don't affect this element.
       const applyPromise = this.resources_.mutateElement(element, () => {
         const mutations = {};
         let width, height;


### PR DESCRIPTION
Fixes #8137.

- Catch and wrap exceptions thrown in `mutatedAttributesCallback`.
- Prefix error messages with "amp-bind:" and clarify some error messages.

/to @jridgewell @kmh287 