### PR TITLE
Observe max URL length in App Engine for error reports.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -374,6 +374,11 @@ export function getErrorReportUrl(message, filename, line, col, error,
   url += '&fr=' + encodeURIComponent(self.location.originalHash
       || self.location.hash);
 
+  // Google App Engine maximum URL length.
+  if (url.length >= 2072) {
+    url = url.substr(0, 2072 - 10 /* length of suffix */)
+        + '&SHORTENED';
+  }
   return url;
 }
 

--- a/src/error.js
+++ b/src/error.js
@@ -358,8 +358,10 @@ export function getErrorReportUrl(message, filename, line, col, error,
       url += `&args=${encodeURIComponent(JSON.stringify(error.args))}`;
     }
 
-    if (!isUserError && !error.ignoreStack) {
-      url += `&s=${encodeURIComponent(error.stack || '')}`;
+    if (!isUserError && !error.ignoreStack && error.stack) {
+      // Shorten
+      const stack = (error.stack || '').substr(0, 1000);
+      url += `&s=${encodeURIComponent(stack)}`;
     }
 
     error.message += ' _reported_';
@@ -376,8 +378,11 @@ export function getErrorReportUrl(message, filename, line, col, error,
 
   // Google App Engine maximum URL length.
   if (url.length >= 2072) {
-    url = url.substr(0, 2072 - 10 /* length of suffix */)
-        + '&SHORTENED';
+    url = url.substr(0, 2072 - 8 /* length of suffix */)
+        // Full remove last URL encoded entity.
+        .replace(/\%[^&%]+$/, '')
+        // Sentinel
+        + '&SHORT=1';
   }
   return url;
 }

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -101,7 +101,7 @@ describe('reportErrorToServer', () => {
     resetExperimentTogglesForTesting(window);
   });
 
-  it('reportError with error object', () => {
+  it('reportError with error object', function SHOULD_BE_IN_STACK() {
     const e = new Error('XYZ');
     const url = parseUrl(
         getErrorReportUrl(undefined, undefined, undefined, undefined, e,
@@ -113,7 +113,7 @@ describe('reportErrorToServer', () => {
     expect(query.m).to.equal('XYZ');
     expect(query.el).to.equal('u');
     expect(query.a).to.equal('0');
-    expect(query.s).to.equal(e.stack.trim());
+    expect(query.s).to.contain('SHOULD_BE_IN_STACK');
     expect(query['3p']).to.equal(undefined);
     expect(e.message).to.contain('_reported_');
     if (location.ancestorOrigins) {
@@ -262,7 +262,7 @@ describe('reportErrorToServer', () => {
     expect(query.f).to.equal('foo.js');
     expect(query.l).to.equal('11');
     expect(query.c).to.equal('22');
-    expect(url.href).to.not.contain('SHORTENED');
+    expect(query.SHORT).to.be.undefined;
   });
 
   it('should accumulate errors', () => {
@@ -280,10 +280,10 @@ describe('reportErrorToServer', () => {
     expect(query.ae).to.equal('1,2');
   });
 
-  it('should accumulate errors', () => {
+  it('should shorten very long reports', () => {
     let message = 'TEST';
     for (let i = 0; i < 4000; i++) {
-      message += 'a';
+      message += '&';
     }
     const url = parseUrl(getErrorReportUrl(undefined, undefined, undefined,
         undefined, new Error(message),true));
@@ -292,8 +292,8 @@ describe('reportErrorToServer', () => {
         'https://amp-error-reporting.appspot.com/r?')).to.equal(0);
 
     expect(query.m).to.match(/^TEST/);
-    expect(url.href).to.have.length(2072);
-    expect(url.href).to.contain('SHORTENED');
+    expect(url.href.length <= 2072).to.be.ok;
+    expect(query.SHORT).to.equal('1');
   });
 
   it('should not double report', () => {

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -262,6 +262,7 @@ describe('reportErrorToServer', () => {
     expect(query.f).to.equal('foo.js');
     expect(query.l).to.equal('11');
     expect(query.c).to.equal('22');
+    expect(url.href).to.not.contain('SHORTENED');
   });
 
   it('should accumulate errors', () => {
@@ -277,6 +278,22 @@ describe('reportErrorToServer', () => {
 
     expect(query.m).to.equal('3');
     expect(query.ae).to.equal('1,2');
+  });
+
+  it('should accumulate errors', () => {
+    let message = 'TEST';
+    for (let i = 0; i < 4000; i++) {
+      message += 'a';
+    }
+    const url = parseUrl(getErrorReportUrl(undefined, undefined, undefined,
+        undefined, new Error(message),true));
+    const query = parseQueryString(url.search);
+    expect(url.href.indexOf(
+        'https://amp-error-reporting.appspot.com/r?')).to.equal(0);
+
+    expect(query.m).to.match(/^TEST/);
+    expect(url.href).to.have.length(2072);
+    expect(url.href).to.contain('SHORTENED');
   });
 
   it('should not double report', () => {


### PR DESCRIPTION
In practice this only cuts off the "accumulated errors" and referrers. Critical parts typically fit.

Fixes #8799

Originally submitted as #8800, reverted from x-platform failures.
