### PR TITLE
amp-bind: add `[slide-count]` attribute to amp-carousel

### DIFF
--- a/examples/bind/carousels.amp.html
+++ b/examples/bind/carousels.amp.html
@@ -31,10 +31,14 @@
 
   <div>
     <h2>Linked carousels</h2>
-    <p [text]="'Selected slide: ' + selectedSlide">Selected slide: None<p>
-
+    <p [text]="'Selected slide: ' + (selectedSlide || 0)">Selected slide: 0<p>
+    <p [text]="'Slide count: ' + (slideCount || 9)">Slide count: 9</p>
+    <div>
+     <button on="tap:AMP.setState({slideCount: slideCount != 4 ? 4 : 9})">Change slide count</button>
+    </div>
     <amp-carousel controls type=slides width=400 height=300
-        [slide]="selectedSlide" on="slideChange:AMP.setState({selectedSlide: event.index})">
+        [slide]="selectedSlide" on="slideChange:AMP.setState({selectedSlide: event.index})"
+        [slide-count]="slideCount">
       <amp-img src="https://ampbyexample.com/img/image1.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image2.jpg" width=400 height=300></amp-img>
       <amp-img src="https://ampbyexample.com/img/image3.jpg" width=400 height=300></amp-img>

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -215,6 +215,7 @@ function createElementRules_() {
     },
     'AMP-CAROUSEL': {
       'slide': null,
+      'slide-count': null,
     },
     'AMP-IFRAME': {
       'src': null,

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -224,14 +224,9 @@ export class AmpSlideScroll extends BaseSlides {
     if (isFinite(slideCount)) {
       // Clamp count to between 0 and the total number of slides
       slideCount = Math.max(Math.min(this.slides_.length, slideCount), 0);
-      const showIndexArr = [];
-      for (let i = 0; i < slideCount; i++) {
-        showIndexArr.push(i);
-      }
-      this.hideRestOfTheSlides_(showIndexArr);
       this.noOfSlides_ = slideCount;
-      if (this.slideIndex_ > slideCount) {
-        this.showSlideWhenReady_(slideCount - 1);
+      if (this.slideIndex_ >= this.noOfSlides_) {
+        this.showSlideWhenReady_(this.noOfSlides_ - 1);
       }
       this.setControlsState();
     }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -220,6 +220,22 @@ export class AmpSlideScroll extends BaseSlides {
     if (slide !== undefined) {
       this.showSlideWhenReady_(slide);
     }
+    const slideCount = mutations['slide-count'];
+    if (slideCount !== undefined && isFinite(slideCount)) {
+      let slideCountNum = Number(slideCount);
+      // Clamp count to between 0 and the total number of slides
+      slideCountNum = Math.max(Math.min(this.slides_.length, slideCountNum), 0);
+      this.noOfSlides_ = slideCountNum;
+      const showIndexArr = [];
+      for (let i = 0; i < slideCountNum; i++) {
+        showIndexArr.push(i);
+      }
+      this.hideRestOfTheSlides_(showIndexArr);
+      if (this.slideIndex_ > slideCountNum) {
+        this.showSlideWhenReady_(slideCountNum - 1);
+      }
+      this.setControlsState();
+    }
   }
 
   /**
@@ -296,7 +312,7 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   hasNext() {
-    return this.shouldLoop || this.slideIndex_ < this.slides_.length - 1;
+    return this.shouldLoop || this.slideIndex_ < this.noOfSlides_ - 1;
   }
 
   /** @override */
@@ -598,8 +614,8 @@ export class AmpSlideScroll extends BaseSlides {
    * @private
    */
   hideRestOfTheSlides_(indexArr) {
-    const noOfSlides_ = this.noOfSlides_;
-    for (let i = 0; i < noOfSlides_; i++) {
+    const totalNumSlides = this.slides_.length;
+    for (let i = 0; i < totalNumSlides; i++) {
       if (!this.slideWrappers_[i].classList.contains(SHOWN_CSS_CLASS)) {
         continue;
       }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -220,19 +220,18 @@ export class AmpSlideScroll extends BaseSlides {
     if (slide !== undefined) {
       this.showSlideWhenReady_(slide);
     }
-    const slideCount = mutations['slide-count'];
-    if (slideCount !== undefined && isFinite(slideCount)) {
-      let slideCountNum = Number(slideCount);
+    let slideCount = Number(mutations['slide-count']);
+    if (isFinite(slideCount)) {
       // Clamp count to between 0 and the total number of slides
-      slideCountNum = Math.max(Math.min(this.slides_.length, slideCountNum), 0);
-      this.noOfSlides_ = slideCountNum;
+      slideCount = Math.max(Math.min(this.slides_.length, slideCount), 0);
       const showIndexArr = [];
-      for (let i = 0; i < slideCountNum; i++) {
+      for (let i = 0; i < slideCount; i++) {
         showIndexArr.push(i);
       }
       this.hideRestOfTheSlides_(showIndexArr);
-      if (this.slideIndex_ > slideCountNum) {
-        this.showSlideWhenReady_(slideCountNum - 1);
+      this.noOfSlides_ = slideCount;
+      if (this.slideIndex_ > slideCount) {
+        this.showSlideWhenReady_(slideCount - 1);
       }
       this.setControlsState();
     }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -225,10 +225,16 @@ export class AmpSlideScroll extends BaseSlides {
       // Clamp count to between 0 and the total number of slides
       slideCount = Math.max(Math.min(this.slides_.length, slideCount), 0);
       this.noOfSlides_ = slideCount;
-      if (this.slideIndex_ >= this.noOfSlides_) {
-        this.showSlideWhenReady_(this.noOfSlides_ - 1);
+      if (this.slideIndex_ !== null) {
+        if (this.slideIndex_ >= this.noOfSlides_) {
+          this.showSlide_(this.noOfSlides_ - 1);
+        } else {
+          const slideIndex = dev().assertNumber(this.slideIndex_);
+          const showIndexArr = this.calculateShownSlides_(slideIndex);
+          this.hideRestOfTheSlides_(showIndexArr);
+        }
+        this.setControlsState();
       }
-      this.setControlsState();
     }
   }
 
@@ -516,19 +522,13 @@ export class AmpSlideScroll extends BaseSlides {
   }
 
   /**
-   * Makes the slide corresponding to the given index and the slides surrounding
-   *     it available for display.
-   * @note Element must be laid out.
-   * @param {number} newIndex Index of the slide to be displayed.
+   * Calculate which slides should be shown.
+   * @param {number} newIndex Index of the slide to be displayed
+   * @return {!Array<number>}
    * @private
    */
-  showSlide_(newIndex) {
+  calculateShownSlides_(newIndex) {
     const noOfSlides_ = this.noOfSlides_;
-    if (newIndex < 0 ||
-        newIndex >= noOfSlides_ ||
-        this.slideIndex_ == newIndex) {
-      return;
-    }
     const prevIndex = (newIndex - 1 >= 0) ? newIndex - 1 :
         (this.shouldLoop) ? noOfSlides_ - 1 : null;
     const nextIndex = (newIndex + 1 < noOfSlides_) ? newIndex + 1 :
@@ -542,6 +542,23 @@ export class AmpSlideScroll extends BaseSlides {
     if (nextIndex != null) {
       showIndexArr.push(nextIndex);
     }
+    return showIndexArr;
+  }
+
+  /**
+   * Makes the slide corresponding to the given index and the slides surrounding
+   *     it available for display.
+   * @note Element must be laid out.
+   * @param {number} newIndex Index of the slide to be displayed.
+   * @private
+   */
+  showSlide_(newIndex) {
+    if (newIndex < 0 ||
+        newIndex >= this.noOfSlides_ ||
+        this.slideIndex_ == newIndex) {
+      return;
+    }
+    const showIndexArr = this.calculateShownSlides_(newIndex);
     if (this.slideIndex_ !== null) {
       this.updateInViewport(this.slides_[
           dev().assertNumber(this.slideIndex_)], false);

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -933,7 +933,7 @@ describe('SlideScroll', () => {
       });
     });
 
-    it('should update slide when `slide` attribute is mutated', () => {
+    it('should update slide when `slide` attribute mutates', () => {
       return getAmpSlideScroll(true).then(obj => {
         const ampSlideScroll = obj.ampSlideScroll;
         const impl = ampSlideScroll.implementation_;
@@ -949,6 +949,22 @@ describe('SlideScroll', () => {
         showSlideSpy.reset();
         impl.mutatedAttributesCallback({slide: Number.POSITIVE_INFINITY});
         expect(showSlideSpy.called).to.be.false;
+      });
+    });
+
+    it('should update slide count when `slide-count` attribute mutates', () => {
+      return getAmpSlideScroll(true).then(obj => {
+        const ampSlideScroll = obj.ampSlideScroll;
+        const impl = ampSlideScroll.implementation_;
+        impl.showSlide_(4);
+        const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+        const hideRestOfTheSlidesSpy =
+            sandbox.spy(impl, 'hideRestOfTheSlides_');
+
+        impl.mutatedAttributesCallback({'slide-count': 2});
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
+        // Should move to last visible slide
+        expect(showSlideSpy).to.have.been.calledWith(1);
       });
     });
 

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -962,9 +962,16 @@ describe('SlideScroll', () => {
             sandbox.spy(impl, 'hideRestOfTheSlides_');
 
         impl.mutatedAttributesCallback({'slide-count': 2});
-        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
+        // 0 appears twice since the carousel is set to loop.
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 0]);
         // Should move to last visible slide
         expect(showSlideSpy).to.have.been.calledWith(1);
+
+        showSlideSpy.reset();
+        hideRestOfTheSlidesSpy.reset();
+        impl.mutatedAttributesCallback({'slide-count': 5});
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 2]);
+        expect(showSlideSpy).to.not.have.been.called;
       });
     });
 

--- a/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/0.1/validator-amp-carousel.protoascii
@@ -57,6 +57,7 @@ tags: {  # <amp-carousel>
   }
   # <amp-bind>
   attrs: { name: "[slide]" }
+  attrs: { name: "[slide-count]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/layout/amp-carousel"
   amp_layout: {


### PR DESCRIPTION
Adds the `[slide-count]` attribute to amp-carousel. When the expression bound to `[slide-count]` is lower than the total number of slides (number of children of the element), the slides beyond the slide-count will be hidden.

Fixes #8921 

/to @camelburrito @choumx @jridgewell  