### PR TITLE
Improve localhost link filtering in markdown during pr-check.js

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -84,6 +84,25 @@ function checkLinks() {
 }
 
 /**
+ * Filters out markdown elements that contain localhost links.
+ *
+ * @param {string} markdown Original markdown.
+ * @return {string} Markdown after filtering out localhost links.
+ */
+function filterLocalhostLinks(markdown) {
+  var localhostPattern = 'http:\/\/localhost:8000';
+  var parenLinks = new RegExp('\\('+ localhostPattern + '[^\\)]*\\)', 'g');
+  var bracketLinks = new RegExp('\\['+ localhostPattern + '[^\\]]*\\]', 'g');
+  var rawLinks = new RegExp(localhostPattern, 'g');
+
+  var filteredMarkdown = markdown;
+  filteredMarkdown = filteredMarkdown.replace(parenLinks, '');
+  filteredMarkdown = filteredMarkdown.replace(bracketLinks, '');
+  filteredMarkdown = filteredMarkdown.replace(rawLinks, '');
+  return filteredMarkdown;
+}
+
+/**
  * Reads the raw contents in the given markdown file, filters out localhost
  * links (because they do not resolve on Travis), and checks for dead links.
  *
@@ -92,7 +111,7 @@ function checkLinks() {
  */
 function runLinkChecker(markdownFile) {
   var markdown = fs.readFileSync(markdownFile).toString();
-  var filteredMarkdown = markdown.replace(/http:\/\/localhost:8000\//g, '');
+  var filteredMarkdown = filterLocalhostLinks(markdown);
   var opts = {
     baseUrl : 'file://' + path.dirname(path.resolve((markdownFile)))
   };

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -85,6 +85,7 @@ function checkLinks() {
 
 /**
  * Filters out markdown elements that contain localhost links.
+ * TODO(rsimha-amp): Simplify this into a single regex.
  *
  * @param {string} markdown Original markdown.
  * @return {string} Markdown after filtering out localhost links.


### PR DESCRIPTION
On further testing, some inline links in markdown were slipping through, causing false negatives in "gulp check-links". This PR goes through the two kinds of markdown elements that contain links (within parentheses and brackets), and then filters out raw localhost links found in text.

For reference, see https://guides.github.com/features/mastering-markdown/#syntax (scroll down to Links)

Issue #7946
Follow up to PR #9099 