### PR TITLE
Forbid bad startsWith and endsWith replacements

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -42,6 +42,7 @@ import {endsWith} from '../src/string';
 import {parseUrl, getSourceUrl, isProxyOrigin} from '../src/url';
 import {dev, initLogConstructor, setReportError, user} from '../src/log';
 import {getMode} from '../src/mode';
+import {startsWith} from '../src/string.js';
 
 // 3P - please keep in alphabetic order
 import {facebook} from './facebook';
@@ -739,7 +740,7 @@ export function parseFragment(fragment) {
     // Some browser, notably Firefox produce an encoded version of the fragment
     // while most don't. Since we know how the string should start, this is easy
     // to detect.
-    if (json.indexOf('{%22') == 0) {
+    if (startsWith(json, '{%22')) {
       json = decodeURIComponent(json);
     }
     return /** @type {!JSONType} */ (json ? JSON.parse(json) : {});

--- a/ads/openx.js
+++ b/ads/openx.js
@@ -16,6 +16,7 @@
 
 import {loadScript, writeScript, validateData} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
+import {startsWith} from '../src/string';
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -53,7 +54,7 @@ export function openx(global, data) {
     // Anything starting with 'dfp' gets promoted.
     openxData.forEach(openxKey => {
       if (openxKey in dfpData && openxKey !== 'dfp') {
-        if (openxKey.indexOf('dfp') === 0) {
+        if (startsWith(openxKey, 'dfp')) {
           // Remove 'dfp' prefix, lowercase the first letter.
           let fixKey = openxKey.substring(3);
           fixKey = fixKey.substring(0,1).toLowerCase() + fixKey.substring(1);

--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -490,7 +490,7 @@ function errHandler(err) {
  * @return {boolean}
  */
 function isPrIdInTitle(str) {
-  return str.indexOf('Merge pull request #') == 0;
+  return str./*OK*/indexOf('Merge pull request #') == 0;
 }
 
 /**
@@ -520,7 +520,7 @@ function isJs(str) {
  * @return {boolean}
  */
 function isAmpRelease(str) {
-  return !!(str && str.indexOf('amp-release') == 0);
+  return !!(str && str./*OK*/indexOf('amp-release') == 0);
 }
 
 /**

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -737,6 +737,20 @@ var forbiddenTermsSrcInclusive = {
   '\\>\\>\\>\\>\\>\\>': {
     message: 'Unresolved merge conflict.',
   },
+  '\\.indexOf\\([\'"][^)]+\\)\\s*===?\\s*0\\b': {
+    message: 'use startsWith helper in src/string.js',
+    whitelist: [
+      'dist.3p/current/integration.js',
+    ],
+  },
+  '\\.indexOf\\(.*===?.*\\.length': 'use endsWith helper in src/string.js',
+  '/url-parse-query-string': {
+    message: 'Import parseQueryString from `src/url.js`',
+    whitelist: [
+      'src/url.js',
+      'src/mode.js',
+    ],
+  },
 };
 
 // Terms that must appear in a source file.

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -749,6 +749,7 @@ var forbiddenTermsSrcInclusive = {
     whitelist: [
       'src/url.js',
       'src/mode.js',
+      'dist.3p/current/integration.js',
     ],
   },
 };

--- a/examples/pwa/pwa.js
+++ b/examples/pwa/pwa.js
@@ -22,6 +22,9 @@ function log(args) {
   console/*OK*/.log.apply(console, var_args);
 }
 
+function startsWith(string, prefix) {
+  return string.lastIndexOf(prefix, 0) == 0;
+}
 
 class Shell {
 
@@ -98,7 +101,7 @@ class Shell {
     if (a) {
       const url = new URL(a.href);
       if (url.origin == this.win.location.origin &&
-              url.pathname.indexOf('/pwa/') == 0 &&
+              startsWith(url.pathname, '/pwa/') &&
               url.pathname.indexOf('amp.max.html') != -1) {
         e.preventDefault();
         const newPage = url.pathname;
@@ -336,7 +339,7 @@ function parseQueryString(queryString) {
   if (!queryString) {
     return params;
   }
-  if (queryString.indexOf('?') == 0 || queryString.indexOf('#') == 0) {
+  if (startsWith(queryString, '?') || startsWith(queryString, '#')) {
     queryString = queryString.substr(1);
   }
   const pairs = queryString.split('&');

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -44,6 +44,7 @@ import {urlReplacementsForDoc} from '../../../src/services';
 import {viewerForDoc} from '../../../src/services';
 import {viewportForDoc} from '../../../src/services';
 import {vsyncFor} from '../../../src/services';
+import {startsWith} from '../../../src/string';
 
 
 /** @const */
@@ -784,7 +785,7 @@ export class AccessService {
         invocation.event.preventDefault();
       }
       this.loginWithType_('');
-    } else if (invocation.method.indexOf('login-') == 0) {
+    } else if (startsWith(invocation.method, 'login-')) {
       if (invocation.event) {
         invocation.event.preventDefault();
       }

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -54,6 +54,7 @@ import {user} from '../../../src/log';
 import {tryParseJson} from '../../../src/json';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';
+import {startsWith} from '../../../src/string';
 
 /*
  * These padding values are specifc to intagram embeds with
@@ -194,8 +195,7 @@ class AmpInstagram extends AMP.BaseElement {
         event.source != this.iframe_.contentWindow) {
       return;
     }
-    if (!event.data ||
-        !(isObject(event.data) || event.data.indexOf('{') == 0)) {
+    if (!event.data || !(isObject(event.data) || startsWith(event.data, '{'))) {
       return;  // Doesn't look like JSON.
     }
     const data = isObject(event.data) ? event.data : tryParseJson(event.data);

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -28,6 +28,7 @@ import {addParamsToUrl} from '../../../src/url';
 import {isObject} from '../../../src/types';
 import {VideoEvents} from '../../../src/video-interface';
 import {videoManagerForDoc} from '../../../src/services';
+import {startsWith} from '../../../src/string';
 
 /**
  * @enum {number}
@@ -283,8 +284,7 @@ class AmpYoutube extends AMP.BaseElement {
         event.source != this.iframe_.contentWindow) {
       return;
     }
-    if (!event.data ||
-        !(isObject(event.data) || event.data.indexOf('{') == 0)) {
+    if (!event.data || !(isObject(event.data) || startsWith(event.data, '{'))) {
       return;  // Doesn't look like JSON.
     }
     const data = isObject(event.data) ? event.data : tryParseJson(event.data);

--- a/src/error.js
+++ b/src/error.js
@@ -434,7 +434,7 @@ export function detectJsEngineFromStack() {
     }
 
     // Safari does not show the context ("object."), just the function name.
-    if (stack.indexOf('t@') === 0) {
+    if (startsWith(stack, 't@')) {
       return 'Safari';
     }
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -22,6 +22,7 @@
 import {dev, user} from './log';
 import {isFiniteNumber} from './types';
 import {setStyles} from './style';
+import {startsWith} from './string';
 
 /**
  * @enum {string}
@@ -139,7 +140,7 @@ export function isLayoutSizeDefined(layout) {
  */
 export function isInternalElement(tag) {
   const tagName = (typeof tag == 'string') ? tag : tag.tagName;
-  return tagName && tagName.toLowerCase().indexOf('i-') == 0;
+  return tagName && startsWith(tagName.toLowerCase(), 'i-');
 }
 
 

--- a/src/mode.js
+++ b/src/mode.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {startsWith} from './string';
+import {parseQueryString_} from './url-parse-query-string';
 
 /**
  * @typedef {{
@@ -82,7 +84,7 @@ function getMode_(win) {
   const isLocalDev = IS_DEV && !!(win.location.hostname == 'localhost' ||
       (FORCE_LOCALDEV && win.location.hostname == AMP_CONFIG_3P_FRAME_HOST) ||
       (win.location.ancestorOrigins && win.location.ancestorOrigins[0] &&
-        win.location.ancestorOrigins[0].indexOf('http://localhost:') == 0)) &&
+        startsWith(win.location.ancestorOrigins[0], 'http://localhost:'))) &&
       // Filter out localhost running against a prod script.
       // Because all allowed scripts are ours, we know that these can only
       // occur during local dev.
@@ -121,43 +123,6 @@ function getMode_(win) {
     rtvVersion,
   };
 }
-
-/**
- * Parses the query string of an URL. This method returns a simple key/value
- * map. If there are duplicate keys the latest value is returned.
- * @param {string} queryString
- * @return {!Object<string, string>}
- * TODO(dvoytenko): dedupe with `url.js:parseQueryString`. This is currently
- * necessary here because `url.js` itself inderectly depends on `mode.js`.
- */
-function parseQueryString_(queryString) {
-  const params = Object.create(null);
-  if (!queryString) {
-    return params;
-  }
-  if (queryString.indexOf('?') == 0 || queryString.indexOf('#') == 0) {
-    queryString = queryString.substr(1);
-  }
-  const pairs = queryString.split('&');
-  for (let i = 0; i < pairs.length; i++) {
-    const pair = pairs[i];
-    const eqIndex = pair.indexOf('=');
-    let name;
-    let value;
-    if (eqIndex != -1) {
-      name = decodeURIComponent(pair.substring(0, eqIndex)).trim();
-      value = decodeURIComponent(pair.substring(eqIndex + 1)).trim();
-    } else {
-      name = decodeURIComponent(pair).trim();
-      value = '';
-    }
-    if (name) {
-      params[name] = value;
-    }
-  }
-  return params;
-}
-
 
 /**
  * Retrieve the `rtvVersion` which will have a numeric prefix

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -26,6 +26,7 @@ import {timerFor} from './services';
 import {platformFor} from './services';
 import {viewerForDoc} from './services';
 import {dev} from './log';
+import {startsWith} from './string';
 
 const ACTIVE_CONNECTION_TIMEOUT_MS = 180 * 1000;
 const PRECONNECT_TIMEOUT_MS = 10 * 1000;
@@ -219,7 +220,7 @@ class PreconnectService {
    * @return {boolean}
    */
   isInterestingUrl_(url) {
-    if (url.indexOf('https:') == 0 || url.indexOf('http:') == 0) {
+    if (startsWith(url, 'https:') || startsWith(url, 'http:')) {
       return true;
     }
     return false;

--- a/src/string.js
+++ b/src/string.js
@@ -33,7 +33,7 @@ export function dashToCamelCase(name) {
 }
 
 /**
- * Polyfill for String.prototype. endsWith.
+ * Polyfill for String.prototype.endsWith.
  * @param {string} string
  * @param {string} suffix
  * @return {boolean}
@@ -44,7 +44,7 @@ export function endsWith(string, suffix) {
 }
 
 /**
- * Polyfill for String.prototype. startsWith.
+ * Polyfill for String.prototype.startsWith.
  * @param {string} string
  * @param {string} prefix
  * @return {boolean}

--- a/src/url-parse-query-string.js
+++ b/src/url-parse-query-string.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {startsWith} from './string';
+
+/**
+ * Parses the query string of an URL. This method returns a simple key/value
+ * map. If there are duplicate keys the latest value is returned.
+ *
+ * DO NOT import the function from this file. Instead, import parseQueryString
+ * from `src/url.js`.
+ *
+ * @param {string} queryString
+ * @return {!Object<string>}
+ */
+export function parseQueryString_(queryString) {
+  const params = Object.create(null);
+  if (!queryString) {
+    return params;
+  }
+  if (startsWith(queryString, '?') || startsWith(queryString, '#')) {
+    queryString = queryString.substr(1);
+  }
+  const pairs = queryString.split('&');
+  for (let i = 0; i < pairs.length; i++) {
+    const pair = pairs[i];
+    const eqIndex = pair.indexOf('=');
+    let name;
+    let value;
+    if (eqIndex != -1) {
+      name = decodeURIComponent(pair.substring(0, eqIndex)).trim();
+      value = decodeURIComponent(pair.substring(eqIndex + 1)).trim();
+    } else {
+      name = decodeURIComponent(pair).trim();
+      value = '';
+    }
+    if (name) {
+      params[name] = value;
+    }
+  }
+  return params;
+}

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -16,6 +16,7 @@
 
 import {getMode} from './mode';
 import {urls} from './config';
+import {startsWith} from './string';
 
 /**
  * Triggers validation for the current document if there is a script in the
@@ -28,7 +29,7 @@ export function maybeValidate(win) {
     return;
   }
   const filename = win.location.href;
-  if (filename.indexOf('about:') == 0) {  // Should only happen in tests.
+  if (startsWith(filename, 'about:')) {  // Should only happen in tests.
     return;
   }
 


### PR DESCRIPTION
We have helpers for these methods, lets make sure we use them. This is
especially valuable for long strings, since our helpers are optimized to
avoid whole string searches.

Oh, and I moved parseQueryString into a separate module, to avoid a
circular dependency TODO.