### PR TITLE
amp-app-banner: undefined check

### DIFF
--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -284,8 +284,10 @@ export class AmpIosAppBanner extends AbstractAppBanner {
     const appId = config['app-id'];
     const openUrl = config['app-argument'];
 
-    user().assert(isProtocolValid(openUrl),
-        '%s: The url in app-argument is invalid', TAG);
+    if (openUrl) {
+      user().assert(isProtocolValid(openUrl),
+          '%s: The url in app-argument is invalid', TAG);
+    }
 
     const installAppUrl = `https://itunes.apple.com/us/app/id${appId}`;
     const openInAppUrl = openUrl || installAppUrl;


### PR DESCRIPTION
was causing `undefined is not an object (evaluating 'a.protocol')` errors. 

will cherry pick.