### PR TITLE
Split-up of amp-bind-integrations.html for amp-live-list

### DIFF
--- a/test/fixtures/amp-bind-integrations/amp-live-list.html
+++ b/test/fixtures/amp-bind-integrations/amp-live-list.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind integration test</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    .original {
+      background-color:green;
+    }
+    .new {
+      background-color:blue;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script src="/dist/amp.js"></script>
+  <script custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
+  <script custom-element="amp-live-list" src="/dist/v0/amp-live-list-0.1.max.js"></script>
+</head>
+<body>
+  <p>AMP-LIVE-LIST</p>
+  <button on="tap:AMP.setState(liveListText='hello world')" id="changeLiveListTextButton"></button>
+  <amp-live-list id="liveList" data-poll-interval="20000" data-max-items-per-page="2">
+    <button update id="liveListUpdateButton" on="tap:liveList.update"></button>
+    <div items id="liveListItems">
+      <div id="liveListItem1" data-sort-time="123456789">
+        <p [text]="liveListText">unbound</p>
+      </div>
+    </div>
+  </amp-live-list>
+</body>
+</html>


### PR DESCRIPTION
Fixes amp-bind: Speed up integration tests #8197
* Part 2: Split up the amp-bind-integrations.html test fixture into multiple files under a single new directory in test/fixtures/
* Split up for amp-live-list
