### PR TITLE
Whitelist certain eventType and scope selector for analytics in scope

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -51,7 +51,7 @@ installVariableService(AMP.win);
 
 const MAX_REPLACES = 16; // The maximum number of entries in a extraUrlParamsReplaceMap
 
-const BLACKLIST_EVENT_IN_SCOPE = [
+const BLACKLIST_EVENT_IN_SANDBOX = [
   AnalyticsEventType.CLICK,
   AnalyticsEventType.TIMER,
   AnalyticsEventType.SCROLL,
@@ -219,7 +219,7 @@ export class AmpAnalytics extends AMP.BaseElement {
         // Check for not supported trigger for sandboxed analytics
         if (this.isSandbox_) {
           const eventType = trigger['on'];
-          if (BLACKLIST_EVENT_IN_SCOPE.indexOf(eventType) > -1) {
+          if (BLACKLIST_EVENT_IN_SANDBOX.indexOf(eventType) > -1) {
             user().error(TAG, eventType + 'is not supported for amp-analytics' +
             ' in scope');
             continue;
@@ -232,7 +232,7 @@ export class AmpAnalytics extends AMP.BaseElement {
           if (!result) {
             return;
           }
-          // replace selector and selectionMethod (visibilitySpec selector as well)
+          // replace selector and selectionMethod
           if (this.isSandbox_) {
             // Only support selection of parent element for analytics in scope
             trigger['selector'] = this.element.parentElement.tagName;

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -26,6 +26,7 @@ import {userNotificationManagerFor} from '../../../src/user-notification';
 import {cryptoFor} from '../../../src/crypto';
 import {xhrFor} from '../../../src/xhr';
 import {toggle} from '../../../src/style';
+import {isEnumValue} from '../../../src/types';
 import {Activity} from './activity-impl';
 import {Cid} from './cid-impl';
 import {
@@ -51,10 +52,9 @@ installVariableService(AMP.win);
 
 const MAX_REPLACES = 16; // The maximum number of entries in a extraUrlParamsReplaceMap
 
-const BLACKLIST_EVENT_IN_SANDBOX = [
-  AnalyticsEventType.CLICK,
-  AnalyticsEventType.TIMER,
-  AnalyticsEventType.SCROLL,
+const WHITELIST_EVENT_IN_SANDBOX = [
+  AnalyticsEventType.VISIBLE,
+  AnalyticsEventType.HIDDEN,
 ];
 
 export class AmpAnalytics extends AMP.BaseElement {
@@ -219,7 +219,8 @@ export class AmpAnalytics extends AMP.BaseElement {
         // Check for not supported trigger for sandboxed analytics
         if (this.isSandbox_) {
           const eventType = trigger['on'];
-          if (BLACKLIST_EVENT_IN_SANDBOX.indexOf(eventType) > -1) {
+          if (isEnumValue(AnalyticsEventType, eventType) &&
+              WHITELIST_EVENT_IN_SANDBOX.indexOf(eventType) == -1) {
             user().error(TAG, eventType + 'is not supported for amp-analytics' +
             ' in scope');
             continue;

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -319,7 +319,7 @@ describe('amp-analytics', function() {
     });
   });
 
-  it.skip('does not send a hit when eventType is blacklist', function() {
+  it('does not send a hit when eventType is blacklist', function() {
     const tracker = ins.ampdocRoot_.getTracker('click', ClickEventTracker);
     const addStub = sandbox.stub(tracker, 'add');
     const analytics = getAnalyticsTag({
@@ -327,7 +327,7 @@ describe('amp-analytics', function() {
       triggers: [{on: 'click', selector: '${foo}', request: 'foo'}],
       vars: {foo: 'bar'},
     }, {
-      'scope': 'true',
+      'sandbox': 'true',
     });
 
     return waitForNoSendRequest(analytics).then(() => {
@@ -815,14 +815,14 @@ describe('amp-analytics', function() {
     });
   });
 
-  it.skip('replace selector and selectionMethod when in scope', () => {
+  it('replace selector and selectionMethod when in scope', () => {
     const tracker = ins.ampdocRoot_.getTracker('visible-v3', VisibilityTracker);
     const addStub = sandbox.stub(tracker, 'add');
     const analytics = getAnalyticsTag({
       requests: {foo: 'https://example.com/bar'},
       triggers: [{on: 'visible-v3', selector: 'amp-iframe', request: 'foo'}],
     }, {
-      'scope': 'true',
+      'sandbox': 'true',
     });
     return waitForNoSendRequest(analytics).then(() => {
       expect(addStub).to.be.calledOnce;

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -16,7 +16,10 @@
 
 import {ANALYTICS_CONFIG} from '../vendors';
 import {AmpAnalytics} from '../amp-analytics';
-import {ClickEventTracker} from '../events';
+import {
+  ClickEventTracker,
+  VisibilityTracker,
+} from '../events';
 import {Crypto} from '../../../../src/service/crypto-impl';
 import {instrumentationServiceForDocForTesting} from '../instrumentation';
 import {
@@ -313,6 +316,22 @@ describe('amp-analytics', function() {
 
     return waitForNoSendRequest(analytics).then(() => {
       expect(sendRequestSpy).to.have.not.been.called;
+    });
+  });
+
+  it.skip('does not send a hit when eventType is blacklist', function() {
+    const tracker = ins.ampdocRoot_.getTracker('click', ClickEventTracker);
+    const addStub = sandbox.stub(tracker, 'add');
+    const analytics = getAnalyticsTag({
+      requests: {foo: 'https://example.com/bar'},
+      triggers: [{on: 'click', selector: '${foo}', request: 'foo'}],
+      vars: {foo: 'bar'},
+    }, {
+      'scope': 'true',
+    });
+
+    return waitForNoSendRequest(analytics).then(() => {
+      expect(addStub).to.not.be.called;;
     });
   });
 
@@ -793,6 +812,24 @@ describe('amp-analytics', function() {
       expect(addStub).to.be.calledOnce;
       const config = addStub.args[0][2];
       expect(config['selector']).to.equal('bar');
+    });
+  });
+
+  it.skip('replace selector and selectionMethod when in scope', () => {
+    const tracker = ins.ampdocRoot_.getTracker('visible-v3', VisibilityTracker);
+    const addStub = sandbox.stub(tracker, 'add');
+    const analytics = getAnalyticsTag({
+      requests: {foo: 'https://example.com/bar'},
+      triggers: [{on: 'visible-v3', selector: 'amp-iframe', request: 'foo'}],
+    }, {
+      'scope': 'true',
+    });
+    return waitForNoSendRequest(analytics).then(() => {
+      expect(addStub).to.be.calledOnce;
+      const config = addStub.args[0][2];
+      expect(config['selector']).to.equal(
+          analytics.element.parentElement.tagName);
+      expect(config['selectionMethod']).to.equal('closest');
     });
   });
 


### PR DESCRIPTION
Alternative solution to #8329

As we agreed would only allow `visible` and `custom` trigger at this point. And the selector has to be the analytics parentElement itself. 
 
@dvoytenko @lannka PTAL