### PR TITLE
Only flush the pre-render metric if the page was eventually used.

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -174,7 +174,13 @@ export class Performance {
             ? (this.win.Date.now() - docVisibleTime)
             //  Prerender was complete before visibility.
             : 0;
-        this.tickDelta('pc', userPerceivedVisualCompletenesssTime);
+        this.viewer_.whenFirstVisible().then(() => {
+          // We only tick this if the page eventually becomes visible,
+          // since otherwise we heavily skew the metric towards the
+          // 0 case, since pre-renders that are never used are highly
+          // likely to fully load before they are never used :)
+          this.tickDelta('pc', userPerceivedVisualCompletenesssTime);
+        });
         this.prerenderComplete_(userPerceivedVisualCompletenesssTime);
       } else {
         // If it didnt start in prerender, no need to calculate anything

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -569,22 +569,29 @@ describes.realWin('performance', {amp: true}, env => {
           expect(tickSpy).to.have.callCount(3);
           whenViewportLayoutCompleteResolve();
           return perf.whenViewportLayoutComplete_().then(() => {
-            expect(tickSpy).to.have.callCount(4);
+            expect(tickSpy).to.have.callCount(3);
             expect(tickSpy.withArgs('ofv')).to.be.calledOnce;
-            expect(tickSpy.withArgs('pc')).to.be.calledOnce;
-            expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(400);
+            return whenFirstVisiblePromise.then(() => {
+              expect(tickSpy).to.have.callCount(4);
+              expect(tickSpy.withArgs('pc')).to.be.calledOnce;
+              expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(400);
+            });
           });
         });
       });
 
-      it('should tick `pc` with `delta=1` when viewport is complete ' +
+      it('should tick `pc` with `delta=0` when viewport is complete ' +
          'before user request document to be visible', () => {
         clock.tick(300);
         whenViewportLayoutCompleteResolve();
         return perf.whenViewportLayoutComplete_().then(() => {
           expect(tickSpy.withArgs('ol')).to.be.calledOnce;
-          expect(tickSpy.withArgs('pc')).to.be.calledOnce;
-          expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(0);
+          expect(tickSpy.withArgs('pc')).to.have.callCount(0);
+          whenFirstVisibleResolve();
+          return whenFirstVisiblePromise.then(() => {
+            expect(tickSpy.withArgs('pc')).to.be.calledOnce;
+            expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(0);
+          });
         });
       });
     });


### PR DESCRIPTION
The way we tick zero if loading completed before a page is used, doesn't make any sense for the case where it is never used, so we exclude that from the metric.