### PR TITLE
Allow multiple callbacks for same response type in IframeMessagingClient

### DIFF
--- a/test/functional/3p/test-iframe-messaging-client.js
+++ b/test/functional/3p/test-iframe-messaging-client.js
@@ -66,6 +66,35 @@ describes.realWin('iframe-messaging-client', {}, env => {
       });
     });
 
+    it('should invoke multiple callbacks on receiving a message of' +
+        ' expected response type', () => {
+      const callbackSpy1 = sandbox.spy();
+      const callbackSpy2 = sandbox.spy();
+      const irrelevantCallbackSpy = sandbox.spy();
+
+      const expectedResponseObject = {
+        type: 'response-type',
+        sentinel: 'sentinel-123',
+        x: 1,
+        y: 'abc',
+      };
+
+      client.registerCallback('response-type', callbackSpy1);
+      client.registerCallback('response-type', callbackSpy2);
+      client.registerCallback('irrelevant-response', irrelevantCallbackSpy);
+
+      postAmpMessage({
+        type: 'response-type',
+        sentinel: 'sentinel-123',
+        x: 1,
+        y: 'abc',
+      }, hostWindow);
+
+      expect(callbackSpy1).to.be.calledWith(expectedResponseObject);
+      expect(callbackSpy2).to.be.calledWith(expectedResponseObject);
+      expect(irrelevantCallbackSpy).to.not.be.called;
+    });
+
     it('should not invoke callback on receiving a message of' +
         ' irrelevant response type', () => {
       const callbackSpy = sandbox.spy();


### PR DESCRIPTION
- Use `Observable` for callbacks in `IframeMessagingClient`.
- Add test to check that multiple callbacks are called.
- Remove observables from `AmpContext`.

I also took the liberty to specify a response type in `AmpContext`.

/cc @bradfrizzell