### PR TITLE
Minor fix of attribute description

### DIFF
--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -62,7 +62,7 @@ Same as `srcset` attribute on the `img` tag. The behavior will be polyfilled whe
 
 **sizes**
 
-Same as `srcset` attribute on the `img` tag. For more information see the [common `sizes` attribute docs](../spec/amp-html-layout.md#sizes).
+Same as `sizes` attribute on the `img` tag. For more information see the [common `sizes` attribute docs](../spec/amp-html-layout.md#sizes).
 
 **alt**
 


### PR DESCRIPTION
On the description for `sizes` attribute, where read:

> **sizes**
> 
> Same as `srcset` attribute on the `img` tag. For more information see the [common `sizes` attribute docs](../spec/amp-html-layout.md#sizes).

should read:

> **sizes**
> 
> Same as `sizes` attribute on the `img` tag. For more information see the [common `sizes` attribute docs](../spec/amp-html-layout.md#sizes).
