### PR TITLE
amp-bind: manually add custom functions to bind whitelist

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -94,7 +94,6 @@ const FUNCTION_WHITELIST = (function() {
     Math.sign,
     encodeURI,
     encodeURIComponent,
-    copyAndSplice,
   ];
   // Creates a prototype-less map of function name to the function itself.
   // This makes function lookups faster (compared to Array.indexOf).
@@ -108,6 +107,10 @@ const FUNCTION_WHITELIST = (function() {
       out[type][f.name] = f;
     }
   });
+
+  // Custom functions (non-js-built-ins) must be added manually as their names
+  // will be minifid at compile time.
+  out[BUILT_IN_FUNCTIONS]['copyAndSplice'] = copyAndSplice;
   return out;
 })();
 

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -109,7 +109,7 @@ const FUNCTION_WHITELIST = (function() {
   });
 
   // Custom functions (non-js-built-ins) must be added manually as their names
-  // will be minifid at compile time.
+  // will be minified at compile time.
   out[BUILT_IN_FUNCTIONS]['copyAndSplice'] = copyAndSplice;
   return out;
 })();


### PR DESCRIPTION
`copyAndSplice` has its name minified at compile time. I tried the `@export` annotation, putting the function at the module level and exporting it, but this is the only way I could get around the problem. I'm open to more suggestions if you have any.

Fixes #9222 

/to @choumx