### PR TITLE
amp-bind: Support range, checkbox, and radio inputs 

### DIFF
--- a/examples/bind/forms.amp.html
+++ b/examples/bind/forms.amp.html
@@ -35,7 +35,7 @@
             <input type="email" name="email" id="email1" required>
           </label>
           <label>
-            <span>Your Orffer</span>
+            <span>Your Offer</span>
             $100
             <input type="range" min="100" max="200" step="10" on="change:AMP.setState({selectedRange: event.value})"/>
             $200

--- a/examples/bind/forms.amp.html
+++ b/examples/bind/forms.amp.html
@@ -19,18 +19,26 @@
   <button on="tap:AMP.setState({selected: 3})">3</button>
   <button on="tap:AMP.setState({selected: 4})">4</button>
 
+  <p [text]="'$' + selectedRange">$0</p>
+
   <h4>Enter your name and email.</h4>
   <form method="post"
         action-xhr="/form/echo-json/post"
         target="_blank">
       <fieldset>
           <label>
-              <span>Your name</span>
-              <input type="text" name="name" id="name1" required>
+            <span>Your name</span>
+            <input type="text" name="name" id="name1" required>
           </label>
           <label>
-              <span>Your email</span>
-              <input type="email" name="email" id="email1" required>
+            <span>Your email</span>
+            <input type="email" name="email" id="email1" required>
+          </label>
+          <label>
+            <span>Your Orffer</span>
+            $100
+            <input type="range" min="100" max="200" step="10" on="change:AMP.setState({selectedRange: event.value})"/>
+            $200
           </label>
           <input type="submit" value="Subscribe">
       </fieldset>

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -125,6 +125,41 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
+  describe('input integration', () => {
+    it('should update dependent bindings on range input changes', () => {
+      const rangeText = fixture.doc.getElementById('rangeText');
+      const range = fixture.doc.getElementById('range');
+      expect(rangeText.textContent).to.equal('Unbound');
+      // Calling #click() the range will not generate a change event
+      // so it must be generated manually.
+      range.value = 47;
+      range.dispatchEvent(new Event('change', {bubbles: true}));
+      return waitForBindApplication().then(() => {
+        expect(rangeText.textContent).to.equal('0 <= 47 <= 100');
+      });
+    });
+
+    it('should update dependent bindings on checkbox input changes', () => {
+      const checkboxText = fixture.doc.getElementById('checkboxText');
+      const checkbox = fixture.doc.getElementById('checkbox');
+      expect(checkboxText.textContent).to.equal('Unbound');
+      checkbox.click();
+      return waitForBindApplication().then(() => {
+        expect(checkboxText.textContent).to.equal('Checked: true');
+      });
+    });
+
+    it('should update dependent bindings on radio input changes', () => {
+      const radioText = fixture.doc.getElementById('radioText');
+      const radio = fixture.doc.getElementById('radio');
+      expect(radioText.textContent).to.equal('Unbound');
+      radio.click();
+      return waitForBindApplication().then(() => {
+        expect(radioText.textContent).to.equal('Checked: true');
+      });
+    });
+  });
+
   describe('amp-carousel integration', () => {
     it('should update dependent bindings on carousel slide changes', () => {
       const slideNum = fixture.doc.getElementById('slideNum');

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -49,18 +49,24 @@ const ELEMENTS_ACTIONS_MAP_ = {
   'AMP': ['setState'],
 };
 
+/** @enum {string} */
+const TYPE = {
+  NUMBER: 'number',
+  BOOLEAN: 'boolean',
+};
+
 /** @const {!Object<string, !Object<string, string>>} */
 const WHITELISTED_INPUT_DATA_ = {
-  range: {
-    min: 'number',
-    max: 'number',
-    value: 'number',
+  'range': {
+    'min': TYPE.NUMBER,
+    'max': TYPE.NUMBER,
+    'value': TYPE.NUMBER,
   },
-  radio: {
-    checked: 'boolean',
+  'radio': {
+    'checked': TYPE.BOOLEAN,
   },
-  checkbox: {
-    checked: 'boolean',
+  'checkbox': {
+    'checked': TYPE.BOOLEAN,
   },
 };
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {createCustomEvent} from '../event-helper'
+import {createCustomEvent} from '../event-helper';
 import {dev, user} from '../log';
 import {
   registerServiceBuilderForDoc,
@@ -50,9 +50,10 @@ const ELEMENTS_ACTIONS_MAP_ = {
   'AMP': ['setState'],
 };
 
+/** @const {!Object<string, !Array<string>>} */
 const WHITELISTED_INPUT_DATA_ = {
   'range': ['min', 'max', 'value'],
-}
+};
 
 /**
  * A map of method argument keys to functions that generate the argument values

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -189,7 +189,7 @@ export class ActionService {
         fieldsToInclude.forEach(field => {
           const value = target[field];
           const valueAsNumber = parseFloat(value);
-          detail[field] = valueAsNumber || value;
+          detail[field] = isNaN(valueAsNumber) ? value : valueAsNumber;
         });
         event.detail = detail;
       }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -49,11 +49,19 @@ const ELEMENTS_ACTIONS_MAP_ = {
   'AMP': ['setState'],
 };
 
-/** @const {!Object<string, !Array<string>>} */
+/** @const {!Object<string, !Object<string, string>>} */
 const WHITELISTED_INPUT_DATA_ = {
-  'range': ['min', 'max', 'value'],
-  'radio': ['checked'],
-  'checkbox': ['checked'],
+  range: {
+    min: 'number',
+    max: 'number',
+    value: 'number',
+  },
+  radio: {
+    checked: 'boolean',
+  },
+  checkbox: {
+    checked: 'boolean',
+  },
 };
 
 /**
@@ -186,10 +194,16 @@ export class ActionService {
       const inputType = target.getAttribute('type');
       const fieldsToInclude = WHITELISTED_INPUT_DATA_[inputType];
       if (fieldsToInclude) {
-        fieldsToInclude.forEach(field => {
+        Object.keys(fieldsToInclude).forEach(field => {
+          const expectedType = fieldsToInclude[field];
           const value = target[field];
-          const valueAsNumber = parseFloat(value);
-          detail[field] = isNaN(valueAsNumber) ? value : valueAsNumber;
+          if (expectedType === 'number') {
+            detail[field] = Number(value);
+          } else if (expectedType === 'boolean') {
+            detail[field] = !!value;
+          } else {
+            detail[field] = value;
+          }
         });
         event.detail = detail;
       }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -186,7 +186,6 @@ export class ActionService {
     if (event.target.tagName.toLowerCase() === 'input') {
       const inputType = target.getAttribute('type');
       const fieldsToInclude = WHITELISTED_INPUT_DATA_[inputType];
-      // TODO(kmh287): Cast numeric values to numbers?
       if (fieldsToInclude) {
         fieldsToInclude.forEach(field => {
           const value = target[field];

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -187,10 +187,7 @@ export class ActionService {
         });
       }
     }
-    const changeEvent = createCustomEvent(this.ampdoc.win, 'change', details);
-    changeEvent.path = event.path;
-    changeEvent.target = event.target;
-    return changeEvent;
+    return createCustomEvent(this.ampdoc.win, 'change', details);
   }
 
   /**

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -174,6 +174,12 @@ export class ActionService {
     }
   }
 
+  /**
+   * Generate custom event from browser `change` event.
+   * @param {!Event} event A `change` event.
+   * @return {!Event} A custom event with a details property containing the
+   *    relevant information for the change that generated the initial event.
+   */
   getChangeDetails_(event) {
     const details = {};
     const target = event.target;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -166,8 +166,9 @@ export class ActionService {
       });
     } else if (name == 'change') {
       this.root_.addEventListener(name, event => {
+        const target = event.target;
         const changeEvent = this.getChangeDetails_(event);
-        this.trigger(dev().assertElement(event.target), name, changeEvent);
+        this.trigger(dev().assertElement(target), name, changeEvent);
       });
     }
   }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -202,7 +202,7 @@ export class ActionService {
           } else if (expectedType === 'boolean') {
             detail[field] = !!value;
           } else {
-            detail[field] = value;
+            detail[field] = String(value);
           }
         });
         event.detail = detail;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -189,7 +189,9 @@ export class ActionService {
       // TODO(kmh287): Cast numeric values to numbers?
       if (fieldsToInclude) {
         fieldsToInclude.forEach(field => {
-          details[field] = target[field];
+          const value = target[field];
+          const valueAsNumber = parseFloat(value);
+          details[field] = valueAsNumber || value;
         });
       }
     }

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -38,10 +38,18 @@
     <button update></button>
   </amp-live-list>
 
-  <p>P TAG</p>
+  <p>TEXT TAGS</p>
   <button on="tap:AMP.setState({boundText: 'hello world'})" id="changeTextButton"></button>
   <button on="tap:AMP.setState({boundClass: 'new'})" id="changeTextClassButton"></button>
   <p id="textElement" class="original" [class]="boundClass" [text]="boundText">unbound</p>
+
+  <p>INPUT</p>
+  <input type="range" min="0" max="100" value="0" on="change:AMP.setState({rangeChange: event})" id="range">
+  <p id="rangeText" [text]="rangeChange.min + ' <= ' + rangeChange.value + ' <= ' + rangeChange.max">Unbound</p>
+  <input type="checkbox" on="change:AMP.setState({checkboxChange: event})" id="checkbox">
+  <p id="checkboxText" [text]="'Checked: ' + checkboxChange.checked" id="checkboxText">Unbound</p>
+  <input type="radio" on="change:AMP.setState({radioChange: event})" id="radio">
+  <p id="radioText" [text]="'Checked: ' + radioChange.checked" id="radioText">Unbound</p>
 
   <p>CAROUSEL</p>
   <button on="tap:AMP.setState({selectedSlide: 1})" id="goToSlide1Button">slide 1!</button>
@@ -120,5 +128,6 @@
   <amp-iframe width=100 height=100 id="ampIframe" sandbox="allow-scripts allow-same-origin allow-popups"
       src="https://player.vimeo.com/video/140261016" [src]="iframe">
   </amp-iframe>
+
 </body>
 </html>

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -982,15 +982,12 @@ describe('Core events', () => {
     const event = {target: element};
     handler(event);
     expect(action.trigger).to.have.been.calledWith(
-      element,
-      'change',
-      sinon.match.any);
-    // Doesn't play well with sinon matchers
-    const customEvent = action.trigger.getCalls()[0].args[2];
-    expect(customEvent.detail).to.deep.equal({
-      min: '0',
-      max: '10',
-      value: '5',
-    });
+        element,
+        'change',
+        // Event doesn't seem to play well with sinon matchers
+        sinon.match(object => {
+          const detail = object.detail;
+          return detail.min == 0 && detail.max == 10 && detail.value == 5;
+        }));
   });
 });

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -931,7 +931,6 @@ describe('Core events', () => {
       services: {
         vsync: {obj: {}},
       },
-      CustomEvent: window.CustomEvent,
     };
     action = new ActionService(new AmpDocSingle(win), document);
     sandbox.stub(action, 'trigger');

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -966,10 +966,7 @@ describe('Core events', () => {
     const element = {tagName: 'target2', nodeType: 1};
     const event = {target: element};
     handler(event);
-    expect(action.trigger).to.have.been.calledWith(
-        element,
-        'change',
-        sinon.match.any);
+    expect(action.trigger).to.have.been.calledWith(element, 'change', event);
   });
 
   it('should trigger change event with details for whitelisted inputs', () => {

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -987,7 +987,6 @@ describe('Core events', () => {
     element.setAttribute('max', '10');
     element.setAttribute('value', '5');
     const event = {target: element};
-    debugger;
     handler(event);
     expect(action.trigger).to.have.been.calledWith(
       element,

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -922,15 +922,12 @@ describe('Core events', () => {
   let sandbox;
   let win;
   let action;
-  let target;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(window.document, 'addEventListener');
     win = {
-      document: {
-        body: {},
-      },
+      document: {body: {}},
       services: {
         vsync: {obj: {}},
       },
@@ -938,9 +935,6 @@ describe('Core events', () => {
     };
     action = new ActionService(new AmpDocSingle(win), document);
     sandbox.stub(action, 'trigger');
-    target = document.createElement('target');
-    target.setAttribute('id', 'amp-test-1');
-
     action.vsync_ = {mutate: callback => callback()};
   });
 
@@ -979,7 +973,6 @@ describe('Core events', () => {
   });
 
   it('should trigger change event with details for whitelisted inputs', () => {
-    expect(window.document.addEventListener).to.have.been.calledWith('change');
     const handler = window.document.addEventListener.getCall(2).args[1];
     const element = document.createElement('input');
     element.setAttribute('type', 'range');


### PR DESCRIPTION
This PR adds support for amp-bind (and actions as a whole) to access the details of a value change on a range input, specifically `min`, `max`, and `value`.

In order to pass these values through on 'change' events, I've replaced the browser-generated event passed through to `action#trigger` with the custom event we use elsewhere when generating events. 

@dvoytenko Dima, you're much more familiar with this code than I am. Is there any code that depends on the events passed through for 'change' events to have properties from the browser-generated event?

Fixes #7765 

/to @choumx @dvoytenko 
/cc @ericlindley-g 