### PR TITLE
amp-state: Allow fetch on page load

### DIFF
--- a/examples/bind/xhr.amp.html
+++ b/examples/bind/xhr.amp.html
@@ -22,16 +22,26 @@
   <button onclick="AMP.toggleExperiment('amp-bind');window.location.href=window.location.href;">Toggle &lt;amp-bind&gt; experiment</button>
 
   <h2>XHR</h2>
-  <p [text]="myState.bindXhrResult">This text will be updated with XHR results.</p>
+  <p [text]="formState.bindXhrResult">This text will be updated with the form's XHR results.</p>
+
+  <p [text]="ampState.items[0].title">This text will be updated with amp-state's XHR results.</p>
+
   <form method="GET" action="/bind/form/get" action-xhr="/bind/form/get" target="_blank"
-      on="submit-success:myState">
+      on="submit-success:formState">
     <input type="submit" value="Submit">
   </form>
 
-  <amp-state id="myState">
+  <amp-state id="formState">
     <script type="application/json">
       {
-        bindXhrResult: 'Not fetched yet...'
+        "bindXhrResult": "Not fetched yet..."
+      }
+    </script>
+  </amp-state>
+
+  <amp-state id="ampState" src="/test/manual/amp-list-data.json?RANDOM">
+    <script type="application/json">
+      {
       }
     </script>
   </amp-state>

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -15,6 +15,7 @@
  */
 
 import {bindForDoc} from '../../../src/services';
+import {fetchBatchedJsonFor} from '../../../src/batched-json';
 import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
 import {isJsonScriptTag} from '../../../src/dom';
@@ -55,23 +56,34 @@ export class AmpState extends AMP.BaseElement {
 
     const TAG = this.getName_();
 
-    toggle(this.element, false);
+    toggle(this.element, /* opt_display */ false);
     this.element.setAttribute('aria-hidden', 'true');
 
-    const children = this.element.children;
-    if (children.length == 1) {
-      const child = children[0];
-      if (isJsonScriptTag(child)) {
-        const json = tryParseJson(children[0].textContent, e => {
-          user().error(TAG, 'Failed to parse state. Is it valid JSON?', e);
-        });
+    // Fetch JSON from endpoint at `src` attribute if it exists,
+    // otherwise parse child script tag.
+    if (this.element.hasAttribute('src')) {
+      fetchBatchedJsonFor(this.getAmpDoc(), this.element).then(json => {
         this.updateState_(json, /* opt_isInit */ true);
-      } else {
-        user().error(TAG,
-            'State should be in a <script> tag with type="application/json"');
+      });
+      if (this.element.children.length > 0) {
+        user().error(TAG, 'Should not have children if src attribute exists.');
       }
-    } else if (children.length > 1) {
-      user().error(TAG, 'Should contain only one <script> child.');
+    } else {
+      const children = this.element.children;
+      if (children.length == 1) {
+        const firstChild = children[0];
+        if (isJsonScriptTag(firstChild)) {
+          const json = tryParseJson(firstChild.textContent, e => {
+            user().error(TAG, 'Failed to parse state. Is it valid JSON?', e);
+          });
+          this.updateState_(json, /* opt_isInit */ true);
+        } else {
+          user().error(TAG,
+              'State should be in a <script> tag with type="application/json"');
+        }
+      } else if (children.length > 1) {
+        user().error(TAG, 'Should contain only one <script> child.');
+      }
     }
   }
 

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -47,9 +47,10 @@ tags: {  # <amp-state> (json)
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/amp-bind"
 }
-tags: {  # <amp-state>
+tags: {  # <amp-state> with json child
   html_format: AMP
   tag_name: "AMP-STATE"
+  spec_name: "amp-state"
   satisfies: "amp-state"
   requires: "amp-bind extension .js script"
   requires: "amp-bind extension .json script"
@@ -60,7 +61,33 @@ tags: {  # <amp-state>
   }
   child_tags: {
     mandatory_num_child_tags: 1
-    child_tag_name_oneof: "SCRIPT"
+    first_child_tag_name_oneof: "SCRIPT"
   }
-  spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/amp-bind"
+  spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/:amp-bind"
+}
+tags: {  # <amp-state> with src
+  html_format: AMP
+  tag_name: "AMP-STATE"
+  spec_name: "amp-state[src]"
+  satisfies: "amp-state"
+  requires: "amp-bind extension .js script"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  attrs: {
+    name: "id"
+    mandatory: true
+  }
+  attrs: { name: "credentials" }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  child_tags: {
+    mandatory_num_child_tags: 0
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -165,14 +165,15 @@ This state can be initialized with the `amp-state` component:
 ```
 
 - [Expressions](#expressions) can reference state variables via dot syntax. In this example, `myState.foo` will evaluate to `"bar"`.
-- An `<amp-state>` element's JSON has a maximum size of 100KB.
+- An `<amp-state>` element's child JSON has a maximum size of 100KB.
+- `<amp-state>` can also specify a CORS URL instead of a child JSON script. See the [Appendix]((#amp-state) for details.
 
-##### AMP.setState()
+#### `AMP.setState()`
 
 State can be mutated by the [`AMP.setState()` action](../../spec/amp-actions-and-events.md).
 
 - `AMP.setState()` performs a deep merge of its arguments with the document state up to a depth of 10.
-- `AMP.setState()` can override data initialized by `amp-state`.
+- `AMP.setState()` can override variables initialized by `amp-state`.
 
 ### Bindings
 
@@ -360,3 +361,40 @@ There are several types of runtime errors that may be encountered when working w
 | Syntax error | `<p [text]="(missingClosingParens">` | *Expression compilation error in...* | Double-check the expression for typos. |
 | Non-whitelisted functions | `<p [text]="alert(1)"></p>` | *alert is not a supported function.* | Only use [whitelisted functions](#whitelisted-functions). |
 | Sanitized result | `<a href="javascript:alert(1)"></a>` | *"javascript:alert(1)" is not a valid result for [href].* | Avoid banned URL protocols or expressions that would fail the AMP Validator. |
+
+## Appendix
+
+### `<amp-state>` specification
+
+Used to initialize the document-scope mutable JSON state that may be referenced by expressions in `amp-bind`. State variables initialized by an `amp-state` element are namespaced by its `id` attribute.
+
+An `amp-state` element may contain either a child `<script>` element **OR** a `src` attribute containing a CORS URL to a remote JSON endpoint, but not both.
+
+```html
+<amp-state id="myLocalState">
+  <script type="application/json">
+    {
+      "foo": "bar"
+    }
+  </script>
+</amp-state>
+
+<amp-state id="myRemoteState" src="https://data.com/articles.json">
+</amp-state>
+```
+
+#### Attributes
+
+**src**
+
+The URL of the remote endpoint that will return the JSON that will update this `amp-state`. This must be a CORS HTTP service.
+
+The `src` attribute allows all standard URL variable substitutions. See the [Substitutions Guide](../../spec/amp-var-substitutions.md) for more info.
+
+**credentials** (optional)
+
+Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
+To send credentials, pass the value of "include". If this is set, the response must follow
+the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
+
+The support values are "omit" and "include". Default is "omit".

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import {assertHttpsUrl} from '../../../src/url';
-import {batchedXhrFor} from '../../../src/services';
-import {getValueForExpr} from '../../../src/json';
+import {fetchBatchedJsonFor} from '../../../src/batched-json';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {templatesFor} from '../../../src/services';
-import {urlReplacementsForDoc} from '../../../src/services';
 import {user} from '../../../src/log';
-
 
 /**
  * The implementation of `amp-list` component. See {@link ../amp-list.md} for
@@ -43,9 +39,6 @@ export class AmpList extends AMP.BaseElement {
     if (!this.container_.hasAttribute('role')) {
       this.container_.setAttribute('role', 'list');
     }
-
-    /** @private @const {!UrlReplacements} */
-    this.urlReplacements_ = urlReplacementsForDoc(this.getAmpDoc());
   }
 
   /** @override */
@@ -55,25 +48,16 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    return this.urlReplacements_.expandAsync(assertHttpsUrl(
-        this.element.getAttribute('src'), this.element)).then(src => {
-          const opts = {};
-          if (this.element.hasAttribute('credentials')) {
-            opts.credentials = this.element.getAttribute('credentials');
-          }
-          if (!opts.credentials) {
-            opts.requireAmpResponseSourceOrigin = false;
-          }
-          return batchedXhrFor(this.win).fetchJson(src, opts);
-        }).then(data => {
-          user().assert(data != null, 'Response is undefined %s', this.element);
-          const itemsExpr = this.element.getAttribute('items') || 'items';
-          const items = getValueForExpr(data, itemsExpr);
+    const itemsExpr = this.element.getAttribute('items') || 'items';
+    return fetchBatchedJsonFor(
+        this.getAmpDoc(), this.element, itemsExpr).then(items => {
           user().assert(items && Array.isArray(items),
-              'Response must contain an array at "%s". %s %s',
-              itemsExpr, this.element, data);
+              'Response must contain an array at "%s". %s',
+              itemsExpr, this.element);
           return templatesFor(this.win).findAndRenderTemplateArray(
               this.element, items).then(this.rendered_.bind(this));
+        }, error => {
+          user().assert(false, error.message, this.element);
         });
   }
 

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -36,8 +36,7 @@ export function fetchBatchedJsonFor(ampdoc, element, opt_expr) {
     const opts = {};
     if (element.hasAttribute('credentials')) {
       opts.credentials = element.getAttribute('credentials');
-    }
-    if (!opts.credentials) {
+    } else {
       opts.requireAmpResponseSourceOrigin = false;
     }
     return batchedXhrFor(ampdoc.win).fetchJson(src, opts);
@@ -45,7 +44,6 @@ export function fetchBatchedJsonFor(ampdoc, element, opt_expr) {
     if (data == null) {
       throw new Error('Response is undefined.');
     }
-    const exprData = getValueForExpr(data, opt_expr || '.');
-    return exprData;
+    return getValueForExpr(data, opt_expr || '.');
   });
 }

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assertHttpsUrl} from './url';
+import {batchedXhrFor, urlReplacementsForDoc} from './services';
+import {getValueForExpr} from './json';
+
+/**
+ * Batch fetches the JSON endpoint at the given element's `src` attribute.
+ * Sets the fetch credentials option from the element's `credentials` attribute,
+ * if it exists.
+ *
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Element} element
+ * @param {string=} opt_expr Dot-syntax reference to subdata of JSON result
+ *     to return. If not specified, entire JSON result is returned.
+ * @return {!Promise<JSONType>} Resolved with JSON result or rejected if
+ *     response is invalid.
+ */
+export function fetchBatchedJsonFor(ampdoc, element, opt_expr) {
+  const url = assertHttpsUrl(element.getAttribute('src'), element);
+  return urlReplacementsForDoc(ampdoc).expandAsync(url).then(src => {
+    const opts = {};
+    if (element.hasAttribute('credentials')) {
+      opts.credentials = element.getAttribute('credentials');
+    }
+    if (!opts.credentials) {
+      opts.requireAmpResponseSourceOrigin = false;
+    }
+    return batchedXhrFor(ampdoc.win).fetchJson(src, opts);
+  }).then(data => {
+    if (data == null) {
+      throw new Error('Response is undefined.');
+    }
+    const exprData = getValueForExpr(data, opt_expr || '.');
+    return exprData;
+  });
+}

--- a/src/services.js
+++ b/src/services.js
@@ -77,13 +77,12 @@ export function batchedXhrFor(window) {
       getService(window, 'batched-xhr'));
 }
 
-// TODO(choumx): Investigate why amp-bind.Bind type reference not recognized.
 /**
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
- * @return {!Promise<*>}
+ * @return {!Promise<!../extensions/amp-bind/0.1/bind-impl.Bind>}
  */
 export function bindForDoc(nodeOrDoc) {
-  return /** @type {!Promise<*>} */ (
+  return /** @type {!Promise<!../extensions/amp-bind/0.1/bind-impl.Bind>} */ (
       getElementServiceForDoc(nodeOrDoc, 'bind', 'amp-bind'));
 }
 


### PR DESCRIPTION
Fixes #7907.

- Moves some batch-fetching logic from `amp-list.js` to new shared file `batched-json.js`.
- Add new optional `src` and `credentials` attributes to `<amp-state>`.