### PR TITLE
Create experiment branch to measure impact of Delayed Fetch when counted on rendered

### DIFF
--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -312,14 +312,16 @@ describe('a4a_config', () => {
       }
     });
 
-    it(`should force controlMeasureOnRender param from URL when pattern=${urlBase}`, () => {
+    it(`should force controlMeasureOnRender param from URL ` +
+       `when pattern=${urlBase}`, () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:3');
       // Should not register as 'A4A enabled', but should still attach the
       // controlMeasureOnRender experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
-      expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.controlMeasureOnRender);
+      expectThereCanBeOnlyOne(element,
+          EXTERNAL_BRANCHES.controlMeasureOnRender);
       expectExternallyTriggered(element);
     });
 

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -46,6 +46,8 @@ const INTERNAL_BRANCHES = {
   control: '3',
   experiment: '4',
 };
+/** @type {!Branch} */
+const MEASURE_ON_RENDER_BRANCH = 5;
 
 /**
  * Checks that element's data-experiment-id tag contains the specified id and
@@ -156,7 +158,7 @@ describe('a4a_config', () => {
   it('should attach expt ID and return true when expt is on', () => {
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID,
-        EXTERNAL_BRANCHES, INTERNAL_BRANCHES, null),
+        EXTERNAL_BRANCHES, INTERNAL_BRANCHES, MEASURE_ON_RENDER_BRANCH),
            'googleAdsIsA4AEnabled').to.be.true;
     expect(win.document.cookie).to.be.null;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
@@ -166,7 +168,7 @@ describe('a4a_config', () => {
   it('should attach control ID and return false when control is on', () => {
     rand.returns(0.25);  // Random value to select the 1st branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, null),
+        INTERNAL_BRANCHES, MEASURE_ON_RENDER_BRANCH),
            'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.control);
@@ -176,7 +178,8 @@ describe('a4a_config', () => {
   it('should not attach ID and return false when selected out', () => {
     toggleExperiment(win, EXP_ID, false, true);
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES,
+        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -186,7 +189,8 @@ describe('a4a_config', () => {
     win.AMP_MODE.localDev = false;
     win.location.href = 'http://somewhere.over.the.rainbow.org/';
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES, 
+        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -195,7 +199,8 @@ describe('a4a_config', () => {
     win.crypto = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES,
+        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -204,7 +209,8 @@ describe('a4a_config', () => {
     win.crypto.subtle = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
+        INTERNAL_BRANCHES, 
+        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
   });
 
@@ -212,7 +218,8 @@ describe('a4a_config', () => {
     win.crypto.webkitSubtle = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
+        INTERNAL_BRANCHES,
+        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
   });
 
@@ -226,7 +233,8 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:spaz');
       toggleExperiment(win, EXP_ID, false, true);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -236,7 +244,8 @@ describe('a4a_config', () => {
       // Force random client-side selection off.
       toggleExperiment(win, EXP_ID, false, true);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -245,7 +254,8 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:spaz');
       rand.returns(0.75);  // Random value to select the 2nd branch
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
       expectInternallyTriggered(element);
@@ -255,7 +265,8 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:');
       rand.returns(0.75);  // Random value to select the 2nd branch
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
       expectInternallyTriggered(element);
@@ -265,7 +276,8 @@ describe('a4a_config', () => {
         () => {
           win.location.search = urlBase.replace('PARAM', 'a4a:2');
           expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-              INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
+              INTERNAL_BRANCHES,
+              MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
           expect(win.document.cookie).to.be.null;
           expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
           expectExternallyTriggered(element);
@@ -276,7 +288,8 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.control);
       expectExternallyTriggered(element);
@@ -287,7 +300,8 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -297,7 +311,8 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
@@ -384,7 +399,8 @@ describe('a4a_config hash param parsing', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
@@ -404,7 +420,8 @@ describe('a4a_config hash param parsing', () => {
       win.location.hash = hashBase.replace('PARAM', 'a4a:2');
       installViewerServiceForDoc(ampdoc);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES,
+          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
       expectExternallyTriggered(element);

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -40,14 +40,13 @@ const EXP_ID = 'EXP_ID';
 const EXTERNAL_BRANCHES = {
   control: '1',
   experiment: '2',
+  controlMeasureOnRender: '3',
 };
 /** @type {!Branches} */
 const INTERNAL_BRANCHES = {
   control: '3',
   experiment: '4',
 };
-/** @type {!Branch} */
-const MEASURE_ON_RENDER_BRANCH = 5;
 
 /**
  * Checks that element's data-experiment-id tag contains the specified id and
@@ -158,7 +157,7 @@ describe('a4a_config', () => {
   it('should attach expt ID and return true when expt is on', () => {
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID,
-        EXTERNAL_BRANCHES, INTERNAL_BRANCHES, MEASURE_ON_RENDER_BRANCH),
+        EXTERNAL_BRANCHES, INTERNAL_BRANCHES),
            'googleAdsIsA4AEnabled').to.be.true;
     expect(win.document.cookie).to.be.null;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
@@ -168,8 +167,7 @@ describe('a4a_config', () => {
   it('should attach control ID and return false when control is on', () => {
     rand.returns(0.25);  // Random value to select the 1st branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, MEASURE_ON_RENDER_BRANCH),
-           'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.control);
     expectInternallyTriggered(element);
@@ -178,8 +176,7 @@ describe('a4a_config', () => {
   it('should not attach ID and return false when selected out', () => {
     toggleExperiment(win, EXP_ID, false, true);
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES,
-        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -189,8 +186,7 @@ describe('a4a_config', () => {
     win.AMP_MODE.localDev = false;
     win.location.href = 'http://somewhere.over.the.rainbow.org/';
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, 
-        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -199,8 +195,7 @@ describe('a4a_config', () => {
     win.crypto = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES,
-        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -209,8 +204,7 @@ describe('a4a_config', () => {
     win.crypto.subtle = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES, 
-        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
   });
 
@@ -218,8 +212,7 @@ describe('a4a_config', () => {
     win.crypto.webkitSubtle = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES,
-        MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
+        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
   });
 
@@ -233,8 +226,7 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:spaz');
       toggleExperiment(win, EXP_ID, false, true);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -244,8 +236,7 @@ describe('a4a_config', () => {
       // Force random client-side selection off.
       toggleExperiment(win, EXP_ID, false, true);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -254,8 +245,7 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:spaz');
       rand.returns(0.75);  // Random value to select the 2nd branch
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
       expectInternallyTriggered(element);
@@ -265,8 +255,7 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:');
       rand.returns(0.75);  // Random value to select the 2nd branch
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
       expectInternallyTriggered(element);
@@ -276,8 +265,7 @@ describe('a4a_config', () => {
         () => {
           win.location.search = urlBase.replace('PARAM', 'a4a:2');
           expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-              INTERNAL_BRANCHES,
-              MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
+              INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
           expect(win.document.cookie).to.be.null;
           expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
           expectExternallyTriggered(element);
@@ -288,8 +276,7 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.control);
       expectExternallyTriggered(element);
@@ -300,8 +287,7 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -311,8 +297,7 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
@@ -326,6 +311,18 @@ describe('a4a_config', () => {
             'element in ', EXTERNAL_BRANCHES[branch]).to.be.false;
       }
     });
+
+    it(`should force control param from URL when pattern=${urlBase}`, () => {
+      win.location.search = urlBase.replace('PARAM', 'a4a:3');
+      // Should not register as 'A4A enabled', but should still attach the
+      // control experiment ID.
+      expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+      expect(win.document.cookie).to.be.null;
+      expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.controlMeasureOnRender);
+      expectExternallyTriggered(element);
+    });
+
   });
 });
 
@@ -399,8 +396,7 @@ describe('a4a_config hash param parsing', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
@@ -420,8 +416,7 @@ describe('a4a_config hash param parsing', () => {
       win.location.hash = hashBase.replace('PARAM', 'a4a:2');
       installViewerServiceForDoc(ampdoc);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES,
-          MEASURE_ON_RENDER_BRANCH), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
       expectExternallyTriggered(element);

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -312,10 +312,10 @@ describe('a4a_config', () => {
       }
     });
 
-    it(`should force control param from URL when pattern=${urlBase}`, () => {
+    it(`should force controlMeasureOnRender param from URL when pattern=${urlBase}`, () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:3');
       // Should not register as 'A4A enabled', but should still attach the
-      // control experiment ID.
+      // controlMeasureOnRender experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
           INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -156,7 +156,7 @@ describe('a4a_config', () => {
   it('should attach expt ID and return true when expt is on', () => {
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID,
-        EXTERNAL_BRANCHES, INTERNAL_BRANCHES),
+        EXTERNAL_BRANCHES, INTERNAL_BRANCHES, null),
            'googleAdsIsA4AEnabled').to.be.true;
     expect(win.document.cookie).to.be.null;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
@@ -166,7 +166,7 @@ describe('a4a_config', () => {
   it('should attach control ID and return false when control is on', () => {
     rand.returns(0.25);  // Random value to select the 1st branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES),
+        INTERNAL_BRANCHES, null),
            'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.control);
@@ -176,7 +176,7 @@ describe('a4a_config', () => {
   it('should not attach ID and return false when selected out', () => {
     toggleExperiment(win, EXP_ID, false, true);
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -186,7 +186,7 @@ describe('a4a_config', () => {
     win.AMP_MODE.localDev = false;
     win.location.href = 'http://somewhere.over.the.rainbow.org/';
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -195,7 +195,7 @@ describe('a4a_config', () => {
     win.crypto = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
     expect(win.document.cookie).to.be.null;
     expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
   });
@@ -204,7 +204,7 @@ describe('a4a_config', () => {
     win.crypto.subtle = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
   });
 
@@ -212,7 +212,7 @@ describe('a4a_config', () => {
     win.crypto.webkitSubtle = null;
     rand.returns(0.75);  // Random value to select the 2nd branch
     expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-        INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+        INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
   });
 
@@ -226,7 +226,7 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:spaz');
       toggleExperiment(win, EXP_ID, false, true);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -236,7 +236,7 @@ describe('a4a_config', () => {
       // Force random client-side selection off.
       toggleExperiment(win, EXP_ID, false, true);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -245,7 +245,7 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:spaz');
       rand.returns(0.75);  // Random value to select the 2nd branch
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
       expectInternallyTriggered(element);
@@ -255,7 +255,7 @@ describe('a4a_config', () => {
       win.location.search = urlBase.replace('PARAM', 'a4a:');
       rand.returns(0.75);  // Random value to select the 2nd branch
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
       expectInternallyTriggered(element);
@@ -265,7 +265,7 @@ describe('a4a_config', () => {
         () => {
           win.location.search = urlBase.replace('PARAM', 'a4a:2');
           expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-              INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+              INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
           expect(win.document.cookie).to.be.null;
           expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
           expectExternallyTriggered(element);
@@ -276,7 +276,7 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.control);
       expectExternallyTriggered(element);
@@ -287,7 +287,7 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.false;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.false;
       expect(win.document.cookie).to.be.null;
       expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
     });
@@ -297,7 +297,7 @@ describe('a4a_config', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
@@ -384,7 +384,7 @@ describe('a4a_config hash param parsing', () => {
       // Should not register as 'A4A enabled', but should still attach the
       // control experiment ID.
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expect(isInManualExperiment(element), 'element in manual experiment')
           .to.be.true;
@@ -404,7 +404,7 @@ describe('a4a_config hash param parsing', () => {
       win.location.hash = hashBase.replace('PARAM', 'a4a:2');
       installViewerServiceForDoc(ampdoc);
       expect(googleAdsIsA4AEnabled(win, element, EXP_ID, EXTERNAL_BRANCHES,
-          INTERNAL_BRANCHES), 'googleAdsIsA4AEnabled').to.be.true;
+          INTERNAL_BRANCHES, null), 'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
       expectExternallyTriggered(element);

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -42,7 +42,6 @@ import {
   DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
   DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
   DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-  DOUBLECLICK_COUNT_ON_RENDER,
 } from '../../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js'; // eslint-disable-line
 import {EXPERIMENT_ATTRIBUTE} from '../utils';
 import {dev} from '../../../../src/log';
@@ -559,8 +558,7 @@ describe('all-traffic-experiments-tests', () => {
           DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH :
           DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH;
         expect(googleAdsIsA4AEnabled(win, element, 'expDoubleclickA4A',
-          external, internal,
-          DOUBLECLICK_COUNT_ON_RENDER)).to.equal(test.shouldServeFastFetch);
+          external, internal)).to.equal(test.shouldServeFastFetch);
         expectCorrectBranchOnly(element, test.branchId);
         expect(win.document.cookie).to.be.null;
       });

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -42,6 +42,7 @@ import {
   DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
   DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
   DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
+  DOUBLECLICK_COUNT_ON_RENDER,
 } from '../../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js'; // eslint-disable-line
 import {EXPERIMENT_ATTRIBUTE} from '../utils';
 import {dev} from '../../../../src/log';
@@ -558,7 +559,8 @@ describe('all-traffic-experiments-tests', () => {
           DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH :
           DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH;
         expect(googleAdsIsA4AEnabled(win, element, 'expDoubleclickA4A',
-          external, internal)).to.equal(test.shouldServeFastFetch);
+          external, internal,
+          DOUBLECLICK_COUNT_ON_RENDER)).to.equal(test.shouldServeFastFetch);
         expectCorrectBranchOnly(element, test.branchId);
         expect(win.document.cookie).to.be.null;
       });

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -28,7 +28,7 @@ import {dev} from '../../../src/log';
 import {viewerForDoc} from '../../../src/services';
 import {parseQueryString} from '../../../src/url';
 
-/** @typedef {{control: string, experiment: string}} */
+/** @typedef {{control: string, experiment: string, controlMeasureOnRender: string}} */
 export let ExperimentInfo;
 
 /** @type {!string} @private */
@@ -62,13 +62,11 @@ const INTERNALLY_SELECTED_ID = '2088462';
  * @param {!ExperimentInfo} internalBranches experiment and control branch IDs to
  *   use when experiment is triggered internally (i.e., via client-side
  *   selection).
- * @param {!string} controlWithDelayedId  Experiment ID string for the branch
- *   that counts Delayed Fetch on render
  * @return {boolean}  Whether Google Ads should attempt to render via the A4A
  *   pathway.
  */
 export function googleAdsIsA4AEnabled(win, element, experimentName,
-    externalBranches, internalBranches, controlWithDelayedId) {
+    externalBranches, internalBranches) {
   if (!isGoogleAdsA4AValidEnvironment(win)) {
     // Serving location doesn't qualify for A4A treatment
     return false;
@@ -76,7 +74,8 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
 
   const isSetFromUrl = maybeSetExperimentFromUrl(win, element,
       experimentName, externalBranches.control,
-      externalBranches.experiment, MANUAL_EXPERIMENT_ID, controlWithDelayedId);
+      externalBranches.experiment, externalBranches.controlMeasureOnRender,
+      MANUAL_EXPERIMENT_ID);
   const experimentInfo = {};
   experimentInfo[experimentName] = internalBranches;
   // Note: Because the same experimentName is being used everywhere here,
@@ -145,14 +144,14 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
  *   the overall experiment.
  * @param {!string} treatmentBranchId  Experiment ID string for the 'treatment'
  *   branch of the overall experiment.
- * @param {!string} manualId  ID of the manual experiment.
- * @param {!string} controlWithDelayedId  Experiment ID string for the branch
+ * @param {!string} controlMeasureOnRender  Experiment ID string for the branch
  *   that counts Delayed Fetch on render
+ * @param {!string} manualId  ID of the manual experiment.
  * @return {boolean}  Whether the experiment state was set from a command-line
  *   parameter or not.
  */
 function maybeSetExperimentFromUrl(win, element, experimentName,
-    controlBranchId, treatmentBranchId, manualId, controlWithDelayedId) {
+    controlBranchId, treatmentBranchId, controlMeasureOnRender, manualId) {
   const expParam = viewerForDoc(element).getParam('exp') ||
       parseQueryString(win.location.search)['exp'];
   if (!expParam) {
@@ -171,7 +170,7 @@ function maybeSetExperimentFromUrl(win, element, experimentName,
     '0': null, // TODO Ensure does not generate exp id
     '1': controlBranchId,
     '2': treatmentBranchId,
-    '3': controlWithDelayedId,
+    '3': controlMeasureOnRender,
   };
   if (argMapping.hasOwnProperty(arg)) {
     forceExperimentBranch(win, experimentName, argMapping[arg]);

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -144,7 +144,7 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
  *   the overall experiment.
  * @param {!string} treatmentBranchId  Experiment ID string for the 'treatment'
  *   branch of the overall experiment.
- * @param {!string} controlMeasureOnRender  Experiment ID string for the branch
+ * @param {?string} controlMeasureOnRender  Experiment ID string for the branch
  *   that counts Delayed Fetch on render
  * @param {!string} manualId  ID of the manual experiment.
  * @return {boolean}  Whether the experiment state was set from a command-line

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -28,7 +28,7 @@ import {dev} from '../../../src/log';
 import {viewerForDoc} from '../../../src/services';
 import {parseQueryString} from '../../../src/url';
 
-/** @typedef {{control: string, experiment: string, controlMeasureOnRender: string}} */
+/** @typedef {{control: string, experiment: string, controlMeasureOnRender: ?string}} */
 export let ExperimentInfo;
 
 /** @type {!string} @private */

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -52,6 +52,7 @@ const ADSENSE_A4A_EXPERIMENT_NAME = 'expAdsenseA4A';
 export const ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152650',
   experiment: '117152651',
+  controlMeasureOnRender: '2093326',
 };
 
 /** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo}  */
@@ -59,9 +60,6 @@ export const ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152670',
   experiment: '117152671',
 };
-
-/** @type {!string} @private */
-const ADSENSE_COUNT_ON_RENDER = '2093326';
 
 /**
  * @param {!Window} win
@@ -73,6 +71,5 @@ export function adsenseIsA4AEnabled(win, element) {
       googleAdsIsA4AEnabled(
         win, element, ADSENSE_A4A_EXPERIMENT_NAME,
         ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
-        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES,
-        ADSENSE_COUNT_ON_RENDER);
+        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES);
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -59,6 +59,7 @@ export const ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES = {
 export const ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
   control: '117152670',
   experiment: '117152671',
+  controlMeasureOnRender: null,
 };
 
 /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -60,6 +60,9 @@ export const ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES = {
   experiment: '117152671',
 };
 
+/** @type {!string} @private */
+const ADSENSE_COUNT_ON_RENDER = '2093326';
+
 /**
  * @param {!Window} win
  * @param {!Element} element
@@ -70,5 +73,6 @@ export function adsenseIsA4AEnabled(win, element) {
       googleAdsIsA4AEnabled(
         win, element, ADSENSE_A4A_EXPERIMENT_NAME,
         ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES,
-        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES);
+        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES,
+        ADSENSE_COUNT_ON_RENDER);
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -71,18 +71,21 @@ export const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH = {
 export const DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH = {
   control: '117152680',
   experiment: '117152681',
+  controlMeasureOnRender: null,
 };
 
 /** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
 export const DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH = {
   control: '2092613',
   experiment: '2092614',
+  controlMeasureOnRender: null,
 };
 
 /** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
 export const DOUBLECLICK_A4A_BETA_BRANCHES = {
   control: '2077830',
   experiment: '2077831',
+  controlMeasureOnRender: null,
 };
 
 export const BETA_ATTRIBUTE = 'data-use-beta-a4a-implementation';

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -32,9 +32,6 @@ import {isExperimentOn} from '../../../src/experiments';
 /** @const {string} */
 const DOUBLECLICK_A4A_EXPERIMENT_NAME = 'expDoubleclickA4A';
 
-/** @type {!string} @private */
-export const DOUBLECLICK_COUNT_ON_RENDER = '2093327';
-
 // The following experiment IDs are used by Google-side servers to
 // understand what experiment is running and what mode the A4A code is
 // running in.  In this experiment phase, we're testing 8 different
@@ -60,12 +57,14 @@ export const DOUBLECLICK_COUNT_ON_RENDER = '2093327';
 export const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH = {
   control: '117152660',
   experiment: '117152661',
+  controlMeasureOnRender: '2093327',
 };
 
 /** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
 export const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH = {
   control: '2092619',
   experiment: '2092620',
+  controlMeasureOnRender: '2093327',
 };
 
 /** @const {!../../../ads/google/a4a/traffic-experiments.ExperimentInfo} */
@@ -114,7 +113,7 @@ export function doubleclickIsA4AEnabled(win, element) {
   }
   const enableA4A = googleAdsIsA4AEnabled(
           win, element, DOUBLECLICK_A4A_EXPERIMENT_NAME,
-          externalBranches, internalBranches, DOUBLECLICK_COUNT_ON_RENDER) ||
+          externalBranches, internalBranches) ||
       (a4aRequested && (isProxyOrigin(win.location) ||
        getMode(win).localDev || getMode(win).test));
   if (enableA4A && a4aRequested && !isInManualExperiment(element)) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -32,6 +32,9 @@ import {isExperimentOn} from '../../../src/experiments';
 /** @const {string} */
 const DOUBLECLICK_A4A_EXPERIMENT_NAME = 'expDoubleclickA4A';
 
+/** @type {!string} @private */
+export const DOUBLECLICK_COUNT_ON_RENDER = '2093327';
+
 // The following experiment IDs are used by Google-side servers to
 // understand what experiment is running and what mode the A4A code is
 // running in.  In this experiment phase, we're testing 8 different
@@ -111,7 +114,7 @@ export function doubleclickIsA4AEnabled(win, element) {
   }
   const enableA4A = googleAdsIsA4AEnabled(
           win, element, DOUBLECLICK_A4A_EXPERIMENT_NAME,
-          externalBranches, internalBranches) ||
+          externalBranches, internalBranches, DOUBLECLICK_COUNT_ON_RENDER) ||
       (a4aRequested && (isProxyOrigin(win.location) ||
        getMode(win).localDev || getMode(win).test));
   if (enableA4A && a4aRequested && !isInManualExperiment(element)) {


### PR DESCRIPTION
Creates a new value for A4A experiment, a4a:3. If this is set, it will 1) do Delayed Fetch (i.e. mimic a4a:1 before launch, or a4a:2 after launch) and 2) force either ADSENSE_COUNT_ON_RENDER or DOUBLECLICK_COUNT_ON_RENDER to be on, depending upon the creative type.