### PR TITLE
added test for handleRequest in test-amp-viewer-integration

### DIFF
--- a/extensions/amp-viewer-integration/0.1/test/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-amp-viewer-integration.js
@@ -221,6 +221,35 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
       expect(resolveSpy).to.have.been.calledWith(JSON.stringify(data));
     });
 
+    it('handleMessage_ should resolve with correct data', () => {
+      const data = 12345;
+
+      const event = {
+        source: window,
+        origin: viewerOrigin,
+        data: {
+          app: '__AMPHTML__',
+          data,
+          name: 'messageName',
+          requestid: 1,
+          rsvp: true,
+          type: 's',
+        },
+      };
+
+      const resolveSpy = sandbox.stub();
+      const rejectSpy = sandbox.stub();
+      const waitingForResponse = {'1': {
+        resolve: resolveSpy,
+        reject: rejectSpy,
+      }};
+
+      sandbox.stub(messaging, 'waitingForResponse_', waitingForResponse);
+      messaging.handleMessage_(event);
+
+      expect(resolveSpy).to.have.been.calledWith(data);
+    });
+
     it('handleMessage_ should reject', () => {
       const event = {
         source: window,


### PR DESCRIPTION
handleMessage_ should resolve with the correct data without being manipulated