### PR TITLE
Don't depend on formatting args in error message in amp-list#layoutCallback

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -19,6 +19,9 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {templatesFor} from '../../../src/services';
 import {user} from '../../../src/log';
 
+/** @const {string} */
+const TAG = 'amp-list';
+
 /**
  * The implementation of `amp-list` component. See {@link ../amp-list.md} for
  * the spec.
@@ -57,7 +60,8 @@ export class AmpList extends AMP.BaseElement {
           return templatesFor(this.win).findAndRenderTemplateArray(
               this.element, items).then(this.rendered_.bind(this));
         }, error => {
-          user().assert(false, error.message, this.element);
+          user().error(TAG,
+              'Error fetching amp-list JSON data', error, this.element);
         });
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -19,9 +19,6 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {templatesFor} from '../../../src/services';
 import {user} from '../../../src/log';
 
-/** @const {string} */
-const TAG = 'amp-list';
-
 /**
  * The implementation of `amp-list` component. See {@link ../amp-list.md} for
  * the spec.
@@ -60,8 +57,7 @@ export class AmpList extends AMP.BaseElement {
           return templatesFor(this.win).findAndRenderTemplateArray(
               this.element, items).then(this.rendered_.bind(this));
         }, error => {
-          user().error(TAG,
-              'Error fetching amp-list JSON data', error, this.element);
+          throw user().createError('Error fetching amp-list', error);
         });
   }
 


### PR DESCRIPTION
Fixed a bug that caused amp-list to send a string to log#assert with fewer string placeholders than provided arguments.

Fixes #8814 

/to @dvoytenko Let me know if you want me to update the assert function to better handle this situation.