### PR TITLE
Activate pump-early-frame experiment for canary.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -18,6 +18,7 @@
   "amp-playbuzz": 1,
   "sentinel-name-change": 1,
   "chunked-amp": 1,
+  "pump-early-frame": 1,
   "make-body-relative": 1,
   "visibility-v2": 1,
   "amp-selector": 1,


### PR DESCRIPTION
This should be activated with the next canary release.

@dvoytenko Could you submit this before the next canary cut?