### PR TITLE
Fix Measuring Child AMP Elements

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1124,6 +1124,11 @@ function createBaseCustomElementClass(win) {
       return this.getResources().getResourceForElement(this).getLayoutBox();
     }
 
+    /** @return {!Layout} */
+    getLayout() {
+      return this.layout_;
+    }
+
     /**
      * Returns a previously measured layout box relative to the page. The
      * fixed-position elements are relative to the top of the document.

--- a/src/dom.js
+++ b/src/dom.js
@@ -31,7 +31,7 @@ const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
 
 /**
  * Determines if this element is an AMP element
- * @param {!Element}
+ * @param {!Element} element
  * @return {boolean}
  */
 export function isAmpElement(element) {

--- a/src/dom.js
+++ b/src/dom.js
@@ -16,6 +16,7 @@
 
 import {dev} from './log';
 import {cssEscape} from '../third_party/css-escape/css-escape';
+import {startsWith} from './string';
 
 const HTML_ESCAPE_CHARS = {
   '&': '&amp;',
@@ -27,6 +28,20 @@ const HTML_ESCAPE_CHARS = {
 };
 const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
 
+
+/**
+ * Determines if this element is an AMP element
+ * @param {!Element}
+ * @return {boolean}
+ */
+export function isAmpElement(element) {
+  const tag = element.tagName;
+  // Use prefix to recognize AMP element. This is necessary because stub
+  // may not be attached yet.
+  return startsWith(tag, 'AMP-') &&
+      // Some "amp-*" elements are not really AMP elements. :smh:
+      !(tag == 'AMP-STICKY-AD-TOP-PADDING' || tag == 'AMP-BODY');
+}
 
 /**
  * Waits until the child element is constructed. Once the child is found, the

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -19,7 +19,7 @@ import {
   layoutRectsOverlap,
   moveLayoutRect,
 } from '../layout-rect';
-import {Layout} from './layout';
+import {Layout} from '../layout';
 import {dev} from '../log';
 import {toggle, computedStyle} from '../style';
 import {isAmpElement} from '../dom';

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -21,8 +21,8 @@ import {
 } from '../layout-rect';
 import {Layout} from './layout';
 import {dev} from '../log';
-import {startsWith} from '../string';
 import {toggle, computedStyle} from '../style';
+import {isAmpElement} from '../dom';
 
 const TAG = 'Resource';
 const RESOURCE_PROP_ = '__AMP__RESOURCE';
@@ -227,9 +227,7 @@ export class Resource {
     if (this.ampAncestor_ === undefined) {
       let ancestor = null;
       for (let n = this.element.parentElement; n; n = n.parentElement) {
-        // Use prefix to recognize AMP element. This is necessary because stub
-        // may not be attached yet.
-        if (startsWith(n.tagName, 'AMP-')) {
+        if (isAmpElement(n)) {
           ancestor = n;
           break;
         }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -19,6 +19,7 @@ import {
   layoutRectsOverlap,
   moveLayoutRect,
 } from '../layout-rect';
+import {Layout} from './layout';
 import {dev} from '../log';
 import {startsWith} from '../string';
 import {toggle, computedStyle} from '../style';
@@ -408,7 +409,9 @@ export class Resource {
       }
       // If this ancestor isn't built yet, that means we don't know what kind
       // of styles will be applied to this element. We must wait.
-      if (!ancestor.isBuilt()) {
+      // Unless the ancestor is a container, in which case the element will
+      // define its own sizing.
+      if (!ancestor.isBuilt() && ancestor.getLayout() !== Layout.CONTAINER) {
         return;
       }
       current = resource;


### PR DESCRIPTION
AMP elements will not be measured until their ancestor AMP elements have been built. This excludes placeholders, which are laid out independent of their ancestor.

Fixes #9267, likely others.