### PR TITLE
Layers/Resources Split (Part 1)

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -259,7 +259,13 @@ var forbiddenTerms = {
     whitelist: [
       'src/runtime.js',
       'src/service/resources-impl.js',
-      'src/service/standard-actions-impl.js',
+    ],
+  },
+  'installLayersServiceForDoc': {
+    message: privateServiceFactory,
+    whitelist: [
+      'src/runtime.js',
+      'src/service/layers-impl.js',
     ],
   },
   'installXhrService': {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -795,7 +795,7 @@ function createBaseCustomElementClass(win) {
           // Already in viewport - start showing loading.
           this.toggleLoading_(true);
         } else if (layoutBox.top < PREPARE_LOADING_THRESHOLD_ &&
-          layoutBox.top >= 0) {
+            layoutBox.top >= 0) {
           // Few top elements will also be pre-initialized with a loading
           // element.
           getVsync(this).mutate(() => {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -57,6 +57,7 @@ import {extensionsFor} from './services';
 import {installHistoryServiceForDoc} from './service/history-impl';
 import {installPlatformService} from './service/platform-impl';
 import {installResourcesServiceForDoc} from './service/resources-impl';
+import {installLayersServiceForDoc} from './service/layers-impl';
 import {
   installShadowDoc,
   shadowDocHasBody,
@@ -141,6 +142,7 @@ export function installAmpdocServices(ampdoc, opt_initParams) {
   installViewerServiceForDoc(ampdoc, opt_initParams);
   installViewportServiceForDoc(ampdoc);
   installHistoryServiceForDoc(ampdoc);
+  installLayersServiceForDoc(ampdoc);
   installResourcesServiceForDoc(ampdoc);
   installUrlReplacementsServiceForDoc(ampdoc);
   installActionServiceForDoc(ampdoc);

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class Layers {
+}
+
+/**
+ * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ */
+export function installLayersServiceForDoc(ampdoc) {
+  registerServiceBuilderForDoc(ampdoc, 'layers', Layers);
+};

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -25,6 +25,11 @@ import {dev} from '../log';
 
 const LAYER_PROP_ = '__AMP__LAYER';
 
+
+/**
+ * Layers is the new home for everything having to do with an element's
+ * size and position relative to its parent container.
+ */
 export class Layers {
   /**
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
@@ -96,7 +101,9 @@ export class Layers {
 }
 
 
-
+/**
+ * LayerElement (née Layout) caches and measures an element's layout rectangle.
+ */
 export class LayerElement {
   /**
    * @param {!AmpElement} element

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -14,7 +14,200 @@
  * limitations under the License.
  */
 
+import {
+  layoutRectLtwh,
+  moveLayoutRect,
+} from '../layout-rect';
+import {computedStyle} from '../style';
+import {registerServiceBuilderForDoc} from '../service';
+import {viewportForDoc} from '../services';
+import {dev} from '../log';
+
+const LAYER_PROP_ = '__AMP__LAYER';
+
 export class Layers {
+  /**
+   * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @private @const {!./ampdoc-impl.AmpDoc} */
+    this.ampdoc_ = ampdoc;
+
+    /** @const {!Window} */
+    this.win = ampdoc.win;
+
+    /** @private @const {!./viewport-impl.Viewport} */
+    this.viewport_ = viewportForDoc(ampdoc);
+  }
+
+  /**
+   * @param {!AmpElement} element
+   */
+  add(element) {
+    new LayerElement(element, this);
+  }
+
+  /**
+   * @param {!AmpElement} unusedElement
+   */
+  remove(unusedElement) {
+  }
+
+  getViewport() {
+    return this.viewport_;
+  }
+
+
+  /****************************
+   * Ferrying to LayerElement *
+   ****************************/
+
+  /**
+   * @param {!AmpElement} element
+   * @return {!../layout-rect.LayoutRectDef}
+   */
+  remeasure(element) {
+    return LayerElement.for(element).remeasure();
+  }
+
+  /**
+   * @param {!AmpElement} element
+   * @return {!../layout-rect.LayoutRectDef}
+   */
+  getPageLayoutBox(element) {
+    return LayerElement.for(element).getPageLayoutBox();
+  }
+
+  /**
+   * @param {!AmpElement} element
+   * @return {!../layout-rect.LayoutRectDef}
+   */
+  getAbsoluteLayoutBox(element) {
+    return LayerElement.for(element).getAbsoluteLayoutBox();
+  }
+
+  /**
+   * @param {!AmpElement} element
+   * @return {boolean}
+   */
+  isFixed(element) {
+    return LayerElement.for(element).isFixed();
+  }
+}
+
+
+
+export class LayerElement {
+  /**
+   * @param {!AmpElement} element
+   * @return {!LayerElement}
+   */
+  static for(element) {
+    return /** @type {!LayerElement} */ (
+        dev().assert(LayerElement.forOptional(element),
+        'Missing layer prop on %s', element));
+  }
+
+  /**
+   * @param {!AmpElement} element
+   * @return {LayerElement}
+   */
+  static forOptional(element) {
+    return /** @type {LayerElement} */ (element[LAYER_PROP_]);
+  }
+
+
+  /**
+   * @param {!AmpElement} element
+   */
+  constructor(element, layers) {
+    element[LAYER_PROP_] = this;
+
+    /** @const {!AmpElement} */
+    this.element_ = element;
+
+    /** @const {!Layers} */
+    this.layers_ = layers;
+
+    /** @private {!../layout-rect.LayoutRectDef} */
+    this.layoutBox_ = layoutRectLtwh(-10000, -10000, 0, 0);
+
+    /** @private {boolean} */
+    this.isFixed_ = false;
+  }
+
+  /**
+   * Returns a previously measured layout box adjusted to absolute positioning.
+   * Note that fixed-position elements change absolute positioning based on the
+   * scroll position (they move with the scroll).
+   * @return {!../layout-rect.LayoutRectDef}
+   */
+  getAbsoluteLayoutBox() {
+    if (!this.isFixed()) {
+      return this.layoutBox_;
+    }
+
+    const viewport = this.layers_.getViewport();
+    return moveLayoutRect(this.layoutBox_, viewport.getScrollLeft(),
+        viewport.getScrollTop());
+  }
+
+  /**
+   * Returns a previously measured layout box relative to the page. The
+   * fixed-position elements are relative to the top of the document.
+   * @return {!../layout-rect.LayoutRectDef}
+   */
+  getPageLayoutBox() {
+    return this.layoutBox_;
+  }
+
+  /**
+   * @return {!../layout-rect.LayoutRectDef} The element's remeasured page
+   *     layout box.
+   */
+  remeasure() {
+    const viewport = this.layers_.getViewport();
+    let box = viewport.getLayoutRect(this.element_);
+
+    // Calculate whether the element is currently is or in `position:fixed`.
+    let isFixed = false;
+    if (box.width > 0 && box.height > 0) {
+      const win = this.layers_.win;
+      const body = win.document.body;
+      for (let n = this.element_; n && n != body; n = n./*OK*/offsetParent) {
+        if (n.isAlwaysFixed && n.isAlwaysFixed()) {
+          isFixed = true;
+          break;
+        }
+
+        if (viewport.isDeclaredFixed(n)
+            && computedStyle(win, n).position == 'fixed') {
+          isFixed = true;
+          break;
+        }
+      }
+    }
+
+    if (isFixed) {
+      // For fixed position elements, we need the relative position to the
+      // viewport. When accessing the layoutBox through #getAbsoluteLayoutBox,
+      // we'll return the new absolute position.
+      box = moveLayoutRect(box, -viewport.getScrollLeft(),
+          -viewport.getScrollTop());
+    }
+
+    this.layoutBox_ = box;
+    this.isFixed_ = isFixed;
+
+    return box;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isFixed() {
+    return this.isFixed_;
+  }
 }
 
 /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -286,7 +286,6 @@ export class Resource {
 
     if (this.hasBeenMeasured()) {
       this.state_ = ResourceState.READY_FOR_LAYOUT;
-      // TODO
       this.element.updateLayoutBox(this.getPageLayoutBox());
     } else {
       this.state_ = ResourceState.NOT_LAID_OUT;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import {
-  layoutRectLtwh,
-  layoutRectsOverlap,
-  moveLayoutRect,
-} from '../layout-rect';
+import {layoutRectsOverlap} from '../layout-rect';
 import {dev} from '../log';
 import {startsWith} from '../string';
-import {toggle, computedStyle} from '../style';
+import {toggle} from '../style';
 
 const TAG = 'Resource';
 const RESOURCE_PROP_ = '__AMP__RESOURCE';
@@ -160,12 +156,6 @@ export class Resource {
     /** @private {*} */
     this.lastLayoutError_ = null;
 
-    /** @private {boolean} */
-    this.isFixed_ = false;
-
-    /** @private {!../layout-rect.LayoutRectDef} */
-    this.layoutBox_ = layoutRectLtwh(-10000, -10000, 0, 0);
-
     /** @private {?../layout-rect.LayoutRectDef} */
     this.initialLayoutBox_ = null;
 
@@ -296,7 +286,8 @@ export class Resource {
 
     if (this.hasBeenMeasured()) {
       this.state_ = ResourceState.READY_FOR_LAYOUT;
-      this.element.updateLayoutBox(this.layoutBox_);
+      // TODO
+      this.element.updateLayoutBox(this.getPageLayoutBox());
     } else {
       this.state_ = ResourceState.NOT_LAID_OUT;
     }
@@ -382,48 +373,18 @@ export class Resource {
 
     this.isMeasureRequested_ = false;
 
-    let box = this.resources_.getViewport().getLayoutRect(this.element);
-    const oldBox = this.layoutBox_;
-    const viewport = this.resources_.getViewport();
-    this.layoutBox_ = box;
-
-    // Calculate whether the element is currently is or in `position:fixed`.
-    let isFixed = false;
-    if (this.isDisplayed()) {
-      const win = this.resources_.win;
-      const body = win.document.body;
-      for (let n = this.element; n && n != body; n = n./*OK*/offsetParent) {
-        if (n.isAlwaysFixed && n.isAlwaysFixed()) {
-          isFixed = true;
-          break;
-        }
-        if (viewport.isDeclaredFixed(n)
-            && computedStyle(win, n).position == 'fixed') {
-          isFixed = true;
-          break;
-        }
-      }
-    }
-    this.isFixed_ = isFixed;
-
-    if (isFixed) {
-      // For fixed position elements, we need the relative position to the
-      // viewport. When accessing the layoutBox through #getLayoutBox, we'll
-      // return the new absolute position.
-      box = this.layoutBox_ = moveLayoutRect(box, -viewport.getScrollLeft(),
-          -viewport.getScrollTop());
-    }
+    const oldBox = this.getPageLayoutBox();
+    const box = this.resources_.getLayers().remeasure(this.element);
 
     // Note that "left" doesn't affect readiness for the layout.
     if (this.state_ == ResourceState.NOT_LAID_OUT ||
-          oldBox.top != box.top ||
-          oldBox.width != box.width ||
-          oldBox.height != box.height) {
-
+        oldBox.top != box.top ||
+        oldBox.width != box.width ||
+        oldBox.height != box.height) {
       if (this.element.isUpgraded() &&
-              this.state_ != ResourceState.NOT_BUILT &&
-              (this.state_ == ResourceState.NOT_LAID_OUT ||
-                  this.element.isRelayoutNeeded())) {
+          this.state_ != ResourceState.NOT_BUILT &&
+          (this.state_ == ResourceState.NOT_LAID_OUT ||
+              this.element.isRelayoutNeeded())) {
         this.state_ = ResourceState.READY_FOR_LAYOUT;
       }
     }
@@ -441,12 +402,7 @@ export class Resource {
    */
   completeCollapse() {
     toggle(this.element, false);
-    this.layoutBox_ = layoutRectLtwh(
-        this.layoutBox_.left,
-        this.layoutBox_.top,
-        0, 0);
-    this.isFixed_ = false;
-    this.element.updateLayoutBox(this.layoutBox_);
+    this.requestMeasure();
     const owner = this.getOwner();
     if (owner) {
       owner.collapsedCallback(this.element);
@@ -496,12 +452,7 @@ export class Resource {
    * @return {!../layout-rect.LayoutRectDef}
    */
   getLayoutBox() {
-    if (!this.isFixed_) {
-      return this.layoutBox_;
-    }
-    const viewport = this.resources_.getViewport();
-    return moveLayoutRect(this.layoutBox_, viewport.getScrollLeft(),
-        viewport.getScrollTop());
+    return this.resources_.getLayers().getAbsoluteLayoutBox(this.element);
   }
 
   /**
@@ -510,7 +461,7 @@ export class Resource {
    * @return {!../layout-rect.LayoutRectDef}
    */
   getPageLayoutBox() {
-    return this.layoutBox_;
+    return this.resources_.getLayers().getPageLayoutBox(this.element);
   }
 
   /**
@@ -520,7 +471,7 @@ export class Resource {
   getInitialLayoutBox() {
     // Before the first measure, there will be no initial layoutBox.
     // Luckily, layoutBox will be present but essentially useless.
-    return this.initialLayoutBox_ || this.layoutBox_;
+    return this.initialLayoutBox_ || this.getPageLayoutBox();
   }
 
   /**
@@ -529,9 +480,10 @@ export class Resource {
    * @return {boolean}
    */
   isDisplayed() {
-    return (this.layoutBox_.height > 0 && this.layoutBox_.width > 0 &&
+    const box = this.getPageLayoutBox();
+    return box.height > 0 && box.width > 0 &&
         !!this.element.ownerDocument &&
-        !!this.element.ownerDocument.defaultView);
+        !!this.element.ownerDocument.defaultView;
   }
 
   /**
@@ -539,7 +491,7 @@ export class Resource {
    * @return {boolean}
    */
   isFixed() {
-    return this.isFixed_;
+    return this.resources_.getLayers().isFixed(this.element);
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -931,10 +931,10 @@ export class Resources {
     /**
    * Collapses the element: ensures that it's `display:none`, notifies its
    * owner and updates the layout box.
-   * @param {!Element} element
+   * @param {!AmpElement} element
    */
   collapseElement(element) {
-    const box = this.viewport_.getLayoutRect(element);
+    const box = element.getLayoutBox();
     const resource = Resource.forElement(element);
     if (box.width != 0 && box.height != 0) {
       this.setRelayoutTop_(box.top);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -26,17 +26,20 @@ import {closest, hasNextNodeInDocumentOrder} from '../dom';
 import {expandLayoutRect} from '../layout-rect';
 import {installInputService} from '../input';
 import {registerServiceBuilderForDoc} from '../service';
-import {inputFor} from '../services';
-import {viewerForDoc} from '../services';
-import {viewportForDoc} from '../services';
-import {vsyncFor} from '../services';
+import {
+  inputFor,
+  viewerForDoc,
+  viewportForDoc,
+  vsyncFor,
+  documentInfoForDoc,
+  layersForDoc,
+} from '../services';
 import {isArray} from '../types';
 import {dev} from '../log';
 import {reportError} from '../error';
 import {filterSplice} from '../utils/array';
 import {getSourceUrl} from '../url';
 import {areMarginsChanged} from '../layout-rect';
-import {documentInfoForDoc} from '../services';
 import {computedStyle} from '../style';
 
 const TAG_ = 'Resources';
@@ -184,6 +187,9 @@ export class Resources {
 
     /** @private @const {!./vsync-impl.Vsync} */
     this.vsync_ = vsyncFor(this.win);
+
+    /** @private @const {!./layers-impl.Layers} */
+    this.layers_ = layersForDoc(this.ampdoc);
 
     /** @private @const {!FocusHistory} */
     this.activeHistory_ = new FocusHistory(this.win, FOCUS_HISTORY_TIMEOUT_);
@@ -423,6 +429,14 @@ export class Resources {
   }
 
   /**
+   * Returns the layers instance
+   * @return {!./layers-impl.Layers}
+   */
+  getLayers() {
+    return this.layers_;
+  }
+
+  /**
    * Returns the viewport instance
    * @return {!./viewport-impl.Viewport}
    */
@@ -452,6 +466,7 @@ export class Resources {
     if (this.addCount_ == 1) {
       this.viewport_.ensureReadyForElements();
     }
+    this.getLayers().add(element);
 
     // First check if the resource is being reparented and if it requires
     // reconstruction. Only already built elements are eligible.
@@ -572,6 +587,7 @@ export class Resources {
       return;
     }
     this.removeResource_(resource);
+    this.getLayers().remove(element);
   }
 
   /**

--- a/src/services.js
+++ b/src/services.js
@@ -153,6 +153,15 @@ export function inputFor(win) {
 
 /**
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+ * @return {!./service/layers-impl.Layers}
+ */
+export function layersForDoc(nodeOrDoc) {
+  return /** @type {!./service/layers-impl.Layers} */ (
+      getServiceForDoc(nodeOrDoc, 'layers'));
+}
+
+/**
+ * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @return {!./service/parallax-impl.ParallaxService}
  */
 export function parallaxForDoc(nodeOrDoc) {

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Layers, LayerElement} from "../../src/service/layers-impl";
+import {layoutRectLtwh} from '../../src/layout-rect';
+
+describes.fakeWin('Layers', {amp: true}, (env) => {
+  let win;
+  let sandbox;
+  let layers;
+
+  beforeEach(() => {
+    win = env.win;
+    sandbox = env.sandbox;
+    layers = new Layers(env.ampdoc);
+  });
+
+  describe('#add', () => {
+    it('creates a LayerElement for the element', () => {
+      const element = {};
+      layers.add(element);
+
+      expect(LayerElement.for(element)).to.not.be.null;
+    });
+  });
+
+  describe('ferrying', () => {
+    let element;
+    let layout;
+
+    beforeEach(() => {
+      element = {};
+      layers.add(element);
+      layout = LayerElement.for(element);
+    });
+
+    it('#remeasure', () => {
+      const stub = sandbox.stub(layout, 'remeasure', () => stub);
+      const ret = layers.remeasure(element);
+
+      expect(stub).to.have.been.called;
+      expect(ret).to.equal(stub);
+    });
+
+    it('#getPageLayoutBox', () => {
+      const stub = sandbox.stub(layout, 'getPageLayoutBox', () => stub);
+      const ret = layers.getPageLayoutBox(element);
+
+      expect(stub).to.have.been.called;
+      expect(ret).to.equal(stub);
+    });
+
+    it('#getAbsoluteLayoutBox', () => {
+      const stub = sandbox.stub(layout, 'getAbsoluteLayoutBox', () => stub);
+      const ret = layers.getAbsoluteLayoutBox(element);
+
+      expect(stub).to.have.been.called;
+      expect(ret).to.equal(stub);
+    });
+
+    it('#isFixed', () => {
+      const stub = sandbox.stub(layout, 'isFixed', () => stub);
+      const ret = layers.isFixed(element);
+
+      expect(stub).to.have.been.called;
+      expect(ret).to.equal(stub);
+    });
+  });
+
+});
+
+describes.fakeWin.only('LayerElement', {amp: true}, (env) => {
+  let win;
+  let sandbox;
+  let layers;
+  let element;
+  let layout;
+  let viewport;
+
+  beforeEach(() => {
+    win = env.win;
+    sandbox = env.sandbox;
+    layers = new Layers(env.ampdoc);
+    element = {};
+    layers.add(element);
+    layout = LayerElement.for(element);
+
+    viewport = {
+      left: 0,
+      top: 20,
+
+      getScrollLeft() {
+        return this.left;
+      },
+
+      getScrollTop() {
+        return this.top;
+      },
+
+      getLayoutRect(element) {
+        return layoutRectLtwh(0, 30, 100, 100);
+      },
+
+      isDeclaredFixed() {
+        return false;
+      }
+    };
+    sandbox.stub(layers, 'getViewport', () => viewport);
+  });
+
+  describe('.for', () => {
+    it('retries LayerElement instance tied to element', () => {
+      expect(LayerElement.for(element)).to.equal(layout);
+    });
+
+    it('throws when element is unregistered', () => {
+      expect(() => {
+        LayerElement.for({});
+      }).to.throw(/Missing layer prop/);
+    });
+  });
+
+  describe('.forOptional', () => {
+    it('retries LayerElement instance tied to element', () => {
+      expect(LayerElement.forOptional(element)).to.equal(layout);
+    });
+
+    it('returns undefined when unregistered', () => {
+      expect(LayerElement.forOptional({})).to.be.undefined;
+    });
+  });
+
+  describe('#getAbsoluteLayoutBox', () => {
+    let viewport;
+
+    beforeEach(() => {
+      element.isAlwaysFixed = () => false;
+      layout.remeasure();
+    });
+
+    describe('when element is fixed-position', () => {
+      beforeEach(() => {
+        element.isAlwaysFixed = () => true;
+        layout.remeasure();
+      });
+
+      it('returns rect based on viewport scroll', () => {
+        expect(layout.getAbsoluteLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(0, 30, 100, 100));
+
+        viewport.top = 100;
+        viewport.left = 10;
+        expect(layout.getAbsoluteLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(10, 110, 100, 100));
+      });
+    });
+
+    describe('when element is not fixed-position', () => {
+      it('returns absolute rect', () => {
+        expect(layout.getAbsoluteLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(0, 30, 100, 100));
+
+        viewport.top = 200;
+        viewport.left = 10;
+        expect(layout.getAbsoluteLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(0, 30, 100, 100));
+      });
+    });
+  });
+
+  describe('#getPageLayoutBox', () => {
+    let viewport;
+
+    beforeEach(() => {
+      element.isAlwaysFixed = () => false;
+      layout.remeasure();
+    });
+
+    describe('when element is fixed-position', () => {
+      beforeEach(() => {
+        element.isAlwaysFixed = () => true;
+        layout.remeasure();
+      });
+
+      it('returns page relative rect', () => {
+        expect(layout.getPageLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(0, 30, 100, 100));
+
+        viewport.top = 100;
+        viewport.left = 10;
+        expect(layout.getPageLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(00, 30, 100, 100));
+      });
+    });
+
+    describe('when element is not fixed-position', () => {
+      it('returns absolute rect', () => {
+        expect(layout.getPageLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(0, 30, 100, 100));
+
+        viewport.top = 200;
+        viewport.left = 10;
+        expect(layout.getPageLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(0, 30, 100, 100));
+      });
+    });
+  });
+});

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -82,7 +82,7 @@ describes.fakeWin('Layers', {amp: true}, (env) => {
 
 });
 
-describes.fakeWin.only('LayerElement', {amp: true}, (env) => {
+describes.fakeWin('LayerElement', {amp: true}, (env) => {
   let win;
   let sandbox;
   let layers;

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-import {Layers, LayerElement} from "../../src/service/layers-impl";
+import {Layers, LayerElement} from '../../src/service/layers-impl';
 import {layoutRectLtwh} from '../../src/layout-rect';
 
-describes.fakeWin('Layers', {amp: true}, (env) => {
-  let win;
+describes.fakeWin('Layers', {amp: true}, env => {
   let sandbox;
   let layers;
 
   beforeEach(() => {
-    win = env.win;
     sandbox = env.sandbox;
     layers = new Layers(env.ampdoc);
   });
@@ -82,8 +80,7 @@ describes.fakeWin('Layers', {amp: true}, (env) => {
 
 });
 
-describes.fakeWin('LayerElement', {amp: true}, (env) => {
-  let win;
+describes.fakeWin('LayerElement', {amp: true}, env => {
   let sandbox;
   let layers;
   let element;
@@ -91,7 +88,6 @@ describes.fakeWin('LayerElement', {amp: true}, (env) => {
   let viewport;
 
   beforeEach(() => {
-    win = env.win;
     sandbox = env.sandbox;
     layers = new Layers(env.ampdoc);
     element = {};
@@ -110,13 +106,13 @@ describes.fakeWin('LayerElement', {amp: true}, (env) => {
         return this.top;
       },
 
-      getLayoutRect(element) {
+      getLayoutRect() {
         return layoutRectLtwh(0, 30, 100, 100);
       },
 
       isDeclaredFixed() {
         return false;
-      }
+      },
     };
     sandbox.stub(layers, 'getViewport', () => viewport);
   });

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -144,8 +144,6 @@ describes.fakeWin.only('LayerElement', {amp: true}, (env) => {
   });
 
   describe('#getAbsoluteLayoutBox', () => {
-    let viewport;
-
     beforeEach(() => {
       element.isAlwaysFixed = () => false;
       layout.remeasure();
@@ -182,8 +180,6 @@ describes.fakeWin.only('LayerElement', {amp: true}, (env) => {
   });
 
   describe('#getPageLayoutBox', () => {
-    let viewport;
-
     beforeEach(() => {
       element.isAlwaysFixed = () => false;
       layout.remeasure();
@@ -197,12 +193,12 @@ describes.fakeWin.only('LayerElement', {amp: true}, (env) => {
 
       it('returns page relative rect', () => {
         expect(layout.getPageLayoutBox()).to.jsonEqual(
-            layoutRectLtwh(0, 30, 100, 100));
+            layoutRectLtwh(0, 10, 100, 100));
 
         viewport.top = 100;
         viewport.left = 10;
         expect(layout.getPageLayoutBox()).to.jsonEqual(
-            layoutRectLtwh(00, 30, 100, 100));
+            layoutRectLtwh(0, 10, 100, 100));
       });
     });
 
@@ -216,6 +212,70 @@ describes.fakeWin.only('LayerElement', {amp: true}, (env) => {
         expect(layout.getPageLayoutBox()).to.jsonEqual(
             layoutRectLtwh(0, 30, 100, 100));
       });
+    });
+  });
+
+  describe('#remeasure', () => {
+    beforeEach(() => {
+      element.isAlwaysFixed = () => false;
+    });
+
+    it('updates the elements rect based on viewport measurement', () => {
+      layout.remeasure();
+      expect(layout.getPageLayoutBox()).to.jsonEqual(
+          layoutRectLtwh(0, 30, 100, 100));
+
+      sandbox.stub(viewport, 'getLayoutRect', () => {
+        return layoutRectLtwh(10, 100, 100, 100);
+      });
+      layout.remeasure();
+      expect(layout.getPageLayoutBox()).to.jsonEqual(
+          layoutRectLtwh(10, 100, 100, 100));
+    });
+
+    it('returns the newly measured page layout rect', () => {
+      const ret = layout.remeasure();
+      expect(ret).to.jsonEqual(layoutRectLtwh(0, 30, 100, 100));
+    });
+
+    describe('when element is fixed', () => {
+      beforeEach(() => {
+        element.isAlwaysFixed = () => true;
+      });
+
+      it('sets isFixed', () => {
+        expect(layout.isFixed()).to.be.false;
+
+        layout.remeasure();
+        expect(layout.isFixed()).to.be.true;
+      });
+
+      it('updates elements rect to a viewport relative layout rect', () => {
+        layout.remeasure();
+        expect(layout.getPageLayoutBox()).to.jsonEqual(
+            layoutRectLtwh(0, 10, 100, 100));
+      });
+
+      it('returns the newly measured viewport relative layout rect', () => {
+        const ret = layout.remeasure();
+        expect(ret).to.jsonEqual(layoutRectLtwh(0, 10, 100, 100));
+      });
+    });
+  });
+
+  describe('#isFixed', () => {
+    it('returns whether element was last measured as fixed-position', () => {
+      element.isAlwaysFixed = () => false;
+      layout.remeasure();
+      expect(layout.isFixed()).to.be.false;
+
+      element.isAlwaysFixed = () => true;
+      layout.remeasure();
+      expect(layout.isFixed()).to.be.true;
+
+      element.isAlwaysFixed = () => false;
+      layout.remeasure();
+      expect(layout.isFixed()).to.be.false;
     });
   });
 });

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -17,12 +17,16 @@
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {Resources} from '../../src/service/resources-impl';
 import {Resource, ResourceState} from '../../src/service/resource';
+import {LayerElement} from '../../src/service/layers-impl';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {viewerForDoc} from '../../src/services';
 import * as sinon from 'sinon';
 
+function stupidMutateLayoutBox(resource, rect) {
+  LayerElement.for(resource.element).layoutBox_ = rect;
+}
 
-describe('Resource', () => {
+describe.only('Resource', () => {
   let sandbox;
   let element;
   let elementMock;
@@ -45,7 +49,7 @@ describe('Resource', () => {
       prerenderAllowed: () => false,
       renderOutsideViewport: () => true,
       build: () => false,
-      getBoundingClientRect: () => null,
+      getBoundingClientRect: () => layoutRectLtwh(0, 0, 100, 100),
       updateLayoutBox: () => {},
       isRelayoutNeeded: () => false,
       layoutCallback: () => {},
@@ -74,7 +78,8 @@ describe('Resource', () => {
     const viewer = viewerForDoc(document);
     sandbox.stub(viewer, 'isRuntimeOn', () => false);
     resources = new Resources(new AmpDocSingle(window));
-    resource = new Resource(1, element, resources);
+    resources.add(element);
+    resource = Resource.forElement(element);
     viewportMock = sandbox.mock(resources.viewport_);
 
     resources.win = {
@@ -156,7 +161,7 @@ describe('Resource', () => {
         .withExactArgs(box)
         .once();
     const stub = sandbox.stub(resource, 'hasBeenMeasured').returns(true);
-    resource.layoutBox_ = box;
+    stupidMutateLayoutBox(resource, box);
     resource.build(false);
     expect(stub).to.be.calledOnce;
     expect(resource.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
@@ -258,17 +263,17 @@ describe('Resource', () => {
   it('should always layout if has not been laid out before', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     resource.state_ = ResourceState.NOT_LAID_OUT;
-    resource.layoutBox_ = {left: 11, top: 12, width: 111, height: 222};
+    const box = layoutRectLtwh(11, 12, 111, 222);
+    stupidMutateLayoutBox(resource, box);
 
-    elementMock.expects('getBoundingClientRect')
-        .returns(resource.layoutBox_).once();
+    elementMock.expects('getBoundingClientRect').returns(box).once();
     resource.measure();
     expect(resource.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
   });
 
   it('should not relayout if has box has not changed', () => {
     resource.state_ = ResourceState.LAYOUT_COMPLETE;
-    resource.layoutBox_ = {left: 11, top: 12, width: 111, height: 222};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 111, height: 222});
 
     // Left is not part of validation.
     elementMock.expects('getBoundingClientRect')
@@ -281,7 +286,7 @@ describe('Resource', () => {
   it('should not relayout if box changed but element didn\'t opt in', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     resource.state_ = ResourceState.LAYOUT_COMPLETE;
-    resource.layoutBox_ = {left: 11, top: 12, width: 111, height: 222};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 111, height: 222});
 
     // Width changed.
     elementMock.expects('getBoundingClientRect')
@@ -295,7 +300,7 @@ describe('Resource', () => {
   it('should relayout if box changed when element opted in', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     resource.state_ = ResourceState.LAYOUT_COMPLETE;
-    resource.layoutBox_ = {left: 11, top: 12, width: 111, height: 222};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 111, height: 222});
 
     // Width changed.
     elementMock.expects('getBoundingClientRect')
@@ -410,7 +415,7 @@ describe('Resource', () => {
   });
 
   it('should hide and update layout box on collapse', () => {
-    resource.layoutBox_ = {left: 11, top: 12, width: 111, height: 222};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 111, height: 222});
     resource.isFixed_ = true;
     elementMock.expects('updateLayoutBox')
         .withExactArgs(sinon.match(data => {
@@ -433,7 +438,7 @@ describe('Resource', () => {
 
   it('should show and request measure on expand', () => {
     resource.element.style.display = 'none';
-    resource.layoutBox_ = {left: 11, top: 12, width: 0, height: 0};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 0, height: 0});
     resource.isFixed_ = false;
     resource.requestMeasure = sandbox.stub();
 
@@ -444,7 +449,7 @@ describe('Resource', () => {
 
   it('should show and request measure on expand', () => {
     resource.element.style.display = 'none';
-    resource.layoutBox_ = {left: 11, top: 12, width: 0, height: 0};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 0, height: 0});
     resource.isFixed_ = false;
     resource.requestMeasure = sandbox.stub();
 
@@ -481,7 +486,7 @@ describe('Resource', () => {
   it('should ignore startLayout if not visible', () => {
     elementMock.expects('layoutCallback').never();
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
-    resource.layoutBox_ = {left: 11, top: 12, width: 0, height: 0};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 0, height: 0});
     expect(() => {
       resource.startLayout();
     }).to.throw(/Not displayed/);
@@ -491,7 +496,7 @@ describe('Resource', () => {
     elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
 
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
-    resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 10, height: 10});
     resource.startLayout();
     expect(resource.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
   });
@@ -500,7 +505,7 @@ describe('Resource', () => {
     elementMock.expects('layoutCallback').never();
 
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
-    resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 10, height: 10});
     resource.layoutCount_ = 1;
     elementMock.expects('isRelayoutNeeded').returns(false).atLeast(1);
     resource.startLayout();
@@ -511,7 +516,7 @@ describe('Resource', () => {
     elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
 
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
-    resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 10, height: 10});
     resource.layoutCount_ = 1;
     elementMock.expects('isRelayoutNeeded').returns(true).atLeast(1);
     resource.startLayout();
@@ -522,7 +527,7 @@ describe('Resource', () => {
     elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
 
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
-    resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 10, height: 10});
     const loaded = resource.loadedOnce();
     const promise = resource.startLayout();
     expect(resource.layoutPromise_).to.not.equal(null);
@@ -541,7 +546,7 @@ describe('Resource', () => {
         .returns(Promise.reject(error)).once();
 
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
-    resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
+    stupidMutateLayoutBox(resource, {left: 11, top: 12, width: 10, height: 10});
     const promise = resource.startLayout();
     expect(resource.layoutPromise_).to.not.equal(null);
     expect(resource.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
@@ -875,7 +880,7 @@ describe('Resource renderOutsideViewport', () => {
       prerenderAllowed: () => false,
       renderOutsideViewport: () => true,
       build: () => false,
-      getBoundingClientRect: () => null,
+      getBoundingClientRect: () => layoutRectLtwh(0, 0, 100, 100),
       updateLayoutBox: () => {},
       isRelayoutNeeded: () => false,
       layoutCallback: () => {},
@@ -886,10 +891,12 @@ describe('Resource renderOutsideViewport', () => {
       resumeCallback: () => false,
       viewportCallback: () => {},
       getPriority: () => 0,
+      applySizesAndMediaQuery: () => {},
     };
 
     resources = new Resources(new AmpDocSingle(window));
-    resource = new Resource(1, element, resources);
+    resources.add(element);
+    resource = Resource.forElement(element);
     viewport = resources.viewport_;
     renderOutsideViewport = sandbox.stub(element, 'renderOutsideViewport');
     sandbox.stub(viewport, 'getRect').returns(layoutRectLtwh(0, 0, 100, 100));
@@ -908,12 +915,12 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is inside viewport', () => {
         it('should allow rendering when bottom falls outside', () => {
-          resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 10, 100, 100));
           expect(resource.renderOutsideViewport()).to.equal(true);
         });
 
         it('should allow rendering when top falls outside', () => {
-          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
           expect(resource.renderOutsideViewport()).to.equal(true);
         });
 
@@ -923,12 +930,12 @@ describe('Resource renderOutsideViewport', () => {
           });
 
           it('should allow rendering when bottom falls outside', () => {
-            resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+            stupidMutateLayoutBox(resource, layoutRectLtwh(0, 10, 100, 100));
             expect(resource.renderOutsideViewport()).to.equal(true);
           });
 
           it('should allow rendering when top falls outside', () => {
-            resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+            stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
             expect(resource.renderOutsideViewport()).to.equal(true);
           });
         });
@@ -936,7 +943,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is just below viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 110, 100, 100));
         });
 
         it('should allow rendering when scrolling towards', () => {
@@ -968,7 +975,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is marginally below viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 250, 100, 100));
         });
 
         it('should allow rendering when scrolling towards', () => {
@@ -1000,7 +1007,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is wayyy below viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 1000, 100, 100));
         });
 
         it('should allow rendering', () => {
@@ -1040,7 +1047,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is just above viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
         });
 
         it('should allow rendering when scrolling towards', () => {
@@ -1072,7 +1079,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is marginally above viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -250, 100, 100));
         });
 
         it('should allow rendering when scrolling towards', () => {
@@ -1104,7 +1111,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is wayyy above viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -1000, 100, 100));
         });
 
         it('should allow rendering', () => {
@@ -1150,12 +1157,12 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is inside viewport', () => {
         it('should allow rendering when bottom falls outside', () => {
-          resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 10, 100, 100));
           expect(resource.renderOutsideViewport()).to.equal(false);
         });
 
         it('should allow rendering when top falls outside', () => {
-          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
           expect(resource.renderOutsideViewport()).to.equal(false);
         });
 
@@ -1165,12 +1172,12 @@ describe('Resource renderOutsideViewport', () => {
           });
 
           it('should allow rendering when bottom falls outside', () => {
-            resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+            stupidMutateLayoutBox(resource, layoutRectLtwh(0, 10, 100, 100));
             expect(resource.renderOutsideViewport()).to.equal(true);
           });
 
           it('should allow rendering when top falls outside', () => {
-            resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+            stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
             expect(resource.renderOutsideViewport()).to.equal(true);
           });
         });
@@ -1178,7 +1185,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is just below viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 110, 100, 100));
         });
 
         it('should disallow rendering when scrolling towards', () => {
@@ -1210,7 +1217,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is marginally below viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 250, 100, 100));
         });
 
         it('should disallow rendering when scrolling towards', () => {
@@ -1242,7 +1249,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is wayyy below viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 1000, 100, 100));
         });
 
         it('should disallow rendering', () => {
@@ -1282,7 +1289,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is just above viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
         });
 
         it('should disallow rendering when scrolling towards', () => {
@@ -1314,7 +1321,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is marginally above viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -250, 100, 100));
         });
 
         it('should disallow rendering when scrolling towards', () => {
@@ -1346,7 +1353,7 @@ describe('Resource renderOutsideViewport', () => {
 
       describe('when element is wayyy above viewport', () => {
         beforeEach(() => {
-          resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -1000, 100, 100));
         });
 
         it('should disallow rendering', () => {
@@ -1393,12 +1400,12 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is inside viewport', () => {
       it('should allow rendering when bottom falls outside', () => {
-        resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, 10, 100, 100));
         expect(resource.renderOutsideViewport()).to.equal(true);
       });
 
       it('should allow rendering when top falls outside', () => {
-        resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
         expect(resource.renderOutsideViewport()).to.equal(true);
       });
 
@@ -1408,12 +1415,12 @@ describe('Resource renderOutsideViewport', () => {
         });
 
         it('should allow rendering when bottom falls outside', () => {
-          resource.layoutBox_ = layoutRectLtwh(0, 10, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, 10, 100, 100));
           expect(resource.renderOutsideViewport()).to.equal(true);
         });
 
         it('should allow rendering when top falls outside', () => {
-          resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+          stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
           expect(resource.renderOutsideViewport()).to.equal(true);
         });
       });
@@ -1421,7 +1428,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is just below viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(0, 110, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, 110, 100, 100));
       });
 
       it('should allow rendering when scrolling towards', () => {
@@ -1453,7 +1460,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is marginally below viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(0, 250, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, 250, 100, 100));
       });
 
       it('should allow rendering when scrolling towards', () => {
@@ -1485,7 +1492,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is wayyy below viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(0, 1000, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, 1000, 100, 100));
       });
 
       it('should disallow rendering', () => {
@@ -1525,7 +1532,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is just above viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(0, -10, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, -10, 100, 100));
       });
 
       it('should allow rendering when scrolling towards', () => {
@@ -1557,7 +1564,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is marginally above viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(0, -250, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, -250, 100, 100));
       });
 
       it('should allow rendering when scrolling towards', () => {
@@ -1589,7 +1596,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is wayyy above viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(0, -1000, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, -1000, 100, 100));
       });
 
       it('should disallow rendering', () => {
@@ -1629,7 +1636,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is on the left of viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(-200, 0, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(-200, 0, 100, 100));
       });
 
       it('should disallow rendering', () => {
@@ -1669,7 +1676,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is on the right of viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(200, 0, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(200, 0, 100, 100));
       });
 
       it('should disallow rendering', () => {
@@ -1709,7 +1716,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is fully in viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(0, 0, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(0, 0, 100, 100));
       });
 
       it('should allow rendering', () => {
@@ -1749,7 +1756,7 @@ describe('Resource renderOutsideViewport', () => {
 
     describe('when element is partially in viewport', () => {
       beforeEach(() => {
-        resource.layoutBox_ = layoutRectLtwh(-50, -50, 100, 100);
+        stupidMutateLayoutBox(resource, layoutRectLtwh(-50, -50, 100, 100));
       });
 
       it('should allow rendering', () => {

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1004,7 +1004,7 @@ describe('Resources discoverWork', () => {
   function createResource(rect) {
     const element = createElement(rect);
     resources.add(element);
-    const resource = Resource.forElement(element)
+    const resource = Resource.forElement(element);
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
     stupidMutateLayoutBox(resource, rect);
     return resource;
@@ -1808,17 +1808,16 @@ describe('Resources changeSize', () => {
       viewportRect = {top: 2, left: 0, right: 100, bottom: 200, height: 200};
       viewportMock.expects('getRect').returns(viewportRect).atLeast(1);
       viewportMock.expects('getScrollHeight').returns(10000).atLeast(1);
-      // TODO
-      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100, bottom: 50,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100,
+          bottom: 50, height: 50});
       vsyncSpy = sandbox.stub(resources.vsync_, 'run');
       resources.visible_ = true;
     });
 
     it('should NOT change size when height is unchanged', () => {
       const callback = sandbox.spy();
-      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100, bottom: 210,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100,
+          bottom: 210, height: 50});
       resources.scheduleChangeSize_(resource1, 50, /* width */ undefined,
           undefined, false, callback);
       resources.mutateWork_();
@@ -1830,8 +1829,8 @@ describe('Resources changeSize', () => {
 
     it('should NOT change size when height and margins are unchanged', () => {
       const callback = sandbox.spy();
-      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100, bottom: 210,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100,
+          bottom: 210, height: 50});
       resource1.element.fakeComputedStyle = {
         marginTop: '1px',
         marginRight: '2px',
@@ -1854,8 +1853,8 @@ describe('Resources changeSize', () => {
 
     it('should change size when margins but not height changed', () => {
       const callback = sandbox.spy();
-      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100, bottom: 210,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100,
+          bottom: 210, height: 50});
       resource1.element.fakeComputedStyle = {
         marginTop: '1px',
         marginRight: '2px',
@@ -1906,8 +1905,8 @@ describe('Resources changeSize', () => {
     });
 
     it('should change size when below the viewport', () => {
-      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100, bottom: 1050,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: 10, left: 0, right: 100,
+          bottom: 1050, height: 50});
       resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
       resources.mutateWork_();
       expect(resources.requestsChangeSize_).to.be.empty;
@@ -1918,8 +1917,8 @@ describe('Resources changeSize', () => {
 
     it('should change size when below the viewport and top margin also changed',
         () => {
-          stupidMutateLayoutBox(resource1, {top: 200, left: 0, right: 100, bottom: 300,
-              height: 100});
+          stupidMutateLayoutBox(resource1, {top: 200, left: 0, right: 100,
+              bottom: 300, height: 100});
           resources.scheduleChangeSize_(resource1, 111, 222, {top: 20}, false);
 
           expect(vsyncSpy).to.be.calledOnce;
@@ -1935,8 +1934,8 @@ describe('Resources changeSize', () => {
 
     it('should change size when box top below the viewport but top margin ' +
         'boundary is above viewport but top margin in unchanged', () => {
-      stupidMutateLayoutBox(resource1, {top: 200, left: 0, right: 100, bottom: 300,
-          height: 100});
+      stupidMutateLayoutBox(resource1, {top: 200, left: 0, right: 100,
+          bottom: 300, height: 100});
       resource1.element.fakeComputedStyle = {
         marginTop: '100px',
         marginRight: '0px',
@@ -1959,8 +1958,8 @@ describe('Resources changeSize', () => {
     it('should NOT change size when top margin boundary within viewport ' +
         'and top margin changed', () => {
       const callback = sandbox.spy();
-      stupidMutateLayoutBox(resource1, {top: 100, left: 0, right: 100, bottom: 300,
-          height: 200});
+      stupidMutateLayoutBox(resource1, {top: 100, left: 0, right: 100,
+          bottom: 300, height: 200});
       resources.scheduleChangeSize_(
           resource1, 111, 222, {top: 20}, false, callback);
 
@@ -1976,8 +1975,8 @@ describe('Resources changeSize', () => {
     });
 
     it('should defer when above the viewport and scrolling on', () => {
-      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100, bottom: -1050,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100,
+          bottom: -1050, height: 50});
       resources.lastVelocity_ = 10;
       resources.lastScrollTime_ = Date.now();
       resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
@@ -1990,8 +1989,8 @@ describe('Resources changeSize', () => {
     it('should defer change size if just inside viewport and viewport ' +
         'scrolled by user.', () => {
       viewportRect.top = 2;
-      stupidMutateLayoutBox(resource1, {top: -50, left: 0, right: 100, bottom: 1,
-          height: 51});
+      stupidMutateLayoutBox(resource1, {top: -50, left: 0, right: 100,
+          bottom: 1, height: 51});
       resources.lastVelocity_ = 10;
       resources.lastScrollTime_ = Date.now();
       resources.scheduleChangeSize_(resource1, 111, 222, false);
@@ -2004,8 +2003,8 @@ describe('Resources changeSize', () => {
     it('should NOT change size and call overflow callback if viewport not ' +
         'scrolled by user.', () => {
       viewportRect.top = 1;
-      stupidMutateLayoutBox(resource1, {top: -50, left: 0, right: 100, bottom: 0,
-          height: 51});
+      stupidMutateLayoutBox(resource1, {top: -50, left: 0, right: 100,
+          bottom: 0, height: 51});
       resources.lastVelocity_ = 10;
       resources.lastScrollTime_ = Date.now();
       resources.scheduleChangeSize_(resource1, 111, 222, false);
@@ -2019,8 +2018,8 @@ describe('Resources changeSize', () => {
     it('should change size when above the vp and adjust scrolling', () => {
       viewportMock.expects('getScrollHeight').returns(2999).once();
       viewportMock.expects('getScrollTop').returns(1777).once();
-      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100, bottom: -1050,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100,
+          bottom: -1050, height: 50});
       resources.lastVelocity_ = 0;
       clock.tick(5000);
       resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
@@ -2044,8 +2043,8 @@ describe('Resources changeSize', () => {
     });
 
     it('should NOT resize when above vp but cannot adjust scrolling', () => {
-      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100, bottom: -1100,
-          height: 100});
+      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100,
+          bottom: -1100, height: 100});
       resources.lastVelocity_ = 0;
       clock.tick(5000);
       resources.scheduleChangeSize_(resource1, 0, 222, undefined, false);
@@ -2059,10 +2058,10 @@ describe('Resources changeSize', () => {
     });
 
     it('should resize if multi request above vp can adjust scroll', () => {
-      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100, bottom: -1100,
-          height: 100});
-      stupidMutateLayoutBox(resource2, {top: -1300, left: 0, right: 100, bottom: -1200,
-          height: 100});
+      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100,
+          bottom: -1100, height: 100});
+      stupidMutateLayoutBox(resource2, {top: -1300, left: 0, right: 100,
+          bottom: -1200, height: 100});
       resources.lastVelocity_ = 0;
       clock.tick(5000);
       resources.scheduleChangeSize_(resource2, 200, 222, undefined, false);
@@ -2084,10 +2083,10 @@ describe('Resources changeSize', () => {
       viewportMock.expects('getRect').returns({
         top: 10, left: 0, right: 100, bottom: 210, height: 200,
       }).once();
-      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100, bottom: -1100,
-          height: 100});
-      stupidMutateLayoutBox(resource2, {top: -1300, left: 0, right: 100, bottom: -1200,
-          height: 100});
+      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100,
+          bottom: -1100, height: 100});
+      stupidMutateLayoutBox(resource2, {top: -1300, left: 0, right: 100,
+          bottom: -1200, height: 100});
       resources.lastVelocity_ = 0;
       clock.tick(5000);
       resources.scheduleChangeSize_(resource1, 92, 222, undefined, false);
@@ -2103,8 +2102,8 @@ describe('Resources changeSize', () => {
     it('should NOT adjust scrolling if height not change above vp', () => {
       viewportMock.expects('getScrollHeight').returns(2999).once();
       viewportMock.expects('getScrollTop').returns(1777).once();
-      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100, bottom: -1050,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100,
+          bottom: -1050, height: 50});
       resources.lastVelocity_ = 0;
       clock.tick(5000);
       resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
@@ -2130,8 +2129,8 @@ describe('Resources changeSize', () => {
     it('should adjust scrolling if height change above vp', () => {
       viewportMock.expects('getScrollHeight').returns(2999).once();
       viewportMock.expects('getScrollTop').returns(1000).once();
-      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100, bottom: -1050,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: -1200, left: 0, right: 100,
+          bottom: -1050, height: 50});
       resources.lastVelocity_ = 0;
       clock.tick(5000);
       resources.scheduleChangeSize_(resource1, 111, 222, undefined, false);
@@ -2173,8 +2172,8 @@ describe('Resources changeSize', () => {
 
     it('should NOT change size when resized margin in viewport and should ' +
         'call overflowCallback', () => {
-      stupidMutateLayoutBox(resource1, {top: -48, left: 0, right: 100, bottom: 2,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: -48, left: 0, right: 100,
+          bottom: 2, height: 50});
       resource1.element.fakeComputedStyle = {
         marginBottom: '21px',
       };
@@ -2197,8 +2196,8 @@ describe('Resources changeSize', () => {
     });
 
     it('should change size when resized margin above viewport', () => {
-      stupidMutateLayoutBox(resource1, {top: -49, left: 0, right: 100, bottom: 1,
-          height: 50});
+      stupidMutateLayoutBox(resource1, {top: -49, left: 0, right: 100,
+          bottom: 1, height: 50});
       resource1.element.fakeComputedStyle = {
         marginBottom: '21px',
       };
@@ -2510,8 +2509,8 @@ describe('Resources mutateElement and collapse', () => {
       index++;
     });
 
-    stupidMutateLayoutBox(resource1, {top: 1000, left: 0, right: 100, bottom: 1050,
-        height: 50});
+    stupidMutateLayoutBox(resource1, {top: 1000, left: 0, right: 100,
+        bottom: 1050, height: 50});
     resources.lastVelocity_ = 0;
     resources.attemptCollapse(resource1.element);
     resources.mutateWork_();


### PR DESCRIPTION
**Can you feel the excitement?!?!**

I bit off way more than I can chew with the first pass of this, so I scrapped it and I'm going to be sending this out piecemeal. This one moves only measurement and the cached layout rectangle to the newly created `Layers` service.