### PR TITLE
Print a clearer error message when flag-config and non-flag-config files are in the same PR

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -14,7 +14,7 @@
   "amp-accordion-session-state-optout": 1,
   "amp-playbuzz": 1,
   "make-body-relative": 1,
-  "chunked-amp": 0,
+  "chunked-amp": 1,
   "amp-selector": 1,
   "sticky-ad-early-load": 1,
   "amp-auto-ads": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -14,7 +14,7 @@
   "amp-accordion-session-state-optout": 1,
   "amp-playbuzz": 1,
   "make-body-relative": 1,
-  "chunked-amp": 1,
+  "chunked-amp": 0,
   "amp-selector": 1,
   "sticky-ad-early-load": 1,
   "amp-auto-ads": 1,

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -262,11 +262,15 @@ function main(argv) {
   if (buildTargets.has('FLAG_CONFIG')) {
     files.forEach((file) => {
       if (!isFlagConfig(file)) {
-        console.log('A pull request may not contain a mix of flag-config and ' +
-            'non-flag-config files. Please make your changes in separate ' +
-            'pull requests.');
-        console.log('If you see a long list of unrelated files below, you ' +
-            'may need to sync your branch to master.');
+        console.log(util.colors.red('ERROR'),
+            'It appears that your PR contains a mix of flag-config files ' +
+            '(*config.json) and non-flag-config files.');
+        console.log('Please make your changes in separate pull requests.');
+        console.log(util.colors.red(
+            'NOTE: If you see a long list of unrelated files below, it is ' +
+            'likely because your branch is very old.'));
+        console.log(util.colors.red(
+            'A full sync to upstream/master should clear this error.'));
         console.log('\nFull list of files in this PR:');
         files.forEach((file) => { console.log('\t' + file); });
         stopTimer('pr-check.js', startTime);

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -269,7 +269,7 @@ function main(argv) {
         console.log('Please make your changes in separate pull requests.');
         console.log(util.colors.yellow(
             'NOTE: If you see a long list of unrelated files below, it is ' +
-            'likely because your branch is very old.'));
+            'likely because your branch is significantly out of sync.'));
         console.log(util.colors.yellow(
             'A full sync to upstream/master should clear this error.'));
         console.log('\nFull list of files in this PR:');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -26,6 +26,7 @@
 const child_process = require('child_process');
 const path = require('path');
 const minimist = require('minimist');
+const util = require('gulp-util');
 
 const gulp = 'node_modules/gulp/bin/gulp.js';
 const fileLogPrefix =

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -267,10 +267,10 @@ function main(argv) {
             'It appears that your PR contains a mix of flag-config files ' +
             '(*config.json) and non-flag-config files.');
         console.log('Please make your changes in separate pull requests.');
-        console.log(util.colors.red(
+        console.log(util.colors.yellow(
             'NOTE: If you see a long list of unrelated files below, it is ' +
             'likely because your branch is very old.'));
-        console.log(util.colors.red(
+        console.log(util.colors.yellow(
             'A full sync to upstream/master should clear this error.'));
         console.log('\nFull list of files in this PR:');
         files.forEach((file) => { console.log('\t' + file); });


### PR DESCRIPTION
From time to time, people hit this error because of a really old branch and wonder what this error is all about. Make the error text easier to spot and easier to understand.