### PR TITLE
Taboola: fixing typo.  the Taboola script supports type "other" not "others".

### DIFF
--- a/ads/taboola.js
+++ b/ads/taboola.js
@@ -28,7 +28,7 @@ export function taboola(global, data) {
   // ensure we have vlid publisher, placement and mode
   // and exactly one page-type
   validateData(data, ['publisher', 'placement', 'mode',
-    ['article', 'video', 'photo', 'search', 'category', 'homepage', 'others']]);
+    ['article', 'video', 'photo', 'search', 'category', 'homepage', 'other']]);
 
   // setup default values for referrer and url
   const params = {


### PR DESCRIPTION
The Taboola script supports type "other" not "others".
code with "data-others" will not load the Taboola widget.

fix for issue : [https://github.com/ampproject/amphtml/issues/8585](https://github.com/ampproject/amphtml/issues/8585)

cc : @zhouyx 