### PR TITLE
Allow href for all SVG tags that allow xlink:href

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1743,8 +1743,14 @@ attr_lists: {
 }
 attr_lists: {
   name: "svg-xlink-attributes"
+  attrs: {
+    name: "href"
+    # Local (within document) URLs only for now.
+    value_regex: "#.*"
+  }
   attrs: { name: "xlink:actuate" }
   attrs: { name: "xlink:arcrole" }
+  # xlink:href is deprecated since SVG2 in favor of href.
   attrs: {
     name: "xlink:href"
     # Local (within document) URLs only for now.

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1743,16 +1743,12 @@ attr_lists: {
 }
 attr_lists: {
   name: "svg-xlink-attributes"
-  attrs: {
-    name: "href"
-    # Local (within document) URLs only for now.
-    value_regex: "#.*"
-  }
   attrs: { name: "xlink:actuate" }
   attrs: { name: "xlink:arcrole" }
-  # xlink:href is deprecated since SVG2 in favor of href.
   attrs: {
     name: "xlink:href"
+    # xlink:href is deprecated since SVG2 in favor of href.
+    alternative_names: "href"
     # Local (within document) URLs only for now.
     value_regex: "#.*"
   }


### PR DESCRIPTION
Per issue #8928, `xlink:href` has been deprecated since SVG2 in favor of `href`. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href
