### PR TITLE
Fast Fetch after swipe back does not send ad request

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -174,6 +174,7 @@ export function googleAdUrl(
         {name: 'isw', value: viewportSize.width},
         {name: 'ish', value: viewportSize.height},
         {name: 'pfx', value: pfx},
+        {name: 'rc', value: a4a.fromResumeCallback ? 1 : null},
       ],
       unboundedQueryParams,
       [

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -453,8 +453,8 @@ export class AmpA4A extends AMP.BaseElement {
       return false;
     }
     if (!isAdPositionAllowed(this.element, this.win)) {
-      user().warn(`<${this.element.tagName}> is not allowed to be placed in ` +
-        `elements with position:fixed: ${this.element}`);
+      user().warn(TAG, `<${this.element.tagName}> is not allowed to be ` +
+        `placed in elements with position:fixed: ${this.element}`);
       return false;
     }
     // OnLayoutMeasure can be called when page is in prerender so delay until

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -167,6 +167,7 @@ export const LIFECYCLE_STAGES = {
   firstVisible: '24',
   visLoadAndOneSec: '25',
   iniLoad: '26',
+  resumeCallback: '27'
 };
 
 /**
@@ -329,8 +330,9 @@ export class AmpA4A extends AMP.BaseElement {
     this.iframe = null;
 
     /**
-     * @return whether most recent ad request was generated as part of resume
-     *    callback.
+     * TODO(keithwrightbos) - remove once resume behavior is verified.
+     * @return {boolean} whether most recent ad request was generated as part
+     *    of resume callback.
      */
     this.fromResumeCallback = false;
   }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -331,7 +331,7 @@ export class AmpA4A extends AMP.BaseElement {
 
     /**
      * TODO(keithwrightbos) - remove once resume behavior is verified.
-     * @return {boolean} whether most recent ad request was generated as part
+     * {boolean} whether most recent ad request was generated as part
      *    of resume callback.
      */
     this.fromResumeCallback = false;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -167,7 +167,7 @@ export const LIFECYCLE_STAGES = {
   firstVisible: '24',
   visLoadAndOneSec: '25',
   iniLoad: '26',
-  resumeCallback: '27'
+  resumeCallback: '27',
 };
 
 /**

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -45,6 +45,7 @@ import {resetScheduledElementForTesting} from '../../../../src/custom-element';
 import {urlReplacementsForDoc} from '../../../../src/services';
 import {incrementLoadingAds} from '../../../amp-ad/0.1/concurrent-load';
 import {platformFor} from '../../../../src/services';
+import {Resource} from '../../../../src/service/resource';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import {dev, user} from '../../../../src/log';
 import {createElementWithAttributes} from '../../../../src/dom';
@@ -641,6 +642,55 @@ describe('amp-a4a', () => {
   });
 
   describe('#onLayoutMeasure', () => {
+    it('resumeCallback calls onLayoutMeasure', () => {
+      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
+      return createIframePromise().then(fixture => {
+        setupForAdTesting(fixture);
+        const doc = fixture.doc;
+        const a4aElement = createA4aElement(doc);
+        const s = doc.createElement('style');
+        s.textContent = '.fixed {position:fixed;}';
+        doc.head.appendChild(s);
+        const a4a = new MockA4AImpl(a4aElement);
+        const renderAmpCreativeSpy = sandbox.spy(a4a, 'renderAmpCreative_');
+        a4a.onLayoutMeasure();
+        expect(a4a.adPromise_).to.be.ok;
+        a4a.layoutCallback().then(() => {
+          expect(renderAmpCreativeSpy.calledOnce,
+              'renderAmpCreative_ called exactly once').to.be.true;
+          a4a.unlayoutCallback();
+          const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
+          a4a.resumeCallback();
+          expect(onLayoutMeasureSpy).to.be.calledOnce;
+          expect(a4a.fromResumeCallback).to.be.true;
+        });
+      });
+    });
+    it('resumeCallback w/ measure required no onLayoutMeasure', () => {
+      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
+      return createIframePromise().then(fixture => {
+        setupForAdTesting(fixture);
+        const doc = fixture.doc;
+        const a4aElement = createA4aElement(doc);
+        const s = doc.createElement('style');
+        s.textContent = '.fixed {position:fixed;}';
+        doc.head.appendChild(s);
+        const a4a = new MockA4AImpl(a4aElement);
+        const renderAmpCreativeSpy = sandbox.spy(a4a, 'renderAmpCreative_');
+        a4a.onLayoutMeasure();
+        expect(a4a.adPromise_).to.be.ok;
+        a4a.layoutCallback().then(() => {
+          expect(renderAmpCreativeSpy.calledOnce,
+              'renderAmpCreative_ called exactly once').to.be.true;
+          a4a.unlayoutCallback();
+          const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
+          sandbox.stub(Resource, 'hasBeenMeasured').returns(false);
+          a4a.resumeCallback();
+          expect(onLayoutMeasureSpy).to.never.be.called;
+          expect(a4a.fromResumeCallback).to.be.true;
+        });
+      });
+    });
     it('should run end-to-end and render in friendly iframe', () => {
       xhrMock.withArgs(TEST_URL, {
         mode: 'cors',
@@ -718,7 +768,8 @@ describe('amp-a4a', () => {
         doc.head.appendChild(s);
         a4aElement.className = 'fixed';
         const a4a = new MockA4AImpl(a4aElement);
-        expect(a4a.onLayoutMeasure.bind(a4a)).to.throw(/fixed/);
+        a4a.onLayoutMeasure();
+        expect(a4a.adPromise_).to.not.be.ok;
       });
     });
     it('does not initialize promise chain 0 height/width', () => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -418,7 +418,8 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
       const ampAnalyticsElement = impl.element.querySelector('amp-analytics');
       expect(ampAnalyticsElement).to.be.ok;
       expect(ampAnalyticsElement.CONFIG).jsonEqual(impl.ampAnalyticsConfig_);
-      expect(ampAnalyticsElement.getAttribute('sandbox')).to.equal('true');;
+      expect(ampAnalyticsElement.getAttribute('sandbox')).to.equal('true');
+      expect(impl.ampAnalyticsElement_).to.be.ok;
       // Exact format of amp-analytics element covered in
       // test/functional/test-analytics.js.
       // Just ensure extensions is loaded, and analytics element appended.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -224,7 +224,8 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
       const ampAnalyticsElement = impl.element.querySelector('amp-analytics');
       expect(ampAnalyticsElement).to.be.ok;
       expect(ampAnalyticsElement.CONFIG).jsonEqual(impl.ampAnalyticsConfig_);
-      expect(ampAnalyticsElement.getAttribute('sandbox')).to.equal('true');;
+      expect(ampAnalyticsElement.getAttribute('sandbox')).to.equal('true');
+      expect(impl.ampAnalyticsElement_).to.be.ok;
       // Exact format of amp-analytics element covered in
       // test/functional/test-analytics.js.
       // Just ensure extensions is loaded, and analytics element appended.

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -21,6 +21,7 @@ import {
 import {createElementWithAttributes} from './dom';
 import {getAmpdoc} from './service';
 import {extensionsFor} from './services';
+import {dev} from './log';
 
 
 /**

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -71,6 +71,7 @@ export function triggerAnalyticsEvent(nodeOrDoc, eventType, opt_vars) {
  * @param {!Element} parentElement
  * @param {!JSONType} config
  * @param {boolean=} loadAnalytics
+ * @return {!Element} created analytics element
  */
 export function insertAnalyticsElement(
     parentElement, config, loadAnalytics = false) {
@@ -95,14 +96,11 @@ export function insertAnalyticsElement(
     // Get Extensions service and force load analytics extension.
     const extensions = extensionsFor(parentElement.ownerDocument.defaultView);
     extensions./*OK*/loadExtension('amp-analytics');
-    parentElement.appendChild(analyticsElem);
-    return;
+  } else {
+    analyticsForDocOrNull(parentElement).then(analytics => {
+      dev().assert(analytics);
+    });
   }
-
-  analyticsForDocOrNull(parentElement).then(analytics => {
-    if (!analytics) {
-      return;
-    }
-    parentElement.appendChild(analyticsElem);
-  });
+  parentElement.appendChild(analyticsElem);
+  return analyticsElem;
 }

--- a/test/functional/test-analytics.js
+++ b/test/functional/test-analytics.js
@@ -103,7 +103,7 @@ describes.realWin('analytics', {amp: true}, env => {
         },
       };
       expect(baseEle.element.querySelector('amp-analytics')).to.be.null;
-      insertAnalyticsElement(baseEle.element, config, true);
+      expect(insertAnalyticsElement(baseEle.element, config, true)).to.be.ok;
       return timer.promise(50).then(() => {
         const analyticsEle = baseEle.element.querySelector('amp-analytics');
         expect(analyticsEle).to.not.be.null;


### PR DESCRIPTION
Steps to reproduce:

- Within AMP viewer go to page that supports and has Fast Fetch enabled
- Swipe to another page.  Creative frame is removed and state is reset.
- Swipe back.  onLayoutMeasure does not execute therefore no ad request is sent

Adds resumeCallback which will call onLayoutMeasure if measure is not already required.

Additionally added the following:

- Remove separate boolean to track if layout measure was executed and instead rely on adPromise being null
- Report if adPromise is null in layoutCallback when not expected
- Fix issue where amp-analytics element is not being removed from adsense/doubleclick extensions as insertAnalyticsElement was not returning the element

cc/ @ampproject/a4a 