### PR TITLE
Report A4A experiment to CSI.

### DIFF
--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -32,7 +32,7 @@ import {
 } from '../../../../src/experiments';
 import {installPlatformService} from '../../../../src/service/platform-impl';
 import {installViewerServiceForDoc} from '../../../../src/service/viewer-impl';
-import {resetServiceForTesting} from '../../../../src/service';
+import {resetServiceForTesting, getService} from '../../../../src/service';
 import {
   installDocumentStateService,
 } from '../../../../src/service/document-state';
@@ -270,6 +270,7 @@ describe('all-traffic-experiments-tests', () => {
     let win;
     let events;
     let element;
+    let addEnabledExperimentSpy;
 
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
@@ -309,6 +310,12 @@ describe('all-traffic-experiments-tests', () => {
       installViewerServiceForDoc(ampdoc);
       element = document.createElement('div');
       document.body.appendChild(element);
+      addEnabledExperimentSpy = sandbox.stub();
+      getService(win, 'performance', () => {
+        return {
+          addEnabledExperiment: addEnabledExperimentSpy,
+        };
+      });
     });
 
     afterEach(() => {
@@ -461,6 +468,12 @@ describe('all-traffic-experiments-tests', () => {
           external, internal)).to.equal(test.shouldServeFastFetch);
         expectCorrectBranchOnly(element, test.branchId);
         expect(win.document.cookie).to.be.null;
+        if (test.branchId) {
+          expect(addEnabledExperimentSpy)
+              .to.be.calledWith('expDoubleclickA4A-' + test.branchId);
+        } else {
+          expect(addEnabledExperimentSpy).to.not.be.called;
+        }
       });
     });
   });

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -30,7 +30,10 @@ import {
   randomlySelectUnsetExperiments,
 } from '../../../src/experiments';
 import {dev} from '../../../src/log';
-import {viewerForDoc} from '../../../src/services';
+import {
+  viewerForDoc,
+  performanceForOrNull,
+} from '../../../src/services';
 import {parseQueryString} from '../../../src/url';
 
 /** @typedef {{
@@ -109,6 +112,10 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
     const selectedBranch = getExperimentBranch(win, experimentName);
     if (selectedBranch) {
       addExperimentIdToElement(selectedBranch, element);
+      const perf = performanceForOrNull(win);
+      if (perf) {
+        perf.addEnabledExperiment(experimentName + '-' + selectedBranch);
+      }
     }
     // Detect how page was selected into the overall experimentName.
     if (isSetFromUrl) {

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -650,22 +650,25 @@ describes.realWin('performance with experiment', {amp: true}, env => {
     perf = performanceFor(win);
   });
 
-  it('legacy-cdn-domain experiment enabled', () => {
-    sandbox.stub(perf, 'getHostname_', () => 'cdn.ampproject.org');
+  it('rtvVersion experiment', () => {
     return perf.coreServicesAvailable().then(() => {
+      viewerSendMessageStub.reset();
       perf.flush();
       expect(viewerSendMessageStub).to.be.calledWith('sendCsi', {
-        ampexp: getMode(win).rtvVersion + ',legacy-cdn-domain',
+        ampexp: getMode(win).rtvVersion,
       });
     });
   });
 
-  it('no experiment', () => {
-    sandbox.stub(perf, 'getHostname_', () => 'curls.cdn.ampproject.org');
+  it('addEnabledExperiment should work', () => {
     return perf.coreServicesAvailable().then(() => {
+      perf.addEnabledExperiment('experiment-a');
+      perf.addEnabledExperiment('experiment-b');
+      perf.addEnabledExperiment('experiment-a'); // duplicated entry
+      viewerSendMessageStub.reset();
       perf.flush();
       expect(viewerSendMessageStub).to.be.calledWith('sendCsi', {
-        ampexp: getMode(win).rtvVersion,
+        ampexp: getMode(win).rtvVersion + ',experiment-a,experiment-b',
       });
     });
   });

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -667,9 +667,14 @@ describes.realWin('performance with experiment', {amp: true}, env => {
       perf.addEnabledExperiment('experiment-a'); // duplicated entry
       viewerSendMessageStub.reset();
       perf.flush();
-      expect(viewerSendMessageStub).to.be.calledWith('sendCsi', {
-        ampexp: getMode(win).rtvVersion + ',experiment-a,experiment-b',
-      });
+      expect(viewerSendMessageStub).to.be.calledWith('sendCsi',
+          sandbox.match(payload => {
+            const experiments = payload.ampexp.split(',');
+            expect(experiments).to.have.length(3);
+            expect(experiments).to.have.members(
+                [getMode(win).rtvVersion, 'experiment-a', 'experiment-b']);
+            return true;
+          }));
     });
   });
 });


### PR DESCRIPTION
- refactored `experiments.js` a bit to expose `addEnabledExperiment` method
- report A4A experiment branches to CSI using `addEnabledExperiment` method
- removed unused `legacy-cdn-domain` experiment