### PR TITLE
Duplicate errors that are un-writable

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -31,7 +31,7 @@ import {
 } from '../../../src/friendly-iframe-embed';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
-import {dev, user} from '../../../src/log';
+import {dev, user, duplicateErrorIfNecessary} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject, isEnumValue} from '../../../src/types';
 import {some} from '../../../src/utils/promise';
@@ -797,7 +797,9 @@ export class AmpA4A extends AMP.BaseElement {
       throw error;
     }
 
-    if (!error || !error.message) {
+    if (error && error.message) {
+      error = duplicateErrorIfNecessary(error);
+    } else {
       error = new Error('unknown error ' + error);
     }
     if (opt_ignoreStack) {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -798,7 +798,7 @@ export class AmpA4A extends AMP.BaseElement {
     }
 
     if (error && error.message) {
-      error = duplicateErrorIfNecessary(error);
+      error = duplicateErrorIfNecessary(/** @type {!Error} */(error));
     } else {
       error = new Error('unknown error ' + error);
     }

--- a/src/error.js
+++ b/src/error.js
@@ -89,7 +89,7 @@ export function reportError(error, opt_associatedElement) {
     let isValidError;
     if (error) {
       if (error.message !== undefined) {
-        error = duplicateErrorIfNecessary(error);
+        error = duplicateErrorIfNecessary(/** @type {!Error} */(error));
         isValidError = true;
       } else {
         const origError = error;

--- a/src/error.js
+++ b/src/error.js
@@ -23,6 +23,7 @@ import {
 import {
   USER_ERROR_SENTINEL,
   isUserErrorMessage,
+  duplicateErrorIfNecessary,
 } from './log';
 import {isProxyOrigin} from './url';
 import {isCanary, experimentTogglesOrNull} from './experiments';
@@ -88,6 +89,7 @@ export function reportError(error, opt_associatedElement) {
     let isValidError;
     if (error) {
       if (error.message !== undefined) {
+        error = duplicateErrorIfNecessary(error);
         isValidError = true;
       } else {
         const origError = error;

--- a/src/log.js
+++ b/src/log.js
@@ -381,6 +381,7 @@ export class Log {
    * @private
    */
   prepareError_(error) {
+    error = duplicateErrorIfNecessary(error);
     if (this.suffix_) {
       if (!error.message) {
         error.message = this.suffix_;
@@ -417,6 +418,30 @@ function pushIfNonEmpty(array, val) {
   }
 }
 
+/**
+ * Some exceptions (DOMException, namely) have read-only message.
+ * @param {!Error} error
+ * @return {!Error};
+ */
+export function duplicateErrorIfNecessary(error) {
+  const message = error.message;
+  const test = String(Math.random());
+  error.message = test;
+
+  if (error.message === test) {
+    error.message = message;
+    return error;
+  }
+
+  const e = new Error(error.message);
+  // Copy all the extraneous things we attach.
+  for (const prop in error) {
+    e[prop] = error[prop];
+  }
+  // Ensure these are copied.
+  e.stack = error.stack;
+  return e;
+}
 
 /**
  * @param {...*} var_args
@@ -429,7 +454,7 @@ function createErrorVargs(var_args) {
   for (let i = 0; i < arguments.length; i++) {
     const arg = arguments[i];
     if (arg instanceof Error && !error) {
-      error = arg;
+      error = duplicateErrorIfNecessary(arg);
     } else {
       if (message) {
         message += ' ';
@@ -437,9 +462,10 @@ function createErrorVargs(var_args) {
       message += arg;
     }
   }
+
   if (!error) {
     error = new Error(message);
-  } else if (message) {
+  } if (message) {
     error.message = message + ': ' + error.message;
   }
   return error;

--- a/src/log.js
+++ b/src/log.js
@@ -465,7 +465,7 @@ function createErrorVargs(var_args) {
 
   if (!error) {
     error = new Error(message);
-  } if (message) {
+  } else if (message) {
     error.message = message + ': ' + error.message;
   }
   return error;

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -19,7 +19,7 @@ import {findIndex} from '../utils/array';
 import {map} from '../utils/object';
 import {documentStateFor} from './document-state';
 import {registerServiceBuilderForDoc} from '../service';
-import {dev} from '../log';
+import {dev, duplicateErrorIfNecessary} from '../log';
 import {isIframed} from '../dom';
 import {
   parseQueryString,
@@ -934,6 +934,7 @@ function parseParams_(str, allParams) {
  */
 function getChannelError(opt_reason) {
   if (opt_reason instanceof Error) {
+    opt_reason = duplicateErrorIfNecessary(opt_reason);
     opt_reason.message = 'No messaging channel: ' + opt_reason.message;
     return opt_reason;
   }

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -536,7 +536,7 @@ describe.only('Logging', () => {
     let log;
     let reportedError;
 
-    beforeEach(function () {
+    beforeEach(function() {
       log = new Log(win, RETURNS_OFF);
       setReportError(function(e) {
         reportedError = e;

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -23,6 +23,7 @@ import {
   rethrowAsync,
   setReportError,
   user,
+  duplicateErrorIfNecessary,
 } from '../../src/log';
 import * as sinon from 'sinon';
 

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -27,7 +27,7 @@ import {
 } from '../../src/log';
 import * as sinon from 'sinon';
 
-describe.only('Logging', () => {
+describe('Logging', () => {
 
   const RETURNS_FINE = () => LogLevel.FINE;
   const RETURNS_INFO = () => LogLevel.INFO;


### PR DESCRIPTION
Certain errors (`DOMException`s, really) have un-writable error
messages. This mucks with our code, since we rewrite it to signal user
errors, give context, etc.

If an error's message isn't writable, duplicate the error with one that
is.

Fixes https://github.com/ampproject/amphtml/issues/8917.