### PR TITLE
Tap events for keyboard navigation

### DIFF
--- a/examples/bind/carousels.amp.html
+++ b/examples/bind/carousels.amp.html
@@ -50,23 +50,23 @@
   <p>Without &lt;amp-selector&gt;</p>
   <amp-carousel controls width=400 height=100>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 0 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 0})"></amp-img>
+        [class]="selectedSlide == 0 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 0})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 1 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 1})"></amp-img>
+        [class]="selectedSlide == 1 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 1})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 2 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 2})"></amp-img>
+        [class]="selectedSlide == 2 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 2})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 3 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 3})"></amp-img>
+        [class]="selectedSlide == 3 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 3})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 4 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 4})"></amp-img>
+        [class]="selectedSlide == 4 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 4})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 5 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 5})"></amp-img>
+        [class]="selectedSlide == 5 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 5})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 6 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 6})"></amp-img>
+        [class]="selectedSlide == 6 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 6})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 7 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 7})"></amp-img>
+        [class]="selectedSlide == 7 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 7})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 8 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 8})"></amp-img>
+        [class]="selectedSlide == 8 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 8})"></amp-img>
   </amp-carousel>
 
   <p>With &lt;amp-selector&gt;</p>

--- a/examples/bind/carousels.amp.html
+++ b/examples/bind/carousels.amp.html
@@ -50,23 +50,23 @@
   <p>Without &lt;amp-selector&gt;</p>
   <amp-carousel controls width=400 height=100>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 0 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 0})"></amp-img>
+        [class]="selectedSlide == 0 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 0})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 1 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 1})"></amp-img>
+        [class]="selectedSlide == 1 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 1})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 2 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 2})"></amp-img>
+        [class]="selectedSlide == 2 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 2})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 3 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 3})"></amp-img>
+        [class]="selectedSlide == 3 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 3})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 4 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 4})"></amp-img>
+        [class]="selectedSlide == 4 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 4})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 5 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 5})"></amp-img>
+        [class]="selectedSlide == 5 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 5})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image1.jpg" width=100 height=75
-        [class]="selectedSlide == 6 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 6})"></amp-img>
+        [class]="selectedSlide == 6 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 6})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image2.jpg" width=100 height=75
-        [class]="selectedSlide == 7 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 7})"></amp-img>
+        [class]="selectedSlide == 7 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 7})"></amp-img>
     <amp-img src="https://ampbyexample.com/img/image3.jpg" width=100 height=75
-        [class]="selectedSlide == 8 ? 'selected' : ''" on="tap:AMP.setState({selectedSlide: 8})"></amp-img>
+        [class]="selectedSlide == 8 ? 'selected' : ''" role="button" tabindex=0 on="tap:AMP.setState({selectedSlide: 8})"></amp-img>
   </amp-carousel>
 
   <p>With &lt;amp-selector&gt;</p>

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -183,7 +183,8 @@ export class ActionService {
         if (event.keyCode == 13 /* enter */ ||
             event.keyCode == 32 /* space */) {
           const element = dev().assertElement(event.target);
-          if (element.getAttribute('role') == 'button') {
+          if (!event.defaultPrevented &&
+              element.getAttribute('role') == 'button') {
             this.trigger(element, name, event);
           }
         }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -185,6 +185,7 @@ export class ActionService {
           const element = dev().assertElement(event.target);
           if (!event.defaultPrevented &&
               element.getAttribute('role') == 'button') {
+            event.preventDefault();
             this.trigger(element, name, event);
           }
         }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Keycodes} from '../utils/keycodes';
 import {dev, user} from '../log';
 import {
   registerServiceBuilderForDoc,
@@ -180,8 +181,8 @@ export class ActionService {
         }
       });
       this.root_.addEventListener('keydown', event => {
-        if (event.keyCode == 13 /* enter */ ||
-            event.keyCode == 32 /* space */) {
+        const keyCode = event.keyCode;
+        if (keyCode == Keycodes.ENTER || keyCode == Keycodes.SPACE) {
           const element = dev().assertElement(event.target);
           if (!event.defaultPrevented &&
               element.getAttribute('role') == 'button') {

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -182,9 +182,9 @@ export class ActionService {
       this.root_.addEventListener('keydown', event => {
         if (event.keyCode == 13 /* enter */ ||
             event.keyCode == 32 /* space */) {
-          if (!event.defaultPrevented &&
-              this.ampdoc.win.document.activeElement == event.target) {
-            this.trigger(dev().assertElement(event.target), name, event);
+          const element = dev().assertElement(event.target);
+          if (element.getAttribute('role') == 'button') {
+            this.trigger(element, name, event);
           }
         }
       });

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -182,7 +182,8 @@ export class ActionService {
       this.root_.addEventListener('keydown', event => {
         if (event.keyCode == 13 /* enter */ ||
             event.keyCode == 32 /* space */) {
-          if (!event.defaultPrevented) {
+          if (!event.defaultPrevented &&
+              this.ampdoc.win.document.activeElement == event.target) {
             this.trigger(dev().assertElement(event.target), name, event);
           }
         }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -176,14 +176,14 @@ export class ActionService {
       // fast-click.
       this.root_.addEventListener('click', event => {
         if (!event.defaultPrevented) {
-          this.trigger(dev().assertElement(event.target), 'tap', event);
+          this.trigger(dev().assertElement(event.target), name, event);
         }
       });
       this.root_.addEventListener('keydown', event => {
         if (event.keyCode == 13 /* enter */ ||
             event.keyCode == 32 /* space */) {
           if (!event.defaultPrevented) {
-            this.trigger(dev().assertElement(event.target), 'tap', event);
+            this.trigger(dev().assertElement(event.target), name, event);
           }
         }
       });

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -179,6 +179,14 @@ export class ActionService {
           this.trigger(dev().assertElement(event.target), 'tap', event);
         }
       });
+      this.root_.addEventListener('keydown', event => {
+        if (event.keyCode == 13 /* enter */ ||
+            event.keyCode == 32 /* space */) {
+          if (!event.defaultPrevented) {
+            this.trigger(dev().assertElement(event.target), 'tap', event);
+          }
+        }
+      });
     } else if (name == 'submit') {
       this.root_.addEventListener(name, event => {
         this.trigger(dev().assertElement(event.target), name, event);

--- a/src/utils/keycodes.js
+++ b/src/utils/keycodes.js
@@ -18,6 +18,7 @@
  * @enum {number}
  */
 export const Keycodes = {
+  ENTER: 13,
   ESCAPE: 27,
   SPACE: 32,
   LEFT_ARROW: 37,

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -945,7 +945,7 @@ describe('Core events', () => {
     sandbox.restore();
   });
 
-  it('should trigger tap event', () => {
+  it('should trigger tap event on click', () => {
     expect(window.document.addEventListener).to.have.been.calledWith('click');
     const handler = window.document.addEventListener.getCall(0).args[1];
     const element = {tagName: 'target1', nodeType: 1};
@@ -954,9 +954,18 @@ describe('Core events', () => {
     expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
   });
 
+  it('should trigger tap event on key press', () => {
+    expect(window.document.addEventListener).to.have.been.calledWith('keydown');
+    const handler = window.document.addEventListener.getCall(1).args[1];
+    const element = {tagName: 'div', nodeType: 1};
+    const event = {target: element, keyCode: 13};
+    handler(event);
+    expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
+  });
+
   it('should trigger submit event', () => {
     expect(window.document.addEventListener).to.have.been.calledWith('submit');
-    const handler = window.document.addEventListener.getCall(1).args[1];
+    const handler = window.document.addEventListener.getCall(2).args[1];
     const element = {tagName: 'target1', nodeType: 1};
     const event = {target: element};
     handler(event);
@@ -965,7 +974,7 @@ describe('Core events', () => {
 
   it('should trigger change event', () => {
     expect(window.document.addEventListener).to.have.been.calledWith('change');
-    const handler = window.document.addEventListener.getCall(2).args[1];
+    const handler = window.document.addEventListener.getCall(3).args[1];
     const element = {tagName: 'target2', nodeType: 1};
     const event = {target: element};
     handler(event);
@@ -973,7 +982,7 @@ describe('Core events', () => {
   });
 
   it('should trigger change event with details for whitelisted inputs', () => {
-    const handler = window.document.addEventListener.getCall(2).args[1];
+    const handler = window.document.addEventListener.getCall(3).args[1];
     const element = document.createElement('input');
     element.setAttribute('type', 'range');
     element.setAttribute('min', '0');

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -959,8 +959,19 @@ describe('Core events', () => {
     const handler = window.document.addEventListener.getCall(1).args[1];
     const element = {tagName: 'div', nodeType: 1};
     const event = {target: element, keyCode: 13};
+    win.document.activeElement = element;
     handler(event);
     expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
+  });
+
+  it('should NOT trigger tap event on key press if event target is ' +
+     'not the active element', () => {
+    expect(window.document.addEventListener).to.have.been.calledWith('keydown');
+    const handler = window.document.addEventListener.getCall(1).args[1];
+    const element = {tagName: 'div', nodeType: 1};
+    const event = {target: element, keyCode: 13};
+    handler(event);
+    expect(action.trigger).to.not.have.been.called;
   });
 
   it('should trigger submit event', () => {

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -960,8 +960,12 @@ describe('Core events', () => {
     const handler = window.document.addEventListener.getCall(1).args[1];
     const element = document.createElement('div');
     element.setAttribute('role', 'button');
-    const event = {target: element, keyCode: 13};
+    const event = {
+      target: element,
+      keyCode: 13,
+      preventDefault: sandbox.stub()};
     handler(event);
+    expect(event.preventDefault).to.have.been.called;
     expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
   });
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -954,21 +954,23 @@ describe('Core events', () => {
     expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
   });
 
-  it('should trigger tap event on key press', () => {
+  it('should trigger tap event on key press if focused element has ' +
+     'role=button', () => {
     expect(window.document.addEventListener).to.have.been.calledWith('keydown');
     const handler = window.document.addEventListener.getCall(1).args[1];
-    const element = {tagName: 'div', nodeType: 1};
+    const element = document.createElement('div');
+    element.setAttribute('role', 'button');
     const event = {target: element, keyCode: 13};
-    win.document.activeElement = element;
     handler(event);
     expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
   });
 
-  it('should NOT trigger tap event on key press if event target is ' +
-     'not the active element', () => {
+  it('should NOT trigger tap event on key press if focused element DOES NOT ' +
+     'have role=button', () => {
     expect(window.document.addEventListener).to.have.been.calledWith('keydown');
     const handler = window.document.addEventListener.getCall(1).args[1];
-    const element = {tagName: 'div', nodeType: 1};
+    const element = document.createElement('div');
+    element.setAttribute('role', 'not-a-button');
     const event = {target: element, keyCode: 13};
     handler(event);
     expect(action.trigger).to.not.have.been.called;

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -21,6 +21,7 @@ import {
   parseActionMap,
 } from '../../src/service/action-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
+import {Keycodes} from '../../src/utils/keycodes';
 import {createCustomEvent} from '../../src/event-helper';
 import {setParentWindow} from '../../src/service';
 import * as sinon from 'sinon';
@@ -962,7 +963,7 @@ describe('Core events', () => {
     element.setAttribute('role', 'button');
     const event = {
       target: element,
-      keyCode: 13,
+      keyCode: Keycodes.ENTER,
       preventDefault: sandbox.stub()};
     handler(event);
     expect(event.preventDefault).to.have.been.called;
@@ -975,7 +976,7 @@ describe('Core events', () => {
     const handler = window.document.addEventListener.getCall(1).args[1];
     const element = document.createElement('div');
     element.setAttribute('role', 'not-a-button');
-    const event = {target: element, keyCode: 13};
+    const event = {target: element, keyCode: Keycodes.ENTER};
     handler(event);
     expect(action.trigger).to.not.have.been.called;
   });

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1014,7 +1014,7 @@ describe('Core events', () => {
   });
 
   it('should trigger change event with details for select elements', () => {
-    const handler = window.document.addEventListener.getCall(2).args[1];
+    const handler = window.document.addEventListener.getCall(3).args[1];
     const element = document.createElement('select');
     element.innerHTML =
         `<option value="foo"></option>


### PR DESCRIPTION
This PR adds support for firing tap listeners on focused elements when a user presses either space or enter.

Partial for #8810 