### PR TITLE
Remove whitelisting of 'i-amp-' prefix.

### DIFF
--- a/spec/amp-cache-modifications.md
+++ b/spec/amp-cache-modifications.md
@@ -279,7 +279,6 @@ Remove any `<meta>` tags except for those that:
  - have attribute `name` with case-insensitive prefix `amp-`
  - have attribute `name` with case-insensitive prefix `amp4ads-`
  - have attribute `name` with case-insensitive prefix `dc.`
- - have attribute `name` with case-insensitive prefix `i-amp-` [temporary, will be removed at a future date]
  - have attribute `name` with case-insensitive prefix `i-amphtml-`
  - have attribute `name` with case-insensitive prefix `twitter:`
  - have attribute `name=apple-itunes-app`


### PR DESCRIPTION
This <meta name=> whitelist is no longer necessary as the AMP Runtime has been updated for all instances of `i-amp-` to `i-amphtml-`.
