### PR TITLE
Validator Rollup

### DIFF
--- a/validator/testdata/feature_tests/link_meta_values.html
+++ b/validator/testdata/feature_tests/link_meta_values.html
@@ -25,6 +25,7 @@
   -->
   <meta name="foo" content="bar">
   <meta property="foo" content="bar">
+  <meta name="amp-experiment-token" content="HfmyLgNLmblRg3Alqy164Vywr">
   <link rel="manifest" href="foo">
   <link rel="manifest foo" href="foo">
   <link rel="shortcut icon" type="a" href="b" sizes="c">

--- a/validator/testdata/feature_tests/link_meta_values.out
+++ b/validator/testdata/feature_tests/link_meta_values.out
@@ -1,6 +1,6 @@
 FAIL
-feature_tests/link_meta_values.html:29:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'manifest foo'. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
-feature_tests/link_meta_values.html:34:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'. [DISALLOWED_HTML]
-feature_tests/link_meta_values.html:35:2 The property 'minimum-scale' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
-feature_tests/link_meta_values.html:35:2 The property 'width' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
-feature_tests/link_meta_values.html:46:2 The mandatory attribute 'rel' is missing in tag 'link rel='. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+feature_tests/link_meta_values.html:30:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'manifest foo'. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+feature_tests/link_meta_values.html:35:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'. [DISALLOWED_HTML]
+feature_tests/link_meta_values.html:36:2 The property 'minimum-scale' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/link_meta_values.html:36:2 The property 'width' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/link_meta_values.html:47:2 The mandatory attribute 'rel' is missing in tag 'link rel='. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 232
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 416
+spec_file_revision: 417
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 221
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 412
+spec_file_revision: 413
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 232
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 415
+spec_file_revision: 416
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 
@@ -421,6 +421,24 @@ tags: {
     }
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-ad"
+}
+# AMP metadata, name=amp-experiment-token
+# Related to AMP Origin Experiments
+tags: {
+  html_format: AMP
+  tag_name: "META"
+  spec_name: "meta name=amp-experiment-token"
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "name"
+    mandatory: true
+    value_casei: "amp-experiment-token"
+    dispatch_key: true
+  }
+  attrs: {
+    name: "content"
+    mandatory: true
+  }
 }
 # AMP metadata, name=amp-link-variable-allowed-origin
 # https://github.com/ampproject/amphtml/issues/8132

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 232
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 414
+spec_file_revision: 415
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 221
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 411
+spec_file_revision: 412
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,12 +20,12 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii) are always released together.
-min_validator_revision_required: 221
+min_validator_revision_required: 232
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 413
+spec_file_revision: 414
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 


### PR DESCRIPTION
Validator changes:
 - Revision bumps.
 - Allow <meta name=amp-experiment-token content=>.