### PR TITLE
Split information about OWNERS out of GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,24 +4,12 @@ This document describes the governance model for the AMP open source project, an
 
 Our governance model is as follows:
 
-## OWNERS
-
-* Changes to the AMP repository have to be approved by the `OWNERS` of the code. Owners are specified by directory via the [OWNERS.yaml](https://github.com/ampproject/amphtml/search?utf8=%E2%9C%93&q=filename%3AOWNERS.yaml&type=Code) file.
-* The creator(s) of a particular component, extensions, plugin or sub system should typically name themselves as owners and they are free to delegate ownership to other GitHub users or teams of the [AMP Project GitHub Project](https://github.com/ampproject).
-* Just to rephrase: Ownership of a sub system is **given out liberally** to whoever seems most knowledgeable about a piece of code. Typically the creator should designate themselves.
-* There is no formal process for ownership removal, but the project reserves the right to remove owner privileges for owners that have not responded to multiple GitHub @-mention notifications over multiple weeks.
-* Owners of higher level directories automatically have ownership (approval rights) for sub directories.
-* These higher level owners would, for example, approve the creation of a new component.
-
-## Core Committers:
-
-* On top of owners approval, each pull request additionally requires review and approval from an AMP Project Core Committer](#list-of-core-committers). (Unless the owner also happens to be a core committer.)
-* These additional reviews primarily ensure the security of the project and ensure uniform application of the [design principles](./DESIGN_PRINCIPLES.md).
 * There is a single [Tech Lead](#list-of-core-committers), who will have the final say on all decisions regarding technical direction.
 * The Tech Lead directs the [Core Committers](#list-of-core-committers), whose members include the Tech Lead and those who have been appointed by the Tech Lead as Core Committers.
 * In the event the Tech Lead is unable to perform their duty, or abdicates, the Core Committers can select a new Tech Lead from amongst themselves.
 * In the unlikely event that there are no more Core Committers, Google Inc. will appoint a new Tech Lead.
 * Significant feature development and changes to AMP require following the ["Intent to implement"](./CONTRIBUTING.md#feature-development) process including approval from the Tech Lead and one Core Committer.
+* Before contributions can be merged into the AMP Project approval must be given by an [Owner and a Core Committer](./contributing/owners-and-committers.md)
 
 ### List of Core Committers:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,7 @@ Our governance model is as follows:
 * The Tech Lead directs the [Core Committers](#list-of-core-committers), whose members include the Tech Lead and those who have been appointed by the Tech Lead as Core Committers.
 * In the event the Tech Lead is unable to perform their duty, or abdicates, the Core Committers can select a new Tech Lead from amongst themselves.
 * In the unlikely event that there are no more Core Committers, Google Inc. will appoint a new Tech Lead.
-* Significant feature development and changes to AMP require following the ["Intent to implement"](./CONTRIBUTING.md#feature-development) process including approval from the Tech Lead and one Core Committer.
+* Significant feature development and changes to AMP require following the ["Intent to implement"](./CONTRIBUTING.md#contributing-features) process including approval from the Tech Lead and one Core Committer.
 * Before contributions can be merged into the AMP Project approval must be given by an [Owner and a Core Committer](./contributing/owners-and-committers.md)
 
 ### List of Core Committers:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,7 +9,7 @@ Our governance model is as follows:
 * In the event the Tech Lead is unable to perform their duty, or abdicates, the Core Committers can select a new Tech Lead from amongst themselves.
 * In the unlikely event that there are no more Core Committers, Google Inc. will appoint a new Tech Lead.
 * Significant feature development and changes to AMP require following the ["Intent to implement"](./CONTRIBUTING.md#contributing-features) process including approval from the Tech Lead and one Core Committer.
-* Before contributions can be merged into the AMP Project approval must be given by an [Owner and a Core Committer](./contributing/owners-and-committers.md)
+* Before contributions can be merged into the AMP Project, approval must be given by an [Owner and a Core Committer](./contributing/owners-and-committers.md)
 
 ### List of Core Committers:
 

--- a/contributing/owners-and-committers.md
+++ b/contributing/owners-and-committers.md
@@ -2,7 +2,7 @@
 
 Contributions to the AMP Project require approval from an [Owner](#owners) of the affected code/document/etc. in addition to a [Core Committer](#core-committers).
 
-This system allows us to maintain security and consistent application of the [design principles](./DESIGN_PRINCIPLES.md) while also allowing for a stronger sense of ownership by the people who are most familiar with a given part of the AMP Project.
+This system allows us to maintain security and consistent application of the [design principles](DESIGN_PRINCIPLES.md) while also allowing for a stronger sense of ownership by the people who are most familiar with a given part of the AMP Project.
 
 ## OWNERS
 
@@ -16,5 +16,5 @@ This system allows us to maintain security and consistent application of the [de
 ## Core Committers
 
 * In addition to approval from an Owner of affected code, each pull request requires review and approval from an AMP Project [Core Committer](../GOVERNANCE.md#list-of-core-committers).
-* These additional reviews primarily ensure the security of the project and ensure uniform application of the [design principles](./DESIGN_PRINCIPLES.md).
+* These additional reviews primarily ensure the security of the project and ensure uniform application of the [design principles](DESIGN_PRINCIPLES.md).
 * Note that it is possible for a person to be both a Core Committer and an Owner for code in a given PR in which case the approval from that reviewer will suffice unless that reviewer indicates otherwise.

--- a/contributing/owners-and-committers.md
+++ b/contributing/owners-and-committers.md
@@ -1,0 +1,20 @@
+# Owners and Committers
+
+Contributions to the AMP Project require approval from an [Owner](#owners) of the affected code/document/etc. in addition to a [Core Committer](#core-committers).
+
+This system allows us to maintain security and consistent application of the [design principles](../DESIGN_PRINCIPLES.md) while also allowing for a stronger sense of ownership by the people who are most familiar with a given part of the AMP Project.
+
+## OWNERS
+
+* Changes to the AMP repository require approval from an Owner of the affected code.  Owners are specified by directory via the [OWNERS.yaml](https://github.com/ampproject/amphtml/search?utf8=%E2%9C%93&q=filename%3AOWNERS.yaml&type=Code) file.
+* The creator(s) of a particular component, extension, plugin or sub system should typically name themselves as an Owner.  They are free to delegate ownership to other GitHub users or teams of the [AMP Project GitHub Project](https://github.com/ampproject).
+* Ownership of a sub system is **given out liberally** to whomever seems most knowledgeable about a piece of code. Typically the creator of a component/etc. should designate themselves as Owner.
+* There is no formal process for ownership removal, but the project reserves the right to remove owner privileges for Owners that have not responded to multiple GitHub @-mention notifications over multiple weeks.
+* Owners of higher level directories automatically have ownership (approval rights) for sub directories.  A higher-level OWNER could, for example, approve the creation of a new component.
+* The AMP Project uses the [github-owners-bot](https://github.com/google/github-owners-bot) to check ownership approval.
+
+## Core Committers
+
+* In addition to approval from an Owner of affected code, each pull request requires review and approval from an AMP Project [Core Committer](../GOVERNANCE.md#core-committers).
+* These additional reviews primarily ensure the security of the project and ensure uniform application of the [design principles](../DESIGN_PRINCIPLES.md).
+* Note that it is possible for a person to be both a Core Committer and an Owner for code in a given PR in which case the approval from that reviewer will suffice unless that reviewer indicates otherwise.

--- a/contributing/owners-and-committers.md
+++ b/contributing/owners-and-committers.md
@@ -2,7 +2,7 @@
 
 Contributions to the AMP Project require approval from an [Owner](#owners) of the affected code/document/etc. in addition to a [Core Committer](#core-committers).
 
-This system allows us to maintain security and consistent application of the [design principles](../DESIGN_PRINCIPLES.md) while also allowing for a stronger sense of ownership by the people who are most familiar with a given part of the AMP Project.
+This system allows us to maintain security and consistent application of the [design principles](./DESIGN_PRINCIPLES.md) while also allowing for a stronger sense of ownership by the people who are most familiar with a given part of the AMP Project.
 
 ## OWNERS
 
@@ -15,6 +15,6 @@ This system allows us to maintain security and consistent application of the [de
 
 ## Core Committers
 
-* In addition to approval from an Owner of affected code, each pull request requires review and approval from an AMP Project [Core Committer](../GOVERNANCE.md#core-committers).
-* These additional reviews primarily ensure the security of the project and ensure uniform application of the [design principles](../DESIGN_PRINCIPLES.md).
+* In addition to approval from an Owner of affected code, each pull request requires review and approval from an AMP Project [Core Committer](../GOVERNANCE.md#list-of-core-committers).
+* These additional reviews primarily ensure the security of the project and ensure uniform application of the [design principles](./DESIGN_PRINCIPLES.md).
 * Note that it is possible for a person to be both a Core Committer and an Owner for code in a given PR in which case the approval from that reviewer will suffice unless that reviewer indicates otherwise.


### PR DESCRIPTION
Implements a fix for issue #8183.

This separates documentation on the approvals a PR requires + the concept of OWNERS out of GOVERNANCE which now focuses more on what the Core Committers are/etc.

cc @cramforce @erwinmombay 