### PR TITLE
amp-bind: Fix mistake in bindable attribute list

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -330,7 +330,7 @@ Only binding to the following components and attributes are allowed:
   </tr>
   <tr>
     <td><code>&lt;amp-list></code></td>
-    <td><code>[src]</code><sup>1</sup></td>
+    <td><code>[src]</code></td>
     <td>Fetches JSON from the new URL and re-renders, replacing old content.</td>
   </tr>
   <tr>


### PR DESCRIPTION
`amp-list` does have a `src` attribute. Removed note that suggested otherwise.