### PR TITLE
Enable "web-worker" in canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -25,5 +25,6 @@
   "amp-auto-ads": 1,
   "slidescroll-disable-css-snap": 1,
   "visibility-v3": 1,
-  "as-use-attr-for-format": 1
+  "as-use-attr-for-format": 1,
+  "web-worker": 1
 }


### PR DESCRIPTION
Fixes #8393. 

Verified that web-worker works in pages served by cache.

/to @cramforce 