### PR TITLE
Update unbuilt CONTAINER element styling

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -271,7 +271,7 @@ i-amphtml-sizer {
   color: transparent !important;
 }
 
-.i-amphtml-notbuilt > * {
+.i-amphtml-notbuilt:not(.i-amphtml-layout-container) > * {
   display: none;
 }
 


### PR DESCRIPTION
Unbuilt `CONTAINER` elements no longer have their children `display: none`d
