### PR TITLE
amp-bind: Integration test for amp-state looping

### DIFF
--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -503,7 +503,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
               'https://www.google.com/bind/second/source',
               sinon.match.any)
           .returns(Promise.resolve({
-            ampStateSrc: 'https://www.google.com/bind/first/source',
+            stateSrc: 'https://www.google.com/bind/first/source',
           }));
       // Changes amp-state's src from .../first/source to .../second/source.
       changeAmpStateSrcButton.click();

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -490,41 +490,41 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
 
   describe('amp-state', () => {
     it('should not loop infinitely if updates change its src binding', () => {
-      // Changes amp-state's src to ...amp-state-src2
       const changeAmpStateSrcButton =
           fixture.doc.getElementById('ampStateSrcButton');
       const triggerBindApplicationButton =
           fixture.doc.getElementById('triggerBindApplicationButton');
       const ampState = fixture.doc.getElementById('ampState');
       const batchedXhr = batchedXhrFor(fixture.win);
-      // Stub XHR for endpoint ...amp-state-src2 that returns state that would
-      // redirect the amp-state's src back to the original src, amp-state-src.
-      sandbox.stub(batchedXhr, 'fetchJson').returns(Promise.resolve({
-        ampStateSrc: 'https://www.google.com/bind/first/source',
-      }));
-      const spy =
-          sandbox.spy(ampState.implementation_, 'mutatedAttributesCallback');
+      // Stub XHR for endpoint such that it returns state that would point
+      // the amp-state element back to its original source.
+      sandbox.stub(batchedXhr, 'fetchJson')
+          .withArgs(
+              'https://www.google.com/bind/second/source',
+              sinon.match.any)
+          .returns(Promise.resolve({
+            ampStateSrc: 'https://www.google.com/bind/first/source',
+          }));
+      // Changes amp-state's src from .../first/source to .../second/source.
       changeAmpStateSrcButton.click();
       return waitForBindApplication().then(() => {
-        expect(spy).to.have.been.calledWith(sinon.match({
-          src: 'https://www.google.com/bind/second/source',
-        }));
-        spy.reset();
+        expect(ampState.getAttribute('src'))
+            .to.equal('https://www.google.com/bind/second/source');
         // Wait for XHR to finish and for bind to re-apply bindings.
         return waitForBindApplication();
       }).then(() => {
-        // amp-state mutation should never trigger an amp-state's
-        // mutatedAttributesCallback
-        expect(spy).to.not.have.been.called;
+        // bind applications caused by an amp-state mutation SHOULD NOT update
+        // src attributes on amp-state elements.
+        expect(ampState.getAttribute('src'))
+            .to.equal('https://www.google.com/bind/second/source');
         // Trigger a bind apply that isn't from an amp-state
         triggerBindApplicationButton.click();
         return waitForBindApplication();
       }).then(() => {
         // Now that a non-amp-state mutation has ocurred, the amp-state's src
         // attribute can be updated with the new src from the XHR.
-        expect(spy).to.have.been.calledWith(sinon.match({
-          src: 'https://www.google.com/bind/first/source',
-        }));
+        expect(ampState.getAttribute('src'))
+            .to.equal('https://www.google.com/bind/first/source');
       });
     });
   });

--- a/extensions/amp-bind/0.1/test/test-bind-integration.js
+++ b/extensions/amp-bind/0.1/test/test-bind-integration.js
@@ -16,18 +16,21 @@
 
 import '../../../amp-carousel/0.1/amp-carousel';
 import {createFixtureIframe} from '../../../../testing/iframe';
-import {bindForDoc} from '../../../../src/services';
+import {batchedXhrFor, bindForDoc} from '../../../../src/services';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
+import * as sinon from 'sinon';
 
 describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   const fixtureLocation = 'test/fixtures/amp-bind-integrations.html';
 
   let fixture;
   let ampdoc;
+  let sandbox;
 
   this.timeout(5000);
 
   beforeEach(() => {
+    sandbox = sinon.sandbox.create();
     return createFixtureIframe(fixtureLocation).then(f => {
       fixture = f;
       return waitForEvent('amp:bind:initialize');
@@ -35,6 +38,10 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
       const ampdocService = ampdocServiceFor(fixture.win);
       ampdoc = ampdocService.getAmpDoc(fixture.doc);
     });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   /**
@@ -71,19 +78,24 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
       const div = fixture.doc.createElement('div');
       div.innerHTML = '<p [onclick]="javascript:alert(document.cookie)" ' +
                          '[onmouseover]="javascript:alert()" ' +
-                         '[style]="background=color:black"></p>';
+                         '[style]="background=color:black" ' +
+                         '[text]="dynamicText"></p>';
       const textElement = div.firstElementChild;
       // for amp-live-list, dynamic element is <div items>, which is a child
       // of the list.
       dynamicTag.firstElementChild.appendChild(textElement);
+      expect(textElement.getAttribute('onclick')).to.be.null;
+      expect(textElement.getAttribute('onmouseover')).to.be.null;
+      expect(textElement.getAttribute('style')).to.be.null;
+      expect(textElement.textContent).to.equal('');
       return waitForAllMutations().then(() => {
-        // Force bind to apply bindings
-        fixture.doc.getElementById('triggerBindApplicationButton').click();
+        fixture.doc.getElementById('changeDynamicTextButton').click();
         return waitForBindApplication();
       }).then(() => {
         expect(textElement.getAttribute('onclick')).to.be.null;
         expect(textElement.getAttribute('onmouseover')).to.be.null;
         expect(textElement.getAttribute('style')).to.be.null;
+        expect(textElement.textContent).to.equal('bound');
       });
     });
 
@@ -472,6 +484,47 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
       return waitForBindApplication().then(() => {
         expect(list.getAttribute('src'))
             .to.equal('https://www.google.com/unbound.json');
+      });
+    });
+  });
+
+  describe('amp-state', () => {
+    it('should not loop infinitely if updates change its src binding', () => {
+      // Changes amp-state's src to ...amp-state-src2
+      const changeAmpStateSrcButton =
+          fixture.doc.getElementById('ampStateSrcButton');
+      const triggerBindApplicationButton =
+          fixture.doc.getElementById('triggerBindApplicationButton');
+      const ampState = fixture.doc.getElementById('ampState');
+      const batchedXhr = batchedXhrFor(fixture.win);
+      // Stub XHR for endpoint ...amp-state-src2 that returns state that would
+      // redirect the amp-state's src back to the original src, amp-state-src.
+      sandbox.stub(batchedXhr, 'fetchJson').returns(Promise.resolve({
+        ampStateSrc: 'https://www.google.com/bind/first/source',
+      }));
+      const spy =
+          sandbox.spy(ampState.implementation_, 'mutatedAttributesCallback');
+      changeAmpStateSrcButton.click();
+      return waitForBindApplication().then(() => {
+        expect(spy).to.have.been.calledWith(sinon.match({
+          src: 'https://www.google.com/bind/second/source',
+        }));
+        spy.reset();
+        // Wait for XHR to finish and for bind to re-apply bindings.
+        return waitForBindApplication();
+      }).then(() => {
+        // amp-state mutation should never trigger an amp-state's
+        // mutatedAttributesCallback
+        expect(spy).to.not.have.been.called;
+        // Trigger a bind apply that isn't from an amp-state
+        triggerBindApplicationButton.click();
+        return waitForBindApplication();
+      }).then(() => {
+        // Now that a non-amp-state mutation has ocurred, the amp-state's src
+        // attribute can be updated with the new src from the XHR.
+        expect(spy).to.have.been.calledWith(sinon.match({
+          src: 'https://www.google.com/bind/first/source',
+        }));
       });
     });
   });

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -27,11 +27,9 @@
 </head>
 
 <body>
-
-  <button on="tap:AMP.setState({})" id="triggerBindApplicationButton"></button>
-
   <p>DYNAMIC TAGS</p>
   <!-- Live list is used for generic dynamic tag testing  -->
+  <button on="tap:AMP.setState({dynamicText: 'bound'})" id="changeDynamicTextButton"></button>
   <amp-live-list id="dynamicTag" data-poll-interval="15000" data-max-items-per-page="2">
     <div items>
       <!-- Children added in test -->
@@ -135,6 +133,12 @@
   <button id='httpListSrcButton' on="tap:AMP.setState({listSrc: 'http://www.google.com/justhttp.json'})">Change amp-list</button>
   <amp-list id='list' src="https://www.google.com/unbound.json" [src]=listSrc>
   </amp-list>
+
+  <p>AMP-STATE</p>
+  <button id="ampStateSrcButton" on="tap:AMP.setState({ampState: {ampStateSrc: 'https://www.google.com/bind/second/source'}})">Change amp-state</button>
+    <button id="triggerBindApplicationButton" on="tap:AMP.setState({})">Trigger application</button>
+  <amp-state id="ampState" src="https://www.google.com/bind/first/source" [src]="ampState.ampStateSrc">
+  </amp-state>
 
 </body>
 </html>

--- a/test/fixtures/amp-bind-integrations.html
+++ b/test/fixtures/amp-bind-integrations.html
@@ -135,9 +135,9 @@
   </amp-list>
 
   <p>AMP-STATE</p>
-  <button id="ampStateSrcButton" on="tap:AMP.setState({ampState: {ampStateSrc: 'https://www.google.com/bind/second/source'}})">Change amp-state</button>
+  <button id="ampStateSrcButton" on="tap:AMP.setState({ampState: {stateSrc: 'https://www.google.com/bind/second/source'}})">Change amp-state</button>
     <button id="triggerBindApplicationButton" on="tap:AMP.setState({})">Trigger application</button>
-  <amp-state id="ampState" src="https://www.google.com/bind/first/source" [src]="ampState.ampStateSrc">
+  <amp-state id="ampState" src="https://www.google.com/bind/first/source" [src]="ampState.stateSrc">
   </amp-state>
 
 </body>


### PR DESCRIPTION
Added an integration test to ensure that an `amp-state` element won't loop endlessly if its `src` attribute is bound to a var in the `amp-state` that can be updated via XHR.

Fixes #9145 

/to @choumx 