### PR TITLE
Split-up of amp-bind-integrations.html for dynamic-tags

### DIFF
--- a/extensions/amp-bind/0.1/test/test-bind-integration-dynamictags.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration-dynamictags.js
@@ -19,7 +19,8 @@ import {bindForDoc} from '../../../../src/bind';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 
 describe.configure().retryOnSaucelabs().run('amp-bind', function() {
-  const fixtureLocation = 'test/fixtures/amp-bind-integrations.html';
+  const fixtureLocation =
+      'test/fixtures/amp-bind-integrations/dynamic-tags.html';
 
   let fixture;
   let ampdoc;

--- a/extensions/amp-bind/0.1/test/test-bind-integration-dynamictags.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration-dynamictags.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createFixtureIframe} from '../../../../testing/iframe';
+import {bindForDoc} from '../../../../src/bind';
+import {ampdocServiceFor} from '../../../../src/ampdoc';
+
+describe.configure().retryOnSaucelabs().run('amp-bind', function() {
+  const fixtureLocation = 'test/fixtures/amp-bind-integrations.html';
+
+  let fixture;
+  let ampdoc;
+
+  this.timeout(5000);
+
+  beforeEach(() => {
+    return createFixtureIframe(fixtureLocation).then(f => {
+      fixture = f;
+      return waitForEvent('amp:bind:initialize');
+    }).then(() => {
+      const ampdocService = ampdocServiceFor(fixture.win);
+      ampdoc = ampdocService.getAmpDoc(fixture.doc);
+    });
+  });
+
+  /**
+   * @param {string} name
+   * @return {!Promise}
+   */
+  function waitForEvent(name) {
+    return new Promise(resolve => {
+      function callback() {
+        resolve();
+        fixture.win.removeEventListener(name, callback);
+      };
+      fixture.win.addEventListener(name, callback);
+    });
+  }
+
+  /** @return {!Promise} */
+  function waitForBindApplication() {
+    // Bind should be available, but need to wait for actions to resolve
+    // service promise for bind and call setState.
+    return bindForDoc(ampdoc).then(unusedBind =>
+        waitForEvent('amp:bind:setState'));
+  }
+
+  /** @return {!Promise} */
+  function waitForAllMutations() {
+    return bindForDoc(ampdoc).then(unusedBind =>
+        waitForEvent('amp:bind:mutated'));
+  }
+
+  describe('detecting bindings under dynamic tags', () => {
+    it('should NOT bind blacklisted attributes', () => {
+      const dynamicTag = fixture.doc.getElementById('dynamicTag');
+      const div = fixture.doc.createElement('div');
+      div.innerHTML = '<p [onclick]="javascript:alert(document.cookie)" ' +
+                         '[onmouseover]="javascript:alert()" ' +
+                         '[style]="background=color:black"></p>';
+      const textElement = div.firstElementChild;
+      // for amp-live-list, dynamic element is <div items>, which is a child
+      // of the list.
+      dynamicTag.firstElementChild.appendChild(textElement);
+      return waitForAllMutations().then(() => {
+        // Force bind to apply bindings
+        fixture.doc.getElementById('triggerBindApplicationButton').click();
+        return waitForBindApplication();
+      }).then(() => {
+        expect(textElement.getAttribute('onclick')).to.be.null;
+        expect(textElement.getAttribute('onmouseover')).to.be.null;
+        expect(textElement.getAttribute('style')).to.be.null;
+      });
+    });
+
+    it('should NOT allow unsecure attribute values', () => {
+      const div = fixture.doc.createElement('div');
+      div.innerHTML = '<a [href]="javascript:alert(1)"></a>';
+      const aElement = div.firstElementChild;
+      const dynamicTag = fixture.doc.getElementById('dynamicTag');
+      dynamicTag.firstElementChild.appendChild(aElement);
+      return waitForAllMutations().then(() => {
+        // Force bind to apply bindings
+        fixture.doc.getElementById('triggerBindApplicationButton').click();
+        return waitForBindApplication();
+      }).then(() => {
+        expect(aElement.getAttribute('href')).to.be.null;
+      });
+    });
+  });
+});

--- a/test/fixtures/amp-bind-integrations/dynamic-tags.html
+++ b/test/fixtures/amp-bind-integrations/dynamic-tags.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind integration test</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    .original {
+      background-color:green;
+    }
+    .new {
+      background-color:blue;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script src="/dist/amp.js"></script>
+  <script custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
+</head>
+<body>
+  <p>DYNAMIC TAGS</p>
+  <!-- For generic dynamic tag tests only. Template tag used as an example. -->
+  <div>
+    <template id="dynamicTemplate"></template>
+    <!-- Siblings added in test -->
+  </div>
+</body>
+</html>

--- a/test/fixtures/amp-bind-integrations/dynamic-tags.html
+++ b/test/fixtures/amp-bind-integrations/dynamic-tags.html
@@ -5,14 +5,6 @@
   <title>amp-bind integration test</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-custom>
-    .original {
-      background-color:green;
-    }
-    .new {
-      background-color:blue;
-    }
-  </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script src="/dist/amp.js"></script>
   <script custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>


### PR DESCRIPTION
Fixes amp-bind: Speed up integration tests #8197
* Part 2: Split up the amp-bind-integrations.html test fixture into multiple files under a single new directory in test/fixtures/
* Split up for dynamic-tags
