### PR TITLE
Fix amp-pixel integration test on Saucelabs.

### DIFF
--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -25,7 +25,7 @@ app.get('/compose-doc', function(req, res) {
   <link rel="canonical" href="http://nonblocking.io/" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="/dist/${process.env.SERVE_MODE == 'compiled' ? 'v0' : 'amp'}.js"></script>
 </head>
 <body>
 ${req.query.body}

--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -14,19 +14,37 @@
  * limitations under the License.
  */
 
+var app = module.exports = require('express').Router();
+
+app.get('/compose-doc', function(req, res) {
+  res.send(`
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="http://nonblocking.io/" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+${req.query.body}
+</body>
+</html>  
+`);
+});
+
 /**
  * A server side temporary request storage which is useful for testing
  * browser sent HTTP requests.
  */
-var app = require('express').Router();
-
 var bank = {};
 
 /**
  * Deposit a request. An ID has to be specified. Will override previous request
  * if the same ID already exists.
  */
-app.get('/deposit/:id', function(req, res) {
+app.get('/request-bank/deposit/:id', function(req, res) {
   if (typeof bank[req.params.id] === 'function') {
     bank[req.params.id](req);
   } else {
@@ -40,7 +58,7 @@ app.get('/deposit/:id', function(req, res) {
  * return it immediately. Otherwise wait until it gets deposited
  * The same request cannot be withdrawn twice at the same time.
  */
-app.get('/withdraw/:id', function(req, res) {
+app.get('/request-bank/withdraw/:id', function(req, res) {
   var result = bank[req.params.id];
   if (typeof result === 'function') {
     return res.status(500).send('another client is withdrawing this ID');
@@ -58,4 +76,3 @@ app.get('/withdraw/:id', function(req, res) {
   }
 });
 
-module.exports = app;

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -30,7 +30,7 @@ var request = require('request');
 var url = require('url');
 
 app.use(bodyParser.json());
-app.use('/request-bank', require('./request-bank'));
+app.use('/amp4test', require('./amp4test'));
 
 // Append ?csp=1 to the URL to turn on the CSP header.
 // TODO: shall we turn on CSP all the time?

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -50,6 +50,7 @@ var forbiddenTerms = {
   '(^-amp-|\\W-amp-)': {
     message: 'Switch to new internal class form',
     whitelist: [
+      'build-system/amp4test.js',
       'build-system/tasks/extension-generator/index.js',
       'css/amp.css',
       'extensions/amp-pinterest/0.1/amp-pinterest.css',

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -18,7 +18,6 @@ import {
   installUrlReplacementsForEmbed,
 } from '../../src/service/url-replacements-impl';
 import {VariableSource} from '../../src/service/variable-source';
-import {isReferrerPolicySupported} from '../../builtins/amp-pixel';
 
 describes.realWin('amp-pixel', {amp: true}, env => {
   let win;

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -124,21 +124,6 @@ describes.realWin('amp-pixel', {amp: true}, env => {
     });
   });
 
-  it('should respect referrerpolicy=no-referrer', () => {
-    const url = 'https://pubads.g.doubleclick.net/activity';
-    createPixel(url, 'no-referrer');
-    return trigger(url).then(element => {
-      if (isReferrerPolicySupported()) {
-        expect(element.referrerPolicy).to.equal('no-referrer');
-      }
-      if (!element.src) {
-        // TODO(@lannka): Please remove the temporary fix
-        return;
-      }
-      expect(element.src).to.equal(url);
-    });
-  });
-
   it('should throw for referrerpolicy with value other than ' +
       'no-referrer', () => {
     expect(() => {

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -19,41 +19,22 @@ import {
   withdrawRequest,
 } from '../../testing/test-helper';
 
-describes.realWin('amp-pixel integration test', {
-  amp: {
-    runtimeOn: true,
-    ampdoc: 'single',
-  },
-  allowExternalResources: true,
+describes.integration('amp-pixel integration test', {
+  body: `<amp-pixel src="${depositRequestUrl('has-referrer')}">`,
 }, env => {
-
-  let win;
-  let doc;
-
-  beforeEach(() => {
-    win = env.win;
-    doc = win.document;
-  });
-
-  it.skip('should keep referrer', () => {
-    // TODO(@lannka): unskip this test
-    const pixel = doc.createElement('amp-pixel');
-    pixel.setAttribute('src', depositRequestUrl('has-referrer'));
-    doc.body.appendChild(pixel);
-
-    return withdrawRequest(win, 'has-referrer').then(request => {
+  it('should keep referrer if no referrerpolicy specified', () => {
+    return withdrawRequest(env.win, 'has-referrer').then(request => {
       expect(request.headers.referer).to.be.ok;
     });
   });
+});
 
-  it.skip('should remove referrer', () => {
-    // TODO(@lannka): unskip this test
-    const pixel = doc.createElement('amp-pixel');
-    pixel.setAttribute('src', depositRequestUrl('no-referrer'));
-    pixel.setAttribute('referrerpolicy', 'no-referrer');
-    doc.body.appendChild(pixel);
-
-    return withdrawRequest(win, 'no-referrer').then(request => {
+describes.integration('amp-pixel integration test', {
+  body: `<amp-pixel src="${depositRequestUrl('no-referrer')}" 
+             referrerpolicy="no-referrer">`,
+}, env => {
+  it('should remove referrer if referrerpolicy=no-referrer', () => {
+    return withdrawRequest(env.win, 'no-referrer').then(request => {
       expect(request.headers.referer).to.not.be.ok;
     });
   });

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -30,7 +30,7 @@ describes.integration('amp-pixel integration test', {
 });
 
 describes.integration('amp-pixel integration test', {
-  body: `<amp-pixel src="${depositRequestUrl('no-referrer')}" 
+  body: `<amp-pixel src="${depositRequestUrl('no-referrer')}"
              referrerpolicy="no-referrer">`,
 }, env => {
   it('should remove referrer if referrerpolicy=no-referrer', () => {

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -33,6 +33,8 @@ import {
   installRuntimeServices,
   registerElementForTesting,
 } from '../src/runtime';
+import {createElementWithAttributes} from '../src/dom';
+import {addParamsToUrl} from '../src/url';
 import {cssText} from '../build/css';
 import {createAmpElementProto} from '../src/custom-element';
 import {installDocService} from '../src/service/ampdoc-impl';
@@ -149,6 +151,9 @@ export const realWin = describeEnv(spec => [
       new AmpFixture(spec),
     ]);
 
+export const integration = describeEnv(spec => [
+  new IntegrationFixture(spec),
+]);
 
 /**
  * A repeating test.
@@ -333,6 +338,42 @@ class SandboxFixture {
   }
 }
 
+/** @implements {Fixture} */
+class IntegrationFixture {
+  /** @param {!{body: string}} spec */
+  constructor(spec) {
+    /** @const */
+    this.spec = spec;
+  }
+
+  /** @override */
+  isOn() {
+    return true;
+  }
+
+  /** @override */
+  setup(env) {
+    const spec = this.spec;
+    return new Promise(function(resolve, reject) {
+      env.iframe = createElementWithAttributes(document, 'iframe', {
+        src: addParamsToUrl('/amp4test/compose-doc', spec),
+      });
+      env.iframe.onload = function() {
+        env.win = env.iframe.contentWindow;
+        resolve();
+      };
+      env.iframe.onerror = reject;
+      document.body.appendChild(env.iframe);
+    });
+  }
+
+  /** @override */
+  teardown(env) {
+    if (env.iframe.parentNode) {
+      env.iframe.parentNode.removeChild(env.iframe);
+    }
+  }
+}
 
 /** @implements {Fixture} */
 class FakeWinFixture {

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -64,7 +64,7 @@ export function assertScreenReaderElement(element) {
 // A server side temporary request storage which is useful for testing
 // browser sent HTTP requests.
 /////////////////
-const REQUEST_URL = '//localhost:9876/request-bank/';
+const REQUEST_URL = '//localhost:9876/amp4test/request-bank/';
 
 export function depositRequestUrl(id) {
   return REQUEST_URL + 'deposit/' + id;


### PR DESCRIPTION
The previous failure was due to the fixture iframe that we created for each test does not have an origin (we use `srcdoc`). In such case, some browsers will take the top window origin as `referrer`, but some will use `null` .

The fix is to fully mimic the real production world. Use an iframe to load a valid AMP page from a server.

Closes #8853