### PR TITLE
Measure step times in pr-check.js

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -25,7 +25,6 @@
  */
 const child_process = require('child_process');
 const path = require('path');
-const performance = require('performance');
 const minimist = require('minimist');
 
 const gulp = 'node_modules/gulp/bin/gulp.js';

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -313,7 +313,7 @@ function main(argv) {
   if (buildTargets.has('BUILD_SYSTEM')) {
     // command.testBuildSystem();
     // Testing. Remove.
-    command.runAllCommands();
+    runAllCommands();
   }
 
   if (buildTargets.has('RUNTIME')) {

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -36,7 +36,7 @@ const gulp = 'node_modules/gulp/bin/gulp.js';
  */
 function startTimer(functionName) {
   const startTime = Date.now();
-  console.log('pr-check.js: Starting ' + functionName + '...');
+  console.log('\npr-check.js: Starting ' + functionName + '...');
   return startTime;
 }
 
@@ -52,7 +52,7 @@ function stopTimer(functionName, startTime) {
   const secs = executionTime.getSeconds();
   console.log(
       'pr-check.js: Done executing ' + functionName + '. ' +
-      'Total time: ' + mins + 'm ' + secs + 's.');
+      'Total time: ' + mins + 'm ' + secs + 's.\n');
 }
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -25,6 +25,7 @@
  */
 const child_process = require('child_process');
 const path = require('path');
+const performance = require('performance');
 const minimist = require('minimist');
 
 const gulp = 'node_modules/gulp/bin/gulp.js';

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -36,7 +36,9 @@ const gulp = 'node_modules/gulp/bin/gulp.js';
  */
 function startTimer(functionName) {
   const startTime = Date.now();
-  console.log(`\npr-check.js: Starting ${functionName}...\n`);
+  console.log(
+      `%c pr-check.js: Starting ${functionName}...`,
+      'color: green; font-weight: bold;');
 }
 
 /**
@@ -47,9 +49,12 @@ function startTimer(functionName) {
 function stopTimer(functionName, startTime) {
   const endTime = Date.now();
   const executionTime = new Date(endTime - startTime);
+  const mins = executionTime.getMinutes();
+  const secs = executionTime.getSeconds();
   console.log(
-      `\npr-check.js: Done executing ${functionName}. Total time: +
-      ${executionTime.getMinutes()}m ${executionTime.getSeconds()}s.\n`);
+      `%c pr-check.js: Done executing ${functionName}. \
+      Total time: ${mins}m ${secs}s.`,
+      'color: green; font-weight: bold;');
 }
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -223,12 +223,12 @@ const command = {
     stopTimer('testRuntime: gulp dep-check', startTime);
 
     // Unit tests with Travis' default chromium
-    let startTime = startTimer('testRuntime: gulp test --nobuild --compiled');
+    startTime = startTimer('testRuntime: gulp test --nobuild --compiled');
     execOrDie(`${gulp} test --nobuild --compiled`);
     stopTimer('testRuntime: gulp test --nobuild --compiled', startTime);
 
     // Integration tests with all saucelabs browsers
-    let startTime = startTimer(
+    startTime = startTimer(
         'testRuntime: gulp test --nobuild --saucelabs ' +
         '--integration --compiled');
     execOrDie(`${gulp} test --nobuild --saucelabs --integration --compiled`);
@@ -239,7 +239,7 @@ const command = {
     // All unit tests with an old chrome (best we can do right now to pass tests
     // and not start relying on new features).
     // Disabled because it regressed. Better to run the other saucelabs tests.
-    let startTime = startTimer(
+    startTime = startTimer(
         'testRuntime: gulp test --nobuild --saucelabs --oldchrome --compiled');
     execOrDie(`${gulp} test --nobuild --saucelabs --oldchrome --compiled`);
     stopTimer(

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -25,7 +25,6 @@
  */
 const child_process = require('child_process');
 const path = require('path');
-const performance = require('performance');
 const minimist = require('minimist');
 
 const gulp = 'node_modules/gulp/bin/gulp.js';
@@ -36,7 +35,7 @@ const gulp = 'node_modules/gulp/bin/gulp.js';
  * @return {DOMHighResTimeStamp}
  */
 function startTimer(functionName) {
-  const startTime = performance.now();
+  const startTime = Date.now();
   console.log(`\npr-check.js: Starting ${functionName}...\n`);
 }
 
@@ -46,7 +45,7 @@ function startTimer(functionName) {
  * @return {DOMHighResTimeStamp}
  */
 function stopTimer(functionName, startTime) {
-  const endTime = performance.now();
+  const endTime = Date.now();
   const executionTime = new Date(endTime - startTime);
   console.log(
       `\npr-check.js: Done executing ${functionName}. Total time: +

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -37,7 +37,7 @@ const gulp = 'node_modules/gulp/bin/gulp.js';
 function startTimer(functionName) {
   const startTime = Date.now();
   console.log(
-      `%c pr-check.js: Starting ${functionName}...`,
+      '%c pr-check.js: Starting ' + functionName + '...',
       'color: green; font-weight: bold;');
 }
 
@@ -52,8 +52,8 @@ function stopTimer(functionName, startTime) {
   const mins = executionTime.getMinutes();
   const secs = executionTime.getSeconds();
   console.log(
-      `%c pr-check.js: Done executing ${functionName}. \
-      Total time: ${mins}m ${secs}s.`,
+      '%c pr-check.js: Done executing ' + functionName + '. ' +
+      'Total time: ' + mins + 'm ' + secs + 's.',
       'color: green; font-weight: bold;');
 }
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -36,9 +36,8 @@ const gulp = 'node_modules/gulp/bin/gulp.js';
  */
 function startTimer(functionName) {
   const startTime = Date.now();
-  console.log(
-      '%c pr-check.js: Starting ' + functionName + '...',
-      'color: green; font-weight: bold;');
+  console.log('pr-check.js: Starting ' + functionName + '...');
+  return startTime;
 }
 
 /**
@@ -52,9 +51,8 @@ function stopTimer(functionName, startTime) {
   const mins = executionTime.getMinutes();
   const secs = executionTime.getSeconds();
   console.log(
-      '%c pr-check.js: Done executing ' + functionName + '. ' +
-      'Total time: ' + mins + 'm ' + secs + 's.',
-      'color: green; font-weight: bold;');
+      'pr-check.js: Done executing ' + functionName + '. ' +
+      'Total time: ' + mins + 'm ' + secs + 's.');
 }
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -311,7 +311,9 @@ function main(argv) {
       sortedBuildTargets.join(', ') + '\n');
 
   if (buildTargets.has('BUILD_SYSTEM')) {
-    command.testBuildSystem();
+    // command.testBuildSystem();
+    // Testing. Remove.
+    command.runAllCommands();
   }
 
   if (buildTargets.has('RUNTIME')) {

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -43,7 +43,7 @@ function startTimer(functionName) {
 /**
  * Stops the timer for the given function and prints the execution time.
  * @param {string} functionName
- * @return {DOMHighResTimeStamp}
+ * @return {Number}
  */
 function stopTimer(functionName, startTime) {
   const endTime = Date.now();
@@ -195,13 +195,25 @@ const command = {
     stopTimer('testBuildSystem', startTime);
   },
   buildRuntime: function() {
-    const startTime = startTimer('buildRuntime');
+    let startTime = startTimer('buildRuntime: gulp clean');
     execOrDie(`${gulp} clean`);
+    stopTimer('buildRuntime: gulp clean', startTime);
+
+    startTime = startTimer('buildRuntime: gulp lint');
     execOrDie(`${gulp} lint`);
+    stopTimer('buildRuntime: gulp lint', startTime);
+
+    startTime = startTimer('buildRuntime: gulp build');
     execOrDie(`${gulp} build`);
+    stopTimer('buildRuntime: gulp build', startTime);
+
+    startTime = startTimer('buildRuntime: gulp check-types');
     execOrDie(`${gulp} check-types`);
+    stopTimer('buildRuntime: gulp check-types', startTime);
+
+    startTime = startTimer('buildRuntime: gulp dist --fortesting');
     execOrDie(`${gulp} dist --fortesting`);
-    stopTimer('buildRuntime', startTime);
+    stopTimer('buildRuntime: gulp dist --fortesting', startTime);
   },
   testRuntime: function() {
     const startTime = startTimer('testRuntime');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -216,19 +216,35 @@ const command = {
     stopTimer('buildRuntime: gulp dist --fortesting', startTime);
   },
   testRuntime: function() {
-    const startTime = startTimer('testRuntime');
     // dep-check needs to occur after build since we rely on build to generate
     // the css files into js files.
+    let startTime = startTimer('testRuntime: gulp dep-check');
     execOrDie(`${gulp} dep-check`);
+    stopTimer('testRuntime: gulp dep-check', startTime);
+
     // Unit tests with Travis' default chromium
+    let startTime = startTimer('testRuntime: gulp test --nobuild --compiled');
     execOrDie(`${gulp} test --nobuild --compiled`);
+    stopTimer('testRuntime: gulp test --nobuild --compiled', startTime);
+
     // Integration tests with all saucelabs browsers
+    let startTime = startTimer(
+        'testRuntime: gulp test --nobuild --saucelabs ' +
+        '--integration --compiled');
     execOrDie(`${gulp} test --nobuild --saucelabs --integration --compiled`);
+    stopTimer(
+        'testRuntime: gulp test --nobuild --saucelabs --integration --compiled',
+        startTime);
+
     // All unit tests with an old chrome (best we can do right now to pass tests
     // and not start relying on new features).
     // Disabled because it regressed. Better to run the other saucelabs tests.
+    let startTime = startTimer(
+        'testRuntime: gulp test --nobuild --saucelabs --oldchrome --compiled');
     execOrDie(`${gulp} test --nobuild --saucelabs --oldchrome --compiled`);
-    stopTimer('testRuntime', startTime);
+    stopTimer(
+        'testRuntime: gulp test --nobuild --saucelabs --oldchrome --compiled',
+        startTime);
   },
   presubmit: function() {
     const startTime = startTimer('presubmit');


### PR DESCRIPTION
This PR adds two functions startTimer and stopTimer that are used to time the individual steps executed by pr-check.js. The idea is to use these measurements to gradually improve the speed of presubmit checks.

Fixes #5647 
