### PR TITLE
Update amp4ads validator test cases to replace usage of v0.js with amp4ads-v0.js.

### DIFF
--- a/validator/testdata/amp4ads_feature_tests/extensions.html
+++ b/validator/testdata/amp4ads_feature_tests/extensions.html
@@ -29,7 +29,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp4ads-boilerplate>body{visibility:hidden}</style>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
 
   <!-- So many AMP extensions! -->
   <script async custom-element="amp-access"

--- a/validator/testdata/amp4ads_feature_tests/noscript.html
+++ b/validator/testdata/amp4ads_feature_tests/noscript.html
@@ -23,7 +23,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp4ads-boilerplate>body{visibility:hidden}</style>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
 </head>
 <body>
   <!-- Invalid -->

--- a/validator/testdata/amp4ads_feature_tests/obsolete_tags.html
+++ b/validator/testdata/amp4ads_feature_tests/obsolete_tags.html
@@ -24,7 +24,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp4ads-boilerplate>body{visibility:hidden}</style>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
 </head>
 <body>
 These tags are not allowed:

--- a/validator/testdata/amp4ads_feature_tests/style-amp-custom.html
+++ b/validator/testdata/amp4ads_feature_tests/style-amp-custom.html
@@ -23,7 +23,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <style amp4ads-boilerplate>body{visibility:hidden}</style>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
   </style>
   <style amp-custom>
     /* Valid. */


### PR DESCRIPTION
Partially addresses https://github.com/ampproject/amphtml/issues/8764