### PR TITLE
Ensure that viewport is instantiated ASAP as other services depend on it

### DIFF
--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1893,7 +1893,8 @@ function getViewportType(win, viewer) {
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  */
 export function installViewportServiceForDoc(ampdoc) {
-  registerServiceBuilderForDoc(ampdoc, 'viewport', ampdoc => {
-    return createViewport(ampdoc);
-  });
+  registerServiceBuilderForDoc(ampdoc, 'viewport',
+      /* constructor */ undefined,
+      ampdoc => createViewport(ampdoc),
+      /* instantiate */ true);
 }


### PR DESCRIPTION
Closes #8918.

Viewport is a force-installed service since it does some top-level DOM reshuffling in some cases. In fact, it's an implicit dependency.
