### PR TITLE
Update AMP4ADS start document for validator.ampproject.org.

### DIFF
--- a/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -63,7 +63,7 @@
       '  \x3Cmeta charset="utf-8">\n' +
       '  \x3Cmeta name="viewport" content="width=device-width,minimum-scale=1">\n' +
       '  \x3Cstyle amp4ads-boilerplate>body{visibility:hidden}\x3C/style>\n' +
-      '  \x3Cscript async src="https://cdn.ampproject.org/v0.js">\x3C/script>\n' +
+      '  \x3Cscript async src="https://cdn.ampproject.org/amp4ads-v0.js">\x3C/script>\n' +
       '\x3C/head>\n' +
       '\x3Cbody>Hello, AMP4ADS world.\x3C/body>\n' +
       '\x3C/html>\n';


### PR DESCRIPTION
The runtime for AMP4ADS is now a seperate script, so we should reference it here.