### PR TITLE
Tick first paint time where available.

### DIFF
--- a/extensions/amp-viewer-integration/TICKEVENTS.md
+++ b/extensions/amp-viewer-integration/TICKEVENTS.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 ### Tick Events
 
-When implementing a viewer one can use the tick events for performance tracking. 
+When implementing a viewer one can use the tick events for performance tracking.
 
 We use very short string names as tick labels, so the table below
 further describes these labels.
@@ -32,3 +32,4 @@ As an example if we executed `perf.tick('label')` we assume we have a counterpar
 | Prerender Complete  | `pc`              | The runtime completes prerending a single document. |
 | Make Body Visible | `mbv` | Make Body Visible Executes. |
 | On First Visible | `ofv` | The first time the page has been turned visible. |
+| First paint time | `fp` | The time on the first non-blank paint of the page. |

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -96,7 +96,7 @@ export class Performance {
 
     // Tick window.onload event.
     whenDocumentComplete(win.document).then(() => {
-      this.tick('ol');
+      this.onload_();
       this.flush();
     });
   }
@@ -149,6 +149,18 @@ export class Performance {
       // Send all csi ticks through.
       this.flush();
     });
+  }
+
+  onload_() {
+    this.tick('ol');
+    // Detect deprecated first pain time API
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=621512
+    // We'll use this until something better is available.
+    if (this.win.chrome && typeof this.win.chrome.loadTimes == 'function') {
+      this.tickDelta('fp',
+          this.win.chrome.loadTimes().firstPaintTime * 1000 -
+              this.win.performance.timing.navigationStart);
+    }
   }
 
   /**

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -31,6 +31,7 @@ describes.realWin('performance', {amp: true}, env => {
   let clock;
   let win;
   let ampdoc;
+  let hasLoadTimes;
 
   beforeEach(() => {
     win = env.win;
@@ -39,6 +40,7 @@ describes.realWin('performance', {amp: true}, env => {
     clock = lolex.install(win, 0, ['Date', 'setTimeout', 'clearTimeout']);
     installPerformanceService(env.win);
     perf = performanceFor(env.win);
+    hasLoadTimes = window.chrome && window.chrome.loadTimes;
   });
 
   describe('when viewer is not ready', () => {
@@ -258,7 +260,8 @@ describes.realWin('performance', {amp: true}, env => {
         return perf.coreServicesAvailable().then(() => {
           expect(flushSpy).to.have.callCount(3);
           expect(perf.isMessagingReady_).to.be.false;
-          expect(perf.events_.length).to.equal(4);
+          const count = hasLoadTimes ? 5 : 4;
+          expect(perf.events_.length).to.equal(count);
         });
       });
     });
@@ -563,16 +566,16 @@ describes.realWin('performance', {amp: true}, env => {
          'to be visible before before first viewport completion', () => {
         clock.tick(100);
         whenFirstVisibleResolve();
-        expect(tickSpy).to.have.callCount(2);
+        expect(tickSpy).to.have.callCount(hasLoadTimes ? 3 : 2);
         return viewer.whenFirstVisible().then(() => {
           clock.tick(400);
-          expect(tickSpy).to.have.callCount(3);
+          expect(tickSpy).to.have.callCount(hasLoadTimes ? 4 : 3);
           whenViewportLayoutCompleteResolve();
           return perf.whenViewportLayoutComplete_().then(() => {
-            expect(tickSpy).to.have.callCount(3);
+            expect(tickSpy).to.have.callCount(hasLoadTimes ? 4 : 3);
             expect(tickSpy.withArgs('ofv')).to.be.calledOnce;
             return whenFirstVisiblePromise.then(() => {
-              expect(tickSpy).to.have.callCount(4);
+              expect(tickSpy).to.have.callCount(hasLoadTimes ? 5 : 4);
               expect(tickSpy.withArgs('pc')).to.be.calledOnce;
               expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(400);
             });


### PR DESCRIPTION
Introduces new `fp` performance metric.

@lannka Could you handle setting this up in our tracking dashboard?