### PR TITLE
amp-hulu

### DIFF
--- a/extensions/amp-hulu/0.1/amp-hulu.js
+++ b/extensions/amp-hulu/0.1/amp-hulu.js
@@ -79,9 +79,8 @@ class AmpHulu extends AMP.BaseElement {
   /** @return {string} */
   getVideoIframeSrc_() {
     dev().assert(this.eid_);
-    return `https://secure.hulu.com/dash/mobile_embed.html?amp=1&eid=${encodeURIComponent(this.eid_ || '')}`;
+    return `https://player.hulu.com/site/dash/mobile_embed.html?amp=1&eid=${encodeURIComponent(this.eid_ || '')}`;
   }
-
 };
 
 AMP.registerElement('amp-hulu', AmpHulu);

--- a/extensions/amp-hulu/0.1/test/test-amp-hulu.js
+++ b/extensions/amp-hulu/0.1/test/test-amp-hulu.js
@@ -44,7 +44,8 @@ describe('amp-hulu', () => {
       const iframe = hulu.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
-      expect(iframe.src).to.equal('https://secure.hulu.com/dash/mobile_embed.html?amp=1&eid=4Dk5F2PYTtrgciuvloH3UA');
+      expect(iframe.src)
+          .to.equal('https://player.hulu.com/site/dash/mobile_embed.html?amp=1&eid=4Dk5F2PYTtrgciuvloH3UA');
     });
   });
 

--- a/extensions/amp-hulu/amp-hulu.md
+++ b/extensions/amp-hulu/amp-hulu.md
@@ -51,7 +51,7 @@ limitations under the License.
 
 **data-eid**
 
-The ID of the video. For example, `4Dk5F2PYTtrgciuvloH3UA` is the eid in the following URL: https://secure.hulu.com/embed.html?eid=4Dk5F2PYTtrgciuvloH3UA.
+The ID of the video. For example, `4Dk5F2PYTtrgciuvloH3UA` is the eid in the following URL: https://player.hulu.com/site/dash/mobile_embed.html?eid=4Dk5F2PYTtrgciuvloH3UA.
 
 **common attributes**
 


### PR DESCRIPTION
# Updated the host of Hulu Player
Hulu has deployed a new host for Hulu Player, all the old resource should be moved to the new host ASAP. `amp-hulu` includes an old Hulu Player URL, which should be updated.