### PR TITLE
Fix iOS 10.3 specific code leaking to older versions

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -246,7 +246,8 @@ export class AmpSlideScroll extends BaseSlides {
       if (this.scrollTimeout_) {
         timerFor(this.win).cancel(this.scrollTimeout_);
       }
-      const timeout = this.isIos_ ? IOS_TOUCH_TIMEOUT : NATIVE_TOUCH_TIMEOUT;
+      const timeout = this.shouldDisableCssSnap_ ? IOS_TOUCH_TIMEOUT
+          : NATIVE_TOUCH_TIMEOUT;
       // Timer that detects scroll end and/or end of snap scroll.
       this.touchEndTimeout_ = timerFor(this.win).delay(() => {
         const currentScrollLeft = this.slidesContainer_./*OK*/scrollLeft;


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/8476

Wrong timeout value was being used for iOS <= 10.2 causing  https://github.com/ampproject/amphtml/issues/8476
