### PR TITLE
amp-bind: Support changing `src` on amp-list

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -441,7 +441,6 @@ app.use('/examples/amp-fresh.amp.(min.|max.)?html', function(req, res, next) {
     next();
 });
 
-
 app.use('/impression-proxy/', function(req, res) {
   assertCors(req, res, ['GET']);
   // Fake response with the following optional fields:
@@ -670,6 +669,28 @@ app.use('/bind/ecommerce/sizes', function(req, res, next) {
     object[req.query.shirt] = prices[req.query.shirt];
     res.json(object);
   }, 1000); // Simulate network delay.
+});
+
+app.use('/list/fruit-data/get', function(req, res, next) {
+  assertCors(req, res, ['GET']);
+  res.json({
+    items: [
+      {name: 'apple', quantity: 47, unitPrice: '0.33'},
+      {name: 'pear', quantity: 538, unitPrice: '0.54'},
+      {name: 'tomato', quantity: 0, unitPrice: '0.23'},
+    ],
+  });
+});
+
+app.use('/list/vegetable-data/get', function(req, res, next) {
+  assertCors(req, res, ['GET']);
+  res.json({
+    items: [
+      {name: 'cabbage', quantity: 5, unitPrice: '1.05'},
+      {name: 'carrot', quantity: 10, unitPrice: '0.01'},
+      {name: 'brocoli', quantity: 7, unitPrice: '0.02'},
+    ],
+  });
 });
 
 // Simulated Cloudflare signed Ad server

--- a/examples/bind/list.html
+++ b/examples/bind/list.html
@@ -21,7 +21,7 @@
     <template type="amp-mustache">
       <strong>Product</strong>: {{name}}
       <strong>Quantity:</strong>: {{quantity}}
-      <strong>Unit Price</strong>: {{unitPrice}}
+      <strong>Unit Price</strong>: ${{unitPrice}}
     </template>
   </amp-list>
 </body>

--- a/examples/bind/list.html
+++ b/examples/bind/list.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind: XHR</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+</head>
+<body>
+
+  <button on="tap:AMP.setState({listSrc:'/list/fruit-data/get'})">Show Fruit</button>
+  <button on="tap:AMP.setState({listSrc:'/list/vegetable-data/get'})">Show Vegetables</button>
+
+  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="listSrc || '/list/fruit-data/get'" width="600" height="600">
+    <template type="amp-mustache">
+      <strong>Product</strong>: {{name}}
+      <strong>Quantity:</strong>: {{quantity}}
+      <strong>Unit Price</strong>: {{unitPrice}}
+    </template>
+  </amp-list>
+</body>

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -233,6 +233,13 @@ function createElementRules_() {
         'alternativeName': 'src',
       },
     },
+    'AMP-LIST': {
+      // TODO(kmh287): Add AMP validator support
+      'src': {
+        'allowedProtocols': {
+          'https': true,
+        },
+    },
     'AMP-SELECTOR': {
       'selected': null,
     },

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -239,6 +239,7 @@ function createElementRules_() {
         'allowedProtocols': {
           'https': true,
         },
+      },
     },
     'AMP-SELECTOR': {
       'selected': null,

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -234,7 +234,6 @@ function createElementRules_() {
       },
     },
     'AMP-LIST': {
-      // TODO(kmh287): Add AMP validator support
       'src': {
         'allowedProtocols': {
           'https': true,

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -339,7 +339,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   });
 
   describe('amp-video integration', () => {
-    it('should change src when the src attribute binding changes', () => {
+    it('should support binding to src', () => {
       const button = fixture.doc.getElementById('changeVidSrcButton');
       const vid = fixture.doc.getElementById('video');
       expect(vid.getAttribute('src')).to
@@ -446,6 +446,32 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
       return waitForBindApplication().then(() => {
         expect(ampIframe.getAttribute('src')).to.contain(newSrc);
         expect(iframe.src).to.contain(newSrc);
+      });
+    });
+  });
+
+  describe('amp-list', () => {
+    it('should support binding to src', () => {
+      const button = fixture.doc.getElementById('listSrcButton');
+      const list = fixture.doc.getElementById('list');
+      expect(list.getAttribute('src'))
+          .to.equal('https://www.google.com/unbound.json');
+      button.click();
+      return waitForBindApplication().then(() => {
+        expect(list.getAttribute('src'))
+            .to.equal('https://www.google.com/bound.json');
+      });
+    });
+
+    it('should NOT change src when new value uses an invalid protocol', () => {
+      const button = fixture.doc.getElementById('httpListSrcButton');
+      const list = fixture.doc.getElementById('list');
+      expect(list.getAttribute('src'))
+          .to.equal('https://www.google.com/unbound.json');
+      button.click();
+      return waitForBindApplication().then(() => {
+        expect(list.getAttribute('src'))
+            .to.equal('https://www.google.com/unbound.json');
       });
     });
   });

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -329,6 +329,11 @@ Only binding to the following components and attributes are allowed:
     <td>See corresponding <a href="https://www.ampproject.org/docs/reference/components/media/amp-img#attributes">amp-img attributes</a>.</td>
   </tr>
   <tr>
+    <td><code>&lt;amp-list></code></td>
+    <td><code>[src]</code><sup>1</sup></td>
+    <td>Fetches JSON from the new URL and re-renders, replacing old content.</td>
+  </tr>
+  <tr>
     <td><code>&lt;amp-selector></code></td>
     <td><code>[selected]</code><sup>1</sup></td>
     <td>Changes the currently selected children element(s)<br>identified by their <code>option</code> attribute values. Supports a comma-separated list of values for multiple selection. <a href="https://ampbyexample.com/advanced/image_galleries_with_amp-carousel/#linking-carousels-with-amp-bind">See an example</a>.</td>

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -404,7 +404,6 @@ Only binding to the following components and attributes are allowed:
     <td>See corresponding <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#Attributes">textarea attributes</a>.</td>
   </tr>
 </table>
-
 <sup>1</sup>Denotes bindable attributes that don't have a non-bindable counterpart.
 
 ## Debugging

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -400,7 +400,6 @@ Only binding to the following components and attributes are allowed:
   </tr>
 </table>
 
-
 <sup>1</sup>Denotes bindable attributes that don't have a non-bindable counterpart.
 
 ## Debugging

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -50,7 +50,7 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    return populateList_();
+    return this.populateList_();
   }
 
   /** @override */
@@ -61,7 +61,7 @@ export class AmpList extends AMP.BaseElement {
       // refreshing amp-list data from the same source?
       const oldSrc = this.element.getAttribute('src');
       if (srcMutation !== oldSrc) {
-        populateList_();
+        this.populateList_();
       }
     }
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -57,6 +57,8 @@ export class AmpList extends AMP.BaseElement {
   mutatedAttributesCallback(mutations) {
     const srcMutation = mutations['src']
     if (srcMutation) {
+      // TODO(kmh287) Should we allow developers to use bind as a means of
+      // refreshing amp-list data from the same source?
       const oldSrc = this.element.getAttribute('src');
       if (srcMutation !== oldSrc) {
         populateList_();
@@ -65,6 +67,8 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
+   * Request list data from `src` and return a promise that resolves when
+   * the list has been populated with rendered list items.
    * @return {!Promise}
    */
   populateList_() {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -15,7 +15,6 @@
  */
 
 import {fetchBatchedJsonFor} from '../../../src/batched-json';
-import {getMode} from '../../../src/mode';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeChildren} from '../../../src/dom';
@@ -39,6 +38,7 @@ export class AmpList extends AMP.BaseElement {
     this.container_ = this.win.document.createElement('div');
     this.applyFillContent(this.container_, true);
     this.element.appendChild(this.container_);
+
     if (!this.container_.hasAttribute('role')) {
       this.container_.setAttribute('role', 'list');
     }
@@ -46,9 +46,6 @@ export class AmpList extends AMP.BaseElement {
     if (!this.element.hasAttribute('aria-live')) {
       this.element.setAttribute('aria-live', 'polite');
     }
-
-    /** @type {Promise} */
-    this.mutationPromise_ = null;
   }
 
   /** @override */
@@ -65,10 +62,7 @@ export class AmpList extends AMP.BaseElement {
   mutatedAttributesCallback(mutations) {
     const srcMutation = mutations['src'];
     if (srcMutation != undefined) {
-      const p = this.populateList_();
-      if (getMode().test) {
-        this.mutationPromise_ = p;
-      }
+      this.populateList_();
     }
   }
 
@@ -117,14 +111,6 @@ export class AmpList extends AMP.BaseElement {
         this.attemptChangeHeight(scrollHeight).catch(() => {});
       }
     });
-  }
-
-  /**
-   * @return {Promise}
-   * @visibleForTesting
-   */
-  mutationPromiseForTesting() {
-    return this.mutationPromise_;
   }
 
 }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -60,7 +60,7 @@ export class AmpList extends AMP.BaseElement {
   /** @override */
   mutatedAttributesCallback(mutations) {
     const srcMutation = mutations['src'];
-    if (srcMutation) {
+    if (srcMutation != undefined) {
       const p = this.populateList_();
       if (getMode().test) {
         this.mutationPromise_ = p;
@@ -115,10 +115,14 @@ export class AmpList extends AMP.BaseElement {
     });
   }
 
-  /** @return {Promise} */
+  /**
+   * @return {Promise}
+   * @visibleForTesting
+   */
   mutationPromiseForTesting() {
     return this.mutationPromise_;
   }
+
 }
 
 AMP.registerElement('amp-list', AmpList);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -15,6 +15,7 @@
  */
 
 import {fetchBatchedJsonFor} from '../../../src/batched-json';
+import {getMode} from '../../..//src/mode';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeChildren} from '../../../src/dom';
@@ -41,6 +42,9 @@ export class AmpList extends AMP.BaseElement {
     if (!this.container_.hasAttribute('role')) {
       this.container_.setAttribute('role', 'list');
     }
+
+    /** @type {Promise} */
+    this.mutationPromise_ = null;
   }
 
   /** @override */
@@ -57,11 +61,9 @@ export class AmpList extends AMP.BaseElement {
   mutatedAttributesCallback(mutations) {
     const srcMutation = mutations['src']
     if (srcMutation) {
-      // TODO(kmh287) Should we allow developers to use bind as a means of
-      // refreshing amp-list data from the same source?
-      const oldSrc = this.element.getAttribute('src');
-      if (srcMutation !== oldSrc) {
-        this.populateList_();
+      const p = this.populateList_();
+      if (getMode().test) {
+        this.mutationPromise_ = p;
       }
     }
   }
@@ -106,6 +108,11 @@ export class AmpList extends AMP.BaseElement {
         this.attemptChangeHeight(scrollHeight).catch(() => {});
       }
     });
+  }
+
+  /** @return {Promise} */
+  mutationPromiseForTesting() {
+    return this.mutationPromise_;
   }
 }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -68,6 +68,11 @@ export class AmpList extends AMP.BaseElement {
     }
   }
 
+  /** @override */
+  getDynamicElementContainers() {
+    return this.container_;
+  }
+
   /**
    * Request list data from `src` and return a promise that resolves when
    * the list has been populated with rendered list items.

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -59,7 +59,7 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    const srcMutation = mutations['src']
+    const srcMutation = mutations['src'];
     if (srcMutation) {
       const p = this.populateList_();
       if (getMode().test) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -70,7 +70,7 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   getDynamicElementContainers() {
-    return this.container_;
+    return [this.container_];
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -15,7 +15,7 @@
  */
 
 import {fetchBatchedJsonFor} from '../../../src/batched-json';
-import {getMode} from '../../..//src/mode';
+import {getMode} from '../../../src/mode';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeChildren} from '../../../src/dom';

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -43,6 +43,10 @@ export class AmpList extends AMP.BaseElement {
       this.container_.setAttribute('role', 'list');
     }
 
+    if (!this.element.hasAttribute('aria-live')) {
+      this.element.setAttribute('aria-live', 'polite');
+    }
+
     /** @type {Promise} */
     this.mutationPromise_ = null;
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -60,8 +60,7 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    const srcMutation = mutations['src'];
-    if (srcMutation != undefined) {
+    if (mutations['src'] != undefined) {
       this.populateList_();
     }
   }

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -128,7 +128,7 @@ describe('amp-list component', () => {
       templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
           element, newItems)
           .returns(newRenderPromise).once();
-      const spy = sinon.spy(list, 'populateList_');
+      const spy = sandbox.spy(list, 'populateList_');
       element.setAttribute('src', 'https://data2.com/list.json');
       list.mutatedAttributesCallback({'src': 'https://data2.com/list.json'});
       expect(spy).to.be.calledOnce;

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -128,15 +128,10 @@ describe('amp-list component', () => {
       templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
           element, newItems)
           .returns(newRenderPromise).once();
+      const spy = sinon.spy(list, 'populateList_');
       element.setAttribute('src', 'https://data2.com/list.json');
       list.mutatedAttributesCallback({'src': 'https://data2.com/list.json'});
-      return list.mutationPromiseForTesting();
-    }).then(() => {
-      return Promise.all([xhrPromise, renderPromise]);
-    }).then(() => {
-      expect(list.container_.contains(itemElement)).to.be.false;
-      expect(list.container_.contains(itemElement2)).to.be.true;
-      expect(list.container_.contains(itemElement3)).to.be.true;
+      expect(spy).to.be.calledOnce;
     });
   });
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -114,7 +114,7 @@ describe('amp-list component', () => {
         element, initialItems)
         .returns(renderPromise);
     listMock.expects('getVsync').returns({
-      measure: func => {}
+      measure: () => {},
     }).twice();
     return list.layoutCallback().then(() => {
       return Promise.all([xhrPromise, renderPromise]);
@@ -137,7 +137,7 @@ describe('amp-list component', () => {
       expect(list.container_.contains(itemElement)).to.be.false;
       expect(list.container_.contains(itemElement2)).to.be.true;
       expect(list.container_.contains(itemElement3)).to.be.true;
-    })
+    });
   });
 
   it('should fail to load b/c data is absent', () => {

--- a/extensions/amp-list/0.1/validator-amp-list.protoascii
+++ b/extensions/amp-list/0.1/validator-amp-list.protoascii
@@ -45,6 +45,8 @@ tags: {  # <amp-list>
   # TODO(gregable): Implement validation that requires the template attr value
   # to reference the id of an existing template element.
   attrs: { name: "template" }
+  # <amp-bind>
+  attrs: { name: "[src]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/amp-list"
   amp_layout: {

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -20,6 +20,7 @@
   <script custom-element="amp-brightcove" src="/dist/v0/amp-brightcove-0.1.max.js"></script>
   <script custom-element="amp-carousel" src="/dist/v0/amp-carousel-0.1.max.js"></script>
   <script custom-element="amp-iframe" src="/dist/v0/amp-iframe-0.1.max.js"></script>
+  <script custom-element="amp-list" src="/dist/v0/amp-list-0.1.max.js"></script>
   <script custom-element="amp-live-list" src="/dist/v0/amp-live-list-0.1.max.js"></script>
   <script custom-element="amp-selector" src="/dist/v0/amp-selector-0.1.max.js"></script>
   <script custom-element="amp-youtube" src="/dist/v0/amp-youtube-0.1.max.js"></script>
@@ -128,6 +129,12 @@
   <amp-iframe width=100 height=100 id="ampIframe" sandbox="allow-scripts allow-same-origin allow-popups"
       src="https://player.vimeo.com/video/140261016" [src]="iframe">
   </amp-iframe>
+
+  <p>AMP-LIST</p>
+  <button id='listSrcButton' on="tap:AMP.setState({listSrc: 'https://www.google.com/bound.json'})">Change amp-list</button>
+  <button id='httpListSrcButton' on="tap:AMP.setState({listSrc: 'http://www.google.com/justhttp.json'})">Change amp-list</button>
+  <amp-list id='list' src="https://www.google.com/unbound.json" [src]=listSrc>
+  </amp-list>
 
 </body>
 </html>


### PR DESCRIPTION
This PR introduces changes to allow binding to src on `amp-list`. When the value of the `src` attribute changes, the `amp-list` element performs another XHR to get new list data and replaces the current data with the rendered results of the XHR.

Reading order:
1. Changes to amp-list
   -  `amp-list.js` for implementation changes
   -  `test-amp-list.js` for updated tests
   -  `validator-amp-list.protoascii` for validator changes
2. Changes to bind 
   - `bind-validator.js` for adding a new rule for `amp-list` and its `src` attribute
   - `test-bind-integration.js` for integration test changes
   -  `amp-bind-integrations.html` for integration test fixture changes
3. Bind example
   - `app.js` To create JSON endpoints for two sets of list data
   - `list.html` For an example of amp-list with a changeable `src`
4. Updated Documentation
   - `amp-bind.md` To document addition of `amp-list` and its `src` property

Partial for #8700 

/to @choumx