### PR TITLE
Service cleanup: Replace all instances of getService* with a third argument

### DIFF
--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -31,7 +31,10 @@ import {
 } from '../../../../src/experiments';
 import {installPlatformService} from '../../../../src/service/platform-impl';
 import {installViewerServiceForDoc} from '../../../../src/service/viewer-impl';
-import {resetServiceForTesting, getService} from '../../../../src/service';
+import {
+  registerServiceBuilder,
+  resetServiceForTesting,
+} from '../../../../src/service';
 import {
   installDocumentStateService,
 } from '../../../../src/service/document-state';
@@ -295,7 +298,7 @@ describe('all-traffic-experiments-tests', () => {
       element = document.createElement('div');
       document.body.appendChild(element);
       addEnabledExperimentSpy = sandbox.stub();
-      getService(win, 'performance', () => {
+      registerServiceBuilder(win, 'performance', function() {
         return {
           addEnabledExperiment: addEnabledExperimentSpy,
         };

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -20,7 +20,7 @@ import {
   ClickEventTracker,
   VisibilityTracker,
 } from '../events';
-import {Crypto} from '../../../../src/service/crypto-impl';
+import {installCryptoService} from '../../../../src/service/crypto-impl';
 import {instrumentationServiceForDocForTesting} from '../instrumentation';
 import {
   installVariableService,
@@ -35,6 +35,7 @@ import {
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
+  getService,
   registerServiceBuilder,
   resetServiceForTesting,
 } from '../../../../src/service';
@@ -96,9 +97,8 @@ describe('amp-analytics', function() {
       });
 
       resetServiceForTesting(iframe.win, 'crypto');
-      registerServiceBuilder(iframe.win, 'crypto', function() {
-        return new Crypto(iframe.win);
-      });
+      installCryptoService(iframe.win, 'crypto');
+      crypto = getService(iframe.win, 'crypto');
       const link = document.createElement('link');
       link.setAttribute('rel', 'canonical');
       link.setAttribute('href', './test-canonical.html');

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -35,7 +35,7 @@ import {
 import {adopt} from '../../../../src/runtime';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
-  getService,
+  registerServiceBuilder,
   resetServiceForTesting,
 } from '../../../../src/service';
 import {markElementScheduledForTesting} from '../../../../src/custom-element';
@@ -83,7 +83,7 @@ describe('amp-analytics', function() {
       markElementScheduledForTesting(iframe.win, 'amp-analytics');
       markElementScheduledForTesting(iframe.win, 'amp-user-notification');
       resetServiceForTesting(iframe.win, 'xhr');
-      getService(iframe.win, 'xhr', () => {
+      registerServiceBuilder(iframe.win, 'xhr', function() {
         return {fetchJson: (url, init) => {
           expect(init.requireAmpResponseSourceOrigin).to.be.undefined;
           if (configWithCredentials) {
@@ -96,8 +96,9 @@ describe('amp-analytics', function() {
       });
 
       resetServiceForTesting(iframe.win, 'crypto');
-      crypto = new Crypto(iframe.win);
-      getService(iframe.win, 'crypto', () => crypto);
+      registerServiceBuilder(iframe.win, 'crypto', function() {
+        return new Crypto(iframe.win);
+      });
       const link = document.createElement('link');
       link.setAttribute('rel', 'canonical');
       link.setAttribute('href', './test-canonical.html');

--- a/extensions/amp-crypto-polyfill/0.1/amp-crypto-polyfill.js
+++ b/extensions/amp-crypto-polyfill/0.1/amp-crypto-polyfill.js
@@ -15,10 +15,12 @@
  */
 
 import * as lib from '../../../third_party/closure-library/sha384-generated';
-import {getService} from '../../../src/service';
+import {registerServiceBuilder} from '../../../src/service';
 
 export function installCryptoPolyfill(win) {
-  getService(win, 'crypto-polyfill', () => lib);
+  registerServiceBuilder(win, 'crypto-polyfill', function() {
+    return lib;
+  });
 }
 
 installCryptoPolyfill(window);

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -18,7 +18,7 @@ import {user} from '../../../src/log';
 import {Layout} from '../../../src/layout';
 import {waitForBodyPromise} from '../../../src/dom';
 import {allocateVariant} from './variant';
-import {getService} from '../../../src/service';
+import {registerServiceBuilder} from '../../../src/service';
 
 /** @const */
 const ATTR_PREFIX = 'amp-x-';
@@ -47,7 +47,9 @@ export class AmpExperiment extends AMP.BaseElement {
         .then(() => results)
         .then(this.addToBody_.bind(this));
 
-    getService(this.win, 'variant', () => this.experimentVariants_);
+    registerServiceBuilder(this.win, 'variant', function() {
+      return this.experimentVariants_
+    });
   }
 
   getConfig_() {

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -48,7 +48,7 @@ export class AmpExperiment extends AMP.BaseElement {
         .then(this.addToBody_.bind(this));
 
     registerServiceBuilder(this.win, 'variant', function() {
-      return this.experimentVariants_
+      return this.experimentVariants_;
     });
   }
 

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -42,13 +42,14 @@ export class AmpExperiment extends AMP.BaseElement {
               });
     });
 
+
     /** @private @const {!Promise<!Object<string, ?string>>} */
-    this.experimentVariants_ = Promise.all(variants)
+    const experimentVariants = Promise.all(variants)
         .then(() => results)
         .then(this.addToBody_.bind(this));
 
     registerServiceBuilder(this.win, 'variant', function() {
-      return this.experimentVariants_;
+      return experimentVariants;
     });
   }
 

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -131,6 +131,7 @@ describe('amp-experiment', () => {
         .returns(Promise.resolve(null));
 
     experiment.buildCallback();
+    debugger;
     return variantForOrNull(win).then(variants => {
       expect(variants).to.jsonEqual({
         'experiment-1': 'variant-a',

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -131,7 +131,6 @@ describe('amp-experiment', () => {
         .returns(Promise.resolve(null));
 
     experiment.buildCallback();
-    debugger;
     return variantForOrNull(win).then(variants => {
       expect(variants).to.jsonEqual({
         'experiment-1': 'variant-a',

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -17,8 +17,8 @@
 import {AmpInstallServiceWorker} from '../amp-install-serviceworker';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 import {
-  getService,
-  getServiceForDoc,
+  registerServiceBuilder,
+  registerServiceBuilderForDoc,
   resetServiceForTesting,
 } from '../../../../src/service';
 import {loadPromise} from '../../../../src/event-helper';
@@ -190,13 +190,13 @@ describes.realWin('amp-install-serviceworker', {
         sourceUrl: 'https://source.example.com/path',
       };
       resetServiceForTesting(env.win, 'documentInfo');
-      getServiceForDoc(doc, 'documentInfo', () => {
+      registerServiceBuilderForDoc(doc, 'documentInfo', function() {
         return {
           get: () => docInfo,
         };
       });
       whenVisible = Promise.resolve();
-      getService(win, 'viewer', () => {
+      registerServiceBuilder(win, 'viewer', function() {
         return {
           whenFirstVisible: () => whenVisible,
           isVisible: () => true,

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -17,7 +17,7 @@
 import {isExperimentOn} from '../../../src/experiments';
 import {xhrFor} from '../../../src/services';
 import {historyForDoc} from '../../../src/services';
-import {getService} from '../../../src/service';
+import {registerServiceBuilder} from '../../../src/service';
 import {Layout} from '../../../src/layout';
 import {base64UrlEncodeFromBytes} from '../../../src/utils/base64';
 import {getCryptoRandomBytesArray} from '../../../src/utils/bytes';
@@ -64,8 +64,9 @@ export class AmpShareTracking extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     if (!this.isExperimentOn_()) {
-      getService(this.win, 'share-tracking',
-          () => Promise.reject(user().createError(TAG + ' disabled')));
+      registerServiceBuilder(this.win, 'share-tracking', function() {
+        return Promise.reject(user().createError(TAG + ' disabled'));
+      });
       user().assert(false, `${TAG} experiment is disabled`);
     }
 
@@ -86,8 +87,9 @@ export class AmpShareTracking extends AMP.BaseElement {
       }
       return {incomingFragment, outgoingFragment};
     });
-
-    getService(this.win, 'share-tracking', () => this.shareTrackingFragments_);
+    registerServiceBuilder(this.win, 'share-tracking', function() {
+      return this.shareTrackingFragments_;
+    });
   }
 
   /**

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -41,9 +41,6 @@ export class AmpShareTracking extends AMP.BaseElement {
     /** @private {string} */
     this.vendorHref_ = '';
 
-    /** @private {?Promise<!Object<string, string>>} */
-    this.shareTrackingFragments_ = null;
-
     /** @private {string} */
     this.originalViewerFragment_ = '';
   }
@@ -73,7 +70,7 @@ export class AmpShareTracking extends AMP.BaseElement {
     this.vendorHref_ = this.element.getAttribute('data-href');
     dev().fine(TAG, 'vendorHref_: ', this.vendorHref_);
 
-    this.shareTrackingFragments_ = Promise.all(
+    const shareTrackingFragments = Promise.all(
       [this.getIncomingFragment_(), this.getOutgoingFragment_()]
     ).then(results => {
       const incomingFragment = results[0];
@@ -88,7 +85,7 @@ export class AmpShareTracking extends AMP.BaseElement {
       return {incomingFragment, outgoingFragment};
     });
     registerServiceBuilder(this.win, 'share-tracking', function() {
-      return this.shareTrackingFragments_;
+      return shareTrackingFragments;
     });
   }
 

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -15,7 +15,6 @@
  */
 
 import {actionServiceForDoc} from './services';
-import {getServiceForDoc} from './service';
 import {dev, user} from './log';
 import {
   assertHttpsUrl,

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -28,11 +28,7 @@ import {
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  */
 export function installGlobalSubmitListenerForDoc(ampdoc) {
-  return getServiceForDoc(ampdoc, 'submit', ampdoc => {
-    ampdoc.getRootNode().addEventListener(
-        'submit', onDocumentFormSubmit_, true);
-    return {};
-  });
+  ampdoc.getRootNode().addEventListener('submit', onDocumentFormSubmit_, true);
 }
 
 

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -17,7 +17,7 @@
 import {iframeMessagingClientFor} from './inabox-iframe-messaging-client';
 import {viewerForDoc} from '../services';
 import {Viewport, ViewportBindingDef} from '../service/viewport-impl';
-import {getServiceForDoc} from '../service';
+import {registerServiceBuilderForDoc} from '../service';
 import {resourcesForDoc} from '../services';
 import {
   nativeIntersectionObserverSupported,
@@ -174,14 +174,17 @@ export class ViewportBindingInabox {
 
 /**
  * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
- * @return {!Viewport}
  */
 export function installInaboxViewportService(ampdoc) {
   const binding = new ViewportBindingInabox(ampdoc.win);
   const viewer = viewerForDoc(ampdoc);
-  const viewport = new Viewport(ampdoc, binding, viewer);
-  return /** @type {!Viewport} */(getServiceForDoc(
-      ampdoc, 'viewport', () => viewport));
+  registerServiceBuilderForDoc(ampdoc,
+      'viewport',
+      function() {
+        return new Viewport(ampdoc, binding, viewer);
+      },
+      /* opt_factory */ undefined,
+      /* opt_instantiate */ true);
 }
 
 /**

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -500,7 +500,11 @@ function registerElementClass(global, name, implementationClass, opt_css) {
     };
   }
   // Resolve this extension's Service Promise.
-  getService(global, name, emptyService);
+  registerServiceBuilder(global,
+      name,
+      emptyService,
+      /* opt_factory */ undefined,
+      /* opt_instantiate */ true);
 }
 
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -499,12 +499,8 @@ function registerElementClass(global, name, implementationClass, opt_css) {
       css: opt_css,
     };
   }
-  // Resolve this extension's Service Promise.
-  registerServiceBuilder(global,
-      name,
-      emptyService,
-      /* opt_factory */ undefined,
-      /* opt_instantiate */ true);
+  // Register this extension to resolve its Service Promise.
+  registerServiceBuilder(global, name, emptyService);
 }
 
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -35,7 +35,7 @@ import {dev, user, initLogConstructor, setReportError} from './log';
 import {reportError} from './error';
 import {
   disposeServicesForDoc,
-  getService,
+  registerServiceBuilder,
   registerServiceBuilderForDoc,
 } from './service';
 import {childElementsByTag} from './dom';

--- a/src/service.js
+++ b/src/service.js
@@ -160,30 +160,16 @@ function getLocalExistingServiceForEmbedWinOrNull(embedWin, id) {
 
 /**
  * Returns a service for the given id and window (a per-window singleton).
- * If the service is not yet available the factory function is invoked and
- * expected to return the service.
  * Users should typically wrap this as a special purpose function (e.g.
  * `vsyncFor(win)`) for type safety and because the factory should not be
  * passed around.
  * @param {!Window} win
  * @param {string} id of the service.
- * @param {function(!Window):T=} opt_factory Factory to create the service
- *     if the service does not exist yet. It is an error if the service does
- *     not exist and the caller does not provide opt_factory.
  * @template T
  * @return {T}
  */
-export function getService(win, id, opt_factory) {
+export function getService(win, id) {
   win = getTopWindow(win);
-  if (!isServiceRegistered(win, id)) {
-    dev().assert(opt_factory, 'Factory not given and service missing %s', id);
-    registerServiceBuilder(
-        win,
-        id,
-        /* opt_ctor */undefined,
-        opt_factory,
-        /* opt_instantiate */ true);
-  }
   return getServiceInternal(win, id);
 }
 
@@ -257,29 +243,14 @@ export function getServicePromiseOrNull(win, id) {
 
 /**
  * Returns a service for the given id and ampdoc (a per-ampdoc singleton).
- * If the service is not yet available the factory function is invoked and
- * expected to return the service.
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @param {string} id of the service.
- * @param {function(!./service/ampdoc-impl.AmpDoc):T=} opt_factory
- *     Factory to create the service if the service does not exist yet.
- *     It is an error if the service does not exist and the caller does
- *     not provide opt_factory.
  * @return {T}
  * @template T
  */
-export function getServiceForDoc(nodeOrDoc, id, opt_factory) {
+export function getServiceForDoc(nodeOrDoc, id) {
   const ampdoc = getAmpdoc(nodeOrDoc);
   const holder = getAmpdocServiceHolder(ampdoc);
-  if (!isServiceRegistered(holder, id)) {
-    dev().assert(opt_factory, 'Factory not given and service missing %s', id);
-    registerServiceBuilderForDoc(
-        ampdoc,
-        id,
-        /* opt_ctor */ undefined,
-        opt_factory,
-        /* opt_instantiate */ true);
-  }
   return getServiceInternal(holder, id);
 }
 

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -20,7 +20,10 @@ import {LOADING_ELEMENTS_, Layout} from '../../src/layout';
 import {installResourcesServiceForDoc} from '../../src/service/resources-impl';
 import {resourcesForDoc} from '../../src/services';
 import {vsyncFor} from '../../src/services';
-import {getService, resetServiceForTesting} from '../../src/service';
+import {
+  registerServiceBuilder,
+  resetServiceForTesting,
+} from '../../src/service';
 import {
   copyElementToChildWindow,
   createAmpElementProto,
@@ -1962,7 +1965,7 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
 
         // Resolve body.
         markElementScheduledForTesting(win, 'element-1');
-        getService(win, 'e1', function() {
+        registerServiceBuilder(win, 'e1', function() {
           return 'fake1';
         });
         doc.body = {};
@@ -1982,7 +1985,7 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
         expect(intervalCallback).to.be.undefined;
 
         // Resolve service.
-        getService(win, 'e1', function() {
+        registerServiceBuilder(win, 'e1', function() {
           return 'fake1';
         });
         return p1;
@@ -2011,7 +2014,7 @@ describes.realWin('services', {
     const p1 = getElementService(env.win, 'e1', 'element-1');
     const p2 = getElementService(env.win, 'e1', 'element-1');
 
-    getService(env.win, 'e1', function() {
+    registerServiceBuilder(env.win, 'e1', function() {
       return 'from e1';
     });
 
@@ -2040,7 +2043,7 @@ describes.realWin('services', {
     markElementScheduledForTesting(env.win, 'element-1');
     const p1 = getElementServiceIfAvailable(env.win, 'e1', 'element-1');
     const p2 = getElementServiceIfAvailable(env.win, 'e2', 'not-available');
-    getService(env.win, 'e1', function() {
+    registerServiceBuilder(env.win, 'e1', function() {
       return 'from e1';
     });
     return p1.then(s1 => {
@@ -2056,7 +2059,7 @@ describes.realWin('services', {
     const p1 = getElementServiceForDoc(env.ampdoc, 'e1', 'element-1');
     const p2 = getElementServiceForDoc(env.ampdoc, 'e1', 'element-1');
 
-    getService(env.win, 'e1', function() {
+    registerServiceBuilder(env.win, 'e1', function() {
       return 'from e1';
     });
 
@@ -2087,7 +2090,7 @@ describes.realWin('services', {
         env.ampdoc, 'e1', 'element-1');
     const p2 = getElementServiceIfAvailableForDoc(
         env.ampdoc, 'e2', 'not-available');
-    getService(env.win, 'e1', function() {
+    registerServiceBuilder(env.win, 'e1', function() {
       return 'from e1';
     });
     return p1.then(s1 => {
@@ -2147,7 +2150,7 @@ describes.realWin('services', {
 
       // Resolve body.
       markElementScheduledForTesting(env.win, 'element-1');
-      getService(env.win, 'e1', function() {
+      registerServiceBuilder(env.win, 'e1', function() {
         return 'fake1';
       });
       bodyResolver();
@@ -2164,7 +2167,7 @@ describes.realWin('services', {
         env.ampdoc, 'e1', 'element-1');
     return Promise.resolve().then(() => {
       // Resolve service.
-      getService(env.win, 'e1', function() {
+      registerServiceBuilder(env.win, 'e1', function() {
         return 'fake1';
       });
       return p1;

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1966,14 +1966,14 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
         // Resolve body.
         markElementScheduledForTesting(win, 'element-1');
         registerServiceBuilder(win, 'e1', function() {
-          return 'fake1';
+          return {str: 'fake1'};
         });
         doc.body = {};
         intervalCallback();
         return p1;
       }).then(service => {
-        expect(resolvedService).to.equal('fake1');
-        expect(service).to.equal('fake1');
+        expect(resolvedService).to.deep.equal({str: 'fake1'});
+        expect(service).to.deep.equal({str: 'fake1'});
       });
     });
 
@@ -1986,11 +1986,11 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
 
         // Resolve service.
         registerServiceBuilder(win, 'e1', function() {
-          return 'fake1';
+          return {str: 'fake1'};
         });
         return p1;
       }).then(service => {
-        expect(service).to.equal('fake1');
+        expect(service).to.deep.equal({str: 'fake1'});
       });
     });
   });
@@ -2015,11 +2015,11 @@ describes.realWin('services', {
     const p2 = getElementService(env.win, 'e1', 'element-1');
 
     registerServiceBuilder(env.win, 'e1', function() {
-      return 'from e1';
+      return {str: 'from e1'};
     });
 
     return p1.then(s1 => {
-      expect(s1).to.equal('from e1');
+      expect(s1).to.deep.equal({str: 'from e1'});
       return p2.then(s2 => {
         expect(s1).to.equal(s2);
       });
@@ -2044,10 +2044,10 @@ describes.realWin('services', {
     const p1 = getElementServiceIfAvailable(env.win, 'e1', 'element-1');
     const p2 = getElementServiceIfAvailable(env.win, 'e2', 'not-available');
     registerServiceBuilder(env.win, 'e1', function() {
-      return 'from e1';
+      return {str: 'from e1'};
     });
     return p1.then(s1 => {
-      expect(s1).to.equal('from e1');
+      expect(s1).to.deep.equal({str: 'from e1'});
       return p2.then(s2 => {
         expect(s2).to.be.null;
       });
@@ -2060,11 +2060,11 @@ describes.realWin('services', {
     const p2 = getElementServiceForDoc(env.ampdoc, 'e1', 'element-1');
 
     registerServiceBuilder(env.win, 'e1', function() {
-      return 'from e1';
+      return {str: 'from e1'};
     });
 
     return p1.then(s1 => {
-      expect(s1).to.equal('from e1');
+      expect(s1).to.deep.equal({str: 'from e1'});
       return p2.then(s2 => {
         expect(s1).to.equal(s2);
       });
@@ -2091,10 +2091,10 @@ describes.realWin('services', {
     const p2 = getElementServiceIfAvailableForDoc(
         env.ampdoc, 'e2', 'not-available');
     registerServiceBuilder(env.win, 'e1', function() {
-      return 'from e1';
+      return {str: 'from e1'};
     });
     return p1.then(s1 => {
-      expect(s1).to.equal('from e1');
+      expect(s1).to.deep.equal({str: 'from e1'});
       return p2.then(s2 => {
         expect(s2).to.be.null;
       });
@@ -2151,13 +2151,13 @@ describes.realWin('services', {
       // Resolve body.
       markElementScheduledForTesting(env.win, 'element-1');
       registerServiceBuilder(env.win, 'e1', function() {
-        return 'fake1';
+        return {str: 'fake1'};
       });
       bodyResolver();
       return p1;
     }).then(service => {
-      expect(resolvedService).to.equal('fake1');
-      expect(service).to.equal('fake1');
+        expect(resolvedService).to.deep.equal({str: 'fake1'});
+        expect(service).to.deep.equal({str: 'fake1'});
     });
   });
 
@@ -2168,11 +2168,11 @@ describes.realWin('services', {
     return Promise.resolve().then(() => {
       // Resolve service.
       registerServiceBuilder(env.win, 'e1', function() {
-        return 'fake1';
+        return {str: 'fake1'};
       });
       return p1;
     }).then(service => {
-      expect(service).to.equal('fake1');
+      expect(service).to.deep.equal({str: 'fake1'});
     });
   });
 });

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -2156,8 +2156,8 @@ describes.realWin('services', {
       bodyResolver();
       return p1;
     }).then(service => {
-        expect(resolvedService).to.deep.equal({str: 'fake1'});
-        expect(service).to.deep.equal({str: 'fake1'});
+      expect(resolvedService).to.deep.equal({str: 'fake1'});
+      expect(service).to.deep.equal({str: 'fake1'});
     });
   });
 

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -287,7 +287,7 @@ describe('service', () => {
         constructor() {
           this.count = ++count;
         }
-      }
+      };
       factory = sandbox.spy(function() {
         return new Class();
       });
@@ -449,7 +449,7 @@ describe('service', () => {
 
       registerServiceBuilderForDoc(node, 'b', function() {
         return {
-          dispose: sinon.stub().throws('intentional'),
+          dispose: sandbox.stub().throws('intentional'),
         };
       });
       const disposableWithError = getServiceForDoc(node, 'b');

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -35,7 +35,7 @@ import {
   installUrlReplacementsServiceForDoc,
   extractClientIdFromGaCookie,
 } from '../../src/service/url-replacements-impl';
-import {getService} from '../../src/service';
+import {registerServiceBuilder} from '../../src/service';
 import {setCookie} from '../../src/cookies';
 import {parseUrl} from '../../src/url';
 import {urlReplacementsForDoc, viewerForDoc} from '../../src/services';
@@ -78,17 +78,21 @@ describes.sandboxed('UrlReplacements', {}, () => {
         }
         if (opt_options.withVariant) {
           markElementScheduledForTesting(iframe.win, 'amp-experiment');
-          getService(iframe.win, 'variant', () => Promise.resolve({
-            'x1': 'v1',
-            'x2': null,
-          }));
+          registerServiceBuilder(iframe.win, 'variant', function() {
+            return Promise.resolve({
+              'x1': 'v1',
+              'x2': null,
+            });
+          });
         }
         if (opt_options.withShareTracking) {
           markElementScheduledForTesting(iframe.win, 'amp-share-tracking');
-          getService(iframe.win, 'share-tracking', () => Promise.resolve({
-            incomingFragment: '12345',
-            outgoingFragment: '54321',
-          }));
+          registerServiceBuilder(iframe.win, 'share-tracking', function() {
+            Promise.resolve({
+              incomingFragment: '12345',
+              outgoingFragment: '54321',
+            });
+          });
         }
       }
       viewerService = viewerForDoc(iframe.ampdoc);

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -88,7 +88,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
         if (opt_options.withShareTracking) {
           markElementScheduledForTesting(iframe.win, 'amp-share-tracking');
           registerServiceBuilder(iframe.win, 'share-tracking', function() {
-            Promise.resolve({
+            return Promise.resolve({
               incomingFragment: '12345',
               outgoingFragment: '54321',
             });

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -40,7 +40,7 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
       [method]: () => {},
     };
   });
-  const service = getServiceForDoc(win, serviceId);
+  const service = getServiceForDoc(ampdoc, serviceId);
   return sandbox.stub(service, method);
 }
 

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -15,20 +15,24 @@
  */
 
 import {xhrServiceForTesting} from '../src/service/xhr-impl';
-import {getService, getServiceForDoc} from '../src/service';
+import {
+  registerServiceBuilder,
+  registerServiceBuilderForDoc,
+} from '../src/service';
 
 export function stubService(sandbox, win, serviceId, method) {
-  const service = getService(win, serviceId, () => {
-    return {
-      [method]: () => {},
-    };
+  const stub = sandbox.stub();
+  registerServiceBuilder(win, serviceId, function() {
+    const service = {};
+    service[method] = stub;
+    return service;
   });
   return sandbox.stub(service, method);
 }
 
 export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
   const stub = sandbox.stub();
-  getServiceForDoc(ampdoc, serviceId, () => {
+  registerServiceBuilderForDoc(ampdoc, serviceId, function() {
     const service = {};
     service[method] = stub;
     return service;

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -16,28 +16,32 @@
 
 import {xhrServiceForTesting} from '../src/service/xhr-impl';
 import {
+  getService,
+  getServiceForDoc,
   registerServiceBuilder,
   registerServiceBuilderForDoc,
 } from '../src/service';
 
 export function stubService(sandbox, win, serviceId, method) {
-  const stub = sandbox.stub();
+  // Register if not already registered.
   registerServiceBuilder(win, serviceId, function() {
-    const service = {};
-    service[method] = stub;
-    return service;
+    return {
+      [method]: () => {};
+    };
   });
-  return stub;
+  const service = getService(win, serviceId);
+  return sandbox.stub(service, method);
 }
 
 export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
-  const stub = sandbox.stub();
+  // Register if not already registered.
   registerServiceBuilderForDoc(ampdoc, serviceId, function() {
-    const service = {};
-    service[method] = stub;
-    return service;
+    return {
+      [method]: () => {};
+    };
   });
-  return stub;
+  const service = getServiceforDoc(win, serviceId);
+  return sandbox.stub(service, method);
 }
 
 /**

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -26,7 +26,7 @@ export function stubService(sandbox, win, serviceId, method) {
   // Register if not already registered.
   registerServiceBuilder(win, serviceId, function() {
     return {
-      [method]: () => {};
+      [method]: () => {},
     };
   });
   const service = getService(win, serviceId);
@@ -37,7 +37,7 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
   // Register if not already registered.
   registerServiceBuilderForDoc(ampdoc, serviceId, function() {
     return {
-      [method]: () => {};
+      [method]: () => {},
     };
   });
   const service = getServiceforDoc(win, serviceId);

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -40,7 +40,7 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
       [method]: () => {},
     };
   });
-  const service = getServiceforDoc(win, serviceId);
+  const service = getServiceForDoc(win, serviceId);
   return sandbox.stub(service, method);
 }
 

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -27,7 +27,7 @@ export function stubService(sandbox, win, serviceId, method) {
     service[method] = stub;
     return service;
   });
-  return sandbox.stub(service, method);
+  return stub;
 }
 
 export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {


### PR DESCRIPTION
Replaces all calls to `getService` and `getServiceForDoc` that provide a factory with calls to `registerServiceBuilder` and `registerServiceBuilderForDoc`. Also adds calls to `getService` and `getServiceForDoc` where needed.

Partial for #8946 