### PR TITLE
amp-bind: An expression for [class] that evaluates to the empty string should verify as if no CSS class were provided

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -773,7 +773,8 @@ export class Bind {
         if (Array.isArray(expectedValue)) {
           classes = expectedValue;
         } else if (typeof expectedValue === 'string') {
-          classes = expectedValue.split(' ');
+          // Empty string must become [], not ['']
+          classes = expectedValue ? expectedValue.split(' ') : [];
         } else {
           const err = user().createError(
               `${TAG}: "${expectedValue}" is not a valid result for [class].`);

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -203,6 +203,16 @@ describes.realWin('Bind', {
     });
   });
 
+  it('should verify class bindings when the binding initially evaluates ' +
+     'to the empty string', () => {
+    window.AMP_MODE = {development: true};
+    createElementWithBinding(`[class]="cssClass || ''" class=""`);
+    const errorStub = env.sandbox.stub(user(), 'createError');
+    return onBindReady().then(() => {
+      expect(errorStub).to.not.have.been.called;
+    });
+  });
+
   it('should verify string attribute bindings in dev mode', () => {
     window.AMP_MODE = {development: true};
     // Only the initial value for [a] binding does not match.


### PR DESCRIPTION
/to @choumx 

Partial for #8933 