### PR TITLE
Treat sticky position as fixed for the purpose of ads.

### DIFF
--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -37,7 +37,9 @@ const CONTAINERS = {
  * @return {boolean}
  */
 function isPositionFixed(el, win) {
-  return computedStyle(win, el).position == 'fixed';
+  const position = computedStyle(win, el).position;
+  // We consider sticky positions as fixed, since they can be fixed.
+  return position == 'fixed' || position == 'sticky';
 }
 
 /**

--- a/test/functional/test-ad-helper.js
+++ b/test/functional/test-ad-helper.js
@@ -52,6 +52,17 @@ describe('ad-helper', () => {
       });
     });
 
+    it('should not allow position sticky-fixed element that is ' +
+        'non-whitelisted element', () => {
+      return createIframePromise().then(iframe => {
+        const nonWhitelistedElement = iframe.doc.createElement('foo-bar');
+        nonWhitelistedElement.style.position = 'sticky';
+        iframe.doc.body.appendChild(nonWhitelistedElement);
+        expect(isAdPositionAllowed(nonWhitelistedElement, iframe.win))
+            .to.be.false;
+      });
+    });
+
     it('should not allow position fixed element inside non-whitelisted ' +
         'element', () => {
       return createIframePromise().then(iframe => {


### PR DESCRIPTION
Since `sticky` position can be effectively `fixed`. `amp-sticky-ad` continues to be available to do the behavior in a compliant way.

Fixes #8371