### PR TITLE
Cleanup amp gist experiment

### DIFF
--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -30,11 +30,7 @@
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
-import {isExperimentOn} from '../../../src/experiments';
-import {user} from '../../../src/log';
 import {Layout} from '../../../src/layout';
-
-const TAG = 'amp-gist';
 
 export class AmpGist extends AMP.BaseElement {
 
@@ -57,12 +53,6 @@ export class AmpGist extends AMP.BaseElement {
   /** @override */
   isLayoutSupported(layout) {
     return layout == Layout.FIXED_HEIGHT;
-  }
-
-  /** @override */
-  buildCallback() {
-    user().assert(isExperimentOn(this.win, TAG),
-        `Experiment "${TAG}" is disabled.`);
   }
 
   /** @override */

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -23,7 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>Experimental</td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -32,6 +32,10 @@ limitations under the License.
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
     <td>fixed-height</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td><a href="https://ampbyexample.com/components/amp-gist/">Annotated code example for amp-gist</a></td>
   </tr>
 </table>
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -267,11 +267,6 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/7670',
   },
   {
-    id: 'amp-gist',
-    name: 'Embed a GitHub gist',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8467',
-  },
-  {
     id: '3p-use-ampcontext',
     name: 'Use AmpContext for window.context messaging',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8239',


### PR DESCRIPTION
Changes `amp-gist` availability from `Experimental` to `Stable`.

- Removes guards from component
- Updates documentation

Closes #8467
