### PR TITLE
Prevent 'forEach is not defined' in installActionHandler (#8702)

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -20,7 +20,7 @@ import {createCustomEvent} from '../../../src/event-helper';
 import {installStylesForShadowRoot} from '../../../src/shadow-embed';
 import {documentInfoForDoc} from '../../../src/services';
 import {iterateCursor} from '../../../src/dom';
-import {setFormForElement} from '../../../src/form';
+import {formOrNullForElement, setFormForElement} from '../../../src/form';
 import {
   assertAbsoluteHttpOrHttpsUrl,
   assertHttpsUrl,
@@ -841,7 +841,8 @@ export class AmpFormService {
     }
 
     iterateCursor(forms, (form, index) => {
-      if (!form.classList.contains('i-amphtml-form')) {
+      const existingAmpForm = formOrNullForElement(form);
+      if (!existingAmpForm) {
         new AmpForm(form, `amp-form-${index}`);
       }
     });

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -273,7 +273,7 @@ export class ActionService {
         'AMP element or a whitelisted target element is expected: %s', debugid);
 
     if (target[ACTION_HANDLER_]) {
-      // Already installed
+      dev().error(TAG_, `Action handler already installed for ${target}`);
       return;
     }
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -280,6 +280,8 @@ export class ActionService {
     /** @const {Array<!ActionInvocation>} */
     const currentQueue = target[ACTION_QUEUE_];
 
+    target[ACTION_HANDLER_] = handler;
+
     // Dequeue the current queue.
     if (isArray(currentQueue)) {
       timerFor(target.ownerDocument.defaultView).delay(() => {
@@ -291,7 +293,6 @@ export class ActionService {
             dev().error(TAG_, 'Action execution failed:', invocation, e);
           }
         });
-        target[ACTION_HANDLER_] = handler;
         target[ACTION_QUEUE_].length = 0;
       }, 1);
     }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -283,7 +283,7 @@ export class ActionService {
     target[ACTION_QUEUE_] = {'push': handler};
 
     // Dequeue the current queue.
-    if (currentQueue) {
+    if (isArray(currentQueue)) {
       timerFor(target.ownerDocument.defaultView).delay(() => {
         // TODO(dvoytenko, #1260): dedupe actions.
         currentQueue.forEach(invocation => {

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -636,6 +636,7 @@ describe('Action method', () => {
   it('should invoke on non-AMP but whitelisted element', () => {
     const handlerSpy = sandbox.spy();
     const target = document.createElement('form');
+    debugger;
     action.installActionHandler(target, handlerSpy);
     action.invoke_(target, 'submit', /* args */ null,
         'button', 'tap');

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -757,6 +757,10 @@ describe('Action interceptor', () => {
     return target['__AMP_ACTION_QUEUE__'];
   }
 
+  function getActionHandler() {
+    return target['__AMP_ACTION_HANDLER__'];
+  }
+
 
   it('should not initialize until called', () => {
     expect(getQueue()).to.be.undefined;
@@ -788,10 +792,12 @@ describe('Action interceptor', () => {
     action.invoke_(target, 'method2', /* args */ null, 'source2', 'event2');
 
     expect(Array.isArray(getQueue())).to.be.true;
+    expect(getActionHandler()).to.be.undefined;
     expect(getQueue()).to.have.length(2);
 
     const handler = sandbox.spy();
     action.installActionHandler(target, handler);
+    expect(getActionHandler()).to.not.be.undefined;
     expect(handler).to.have.not.been.called;
 
     clock.tick(10);

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -636,7 +636,6 @@ describe('Action method', () => {
   it('should invoke on non-AMP but whitelisted element', () => {
     const handlerSpy = sandbox.spy();
     const target = document.createElement('form');
-    debugger;
     action.installActionHandler(target, handlerSpy);
     action.invoke_(target, 'submit', /* args */ null,
         'button', 'tap');
@@ -793,7 +792,6 @@ describe('Action interceptor', () => {
 
     const handler = sandbox.spy();
     action.installActionHandler(target, handler);
-    expect(Array.isArray(getQueue())).to.be.false;
     expect(handler).to.have.not.been.called;
 
     clock.tick(10);
@@ -812,7 +810,6 @@ describe('Action interceptor', () => {
     expect(inv1.event).to.equal('event2');
 
     action.invoke_(target, 'method3', /* args */ null, 'source3', 'event3');
-    expect(Array.isArray(getQueue())).to.be.false;
     expect(handler).to.have.callCount(3);
     const inv2 = handler.getCall(2).args[0];
     expect(inv2.target).to.equal(target);


### PR DESCRIPTION
This PR:

- Changes how the amp form service prevents creating multiple AmpForm instances for the same form
- Changes usage of ACTION_QUEUE_ in `action-impl.js`to prevent the error in #8702 

/to @dvoytenko 