### PR TITLE
Simple doc fix

### DIFF
--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -53,7 +53,7 @@ limitations under the License.
     - `<amp-list>`
     - `<amp-live-list>`
     - `<amp-social-share>`
-- The max-height of the sidebar is 100vh, if the height exceeds 100vh then a vertical scrollbar appears. The default height is set to 100vw in CSS and is overridable in CSS.
+- The max-height of the sidebar is 100vh, if the height exceeds 100vh then a vertical scrollbar appears. The default height is set to 100vh in CSS and is overridable in CSS.
 - The width of the sidebar can be set and adjusted between 45px and 80vw using CSS.
 - Touch zoom is disabled on the `amp-sidebar` and it's mask when the sidebar is open.
 


### PR DESCRIPTION
Most people probably figured it out, but the default height for the sidebar is set at 100vh, not 100vw.