### PR TITLE
Protect from invalid intersectioRatio values

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -425,6 +425,34 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     });
   });
 
+  it('should protect from invalid intersection values', () => {
+    const target = win.document.createElement('div');
+    root.listenElement(target, {}, null, eventResolver);
+    expect(root.models_).to.have.length(1);
+    const model = root.models_[0];
+
+    const inOb = root.getIntersectionObserver_();
+    expect(model.getVisibility_()).to.equal(0);
+
+    // Valid value.
+    inOb.callback([{target, intersectionRatio: 0.3}]);
+    expect(model.getVisibility_()).to.equal(0.3);
+
+    // Invalid negative value.
+    inOb.callback([{target, intersectionRatio: -0.01}]);
+    expect(model.getVisibility_()).to.equal(0);
+
+    inOb.callback([{target, intersectionRatio: -1000}]);
+    expect(model.getVisibility_()).to.equal(0);
+
+    // Invalid overflow value.
+    inOb.callback([{target, intersectionRatio: 1.01}]);
+    expect(model.getVisibility_()).to.equal(1);
+
+    inOb.callback([{target, intersectionRatio: 1000}]);
+    expect(model.getVisibility_()).to.equal(1);
+  });
+
   it('should listen on a element with different specs', () => {
     clock.tick(1);
     const inOb = root.getIntersectionObserver_();

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -421,9 +421,6 @@ describes.sandboxed('VisibilityModel', {}, () => {
       vh.updateCounters_(0);
       expect(vh.matchesVisibility_).to.be.false;
 
-      vh.updateCounters_(-1);
-      expect(vh.matchesVisibility_).to.be.false;
-
       vh.updateCounters_(0.0001);
       expect(vh.matchesVisibility_).to.be.true;
 
@@ -432,9 +429,16 @@ describes.sandboxed('VisibilityModel', {}, () => {
 
       vh.updateCounters_(1);
       expect(vh.matchesVisibility_).to.be.true;
+    });
 
-      vh.updateCounters_(1.00001);
-      expect(vh.matchesVisibility_).to.be.false;
+    it('should NOT allow invalid values', () => {
+      const vh = new VisibilityModel(NO_SPEC, NO_CALC);
+      expect(() => {
+        vh.updateCounters_(-1);
+      }).to.throw(/invalid visibility value/);
+      expect(() => {
+        vh.updateCounters_(1.00001);
+      }).to.throw(/invalid visibility value/);
     });
 
     it('should match custom visibility position', () => {
@@ -443,9 +447,6 @@ describes.sandboxed('VisibilityModel', {}, () => {
         visiblePercentageMax: 90,
       }, NO_CALC);
       vh.updateCounters_(0);
-      expect(vh.matchesVisibility_).to.be.false;
-
-      vh.updateCounters_(-1);
       expect(vh.matchesVisibility_).to.be.false;
 
       vh.updateCounters_(0.1);
@@ -461,9 +462,6 @@ describes.sandboxed('VisibilityModel', {}, () => {
       expect(vh.matchesVisibility_).to.be.false;
 
       vh.updateCounters_(1);
-      expect(vh.matchesVisibility_).to.be.false;
-
-      vh.updateCounters_(1.00001);
       expect(vh.matchesVisibility_).to.be.false;
     });
 

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -514,6 +514,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
    * @private
    */
   onIntersectionChange_(target, intersectionRatio) {
+    intersectionRatio = Math.min(Math.max(intersectionRatio, 0), 1);
     const id = getElementId(target);
     const trackedElement = this.trackedElements_[id];
     if (trackedElement) {

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -230,6 +230,8 @@ export class VisibilityModel {
    * @private
    */
   updateCounters_(visibility) {
+    dev().assert(visibility >= 0 && visibility <= 1,
+        'invalid visibility value: %s', visibility);
     const now = Date.now();
 
     if (visibility > 0) {


### PR DESCRIPTION
Closes #8771 

This happens regularly, especially with `position:fixed` elements. \o/

/cc @lannka @zhouyx @keithwrightbos @tdrl