### PR TITLE
Prevent amp-carousel next/previous icons fade away on desktop

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -65,8 +65,12 @@ amp-carousel[controls] .amp-carousel-button,
   background-size: 18px 18px;
 }
 
-:not(.amp-mode-mouse) .-amp-carousel-button-start-hint .amp-carousel-button:not(.amp-disabled) {
+.-amp-carousel-button-start-hint .amp-carousel-button:not(.amp-disabled) {
   animation: -amp-carousel-hint 1s ease-in 3s 1 normal both;
+}
+
+.amp-mode-mouse .-amp-carousel-button-start-hint .amp-carousel-button:not(.amp-disabled) {
+  animation: none;
 }
 
 @keyframes -amp-carousel-hint {


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/7845 

We can't use `:not` here. It will match "something" unless carousel is direct child of `body`