### PR TITLE
Introduce examiner.js to use LongTask API to detect long running javascript in 3p frames

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -365,6 +365,7 @@ function watch() {
 
   return Promise.all([
     buildAlp({watch: true}),
+    buildExaminer({watch: true}),
     buildExtensions({watch: true}),
     compile(true),
   ]);
@@ -509,6 +510,7 @@ function build() {
   return Promise.all([
     polyfillsForTests(),
     buildAlp(),
+    buildExaminer(),
     buildSw(),
     buildWebWorker(),
     buildExtensions({bundleOnlyIfListedInFiles: true}),
@@ -529,6 +531,7 @@ function dist() {
     // When adding a line here, consider whether you need to include polyfills
     // and whether you need to init logging (initLogConstructor).
     buildAlp({minify: true, watch: false, preventRemoveAndMakeDir: true}),
+    buildExaminer({minify: true, watch: false, preventRemoveAndMakeDir: true}),
     buildSw({minify: true, watch: false, preventRemoveAndMakeDir: true}),
     buildWebWorker({minify: true, watch: false, preventRemoveAndMakeDir: true}),
     buildExtensions({minify: true, preventRemoveAndMakeDir: true}),
@@ -896,6 +899,25 @@ function buildAlp(options) {
     minify: options.minify || argv.minify,
     includePolyfills: true,
     minifiedName: 'alp.js',
+    preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
+  });
+}
+
+/**
+ * Build Examiner JS.
+ *
+ * @param {!Object} options
+ */
+function buildExaminer(options) {
+  options = options || {};
+  $$.util.log('Bundling examiner.js');
+
+  return compileJs('./src/examiner/', 'examiner.js', './dist/', {
+    toName: 'examiner.max.js',
+    watch: options.watch,
+    minify: options.minify || argv.minify,
+    includePolyfills: true,
+    minifiedName: 'examiner.js',
     preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
   });
 }

--- a/src/examiner/examiner.js
+++ b/src/examiner/examiner.js
@@ -39,7 +39,7 @@ function detectLongTasks(win) {
           culprit = `<amp-ad type="${match[1]}">`;
         }
       }
-      console.log(
+      console./*OK*/log(
           `%c LONG TASK %c ${duration}ms from ${culprit}`,
           'background: red; color: white',
           'background: #fff; color: #000'

--- a/src/examiner/examiner.js
+++ b/src/examiner/examiner.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-if (isLongTaskApiSupported(window)) {
-  detectLongTasks(window);
+if (isLongTaskApiSupported(self)) {
+  detectLongTasks(self);
 }
 
 function detectLongTasks(win) {

--- a/src/examiner/examiner.js
+++ b/src/examiner/examiner.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (isLongTaskApiSupported(window)) {
+  detectLongTasks(window);
+}
+
+function detectLongTasks(win) {
+  const observer = new win.PerformanceObserver(function(entryList) {
+    const entries = entryList.getEntries();
+    for (let i = 0; i < entries.length; i++) {
+      if (entries[i].entryType != 'longtask'
+          || entries[i].name != 'cross-origin-descendant') {
+        continue;
+      }
+      const attr = entries[i].attribution[0];
+      if (!attr || !attr.containerSrc) {
+        continue;
+      }
+
+      const duration = entries[i].duration;
+      let culprit = attr.containerSrc;
+      if (attr.containerName) {
+        const match = attr.containerName.match(/"type":"([^\"]*)"/);
+        if (match.length > 1) {
+          culprit = `<amp-ad type="${match[1]}">`;
+        }
+      }
+      console.log(
+          `%c LONG TASK %c ${duration}ms from ${culprit}`,
+          'background: red; color: white',
+          'background: #fff; color: #000'
+      );
+    }
+  });
+  observer.observe({entryTypes: ['longtask']});
+}
+
+function isLongTaskApiSupported(win) {
+  return !!win.PerformanceObserver
+      && !!win.TaskAttributionTiming
+      && ('containerName' in win.TaskAttributionTiming.prototype);
+}


### PR DESCRIPTION
for #9326 

LongTask API is now available in latest Chrome (58.0)
This is an example of using LongTask API to find 3P frame culprit.

<img width="426" alt="screen shot 2017-05-10 at 10 37 12 pm" src="https://cloud.githubusercontent.com/assets/8496897/25934196/3ec1034e-35d1-11e7-9e9c-578cae4a943f.png">
