### PR TITLE
AMP Ad Fast Fetch: ensure onCreativeRender fires after iframe append for xdomain flow

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1179,13 +1179,13 @@ export class AmpA4A extends AMP.BaseElement {
     // Iframe is appended to element as part of xorigin frame handler init.
     // Executive onCreativeRender after init to ensure it can get reference
     // to frame but prior to load to allow for earlier access.
-    const loadPromise =
+    const frameLoadPromise =
         this.xOriginIframeHandler_.init(iframe, /* opt_isA4A */ true);
     protectFunctionWrapper(this.onCreativeRender, this, err => {
       dev().error(TAG, this.element.getAttribute('type'),
           'Error executing onCreativeRender', err);
     })(false);
-    return loadPromise;
+    return frameLoadPromise;
   }
 
   /**


### PR DESCRIPTION
For xdomain, non-validated AMP creative flow, currently onCreativeRender fires prior to iframe append possibly causing amp-analytics appended by AdSense/Doubleclick to fire visibility event early due to load being processed without taking frame into account.  Modify to ensure it fires AFTER iframe child append.

/cc @ampproject/a4a 