### PR TITLE
amp-bind: Remove key-value setState syntax

### DIFF
--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -96,12 +96,9 @@ export class StandardActions {
             }
             bind.setStateWithExpression(objectString, scope);
           } else {
-            user().warn('AMP-BIND', `Key-value syntax for AMP.setState() will `
-                + `be removed soon. Please use the object-literal syntax `
-                + `instead, e.g. "AMP.setState({foo: 'bar'})" instead of `
+            user().error('AMP-BIND', `Please use the object-literal syntax, `
+                + `e.g. "AMP.setState({foo: 'bar'})" instead of `
                 + `"AMP.setState(foo='bar')".`);
-            // Key-value args.
-            bind.setState(args);
           }
         });
         return;

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {StandardActions} from '../../src/service/standard-actions-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
+import {OBJECT_STRING_ARGS_KEY} from '../../src/service/action-impl';
+import {StandardActions} from '../../src/service/standard-actions-impl';
 import {bindForDoc, historyForDoc} from '../../src/services';
 import {installHistoryServiceForDoc} from '../../src/service/history-impl';
 import {setParentWindow} from '../../src/service';
@@ -161,14 +162,15 @@ describes.sandboxed('StandardActions', {}, () => {
     });
 
     it('should implement setState', () => {
-      const setStateSpy = sandbox.spy();
-      const bind = {setState: setStateSpy};
+      const setStateWithExpressionSpy = sandbox.spy();
+      const bind = {setStateWithExpression: setStateWithExpressionSpy};
       window.services.bind = {obj: bind};
       const args = {};
+      args[OBJECT_STRING_ARGS_KEY] = '{foo: 123}';
       standardActions.handleAmpTarget({method: 'setState', args});
       return bindForDoc(standardActions.ampdoc).then(() => {
-        expect(setStateSpy).to.be.calledOnce;
-        expect(setStateSpy).to.be.calledWith(args);
+        expect(setStateWithExpressionSpy).to.be.calledOnce;
+        expect(setStateWithExpressionSpy).to.be.calledWith('{foo: 123}');
       });
     });
   });


### PR DESCRIPTION
Follow-up to #8390. Will submit after this week's canary cut (warning will have been in prod for 2+ weeks).

- Force users to use `AMP.setState({foo: 123})` instead of `AMP.setState(foo=123)` which supports more powerful syntax consistent with expressions in `amp-bind`.