### PR TITLE
Fix race condition between amp-bind's scan and amp-form

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -400,8 +400,8 @@ export class Bind {
       const element = dev().assertElement(node);
       const tagName = element.tagName;
       const observeElement = elementToObserve => {
-          this.mutationObserver_.observe(elementToObserve, {childList: true});
-      }
+        this.mutationObserver_.observe(elementToObserve, {childList: true});
+      };
 
       if (typeof element.getDynamicElementContainers === 'function') {
         element.getDynamicElementContainers().forEach(observeElement);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -136,6 +136,17 @@ export class Bind {
     });
 
     /**
+     * Form implementations are not filled in until ampdoc is ready.
+     * So we must wait for that to finish before scanning form elements
+     * for dynamic components.
+     * @private {!Promise}
+     */
+    this.formInitializationPromise_ =
+        ampFormServiceForDoc(this.ampdoc).then(ampFormService => {
+          return ampFormService.whenInitialized();
+        });
+
+    /**
      * @private {?Promise}
      */
     this.setStatePromise_ = null;
@@ -406,8 +417,7 @@ export class Bind {
       if (typeof element.getDynamicElementContainers === 'function') {
         element.getDynamicElementContainers().forEach(observeElement);
       } else if (element.tagName === 'FORM') {
-        // Form implementations are not filled in until ampdoc is ready.
-        ampFormServiceForDoc(this.ampdoc).whenFinished().then(() => {
+        this.formInitializationPromise_.then(() => {
           const form = formOrNullForElement(element);
           dev().assert(form, 'could not find form implementation');
           form.getDynamicElementContainers().forEach(observeElement);

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -15,7 +15,6 @@
  */
 
 import * as sinon from 'sinon';
-import {AmpForm} from '../../../amp-form/0.1/amp-form';
 import {Bind} from '../bind-impl';
 import {BindExpression} from '../bind-expression';
 import {BindValidator} from '../bind-validator';
@@ -174,7 +173,7 @@ describes.realWin('Bind', {
     parent.appendChild(dynamicTag);
     parent.getDynamicElementContainers = () => {
       return [dynamicTag];
-    }
+    };
     return onBindReady().then(() => {
       expect(bind.boundElements_.length).to.equal(0);
       const elementWithBinding = createElementWithBinding('[onePlusOne]="1+1"');

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -169,13 +169,12 @@ describes.realWin('Bind', {
 
   it('should dynamically detect new bindings under dynamic tags', () => {
     const doc = env.win.document;
-    const form = doc.createElement('form');
-    doc.getElementById('parent').appendChild(form);
+    const parent = doc.getElementById('parent');
     const dynamicTag = doc.createElement('div');
-    dynamicTag.setAttribute('submit-success', null);
-    form.appendChild(dynamicTag);
-    // Wrap form in amp-form implementation so bind can access it
-    new AmpForm(form);
+    parent.appendChild(dynamicTag);
+    parent.getDynamicElementContainers = () => {
+      return [dynamicTag];
+    }
     return onBindReady().then(() => {
       expect(bind.boundElements_.length).to.equal(0);
       const elementWithBinding = createElementWithBinding('[onePlusOne]="1+1"');

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -801,9 +801,9 @@ export class AmpFormService {
    * Returns a promise that resolves when all form implementations (if any)
    * have been upgraded.
    */
-   whenFinished() {
+  whenFinished() {
     return this.whenFinished_;
-   }
+  }
 
   /**
    * Install the amp-form CSS

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -793,16 +793,17 @@ export class AmpFormService {
    */
   constructor(ampdoc) {
     /** @const @private {!Promise} */
-    this.whenFinished_ = this.installStyles_(ampdoc)
+    this.whenInitialized_ = this.installStyles_(ampdoc)
         .then(() => this.installHandlers_(ampdoc));
   }
 
   /**
    * Returns a promise that resolves when all form implementations (if any)
    * have been upgraded.
+   * @return {!Promise}
    */
-  whenFinished() {
-    return this.whenFinished_;
+  whenInitialized() {
+    return this.whenInitialized_;
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -792,8 +792,18 @@ export class AmpFormService {
    * @param  {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
-    this.installStyles_(ampdoc).then(() => this.installHandlers_(ampdoc));
+    /** @const @private {!Promise} */
+    this.whenFinished_ = this.installStyles_(ampdoc)
+        .then(() => this.installHandlers_(ampdoc));
   }
+
+  /**
+   * Returns a promise that resolves when all form implementations (if any)
+   * have been upgraded.
+   */
+   whenFinished() {
+    return this.whenFinished_;
+   }
 
   /**
    * Install the amp-form CSS

--- a/src/services.js
+++ b/src/services.js
@@ -69,6 +69,15 @@ export function activityForDoc(nodeOrDoc) {
 }
 
 /**
+ * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+ * @return {!../extensions/amp-form/0.1/amp-form.AmpFormService}
+ */
+export function ampFormServiceForDoc(nodeOrDoc) {
+  return /** @type {!../extensions/amp-form/0.1/amp-form.AmpFormService} */ (
+    getServiceForDoc(nodeOrDoc, 'amp-form'));
+}
+
+/**
  * @param {!Window} window
  * @return {!./service/batched-xhr-impl.BatchedXhr}
  */

--- a/src/services.js
+++ b/src/services.js
@@ -70,11 +70,11 @@ export function activityForDoc(nodeOrDoc) {
 
 /**
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
- * @return {!../extensions/amp-form/0.1/amp-form.AmpFormService}
+ * @return {!Promise<../extensions/amp-form/0.1/amp-form.AmpFormService>}
  */
 export function ampFormServiceForDoc(nodeOrDoc) {
-  return /** @type {!../extensions/amp-form/0.1/amp-form.AmpFormService} */ (
-    getServiceForDoc(nodeOrDoc, 'amp-form'));
+  return /** @type {!Promise<../extensions/amp-form/0.1/amp-form.AmpFormService>} */ ( // eslint-disable-line max-len
+    getServicePromiseForDoc(nodeOrDoc, 'amp-form'));
 }
 
 /**

--- a/src/services.js
+++ b/src/services.js
@@ -70,10 +70,10 @@ export function activityForDoc(nodeOrDoc) {
 
 /**
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
- * @return {!Promise<../extensions/amp-form/0.1/amp-form.AmpFormService>}
+ * @return {!Promise<!../extensions/amp-form/0.1/amp-form.AmpFormService>}
  */
 export function ampFormServiceForDoc(nodeOrDoc) {
-  return /** @type {!Promise<../extensions/amp-form/0.1/amp-form.AmpFormService>} */ ( // eslint-disable-line max-len
+  return /** @type {!Promise<!../extensions/amp-form/0.1/amp-form.AmpFormService>} */ ( // eslint-disable-line max-len
     getElementServiceForDoc(nodeOrDoc, 'amp-form', 'amp-form'));
 }
 

--- a/src/services.js
+++ b/src/services.js
@@ -74,7 +74,7 @@ export function activityForDoc(nodeOrDoc) {
  */
 export function ampFormServiceForDoc(nodeOrDoc) {
   return /** @type {!Promise<../extensions/amp-form/0.1/amp-form.AmpFormService>} */ ( // eslint-disable-line max-len
-    getServicePromiseForDoc(nodeOrDoc, 'amp-form'));
+    getElementServiceForDoc(nodeOrDoc, 'amp-form', 'amp-form'));
 }
 
 /**


### PR DESCRIPTION
Added a `whenFinished` promise to the AmpFormService to prevent a race condition between bind's scan and AmpFormService filling in form elements with an AmpForm implementation.

Fixes #8647 #8653 

/to @choumx @dvoytenko 