### PR TITLE
Observe max URL length in App Engine for error reports.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -374,6 +374,11 @@ export function getErrorReportUrl(message, filename, line, col, error,
   url += '&fr=' + encodeURIComponent(self.location.originalHash
       || self.location.hash);
 
+  // Google App Engine maximum URL length.
+  if (url.length >= 2072) {
+    url = url.substr(0, 2072 - 10 /* length of suffix */)
+        + '&SHORTENED';
+  }
   return url;
 }
 

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -262,6 +262,7 @@ describe('reportErrorToServer', () => {
     expect(query.f).to.equal('foo.js');
     expect(query.l).to.equal('11');
     expect(query.c).to.equal('22');
+    expect(url.href).to.not.contain('SHORTENED');
   });
 
   it('should accumulate errors', () => {
@@ -277,6 +278,22 @@ describe('reportErrorToServer', () => {
 
     expect(query.m).to.equal('3');
     expect(query.ae).to.equal('1,2');
+  });
+
+  it('should accumulate errors', () => {
+    let message = 'TEST';
+    for (let i = 0; i < 4000; i++) {
+      message += 'a';
+    }
+    const url = parseUrl(getErrorReportUrl(undefined, undefined, undefined,
+        undefined, new Error(message),true));
+    const query = parseQueryString(url.search);
+    expect(url.href.indexOf(
+        'https://amp-error-reporting.appspot.com/r?')).to.equal(0);
+
+    expect(query.m).to.match(/^TEST/);
+    expect(url.href).to.have.length(2072);
+    expect(url.href).to.contain('SHORTENED');
   });
 
   it('should not double report', () => {


### PR DESCRIPTION
In practice this only cuts off the "accumulated errors" and referrers. Critical parts typically fit.

Fixes #8799