### PR TITLE
Add default aria-live attributes to amp-live-list and amp-fresh

### DIFF
--- a/extensions/amp-fresh/0.1/amp-fresh.js
+++ b/extensions/amp-fresh/0.1/amp-fresh.js
@@ -59,8 +59,11 @@ export class AmpFresh extends AMP.BaseElement {
 
     installAmpFreshManagerForDoc(this.element);
     this.manager_ = ampFreshManagerForDoc(this.element);
-
     this.manager_.register(this.ampFreshId_, this);
+
+    if (!this.element.hasAttribute('aria-live')) {
+      this.element.setAttribute('aria-live', 'polite');
+    }
   }
 
   /**

--- a/extensions/amp-fresh/0.1/test/test-amp-fresh.js
+++ b/extensions/amp-fresh/0.1/test/test-amp-fresh.js
@@ -82,10 +82,10 @@ describe('amp-fresh', () => {
   it('should have aria-live=polite by default', () => {
     fresh.buildCallback();
     expect(fresh.element.getAttribute('aria-live')).to.equal('polite');
+  });
 
+  it('should use explicitly defined aria-live attribute value', () => {
     elem.setAttribute('aria-live', 'assertive');
-    elem.setAttribute('id', 'amp-fresh-2');
-    fresh = new AmpFresh(elem);
     fresh.buildCallback();
     expect(fresh.element.getAttribute('aria-live')).to.equal('assertive');
   });

--- a/extensions/amp-fresh/0.1/test/test-amp-fresh.js
+++ b/extensions/amp-fresh/0.1/test/test-amp-fresh.js
@@ -78,4 +78,15 @@ describe('amp-fresh', () => {
     expect(fresh.element.innerHTML).to.equal(
         '<span>hello</span><div>world</div>!');
   });
+
+  it('should have aria-live=polite by default', () => {
+    fresh.buildCallback();
+    expect(fresh.element.getAttribute('aria-live')).to.equal('polite');
+
+    elem.setAttribute('aria-live', 'assertive');
+    elem.setAttribute('id', 'amp-fresh-2');
+    fresh = new AmpFresh(elem);
+    fresh.buildCallback();
+    expect(fresh.element.getAttribute('aria-live')).to.equal('assertive');
+  });
 });

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -223,6 +223,10 @@ export class AmpLiveList extends AMP.BaseElement {
         this.itemsSlot_, true);
 
     this.registerAction('update', this.updateAction_.bind(this));
+
+    if (!this.element.hasAttribute('aria-live')) {
+      this.element.setAttribute('aria-live', 'polite');
+    }
   }
 
   /** @override */

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -255,6 +255,22 @@ describe('amp-live-list', () => {
     }).to.throw(/must have an "items" slot/);
   });
 
+  it('should have aria-live=polite by default', () => {
+    buildElement(elem, dftAttrs);
+    liveList.buildCallback();
+    expect(liveList.element.getAttribute('aria-live')).to.equal('polite');
+
+    buildElement(elem, {
+      'aria-live': 'assertive',
+      'id': 'my-list',
+      'data-poll-interval': 2000,
+      'data-max-items-per-page': 5,
+      'data-sort-time': Date.now(),
+    });
+    liveList.buildCallback();
+    expect(liveList.element.getAttribute('aria-live')).to.equal('assertive');
+  });
+
   describe('#update', () => {
 
     beforeEach(() => {

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -259,7 +259,9 @@ describe('amp-live-list', () => {
     buildElement(elem, dftAttrs);
     liveList.buildCallback();
     expect(liveList.element.getAttribute('aria-live')).to.equal('polite');
+  });
 
+  it('should use explicitly defined aria-live attribute value', () => {
     buildElement(elem, {
       'aria-live': 'assertive',
       'id': 'my-list',


### PR DESCRIPTION
This PR gives these elements `aria-live=polite` by default, but allows this to be explicitly overridden by developers.

Fixes #5512

/to @aghassemi