### PR TITLE
Improve amp-bind documentation

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -168,15 +168,13 @@ When the **state** changes, expressions are re-evaluated and the bound elements'
 
 Only binding to the following components and attributes are allowed. Most bindable attributes correspond to a non-bindable counterpart, e.g. for `<amp-img>`, `[src]` changes the value of `src`.
 
-(*) Denotes bindable attributes that don't have a non-bindable counterpart.
-
 | Component | Attribute(s) | Behavior |
 | --- | --- | --- |
 | `<amp-brightcove>` | `[data-account]`<br>`[data-embed]`<br>`[data-player]`<br>`[data-player-id]`<br>`[data-playlist-id]`<br>`[data-video-id]` | Changes the displayed Brightcove video. |
-| `<amp-carousel type=slides>` | `[slide]`* | Changes the currently displayed slide index. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
+| `<amp-carousel type=slides>` | `[slide]`<sup>1</sup> | Changes the currently displayed slide index. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
 | `<amp-iframe>` | `[src]` | Changes the iframe's source URL. |
 | `<amp-img>` | `[alt]`<br>`[attribution]`<br>`[src]`<br>`[srcset]` | See corresponding [amp-img attributes](https://www.ampproject.org/docs/reference/components/media/amp-img#attributes). |
-| `<amp-selector>` | `[selected]`* | Changes the currently selected children element(s)<br>identified by their `option` attribute values. Supports a comma-separated list of values for multiple selection. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
+| `<amp-selector>` | `[selected]`<sup>1</sup> | Changes the currently selected children element(s)<br>identified by their `option` attribute values. Supports a comma-separated list of values for multiple selection. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
 | `<amp-video>` | `[alt]`<br>`[attribution]`<br>`[controls]`<br>`[loop]`<br>`[poster]`<br>`[preload]`<br>`[src]` | See corresponding [amp-video attributes](https://www.ampproject.org/docs/reference/components/media/amp-video#attributes). |
 | `<amp-youtube>` | `[data-videoid]` | Changes the displayed YouTube video. |
 | `<a>` | `[href]` | Changes the link. |
@@ -189,6 +187,8 @@ Only binding to the following components and attributes are allowed. Most bindab
 | `<source>` | `[src]`<br>`[type]` | See corresponding [source attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#Attributes). |
 | `<track>` | `[label]`<br>`[src]`<br>`[srclang]` | See corresponding [track attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track#Attributes). |
 | `<textarea>` | `[autocomplete]`<br>`[autofocus]`<br>`[cols]`<br>`[disabled]`<br>`[maxlength]`<br>`[minlength]`<br>`[placeholder]`<br>`[readonly]`<br>`[required]`<br>`[rows]`<br>`[selectiondirection]`<br>`[selectionend]`<br>`[selectionstart]`<br>`[spellcheck]`<br>`[wrap]` | See corresponding [textarea attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#Attributes). |
+
+<sup>1</sup>Denotes bindable attributes that don't have a non-bindable counterpart.
 
 ### Expressions
 
@@ -203,14 +203,17 @@ Only binding to the following components and attributes are allowed. Most bindab
 - Undefined variables and array-index-out-of-bounds return `null` instead of `undefined` or throwing errors.
 - A single expression is currently capped at 50 operands for performance reasons. Please [contact us](https://github.com/ampproject/amphtml/issues/new) if this is insufficient for your use case.
 
+The full expression grammar and implementation can be found in [bind-expr-impl.jison](./0.1/bind-expr-impl.jison) and [bind-expression.js](./0.1/bind-expression.js).
+
 #### Whitelisted functions
 
 | Object type | Function(s) | Example |
 | --- | --- | --- |
 | [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods) | `concat`<br>`includes`<br>`indexOf`<br>`join`<br>`lastIndexOf`<br>`slice` | `// Returns true.`<br>`[1, 2, 3].includes(1)` |
 | [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Methods) | `charAt`<br>`charCodeAt`<br>`concat`<br>`indexOf`<br>`lastIndexOf`<br>`slice`<br>`split`<br>`substr`<br>`substring`<br>`toLowerCase`<br>`toUpperCase` | `// Returns 'abcdef'.`<br>`'abc'.concat('def')` |
+| [`Math`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math)<sup>2</sup> | `abs`<br>`ceil`<br>`floor`<br>`max`<br>`min`<br>`random`<br>`round`<br>`sign` | `// Returns 1.`<br>`abs(-1)` |
 
-The full expression grammar and implementation can be found in [bind-expr-impl.jison](./0.1/bind-expr-impl.jison) and [bind-expression.js](./0.1/bind-expression.js).
+<sup>2</sup>`Math` functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.
 
 #### BNF-like grammar
 

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -37,23 +37,86 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-bind/">Annotated code example for amp-bind</a></td>
+    <td>
+      <ul>
+        <li><a href="https://ampbyexample.com/components/amp-bind/">Introductory code example with annotations</a></li>
+        <li><a href="https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind">Linked image carousels example with annotations</a></li>
+        <li><a href="https://ampbyexample.com/samples_templates/product/">E-commerce product page example with annotations</a></li>
+      </ul>
+    </td>
   </tr>
 </table>
 
-## Overview
+## A simple example
 
 `amp-bind` allows you to add custom stateful interactivity to your AMP pages via data binding and JS-like expressions.
 
-A simple example:
+Let's start with a simple example:
 
 ```html
-<p [text]="message">Hello amp-bind</p>
+<p [text]="'Hello ' + foo">Hello World</p>
 
-<button on="tap:AMP.setState({message: 'Hello World'})">
+<button on="tap:AMP.setState({foo: 'amp-bind'})">
 ```
 
-Tapping the button causes the `<p>` element's text to change to "Hello World".
+Tapping the button causes the `<p>` element's text to change from "Hello World" to "Hello amp-bind".
+
+## How does it work?
+
+`amp-bind` has three main components:
+
+1. [State](#state)
+  - In the example above, the state is empty before tapping the button and `{foo: 'amp-bind'}` after tapping the button.
+2. [Expressions](#expressions)
+  - The example above has a single expression, `'Hello' + foo`, which concatenates the string literal `'Hello'` and the variable state `foo`.
+3. [Bindings](#bindings)
+  - The example above has a single binding, `[text]`, which causes the `<p>` element to update its text every time the bound expression's value changes.
+
+Note that `amp-bind` does no evaluate expressions on page load, so there's no risk of unexpected content jumping. `amp-bind` also takes special care to ensure speed, security and performance on AMP pages.
+
+Check out the AMP Conf 2017 talk "[Turing complete...AMP Pages?!](https://www.youtube.com/watch?v=xzCFU8b5fCU)" for a video introduction to the feature.
+
+## A slightly more complex example
+
+```html
+<!-- Store complex nested JSON data in <amp-state> elements. -->
+<amp-state id="myAnimals">
+  <script type="application/json">
+    {
+      "dog": {
+        "imageUrl": "/img/dog.jpg",
+        "style": "greenBackground"
+      },
+      "cat": {
+        "imageUrl": "/img/cat.jpg",
+        "style": "redBackground"
+      }
+    }
+  </script>
+</amp-state>
+
+<p [text]="'This is a ' + currentAnimal + '.'">This is a dog.</p>
+
+<!-- CSS classes can also be added or removed with [class]. -->
+<p class="greenBackground" [class]="myAnimals[currentAnimal].style">
+  Each animal has a different background color.
+</p>
+
+<!-- Or change an image's src with the [src] binding. -->
+<amp-img width="300" height="200" src="/img/dog.jpg"
+    [src]="myAnimals[currentAnimal].imageUrl">
+</amp-img>
+
+<button on="tap:AMP.setState({currentAnimal: 'cat'})">Set to Cat</button>
+```
+
+In this example, tapping the button will change the following:
+
+1. The first `<p>` element's text will read "This is a cat".
+2. The second `<p>` element's `class` attribute will be "redBackground".
+3. The `amp-img` element will show the image of a cat.
+
+[Try out the **live demo**](https://ampbyexample.com/components/amp-bind/) for this example with code annotations!
 
 ## Details
 
@@ -61,12 +124,14 @@ Tapping the button causes the `<p>` element's text to change to "Hello World".
 
 Each AMP document that uses `amp-bind` has document-scope mutable JSON data, or **state**.
 
-The state can be initialized with the `amp-state` component:
+This state can be initialized with the `amp-state` component:
 
 ```html
 <amp-state id="myState">
   <script type="application/json">
-    {"foo": "bar"}
+    {
+      "foo": "bar"
+    }
   </script>
 </amp-state>
 ```
@@ -76,48 +141,76 @@ The state can be initialized with the `amp-state` component:
 
 ##### AMP.setState()
 
-State can be mutated by the new `AMP.setState()` [action](../../spec/amp-actions-and-events.md).
+State can be mutated by the [`AMP.setState()` action](../../spec/amp-actions-and-events.md).
 
 - `AMP.setState()` performs a [shallow merge](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) of its arguments with the document state.
 - `AMP.setState()` can override data initialized by `amp-state`.
 
-### Binding
+### Bindings
 
-A binding is a special attribute of the form `[property]` that links an element's property to an [expression](#expressions).
+A **binding** is a special attribute of the form `[property]` that links an element's property to an [expression](#expressions).
 
 When the **state** changes, expressions are re-evaluated and the bound elements' properties are updated with the new expression results.
 
 `amp-bind` supports data bindings on three types of element state:
 
-| Type | Syntax | Details |
+| Type | Attribute | Details |
 | --- | --- | --- |
 | [Node.textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) | `[text]` | Supported on most text elements.
-| [CSS Classes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class) | `[class]` | Expression result must be a space-delimited string.
-| Element-specific attribute | `[<attr>]` | Only whitelisted attributes are supported.<br>Boolean expression results toggle boolean attributes.
+| [CSS classes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class) | `[class]` | Expression result must be a space-delimited string.
+| Size of [AMP elements](https://www.ampproject.org/docs/reference/components) | `[width]`<br>`[height]` | Changes the width and/or height of the AMP element. |
+| Element-specific attribute | [Various](#element-specific-attributes). | Boolean expression results toggle boolean attributes.
 
-- For security reasons, binding to `innerHTML` is disallowed
-- All attribute bindings are sanitized for unsafe URL protocols (e.g. `javascript:`)
+- For security reasons, binding to `innerHTML` is disallowed.
+- All attribute bindings are sanitized for unsafe values, e.g. URL protocols (e.g. `javascript:`).
 
 #### Element-specific attributes
 
-Most attributes accepted by the [AMP Validator](https://validator.ampproject.org/) for AMP and non-AMP elements, are bindable.
+Only binding to the following components and attributes are allowed. Most bindable attributes correspond to a non-bindable counterpart, e.g. for `<amp-img>`, `[src]` changes the value of `src`.
 
-There are also special bindable attributes without non-bindable counterparts:
+(*) Denotes bindable attributes that don't have a non-bindable counterpart.
 
-| Component | Attribute | Details | Example |
-| --- | --- | --- | --- |
-| amp-carousel[type=slides] | `[slide]` | The currently displayed slide index. | [Linked carousels](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind)
-| amp-selector | `[selected]` | The `option` attribute values of the currently selected children elements. | [Linked carousels](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind)
+| Component | Attribute(s) | Behavior |
+| --- | --- | --- |
+| `<amp-brightcove>` | `[data-account]`<br>`[data-embed]`<br>`[data-player]`<br>`[data-player-id]`<br>`[data-playlist-id]`<br>`[data-video-id]` | Changes the displayed Brightcove video. |
+| `<amp-carousel type=slides>` | `[slide]`* | Changes the currently displayed slide index. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
+| `<amp-iframe>` | `[src]` | Changes the iframe's source URL. |
+| `<amp-img>` | `[alt]`<br>`[attribution]`<br>`[src]`<br>`[srcset]` | Various. See [amp-img attributes](https://www.ampproject.org/docs/reference/components/media/amp-img#attributes). |
+| `<amp-selector>` | `[selected]`* | Changes the currently selected children element(s)<br>identified by their `option` attribute values. Supports a comma-separated list of values for multiple selection. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
+| `<amp-video>` | `[alt]`<br>`[attribution]`<br>`[controls]`<br>`[loop]`<br>`[poster]`<br>`[preload]`<br>`[src]` | Various. See [amp-video attributes](https://www.ampproject.org/docs/reference/components/media/amp-video#attributes). |
+| `<amp-youtube>` | `[data-videoid]` | Changes the displayed YouTube video. |
+| `<a>` | `[href]` | Changes the link. |
+| `<button>` | `[disabled]`<br>`[type]`<br>`[value]` | Various. See [button attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes). |
+| `<fieldset>` | `[disabled]` | Enables or disables the fieldset. |
+| `<input>` | `[accept]`<br>`[accessKey]`<br>`[autocomplete]`<br>`[checked]`<br>`[disabled]`<br>`[height]`<br>`[inputmode]`<br>`[max]`<br>`[maxlength]`<br>`[min]`<br>`[minlength]`<br>`[multiple]`<br>`[pattern]`<br>`[placeholder]`<br>`[readonly]`<br>`[required]`<br>`[selectiondirection]`<br>`[size]`<br>`[spellcheck]`<br>`[step]`<br>`[type]`<br>`[value]`<br>`[width]` | Various. See [input attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes). |
+| `<option>` | `[disabled]`<br>`[label]`<br>`[selected]`<br>`[value]` | Various. See [option attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#Attributes). |
+| `<optgroup>` | `[disabled]`<br>`[label]` | Various. See [optgroup attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup#Attributes). |
+| `<select>` | `[autofocus]`<br>`[disabled]`<br>`[multiple]`<br>`[required]`<br>`[size]` | Various. See [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#Attributes). |
+| `<source>` | `[src]`<br>`[type]` | Various. See [source attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#Attributes). |
+| `<track>` | `[label]`<br>`[src]`<br>`[srclang]` | Various. See [track attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track#Attributes). |
+| `<textarea>` | `[autocomplete]`<br>`[autofocus]`<br>`[cols]`<br>`[disabled]`<br>`[maxlength]`<br>`[minlength]`<br>`[placeholder]`<br>`[readonly]`<br>`[required]`<br>`[rows]`<br>`[selectiondirection]`<br>`[selectionend]`<br>`[selectionstart]`<br>`[spellcheck]`<br>`[wrap]` | Various. See [textarea attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#Attributes). |
 
 ### Expressions
 
-`amp-bind` expressions are JS-like with some important differences:
+`amp-bind` expressions are similar to JavaScript with some important differences.
 
-- Expressions may only access the document [state](#state)
-- Expressions do **not** have access to globals like `window` or `document`
-- Only whitelisted functions are allowed
-- Custom functions, classes and control flow statements (e.g. `for`) are disallowed
-- Undefined variables and array-index-out-of-bounds return `null` instead of throwing errors
+#### Differences from JavaScript
+
+- Expressions may only access the containing document's [state](#state).
+- Expressions **do not** have access to globals like `window` or `document`.
+- Only [whitelisted functions](#whitelisted-functions) are allowed.
+- Custom functions, classes and some control flow statements (e.g. `for`) are disallowed.
+- Undefined variables and array-index-out-of-bounds return `null` instead of `undefined` or throwing errors.
+- A single expression is currently capped at 50 operands for performance reasons. Please [contact us](https://github.com/ampproject/amphtml/issues/new) if this is insufficient for your use case.
+
+#### Whitelisted functions
+
+| Object type | Function(s) | Example |
+| --- | --- | --- |
+| [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods) | `concat`<br>`includes`<br>`indexOf`<br>`join`<br>`lastIndexOf`<br>`slice` | `// Returns true.`<br>`[1, 2, 3].includes(1)` |
+| [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Methods) | `charAt`<br>`charCodeAt`<br>`concat`<br>`indexOf`<br>`lastIndexOf`<br>`slice`<br>`split`<br>`substr`<br>`substring`<br>`toLowerCase`<br>`toUpperCase` | `// Returns 'abcdef'.`<br>`'abc'.concat('def')` |
+
+The full expression grammar and implementation can be found in [bind-expr-impl.jison](./0.1/bind-expr-impl.jison) and [bind-expression.js](./0.1/bind-expression.js).
 
 #### BNF-like grammar
 
@@ -197,27 +290,3 @@ object:
 key_value:
   expr ':' expr
 ```
-
-#### Whitelisted functions
-
-```text
-Array.concat()
-Array.includes()
-Array.indexOf()
-Array.join()
-Array.lastIndexOf()
-Array.slice()
-String.charAt()
-String.charCodeAt()
-String.concat()
-String.indexOf()
-String.lastIndexOf()
-String.slice()
-String.split()
-String.substr()
-String.substring()
-String.toLowerCase()
-String.toUpperCase()
-```
-
-The full expression grammar and implementation can be found in [bind-expr-impl.jison](./0.1/bind-expr-impl.jison) and [bind-expression.js](./0.1/bind-expression.js).

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -68,11 +68,11 @@ Tapping the button causes the `<p>` element's text to change from "Hello World" 
 1. [State](#state)
   - In the example above, the state is empty before tapping the button and `{foo: 'amp-bind'}` after tapping the button.
 2. [Expressions](#expressions)
-  - The example above has a single expression, `'Hello' + foo`, which concatenates the string literal `'Hello'` and the variable state `foo`.
+  - The example above has a single expression, `'Hello' + foo`, which concatenates the string literal `'Hello '` and the variable state `foo`.
 3. [Bindings](#bindings)
-  - The example above has a single binding, `[text]`, which causes the `<p>` element to update its text every time the bound expression's value changes.
+  - The example above has a single binding, `[text]`, which causes the `<p>` element to update its text every time the expression's value changes.
 
-Note that `amp-bind` does no evaluate expressions on page load, so there's no risk of unexpected content jumping. `amp-bind` also takes special care to ensure speed, security and performance on AMP pages.
+Note that `amp-bind` does not evaluate expressions on page load, so there's no risk of content jumping unexpectedly. `amp-bind` also takes special care to ensure speed, security and performance on AMP pages.
 
 Check out the AMP Conf 2017 talk "[Turing complete...AMP Pages?!](https://www.youtube.com/watch?v=xzCFU8b5fCU)" for a video introduction to the feature.
 
@@ -175,20 +175,20 @@ Only binding to the following components and attributes are allowed. Most bindab
 | `<amp-brightcove>` | `[data-account]`<br>`[data-embed]`<br>`[data-player]`<br>`[data-player-id]`<br>`[data-playlist-id]`<br>`[data-video-id]` | Changes the displayed Brightcove video. |
 | `<amp-carousel type=slides>` | `[slide]`* | Changes the currently displayed slide index. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
 | `<amp-iframe>` | `[src]` | Changes the iframe's source URL. |
-| `<amp-img>` | `[alt]`<br>`[attribution]`<br>`[src]`<br>`[srcset]` | Various. See [amp-img attributes](https://www.ampproject.org/docs/reference/components/media/amp-img#attributes). |
+| `<amp-img>` | `[alt]`<br>`[attribution]`<br>`[src]`<br>`[srcset]` | See corresponding [amp-img attributes](https://www.ampproject.org/docs/reference/components/media/amp-img#attributes). |
 | `<amp-selector>` | `[selected]`* | Changes the currently selected children element(s)<br>identified by their `option` attribute values. Supports a comma-separated list of values for multiple selection. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
-| `<amp-video>` | `[alt]`<br>`[attribution]`<br>`[controls]`<br>`[loop]`<br>`[poster]`<br>`[preload]`<br>`[src]` | Various. See [amp-video attributes](https://www.ampproject.org/docs/reference/components/media/amp-video#attributes). |
+| `<amp-video>` | `[alt]`<br>`[attribution]`<br>`[controls]`<br>`[loop]`<br>`[poster]`<br>`[preload]`<br>`[src]` | See corresponding [amp-video attributes](https://www.ampproject.org/docs/reference/components/media/amp-video#attributes). |
 | `<amp-youtube>` | `[data-videoid]` | Changes the displayed YouTube video. |
 | `<a>` | `[href]` | Changes the link. |
-| `<button>` | `[disabled]`<br>`[type]`<br>`[value]` | Various. See [button attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes). |
+| `<button>` | `[disabled]`<br>`[type]`<br>`[value]` | See corresponding [button attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes). |
 | `<fieldset>` | `[disabled]` | Enables or disables the fieldset. |
-| `<input>` | `[accept]`<br>`[accessKey]`<br>`[autocomplete]`<br>`[checked]`<br>`[disabled]`<br>`[height]`<br>`[inputmode]`<br>`[max]`<br>`[maxlength]`<br>`[min]`<br>`[minlength]`<br>`[multiple]`<br>`[pattern]`<br>`[placeholder]`<br>`[readonly]`<br>`[required]`<br>`[selectiondirection]`<br>`[size]`<br>`[spellcheck]`<br>`[step]`<br>`[type]`<br>`[value]`<br>`[width]` | Various. See [input attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes). |
-| `<option>` | `[disabled]`<br>`[label]`<br>`[selected]`<br>`[value]` | Various. See [option attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#Attributes). |
-| `<optgroup>` | `[disabled]`<br>`[label]` | Various. See [optgroup attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup#Attributes). |
-| `<select>` | `[autofocus]`<br>`[disabled]`<br>`[multiple]`<br>`[required]`<br>`[size]` | Various. See [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#Attributes). |
-| `<source>` | `[src]`<br>`[type]` | Various. See [source attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#Attributes). |
-| `<track>` | `[label]`<br>`[src]`<br>`[srclang]` | Various. See [track attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track#Attributes). |
-| `<textarea>` | `[autocomplete]`<br>`[autofocus]`<br>`[cols]`<br>`[disabled]`<br>`[maxlength]`<br>`[minlength]`<br>`[placeholder]`<br>`[readonly]`<br>`[required]`<br>`[rows]`<br>`[selectiondirection]`<br>`[selectionend]`<br>`[selectionstart]`<br>`[spellcheck]`<br>`[wrap]` | Various. See [textarea attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#Attributes). |
+| `<input>` | `[accept]`<br>`[accessKey]`<br>`[autocomplete]`<br>`[checked]`<br>`[disabled]`<br>`[height]`<br>`[inputmode]`<br>`[max]`<br>`[maxlength]`<br>`[min]`<br>`[minlength]`<br>`[multiple]`<br>`[pattern]`<br>`[placeholder]`<br>`[readonly]`<br>`[required]`<br>`[selectiondirection]`<br>`[size]`<br>`[spellcheck]`<br>`[step]`<br>`[type]`<br>`[value]`<br>`[width]` | See corresponding [input attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes). |
+| `<option>` | `[disabled]`<br>`[label]`<br>`[selected]`<br>`[value]` | See corresponding [option attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#Attributes). |
+| `<optgroup>` | `[disabled]`<br>`[label]` | See corresponding [optgroup attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup#Attributes). |
+| `<select>` | `[autofocus]`<br>`[disabled]`<br>`[multiple]`<br>`[required]`<br>`[size]` | See corresponding [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#Attributes). |
+| `<source>` | `[src]`<br>`[type]` | See corresponding [source attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#Attributes). |
+| `<track>` | `[label]`<br>`[src]`<br>`[srclang]` | See corresponding [track attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track#Attributes). |
+| `<textarea>` | `[autocomplete]`<br>`[autofocus]`<br>`[cols]`<br>`[disabled]`<br>`[maxlength]`<br>`[minlength]`<br>`[placeholder]`<br>`[readonly]`<br>`[required]`<br>`[rows]`<br>`[selectiondirection]`<br>`[selectionend]`<br>`[selectionstart]`<br>`[spellcheck]`<br>`[wrap]` | See corresponding [textarea attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#Attributes). |
 
 ### Expressions
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -96,12 +96,9 @@ export class StandardActions {
             }
             bind.setStateWithExpression(objectString, scope);
           } else {
-            user().warn('AMP-BIND', `Key-value syntax for AMP.setState() will `
-                + `be removed soon. Please use the object-literal syntax `
-                + `instead, e.g. "AMP.setState({foo: 'bar'})" instead of `
+            user().error('AMP-BIND', `Please use the object-literal syntax, `
+                + `e.g. "AMP.setState({foo: 'bar'})" instead of `
                 + `"AMP.setState(foo='bar')".`);
-            // Key-value args.
-            bind.setState(args);
           }
         });
         return;

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -96,9 +96,12 @@ export class StandardActions {
             }
             bind.setStateWithExpression(objectString, scope);
           } else {
-            user().error('AMP-BIND', `Please use the object-literal syntax, `
-                + `e.g. "AMP.setState({foo: 'bar'})" instead of `
+            user().warn('AMP-BIND', `Key-value syntax for AMP.setState() will `
+                + `be removed soon. Please use the object-literal syntax `
+                + `instead, e.g. "AMP.setState({foo: 'bar'})" instead of `
                 + `"AMP.setState(foo='bar')".`);
+            // Key-value args.
+            bind.setState(args);
           }
         });
         return;


### PR DESCRIPTION
Fixes #8392.

- Rework the "Overview" section.
- Update the list of whitelisted functions and add the new perf constraints.
- Add a more complex example based off of the ABE sample.