### PR TITLE
Only allow setting cookies on AMP cache domains when explicitly allowed.

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import {isProxyOrigin, parseUrl} from './url';
+import {endsWith} from './string';
+import {urls} from './config';
+
 
 /**
  * Returns the value of the cookie. The cookie access is restricted and must
@@ -78,8 +82,10 @@ function tryGetDocumentCookieNoInline(win) {
  *       scope allowed by the browser. E.g. on example.com if we are currently
  *       on www.example.com.
  *     - domain: Explicit domain to set.
+ *     - allowOnProxyOrigin: Allow setting a cookie on the AMP Cache.
  */
 export function setCookie(win, name, value, expirationTime, opt_options) {
+  checkOriginForSettingCookie(win, opt_options, name);
   if (opt_options && opt_options.highestAvailableDomain) {
     const parts = win.location.hostname.split('.');
     let domain = parts[parts.length - 1];
@@ -127,4 +133,29 @@ function trySetCookie(win, name, value, expirationTime, domain) {
     // when AMP docs are opened on origins that do not allow setting
     // cookies such as null origins.
   };
+}
+
+/**
+ * Throws if a given cookie should not be set on the given origin.
+ * This is a defense-in-depth. Callers should never run into this.
+ *
+ * @param {!Window} win
+ * @param {!Object|undefined} options
+ * @param {string} name For the error message.
+ */
+function checkOriginForSettingCookie(win, options, name) {
+  if (options && options.allowOnProxyOrigin) {
+    return;
+  }
+  if (isProxyOrigin(win.location.href)) {
+    throw new Error('Should never attempt to set cookie on proxy origin: '
+        + name);
+  }
+
+  const current = parseUrl(win.location.href).hostname.toLowerCase();
+  const proxy = parseUrl(urls.cdn).hostname.toLowerCase();
+  if (current == proxy || endsWith(current, '.' + proxy)) {
+    throw new Error('Should never attempt to set cookie on proxy origin.'
+        + ' (in depth check): ' + name);
+  }
 }

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -195,6 +195,7 @@ function saveExperimentTogglesToCookie(win, toggles) {
       Date.now() + COOKIE_EXPIRATION_INTERVAL, {
         // Set explicit domain, so the cookie gets send to sub domains.
         domain: win.location.hostname,
+        allowOnProxyOrigin: true,
       });
 }
 

--- a/test/functional/test-cookies.js
+++ b/test/functional/test-cookies.js
@@ -19,7 +19,7 @@ import {getCookie, setCookie} from '../../src/cookies';
 
 describe('cookies', () => {
 
-  function expectCookie(cookiesString, cookieName) {
+  function expectCookie(cookiesString, cookieName, opt_locationHref) {
     return expect(getCookie({
       document: {
         cookie: cookiesString,
@@ -52,13 +52,18 @@ describe('cookies', () => {
 
   it('should write the cookie', () => {
     const doc = {};
-    setCookie({document: doc}, 'c&1', 'v&1', 1447383159853);
+    setCookie({
+      document: doc,
+      location: {
+        href: 'https://www.example.com/test',
+      },
+    }, 'c&1', 'v&1', 1447383159853);
     expect(doc.cookie).to.equal(
         'c%261=v%261; path=/; expires=Fri, 13 Nov 2015 02:52:39 GMT');
   });
 
   it('should write the cookie to the right domain', () => {
-    function test(hostname, targetDomain, opt_noset) {
+    function test(hostname, targetDomain, opt_noset, opt_allowOnProxyOrigin) {
       let cookie;
       const doc = {
         set cookie(val) {
@@ -76,9 +81,15 @@ describe('cookies', () => {
           return cookie;
         },
       };
-      setCookie({document: doc, location: {hostname}},
+      setCookie({
+        document: doc,
+        location: {
+          hostname,
+          href: 'https://' + hostname + ':8000/test.html',
+        }},
           'c&1', 'v&1', 1447383159853, {
             highestAvailableDomain: true,
+            allowOnProxyOrigin: !!opt_allowOnProxyOrigin,
           });
       if (opt_noset) {
         expect(cookie).to.be.undefined;
@@ -95,9 +106,29 @@ describe('cookies', () => {
     test('123.www.example.com', '123.www.example.com');
     test('www.example.net', 'example.com', true);
     test('example.net', 'example.com', true);
-    test('www.ampproject.org', 'ampproject.org', true);
-    test('cdn.ampproject.org', 'ampproject.org', true);
+    test('cdn.ampproject.org', 'ampproject.org', true, true);
+    expect(() => {
+      test('cdn.ampproject.org', 'ampproject.org', true);
+    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+    expect(() => {
+      test('CDN.ampproject.org', 'ampproject.org', true);
+    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+    expect(() => {
+      test('CDN.ampproject.org', 'AMPproject.org', true);
+    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
     test('www.ampproject.org', 'www.ampproject.org');
-    test('cdn.ampproject.org', 'cdn.ampproject.org');
+    test('cdn.ampproject.org', 'cdn.ampproject.org', false, true);
+    expect(() => {
+      test('cdn.ampproject.org', 'cdn.ampproject.org', false);
+    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+    expect(() => {
+      test('foo.bar.cdn.ampproject.org', 'foo.bar.cdn.ampproject.org', false);
+    }).to.throw(/in depth check/);
+    expect(() => {
+      test('&&&.cdn.ampproject.org', '&&&.cdn.ampproject.org', false);
+    }).to.throw(/in depth check/);
+    expect(() => {
+      test('&&&.CDN.ampproject.org', '&&&.cdn.AMPproject.org', false);
+    }).to.throw(/in depth check/);
   });
 });

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -194,6 +194,7 @@ describe('toggleExperiment', () => {
       document: doc,
       location: {
         hostname: 'test.test',
+        href: 'https://test.test/test.html',
       },
     }, experimentId, opt_on);
     const parts = doc.cookie.split(/\s*;\s*/g);
@@ -269,6 +270,7 @@ describe('toggleExperiment', () => {
       },
       location: {
         hostname: 'test.test',
+        href: 'https://test.test/test.html',
       },
     };
     toggleExperiment(win, 'transient', true, true);
@@ -327,6 +329,7 @@ describe('toggleExperiment', () => {
       },
       location: {
         hostname: 'test.test',
+        href: 'https://test.test/test.html',
       },
     };
     // Make sure some experiments are enabled in the cookie.

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -443,6 +443,7 @@ function toggleExperiment_(id, name, opt_on) {
           (on ? '1' : '0'), (on ? validUntil : 0), {
             // Set explicit domain, so the cookie gets send to sub domains.
             domain: location.hostname,
+            allowOnProxyOrigin: true,
           });
       // Reflect default experiment state.
       self.location.reload();


### PR DESCRIPTION
Otherwise throw an error, so instances of this can be debugged.