### PR TITLE
Delayed rendering via safeframe in Fast Fetch should support AmpContext

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -171,14 +171,17 @@ export class AmpContext {
     // to check the name attribute as it has been bypassed.
     // TODO(alanorozco): why the heck could AMP_CONTEXT_DATA be two different
     // types? FIX THIS.
-    if (!this.win_.AMP_CONTEXT_DATA && !this.win_.sf_) {
-      this.setupMetadata_(this.win_.name);
-    } else if (this.win_.sf_ && this.win_.sf_.cfg) {
+    if (/** @type {?Object} */(this.win_.sf_) &&
+        /** @type {?Object} */(this.win_.sf_.cfg)) {
       this.setupMetadata_(this.win_.sf_.cfg);
-    } else if (typeof this.win_.AMP_CONTEXT_DATA == 'string') {
-      this.sentinel = this.win_.AMP_CONTEXT_DATA;
+    } else if (this.win_.AMP_CONTEXT_DATA) {
+      if (typeof this.win_.AMP_CONTEXT_DATA == 'string') {
+        this.sentinel = this.win_.AMP_CONTEXT_DATA;
+      } else {
+        this.setupMetadata_(this.win_.AMP_CONTEXT_DATA);
+      }
     } else {
-      this.setupMetadata_(this.win_.AMP_CONTEXT_DATA);
+      this.setupMetadata_(this.win_.name);
     }
   }
 }

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -171,8 +171,10 @@ export class AmpContext {
     // to check the name attribute as it has been bypassed.
     // TODO(alanorozco): why the heck could AMP_CONTEXT_DATA be two different
     // types? FIX THIS.
-    if (!this.win_.AMP_CONTEXT_DATA) {
+    if (!this.win_.AMP_CONTEXT_DATA && !this.win_.sf_) {
       this.setupMetadata_(this.win_.name);
+    } else if (this.win_.sf_ && this.win_.sf_.cfg) {
+      this.setupMetadata_(this.win_.sf_.cfg);
     } else if (typeof this.win_.AMP_CONTEXT_DATA == 'string') {
       this.sentinel = this.win_.AMP_CONTEXT_DATA;
     } else {

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -17,6 +17,7 @@ import {dev} from '../src/log';
 import {IframeMessagingClient} from './iframe-messaging-client';
 import {MessageType} from '../src/3p-frame-messaging';
 import {tryParseJson} from '../src/json';
+import {isObject} from '../src/types';
 
 export class AmpContext {
 
@@ -171,13 +172,12 @@ export class AmpContext {
     // to check the name attribute as it has been bypassed.
     // TODO(alanorozco): why the heck could AMP_CONTEXT_DATA be two different
     // types? FIX THIS.
-    if (/** @type {?Object} */(this.win_.sf_) &&
-        /** @type {?Object} */(this.win_.sf_.cfg)) {
-      this.setupMetadata_(this.win_.sf_.cfg);
+    if (isObject(this.win_.sf_) && isObject(this.win_.sf_.cfg)) {
+      this.setupMetadata_(/** @type {!Object}*/(this.win_.sf_.cfg));
     } else if (this.win_.AMP_CONTEXT_DATA) {
       if (typeof this.win_.AMP_CONTEXT_DATA == 'string') {
         this.sentinel = this.win_.AMP_CONTEXT_DATA;
-      } else {
+      } else if (isObject(this.win_.AMP_CONTEXT_DATA)) {
         this.setupMetadata_(this.win_.AMP_CONTEXT_DATA);
       }
     } else {

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -172,8 +172,8 @@ export class AmpContext {
     // to check the name attribute as it has been bypassed.
     // TODO(alanorozco): why the heck could AMP_CONTEXT_DATA be two different
     // types? FIX THIS.
-    if (isObject(this.win_.sf_) && isObject(this.win_.sf_.cfg)) {
-      this.setupMetadata_(/** @type {!Object}*/(this.win_.sf_.cfg));
+    if (isObject(this.win_.sf_) && this.win_.sf_.cfg) {
+      this.setupMetadata_(/** @type {!string}*/(this.win_.sf_.cfg));
     } else if (this.win_.AMP_CONTEXT_DATA) {
       if (typeof this.win_.AMP_CONTEXT_DATA == 'string') {
         this.sentinel = this.win_.AMP_CONTEXT_DATA;

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -31,6 +31,7 @@ window.context.experimentToggles;
 window.services;
 
 // Safeframe
+// TODO(bradfrizzell) Move to its own extern. Not relevant to all AMP.
 /* @type {?Object} */
 window.sf_ = {};
 /* @type {?Object} */

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -30,6 +30,10 @@ window.context.experimentToggles;
 // Service Holder
 window.services;
 
+// Safeframe
+window.sf_ = {};
+window.sf_.cfg;
+
 // Exposed to custom ad iframes.
 /* @type {!Function} */
 window.draw3p;

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -31,7 +31,9 @@ window.context.experimentToggles;
 window.services;
 
 // Safeframe
+/* @type {?Object} */
 window.sf_ = {};
+/* @type {?Object} */
 window.sf_.cfg;
 
 // Exposed to custom ad iframes.

--- a/examples/ac-creative.js
+++ b/examples/ac-creative.js
@@ -1,0 +1,87 @@
+if (!window.context){
+  // window.context doesn't exist yet, must perform steps to create it
+  // before using it
+  console.log("window.context NOT READY");
+
+  // must add listener for the creation of window.context
+  window.addEventListener('amp-windowContextCreated', function(){
+    console.log("window.context created and ready to use");
+    window.context.onResizeSuccess(resizeSuccessCallback);
+    window.context.onResizeDenied(resizeDeniedCallback);
+  });
+
+  // load ampcontext-lib.js which will create window.context
+  ampContextScript = document.createElement('script');
+  ampContextScript.src = "https://localhost:8000/dist.3p/current/ampcontext-lib.js";
+  document.head.appendChild(ampContextScript);
+}
+
+function intersectionCallback(payload){
+  changes = payload.changes;
+  // Code below is simply an example.
+  var latestChange = changes[changes.length - 1];
+
+  // Amp-ad width and height.
+  var w = latestChange.boundingClientRect.width;
+  var h = latestChange.boundingClientRect.height;
+
+  // Visible width and height.
+  var vw = latestChange.intersectionRect.width;
+  var vh = latestChange.intersectionRect.height;
+
+  // Position in the viewport.
+  var vx = latestChange.boundingClientRect.x;
+  var vy = latestChange.boundingClientRect.y;
+
+  // Viewable percentage.
+  var viewablePerc = (vw * vh) / (w * h) * 100;
+
+  console.log(viewablePerc, w, h, vw, vh, vx, vy);
+
+}
+
+function dummyCallback(changes){
+  console.log(changes);
+}
+
+var shouldStopVis = false;
+var stopVisFunc;
+var shouldStopInt = false;
+var stopIntFunc;
+
+function resizeSuccessCallback(requestedHeight, requestedWidth){
+  console.log("Success!");
+  console.log(this);
+  resizeTo(requestedHeight, requestedWidth);
+  console.log(requestedHeight);
+  console.log(requestedWidth);
+}
+
+function resizeTo(height, width){
+  this.innerWidth = width;
+  this.innerHeight = height;
+}
+
+function resizeDeniedCallback(requestedHeight, requestedWidth){
+  console.log("DENIED");
+  console.log(requestedHeight);
+  console.log(requestedWidth);
+}
+
+function toggleObserveIntersection(){
+  if (shouldStopInt){
+    stopIntFunc();
+  } else {
+    stopIntFunc = window.context.observeIntersection(intersectionCallback);
+  }
+  shouldStopInt = !shouldStopInt;
+}
+
+function toggleObserveVisibility(){
+  if (shouldStopVis){
+    stopVisFunc();
+  } else {
+    stopVisFunc = window.context.observePageVisibility(dummyCallback);
+  }
+  shouldStopVis = !shouldStopVis;
+}

--- a/examples/ampcontext-creative-json.html
+++ b/examples/ampcontext-creative-json.html
@@ -1,0 +1,3 @@
+{"creative":
+"<!doctype html><html>  <head>    <style>body { background: lightblue; }</style>    <script src='https://localhost:8000/examples/ac-creative.js'></script>  </head>  <body>    Test Ad using ampcontext.js to create window.context    <button onclick='toggleObserveIntersection()'>Toggle Observe Intersections</button>    <button onclick='toggleObserveVisibility()'>Toggle Observe visibility</button>    <button onclick='window.context.requestResize(500,600)'>resize ad</button>    <button onclick='console.log(window.context)'>console.log(window.context)</button>  </body></html>",
+"signature":"123"}

--- a/examples/loads-windowcontext-creative-https.html
+++ b/examples/loads-windowcontext-creative-https.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html ⚡>
+  <head>
+        <meta charset="utf-8">
+    <title>window.context Example</title>
+    <link rel="canonical" href="./regular-html-version.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <style type="text/css">
+      #filler_space {
+        height: 300px;
+        width: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 style="font-size: 1em;"> window.context example </h1>
+    <p> Creative not loading? Make sure you put .max in the url for the page </p>
+
+    <h2> A4A + JS Creative in safeframe - needs HTTPS</h2>
+    <amp-ad width="300" height="400"
+            type="fake"
+            data-use-a4a="true"
+            src="/examples/ampcontext-creative-json.html">
+    </amp-ad>
+  </body>
+
+</html>

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1225,15 +1225,13 @@ export class AmpA4A extends AMP.BaseElement {
     this.protectedEmitLifecycleEvent_('renderSafeFrameStart');
     return utf8Decode(creativeBody).then(creative => {
       let srcPath;
-      let nameData;
+      let name;
       switch (method) {
         case XORIGIN_MODE.SAFEFRAME:
           srcPath = SAFEFRAME_IMPL_PATH + '?n=0';
-          nameData = `${SAFEFRAME_VERSION};${creative.length};${creative}`;
           break;
         case XORIGIN_MODE.NAMEFRAME:
           srcPath = getDefaultBootstrapBaseUrl(this.win, 'nameframe');
-          nameData = '';
           // Name will be set for real below in nameframe case.
           break;
         default:
@@ -1252,18 +1250,22 @@ export class AmpA4A extends AMP.BaseElement {
             'height': this.element.getAttribute('height'),
             'width': this.element.getAttribute('width'),
             'src': srcPath,
-            'name': nameData,
           }, SHARED_IFRAME_PROPERTIES));
-      if (method == XORIGIN_MODE.NAMEFRAME) {
         // TODO(bradfrizzell): change name of function and var
-        const attributes = getContextMetadata(
-            this.win, this.element, this.sentinel);
+      let attributes = getContextMetadata(
+          this.win, this.element, this.sentinel);
+      if (method == XORIGIN_MODE.NAMEFRAME) {
         attributes['creative'] = creative;
-        const name = JSON.stringify(attributes);
+        name = JSON.stringify(attributes);
         // Need to reassign the name once we've generated the context
         // attributes off of the iframe. Need the iframe to generate.
         iframe.setAttribute('name', name);
         iframe.setAttribute('data-amp-3p-sentinel', this.sentinel);
+      } else if (method == XORIGIN_MODE.SAFEFRAME) {
+        attributes = JSON.stringify(attributes);
+        name = `${SAFEFRAME_VERSION};${creative.length};${creative}` +
+            `${attributes}`;
+        iframe.setAttribute('name', name);
       }
       return this.iframeRenderHelper_(iframe);
     });

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1266,6 +1266,7 @@ export class AmpA4A extends AMP.BaseElement {
         name = `${SAFEFRAME_VERSION};${creative.length};${creative}` +
             `${attributes}`;
         iframe.setAttribute('name', name);
+        iframe.setAttribute('data-amp-3p-sentinel', this.sentinel);
       }
       return this.iframeRenderHelper_(iframe);
     });

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1162,10 +1162,17 @@ export class AmpA4A extends AMP.BaseElement {
    * Shared functionality for cross-domain iframe-based rendering methods.
    * @param {!Element} iframe Iframe to render.  Should be fully configured
    * (all attributes set), but not yet attached to DOM.
+   * @param {!string} name
    * @return {!Promise} awaiting load event for ad frame
    * @private
    */
-  iframeRenderHelper_(iframe) {
+  iframeRenderHelper_(iframe, name) {
+    if (name) {
+      iframe.setAttribute('name', name);
+    }
+    if (this.sentinel) {
+      iframe.setAttribute('data-amp-3p-sentinel', this.sentinel);
+    }
     // TODO(keithwrightbos): noContentCallback?
     this.xOriginIframeHandler_ = new AMP.AmpAdXOriginIframeHandler(this);
     return this.xOriginIframeHandler_.init(iframe, /* opt_isA4A */ true);
@@ -1201,11 +1208,9 @@ export class AmpA4A extends AMP.BaseElement {
           'src': xhrFor(this.win).getCorsUrl(this.win, adUrl),
         }, SHARED_IFRAME_PROPERTIES));
     // Can't get the attributes until we have the iframe, then set it.
-    const attributes = getContextMetadata(
-        this.win, this.element, this.sentinel);
-    iframe.setAttribute('name', JSON.stringify(attributes));
-    iframe.setAttribute('data-amp-3p-sentinel', this.sentinel);
-    return this.iframeRenderHelper_(iframe);
+    const name = JSON.stringify(getContextMetadata(
+        this.win, this.element, this.sentinel));
+    return this.iframeRenderHelper_(iframe, name);
   }
 
   /**
@@ -1225,7 +1230,7 @@ export class AmpA4A extends AMP.BaseElement {
     this.protectedEmitLifecycleEvent_('renderSafeFrameStart');
     return utf8Decode(creativeBody).then(creative => {
       let srcPath;
-      let name;
+      let name = '';
       switch (method) {
         case XORIGIN_MODE.SAFEFRAME:
           srcPath = SAFEFRAME_IMPL_PATH + '?n=0';
@@ -1262,13 +1267,7 @@ export class AmpA4A extends AMP.BaseElement {
         name = `${SAFEFRAME_VERSION};${creative.length};${creative}` +
             `${contextMetadata}`;
       }
-      if (name) {
-        iframe.setAttribute('name', name);
-      }
-      if (this.sentinel) {
-        iframe.setAttribute('data-amp-3p-sentinel', this.sentinel);
-      }
-      return this.iframeRenderHelper_(iframe);
+      return this.iframeRenderHelper_(iframe, name);
     });
   }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1259,6 +1259,7 @@ export class AmpA4A extends AMP.BaseElement {
         // TODO(bradfrizzell): change name of function and var
       let contextMetadata = getContextMetadata(
           this.win, this.element, this.sentinel);
+      // TODO(bradfrizzell) Clean up name assigning.
       if (method == XORIGIN_MODE.NAMEFRAME) {
         contextMetadata['creative'] = creative;
         name = JSON.stringify(contextMetadata);

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1252,20 +1252,20 @@ export class AmpA4A extends AMP.BaseElement {
             'src': srcPath,
           }, SHARED_IFRAME_PROPERTIES));
         // TODO(bradfrizzell): change name of function and var
-      let attributes = getContextMetadata(
+      let contextMetadata = getContextMetadata(
           this.win, this.element, this.sentinel);
       if (method == XORIGIN_MODE.NAMEFRAME) {
-        attributes['creative'] = creative;
-        name = JSON.stringify(attributes);
-        // Need to reassign the name once we've generated the context
-        // attributes off of the iframe. Need the iframe to generate.
-        iframe.setAttribute('name', name);
-        iframe.setAttribute('data-amp-3p-sentinel', this.sentinel);
+        contextMetadata['creative'] = creative;
+        name = JSON.stringify(contextMetadata);
       } else if (method == XORIGIN_MODE.SAFEFRAME) {
-        attributes = JSON.stringify(attributes);
+        contextMetadata = JSON.stringify(contextMetadata);
         name = `${SAFEFRAME_VERSION};${creative.length};${creative}` +
-            `${attributes}`;
+            `${contextMetadata}`;
+      }
+      if (name) {
         iframe.setAttribute('name', name);
+      }
+      if (this.sentinel) {
         iframe.setAttribute('data-amp-3p-sentinel', this.sentinel);
       }
       return this.iframeRenderHelper_(iframe);

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -176,8 +176,23 @@ describe('amp-a4a', () => {
     const child = element.querySelector(
         `iframe[src^="${SAFEFRAME_IMPL_PATH}"][name]`);
     expect(child).to.be.ok;
-    expect(child.getAttribute('name')).to.match(/[^;]+;\d+;[\s\S]+/);
-    expect(child).to.be.visible;
+    const name = child.getAttribute('name');
+    expect(name).to.match(/[^;]+;\d+;[\s\S]+/);
+    const re = /^([^;]+);(\d+);([\s\S]*)$/;
+    const match = re.exec(name);
+    expect(match).to.be.ok;
+    const contentLength = Number(match[2]);
+    const rest = match[3];
+    expect(rest.length > contentLength).to.be.true;
+    const data = JSON.parse(rest.substr(contentLength));
+    expect(data).to.be.ok;
+    verifyContext(data._context);
+  }
+
+  function verifyContext(context) {
+    expect(context).to.be.ok;
+    expect(context.sentinel).to.be.ok;
+    expect(context.sentinel).to.match(/((\d+)-\d+)/);
   }
 
   // Checks that element is an amp-ad that is rendered via nameframe.
@@ -211,10 +226,7 @@ describe('amp-a4a', () => {
     let attributes;
     expect(() => {attributes = JSON.parse(nameData);}).not.to.throw(Error);
     expect(attributes).to.be.ok;
-    expect(attributes._context).to.be.ok;
-    const sentinel = attributes._context.sentinel;
-    expect(sentinel).to.be.ok;
-    expect(sentinel).to.match(/((\d+)-\d+)/);
+    verifyContext(attributes._context);
   }
 
   describe('ads are visible', () => {


### PR DESCRIPTION
Currently, AmpContext is supported in delayed rendering in fast fetch via Nameframe and direct cache rendering. However safeframe is not yet supported. This change passes the metadata into the safeframe, and makes a change to the setup within AmpContext to support this change. 

Example files were added that are useful for manual testing of this fact. If these examples are too cluttery I can remove them and just keep them elsewhere for my own uses. 