### PR TITLE
amp-state: Remove restriction that amp-state elements must have a JSON descendant or a src attriute, but not both

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -106,6 +106,9 @@ export class AmpState extends AMP.BaseElement {
     // If both `src` and child script tag are provided,
     // state fetched from `src` takes precedence.
     const children = this.element.children;
+    if (children.length == 0 && !this.element.hasAttribute('src')) {
+      user().error(TAG, 'Needs either a <script> child or src attribute');
+    }
     if (children.length == 1) {
       this.parseChildAndUpdateState_();
     } else if (children.length > 1) {
@@ -117,6 +120,7 @@ export class AmpState extends AMP.BaseElement {
         this.updateStatePromise = p;
       }
     }
+
   }
 
   /**

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -120,11 +120,10 @@ export class AmpState extends AMP.BaseElement {
 
   /**
    * @param {boolean} isInit
-   * @return {!Promise}
    * @private
    */
   fetchSrcAndUpdateState_(isInit) {
-    return fetchBatchedJsonFor(this.getAmpDoc(), this.element).then(json => {
+    fetchBatchedJsonFor(this.getAmpDoc(), this.element).then(json => {
       this.updateState_(json, isInit);
     });
   }

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -26,11 +26,11 @@ import {dev, user} from '../../../src/log';
 export class AmpState extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
-  constructor(elemment) {
+  constructor(element) {
     super(element);
 
     /** @visibleForTesting {?Promise} */
-    this.initializePromise = null;
+    this.updateStatePromise = null;
   }
 
 
@@ -67,26 +67,9 @@ export class AmpState extends AMP.BaseElement {
     toggle(this.element, /* opt_display */ false);
     this.element.setAttribute('aria-hidden', 'true');
 
-<<<<<<< HEAD
     // Don't parse or fetch in prerender mode.
     const viewer = viewerForDoc(this.getAmpDoc());
     viewer.whenFirstVisible().then(() => this.initialize_());
-=======
-    // If both `src` and child script tag are provided,
-    // state fetched from `src` takes precedence.
-    const children = this.element.children;
-    if (children.length == 1) {
-      this.parseChildAndUpdateState_();
-    } else if (children.length > 1) {
-      user().error(TAG, 'Should contain only one <script> child.');
-    }
-    if (this.element.hasAttribute('src')) {
-      const p = this.fetchSrcAndUpdateState_(/* isInit */ true);
-      if (getmode().test) {
-        this.initializePromise = p;
-      }
-    }
->>>>>>> ecaba238... partial work on augmenting amp-state tests
   }
 
   /** @override */
@@ -100,6 +83,9 @@ export class AmpState extends AMP.BaseElement {
     const src = mutations['src'];
     if (src !== undefined) {
       this.fetchSrcAndUpdateState_(/* isInit */ false);
+      if (getMode().test) {
+        this.updateStatePromise = p;
+      }
     }
   }
 
@@ -124,7 +110,10 @@ export class AmpState extends AMP.BaseElement {
       user().error(TAG, 'Should contain only one <script> child.');
     }
     if (this.element.hasAttribute('src')) {
-      this.fetchSrcAndUpdateState_(/* isInit */ true);
+      const p = this.fetchSrcAndUpdateState_(/* isInit */ true);
+      if (getMode().test) {
+        this.updateStatePromise = p;
+      }
     }
   }
 
@@ -163,7 +152,7 @@ export class AmpState extends AMP.BaseElement {
    * @private
    */
   fetchSrcAndUpdateState_(isInit) {
-    const ampdoc = this.getAmpdoc();
+    const ampdoc = this.getAmpDoc();
     return this.fetchBatchedJsonFor_(ampdoc, this.element).then(json => {
       this.updateState_(json, isInit);
     });

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -84,7 +84,7 @@ export class AmpState extends AMP.BaseElement {
     }
     const src = mutations['src'];
     if (src !== undefined) {
-      this.fetchSrcAndUpdateState_(/* isInit */ false);
+      const p = this.fetchSrcAndUpdateState_(/* isInit */ false);
       if (getMode().test) {
         this.updateStatePromise = p;
       }

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -29,8 +29,10 @@ export class AmpState extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @visibleForTesting {?Promise} */
-    this.updateStatePromise = null;
+    if (getMode().test) {
+      /** @visibleForTesting {?Promise} */
+      this.updateStatePromise = null;
+    }
   }
 
 

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -137,7 +137,7 @@ export class AmpState extends AMP.BaseElement {
 
   /**
    * Wrapper to stub during testing.
-   * @param {!../../../service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    * @param {!Element} element
    * @return {!Promise}
    * @visibleForTesting

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -92,7 +92,7 @@ describes.realWin('AmpState', {
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
-      expect(fetchSpy).calledWithExactly(/* isInit */true);
+      expect(fetchSpy).to.not.have.been.called;
       expect(updateStub).calledWithMatch({foo: 'bar'});
     });
   });

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -24,7 +24,6 @@ describes.realWin('AmpState', {
   },
 }, env => {
   let ampState;
-  let fetchStub;
   let updateStub;
 
   // Viewer-related vars.

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -89,6 +89,15 @@ describes.realWin('AmpState', {
     });
   });
 
+  it('should parse child and fetch `src` if both proided at build', () => {
+    ampState.innerHTML = '<script type="application/json">' +
+        '{"foo": "bar"}</script>';
+    ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
+    ampState.implementation_.buildCallback();
+    expect(updateStub).calledWithMatch({foo: 'bar'});
+    expect(fetchStub).calledWith(/* opt_isInit */ true);
+  });
+
   it('should fetch json if `src` is mutated', () => {
     ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
     ampState.build();

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -86,16 +86,18 @@ describes.realWin('AmpState', {
     ampState.build();
 
     // IMPORTANT: No parsing should happen until viewer is visible.
+    expect(fetchSpy).to.not.have.been.called;
     expect(batchedJsonStub).to.not.have.been.called;
     expect(updateStub).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
+      expect(fetchSpy).calledWithExactly(/* isInit */true);
       expect(updateStub).calledWithMatch({foo: 'bar'});
     });
   });
 
-  it('should parse child and fetch `src` if both proided at build', () => {
+  it('should parse child and fetch `src` if both provided at build', () => {
     ampState.innerHTML = '<script type="application/json">' +
         '{"foo": "bar"}</script>';
     ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
@@ -124,6 +126,7 @@ describes.realWin('AmpState', {
     const isVisibleStub = env.sandbox.stub(viewer, 'isVisible');
     isVisibleStub.returns(false);
     ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
+    expect(fetchSpy).to.not.have.been.called;
     expect(batchedJsonStub).to.not.have.been.called;
 
     isVisibleStub.returns(true);

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -96,7 +96,7 @@ describes.realWin('AmpState', {
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
       expect(fetchStub).calledWith(/* opt_isInit */ true);
-      return ampState.implementation_.initializePromise;
+      return ampState.implementation_.updateStatePromise;
     }).then(() => {
       expect(updateStub).calledWithMatch({baz: 'qux'});
     });
@@ -116,7 +116,7 @@ describes.realWin('AmpState', {
     return whenFirstVisiblePromise.then(() => {
       expect(updateStub).calledWithMatch({foo: 'bar'});
       expect(fetchStub).calledWith(/* opt_isInit */ true);
-      return ampState.implementation_.initializePromise;
+      return ampState.implementation_.updateStatePromise;
     }).then(() => {
       expect(updateStub).calledWithMatch({baz: 'qux'});
     });
@@ -135,5 +135,8 @@ describes.realWin('AmpState', {
     isVisibleStub.returns(true);
     ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
     expect(fetchStub).calledWithExactly(/* isInit */ false);
+    return ampState.implementation_.updateStatePromise.then(() => {
+      expect(updateStub).calledWithMatch({baz: 'qux'});
+    });
   });
 });

--- a/extensions/amp-bind/0.1/test/validator-amp-bind.html
+++ b/extensions/amp-bind/0.1/test/validator-amp-bind.html
@@ -58,5 +58,17 @@
       }
     </script>
   </amp-state>
+
+  <amp-state id="myState2" src="https://www.google.com/" credentials="omit">
+  </amp-state>
+
+  <amp-state id="myState3" src="https://www.google.com/" credentials="include">
+    <script type="application/json">
+      {
+        "myStateKey1": "myStateValue1"
+      }
+    </script>
+  </amp-state>
+
 </body>
 </html>

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -52,6 +52,7 @@ tags: {  # <amp-state>
   spec_name: "amp-state"
   satisfies: "amp-state"
   requires: "amp-bind extension .js script"
+  requires: "amp-bind extension .json script"
   disallowed_ancestor: "AMP-SIDEBAR"
   attrs: { name: "credentials" }
   attrs: {

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -50,7 +50,6 @@ tags: {  # <amp-state>
   html_format: AMP
   tag_name: "AMP-STATE"
   spec_name: "amp-state"
-  satisfies: "amp-state"
   requires: "amp-bind extension .js script"
   requires: "amp-bind extension .json script"
   disallowed_ancestor: "AMP-SIDEBAR"

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -46,7 +46,7 @@ tags: {  # <amp-state> (json)
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }
-tags: {  # <amp-state>
+tags: {  # <amp-state> with json child
   html_format: AMP
   tag_name: "AMP-STATE"
   spec_name: "amp-state"
@@ -68,5 +68,36 @@ tags: {  # <amp-state>
   }
   # <amp-bind>
   attrs: { name: "[src]" }
+  child_tags: {
+    mandatory_num_child_tags: 1
+    first_child_tag_name_oneof: "SCRIPT"
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
+}
+tags: {  # <amp-state> with src only
+  html_format: AMP
+  tag_name: "AMP-STATE"
+  spec_name: "amp-state[src]"
+  requires: "amp-bind extension .js script"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  attrs: {
+    name: "id"
+    mandatory: true
+  }
+  attrs: { name: "credentials" }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  # <amp-bind>
+  attrs: { name: "[src]" }
+  child_tags: {
+    mandatory_num_child_tags: 0
+  }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -46,39 +46,20 @@ tags: {  # <amp-state> (json)
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }
-tags: {  # <amp-state> with json child
+tags: {  # <amp-state>
   html_format: AMP
   tag_name: "AMP-STATE"
   spec_name: "amp-state"
-  requires: "amp-bind extension .js script"
-  requires: "amp-bind extension .json script"
-  disallowed_ancestor: "AMP-SIDEBAR"
-  attrs: {
-    name: "id"
-    mandatory: true
-  }
-  # <amp-bind>
-  attrs: { name: "[src]" }
-  child_tags: {
-    mandatory_num_child_tags: 1
-    first_child_tag_name_oneof: "SCRIPT"
-  }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
-}
-tags: {  # <amp-state> with src
-  html_format: AMP
-  tag_name: "AMP-STATE"
-  spec_name: "amp-state[src]"
+  satisfies: "amp-state"
   requires: "amp-bind extension .js script"
   disallowed_ancestor: "AMP-SIDEBAR"
-  attrs: {
-    name: "id"
-    mandatory: true
-  }
   attrs: { name: "credentials" }
   attrs: {
-    name: "src"
+    name: "id"
     mandatory: true
+  }
+  attrs: {
+    name: "src"
     value_url: {
       allowed_protocol: "https"
       allow_relative: true  # Will be set to false at a future date.
@@ -87,8 +68,5 @@ tags: {  # <amp-state> with src
   }
   # <amp-bind>
   attrs: { name: "[src]" }
-  child_tags: {
-    mandatory_num_child_tags: 0
-  }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }


### PR DESCRIPTION
This PR removes a requirement on `amp-state` that each `amp-state` element have a child JSON declaring state or a src attribute for fetching state via XHR, but not both. Either or both can now be used. If both are used, state retrieved via XHR will overwrite conflicting state from a child JSON.

Fixes #8844 

/to @choumx @honeybadgerdontcare  @jridgewell 
