### PR TITLE
Fixing WhatsApp social share on iOS 10.3

### DIFF
--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -88,10 +88,12 @@ class AmpSocialShare extends AMP.BaseElement {
     const urlReplacements = urlReplacementsForDoc(this.getAmpDoc());
     urlReplacements.expandAsync(hrefWithVars).then(href => {
       this.href_ = href;
-      // mailto: protocol breaks when opened in _blank on iOS Safari.
+      // mailto:, whatsapp: protocols breaks when opened in _blank on iOS Safari
       const isMailTo = /^mailto:$/.test(parseUrl(href).protocol);
+      const isWhatsApp = /^whatsapp:$/.test(parseUrl(href).protocol);
       const isIosSafari = this.platform_.isIos() && this.platform_.isSafari();
-      this.target_ = (isIosSafari && isMailTo) ? '_top' : '_blank';
+      this.target_ = (isIosSafari && (isMailTo || isWhatsApp))
+          ? '_top' : '_blank';
     });
 
     this.element.setAttribute('role', 'link');


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/8477 

Test Page: https://temp-87db0.firebaseapp.com/examples/empty.amp.html 

Tested in iOS 10.3 and 10.2 Chrome and Safari

**Issue:**
Similar to `mailto:` , iOS 10.3 now does not open `whatsapp:` schemes unless target is `_top`. Fortunately using '_top' also works in older versions.