### PR TITLE
amp-bind explicitly name copyAndSplice

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -51,7 +51,7 @@ const FUNCTION_WHITELIST = (function() {
      * @param {...?} items
      */
     /*eslint "no-unused-vars": 0*/
-    'copyAndSplice': function(array, start, deleteCount, items) {
+    'copyAndSplice': function copyAndSplice(array, start, deleteCount, items) {
       if (!isArray(array)) {
         throw new Error(
           `copyAndSplice: ${array} is not an array.`);

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -38,31 +38,25 @@ const BUILT_IN_FUNCTIONS = 'built-in-functions';
 const FUNCTION_WHITELIST = (function() {
 
   /**
-   * Custom wrappers for mutating array methods so that we can offer the
-   * same functionality without allowing mutation on variables in bind scope.
+   * Similar to Array.prototype.splice, except it returns a copy of the
+   * passed-in array with the desired modifications.
+   * @param {!Array} array
+   * @param {number=} start
+   * @param {number=} deleteCount
+   * @param {...?} items
    */
-  const BindArrays = {
-    /**
-     * Similar to Array.prototype.splice, except it returns a copy of the
-     * passed-in array with the desired modifications.
-     * @param {!Array} array
-     * @param {number=} start
-     * @param {number=} deleteCount
-     * @param {...?} items
-     */
-    /*eslint "no-unused-vars": 0*/
-    'copyAndSplice': function copyAndSplice(array, start, deleteCount, items) {
-      if (!isArray(array)) {
-        throw new Error(
-          `copyAndSplice: ${array} is not an array.`);
-      }
-      const copy = Array.prototype.slice.call(array);
-      Array.prototype.splice.apply(
-          copy,
-          Array.prototype.slice.call(arguments, 1));
-      return copy;
-    },
-  };
+  /*eslint "no-unused-vars": 0*/
+  function copyAndSplice(array, start, deleteCount, items) {
+    if (!isArray(array)) {
+      throw new Error(
+        `copyAndSplice: ${array} is not an array.`);
+    }
+    const copy = Array.prototype.slice.call(array);
+    Array.prototype.splice.apply(
+        copy,
+        Array.prototype.slice.call(arguments, 1));
+    return copy;
+  }
 
   const whitelist = {
     '[object Array]':
@@ -98,7 +92,7 @@ const FUNCTION_WHITELIST = (function() {
     Math.random,
     Math.round,
     Math.sign,
-    BindArrays.copyAndSplice,
+    copyAndSplice,
   ];
   // Creates a prototype-less map of function name to the function itself.
   // This makes function lookups faster (compared to Array.indexOf).


### PR DESCRIPTION
Explicitly name `copyAndSplice` to fix test failure on master. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name

/to @choumx 