### PR TITLE
Tighten amp-state script validation.

### DIFF
--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -30,6 +30,7 @@ tags: {  # <amp-state> (json)
   tag_name: "SCRIPT"
   spec_name: "amp-bind extension .json script"
   mandatory_parent: "AMP-STATE"
+  satisfies: "amp-bind extension .json script"
   requires: "amp-bind extension .js script"
   attrs: { name: "nonce" }
   attrs: {
@@ -51,10 +52,15 @@ tags: {  # <amp-state>
   tag_name: "AMP-STATE"
   satisfies: "amp-state"
   requires: "amp-bind extension .js script"
+  requires: "amp-bind extension .json script"
   disallowed_ancestor: "AMP-SIDEBAR"
   attrs: {
     name: "id"
     mandatory: true
+  }
+  child_tags: {
+    mandatory_num_child_tags: 1
+    child_tag_name_oneof: "SCRIPT"
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/amp-bind"
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 221
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 401
+spec_file_revision: 402
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 


### PR DESCRIPTION
amp-state must have 1 child and that child must be <script type=application/json></script>

Makes the following three cases invalid:

```
<amp-state>
</amp-state>
```

```
<amp-state>
<script type=application/json>
...
</script>
<script type=application/json>
</script>
</amp-state>
```

```
<amp-state>
<script type=application/json>
...
</script>
<span></span>
</amp-state>
```