### PR TITLE
Service Registration: Cleanup of service.js

### DIFF
--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -19,7 +19,6 @@ import {
   UserNotificationManager,
 } from '../amp-user-notification';
 import {createIframePromise} from '../../../../testing/iframe';
-import {getExistingServiceForDoc} from '../../../../src/service';
 import * as sinon from 'sinon';
 
 
@@ -50,7 +49,7 @@ describe('amp-user-notification', () => {
   function getUserNotification(attrs = {}) {
     return createIframePromise().then(iframe_ => {
       iframe = iframe_;
-      storage = getExistingServiceForDoc(iframe.ampdoc, 'storage');
+      storage = getServiceForDoc(iframe.ampdoc, 'storage');
       storageMock = sandbox.mock(storage);
       return buildElement(iframe.doc, iframe.ampdoc, attrs);
     });

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -19,6 +19,7 @@ import {
   UserNotificationManager,
 } from '../amp-user-notification';
 import {createIframePromise} from '../../../../testing/iframe';
+import {getServiceForDoc} from '../../../../src/service';
 import * as sinon from 'sinon';
 
 

--- a/src/service.js
+++ b/src/service.js
@@ -414,6 +414,7 @@ function getServiceInternal(holder, id) {
   if (!s.obj) {
     dev().assert(s.build, `Service ${id} registered without builder nor impl.`);
     s.obj = s.build();
+    dev().assert(s.obj, `Service ${id} built to null.`);
     // The service may have been requested already, in which case we have a
     // pending promise we need to fulfill.
     if (s.resolve) {
@@ -512,7 +513,7 @@ function getServicePromiseOrNullInternal(holder, id) {
         // Instantiate service
         getServiceInternal(holder, id);
       }
-      return s.promise = Promise.resolve(s.obj);
+      return s.promise = Promise.resolve(/** @type {!Object} */ (s.obj));
     }
   }
   return null;

--- a/src/service.js
+++ b/src/service.js
@@ -126,7 +126,7 @@ export function installServiceInEmbedScope(embedWin, id, service) {
       /* opt_ctor */ undefined,
       () => service);
   // Force service to build
-  getService(embedWin, id);
+  getServiceInternal(embedWin, embedWin, id);
 }
 
 /**

--- a/src/service.js
+++ b/src/service.js
@@ -417,7 +417,7 @@ function getServiceInternal(holder, id) {
     // The service may have been requested already, in which case we have a
     // pending promise we need to fulfill.
     if (s.resolve) {
-      s.resolve((s.obj));
+      s.resolve(s.obj);
     }
     s.build = null;
   }
@@ -507,14 +507,12 @@ function getServicePromiseOrNullInternal(holder, id) {
   if (s) {
     if (s.promise) {
       return s.promise;
-    } else if (s.obj) {
-      return s.promise = Promise.resolve(s.obj);
     } else {
-      dev().assert(s.build,
-          'Expected object, promise, or builder to be present');
-      const service = getServiceInternal(holder, id);
-      dev().assert(service, 'Unexpected null service');
-      return s.promise = Promise.resolve(/** @type {!Object} */ (service));
+      if (!s.obj) {
+        // Instantiate service
+        getServiceInternal(holder, id);
+      }
+      return s.promise = Promise.resolve(s.obj);
     }
   }
   return null;

--- a/src/service.js
+++ b/src/service.js
@@ -461,7 +461,7 @@ function registerServiceInternal(holder, context, id, opt_ctor, opt_factory) {
   // The service may have been requested already, in which case there is a
   // pending promise that needs to fulfilled.
   if (s.resolve) {
-    // getServiceInternal will resolve the project.
+    // getServiceInternal will resolve the promise.
     getServiceInternal(holder, id);
   }
 }
@@ -509,10 +509,8 @@ function getServicePromiseOrNullInternal(holder, id) {
     if (s.promise) {
       return s.promise;
     } else {
-      if (!s.obj) {
-        // Instantiate service
-        getServiceInternal(holder, id);
-      }
+      // Instantiate service if not already instantiated.
+      getServiceInternal(holder, id);
       return s.promise = Promise.resolve(/** @type {!Object} */ (s.obj));
     }
   }

--- a/src/services.js
+++ b/src/services.js
@@ -18,7 +18,7 @@ import {
   getService,
   getServiceForDoc,
   getServicePromiseForDoc,
-  getExistingServiceForWindowOrNull,
+  getExistingServiceOrNull,
   getExistingServiceForDocInEmbedScope,
 } from './service';
 import {
@@ -175,7 +175,7 @@ export function performanceFor(window) {
  */
 export function performanceForOrNull(window) {
   return /** @type {!./service/performance-impl.Performance}*/ (
-      getExistingServiceForWindowOrNull(window, 'performance'));
+      getExistingServiceOrNull(window, 'performance'));
 }
 
 /**

--- a/test/functional/test-analytics.js
+++ b/test/functional/test-analytics.js
@@ -88,7 +88,7 @@ describes.realWin('analytics', {amp: true}, env => {
       win.document.body.appendChild(ele);
       const baseEle = new BaseElement(ele);
       registerServiceBuilderForDoc(
-        ampdoc, 'amp-analytics-instrumentation', MockInstrumentation);
+          ampdoc, 'amp-analytics-instrumentation', MockInstrumentation);
       // Force instantiation
       getServiceForDoc(ampdoc, 'amp-analytics-instrumentation');
       const config = {

--- a/test/functional/test-analytics.js
+++ b/test/functional/test-analytics.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {fromClassForDoc} from '../../src/service';
 import {
   getServiceForDoc,
   registerServiceBuilderForDoc,
@@ -88,8 +87,10 @@ describes.realWin('analytics', {amp: true}, env => {
       const ele = win.document.createElement('div');
       win.document.body.appendChild(ele);
       const baseEle = new BaseElement(ele);
-      fromClassForDoc(
-          ampdoc, 'amp-analytics-instrumentation', MockInstrumentation);
+      registerServiceBuilderForDoc(
+        ampdoc, 'amp-analytics-instrumentation', MockInstrumentation);
+      // Force instantiation
+      getServiceForDoc(ampdoc, 'amp-analytics-instrumentation');
       const config = {
         'requests': {
           'pageview': 'https://example.com/analytics',

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -201,6 +201,15 @@ describe('service', () => {
       expect(p).to.not.be.null;
     });
 
+    it('should set service builders to null after instantiation', () => {
+      registerServiceBuilder(window, 'a', Class);
+      expect(window.services['a'].obj).to.be.null;
+      expect(window.services['a'].build).to.not.be.null;
+      getService(window, 'a');
+      expect(window.services['a'].obj).to.not.be.null;
+      expect(window.services['a'].build).to.be.null;
+    });
+
     it('should resolve service for a child window', () => {
       const c = getService(window, 'c', factory);
 

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -19,11 +19,9 @@ import {
   assertDisposable,
   assertEmbeddable,
   disposeServicesForDoc,
-  fromClass,
   getExistingServiceForDocInEmbedScope,
-  getExistingServiceForWindowInEmbedScope,
-  getExistingServiceForDoc,
-  getExistingServiceForWindow,
+  getExistingServiceInEmbedScope,
+  getExistingService,
   getParentWindowFrameElement,
   getService,
   getServiceForDoc,
@@ -115,19 +113,6 @@ describe('service', () => {
       expect(factory.args[1][0]).to.equal(window);
     });
 
-    it('should make instances from class', () => {
-
-      const a1 = fromClass(window, 'a', Class);
-      const a2 = fromClass(window, 'a', Class);
-      expect(a1).to.equal(a2);
-      expect(a1.count).to.equal(1);
-
-      const b1 = fromClass(window, 'b', Class);
-      const b2 = fromClass(window, 'b', Class);
-      expect(b1).to.equal(b2);
-      expect(b1).to.not.equal(a1);
-    });
-
     it('should not instantiate service when registered', () => {
       registerServiceBuilder(window, 'a', Class);
       expect(count).to.equal(0);
@@ -152,14 +137,14 @@ describe('service', () => {
 
     it('should return the service when it exists', () => {
       const c1 = getService(window, 'c', factory);
-      const c2 = getExistingServiceForWindow(window, 'c');
+      const c2 = getExistingService(window, 'c');
       expect(c1).to.equal(c2);
     });
 
     it('should throw before creation', () => {
       getService(window, 'another service to avoid NPE', () => {});
       expect(() => {
-        getExistingServiceForWindow(window, 'c');
+        getExistingService(window, 'c');
       }).to.throw();
     });
 
@@ -224,13 +209,13 @@ describe('service', () => {
       const child = {};
       setParentWindow(child, window);
       expect(getService(child, 'c', factory)).to.equal(c);
-      expect(getExistingServiceForWindow(child, 'c')).to.equal(c);
+      expect(getExistingService(child, 'c')).to.equal(c);
 
       // A grandchild.
       const grandchild = {};
       setParentWindow(grandchild, child);
       expect(getService(grandchild, 'c', factory)).to.equal(c);
-      expect(getExistingServiceForWindow(grandchild, 'c')).to.equal(c);
+      expect(getExistingService(grandchild, 'c')).to.equal(c);
     });
 
     describe('embed service', () => {
@@ -250,30 +235,30 @@ describe('service', () => {
       });
 
       it('should return top service for top window', () => {
-        expect(getExistingServiceForWindowInEmbedScope(window, 'c'))
+        expect(getExistingServiceInEmbedScope(window, 'c'))
             .to.equal(topService);
       });
 
       it('should return top service when not overriden', () => {
-        expect(getExistingServiceForWindowInEmbedScope(childWin, 'c'))
+        expect(getExistingServiceInEmbedScope(childWin, 'c'))
             .to.equal(topService);
-        expect(getExistingServiceForWindowInEmbedScope(grandchildWin, 'c'))
+        expect(getExistingServiceInEmbedScope(grandchildWin, 'c'))
             .to.equal(topService);
       });
 
       it('should return overriden service', () => {
         const overridenService = {};
         installServiceInEmbedScope(childWin, 'c', overridenService);
-        expect(getExistingServiceForWindowInEmbedScope(childWin, 'c'))
+        expect(getExistingServiceInEmbedScope(childWin, 'c'))
             .to.equal(overridenService);
         // Top-level service doesn't change.
-        expect(getExistingServiceForWindow(window, 'c'))
+        expect(getExistingService(window, 'c'))
             .to.equal(topService);
 
         // Notice that only direct overrides are allowed for now. This is
         // arbitrary can change in the future to allow hierarchical lookup
         // up the window chain.
-        expect(getExistingServiceForWindow(grandchildWin, 'c'))
+        expect(getExistingService(grandchildWin, 'c'))
             .to.equal(topService);
       });
     });
@@ -325,7 +310,7 @@ describe('service', () => {
 
       const b1 = getServiceForDoc(node, 'b', factory);
       const b2 = getServiceForDoc(node, 'b', factory);
-      const b3 = getExistingServiceForDoc(node, 'b');
+      const b3 = getServiceForDoc(node, 'b');
       expect(b1).to.equal(b2);
       expect(b1).to.equal(b3);
       expect(b1).to.not.equal(a1);
@@ -340,7 +325,7 @@ describe('service', () => {
 
       const a1 = getServiceForDoc(ampdoc, 'a', factory);
       const a2 = getServiceForDoc(ampdoc, 'a', factory);
-      const a3 = getExistingServiceForDoc(ampdoc, 'a', factory);
+      const a3 = getServiceForDoc(ampdoc, 'a', factory);
       expect(a1).to.equal(a2);
       expect(a1).to.equal(a3);
       expect(a1).to.equal(1);
@@ -434,7 +419,7 @@ describe('service', () => {
           {nodeType: 1, ownerDocument: {defaultView: childWin}};
       setParentWindow(childWin, windowApi);
       expect(getServiceForDoc(childWinNode, 'c', factory)).to.equal(c);
-      expect(getExistingServiceForDoc(childWinNode, 'c')).to.equal(c);
+      expect(getServiceForDoc(childWinNode, 'c')).to.equal(c);
 
       // A grandchild.
       const grandchildWin = {};
@@ -442,7 +427,7 @@ describe('service', () => {
           {nodeType: 1, ownerDocument: {defaultView: grandchildWin}};
       setParentWindow(grandchildWin, childWin);
       expect(getServiceForDoc(grandChildWinNode, 'c', factory)).to.equal(c);
-      expect(getExistingServiceForDoc(grandChildWinNode, 'c')).to.equal(c);
+      expect(getServiceForDoc(grandChildWinNode, 'c')).to.equal(c);
     });
 
     it('should dispose disposable services', () => {

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -21,7 +21,7 @@ import {
   disposeServicesForDoc,
   getExistingServiceForDocInEmbedScope,
   getExistingServiceInEmbedScope,
-  getExistingService,
+  getExistingServiceOrNull,
   getParentWindowFrameElement,
   getService,
   getServiceForDoc,
@@ -137,14 +137,13 @@ describe('service', () => {
 
     it('should return the service when it exists', () => {
       const c1 = getService(window, 'c', factory);
-      const c2 = getExistingService(window, 'c');
+      const c2 = getExistingServiceOrNull(window, 'c');
       expect(c1).to.equal(c2);
     });
 
-    it('should throw before creation', () => {
-      getService(window, 'another service to avoid NPE', () => {});
+    it('should throw before creation if factory is not provided', () => {
       expect(() => {
-        getExistingService(window, 'c');
+        getService(window, 'c');
       }).to.throw();
     });
 
@@ -209,13 +208,13 @@ describe('service', () => {
       const child = {};
       setParentWindow(child, window);
       expect(getService(child, 'c', factory)).to.equal(c);
-      expect(getExistingService(child, 'c')).to.equal(c);
+      expect(getExistingServiceOrNull(child, 'c')).to.equal(c);
 
       // A grandchild.
       const grandchild = {};
       setParentWindow(grandchild, child);
       expect(getService(grandchild, 'c', factory)).to.equal(c);
-      expect(getExistingService(grandchild, 'c')).to.equal(c);
+      expect(getExistingServiceOrNull(grandchild, 'c')).to.equal(c);
     });
 
     describe('embed service', () => {
@@ -252,13 +251,13 @@ describe('service', () => {
         expect(getExistingServiceInEmbedScope(childWin, 'c'))
             .to.equal(overridenService);
         // Top-level service doesn't change.
-        expect(getExistingService(window, 'c'))
+        expect(getExistingServiceOrNull(window, 'c'))
             .to.equal(topService);
 
         // Notice that only direct overrides are allowed for now. This is
         // arbitrary can change in the future to allow hierarchical lookup
         // up the window chain.
-        expect(getExistingService(grandchildWin, 'c'))
+        expect(getExistingServiceOrNull(grandchildWin, 'c'))
             .to.equal(topService);
       });
     });


### PR DESCRIPTION
Now that no services use the `fromClass` and `fromClassForDoc` codepaths, service.js can be cleaned up a bit. This PR:

- removes `fromClass` and `fromClassForDoc`. The same functionality is provided by `registerService` + `getService` and `registerServiceForDoc` + `getServiceForDoc`
- Removes `getExistingService{,forDoc}` methods whose functionality is provided by asserts elsewhere. 
- `getExistingServiceForWindowOrNull` has been renamed to be consistent with other function names
- Removes legacy code path related to the removed functions

/to @choumx @dvoytenko 

Closes #4986 