### PR TITLE
Fix web-worker-related bugs

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -279,6 +279,7 @@ var forbiddenTerms = {
       'extensions/amp-access/0.1/amp-login-done.js',
       'src/runtime.js',
       'src/log.js',
+      'src/web-worker/web-worker.js',
       'tools/experiments/experiments.js',
     ],
   },

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -28,7 +28,7 @@ import {filterSplice} from '../../../src/utils/array';
 export let BindingDef;
 
 /**
- * Error that can be passed through web worker
+ * Error-like object that can be passed through web worker boundary.
  * @typedef {{
  *   message: string,
  *   stack: string,
@@ -55,7 +55,7 @@ export class BindEvaluator {
    * Parses and stores given bindings into expression objects and returns map
    * of expression string to parse errors.
    * @param {!Array<BindingDef>} bindings
-   * @return {!Object<string,EvaluatorErrorDef>},
+   * @return {!Object<string, EvaluatorErrorDef>},
    */
   addBindings(bindings) {
     const errors = Object.create(null);
@@ -63,10 +63,7 @@ export class BindEvaluator {
     bindings.forEach(binding => {
       const parsed = this.parse_(binding.expressionString);
       if (parsed.error) {
-        errors[binding.expressionString] = {
-          message: parsed.error.message,
-          stack: parsed.error.stack,
-        };
+        errors[binding.expressionString] = parsed.error;
       } else {
         this.bindings_.push(binding);
       }
@@ -121,7 +118,7 @@ export class BindEvaluator {
       }
       const {result, error} = this.evaluate_(expression, scope);
       if (error) {
-        errors[expressionString] = {message: error.message, stack: error.stack};
+        errors[expressionString] = error;
         return;
       }
       cache[expressionString] = result;
@@ -157,7 +154,7 @@ export class BindEvaluator {
    * @param {!Object} scope
    * @return {{
    *   result: ./bind-expression.BindExpressionResultDef,
-   *   error: Error,
+   *   error: EvaluatorErrorDef,
    * }}
    */
   evaluateExpression(expressionString, scope) {
@@ -177,7 +174,7 @@ export class BindEvaluator {
    * @param {string} expressionString
    * @return {{
    *   expression: BindExpression,
-   *   error: Error,
+   *   error: EvaluatorErrorDef,
    * }}
    * @private
    */
@@ -189,7 +186,7 @@ export class BindEvaluator {
         expression = new BindExpression(expressionString);
         this.expressions_[expressionString] = expression;
       } catch (e) {
-        error = e;
+        error = {message: e.message, stack: e.stack};
       }
     }
     return {expression, error};
@@ -201,7 +198,7 @@ export class BindEvaluator {
    * @param {!Object} scope
    * @return {{
    *   result: ./bind-expression.BindExpressionResultDef,
-   *   error: Error,
+   *   error: EvaluatorErrorDef,
    * }}
    * @private
    */
@@ -211,7 +208,7 @@ export class BindEvaluator {
     try {
       result = expression.evaluate(scope);
     } catch (e) {
-      error = e;
+      error = {message: e.message, stack: e.stack};
     }
     return {result, error};
   }

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -154,7 +154,7 @@ export class BindEvaluator {
    * @param {!Object} scope
    * @return {{
    *   result: ./bind-expression.BindExpressionResultDef,
-   *   error: EvaluatorErrorDef,
+   *   error: ?EvaluatorErrorDef,
    * }}
    */
   evaluateExpression(expressionString, scope) {
@@ -174,7 +174,7 @@ export class BindEvaluator {
    * @param {string} expressionString
    * @return {{
    *   expression: BindExpression,
-   *   error: EvaluatorErrorDef,
+   *   error: ?EvaluatorErrorDef,
    * }}
    * @private
    */
@@ -198,7 +198,7 @@ export class BindEvaluator {
    * @param {!Object} scope
    * @return {{
    *   result: ./bind-expression.BindExpressionResultDef,
-   *   error: EvaluatorErrorDef,
+   *   error: ?EvaluatorErrorDef,
    * }}
    * @private
    */

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -114,7 +114,7 @@ export class BindExpression {
     const skipConstraint = getMode().localDev && !getMode().test;
     if (size > maxSize && !skipConstraint) {
       throw new Error(`Expression size (${size}) exceeds max (${maxSize}). ` +
-          `Please reduce number of operands in: "${expressionString}"`);
+          `Please reduce number of operands.`);
     }
   }
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -285,7 +285,7 @@ export class Bind {
         if (elements.length > 0) {
           const parseError = parseErrors[expressionString];
           const userError = user().createError(
-              `${TAG}: Expression syntax error in "${expressionString}". `
+              `${TAG}: Expression compilation error in "${expressionString}". `
               + parseError.message);
           userError.stack = parseError.stack;
           reportError(userError, elements[0]);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -268,8 +268,9 @@ export class Bind {
             `bindings will be ignored.`);
       }
 
-      // Parse on web worker if experiment is enabled.
-      if (this.workerExperimentEnabled_) {
+      if (bindings.length == 0) {
+        return {};
+      } else if (this.workerExperimentEnabled_) {
         dev().fine(TAG, `Asking worker to parse expressions...`);
         return invokeWebWorker(this.win_, 'bind.addBindings', [bindings]);
       } else {
@@ -329,13 +330,17 @@ export class Bind {
       }
 
       // Remove the bindings from the evaluator.
-      if (this.workerExperimentEnabled_) {
-        dev().fine(TAG, `Asking worker to parse expressions...`);
-        return invokeWebWorker(
-            this.win_, 'bind.removeBindings', [deletedExpressions]);
-      } else {
-        this.evaluator_.removeBindingsWithExpressionStrings(deletedExpressions);
+      if (deletedExpressions.length > 0) {
+        if (this.workerExperimentEnabled_) {
+          dev().fine(TAG, `Asking worker to parse expressions...`);
+          return invokeWebWorker(
+              this.win_, 'bind.removeBindings', [deletedExpressions]);
+        } else {
+          this.evaluator_.removeBindingsWithExpressionStrings(
+              deletedExpressions);
+        }
       }
+
       resolve();
     });
   }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -116,6 +116,10 @@ export class Bind {
     /** @const @private {boolean} */
     this.workerExperimentEnabled_ = isExperimentOn(this.win_, 'web-worker');
 
+    if (!this.workerExperimentEnabled_) {
+      this.evaluator_ = new BindEvaluator();
+    }
+
     /**
      * Resolved when the service is fully initialized.
      * @const @private {Promise}
@@ -191,7 +195,7 @@ export class Bind {
         userError.stack = error.stack;
         reportError(userError);
       } else {
-        return this.setState(returnValue.result);
+        return this.setState(result);
       }
     });
     return this.setStatePromise_;
@@ -276,7 +280,6 @@ export class Bind {
         dev().fine(TAG, `Asking worker to parse expressions...`);
         return invokeWebWorker(this.win_, 'bind.addBindings', [bindings]);
       } else {
-        this.evaluator_ = this.evaluator_ || new BindEvaluator();
         const parseErrors = this.evaluator_.addBindings(bindings);
         return parseErrors;
       }
@@ -334,8 +337,8 @@ export class Bind {
       if (deletedExpressions.length > 0) {
         if (this.workerExperimentEnabled_) {
           dev().fine(TAG, `Asking worker to remove expressions...`);
-          return invokeWebWorker(
-              this.win_, 'bind.removeBindings', [deletedExpressions]);
+          return invokeWebWorker(this.win_,
+              'bind.removeBindingsWithExpressionStrings', [deletedExpressions]);
         } else {
           this.evaluator_.removeBindingsWithExpressionStrings(
               deletedExpressions);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -331,9 +331,8 @@ export class Bind {
       // Remove the bindings from the evaluator.
       if (this.workerExperimentEnabled_) {
         dev().fine(TAG, `Asking worker to parse expressions...`);
-        return invokeWebWorker(this.win_,
-          'bind.removeBindingsWithExpressionStrings',
-          [deletedExpressions]);
+        return invokeWebWorker(
+            this.win_, 'bind.removeBindings', [deletedExpressions]);
       } else {
         this.evaluator_.removeBindingsWithExpressionStrings(deletedExpressions);
       }

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -43,7 +43,7 @@ self.addEventListener('message', function(event) {
       evaluator_ = evaluator_ || new BindEvaluator();
       returnValue = evaluator_.addBindings.apply(evaluator_, args);
       break;
-    case 'bind.removeBindings':
+    case 'bind.removeBindingsWithExpressionStrings':
       if (evaluator_) {
         const removeBindings = evaluator_.removeBindingsWithExpressionStrings;
         returnValue = removeBindings.apply(evaluator_, args);

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -24,8 +24,10 @@
 import '../../third_party/babel/custom-babel-helpers';
 import {BindEvaluator} from '../../extensions/amp-bind/0.1/bind-evaluator';
 import {FromWorkerMessageDef, ToWorkerMessageDef} from './web-worker-defines';
+import {initLogConstructor} from '../../src/log';
 import {installWorkerErrorReporting} from '../worker-error-reporting';
 
+initLogConstructor();
 installWorkerErrorReporting('ww');
 
 /** @private {BindEvaluator} */


### PR DESCRIPTION
Fixes #8519.

- Method string is `bind.removeBindings`, not `bind.removeBindingsWithExpressions`.
- Call `initLogConstructor` in entry point.
- Only invoke if operation is not a no-op and other misc. cleanup.

/to @kmh287 