### PR TITLE
Percy visual diff tests

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -20,7 +20,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 
 const percyCommand = 'percy snapshot';
-const defaultWidths = [750, 1080];  // iPhone: 750. Pixel: 1080.
+const defaultWidths = [375, 411];  // CSS widths: iPhone: 375, Pixel: 411.
 
 /**
  * Executes the provided command; terminates this program in case of failure.
@@ -154,7 +154,7 @@ gulp.task('visual-diff', 'Runs visual diff tests using Percy', runTests, {
   options: {
     'webpage': '  Path of the webpage being tested, relative to amphtml/.' +
         ' Used this as the baseurl while looking up snapshots on Percy.',
-    'widths': '  CSV with the widths to test. Defaults to '
-        + defaultWidths.toString() + '.'
+    'widths': '  CSV with the device CSS widths to test. Defaults to '
+        + defaultWidths.toString() + ' (iPhone and Pixel).'
   }
 });

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -129,6 +129,10 @@ function constructCommandLine(percyKeys) {
   commandLine.push('--baseurl /' + percyArgs.webpage);
   commandLine.push('--widths ' + percyArgs.widths);
 
+  // Other args.
+  commandLine.push('--enable_javascript');
+  commandLine.push('--include_all');
+
   // The webpage being tested is typically the last arg.
   commandLine.push(percyArgs.webpage);
 

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -14,18 +14,146 @@
  * limitations under the License.
  */
 
-var gulp = require('gulp-help')(require('gulp'));
-var util = require('gulp-util');
+const argv = require('minimist')(process.argv.slice(2));
+const child_process = require('child_process');
+const gulp = require('gulp-help')(require('gulp'));
+const util = require('gulp-util');
 
+const percyCommand = 'percy snapshot';
+const defaultWidths = [750, 1080];  // iPhone: 750. Pixel: 1080.
+
+/**
+ * Executes the provided command; terminates this program in case of failure.
+ * Copied from pr-check.js.
+ * TODO(rsimha-amp): Refactor this into a shared library. Issue #9038.
+ *
+ * @param {string} cmd
+ */
+function execOrDie(cmd) {
+  const p =
+      child_process.spawnSync('/bin/sh', ['-c', cmd], {'stdio': 'inherit'});
+  if (p.status != 0) {
+    console.error(`\n${fileLogPrefix}exiting due to failing command: ${cmd}`);
+    process.exit(p.status)
+  }
+}
+
+/**
+ * Extracts Percy project keys from the environment.
+ *
+ * @return {!Object} Object containing Percy project and token.
+ */
+function extractPercyKeys() {
+  // Repo slug to which to upload snapshots. Same as the Github repo slug.
+  let percyProject = '';
+  if (process.env.PERCY_PROJECT) {
+    percyProject = process.env.PERCY_PROJECT;
+  } else {
+    util.log(util.colors.red(
+        'PERCY_PROJECT must be specified as an environment variable'));
+    done();
+  }
+  util.log('Percy project: ', util.colors.magenta(percyProject));
+
+  // Secret token for the percy project.
+  let percyToken = '';
+  if (process.env.PERCY_TOKEN) {
+    percyToken = process.env.PERCY_TOKEN;
+  } else {
+    util.log(util.colors.red(
+        'PERCY_TOKEN must be specified as an environment variable'));
+    done();
+  }
+  util.log('Percy token: ', util.colors.magenta(percyToken));
+  return {
+    percyProject: percyProject,
+    percyToken: percyToken
+  };
+}
+
+/**
+ * Extracts Percy args from the command line.
+ *
+ * @return {!Object} Object containing extracted args.
+ */
+function extractPercyArgs() {
+  // Webpage to snapshot. This is a path, relative to amphtml/.
+  let webpage = '';
+  if (argv.webpage) {
+    webpage = argv.webpage;
+  } else {
+    console./*OK*/error(util.colors.red(
+        'Must specify a webpage to diff via --webpage'));
+    process.exit(1);
+  }
+  util.log('Webpage: ', util.colors.magenta(webpage));
+
+  // Smartphone screen widths to snapshot.
+  let widths = defaultWidths;
+  if (argv.widths) {
+    widths = JSON.parse("[" + argv.widths + "]");
+  }
+  util.log('Widths: ', util.colors.magenta(widths.toString()));
+
+  // TODO(rsimha): Separate out some test pages into directories, and then
+  // add an arg to include the directory containing assets for those pages.
+
+  return {
+    webpage: webpage,
+    widths: widths
+  };
+}
+
+/**
+ * Constructs the Percy command line with various args.
+ *
+ * @param {!Object} percyKeys Object containing access keys for the Percy repo.
+ * @return {String} Full command line to be executed.
+ */
+function constructCommandLine(percyKeys) {
+  let commandLine = [];
+
+  // Percy project keys.
+  commandLine.push('PERCY_PROJECT=' + percyKeys.percyProject);
+  commandLine.push('PERCY_TOKEN=' + percyKeys.percyToken);
+
+  // Main snapshot command.
+  commandLine.push(percyCommand);
+
+  // Percy repo slug. This matches up exactly with the amphtml Github repo slug.
+  commandLine.push('--repo ' + percyKeys.percyProject);
+
+  // Percy args.
+  const percyArgs = extractPercyArgs();
+  commandLine.push('--baseurl /' + percyArgs.webpage);
+  commandLine.push('--widths ' + percyArgs.widths);
+
+  // The webpage being tested is typically the last arg.
+  commandLine.push(percyArgs.webpage);
+
+  util.log('Executing command line:');
+  commandLine.forEach((command) => {
+    util.log('\t', util.colors.cyan(command));
+  });
+  return commandLine.join(' ');
+}
 
 /**
  * Run visual diff tests
- *
- * @param {function} done callback
  */
-function visualDiff() {
+function runTests() {
   util.log(util.colors.yellow('Running visual diff tests...'));
+  const percyKeys = extractPercyKeys();
+  const commandLine = constructCommandLine(percyKeys);
+  execOrDie(commandLine);
 }
 
 
-gulp.task('visual-diff', 'Runs Visual diff tests.', visualDiff);
+gulp.task('visual-diff', 'Runs visual diff tests using Percy', runTests, {
+  options: {
+    'webpage': '  Path of the webpage being tested, relative to amphtml/.' +
+        ' Used this as the baseurl while looking up snapshots on Percy.',
+    'widths': '  CSV with the widths to test. Defaults to '
+        + defaultWidths.toString() + '.'
+  }
+});

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -33,7 +33,8 @@ function execOrDie(cmd) {
   const p =
       child_process.spawnSync('/bin/sh', ['-c', cmd], {'stdio': 'inherit'});
   if (p.status != 0) {
-    console.error(`\n${fileLogPrefix}exiting due to failing command: ${cmd}`);
+    console/*OK*/.log(
+        `\n${fileLogPrefix}exiting due to failing command: ${cmd}`);
     process.exit(p.status)
   }
 }

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-require('./babel-helpers');
-require('./changelog');
-require('./clean');
-require('./compile');
-require('./compile-access-expr');
-require('./compile-bind-expr');
-require('./csvify-size');
-require('./dep-check');
-require('./get-zindex');
-require('./lint');
-require('./extension-generator');
-require('./prepend-global');
-require('./presubmit-checks');
-require('./serve');
-require('./size');
-require('./release-tagging');
-require('./runtime-test');
-require('./validator');
-require('./visual-diff');
+var gulp = require('gulp-help')(require('gulp'));
+var util = require('gulp-util');
+
+
+/**
+ * Run visual diff tests
+ *
+ * @param {function} done callback
+ */
+function visualDiff() {
+  util.log(util.colors.yellow('Running visual diff tests...'));
+}
+
+
+gulp.task('visual-diff', 'Runs Visual diff tests.', visualDiff);

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -21,6 +21,9 @@ const util = require('gulp-util');
 
 const percyCommand = 'percy snapshot';
 const defaultWidths = [375, 411];  // CSS widths: iPhone: 375, Pixel: 411.
+const percyProjectSeparator = '/';  // Standard format of repo slug: "foo/bar".
+const percyTokenLength = 64;  // Standard Percy API key length.
+
 
 /**
  * Executes the provided command; terminates this program in case of failure.
@@ -52,7 +55,7 @@ function extractPercyKeys() {
     process.exit(1);
   }
   const percyProject = process.env.PERCY_PROJECT;
-  if (!percyProject.includes('/')) {
+  if (!percyProject.includes(percyProjectSeparator)) {
     util.log(util.colors.red(
         'Error: PERCY_PROJECT doesn\'t look like a valid repo slug'));
     process.exit(1);
@@ -66,7 +69,7 @@ function extractPercyKeys() {
     process.exit(1);
   }
   const percyToken = process.env.PERCY_TOKEN;
-  if (percyToken.length != 64) {
+  if (percyToken.length != percyTokenLength) {
     util.log(util.colors.red(
         'Error: PERCY_TOKEN doesn\'t look like a valid Percy API key'));
     process.exit(1);


### PR DESCRIPTION
This CL adds a new gulp task called "visual-diff". It uses the Percy service (https://percy.io/) to snapshot a web page using the local state (HEAD) of the AMP runtime, and then compare it with previous known good snapshots.

This CL adds the argument parsing logic for the gulp task, and constructs a working Percy command line. It is not yet hooked up to Travis, as we're still using a free Percy account for ampproject/amphtml, and do not have the quota to run snapshot tests as part of every Travis PR check.

Usage:

1. Set environment variables for `PERCY_PROJECT` and `PERCY_TOKEN` specific to the ampproject/amphtml Percy project
2. Run `gulp visual-diff --webpage <relative path from amphtml/ of webpage to diff>  --widths <comma separated screen widths in pixels>`

e.g: `gulp visual-diff --webpage examples/article.amp.html  --widths 750,1080`

Fixes #9068 
Issue #8340  
