### PR TITLE
Don't call listeners with explicit context

### DIFF
--- a/src/event-helper-listen.js
+++ b/src/event-helper-listen.js
@@ -34,7 +34,7 @@ export function internalListenImplementation(element, eventType, listener,
   /** @type {?Function}  */
   let wrapped = event => {
     try {
-      return localListener.call(this, event);
+      return localListener(event);
     } catch (e) {
       // reportError is installed globally per window in the entry point.
       self.reportError(e);

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -67,7 +67,7 @@ export function listenOnce(element, eventType, listener, opt_capture) {
   let localListener = listener;
   const unlisten = internalListenImplementation(element, eventType, event => {
     try {
-      localListener.call(this, event);
+      localListener(event);
     } finally {
       // Ensure listener is GC'd
       localListener = null;


### PR DESCRIPTION
It's unneeded. Doing a grep search, we only pass arrow functions into listen, and arrow functions cannot receive a context (they inherit it from their parent scope).