### PR TITLE
Don't use ES6 syntax in gulp task definitions

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -36,8 +36,7 @@ function execOrDie(cmd) {
   var p =
       child_process.spawnSync('/bin/sh', ['-c', cmd], {'stdio': 'inherit'});
   if (p.status != 0) {
-    console/*OK*/.log(
-        `\n${fileLogPrefix}exiting due to failing command: ${cmd}`);
+    console/*OK*/.log('\nExiting due to failing command: ' + cmd);
     process.exit(p.status)
   }
 }
@@ -142,9 +141,10 @@ function constructCommandLine(percyKeys) {
   commandLine.push(percyArgs.webpage);
 
   util.log('Executing command line:');
-  commandLine.forEach((command) => {
+  commandLine.forEach(function(command) {
     util.log('\t', util.colors.cyan(command));
   });
+
   return commandLine.join(' ');
 }
 

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -88,7 +88,7 @@ function extractPercyKeys() {
  */
 function extractPercyArgs() {
   // Webpage to snapshot. This is a path, relative to amphtml/.
-  let webpage = '';
+  var webpage = '';
   if (argv.webpage) {
     webpage = argv.webpage;
   } else {
@@ -99,7 +99,7 @@ function extractPercyArgs() {
   util.log('Webpage: ', util.colors.magenta(webpage));
 
   // Smartphone screen widths to snapshot.
-  let widths = defaultWidths;
+  var widths = defaultWidths;
   if (argv.widths) {
     widths = argv.widths.split(',');
   }
@@ -121,7 +121,7 @@ function extractPercyArgs() {
  * @return {string} Full command line to be executed.
  */
 function constructCommandLine(percyKeys) {
-  let commandLine = [];
+  var commandLine = [];
 
   // Main snapshot command.
   commandLine.push(percyCommand);

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-const argv = require('minimist')(process.argv.slice(2));
-const child_process = require('child_process');
-const gulp = require('gulp-help')(require('gulp'));
-const util = require('gulp-util');
+var argv = require('minimist')(process.argv.slice(2));
+var child_process = require('child_process');
+var gulp = require('gulp-help')(require('gulp'));
+var util = require('gulp-util');
 
-const percyCommand = 'percy snapshot';
-const defaultWidths = [375, 411];  // CSS widths: iPhone: 375, Pixel: 411.
-const percyProjectSeparator = '/';  // Standard format of repo slug: "foo/bar".
-const percyTokenLength = 64;  // Standard Percy API key length.
+var percyCommand = 'percy snapshot';
+var defaultWidths = [375, 411];  // CSS widths: iPhone: 375, Pixel: 411.
+var percyProjectSeparator = '/';  // Standard format of repo slug: "foo/bar".
+var percyTokenLength = 64;  // Standard Percy API key length.
 
 
 /**
@@ -33,7 +33,7 @@ const percyTokenLength = 64;  // Standard Percy API key length.
  * @param {string} cmd
  */
 function execOrDie(cmd) {
-  const p =
+  var p =
       child_process.spawnSync('/bin/sh', ['-c', cmd], {'stdio': 'inherit'});
   if (p.status != 0) {
     console/*OK*/.log(
@@ -54,8 +54,8 @@ function extractPercyKeys() {
         'Error: PERCY_PROJECT must be specified as an environment variable'));
     process.exit(1);
   }
-  const percyProject = process.env.PERCY_PROJECT;
-  if (!percyProject.includes(percyProjectSeparator)) {
+  var percyProject = process.env.PERCY_PROJECT;
+  if (percyProject.indexOf(percyProjectSeparator) == -1) {
     util.log(util.colors.red(
         'Error: PERCY_PROJECT doesn\'t look like a valid repo slug'));
     process.exit(1);
@@ -68,7 +68,7 @@ function extractPercyKeys() {
         'Error: PERCY_TOKEN must be specified as an environment variable'));
     process.exit(1);
   }
-  const percyToken = process.env.PERCY_TOKEN;
+  var percyToken = process.env.PERCY_TOKEN;
   if (percyToken.length != percyTokenLength) {
     util.log(util.colors.red(
         'Error: PERCY_TOKEN doesn\'t look like a valid Percy API key'));
@@ -130,7 +130,7 @@ function constructCommandLine(percyKeys) {
   commandLine.push('--repo ' + percyKeys.percyProject);
 
   // Percy args.
-  const percyArgs = extractPercyArgs();
+  var percyArgs = extractPercyArgs();
   commandLine.push('--baseurl /' + percyArgs.webpage);
   commandLine.push('--widths ' + percyArgs.widths);
 
@@ -153,8 +153,8 @@ function constructCommandLine(percyKeys) {
  */
 function runTests() {
   util.log(util.colors.yellow('Running visual diff tests...'));
-  const percyKeys = extractPercyKeys();
-  const commandLine = constructCommandLine(percyKeys);
+  var percyKeys = extractPercyKeys();
+  var commandLine = constructCommandLine(percyKeys);
   execOrDie(commandLine);
 }
 


### PR DESCRIPTION
This PR fixes all instances of ES6 syntax in visual-diff.js.

FIxes #9106 