### PR TITLE
Sticky ad: wait for fixed layer to complete before loading an ad

### DIFF
--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -156,12 +156,12 @@ class AmpStickyAd extends AMP.BaseElement {
    * @private
    */
   onScroll_() {
-    if (isExperimentOn(this.win, EARLY_LOAD_EXPERIMENT)) {
+    const scrollTop = this.viewport_.getScrollTop();
+    if (isExperimentOn(this.win, EARLY_LOAD_EXPERIMENT) && scrollTop > 1) {
       this.display_();
       return;
     }
 
-    const scrollTop = this.viewport_.getScrollTop();
     const viewportHeight = this.viewport_.getSize().height;
     // Check user has scrolled at least one viewport from init position.
     if (scrollTop > viewportHeight) {
@@ -177,9 +177,10 @@ class AmpStickyAd extends AMP.BaseElement {
     this.removeOnScrollListener_();
     this.deferMutate(() => {
       this.visible_ = true;
-      this.viewport_.addToFixedLayer(this.element);
       this.addCloseButton_();
-      this.scheduleLayoutForAd_();
+      this.viewport_.addToFixedLayer(
+          this.element, /* forceTransfer */ true)
+          .then(() => this.scheduleLayoutForAd_());
     });
   }
 

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -331,7 +331,7 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
   let win;
   let ampStickyAd;
   let impl;
-  let addToFixedLayerStub, addToFixedLayerPromise;
+  let addToFixedLayerPromise;
   beforeEach(done => {
     win = env.win;
     ampStickyAd = win.document.createElement('amp-sticky-ad');
@@ -345,7 +345,7 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     ampStickyAd.build();
     impl = ampStickyAd.implementation_;
     addToFixedLayerPromise = Promise.resolve();
-    addToFixedLayerStub = sandbox.stub(impl.viewport_, 'addToFixedLayer',
+    sandbox.stub(impl.viewport_, 'addToFixedLayer',
         () => addToFixedLayerPromise);
     return ampAd.implementation_.upgradeCallback().then(() => {
       done();

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -1,3 +1,4 @@
+
 /**
  * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
  *
@@ -32,6 +33,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
   let win;
   let ampStickyAd;
   let impl;
+  let addToFixedLayerStub, addToFixedLayerPromise;
   describe('with valid child 1.0', () => {
     beforeEach(() => {
       win = env.win;
@@ -42,6 +44,9 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       win.document.body.appendChild(ampStickyAd);
       ampStickyAd.build();
       impl = ampStickyAd.implementation_;
+      addToFixedLayerPromise = Promise.resolve();
+      addToFixedLayerStub = sandbox.stub(impl.viewport_, 'addToFixedLayer',
+          () => addToFixedLayerPromise);
     });
 
     it('should listen to scroll event', () => {
@@ -107,8 +112,13 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       impl.onScroll_();
       expect(getScrollTopSpy).to.have.been.called;
       expect(getSizeSpy).to.have.been.called;
-      expect(scheduleLayoutSpy).to.have.been.called;
       expect(removeOnScrollListenerSpy).to.have.been.called;
+      // Layout on ad is called only after fixed layer is done.
+      expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(addToFixedLayerStub).to.have.been.calledOnce;
+      return addToFixedLayerPromise.then(() => {
+        expect(scheduleLayoutSpy).to.have.been.calledOnce;
+      });
     });
 
     it('experiment version, should display once user scroll', () => {
@@ -119,7 +129,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
           sandbox.spy(impl, 'removeOnScrollListener_');
 
       const getScrollTopStub = sandbox.stub(impl.viewport_, 'getScrollTop');
-      getScrollTopStub.returns(1);
+      getScrollTopStub.returns(2);
       const getSizeStub = sandbox.stub(impl.viewport_, 'getSize');
       getSizeStub.returns({
         height: 50,
@@ -136,9 +146,14 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       };
 
       impl.onScroll_();
-      expect(scheduleLayoutSpy).to.have.been.called;
       expect(removeOnScrollListenerSpy).to.have.been.called;
       toggleExperiment(win, 'sticky-ad-early-load');
+      // Layout on ad is called only after fixed layer is done.
+      expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(addToFixedLayerStub).to.have.been.calledOnce;
+      return addToFixedLayerPromise.then(() => {
+        expect(scheduleLayoutSpy).to.have.been.calledOnce;
+      });
     });
 
     it('should set body borderBottom correctly', () => {
@@ -316,6 +331,7 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
   let win;
   let ampStickyAd;
   let impl;
+  let addToFixedLayerStub, addToFixedLayerPromise;
   beforeEach(done => {
     win = env.win;
     ampStickyAd = win.document.createElement('amp-sticky-ad');
@@ -328,6 +344,9 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     win.document.body.appendChild(ampStickyAd);
     ampStickyAd.build();
     impl = ampStickyAd.implementation_;
+    addToFixedLayerPromise = Promise.resolve();
+    addToFixedLayerStub = sandbox.stub(impl.viewport_, 'addToFixedLayer',
+        () => addToFixedLayerPromise);
     return ampAd.implementation_.upgradeCallback().then(() => {
       done();
     });
@@ -358,7 +377,8 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     impl.ad_.signals().signal('load-end');
     const layoutPromise = impl.layoutAd_();
     const bodyPromise = impl.viewport_.ampdoc.whenBodyAvailable();
-    return Promise.all([layoutPromise, bodyPromise]).then(() => {
+    const p = Promise.all([addToFixedLayerPromise, layoutPromise, bodyPromise]);
+    return p.then(() => {
       let borderWidth = win.getComputedStyle(win.document.body, null)
           .getPropertyValue('border-bottom-width');
       expect(borderWidth).to.equal('54px');
@@ -397,7 +417,8 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     impl.ad_.signals().signal('load-end');
     const layoutPromise = impl.layoutAd_();
     const bodyPromise = impl.viewport_.ampdoc.whenBodyAvailable();
-    return Promise.all([layoutPromise, bodyPromise]).then(() => {
+    const p = Promise.all([addToFixedLayerPromise, layoutPromise, bodyPromise]);
+    return p.then(() => {
       let borderWidth = win.getComputedStyle(win.document.body, null)
           .getPropertyValue('border-bottom-width');
       expect(borderWidth).to.equal('54px');

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -183,6 +183,7 @@ export class FixedLayer {
    * @param {!Element} element
    * @param {boolean=} opt_forceTransfer If set to true , then the element needs
    *    to be forcefully transferred to the transfer layer.
+   * @return {!Promise}
    */
   addElement(element, opt_forceTransfer) {
     this.setupElement_(
@@ -191,7 +192,7 @@ export class FixedLayer {
         /* position */ 'fixed',
         opt_forceTransfer);
     this.sortInDomOrder_();
-    this.update();
+    return this.update();
   }
 
   /**

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -585,9 +585,10 @@ export class Viewport {
    * @param {!Element} element
    * @param {boolean=} opt_forceTransfer If set to true , then the element needs
    *    to be forcefully transferred to the fixed layer.
+   * @return {!Promise}
    */
   addToFixedLayer(element, opt_forceTransfer) {
-    this.fixedLayer_.addElement(element, opt_forceTransfer);
+    return this.fixedLayer_.addElement(element, opt_forceTransfer);
   }
 
   /**


### PR DESCRIPTION
Partial for #8780.

What likely was happening here is that the ad's iframe was reloaded by browser when the ad was transferred to the fixed layer. Browsers always reset/reload iframe's window when reparented, so this is somewhat likely.

/cc @keithwrightbos 