### PR TITLE
brainy amp-ad:change contact URL

### DIFF
--- a/ads/brainy.md
+++ b/ads/brainy.md
@@ -28,7 +28,7 @@ limitations under the License.
 
 ## Configuration
 
-For configuration details and to generate your tags, please contact http://www.opt.ne.jp/contact_detail/id=8
+For configuration details and to generate your tags, please contact https://www.brainy-inc.co.jp/#page-contact
 
 Supported parameters:
 


### PR DESCRIPTION
We changed our contact information because of company split from "OPT, Inc". Could you please check it? We already started offering a service of amp-ad so it would be great if we don't have to re-make our amp-ad codes. We have changed user information of github but haven't signed CLA as our new company "brainy, Inc". So there are two questions, "Can we still keep our rights to make any change on our amp-ad codes that we contributed as "OPT, Inc" before?", and "Is there any problem to use/edit our amp-ad codes without signing new CLA? If so, please tell us what to do next."  Thank you in advance.

Our PR in the past 
#7224
#6435