### PR TITLE
Carve-out Doubleclick Fast Fetch if useSameDomainRenderingUntilDeprecated

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -78,6 +78,9 @@ export const BETA_ATTRIBUTE = 'data-use-beta-a4a-implementation';
  * @returns {boolean}
  */
 export function doubleclickIsA4AEnabled(win, element) {
+  if (element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
+    return false;
+  }
   const a4aRequested = element.hasAttribute(BETA_ATTRIBUTE);
   // Note: Under this logic, a4aRequested shortcuts googleAdsIsA4AEnabled and,
   // therefore, carves out of the experiment branches.  Any publisher using this

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -83,6 +83,14 @@ describe('doubleclick-a4a-config', () => {
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
     });
 
+    it('should not enable a4a if useSameDomainRenderingUntilDeprecated', () => {
+      const elem = testFixture.doc.createElement('div');
+      elem.setAttribute('useSameDomainRenderingUntilDeprecated', 'true');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+    });
+
     [-1, 0, 1, 2].forEach(expFlagValue => {
       it(`exp flag=${expFlagValue} should set eid attribute`, () => {
         mockWin.location = parseUrl(


### PR DESCRIPTION
See [description](https://github.com/ampproject/amphtml/blob/master/ads/google/doubleclick.md#temporary-use-of-usesamedomainrenderinguntildeprecated) of useSameDomainRenderingUntilDeprecated.  Usage is for creatives that assume access to window.context which is unavailable when in the Fast Fetch flow therefore carving-out.

useSameDomainRenderingUntilDeprecated is to be removed in the near future once loading context library within creative via script include is supported after which this carve-out will be removed.

/cc @ampproject/a4a 