### PR TITLE
A4A: Remove CSI pings from DOM

### DIFF
--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -256,19 +256,7 @@ export class GoogleAdLifecycleReporter extends BaseLifecycleReporter {
    * @visibleForTesting
    */
   emitPing_(url) {
-    const pingElement = this.element_.ownerDocument.createElement('img');
-    pingElement.setAttribute('src', url);
-    // Styling is copied directly from amp-pixel's CSS.  This is a kludgy way
-    // to do this -- much better would be to invoke amp-pixel's styling directly
-    // or to add an additional style selector for these ping pixels.
-    // However, given that this is a short-term performance system, I'd rather
-    // not tamper with AMP-wide CSS just to create styling for this
-    // element.
-    pingElement.setAttribute('style',
-        'position:fixed!important;top:0!important;width:1px!important;' +
-        'height:1px!important;overflow:hidden!important;visibility:hidden');
-    pingElement.setAttribute('aria-hidden', 'true');
-    this.element_.parentNode.insertBefore(pingElement, this.element_);
+    new Image().src = url;
     dev().info('PING', url);
   }
 

--- a/ads/google/a4a/test/test-google-data-reporter.js
+++ b/ads/google/a4a/test/test-google-data-reporter.js
@@ -212,7 +212,6 @@ describe('#getLifecycleReporter', () => {
         const viewer = env.win.services.viewer.obj;
         viewer.firstVisibleTime_ = viewer.lastVisibleTime_ = Date.now();
         mockReporter.sendPing('renderFriendlyStart');
-        const pingElements = env.win.document.querySelectorAll('img');
         expect(emitPingStub).to.be.calledOnce;
         const pingUrl = emitPingStub.firstCall.args[0];
         const experimentId =

--- a/ads/google/a4a/test/test-google-data-reporter.js
+++ b/ads/google/a4a/test/test-google-data-reporter.js
@@ -156,6 +156,7 @@ describe('#getLifecycleReporter', () => {
       get: h => { return h in headerData ? headerData[h] : null; },
     };
     let mockReporter;
+    let emitPingStub;
     beforeEach(() => {
       const fakeElt = env.createAmpElement('div');
       env.win.Math = Math;
@@ -163,6 +164,7 @@ describe('#getLifecycleReporter', () => {
       mockReporter = new GoogleAdLifecycleReporter(
           env.win, fakeElt, 'test', 37);
       mockReporter.setPingAddress('http://localhost:9876/');
+      emitPingStub = sandbox.stub(mockReporter, 'emitPing_');
     });
 
     it('should pick up qqid from headers', () => {
@@ -170,11 +172,8 @@ describe('#getLifecycleReporter', () => {
       expect(mockReporter.extraVariables_).to.be.empty;
       setGoogleLifecycleVarsFromHeaders(headerMock, mockReporter);
       mockReporter.sendPing('preAdThrottle');
-      const pingElements = env.win.document.querySelectorAll('img');
-      expect(pingElements.length).to.equal(1);
-      const pingUrl = pingElements[0].getAttribute('src');
-      expect(pingUrl).to.be.ok;
-      expect(pingUrl).to.match(/[&?]qqid.37=test_qqid/);
+      expect(emitPingStub).to.be.calledOnce;
+      expect(emitPingStub).to.be.calledWithMatch(/[&?]qqid.37=test_qqid/);
     });
 
     it('should pick up rendering method from headers', () => {
@@ -182,17 +181,15 @@ describe('#getLifecycleReporter', () => {
       expect(mockReporter.extraVariables_).to.be.empty;
       setGoogleLifecycleVarsFromHeaders(headerMock, mockReporter);
       mockReporter.sendPing('preAdThrottle');
-      const pingElements = env.win.document.querySelectorAll('img');
-      expect(pingElements.length).to.equal(1);
-      const pingUrl = pingElements[0].getAttribute('src');
-      expect(pingUrl).to.be.ok;
-      expect(pingUrl).to.match(/[&?]rm.37=fnord/);
+      expect(emitPingStub).to.be.calledOnce;
+      expect(emitPingStub).to.be.calledWithMatch(/[&?]rm.37=fnord/);
     });
   });
 
   describes.sandboxed('#googleLifecycleReporterFactory', {}, () => {
     describes.fakeWin('default parameters', {amp: true}, env => {
       let mockReporter;
+      let emitPingStub;
       beforeEach(() => {
         const fakeElt = env.win.document.createElement('div');
         fakeElt.setAttribute('data-amp-slot-index', '22');
@@ -208,6 +205,7 @@ describe('#getLifecycleReporter', () => {
         mockReporter = googleLifecycleReporterFactory(a4aContainer);
         expect(mockReporter).to.be.instanceOf(GoogleAdLifecycleReporter);
         mockReporter.setPingAddress('http://localhost:9876/');
+        emitPingStub = sandbox.stub(mockReporter, 'emitPing_');
       });
 
       it('should generate a ping with known parameters', () => {
@@ -215,9 +213,8 @@ describe('#getLifecycleReporter', () => {
         viewer.firstVisibleTime_ = viewer.lastVisibleTime_ = Date.now();
         mockReporter.sendPing('renderFriendlyStart');
         const pingElements = env.win.document.querySelectorAll('img');
-        expect(pingElements.length).to.equal(1);
-        const pingUrl = pingElements[0].getAttribute('src');
-        expect(pingUrl).to.be.ok;
+        expect(emitPingStub).to.be.calledOnce;
+        const pingUrl = emitPingStub.firstCall.args[0];
         const experimentId =
           DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment;
         const expectedParams = [

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -35,24 +35,6 @@ function expectMatchesAll(address, matchList) {
   });
 }
 
-/**
- * Verify that `element` has at least one sibling DOM node that is an
- * `img` tag whose `src` matches all of the patterns in `matchList`.
- *
- * @param {!Element} element
- * @param {!Array<!RegExp>} matchList
- */
-function expectHasSiblingImgMatchingAll(element, matchList) {
-  const imgSiblings = toArray(element.parentElement.querySelectorAll('img'));
-  expect(imgSiblings).to.not.be.empty;
-  const result = imgSiblings.some(e => {
-    const src = e.getAttribute('src');
-    return matchList.map(m => m.test(src)).every(x => x);
-  });
-  expect(result, 'No element sibling of ' + element + ' matched all patterns')
-      .to.be.true;
-}
-
 describe('BaseLifecycleReporter', () => {
   describes.fakeWin('', {}, env => {
     let doc;
@@ -123,7 +105,7 @@ describe('GoogleAdLifecycleReporter', () => {
   });
 
   describe('#sendPing', () => {
-    it('should request a single ping and insert into DOM', () => {
+    it('should request a single ping', () => {
       return iframe.then(({viewer, elem, reporter}) => {
         const iniTime = reporter.initTime_;
         sandbox.stub(viewer, 'getFirstVisibleTime', () => iniTime + 11);
@@ -145,7 +127,6 @@ describe('GoogleAdLifecycleReporter', () => {
           /[&?]p_v2=12(&|$)/,
         ];
         expectMatchesAll(arg, expectations);
-        expectHasSiblingImgMatchingAll(elem, expectations);
       });
     });
 
@@ -183,7 +164,6 @@ describe('GoogleAdLifecycleReporter', () => {
           ];
           const arg = emitPingSpy.getCall(count++).args[0];
           expectMatchesAll(arg, expectations);
-          expectHasSiblingImgMatchingAll(elem, expectations);
         }
       });
     });
@@ -219,12 +199,10 @@ describe('GoogleAdLifecycleReporter', () => {
           }
         });
         expect(emitPingSpy.callCount).to.equal(nSlots * nStages);
-        const allImgNodes = toArray(doc.querySelectorAll('img'));
-        expect(allImgNodes.length).to.equal(nSlots * nStages);
         let commonCorrelator;
         const slotCounts = {};
-        allImgNodes.forEach(n => {
-          const src = n.getAttribute('src');
+        for (let i = 0; i < emitPingSpy.callCount; ++i) {
+          const src = emitPingSpy.getCall(i).args[0];
           expect(src).to.match(/[?&]s=test_foo(&|$)/);
           expect(src).to.match(/[?&]c=[0-9]+/);
           const corr = /[?&]c=([0-9]+)/.exec(src)[1];
@@ -233,7 +211,7 @@ describe('GoogleAdLifecycleReporter', () => {
           expect(corr).to.equal(commonCorrelator);
           slotCounts[slotId] = slotCounts[slotId] || 0;
           ++slotCounts[slotId];
-        });
+        };
         // SlotId 0 corresponds to unusedReporter, so ignore it.
         for (let s = 1; s <= nSlots; ++s) {
           expect(slotCounts[s], 'slotCounts[' + s + ']').to.equal(nStages);
@@ -258,7 +236,6 @@ describe('GoogleAdLifecycleReporter', () => {
           /gack=flubble/,
         ];
         expectMatchesAll(arg, expectations);
-        expectHasSiblingImgMatchingAll(elem, expectations);
       });
     });
 
@@ -294,7 +271,6 @@ describe('GoogleAdLifecycleReporter', () => {
           /baz=0/,
         ];
         expectMatchesAll(arg, expectations);
-        expectHasSiblingImgMatchingAll(elem, expectations);
       });
     });
 
@@ -333,7 +309,6 @@ describe('GoogleAdLifecycleReporter', () => {
           /zort=[0-9.]+/,
         ];
         expectMatchesAll(arg, expectations);
-        expectHasSiblingImgMatchingAll(elem, expectations);
       });
     });
   });
@@ -353,7 +328,6 @@ describe('GoogleAdLifecycleReporter', () => {
           /[&?]s=test_foo/,
         ];
         expectMatchesAll(arg, expectations);
-        expectHasSiblingImgMatchingAll(elem, expectations);
       });
     });
 
@@ -372,7 +346,6 @@ describe('GoogleAdLifecycleReporter', () => {
           /zort=12345/,
         ];
         expectMatchesAll(arg, expectations);
-        expectHasSiblingImgMatchingAll(elem, expectations);
       });
     });
 
@@ -393,7 +366,6 @@ describe('GoogleAdLifecycleReporter', () => {
           /flub=0/,
         ];
         expectMatchesAll(arg, expectations);
-        expectHasSiblingImgMatchingAll(elem, expectations);
       });
     });
   });

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -20,7 +20,6 @@ import {
 } from '../performance';
 import {createIframePromise} from '../../../../testing/iframe';
 import {viewerForDoc} from '../../../../src/services';
-import {toArray} from '../../../../src/types';
 import * as sinon from 'sinon';
 
 /**
@@ -97,7 +96,7 @@ describe('GoogleAdLifecycleReporter', () => {
         'p_v1': 'AD_PAGE_FIRST_VISIBLE_TIME',
         'p_v2': 'AD_PAGE_LAST_VISIBLE_TIME',
       });
-      return {win, doc, viewer, elem, reporter};
+      return {win, doc, viewer, reporter};
     });
   });
   afterEach(() => {
@@ -106,7 +105,7 @@ describe('GoogleAdLifecycleReporter', () => {
 
   describe('#sendPing', () => {
     it('should request a single ping', () => {
-      return iframe.then(({viewer, elem, reporter}) => {
+      return iframe.then(({viewer, reporter}) => {
         const iniTime = reporter.initTime_;
         sandbox.stub(viewer, 'getFirstVisibleTime', () => iniTime + 11);
         sandbox.stub(viewer, 'getLastVisibleTime', () => iniTime + 12);
@@ -131,7 +130,7 @@ describe('GoogleAdLifecycleReporter', () => {
     });
 
     it('should request multiple pings and write all to the DOM', () => {
-      return iframe.then(({unusedWin, unusedDoc, elem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         const stages = {
           adSlotCleared: '-1',
           urlBuilt: '1',
@@ -169,7 +168,7 @@ describe('GoogleAdLifecycleReporter', () => {
     });
 
     it('should use diff slot IDs, but the same correlator', () => {
-      return iframe.then(({win, doc, unusedElem, unusedReporter}) => {
+      return iframe.then(({win, doc, unusedReporter}) => {
         const stages = {
           adSlotBuilt: '0',
           adResponseValidateStart: '5',
@@ -222,7 +221,7 @@ describe('GoogleAdLifecycleReporter', () => {
 
   describe('#setPingParameter', () => {
     it('should pass through static ping variables', () => {
-      return iframe.then(({unusedWin, unusedDoc, elem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         expect(emitPingSpy).to.not.be.called;
         reporter.setPingParameter('zort', 314159);
         reporter.setPingParameter('gack', 'flubble');
@@ -240,7 +239,7 @@ describe('GoogleAdLifecycleReporter', () => {
     });
 
     it('does not allow empty args', () => {
-      return iframe.then(({unusedWin, unusedDoc, unusedElem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         expect(emitPingSpy).to.not.be.called;
         reporter.setPingParameter('', '');
         reporter.setPingParameter('foo', '');
@@ -257,7 +256,7 @@ describe('GoogleAdLifecycleReporter', () => {
     });
 
     it('does allow value === 0', () => {
-      return iframe.then(({unusedWin, unusedDoc, elem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         expect(emitPingSpy).to.not.be.called;
         reporter.setPingParameter('foo', 0);
         reporter.setPingParameter('bar', 0.0);
@@ -275,7 +274,7 @@ describe('GoogleAdLifecycleReporter', () => {
     });
 
     it('should uri encode extra params', () => {
-      return iframe.then(({unusedWin, unusedDoc, unusedElem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         expect(emitPingSpy).to.not.be.called;
         reporter.setPingParameter('evil',
             '<script src="https://evil.com">doEvil()</script>');
@@ -297,7 +296,7 @@ describe('GoogleAdLifecycleReporter', () => {
     });
 
     it('should expand URL parameters in extra params', () => {
-      return iframe.then(({unusedWin, unusedDoc, elem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         expect(emitPingSpy).to.not.be.called;
         reporter.setPingParameter('zort', 'RANDOM');
         reporter.sendPing('adRequestStart');
@@ -315,7 +314,7 @@ describe('GoogleAdLifecycleReporter', () => {
 
   describe('#setPingParameters', () => {
     it('should do nothing on an an empty input', () => {
-      return iframe.then(({unusedWin, unusedDoc, elem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         const setPingParameterSpy = sandbox.spy(reporter, 'setPingParameter');
         expect(emitPingSpy).to.not.be.called;
         reporter.setPingParameters({});
@@ -332,7 +331,7 @@ describe('GoogleAdLifecycleReporter', () => {
     });
 
     it('should set a singleton input', () => {
-      return iframe.then(({unusedWin, unusedDoc, elem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         const setPingParameterSpy = sandbox.spy(reporter, 'setPingParameter');
         expect(emitPingSpy).to.not.be.called;
         reporter.setPingParameters({zort: '12345'});
@@ -350,7 +349,7 @@ describe('GoogleAdLifecycleReporter', () => {
     });
 
     it('should set multiple inputs', () => {
-      return iframe.then(({unusedWin, unusedDoc, elem, reporter}) => {
+      return iframe.then(({unusedWin, unusedDoc, reporter}) => {
         const setPingParameterSpy = sandbox.spy(reporter, 'setPingParameter');
         expect(emitPingSpy).to.not.be.called;
         reporter.setPingParameters({zort: '12345', gax: 99, flub: 0});


### PR DESCRIPTION
Avoids writing CSI ping beacons to DOM -- now sends them just with `new Image()`.  Maintains `dev().info` for console messaging in dev mode, though.