### PR TITLE
Enable old chrome saucelabs testing

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -218,7 +218,7 @@ const command = {
     // All unit tests with an old chrome (best we can do right now to pass tests
     // and not start relying on new features).
     // Disabled because it regressed. Better to run the other saucelabs tests.
-    // execOrDie(`${gulp} test --nobuild --saucelabs --oldchrome --compiled`);
+    execOrDie(`${gulp} test --nobuild --saucelabs --oldchrome --compiled`);
   },
   presubmit: function() {
     execOrDie(`${gulp} presubmit`);


### PR DESCRIPTION
Fix https://github.com/ampproject/amphtml/issues/9030
Revert of https://github.com/ampproject/amphtml/pull/9034
I think my change https://github.com/ampproject/amphtml/pull/9041 might fix the old chrome from failing so we can try to enable it