### PR TITLE
Provide Position API to ad

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -153,6 +153,24 @@ export class AbstractAmpContext {
   };
 
   /**
+   *  Send message to runtime to start sending position messages.
+   *  @param {function(Object)} callback Function to call every time we
+   *    receive a position info message.
+   *  @returns {function()} that when called stops triggering the callback
+   *    every time we receive a position info message.
+   */
+  observePosition(callback) {
+    const unlisten = this.client_.makeRequest(
+        MessageType.SEND_POSITIONS,
+        MessageType.POSITION,
+        data => {
+          callback(data);
+        });
+
+    return unlisten;
+  };
+
+  /**
    *  Send message to runtime requesting to resize ad to height and width.
    *    This is not guaranteed to succeed. All this does is make the request.
    *  @param {number} width The new width for the ad we are requesting.

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -22,7 +22,8 @@ import {dev} from '../src/log';
  * @param {!Object} data
  */
 export function _ping_(global, data) {
-  validateData(data, [], ['valid', 'adHeight', 'adWidth', 'enableIo', 'url']);
+  validateData(data, [],
+      ['valid', 'adHeight', 'adWidth', 'enableIo', 'url', 'enablePosition']);
   global.document.getElementById('c').textContent = data.ping;
   global.ping = Object.create(null);
 
@@ -68,6 +69,12 @@ export function _ping_(global, data) {
         });
         // store changes to global.lastIO for testing purpose
         global.ping.lastIO = changes[changes.length - 1];
+      });
+    }
+    if (data.enablePosition) {
+      global.context.observePosition(function(data) {
+        dev().info('AMP-AD', 'Position: ' +
+            `target top ${data.target.top}, viewport top ${data.viewport.top}`);
       });
     }
   } else {

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -20,6 +20,9 @@ import {
   IntersectionObserver,
 } from '../../../src/intersection-observer';
 import {
+  PositionObserverApi,
+} from '../../../src/position-observer';
+import {
   SubscriptionApi,
   listenFor,
   listenForOncePromise,
@@ -58,6 +61,9 @@ export class AmpAdXOriginIframeHandler {
     /** @private {?IntersectionObserver} */
     this.intersectionObserver_ = null;
 
+    /** @private {?PositionObserverApi} */
+    this.positionObserver_ = null;
+
     /** @private {SubscriptionApi} */
     this.embedStateApi_ = null;
 
@@ -84,6 +90,10 @@ export class AmpAdXOriginIframeHandler {
 
     // Init IntersectionObserver service.
     this.intersectionObserver_ = new IntersectionObserver(
+        this.baseInstance_, this.iframe, true);
+
+    // Init PositionObserver service.
+    this.positionObserver_ = new PositionObserverApi(
         this.baseInstance_, this.iframe, true);
 
     this.embedStateApi_ = new SubscriptionApi(
@@ -288,6 +298,10 @@ export class AmpAdXOriginIframeHandler {
       this.intersectionObserver_.destroy();
       this.intersectionObserver_ = null;
     }
+    if (this.positionObserver_) {
+      this.positionObserver_.destroy();
+      this.positionObserver_ = null;
+    }
   }
 
   /**
@@ -366,9 +380,12 @@ export class AmpAdXOriginIframeHandler {
    */
   onLayoutMeasure() {
     // When the framework has the need to remeasure us, our position might
-    // have changed. Send an intersection record if needed.
+    // have changed. Send an intersection and position record if needed.
     if (this.intersectionObserver_) {
       this.intersectionObserver_.fire();
+    }
+    if (this.positionObserver_) {
+      this.positionObserver_.fire();
     }
   }
 }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -24,6 +24,8 @@ import {
 } from '../../../../testing/iframe';
 import {AmpAdUIHandler} from '../amp-ad-ui';
 import {timerFor} from '../../../../src/services';
+import {PositionObserverApi} from '../../../../src/position-observer';
+import {layoutRectLtwh} from '../../../../src/layout-rect';
 import * as sinon from 'sinon';
 
 describe('amp-ad-xorigin-iframe-handler', () => {
@@ -329,6 +331,32 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         requestedWidth: undefined,
         requestedHeight: 217,
         type: 'embed-size-changed',
+        sentinel: 'amp3ptest' + testIndex,
+      }));
+    });
+
+    it('should be able to use position API', () => {
+      sandbox.stub(adImpl, 'getVsync', () => {
+        return {
+          measure: function(callback) {
+            callback();
+          },
+        };
+      });
+      sandbox.stub(iframeHandler.positionObserver_, 'getPosition_', () => {
+        return {
+          viewport: layoutRectLtwh(0, 0, 0, 0),
+          target: layoutRectLtwh(0, 0, 0, 0),
+        };
+      });
+      iframe.postMessageToParent({
+        type: 'send-positions',
+        sentinel: 'amp3ptest' + testIndex,
+      });
+      return iframe.expectMessageFromParent('amp-' + JSON.stringify({
+        viewport: layoutRectLtwh(0, 0, 0, 0),
+        target: layoutRectLtwh(0, 0, 0, 0),
+        type: 'position',
         sentinel: 'amp3ptest' + testIndex,
       }));
     });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -343,11 +343,11 @@ describe('amp-ad-xorigin-iframe-handler', () => {
           },
         };
       });
-      sandbox.stub(iframeHandler.positionObserver_, 'getPosition_', () => {
-        return {
+      sandbox.stub/*OK*/(iframeHandler.positionObserver_, 'getPosition_', () => {
+        return Promise.resolve({
           viewport: layoutRectLtwh(0, 0, 0, 0),
           target: layoutRectLtwh(0, 0, 0, 0),
-        };
+        });
       });
       iframe.postMessageToParent({
         type: 'send-positions',

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -34,8 +34,6 @@ export const MessageType = {
   EMBED_SIZE: 'embed-size',
   EMBED_SIZE_CHANGED: 'embed-size-changed',
   EMBED_SIZE_DENIED: 'embed-size-denied',
-
-  // For amp-inabox
   SEND_POSITIONS: 'send-positions',
   POSITION: 'position',
 };

--- a/src/position-observer.js
+++ b/src/position-observer.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SubscriptionApi} from './iframe-helper';
+import {MessageType} from './3p-frame-messaging.js';
+import {rateLimit} from './utils/rate-limit';
+import {LayoutRectDef} from './layout-rect';
+
+/** @const */
+const MIN_EVENT_INTERVAL_IN_MS = 100;
+
+/**
+ * @typedef {{
+ *   viewport: !LayoutRectDef,
+ *   target: !LayoutRectDef
+ * }}
+ */
+let PositionEntryDef;
+
+export class PositionObserverApi {
+  /**
+   * @param {!AMP.BaseElement} baseElement
+   * @param {!Element} iframe
+   * @param {boolean=} opt_is3p
+   */
+  constructor(baseElement, iframe, opt_is3p) {
+    /** @private @const {!AMP.BaseElement} */
+    this.baseElement_ = baseElement;
+
+    /** @private @const {!./service/viewport-impl.Viewport} */
+    this.viewport_ = baseElement.getViewport();
+
+    /** @private {?SubscriptionApi} */
+    this.subscriptionApi_ = new SubscriptionApi(
+        iframe, MessageType.SEND_POSITIONS, opt_is3p || false, () => {
+          // Sending one immediately
+          this.fire();
+          this.startSendingPosition_();
+        });
+
+    /** @const {function()} */
+    this.fire = rateLimit(this.baseElement_.win, () => {
+      console.log('ratelimit');
+      this.baseElement_.getVsync().measure(() => {
+        console.log('eeeee');
+        this.subscriptionApi_.send(MessageType.POSITION, this.getPosition_());
+      });
+    }, MIN_EVENT_INTERVAL_IN_MS);
+
+    /** @private {?Function} */
+    this.unlistenOnDestroy_ = null;
+  }
+
+  /**
+   * Function to start listening to viewport event and observe element position.
+   * @private
+   */
+  startSendingPosition_() {
+    // TODO: register element to positionObserver once layer manager supports
+    const unlistenViewportScroll = this.viewport_.onScroll(this.fire);
+    const unlistenViewportChange = this.viewport_.onChange(this.fire);
+    this.unlistenOnDestroy_ = () => {
+      unlistenViewportScroll();
+      unlistenViewportChange();
+    };
+  }
+
+  /**
+   * Clean all listeners
+   */
+  destroy() {
+    if (this.unlistenOnDestroy_) {
+      this.unlistenOnDestroy_();
+      this.unlistenOnDestroy_ = null;
+    }
+    if (this.subscriptionApi_) {
+      this.subscriptionApi_.destroy();
+      this.subscriptionApi_ = null;
+    }
+  }
+
+  /**
+   * Get the position info.
+   * Note: need to call in vsync
+   * @return {PositionEntryDef}
+   */
+  getPosition_() {
+    return {
+      viewport: this.viewport_.getRect(),
+      target: this.baseElement_.getLayoutBox(),
+    };
+  }
+}
+

--- a/test/functional/test-amp-context.js
+++ b/test/functional/test-amp-context.js
@@ -181,6 +181,42 @@ describe('3p ampcontext.js', () => {
     expect(callbackSpy.calledTwice).to.be.true;
   });
 
+  it('should be able to send an position observer request', () => {
+    win.name = generateSerializedAttributes();
+    const context = new AmpContext(win);
+    const callbackSpy = sandbox.spy();
+
+    // Resetting since a message is sent on construction.
+    windowPostMessageSpy.reset();
+
+    const stopObserving = context.observePosition(callbackSpy);
+    expect(windowPostMessageSpy.calledOnce).to.be.true;
+    expect(windowPostMessageSpy.calledWith({
+      sentinel: '1-291921',
+      type: MessageType.SEND_POSITIONS,
+    }, '*'));
+
+    // send an position message down
+    const messagePayload = {
+      sentinel: '1-291921',
+      type: MessageType.POSITION,
+    };
+    const messageData = 'amp-' + JSON.stringify(messagePayload);
+    const message = {
+      source: context.client_.hostWindow_,
+      data: messageData,
+    };
+    windowMessageHandler(message);
+
+    expect(callbackSpy.calledWith(messagePayload));
+
+    callbackSpy.reset();
+    // Stop listening
+    stopObserving();
+    windowMessageHandler(message);
+    expect(callbackSpy).to.not.be.called;
+  });
+
   it('should send a pM and set callback when onPageVisibilityChange()', () => {
     win.name = generateSerializedAttributes();
     const context = new AmpContext(win);

--- a/test/functional/test-position-observer.js
+++ b/test/functional/test-position-observer.js
@@ -41,7 +41,6 @@ describes.realWin('PositionObserverApi', {
     sandbox.stub(baseElement, 'getViewport', () => {
       return {
         getRect: () => {
-          console.log("asdfsdf");
           return layoutRectLtwh(1, 2, 3, 4);
         },
       };
@@ -55,13 +54,12 @@ describes.realWin('PositionObserverApi', {
     posObserver = new PositionObserverApi(baseElement, iframe);
   });
 
-  it('should send one immediately wit correct value', () => {
-    const sendSpy = sandbox.spy(posObserver.subscriptionApi_, 'send');
-    posObserver.fire();
-    expect(sendSpy).to.be.calledOnce;
-    expect(sendSpy).to.be.calledWith('position', {
-      viewport: layoutRectLtwh(1, 2, 3, 4),
-      target: layoutRectLtwh(5, 6, 7, 8),
+  it('should get position with correct value', () => {
+    return posObserver.getPosition_().then(position => {
+      expect(position).to.deep.equal({
+        viewport: layoutRectLtwh(1, 2, 3, 4),
+        target: layoutRectLtwh(5, 6, 7, 8),
+      });
     });
   });
 });

--- a/test/functional/test-position-observer.js
+++ b/test/functional/test-position-observer.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {PositionObserverApi} from '../../src/position-observer';
+import {BaseElement} from '../../src/base-element';
+import {layoutRectLtwh} from '../../src/layout-rect';
+
+describes.realWin('PositionObserverApi', {
+  amp: {
+    ampdoc: 'single',
+  },
+}, env => {
+  let sandbox;
+  let baseElement;
+  let posObserver;
+  beforeEach(() => {
+    sandbox = env.sandbox;
+    const element = env.win.document.createElement('div');
+    env.win.document.body.appendChild(element);
+    baseElement = new BaseElement(element);
+    sandbox.stub(baseElement, 'getVsync', () => {
+      return {
+        measure: function(callback) {
+          callback();
+        },
+      };
+    });
+    sandbox.stub(baseElement, 'getViewport', () => {
+      return {
+        getRect: () => {
+          console.log("asdfsdf");
+          return layoutRectLtwh(1, 2, 3, 4);
+        },
+      };
+    });
+    sandbox.stub(baseElement, 'getLayoutBox', () => {
+      return layoutRectLtwh(5, 6, 7, 8);
+    });
+
+    const iframe = env.win.document.createElement('iframe');
+    iframe.src = 'no-use';
+    posObserver = new PositionObserverApi(baseElement, iframe);
+  });
+
+  it('should send one immediately wit correct value', () => {
+    const sendSpy = sandbox.spy(posObserver.subscriptionApi_, 'send');
+    posObserver.fire();
+    expect(sendSpy).to.be.calledOnce;
+    expect(sendSpy).to.be.calledWith('position', {
+      viewport: layoutRectLtwh(1, 2, 3, 4),
+      target: layoutRectLtwh(5, 6, 7, 8),
+    });
+  });
+});

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -30,6 +30,7 @@ function createIframeWithApis(fixture) {
   let iframe;
   let ampAd;
   let lastIO = null;
+  let lastPosition = null;
   const platform = platformFor(fixture.win);
   return pollForLayout(fixture.win, 1, 5500).then(() => {
     // test amp-ad will create an iframe
@@ -104,13 +105,21 @@ function createIframeWithApis(fixture) {
     });
   }).then(() => {
     lastIO = null;
+    lastPosition = null;
     iframe.contentWindow.context.observeIntersection(changes => {
       lastIO = changes[changes.length - 1];
+    });
+    iframe.contentWindow.context.observePosition(data => {
+      lastPosition = data.target;
     });
     fixture.win.scrollTo(0, 1000);
     fixture.win.document.body.dispatchEvent(new Event('scroll'));
     return poll('wait for new IO entry', () => {
       return lastIO != null;
+    });
+  }).then(() => {
+    return poll('wait for new position', () => {
+      return lastPosition != null;
     });
   });
 }

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -30,7 +30,6 @@ function createIframeWithApis(fixture) {
   let iframe;
   let ampAd;
   let lastIO = null;
-  let lastPosition = null;
   const platform = platformFor(fixture.win);
   return pollForLayout(fixture.win, 1, 5500).then(() => {
     // test amp-ad will create an iframe
@@ -105,21 +104,13 @@ function createIframeWithApis(fixture) {
     });
   }).then(() => {
     lastIO = null;
-    lastPosition = null;
     iframe.contentWindow.context.observeIntersection(changes => {
       lastIO = changes[changes.length - 1];
-    });
-    iframe.contentWindow.context.observePosition(data => {
-      lastPosition = data.target;
     });
     fixture.win.scrollTo(0, 1000);
     fixture.win.document.body.dispatchEvent(new Event('scroll'));
     return poll('wait for new IO entry', () => {
       return lastIO != null;
-    });
-  }).then(() => {
-    return poll('wait for new position', () => {
-      return lastPosition != null;
     });
   });
 }

--- a/test/manual/fakead3p.amp.html
+++ b/test/manual/fakead3p.amp.html
@@ -80,7 +80,8 @@
         data-valid='true'
         data-ad-width=50
         data-ad-height=50
-        data-enable-io='true'>
+        data-enable-io='true'
+        data-enable-position='true'>
     </amp-ad>
   </div>
 


### PR DESCRIPTION
For #6873 
@alanorozco  I didn't make change  to `integration.js` When would `3p-use-ampcontext` be live?

Note: We once agreed to only send position if ad is in viewport. However to support inabox current logic, we need to send position even outside viewport. Not sure we want to do that. 

I only add the API to `<amp-ad>` not `<amp-iframe>` since there's no requirement for iframe case.
Need to document the API afterwards. 

cc @jasti  