### PR TITLE
Amp gist: Update layout.

### DIFF
--- a/examples/amp-gist.amp.html
+++ b/examples/amp-gist.amp.html
@@ -16,25 +16,22 @@
   <h1>AMP-GIST Examples</h1>
   <h2>Long Example</h2>
   <amp-gist 
-    layout="responsive" 
+    layout="fixed-height" 
     data-gistid="a19e811dcd7df10c4da0931641538497" 
-    width="100" 
-    height="100">
+    height="1613">
   </amp-gist>
   <h2>Smaller Example</h2>
   <amp-gist 
-    layout="responsive" 
+    layout="fixed-height" 
     data-gistid="b9bb35bc68df68259af94430f012425f" 
-    width="100" 
-    height="100">
+    height="225">
   </amp-gist>
   <h2>Single File Example</h2>
   <amp-gist 
-    layout="responsive" 
+    layout="fixed-height" 
     data-gistid="a19e811dcd7df10c4da0931641538497" 
     data-file="index.js"
-    width="100" 
-    height="100">
+    height="65">
   </amp-gist>
 </body>
 </html>

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -29,7 +29,6 @@
 
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
-import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
 import {user} from '../../../src/log';

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -20,10 +20,9 @@
  * Example:
  * <code>
  * <amp-gist
- *   layout="responsive"
+ *   layout="fixed-height"
  *   data-gistid="a19e811dcd7df10c4da0931641538497"
- *   width="100"
- *   height="100">
+ *   height="1613">
  * </amp-gist>
  * </code>
  */

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -33,6 +33,7 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
 import {user} from '../../../src/log';
+import {Layout} from '../../../src/layout';
 
 const TAG = 'amp-gist';
 
@@ -56,7 +57,7 @@ export class AmpGist extends AMP.BaseElement {
 
   /** @override */
   isLayoutSupported(layout) {
-    return isLayoutSizeDefined(layout);
+    return layout == Layout.FIXED_HEIGHT;
   }
 
   /** @override */

--- a/extensions/amp-gist/0.1/validator-amp-gist.protoascii
+++ b/extensions/amp-gist/0.1/validator-amp-gist.protoascii
@@ -42,11 +42,6 @@ tags: {  # <amp-gist>
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-gist"
   amp_layout: {
-    supported_layouts: CONTAINER
-    supported_layouts: FILL
-    supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
-    supported_layouts: FLEX_ITEM
-    supported_layouts: RESPONSIVE
   }
 }

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -31,7 +31,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
+    <td>fixed-height</td>
   </tr>
 </table>
 
@@ -42,8 +42,8 @@ limitations under the License.
 ```html
 <amp-gist
     data-gistid="b9bb35bc68df68259af94430f012425f"
-    layout="responsive"
-    width="480" height="270">
+    layout="fixed-height"
+    height="225">
 </amp-gist>
 ```
 
@@ -53,14 +53,15 @@ limitations under the License.
 <amp-gist
     data-gistid="a19e811dcd7df10c4da0931641538497"
     data-file="hi.c"
-    layout="responsive"
-    width="480" height="270">
+    layout="fixed-height"
+    height="185">
 </amp-gist>
 ```
 
 ## Behavior
 
-This extension creates an iframe and displays the gist from GitHub.
+This extension creates an iframe and displays the gist from GitHub. **You must find the 
+height of the gist by inspecting it with your browser** (e.g. Chrome Developer Tools).
 
 ## Attributes
 
@@ -68,6 +69,12 @@ These are the valid attributes for the `amp-gist` component:
 
 **data-gistid** (required)
 The ID of the gist to embed.
+
+**layout** (required)
+Currently only supports `fixed-height`
+
+**height** (required)
+The height of the gist or gist file in pixels.
 
 **data-file** (optional)
 `data-file` is used for displaying only one file in a gist.

--- a/validator/testdata/feature_tests/amp-gist.html
+++ b/validator/testdata/feature_tests/amp-gist.html
@@ -17,9 +17,8 @@
 <body>
   <amp-gist
      data-gistid="a19e811dcd7df10c4da0931641538497"
-     layout="responsive" 
-     width="150" 
-     height="80">
+     layout="fixed-height" 
+     height="1613">
   </amp-gist>
 </body>
 </html>


### PR DESCRIPTION
The layout `fixed-height` is best suited for this component to help prevent layout jumps.

- Helps reduce possibility of layout thrashing

Most of the time the embed will have a fixed height. Even in the instances where the height may not be predictable, it is still better to be close since it will resize.

Closes #8523.

/cc @aghassemi 