### PR TITLE
Add cdnProxyRegex to AMP_CONFIG so it can be overriden externally

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -26,13 +26,17 @@ const env = self.AMP_CONFIG || {};
 const thirdPartyFrameRegex = typeof env['thirdPartyFrameRegex'] == 'string' ?
     new RegExp(env['thirdPartyFrameRegex']) : env['thirdPartyFrameRegex'];
 
+const cdnProxyRegex = typeof env['cdnProxyRegex'] == 'string' ?
+    new RegExp(env['cdnProxyRegex']) : env['cdnProxyRegex'];
+
 /** @type {!Object<string, string|boolean|RegExp>} */
 export const urls = {
   thirdParty: env['thirdPartyUrl'] || 'https://3p.ampproject.net',
   thirdPartyFrameHost: env['thirdPartyFrameHost'] || 'ampproject.net',
   thirdPartyFrameRegex: thirdPartyFrameRegex || /^d-\d+\.ampproject\.net$/,
   cdn: env['cdnUrl'] || 'https://cdn.ampproject.org',
-  cdnProxyRegex: /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org/,
+  cdnProxyRegex: cdnProxyRegex ||
+      /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org/,
   localhostRegex: /^https?:\/\/localhost(:\d+)?$/,
   errorReporting: env['errorReportingUrl'] ||
       'https://amp-error-reporting.appspot.com/r',


### PR DESCRIPTION
`cdnProxyRegex` in configuration is now set from AMP_CONFIG rather than using hard-coded regex that looks for cdn.ampproject.org. This allows other caches to override this value.