### PR TITLE
AmpContext should initialize properly for 3p frames

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -137,7 +137,7 @@ export class AmpContext {
     if (!dataObject) {
       throw new Error('Could not setup metadata.');
     }
-    const context = dataObject._context;
+    const context = dataObject._context || dataObject.attributes._context;
     this.location = context.location;
     this.canonicalUrl = context.canonicalUrl;
     this.pageViewId = context.pageViewId;


### PR DESCRIPTION
This is a quick-fix for a bug identified by @alanorozco in reviewing https://github.com/ampproject/amphtml/pull/8502#pullrequestreview-30576387 

One of the ways that AmpContext can initialize is off of a data blob on the name of the iframe it lives inside. AmpContext expect the data on the name to be of the format (when deserialized): 

`{"_context" : {"location": "foo.com" ... } }`

For the A4A flow, this is in fact what it can expect when it initializes off just the name. However, for the 3P rendering flow, the name actually looks like: 

`{"attributes": {"_context" : {"location": "foo.com" ...} } } `

I.e. the _context blob is nested one layer deeper. This fix accounts for the _context blob being at either level. 

This is a straightforward fix, but it might be better to ultimately bring 3P and A4A up to parity in terms of what they write to the name. However, doing so might be ugly for A4A as it would be nesting the _context blob an extra level deep for no reason. 