### PR TITLE
Add keyboard support to amp-accordion

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -62,14 +62,14 @@ class AmpAccordion extends AMP.BaseElement {
           'Sections should be enclosed in a <section> tag, ' +
           'See https://github.com/ampproject/amphtml/blob/master/extensions/' +
           'amp-accordion/amp-accordion.md. Found in: %s', this.element);
-      const sectionComponents_ = section.children;
+      const sectionComponents = section.children;
       user().assert(
-          sectionComponents_.length == 2,
+          sectionComponents.length == 2,
           'Each section must have exactly two children. ' +
           'See https://github.com/ampproject/amphtml/blob/master/extensions/' +
           'amp-accordion/amp-accordion.md. Found in: %s', this.element);
       this.mutateElement(() => {
-        const content = sectionComponents_[1];
+        const content = sectionComponents[1];
         content.classList.add('i-amphtml-accordion-content');
         let contentId = content.getAttribute('id');
         if (!contentId) {
@@ -83,7 +83,7 @@ class AmpAccordion extends AMP.BaseElement {
           section.removeAttribute('expanded');
         }
 
-        const header = sectionComponents_[0];
+        const header = sectionComponents[0];
         header.classList.add('i-amphtml-accordion-header');
         header.setAttribute('role', 'heading');
         header.setAttribute('aria-controls', contentId);
@@ -157,8 +157,8 @@ class AmpAccordion extends AMP.BaseElement {
    */
   onHeaderPicked_(header) {
     const section = header.parentElement;
-    const sectionComponents_ = section.children;
-    const content = sectionComponents_[1];
+    const sectionComponents = section.children;
+    const content = sectionComponents[1];
     const contentId = content.getAttribute('id');
     const isSectionClosedAfterClick = section.hasAttribute('expanded');
     this.mutateElement(() => {

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -70,17 +70,6 @@ class AmpAccordion extends AMP.BaseElement {
           'See https://github.com/ampproject/amphtml/blob/master/extensions/' +
           'amp-accordion/amp-accordion.md. Found in: %s', this.element);
       this.mutateElement(() => {
-        const header = sectionComponents_[0];
-        header.classList.add('i-amphtml-accordion-header');
-        header.setAttribute('role', 'button');
-        header.setAttribute('aria-controls', contentId);
-        header.setAttribute('aria-expanded',
-            section.hasAttribute('expanded').toString());
-        if (!header.hasAttribute('tabindex')) {
-          header.setAttribute('tabindex', 0);
-        }
-        this.headers_.push(header);
-
         const content = sectionComponents_[1];
         content.classList.add('i-amphtml-accordion-content');
         let contentId = content.getAttribute('id');
@@ -94,6 +83,14 @@ class AmpAccordion extends AMP.BaseElement {
         } else if (this.currentState_[contentId] == false) {
           section.removeAttribute('expanded');
         }
+
+        const header = sectionComponents_[0];
+        header.classList.add('i-amphtml-accordion-header');
+        header.setAttribute('role', 'button');
+        header.setAttribute('aria-controls', contentId);
+        header.setAttribute('aria-expanded',
+            section.hasAttribute('expanded').toString());
+        this.headers_.push(header);
       });
     });
 
@@ -151,8 +148,13 @@ class AmpAccordion extends AMP.BaseElement {
     }
   }
 
+  /**
+   * Handles user action on an accordion header, agnostic of input method.
+   * @param {!Element} header
+   * @private
+   */
   onHeaderPicked_(header) {
-    const section = header.parentNode;
+    const section = header.parentElement;
     const sectionComponents_ = section.children;
     const content = sectionComponents_[1];
     const contentId = content.getAttribute('id');
@@ -176,23 +178,26 @@ class AmpAccordion extends AMP.BaseElement {
    * @private
    */
   clickHandler_(event) {
-    debugger;
-    /** @const {!Element} */
     const target = event.target;
     if (this.headers_.includes(target)) {
       event.preventDefault();
-      this.onHeaderPicked_(target);
+      const header = dev().assertElement(target);
+      this.onHeaderPicked_(header);
     }
   }
 
+  /**
+   * Handles accordion key presses ot expand/collapse its content.
+   * @param {!Event} event keydown event.
+   */
   keyDownHandler_(event) {
-    debugger;
     const target = event.target;
     const keyCode = event.keyCode;
     if (keyCode == Keycodes.ENTER || keyCode == Keycodes.SPACE) {
       if (this.headers_.includes(target)) {
         event.preventDefault();
-        this.onHeaderPicked_(target);
+        const header = dev().assertElement(target);
+        this.onHeaderPicked_(header);
       }
     }
   }

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -15,7 +15,7 @@
  */
 
 import {CSS} from '../../../build/amp-accordion-0.1.css';
-import {Keycodes} from '../../../src/utils/keycodes';
+import {KeyCodes} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
 import {removeFragment} from '../../../src/url';
@@ -206,12 +206,12 @@ class AmpAccordion extends AMP.BaseElement {
     }
     const keyCode = event.keyCode;
     switch (keyCode) {
-      case Keycodes.UP_ARROW: /* fallthrough */
-      case Keycodes.DOWN_ARROW:
+      case KeyCodes.UP_ARROW: /* fallthrough */
+      case KeyCodes.DOWN_ARROW:
         this.navigationKeyDownHandler_(event);
         return;
-      case Keycodes.ENTER: /* fallthrough */
-      case Keycodes.SPACE:
+      case KeyCodes.ENTER: /* fallthrough */
+      case KeyCodes.SPACE:
         this.activationKeyDownHandler_(event);
         return;
     }
@@ -229,7 +229,7 @@ class AmpAccordion extends AMP.BaseElement {
     if (index !== -1) {
       event.preventDefault();
       // Up and down are the same regardless of locale direction.
-      const diff = event.keyCode == Keycodes.UP_ARROW ? -1 : 1;
+      const diff = event.keyCode == KeyCodes.UP_ARROW ? -1 : 1;
       // If user navigates one past the beginning or end, wrap around.
       let newFocusIndex = (index + diff) % this.headers_.length;
       if (newFocusIndex < 0) {

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -209,7 +209,7 @@ class AmpAccordion extends AMP.BaseElement {
    * @private
    */
   navigationKeyDownHandler_(event) {
-    const header = event.currentTarget;
+    const header = dev().assertElement(event.currentTarget);
     const index = this.headers_.indexOf(header);
     if (index !== -1) {
       event.preventDefault();

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -93,10 +93,10 @@ class AmpAccordion extends AMP.BaseElement {
           header.setAttribute('tabindex', 0);
         }
         this.headers_.push(header);
+        header.addEventListener('click', this.clickHandler_.bind(this));
       });
     });
 
-    this.element.addEventListener('click', this.clickHandler_.bind(this));
     this.element.addEventListener('keydown', this.keyDownHandler_.bind(this));
   }
 
@@ -180,20 +180,9 @@ class AmpAccordion extends AMP.BaseElement {
    * @private
    */
   clickHandler_(event) {
-    // Need to support clicks on any children of the header.
-    let header;
-    for (let i = 0; i < this.headers_.length; i++) {
-      const curr = this.headers_[i];
-      if (curr.contains(event.target)) {
-        header = curr;
-        break;
-      }
-    }
-    if (header) {
-      header = dev().assertElement(header);
-      event.preventDefault();
-      this.onHeaderPicked_(header);
-    }
+    event.preventDefault();
+    const header = dev().assertElement(event.currentTarget);
+    this.onHeaderPicked_(header);
   }
 
   /**

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -49,8 +49,6 @@ class AmpAccordion extends AMP.BaseElement {
   buildCallback() {
     this.sessionOptOut_ = this.element.hasAttribute('disable-session-states');
 
-    this.element.setAttribute('role', 'tablist');
-
     // sessionStorage key: special created id for this element, this.sessionId_.
     // sessionStorage value: string that can convert to this.currentState_ obj.
     this.sessionId_ = this.getSessionStorageKey_();
@@ -86,7 +84,7 @@ class AmpAccordion extends AMP.BaseElement {
 
         const header = sectionComponents_[0];
         header.classList.add('i-amphtml-accordion-header');
-        header.setAttribute('role', 'button');
+        header.setAttribute('role', 'heading');
         header.setAttribute('aria-controls', contentId);
         header.setAttribute('aria-expanded',
             section.hasAttribute('expanded').toString());

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -89,6 +89,9 @@ class AmpAccordion extends AMP.BaseElement {
         header.setAttribute('aria-controls', contentId);
         header.setAttribute('aria-expanded',
             section.hasAttribute('expanded').toString());
+        if (!header.hasAttribute('tabindex')) {
+          header.setAttribute('tabindex', 0);
+        }
         this.headers_.push(header);
       });
     });

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -179,9 +179,18 @@ class AmpAccordion extends AMP.BaseElement {
    */
   clickHandler_(event) {
     const target = event.target;
-    if (this.headers_.includes(target)) {
+    // Need to support clicks on any children of the header.
+    let header;
+    for (let i = 0; i < this.headers_.length; i++) {
+      const curr = this.headers_[i];
+      if (curr.contains(event.target)) {
+        header = curr;
+        break;
+      }
+    }
+    if (header) {
+      header = dev().assertElement(header);
       event.preventDefault();
-      const header = dev().assertElement(target);
       this.onHeaderPicked_(header);
     }
   }
@@ -194,6 +203,8 @@ class AmpAccordion extends AMP.BaseElement {
     const target = event.target;
     const keyCode = event.keyCode;
     if (keyCode == Keycodes.ENTER || keyCode == Keycodes.SPACE) {
+      // TODO(kmh287): Should we also support activation of children of the
+      // header?
       if (this.headers_.includes(target)) {
         event.preventDefault();
         const header = dev().assertElement(target);

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -198,6 +198,9 @@ class AmpAccordion extends AMP.BaseElement {
    * @param {!Event} event keydown event.
    */
   keyDownHandler_(event) {
+    if (event.defaultPrevented) {
+      return;
+    }
     const keyCode = event.keyCode;
     switch (keyCode) {
       case Keycodes.UP_ARROW: /* fallthrough */
@@ -212,7 +215,8 @@ class AmpAccordion extends AMP.BaseElement {
   }
 
   /**
-   * Handles keyboard navigation events.
+   * Handles keyboard navigation events. Only respond to keyboard navigation
+   * if a section header already has focus.
    * @param {!Event} event
    * @private
    */
@@ -220,6 +224,7 @@ class AmpAccordion extends AMP.BaseElement {
     const target = event.target;
     const index = this.headers_.indexOf(target);
     if (index !== -1) {
+      event.preventDefault();
       // Up and down are the same regardless of locale direction.
       const diff = event.keyCode == Keycodes.UP_ARROW ? -1 : 1;
       // If user navigates one past the beginning or end, wrap around.

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -16,6 +16,7 @@
 
 import {Keycodes} from '../../../../src/utils/keycodes';
 import {createIframePromise} from '../../../../testing/iframe';
+import {tryFocus} from '../../../../src/dom';
 import '../amp-accordion';
 
 
@@ -28,7 +29,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       ampAccordion.implementation_.mutateElement = fn => fn();
       for (let i = 0; i < 3; i++) {
         const section = iframe.doc.createElement('section');
-        section.innerHTML = '<h2>Section ' + i +
+        section.innerHTML = '<h2 tabindex="0">Section ' + i +
             '<span>nested stuff<span></h2><div id=\'test' + i +
             '\'>Loreum ipsum</div>';
         ampAccordion.appendChild(section);
@@ -158,6 +159,32 @@ describes.sandboxed('amp-accordion', {}, () => {
       expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.false;
       expect(headerElements[1].getAttribute('aria-expanded')).to.equal('false');
       expect(keyDownEvent.preventDefault.called).to.be.true;
+    });
+  });
+
+  it('should be navigable by up and down arrow keys when ' +
+     'any header has focus', () => {
+    return getAmpAccordion().then(obj => {
+      const iframe = obj.iframe;
+      const headerElements = iframe.doc.querySelectorAll(
+          'section > *:first-child');
+      // Focus the first header,
+      tryFocus(headerElements[0]);
+      const upArrowEvent = {
+        keyCode: Keycodes.UP_ARROW,
+        target: headerElements[0],
+        preventDefault: sandbox.spy(),
+      };
+      obj.ampAccordion.implementation_.keyDownHandler_(upArrowEvent);
+      expect(iframe.doc.activeElement)
+          .to.equal(headerElements[headerElements.length - 1]);
+      const downArrowEvent = {
+        keyCode: Keycodes.DOWN_ARROW,
+        target: headerElements[headerElements.length - 1],
+        preventDefault: sandbox.spy(),
+      };
+      obj.ampAccordion.implementation_.keyDownHandler_(downArrowEvent);
+      expect(iframe.doc.activeElement).to.equal(headerElements[0]);
     });
   });
 

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Keycodes} from '../../../../src/utils/keycodes';
+import {KeyCodes} from '../../../../src/utils/key-codes';
 import {createIframePromise} from '../../../../testing/iframe';
 import {tryFocus} from '../../../../src/dom';
 import '../amp-accordion';
@@ -107,7 +107,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       const headerElements = iframe.doc.querySelectorAll(
           'section > *:first-child');
       const keyDownEvent = {
-        keyCode: Keycodes.SPACE,
+        keyCode: KeyCodes.SPACE,
         target: headerElements[0],
         preventDefault: sandbox.spy(),
       };
@@ -129,7 +129,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       const child = iframe.doc.createElement('div');
       headerElements[0].appendChild(child);
       const keyDownEvent = {
-        keyCode: Keycodes.ENTER,
+        keyCode: KeyCodes.ENTER,
         target: child,
         preventDefault: sandbox.spy(),
       };
@@ -149,7 +149,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       const headerElements = iframe.doc.querySelectorAll(
           'section > *:first-child');
       const keyDownEvent = {
-        keyCode: Keycodes.ENTER,
+        keyCode: KeyCodes.ENTER,
         target: headerElements[1],
         preventDefault: sandbox.spy(),
       };
@@ -171,7 +171,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       // Focus the first header,
       tryFocus(headerElements[0]);
       const upArrowEvent = {
-        keyCode: Keycodes.UP_ARROW,
+        keyCode: KeyCodes.UP_ARROW,
         target: headerElements[0],
         preventDefault: sandbox.spy(),
       };
@@ -179,7 +179,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       expect(iframe.doc.activeElement)
           .to.equal(headerElements[headerElements.length - 1]);
       const downArrowEvent = {
-        keyCode: Keycodes.DOWN_ARROW,
+        keyCode: KeyCodes.DOWN_ARROW,
         target: headerElements[headerElements.length - 1],
         preventDefault: sandbox.spy(),
       };

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -55,7 +55,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       };
       expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
       expect(headerElements[0].getAttribute('aria-expanded')).to.equal('false');
-      obj.ampAccordion.implementation_.clickHandler_(clickEvent);
+      obj.ampAccordion.implementation_.onHeaderPicked_(clickEvent);
       expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.true;
       expect(headerElements[0].getAttribute('aria-expanded')).to.equal('true');
       expect(clickEvent.preventDefault.called).to.be.true;
@@ -77,7 +77,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       };
       expect(header.parentNode.hasAttribute('expanded')).to.be.false;
       expect(header.getAttribute('aria-expanded')).to.equal('false');
-      obj.ampAccordion.implementation_.clickHandler_(clickEvent);
+      obj.ampAccordion.implementation_.onHeaderPicked_(clickEvent);
       expect(header.parentNode.hasAttribute('expanded')).to.be.true;
       expect(header.getAttribute('aria-expanded')).to.equal('true');
       expect(clickEvent.preventDefault.called).to.be.true;
@@ -96,7 +96,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       };
       expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
       expect(headerElements[1].getAttribute('aria-expanded')).to.equal('true');
-      obj.ampAccordion.implementation_.clickHandler_(clickEvent);
+      obj.ampAccordion.implementation_.onHeaderPicked_(clickEvent);
       expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.false;
       expect(headerElements[1].getAttribute('aria-expanded')).to.equal('false');
       expect(clickEvent.preventDefault.called).to.be.true;
@@ -112,6 +112,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       const keyDownEvent = {
         keyCode: KeyCodes.SPACE,
         target: headerElements[0],
+        currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
       };
       expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
@@ -134,6 +135,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       const keyDownEvent = {
         keyCode: KeyCodes.ENTER,
         target: child,
+        currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
       };
       expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
@@ -154,6 +156,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       const keyDownEvent = {
         keyCode: KeyCodes.ENTER,
         target: headerElements[1],
+        currentTarget: headerElements[1],
         preventDefault: sandbox.spy(),
       };
       expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
@@ -176,6 +179,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       const upArrowEvent = {
         keyCode: KeyCodes.UP_ARROW,
         target: headerElements[0],
+        currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
       };
       obj.ampAccordion.implementation_.keyDownHandler_(upArrowEvent);
@@ -184,6 +188,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       const downArrowEvent = {
         keyCode: KeyCodes.DOWN_ARROW,
         target: headerElements[headerElements.length - 1],
+        currentTarget: headerElements[headerElements.length - 1],
         preventDefault: sandbox.spy(),
       };
       obj.ampAccordion.implementation_.keyDownHandler_(downArrowEvent);
@@ -220,10 +225,10 @@ describes.sandboxed('amp-accordion', {}, () => {
         preventDefault: sandbox.spy(),
       };
       expect(Object.keys(impl.currentState_)).to.have.length(0);
-      impl.clickHandler_(clickEventExpandElement);
+      impl.onHeaderPicked_(clickEventExpandElement);
       expect(Object.keys(impl.currentState_)).to.have.length(1);
       expect(impl.currentState_['test0']).to.be.true;
-      impl.clickHandler_(clickEventCollapseElement);
+      impl.onHeaderPicked_(clickEventCollapseElement);
       expect(Object.keys(impl.currentState_)).to.have.length(2);
       expect(impl.currentState_['test0']).to.be.true;
       expect(impl.currentState_['test1']).to.be.false;
@@ -292,7 +297,7 @@ describes.sandboxed('amp-accordion', {}, () => {
         currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
       };
-      impl.clickHandler_(clickEventExpandElement);
+      impl.onHeaderPicked_(clickEventExpandElement);
       expect(getSessionStateSpy).to.not.have.been.called;
       expect(setSessionStateSpy).to.not.have.been.called;
       expect(Object.keys(impl.currentState_)).to.have.length(1);
@@ -321,7 +326,7 @@ describes.sandboxed('amp-accordion', {}, () => {
           currentTarget: headerElements1[0],
           preventDefault: sandbox.spy(),
         };
-        ampAccordion1.implementation_.clickHandler_(clickEventElement);
+        ampAccordion1.implementation_.onHeaderPicked_(clickEventElement);
         ampAccordion2.implementation_.buildCallback();
         const headerElements2 = ampAccordion2.querySelectorAll(
           'section > *:first-child');

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -50,6 +50,7 @@ describes.sandboxed('amp-accordion', {}, () => {
           'section > *:first-child');
       const clickEvent = {
         target: headerElements[0],
+        currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
       };
       expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
@@ -71,6 +72,7 @@ describes.sandboxed('amp-accordion', {}, () => {
       header.appendChild(child);
       const clickEvent = {
         target: child,
+        currentTarget: header,
         preventDefault: sandbox.spy(),
       };
       expect(header.parentNode.hasAttribute('expanded')).to.be.false;
@@ -89,6 +91,7 @@ describes.sandboxed('amp-accordion', {}, () => {
           'section > *:first-child');
       const clickEvent = {
         target: headerElements[1],
+        currentTarget: headerElements[1],
         preventDefault: sandbox.spy(),
       };
       expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
@@ -208,10 +211,12 @@ describes.sandboxed('amp-accordion', {}, () => {
           'section > *:first-child');
       const clickEventExpandElement = {
         target: headerElements[0],
+        currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
       };
       const clickEventCollapseElement = {
         target: headerElements[1],
+        currentTarget: headerElements[1],
         preventDefault: sandbox.spy(),
       };
       expect(Object.keys(impl.currentState_)).to.have.length(0);
@@ -284,6 +289,7 @@ describes.sandboxed('amp-accordion', {}, () => {
           'section > *:first-child');
       const clickEventExpandElement = {
         target: headerElements[0],
+        currentTarget: headerElements[0],
         preventDefault: sandbox.spy(),
       };
       impl.clickHandler_(clickEventExpandElement);
@@ -312,6 +318,7 @@ describes.sandboxed('amp-accordion', {}, () => {
           'section > *:first-child');
         const clickEventElement = {
           target: headerElements1[0],
+          currentTarget: headerElements1[0],
           preventDefault: sandbox.spy(),
         };
         ampAccordion1.implementation_.clickHandler_(clickEventElement);

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -323,7 +323,7 @@ export class AmpSelector extends AMP.BaseElement {
       case KeyCodes.LEFT_ARROW: /* fallthrough */
       case KeyCodes.UP_ARROW: /* fallthrough */
       case KeyCodes.RIGHT_ARROW: /* fallthrough */
-      case KeyCodes.DOWN_ARROW: /* fallthrough */
+      case KeyCodes.DOWN_ARROW:
         if (this.kbSelectMode_ != KEYBOARD_SELECT_MODES.NONE) {
           this.navigationKeyDownHandler_(event);
         }

--- a/test/manual/amp-accordion.amp.html
+++ b/test/manual/amp-accordion.amp.html
@@ -25,19 +25,19 @@
   <h1>AMP #0</h1>
   <amp-accordion>
     <section>
-      <h2>Section 1</h2>
+      <h2 tabindex="0">Section 1</h2>
       <div>
         <a href="https://google.com">Google</a>
       </div>
     </section>
     <section expanded>
-      <h2>Section 2</h2>
+      <h2 tabindex="0">Section 2</h2>
       <div>
         Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus
       </div>
     </section>
     <section>
-      <h2>Section 3</h2>
+      <h2 tabindex="0">Section 3</h2>
       <div>
         <amp-img id="img1" srcset="https://lh4.googleusercontent.com/kDqWeHQ0Zt-UFeHAlc2ydE9AwK7W-kbMXBqyuNvPNy0mNSGAP7FOVB3_1iAOdbQSsbZByErbehvvSKtnTb1L5GoYreijfKwgYwpP1eLCHyl9Am7BSpwRuBABOAO12PtyPBTirdAadnxOmfq9dH_rsLSTaYGmNz1D5QIwXeWd8UeDNUQ3f-cMgvkq4ePqmKoe9t5ySqqLMZs-v3wTi2pd4jV_CurzcMB76k_b4lyD5w77NUowkSaQfscYVQpkDjo6OgG2nBiKJ2TITWVDu2rvt6NuEoOD9xaHgXuv81OnOjXCokxZd5K6TZiAH-Qm1jTKGMANklXiXt6hbwrN3QPA1mq2FardxGNLj1_oqOpXaqfUuj8LvejFRY6zJMGq0r6S_TEtPvbyulIg4PkKPIaVzi5nVdGrAWWoesWh-ORqmxZ4FIhdbd_Igsdh5AcMETBcZz3l5-IX0hmnyUeT5IOPSGw-p3Esgp_abwWB9-kElEiiHPD4QuQ_swsRu0NSFwfRi_QefnJQJ5UATng6iVP3K0g7uumHcwLtFId0vCeHp4A=w1024-h768-no" width=512 height=344></amp-img>
       </div>
@@ -45,14 +45,14 @@
   </amp-accordion>
   <amp-accordion disable-session-states>
     <section>
-      <h1>1) Click me first... two time - <i>2) Click me now ... two time</i></h1>
+      <h1 tabindex="0">1) Click me first... two time - <i>2) Click me now ... two time</i></h1>
       <p>Bunch of awesome content</p>
     </section>
   </amp-accordion>
 
   <amp-accordion>
     <section>
-      <h1>
+      <h1 tabindex="0">
         Click here to open
         <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" layout="fixed" height=45 width=45 class="show-on-collapse"></amp-img>
         <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" layout="fixed" height=45 width=45 class="show-on-expand"></amp-img>


### PR DESCRIPTION
Adds keyboard support to `amp-accordion`

- Pressing enter or space when a header is focused should toggle expansion of the associated content
- Pressing the up or down arrows when a header is focused should move to the previous or next headers. This selection should loop around.

[W3 accordion a11y spec](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion)

Partial for #8810 

/to @aghassemi @camelburrito 