### PR TITLE
Revert "Enable old chrome saucelabs testing (#9071)"

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -218,7 +218,7 @@ const command = {
     // All unit tests with an old chrome (best we can do right now to pass tests
     // and not start relying on new features).
     // Disabled because it regressed. Better to run the other saucelabs tests.
-    execOrDie(`${gulp} test --nobuild --saucelabs --oldchrome --compiled`);
+    // execOrDie(`${gulp} test --nobuild --saucelabs --oldchrome --compiled`);
   },
   presubmit: function() {
     execOrDie(`${gulp} presubmit`);


### PR DESCRIPTION
Looks like #9071 is causing builds on master to consistently time out: 
```
01 05 2017 22:01:32.292:ERROR [launcher.sauce]: Heartbeat to chrome 45 failed
  [title()] Error response status: 13, , UnknownError - An unknown server-side error occurred while processing the command. Selenium error: ERROR Internal Server Error
```
https://travis-ci.org/ampproject/amphtml/builds/227734045