### PR TITLE
Lowering heavier embed's viewport score

### DIFF
--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -30,6 +30,14 @@ class AmpFacebookComments extends AMP.BaseElement {
     this.iframe_ = null;
   }
 
+  /** @override */
+  renderOutsideViewport() {
+    // We are conservative about loading heavy embeds.
+    // This will still start loading before they become visible, but it
+    // won't typically load a large number of embeds.
+    return 0.75;
+  }
+
   /**
    * @param {boolean=} opt_onLayout
    * @override

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -30,6 +30,14 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.iframe_ = null;
   }
 
+  /** @override */
+  renderOutsideViewport() {
+    // We are conservative about loading heavy embeds.
+    // This will still start loading before they become visible, but it
+    // won't typically load a large number of embeds.
+    return 0.75;
+  }
+
   /**
    * @param {boolean=} opt_onLayout
    * @override

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -30,6 +30,14 @@ class AmpFacebook extends AMP.BaseElement {
     this.iframe_ = null;
   }
 
+    /** @override */
+  renderOutsideViewport() {
+    // We are conservative about loading heavy embeds.
+    // This will still start loading before they become visible, but it
+    // won't typically load a large number of embeds.
+    return 0.75;
+  }
+
   /**
    * @param {boolean=} opt_onLayout
    * @override


### PR DESCRIPTION
All `facebook-*` components to `0.75` for `renderOutsideViewport` so they don't load too early.