### PR TITLE
Implement debounced input action

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -209,7 +209,8 @@ app.use('/form/search-html/get', function(req, res) {
 app.use('/form/search-json/get', function(req, res) {
   assertCors(req, res, ['GET']);
   res.json({
-    results: [{title: 'Result 1'}, {title: 'Result 2'}, {title: 'Result 3'}]
+    term: req.query.term,
+    results: [{title: 'Result 1'}, {title: 'Result 2'}, {title: 'Result 3'}],
   });
 });
 

--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -719,5 +719,31 @@
     </div>
 </form>
 
+<h4>Debounced search</h4>
+<form
+  id="debounced-search"
+  method="get"
+  action="/form/search-html/get"
+  action-xhr="/form/search-json/get"
+  target="_blank"
+>
+    <fieldset>
+        <label>
+            <span>Search for</span>
+            <input type="search" on="input-debounced:debounced-search.submit" name="term" required>
+        </label>
+        <input type="submit" value="Search">
+    </fieldset>
+
+    <div submit-success>
+        <template type="amp-mustache">
+            <h1>Here are the results for the search: {{term}}</h1>
+            <ul>
+                {{#results}}<li>{{title}}</li>{{/results}}
+            </ul>
+        </template>
+    </div>
+</form>
+
 </body>
 </html>

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -205,10 +205,14 @@ export class ActionService {
         this.trigger(dev().assertElement(event.target), name, event);
       });
     } else if (name == 'input-debounced') {
-      this.root_.addEventListener('input', debounce(this.ampdoc.win, event => {
-        const target = dev().assertElement(event.target);
-        this.trigger(target, name, /** @type {Event} */ (event));
-      }, DEFAULT_DEBOUNCE_WAIT));
+      const inputDebounced = debounce(this.ampdoc.win, (target, event) => {
+        this.trigger(
+            dev().assertElement(target), name, /** @type {?Event} */ (event));
+      }, DEFAULT_DEBOUNCE_WAIT);
+
+      this.root_.addEventListener('input', event => {
+        inputDebounced(event.target, event);
+      });
     }
   }
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -47,6 +47,9 @@ const ACTION_HANDLER_ = '__AMP_ACTION_HANDLER__';
 /** @const {string} */
 const DEFAULT_METHOD_ = 'activate';
 
+/** @const {number} */
+const DEFAULT_DEBOUNCE_WAIT = 300; // ms
+
 /** @const {!Object<string,!Array<string>>} */
 const ELEMENTS_ACTIONS_MAP_ = {
   'form': ['submit'],
@@ -156,8 +159,8 @@ export class ActionService {
     // Add core events.
     this.addEvent('tap');
     this.addEvent('submit');
-    // TODO(mkhatib, #5702): Consider a debounced-input event for text-type inputs.
     this.addEvent('change');
+    this.addEvent('input-debounced');
   }
 
   /** @override */
@@ -200,6 +203,10 @@ export class ActionService {
         this.addChangeDetails_(event);
         this.trigger(dev().assertElement(event.target), name, event);
       });
+    } else if (name == 'input-debounced') {
+      this.root_.addEventListener('input', debounce_(event => {
+        this.trigger(dev().assertElement(event.target), name, event);
+      }, DEFAULT_DEBOUNCE_WAIT));
     }
   }
 
@@ -472,6 +479,20 @@ export class ActionService {
     }
     return actionMap;
   }
+}
+
+// TODO(cvializ): DO NOT SUBMIT
+// wait for common debounce function to be merged in
+// https://github.com/ampproject/amphtml/pull/9252/
+function debounce_(func, wait) {
+  let timeout;
+  return function() {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      timeout = null;
+      func.apply(this, arguments);
+    }, wait);
+  };
 }
 
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -499,27 +499,28 @@ export class ActionService {
 
 
 /**
- * A clone of an event object with its function properties noop'd.
+ * A clone of an event object with its function properties replaced.
  * This is useful e.g. for event objects that need to be passed to an async
  * context, but the browser might have cleaned up the original event object.
- * This clone noops functions since they won't behave normally after the
- * original object has been destroyed.
+ * This clone replaces functions with error throws since they won't behave
+ * normally after the original object has been destroyed.
+ * @private visible for testing
  */
-class DeferredEvent {
+export class DeferredEvent {
   /**
    * @param {!Event} event
    */
   constructor(event) {
-    cloneWithoutFunctions(event, this);
-
     /** @type {?Object} */
     this.detail = null;
+
+    cloneWithoutFunctions(event, this);
   }
 }
 
 
 /**
- * Clones an object and noops its function properties.
+ * Clones an object and replaces its function properties with throws.
  * @param {!T} original
  * @param {!T=} opt_dest
  * @return {!T}
@@ -531,7 +532,7 @@ function cloneWithoutFunctions(original, opt_dest) {
   for (const prop in original) {
     const value = original[prop];
     if (typeof value === 'function') {
-      clone[prop] = noop;
+      clone[prop] = notImplemented;
     } else {
       clone[prop] = original[prop];
     }
@@ -539,8 +540,11 @@ function cloneWithoutFunctions(original, opt_dest) {
   return clone;
 }
 
+
 /** @private */
-function noop() { }
+function notImplemented() {
+  dev().assert(null, 'Deferred events cannot access native event functions.');
+}
 
 
 /**

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -208,7 +208,7 @@ export class ActionService {
       });
     } else if (name == 'change') {
       this.root_.addEventListener(name, event => {
-        this.addChangeDetails_(event);
+        this.addInputMutateDetails_(event);
         this.trigger(dev().assertElement(event.target), name, event);
       });
     } else if (name == 'input-debounced') {
@@ -221,17 +221,19 @@ export class ActionService {
         // Create a DeferredEvent to avoid races where the browser cleans up
         // the event object before the async debounced function is called.
         const deferredEvent = new DeferredEvent(event);
+        this.addInputMutateDetails_(deferredEvent);
         debouncedInput(deferredEvent);
       });
     }
   }
 
   /**
-   * Given a browser 'change' event, add `details` property containing the
-   * relevant information for the change that generated the initial event.
+   * Given a browser 'change' or 'input' event, add `details` property
+   * containing the relevant information for the change that generated
+   * the initial event.
    * @param {!ActionEventDef} event A `change` event.
    */
-  addChangeDetails_(event) {
+  addInputMutateDetails_(event) {
     const detail = map();
     const target = event.target;
     const tagName = target.tagName.toLowerCase();

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -15,6 +15,7 @@
  */
 
 import {KeyCodes} from '../utils/key-codes';
+import {debounce} from '../utils/rate-limit';
 import {dev, user} from '../log';
 import {
   registerServiceBuilderForDoc,
@@ -204,7 +205,7 @@ export class ActionService {
         this.trigger(dev().assertElement(event.target), name, event);
       });
     } else if (name == 'input-debounced') {
-      this.root_.addEventListener('input', debounce_(event => {
+      this.root_.addEventListener('input', debounce(this.ampdoc.win, event => {
         this.trigger(dev().assertElement(event.target), name, event);
       }, DEFAULT_DEBOUNCE_WAIT));
     }
@@ -479,20 +480,6 @@ export class ActionService {
     }
     return actionMap;
   }
-}
-
-// TODO(cvializ): DO NOT SUBMIT
-// wait for common debounce function to be merged in
-// https://github.com/ampproject/amphtml/pull/9252/
-function debounce_(func, wait) {
-  let timeout;
-  return function() {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => {
-      timeout = null;
-      func.apply(this, arguments);
-    }, wait);
-  };
 }
 
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -23,6 +23,7 @@ import {
 } from '../service';
 import {getMode} from '../mode';
 import {isArray} from '../types';
+import {isExperimentOn} from '../experiments';
 import {map} from '../utils/object';
 import {timerFor} from '../services';
 import {vsyncFor} from '../services';
@@ -231,7 +232,7 @@ export class ActionService {
    * Given a browser 'change' or 'input' event, add `details` property
    * containing the relevant information for the change that generated
    * the initial event.
-   * @param {!ActionEventDef} event A `change` event.
+   * @param {!ActionEventDef} event
    */
   addInputMutateDetails_(event) {
     const detail = map();
@@ -358,6 +359,12 @@ export class ActionService {
 
     for (let i = 0; i < action.actionInfos.length; i++) {
       const actionInfo = action.actionInfos[i];
+
+      if (actionInfo.event === 'input-debounced') {
+        user().assert(isExperimentOn(this.ampdoc.win, 'input-debounced'),
+            'Enable "input-debounced" experiment to use input-debounced');
+      }
+
       // Replace any variables in args with data in `event`.
       const args = applyActionInfoArgs(actionInfo.args, event);
 
@@ -404,6 +411,7 @@ export class ActionService {
    * @param {?Element} source
    * @param {?ActionEventDef} event
    * @param {?ActionInfoDef} actionInfo
+   * @private visible for testing
    */
   invoke_(target, method, args, source, event, actionInfo) {
     const invocation = new ActionInvocation(target, method, args,

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -206,7 +206,8 @@ export class ActionService {
       });
     } else if (name == 'input-debounced') {
       this.root_.addEventListener('input', debounce(this.ampdoc.win, event => {
-        this.trigger(dev().assertElement(event.target), name, event);
+        const target = dev().assertElement(event.target);
+        this.trigger(target, name, /** @type {Event} */ (event));
       }, DEFAULT_DEBOUNCE_WAIT));
     }
   }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -346,12 +346,12 @@ export class ActionService {
 
   /**
    * @param {!Element} source
-   * @param {string} ActionEventDefType
+   * @param {string} actionEventType
    * @param {?ActionEventDef} event
    * @private
    */
-  action_(source, ActionEventDefType, event) {
-    const action = this.findAction_(source, ActionEventDefType);
+  action_(source, actionEventType, event) {
+    const action = this.findAction_(source, actionEventType);
     if (!action) {
       // TODO(dvoytenko): implement default (catch-all) actions.
       return;
@@ -461,14 +461,14 @@ export class ActionService {
 
   /**
    * @param {!Element} target
-   * @param {string} ActionEventDefType
+   * @param {string} actionEventType
    * @return {?{node: !Element, actionInfos: !Array<!ActionInfoDef>}}
    */
-  findAction_(target, ActionEventDefType) {
+  findAction_(target, actionEventType) {
     // Go from target up the DOM tree and find the applicable action.
     let n = target;
     while (n) {
-      const actionInfos = this.matchActionInfos_(n, ActionEventDefType);
+      const actionInfos = this.matchActionInfos_(n, actionEventType);
       if (actionInfos) {
         return {node: n, actionInfos: dev().assert(actionInfos)};
       }
@@ -479,15 +479,15 @@ export class ActionService {
 
   /**
    * @param {!Element} node
-   * @param {string} ActionEventDefType
+   * @param {string} actionEventType
    * @return {?Array<!ActionInfoDef>}
    */
-  matchActionInfos_(node, ActionEventDefType) {
+  matchActionInfos_(node, actionEventType) {
     const actionMap = this.getActionMap_(node);
     if (!actionMap) {
       return null;
     }
-    return actionMap[ActionEventDefType] || null;
+    return actionMap[actionEventType] || null;
   }
 
   /**

--- a/src/utils/rate-limit.js
+++ b/src/utils/rate-limit.js
@@ -20,9 +20,9 @@
  * smaller than the given minimal interval.
  *
  * @param {!Window} win
- * @param {function()} callback
+ * @param {function(...*)} callback
  * @param {number} minInterval the minimum time interval in millisecond
- * @returns {function()}
+ * @returns {function(...*)}
  */
 export function throttle(win, callback, minInterval) {
   let locker = 0;
@@ -59,9 +59,9 @@ export function throttle(win, callback, minInterval) {
  * invoked.
  *
  * @param {!Window} win
- * @param {function()} callback
+ * @param {function(...*)} callback
  * @param {number} minInterval the minimum time interval in millisecond
- * @returns {function()}
+ * @returns {function(...*)}
  */
 export function debounce(win, callback, minInterval) {
   let locker = 0;

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1053,12 +1053,17 @@ describe('Core events', () => {
     it('should replace functions with throws', () => {
       const event = createCustomEvent(window, 'MyEvent', {foo: 'bar'});
       const deferredEvent = new DeferredEvent(event);
+      const errorText = 'cannot access native event functions';
 
+      // Specifically test these commonly used functions
+      expect(() => deferredEvent.preventDefault()).to.throw(errorText);
+      expect(() => deferredEvent.stopPropagation()).to.throw(errorText);
+
+      // Test all functions
       for (const key in deferredEvent) {
         const value = deferredEvent[key];
         if (typeof value === 'function') {
-          expect(() => value()).to.throw(
-              'cannot access native event functions');
+          expect(() => value()).to.throw(errorText);
         }
       }
     });

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -16,6 +16,7 @@
 
 import {
   ActionService,
+  DeferredEvent,
   OBJECT_STRING_ARGS_KEY,
   applyActionInfoArgs,
   parseActionMap,
@@ -1037,4 +1038,29 @@ describe('Core events', () => {
         }));
   });
 
+  describe('DeferredEvent', () => {
+    it('should copy the properties of an event object', () => {
+      const event = createCustomEvent(window, 'MyEvent', {foo: 'bar'});
+      const deferredEvent = new DeferredEvent(event);
+
+      for (const key in deferredEvent) {
+        if (typeof deferredEvent[key] !== 'function') {
+          expect(deferredEvent[key]).to.deep.equal(event[key]);
+        }
+      }
+    });
+
+    it('should replace functions with throws', () => {
+      const event = createCustomEvent(window, 'MyEvent', {foo: 'bar'});
+      const deferredEvent = new DeferredEvent(event);
+
+      for (const key in deferredEvent) {
+        const value = deferredEvent[key];
+        if (typeof value === 'function') {
+          expect(() => value()).to.throw(
+              'cannot access native event functions');
+        }
+      }
+    });
+  });
 });

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -24,6 +24,7 @@ import {
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {KeyCodes} from '../../src/utils/key-codes';
 import {createCustomEvent} from '../../src/event-helper';
+import {toggleExperiment} from '../../src/experiments';
 import {setParentWindow} from '../../src/service';
 import * as sinon from 'sinon';
 
@@ -924,27 +925,37 @@ describes.sandboxed('Action global target', {}, () => {
 });
 
 
-describe('Core events', () => {
+describes.fakeWin('Core events', {amp: true}, env => {
   let sandbox;
   let win;
+  let window;
+  let document;
   let action;
+  let triggerPromise;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    win = window = env.win;
+    document = window.document;
+    sandbox = env.sandbox;
     sandbox.stub(window.document, 'addEventListener');
-    win = {
-      document: {body: {}},
-      services: {
-        vsync: {obj: {}},
-      },
-    };
-    action = new ActionService(new AmpDocSingle(win), document);
-    sandbox.stub(action, 'trigger');
+    const ampdoc = env.ampdoc;
+    action = new ActionService(ampdoc, document);
+    const originalTrigger = action.trigger;
+    triggerPromise = new Promise((resolve, reject) => {
+      sandbox.stub(action, 'trigger', () => {
+        try {
+          originalTrigger.apply(action, action.trigger.getCall(0).args);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
     action.vsync_ = {mutate: callback => callback()};
   });
 
   afterEach(() => {
-    sandbox.restore();
+    toggleExperiment(win, 'input-debounced', false);
   });
 
   it('should trigger tap event on click', () => {
@@ -1029,6 +1040,8 @@ describe('Core events', () => {
     element.selectedIndex = 2;
     const event = {target: element};
     handler(event);
+
+
     expect(action.trigger).to.have.been.calledWith(
         element,
         'change',
@@ -1036,6 +1049,54 @@ describe('Core events', () => {
           const detail = object.detail;
           return detail.value == 'qux';
         }));
+  });
+
+  it('should trigger input-debounced event on input', () => {
+    toggleExperiment(window, 'input-debounced', true);
+    sandbox.stub(action, 'invoke_');
+    const handler = window.document.addEventListener.getCall(4).args[1];
+    const element = document.createElement('input');
+    element.id = 'test';
+    element.setAttribute('on', 'input-debounced:test.hide');
+    element.value = 'foo bar baz';
+    const event = {target: element};
+    document.body.appendChild(element);
+    handler(event);
+
+    return triggerPromise.then(() => {
+      expect(action.trigger).to.have.been.calledWith(
+          element,
+          'input-debounced',
+          sinon.match(event => {
+            const value = event.target.value;
+            return value == 'foo bar baz';
+          }));
+      toggleExperiment(window, 'input-debounced', false);
+    }, () => {
+      assert.fail('Should succeed with experiment.');
+    });
+  });
+
+  it('should not handle input-debounced event without experiment', () => {
+    const handler = window.document.addEventListener.getCall(4).args[1];
+    const element = document.createElement('input');
+    element.setAttribute('on', 'input-debounced:body.hide');
+    element.value = 'foo bar baz';
+    const event = {target: element};
+    handler(event);
+
+    return triggerPromise.then(() => {
+      assert.fail('Should not succeed without experiment.');
+    }, error => {
+      expect(error).to.match(/"input-debounced" experiment/);
+      expect(action.trigger).to.have.been.calledWith(
+          element,
+          'input-debounced',
+          sinon.match(event => {
+            const value = event.target.value;
+            return value == 'foo bar baz';
+          }));
+    });
   });
 
   describe('DeferredEvent', () => {

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1041,7 +1041,6 @@ describes.fakeWin('Core events', {amp: true}, env => {
     const event = {target: element};
     handler(event);
 
-
     expect(action.trigger).to.have.been.calledWith(
         element,
         'change',

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -273,6 +273,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/8736',
   },
   {
+    id: 'input-debounced',
+    name: 'A debounced input event for AMP actions',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/9413',
+    spec: 'https://github.com/ampproject/amphtml/issues/9277',
+  },
+  {
     id: 'amp-ima-video',
     name: 'IMA-integrated Video Player',
   },


### PR DESCRIPTION
Implement an `input-debounced` event and example.

Only merge this after #9252 to use the its performant debounce method.

Closes #8824 and #5702