### PR TITLE
Fix ALP dependencies for PWA

### DIFF
--- a/src/amp-shadow.js
+++ b/src/amp-shadow.js
@@ -48,7 +48,7 @@ installRuntimeServices(self);
 
 // Impression tracking for PWA is not meaningful, but the dependent code
 // has to be unblocked.
-doNotTrackImpression(self);
+doNotTrackImpression();
 
 // Builtins.
 installBuiltins(self);

--- a/src/amp-shadow.js
+++ b/src/amp-shadow.js
@@ -29,6 +29,7 @@ import {
 } from './runtime';
 import {bodyAlwaysVisible} from './style-installer';
 import {deactivateChunking} from './chunk';
+import {doNotTrackImpression} from './impression';
 import {stubElements} from './custom-element';
 
 
@@ -44,6 +45,10 @@ installDocService(self, /* isSingleDoc */ false);
 
 // Core services.
 installRuntimeServices(self);
+
+// Impression tracking for PWA is not meaningful, but the dependent code
+// has to be unblocked.
+doNotTrackImpression(self);
 
 // Builtins.
 installBuiltins(self);

--- a/src/impression.js
+++ b/src/impression.js
@@ -100,9 +100,8 @@ export function maybeTrackImpression(win) {
 
 /**
  * Signal that impression tracking is not relevant in this environment.
- * @param {!Window} win
  */
-export function doNotTrackImpression(win) {
+export function doNotTrackImpression() {
   trackImpressionPromise = Promise.resolve();
 }
 

--- a/src/impression.js
+++ b/src/impression.js
@@ -99,6 +99,14 @@ export function maybeTrackImpression(win) {
 }
 
 /**
+ * Signal that impression tracking is not relevant in this environment.
+ * @param {!Window} win
+ */
+export function doNotTrackImpression(win) {
+  trackImpressionPromise = Promise.resolve();
+}
+
+/**
  * Send the url to ad server and wait for its response
  * @param {!Window} win
  * @param {string} clickUrl


### PR DESCRIPTION
It turns out that the #9080 fix was only partially correct :) While, the ALP code is not really needed, there are many dependencies on it throughout the code and thus it's best to resolve the service.