### PR TITLE
remove css from amp-embed

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -187,10 +187,14 @@ export class AmpAdUIHandler {
 
   /**
    * @param {string} name
-   * @return {!Element}
+   * @return {?Element}
    * @private
    */
   addDefaultUiComponent_(name) {
+    if (this.element_.tagName == 'AMP-EMBED') {
+      // Do nothing for amp-embed element;
+      return null;
+    }
     const uiComponent = this.doc_.createElement('div');
     uiComponent.setAttribute(name, '');
 

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -18,7 +18,8 @@
  * Force the layout box of the ad iframe to be exactly as big as the actual
  * iframe. The `amp-ad` tag itself can be freely styled.
  */
-amp-ad iframe {
+amp-ad iframe,
+amp-embed iframe {
   border: 0 !important;
   margin: 0 !important;
   padding: 0 !important;

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -102,4 +102,4 @@ export class AmpAd extends AMP.BaseElement {
 }
 
 AMP.registerElement('amp-ad', AmpAd, CSS);
-AMP.registerElement('amp-embed', AmpAd, CSS);
+AMP.registerElement('amp-embed', AmpAd);

--- a/src/loader.js
+++ b/src/loader.js
@@ -17,7 +17,6 @@
 /** @private @const */
 const LINE_LOADER_ELEMENTS = {
   'AMP-AD': true,
-  'AMP-EMBED': true,
 };
 
 /**


### PR DESCRIPTION
Fix #7372 #7752 
Nothing in `amp-ad.css` is being applied to `<amp-embed>`. 

I also noticed one thing we don't have. We may want to  apply the same rule to amp embed's iframe? https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad/0.1/amp-ad.css#L21