### PR TITLE
Doubleclick Fast Fetch: Measure potential delay of waiting for all ad urls to be constructed

### DIFF
--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import {EXPERIMENT_ATTRIBUTE, QQID_HEADER} from './utils';
-import {BaseLifecycleReporter, GoogleAdLifecycleReporter} from './performance';
-import {getMode} from '../../../src/mode';
 import {
-  isExperimentOn,
-  toggleExperiment,
-  randomlySelectUnsetExperiments,
-} from '../../../src/experiments';
-
+  EXPERIMENT_ATTRIBUTE,
+  QQID_HEADER,
+  isReportingEnabled,
+} from './utils';
+import {BaseLifecycleReporter, GoogleAdLifecycleReporter} from './performance';
+import {randomlySelectUnsetExperiments} from '../../../src/experiments';
 import {
     parseExperimentIds,
     isInManualExperiment,
@@ -116,29 +114,11 @@ function isInReportableBranch(ampElement, namespace) {
  * @visibleForTesting
  */
 export function getLifecycleReporter(ampElement, namespace, slotId) {
-  // Carve-outs: We only want to enable profiling pingbacks when:
-  //   - The ad is from one of the Google networks (AdSense or Doubleclick).
-  //   - The ad slot is in the A4A-vs-3p amp-ad control branch (either via
-  //     internal, client-side selection or via external, Google Search
-  //     selection).
-  //   - We haven't turned off profiling via the rate controls in
-  //     build-system/global-config/{canary,prod}-config.json
-  // If any of those fail, we use the `BaseLifecycleReporter`, which is a
-  // a no-op (sends no pings).
-  const type = ampElement.element.getAttribute('type');
-  const win = ampElement.win;
-  const experimentName = 'a4aProfilingRate';
-  // In local dev mode, neither the canary nor prod config files is available,
-  // so manually set the profiling rate, for testing/dev.
-  if (getMode().localDev) {
-    toggleExperiment(win, experimentName, true, true);
-  }
-  randomlySelectUnsetExperiments(win, PROFILING_BRANCHES);
-  if ((type == 'doubleclick' || type == 'adsense') &&
-      isInReportableBranch(ampElement, namespace) &&
-      isExperimentOn(win, experimentName)) {
-    return new GoogleAdLifecycleReporter(win, ampElement.element, namespace,
-        Number(slotId));
+  randomlySelectUnsetExperiments(ampElement.win, PROFILING_BRANCHES);
+  if (isReportingEnabled(ampElement) &&
+      isInReportableBranch(ampElement, namespace)) {
+    return new GoogleAdLifecycleReporter(ampElement.win, ampElement.element,
+      namespace, Number(slotId));
   } else {
     return new BaseLifecycleReporter();
   }
@@ -204,4 +184,3 @@ export function setGoogleLifecycleVarsFromHeaders(headers, reporter) {
   pingParameters[renderingMethodKey] = headers.get(renderingMethodHeader);
   reporter.setPingParameters(pingParameters);
 }
-

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -25,6 +25,10 @@ import {isProxyOrigin} from '../../../src/url';
 import {viewerForDoc} from '../../../src/services';
 import {base64UrlDecodeToBytes} from '../../../src/utils/base64';
 import {domFingerprint} from '../../../src/utils/dom-fingerprint';
+import {
+  isExperimentOn,
+  toggleExperiment,
+} from '../../../src/experiments';
 
 /** @const {string} */
 const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
@@ -90,6 +94,33 @@ export function isGoogleAdsA4AValidEnvironment(win) {
   // mode, regardless of origin path.
   return supportsNativeCrypto &&
       (isProxyOrigin(win.location) || getMode().localDev || getMode().test);
+}
+
+/**
+ * @param {!AMP.BaseElement} ampElement The element on whose lifecycle this
+ *    reporter will be reporting.
+ * @return {boolean} whether reporting is enabled for this element
+ */
+export function isReportingEnabled(ampElement) {
+  // Carve-outs: We only want to enable profiling pingbacks when:
+  //   - The ad is from one of the Google networks (AdSense or Doubleclick).
+  //   - The ad slot is in the A4A-vs-3p amp-ad control branch (either via
+  //     internal, client-side selection or via external, Google Search
+  //     selection).
+  //   - We haven't turned off profiling via the rate controls in
+  //     build-system/global-config/{canary,prod}-config.json
+  // If any of those fail, we use the `BaseLifecycleReporter`, which is a
+  // a no-op (sends no pings).
+  const type = ampElement.element.getAttribute('type');
+  const win = ampElement.win;
+  const experimentName = 'a4aProfilingRate';
+  // In local dev mode, neither the canary nor prod config files is available,
+  // so manually set the profiling rate, for testing/dev.
+  if (getMode().localDev) {
+    toggleExperiment(win, experimentName, true, true);
+  }
+  return (type == 'doubleclick' || type == 'adsense') &&
+      isExperimentOn(win, experimentName);
 }
 
 /**

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -710,7 +710,7 @@ export class AmpA4A extends AMP.BaseElement {
     }
     this.win['a4a-measuring-ad-urls'] =
      (() => resourcesForDoc(this.element).getMeasuredResources(this.win,
-       (r) => {
+       r => {
          return r.element.tagName == 'AMP-AD' &&
            r.element.getAttribute('type') == type;
        })
@@ -724,7 +724,7 @@ export class AmpA4A extends AMP.BaseElement {
            //
            return instance.adUrlsPromise_;
          })));
-       return Promise.all(getAdUrlsPromise).then(unused_urls => {
+       return Promise.all(getAdUrlsPromise).then(unusedUrls => {
          if (promiseId != this.promiseId_) {
            throw cancellation();
          }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -446,7 +446,7 @@ export class AmpA4A extends AMP.BaseElement {
   }
 
   /**
-   * @return {!../../..//src/service/resource}
+   * @return {!../../../src/service/resource}
    * @visibileForTesting
    */
   getResource() {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -724,7 +724,7 @@ export class AmpA4A extends AMP.BaseElement {
            //
            return instance.adUrlsPromise_;
          })));
-       return Promise.all(getAdUrlsPromise).then(unusedUrls => {
+       return Promise.all(getAdUrlsPromise).then(adUrls => {
          if (promiseId != this.promiseId_) {
            throw cancellation();
          }
@@ -733,6 +733,7 @@ export class AmpA4A extends AMP.BaseElement {
                'met.delta.AD_SLOT_ID': Math.round(
                    this.getNow_() - startTime),
                'totalSlotCount.AD_SLOT_ID': getAdUrlsPromise.length,
+               'totalUrlCount.AD_SLOT_ID': adUrls.filter(url => !!url).length,
              });
        });
      }))();

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -439,11 +439,18 @@ export class AmpA4A extends AMP.BaseElement {
     this.fromResumeCallback = true;
     // If layout of page has not changed, onLayoutMeasure will not be called
     // so do so explicitly.
-    const resource =
-      this.element.getResources().getResourceForElement(this.element);
+    const resource = this.getResource();
     if (resource.hasBeenMeasured() && !resource.isMeasureRequested()) {
       this.onLayoutMeasure();
     }
+  }
+
+  /**
+   * @return {!../../..//src/service/resource}
+   * @visibileForTesting
+   */
+  getResource() {
+    return this.element.getResources().getResourceForElement(this.element);
   }
 
   /**
@@ -727,7 +734,8 @@ export class AmpA4A extends AMP.BaseElement {
        const getAdUrlsPromise = [];
        resources.forEach(r => getAdUrlsPromise.push(r.element.getImpl().then(
          instance => {
-           //
+           // Note that ad url promise could be null if isValidElement returns
+           // false.
            return instance.adUrlsPromise_;
          })));
        return Promise.all(getAdUrlsPromise).then(adUrls => {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -722,7 +722,7 @@ export class AmpA4A extends AMP.BaseElement {
       return;
     }
     this.win['a4a-measuring-ad-urls'] =
-     (() => resourcesForDoc(this.element).getMeasuredResources(this.win,
+     resourcesForDoc(this.element).getMeasuredResources(this.win,
        r => {
          return r.element.tagName == 'AMP-AD' &&
            r.element.getAttribute('type') == type;
@@ -731,29 +731,25 @@ export class AmpA4A extends AMP.BaseElement {
        if (promiseId != this.promiseId_) {
          throw cancellation();
        }
-       const getAdUrlsPromise = [];
-       resources.forEach(r => getAdUrlsPromise.push(r.element.getImpl().then(
-         instance => {
-           // Note that ad url promise could be null if isValidElement returns
-           // false.
-           return instance.adUrlsPromise_;
-         })));
+       const getAdUrlsPromise = resources.map(r => r.element.getImpl().then(
+         // Note that ad url promise could be null if isValidElement returns
+         // false.
+         instance => instance.adUrlsPromise_));
        return Promise.all(getAdUrlsPromise).then(adUrls => {
          if (promiseId != this.promiseId_) {
            throw cancellation();
          }
          this.protectedEmitLifecycleEvent_(
              'sraBuildRequestDelay', {
-               'met.delta.AD_SLOT_ID': Math.round(
-                   this.getNow_() - startTime),
-               'totalSlotCount.AD_SLOT_ID': getAdUrlsPromise.length,
+               'met.delta.AD_SLOT_ID': Math.round(Date.now() - startTime),
+               'totalSlotCount.AD_SLOT_ID': adUrls.length,
                'totalUrlCount.AD_SLOT_ID': adUrls.filter(url => !!url).length,
                'totalQueriedSlotCount.AD_SLOT_ID':
                   this.win.document.querySelectorAll('amp-ad[type=doubleclick]')
                     .length,
              });
        });
-     }))();
+     });
   }
 
   /**

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -748,6 +748,9 @@ export class AmpA4A extends AMP.BaseElement {
                    this.getNow_() - startTime),
                'totalSlotCount.AD_SLOT_ID': getAdUrlsPromise.length,
                'totalUrlCount.AD_SLOT_ID': adUrls.filter(url => !!url).length,
+               'totalQueriedSlotCount.AD_SLOT_ID':
+                  this.win.document.querySelectorAll('amp-ad[type=doubleclick]')
+                    .length,
              });
        });
      }))();

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -58,6 +58,7 @@ import {A4AVariableSource} from './a4a-variable-source';
 // TODO(tdrl): Temporary.  Remove when we migrate to using amp-analytics.
 import {getTimingDataAsync} from '../../../src/service/variable-source';
 import {getContextMetadata} from '../../../src/iframe-attributes';
+import {isReportingEnabled} from '../../../ads/google/a4a/utils';
 
 /** @type {string} */
 const METADATA_STRING = '<script type="application/json" amp-ad-metadata>';
@@ -169,6 +170,7 @@ export const LIFECYCLE_STAGES = {
   visLoadAndOneSec: '25',
   iniLoad: '26',
   resumeCallback: '27',
+  sraBuildRequestDelay: '28',
 };
 
 /**
@@ -530,8 +532,9 @@ export class AmpA4A extends AMP.BaseElement {
         /** @return {!Promise<?Response>} */
         .then(adUrl => {
           checkStillCurrent(promiseId);
-          if (this.element.getAttribute('type') == 'doubleclick' &&
-              isExperimentOn(this.win, 'a4a-measure-get-ad-urls')) {
+          if ((getMode().localDev ||
+              isExperimentOn(this.win, 'a4a-measure-get-ad-urls')) &&
+              isReportingEnabled(this)) {
             this.adUrlsPromise_ = new Promise(resolve => {
               adUrlPromiseResolver = resolve;
             });

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -446,7 +446,7 @@ export class AmpA4A extends AMP.BaseElement {
   }
 
   /**
-   * @return {!../../../src/service/resource}
+   * @return {!../../../src/service/resource.Resource}
    * @visibileForTesting
    */
   getResource() {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -45,7 +45,6 @@ import {resetScheduledElementForTesting} from '../../../../src/custom-element';
 import {urlReplacementsForDoc} from '../../../../src/services';
 import {incrementLoadingAds} from '../../../amp-ad/0.1/concurrent-load';
 import {platformFor, timerFor} from '../../../../src/services';
-import {Resource} from '../../../../src/service/resource';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import {dev, user} from '../../../../src/log';
 import {createElementWithAttributes} from '../../../../src/dom';
@@ -686,16 +685,19 @@ describe('amp-a4a', () => {
         doc.head.appendChild(s);
         const a4a = new MockA4AImpl(a4aElement);
         const renderAmpCreativeSpy = sandbox.spy(a4a, 'renderAmpCreative_');
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;
-        a4a.layoutCallback().then(() => {
+        return a4a.layoutCallback().then(() => {
           expect(renderAmpCreativeSpy.calledOnce,
               'renderAmpCreative_ called exactly once').to.be.true;
           a4a.unlayoutCallback();
           const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
-          sandbox.stub(Resource, 'hasBeenMeasured').returns(false);
+          //sandbox.stub(Resource.prototype, 'hasBeenMeasured').returns(false);
+          sandbox.stub(AmpA4A.prototype, 'getResource').returns(
+            {'hasBeenMeasured': () => false});
           a4a.resumeCallback();
-          expect(onLayoutMeasureSpy).to.never.be.called;
+          expect(onLayoutMeasureSpy).to.not.be.called;
           expect(a4a.fromResumeCallback).to.be.true;
         });
       });

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1177,7 +1177,7 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Returns reference to implementation after it has been built.
-     * @return {!Promise<?./base-element.BaseElement>}
+     * @return {!Promise<!./base-element.BaseElement>}
      */
     getImpl() {
       return this.whenBuilt().then(() => this.implementation_);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1176,6 +1176,14 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * Returns reference to implementation after it has been built.
+     * @return {!Promise<?./base-element.BaseElement>}
+     */
+    getImpl() {
+      return this.whenBuilt().then(() => this.implementation_);
+    }
+
+    /**
      * Instructs the element to layout its content and load its resources if
      * necessary by calling the {@link BaseElement.layoutCallback} method that
      * should be implemented by BaseElement subclasses. Must return a promise

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -285,7 +285,7 @@ export class Resources {
    * Returns a subset of resources which are (1) belong to the specified host
    * window, and (2) meet the filterFn given.
    * @param {!Window} hostWin
-   * @param {!function(!Resource):bool} filterFn
+   * @param {!function(!Resource):boolean} filterFn
    * @return {!Promise<!Array<!Resource>>}
    */
   getMeasuredResources(hostWin, filterFn) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -298,7 +298,7 @@ export class Resources {
       // Second, wait for any left-over elements to complete measuring.
       const measurePromiseArray = [];
       this.resources_.forEach(r => {
-        if (!r.hasBeenMeasured() &&   r.hostWin == hostWin && !r.hasOwner()) {
+        if (!r.hasBeenMeasured() && r.hostWin == hostWin && !r.hasOwner()) {
           measurePromiseArray.push(this.ensuredMeasured_(r));
         }
       });
@@ -318,7 +318,7 @@ export class Resources {
    * @return {!Promise<!Array<!Resource>>}
    */
   getResourcesInRect(hostWin, rect, opt_isInPrerender) {
-    return this.getMeasuredResources(hostWin, (r) => {
+    return this.getMeasuredResources(hostWin, r => {
       // TODO(jridgewell): Remove isFixed check here once the position
       // is calculted correctly in a separate layer for embeds.
       if (!r.isDisplayed() || (!r.overlaps(rect) && !r.isFixed()) ||


### PR DESCRIPTION
In advance of adding Doubleclick Fast Fetch SRA support (see #9115), measure the amount of time between first ad slot url construction and last.  This will help determine if explicit SRA (waiting for each slot to build its URL) is viable by determining the amount of delay it imposes on the first slot.  Note:

- Guarded by an experiment "'a4a-measure-get-ad-urls"
- Only enabled for doubleclick/adsense Fast Fetch based and CSI sampling indicates data collection
- Results in sending CSI ping