### PR TITLE
amp-auto-ads: Wires up a holdout experiment for AdSense to study the effect of running amp-auto-ads

### DIFF
--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -18,7 +18,6 @@ import {ampdocServiceFor} from '../../../../src/ampdoc';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {
   addExperimentIdToElement,
-  mergeExperimentIds,
   isInExperiment,
   isExternallyTriggeredExperiment,
   isInternallyTriggeredExperiment,
@@ -211,21 +210,6 @@ describe('all-traffic-experiments-tests', () => {
       element.setAttribute(EXPERIMENT_ATTRIBUTE, '99,14,873,k,44');
       addExperimentIdToElement('3', element);
       expect(element.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal('3');
-    });
-  });
-
-  describe('#mergeExperimentIds', () => {
-    it('should merge a single id to itself', () => {
-      expect(mergeExperimentIds('12345')).to.equal('12345');
-    });
-    it('should merge a single ID to a list', () => {
-      expect(mergeExperimentIds('12345', '3,4,5,6')).to.equal('3,4,5,6,12345');
-    });
-    it('should discard invalid ID', () => {
-      expect(mergeExperimentIds('frob', '3,4,5,6')).to.equal('3,4,5,6');
-    });
-    it('should return empty string for invalid input', () => {
-      expect(mergeExperimentIds('frob')).to.equal('');
     });
   });
 

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -22,7 +22,11 @@
  * impacts on click-throughs.
  */
 
-import {isGoogleAdsA4AValidEnvironment, EXPERIMENT_ATTRIBUTE} from './utils';
+import {
+  isGoogleAdsA4AValidEnvironment,
+  mergeExperimentIds,
+  EXPERIMENT_ATTRIBUTE,
+} from './utils';
 import {
   isExperimentOn,
   forceExperimentBranch,
@@ -310,28 +314,6 @@ export function validateExperimentIds(idList) {
 }
 
 /**
- * Add a new experiment ID to a (possibly empty) existing set of experiment IDs.
- * The {@code currentIdString} may be {@code null} or {@code ''}, but if it is
- * populated, it must contain a comma-separated list of integer experiment IDs
- * (per {@code parseExperimentIds()}).  Returns the new set of IDs, encoded
- * as a comma-separated list.  Does not de-duplicate ID entries.
- *
- * @param {!string} newId  ID to merge in.  Must be a stringified integer
- *   (base 10).
- * @param {?string} currentIdString  If present, a string containing a
- *   comma-separated list of integer experiment IDs.
- * @returns {string}  New experiment list string, including newId iff it is
- *   a valid (integer) experiment ID.
- * @see parseExperimentIds, validateExperimentIds
- */
-export function mergeExperimentIds(newId, currentIdString) {
-  if (newId && !isNaN(parseInt(newId, 10))) {
-    return currentIdString ? (currentIdString + ',' + newId) : newId;
-  }
-  return currentIdString || '';
-}
-
-/**
  * Adds a single experimentID to an element iff it's a valid experiment ID.
  *
  * @param {!string} experimentId  ID to add to the element.
@@ -341,7 +323,7 @@ export function addExperimentIdToElement(experimentId, element) {
   const currentEids = element.getAttribute(EXPERIMENT_ATTRIBUTE);
   if (currentEids && validateExperimentIds(parseExperimentIds(currentEids))) {
     element.setAttribute(EXPERIMENT_ATTRIBUTE,
-        mergeExperimentIds(experimentId, currentEids));
+        mergeExperimentIds([experimentId], currentEids));
   } else {
     element.setAttribute(EXPERIMENT_ATTRIBUTE, experimentId);
   }

--- a/ads/google/adsense-amp-auto-ads.js
+++ b/ads/google/adsense-amp-auto-ads.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {
+  randomlySelectUnsetExperiments,
+  getExperimentBranch,
+} from '../../src/experiments';
+
+
+/** @const {string} */
+export const ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME =
+    'amp-auto-ads-adsense-holdout';
+
+
+/**
+ * @enum {string}
+ */
+export const AdSenseAmpAutoAdsHoldoutBranches = {
+  CONTROL: '3782001',  // don't run amp-auto-ads
+  EXPERIMENT: '3782002',  // do run amp-auto-ads
+};
+
+
+/** @const {!../../src/experiments.ExperimentInfo} */
+const ADSENSE_AMP_AUTO_ADS_EXPERIMENT_INFO = {
+  isTrafficEligible: win => !!win.document.querySelector('AMP-AUTO-ADS'),
+  branches: [
+    AdSenseAmpAutoAdsHoldoutBranches.CONTROL,
+    AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT,
+  ],
+};
+
+
+/**
+ * This has the side-effect of selecting the page into a branch of the
+ * experiment, which becomes sticky for the entire pageview.
+ *
+ * @param {!Window} win
+ * @return {?string}
+ */
+export function getAdSenseAmpAutoAdsExpBranch(win) {
+  const experiments = {};
+  experiments[ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME] =
+      ADSENSE_AMP_AUTO_ADS_EXPERIMENT_INFO;
+  randomlySelectUnsetExperiments(win, experiments);
+  return getExperimentBranch(win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME)
+      || null;
+};

--- a/ads/google/test/test-adsense-amp-auto-ads.js
+++ b/ads/google/test/test-adsense-amp-auto-ads.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+  AdSenseAmpAutoAdsHoldoutBranches,
+  getAdSenseAmpAutoAdsExpBranch,
+} from '../adsense-amp-auto-ads';
+import {
+  RANDOM_NUMBER_GENERATORS,
+  toggleExperiment,
+} from '../../../src/experiments';
+
+describes.realWin('adsense-amp-auto-ads', {}, env => {
+  let win;
+  let sandbox;
+  let accurateRandomStub;
+  let cachedAccuratePrng;
+
+  beforeEach(() => {
+    win = env.win;
+    sandbox = env.sandbox;
+
+    accurateRandomStub = sandbox.stub().returns(-1);
+    cachedAccuratePrng = RANDOM_NUMBER_GENERATORS.accuratePrng;
+    RANDOM_NUMBER_GENERATORS.accuratePrng = accurateRandomStub;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    RANDOM_NUMBER_GENERATORS.accuratePrng = cachedAccuratePrng;
+  });
+
+  it('should pick the control branch when experiment on and amp-auto-ads ' +
+      'tag present.', () => {
+    const ampAutoAdsEl = win.document.createElement('amp-auto-ads');
+    win.document.body.appendChild(ampAutoAdsEl);
+    toggleExperiment(win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, true);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.4);
+    expect(getAdSenseAmpAutoAdsExpBranch(win))
+        .to.equal(AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
+  });
+
+  it('should pick the experiment branch when experiment on and amp-auto-ads ' +
+      'tag present.', () => {
+    const ampAutoAdsEl = win.document.createElement('amp-auto-ads');
+    win.document.body.appendChild(ampAutoAdsEl);
+    toggleExperiment(win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, true);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.6);
+    expect(getAdSenseAmpAutoAdsExpBranch(win))
+        .to.equal(AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
+  });
+
+  it('should not pick a branch when experiment off.', () => {
+    const ampAutoAdsEl = win.document.createElement('amp-auto-ads');
+    win.document.body.appendChild(ampAutoAdsEl);
+    toggleExperiment(win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, false);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.4);
+    expect(getAdSenseAmpAutoAdsExpBranch(win)).to.be.null;
+  });
+
+  it('should not pick a branch when experiment on but no and amp-auto-ads ' +
+      'tag present.', () => {
+    toggleExperiment(win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, true);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.4);
+    expect(getAdSenseAmpAutoAdsExpBranch(win)).to.be.null;
+  });
+});
+
+

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -100,6 +100,7 @@ exports.rules = [
       'ads/**->src/types.js',
       'ads/**->src/string.js',
       'ads/**->src/style.js',
+      'ads/google/adsense-amp-auto-ads.js->src/experiments.js',
       // ads/google/a4a doesn't contain 3P ad code and should probably move
       // somewhere else at some point
       'ads/google/a4a/**->src/ad-cid.js',

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -48,6 +48,9 @@ import {
 import {viewerForDoc} from '../../../src/services';
 import {AdsenseSharedState} from './adsense-shared-state';
 import {insertAnalyticsElement} from '../../../src/analytics';
+import {
+  getAdSenseAmpAutoAdsExpBranch,
+} from '../../../ads/google/adsense-amp-auto-ads';
 
 /** @const {string} */
 const ADSENSE_BASE_URL = 'https://googleads.g.doubleclick.net/pagead/ads';
@@ -183,8 +186,14 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       paramList.push({name: 'prev_fmts', value: sharedStateParams.prevFmts});
     }
 
+    const experimentIds = [];
+    const ampAutoAdsBranch = getAdSenseAmpAutoAdsExpBranch(this.win);
+    if (ampAutoAdsBranch) {
+      experimentIds.push(ampAutoAdsBranch);
+    }
+
     return googleAdUrl(
-        this, ADSENSE_BASE_URL, startTime, paramList, []);
+        this, ADSENSE_BASE_URL, startTime, paramList, [], experimentIds);
   }
 
   /** @override */

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import {
+  AdSenseAmpAutoAdsHoldoutBranches,
+  getAdSenseAmpAutoAdsExpBranch,
+} from '../../../ads/google/adsense-amp-auto-ads';
 import {buildUrl} from '../../../ads/google/a4a/url-builder';
 import {documentInfoForDoc} from '../../../src/services';
 import {parseUrl} from '../../../src/url';
@@ -26,6 +30,13 @@ import {viewportForDoc} from '../../../src/services';
  * @interface
  */
 class AdNetworkConfigDef {
+
+  /**
+   * Indicates whether amp-auto-ads should be enabled on this pageview.
+   * @param {!Window} unusedWin
+   * @return {boolean} true if amp-auto-ads should be enabled on this pageview.
+   */
+  isEnabled(unusedWin) {}
 
   /**
    * @return {string}
@@ -68,6 +79,14 @@ class AdSenseNetworkConfig {
    */
   constructor(autoAmpAdsElement) {
     this.autoAmpAdsElement_ = autoAmpAdsElement;
+  }
+
+  /**
+   * @param {!Window} win
+   */
+  isEnabled(win) {
+    const branch = getAdSenseAmpAutoAdsExpBranch(win);
+    return branch != AdSenseAmpAutoAdsHoldoutBranches.CONTROL;
   }
 
   /** @override */

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -39,6 +39,10 @@ export class AmpAutoAds extends AMP.BaseElement {
     const adNetwork = getAdNetworkConfig(type, this.element);
     user().assert(adNetwork, 'No AdNetworkConfig for type: ' + type);
 
+    if (!adNetwork.isEnabled(this.win)) {
+      return;
+    }
+
     this.getConfig_(adNetwork.getConfigUrl()).then(configObj => {
       if (!configObj) {
         return;

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -15,7 +15,15 @@
  */
 
 import {getAdNetworkConfig} from '../ad-network-config';
+import {
+  toggleExperiment,
+  forceExperimentBranch,
+} from '../../../../src/experiments';
 import {viewportForDoc} from '../../../../src/services';
+import {
+  ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+  AdSenseAmpAutoAdsHoldoutBranches,
+} from '../../../../ads/google/adsense-amp-auto-ads';
 
 describes.realWin('ad-network-config', {
   amp: {
@@ -44,6 +52,31 @@ describes.realWin('ad-network-config', {
 
     beforeEach(() => {
       ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+    });
+
+    it('should report enabled when holdout experiment not on', () => {
+      toggleExperiment(
+          env.win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, false);
+      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      expect(adNetwork.isEnabled(env.win)).to.equal(true);
+    });
+
+    it('should report enabled when holdout experiment on and experiment ' +
+        'branch picked', () => {
+      forceExperimentBranch(env.win,
+          ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+          AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
+      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      expect(adNetwork.isEnabled(env.win)).to.equal(true);
+    });
+
+    it('should report disabled when holdout experiment on and control ' +
+        'branch picked', () => {
+      forceExperimentBranch(env.win,
+          ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+          AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
+      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      expect(adNetwork.isEnabled(env.win)).to.equal(false);
     });
 
     it('should generate the config fetch URL', () => {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -93,6 +93,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6217',
   },
   {
+    id: 'amp-auto-ads-adsense-holdout',
+    name: 'AMP Auto Ads AdSense Holdout',
+    spec: 'https://github.com/ampproject/amphtml/issues/6196',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/9247',
+  },
+  {
     id: 'amp-google-vrview-image',
     name: 'AMP VR Viewer for images via Google VRView',
     spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +


### PR DESCRIPTION
Only ads that use the fast-fetch code path are labelled with experiment IDs. This is fine as fast-fetch will soon be the norm for AdSense amp-ads.

Only affects AdSense code paths.