### PR TITLE
Fix flaky log test

### DIFF
--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -293,7 +293,6 @@ describe('Logging', () => {
       log = new Log(win, RETURNS_FINE, USER_ERROR_SENTINEL);
     });
 
-    // TODO(amphtml): Unskip when #8387 is fixed.
     it('should fail', () => {
       expect(function() {
         log.assert(false, 'xyz');

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -55,6 +55,7 @@ describe('Logging', () => {
       setTimeout: timeoutSpy,
       reportError: error => error,
     };
+    sandbox.stub(self, 'reportError', error => error);
   });
 
   afterEach(() => {
@@ -384,25 +385,21 @@ describe('Logging', () => {
       expect(error.expected).to.be.undefined;
       expect(error).to.be.instanceof(Error);
       expect(isUserErrorMessage(error.message)).to.be.true;
-      expect(error.message).to.contain('test');
+      expect(error.message).to.equal('test' + USER_ERROR_SENTINEL);
     });
 
     it('should create suffixed errors from error', () => {
       const error = log.createError(new Error('test'));
       expect(error).to.be.instanceof(Error);
       expect(isUserErrorMessage(error.message)).to.be.true;
-      expect(error.message).to.contain('test');
+      expect(error.message).to.equal('test' + USER_ERROR_SENTINEL);
     });
 
     it('should only add suffix once', () => {
       const error = log.createError(new Error('test' + USER_ERROR_SENTINEL));
+      expect(error).to.be.instanceof(Error);
       expect(isUserErrorMessage(error.message)).to.be.true;
-      expect(error.message).to.contain('test');
-
-      let message = error.message;
-      expect(message.indexOf(USER_ERROR_SENTINEL)).to.not.equal(-1);
-      message = message.replace(USER_ERROR_SENTINEL, '');
-      expect(message.indexOf(USER_ERROR_SENTINEL)).to.equal(-1);
+      expect(error.message).to.equal('test' + USER_ERROR_SENTINEL);
     });
 
     it('should strip suffix if not available', () => {
@@ -419,7 +416,7 @@ describe('Logging', () => {
       const error = log.createError('test');
       expect(error).to.be.instanceof(Error);
       expect(isUserErrorMessage(error.message)).to.be.false;
-      expect(error.message).to.contain('test-other');
+      expect(error.message).to.equal('test-other');
     });
 
     it('should pass for elements', () => {

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -53,6 +53,7 @@ describe('Logging', () => {
         log: logSpy,
       },
       setTimeout: timeoutSpy,
+      reportError: error => error,
     };
   });
 
@@ -293,7 +294,7 @@ describe('Logging', () => {
     });
 
     // TODO(amphtml): Unskip when #8387 is fixed.
-    it.skip('should fail', () => {
+    it('should fail', () => {
       expect(function() {
         log.assert(false, 'xyz');
       }).to.throw(/xyz/);

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -61,6 +61,7 @@ describe('Logging', () => {
   afterEach(() => {
     sandbox.restore();
     sandbox = null;
+    window.AMP_MODE = undefined;
   });
 
   describe('Level', () => {


### PR DESCRIPTION
The deliberately failed assertions would try to report 1% of the time, causing this test to be flaky. For the unit tests in this file, I've replaced the `reportError` function on the window (added in `error.js`) to just return the passed-in error.

Fixes #8387 

/to @choumx 