### PR TITLE
amp-auto-ads: Ad placement configuration errors are user errors

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/ad-strategy.js
@@ -15,7 +15,7 @@
  */
 
 import {DataAttributeDef, PlacementState} from './placement';
-import {dev} from '../../../src/log';
+import {user} from '../../../src/log';
 
 /** @const */
 const TAG = 'amp-auto-ads';
@@ -85,7 +85,7 @@ export class AdStrategy {
   placeNextAd_() {
     const nextPlacement = this.availablePlacements_.shift();
     if (!nextPlacement) {
-      dev().warn(TAG, 'unable to fulfill ad strategy');
+      user().warn(TAG, 'unable to fulfill ad strategy');
       return Promise.resolve(false);
     }
     return nextPlacement.placeAd(this.baseAttributes_, this.adTracker_)

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -16,7 +16,7 @@
 
 import {AdTracker, getExistingAds} from './ad-tracker';
 import {AdStrategy} from './ad-strategy';
-import {dev, user} from '../../../src/log';
+import {user} from '../../../src/log';
 import {xhrFor} from '../../../src/services';
 import {getAdNetworkConfig} from './ad-network-config';
 import {isExperimentOn} from '../../../src/experiments';
@@ -72,8 +72,8 @@ export class AmpAutoAds extends AMP.BaseElement {
     return xhrFor(this.win)
         .fetchJson(configUrl, xhrInit)
         .catch(reason => {
-          dev().error(TAG, 'amp-auto-ads config xhr failed: ' + reason);
-          return null;
+          user().error(TAG, 'amp-auto-ads config xhr failed: ' + reason);
+          throw reason;
         });
   }
 }

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -40,6 +40,10 @@ export class AmpAutoAds extends AMP.BaseElement {
     user().assert(adNetwork, 'No AdNetworkConfig for type: ' + type);
 
     this.getConfig_(adNetwork.getConfigUrl()).then(configObj => {
+      if (!configObj) {
+        return;
+      }
+
       const placements = getPlacementsFromConfigObj(this.win, configObj);
       const attributes = Object.assign(adNetwork.getAttributes(),
           getAttributesFromConfigObj(configObj));
@@ -73,7 +77,7 @@ export class AmpAutoAds extends AMP.BaseElement {
         .fetchJson(configUrl, xhrInit)
         .catch(reason => {
           user().error(TAG, 'amp-auto-ads config xhr failed: ' + reason);
-          throw reason;
+          return null;
         });
   }
 }

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from '../../../src/log';
+import {dev, user} from '../../../src/log';
 import {getAttributesFromConfigObj} from './attributes';
 import {resourcesForDoc} from '../../../src/services';
 import {
@@ -217,7 +217,7 @@ export class Placement {
 export function getPlacementsFromConfigObj(win, configObj) {
   const placementObjs = configObj['placements'];
   if (!placementObjs) {
-    dev().warn(TAG, 'No placements in config');
+    user().warn(TAG, 'No placements in config');
     return [];
   }
   const placements = [];
@@ -237,18 +237,18 @@ export function getPlacementsFromConfigObj(win, configObj) {
 function getPlacementsFromObject(win, placementObj, placements) {
   const injector = INJECTORS[placementObj['pos']];
   if (!injector) {
-    dev().warn(TAG, 'No injector for position');
+    user().warn(TAG, 'No injector for position');
     return;
   }
   const anchor = placementObj['anchor'];
   if (!anchor) {
-    dev().warn(TAG, 'No anchor in placement');
+    user().warn(TAG, 'No anchor in placement');
     return;
   }
   const anchorElements =
       getAnchorElements(win.document.documentElement, anchor);
   if (!anchorElements.length) {
-    dev().warn(TAG, 'No anchor element found');
+    user().warn(TAG, 'No anchor element found');
     return;
   }
   let margins = undefined;
@@ -282,7 +282,7 @@ function getPlacementsFromObject(win, placementObj, placements) {
 function getAnchorElements(rootElement, anchorObj) {
   const selector = anchorObj['selector'];
   if (!selector) {
-    dev().warn(TAG, 'No selector in anchor');
+    user().warn(TAG, 'No selector in anchor');
     return [];
   }
   let elements = [].slice.call(scopedQuerySelectorAll(rootElement, selector));
@@ -323,13 +323,13 @@ function isPositionValid(anchorElement, position) {
       position == Position.BEFORE || position == Position.AFTER ?
           anchorElement.parentElement : anchorElement;
   if (!elementToCheckOrNull) {
-    dev().warn(TAG, 'Parentless anchor with BEFORE/AFTER position.');
+    user().warn(TAG, 'Parentless anchor with BEFORE/AFTER position.');
     return false;
   }
   const elementToCheck = dev().assertElement(elementToCheckOrNull);
   return !BLACKLISTED_ANCESTOR_TAGS.some(tagName => {
     if (closestByTag(elementToCheck, tagName)) {
-      dev().warn(TAG, 'Placement inside blacklisted ancestor: ' + tagName);
+      user().warn(TAG, 'Placement inside blacklisted ancestor: ' + tagName);
       return true;
     }
     return false;


### PR DESCRIPTION
This moves all configuration errors into the user logs. The configurations aren't the AMP developers' responsibility, they're the ad server's.

This also cancels the entire promise queue if fetching/parsing of the configuration fails. There's no point in running any of the other code if it does.

Fixes https://github.com/ampproject/amphtml/issues/8997.
Fixes https://github.com/ampproject/amphtml/issues/8998.
Fixes #9023.

/to @tlong2 