### PR TITLE
amp-bind: Allow binding to amp-state[src]

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -645,11 +645,51 @@ app.get(['/examples/*', '/test/manual/*'], function(req, res, next) {
   });
 });
 
+// Data for example: http://localhost:8000/examples/bind/xhr.amp.max.html
 app.use('/bind/form/get', function(req, res, next) {
   assertCors(req, res, ['GET']);
   res.json({
     bindXhrResult: 'I was fetched from the server!'
   });
+});
+
+// Data for example: http://localhost:8000/examples/bind/ecommerce.amp.max.html
+app.use('/bind/ecommerce/sizes', function(req, res, next) {
+  assertCors(req, res, ['GET']);
+  setTimeout(() => {
+    var prices = {
+      "0": {
+        "sizes": ["XS"]
+      },
+      "1": {
+        "sizes": ["S", "M", "L"]
+      },
+      "2": {
+        "sizes": ["XL"]
+      },
+      "3": {
+        "sizes": ["M", "XL"]
+      },
+      "4": {
+        "sizes": ["S", "L"]
+      },
+      "5": {
+        "sizes": ["S", "XL"]
+      },
+      "6": {
+        "sizes": ["XS", "M"]
+      },
+      "7": {
+        "sizes": ["M", "L", "XL"]
+      },
+      "8": {
+        "sizes": ["XS", "M", "XL"]
+      }
+    };
+    const object = {};
+    object[req.query.shirt] = prices[req.query.shirt];
+    res.json(object);
+  }, 1000); // Simulate network delay.
 });
 
 // Simulated Cloudflare signed Ad server

--- a/examples/bind/ecommerce.amp.html
+++ b/examples/bind/ecommerce.amp.html
@@ -30,11 +30,17 @@
 
   <h2>E-commerce</h2>
 
-  <amp-img width=400 height=400 src="./shirts/black.jpg" [src]="shirts[selectedIndex].src"></amp-img>
+  <amp-img width=400 height=400 src="./shirts/black.jpg" [src]="shirts[selectedIndex].image"></amp-img>
 
   <p>COLOR: <span [text]="shirts[selectedIndex].color">black</span></p>
 
-  <p>SIZE: <span [text]="shirts[selectedIndex].sizes.join(', ')">XS</span></p>
+  <p>SIZE:
+    <span [text]="shirts[selectedIndex].sizes
+        ? shirts[selectedIndex].sizes.join(', ')
+        : 'Fetching available sizes...'">
+      XS
+    </span>
+  </p>
 
   <amp-selector on="select:AMP.setState({selectedIndex: event.targetOption})">
     <amp-img width=50 height=50 src="./shirts/black.jpg" option=0></amp-img>
@@ -48,53 +54,51 @@
     <amp-img width=50 height=50 src="./shirts/wine.jpg" option=8></amp-img>
   </amp-selector>
 
-  <amp-state id="shirts">
+  <!--
+    Available shirts, maps unique identifier to {color, image}. Sizes are fetched remotely.
+
+    When a shirt color is selected, `selectedIndex` changes which causes this
+    <amp-state> to perform an XHR to the new [src] value. Upon completion,
+    the XHR response is merged into the state under its "id" attribute ("shirts").
+  -->
+  <amp-state id="shirts" [src]="'/bind/ecommerce/sizes?shirt=' + selectedIndex">
     <script type="application/json">
       {
         "0": {
           "color": "black",
-          "src": "./shirts/black.jpg",
-          "sizes": ["XS"]
+          "image": "./shirts/black.jpg"
         },
         "1": {
           "color": "blue",
-          "src": "./shirts/blue.jpg",
-          "sizes": ["S", "M", "L"]
+          "image": "./shirts/blue.jpg"
         },
         "2": {
           "color": "brown",
-          "src": "./shirts/brown.jpg",
-          "sizes": ["XL"]
+          "image": "./shirts/brown.jpg"
         },
         "3": {
           "color": "dark green",
-          "src": "./shirts/dark-green.jpg",
-          "sizes": ["M", "XL"]
+          "image": "./shirts/dark-green.jpg"
         },
         "4": {
           "color": "gray",
-          "src": "./shirts/gray.jpg",
-          "sizes": ["S", "L"]
+          "image": "./shirts/gray.jpg"
         },
         "5": {
           "color": "light gray",
-          "src": "./shirts/light-gray.jpg",
-          "sizes": ["S", "XL"]
+          "image": "./shirts/light-gray.jpg"
         },
         "6": {
           "color": "navy",
-          "src": "./shirts/navy.jpg",
-          "sizes": ["XS", "M"]
+          "image": "./shirts/navy.jpg"
         },
         "7": {
           "color": "white",
-          "src": "./shirts/white.jpg",
-          "sizes": ["M", "L", "XL"]
+          "image": "./shirts/white.jpg"
         },
         "8": {
           "color": "wine",
-          "src": "./shirts/wine.jpg",
-          "sizes": ["XS", "M", "XL"]
+          "image": "./shirts/wine.jpg"
         }
       }
     </script>

--- a/examples/bind/ecommerce.amp.html
+++ b/examples/bind/ecommerce.amp.html
@@ -60,6 +60,28 @@
     When a shirt color is selected, `selectedIndex` changes which causes this
     <amp-state> to perform an XHR to the new [src] value. Upon completion,
     the XHR response is merged into the state under its "id" attribute ("shirts").
+
+    This has the limitation that data returned by the XHR must have the same
+    hierarchical structure as the existing data.
+
+    For example, the XHR must return something like:
+      {
+        "3": {
+          "sizes": ["S", "L"]
+        }
+      }
+
+    By contrast, it must NOT return something like:
+      {
+        "sizes": ["S", "L"]
+      }
+
+    In order to support the latter, we'd need to:
+      - Add support for a new action event, AND
+      - Force quotation marks for literal keys, AND
+      - Reintroduce variables in object keys (removed in #7582)
+
+    <amp-state [src]="..." on="fetch:AMP.setState({"shirts": {selectedIndex: event.response}})"
   -->
   <amp-state id="shirts" [src]="'/bind/ecommerce/sizes?shirt=' + selectedIndex">
     <script type="application/json">

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -44,7 +44,7 @@ export class AmpState extends AMP.BaseElement {
   activate(invocation) {
     const event = invocation.event;
     if (event && event.detail) {
-      this.updateState_(event.detail.response);
+      this.updateState_(event.detail.response, /* isInit */ false);
     }
   }
 
@@ -62,7 +62,7 @@ export class AmpState extends AMP.BaseElement {
     // Fetch JSON from endpoint at `src` attribute if it exists,
     // otherwise parse child script tag.
     if (this.element.hasAttribute('src')) {
-      this.fetchSrcAndUpdateState_(/* opt_isInit */ true);
+      this.fetchSrcAndUpdateState_(/* isInit */ true);
       if (this.element.children.length > 0) {
         user().error(TAG, 'Should not have children if src attribute exists.');
       }
@@ -74,7 +74,7 @@ export class AmpState extends AMP.BaseElement {
           const json = tryParseJson(firstChild.textContent, e => {
             user().error(TAG, 'Failed to parse state. Is it valid JSON?', e);
           });
-          this.updateState_(json, /* opt_isInit */ true);
+          this.updateState_(json, /* isInit */ true);
         } else {
           user().error(TAG,
               'State should be in a <script> tag with type="application/json"');
@@ -89,7 +89,7 @@ export class AmpState extends AMP.BaseElement {
   mutatedAttributesCallback(mutations) {
     const src = mutations['src'];
     if (src !== undefined) {
-      this.fetchSrcAndUpdateState_(/* opt_isInit */ false);
+      this.fetchSrcAndUpdateState_(/* isInit */ false);
     }
   }
 
@@ -100,21 +100,21 @@ export class AmpState extends AMP.BaseElement {
   }
 
   /**
-   * @param {boolean=} opt_isInit
+   * @param {boolean} isInit
    * @private
    */
-  fetchSrcAndUpdateState_(opt_isInit) {
+  fetchSrcAndUpdateState_(isInit) {
     fetchBatchedJsonFor(this.getAmpDoc(), this.element).then(json => {
-      this.updateState_(json, opt_isInit);
+      this.updateState_(json, isInit);
     });
   }
 
   /**
    * @param {*} json
-   * @param {boolean=} opt_isInit
+   * @param {boolean} isInit
    * @private
    */
-  updateState_(json, opt_isInit) {
+  updateState_(json, isInit) {
     if (json === undefined || json === null) {
       return;
     }
@@ -122,7 +122,7 @@ export class AmpState extends AMP.BaseElement {
     const state = Object.create(null);
     state[id] = json;
     bindForDoc(this.getAmpDoc()).then(bind => {
-      bind.setState(state, opt_isInit);
+      bind.setState(state, isInit);
     });
   }
 

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -62,9 +62,7 @@ export class AmpState extends AMP.BaseElement {
     // Fetch JSON from endpoint at `src` attribute if it exists,
     // otherwise parse child script tag.
     if (this.element.hasAttribute('src')) {
-      fetchBatchedJsonFor(this.getAmpDoc(), this.element).then(json => {
-        this.updateState_(json, /* opt_isInit */ true);
-      });
+      this.fetchSrcAndUpdateState_(/* opt_isInit */ true);
       if (this.element.children.length > 0) {
         user().error(TAG, 'Should not have children if src attribute exists.');
       }
@@ -88,9 +86,27 @@ export class AmpState extends AMP.BaseElement {
   }
 
   /** @override */
+  mutatedAttributesCallback(mutations) {
+    const src = mutations['src'];
+    if (src !== undefined) {
+      this.fetchSrcAndUpdateState_(/* opt_isInit */ false);
+    }
+  }
+
+  /** @override */
   renderOutsideViewport() {
     // We want the state data to be available wherever it is in the document.
     return true;
+  }
+
+  /**
+   * @param {boolean=} opt_isInit
+   * @private
+   */
+  fetchSrcAndUpdateState_(opt_isInit) {
+    fetchBatchedJsonFor(this.getAmpDoc(), this.element).then(json => {
+      this.updateState_(json, opt_isInit);
+    });
   }
 
   /**

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -17,6 +17,7 @@
 import {bindForDoc} from '../../../src/services';
 import {fetchBatchedJsonFor} from '../../../src/batched-json';
 import {getMode} from '../../../src/mode';
+import {isBindEnabledFor} from './bind-impl';
 import {isExperimentOn} from '../../../src/experiments';
 import {isJsonScriptTag} from '../../../src/dom';
 import {toggle} from '../../../src/style';
@@ -50,8 +51,7 @@ export class AmpState extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    // Allow integration test to access this class in testing mode.
-    user().assert(getMode().test || isExperimentOn(this.win, 'amp-bind'),
+    user().assert(isBindEnabledFor(this.win),
         `Experiment "amp-bind" is disabled.`);
 
     const TAG = this.getName_();

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -16,9 +16,7 @@
 
 import {bindForDoc} from '../../../src/services';
 import {fetchBatchedJsonFor} from '../../../src/batched-json';
-import {getMode} from '../../../src/mode';
 import {isBindEnabledFor} from './bind-impl';
-import {isExperimentOn} from '../../../src/experiments';
 import {isJsonScriptTag} from '../../../src/dom';
 import {toggle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -78,7 +78,7 @@ export class Bind {
   constructor(ampdoc) {
     // Allow integration test to access this class in testing mode.
     /** @const @private {boolean} */
-    this.enabled_ = getMode().test || isExperimentOn(ampdoc.win, TAG);
+    this.enabled_ = isBindEnabledFor(ampdoc.win);
     user().assert(this.enabled_, `Experiment "${TAG}" is disabled.`);
 
     /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
@@ -927,4 +927,25 @@ export class Bind {
       this.win_.dispatchEvent(new Event(name));
     }
   }
+}
+
+/**
+ * @param {Window} win
+ * @return {boolean}
+ */
+export function isBindEnabledFor(win) {
+  // Allow integration tests access.
+  if (getMode().test) {
+    return true;
+  }
+  if (isExperimentOn(win, TAG)) {
+    return true;
+  }
+  // TODO(choumx): Replace with real origin trial feature when implemented.
+  const token =
+      win.document.head.querySelector('meta[name="amp-experiment-token"]');
+  if (token && token.getAttribute('content') === 'HfmyLgNLmblRg3Alqy164Vywr') {
+    return true;
+  }
+  return false;
 }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -930,7 +930,7 @@ export class Bind {
 }
 
 /**
- * @param {Window} win
+ * @param {!Window} win
  * @return {boolean}
  */
 export function isBindEnabledFor(win) {

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -237,7 +237,11 @@ function createElementRules_() {
       'selected': null,
     },
     'AMP-STATE': {
-      'src': null,
+      'src': {
+        'allowedProtocols': {
+          'https': true,
+        },
+      },
     },
     'AMP-VIDEO': {
       'alt': null,

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -236,6 +236,9 @@ function createElementRules_() {
     'AMP-SELECTOR': {
       'selected': null,
     },
+    'AMP-STATE': {
+      'src': null,
+    },
     'AMP-VIDEO': {
       'alt': null,
       'attribution': null,

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -25,7 +25,7 @@ describe('AmpState', () => {
   let updateStub;
 
   function getAmpState() {
-    return createIframePromise(true, undefined).then(iframe => {
+    return createIframePromise(true).then(iframe => {
       const el = iframe.doc.createElement('amp-state');
       el.setAttribute('id', 'myAmpState');
       return iframe.addElement(el);

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as sinon from 'sinon';
+import '../amp-bind';
+import {createIframePromise} from '../../../../testing/iframe';
+
+describe('AmpState', () => {
+  let sandbox;
+  let ampState;
+  let fetchStub;
+  let updateStub;
+
+  function getAmpState() {
+    return createIframePromise(true, undefined).then(iframe => {
+      const el = iframe.doc.createElement('amp-state');
+      el.setAttribute('id', 'myAmpState');
+      return iframe.addElement(el);
+    });
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    return getAmpState().then(element => {
+      ampState = element;
+
+      const impl = ampState.implementation_;
+      fetchStub = sandbox.stub(impl, 'fetchSrcAndUpdateState_');
+      updateStub = sandbox.stub(impl, 'updateState_');
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should parse its child script if `src` is not present at build', () => {
+    ampState.innerHTML = '<script type="application/json">' +
+        '{"foo": "bar"}</script>';
+    ampState.implementation_.buildCallback();
+    expect(fetchStub).to.not.have.been.called;
+    expect(updateStub).calledWithMatch({foo: 'bar'});
+  });
+
+  it('should fetch json if `src` is present at build', () => {
+    ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
+    ampState.implementation_.buildCallback();
+    expect(fetchStub).calledWith(/* opt_isInit */ true);
+    expect(updateStub).to.not.have.been.called;
+  });
+
+  it('should fetch json if `src` is mutated', () => {
+    ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
+    ampState.mutatedAttributesCallback({
+      src: 'https://foo.com/bar?baz=1',
+    });
+    expect(fetchStub).calledWith(/* opt_isInit */ false);
+  });
+});

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -196,6 +196,18 @@ describe('BindValidator', () => {
       expect(val.canBind('AMP-SELECTOR', 'selected')).to.be.true;
     });
 
+    it('should support <amp-state>', () => {
+      expect(val.canBind('AMP-STATE', 'src')).to.be.true;
+
+      // src
+      expect(val.isResultValid(
+          'AMP-STATE', 'src', 'https://foo.com/bar.json')).to.be.true;
+      expect(val.isResultValid(
+          'AMP-STATE', 'src', 'http://foo.com/bar.json')).to.be.false;
+      expect(val.isResultValid(
+          'AMP-STATE', 'src', 'data://foo.com/bar.json')).to.be.false;
+    });
+
     it('should support <amp-video>', () => {
       expect(val.canBind('AMP-VIDEO', 'loop')).to.be.true;
       expect(val.canBind('AMP-VIDEO', 'poster')).to.be.true;

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -59,6 +59,8 @@ tags: {  # <amp-state> with json child
     name: "id"
     mandatory: true
   }
+  # <amp-bind>
+  attrs: { name: "[src]" }
   child_tags: {
     mandatory_num_child_tags: 1
     first_child_tag_name_oneof: "SCRIPT"
@@ -86,8 +88,10 @@ tags: {  # <amp-state> with src
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
+  # <amp-bind>
+  attrs: { name: "[src]" }
   child_tags: {
     mandatory_num_child_tags: 0
   }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
+  spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/amp-bind"
 }

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -204,6 +204,7 @@ Only binding to the following components and attributes are allowed. Most bindab
 | `<amp-iframe>` | `[src]` | Changes the iframe's source URL. |
 | `<amp-img>` | `[alt]`<br>`[attribution]`<br>`[src]`<br>`[srcset]` | See corresponding [amp-img attributes](https://www.ampproject.org/docs/reference/components/media/amp-img#attributes). |
 | `<amp-selector>` | `[selected]`<sup>1</sup> | Changes the currently selected children element(s)<br>identified by their `option` attribute values. Supports a comma-separated list of values for multiple selection. [See an example](https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind).
+| `<amp-state>` | `[src]` | Fetches JSON from the new URL and merges it into the existing state. |
 | `<amp-video>` | `[alt]`<br>`[attribution]`<br>`[controls]`<br>`[loop]`<br>`[poster]`<br>`[preload]`<br>`[src]` | See corresponding [amp-video attributes](https://www.ampproject.org/docs/reference/components/media/amp-video#attributes). |
 | `<amp-youtube>` | `[data-videoid]` | Changes the displayed YouTube video. |
 | `<a>` | `[href]` | Changes the link. |


### PR DESCRIPTION
Fixes #8648.

- Allows large datasets to be fetched incrementally vs. completely at page load.

Context: https://github.com/ampproject/amphtml/issues/8648#issuecomment-293077744