### PR TITLE
amp-bind: verify warning improvements

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -71,8 +71,9 @@ let BoundPropertyDef;
  */
 let BoundElementDef;
 
+/** @private {!Object<string, !Array<string>>} */
 const BIND_ONLY_ATTRIBUTES = map({
-  'amp-carousel' : ['slide'],
+  'amp-carousel': ['slide'],
   'amp-selector': ['selected'],
 });
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -17,22 +17,23 @@
 import {BindExpressionResultDef} from './bind-expression';
 import {BindingDef, BindEvaluator} from './bind-evaluator';
 import {BindValidator} from './bind-validator';
-import {chunk, ChunkPriority} from '../../../src/chunk';
-import {dev, user} from '../../../src/log';
-import {deepMerge} from '../../../src/utils/object';
-import {getMode} from '../../../src/mode';
-import {formOrNullForElement} from '../../../src/form';
-import {isArray, isObject, toArray} from '../../../src/types';
-import {isExperimentOn} from '../../../src/experiments';
-import {invokeWebWorker} from '../../../src/web-worker/amp-worker';
-import {isFiniteNumber} from '../../../src/types';
-import {reportError} from '../../../src/error';
 import {
   ampFormServiceForDoc,
   resourcesForDoc,
   viewerForDoc,
 } from '../../../src/services';
+import {chunk, ChunkPriority} from '../../../src/chunk';
+import {dev, user} from '../../../src/log';
+import {deepMerge} from '../../../src/utils/object';
+import {getMode} from '../../../src/mode';
 import {filterSplice} from '../../../src/utils/array';
+import {formOrNullForElement} from '../../../src/form';
+import {invokeWebWorker} from '../../../src/web-worker/amp-worker';
+import {isArray, isObject, toArray} from '../../../src/types';
+import {isExperimentOn} from '../../../src/experiments';
+import {isFiniteNumber} from '../../../src/types';
+import {map} from '../../../src/utils/object';
+import {reportError} from '../../../src/error';
 import {rewriteAttributeValue} from '../../../src/sanitizer';
 
 const TAG = 'amp-bind';
@@ -69,6 +70,11 @@ let BoundPropertyDef;
  * }}
  */
 let BoundElementDef;
+
+const BIND_ONLY_ATTRIBUTES = map({
+  'amp-carousel' : ['slide'],
+  'amp-selector': ['selected'],
+});
 
 /**
  * Bind is the service that handles the Bind lifecycle, from identifying
@@ -775,6 +781,13 @@ export class Bind {
    */
   verifyBinding_(boundProperty, element, expectedValue) {
     const property = boundProperty.property;
+
+    // Don't show a warning for bind-only attributes,
+    // like 'slide' on amp-carousel.
+    const bindOnlyAttrs = BIND_ONLY_ATTRIBUTES[element.tagName.toLowerCase()];
+    if (bindOnlyAttrs && bindOnlyAttrs.includes(property)) {
+      return;
+    }
 
     let initialValue;
     let match = true;

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -71,10 +71,15 @@ let BoundPropertyDef;
  */
 let BoundElementDef;
 
-/** @private {!Object<string, !Array<string>>} */
+/**
+ * A map of tag names to arrays of attributes that do not have non-bind
+ * counterparts. For instance, amp-carousel allows a `[slide]` attribute,
+ * but does not support a `slide` attribute.
+ * @private {!Object<string, !Array<string>>}
+ */
 const BIND_ONLY_ATTRIBUTES = map({
-  'amp-carousel': ['slide'],
-  'amp-selector': ['selected'],
+  'AMP-CAROUSEL': ['slide'],
+  'AMP-SELECTOR': ['selected'],
 });
 
 /**
@@ -785,7 +790,7 @@ export class Bind {
 
     // Don't show a warning for bind-only attributes,
     // like 'slide' on amp-carousel.
-    const bindOnlyAttrs = BIND_ONLY_ATTRIBUTES[element.tagName.toLowerCase()];
+    const bindOnlyAttrs = BIND_ONLY_ATTRIBUTES[element.tagName];
     if (bindOnlyAttrs && bindOnlyAttrs.includes(property)) {
       return;
     }


### PR DESCRIPTION
When #development=1, we shouldn't warn users that bind attributes don't match their non-bind counterparts when non-bind counterparts aren't valid AMP attributes. For instance, `amp-carousel` supports the `[slide]` bind attribute, but does not support a non-bind `slide` attribute. 

Fixes #8933 

/to @choumx 