### PR TITLE
Add `keyboard-select-mode` to amp-selector

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -554,7 +554,7 @@
 <form method="post"
       action-xhr="/form/echo-json/post"
       target="_blank">
-    <amp-selector layout="container" name="multi_image_select" multiple>
+    <amp-selector layout="container" name="multi_image_select" multiple keyboard-select-mode="focus">
         <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=50 height=50 option="1" selected></amp-img>
         <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=50 height=50 option="2"></amp-img>
         <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="3" selected></amp-img>

--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -555,10 +555,10 @@
       action-xhr="/form/echo-json/post"
       target="_blank">
     <amp-selector layout="container" name="multi_image_select" multiple>
-        <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=50 height=50 option="1" selected id="selector0"></amp-img>
-        <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=50 height=50 option="2" id="selector1"></amp-img>
-        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="3" selected id="selector2"></amp-img>
-        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="4" id="selector3"></amp-img>
+        <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=50 height=50 option="1" selected></amp-img>
+        <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=50 height=50 option="2"></amp-img>
+        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="3" selected></amp-img>
+        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="4"></amp-img>
     </amp-selector>
     <input type="Submit">
 </form>

--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -555,10 +555,10 @@
       action-xhr="/form/echo-json/post"
       target="_blank">
     <amp-selector layout="container" name="multi_image_select" multiple>
-        <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=50 height=50 option="1" selected></amp-img>
-        <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=50 height=50 option="2"></amp-img>
-        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="3" selected></amp-img>
-        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="4"></amp-img>
+        <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=50 height=50 option="1" selected id="selector0"></amp-img>
+        <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=50 height=50 option="2" id="selector1"></amp-img>
+        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="3" selected id="selector2"></amp-img>
+        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=50 height=50 option="4" id="selector3"></amp-img>
     </amp-selector>
     <input type="Submit">
 </form>

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -130,10 +130,10 @@ export class AmpSelector extends AMP.BaseElement {
       this.clearAllSelections_();
       return;
     }
-    const selectedArray = Array.isArray(newValue) ? newValue : [newValue];
+    let selectedArray = Array.isArray(newValue) ? newValue : [newValue];
     // Only use first value if multiple selection is disabled.
     if (!this.isMultiple_) {
-      selectedArray.length = 1;
+      selectedArray = selectedArray.slice(0, 1);
     }
     // Convert array values to strings and create map for fast lookup.
     const selectedMap = selectedArray.reduce((map, value) => {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -57,7 +57,12 @@ export class AmpSelector extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private {number} */
+    /**
+     * The index of the option that should receive tab focus. Only one
+     * option should ever receive tab focus, with the other options reachable
+     * by arrow keys when the option is in focus.
+     * @private {number}
+     */
     this.focusedIndex_ = 0;
 
     /** @private {!KEYBOARD_SELECT_MODES} */
@@ -308,33 +313,34 @@ export class AmpSelector extends AMP.BaseElement {
     // Make currently selected option unfocusable
     this.options_[this.focusedIndex_].tabIndex = -1;
 
-    const dir = this.win.document.body.getAttribute('dir') || 'ltr';
-    const ltr = dir != 'rtl';
-    let delta = 0;
+    const isLtr = this.win.document.body.getAttribute('dir') != 'rtl';
+    let dir = 0;
 
     switch (event.keyCode) {
       case 37: // Left
-        delta = ltr ? -1 : 1;
+        dir = isLtr ? -1 : 1;
         break;
       case 38: // Up
-        delta = -1;
+        dir = -1;
         break;
       case 39: // Right
-        delta = ltr ? 1 : -1;
+        dir = isLtr ? 1 : -1;
         break;
       case 40: // Down
-        delta = 1;
+        dir = 1;
         break;
     }
 
-    if (delta == 0) {
+    if (dir == 0) {
       return;
     }
     event.preventDefault();
 
-    this.focusedIndex_ = (this.focusedIndex_ + delta) % this.options_.length;
+    // Change the focus to the next element in the specified direction.
+    // The selection should loop around if the user attempts to go one
+    // past the beginning or end.
+    this.focusedIndex_ = (this.focusedIndex_ + dir) % this.options_.length;
     if (this.focusedIndex_ < 0) {
-      // Wrap back around
       this.focusedIndex_ = this.focusedIndex_ + this.options_.length;
     }
 

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -15,6 +15,7 @@
  */
 
 import {CSS} from '../../../build/amp-selector-0.1.css';
+import {Keycodes} from '../../../src/utils/keycodes';
 import {actionServiceForDoc} from '../../../src/services';
 import {closestBySelector, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
@@ -314,19 +315,19 @@ export class AmpSelector extends AMP.BaseElement {
     let dir = 0;
 
     switch (event.keyCode) {
-      case 37: // Left
+      case Keycodes.LEFT_ARROW:
         // Left is considered 'previous' in LTR and 'next' in RTL.
         dir = isLtr ? -1 : 1;
         break;
-      case 38: // Up
+      case Keycodes.UP_ARROW:
         // Up is considered 'previous' in both LTR and RTL.
         dir = -1;
         break;
-      case 39: // Right
+      case Keycodes.RIGHT_ARROW:
         // Right is considered 'next' in LTR and 'previous' in RTL.
         dir = isLtr ? 1 : -1;
         break;
-      case 40: // Down
+      case Keycodes.DOWN_ARROW:
         // Down is considered 'next' in both LTR and RTL.
         dir = 1;
         break;

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -61,7 +61,7 @@ export class AmpSelector extends AMP.BaseElement {
     this.focusedIndex_ = 0;
 
     /** @private {!KEYBOARD_SELECT_MODES} */
-    this.kbSelectMode_ = KEYBOARD_SELECT_MODES.FOCUS;
+    this.kbSelectMode_ = KEYBOARD_SELECT_MODES.NONE;
   }
 
   /** @override */

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -16,7 +16,7 @@
 
 import {CSS} from '../../../build/amp-selector-0.1.css';
 import {actionServiceForDoc} from '../../../src/services';
-import {childElement, closest} from '../../../src/dom';
+import {closest} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 
@@ -59,7 +59,7 @@ export class AmpSelector extends AMP.BaseElement {
     /** @private {number} */
     this.focusedIndex_ = 0;
 
-    /** @private {?KBSupportMode} */
+    /** @private {!KB_SUPPORT} */
     this.kbSupportMode_ = KB_SUPPORT.FOCUS;
   }
 
@@ -243,7 +243,6 @@ export class AmpSelector extends AMP.BaseElement {
   /**
    * Handles user selection on an option.
    * @param {!Element} el The element selected.
-   * @return {!Promise} Resolves when element has been mutated.
    */
   onOptionSelected_(el) {
     if (el.hasAttribute('disabled')) {
@@ -333,7 +332,7 @@ export class AmpSelector extends AMP.BaseElement {
     // Focus newly selected option
     const newSelectedOption = this.options_[this.focusedIndex_];
     newSelectedOption.tabIndex = 0;
-    newSelectedOption.focus();
+    newSelectedOption./*REVIEW*/focus();
     if (!this.isMultiple_ && this.kbSupportMode_ == KB_SUPPORT.SELECT) {
       this.onOptionSelected_(newSelectedOption);
     }

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -16,7 +16,7 @@
 
 import {CSS} from '../../../build/amp-selector-0.1.css';
 import {actionServiceForDoc} from '../../../src/services';
-import {closest, tryFocus} from '../../../src/dom';
+import {closestBySelector, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {isEnumValue} from '../../../src/types';
@@ -130,10 +130,10 @@ export class AmpSelector extends AMP.BaseElement {
       this.clearAllSelections_();
       return;
     }
-    let selectedArray = Array.isArray(newValue) ? newValue : [newValue];
+    const selectedArray = Array.isArray(newValue) ? newValue : [newValue];
     // Only use first value if multiple selection is disabled.
     if (!this.isMultiple_) {
-      selectedArray = selectedArray.slice(0, 1);
+      selectedArray.length = 1;
     }
     // Convert array values to strings and create map for fast lookup.
     const selectedMap = selectedArray.reduce((map, value) => {
@@ -252,7 +252,7 @@ export class AmpSelector extends AMP.BaseElement {
    * Handles user selection on an option.
    * @param {!Element} el The element selected.
    */
-  onOptionSelected_(el) {
+  onOptionPicked_(el) {
     if (el.hasAttribute('disabled')) {
       return;
     }
@@ -298,10 +298,10 @@ export class AmpSelector extends AMP.BaseElement {
       return;
     }
     if (!el.hasAttribute('option')) {
-      el = closest(el, e => e.hasAttribute('option'), this.element);
+      el = closestBySelector(el, '[option]');
     }
     if (el) {
-      this.onOptionSelected_(el);
+      this.onOptionPicked_(el);
     }
   }
 
@@ -310,9 +310,6 @@ export class AmpSelector extends AMP.BaseElement {
    * @param {!Event} event
    */
   keyDownHandler_(event) {
-    // Make currently selected option unfocusable
-    this.options_[this.focusedIndex_].tabIndex = -1;
-
     const isLtr = this.win.document.body.getAttribute('dir') != 'rtl';
     let dir = 0;
 
@@ -340,6 +337,9 @@ export class AmpSelector extends AMP.BaseElement {
     }
     event.preventDefault();
 
+    // Make currently selected option unfocusable
+    this.options_[this.focusedIndex_].tabIndex = -1;
+
     // Change the focus to the next element in the specified direction.
     // The selection should loop around if the user attempts to go one
     // past the beginning or end.
@@ -352,9 +352,8 @@ export class AmpSelector extends AMP.BaseElement {
     const newSelectedOption = this.options_[this.focusedIndex_];
     newSelectedOption.tabIndex = 0;
     tryFocus(newSelectedOption);
-    if (!this.isMultiple_ &&
-        this.kbSelectMode_ == KEYBOARD_SELECT_MODES.SELECT) {
-      this.onOptionSelected_(newSelectedOption);
+    if (this.kbSelectMode_ == KEYBOARD_SELECT_MODES.SELECT) {
+      this.onOptionPicked_(newSelectedOption);
     }
   }
 

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -100,7 +100,7 @@ export class AmpSelector extends AMP.BaseElement {
     this.init_();
     if (!this.isDisabled_) {
       this.element.addEventListener('click', this.clickHandler_.bind(this));
-      if (this.kbSelectMode_ !== KEYBOARD_SELECT_MODES.NONE) {
+      if (this.kbSelectMode_ != KEYBOARD_SELECT_MODES.NONE) {
         this.element.addEventListener('keydown',
             this.keyDownHandler_.bind(this));
       }
@@ -160,7 +160,7 @@ export class AmpSelector extends AMP.BaseElement {
    * @private
    */
   updateFocus_() {
-    if (this.kbSelectMode_ === KEYBOARD_SELECT_MODES.NONE) {
+    if (this.kbSelectMode_ == KEYBOARD_SELECT_MODES.NONE) {
       // Don't manage focus.
       return;
     }
@@ -309,20 +309,25 @@ export class AmpSelector extends AMP.BaseElement {
     this.options_[this.focusedIndex_].tabIndex = -1;
 
     const dir = this.win.document.body.getAttribute('dir') || 'ltr';
+    const ltr = dir != 'rtl';
     let delta = 0;
 
     switch (event.keyCode) {
       case 37: // Left
+        delta = ltr ? -1 : 1;
+        break;
       case 38: // Up
-        delta = dir === 'rtl' ? 1 : -1;
+        delta = -1;
         break;
       case 39: // Right
+        delta = ltr ? 1 : -1;
+        break;
       case 40: // Down
-        delta = dir === 'rtl' ? -1 : 1;
+        delta = 1;
         break;
     }
 
-    if (delta === 0) {
+    if (delta == 0) {
       return;
     }
     event.preventDefault();

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -325,6 +325,7 @@ export class AmpSelector extends AMP.BaseElement {
     if (delta === 0) {
       return;
     }
+    event.preventDefault();
 
     this.focusedIndex_ = (this.focusedIndex_ + delta) % this.options_.length;
     if (this.focusedIndex_ < 0) {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -318,15 +318,19 @@ export class AmpSelector extends AMP.BaseElement {
 
     switch (event.keyCode) {
       case 37: // Left
+        // Left is considered 'previous' in LTR and 'next' in RTL.
         dir = isLtr ? -1 : 1;
         break;
       case 38: // Up
+        // Up is considered 'previous' in both LTR and RTL.
         dir = -1;
         break;
       case 39: // Right
+        // Right is considered 'next' in LTR and 'previous' in RTL.
         dir = isLtr ? 1 : -1;
         break;
       case 40: // Down
+        // Down is considered 'next' in both LTR and RTL.
         dir = 1;
         break;
     }

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -85,7 +85,7 @@ describes.realWin('amp-selector', {
       const event = {
         keyCode: key,
         preventDefault: () => {},
-      }
+      };
       impl.keyHandler_(event);
     }
 
@@ -603,8 +603,8 @@ describes.realWin('amp-selector', {
             multiple: true,
           },
           config: {
-            count: 3
-          }
+            count: 3,
+          },
         });
         ampSelector.children[1].setAttribute('selected', '');
         ampSelector.build();

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -86,7 +86,7 @@ describes.realWin('amp-selector', {
         keyCode: key,
         preventDefault: () => {},
       };
-      impl.keyHandler_(event);
+      impl.keyDownHandler_(event);
     }
 
     it('should build properly', () => {
@@ -567,17 +567,21 @@ describes.realWin('amp-selector', {
           ampSelector, 'select', /* CustomEvent */ eventMatcher);
     });
 
-    describe('keyboard-support', () => {
+    describe('keyboard-select-mode', () => {
 
-      it('should have `focus` mode by default', () => {
+      it('should have `none` mode by default', () => {
         const ampSelector = getSelector({});
         ampSelector.build();
-        expect(ampSelector.getAttribute('keyboard-support')).to.equal('focus');
+        expect(ampSelector.implementation_.kbSelectMode_).to.equal('none');
       });
 
       it('should initially focus selected option ONLY if ' +
          'it exists for single-select, otherwise first option', () => {
-        const selectorWithNoSelection = getSelector({});
+        const selectorWithNoSelection = getSelector({
+          attributes: {
+            'keyboard-select-mode': 'focus',
+          },
+        });
         selectorWithNoSelection.build();
         expect(selectorWithNoSelection.children[0].tabIndex).to.equal(0);
         for (let i = 1; i < selectorWithNoSelection.children.length; i++) {
@@ -586,6 +590,9 @@ describes.realWin('amp-selector', {
         }
 
         const selectorWithSelection = getSelector({
+          attributes: {
+            'keyboard-select-mode': 'focus',
+          },
           config: {
             count: 3,
           },
@@ -601,6 +608,7 @@ describes.realWin('amp-selector', {
         const ampSelector = getSelector({
           attributes: {
             multiple: true,
+            'keyboard-select-mode': 'focus',
           },
           config: {
             count: 3,
@@ -613,10 +621,10 @@ describes.realWin('amp-selector', {
         expect(ampSelector.children[2].tabIndex).to.equal(-1);
       });
 
-      it('should NOT update focus when keyboard-support is disabled', () => {
+      it('should NOT update focus if keyboard-select-mode is disabled', () => {
         const ampSelector = getSelector({
           attributes: {
-            'keyboard-support': 'none',
+            'keyboard-select-mode': 'none',
           },
           config: {
             count: 3,
@@ -629,8 +637,11 @@ describes.realWin('amp-selector', {
       });
 
       it('should update focus when the user presses the arrow keys when ' +
-         'keyboard-support is enabled', () => {
+         'keyboard-select-mode is enabled', () => {
         const ampSelector = getSelector({
+          attributes: {
+            'keyboard-select-mode': 'focus',
+          },
           config: {
             count: 3,
           },
@@ -639,13 +650,13 @@ describes.realWin('amp-selector', {
         expect(ampSelector.children[0].tabIndex).to.equal(0);
         expect(ampSelector.children[1].tabIndex).to.equal(-1);
         expect(ampSelector.children[2].tabIndex).to.equal(-1);
-        // Right
-        keyPress(ampSelector, 39);
-        expect(ampSelector.children[0].tabIndex).to.equal(-1);
-        expect(ampSelector.children[1].tabIndex).to.equal(0);
-        expect(ampSelector.children[2].tabIndex).to.equal(-1);
         // Left
         keyPress(ampSelector, 37);
+        expect(ampSelector.children[0].tabIndex).to.equal(-1);
+        expect(ampSelector.children[1].tabIndex).to.equal(-1);
+        expect(ampSelector.children[2].tabIndex).to.equal(0);
+        // Right
+        keyPress(ampSelector, 39);
         expect(ampSelector.children[0].tabIndex).to.equal(0);
         expect(ampSelector.children[1].tabIndex).to.equal(-1);
         expect(ampSelector.children[2].tabIndex).to.equal(-1);
@@ -654,6 +665,9 @@ describes.realWin('amp-selector', {
       it('should update focus for single-select when ' +
          'selection is changed without user interaction', () => {
         const ampSelector = getSelector({
+          attributes: {
+            'keyboard-select-mode': 'focus',
+          },
           config: {
             count: 3,
           },
@@ -673,7 +687,7 @@ describes.realWin('amp-selector', {
       it('should NOT allow `select` mode for multi-select selectors', () => {
         const ampSelector = getSelector({
           attributes: {
-            'keyboard-support': 'select',
+            'keyboard-select-mode': 'select',
             multiple: true,
           },
         });
@@ -684,7 +698,7 @@ describes.realWin('amp-selector', {
       it('should ONLY change selection in `select` mode', () => {
         const ampSelector = getSelector({
           attributes: {
-            'keyboard-support': 'select',
+            'keyboard-select-mode': 'select',
           },
           config: {
             count: 3,

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -80,6 +80,15 @@ describes.realWin('amp-selector', {
       return ampSelector;
     }
 
+    function keyPress(ampSelector, key) {
+      const impl = ampSelector.implementation_;
+      const event = {
+        keyCode: key,
+        preventDefault: () => {},
+      }
+      impl.keyHandler_(event);
+    }
+
     it('should build properly', () => {
       let ampSelector = getSelector({});
       let impl = ampSelector.implementation_;
@@ -556,6 +565,148 @@ describes.realWin('amp-selector', {
           sandbox.match.has('detail', sandbox.match.has('targetOption', '3'));
       expect(triggerSpy).to.have.been.calledWith(
           ampSelector, 'select', /* CustomEvent */ eventMatcher);
+    });
+
+    describe('keyboard-support', () => {
+
+      it('should have `focus` mode by default', () => {
+        const ampSelector = getSelector({});
+        ampSelector.build();
+        expect(ampSelector.getAttribute('keyboard-support')).to.equal('focus');
+      });
+
+      it('should initially focus selected option ONLY if ' +
+         'it exists for single-select, otherwise first option', () => {
+        const selectorWithNoSelection = getSelector({});
+        selectorWithNoSelection.build();
+        expect(selectorWithNoSelection.children[0].tabIndex).to.equal(0);
+        for (let i = 1; i < selectorWithNoSelection.children.length; i++) {
+          // No other options should be reachable by
+          expect(selectorWithNoSelection.children[i].tabIndex).to.equal(-1);
+        }
+
+        const selectorWithSelection = getSelector({
+          config: {
+            count: 3,
+          },
+        });
+        selectorWithSelection.children[1].setAttribute('selected', '');
+        selectorWithSelection.build();
+        expect(selectorWithSelection.children[0].tabIndex).to.equal(-1);
+        expect(selectorWithSelection.children[1].tabIndex).to.equal(0);
+        expect(selectorWithSelection.children[2].tabIndex).to.equal(-1);
+      });
+
+      it('should initially focus first option for multi-select', () => {
+        const ampSelector = getSelector({
+          attributes: {
+            multiple: true,
+          },
+          config: {
+            count: 3
+          }
+        });
+        ampSelector.children[1].setAttribute('selected', '');
+        ampSelector.build();
+        expect(ampSelector.children[0].tabIndex).to.equal(0);
+        expect(ampSelector.children[1].tabIndex).to.equal(-1);
+        expect(ampSelector.children[2].tabIndex).to.equal(-1);
+      });
+
+      it('should NOT update focus when keyboard-support is disabled', () => {
+        const ampSelector = getSelector({
+          attributes: {
+            'keyboard-support': 'none',
+          },
+          config: {
+            count: 3,
+          },
+        });
+        const addEventSpy = sandbox.spy(ampSelector, 'addEventListener');
+        ampSelector.build();
+        expect(addEventSpy.calledWith('click')).to.be.true;
+        expect(addEventSpy.calledWith('keydown')).to.be.false;
+      });
+
+      it('should update focus when the user presses the arrow keys when ' +
+         'keyboard-support is enabled', () => {
+        const ampSelector = getSelector({
+          config: {
+            count: 3,
+          },
+        });
+        ampSelector.build();
+        expect(ampSelector.children[0].tabIndex).to.equal(0);
+        expect(ampSelector.children[1].tabIndex).to.equal(-1);
+        expect(ampSelector.children[2].tabIndex).to.equal(-1);
+        // Right
+        keyPress(ampSelector, 39);
+        expect(ampSelector.children[0].tabIndex).to.equal(-1);
+        expect(ampSelector.children[1].tabIndex).to.equal(0);
+        expect(ampSelector.children[2].tabIndex).to.equal(-1);
+        // Left
+        keyPress(ampSelector, 37);
+        expect(ampSelector.children[0].tabIndex).to.equal(0);
+        expect(ampSelector.children[1].tabIndex).to.equal(-1);
+        expect(ampSelector.children[2].tabIndex).to.equal(-1);
+      });
+
+      it('should update focus for single-select when ' +
+         'selection is changed without user interaction', () => {
+        const ampSelector = getSelector({
+          config: {
+            count: 3,
+          },
+        });
+        ampSelector.children[1].setAttribute('selected', '');
+        ampSelector.build();
+        expect(ampSelector.children[0].tabIndex).to.equal(-1);
+        expect(ampSelector.children[1].tabIndex).to.equal(0);
+        expect(ampSelector.children[2].tabIndex).to.equal(-1);
+
+        ampSelector.implementation_.mutatedAttributesCallback({selected: 2});
+        expect(ampSelector.children[0].tabIndex).to.equal(-1);
+        expect(ampSelector.children[1].tabIndex).to.equal(-1);
+        expect(ampSelector.children[2].tabIndex).to.equal(0);
+      });
+
+      it('should NOT allow `select` mode for multi-select selectors', () => {
+        const ampSelector = getSelector({
+          attributes: {
+            'keyboard-support': 'select',
+            multiple: true,
+          },
+        });
+        expect(() => ampSelector.build())
+            .to.throw(/not supported for multiple selection amp-selector​​​/);
+      });
+
+      it('should ONLY change selection in `select` mode', () => {
+        const ampSelector = getSelector({
+          attributes: {
+            'keyboard-support': 'select',
+          },
+          config: {
+            count: 3,
+          },
+        });
+        ampSelector.build();
+        const impl = ampSelector.implementation_;
+        impl.mutateElement = fn => fn();
+        expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
+        expect(ampSelector.children[1].hasAttribute('selected')).to.be.false;
+        expect(ampSelector.children[2].hasAttribute('selected')).to.be.false;
+        // Down
+        keyPress(ampSelector, 40);
+        expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
+        expect(ampSelector.children[1].hasAttribute('selected')).to.be.true;
+        expect(ampSelector.children[2].hasAttribute('selected')).to.be.false;
+        // Up
+        keyPress(ampSelector, 38);
+        expect(ampSelector.children[0].hasAttribute('selected')).to.be.true;
+        expect(ampSelector.children[1].hasAttribute('selected')).to.be.false;
+        expect(ampSelector.children[2].hasAttribute('selected')).to.be.false;
+      });
     });
   });
 });

--- a/extensions/amp-selector/0.1/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/0.1/validator-amp-selector.protoascii
@@ -46,7 +46,7 @@ tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
   # <amp-bind>
   attrs: {
     name: "[selected]"
-    value_regex: "none|focus|select"
+    value_regex_casei: "none|focus|select"
   }
   reference_points: {
     tag_spec_name: "AMP-SELECTOR option"

--- a/extensions/amp-selector/0.1/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/0.1/validator-amp-selector.protoascii
@@ -33,6 +33,7 @@ tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
   disallowed_ancestor: "AMP-SELECTOR"
   disallowed_ancestor: "AMP-SIDEBAR"
   requires: "amp-selector extension .js script"
+  attrs: { name: "keyboard-select-mode" }
   attrs: {
     name: "disabled"
     value: ""

--- a/extensions/amp-selector/0.1/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/0.1/validator-amp-selector.protoascii
@@ -33,7 +33,10 @@ tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
   disallowed_ancestor: "AMP-SELECTOR"
   disallowed_ancestor: "AMP-SIDEBAR"
   requires: "amp-selector extension .js script"
-  attrs: { name: "keyboard-select-mode" }
+  attrs: {
+    name: "keyboard-select-mode"
+    value_regex_casei: "none|focus|select"
+  }
   attrs: {
     name: "disabled"
     value: ""
@@ -46,7 +49,6 @@ tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
   # <amp-bind>
   attrs: {
     name: "[selected]"
-    value_regex_casei: "none|focus|select"
   }
   reference_points: {
     tag_spec_name: "AMP-SELECTOR option"

--- a/extensions/amp-selector/0.1/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/0.1/validator-amp-selector.protoascii
@@ -47,9 +47,7 @@ tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
     value: ""
   }
   # <amp-bind>
-  attrs: {
-    name: "[selected]"
-  }
+  attrs: { name: "[selected]" }
   reference_points: {
     tag_spec_name: "AMP-SELECTOR option"
   }

--- a/extensions/amp-selector/0.1/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/0.1/validator-amp-selector.protoascii
@@ -44,7 +44,10 @@ tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
     value: ""
   }
   # <amp-bind>
-  attrs: { name: "[selected]" }
+  attrs: {
+    name: "[selected]"
+    value_regex: "none|focus|select"
+  }
   reference_points: {
     tag_spec_name: "AMP-SELECTOR option"
   }


### PR DESCRIPTION
Adds `keyboard-support` attribute to amp-selector with three modes:
1. `focus` pressing the arrow keys moves focus between options
2. `select` pressing the arrow keys on a single-select selector will change the current selection
3. `none`  (default) pressing the arrow keys does nothing

An edge case to consider:
For a single-select selector with `keyboard-select-mode='select'` a user will need to move selection forward and back in order to select the first option, as TABing to the amp-selector will not currently select its first option. Would appreciate some input on how to handle this case.

I tested this on desktop and on an android emulator with talkback. Both look fine. @aghassemi  I know you mentioned on the issue that changing tabindex won't work for mobile screen readers. Testing with talkback on an emulator, I was able to move accessibility focus between options, even when the options had tabindex == -1. Would I see this behavior on a real device vs an emulator, or do you know of other mobile screen readers that might behave differently?

Fixes #8613 

/to @aghassemi @camelburrito 