### PR TITLE
Fast Fetch Doubleclick: disable SRA get url measure for production release

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -19,5 +19,5 @@
   "a4aFastFetchDoubleclickLaunched": 0,
   "a4aFastFetchAdSenseLaunched": 0,
   "pump-early-frame": 1,
-  "a4a-measure-get-ad-urls": 1
+  "a4a-measure-get-ad-urls": 0
 }


### PR DESCRIPTION
Only enable in canary to ensure proper behavior before enabling in production.