### PR TITLE
Don't require amp-state in amp-bind pages

### DIFF
--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -50,7 +50,6 @@ tags: {  # <amp-state> with json child
   html_format: AMP
   tag_name: "AMP-STATE"
   spec_name: "amp-state"
-  satisfies: "amp-state"
   requires: "amp-bind extension .js script"
   requires: "amp-bind extension .json script"
   disallowed_ancestor: "AMP-SIDEBAR"
@@ -70,7 +69,6 @@ tags: {  # <amp-state> with src
   html_format: AMP
   tag_name: "AMP-STATE"
   spec_name: "amp-state[src]"
-  satisfies: "amp-state"
   requires: "amp-bind extension .js script"
   disallowed_ancestor: "AMP-SIDEBAR"
   attrs: {

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -17,7 +17,6 @@ tags: {  # amp-bind
   html_format: AMP
   tag_name: "SCRIPT"
   satisfies: "amp-bind extension .js script"
-  requires: "amp-state"
   extension_spec: {
     name: "amp-bind"
     allowed_versions: "0.1"


### PR DESCRIPTION
Fixes #9136. 

- Usage of `amp-state` elements in pages with `amp-bind` should be optional.

/to @honeybadgerdontcare 