### PR TITLE
Fixing ima experiment tests

### DIFF
--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -257,11 +257,11 @@ export function runVideoPlayerIntegrationTests(
 
   function cleanUp() {
     if (fixtureGlobal) {
-      fixtureGlobal.doc.body.removeChild(videoGlobal);
-      fixtureGlobal.iframe.remove();
       if (opt_experiment) {
         toggleExperiment(fixtureGlobal.win, opt_experiment, false);
       }
+      fixtureGlobal.doc.body.removeChild(videoGlobal);
+      fixtureGlobal.iframe.remove();
     }
   }
 }


### PR DESCRIPTION
Looks like there is a race with `iframe.remove();` and `toggleExperiment(fixtureGlobal.win, opt_experiment, false);`. Hopefully this would make master green again.

