### PR TITLE
Allow referrerpolicy for amp-pixel

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3115,6 +3115,10 @@ tags: {  # <amp-pixel>
   tag_name: "AMP-PIXEL"
   disallowed_ancestor: "AMP-SIDEBAR"
   attrs: {
+    name: "referrerpolicy"
+    value: "no-referrer"
+  }
+  attrs: {
     name: "src"
     mandatory: true
     value_url: {


### PR DESCRIPTION
Per [spec](https://github.com/ampproject/amphtml/blob/master/builtins/amp-pixel.md#attributes), referrerpolicy is optional with only allowed value of "no-referrer".

Addresses issue #8979.
