### PR TITLE
Add max size limit for amp-state

### DIFF
--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -51,7 +51,7 @@ tags: {  # <amp-state> (json)
   }
   cdata: {
     max_bytes: 100000
-    max_bytes_spec_url: "https://www.ampproject.org/docs/reference/components#state"
+    max_bytes_spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/amp-bind#state"
     blacklisted_cdata_regex: {
       regex: "<!--"
       error_message: "html comments"

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -50,6 +50,8 @@ tags: {  # <amp-state> (json)
     dispatch_key: true
   }
   cdata: {
+    max_bytes: 100000
+    max_bytes_spec_url: "https://www.ampproject.org/docs/reference/components#state"
     blacklisted_cdata_regex: {
       regex: "<!--"
       error_message: "html comments"

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -71,8 +71,8 @@ The state can be initialized with the `amp-state` component:
 </amp-state>
 ```
 
-[Expressions](#expressions) can reference state variables via dot syntax. In this example, `myState.foo` will evaluate to `"bar"`.
-
+- [Expressions](#expressions) can reference state variables via dot syntax. In this example, `myState.foo` will evaluate to `"bar"`.
+- An `<amp-state>` element's JSON has a maximum size of 100KB.
 
 ##### AMP.setState()
 


### PR DESCRIPTION
Partial for #8057.

- Adds 100KB per-element JSON size limit (takes 20ms to parse on my MBP with 10x throttling).

This can be skirted by using multiple `<amp-state>` elements but might still be a useful guideline for developers who may be tempted to throw the kitchen sink in. 

If we still see misuse of amp-state in the wild, we can either move parsing off the critical path or cap the number of `<amp-state>` elements too.