### PR TITLE
Move up loading of amp-analytics extension for AdSense/Doubleclick A4A Impls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ typings
 typings.json
 build-system/runner/TESTS-TestSuites.xml
 /test/manual/amp-ad.adtech.html
+yarn.lock

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -346,14 +346,18 @@ export function additionalDimensions(win, viewportSize) {
  * @param {!../../../src/service/xhr-impl.FetchResponseHeaders} responseHeaders
  *   XHR service FetchResponseHeaders object containing the response
  *   headers.
+ * @param {!../../../src/service/extensions-impl.Extensions} extensions
  * @return {?AmpAnalyticsConfigDef} config or null if invalid/missing.
  */
-export function extractAmpAnalyticsConfig(responseHeaders) {
+export function extractAmpAnalyticsConfig(responseHeaders, extensions) {
   if (responseHeaders.has(AMP_ANALYTICS_HEADER)) {
     try {
       const analyticsConfig =
         JSON.parse(responseHeaders.get(AMP_ANALYTICS_HEADER));
       dev().assert(Array.isArray(analyticsConfig['url']));
+      if (analyticsConfig.url.length) {
+        extensions.loadExtension('amp-analytics');
+      }
       return {urls: analyticsConfig.url};
     } catch (err) {
       dev().error('AMP-A4A', 'Invalid analytics', err,
@@ -367,15 +371,12 @@ export function extractAmpAnalyticsConfig(responseHeaders) {
  * Creates amp-analytics element within a4a element using urls specified
  * with amp-ad closest selector and min 50% visible for 1 sec.
  * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A} a4a
- * @param {!../../../src/service/extensions-impl.Extensions} extensions
  * @param {?AmpAnalyticsConfigDef} inputConfig
  */
-export function injectActiveViewAmpAnalyticsElement(
-    a4a, extensions, inputConfig) {
+export function injectActiveViewAmpAnalyticsElement(a4a, inputConfig) {
   if (!inputConfig || !inputConfig.urls.length) {
     return;
   }
-  extensions.loadExtension('amp-analytics');
   const ampAnalyticsElem =
     a4a.element.ownerDocument.createElement('amp-analytics');
   ampAnalyticsElem.setAttribute('scoped', '');

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -178,7 +178,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   /** @override */
   extractCreativeAndSignature(responseText, responseHeaders) {
     setGoogleLifecycleVarsFromHeaders(responseHeaders, this.lifecycleReporter_);
-    this.ampAnalyticsConfig = extractAmpAnalyticsConfig(responseHeaders);
+    this.ampAnalyticsConfig =
+      extractAmpAnalyticsConfig(responseHeaders, this.extensions_);
     return extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
   }
 
@@ -241,8 +242,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   /** @override */
   onCreativeRender(isVerifiedAmpCreative) {
     super.onCreativeRender(isVerifiedAmpCreative);
-    injectActiveViewAmpAnalyticsElement(
-      this, this.extensions_, this.ampAnalyticsConfig);
+    injectActiveViewAmpAnalyticsElement(this, this.ampAnalyticsConfig);
   }
 }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -150,7 +150,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /** @override */
   extractCreativeAndSignature(responseText, responseHeaders) {
     setGoogleLifecycleVarsFromHeaders(responseHeaders, this.lifecycleReporter_);
-    this.ampAnalyticsConfig = extractAmpAnalyticsConfig(responseHeaders);
+    this.ampAnalyticsConfig =
+      extractAmpAnalyticsConfig(responseHeaders, this.extensions_);
     return extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
   }
 
@@ -181,8 +182,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /** @override */
   onCreativeRender(isVerifiedAmpCreative) {
     super.onCreativeRender(isVerifiedAmpCreative);
-    injectActiveViewAmpAnalyticsElement(
-      this, this.extensions_, this.ampAnalyticsConfig);
+    injectActiveViewAmpAnalyticsElement(this, this.ampAnalyticsConfig);
   }
 
   /**


### PR DESCRIPTION
AdSense/Doubleclick implementations use the existence of a header in the ad response to load an amp-analytics element.  Currently the loading of the extension is done when the amp-analytics element is added during layoutCallbackout however it is possible that the extension itself does not yet exist on the page.  Move loading of the extension earlier to when valid header is handled to ensure later additional of amp-analytics element is not throttled by loading of extension.