### PR TITLE
Clean state from ad uiHandler

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -45,7 +45,6 @@ import {cryptoFor} from '../../../src/crypto';
 import {isExperimentOn} from '../../../src/experiments';
 import {setStyle} from '../../../src/style';
 import {handleClick} from '../../../ads/alp/handler';
-import {AdDisplayState} from '../../../extensions/amp-ad/0.1/amp-ad-ui';
 import {
   getDefaultBootstrapBaseUrl,
   generateSentinel,
@@ -356,7 +355,6 @@ export class AmpA4A extends AMP.BaseElement {
     const adType = this.element.getAttribute('type');
     this.config = adConfig[adType] || {};
     this.uiHandler = new AMP.AmpAdUIHandler(this);
-    this.uiHandler.init();
     if (!this.win.ampA4aValidationKeys) {
       // Without the following variable assignment, there's no way to apply a
       // type annotation to a win-scoped variable, so the type checker doesn't
@@ -980,7 +978,7 @@ export class AmpA4A extends AMP.BaseElement {
     this.promiseId_++;
     this.adUrlsPromise_ = null;
     this.protectedEmitLifecycleEvent_('adSlotCleared');
-    this.uiHandler.setDisplayState(AdDisplayState.NOT_LAID_OUT);
+    this.uiHandler.applyUnlayoutUI();
     if (this.originalSlotSize_) {
       super.attemptChangeSize(
         this.originalSlotSize_.height, this.originalSlotSize_.width)
@@ -1035,7 +1033,7 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override */
   createPlaceholderCallback() {
-    return this.uiHandler.createPlaceholderCallback();
+    return this.uiHandler.createPlaceholder();
   }
 
   /**
@@ -1077,8 +1075,7 @@ export class AmpA4A extends AMP.BaseElement {
     // Store original size to allow for reverting on unlayoutCallback so that
     // subsequent pageview allows for ad request.
     this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
-    this.uiHandler.setDisplayState(AdDisplayState.LOADING);
-    this.uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+    this.uiHandler.applyNoContentUI();
     this.isCollapsed_ = true;
   }
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -52,7 +52,6 @@ import {dev, user} from '../../../../src/log';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
-import {AdDisplayState} from '../../../../extensions/amp-ad/0.1/amp-ad-ui';
 import * as sinon from 'sinon';
 
 function setupForAdTesting(fixture) {
@@ -1103,17 +1102,18 @@ describe('amp-a4a', () => {
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         const forceCollapseSpy = sandbox.spy(a4a, 'forceCollapse');
-        const expectStates = [];
+        const noContentUISpy = sandbox.spy();
+        const unlayoutUISpy = sandbox.spy();
         a4a.uiHandler = {
-          setDisplayState: state => {expectStates.push(state);},
+          applyNoContentUI: () => {noContentUISpy();},
+          applyUnlayoutUI: () => {unlayoutUISpy();},
         };
         sandbox.stub(a4a, 'getLayoutBox').returns({width: 123, height: 456});
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;
         return a4a.adPromise_.then(() => {
           expect(forceCollapseSpy).to.be.calledOnce;
-          expect(expectStates).to.deep.equal(
-            [AdDisplayState.LOADING, AdDisplayState.LOADED_NO_CONTENT]);
+          expect(noContentUISpy).to.be.calledOnce;
           return a4a.layoutCallback().then(() => {
             // should have no iframe.
             expect(a4aElement.querySelector('iframe')).to.not.be.ok;
@@ -1128,6 +1128,7 @@ describe('amp-a4a', () => {
             sandbox.stub(AMP.BaseElement.prototype, 'attemptChangeSize')
               .returns(attemptChangeSizePromise);
             a4a.unlayoutCallback();
+            expect(unlayoutUISpy).to.be.calledOnce;
             expect(a4a.originalSlotSize_).to.be.ok;
             attemptChangeSizeResolver();
             return timerFor(a4a.win).promise(1).then(() => {
@@ -1156,17 +1157,17 @@ describe('amp-a4a', () => {
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         const forceCollapseSpy = sandbox.spy(a4a, 'forceCollapse');
-        const expectStates = [];
+        const noContentUISpy = sandbox.spy();
         a4a.uiHandler = {
-          setDisplayState: state => {expectStates.push(state);},
+          applyNoContentUI: () => {noContentUISpy();},
+          applyUnlayoutUI: () => {},
         };
         sandbox.stub(a4a, 'getLayoutBox').returns({width: 123, height: 456});
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;
         return a4a.adPromise_.then(() => {
           expect(forceCollapseSpy).to.be.calledOnce;
-          expect(expectStates).to.deep.equal(
-            [AdDisplayState.LOADING, AdDisplayState.LOADED_NO_CONTENT]);
+          expect(noContentUISpy).to.be.calledOnce;
           return a4a.layoutCallback().then(() => {
             // should have no iframe.
             expect(a4aElement.querySelector('iframe')).to.not.be.ok;
@@ -1512,7 +1513,7 @@ describe('amp-a4a', () => {
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         const adPromise = a4a.adPromise_;
-        // This is to prevent `displayUnlayoutUI` to be called;
+        // This is to prevent `applyUnlayoutUI` to be called;
         a4a.uiHandler.state = 0;
         a4a.unlayoutCallback();
         // Force vsync system to run all queued tasks, so that DOM mutations

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -51,4 +51,12 @@ export class MockA4AImpl extends AmpA4A {
   getFallback() {
     return null;
   }
+
+  toggleFallback() {
+    // Do nothing.
+  }
+
+  deferMutate(callback) {
+    callback();
+  }
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -604,7 +604,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
                 'data-amp-slot-index');
 
             impl.layoutMeasureExecuted_ = true;
-            impl.uiHandler = {setDisplayState: () => {}};
+            impl.uiHandler = {displayUnlayoutUI: () => {}};
             const placeholder = document.createElement('div');
             placeholder.setAttribute('placeholder', '');
             const fallback = document.createElement('div');

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -604,7 +604,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
                 'data-amp-slot-index');
 
             impl.layoutMeasureExecuted_ = true;
-            impl.uiHandler = {displayUnlayoutUI: () => {}};
+            impl.uiHandler = {applyUnlayoutUI: () => {}};
             const placeholder = document.createElement('div');
             placeholder.setAttribute('placeholder', '');
             const fallback = document.createElement('div');

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -406,7 +406,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
                 'data-amp-slot-index');
 
             impl.layoutMeasureExecuted_ = true;
-            impl.uiHandler = {setDisplayState: () => {}};
+            impl.uiHandler = {displayUnlayoutUI: () => {}};
             const placeholder = document.createElement('div');
             placeholder.setAttribute('placeholder', '');
             const fallback = document.createElement('div');

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -406,7 +406,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
                 'data-amp-slot-index');
 
             impl.layoutMeasureExecuted_ = true;
-            impl.uiHandler = {displayUnlayoutUI: () => {}};
+            impl.uiHandler = {applyUnlayoutUI: () => {}};
             const placeholder = document.createElement('div');
             placeholder.setAttribute('placeholder', '');
             const fallback = document.createElement('div');

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -34,7 +34,7 @@ import {user, dev} from '../../../src/log';
 import {getIframe} from '../../../src/3p-frame';
 import {setupA2AListener} from './a2a-listener';
 import {moveLayoutRect} from '../../../src/layout-rect';
-import {AdDisplayState, AmpAdUIHandler} from './amp-ad-ui';
+import {AmpAdUIHandler} from './amp-ad-ui';
 
 /** @const {!string} Tag name for 3P AD implementation. */
 export const TAG_3P_IMPL = 'amp-ad-3p-impl';
@@ -125,7 +125,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     user().assert(this.config, `Type "${adType}" is not supported in amp-ad`);
 
     this.uiHandler = new AmpAdUIHandler(this);
-    this.uiHandler.init();
 
     setupA2AListener(this.win);
   }
@@ -222,7 +221,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         'position:fixed: %s', this.element);
     incrementLoadingAds(this.win);
     return this.layoutPromise_ = getAdCid(this).then(cid => {
-      this.uiHandler.setDisplayState(AdDisplayState.LOADING);
       const opt_context = {
         clientId: cid || null,
         container: this.container_,
@@ -251,7 +249,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   /** @override  */
   unlayoutCallback() {
     this.layoutPromise_ = null;
-    this.uiHandler.setDisplayState(AdDisplayState.NOT_LAID_OUT);
+    this.uiHandler.applyUnlayoutUI();
     if (this.xOriginIframeHandler_) {
       this.xOriginIframeHandler_.freeXOriginIframe();
       this.xOriginIframeHandler_ = null;
@@ -262,7 +260,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
   /** @override */
   createPlaceholderCallback() {
-    return this.uiHandler.createPlaceholderCallback();
+    return this.uiHandler.createPlaceholder();
   }
 
   /**

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -21,7 +21,7 @@ import {xhrFor} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
 import {ancestorElementsByTag} from '../../../src/dom';
 import {removeChildren} from '../../../src/dom';
-import {AdDisplayState, AmpAdUIHandler} from './amp-ad-ui';
+import {AmpAdUIHandler} from './amp-ad-ui';
 
 /** @const {!string} Tag name for custom ad implementation. */
 export const TAG_AD_CUSTOM = 'amp-ad-custom';
@@ -74,7 +74,6 @@ export class AmpAdCustom extends AMP.BaseElement {
         'custom ad slot should be alphanumeric: ' + this.slot_);
 
     this.uiHandler = new AmpAdUIHandler(this);
-    this.uiHandler.init();
   }
 
   /** @override */
@@ -87,7 +86,6 @@ export class AmpAdCustom extends AMP.BaseElement {
       ampCustomadXhrPromises[fullUrl] = xhrFor(this.win).fetchJson(fullUrl);
     }
     return ampCustomadXhrPromises[fullUrl].then(data => {
-      this.uiHandler.setDisplayState(AdDisplayState.LOADING);
       const element = this.element;
       // We will get here when the data has been fetched from the server
       let templateData = data;
@@ -97,7 +95,7 @@ export class AmpAdCustom extends AMP.BaseElement {
       }
       // Set UI state
       if (templateData !== null && typeof templateData == 'object') {
-        this.uiHandler.setDisplayState(AdDisplayState.LOADED_RENDER_START);
+        this.renderStarted();
         templatesFor(this.win).findAndRenderTemplate(element, templateData)
           .then(renderedElement => {
           // Get here when the template has been rendered
@@ -106,15 +104,20 @@ export class AmpAdCustom extends AMP.BaseElement {
             element.appendChild(renderedElement);
           });
       } else {
-        this.uiHandler.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+        this.uiHandler.applyNoContentUI();
       }
     });
   }
 
   /** @override  */
   unlayoutCallback() {
-    this.uiHandler.setDisplayState(AdDisplayState.NOT_LAID_OUT);
+    this.uiHandler.applyUnlayoutUI();
     return true;
+  }
+
+  /** @override */
+  createPlaceholderCallback() {
+    return this.uiHandler.createPlaceholder();
   }
 
   /**

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -14,41 +14,8 @@
  * limitations under the License.
  */
 
-import {dev} from '../../../src/log';
 import {getAdContainer} from '../../../src/ad-helper';
 import {isExperimentOn} from '../../../src/experiments';
-
-const TAG = 'AmpAdUIHandler';
-
-/**
- * Ad display state.
- * @enum {number}
- */
-export const AdDisplayState = {
-  /**
-   * The ad has not been laid out, or the ad has already be unlaid out
-   */
-  NOT_LAID_OUT: 0,
-
-  /**
-   * The ad has been laid out, but runtime haven't received any response from
-   * the ad server.
-   */
-  LOADING: 1,
-
-  /**
-   * The ad has been laid out, and runtime has received render-start msg from
-   * ad server.
-   * Not used now.
-   */
-  LOADED_RENDER_START: 2,
-
-  /**
-   * The ad has been laid out, and runtime has received no-content msg from
-   * ad server.
-   */
-  LOADED_NO_CONTENT: 3,
-};
 
 export class AmpAdUIHandler {
 
@@ -65,123 +32,44 @@ export class AmpAdUIHandler {
     /** @private @const {!Document} */
     this.doc_ = baseInstance.win.document;
 
-    /** {number} */
-    this.state = AdDisplayState.NOT_LAID_OUT;
-
-    /** {!boolean} */
-    this.hasPageProvidedFallback_ = !!baseInstance.getFallback();
-  }
-
-  /**
-   * TODO(@zhouyx): Add ad tag to the ad.
-   */
-  init() {
-    if (this.hasPageProvidedFallback_) {
-      return;
-    }
-
-    // Apply default fallback div when there's no default one
-    this.addDefaultUiComponent_('fallback');
-  }
-
-  /**
-   * Exposed function to ad that enable them to set UI to correct display state
-   * @param {number} state
-   */
-  setDisplayState(state) {
-    if (this.state == AdDisplayState.NOT_LAID_OUT) {
-      // Once unlayout UI applied, only another layout will change the UI again
-      if (state != AdDisplayState.LOADING) {
-        return;
-      }
-    }
-    switch (state) {
-      case AdDisplayState.LOADING:
-        this.displayLoadingUI_();
-        break;
-      case AdDisplayState.LOADED_RENDER_START:
-        this.displayRenderStartUI_();
-        break;
-      case AdDisplayState.LOADED_NO_CONTENT:
-        this.displayNoContentUI_();
-        break;
-      case AdDisplayState.NOT_LAID_OUT:
-        this.displayUnlayoutUI_();
-        break;
-      default:
-        dev().error(TAG, 'state is not supported');
+    if (!baseInstance.getFallback()) {
+      this.addDefaultUiComponent_('fallback');
     }
   }
 
   /**
-   * See BaseElement method.
+   * Create a default placeholder if not provided.
+   * Should be called in baseElement createPlaceholderCallback.
    */
-  createPlaceholderCallback() {
+  createPlaceholder() {
     return this.addDefaultUiComponent_('placeholder');
   }
 
   /**
-   * TODO(@zhouyx): apply placeholder, add ad loading indicator
-   * @private
-   */
-  displayLoadingUI_() {
-    this.state = AdDisplayState.LOADING;
-    this.baseInstance_.togglePlaceholder(true);
-  }
-
-  /**
-   * TODO(@zhouyx): remove ad loading indicator
-   * @private
-   */
-  displayRenderStartUI_() {
-    this.state = AdDisplayState.LOADED_RENDER_START;
-    this.baseInstance_.togglePlaceholder(false);
-  }
-
-  /**
    * Apply UI for laid out ad with no-content
-   * If fallback exist try to display provided fallback
-   * Else try to collapse the ad (Note: may not succeed)
-   * TODO(@zhouyx): apply fallback, remove ad loading indicator
-   * @private
+   * Order: try collapse -> apply provided fallback -> apply default fallback
    */
-  displayNoContentUI_() {
+  applyNoContentUI() {
     if (getAdContainer(this.element_) == 'AMP-STICKY-AD') {
       // Special case: force collapse sticky-ad if no content.
       this.baseInstance_./*OK*/collapse();
-      this.state = AdDisplayState.LOADED_NO_CONTENT;
       return;
     }
     // The order here is collapse > user provided fallback > default fallback
-    this.baseInstance_.attemptCollapse().then(() => {
-      this.state = AdDisplayState.LOADED_NO_CONTENT;
-    }, () => {
+    this.baseInstance_.attemptCollapse().then(() => {}, () => {
       this.baseInstance_.deferMutate(() => {
-        if (this.state == AdDisplayState.NOT_LAID_OUT) {
-          // If already unlaid out, do not replace current placeholder.
-          return;
-        }
         this.baseInstance_.togglePlaceholder(false);
         this.baseInstance_.toggleFallback(true);
-        this.state = AdDisplayState.LOADED_NO_CONTENT;
       });
     });
   }
 
   /**
-   * Apply UI for unlaid out ad
-   * Hide fallback and show placeholder if exists
-   * Once unlayout UI applied, only another layout will change the UI again
-   * TODO(@zhouyx): remove ad loading indicator
-   * @private
+   * Apply UI for unlaid out ad: Hide fallback.
+   * Note: No need to togglePlaceholder here, unlayout show it by default.
    */
-  displayUnlayoutUI_() {
-    this.state = AdDisplayState.NOT_LAID_OUT;
+  applyUnlayoutUI() {
     this.baseInstance_.deferMutate(() => {
-      if (this.state != AdDisplayState.NOT_LAID_OUT) {
-        return;
-      }
-      this.baseInstance_.togglePlaceholder(true);
       this.baseInstance_.toggleFallback(false);
     });
   }

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {AdDisplayState} from './amp-ad-ui';
 import {CommonSignals} from '../../../src/common-signals';
 import {
   IntersectionObserver,
@@ -272,7 +271,6 @@ export class AmpAdXOriginIframeHandler {
    * @private
    */
   renderStart_(opt_info) {
-    this.uiHandler_.setDisplayState(AdDisplayState.LOADED_RENDER_START);
     this.baseInstance_.renderStarted();
     if (!opt_info) {
       return;
@@ -313,7 +311,7 @@ export class AmpAdXOriginIframeHandler {
       return;
     }
     this.freeXOriginIframe(this.iframe.name.indexOf('_master') >= 0);
-    this.uiHandler_.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+    this.uiHandler_.applyNoContentUI();
   }
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1583,7 +1583,7 @@ function createBaseCustomElementClass(win) {
     toggleFallback(show) {
       assertNotTemplate(this);
       const resourceState = this.getResourceState_();
-      // Do not show fallback if element has not been scheduled layout yet
+      // Do not show fallback before layout
       if (show && (resourceState == ResourceState.NOT_BUILT ||
           resourceState == ResourceState.NOT_LAID_OUT ||
           resourceState == ResourceState.READY_FOR_LAYOUT)) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1577,14 +1577,14 @@ function createBaseCustomElementClass(win) {
     /**
      * Hides or shows the fallback, if available. This function must only
      * be called inside a mutate context.
-     * @param {boolean} state
+     * @param {boolean} show
      * @package @final @this {!Element}
      */
-    toggleFallback(state) {
+    toggleFallback(show) {
       assertNotTemplate(this);
       const resourceState = this.getResourceState_();
       // Do not show fallback if element has not been scheduled layout yet
-      if (state && (resourceState == ResourceState.NOT_BUILT ||
+      if (show && (resourceState == ResourceState.NOT_BUILT ||
           resourceState == ResourceState.NOT_LAID_OUT ||
           resourceState == ResourceState.READY_FOR_LAYOUT)) {
         return;
@@ -1593,8 +1593,8 @@ function createBaseCustomElementClass(win) {
       // The reasons for this are: (a) "not supported" is the state of the whole
       // element, (b) some realyout is expected and (c) fallback condition would
       // be rare.
-      this.classList.toggle('amp-notsupported', state);
-      if (state == true) {
+      this.classList.toggle('amp-notsupported', show);
+      if (show == true) {
         const fallbackElement = this.getFallback();
         if (fallbackElement) {
           this.getResources().scheduleLayout(this, fallbackElement);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1581,13 +1581,14 @@ function createBaseCustomElementClass(win) {
      * @package @final @this {!Element}
      */
     toggleFallback(state) {
+      assertNotTemplate(this);
+      const resourceState = this.getResourceState_();
       // Do not show fallback if element has not been scheduled layout yet
-      if (state && (this.getResourceState_() == ResourceState.NOT_BUILT ||
-          this.getResourceState_() == ResourceState.NOT_LAID_OUT ||
-          this.getResourceState_() == ResourceState.READY_FOR_LAYOUT)) {
+      if (state && (resourceState == ResourceState.NOT_BUILT ||
+          resourceState == ResourceState.NOT_LAID_OUT ||
+          resourceState == ResourceState.READY_FOR_LAYOUT)) {
         return;
       }
-      assertNotTemplate(this);
       // This implementation is notably less efficient then placeholder toggling.
       // The reasons for this are: (a) "not supported" is the state of the whole
       // element, (b) some realyout is expected and (c) fallback condition would

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -40,6 +40,7 @@ import {
 import * as dom from './dom';
 import {setStyle, setStyles} from './style';
 import {LayoutDelayMeter} from './layout-delay-meter';
+import {ResourceState} from './service/resource';
 
 const TAG_ = 'CustomElement';
 
@@ -1172,6 +1173,14 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * Returns the current resource state of the element.
+     * @return {!ResourceState}
+     */
+    getResourceState_() {
+      return this.getResources().getResourceForElement(this).getState();
+    }
+
+    /**
      * The runtime calls this method to determine if {@link layoutCallback}
      * should be called again when layout changes.
      * @return {boolean}
@@ -1572,6 +1581,12 @@ function createBaseCustomElementClass(win) {
      * @package @final @this {!Element}
      */
     toggleFallback(state) {
+      // Do not show fallback if element has not been scheduled layout yet
+      if (state && (this.getResourceState_() == ResourceState.NOT_BUILT ||
+          this.getResourceState_() == ResourceState.NOT_LAID_OUT ||
+          this.getResourceState_() == ResourceState.READY_FOR_LAYOUT)) {
+        return;
+      }
       assertNotTemplate(this);
       // This implementation is notably less efficient then placeholder toggling.
       // The reasons for this are: (a) "not supported" is the state of the whole
@@ -1593,6 +1608,7 @@ function createBaseCustomElementClass(win) {
      */
     renderStarted() {
       this.signals_.signal(CommonSignals.RENDER_START);
+      this.togglePlaceholder(false);
       this.toggleLoading_(false);
     }
 


### PR DESCRIPTION
Close #9072 
A refactor to the uiHandler class. Removed state and renamed functions.  

I add an extra check to customeElement `toggleFallback` method, to only enable display and schedule layout for fallback if element has at least been scheduled layout.  I think it makes sense to never` toggleFallback(true)` before trying to layout element. But want to confirm. cc @jridgewell @dvoytenko  