### PR TITLE
amp-bind: Expose encodeURI and encodeURIComponent in bind

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -92,6 +92,8 @@ const FUNCTION_WHITELIST = (function() {
     Math.random,
     Math.round,
     Math.sign,
+    encodeURI,
+    encodeURIComponent,
     copyAndSplice,
   ];
   // Creates a prototype-less map of function name to the function itself.

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -269,8 +269,10 @@ describe('BindExpression', () => {
   });
 
   it('should support encodeURI and encodeURIComponent', () => {
-    expect(evaluate('encodeURI("Hello World")')).to.equal('Hello%20World');
-    expect(evaluate('encodeURIComponent("#foo=bar")')).to.equal('%23foo%3Dbar');
+    expect(evaluate('encodeURI("http://www.google.com/s p a c e.html")'))
+        .to.equal('http://www.google.com/s%20p%20a%20c%20e.html');
+    expect(evaluate('encodeURIComponent("hello world")'))
+        .to.equal('hello%20world');
   });
 
   it('should support BindArrays functions', () => {

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -268,6 +268,11 @@ describe('BindExpression', () => {
     }).to.throw(unsupportedFunctionError);
   });
 
+  it('should support encodeURI and encodeURIComponent', () => {
+    expect(evaluate('encodeURI("Hello World")')).to.equal('Hello%20World');
+    expect(evaluate('encodeURIComponent("#foo=bar")')).to.equal('%23foo%3Dbar');
+  });
+
   it('should support BindArrays functions', () => {
     const arr = [1, 2, 3];
     expect(() => evaluate('copyAndSplice()')).to.throw(/not an array/);
@@ -440,8 +445,6 @@ describe('BindExpression', () => {
     expect(() => { evaluate('parseInt()'); }).to.throw();
     expect(() => { evaluate('decodeURI()'); }).to.throw();
     expect(() => { evaluate('decodeURIComponent()'); }).to.throw();
-    expect(() => { evaluate('encodeURI()'); }).to.throw();
-    expect(() => { evaluate('encodeURIComponent()'); }).to.throw();
     expect(() => { evaluate('escape()'); }).to.throw();
     expect(() => { evaluate('unescape()'); }).to.throw();
 

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -271,8 +271,8 @@ describe('BindExpression', () => {
   it('should support encodeURI and encodeURIComponent', () => {
     expect(evaluate('encodeURI("http://www.google.com/s p a c e.html")'))
         .to.equal('http://www.google.com/s%20p%20a%20c%20e.html');
-    expect(evaluate('encodeURIComponent("hello world")'))
-        .to.equal('hello%20world');
+    expect(evaluate('encodeURIComponent("http://www.google.com/foo?foo=bar")'))
+        .to.equal('http%3A%2F%2Fwww.google.com%2Ffoo%3Ffoo%3Dbar');
   });
 
   it('should support BindArrays functions', () => {

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -243,6 +243,7 @@ null || 'default' // 'default'
 | [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods) | `concat`<br>`includes`<br>`indexOf`<br>`join`<br>`lastIndexOf`<br>`slice` | `// Returns true.`<br>`[1, 2, 3].includes(1)` |
 | [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Methods) | `charAt`<br>`charCodeAt`<br>`concat`<br>`indexOf`<br>`lastIndexOf`<br>`slice`<br>`split`<br>`substr`<br>`substring`<br>`toLowerCase`<br>`toUpperCase` | `// Returns 'abcdef'.`<br>`'abc'.concat('def')` |
 | [`Math`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math)<sup>2</sup> | `abs`<br>`ceil`<br>`floor`<br>`max`<br>`min`<br>`random`<br>`round`<br>`sign` | `// Returns 1.`<br>`abs(-1)` |
+| [`Global`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects) | `encodeURI`<br>`encodeURIComponent`<br>|`// Returns 'hello%20world'`<br>encodeURIComponent('hello world')
 | [Custom built-ins](#custom-built-in-functions)<sup>2</sup> | `copyAndSplice` | `// Returns [1, 47 ,3].`<br>`copyAndSplice([1, 2, 3], 1, 1, 47)` |
 
 <sup>2</sup>Functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -243,7 +243,7 @@ null || 'default' // 'default'
 | [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods) | `concat`<br>`includes`<br>`indexOf`<br>`join`<br>`lastIndexOf`<br>`slice` | `// Returns true.`<br>`[1, 2, 3].includes(1)` |
 | [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Methods) | `charAt`<br>`charCodeAt`<br>`concat`<br>`indexOf`<br>`lastIndexOf`<br>`slice`<br>`split`<br>`substr`<br>`substring`<br>`toLowerCase`<br>`toUpperCase` | `// Returns 'abcdef'.`<br>`'abc'.concat('def')` |
 | [`Math`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math)<sup>2</sup> | `abs`<br>`ceil`<br>`floor`<br>`max`<br>`min`<br>`random`<br>`round`<br>`sign` | `// Returns 1.`<br>`abs(-1)` |
-| [`Global`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects) | `encodeURI`<br>`encodeURIComponent`<br>|`// Returns 'hello%20world'`<br>encodeURIComponent('hello world')
+| [`Global`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects)<sup>2</sup> | `encodeURI`<br>`encodeURIComponent`<br>|`// Returns 'hello%20world'`<br>`encodeURIComponent('hello world')`
 | [Custom built-ins](#custom-built-in-functions)<sup>2</sup> | `copyAndSplice` | `// Returns [1, 47 ,3].`<br>`copyAndSplice([1, 2, 3], 1, 1, 47)` |
 
 <sup>2</sup>Functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.


### PR DESCRIPTION
Adds support for `encodeURI` and `encodeURIComponent` in bind. 

Partial for #8700 

/to @choumx 