### PR TITLE
Remove timer dependency from event-helpers (listen, listenOnce)

### DIFF
--- a/src/base-element.js
+++ b/src/base-element.js
@@ -493,16 +493,14 @@ export class BaseElement {
 
   /**
    * Returns a promise that will resolve or fail based on the element's 'load'
-   * and 'error' events. Optionally this method takes a timeout, which will reject
-   * the promise if the resource has not loaded by then.
+   * and 'error' events.
    * @param {T} element
-   * @param {number=} opt_timeout
    * @return {!Promise<T>}
    * @template T
    * @final
    */
-  loadPromise(element, opt_timeout) {
-    return loadPromise(element, opt_timeout);
+  loadPromise(element) {
+    return loadPromise(element);
   }
 
   /** @private */

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -83,19 +83,19 @@ export function listenOnce(element, eventType, listener, opt_capture) {
  * @param {!EventTarget} element
  * @param {string} eventType
  * @param {boolean=} opt_capture
- * @param {function(function(*))} opt_canceler An optional function that, when
+ * @param {function(!UnlistenDef)=} opt_cancel An optional function that, when
  *     provided, will be called with the unlistener. This gives the caller
  *     access to the unlistener, so it may be called manually when necessary.
  * @return {!Promise<!Event>}
  */
-export function listenOncePromise(element, eventType, opt_capture, opt_canceler) {
+export function listenOncePromise(element, eventType, opt_capture, opt_cancel) {
   let unlisten;
   const eventPromise = new Promise((resolve, unusedReject) => {
     unlisten = listenOnce(element, eventType, resolve, opt_capture);
   });
   eventPromise.then(unlisten, unlisten);
-  if (opt_canceler) {
-    opt_canceler(unlisten);
+  if (opt_cancel) {
+    opt_cancel(unlisten);
   }
   return eventPromise;
 }
@@ -147,8 +147,8 @@ export function loadPromise(eleOrWindow) {
     if (unlistenError) {
       unlistenError();
     }
-    return eleOrWindow
-  }, err => {
+    return eleOrWindow;
+  }, () => {
     if (unlistenLoad) {
       unlistenLoad();
     }

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -116,11 +116,10 @@ export function isLoaded(eleOrWindow) {
  * and 'error' events. Optionally this method takes a timeout, which will reject
  * the promise if the resource has not loaded by then.
  * @param {T} eleOrWindow Supports both Elements and as a special case Windows.
- * @param {number=} opt_timeout
  * @return {!Promise<T>}
  * @template T
  */
-export function loadPromise(eleOrWindow, opt_timeout) {
+export function loadPromise(eleOrWindow) {
   let unlistenLoad;
   let unlistenError;
   if (isLoaded(eleOrWindow)) {
@@ -141,8 +140,7 @@ export function loadPromise(eleOrWindow, opt_timeout) {
     }
   });
   loadingPromise = loadingPromise.then(() => eleOrWindow, failedToLoad);
-  return racePromise_(loadingPromise, unlistenLoad, unlistenError,
-      opt_timeout);
+  return racePromise_(loadingPromise, unlistenLoad, unlistenError, 0);
 }
 
 /**

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -90,7 +90,7 @@ export function listenOnce(element, eventType, listener, opt_capture) {
  */
 export function listenOncePromise(element, eventType, opt_capture, opt_cancel) {
   let unlisten;
-  const eventPromise = new Promise((resolve, unusedReject) => {
+  const eventPromise = new Promise(resolve => {
     unlisten = listenOnce(element, eventType, resolve, opt_capture);
   });
   eventPromise.then(unlisten, unlisten);

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -15,7 +15,6 @@
  */
 
 import {internalListenImplementation} from './event-helper-listen';
-import {timerFor} from './services';
 import {user} from './log';
 
 /** @const {string}  */
@@ -80,21 +79,25 @@ export function listenOnce(element, eventType, listener, opt_capture) {
 
 /**
  * Returns  a promise that will resolve as soon as the specified event has
- * fired on the element. Optionally, opt_timeout can be specified that will
- * reject the promise if the event has not fired by then.
+ * fired on the element.
  * @param {!EventTarget} element
  * @param {string} eventType
  * @param {boolean=} opt_capture
- * @param {number=} opt_timeout
+ * @param {function(function(*))} opt_canceler An optional function that, when
+ *     provided, will be called with the unlistener. This gives the caller
+ *     access to the unlistener, so it may be called manually when necessary.
  * @return {!Promise<!Event>}
  */
-export function listenOncePromise(element, eventType, opt_capture,
-    opt_timeout) {
+export function listenOncePromise(element, eventType, opt_capture, opt_canceler) {
   let unlisten;
   const eventPromise = new Promise((resolve, unusedReject) => {
     unlisten = listenOnce(element, eventType, resolve, opt_capture);
   });
-  return racePromise_(eventPromise, unlisten, undefined, opt_timeout);
+  eventPromise.then(unlisten, unlisten);
+  if (opt_canceler) {
+    opt_canceler(unlisten);
+  }
+  return eventPromise;
 }
 
 
@@ -125,7 +128,7 @@ export function loadPromise(eleOrWindow) {
   if (isLoaded(eleOrWindow)) {
     return Promise.resolve(eleOrWindow);
   }
-  let loadingPromise = new Promise((resolve, reject) => {
+  const loadingPromise = new Promise((resolve, reject) => {
     // Listen once since IE 5/6/7 fire the onload event continuously for
     // animated GIFs.
     const tagName = eleOrWindow.tagName;
@@ -139,18 +142,29 @@ export function loadPromise(eleOrWindow) {
       unlistenError = listenOnce(eleOrWindow, 'error', reject);
     }
   });
-  loadingPromise = loadingPromise.then(() => eleOrWindow, failedToLoad);
-  return racePromise_(loadingPromise, unlistenLoad, unlistenError, 0);
+
+  return loadingPromise.then(() => {
+    if (unlistenError) {
+      unlistenError();
+    }
+    return eleOrWindow
+  }, err => {
+    if (unlistenLoad) {
+      unlistenLoad();
+    }
+    failedToLoad(eleOrWindow);
+  });
 }
 
 /**
  * Emit error on load failure.
- * @param {*} event
+ * @param {!Element|!Window} eleOrWindow Supports both Elements and as a special
+ *     case Windows.
  */
-function failedToLoad(event) {
+function failedToLoad(eleOrWindow) {
   // Report failed loads as user errors so that they automatically go
   // into the "document error" bucket.
-  let target = event.target;
+  let target = eleOrWindow;
   if (target && target.src) {
     target = target.src;
   }
@@ -164,30 +178,4 @@ function failedToLoad(event) {
  */
 export function isLoadErrorMessage(message) {
   return message.indexOf(LOAD_FAILURE_PREFIX) != -1;
-}
-
-/**
- * @param {!Promise<TYPE>} promise
- * @param {UnlistenDef|undefined} unlisten1
- * @param {UnlistenDef|undefined} unlisten2
- * @param {number|undefined} timeout
- * @return {!Promise<TYPE>}
- * @template TYPE
- */
-function racePromise_(promise, unlisten1, unlisten2, timeout) {
-  let racePromise;
-  if (timeout === undefined) {
-    // Timeout is not specified: return promise.
-    racePromise = promise;
-  } else {
-    // Timeout has been specified: add a timeout condition.
-    racePromise = timerFor(self).timeoutPromise(timeout || 0, promise);
-  }
-  if (unlisten1) {
-    racePromise.then(unlisten1, unlisten1);
-  }
-  if (unlisten2) {
-    racePromise.then(unlisten2, unlisten2);
-  }
-  return racePromise;
 }

--- a/src/input.js
+++ b/src/input.js
@@ -16,7 +16,7 @@
 
 import {Observable} from './observable';
 import {dev} from './log';
-import {timerFor} from './timer';
+import {timerFor} from './services';
 import {listenOnce, listenOncePromise} from './event-helper';
 import {registerServiceBuilder} from './service';
 

--- a/test/functional/test-event-helper.js
+++ b/test/functional/test-event-helper.js
@@ -35,14 +35,12 @@ describe('EventHelper', () => {
   }
 
   let sandbox;
-  let clock;
   let element;
   let loadObservable;
   let errorObservable;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    clock = sandbox.useFakeTimers();
     loadObservable = new Observable();
     errorObservable = new Observable();
     element = {
@@ -150,22 +148,6 @@ describe('EventHelper', () => {
       expect(result).to.equal(event);
     });
     loadObservable.fire(event);
-    return promise;
-  });
-
-  it('listenOncePromise - with time limit', () => {
-    const event = getEvent('load', element);
-    const promise = expect(listenOncePromise(element, 'load', false, 100))
-      .to.eventually.become(event);
-    clock.tick(99);
-    loadObservable.fire(event);
-    return promise;
-  });
-
-  it('listenOncePromise - timeout', () => {
-    const promise = expect(listenOncePromise(element, 'load', false, 100))
-      .to.eventually.be.rejectedWith('timeout');
-    clock.tick(101);
     return promise;
   });
 

--- a/test/functional/test-input.js
+++ b/test/functional/test-input.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {installTimerService} from '../../src/service/timer-impl.js';
 import {Input} from '../../src/input';
 import * as sinon from 'sinon';
 
@@ -48,7 +49,9 @@ describe('Input', () => {
       document: documentApi,
       navigator: {},
       ontouchstart: '',
+      setTimeout: window.setTimeout,
     };
+    installTimerService(windowApi);
 
     input = new Input(windowApi);
   });


### PR DESCRIPTION
This inverts the responsibility of calling the unlistener. Now, the
caller can be given access the `unlisten` by passing a closure. The
closure is called with `unlisten` as the param, giving the caller
access. When the caller determines it is time to stop listening (due to
timeout, etc), it can manually cleanup.

Fixes #8316.