### PR TITLE
Remove P2R blocker from inabox

### DIFF
--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -27,7 +27,6 @@ import {
   installPerformanceService,
   performanceFor,
 } from '../service/performance-impl';
-import {installPullToRefreshBlocker} from '../pull-to-refresh';
 import {installStyles, makeBodyVisible} from '../style-installer';
 import {installErrorReporting} from '../error';
 import {installDocService} from '../service/ampdoc-impl';
@@ -109,7 +108,6 @@ startupChunk(self.document, function initial() {
       stubElements(self);
     });
     startupChunk(self.document, function final() {
-      installPullToRefreshBlocker(self);
       installAnchorClickInterceptor(ampdoc, self);
 
       maybeValidate(self);


### PR DESCRIPTION
P2R blocker is not needed and might be dangerous in in-a-box. This is basically a thing that blocks page refresh for scrollable iframes.