### PR TITLE
amp-facebook-*: support different languages #9264

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -29,7 +29,7 @@ import {user} from '../src/log';
  * @param {function(!Object)} cb
  */
 function getFacebookSdk(global, cb) {
-  loadScript(global, 'https://connect.facebook.net/en_US/sdk.js', () => {
+  loadScript(global, 'https://connect.facebook.net/'+window.navigator.language.replace("-", "_")+'/sdk.js', () => {
     cb(global.FB);
   });
 }

--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -29,7 +29,7 @@ import {user} from '../src/log';
  * @param {function(!Object)} cb
  */
 function getFacebookSdk(global, cb) {
-  loadScript(global, 'https://connect.facebook.net/'+window.navigator.language.replace('-', '_')+'/sdk.js', () => {
+  loadScript(global, 'https://connect.facebook.net/' + window.navigator.language.replace('-', '_') + '/sdk.js', () => {
     cb(global.FB);
   });
 }

--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -29,7 +29,7 @@ import {user} from '../src/log';
  * @param {function(!Object)} cb
  */
 function getFacebookSdk(global, cb) {
-  loadScript(global, 'https://connect.facebook.net/'+window.navigator.language.replace("-", "_")+'/sdk.js', () => {
+  loadScript(global, 'https://connect.facebook.net/'+window.navigator.language.replace('-', '_')+'/sdk.js', () => {
     cb(global.FB);
   });
 }

--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -16,7 +16,7 @@
 
 import {loadScript} from './3p';
 import {user} from '../src/log';
-
+import {dashToUnderline} from '../src/string';
 
 /**
  * Produces the Facebook SDK object for the passed in callback.
@@ -29,7 +29,7 @@ import {user} from '../src/log';
  * @param {function(!Object)} cb
  */
 function getFacebookSdk(global, cb) {
-  loadScript(global, 'https://connect.facebook.net/' + window.navigator.language.replace('-', '_') + '/sdk.js', () => {
+  loadScript(global, 'https://connect.facebook.net/' + dashToUnderline(window.navigator.language) + '/sdk.js', () => {
     cb(global.FB);
   });
 }

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -46,7 +46,7 @@ class AmpFacebookComments extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/en_US/sdk.js', 'script');
+        'https://connect.facebook.net/'+window.navigator.language.replace("-", "_")+'/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -19,6 +19,7 @@ import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
+import {dashToUnderline} from '../../../src/string';
 
 class AmpFacebookComments extends AMP.BaseElement {
 
@@ -46,7 +47,7 @@ class AmpFacebookComments extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/' + window.navigator.language.replace('-', '_') + '/sdk.js', 'script');
+        'https://connect.facebook.net/' + dashToUnderline(window.navigator.language) + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -46,7 +46,7 @@ class AmpFacebookComments extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/'+window.navigator.language.replace("-", "_")+'/sdk.js', 'script');
+        'https://connect.facebook.net/'+window.navigator.language.replace('-', '_')+'/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -46,7 +46,7 @@ class AmpFacebookComments extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/'+window.navigator.language.replace('-', '_')+'/sdk.js', 'script');
+        'https://connect.facebook.net/' + window.navigator.language.replace('-', '_') + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -46,7 +46,7 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/' + window.navigator.language.replace('-','_') + '/sdk.js', 'script');
+        'https://connect.facebook.net/' + window.navigator.language.replace('-', '_') + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -46,7 +46,7 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/'+window.navigator.language.replace("-", "_")+'/sdk.js', 'script');
+        'https://connect.facebook.net/'+window.navigator.language.replace('-','_')+'/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -19,6 +19,7 @@ import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
+import {dashToUnderline} from '../../../src/string';
 
 class AmpFacebookLike extends AMP.BaseElement {
 
@@ -46,7 +47,7 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/' + window.navigator.language.replace('-', '_') + '/sdk.js', 'script');
+        'https://connect.facebook.net/' + dashToUnderline(window.navigator.language) + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -46,7 +46,7 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/'+window.navigator.language.replace('-','_')+'/sdk.js', 'script');
+        'https://connect.facebook.net/' + window.navigator.language.replace('-','_') + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -46,7 +46,7 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/en_US/sdk.js', 'script');
+        'https://connect.facebook.net/'+window.navigator.language.replace("-", "_")+'/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -46,7 +46,7 @@ class AmpFacebook extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/'+window.navigator.language.replace("-", "_")+'/sdk.js', 'script');
+        'https://connect.facebook.net/'+window.navigator.language.replace('-','_')+'/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -46,7 +46,7 @@ class AmpFacebook extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/'+window.navigator.language.replace('-','_')+'/sdk.js', 'script');
+        'https://connect.facebook.net/' + window.navigator.language.replace('-', '_') + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -19,6 +19,7 @@ import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
+import {dashToUnderline} from '../../../src/string';
 
 class AmpFacebook extends AMP.BaseElement {
 
@@ -46,7 +47,7 @@ class AmpFacebook extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/' + window.navigator.language.replace('-', '_') + '/sdk.js', 'script');
+        'https://connect.facebook.net/' + dashToUnderline(window.navigator.language) + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -46,7 +46,7 @@ class AmpFacebook extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/en_US/sdk.js', 'script');
+        'https://connect.facebook.net/'+window.navigator.language.replace("-", "_")+'/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/src/string.js
+++ b/src/string.js
@@ -33,6 +33,14 @@ export function dashToCamelCase(name) {
 }
 
 /**
+ * @param {string} name Attribute name with dashes
+ * @return {string} Dashes replaced by underlines.
+ */
+export function dashToUnderline(name) {
+  return name.replace('-', '_')
+}
+
+/**
  * Polyfill for String.prototype.endsWith.
  * @param {string} string
  * @param {string} suffix
@@ -84,4 +92,3 @@ export function expandTemplate(template, getter, opt_maxIterations) {
   }
   return template;
 }
-

--- a/src/string.js
+++ b/src/string.js
@@ -37,7 +37,7 @@ export function dashToCamelCase(name) {
  * @return {string} Dashes replaced by underlines.
  */
 export function dashToUnderline(name) {
-  return name.replace('-', '_')
+  return name.replace('-', '_');
 }
 
 /**


### PR DESCRIPTION
Get user navigator language and load Facebook SDK.

As `window.navigator.language` returns data with dash (ex.: **pt-BR**) and Facebook expect a underline (ex.: **pt_BR**), I use `replace("-", "_")`.