### PR TITLE
Support 'hidden' trigger for visibility-v3

### DIFF
--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -88,6 +88,7 @@ Container for analytics tags. Positioned far away from top to make sure that doe
       "visibilitySpec": {
         "selector": "#anim-id",
         "visiblePercentageMin": 20,
+        "visiblePercentageMin": 1000,
         "continuousTimeMax": 5000
       },
       "vars": {

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -27,7 +27,10 @@ import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {layoutRectLtwh} from '../../../src/layout-rect';
 import {map} from '../../../src/utils/object';
-import {viewportForDoc} from '../../../src/services';
+import {
+  viewerForDoc,
+  viewportForDoc,
+} from '../../../src/services';
 import {whenContentIniLoad} from '../../../src/friendly-iframe-embed';
 
 const TAG = 'amp-analytics';
@@ -87,6 +90,14 @@ export class AnalyticsRoot {
    * @abstract
    */
   getRoot() {}
+
+  /**
+   * The viewer of analytics root
+   * @return {!../../../src/service/viewer-impl.Viewer}
+   */
+  getViewer() {
+    return viewerForDoc(this.ampdoc);
+  }
 
   /**
    * The root element within the analytics root.

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -426,21 +426,16 @@ export class VisibilityTracker extends EventTracker {
    */
   createReportReadyPromise_() {
     const viewer = this.root.getViewer();
-    let resolver = null;
-    const viewerHiddenPromise = new Promise(resolve => {
-      resolver = resolve;
-    });
 
     if (!viewer.isVisible()) {
       return Promise.resolve();
     }
-    viewer.onVisibilityChanged(() => {
-      if (!viewer.isVisible()) {
-        resolver();
-      }
-    });
 
-    return viewerHiddenPromise;
+    return new Promise(resolve => {
+      viewer.onVisibilityChanged(() => {
+        resolve();
+      });
+    });
   }
 
   /**

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -433,7 +433,9 @@ export class VisibilityTracker extends EventTracker {
 
     return new Promise(resolve => {
       viewer.onVisibilityChanged(() => {
-        resolve();
+        if (!viewer.isVisible()) {
+          resolve();
+        }
       });
     });
   }

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -105,7 +105,7 @@ const EVENT_TRACKERS = {
     klass: VisibilityTracker,
   },
   'hidden-v3': {
-    name: 'visible-v3',
+    name: 'visible-v3', // Reuse tracker with visibility
     allowedFor: ALLOWED_FOR_ALL,
     klass: VisibilityTracker,
   },

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -105,7 +105,7 @@ const EVENT_TRACKERS = {
     klass: VisibilityTracker,
   },
   'hidden-v3': {
-    name: 'hidden-v3',
+    name: 'visible-v3',
     allowedFor: ALLOWED_FOR_ALL,
     klass: VisibilityTracker,
   },
@@ -570,15 +570,13 @@ export class AnalyticsGroup {
    */
   addTrigger(config, handler) {
     let eventType = dev().assertString(config['on']);
-    let trackerType = eventType;
     // TODO(dvoytenko, #8121): Cleanup visibility-v3 experiment.
     if ((eventType == 'visible' || eventType == 'hidden')
         && this.visibilityV3_) {
       eventType += '-v3';
-      trackerType = 'visible-v3';
     }
-    let trackerProfile = EVENT_TRACKERS[trackerType];
-    if (!trackerProfile && !isEnumValue(AnalyticsEventType, trackerType)) {
+    let trackerProfile = EVENT_TRACKERS[eventType];
+    if (!trackerProfile && !isEnumValue(AnalyticsEventType, eventType)) {
       trackerProfile = EVENT_TRACKERS['custom'];
     }
     if (trackerProfile) {

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -104,6 +104,11 @@ const EVENT_TRACKERS = {
     allowedFor: ALLOWED_FOR_ALL,
     klass: VisibilityTracker,
   },
+  'hidden-v3': {
+    name: 'hidden-v3',
+    allowedFor: ALLOWED_FOR_ALL,
+    klass: VisibilityTracker,
+  },
 };
 
 /** @const {string} */
@@ -565,12 +570,15 @@ export class AnalyticsGroup {
    */
   addTrigger(config, handler) {
     let eventType = dev().assertString(config['on']);
+    let trackerType = eventType;
     // TODO(dvoytenko, #8121): Cleanup visibility-v3 experiment.
-    if (eventType == 'visible' && this.visibilityV3_) {
-      eventType = 'visible-v3';
+    if ((eventType == 'visible' || eventType == 'hidden')
+        && this.visibilityV3_) {
+      eventType += '-v3';
+      trackerType = 'visible-v3';
     }
-    let trackerProfile = EVENT_TRACKERS[eventType];
-    if (!trackerProfile && !isEnumValue(AnalyticsEventType, eventType)) {
+    let trackerProfile = EVENT_TRACKERS[trackerType];
+    if (!trackerProfile && !isEnumValue(AnalyticsEventType, trackerType)) {
       trackerProfile = EVENT_TRACKERS['custom'];
     }
     if (trackerProfile) {

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -455,6 +455,7 @@ describes.realWin('Events', {amp: 1}, env => {
           .withExactArgs(
               matchEmptySpec,
               /* readyPromise */ null,
+              /* createReadyReportPromiseFunc */ null,
               saveCallback)
           .returns(unlisten)
           .once();
@@ -482,6 +483,7 @@ describes.realWin('Events', {amp: 1}, env => {
           .withExactArgs(
               matchEmptySpec,
               readyPromise,
+              null,
               saveCallback)
           .returns(unlisten)
           .once();
@@ -510,6 +512,7 @@ describes.realWin('Events', {amp: 1}, env => {
           .withExactArgs(
               config.visibilitySpec,
               readyPromise,
+              /* createReadyReportPromiseFunc */ null,
               saveCallback)
           .returns(unlisten)
           .once();
@@ -540,6 +543,7 @@ describes.realWin('Events', {amp: 1}, env => {
               target,
               config.visibilitySpec,
               readyPromise,
+              /* createReadyReportPromiseFunc */ null,
               saveCallback)
           .returns(unlisten)
           .once();
@@ -580,6 +584,7 @@ describes.realWin('Events', {amp: 1}, env => {
               target,
               matchEmptySpec,
               readyPromise,
+              /* createReadyReportPromiseFunc */ null,
               saveCallback)
           .returns(unlisten)
           .once();
@@ -676,6 +681,18 @@ describes.realWin('Events', {amp: 1}, env => {
             return promise2;
           });
         });
+      });
+    });
+
+    describe('should create correct readyReportPromise', () => {
+      it('with viewer hidden', () => {
+        sandbox.stub(tracker.root, 'getViewer', () => {
+          return {
+            isVisible: () => {return false;},
+          };
+        });
+        const promise = tracker.createReportReadyPromise_();
+        return promise;
       });
     });
   });

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -235,6 +235,20 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
           analyticsElement, 'visible-v3', config, handler);
     });
 
+    it('should add "visible-v3" trigger for hidden', () => {
+      toggleExperiment(win, 'visibility-v3', true);
+      group = service.createAnalyticsGroup(analyticsElement);
+      const config = {on: 'hidden'};
+      const getTrackerSpy = sandbox.spy(root, 'getTracker');
+      group.addTrigger(config, () => {});
+      expect(getTrackerSpy).to.be.calledWith('visible-v3');
+      const tracker = root.getTrackerOptional('visible-v3');
+      const unlisten = function() {};
+      const stub = sandbox.stub(tracker, 'add', () => unlisten);
+      group.addTrigger(config, () => {});
+      expect(stub).to.be.calledWith(analyticsElement, 'hidden-v3', config);
+    });
+
     it('should use "visible-v3" for "visible" w/experiment', () => {
       // TODO(dvoytenko, #8121): Cleanup visibility-v3 experiment.
       toggleExperiment(win, 'visibility-v3', true);

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -450,7 +450,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 
   it('should protect from invalid intersection values', () => {
     const target = win.document.createElement('div');
-    root.listenElement(target, {}, null, eventResolver);
+    root.listenElement(target, {}, null, null, eventResolver);
     expect(root.models_).to.have.length(1);
     const model = root.models_[0];
 

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -200,14 +200,16 @@ export class VisibilityManager {
    * `readyPromise` is resolved, if specified.
    * @param {!Object<string, *>} spec
    * @param {?Promise} readyPromise
+   * @param {?function()} createReportPromiseFunc
    * @param {function(!Object<string, *>)} callback
    * @return {!UnlistenDef}
    */
-  listenRoot(spec, readyPromise, callback) {
+  listenRoot(spec, readyPromise, createReportPromiseFunc, callback) {
     const model = new VisibilityModel(
         spec,
         this.getRootVisibility.bind(this));
-    return this.listen_(model, spec, readyPromise, callback);
+    return this.listen_(
+        model, spec, readyPromise, createReportPromiseFunc, callback);
   }
 
   /**
@@ -217,32 +219,41 @@ export class VisibilityManager {
    * @param {!Element} element
    * @param {!Object<string, *>} spec
    * @param {?Promise} readyPromise
+   * @param {?function()} createReportPromiseFunc
    * @param {function(!Object<string, *>)} callback
    * @return {!UnlistenDef}
    */
-  listenElement(element, spec, readyPromise, callback) {
+  listenElement(
+      element, spec, readyPromise, createReportPromiseFunc, callback) {
     const model = new VisibilityModel(
         spec,
         this.getElementVisibility.bind(this, element));
-    return this.listen_(model, spec, readyPromise, callback, element);
+    return this.listen_(
+        model, spec, readyPromise, createReportPromiseFunc, callback, element);
   }
 
   /**
    * @param {!VisibilityModel} model
    * @param {!Object<string, *>} spec
    * @param {?Promise} readyPromise
+   * @param {?function()} createReportPromiseFunc
    * @param {function(!Object<string, *>)} callback
    * @param {!Element=} opt_element
    * @return {!UnlistenDef}
    * @private
    */
-  listen_(model, spec, readyPromise, callback, opt_element) {
+  listen_(model, spec,
+      readyPromise, createReportPromiseFunc, callback, opt_element) {
     // Block visibility.
     if (readyPromise) {
       model.setReady(false);
       readyPromise.then(() => {
         model.setReady(true);
       });
+    }
+
+    if (createReportPromiseFunc) {
+      model.setReportReady(createReportPromiseFunc);
     }
 
     // Process the event.

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -200,7 +200,7 @@ export class VisibilityManager {
    * `readyPromise` is resolved, if specified.
    * @param {!Object<string, *>} spec
    * @param {?Promise} readyPromise
-   * @param {?function()} createReportPromiseFunc
+   * @param {?function():!Promise} createReportPromiseFunc
    * @param {function(!Object<string, *>)} callback
    * @return {!UnlistenDef}
    */
@@ -219,7 +219,7 @@ export class VisibilityManager {
    * @param {!Element} element
    * @param {!Object<string, *>} spec
    * @param {?Promise} readyPromise
-   * @param {?function()} createReportPromiseFunc
+   * @param {?function():!Promise} createReportPromiseFunc
    * @param {function(!Object<string, *>)} callback
    * @return {!UnlistenDef}
    */
@@ -236,7 +236,7 @@ export class VisibilityManager {
    * @param {!VisibilityModel} model
    * @param {!Object<string, *>} spec
    * @param {?Promise} readyPromise
-   * @param {?function()} createReportPromiseFunc
+   * @param {?function():!Promise} createReportPromiseFunc
    * @param {function(!Object<string, *>)} callback
    * @param {!Element=} opt_element
    * @return {!UnlistenDef}

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -68,6 +68,12 @@ export class VisibilityModel {
     /** @private {boolean} */
     this.ready_ = true;
 
+    /** @private {boolean} */
+    this.reportReady_ = true;
+
+    /** @private {?function()} */
+    this.createReportReadyPromise_ = null;
+
     /** @private {?number} */
     this.scheduledRunId_ = null;
 
@@ -154,6 +160,16 @@ export class VisibilityModel {
   }
 
   /**
+   * Sets that the model needs to wait on extra report ready promise
+   * after all visibility conditions have been met to call report handler
+   * @param {!function()} callback
+   */
+  setReportReady(callback) {
+    this.reportReady_ = false;
+    this.createReportReadyPromise_ = callback;
+  }
+
+  /**
    * @return {number}
    * @private
    */
@@ -207,8 +223,24 @@ export class VisibilityModel {
         clearTimeout(this.scheduledRunId_);
         this.scheduledRunId_ = null;
       }
-      this.eventResolver_();
-      this.eventResolver_ = null;
+      if (this.reportReady_) {
+        this.eventResolver_();
+        this.eventResolver_ = null;
+      }
+      if (!this.reportReady_ && this.createReportReadyPromise_) {
+        const reportReadyPromise = this.createReportReadyPromise_();
+        dev().assert(reportReadyPromise
+            && typeof reportReadyPromise.then == 'function',
+            'reportReadyPromise is not a promise');
+        this.createReportReadyPromise_ = null;
+        reportReadyPromise.then(() => {
+          this.reportReady_ = true;
+          // Need to update one more time in case time exceeds
+          // maxContinuousVisibleTime.
+          this.update();
+        });
+        // create report ready promise, to wait to call report again.
+      }
     } else if (this.matchesVisibility_ && !this.scheduledRunId_) {
       // There is unmet duration condition, schedule a check
       const timeToWait = this.computeTimeToWait_();


### PR DESCRIPTION
for #8315 

I went with the approach that pass in a function to generate reportReady promise.  Will only generate the promise after conditionMet.

I didn't add another experimental tag for this. Can always add one if anyone feels it is necessary. 

noted the viewer visible doesn't work for inabox case, and will not address it in this PR. 