### PR TITLE
Adds method to allow implementing networks to execute custom reset logic.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -860,7 +860,7 @@ export class AmpA4A extends AMP.BaseElement {
     }
 
     // Remove rendering frame, if it exists.
-    if (this.iframe) {
+    if (this.iframe && this.iframe.parentElement) {
       this.iframe.parentElement.removeChild(this.iframe);
       this.iframe = null;
     }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -849,6 +849,7 @@ export class AmpA4A extends AMP.BaseElement {
   /** @override  */
   unlayoutCallback() {
     this.protectedEmitLifecycleEvent_('adSlotCleared');
+    this.resetSlot();
     this.uiHandler.setDisplayState(AdDisplayState.NOT_LAID_OUT);
     this.isCollapsed_ = false;
 
@@ -863,7 +864,6 @@ export class AmpA4A extends AMP.BaseElement {
       return true;
     }
 
-    removeChildren(this.element);
     this.adPromise_ = null;
     this.adUrl_ = null;
     this.creativeBody_ = null;
@@ -880,6 +880,15 @@ export class AmpA4A extends AMP.BaseElement {
     this.promiseId_++;
     return true;
   }
+
+  /**
+   * To be overriden by implementing network.
+   * This function is called in unlayoutCallback(), and provides a hook for
+   * implementing networks to perform any custom resetting logic. This function
+   * is the first thing called by unlayoutCallback(), except for the
+   * adSlotCleared ping event, which is emitted first.
+   */
+  resetSlot() {}
 
   /** @override  */
   viewportCallback(inViewport) {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -845,7 +845,6 @@ export class AmpA4A extends AMP.BaseElement {
   /** @override  */
   unlayoutCallback() {
     this.protectedEmitLifecycleEvent_('adSlotCleared');
-    this.resetSlot();
     this.uiHandler.setDisplayState(AdDisplayState.NOT_LAID_OUT);
     this.isCollapsed_ = false;
 
@@ -860,10 +859,15 @@ export class AmpA4A extends AMP.BaseElement {
       return true;
     }
 
+    // Remove rendering frame, if it exists.
+    if (this.iframe) {
+      this.element.removeChild(this.iframe);
+      this.iframe = null;
+    }
+
     this.adPromise_ = null;
     this.adUrl_ = null;
     this.creativeBody_ = null;
-    this.iframe = null;
     this.isVerifiedAmpCreative_ = false;
     this.experimentalNonAmpCreativeRenderMethod_ =
         platformFor(this.win).isIos() ? XORIGIN_MODE.SAFEFRAME : null;
@@ -876,15 +880,6 @@ export class AmpA4A extends AMP.BaseElement {
     this.promiseId_++;
     return true;
   }
-
-  /**
-   * To be overriden by implementing network.
-   * This function is called in unlayoutCallback(), and provides a hook for
-   * implementing networks to perform any custom resetting logic. This function
-   * is the first thing called by unlayoutCallback(), except for the
-   * adSlotCleared ping event, which is emitted first.
-   */
-  resetSlot() {}
 
   /** @override  */
   viewportCallback(inViewport) {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -861,7 +861,7 @@ export class AmpA4A extends AMP.BaseElement {
 
     // Remove rendering frame, if it exists.
     if (this.iframe) {
-      this.element.removeChild(this.iframe);
+      this.iframe.parentElement.removeChild(this.iframe);
       this.iframe = null;
     }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -20,11 +20,7 @@ import {
 } from '../../amp-ad/0.1/concurrent-load';
 import {adConfig} from '../../../ads/_config';
 import {signingServerURLs} from '../../../ads/_a4a-config';
-import {
-  removeChildren,
-  createElementWithAttributes,
-} from '../../../src/dom';
-
+import {createElementWithAttributes} from '../../../src/dom';
 import {cancellation, isCancellation} from '../../../src/error';
 import {
   installAnchorClickInterceptor,

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -270,7 +270,11 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     if (this.uniqueSlotId_) {
       sharedState.removeSlot(this.uniqueSlotId_);
     }
-    this.ampAnalyticsConfig_ = null;
+    if (this.ampAnalyticsConfig_) {
+      this.ampAnalyticsConfig_.parentElement.removeChild(
+          this.ampAnalyticsConfig_);
+      this.ampAnalyticsConfig_ = null;
+    }
   }
 }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -253,6 +253,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   onCreativeRender(isVerifiedAmpCreative) {
     super.onCreativeRender(isVerifiedAmpCreative);
     if (this.ampAnalyticsConfig_) {
+      dev().assert(!this.ampAnalyticsElement_);
       this.ampAnalyticsElement_ =
           insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
     }
@@ -274,7 +275,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     if (this.uniqueSlotId_) {
       sharedState.removeSlot(this.uniqueSlotId_);
     }
-    if (this.ampAnalyticsElement_) {
+    dev().assert(this.ampAnalyticsElement_);
+    if(this.ampAnalyticsElement_ && this.ampAnalyticsElement_.parentElement) {
       this.ampAnalyticsElement_.parentElement.removeChild(
           this.ampAnalyticsElement_);
       this.ampAnalyticsElement_ = null;

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -262,7 +262,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   }
 
   /** @override */
-  resetSlot() {
+  unlayoutCallback() {
+    super.unlayoutCallback();
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
@@ -270,9 +271,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       sharedState.removeSlot(this.uniqueSlotId_);
     }
     this.ampAnalyticsConfig_ = null;
-    if (this.iframe) {
-      this.element.removeChild(this.iframe);
-    }
   }
 }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -35,6 +35,7 @@ import {
   googleLifecycleReporterFactory,
   setGoogleLifecycleVarsFromHeaders,
 } from '../../../ads/google/a4a/google-data-reporter';
+import {removeElement} from '../../../src/dom';
 import {getMode} from '../../../src/mode';
 import {stringHash32} from '../../../src/crypto';
 import {dev} from '../../../src/log';
@@ -275,9 +276,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     if (this.uniqueSlotId_) {
       sharedState.removeSlot(this.uniqueSlotId_);
     }
-    if (this.ampAnalyticsElement_ && this.ampAnalyticsElement_.parentElement) {
-      this.ampAnalyticsElement_.parentElement.removeChild(
-          this.ampAnalyticsElement_);
+    if (this.ampAnalyticsElement_) {
+      removeElement(this.ampAnalyticsElement_);
       this.ampAnalyticsElement_ = null;
     }
     this.ampAnalyticsConfig_ = null;

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -239,18 +239,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     this.lifecycleReporter_.sendPing(eventName);
   }
 
-  /** @override */
-  unlayoutCallback() {
-    super.unlayoutCallback();
-    this.element.setAttribute('data-amp-slot-index',
-        this.win.ampAdSlotIdCounter++);
-    this.lifecycleReporter_ = this.initLifecycleReporter();
-    if (this.uniqueSlotId_) {
-      sharedState.removeSlot(this.uniqueSlotId_);
-    }
-    this.ampAnalyticsConfig_ = null;
-  }
-
   /**
    * @return {!../../../ads/google/a4a/performance.BaseLifecycleReporter}
    */
@@ -271,6 +259,20 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       width: `${this.size_.width}px`,
       height: `${this.size_.height}px`,
     });
+  }
+
+  /** @override */
+  resetSlot() {
+    this.element.setAttribute('data-amp-slot-index',
+        this.win.ampAdSlotIdCounter++);
+    this.lifecycleReporter_ = this.initLifecycleReporter();
+    if (this.uniqueSlotId_) {
+      sharedState.removeSlot(this.uniqueSlotId_);
+    }
+    this.ampAnalyticsConfig_ = null;
+    if (this.iframe) {
+      this.element.removeChild(this.iframe);
+    }
   }
 }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -275,7 +275,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     if (this.uniqueSlotId_) {
       sharedState.removeSlot(this.uniqueSlotId_);
     }
-    dev().assert(this.ampAnalyticsElement_);
     if (this.ampAnalyticsElement_ && this.ampAnalyticsElement_.parentElement) {
       this.ampAnalyticsElement_.parentElement.removeChild(
           this.ampAnalyticsElement_);

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -108,6 +108,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
     /** @private {?({width, height}|../../../src/layout-rect.LayoutRectDef)} */
     this.size_ = null;
+
+    /** @private {?Element} */
+    this.ampAnalyticsElement_ = null;
   }
 
   /** @override */
@@ -250,7 +253,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   onCreativeRender(isVerifiedAmpCreative) {
     super.onCreativeRender(isVerifiedAmpCreative);
     if (this.ampAnalyticsConfig_) {
-      insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
+      this.ampAnalyticsElement_ =
+          insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
     }
 
     this.lifecycleReporter_.addPingsForVisibility(this.element);
@@ -270,11 +274,12 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     if (this.uniqueSlotId_) {
       sharedState.removeSlot(this.uniqueSlotId_);
     }
-    if (this.ampAnalyticsConfig_) {
-      this.ampAnalyticsConfig_.parentElement.removeChild(
-          this.ampAnalyticsConfig_);
-      this.ampAnalyticsConfig_ = null;
+    if (this.ampAnalyticsElement_) {
+      this.ampAnalyticsElement_.parentElement.removeChild(
+          this.ampAnalyticsElement_);
+      this.ampAnalyticsElement_ = null;
     }
+    this.ampAnalyticsConfig_ = null;
   }
 }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -276,7 +276,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       sharedState.removeSlot(this.uniqueSlotId_);
     }
     dev().assert(this.ampAnalyticsElement_);
-    if(this.ampAnalyticsElement_ && this.ampAnalyticsElement_.parentElement) {
+    if (this.ampAnalyticsElement_ && this.ampAnalyticsElement_.parentElement) {
       this.ampAnalyticsElement_.parentElement.removeChild(
           this.ampAnalyticsElement_);
       this.ampAnalyticsElement_ = null;

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -583,7 +583,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
             impl.unlayoutCallback();
             expect(resetSlotSpy).to.be.called.once;
             expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
-            expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
+            expect(impl.element.querySelector('div[fallback]')).to.be.ok;
             expect(impl.element.querySelector('iframe')).to.be.null;
             expect(impl.iframe).to.be.null;
             expect(impl.ampAnalyticsConfig_).to.be.null;

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -574,14 +574,20 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
             fallback.setAttribute('fallback', '');
             impl.element.appendChild(placeholder);
             impl.element.appendChild(fallback);
-            impl.ampAnalyticsConfig_ = {};
+            // For the purposes of this test, we only care that this is of type
+            // Element.
+            impl.ampAnalyticsConfig_ = document.createElement('amp-analytics');
+            impl.element.appendChild(impl.ampAnalyticsConfig_);
 
             expect(impl.iframe).to.be.ok;
             expect(impl.ampAnalyticsConfig_).to.be.ok;
+            expect(impl.element.querySelector('iframe')).to.be.ok;
+            expect(impl.element.querySelector('amp-analytics')).to.be.ok;
             impl.unlayoutCallback();
             expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
             expect(impl.element.querySelector('div[fallback]')).to.be.ok;
             expect(impl.element.querySelector('iframe')).to.be.null;
+            expect(impl.element.querySelector('amp-analytics')).to.be.null;
             expect(impl.iframe).to.be.null;
             expect(impl.ampAnalyticsConfig_).to.be.null;
             expect(impl.element.getAttribute('data-amp-slot-index')).to

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -574,10 +574,10 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
             fallback.setAttribute('fallback', '');
             impl.element.appendChild(placeholder);
             impl.element.appendChild(fallback);
-            // For the purposes of this test, we only care that this is of type
-            // Element.
-            impl.ampAnalyticsConfig_ = document.createElement('amp-analytics');
-            impl.element.appendChild(impl.ampAnalyticsConfig_);
+            impl.ampAnalyticsConfig_ = {};
+            impl.ampAnalyticsElement_ =
+                document.createElement('amp-analytics');
+            impl.element.appendChild(impl.ampAnalyticsElement_);
 
             expect(impl.iframe).to.be.ok;
             expect(impl.ampAnalyticsConfig_).to.be.ok;
@@ -590,6 +590,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
             expect(impl.element.querySelector('amp-analytics')).to.be.null;
             expect(impl.iframe).to.be.null;
             expect(impl.ampAnalyticsConfig_).to.be.null;
+            expect(impl.ampAnalyticsElement_).to.be.null;
             expect(impl.element.getAttribute('data-amp-slot-index')).to
                 .equal(String(Number(slotIdBefore) + 1));
           });

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -565,8 +565,6 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
           }).then(() => {
             const slotIdBefore = impl.element.getAttribute(
                 'data-amp-slot-index');
-            const resetSlotSpy = sandbox.spy(AmpAdNetworkAdsenseImpl.prototype,
-                'resetSlot');
 
             impl.layoutMeasureExecuted_ = true;
             impl.uiHandler = {setDisplayState: () => {}};
@@ -581,7 +579,6 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
             expect(impl.iframe).to.be.ok;
             expect(impl.ampAnalyticsConfig_).to.be.ok;
             impl.unlayoutCallback();
-            expect(resetSlotSpy).to.be.called.once;
             expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
             expect(impl.element.querySelector('div[fallback]')).to.be.ok;
             expect(impl.element.querySelector('iframe')).to.be.null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -184,14 +184,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  resetSlot() {
+  unlayoutCallback() {
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
     this.ampAnalyticsConfig_ = null;
-    if (this.iframe) {
-      this.element.removeChild(this.iframe);
-    }
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -189,7 +189,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
-    this.ampAnalyticsConfig_ = null;
+    if (this.ampAnalyticsConfig_) {
+      this.ampAnalyticsConfig_.parentElement.removeChild(
+          this.ampAnalyticsConfig_);
+      this.ampAnalyticsConfig_ = null;
+    }
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -37,6 +37,7 @@ import {
   setGoogleLifecycleVarsFromHeaders,
 } from '../../../ads/google/a4a/google-data-reporter';
 import {stringHash32} from '../../../src/crypto';
+import {removeElement} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {extensionsFor} from '../../../src/services';
 import {isExperimentOn} from '../../../src/experiments';
@@ -192,9 +193,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
-    if (this.ampAnalyticsElement_ && this.ampAnalyticsElement_.parentElement) {
-      this.ampAnalyticsElement_.parentElement.removeChild(
-          this.ampAnalyticsElement_);
+    if (this.ampAnalyticsElement_) {
+      removeElement(this.ampAnalyticsElement_);
       this.ampAnalyticsElement_ = null;
     }
     this.ampAnalyticsConfig_ = null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -192,7 +192,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
-    dev().assert(this.ampAnalyticsElement_);
     if (this.ampAnalyticsElement_ && this.ampAnalyticsElement_.parentElement) {
       this.ampAnalyticsElement_.parentElement.removeChild(
           this.ampAnalyticsElement_);
@@ -212,6 +211,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   onCreativeRender(isVerifiedAmpCreative) {
     super.onCreativeRender(isVerifiedAmpCreative);
     if (this.ampAnalyticsConfig_) {
+      dev().assert(!this.ampAnalyticsElement_);
       this.ampAnalyticsElement_ =
           insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -77,6 +77,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     /** @private {?({width, height}|../../../src/layout-rect.LayoutRectDef)} */
     this.size_ = null;
+
+    /** @private {?Element} */
+    this.ampAnalyticsElement_ = null;
   }
 
   /** @override */
@@ -189,11 +192,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
-    if (this.ampAnalyticsConfig_) {
-      this.ampAnalyticsConfig_.parentElement.removeChild(
-          this.ampAnalyticsConfig_);
-      this.ampAnalyticsConfig_ = null;
+    if (this.ampAnalyticsElement_) {
+      this.ampAnalyticsElement_.parentElement.removeChild(
+          this.ampAnalyticsElement_);
+      this.ampAnalyticsElement_ = null;
     }
+    this.ampAnalyticsConfig_ = null;
   }
 
   /**
@@ -207,7 +211,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   onCreativeRender(isVerifiedAmpCreative) {
     super.onCreativeRender(isVerifiedAmpCreative);
     if (this.ampAnalyticsConfig_) {
-      insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
+      this.ampAnalyticsElement_ =
+          insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
     }
 
     this.lifecycleReporter_.addPingsForVisibility(this.element);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -185,6 +185,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   unlayoutCallback() {
+    super.unlayoutCallback();
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -184,12 +184,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  unlayoutCallback() {
-    super.unlayoutCallback();
+  resetSlot() {
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
     this.ampAnalyticsConfig_ = null;
+    if (this.iframe) {
+      this.element.removeChild(this.iframe);
+    }
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -192,7 +192,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.element.setAttribute('data-amp-slot-index',
         this.win.ampAdSlotIdCounter++);
     this.lifecycleReporter_ = this.initLifecycleReporter();
-    if (this.ampAnalyticsElement_) {
+    dev().assert(this.ampAnalyticsElement_);
+    if (this.ampAnalyticsElement_ && this.ampAnalyticsElement_.parentElement) {
       this.ampAnalyticsElement_.parentElement.removeChild(
           this.ampAnalyticsElement_);
       this.ampAnalyticsElement_ = null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -403,6 +403,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           }).then(() => {
             const slotIdBefore = impl.element.getAttribute(
                 'data-amp-slot-index');
+
             impl.layoutMeasureExecuted_ = true;
             impl.uiHandler = {setDisplayState: () => {}};
             const placeholder = document.createElement('div');
@@ -411,10 +412,10 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
             fallback.setAttribute('fallback', '');
             impl.element.appendChild(placeholder);
             impl.element.appendChild(fallback);
-            // For the purposes of this test, we only care that this is of type
-            // Element.
-            impl.ampAnalyticsConfig_ = document.createElement('amp-analytics');
-            impl.element.appendChild(impl.ampAnalyticsConfig_);
+            impl.ampAnalyticsConfig_ = {};
+            impl.ampAnalyticsElement_ =
+                document.createElement('amp-analytics');
+            impl.element.appendChild(impl.ampAnalyticsElement_);
 
             expect(impl.iframe).to.be.ok;
             expect(impl.ampAnalyticsConfig_).to.be.ok;
@@ -427,6 +428,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
             expect(impl.element.querySelector('amp-analytics')).to.be.null;
             expect(impl.iframe).to.be.null;
             expect(impl.ampAnalyticsConfig_).to.be.null;
+            expect(impl.ampAnalyticsElement_).to.be.null;
             expect(impl.element.getAttribute('data-amp-slot-index')).to
                 .equal(String(Number(slotIdBefore) + 1));
           });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -421,7 +421,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
             impl.unlayoutCallback();
             expect(resetSlotSpy).to.be.called.once;
             expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
-            expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
+            expect(impl.element.querySelector('div[fallback]')).to.be.ok;
             expect(impl.element.querySelector('iframe')).to.be.null;
             expect(impl.iframe).to.be.null;
             expect(impl.ampAnalyticsConfig_).to.be.null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -411,14 +411,20 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
             fallback.setAttribute('fallback', '');
             impl.element.appendChild(placeholder);
             impl.element.appendChild(fallback);
-            impl.ampAnalyticsConfig_ = {};
+            // For the purposes of this test, we only care that this is of type
+            // Element.
+            impl.ampAnalyticsConfig_ = document.createElement('amp-analytics');
+            impl.element.appendChild(impl.ampAnalyticsConfig_);
 
             expect(impl.iframe).to.be.ok;
             expect(impl.ampAnalyticsConfig_).to.be.ok;
+            expect(impl.element.querySelector('iframe')).to.be.ok;
+            expect(impl.element.querySelector('amp-analytics')).to.be.ok;
             impl.unlayoutCallback();
             expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
             expect(impl.element.querySelector('div[fallback]')).to.be.ok;
             expect(impl.element.querySelector('iframe')).to.be.null;
+            expect(impl.element.querySelector('amp-analytics')).to.be.null;
             expect(impl.iframe).to.be.null;
             expect(impl.ampAnalyticsConfig_).to.be.null;
             expect(impl.element.getAttribute('data-amp-slot-index')).to

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -401,9 +401,8 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
             width: '300',
             height: '150',
           }).then(() => {
-            const resetSlotSpy = sandbox.spy(
-                AmpAdNetworkDoubleclickImpl.prototype, 'resetSlot');
-
+            const slotIdBefore = impl.element.getAttribute(
+                'data-amp-slot-index');
             impl.layoutMeasureExecuted_ = true;
             impl.uiHandler = {setDisplayState: () => {}};
             const placeholder = document.createElement('div');

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -401,8 +401,6 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
             width: '300',
             height: '150',
           }).then(() => {
-            const slotIdBefore = impl.element.getAttribute(
-                'data-amp-slot-index');
             const resetSlotSpy = sandbox.spy(
                 AmpAdNetworkDoubleclickImpl.prototype, 'resetSlot');
 
@@ -419,7 +417,6 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
             expect(impl.iframe).to.be.ok;
             expect(impl.ampAnalyticsConfig_).to.be.ok;
             impl.unlayoutCallback();
-            expect(resetSlotSpy).to.be.called.once;
             expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
             expect(impl.element.querySelector('div[fallback]')).to.be.ok;
             expect(impl.element.querySelector('iframe')).to.be.null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -44,6 +44,32 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
   let impl;
   let element;
 
+  /**
+   * Creates an iframe promise, and instantiates element and impl, adding the
+   * former to the document of the iframe.
+   * @param {{width, height, type}} config
+   * @return The iframe promise.
+   */
+  function createImplTag(config) {
+    config.type = 'doubleclick';
+    return createIframePromise().then(fixture => {
+      setupForAdTesting(fixture);
+      element = createElementWithAttributes(fixture.doc, 'amp-ad', config);
+      // To trigger CSS styling.
+      element.setAttribute('data-a4a-upgrade-type',
+          'amp-ad-network-doubleclick-impl');
+      // Used to test styling which is targetted at first iframe child of
+      // amp-ad.
+      const iframe = fixture.doc.createElement('iframe');
+      element.appendChild(iframe);
+      document.body.appendChild(element);
+      impl = new AmpAdNetworkDoubleclickImpl(element);
+      impl.iframe = iframe;
+      return fixture;
+    });
+  }
+
+
   describe('#isValidElement', () => {
     beforeEach(() => {
       element = document.createElement('amp-ad');
@@ -207,30 +233,6 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
 
   describe('centering', () => {
     const size = {width: '300px', height: '150px'};
-    /**
-     * Creates an iframe promise, and instantiates element and impl, adding the
-     * former to the document of the iframe.
-     * @param {{width, height, type}} config
-     * @return The iframe promise.
-     */
-    function createImplTag(config) {
-      config.type = 'doubleclick';
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        element = createElementWithAttributes(fixture.doc, 'amp-ad', config);
-        // To trigger CSS styling.
-        element.setAttribute('data-a4a-upgrade-type',
-            'amp-ad-network-doubleclick-impl');
-        // Used to test styling which is targetted at first iframe child of
-        // amp-ad.
-        const iframe = fixture.doc.createElement('iframe');
-        element.appendChild(iframe);
-        document.body.appendChild(element);
-        impl = new AmpAdNetworkDoubleclickImpl(element);
-        impl.iframe = iframe;
-        return fixture;
-      });
-    }
 
     function verifyCss(iframe, expectedSize) {
       expect(iframe).to.be.ok;
@@ -389,6 +391,43 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           return impl.getAdUrl().then(url =>
               // Ensure that "auto" doesn't appear anywhere here:
               expect(url).to.match(/sz=[0-9]+x[0-9]+/));
+        });
+  });
+
+  describe('#unlayoutCallback', () => {
+    it('should call #resetSlot, remove child iframe, but keep other children',
+        () => {
+          return createImplTag({
+            width: '300',
+            height: '150',
+          }).then(() => {
+            const slotIdBefore = impl.element.getAttribute(
+                'data-amp-slot-index');
+            const resetSlotSpy = sandbox.spy(
+                AmpAdNetworkDoubleclickImpl.prototype, 'resetSlot');
+
+            impl.layoutMeasureExecuted_ = true;
+            impl.uiHandler = {setDisplayState: () => {}};
+            const placeholder = document.createElement('div');
+            placeholder.setAttribute('placeholder', '');
+            const fallback = document.createElement('div');
+            fallback.setAttribute('fallback', '');
+            impl.element.appendChild(placeholder);
+            impl.element.appendChild(fallback);
+            impl.ampAnalyticsConfig_ = {};
+
+            expect(impl.iframe).to.be.ok;
+            expect(impl.ampAnalyticsConfig_).to.be.ok;
+            impl.unlayoutCallback();
+            expect(resetSlotSpy).to.be.called.once;
+            expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
+            expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
+            expect(impl.element.querySelector('iframe')).to.be.null;
+            expect(impl.iframe).to.be.null;
+            expect(impl.ampAnalyticsConfig_).to.be.null;
+            expect(impl.element.getAttribute('data-amp-slot-index')).to
+                .equal(String(Number(slotIdBefore) + 1));
+          });
         });
   });
 });


### PR DESCRIPTION
We will no longer remove all child elements of an amp-ad slot. Instead, we now provide a public method to allow implementing networks to execute custom reset logic.

Fixes #8767 