### PR TITLE
Change link checker to warning-only

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -60,14 +60,16 @@ function checkLinks() {
         }
       });
       if(deadLinksFoundInFile) {
+        filesWithDeadLinks.push(markdownFiles[index]);
         util.log(
-            util.colors.yellow('WARNING'), 'Possible dead link(s) found in',
+            util.colors.yellow('WARNING'),
+            'Possible dead link(s) found in',
             util.colors.magenta(markdownFiles[index]),
             '(please update if necessary).');
-            filesWithDeadLinks.push(markdownFiles[index]);
       } else {
         util.log(
-            util.colors.green('SUCCESS'), 'All links in',
+            util.colors.green('SUCCESS'),
+            'All links in',
             util.colors.magenta(markdownFiles[index]), 'are alive.');
       }
     });

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -61,8 +61,9 @@ function checkLinks() {
       });
       if(deadLinksFoundInFile) {
         util.log(
-            util.colors.red('ERROR'), 'Dead links found in',
-            util.colors.magenta(markdownFiles[index]), '(please update it).');
+            util.colors.yellow('WARNING'), 'Dead links potentially found in',
+            util.colors.magenta(markdownFiles[index]),
+            '(please update if necessary).');
             filesWithDeadLinks.push(markdownFiles[index]);
       } else {
         util.log(
@@ -72,9 +73,10 @@ function checkLinks() {
     });
     if (deadLinksFound) {
         util.log(
-            util.colors.red('ERROR'), 'Dead links found. Please update',
-            util.colors.magenta(filesWithDeadLinks.join(',')));
-       process.exit(1);
+            util.colors.yellow('WARNING'),
+            'Dead links potentially found. Please update',
+            util.colors.magenta(filesWithDeadLinks.join(',')),
+            'if necessary.');
     } else {
         util.log(
             util.colors.green('SUCCESS'),

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -61,7 +61,7 @@ function checkLinks() {
       });
       if(deadLinksFoundInFile) {
         util.log(
-            util.colors.yellow('WARNING'), 'Dead links potentially found in',
+            util.colors.yellow('WARNING'), 'Possible dead link(s) found in',
             util.colors.magenta(markdownFiles[index]),
             '(please update if necessary).');
             filesWithDeadLinks.push(markdownFiles[index]);
@@ -74,7 +74,7 @@ function checkLinks() {
     if (deadLinksFound) {
         util.log(
             util.colors.yellow('WARNING'),
-            'Dead links potentially found. Please update',
+            'Possible dead link(s) found. Please update',
             util.colors.magenta(filesWithDeadLinks.join(',')),
             'if necessary.');
     } else {


### PR DESCRIPTION
This PR makes the link checker a warning-only tool that does not block PR merges. This is because some md files contain script tags that have links in them, and they are being detected as false negatives. If we figure out a way to ignore such links, we can consider making it PR blocking once again.

/to @dvoytenko @choumx