### PR TITLE
Decrease time until SW installation from 20s to 10s.

### DIFF
--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -103,7 +103,7 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
       // only engaged with superficially.
       timerFor(this.win).delay(() => {
         this.deferMutate(this.insertIframe_.bind(this));
-      }, 20000);
+      }, 10000);
     });
   }
 

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -223,7 +223,7 @@ describes.realWin('amp-install-serviceworker', {
         deferredMutate = fn;
       };
       return whenVisible.then(() => {
-        clock.tick(19999);
+        clock.tick(9999);
         expect(deferredMutate).to.be.undefined;
         expect(iframe).to.be.undefined;
         clock.tick(1);


### PR DESCRIPTION
We want to only do this when users really engaged with a page, but feedback was that 20s may be too long.

Fixes #8376
