### PR TITLE
Support action chaining (for multiple actions in a single event)

### DIFF
--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -766,6 +766,7 @@ export class AccessService {
 
   /**
    * @param {!../../../src/service/action-impl.ActionInvocation} invocation
+   * @return {?Promise}
    * @private
    */
   handleAction_(invocation) {
@@ -780,6 +781,7 @@ export class AccessService {
       }
       this.loginWithType_(invocation.method.substring('login-'.length));
     }
+    return null;
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -215,6 +215,7 @@ export class AmpForm {
 
   /**
    * @param {!../../../src/service/action-impl.ActionInvocation} invocation
+   * @return {?Promise}
    * @private
    */
   actionHandler_(invocation) {
@@ -223,6 +224,7 @@ export class AmpForm {
         this.handleSubmitAction_(invocation);
       });
     }
+    return null;
   }
 
   /**

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -392,7 +392,7 @@ export class ActionService {
 
       // Wait for the previous action, if applicable.
       currentPromise = (currentPromise)
-          ? currentPromise.then(() => invoke())
+          ? currentPromise.then(invoke())
           : invoke();
     });
   }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -392,7 +392,7 @@ export class ActionService {
 
       // Wait for the previous action, if applicable.
       currentPromise = (currentPromise)
-          ? currentPromise.then(invoke())
+          ? currentPromise.then(invoke)
           : invoke();
     });
   }

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -109,15 +109,15 @@ export class StandardActions {
         this.handleAmpPushState_(invocation);
         return;
       case 'setState':
+        const actions = /** @type {!Array} */ (dev().assert(opt_actionInfos));
+        const index = dev().assertNumber(opt_actionIndex);
         // Only allow one AMP.setState action per event.
-        const actionInfos =
-            /** @type {!Array} */ (dev().assert(opt_actionInfos));
-        const firstSetState = findIndex(actionInfos, actionInfo => {
-          return actionInfo.target == 'AMP' && actionInfo.method == 'setState';
-        });
-        if (dev().assertNumber(opt_actionIndex) > firstSetState) {
-          user().error('AMP-BIND', 'Only one state action allowed per event.');
-          return null;
+        for (let i = 0; i < index; i++) {
+          const action = actions[i];
+          if (action.target == 'AMP' && action.method == 'setState') {
+            user().error('AMP-BIND', 'One state action allowed per event.');
+            return null;
+          }
         }
         return this.handleAmpSetState_(invocation);
       case 'navigateTo':

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -119,7 +119,7 @@ export class StandardActions {
 
   /**
    * @param {!./action-impl.ActionInvocation} invocation
-   * @return {!Promise}
+   * @return {?Promise}
    * @private
    */
   handleAmpSetState_(invocation) {
@@ -141,7 +141,7 @@ export class StandardActions {
    */
   handleAmpBindAction_(invocation, opt_pushState) {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
-      return Promise.resolve();
+      return null;
     }
     return Services.bindForDocOrNull(invocation.target).then(bind => {
       user().assert(bind, 'AMP-BIND is not installed.');

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -97,6 +97,10 @@ export class StandardActions {
    * See `amp-actions-and-events.md` for documentation.
    *
    * @param {!./action-impl.ActionInvocation} invocation
+   * @return {Promise} Returns a Promise if the action invocation should be
+   *     allowed to complete before invoking the next action (if any).
+   *     Otherwise, returns null.
+   * @throws {Error} If action is not recognized.
    */
   handleAmpTarget(invocation) {
     switch (invocation.method) {
@@ -104,17 +108,13 @@ export class StandardActions {
         this.handleAmpPushState_(invocation);
         return;
       case 'setState':
-        this.handleAmpSetState_(invocation);
-        return;
+        return this.handleAmpSetState_(invocation);
       case 'navigateTo':
-        this.handleAmpNavigateTo_(invocation);
-        return;
+        return this.handleAmpNavigateTo_(invocation);
       case 'goBack':
-        this.handleAmpGoBack_(invocation);
-        return;
+        return this.handleAmpGoBack_(invocation);
       case 'print':
-        this.handleAmpPrint_(invocation);
-        return;
+        return this.handleAmpPrint_(invocation);
     }
     throw user().createError('Unknown AMP action ', invocation.method);
   }

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -109,6 +109,7 @@ export class StandardActions {
         this.handleAmpPushState_(invocation);
         return;
       case 'setState':
+        // Only allow one AMP.setState action per event.
         const actionInfos =
             /** @type {!Array} */ (dev().assert(opt_actionInfos));
         const firstSetState = findIndex(actionInfos, actionInfo => {

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -713,7 +713,7 @@ describe('Multiple handlers action method', () => {
     onEnqueue1 = sandbox.spy();
     onEnqueue2 = sandbox.spy();
     targetElement = document.createElement('target');
-    targetElement.setAttribute('on', `tap:foo.method1,bar.method2`);
+    targetElement.setAttribute('on', 'tap:foo.method1,bar.method2');
     parent = document.createElement('parent');
     child = document.createElement('child');
     parent.appendChild(targetElement);

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -16,6 +16,7 @@
 
 import {ActionTrust} from '../../src/action-trust';
 import {
+  ActionInvocation,
   ActionService,
   DeferredEvent,
   OBJECT_STRING_ARGS_KEY,
@@ -599,8 +600,8 @@ describe('Action method', () => {
 
 
   it('should invoke on the AMP element', () => {
-    action.invoke_(execElement, 'method1', /* args */ null,
-        'source1', 'event1');
+    action.invoke_(new ActionInvocation(execElement, 'method1', /* args */ null,
+        'source1', 'event1'));
     expect(onEnqueue).to.be.calledOnce;
     const inv = onEnqueue.getCall(0).args[0];
     expect(inv.target).to.equal(execElement);
@@ -611,8 +612,8 @@ describe('Action method', () => {
   });
 
   it('should invoke on the AMP element with args', () => {
-    action.invoke_(execElement, 'method1', {'key1': 11},
-        'source1', 'event1');
+    action.invoke_(new ActionInvocation(execElement, 'method1', {'key1': 11},
+        'source1', 'event1'));
     expect(onEnqueue).to.be.calledOnce;
     const inv = onEnqueue.getCall(0).args[0];
     expect(inv.target).to.equal(execElement);
@@ -624,16 +625,16 @@ describe('Action method', () => {
 
   it('should not allow invoke on non-AMP and non-whitelisted element', () => {
     expect(() => {
-      action.invoke_(document.createElement('img'), 'method1', /* args */ null,
-          'source1', 'event1');
+      action.invoke_(new ActionInvocation(document.createElement('img'),
+          'method1', /* args */ null, 'source1', 'event1'));
     }).to.throw(/Target element does not support provided action/);
     expect(onEnqueue).to.have.not.been.called;
   });
 
   it('should not allow invoke on unresolved AMP element', () => {
     expect(() => {
-      action.invoke_({tagName: 'amp-img'}, 'method1', /* args */ null,
-          'source1', 'event1');
+      action.invoke_(new ActionInvocation(document.createElement('amp-foo'),
+          'method1', /* args */ null, 'source1', 'event1'));
     }).to.throw(/Unrecognized AMP element/);
     expect(onEnqueue).to.have.not.been.called;
   });
@@ -675,8 +676,8 @@ describe('installActionHandler', () => {
     const handlerSpy = sandbox.spy();
     const target = document.createElement('form');
     action.installActionHandler(target, handlerSpy);
-    action.invoke_(target, 'submit', /* args */ null,
-        'button', 'tap', ActionTrust.HIGH);
+    action.invoke_(new ActionInvocation(target, 'submit', /* args */ null,
+        'button', 'tap', ActionTrust.HIGH));
     expect(handlerSpy).to.be.calledOnce;
     const callArgs = handlerSpy.getCall(0).args[0];
     expect(callArgs.target).to.be.equal(target);
@@ -691,12 +692,12 @@ describe('installActionHandler', () => {
     const target = document.createElement('form');
     action.installActionHandler(target, handlerSpy, ActionTrust.HIGH);
 
-    action.invoke_(target, 'submit', /* args */ null,
-        'button', 'tap', ActionTrust.LOW);
+    action.invoke_(new ActionInvocation(target, 'submit', /* args */ null,
+        'button', 'tap', ActionTrust.LOW));
     expect(handlerSpy).to.not.be.called;
 
-    action.invoke_(target, 'submit', /* args */ null,
-        'button', 'tap', ActionTrust.HIGH);
+    action.invoke_(new ActionInvocation(target, 'submit', /* args */ null,
+        'button', 'tap', ActionTrust.HIGH));
     expect(handlerSpy).to.be.calledOnce;
   });
 });
@@ -819,8 +820,10 @@ describe('Action interceptor', () => {
   });
 
   it('should queue actions', () => {
-    action.invoke_(target, 'method1', /* args */ null, 'source1', 'event1');
-    action.invoke_(target, 'method2', /* args */ null, 'source2', 'event2');
+    action.invoke_(new ActionInvocation(target, 'method1', /* args */ null,
+        'source1', 'event1'));
+    action.invoke_(new ActionInvocation(target, 'method2', /* args */ null,
+        'source2', 'event2'));
 
     const queue = getQueue();
     expect(Array.isArray(queue)).to.be.true;
@@ -840,10 +843,10 @@ describe('Action interceptor', () => {
   });
 
   it('should dequeue actions after handler set', () => {
-    action.invoke_(target, 'method1', /* args */ null, 'source1', 'event1',
-        ActionTrust.HIGH);
-    action.invoke_(target, 'method2', /* args */ null, 'source2', 'event2',
-        ActionTrust.HIGH);
+    action.invoke_(new ActionInvocation(target, 'method1', /* args */ null,
+        'source1', 'event1', ActionTrust.HIGH));
+    action.invoke_(new ActionInvocation(target, 'method2', /* args */ null,
+        'source2', 'event2', ActionTrust.HIGH));
 
     expect(Array.isArray(getQueue())).to.be.true;
     expect(getActionHandler()).to.be.undefined;
@@ -869,8 +872,8 @@ describe('Action interceptor', () => {
     expect(inv1.source).to.equal('source2');
     expect(inv1.event).to.equal('event2');
 
-    action.invoke_(target, 'method3', /* args */ null, 'source3', 'event3',
-        ActionTrust.HIGH);
+    action.invoke_(new ActionInvocation(target, 'method3', /* args */ null,
+        'source3', 'event3', ActionTrust.HIGH));
     expect(handler).to.have.callCount(3);
     const inv2 = handler.getCall(2).args[0];
     expect(inv2.target).to.equal(target);
@@ -905,13 +908,13 @@ describe('Action common handler', () => {
     action.addGlobalMethodHandler('action1', action1);
     action.addGlobalMethodHandler('action2', action2);
 
-    action.invoke_(target, 'action1', /* args */ null, 'source1', 'event1',
-        ActionTrust.HIGH);
+    action.invoke_(new ActionInvocation(target, 'action1', /* args */ null,
+        'source1', 'event1', ActionTrust.HIGH));
     expect(action1).to.be.calledOnce;
     expect(action2).to.have.not.been.called;
 
-    action.invoke_(target, 'action2', /* args */ null, 'source2', 'event2',
-        ActionTrust.HIGH);
+    action.invoke_(new ActionInvocation(target, 'action2', /* args */ null,
+        'source2', 'event2', ActionTrust.HIGH));
     expect(action2).to.be.calledOnce;
     expect(action1).to.be.calledOnce;
 
@@ -922,12 +925,12 @@ describe('Action common handler', () => {
     const handler = sandbox.spy();
     action.addGlobalMethodHandler('foo', handler, ActionTrust.HIGH);
 
-    action.invoke_(target, 'foo', /* args */ null, 'source1', 'event1',
-        ActionTrust.LOW);
+    action.invoke_(new ActionInvocation(target, 'foo', /* args */ null,
+        'source1', 'event1', ActionTrust.LOW));
     expect(handler).to.not.be.called;
 
-    action.invoke_(target, 'foo', /* args */ null, 'source1', 'event1',
-        ActionTrust.HIGH);
+    action.invoke_(new ActionInvocation(target, 'foo', /* args */ null,
+        'source1', 'event1', ActionTrust.HIGH));
     expect(handler).to.be.calledOnce;
   });
 });

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -264,21 +264,17 @@ describes.sandboxed('StandardActions', {}, () => {
         },
       };
 
-      const args = {};
-      args[OBJECT_STRING_ARGS_KEY] = '{foo: 123}';
+      const args = {
+        [OBJECT_STRING_ARGS_KEY]: '{foo: 123}',
+      };
+      const target = ampdoc;
+      const satisfiesTrust = () => true;
+      const setState = {method: 'setState', args, target, satisfiesTrust};
+      const pushState = {method: 'pushState', args, target, satisfiesTrust};
 
-      standardActions.handleAmpTarget({
-        method: 'setState',
-        args,
-        target: ampdoc,
-        satisfiesTrust: () => true,
-      });
-      standardActions.handleAmpTarget({
-        method: 'pushState',
-        args,
-        target: ampdoc,
-        satisfiesTrust: () => true,
-      });
+      standardActions.handleAmpTarget(setState, 0, []);
+      standardActions.handleAmpTarget(pushState, 0, []);
+
       return Services.bindForDocOrNull(ampdoc).then(() => {
         expect(setStateSpy).to.be.calledOnce;
         expect(setStateSpy).to.be.calledWith('{foo: 123}');


### PR DESCRIPTION
Fixes #10914.

- Add a `{?Promise}` return type to action handlers.
- If an action handler returns a Promise, subsequent actions triggered by the same event will wait for the Promise to resolve before invocation.
- Only allow a single `AMP.setState` per action "chain" to sidestep performance constraint issue (for now).

Related: https://github.com/ampproject/amphtml/issues/8648#issuecomment-293077744.