### PR TITLE
Expose login url building to amp access service

### DIFF
--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -219,12 +219,13 @@ export class LaterpayVendor {
     const urlPromise = this.accessService_.buildUrl(
       url, /* useAuthData */ false);
     return urlPromise.then(url => {
-      dev().fine(TAG, 'Authorization URL: ', url);
+      return this.accessService_.getLoginUrl(url);
+    }).then(url => {
+      dev().info(TAG, 'Authorization URL: ', url);
       return this.timer_.timeoutPromise(
           AUTHORIZATION_TIMEOUT,
           this.xhr_.fetchJson(url, {
             credentials: 'include',
-            requireAmpResponseSourceOrigin: true,
           }));
     });
   }
@@ -464,12 +465,8 @@ export class LaterpayVendor {
    */
   handlePurchase_(ev, purchaseUrl) {
     ev.preventDefault();
-    const configuredUrl = purchaseUrl +
-                '?return_url=RETURN_URL' +
-                '&article_url=SOURCE_URL' +
-                '&amp_reader_id=READER_ID';
     const urlPromise = this.accessService_.buildUrl(
-      configuredUrl, /* useAuthData */ false);
+      purchaseUrl, /* useAuthData */ false);
     return urlPromise.then(url => {
       dev().fine(TAG, 'Authorization URL: ', url);
       this.accessService_.loginWithUrl(

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -43,6 +43,7 @@ describes.fakeWin('LaterpayVendor', {
       getAdapterConfig: () => { return laterpayConfig; },
       buildUrl: () => {},
       loginWithUrl: () => {},
+      getLoginUrl: () => {},
     };
     accessServiceMock = sandbox.mock(accessService);
 
@@ -83,10 +84,12 @@ describes.fakeWin('LaterpayVendor', {
         .withExactArgs('https://baseurl?param&article_title=test%20title', false)
         .returns(Promise.resolve('https://builturl'))
         .once();
+      accessServiceMock.expects('getLoginUrl')
+        .returns(Promise.resolve('https://builturl'))
+        .once();
       xhrMock.expects('fetchJson')
         .withExactArgs('https://builturl', {
           credentials: 'include',
-          requireAmpResponseSourceOrigin: true,
         })
         .returns(Promise.resolve({access: true}))
         .once();
@@ -100,10 +103,12 @@ describes.fakeWin('LaterpayVendor', {
       accessServiceMock.expects('buildUrl')
         .returns(Promise.resolve('https://builturl'))
         .once();
+      accessServiceMock.expects('getLoginUrl')
+        .returns(Promise.resolve('https://builturl'))
+        .once();
       xhrMock.expects('fetchJson')
         .withExactArgs('https://builturl', {
           credentials: 'include',
-          requireAmpResponseSourceOrigin: true,
         })
         .returns(Promise.resolve({status: 204}))
         .once();
@@ -116,10 +121,12 @@ describes.fakeWin('LaterpayVendor', {
       accessServiceMock.expects('buildUrl')
         .returns(Promise.resolve('https://builturl'))
         .once();
+      accessServiceMock.expects('getLoginUrl')
+        .returns(Promise.resolve('https://builturl'))
+        .once();
       xhrMock.expects('fetchJson')
         .withExactArgs('https://builturl', {
           credentials: 'include',
-          requireAmpResponseSourceOrigin: true,
         })
         .returns(Promise.reject({
           response: {status: 402},

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -34,7 +34,7 @@ import {isExperimentOn} from '../../../src/experiments';
 import {isObject} from '../../../src/types';
 import {listenOnce} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
-import {openLoginDialog} from './login-dialog';
+import {getLoginUrl, openLoginDialog} from './login-dialog';
 import {parseQueryString} from '../../../src/url';
 import {performanceForOrNull} from '../../../src/services';
 import {resourcesForDoc} from '../../../src/services';
@@ -794,6 +794,15 @@ export class AccessService {
   }
 
   /**
+   * Expose the getLoginUrl method with the current ampdoc context
+   * @param {string|!Promise<string>} urlOrPromise
+   * @return {!Promise<string>}
+   */
+  getLoginUrl(urlOrPromise) {
+    return getLoginUrl(this.ampdoc, urlOrPromise);
+  }
+
+  /**
    * Runs the login flow using one of the predefined urls in the amp-access config
    *
    * @private
@@ -919,8 +928,8 @@ export class AccessService {
     }
     return Promise.all(promises);
   }
-}
 
+}
 
 /**
  * @typedef {{

--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -28,6 +28,20 @@ const TAG = 'amp-access-login';
 /** @const {!RegExp} */
 const RETURN_URL_REGEX = new RegExp('RETURN_URL');
 
+/**
+ * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {string|!Promise<string>} urlOrPromise
+ * @return {!WebLoginDialog|!ViewerLoginDialog}
+ */
+export function createLoginDialog(ampdoc, urlOrPromise) {
+  const viewer = viewerForDoc(ampdoc);
+  const overrideDialog = parseInt(viewer.getParam('dialog'), 10);
+  if (overrideDialog) {
+    return new ViewerLoginDialog(viewer, urlOrPromise);
+  }
+  return new WebLoginDialog(ampdoc.win, viewer, urlOrPromise);
+}
+
 
 /**
  * Opens the login dialog for the specified URL. If the login dialog succeeds,
@@ -38,12 +52,17 @@ const RETURN_URL_REGEX = new RegExp('RETURN_URL');
  * @return {!Promise<string>}
  */
 export function openLoginDialog(ampdoc, urlOrPromise) {
-  const viewer = viewerForDoc(ampdoc);
-  const overrideDialog = parseInt(viewer.getParam('dialog'), 10);
-  if (overrideDialog) {
-    return new ViewerLoginDialog(viewer, urlOrPromise).open();
-  }
-  return new WebLoginDialog(ampdoc.win, viewer, urlOrPromise).open();
+  return createLoginDialog(ampdoc, urlOrPromise).open();
+}
+
+/**
+ * Gets the final login URL with all the performed replacements.
+ * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {string|!Promise<string>} urlOrPromise
+ * @return {!Promise<string>}
+ */
+export function getLoginUrl(ampdoc, urlOrPromise) {
+  return createLoginDialog(ampdoc, urlOrPromise).getLoginUrl();
 }
 
 
@@ -64,12 +83,9 @@ class ViewerLoginDialog {
   }
 
   /**
-   * Opens the dialog. Returns the promise that will yield with the dialog's
-   * result or will be rejected if dialog fails. The dialog's result is
-   * typically a hash string from the return URL.
-   * @return {!Promise<string>}
-   */
-  open() {
+  * @return {!Promise<string>}
+  */
+  getLoginUrl() {
     let urlPromise;
     if (typeof this.urlOrPromise == 'string') {
       urlPromise = Promise.resolve(this.urlOrPromise);
@@ -77,13 +93,26 @@ class ViewerLoginDialog {
       urlPromise = this.urlOrPromise;
     }
     return urlPromise.then(url => {
-      const loginUrl = buildLoginUrl(url, 'RETURN_URL');
+      return buildLoginUrl(url, 'RETURN_URL');
+    });
+  }
+
+
+  /**
+   * Opens the dialog. Returns the promise that will yield with the dialog's
+   * result or will be rejected if dialog fails. The dialog's result is
+   * typically a hash string from the return URL.
+   * @return {!Promise<string>}
+   */
+  open() {
+    return this.getLoginUrl().then(loginUrl => {
       dev().fine(TAG, 'Open viewer dialog: ', loginUrl);
       return this.viewer.sendMessageAwaitResponse('openDialog', {
         'url': loginUrl,
       });
     });
   }
+
 }
 
 
@@ -170,6 +199,21 @@ export class WebLoginDialog {
       this.messageUnlisten_();
       this.messageUnlisten_ = null;
     }
+  }
+
+  /**
+  * @return {!Promise<string>}
+  */
+  getLoginUrl() {
+    let urlPromise;
+    if (typeof this.urlOrPromise == 'string') {
+      urlPromise = Promise.resolve(this.urlOrPromise);
+    } else {
+      urlPromise = this.urlOrPromise;
+    }
+    return urlPromise.then(url => {
+      return buildLoginUrl(url, this.getReturnUrl_());
+    });
   }
 
   /** @private */


### PR DESCRIPTION
@dvoytenko this is the PR I mentioned in the email I sent you recently.

This is also mostly an experiment for now just to check if this is an approach we could take. I'll fix docs/tests later on.

The reasoning for this is the following: our "login urls" are retrieved from our authorization endpoint response.

All the information necessary for those login urls (including the return url) is baked into them by our internal service (I believe I had explained how we build those urls when we built the initial implementation of amp-access-laterpay and it's very likely you don't remember, so I can provide a better explanation of this if you'd like).

For that reason, we need to send the `RETURN_URL` at the time of contacting the authorization endpoint.

The code changes in this PR are able to achieve that.

Do you think this is an acceptable approach? Do you see any reason as to why we shouldn't do this and take a different approach?