### PR TITLE
Update validator extension to support new AMP CURLS

### DIFF
--- a/validator/chromeextension/content_script.js
+++ b/validator/chromeextension/content_script.js
@@ -28,7 +28,7 @@ globals.ampCaches = [
       }
     },
     'isAmpCache': function() {
-      return window.location.hostname === 'cdn.ampproject.org';
+      return window.location.hostname.endsWith('cdn.ampproject.org');
     },
   }
 ];

--- a/validator/chromeextension/manifest.json
+++ b/validator/chromeextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
AMP Cache URLs with example-com.cdn.ampproject.org would be recognized as AMP Cache URLs in the extension and display a redirect to canonical.