### PR TITLE
Rephrase requirement for ad width/height setting

### DIFF
--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -50,8 +50,7 @@ custom element called `<amp-ad>`. No ad network provided JavaScript is allowed t
 different origin (via iframe sandbox) as the AMP document and executes the ad
 network’s JS inside that iframe sandbox.
 
-The `<amp-ad>` requires width and height values to be specified like all
-resources in AMP. It requires a `type` argument that select what ad network is displayed. All `data-*` attributes on the tag are automatically passed as arguments to the code that eventually renders the ad. What `data-` attributes are required for a given type of network depends and must be documented with the ad network.
+The `<amp-ad>` requires width and height values to be specified according to the [rule](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#tldr-summary-of-layout-requirements--behaviors) of its layout type. It requires a `type` argument that select what ad network is displayed. All `data-*` attributes on the tag are automatically passed as arguments to the code that eventually renders the ad. What `data-` attributes are required for a given type of network depends and must be documented with the ad network.
 
 ```html
 <amp-ad width=300 height=250
@@ -124,7 +123,7 @@ resources in AMP. It requires a `type` argument that select what ad network is d
 - [FlexOneELEPHANT](../../ads/f1e.md)
 - [Felmat](../../ads/felmat.md)
 - [Flite](../../ads/flite.md)
-- [Fusion](../../ads/fusion.md) 
+- [Fusion](../../ads/fusion.md)
 - [GenieeSSP](../../ads/genieessp.md)
 - [GMOSSP](../../ads/gmossp.md)
 - [Holder](../../ads/holder.md)
@@ -221,7 +220,7 @@ An optional attribute. If provided, will require confirming the [amp-user-notifi
 
 **data-loading-strategy**
 
-Instructs AMP to load ads in a way that prefers a high degree of viewability, while sometimes loading too late to generate a view. Supported value: `prefer-viewability-over-views`. 
+Instructs AMP to load ads in a way that prefers a high degree of viewability, while sometimes loading too late to generate a view. Supported value: `prefer-viewability-over-views`.
 
 **common attributes**
 


### PR DESCRIPTION
@bpaduch PTAL
`<amp-ad>` doesn't always require attribute width/height. As some of the layout type it supports doesn't need width/height to be specified.

 I feel our doc is confusing with 
> The `<amp-ad>` requires width and height values to be specified like all resources in AMP.

I rephrased the word a bit. Please advise. 