### PR TITLE
Allow protocol-relative urls in amp-iframe

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -65,8 +65,8 @@ export class AmpIframe extends AMP.BaseElement {
     // Checks are mostly there to prevent people easily do something
     // they did not mean to.
     user().assert(
-        isSecureUrl(url) || url.protocol == 'data:',
-        'Invalid <amp-iframe> src. Must start with https://. Found %s',
+        isSecureUrl(url) || url.protocol == 'data:' || src.indexOf('//') == 0,
+        'Invalid <amp-iframe> src. Must start with https:// or //. Found %s',
         this.element);
     const containerUrl = parseUrl(containerSrc);
     user().assert(

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -45,7 +45,7 @@ limitations under the License.
 
 - `amp-iframe` may not appear close to the top of the document (except for iframes that use `placeholder` as described below). They must be either 600px away from the top or not within the first 75% of the viewport when scrolled to the top – whichever is smaller. NOTE: We are currently looking for feedback as to how well this restriction works in practice.
 - By default, an amp-iframe is sandboxed ([details](#sandbox)).
-- They must only request resources via HTTPS or from a data-URI or via the srcdoc attribute.
+- They must only request resources via HTTPS, a protocol-relative URL, from a data-URI or via the srcdoc attribute.
 - They must not be in the same origin as the container unless they do not allow `allow-same-origin` in the sandbox attribute. See the doc ["Iframe origin policy"](../../spec/amp-iframe-origin-policy.md) for further details on allowed origins for iframes.
 
 Example:


### PR DESCRIPTION
Currently amp-iframe only allows secure URLs, data-URIs or srcdocs.  This pull allows protocol-relative urls to be used, which can be useful in dev environments.  Then, when served from production AMP caches, these URLs can be expected to resolve to https, preserving the original intent of this restriction.

I realize protocol-relative URLs are not generally a good idea when there's a chance they may appear on a non-secure page in production, so if there's a better way to solve this issue for dev environments, I'd be all for it.  Not clear to me if there's currently a way to assert a less restrictive set of requirements for dev environments only (something like `#log=0` that would affect asserts as well as logging?), though I could imagine such a thing could be problematic if it leads to developers pushing broken pages into production...