### PR TITLE
amp-bind: Deprecate key-value syntax for AMP.setState() 

### DIFF
--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -32,8 +32,7 @@
   <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" [src]="imgSrc" width=100 [width]="imgSize" height=100 [height]="imgSize" alt="asdf" [alt]="imgAlt"></amp-img>
   <p>The image above will increase in size and change its src</p>
   <div>
-    <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog')">Click me (key-value args)</button>
-    <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog'})">Click me (object args)</button>
+    <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog'})">Click me</button>
   </div>
 
   <amp-state id="myState">

--- a/examples/bind/carousels.amp.html
+++ b/examples/bind/carousels.amp.html
@@ -34,7 +34,7 @@
     <p [text]="'Selected slide: ' + selectedSlide">Selected slide: None<p>
 
     <amp-carousel controls type=slides width=400 height=300
-        [slide]="selectedSlide" on="slideChange:AMP.setState(selectedSlide=event.index)">
+        [slide]="selectedSlide" on="slideChange:AMP.setState({selectedSlide: event.index})">
       <amp-img src="https://ampbyexample.com/img/image1.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image2.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image3.jpg" width=400 height=300></amp-img>
@@ -50,27 +50,28 @@
   <p>Without &lt;amp-selector&gt;</p>
   <amp-carousel controls width=400 height=100>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 0 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=0)"></amp-img>
+        [class]="selectedSlide == 0 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 0})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 1 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=1)"></amp-img>
+        [class]="selectedSlide == 1 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 1})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 2 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=2)"></amp-img>
+        [class]="selectedSlide == 2 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 2})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 3 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=3)"></amp-img>
+        [class]="selectedSlide == 3 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 3})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 4 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=4)"></amp-img>
+        [class]="selectedSlide == 4 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 4})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 5 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=5)"></amp-img>
+        [class]="selectedSlide == 5 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 5})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 6 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=6)"></amp-img>
+        [class]="selectedSlide == 6 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 6})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 7 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=7)"></amp-img>
+        [class]="selectedSlide == 7 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 7})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 8 ? 'selected' : ''" on="tap:AMP.setState(selectedSlide=8)"></amp-img>
+        [class]="selectedSlide == 8 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 8})"></amp-img>
   </amp-carousel>
 
   <p>With &lt;amp-selector&gt;</p>
-  <amp-selector layout=container name="carousel-selector" [selected]="selectedSlide" on="select:AMP.setState(selectedSlide=event.targetOption)">
+  <amp-selector layout=container name="carousel-selector" [selected]="selectedSlide"
+      on="select:AMP.setState({selectedSlide: event.targetOption})">
     <amp-carousel controls width=400 height=100>
         <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75 option=0></amp-img>
         <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75 option=1></amp-img>

--- a/examples/bind/ecommerce.amp.html
+++ b/examples/bind/ecommerce.amp.html
@@ -36,7 +36,7 @@
 
   <p>SIZE: <span [text]="shirts[selectedIndex].sizes.join(', ')">XS</span></p>
 
-  <amp-selector on="select:AMP.setState(selectedIndex=event.targetOption)">
+  <amp-selector on="select:AMP.setState({selectedIndex: event.targetOption})">
     <amp-img width=50 height=50 src="./shirts/black.jpg" option=0></amp-img>
     <amp-img width=50 height=50 src="./shirts/blue.jpg" option=1></amp-img>
     <amp-img width=50 height=50 src="./shirts/brown.jpg" option=2></amp-img>

--- a/examples/bind/forms.amp.html
+++ b/examples/bind/forms.amp.html
@@ -14,10 +14,10 @@
 <body>
 
   <p>Submit the form and then press a button to change the text in the below template</p>
-  <button on="tap:AMP.setState(selected=1)">1</button>
-  <button on="tap:AMP.setState(selected=2)">2</button>
-  <button on="tap:AMP.setState(selected=3)">3</button>
-  <button on="tap:AMP.setState(selected=4)">4</button>
+  <button on="tap:AMP.setState({selected: 1})">1</button>
+  <button on="tap:AMP.setState({selected: 2})">2</button>
+  <button on="tap:AMP.setState({selected: 3})">3</button>
+  <button on="tap:AMP.setState({selected: 4})">4</button>
 
   <h4>Enter your name and email.</h4>
   <form method="post"

--- a/examples/bind/iframe.amp.html
+++ b/examples/bind/iframe.amp.html
@@ -28,7 +28,7 @@
   <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle &lt;amp-bind&gt; experiment</button>
 
   <h2>amp-iframe (scroll down)</h2>
-  <button on="tap:AMP.setState(bling='https://giphy.com/embed/DKG1OhBUmxL4Q')">Change iframe src</button>
+  <button on="tap:AMP.setState({bling: 'https://giphy.com/embed/DKG1OhBUmxL4Q'})">Change iframe src</button>
 
   <amp-iframe width="500" height="281"
       sandbox="allow-scripts allow-same-origin allow-popups" allowfullscreen frameborder="0"

--- a/examples/bind/live-list.amp.html
+++ b/examples/bind/live-list.amp.html
@@ -17,9 +17,9 @@
       <div class="content-container">
         <div class="article-body" itemprop="articleBody">
           <h2> Select your favorite food </h2>
-          <button on="tap:AMP.setState(favoriteFood='pizza')">Pizza</button>
-          <button on="tap:AMP.setState(favoriteFood='pasta')">Pasta</button>
-          <button on="tap:AMP.setState(favoriteFood='cake')">Cake</button>
+          <button on="tap:AMP.setState({favoriteFood: 'pizza'})">Pizza</button>
+          <button on="tap:AMP.setState({favoriteFood: 'pasta'})">Pasta</button>
+          <button on="tap:AMP.setState({favoriteFood: 'cake'})">Cake</button>
           <amp-live-list
             layout="container"
             data-poll-interval="15000"

--- a/examples/bind/sandbox.amp.html
+++ b/examples/bind/sandbox.amp.html
@@ -68,7 +68,7 @@
   <p>2. Click "Evaluate" to reevaluate all expressions and apply updates to page.</p>
 
   <div>
-    <button on="tap:AMP.setState()">Evaluate</button>
+    <button on="tap:AMP.setState({})">Evaluate</button>
   </div>
 </body>
 </html>

--- a/examples/csp.amp.html
+++ b/examples/csp.amp.html
@@ -54,7 +54,7 @@ To update, copy current Proxy CSP into meta tag. This file intentionally does no
 <amp-img src="https://cdn.ampproject.org/i/s/i.guim.co.uk/img/media/dc4d6f2e1198a804b9c9d4b70515a8f7915e1943/0_0_6144_3688/master/6144.jpg?w=700&q=85&auto=format&sharp=10&s=e13bbb3b723ce2d831869edc96ec4b96" width=50 height=50></amp-img>
 <h2>Should say "Hello World" when button is clicked</h2>
 <p [text]="foo"></p>
-<button on="tap:AMP.setState(foo='Hello World')">Click me</button>
+<button on="tap:AMP.setState({foo: 'Hello World'})">Click me</button>
 
 <h2 class="font">Different font</h2>
 </body>

--- a/extensions/amp-bind/0.1/test/validator-amp-bind.html
+++ b/extensions/amp-bind/0.1/test/validator-amp-bind.html
@@ -20,7 +20,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>amp-bind</title>
+  <title>amp-bind: Basic</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
@@ -32,18 +32,14 @@
     .redBackground {
       background-color: red;
     }
+    button {
+      border: solid 1px black;
+    }
   </style>
 </head>
 
 <body>
-  <amp-state id="myState">
-    <script type="application/json">
-      {
-        "myStateKey1": "myStateValue1"
-      }
-    </script>
-  </amp-state>
-
+  <h2>Basic example</h2>
   <p [text]="foo">After clicking the button below, this will read 'foo'<p>
   <p id="foo" [text]="foo + 'bar'">And this will read 'foobar'<p>
   <p [text]="myState.myStateKey1">This will read 'myStateValue1'<p>
@@ -51,7 +47,16 @@
   <p [class]="textClass">This text will have have a red background color</p>
   <amp-img src="https://ampbyexample.com/img/Border_Collie.jpg" [src]="imgSrc" width=100 [width]="imgSize" height=100 [height]="imgSize" alt="asdf" [alt]="imgAlt"></amp-img>
   <p>The image above will increase in size and change its src</p>
-  <hr>
-  <button on="tap:AMP.setState(foo='foo', isButtonDisabled=true, textClass='redBackground', imgSrc='https://ampbyexample.com/img/Shetland_Sheepdog.jpg', imgSize=200, imgAlt='Sheepdog', videoSrc='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4')">Click me</button>
+  <div>
+    <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog'})">Click me</button>
+  </div>
+
+  <amp-state id="myState">
+    <script type="application/json">
+      {
+        "myStateKey1": "myStateValue1"
+      }
+    </script>
+  </amp-state>
 </body>
 </html>

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -96,7 +96,7 @@ export class StandardActions {
             }
             bind.setStateWithExpression(objectString, scope);
           } else {
-            user().warn('amp-bind', `Key-value syntax for AMP.setState() will `
+            user().warn('AMP-BIND', `Key-value syntax for AMP.setState() will `
                 + `be removed soon. Please use the object-literal syntax `
                 + `instead, e.g. "AMP.setState({foo: 'bar'})" instead of `
                 + `"AMP.setState(foo='bar')".`);

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -25,7 +25,6 @@ import {installResourcesServiceForDoc} from './resources-impl';
 import {computedStyle, getStyle, toggle} from '../style';
 import {vsyncFor} from '../vsync';
 
-
 /**
  * @param {!Element} element
  * @return {boolean}
@@ -97,6 +96,10 @@ export class StandardActions {
             }
             bind.setStateWithExpression(objectString, scope);
           } else {
+            user().warn('amp-bind', `Key-value syntax for AMP.setState() will `
+                + `be removed soon. Please use the object-literal syntax `
+                + `instead, e.g. "AMP.setState({foo: 'bar'})" instead of `
+                + `"AMP.setState(foo='bar')".`);
             // Key-value args.
             bind.setState(args);
           }

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -34,26 +34,26 @@
   </div>
 
   <p>P TAG</p>
-  <button on="tap:AMP.setState(boundText='hello world')" id="changeTextButton"></button>
-  <button on="tap:AMP.setState(boundClass='new')" id="changeTextClassButton"></button>
+  <button on="tap:AMP.setState({boundText: 'hello world'})" id="changeTextButton"></button>
+  <button on="tap:AMP.setState({boundClass: 'new'})" id="changeTextClassButton"></button>
   <p id="textElement" class="original" [class]="boundClass" [text]="boundText">unbound</p>
 
   <p>CAROUSEL</p>
-  <button on="tap:AMP.setState(selectedSlide=1)" id="goToSlide1Button">slide 1!</button>
+  <button on="tap:AMP.setState({selectedSlide: 1})" id="goToSlide1Button">slide 1!</button>
   <p id="slideNum" [text]="selectedSlide">0</p>
-  <amp-carousel width="300" height="100" type="slides"  id="carousel" on="slideChange:AMP.setState(selectedSlide=event.index)" [slide]="selectedSlide">
+  <amp-carousel width="300" height="100" type="slides"  id="carousel" on="slideChange:AMP.setState({selectedSlide: event.index})" [slide]="selectedSlide">
     <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
     <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
     <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
   </amp-carousel>
 
   <p>AMP-IMG</p>
-  <button on="tap:AMP.setState(imageSrc='http://www.google.com/image2')" id="changeImgSrcButton"></button>
-  <button on="tap:AMP.setState(imageSrc='?__amp_source_origin')" id="invalidSrcButton"></button>
-  <button on="tap:AMP.setState(imageSrc='ftp://foo:bar@192.168.1.1/lol.jpg')" id="ftpSrcButton"></button>
-  <button on="tap:AMP.setState(imageSrc='tel:1-555-867-5309')" id="telSrcButton"></button>
-  <button on="tap:AMP.setState(imageAlt='hello world')" id="changeImgAltButton"></button>
-  <button on="tap:AMP.setState(imageWidth=300, imageHeight=300)" id="changeImgDimensButton"></button>
+  <button on="tap:AMP.setState({imageSrc: 'http://www.google.com/image2'})" id="changeImgSrcButton"></button>
+  <button on="tap:AMP.setState({imageSrc: '?__amp_source_origin'})" id="invalidSrcButton"></button>
+  <button on="tap:AMP.setState({imageSrc: 'ftp://foo:bar@192.168.1.1/lol.jpg'})" id="ftpSrcButton"></button>
+  <button on="tap:AMP.setState({imageSrc: 'tel:1-555-867-5309'})" id="telSrcButton"></button>
+  <button on="tap:AMP.setState({imageAlt: 'hello world'})" id="changeImgAltButton"></button>
+  <button on="tap:AMP.setState({imageWidth: 300, imageHeight: 300})" id="changeImgDimensButton"></button>
 
   <amp-img id="image"
     src="http://www.google.com/image1" [src]="imageSrc"
@@ -63,22 +63,22 @@
     layout="responsive"></amp-img>
 
   <p>AMP-SELECTOR</p>
-  <button on="tap:AMP.setState(selected=2)" id="changeSelectionButton">Change selection to 2!</button>
+  <button on="tap:AMP.setState({selected: 2})" id="changeSelectionButton">Change selection to 2!</button>
   <p id=selectionText [text]="selected">None</p>
-  <amp-selector layout="container" [selected]="selected" on="select:AMP.setState(selected=event.targetOption)">
+  <amp-selector layout="container" [selected]="selected" on="select:AMP.setState({selected: event.targetOption})">
     <amp-img src="/image0.jpg" width="60" height="40" option="1" id="selectorImg1"></amp-img>
     <amp-img src="/image1.jpg" width="60" height="40" option="2" id="selectorImg2"></amp-img>
     <amp-img src="/image2.jpg" width="60" height="40" option="3" id="selectorImg3"></amp-img>
   </amp-selector>
 
   <p>AMP-VIDEO</p>
-  <button on="tap:AMP.setState(videoSrc='https://www.google.com/bound.webm')" id="changeVidSrcButton"></button>
-  <button on="tap:AMP.setState(videoSrc='http://www.google.com/justhttp.ogg')" id="httpVidSrcButton"></button>
-  <button on="tap:AMP.setState(videoSrc='?__amp_source_origin')" id="disallowedVidUrlButton"></button>
-  <button on="tap:AMP.setState(videoAlt='hello world')" id="changeVidAltButton"></button>
-  <button on="tap:AMP.setState(videoWidth=300, videoHeight=300)" id="changeVidDimensButton"></button>
-  <button on="tap:AMP.setState(videoControls=true)" id="showVidControlsButton"></button>
-  <button on="tap:AMP.setState(videoControls=false)" id="hideVidControlsButton"></button>
+  <button on="tap:AMP.setState({videoSrc: 'https://www.google.com/bound.webm'})" id="changeVidSrcButton"></button>
+  <button on="tap:AMP.setState({videoSrc: 'http://www.google.com/justhttp.ogg'})" id="httpVidSrcButton"></button>
+  <button on="tap:AMP.setState({videoSrc: '?__amp_source_origin')}" id="disallowedVidUrlButton"></button>
+  <button on="tap:AMP.setState({videoAlt: 'hello world'})" id="changeVidAltButton"></button>
+  <button on="tap:AMP.setState({videoWidth: 300, videoHeight: 300})" id="changeVidDimensButton"></button>
+  <button on="tap:AMP.setState({videoControls: true})" id="showVidControlsButton"></button>
+  <button on="tap:AMP.setState({videoControls: false})" id="hideVidControlsButton"></button>
   <amp-video layout="responsive" id="video"
     src="https://www.google.com/unbound.webm" [src]="videoSrc"
     alt="unbound" [alt]="videoAlt"
@@ -88,7 +88,7 @@
   </amp-video>
 
   <p>AMP-LIVE-LIST</p>
-  <button on="tap:AMP.setState(liveListText='hello world')" id="changeLiveListTextButton"></button>
+  <button on="tap:AMP.setState({liveListText: 'hello world'})" id="changeLiveListTextButton"></button>
   <amp-live-list id="liveList" data-poll-interval="20000" data-max-items-per-page="2">
     <button update id="liveListUpdateButton" on="tap:liveList.update"></button>
     <div items id="liveListItems">
@@ -99,19 +99,19 @@
   </amp-live-list>
 
   <p>AMP-YOUTUBE</p>
-  <button on="tap:AMP.setState(youtube='bound')" id="youtubeButton"></button>
+  <button on="tap:AMP.setState({youtube: 'bound'})" id="youtubeButton"></button>
   <amp-youtube width=480 height=270 id="youtube" data-videoid="unbound"
       [data-videoid]="youtube">
   </amp-youtube>
 
   <p>AMP-BRIGHTCOVE</p>
-  <button id="brightcoveButton" on="tap:AMP.setState(brightcove='bound')">Change amp-brightcove</button>
+  <button id="brightcoveButton" on="tap:AMP.setState({brightcove: 'bound'})">Change amp-brightcove</button>
   <amp-brightcove width=480 height=270 id="brightcove" [data-account]="brightcove"
       data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c">
   </amp-brightcove>
 
   <p>AMP-IFRAME</p>
-  <button id="iframeButton" on="tap:AMP.setState(iframe='https://giphy.com/embed/DKG1OhBUmxL4Q')">Change amp-iframe</button>
+  <button id="iframeButton" on="tap:AMP.setState({iframe: 'https://giphy.com/embed/DKG1OhBUmxL4Q'})">Change amp-iframe</button>
   <amp-iframe width=100 height=100 id="ampIframe" sandbox="allow-scripts allow-same-origin allow-popups"
       src="https://player.vimeo.com/video/140261016" [src]="iframe">
   </amp-iframe>

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -74,7 +74,7 @@
   <p>AMP-VIDEO</p>
   <button on="tap:AMP.setState({videoSrc: 'https://www.google.com/bound.webm'})" id="changeVidSrcButton"></button>
   <button on="tap:AMP.setState({videoSrc: 'http://www.google.com/justhttp.ogg'})" id="httpVidSrcButton"></button>
-  <button on="tap:AMP.setState({videoSrc: '?__amp_source_origin')}" id="disallowedVidUrlButton"></button>
+  <button on="tap:AMP.setState({videoSrc: '?__amp_source_origin'})" id="disallowedVidUrlButton"></button>
   <button on="tap:AMP.setState({videoAlt: 'hello world'})" id="changeVidAltButton"></button>
   <button on="tap:AMP.setState({videoWidth: 300, videoHeight: 300})" id="changeVidDimensButton"></button>
   <button on="tap:AMP.setState({videoControls: true})" id="showVidControlsButton"></button>


### PR DESCRIPTION
Partial for #8390.

- Change all example code to use object-literal syntax.
- Add user warning for using key-value syntax (will be removed in following release).

/to @kmh287 