### PR TITLE
Fix race condition in service registration

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -533,7 +533,9 @@ function registerServiceInternal(holder, context, id, opt_ctor, opt_factory) {
   // The service may have been requested already, in which case there is a
   // pending promise that needs to fulfilled.
   if (s.promise && s.resolve) {
-    s.resolve(s.build());
+    const obj = s.build();
+    s.obj = obj;
+    s.resolve(obj);
   }
 }
 

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -375,8 +375,19 @@ describe('service', () => {
     it('should not instantiate service when registered', () => {
       registerServiceBuilderForDoc(ampdoc, 'fake service', factory);
       expect(count).to.equal(0);
+      getServicePromiseForDoc(ampdoc, 'fake service');
       getServiceForDoc(ampdoc, 'fake service');
       expect(count).to.equal(1);
+    });
+
+    it('should not instantiate service when registered (race)', () => {
+      getServicePromiseForDoc(ampdoc, 'fake service');
+      registerServiceBuilderForDoc(ampdoc, 'fake service', factory);
+      expect(count).to.equal(1);
+      getServiceForDoc(ampdoc, 'fake service');
+      return Promise.resolve().then(() => {
+        expect(count).to.equal(1);
+      });
     });
 
     it('should work without a factory', () => {


### PR DESCRIPTION
Happened when

- A promise for a service was requested before the service was registered.
- And then another syncronous service was requested.