### PR TITLE
amp-bind: Only get form service if needed

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -136,17 +136,6 @@ export class Bind {
     });
 
     /**
-     * Form implementations are not filled in until ampdoc is ready.
-     * So we must wait for that to finish before scanning form elements
-     * for dynamic components.
-     * @private {!Promise}
-     */
-    this.formInitializationPromise_ =
-        ampFormServiceForDoc(this.ampdoc).then(ampFormService => {
-          return ampFormService.whenInitialized();
-        });
-
-    /**
      * @private {?Promise}
      */
     this.setStatePromise_ = null;
@@ -417,9 +406,11 @@ export class Bind {
       if (typeof element.getDynamicElementContainers === 'function') {
         element.getDynamicElementContainers().forEach(observeElement);
       } else if (element.tagName === 'FORM') {
-        this.formInitializationPromise_.then(() => {
+        ampFormServiceForDoc(this.ampdoc).then(ampFormService => {
+          return ampFormService.whenInitialized();
+        }).then(() => {
           const form = formOrNullForElement(element);
-          dev().assert(form, 'could not find form implementation');
+          dev().assert(form, 'Could not find form implementation for element.');
           form.getDynamicElementContainers().forEach(observeElement);
         });
       }


### PR DESCRIPTION
Fixes #8812.

- Fixes form error on load for pages without `amp-form`. 
- Bad suggestion from me in #8661. 😛 

/to @kmh287 