### PR TITLE
Add keyboard support to amp-social-share

### DIFF
--- a/examples/social-share.amp.html
+++ b/examples/social-share.amp.html
@@ -35,22 +35,55 @@
     <h1>Social Share</h1>
 
     <div class="social-box">
-      <amp-social-share type="email" data-param-subject="Hello World" data-param-body="What's up?"></amp-social-share>
-      <amp-social-share type="whatsapp"></amp-social-share>
-      <amp-social-share type="pinterest" data-param-media="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no"></amp-social-share>
-      <amp-social-share type="system" data-mode="replace" data-param-text="Shared via the Web Share API"></amp-social-share>
+      <amp-social-share type="email"
+                        data-param-subject="Hello World"
+                        data-param-body="What's up?"
+                        tabindex="0"
+                        aria-label="Share by email">
+      </amp-social-share>
+      <amp-social-share type="whatsapp"
+                        tabindex="0"
+                        aria-label="Share to Whatsapp">
+      </amp-social-share>
+      <amp-social-share type="pinterest"
+                        data-param-media="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no"
+                        tabindex="0"
+                        aria-label="Share to Pinterest">
+      </amp-social-share>
+      <amp-social-share type="system"
+                        data-mode="replace"
+                        data-param-text="Shared via the Web Share API"
+                        tabindex="-1">
+      </amp-social-share>
       <amp-social-share type="facebook"
                         data-param-text="Hello world"
                         data-param-href="https://example.com/?ref=URL"
-                        data-param-app_id="145634995501895"></amp-social-share>
-
-      <amp-social-share type="twitter"></amp-social-share>
-      <amp-social-share type="linkedin" width="108" height="44" layout="fixed"></amp-social-share>
-
-      <amp-social-share layout="responsive" width="40" height="40" type="baidu"
+                        data-param-app_id="145634995501895"
+                        tabindex="0"
+                        aria-label="Share to Facebook">
+      </amp-social-share>
+      <amp-social-share type="twitter"
+                        tabindex="0"
+                        aria-label="Share to Twitter">
+      </amp-social-share>
+      <amp-social-share type="linkedin"
+                        width="108"
+                        height="44"
+                        layout="fixed"
+                        tabindex="0"
+                        aria-label="Share to LinkedIn">
+      </amp-social-share>
+      <amp-social-share layout="responsive"
+                        width="40"
+                        height="40"
+                        type="baidu"
                         data-share-endpoint="http://cang.baidu.com/do/add"
                         data-param-iu="CANONICAL_URL"
-                        data-param-it="TITLE">B</amp-social-share>
+                        data-param-it="TITLE"
+                        tabindex="0"
+                        aria-label="Share to Baidu">
+        B
+      </amp-social-share>
 
     </div>
   </body>

--- a/examples/social-share.amp.html
+++ b/examples/social-share.amp.html
@@ -38,16 +38,13 @@
       <amp-social-share type="email"
                         data-param-subject="Hello World"
                         data-param-body="What's up?"
-                        tabindex="0"
                         aria-label="Share by email">
       </amp-social-share>
       <amp-social-share type="whatsapp"
-                        tabindex="0"
                         aria-label="Share to Whatsapp">
       </amp-social-share>
       <amp-social-share type="pinterest"
                         data-param-media="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no"
-                        tabindex="0"
                         aria-label="Share to Pinterest">
       </amp-social-share>
       <amp-social-share type="system"
@@ -59,18 +56,15 @@
                         data-param-text="Hello world"
                         data-param-href="https://example.com/?ref=URL"
                         data-param-app_id="145634995501895"
-                        tabindex="0"
                         aria-label="Share to Facebook">
       </amp-social-share>
       <amp-social-share type="twitter"
-                        tabindex="0"
                         aria-label="Share to Twitter">
       </amp-social-share>
       <amp-social-share type="linkedin"
                         width="108"
                         height="44"
                         layout="fixed"
-                        tabindex="0"
                         aria-label="Share to LinkedIn">
       </amp-social-share>
       <amp-social-share layout="responsive"
@@ -80,7 +74,6 @@
                         data-share-endpoint="http://cang.baidu.com/do/add"
                         data-param-iu="CANONICAL_URL"
                         data-param-it="TITLE"
-                        tabindex="0"
                         aria-label="Share to Baidu">
         B
       </amp-social-share>

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Keycodes} from '../../../src/utils/keycodes';
 import {addParamsToUrl, parseUrl, parseQueryString} from '../../../src/url';
 import {setStyle} from '../../../src/style';
 import {getDataParamsFromAttributes} from '../../../src/dom';
@@ -96,13 +97,34 @@ class AmpSocialShare extends AMP.BaseElement {
           ? '_top' : '_blank';
     });
 
-    this.element.setAttribute('role', 'link');
+    this.element.setAttribute('role', 'button');
     this.element.addEventListener('click', () => this.handleClick_());
+    this.element.addEventListener('keydown', this.handleKeyDown_.bind(this));
     this.element.classList.add(`amp-social-share-${typeAttr}`);
   }
 
-  /** @private */
+  /**
+   * Handle key presses on the element.
+   * @param {!Event} event
+   * @private
+   */
+  handleKeyDown_(event) {
+    let keyCode = event.keyCode;
+    if (keyCode == Keycodes.SPACE || keyCode == Keycodes.ENTER) {
+      this.handleActivation_();
+    }
+  }
+
+  /**
+   * Handle clicks on the element.
+   * @private
+   */
   handleClick_() {
+    this.handleActivation_();
+  }
+
+  /** @private */
+  handleActivation_() {
     user().assert(this.href_ && this.target_, 'Clicked before href is set.');
     const href = dev().assertString(this.href_);
     const target = dev().assertString(this.target_);

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -98,6 +98,9 @@ class AmpSocialShare extends AMP.BaseElement {
     });
 
     this.element.setAttribute('role', 'button');
+    if (!this.element.hasAttribute('tabindex')) {
+      this.element.setAttribute('tabindex', '0');
+    }
     this.element.addEventListener('click', () => this.handleClick_());
     this.element.addEventListener('keydown', this.handleKeyPress_.bind(this));
     this.element.classList.add(`amp-social-share-${typeAttr}`);

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -99,7 +99,7 @@ class AmpSocialShare extends AMP.BaseElement {
 
     this.element.setAttribute('role', 'button');
     this.element.addEventListener('click', () => this.handleClick_());
-    this.element.addEventListener('keydown', this.handleKeyDown_.bind(this));
+    this.element.addEventListener('keydown', this.handleKeyPress_.bind(this));
     this.element.classList.add(`amp-social-share-${typeAttr}`);
   }
 
@@ -108,9 +108,10 @@ class AmpSocialShare extends AMP.BaseElement {
    * @param {!Event} event
    * @private
    */
-  handleKeyDown_(event) {
-    let keyCode = event.keyCode;
+  handleKeyPress_(event) {
+    const keyCode = event.keyCode;
     if (keyCode == Keycodes.SPACE || keyCode == Keycodes.ENTER) {
+      event.preventDefault();
       this.handleActivation_();
     }
   }

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -225,4 +225,11 @@ describe('amp-social-share', () => {
       );
     });
   });
+
+  it('has tabindex set to 0 by default', () => {
+    return getShare('twitter').then(el => {
+      expect(el.getAttribute('tabindex')).to.equal('0');
+    });
+  });
+
 });

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Keycodes} from '../../../../src/utils/keycodes';
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
 import * as sinon from 'sinon';
@@ -151,8 +152,9 @@ describe('amp-social-share', () => {
           'https://twitter.com/intent/tweet');
 
       expect(el.implementation_.href_).to.not.contain('TITLE');
-      expect(el.addEventListener).to.be.calledOnce;
+      expect(el.addEventListener).to.be.calledTwice;
       expect(el.addEventListener).to.be.calledWith('click');
+      expect(el.addEventListener).to.be.calledWith('keydown');
     });
   });
 
@@ -198,6 +200,28 @@ describe('amp-social-share', () => {
           'mailto:?subject=doc%20title&' +
             'body=https%3A%2F%2Fcanonicalexample.com%2F',
           '_top', 'resizable,scrollbars,width=640,height=480'
+      );
+    });
+  });
+
+  it('should handle key presses', () => {
+    return getShare('twitter').then(el => {
+      const nonActivationEvent = {
+        preventDefault: () => {},
+        keyCode: Keycodes.RIGHT_ARROW,
+      };
+      const activationEvent = {
+        preventDefault: () => {},
+        keyCode: Keycodes.SPACE,
+      };
+      el.implementation_.handleKeyPress_(nonActivationEvent);
+      expect(el.implementation_.win.open).to.not.have.been.called;
+      el.implementation_.handleKeyPress_(activationEvent);
+      expect(el.implementation_.win.open).to.be.calledOnce;
+      expect(el.implementation_.win.open).to.be.calledWith(
+        'https://twitter.com/intent/tweet?text=doc%20title&' +
+          'url=https%3A%2F%2Fcanonicalexample.com%2F',
+          '_blank', 'resizable,scrollbars,width=640,height=480'
       );
     });
   });


### PR DESCRIPTION
Adds keyboard support to `amp-social-share`. 
- Pressing enter or space when an `amp-social-share` is focused will activate the element as a click would
- The role of amp-social-share has been changed from "link" to "button"

Partial for #8810 

/to @aghassemi 