### PR TITLE
amp-bind: Fix [class] verify bug

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -763,7 +763,10 @@ export class Bind {
         if (Array.isArray(expectedValue)) {
           classes = expectedValue;
         } else if (typeof expectedValue === 'string') {
-          classes = expectedValue.split(' ');
+          const trimmed = expectedValue.trim();
+          if (trimmed.length > 0) {
+            classes = trimmed.split(' ');
+          }
         } else {
           const err = user().createError(
               `${TAG}: "${expectedValue}" is not a valid result for [class].`);

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -194,7 +194,9 @@ describes.realWin('Bind', {
 
   it('should verify class bindings in dev mode', () => {
     window.AMP_MODE = {development: true};
-    createElementWithBinding(`[class]="'foo'" class="foo"`); // No error.
+    createElementWithBinding(`[class]="'foo'" class="foo"`);
+    createElementWithBinding(`[class]="'foo'" class=" foo "`);
+    createElementWithBinding(`[class]="''"`);
     createElementWithBinding(`[class]="'bar'" class="qux"`); // Error.
     const errorStub = env.sandbox.stub(user(), 'createError');
     return onBindReady().then(() => {


### PR DESCRIPTION
Partial for #8933.

- Verify empty string `[class]` correctly and ignore leading/trailing whitespaces.

/to @kmh287 