### PR TITLE
amp-bind: Add copyAndSplice to bind

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -58,32 +58,10 @@ const FUNCTION_WHITELIST = (function() {
             `copyAndSplice: ${array} is not an array; returning null.`);
         return null;
       }
-      const copy = array.slice();
-      copy.splice.apply(copy, Array.prototype.slice.call(arguments, 1));
-      return copy;
-    },
-
-    /**
-     * Similar to array[index] = item except it returns a copy of the
-     * passed-in array with the desired modification.
-     * @param {!Array} array
-     * @param {!number} index, must be an integer
-     * @param {?=} item, null if unspecified
-     */
-    'copyAndSet': function(array, index, item) {
-      if (!isArray(array)) {
-        user().warn(
-            TAG,
-            `copyAndSet: ${array} is not an array; returning null.`);
-        return null;
-      }
-      const copy = array.slice();
-      // Don't allow indexing with non-integers which is allowed in JS
-      if (typeof index === 'number'
-          && isFinite(index)
-          && Math.floor(index) === index) {
-        copy[index] = item === undefined ? null : item;
-      }
+      const copy = Array.prototype.slice.call(array);
+      Array.prototype.splice.apply(
+          copy,
+          Array.prototype.slice.call(arguments, 1));
       return copy;
     },
   };
@@ -123,7 +101,6 @@ const FUNCTION_WHITELIST = (function() {
     Math.round,
     Math.sign,
     BindArrays.copyAndSplice,
-    BindArrays.copyAndSet,
   ];
   // Creates a prototype-less map of function name to the function itself.
   // This makes function lookups faster (compared to Array.indexOf).

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -41,7 +41,7 @@ const FUNCTION_WHITELIST = (function() {
    * same functionality without allowing mutation on variables in bind scope.
    */
   const BindArrays = {
-    'arraySplice': function(array, start, deleteCount) {
+    'arraySplice': function(array) {
       const copy = array.slice();
       copy.splice.apply(copy, Array.prototype.slice.call(arguments, 1));
       return copy;
@@ -49,11 +49,13 @@ const FUNCTION_WHITELIST = (function() {
     'arraySet': function(array, index, item) {
       const copy = array.slice();
       // Don't allow indexing with non-numbers which is allowed in JS
-      if (typeof index === 'number' && index == index) {
+      if (typeof index === 'number'
+          && isFinite(index)
+          && Math.floor(index) === index) {
         copy[index] = item !== undefined ? item : null;
       }
       return copy;
-    }
+    },
   };
 
   const whitelist = {

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -70,7 +70,7 @@ const FUNCTION_WHITELIST = (function() {
      * @param {!number} index, must be an integer
      * @param {?=} item, null if unspecified
      */
-    'arraySet': function(array, index, item) {
+    'copyAndSet': function(array, index, item) {
       if (!isArray(array)) {
         user().warn(
             TAG,
@@ -123,7 +123,7 @@ const FUNCTION_WHITELIST = (function() {
     Math.round,
     Math.sign,
     BindArrays.copyAndSplice,
-    BindArrays.arraySet,
+    BindArrays.copyAndSet,
   ];
   // Creates a prototype-less map of function name to the function itself.
   // This makes function lookups faster (compared to Array.indexOf).

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -54,8 +54,7 @@ const FUNCTION_WHITELIST = (function() {
     'copyAndSplice': function(array, start, deleteCount, items) {
       if (!isArray(array)) {
         throw new Error(
-          `copyAndSplice: ${array} is not an array; returning null.`);
-        return null;
+          `copyAndSplice: ${array} is not an array.`);
       }
       const copy = Array.prototype.slice.call(array);
       Array.prototype.splice.apply(

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -69,7 +69,7 @@ const FUNCTION_WHITELIST = (function() {
       if (typeof index === 'number'
           && isFinite(index)
           && Math.floor(index) === index) {
-        copy[index] = item !== undefined ? item : null;
+        copy[index] = item === undefined ? null : item;
       }
       return copy;
     },

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -53,9 +53,8 @@ const FUNCTION_WHITELIST = (function() {
     /*eslint "no-unused-vars": 0*/
     'copyAndSplice': function(array, start, deleteCount, items) {
       if (!isArray(array)) {
-        user().warn(
-            TAG,
-            `copyAndSplice: ${array} is not an array; returning null.`);
+        throw new Error(
+          `copyAndSplice: ${array} is not an array; returning null.`);
         return null;
       }
       const copy = Array.prototype.slice.call(array);

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -41,14 +41,31 @@ const FUNCTION_WHITELIST = (function() {
    * same functionality without allowing mutation on variables in bind scope.
    */
   const BindArrays = {
-    'arraySplice': function(array) {
+    /**
+     * Similar to Array.prototype.splice, except it returns a copy of the
+     * passed-in array with the desired modifications.
+     * @param {!Array} array
+     * @param {number=} start
+     * @param {number=} end
+     * @param {...?} items
+     */
+    /*eslint "no-unused-vars": 0*/
+    'arraySplice': function(array, start, end, items) {
       const copy = array.slice();
       copy.splice.apply(copy, Array.prototype.slice.call(arguments, 1));
       return copy;
     },
+
+    /**
+     * Similar to array[index] = item except it returns a copy of the
+     * passed-in array with the desired modification.
+     * @param {!Array} array
+     * @param {!number} index, must be an integer
+     * @param {?=} item, null if unspecified
+     */
     'arraySet': function(array, index, item) {
       const copy = array.slice();
-      // Don't allow indexing with non-numbers which is allowed in JS
+      // Don't allow indexing with non-integers which is allowed in JS
       if (typeof index === 'number'
           && isFinite(index)
           && Math.floor(index) === index) {

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -16,6 +16,7 @@
 
 import {AstNodeType} from './bind-expr-defines';
 import {getMode} from '../../../src/mode';
+import {isArray, isObject} from '../../../src/types';
 import {parser} from './bind-expr-impl';
 import {user} from '../../../src/log';
 
@@ -46,11 +47,17 @@ const FUNCTION_WHITELIST = (function() {
      * passed-in array with the desired modifications.
      * @param {!Array} array
      * @param {number=} start
-     * @param {number=} end
+     * @param {number=} deleteCount
      * @param {...?} items
      */
     /*eslint "no-unused-vars": 0*/
-    'arraySplice': function(array, start, end, items) {
+    'copyAndSplice': function(array, start, deleteCount, items) {
+      if (!isArray(array)) {
+        user().warn(
+            TAG,
+            `copyAndSplice: ${array} is not an array; returning null.`);
+        return null;
+      }
       const copy = array.slice();
       copy.splice.apply(copy, Array.prototype.slice.call(arguments, 1));
       return copy;
@@ -64,6 +71,12 @@ const FUNCTION_WHITELIST = (function() {
      * @param {?=} item, null if unspecified
      */
     'arraySet': function(array, index, item) {
+      if (!isArray(array)) {
+        user().warn(
+            TAG,
+            `copyAndSet: ${array} is not an array; returning null.`);
+        return null;
+      }
       const copy = array.slice();
       // Don't allow indexing with non-integers which is allowed in JS
       if (typeof index === 'number'
@@ -109,7 +122,7 @@ const FUNCTION_WHITELIST = (function() {
     Math.random,
     Math.round,
     Math.sign,
-    BindArrays.arraySplice,
+    BindArrays.copyAndSplice,
     BindArrays.arraySet,
   ];
   // Creates a prototype-less map of function name to the function itself.
@@ -397,7 +410,7 @@ export class BindExpression {
    */
   containsObject_(array) {
     for (let i = 0; i < array.length; i++) {
-      if (Object.prototype.toString.call(array[i]) === '[object Object]') {
+      if (isObject(array[i])) {
         return true;
       }
     }

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -278,11 +278,11 @@ describe('BindExpression', () => {
     expect(evaluate('copyAndSplice(arr, 1, 1, 47)', {arr})).to
         .deep.equal([1, 47, 3]);
 
-    expect(evaluate('arraySet()')).to.be.null;
-    expect(evaluate('arraySet(arr)', {arr})).to.not.equal(arr);
-    expect(evaluate('arraySet(arr)', {arr})).to.deep.equal(arr);
-    expect(evaluate('arraySet(arr, 2)', {arr})).to.deep.equal([1, 2, null]);
-    expect(evaluate('arraySet(arr, 2, 47)', {arr})).to.deep.equal([1, 2, 47]);
+    expect(evaluate('copyAndSet()')).to.be.null;
+    expect(evaluate('copyAndSet(arr)', {arr})).to.not.equal(arr);
+    expect(evaluate('copyAndSet(arr)', {arr})).to.deep.equal(arr);
+    expect(evaluate('copyAndSet(arr, 2)', {arr})).to.deep.equal([1, 2, null]);
+    expect(evaluate('copyAndSet(arr, 2, 47)', {arr})).to.deep.equal([1, 2, 47]);
   });
 
   it('should NOT allow access to prototype properties', () => {

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -270,13 +270,15 @@ describe('BindExpression', () => {
 
   it('should support BindArrays functions', () => {
     const arr = [1, 2, 3];
-    expect(evaluate('arraySplice(arr)', {arr})).to.not.equal(arr);
-    expect(evaluate('arraySplice(arr)', {arr})).to.deep.equal(arr);
-    expect(evaluate('arraySplice(arr, 1)', {arr})).to.deep.equal([1]);
-    expect(evaluate('arraySplice(arr, 1, 1)', {arr})).to.deep.equal([1, 3]);
-    expect(evaluate('arraySplice(arr, 1, 1, 47)', {arr})).to
+    expect(evaluate('copyAndSplice()')).to.be.null;
+    expect(evaluate('copyAndSplice(arr)', {arr})).to.not.equal(arr);
+    expect(evaluate('copyAndSplice(arr)', {arr})).to.deep.equal(arr);
+    expect(evaluate('copyAndSplice(arr, 1)', {arr})).to.deep.equal([1]);
+    expect(evaluate('copyAndSplice(arr, 1, 1)', {arr})).to.deep.equal([1, 3]);
+    expect(evaluate('copyAndSplice(arr, 1, 1, 47)', {arr})).to
         .deep.equal([1, 47, 3]);
 
+    expect(evaluate('arraySet()')).to.be.null;
     expect(evaluate('arraySet(arr)', {arr})).to.not.equal(arr);
     expect(evaluate('arraySet(arr)', {arr})).to.deep.equal(arr);
     expect(evaluate('arraySet(arr, 2)', {arr})).to.deep.equal([1, 2, null]);

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -270,7 +270,9 @@ describe('BindExpression', () => {
 
   it('should support BindArrays functions', () => {
     const arr = [1, 2, 3];
-    expect(evaluate('copyAndSplice()')).to.be.null;
+    expect(() => evaluate('copyAndSplice()')).to.throw(/not an array/);
+    expect(() => evaluate('copyAndSplice(x)', {x: 8472}))
+        .to.throw(/not an array/);
     expect(evaluate('copyAndSplice(arr)', {arr})).to.not.equal(arr);
     expect(evaluate('copyAndSplice(arr)', {arr})).to.deep.equal(arr);
     expect(evaluate('copyAndSplice(arr, 1)', {arr})).to.deep.equal([1]);

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -268,6 +268,21 @@ describe('BindExpression', () => {
     }).to.throw(unsupportedFunctionError);
   });
 
+  it('should support BindArrays functions', () => {
+    const arr = [1, 2, 3];
+    expect(evaluate('arraySplice(arr)', {arr})).to.not.equal(arr);
+    expect(evaluate('arraySplice(arr)', {arr})).to.deep.equal(arr);
+    expect(evaluate('arraySplice(arr, 1)', {arr})).to.deep.equal([1]);
+    expect(evaluate('arraySplice(arr, 1, 1)', {arr})).to.deep.equal([1, 3]);
+    expect(evaluate('arraySplice(arr, 1, 1, 47)', {arr})).to
+        .deep.equal([1, 47, 3]);
+
+    expect(evaluate('arraySet(arr)', {arr})).to.not.equal(arr);
+    expect(evaluate('arraySet(arr)', {arr})).to.deep.equal(arr);
+    expect(evaluate('arraySet(arr, 2)', {arr})).to.deep.equal([1, 2, null]);
+    expect(evaluate('arraySet(arr, 2, 47)', {arr})).to.deep.equal([1, 2, 47]);
+  });
+
   it('should NOT allow access to prototype properties', () => {
     expect(evaluate('constructor')).to.be.null;
     expect(evaluate('prototype')).to.be.null;

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -277,12 +277,6 @@ describe('BindExpression', () => {
     expect(evaluate('copyAndSplice(arr, 1, 1)', {arr})).to.deep.equal([1, 3]);
     expect(evaluate('copyAndSplice(arr, 1, 1, 47)', {arr})).to
         .deep.equal([1, 47, 3]);
-
-    expect(evaluate('copyAndSet()')).to.be.null;
-    expect(evaluate('copyAndSet(arr)', {arr})).to.not.equal(arr);
-    expect(evaluate('copyAndSet(arr)', {arr})).to.deep.equal(arr);
-    expect(evaluate('copyAndSet(arr, 2)', {arr})).to.deep.equal([1, 2, null]);
-    expect(evaluate('copyAndSet(arr, 2, 47)', {arr})).to.deep.equal([1, 2, 47]);
   });
 
   it('should NOT allow access to prototype properties', () => {


### PR DESCRIPTION
This PR adds two new new functions that can be used in bind expressions

- `copyAndSplice(array, start, end, items...)`

similar to Array.prototype.slice, except that it returns a copy of the array with the desired modifications

- `arraySet(array, index, item)`

similar to `array[index] = item` except that index must be an integer and item cannot be `undefined`. 

Partial for #8394 

/to @choumx @jridgewell 