### PR TITLE
Fix dep-check error log

### DIFF
--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -34,7 +34,7 @@ var util = require('gulp-util');
 var root = process.cwd();
 var absPathRegExp = new RegExp(`^${root}/`);
 var argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
-var red = (msg) => $$.util.log($$.util.colors.red(msg));
+var red = (msg) => util.log(util.colors.red(msg));
 
 
 /**


### PR DESCRIPTION
dep-check error log is not outputting correct information.
I get: 
```
TypeError: Cannot read property 'log' of undefined
    at red (/Users/zhouyx/amphtml/build-system/tasks/dep-check.js:37:27)
```
