### PR TITLE
amp-state: Prevent update cycles from [src] mutation

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -40,6 +40,15 @@ export class AmpState extends AMP.BaseElement {
   }
 
   /** @override */
+  activate(unusedInvocation) {
+    // TODO(choumx): Remove this after a few weeks in production.
+    const TAG = this.getName_();
+    user().error(TAG,
+        'Please use AMP.setState() action explicitly, e.g. ' +
+        'on="submit-success:AMP.setState({myAmpState: event.response})"');
+  }
+
+  /** @override */
   buildCallback() {
     user().assert(isBindEnabledFor(this.win),
         `Experiment "amp-bind" is disabled.`);
@@ -126,7 +135,7 @@ export class AmpState extends AMP.BaseElement {
     state[id] = json;
     bindForDoc(this.getAmpDoc()).then(bind => {
       bind.setState(state,
-          /* opt_skipEval */ isInit, /* opt_fromAmpState */ isInit);
+          /* opt_skipEval */ isInit, /* opt_isAmpStateMutation */ !isInit);
     });
   }
 

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -43,7 +43,8 @@ export class AmpState extends AMP.BaseElement {
   activate(invocation) {
     const event = invocation.event;
     if (event && event.detail) {
-      this.updateState_(event.detail.response, /* isInit */ false);
+      this.updateState_(event.detail.response,
+          /* isInit */ false, /* isMutation */ false);
     }
   }
 
@@ -70,7 +71,7 @@ export class AmpState extends AMP.BaseElement {
     }
     const src = mutations['src'];
     if (src !== undefined) {
-      this.fetchSrcAndUpdateState_(/* isInit */ false);
+      this.fetchSrcAndUpdateState_(/* isInit */ false, /* isMutation */ true);
     }
   }
 
@@ -87,7 +88,8 @@ export class AmpState extends AMP.BaseElement {
     // Fetch JSON from endpoint at `src` attribute if it exists,
     // otherwise parse child script tag.
     if (this.element.hasAttribute('src')) {
-      this.fetchSrcAndUpdateState_(/* isInit */ true);
+      this.fetchSrcAndUpdateState_(
+          /* isInit */ true, /* isMutation */ false);
       if (this.element.children.length > 0) {
         user().error(TAG, 'Should not have children if src attribute exists.');
       }
@@ -99,7 +101,7 @@ export class AmpState extends AMP.BaseElement {
           const json = tryParseJson(firstChild.textContent, e => {
             user().error(TAG, 'Failed to parse state. Is it valid JSON?', e);
           });
-          this.updateState_(json, /* isInit */ true);
+          this.updateState_(json, /* isInit */ true, /* isMutation */ false);
         } else {
           user().error(TAG,
               'State should be in a <script> tag with type="application/json"');
@@ -112,20 +114,22 @@ export class AmpState extends AMP.BaseElement {
 
   /**
    * @param {boolean} isInit
+   * @param {boolean} isMutation
    * @private
    */
-  fetchSrcAndUpdateState_(isInit) {
+  fetchSrcAndUpdateState_(isInit, isMutation) {
     fetchBatchedJsonFor(this.getAmpDoc(), this.element).then(json => {
-      this.updateState_(json, isInit);
+      this.updateState_(json, isInit, isMutation);
     });
   }
 
   /**
    * @param {*} json
    * @param {boolean} isInit
+   * @param {boolean} isMutation
    * @private
    */
-  updateState_(json, isInit) {
+  updateState_(json, isInit, isMutation) {
     if (json === undefined || json === null) {
       return;
     }
@@ -133,7 +137,7 @@ export class AmpState extends AMP.BaseElement {
     const state = Object.create(null);
     state[id] = json;
     bindForDoc(this.getAmpDoc()).then(bind => {
-      bind.setState(state, isInit);
+      bind.setState(state, isInit, isMutation);
     });
   }
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -172,16 +172,18 @@ export class Bind {
       return Promise.resolve();
     }
 
-    const promise = this.initializePromise_.then(() => {
-      user().fine(TAG, 'State updated; re-evaluating expressions...');
-      return this.evaluate_().then(results =>
-          this.apply_(results, opt_fromAmpState));
-    });
+    user().fine(TAG, 'State updated; re-evaluating expressions...');
+
+    const promise = this.initializePromise_
+        .then(() => this.evaluate_())
+        .then(results => this.apply_(results, opt_fromAmpState));
+
     if (getMode().test) {
       promise.then(() => {
         this.dispatchEventForTesting_('amp:bind:setState');
       });
     }
+
     return this.setStatePromise_ = promise;
   }
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -155,10 +155,10 @@ export class Bind {
    * evaluation unless `opt_skipEval` is false.
    * @param {!Object} state
    * @param {boolean=} opt_skipEval
-   * @param {boolean=} opt_fromAmpState
+   * @param {boolean=} opt_isAmpStateMutation
    * @return {!Promise}
    */
-  setState(state, opt_skipEval, opt_fromAmpState) {
+  setState(state, opt_skipEval, opt_isAmpStateMutation) {
     user().assert(this.enabled_, `Experiment "${TAG}" is disabled.`);
 
     // TODO(choumx): What if `state` contains references to globals?
@@ -176,7 +176,7 @@ export class Bind {
 
     const promise = this.initializePromise_
         .then(() => this.evaluate_())
-        .then(results => this.apply_(results, opt_fromAmpState));
+        .then(results => this.apply_(results, opt_isAmpStateMutation));
 
     if (getMode().test) {
       promise.then(() => {
@@ -632,16 +632,16 @@ export class Bind {
   /**
    * Applies expression results to the DOM.
    * @param {Object<string, ./bind-expression.BindExpressionResultDef>} results
-   * @param {boolean=} opt_fromAmpState
+   * @param {boolean=} opt_isAmpStateMutation
    * @private
    */
-  apply_(results, opt_fromAmpState) {
+  apply_(results, opt_isAmpStateMutation) {
     const applyPromises = [];
     this.boundElements_.forEach(boundElement => {
       const {element, boundProperties} = boundElement;
       // If this "apply" round is triggered by an <amp-state> mutation,
       // ignore updates to <amp-state> element to prevent update cycles.
-      if (opt_fromAmpState && element.tagName === 'AMP-STATE') {
+      if (opt_isAmpStateMutation && element.tagName === 'AMP-STATE') {
         return;
       }
       const updates = this.calculateUpdates_(boundProperties, results);

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -64,7 +64,9 @@ describes.realWin('AmpState', {
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
-      expect(fetchStub).calledWith(/* opt_isInit */ true);
+      expect(fetchStub).calledWithExactly(
+          /* isInit */ true, /* isMutation */ false);
+      expect(updateStub).to.not.have.been.called;
     });
   });
 
@@ -79,6 +81,7 @@ describes.realWin('AmpState', {
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
+      expect(fetchStub).to.not.have.been.called;
       expect(updateStub).calledWithMatch({foo: 'bar'});
     });
   });
@@ -95,6 +98,7 @@ describes.realWin('AmpState', {
 
     isVisibleStub.returns(true);
     ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
-    expect(fetchStub).calledWith(/* opt_isInit */ false);
+    expect(fetchStub).calledWithExactly(
+        /* isInit */ false, /* isMutation */ true);
   });
 });

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -50,6 +50,10 @@ describes.realWin('AmpState', {
     ampState = getAmpState();
 
     const impl = ampState.implementation_;
+
+    // For simpler testing, stub the fetching and update call to Bind service.
+    // - `fetchStub should only be called when fetching remote JSON data
+    // - `updateStub` should only be called when parsing a child script
     fetchStub = sandbox.stub(impl, 'fetchSrcAndUpdateState_');
     updateStub = sandbox.stub(impl, 'updateState_');
   });

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -68,8 +68,7 @@ describes.realWin('AmpState', {
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
-      expect(fetchStub).calledWithExactly(
-          /* isInit */ true, /* isMutation */ false);
+      expect(fetchStub).calledWithExactly(/* isInit */ true);
       expect(updateStub).to.not.have.been.called;
     });
   });
@@ -102,7 +101,6 @@ describes.realWin('AmpState', {
 
     isVisibleStub.returns(true);
     ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
-    expect(fetchStub).calledWithExactly(
-        /* isInit */ false, /* isMutation */ true);
+    expect(fetchStub).calledWithExactly(/* isInit */ false);
   });
 });

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -293,9 +293,9 @@ describes.realWin('Bind', {
     const element = createElementWithBinding(`[src]="foo"`, 'amp-state');
     expect(element.getAttribute('src')).to.be.null;
     const promise = onBindReadyAndSetState(
-        {foo: '/foo'}, /* opt_fromAmpState */ true);
+        {foo: '/foo'}, /* opt_isAmpStateMutation */ true);
     return promise.then(() => {
-      // <amp-state> should _not_ be updated if `opt_fromAmpState` is true.
+      // Should _not_ be updated if `opt_isAmpStateMutation` is true.
       expect(element.getAttribute('src')).to.be.null;
     });
   });

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -95,12 +95,12 @@ describes.realWin('Bind', {
   /**
    * Calls `callback` when digest that updates bind state to `state` completes.
    * @param {!Object} state
-   * @param {boolean=} opt_fromAmpState
+   * @param {boolean=} opt_isAmpStateMutation
    * @return {!Promise}
    */
-  function onBindReadyAndSetState(state, opt_fromAmpState) {
+  function onBindReadyAndSetState(state, opt_isAmpStateMutation) {
     return bind.initializePromiseForTesting().then(() => {
-      return bind.setState(state, opt_fromAmpState);
+      return bind.setState(state, opt_isAmpStateMutation);
     }).then(() => {
       env.flushVsync();
       return bind.setStatePromiseForTesting();

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -95,14 +95,27 @@ describes.realWin('Bind', {
   /**
    * Calls `callback` when digest that updates bind state to `state` completes.
    * @param {!Object} state
+   * @param {boolean=} opt_fromAmpState
    * @return {!Promise}
    */
-  function onBindReadyAndSetState(state) {
+  function onBindReadyAndSetState(state, opt_fromAmpState) {
     return bind.initializePromiseForTesting().then(() => {
-      return bind.setState(state);
+      return bind.setState(state, opt_fromAmpState);
     }).then(() => {
       env.flushVsync();
       return bind.setStatePromiseForTesting();
+    });
+  }
+
+  /**
+   * Calls `callback` when digest that updates bind state to `state` completes.
+   * @param {!Object} state
+   * @param {!Function} callback
+   * @return {!Promise}
+   */
+  function onBindReadyAndSetStateWithExpression(expression, scope) {
+    return bind.setStateWithExpression(expression, scope).then(() => {
+      env.flushVsync();
     });
   }
 
@@ -117,18 +130,6 @@ describes.realWin('Bind', {
         env.win.removeEventListener(callback);
       };
       env.win.addEventListener(name, callback);
-    });
-  }
-
-  /**
-   * Calls `callback` when digest that updates bind state to `state` completes.
-   * @param {!Object} state
-   * @param {!Function} callback
-   * @return {!Promise}
-   */
-  function onBindReadyAndSetStateWithExpression(expression, scope) {
-    return bind.setStateWithExpression(expression, scope).then(() => {
-      env.flushVsync();
     });
   }
 
@@ -285,6 +286,17 @@ describes.realWin('Bind', {
         '{"onePlusOne": one + one}', {one: 1});
     return promise.then(() => {
       expect(element.textContent).to.equal('2');
+    });
+  });
+
+  it('should ignore <amp-state> updates if specified in `setState`', () => {
+    const element = createElementWithBinding(`[src]="foo"`, 'amp-state');
+    expect(element.getAttribute('src')).to.be.null;
+    const promise = onBindReadyAndSetState(
+        {foo: '/foo'}, /* opt_fromAmpState */ true);
+    return promise.then(() => {
+      // <amp-state> should _not_ be updated if `opt_fromAmpState` is true.
+      expect(element.getAttribute('src')).to.be.null;
     });
   });
 

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -341,7 +341,7 @@ Only binding to the following components and attributes are allowed:
   <tr>
     <td><code>&lt;amp-state></code></td>
     <td><code>[src]</code></td>
-    <td>Fetches JSON from the new URL and merges it into the existing state. <em>Note that resulting updates will ignore <code>&lt;amp-state&gt;</code> elements to prevent cycles.</em></td>
+    <td>Fetches JSON from the new URL and merges it into the existing state. <em>Note the following update will ignore <code>&lt;amp-state&gt;</code> elements to prevent cycles.</em></td>
   </tr>
   <tr>
     <td><code>&lt;amp-video></code></td>

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -341,7 +341,7 @@ Only binding to the following components and attributes are allowed:
   <tr>
     <td><code>&lt;amp-state></code></td>
     <td><code>[src]</code></td>
-    <td>Fetches JSON from the new URL and merges it into the existing state. </td>
+    <td>Fetches JSON from the new URL and merges it into the existing state. <em>Note that resulting updates will ignore <code>&lt;amp-state&gt;</code> elements to prevent cycles.</em></td>
   </tr>
   <tr>
     <td><code>&lt;amp-video></code></td>


### PR DESCRIPTION
Fixes #8948.

- Prevent `amp-state[src]` update cycles by special-casing `<amp-state>` elements to be ignored in updates triggered by `amp-state[src]`.
- Rename `digest_` method to `evaluate_` and remove optional param.

This solution means we have to be careful with #8397 to prevent a workaround with intermediary vars.