### PR TITLE
Allow carousel next and prev buttons to be reachable and usable by keyboard

### DIFF
--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -71,9 +71,11 @@ export class BaseCarousel extends AMP.BaseElement {
     // TODO(erwinm): Does label need i18n support in the future? or provide
     // a way to be overridden.
     this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
+    this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onclick = () => {
       this.interactionPrev();
     };
+
     this.element.appendChild(this.prevButton_);
 
     this.nextButton_ = this.element.ownerDocument.createElement('div');
@@ -81,6 +83,7 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.classList.add('amp-carousel-button-next');
     this.nextButton_.setAttribute('role', 'button');
     this.nextButton_.setAttribute('aria-label', 'Next item in carousel');
+    this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onclick = () => {
       this.interactionNext();
     };

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Keycodes} from '../../../src/utils/keycodes';
 import {timerFor} from '../../../src/services';
 
 /**
@@ -73,7 +74,7 @@ export class BaseCarousel extends AMP.BaseElement {
     this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
-      if (event.keyCode == 13 /* enter */ || event.keyCode == 32 /* space */) {
+      if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {
         if (!event.defaultPrevented) {
           event.preventDefault();
           this.interactionPrev();
@@ -92,7 +93,7 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.setAttribute('aria-label', 'Next item in carousel');
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {
-      if (event.keyCode == 13 /* enter */ || event.keyCode == 32 /* space */) {
+      if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {
         if (!event.defaultPrevented) {
           event.preventDefault();
           this.interactionNext();

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -74,7 +74,10 @@ export class BaseCarousel extends AMP.BaseElement {
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
       if (event.keyCode == 13 /* enter */ || event.keyCode == 32 /* space */) {
-        this.interactionPrev();
+        if (!event.defaultPrevented) {
+          event.preventDefault();
+          this.interactionPrev();
+        }
       }
     };
     this.prevButton_.onclick = () => {
@@ -90,7 +93,10 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {
       if (event.keyCode == 13 /* enter */ || event.keyCode == 32 /* space */) {
-        this.interactionNext();
+        if (!event.defaultPrevented) {
+          event.preventDefault();
+          this.interactionNext();
+        }
       }
     };
     this.nextButton_.onclick = () => {

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -80,7 +80,6 @@ export class BaseCarousel extends AMP.BaseElement {
     this.prevButton_.onclick = () => {
       this.interactionPrev();
     };
-
     this.element.appendChild(this.prevButton_);
 
     this.nextButton_ = this.element.ownerDocument.createElement('div');

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -72,6 +72,11 @@ export class BaseCarousel extends AMP.BaseElement {
     // a way to be overridden.
     this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
     this.prevButton_.setAttribute('tabindex', 0);
+    this.prevButton_.onkeydown = event => {
+      if (event.keyCode == 13 /* enter */ || event.keyCode == 32 /* space */) {
+        this.interactionPrev();
+      }
+    };
     this.prevButton_.onclick = () => {
       this.interactionPrev();
     };
@@ -84,6 +89,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.setAttribute('role', 'button');
     this.nextButton_.setAttribute('aria-label', 'Next item in carousel');
     this.nextButton_.setAttribute('tabindex', 0);
+    this.nextButton_.onkeydown = event => {
+      if (event.keyCode == 13 /* enter */ || event.keyCode == 32 /* space */) {
+        this.interactionNext();
+      }
+    };
     this.nextButton_.onclick = () => {
       this.interactionNext();
     };

--- a/src/utils/keycodes.js
+++ b/src/utils/keycodes.js
@@ -18,6 +18,7 @@
  * @enum {number}
  */
 export const Keycodes = {
+  ENTER: 13,
   ESCAPE: 27,
   SPACE: 32,
   LEFT_ARROW: 37,


### PR DESCRIPTION
Buttons should be discoverable by TAB navigation. Pressing enter or space while buttons are focused should perform the same action as clicking them.

Partial for #8810 