### PR TITLE
Fix flaky amp-ad-3p-impl preconnect test

### DIFF
--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -179,10 +179,8 @@ describe('amp-ad-3p-impl', () => {
     });
   });
 
-  // TODO(#8965) unskip test
   describe('preconnectCallback', () => {
-    it.configure().skipOldChrome()
-    .run('should add preconnect and prefech to DOM header', () => {
+    it('should add preconnect and prefech to DOM header', () => {
       ad3p.buildCallback();
       ad3p.preconnectCallback();
       return whenFirstVisible.then(() => {

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -19,7 +19,9 @@ import {getService, getServiceForDoc} from '../src/service';
 
 export function stubService(sandbox, win, serviceId, method) {
   const service = getService(win, serviceId, () => {
-    return {};
+    return {
+      [method]: () => {},
+    };
   });
   return sandbox.stub(service, method);
 }

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -18,13 +18,10 @@ import {xhrServiceForTesting} from '../src/service/xhr-impl';
 import {getService, getServiceForDoc} from '../src/service';
 
 export function stubService(sandbox, win, serviceId, method) {
-  const stub = sandbox.stub();
-  getService(win, serviceId, () => {
-    const service = {};
-    service[method] = stub;
-    return service;
+  const service = getService(win, serviceId, () => {
+    return {};
   });
-  return stub;
+  return sandbox.stub(service, method);
 }
 
 export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {

--- a/third_party/babel/custom-babel-helpers.js
+++ b/third_party/babel/custom-babel-helpers.js
@@ -92,5 +92,6 @@
 
   babelHelpers.defineProperty = function(obj, key, value) {
       obj[key] = value;
+      return obj;
   };
 })(typeof global === "undefined" ? self : global);


### PR DESCRIPTION
The issue was that the old `stubService` would only stub unregistered services.