### PR TITLE
Validator Initial Release Changelog

### DIFF
--- a/validator/CHANGELOG.md
+++ b/validator/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/validator/CHANGELOG.md
+++ b/validator/CHANGELOG.md
@@ -1,0 +1,31 @@
+<!---
+Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# AMP HTML ⚡ Validator Release Changelog
+
+Releases to the
+[AMP HTML Validator](https://github.com/ampproject/amphtml/blob/master/validator/README.md).
+
+Releases are listed in reverse chronological order, with the most recent release
+at the top of this file. This file will be updated at approximately the same
+time as https://cdn.ampproject.org/v0/validator.js is updated.
+
+## Releases
+
+### 10:00 PM, May 8, 2017 UTC
+
+First Release in Changelog. No release notes.
+

--- a/validator/CHANGELOG.md
+++ b/validator/CHANGELOG.md
@@ -25,6 +25,11 @@ time as https://cdn.ampproject.org/v0/validator.js is updated.
 
 ## Releases
 
+<!--
+Please add new release changes here. Use the time in UTC for the header and
+mention and release notes since the last change as well as the version numbers.
+-->
+
 ### 10:00 PM, May 8, 2017 UTC
 
 First Release in Changelog. No release notes.


### PR DESCRIPTION
Check in an initial changelog for tracking validator releases. This version isn't all that interesting, but later releases should be.

Addresses https://github.com/ampproject/amphtml/issues/8978