### PR TITLE
Don't deep merge an object with itself in object util function

### DIFF
--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -70,6 +70,9 @@ function deepMerge_(target, source, maxDepth) {
       throw new Error('Source object contains circular references');
     }
     seen.push(source);
+    if (target === source) {
+      continue;
+    }
     if (depth > maxDepth) {
       Object.assign(target, source);
       continue;

--- a/test/functional/test-object.js
+++ b/test/functional/test-object.js
@@ -179,6 +179,16 @@ describe('Object', () => {
         f: undefined,
       });
     });
+
+    it('should short circuit when merging the same object', () => {
+      const destObject = {
+        set a(val) {
+          throw new Error('deep merge tried to merge object with itself');
+        },
+      };
+      expect(object.deepMerge(destObject, destObject)).to.not.throw;
+    });
+
   });
 
 });


### PR DESCRIPTION
Bail out of deep merge if the source and target objects are the same object.