### PR TITLE
Usage example for link checker

### DIFF
--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -151,6 +151,7 @@ Now that you have all of the files copied locally you can actually build the cod
 amphtml uses Node.js, the yarn package manager and the Gulp build system to build amphtml and start up a local server that lets you try out your changes.  Installing these and getting amphtml built is straightforward:
 
 * Install [NodeJS](https://nodejs.org/) (which includes npm).
+* [Valid Link](http://example.com)
 
 * Install [yarn](https://yarnpkg.com/en/docs/install)
 
@@ -325,7 +326,7 @@ If the tests have failed you will need to determine whether the failure is relat
 
 If the failing test looks completely unrelated to your change, it *might* be due to bad code/tests that have made it into the amphtml repository.  You can check the latest [amphtml test run on Travis](https://travis-ci.org/ampproject/amphtml/builds).  If it's green (meaning the tests pass) then it's more likely the failure is a problem with your change.  If it's red, you can click through to see if the failing tests are the same as the ones you see locally.
 
-Fixing the tests will depend heavily on the change you are making and what tests are failing.  If you need help to fix them you can ask on the GitHub issue you're working on or reach out to the community as described in [How to get help](#how-to-get-help).  
+Fixing the tests will depend heavily on the change you are making and what tests are failing.  If you need help to fix them you can ask on the GitHub issue you're working on or reach out to the community as described in [How to get help](#how-to-get-help).
 
 ## Adding tests for your change
 
@@ -389,7 +390,7 @@ Note that you *can* edit files in your branch directly on GitHub using the web U
 In order for your changes to become part of the amphtml repository, you will need to get your code reviewed by one of the [core committers](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md) via a Pull Request (PR).  In fact you won't actually merge your code into the amphtml repository directly; once a core committer approves it he or she will handle the merge for you.
 
 Once your code is ready for a review, go to [https://github.com/ampproject/amphtml](https://github.com/ampproject/amphtml) and click on the "Compare & pull request" button on the "recently pushed branches" banner.  If that banner isn't visible, go to your GitHub fork at
-`https://github.com/<username>/amphtml`, use the Branch dropdown to select the branch that contains the changes you want reviewed and press the "New pull request" button.  
+`https://github.com/<username>/amphtml`, use the Branch dropdown to select the branch that contains the changes you want reviewed and press the "New pull request" button.
 
 On the "Open a pull request" page, you will see dropdowns at the top indicating the proposed merge.  It will look something like:
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -27,6 +27,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * Install [NodeJS](https://nodejs.org/)
 
+* Install [Invalid Link](https://website-that-does-not-exist.org/)
 * Install [yarn](https://yarnpkg.com/en/docs/install)
 
 * Install Gulp by running `yarn global add gulp`


### PR DESCRIPTION
DO NOT MERGE.

This is an example of how to use the new link checker tool. It will automatically be run as part of the presubmit tests for any PR containing a DOCS change.

To test local changes to markdown files:
1) Install the link checker tool using "yarn add markdown-link-check" (this is a one-time step)
2) Run "gulp check-links --files aaa/FOO.md,bbb/BAR.md"