### PR TITLE
Refactor exec commands in build-system into their own library

### DIFF
--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Provides functions for executing tasks in a child process.
+ */
+
+var child_process = require('child_process');
+var util = require('gulp-util');
+
+/**
+ * Spawns the given command in a child process.
+ *
+ * @param {string} cmd
+ */
+function spawnProcess(cmd){
+  return child_process.spawnSync('/bin/sh', ['-c', cmd], {'stdio': 'inherit'});
+}
+
+/**
+ * Executes the provided command, and prints a message if the command fails.
+ *
+ * @param {string} cmd Command line to execute.
+ */
+exports.exec = function(cmd) {
+  var p = spawnProcess(cmd);
+  if (p.status != 0) {
+    console/*OK*/.log(util.colors.yellow('\nCommand failed: ' + cmd));
+  }
+}
+
+/**
+ * Executes the provided command, and terminates the program in case of failure.
+ *
+ * @param {string} cmd Command line to execute.
+ */
+exports.execOrDie = function(cmd) {
+  const p = spawnProcess(cmd);
+  if (p.status != 0) {
+    console.error(`\n${fileLogPrefix}exiting due to failing command: ${cmd}`);
+    process.exit(p.status)
+  }
+}

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -25,6 +25,7 @@ var util = require('gulp-util');
  * Spawns the given command in a child process.
  *
  * @param {string} cmd
+ * @return {<Object>} Process info.
  */
 function spawnProcess(cmd){
   return child_process.spawnSync('/bin/sh', ['-c', cmd], {'stdio': 'inherit'});
@@ -50,7 +51,7 @@ exports.exec = function(cmd) {
 exports.execOrDie = function(cmd) {
   const p = spawnProcess(cmd);
   if (p.status != 0) {
-    console.error(`\n${fileLogPrefix}exiting due to failing command: ${cmd}`);
+    console/*OK*/.error(util.colors.red('\nCommand failed: ' + cmd));
     process.exit(p.status)
   }
 }

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -18,7 +18,6 @@
 var argv = require('minimist')(process.argv.slice(2));
 var config = require('../config');
 var eslint = require('gulp-eslint');
-var exec = require('child_process').exec;
 var gulp = require('gulp-help')(require('gulp'));
 var gulpIf = require('gulp-if');
 var lazypipe = require('lazypipe');

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -15,7 +15,7 @@
  */
 
 var argv = require('minimist')(process.argv.slice(2));
-var child_process = require('child_process');
+var exec = require('../exec.js').exec;
 var fs = require('fs-extra');
 var gulp = require('gulp-help')(require('gulp'));
 var util = require('gulp-util');
@@ -25,20 +25,6 @@ var defaultWidths = [375, 411];  // CSS widths: iPhone: 375, Pixel: 411.
 var percyProjectSeparator = '/';  // Standard format of repo slug: "foo/bar".
 var percyTokenLength = 64;  // Standard Percy API key length.
 var visualTestsFile = 'test/visual-diff/visual-tests.json';
-
-/**
- * Executes the provided command. Copied from pr-check.js.
- * TODO(rsimha-amp): Refactor this into a shared library. Issue #9038.
- *
- * @param {string} cmd
- */
-function exec(cmd) {
-  var p =
-      child_process.spawnSync('/bin/sh', ['-c', cmd], {'stdio': 'inherit'});
-  if (p.status != 0) {
-    console/*OK*/.log(util.colors.yellow('\nCommand failed: ' + cmd));
-  }
-}
 
 /**
  * Extracts and verifies Percy project keys from the environment.


### PR DESCRIPTION
Moves the versions of exec() and execOrDie() that use child_process.spawnSync into their own library.

Fixes issue #9038 