### PR TITLE
AMP Fast Fetch: Attempt to revert resize changes within unlayoutCallback

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -881,7 +881,7 @@ export class AmpA4A extends AMP.BaseElement {
     // unlayoutCallback so that it is reverted to original size in case
     // of resumeCallback.
     this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
-    super.attemptChangeSize(newHeight, newWidth).catch(() => {});
+    return super.attemptChangeSize(newHeight, newWidth).catch(() => {});
   }
 
   /** @override  */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -896,7 +896,7 @@ export class AmpA4A extends AMP.BaseElement {
         .then(() => {
           this.originalSlotSize_ = null;
         })
-        .catch((err) => {
+        .catch(err => {
           // TODO(keithwrightbos): if we are unable to revert size, on next
           // trigger of promise chain the ad request may fail due to invalid
           // slot size.  Determine how to handle this case.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -880,7 +880,7 @@ export class AmpA4A extends AMP.BaseElement {
     // Store original size of slot in order to allow re-expansion on
     // unlayoutCallback so that it is reverted to original size in case
     // of resumeCallback.
-    this.originalSlotSize_ = this.getIntersectionElementLayoutBox();
+    this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
     super.attemptChangeSize(newHeight, newWidth).catch(() => {});
   }
 
@@ -891,18 +891,17 @@ export class AmpA4A extends AMP.BaseElement {
     this.protectedEmitLifecycleEvent_('adSlotCleared');
     this.uiHandler.setDisplayState(AdDisplayState.NOT_LAID_OUT);
     if (this.originalSlotSize_) {
-      // Attempt to revert any size change, this could fail but is unlikely as
-      // we can assume the document is no longer visible.
-      protectFunctionWrapper(
-        () => {
-          super.attemptChangeSize(
-            this.originalSlotSize_.height, this.originalSlotSize_.width);
-        }, this,
-        (err, varArgs) => {
-          dev().error(TAG, this.element.getAttribute('type'),
-              'Error attempting to revert resize', err, varArgs) ;
-        })();
-      this.originalSlotSize_ = null;
+      super.attemptChangeSize(
+        this.originalSlotSize_.height, this.originalSlotSize_.width)
+        .then(() => {
+          this.originalSlotSize_ = null;
+        })
+        .catch((err) => {
+          // TODO(keithwrightbos): if we are unable to revert size, on next
+          // trigger of promise chain the ad request may fail due to invalid
+          // slot size.  Determine how to handle this case.
+          dev().warn(TAG, 'unable to revert to original size', err);
+        });
     }
 
     this.isCollapsed_ = false;
@@ -986,7 +985,7 @@ export class AmpA4A extends AMP.BaseElement {
     dev().assert(this.uiHandler);
     // Store original size to allow for reverting on unlayoutCallback so that
     // subsequent pageview allows for ad request.
-    this.originalSlotSize_ = this.getIntersectionElementLayoutBox();
+    this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
     this.uiHandler.setDisplayState(AdDisplayState.LOADING);
     this.uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
     this.isCollapsed_ = true;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -44,7 +44,7 @@ import {utf8Encode} from '../../../../src/utils/bytes';
 import {resetScheduledElementForTesting} from '../../../../src/custom-element';
 import {urlReplacementsForDoc} from '../../../../src/services';
 import {incrementLoadingAds} from '../../../amp-ad/0.1/concurrent-load';
-import {platformFor} from '../../../../src/services';
+import {platformFor, timerFor} from '../../../../src/services';
 import {Resource} from '../../../../src/service/resource';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import {dev, user} from '../../../../src/log';
@@ -1013,8 +1013,7 @@ describe('amp-a4a', () => {
         a4a.uiHandler = {
           setDisplayState: state => {expectStates.push(state);},
         };
-        sandbox.stub(a4a, 'getIntersectionElementLayoutBox').returns(
-          {width: 123, height: 456});
+        sandbox.stub(a4a, 'getLayoutBox').returns({width: 123, height: 456});
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;
         return a4a.adPromise_.then(() => {
@@ -1028,9 +1027,18 @@ describe('amp-a4a', () => {
             // call unlayout callback and verify it attempts to revert the size
             expect(a4a.originalSlotSize_).to.deep
               .equal({width: 123, height: 456});
-            sandbox.stub(AMP.BaseElement.prototype, 'attemptChangeSize');
+            let attemptChangeSizeResolver;
+            const attemptChangeSizePromise = new Promise(resolve => {
+              attemptChangeSizeResolver = resolve;
+            });
+            sandbox.stub(AMP.BaseElement.prototype, 'attemptChangeSize')
+              .returns(attemptChangeSizePromise);
             a4a.unlayoutCallback();
-            expect(a4a.originalSlotSize_).to.not.be.ok;
+            expect(a4a.originalSlotSize_).to.be.ok;
+            attemptChangeSizeResolver();
+            return timerFor(a4a.win).promise(1).then(() => {
+              expect(a4a.originalSlotSize_).to.not.be.ok;
+            });
           });
         });
       });
@@ -1058,8 +1066,7 @@ describe('amp-a4a', () => {
         a4a.uiHandler = {
           setDisplayState: state => {expectStates.push(state);},
         };
-        sandbox.stub(a4a, 'getIntersectionElementLayoutBox').returns(
-          {width: 123, height: 456});
+        sandbox.stub(a4a, 'getLayoutBox').returns({width: 123, height: 456});
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;
         return a4a.adPromise_.then(() => {
@@ -1073,9 +1080,18 @@ describe('amp-a4a', () => {
             // call unlayout callback and verify it attempts to revert the size
             expect(a4a.originalSlotSize_).to.deep
               .equal({width: 123, height: 456});
-            sandbox.stub(AMP.BaseElement.prototype, 'attemptChangeSize');
+            let attemptChangeSizeResolver;
+            const attemptChangeSizePromise = new Promise(resolve => {
+              attemptChangeSizeResolver = resolve;
+            });
+            sandbox.stub(AMP.BaseElement.prototype, 'attemptChangeSize')
+              .returns(attemptChangeSizePromise);
             a4a.unlayoutCallback();
-            expect(a4a.originalSlotSize_).to.not.be.ok;
+            expect(a4a.originalSlotSize_).to.be.ok;
+            attemptChangeSizeResolver();
+            return timerFor(a4a.win).promise(1).then(() => {
+              expect(a4a.originalSlotSize_).to.not.be.ok;
+            });
           });
         });
       });


### PR DESCRIPTION
When users swipe between pages within the viewer, unlayoutCallback is executed which resets state.  This reset should include attempting to revert the slot size back to its original as it could have been modified via resizes or collapse.

cc/ @ampproject/a4a 