### PR TITLE
Fast Fetch, non-AMP creatives remove remove load promise requirement for removing loader

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -253,6 +253,7 @@ describe('amp-a4a', () => {
       delete headers[SIGNATURE_HEADER];
       // If rendering type is safeframe, we SHOULD attach a SafeFrame.
       headers[RENDERING_TYPE_HEADER] = 'safeframe';
+      a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
         const child = a4aElement.querySelector('iframe[name]');
@@ -272,6 +273,7 @@ describe('amp-a4a', () => {
       // safeframe).
       delete headers[RENDERING_TYPE_HEADER];
       fixture.doc.body.appendChild(a4aElement);
+      a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
         // Force vsync system to run all queued tasks, so that DOM mutations
@@ -287,6 +289,7 @@ describe('amp-a4a', () => {
     it('for cached content iframe rendering case', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
       delete headers[SIGNATURE_HEADER];
+      a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
         const child = a4aElement.querySelector('iframe[src]');
@@ -298,6 +301,7 @@ describe('amp-a4a', () => {
 
     it('for A4A friendly iframe rendering case', () => {
       expect(a4a.friendlyIframeEmbed_).to.not.exist;
+      a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
         const child = a4aElement.querySelector('iframe[srcdoc]');
@@ -626,6 +630,7 @@ describe('amp-a4a', () => {
         a4aElement.setAttribute('type', 'doubleclick');
         const a4a = new MockA4AImpl(a4aElement);
         doc.body.appendChild(a4aElement);
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         const renderPromise = a4a.layoutCallback();
         return renderPromise.then(() => {
@@ -815,6 +820,7 @@ describe('amp-a4a', () => {
           sandbox.stub(a4a, 'renderAmpCreative_').returns(
             Promise.reject('amp render failure'));
         }
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.instanceof(Promise);
         return a4a.adPromise_.then(promiseResult => {
@@ -929,13 +935,13 @@ describe('amp-a4a', () => {
         const lifecycleEventStub = sandbox.stub(
             a4a, 'protectedEmitLifecycleEvent_');
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.instanceof(Promise);
         return a4a.layoutCallback().then(() => {
           expect(getAdUrlSpy.calledOnce, 'getAdUrl called exactly once')
               .to.be.true;
           // Verify iframe presence and lack of visibility hidden
-          expect(a4aElement.children).to.have.lengthOf(1);
           const iframe = a4aElement.querySelector('iframe[src]');
           expect(iframe).to.be.ok;
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
@@ -952,12 +958,12 @@ describe('amp-a4a', () => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.adPromise_.then(() => a4a.layoutCallback().then(() => {
           // Verify iframe presence and lack of visibility hidden
-          expect(a4aElement.children).to.have.lengthOf(1);
-          const iframe = a4aElement.children[0];
-          expect(iframe.tagName).to.equal('IFRAME');
+          expect(a4aElement.querySelectorAll('iframe').length).to.equal(1);
+          const iframe = a4aElement.querySelectorAll('iframe')[0];
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
           expect(iframe).to.be.visible;
           expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
@@ -974,16 +980,16 @@ describe('amp-a4a', () => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         const layoutCallbackPromise = a4a.layoutCallback();
         rejectXhr(new Error('XHR Error'));
         return layoutCallbackPromise.then(() => {
           // Verify iframe presence and lack of visibility hidden
-          expect(a4aElement.children).to.have.lengthOf(1);
-          const iframe = a4aElement.children[0];
-          expect(iframe.tagName).to.equal('IFRAME');
+          expect(a4aElement.querySelectorAll('iframe').length).to.equal(1);
+          const iframe = a4aElement.querySelectorAll('iframe')[0];
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
-          expect(iframe.style.visibility).to.equal('');
+          expect(iframe).to.be.visible;
           expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
         });
       });

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -193,9 +193,6 @@ export class AmpAdXOriginIframeHandler {
     });
 
     this.element_.appendChild(this.iframe);
-    // Set iframe initially hidden which will be removed on render-start or
-    // load, whichever is earlier.
-    setStyle(this.iframe, 'visibility', 'hidden');
     if (opt_isA4A) {
       // A4A writes creative frame directly to page once creative is received
       // and therefore does not require render start message so attach and
@@ -204,10 +201,13 @@ export class AmpAdXOriginIframeHandler {
       // that occurred for Fast Fetch.
       this.renderStart_();
       renderStartResolve();
-    }
-    if (this.baseInstance_.lifecycleReporter) {
+    } else {
+      // Set iframe initially hidden which will be removed on render-start or
+      // load, whichever is earlier.
+      setStyle(this.iframe, 'visibility', 'hidden');
       this.baseInstance_.lifecycleReporter.addPingsForVisibility(this.element_);
     }
+
     Promise.race([
       renderStartPromise,
       iframeLoadPromise,

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -193,13 +193,13 @@ export class AmpAdXOriginIframeHandler {
     });
 
     if (opt_isA4A) {
-      // A4A writes creative frame directly to page therefore does not expect
-      // post message to unset visibility hidden
+      // A4A writes creative frame directly to page once creative is received
+      // and therefore does not require render start message so attach and
+      // impose no loader delay.  Network is using renderStart or
+      // bootstrap-loaded to indicate ad request was sent, either way we know
+      // that occurred for Fast Fetch.
       this.element_.appendChild(this.iframe);
-      // TODO(dvoytenko): if this is guaranteed to be a quasi-valid AMP creative
-      // then the `ini-load` message will work better here. Reconsider once
-      // `ini-load` message is supported in the in-a-box.
-      return iframeLoadPromise;
+      return Promise.resolve();
     }
 
     // Set iframe initially hidden which will be removed on render-start or

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -193,6 +193,9 @@ export class AmpAdXOriginIframeHandler {
     });
 
     this.element_.appendChild(this.iframe);
+    // Set iframe initially hidden which will be removed on render-start or
+    // load, whichever is earlier.
+    setStyle(this.iframe, 'visibility', 'hidden');
     if (opt_isA4A) {
       // A4A writes creative frame directly to page once creative is received
       // and therefore does not require render start message so attach and
@@ -201,10 +204,8 @@ export class AmpAdXOriginIframeHandler {
       // that occurred for Fast Fetch.
       this.renderStart_();
       renderStartResolve();
-    } else {
-      // Set iframe initially hidden which will be removed on render-start or
-      // load, whichever is earlier.
-      setStyle(this.iframe, 'visibility', 'hidden');
+    }
+    if (this.baseInstance_.lifecycleReporter) {
       this.baseInstance_.lifecycleReporter.addPingsForVisibility(this.element_);
     }
     Promise.race([

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -96,8 +96,6 @@ export class AmpAdXOriginIframeHandler {
           this.element_.creativeId = info.data.id;
         });
 
-    // TODO(keithwrightbos) - move to within not A4A else block to ensure this
-    // is only available to ad networks?
     this.unlisteners_.push(listenFor(this.iframe, 'get-html',
       (info, source, origin) => {
         if (!this.iframe) {
@@ -144,15 +142,6 @@ export class AmpAdXOriginIframeHandler {
       });
     }
 
-    // Wait for initial load signal. Notice that this signal is not
-    // used to resolve the final layout promise because iframe may still be
-    // consuming significant network and CPU resources.
-    listenForOncePromise(this.iframe, CommonSignals.INI_LOAD, true).then(() => {
-      // TODO(dvoytenko, #7788): ensure that in-a-box "ini-load" message is
-      // received here as well.
-      this.baseInstance_.signals().signal(CommonSignals.INI_LOAD);
-    });
-
     // Calculate render-start and no-content signals.
     let renderStartResolve;
     const renderStartPromise = new Promise(resolve => {
@@ -163,7 +152,7 @@ export class AmpAdXOriginIframeHandler {
       noContentResolve = resolve;
     });
     if (this.baseInstance_.config &&
-      this.baseInstance_.config.renderStartImplemented) {
+            this.baseInstance_.config.renderStartImplemented) {
       // When `render-start` is supported, these signals are mutually
       // exclusive. Whichever arrives first wins.
       listenForOncePromise(this.iframe,
@@ -193,6 +182,16 @@ export class AmpAdXOriginIframeHandler {
         noContentResolve();
       });
     }
+
+    // Wait for initial load signal. Notice that this signal is not
+    // used to resolve the final layout promise because iframe may still be
+    // consuming significant network and CPU resources.
+    listenForOncePromise(this.iframe, CommonSignals.INI_LOAD, true).then(() => {
+      // TODO(dvoytenko, #7788): ensure that in-a-box "ini-load" message is
+      // received here as well.
+      this.baseInstance_.signals().signal(CommonSignals.INI_LOAD);
+    });
+
     this.element_.appendChild(this.iframe);
     if (opt_isA4A) {
       // A4A writes creative frame directly to page once creative is received

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -244,10 +244,12 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       };
     });
 
-    it('should resolve directly if it is A4A', () => {
-      return iframeHandler.init(iframe, true).then(() => {
+    it('should be immediately visible if it is A4A', () => {
+      const initPromise = iframeHandler.init(iframe, true);
+      expect(iframe).to.be.visible;
+      initPromise.then(() => {
         expect(iframe.style.visibility).to.equal('');
-        expect(iframe.readyState).to.not.equal('complete');
+        expect(iframe.readyState).to.equal('complete');
       });
     });
   });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -247,7 +247,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     it('should resolve directly if it is A4A', () => {
       return iframeHandler.init(iframe, true).then(() => {
         expect(iframe.style.visibility).to.equal('');
-        expect(iframe.readyState).to.equal('complete');
+        expect(iframe.readyState).to.not.equal('complete');
       });
     });
   });


### PR DESCRIPTION
Fast Fetch, non-AMP creatives require load before loading message is removed.  This does not meet parity with delayed fetch that uses either bootstrap-loaded or render-start messages both of which serve to indicate ad tag has executed (and for render-start gotten an ad response).  Given Fast Fetch does not write the xdomain frame until both of those have occurred, no need to wait.

cc/ @ampproject/a4a 