### PR TITLE
amp-gist: Implement support for optional `data-file` attribute.

### DIFF
--- a/3p/github.js
+++ b/3p/github.js
@@ -17,7 +17,6 @@
 import {writeScript} from './3p';
 import {user} from '../src/log';
 
-
 /**
  * Get the correct script for the gist.
  *
@@ -44,11 +43,10 @@ export function github(global, data) {
     'The data-gistid attribute is required for <amp-gist> %s',
     data.element);
 
-  const gistid = data.gistid;
-  let gistUrl = 'https://gist.github.com/' + gistid + '.js';
+  let gistUrl = 'https://gist.github.com/' + encodeURIComponent(data.gistid) + '.js';
 
   if (data.file) {
-    gistUrl += '?file=' + data.file;
+    gistUrl += '?file=' + encodeURIComponent(data.file);
   }
 
   getGistJs(global, gistUrl, function() {

--- a/3p/github.js
+++ b/3p/github.js
@@ -45,9 +45,9 @@ export function github(global, data) {
     data.element);
 
   const gistid = data.gistid;
-  var gistUrl = 'https://gist.github.com/' + gistid + '.js';
+  let gistUrl = 'https://gist.github.com/' + gistid + '.js';
 
-  if(data.file) {
+  if (data.file) {
     gistUrl += '?file=' + data.file;
   }
 

--- a/3p/github.js
+++ b/3p/github.js
@@ -45,8 +45,9 @@ export function github(global, data) {
     data.element);
 
   const gistid = data.gistid;
+  const gistUrl = 'https://gist.github.com/' + gistid + '.js';
 
-  getGistJs(global, 'https://gist.github.com/' + gistid + '.js', function() {
+  getGistJs(global, gistUrl, function() {
     // Dimensions are given by the parent frame.
     delete data.width;
     delete data.height;

--- a/3p/github.js
+++ b/3p/github.js
@@ -45,7 +45,11 @@ export function github(global, data) {
     data.element);
 
   const gistid = data.gistid;
-  const gistUrl = 'https://gist.github.com/' + gistid + '.js';
+  var gistUrl = 'https://gist.github.com/' + gistid + '.js';
+
+  if(data.file) {
+    gistUrl += '?file=' + data.file;
+  }
 
   getGistJs(global, gistUrl, function() {
     // Dimensions are given by the parent frame.

--- a/examples/amp-gist.amp.html
+++ b/examples/amp-gist.amp.html
@@ -13,7 +13,8 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <h1>AMP-GIST Example</h1>
+  <h1>AMP-GIST Examples</h1>
+  <h2>Long Example</h2>
   <amp-gist 
     layout="responsive" 
     data-gistid="a19e811dcd7df10c4da0931641538497" 
@@ -24,6 +25,14 @@
   <amp-gist 
     layout="responsive" 
     data-gistid="b9bb35bc68df68259af94430f012425f" 
+    width="100" 
+    height="100">
+  </amp-gist>
+  <h2>Single File Example</h2>
+  <amp-gist 
+    layout="responsive" 
+    data-gistid="a19e811dcd7df10c4da0931641538497" 
+    data-file="index.js"
     width="100" 
     height="100">
   </amp-gist>

--- a/extensions/amp-gist/0.1/validator-amp-gist.protoascii
+++ b/extensions/amp-gist/0.1/validator-amp-gist.protoascii
@@ -34,6 +34,10 @@ tags: {  # <amp-gist>
     name: "data-gistid"
     mandatory: true
   }
+  attrs: {
+    name: "data-file"
+    value: ""
+  }
   satisfies: "amp-gist"
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-gist"

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -35,13 +35,24 @@ limitations under the License.
   </tr>
 </table>
 
-## Example
+## Examples
 
-Example:
+### Multiple files
 
 ```html
 <amp-gist
     data-gistid="b9bb35bc68df68259af94430f012425f"
+    layout="responsive"
+    width="480" height="270">
+</amp-gist>
+```
+
+### Single file
+
+```html
+<amp-gist
+    data-gistid="a19e811dcd7df10c4da0931641538497"
+    data-file="hi.c"
     layout="responsive"
     width="480" height="270">
 </amp-gist>
@@ -53,7 +64,7 @@ This extension creates an iframe and displays the gist from GitHub.
 
 ## Attributes
 
-It requires the `data-gistid` attribute of the gist.
+It requires the `data-gistid` attribute of the gist. The `data-file` is used for displaying only one file in a gist and it is optional.
 
 ## Validation
 See [amp-gist rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-gist/0.1/validator-amp-gist.protoascii) in the AMP validator specification.

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -64,7 +64,13 @@ This extension creates an iframe and displays the gist from GitHub.
 
 ## Attributes
 
-It requires the `data-gistid` attribute of the gist. The `data-file` is used for displaying only one file in a gist and it is optional.
+These are the valid attributes for the `amp-gist` component:
+
+**data-gistid** (required)
+The ID of the gist to embed.
+
+**data-file** (optional)
+`data-file` is used for displaying only one file in a gist.
 
 ## Validation
 See [amp-gist rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-gist/0.1/validator-amp-gist.protoascii) in the AMP validator specification.

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -27,7 +27,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
-    <td><code>&lt;script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-gist-0.1.js">&lt;/script></code></td>
+    <td><code>&lt;script async custom-element="amp-gist" src="https://cdn.ampproject.org/v0/amp-gist-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>


### PR DESCRIPTION
Some users of Github's Gist embeds don't always embed all the files consecutively. Users will separate each file on their website to allow for explanations between each embed.

- Implements optional `data-file` attribute
- Gives user more control over what is displayed

This gives the user more control of how the gists are displayed on their page.

Closes #8489.

/cc @aarongustafson 