### PR TITLE
Flips dc-use-attr-for-format experiment on.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -25,6 +25,5 @@
   "amp-auto-ads": 1,
   "slidescroll-disable-css-snap": 1,
   "visibility-v3": 1,
-  "dc-use-attr-for-format": 1,
   "as-use-attr-for-format": 1
 }

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -24,5 +24,7 @@
   "sticky-ad-early-load": 1,
   "amp-auto-ads": 1,
   "slidescroll-disable-css-snap": 1,
-  "visibility-v3": 1
+  "visibility-v3": 1,
+  "dc-use-attr-for-format": 1,
+  "as-use-attr-for-format": 1
 }


### PR DESCRIPTION
This flag will tell adsense-impl to attempt to use its slot width/height attributes as the format on the ad request.