### PR TITLE
Amp-Gist: Have links open in new tab (#8587)

### DIFF
--- a/3p/github.js
+++ b/3p/github.js
@@ -54,6 +54,14 @@ export function github(global, data) {
     delete data.width;
     delete data.height;
     const gistContainer = global.document.querySelector('#c .gist');
+
+    // get all links in the embed
+    const gistLinks = gistContainer.querySelectorAll('.gist-meta a');
+    for (let i = 0; i < gistLinks.length; i++) {
+      // have the links open in a new tab #8587
+      gistLinks[i].target = '_BLANK';
+    }
+
     context.updateDimensions(
       gistContainer./*OK*/offsetWidth,
       gistContainer./*OK*/offsetHeight

--- a/3p/github.js
+++ b/3p/github.js
@@ -56,7 +56,7 @@ export function github(global, data) {
     const gistContainer = global.document.querySelector('#c .gist');
 
     // get all links in the embed
-    const gistLinks = gistContainer.querySelectorAll('.gist-meta a');
+    const gistLinks = global.document.querySelectorAll('.gist-meta a');
     for (let i = 0; i < gistLinks.length; i++) {
       // have the links open in a new tab #8587
       gistLinks[i].target = '_BLANK';


### PR DESCRIPTION
This pull request fixes the links at the bottom of a embedded gist.

- Fixes error when clicking link
- Opens links in new tab

It was trying to open the links in the iframe, but I don't believe that is a good idea, as it may lead to unpredictable content.

Fixes #8587

/cc @aghassemi @rowan-m

Please don't merge this until @rowan-m has accepted this as a solution to issue #8587.
