### PR TITLE
AmpAd Fast Fetch: Do not send public key request until out of prerender state

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1172,7 +1172,7 @@ export class AmpA4A extends AMP.BaseElement {
             result.keys = [];
           }
           return result;
-        }).then(jwkSet => {
+        })).then(jwkSet => {
           return {
             serviceName: jwkSet.serviceName,
             keys: jwkSet.keys.map(jwk =>
@@ -1191,7 +1191,7 @@ export class AmpA4A extends AMP.BaseElement {
           // the keys, probably b/c of a network condition.  We should
           // re-trigger key fetching later.
           return {serviceName: currServiceName, keys: []};
-        }));
+        });
       } else {
         // The given serviceName does not have a corresponding URL in
         // _a4a-config.js.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -255,17 +255,6 @@ export class AmpA4A extends AMP.BaseElement {
     /** @private @const {!../../../src/service/crypto-impl.Crypto} */
     this.crypto_ = cryptoFor(this.win);
 
-    if (!this.win.ampA4aValidationKeys) {
-      // Without the following variable assignment, there's no way to apply a
-      // type annotation to a win-scoped variable, so the type checker doesn't
-      // catch type errors here.  This no-op allows us to enforce some type
-      // expectations.  The const assignment will hopefully be optimized
-      // away by the compiler.  *fingers crossed*
-      /** @type {!AllServicesCryptoKeysDef} */
-      const forTypeSafety = this.getKeyInfoSets_();
-      this.win.ampA4aValidationKeys = forTypeSafety;
-    }
-
     /** @private {?ArrayBuffer} */
     this.creativeBody_ = null;
 
@@ -366,6 +355,16 @@ export class AmpA4A extends AMP.BaseElement {
     this.config = adConfig[adType] || {};
     this.uiHandler = new AMP.AmpAdUIHandler(this);
     this.uiHandler.init();
+    if (!this.win.ampA4aValidationKeys) {
+      // Without the following variable assignment, there's no way to apply a
+      // type annotation to a win-scoped variable, so the type checker doesn't
+      // catch type errors here.  This no-op allows us to enforce some type
+      // expectations.  The const assignment will hopefully be optimized
+      // away by the compiler.  *fingers crossed*
+      /** @type {!AllServicesCryptoKeysDef} */
+      const forTypeSafety = this.getKeyInfoSets_();
+      this.win.ampA4aValidationKeys = forTypeSafety;
+    }
   }
 
   /** @override */

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -329,6 +329,7 @@ describe('amp-a4a', () => {
           () => iniLoadPromise);
       const lifecycleEventStub = sandbox.stub(
           a4a, 'protectedEmitLifecycleEvent_');
+      a4a.buildCallback();
       a4a.onLayoutMeasure();
       const layoutPromise = a4a.layoutCallback();
       return Promise.resolve().then(() => {
@@ -360,6 +361,7 @@ describe('amp-a4a', () => {
 
     it('should update embed visibility', () => {
       sandbox.stub(a4a, 'isInViewport', () => false);
+      a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
         a4a.vsync_.runScheduledTasks_();
@@ -647,6 +649,7 @@ describe('amp-a4a', () => {
     ['nameframe', 'safeframe'].forEach(renderType => {
       it(`should not use ${renderType} if creative is A4A`, () => {
         headers[RENDERING_TYPE_HEADER] = renderType;
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           // Force vsync system to run all queued tasks, so that DOM mutations
@@ -659,6 +662,7 @@ describe('amp-a4a', () => {
       it(`should not use ${renderType} even if onLayoutMeasure called ` +
           'multiple times', () => {
         headers[RENDERING_TYPE_HEADER] = renderType;
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         a4a.onLayoutMeasure();
         a4a.onLayoutMeasure();
@@ -782,6 +786,7 @@ describe('amp-a4a', () => {
         const renderAmpCreativeSpy = sandbox.spy(a4a, 'renderAmpCreative_');
         const loadExtensionSpy =
             sandbox.spy(Extensions.prototype, 'loadExtension');
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.instanceof(Promise);
         return a4a.adPromise_.then(promiseResult => {
@@ -976,6 +981,7 @@ describe('amp-a4a', () => {
                 signature: base64UrlDecodeToBytes(validCSSAmp.signature),
               };
             }));
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           expect(a4a.isVerifiedAmpCreative_).to.be.true;
@@ -1723,7 +1729,8 @@ describe('amp-a4a', () => {
     it('should fetch a single key', () => {
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);
@@ -1757,14 +1764,13 @@ describe('amp-a4a', () => {
         }));
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
-      return timerFor(win).promise(1).then(() => {
-        expect(xhrMockJson).to.not.be.called;
-        firstVisibleResolve();
-        return Promise.all(result).then(() => {
-          expect(xhrMockJson).to.be.calledOnce;
-        });
+      expect(xhrMockJson).to.not.be.called;
+      firstVisibleResolve();
+      return Promise.all(result).then(() => {
+        expect(xhrMockJson).to.be.calledOnce;
       });
     });
 
@@ -1774,7 +1780,8 @@ describe('amp-a4a', () => {
         .to.be.true;
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);  // Only one service.
@@ -1797,7 +1804,8 @@ describe('amp-a4a', () => {
           Promise.resolve({keys: [testKey, testKey, testKey]}));
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);  // Only one service.
@@ -1834,7 +1842,8 @@ describe('amp-a4a', () => {
               Promise.resolve({keys: [JSON.parse(validCSSAmp.publicKey)]}));
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(2);  // Two services.
@@ -1864,7 +1873,8 @@ describe('amp-a4a', () => {
           }).returns(Promise.resolve({keys: ['invalid key data']}));
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);  // Only one service.
@@ -1895,7 +1905,8 @@ describe('amp-a4a', () => {
               new TypeError('some random network error')));
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);  // Only one service.
@@ -1919,7 +1930,8 @@ describe('amp-a4a', () => {
               new TypeError('some random network error')));
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(2);  // Two services.
@@ -1951,7 +1963,8 @@ describe('amp-a4a', () => {
       getSigningServiceNamesMock.returns(['fnord']);
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
-      const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
+      a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
       expect(xhrMockJson).not.to.be.called;
       expect(result).to.be.instanceof(Array);

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1725,7 +1725,9 @@ describe('amp-a4a', () => {
       // Key fetch happens on A4A class construction.
       const unusedA4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
       const result = win.ampA4aValidationKeys;
-      return timerFor(win).promise(1).then(() => {
+      expect(result).to.be.instanceof(Array);
+      expect(result).to.have.lengthOf(1);
+      return Promise.all(result).then(serviceInfos => {
         expect(xhrMockJson).to.be.calledOnce;
         expect(xhrMockJson).to.be.calledWith(
             'https://cdn.ampproject.org/amp-ad-verifying-keyset.json', {
@@ -1734,19 +1736,15 @@ describe('amp-a4a', () => {
               ampCors: false,
               credentials: 'omit',
             });
-        expect(result).to.be.instanceof(Array);
-        expect(result).to.have.lengthOf(1);
-        expect(result[0]).to.be.instanceof(Promise);
-        return result[0].then(serviceInfo => {
-          expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
-          expect(serviceInfo['serviceName']).to.equal('google');
-          expect(serviceInfo['keys']).to.be.an.instanceof(Array);
-          expect(serviceInfo['keys']).to.have.lengthOf(1);
-          const keyInfoPromise = serviceInfo['keys'][0];
-          expect(keyInfoPromise).to.be.an.instanceof(Promise);
-          return keyInfoPromise.then(keyInfo => {
-            verifyIsKeyInfo(keyInfo);
-          });
+        const serviceInfo = serviceInfos[0];
+        expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
+        expect(serviceInfo['serviceName']).to.equal('google');
+        expect(serviceInfo['keys']).to.be.an.instanceof(Array);
+        expect(serviceInfo['keys']).to.have.lengthOf(1);
+        const keyInfoPromise = serviceInfo['keys'][0];
+        expect(keyInfoPromise).to.be.an.instanceof(Promise);
+        return keyInfoPromise.then(keyInfo => {
+          verifyIsKeyInfo(keyInfo);
         });
       });
     });


### PR DESCRIPTION
Currently public keys are fetched as part of the constructor causing requests on pages that may be in a prerender state.  Most of the time keys should be in cache but when not and viewed from a search results page with multiple AMP windows, multiple requests are sent in parallel.  Ensure that they are only sent when the page is not in a prerender state thereby reducing the number of requests.

Protected behind experiment (a4a-disable-cryptokey-viewer-check) with default being to delay public key fetch until page visible.

cc/ @ampproject/a4a @oliy