### PR TITLE
Fix initialization of lifecycle reporter for delayed fetch slots.

### DIFF
--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -103,7 +103,7 @@ function isInReportableBranch(ampElement, namespace) {
  * @param {string} namespace
  * @param {number|string} slotId A unique numeric identifier in the page for
  *    the given element's slot.
- * @return {!GoogleAdLifecycleReporter|!BaseLifecycleReporter}
+ * @return {!./performance.BaseLifecycleReporter}
  */
 export function getLifecycleReporter(ampElement, namespace, slotId) {
   // Carve-outs: We only want to enable profiling pingbacks when:
@@ -136,12 +136,14 @@ export function getLifecycleReporter(ampElement, namespace, slotId) {
 
 /**
  * Creates or reinitializes a lifecycle reporter for Google ad network
- * implementations.
+ * implementations.  (I.e., 'type="doubleclick"' and 'type="adsense"'.)  For
+ * non-Google networks, returns a BaseLifecycleReporter -- a stub reporter that
+ * generates no outputs.
  *
  * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A} a4aElement
  * @param {string=} opt_namespace  CSI ping namespace.  For example, a key
  *   of #ReporterNamespace.
- * @return {!./performance.GoogleAdLifecycleReporter|!./performance.BaseLifecycleReporter}
+ * @return {!./performance.BaseLifecycleReporter}
  */
 export function googleLifecycleReporterFactory(a4aElement, opt_namespace) {
   const namespace = opt_namespace || ReporterNamespace.A4A;

--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -140,16 +140,16 @@ export function getLifecycleReporter(ampElement, namespace, slotId) {
  * non-Google networks, returns a BaseLifecycleReporter -- a stub reporter that
  * generates no outputs.
  *
- * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A} a4aElement
+ * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A|!../../../extensions/amp-ad/0.1/amp-ad-3p-impl.AmpAd3PImpl} element
  * @param {string=} opt_namespace  CSI ping namespace.  For example, a key
  *   of #ReporterNamespace.
  * @return {!./performance.BaseLifecycleReporter}
  */
-export function googleLifecycleReporterFactory(a4aElement, opt_namespace) {
+export function googleLifecycleReporterFactory(element, opt_namespace) {
   const namespace = opt_namespace || ReporterNamespace.A4A;
   const reporter =
-      (getLifecycleReporter(a4aElement, namespace,
-          a4aElement.element.getAttribute('data-amp-slot-index')));
+      (getLifecycleReporter(element, namespace,
+          element.element.getAttribute('data-amp-slot-index')));
   reporter.setPingParameters({
     's': 'AD_SLOT_NAMESPACE',
     'v': '2',
@@ -162,8 +162,8 @@ export function googleLifecycleReporterFactory(a4aElement, opt_namespace) {
     'stageIdx': 'AD_SLOT_EVENT_ID',
     'met.AD_SLOT_NAMESPACE.AD_SLOT_ID':
         'AD_SLOT_EVENT_NAME.AD_SLOT_TIME_TO_EVENT',
-    'e.AD_SLOT_ID': a4aElement.element.getAttribute(EXPERIMENT_ATTRIBUTE),
-    'adt.AD_SLOT_ID': a4aElement.element.getAttribute('type'),
+    'e.AD_SLOT_ID': element.element.getAttribute(EXPERIMENT_ATTRIBUTE),
+    'adt.AD_SLOT_ID': element.element.getAttribute('type'),
     // Page-level visibility times: `firstVisibleTime.T,.lastVisibleTime.T`.
     'met.AD_SLOT_NAMESPACE':
         'firstVisibleTime.AD_PAGE_FIRST_VISIBLE_TIME' +

--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -153,6 +153,7 @@ export function googleLifecycleReporterFactory(element, opt_namespace) {
           element.element.getAttribute('data-amp-slot-index')));
   reporter.setPingParameters({
     's': 'AD_SLOT_NAMESPACE',
+    'dt': 'NAV_TIMING(navigationStart)',
     'v': '2',
     'c': 'AD_PAGE_CORRELATOR',
     'rls': 'AMP_VERSION',

--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -139,12 +139,14 @@ export function getLifecycleReporter(ampElement, namespace, slotId) {
  * implementations.
  *
  * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A} a4aElement
- * @return {!./performance.GoogleAdLifecycleReporter}
+ * @param {string=} opt_namespace  CSI ping namespace.  For example, a key
+ *   of #ReporterNamespace.
+ * @return {!./performance.GoogleAdLifecycleReporter|!./performance.BaseLifecycleReporter}
  */
-export function googleLifecycleReporterFactory(a4aElement) {
+export function googleLifecycleReporterFactory(a4aElement, opt_namespace) {
+  const namespace = opt_namespace || ReporterNamespace.A4A;
   const reporter =
-      /** @type {!./performance.GoogleAdLifecycleReporter} */
-      (getLifecycleReporter(a4aElement, ReporterNamespace.A4A,
+      (getLifecycleReporter(a4aElement, namespace,
           a4aElement.element.getAttribute('data-amp-slot-index')));
   reporter.setPingParameters({
     's': 'AD_SLOT_NAMESPACE',

--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -141,16 +141,16 @@ export function getLifecycleReporter(ampElement, namespace, slotId) {
  * non-Google networks, returns a BaseLifecycleReporter -- a stub reporter that
  * generates no outputs.
  *
- * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A|!../../../extensions/amp-ad/0.1/amp-ad-3p-impl.AmpAd3PImpl} element
+ * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A|!../../../extensions/amp-ad/0.1/amp-ad-3p-impl.AmpAd3PImpl} baseInstance
  * @param {string=} opt_namespace  CSI ping namespace.  For example, a key
  *   of #ReporterNamespace.
  * @return {!./performance.BaseLifecycleReporter}
  */
-export function googleLifecycleReporterFactory(element, opt_namespace) {
+export function googleLifecycleReporterFactory(baseInstance, opt_namespace) {
   const namespace = opt_namespace || ReporterNamespace.A4A;
   const reporter =
-      (getLifecycleReporter(element, namespace,
-          element.element.getAttribute('data-amp-slot-index')));
+      (getLifecycleReporter(baseInstance, namespace,
+          baseInstance.element.getAttribute('data-amp-slot-index')));
   reporter.setPingParameters({
     's': 'AD_SLOT_NAMESPACE',
     'dt': 'NAV_TIMING(navigationStart)',
@@ -164,8 +164,8 @@ export function googleLifecycleReporterFactory(element, opt_namespace) {
     'stageIdx': 'AD_SLOT_EVENT_ID',
     'met.AD_SLOT_NAMESPACE.AD_SLOT_ID':
         'AD_SLOT_EVENT_NAME.AD_SLOT_TIME_TO_EVENT',
-    'e.AD_SLOT_ID': element.element.getAttribute(EXPERIMENT_ATTRIBUTE),
-    'adt.AD_SLOT_ID': element.element.getAttribute('type'),
+    'e.AD_SLOT_ID': baseInstance.element.getAttribute(EXPERIMENT_ATTRIBUTE),
+    'adt.AD_SLOT_ID': baseInstance.element.getAttribute('type'),
     // Page-level visibility times: `firstVisibleTime.T,.lastVisibleTime.T`.
     'met.AD_SLOT_NAMESPACE':
         'firstVisibleTime.AD_PAGE_FIRST_VISIBLE_TIME' +

--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -104,6 +104,7 @@ function isInReportableBranch(ampElement, namespace) {
  * @param {number|string} slotId A unique numeric identifier in the page for
  *    the given element's slot.
  * @return {!./performance.BaseLifecycleReporter}
+ * @visibleForTesting
  */
 export function getLifecycleReporter(ampElement, namespace, slotId) {
   // Carve-outs: We only want to enable profiling pingbacks when:

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -244,7 +244,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   }
 
   /**
-   * @return {!../../../ads/google/a4a/performance.GoogleAdLifecycleReporter}
+   * @return {!../../../ads/google/a4a/performance.BaseLifecycleReporter}
    */
   initLifecycleReporter() {
     return googleLifecycleReporterFactory(this);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -184,7 +184,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /**
-   * @return {!../../../ads/google/a4a/performance.GoogleAdLifecycleReporter}
+   * @return {!../../../ads/google/a4a/performance.BaseLifecycleReporter}
    */
   initLifecycleReporter() {
     return googleLifecycleReporterFactory(this);

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -222,7 +222,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (this.layoutPromise_) {
       return this.layoutPromise_;
     }
-    this.lifecycleReporter.sendPing('preAdThrottle');
+    this.emitLifecycleEvent('preAdThrottle');
     user().assert(!this.isInFixedContainer_,
         '<amp-ad> is not allowed to be placed in elements with ' +
         'position:fixed: %s', this.element);
@@ -238,7 +238,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       // because both happen inside a cross-domain iframe.  Separating them
       // here, though, allows us to measure the impact of ad throttling via
       // incrementLoadingAds().
-      this.lifecycleReporter.sendPing('adRequestStart');
+      this.emitLifecycleEvent('adRequestStart');
       const iframe = getIframe(this.element.ownerDocument.defaultView,
           this.element, undefined, opt_context);
       this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(
@@ -265,7 +265,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.xOriginIframeHandler_.freeXOriginIframe();
       this.xOriginIframeHandler_ = null;
     }
-    this.lifecycleReporter.sendPing('adSlotCleared');
+    this.emitLifecycleEvent('adSlotCleared');
     return true;
   }
 


### PR DESCRIPTION
A4A Fast Fetch has been emitting "lifecycle reporting" pings for some time.  The intention was always to emit a corresponding set of pings for Delayed Fetch (a.k.a., 3p) slots when running on Google ad tag types (`<amp-ad type="doubleclick">` and `type="adsense"`), and the notification points have been present in the code.  However, due to a bug in lifecycle reporter initialization, the notifications were not being turned into actual data pings.  This fixes initialization so that pings are sent for Delayed Fetch as well as for Fast Fetch slots.