### PR TITLE
Service cleanup: Require a constructor for all services

### DIFF
--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -21,7 +21,7 @@ import {accessServiceForDoc} from '../../../src/services';
 AMP.extension('amp-access-laterpay', '0.1', function(AMP) {
   AMP.registerServiceForDoc(
       'laterpay',
-      ampdoc => {
+      function(ampdoc) {
         return accessServiceForDoc(ampdoc).then(accessService => {
           const vendor = new LaterpayVendor(accessService);
           accessService.registerVendor('laterpay', vendor);

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.js
@@ -21,7 +21,6 @@ import {accessServiceForDoc} from '../../../src/services';
 AMP.extension('amp-access-laterpay', '0.1', function(AMP) {
   AMP.registerServiceForDoc(
       'laterpay',
-      /* ctor */ undefined,
       ampdoc => {
         return accessServiceForDoc(ampdoc).then(accessService => {
           const vendor = new LaterpayVendor(accessService);

--- a/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
@@ -164,7 +164,7 @@ export function installDynamicClassesForTesting(ampdoc) {
 // Register doc-service factory.
 AMP.registerServiceForDoc(
     'amp-dynamic-css-classes',
-    ampdoc => {
+    function(ampdoc) {
       addRuntimeClasses(ampdoc);
       return {};
     });

--- a/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
@@ -164,7 +164,6 @@ export function installDynamicClassesForTesting(ampdoc) {
 // Register doc-service factory.
 AMP.registerServiceForDoc(
     'amp-dynamic-css-classes',
-    /* ctor */ undefined,
     ampdoc => {
       addRuntimeClasses(ampdoc);
       return {};

--- a/src/inabox/inabox-iframe-messaging-client.js
+++ b/src/inabox/inabox-iframe-messaging-client.js
@@ -32,7 +32,6 @@ export function iframeMessagingClientFor(win) {
 export function installIframeMessagingClient(win) {
   registerServiceBuilder(win,
       'iframeMessagingClient',
-      /* opt_ctor */ undefined,
       createIframeMessagingClient.bind(null, win),
       /* opt_instantiate */ true);
 }

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -183,7 +183,6 @@ export function installInaboxViewportService(ampdoc) {
       function() {
         return new Viewport(ampdoc, binding, viewer);
       },
-      /* opt_factory */ undefined,
       /* opt_instantiate */ true);
 }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -509,14 +509,12 @@ function registerElementClass(global, name, implementationClass, opt_css) {
  * @param {!Window} global
  * @param {!./service/extensions-impl.Extensions} extensions
  * @param {string} name
- * @param {function(new:Object, !./service/ampdoc-impl.AmpDoc)=} opt_ctor
- * @param {function(!./service/ampdoc-impl.AmpDoc):!Object=} opt_factory
+ * @param {!function(new:Object, !./service/ampdoc-impl.AmpDoc)} ctor
  */
-function prepareAndRegisterServiceForDoc(global, extensions,
-    name, opt_ctor, opt_factory) {
+function prepareAndRegisterServiceForDoc(global, extensions, name, ctor) {
   const ampdocService = ampdocServiceFor(global);
   const ampdoc = ampdocService.getAmpDoc();
-  registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory);
+  registerServiceForDoc(ampdoc, name, ctor);
 }
 
 
@@ -525,13 +523,12 @@ function prepareAndRegisterServiceForDoc(global, extensions,
  * @param {!Window} global
  * @param {!./service/extensions-impl.Extensions} extensions
  * @param {string} name
- * @param {function(new:Object, !./service/ampdoc-impl.AmpDoc)=} opt_ctor
- * @param {function(!./service/ampdoc-impl.AmpDoc):!Object=} opt_factory
+ * @param {!function(new:Object, !./service/ampdoc-impl.AmpDoc)} ctor
  */
 function prepareAndRegisterServiceForDocShadowMode(global, extensions,
-    name, opt_ctor, opt_factory) {
+    name, ctor) {
   addDocFactoryToExtension(extensions, ampdoc => {
-    registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory);
+    registerServiceForDoc(ampdoc, name, ctor);
   }, name);
 }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -541,17 +541,12 @@ function prepareAndRegisterServiceForDocShadowMode(global, extensions,
  * modes.
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @param {string} name
- * @param {function(new:Object, !./service/ampdoc-impl.AmpDoc)=} opt_ctor
- * @param {function(!./service/ampdoc-impl.AmpDoc):!Object=} opt_factory
+ * @param {function(new:Object, !./service/ampdoc-impl.AmpDoc)} ctor
  */
-function registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory) {
+function registerServiceForDoc(ampdoc, name, ctor) {
   // TODO(kmh287): Investigate removing the opt_instantiate arg after
   // all other services have been refactored.
-  registerServiceBuilderForDoc(ampdoc,
-                               name,
-                               opt_ctor,
-                               opt_factory,
-                               /* opt_instantiate */ true);
+  registerServiceBuilderForDoc(ampdoc, name, ctor, /* opt_instantiate */ true);
 }
 
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -509,12 +509,14 @@ function registerElementClass(global, name, implementationClass, opt_css) {
  * @param {!Window} global
  * @param {!./service/extensions-impl.Extensions} extensions
  * @param {string} name
- * @param {!function(new:Object, !./service/ampdoc-impl.AmpDoc)} ctor
+ * @param {function(new:Object, !./service/ampdoc-impl.AmpDoc)=} opt_ctor
+ * @param {function(!./service/ampdoc-impl.AmpDoc):!Object=} opt_factory
  */
-function prepareAndRegisterServiceForDoc(global, extensions, name, ctor) {
+function prepareAndRegisterServiceForDoc(global, extensions,
+    name, opt_ctor, opt_factory) {
   const ampdocService = ampdocServiceFor(global);
   const ampdoc = ampdocService.getAmpDoc();
-  registerServiceForDoc(ampdoc, name, ctor);
+  registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory);
 }
 
 
@@ -523,12 +525,13 @@ function prepareAndRegisterServiceForDoc(global, extensions, name, ctor) {
  * @param {!Window} global
  * @param {!./service/extensions-impl.Extensions} extensions
  * @param {string} name
- * @param {!function(new:Object, !./service/ampdoc-impl.AmpDoc)} ctor
+ * @param {function(new:Object, !./service/ampdoc-impl.AmpDoc)=} opt_ctor
+ * @param {function(!./service/ampdoc-impl.AmpDoc):!Object=} opt_factory
  */
 function prepareAndRegisterServiceForDocShadowMode(global, extensions,
-    name, ctor) {
+    name, opt_ctor, opt_factory) {
   addDocFactoryToExtension(extensions, ampdoc => {
-    registerServiceForDoc(ampdoc, name, ctor);
+    registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory);
   }, name);
 }
 
@@ -538,12 +541,23 @@ function prepareAndRegisterServiceForDocShadowMode(global, extensions,
  * modes.
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @param {string} name
- * @param {function(new:Object, !./service/ampdoc-impl.AmpDoc)} ctor
+ * @param {function(new:Object, !./service/ampdoc-impl.AmpDoc)=} opt_ctor
+ * @param {function(!./service/ampdoc-impl.AmpDoc):!Object=} opt_factory
  */
-function registerServiceForDoc(ampdoc, name, ctor) {
+function registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory) {
+  // TODO(kmh287): Refactor to remove opt_factory param once #9212 has been
+  // in prod for two releases.
+  // Wrapping factory in function is necessary as opt_factory could be an
+  // arrow function, which cannot be used as constructors.
+  const ctor = opt_ctor || function(ampdoc) {
+    return opt_factory(ampdoc);
+  };
   // TODO(kmh287): Investigate removing the opt_instantiate arg after
   // all other services have been refactored.
-  registerServiceBuilderForDoc(ampdoc, name, ctor, /* opt_instantiate */ true);
+  registerServiceBuilderForDoc(ampdoc,
+                               name,
+                               ctor,
+                               /* opt_instantiate */ true);
 }
 
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -545,7 +545,7 @@ function prepareAndRegisterServiceForDocShadowMode(global, extensions,
  * @param {function(!./service/ampdoc-impl.AmpDoc):!Object=} opt_factory
  */
 function registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory) {
-  // TODO(kmh287): Refactor to remove opt_factory param once #9212 has been
+  // TODO(kmh287, #9292): Refactor to remove opt_factory param once #9212 has been
   // in prod for two releases.
   // Wrapping factory in function is necessary as opt_factory could be an
   // arrow function, which cannot be used as constructors.

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -514,6 +514,8 @@ function registerElementClass(global, name, implementationClass, opt_css) {
  */
 function prepareAndRegisterServiceForDoc(global, extensions,
     name, opt_ctor, opt_factory) {
+  // TODO(kmh287, #9292): Refactor to remove opt_factory param and require ctor
+  // once #9212 has been in prod for two releases.
   const ampdocService = ampdocServiceFor(global);
   const ampdoc = ampdocService.getAmpDoc();
   registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory);
@@ -530,6 +532,8 @@ function prepareAndRegisterServiceForDoc(global, extensions,
  */
 function prepareAndRegisterServiceForDocShadowMode(global, extensions,
     name, opt_ctor, opt_factory) {
+  // TODO(kmh287, #9292): Refactor to remove opt_factory param and require ctor
+  // once #9212 has been in prod for two releases.
   addDocFactoryToExtension(extensions, ampdoc => {
     registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory);
   }, name);
@@ -545,8 +549,8 @@ function prepareAndRegisterServiceForDocShadowMode(global, extensions,
  * @param {function(!./service/ampdoc-impl.AmpDoc):!Object=} opt_factory
  */
 function registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory) {
-  // TODO(kmh287, #9292): Refactor to remove opt_factory param once #9212 has been
-  // in prod for two releases.
+  // TODO(kmh287, #9292): Refactor to remove opt_factory param and require ctor
+  // once #9212 has been in prod for two releases.
   // Wrapping factory in function is necessary as opt_factory could be an
   // arrow function, which cannot be used as constructors.
   const ctor = opt_ctor || function(ampdoc) {

--- a/src/service.js
+++ b/src/service.js
@@ -30,8 +30,9 @@ import {dev} from './log';
  *   obj: (?Object),
  *   promise: (?Promise),
  *   resolve: (?function(!Object)),
- *   context: (!Window|!./service/ampdoc-impl.AmpDoc),
- *   ctor: {?function(new:Object,!Window|!./service/ampdoc-impl.AmpDoc):!Object}
+ *   context: (?Window|?./service/ampdoc-impl.AmpDoc),
+ *   ctor: (?function(new:Object, !Window)|
+ *          ?function(new:Object, !./service/ampdoc-impl.AmpDoc)),
  * }}
  */
 let ServiceHolderDef;
@@ -178,7 +179,7 @@ export function getService(win, id) {
  * Registers a service given a class to be used as implementation.
  * @param {!Window} win
  * @param {string} id of the service.
- * @param {function(new:Object, !Window)=} constructor
+ * @param {function(new:Object, !Window)} constructor
  * @param {boolean=} opt_instantiate Whether to immediately create the service
  */
 export function registerServiceBuilder(win,
@@ -380,7 +381,7 @@ function getServiceInternal(holder, id) {
   const services = getServices(holder);
   const s = services[id];
   if (!s.obj) {
-    dev().assert(s.ctor, `Service ${id} registered without constructor nor impl.`);
+    dev().assert(s.ctor, `Service ${id} registered without ctor nor impl.`);
     dev().assert(s.context, `Service ${id} registered without context.`);
     s.obj = new s.ctor(s.context);
     dev().assert(s.obj, `Service ${id} constructed to null.`);
@@ -399,7 +400,8 @@ function getServiceInternal(holder, id) {
  * @param {!Object} holder Object holding the service instance.
  * @param {!Window|!./service/ampdoc-impl.AmpDoc} context Win or AmpDoc.
  * @param {string} id of the service.
- * @param {!function(new:Object,!Window|!./service/ampdoc-impl.AmpDoc):!Object}
+ * @param {?function(new:Object, !Window)|
+ *         ?function(new:Object, !./service/ampdoc-impl.AmpDoc)}
  *     ctor Constructor function to new the service. Called with context.
  */
 function registerServiceInternal(holder, context, id, ctor) {

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -922,6 +922,5 @@ export function installActionServiceForDoc(ampdoc) {
       ampdoc,
       'action',
       ActionService,
-      /* opt_factory */ undefined,
       /* opt_instantiate */ true);
 }

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -482,6 +482,6 @@ export function installDocService(win, isSingleDoc) {
       win,
       'ampdoc',
       function() {
-        return new AmpDocService(win, isSingleDoc)
+        return new AmpDocService(win, isSingleDoc);
       });
 };

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -481,5 +481,7 @@ export function installDocService(win, isSingleDoc) {
   registerServiceBuilder(
       win,
       'ampdoc',
-      () => new AmpDocService(win, isSingleDoc));
+      function() {
+        return new AmpDocService(win, isSingleDoc)
+      });
 };

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -481,6 +481,5 @@ export function installDocService(win, isSingleDoc) {
   registerServiceBuilder(
       win,
       'ampdoc',
-      /* opt_constructor */ undefined,
       () => new AmpDocService(win, isSingleDoc));
 };

--- a/src/service/document-click.js
+++ b/src/service/document-click.js
@@ -49,7 +49,6 @@ export function installGlobalClickListenerForDoc(ampdoc) {
       ampdoc,
       TAG,
       ClickHandler,
-      /* opt_factory */ undefined,
       /* opt_instantiate */ true);
 }
 

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -866,5 +866,7 @@ export function installHistoryServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(
       ampdoc,
       'history',
-      ampdoc => createHistory(ampdoc));
+      function(ampdoc) {
+        return createHistory(ampdoc);
+      });
 }

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -866,6 +866,5 @@ export function installHistoryServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(
       ampdoc,
       'history',
-      /* opt_constructor */ undefined,
       ampdoc => createHistory(ampdoc));
 }

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -863,10 +863,5 @@ function createHistory(ampdoc) {
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  */
 export function installHistoryServiceForDoc(ampdoc) {
-  registerServiceBuilderForDoc(
-      ampdoc,
-      'history',
-      function(ampdoc) {
-        return createHistory(ampdoc);
-      });
+  registerServiceBuilderForDoc(ampdoc, 'history', createHistory);
 }

--- a/src/service/parallax-impl.js
+++ b/src/service/parallax-impl.js
@@ -213,6 +213,5 @@ export function installParallaxForDoc(nodeOrDoc) {
       nodeOrDoc,
       'amp-fx-parallax',
       ParallaxService,
-      /* opt_factory */ undefined,
       /* opt instantiate */ true);
 };

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -191,6 +191,5 @@ export function installStandardActionsForDoc(ampdoc) {
       ampdoc,
       'standard-actions',
       StandardActions,
-      /* opt_factory */ undefined,
       /* opt_instantiate */ true);
 };

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -387,7 +387,6 @@ export function installStorageServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(
       ampdoc,
       'storage',
-      /* opt_ctor */ undefined,
       () => {
         const viewer = viewerForDoc(ampdoc);
         const overrideStorage = parseInt(viewer.getParam('storage'), 10);

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -387,7 +387,7 @@ export function installStorageServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(
       ampdoc,
       'storage',
-      () => {
+      function() {
         const viewer = viewerForDoc(ampdoc);
         const overrideStorage = parseInt(viewer.getParam('storage'), 10);
         const binding = overrideStorage ?

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -972,7 +972,6 @@ export function installUrlReplacementsServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(
       ampdoc,
       'url-replace',
-      /* opt_constructor */ undefined,
       doc => new UrlReplacements(doc, new GlobalVariableSource(doc)));
 }
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -973,7 +973,7 @@ export function installUrlReplacementsServiceForDoc(ampdoc) {
       ampdoc,
       'url-replace',
       function(doc) {
-        return new UrlReplacements(doc, new GlobalVariableSource(doc))
+        return new UrlReplacements(doc, new GlobalVariableSource(doc));
       });
 }
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -972,7 +972,9 @@ export function installUrlReplacementsServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(
       ampdoc,
       'url-replace',
-      doc => new UrlReplacements(doc, new GlobalVariableSource(doc)));
+      function(doc) {
+        return new UrlReplacements(doc, new GlobalVariableSource(doc))
+      });
 }
 
 /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -981,6 +981,8 @@ export function setViewerVisibilityState(viewer, state) {
 export function installViewerServiceForDoc(ampdoc, opt_initParams) {
   registerServiceBuilderForDoc(ampdoc,
       'viewer',
-      () => new Viewer(ampdoc, opt_initParams),
+      function() {
+        return new Viewer(ampdoc, opt_initParams);
+      },
       /* opt_instantiate */ true);
 }

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -981,7 +981,6 @@ export function setViewerVisibilityState(viewer, state) {
 export function installViewerServiceForDoc(ampdoc, opt_initParams) {
   registerServiceBuilderForDoc(ampdoc,
       'viewer',
-      /* opt_ctor */ undefined,
       () => new Viewer(ampdoc, opt_initParams),
       /* opt_instantiate */ true);
 }

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1890,8 +1890,6 @@ function getViewportType(win, viewer) {
 export function installViewportServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(ampdoc,
       'viewport',
-      function(ampdoc) {
-        return createViewport(ampdoc);
-      },
+      createViewport,
       /* opt_instantiate */ true);
 }

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1890,6 +1890,8 @@ function getViewportType(win, viewer) {
 export function installViewportServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(ampdoc,
       'viewport',
-      ampdoc => createViewport(ampdoc),
+      function(ampdoc) {
+        return createViewport(ampdoc);
+      },
       /* opt_instantiate */ true);
 }

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -1888,8 +1888,8 @@ function getViewportType(win, viewer) {
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  */
 export function installViewportServiceForDoc(ampdoc) {
-  registerServiceBuilderForDoc(ampdoc, 'viewport',
-      /* constructor */ undefined,
+  registerServiceBuilderForDoc(ampdoc,
+      'viewport',
       ampdoc => createViewport(ampdoc),
-      /* instantiate */ true);
+      /* opt_instantiate */ true);
 }

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1983,8 +1983,6 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
       const p1 = getElementServiceIfAvailable(win, 'e1', 'element-1');
       return Promise.resolve().then(() => {
         expect(intervalCallback).to.be.undefined;
-
-        // Resolve service.
         registerServiceBuilder(win, 'e1', function() {
           return {str: 'fake1'};
         });
@@ -2166,7 +2164,6 @@ describes.realWin('services', {
     const p1 = getElementServiceIfAvailableForDoc(
         env.ampdoc, 'e1', 'element-1');
     return Promise.resolve().then(() => {
-      // Resolve service.
       registerServiceBuilder(env.win, 'e1', function() {
         return {str: 'fake1'};
       });

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -575,8 +575,10 @@ describes.fakeWin('runtime', {
     });
 
     it('should register doc-service factory and install it immediately', () => {
+      let count = 0;
       function factory() {
-        return 'A';
+        count++;
+        return {str: 'A'};
       }
       const ampdoc = new AmpDocSingle(win);
       ampdocServiceMock.expects('getAmpDoc')
@@ -585,7 +587,7 @@ describes.fakeWin('runtime', {
       win.AMP.push({
         n: 'amp-ext',
         f: amp => {
-          amp.registerServiceForDoc('service1', undefined, factory);
+          amp.registerServiceForDoc('service1', factory);
         },
       });
       runChunksForTesting(win.document);
@@ -595,7 +597,8 @@ describes.fakeWin('runtime', {
       expect(extHolder.docFactories).to.have.length(0);
 
       // Already installed.
-      expect(getServiceForDoc(ampdoc, 'service1')).to.equal('A');
+      expect(count).to.equal(1);
+      expect(getServiceForDoc(ampdoc, 'service1')).to.deep.equal({str: 'A'});
     });
   });
 

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -83,14 +83,14 @@ describe('service', () => {
 
     beforeEach(() => {
       count = 0;
-      factory = sandbox.spy(function() {
-        return new Class();
-      });
       Class = class {
         constructor() {
           this.count = ++count;
         }
       };
+      factory = sandbox.spy(() => {
+        return new Class();
+      });
       resetServiceForTesting(window, 'a');
       resetServiceForTesting(window, 'b');
       resetServiceForTesting(window, 'c');
@@ -202,10 +202,10 @@ describe('service', () => {
     it('should set service builders to null after instantiation', () => {
       registerServiceBuilder(window, 'a', Class);
       expect(window.services['a'].obj).to.be.null;
-      expect(window.services['a'].build).to.not.be.null;
+      expect(window.services['a'].ctor).to.not.be.null;
       getService(window, 'a');
       expect(window.services['a'].obj).to.not.be.null;
-      expect(window.services['a'].build).to.be.null;
+      expect(window.services['a'].ctor).to.be.null;
     });
 
     it('should resolve service for a child window', () => {


### PR DESCRIPTION
This PR removes the optional constructor or optional factory from service registration and instead requires one function that will always be called with `new`. Services that were previously built with factories pass those factories in as this function. These factories will work identically as before with one caveat: they must not return primitives. 

```js
const f = function() {
  return 'Hello World'
}

f()     // 'Hello World'
new f() // {}
```

This was only a problem in our tests, which needed to be changed to ensure fake factories always returned an object instead of primitives.

/to @dvoytenko @jridgewell I think this is more what you meant on #8946 and https://github.com/ampproject/amphtml/pull/9141#discussion_r114869454 though I'm worried about the following scenario.

```js
const g = () => 'Hello World'
g()     // 'Hello World'
new g() // TypeError: h is not a constructor
```
Is this something we should worry about? I can do this in the developer console, but as I write this all tests are passing, including ones that test services that are constructed via factory.