### PR TITLE
Update amp-selector markdown

### DIFF
--- a/extensions/amp-selector/amp-selector.md
+++ b/extensions/amp-selector/amp-selector.md
@@ -83,15 +83,15 @@ Example:
 </amp-selector>
 ```
 
-##Attributes
+## Attributes
 
-###Attributes on `<amp-selector>`
+### Attributes on `<amp-selector>`
 
 **disabled, form, multiple, name**
 
 The attributes above behave the same way as they do on a standard HTML [`<select>`](https://developer.mozilla.org/en/docs/Web/HTML/Element/select) element.
 
-###Attributes on `<amp-selector>` options
+### Attributes on `<amp-selector>` options
 
 **option**
 


### PR DESCRIPTION
Headers need a space after the `#`.