### PR TITLE
Youtube no longer sends onready - and is not needed

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -203,7 +203,10 @@ class AmpYoutube extends AMP.BaseElement {
 
     return this.loadPromise(iframe)
         .then(() => this.listenToFrame_())
-        .then(() => this.playerReadyPromise_);
+        .then(() => {
+          this.element.dispatchCustomEvent(VideoEvents.LOAD);
+          this.playerReadyResolver_(this.iframe_);
+        });
   }
 
   /** @override */
@@ -288,10 +291,7 @@ class AmpYoutube extends AMP.BaseElement {
     if (data === undefined) {
       return; // We only process valid JSON.
     }
-    if (data.event == 'onReady') {
-      this.element.dispatchCustomEvent(VideoEvents.LOAD);
-      this.playerReadyResolver_(this.iframe_);
-    } else if (data.event == 'infoDelivery' &&
+    if (data.event == 'infoDelivery' &&
         data.info && data.info.playerState !== undefined) {
       this.playerState_ = data.info.playerState;
       if (this.playerState_ == PlayerStates.PAUSED) {


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/8828 

YouTube seems to have switched to a new player code, and it no longer send onready message if player is not initially visible and based on testing doesn't look like we need it anymore. On the plus side, new player seems much faster!

@zhouyx Sorry, need prod and canary patched.
