### PR TITLE
amp-bind: bind-impl shouldn't expect form service to exist

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -149,7 +149,7 @@ export class Bind {
           if (ampFormService) {
             return ampFormService.whenInitialized();
           } else {
-            return Promise.reject(new Error('Form service not present'));
+            throw new Error('Form service not present');
           }
         });
 

--- a/src/services.js
+++ b/src/services.js
@@ -72,9 +72,9 @@ export function activityForDoc(nodeOrDoc) {
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @return {!Promise<!../extensions/amp-form/0.1/amp-form.AmpFormService>}
  */
-export function ampFormServiceForDoc(nodeOrDoc) {
+export function ampFormServiceOrNullForDoc(nodeOrDoc) {
   return /** @type {!Promise<!../extensions/amp-form/0.1/amp-form.AmpFormService>} */ ( // eslint-disable-line max-len
-    getElementServiceForDoc(nodeOrDoc, 'amp-form', 'amp-form'));
+    getElementServiceIfAvailableForDoc(nodeOrDoc, 'amp-form', 'amp-form'));
 }
 
 /**


### PR DESCRIPTION
In order to access amp-form implementations for form elements, bind needs to access the AmpFormService. This PR fixes a bug in bind that expects the service to exist. 

Fixes #8812