### PR TITLE
Fix for IE: Prevent assigning undefined value to iframe element.

### DIFF
--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -97,8 +97,13 @@ export function getIframe(parentWindow, parentElement, opt_type, opt_context) {
   iframe.src = baseUrl;
   iframe.ampLocation = parseUrl(baseUrl);
   iframe.name = name;
-  iframe.width = attributes.width;
-  iframe.height = attributes.height;
+  // Add the check before assigning to prevent IE throw Invalid argument error
+  if (attributes.width) {
+    iframe.width = attributes.width;
+  }
+  if (attributes.height) {
+    iframe.height = attributes.height;
+  }
   iframe.setAttribute('scrolling', 'no');
   setStyle(iframe, 'border', 'none');
   /** @this {!Element} */


### PR DESCRIPTION
fix #8210 
Tested on IE 11.