### PR TITLE
amp-bind: Add function to print bind's scope

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -946,7 +946,6 @@ export class Bind {
     dev().info(TAG, s);
   }
 
-
   /**
    * Wait for bind scan to finish for testing.
    *

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -140,7 +140,7 @@ export class Bind {
     // Expose for testing on dev.
     if (getMode().localDev) {
       AMP.reinitializeBind = this.initialize_.bind(this);
-      AMP.printAmpState = this.printAmpState_.bind(this);
+      AMP.printState = this.printState_.bind(this);
     }
   }
 
@@ -927,7 +927,7 @@ export class Bind {
    * Print out the current state in the console.
    * @private
    */
-  printAmpState_() {
+  printState_() {
     const seen = [];
     const s = JSON.stringify(this.scope_, (key, value) => {
       if (isObject(value)) {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -929,15 +929,11 @@ export class Bind {
    */
   printAmpState_() {
     const seen = [];
-    const seenNames = [];
     const s = JSON.stringify(this.scope_, (key, value) => {
       if (isObject(value)) {
-        const index = seen.indexOf(value);
-        if (index !== -1) {
-          const name = seenNames[index];
-          return `**Circular reference to '${name}'**`;
+        if (seen.includes(value)) {
+          return '[Circular]';
         } else {
-          seenNames.push(key);
           seen.push(value);
         }
       }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -925,6 +925,7 @@ export class Bind {
 
   /**
    * Print out the current state in the console.
+   * @private
    */
   printAmpState_() {
     const seen = [];

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -139,7 +139,6 @@ export class Bind {
 
     // Expose for testing on dev.
     if (getMode().localDev) {
-      AMP.reinitializeBind = this.initialize_.bind(this);
       AMP.printState = this.printState_.bind(this);
     }
   }

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -408,7 +408,7 @@ Only binding to the following components and attributes are allowed:
 
 ## Debugging
 
-Test in development mode (with the URL fragment `#development=1`) to highlight warnings and errors during development.
+Test in development mode (with the URL fragment `#development=1`) to highlight warnings and errors during development and to access special debugging functions.
 
 ### Warnings
 
@@ -470,6 +470,10 @@ There are several types of runtime errors that may be encountered when working w
     <td>Avoid banned URL protocols or expressions that would fail the AMP Validator.</td>
   </tr>
 </table>
+
+### Debugging State
+
+In development mode, use `AMP.printState()` to print the current state to the console.
 
 ## Appendix
 

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -493,7 +493,7 @@ An `amp-state` element may contain either a child `<script>` element **OR** a `s
 <amp-state id="myRemoteState" src="https://data.com/articles.json">
 </amp-state>
 ```
-<br>
+
 #### Attributes
 
 **src**


### PR DESCRIPTION
Adds a function enabled in dev mode to print out bind's scope.

The function allows for scope to have circular references, though currently I'm not sure that it's possible for such references to get into bind's scope. 

Fixes #8719 

/to @choumx 