### PR TITLE
amp-bind: Local data for amp-list

### DIFF
--- a/examples/bind/list.html
+++ b/examples/bind/list.html
@@ -16,8 +16,19 @@
 
   <button on="tap:AMP.setState({listSrc:'/list/fruit-data/get'})">Show Fruit</button>
   <button on="tap:AMP.setState({listSrc:'/list/vegetable-data/get'})">Show Vegetables</button>
+    <button on="tap:AMP.setState({
+    localData: [{
+      name: 'pizza',
+      quantity: 1976,
+      unitPrice: 3.50
+    }, {
+      name: 'ice cream',
+      quantity: 108,
+      unitPrice: 6.50
+    }]
+  })">Show Other Foods</button>
 
-  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="listSrc || '/list/fruit-data/get'" width="600" height="600">
+  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="listSrc || '/list/fruit-data/get'" width="600" height="600" [localData]="localData">
     <template type="amp-mustache">
       <strong>Product</strong>: {{name}}
       <strong>Quantity:</strong>: {{quantity}}

--- a/examples/bind/list.html
+++ b/examples/bind/list.html
@@ -17,7 +17,7 @@
   <button on="tap:AMP.setState({listSrc:'/list/fruit-data/get'})">Show Fruit</button>
   <button on="tap:AMP.setState({listSrc:'/list/vegetable-data/get'})">Show Vegetables</button>
     <button on="tap:AMP.setState({
-    localData: [{
+    localState: [{
       name: 'pizza',
       quantity: 1976,
       unitPrice: 3.50
@@ -28,7 +28,7 @@
     }]
   })">Show Other Foods</button>
 
-  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="listSrc || '/list/fruit-data/get'" width="600" height="600" [localData]="localData">
+  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="listSrc || '/list/fruit-data/get'" width="600" height="600" [state]="localState">
     <template type="amp-mustache">
       <strong>Product</strong>: {{name}}
       <strong>Quantity:</strong>: {{quantity}}

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -78,8 +78,8 @@ let BoundElementDef;
  * @private {!Object<string, !Array<string>>}
  */
 const BIND_ONLY_ATTRIBUTES = map({
-  'AMP-LIST': ['state'],
   'AMP-CAROUSEL': ['slide'],
+  'AMP-LIST': ['state'],
   'AMP-SELECTOR': ['selected'],
 });
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -78,6 +78,7 @@ let BoundElementDef;
  * @private {!Object<string, !Array<string>>}
  */
 const BIND_ONLY_ATTRIBUTES = map({
+  'AMP-LIST': ['localdata'],
   'AMP-CAROUSEL': ['slide'],
   'AMP-SELECTOR': ['selected'],
 });

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -78,7 +78,7 @@ let BoundElementDef;
  * @private {!Object<string, !Array<string>>}
  */
 const BIND_ONLY_ATTRIBUTES = map({
-  'AMP-LIST': ['localdata'],
+  'AMP-LIST': ['state'],
   'AMP-CAROUSEL': ['slide'],
   'AMP-SELECTOR': ['selected'],
 });

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -239,6 +239,7 @@ function createElementRules_() {
           'https': true,
         },
       },
+      'localdata': null,
     },
     'AMP-SELECTOR': {
       'selected': null,

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -239,7 +239,7 @@ function createElementRules_() {
           'https': true,
         },
       },
-      'localdata': null,
+      'state': null,
     },
     'AMP-SELECTOR': {
       'selected': null,

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -60,15 +60,18 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    if (mutations['src'] != undefined) {
+    const srcMutation = mutations['src'];
+    const stateMutation = mutations['state'];
+    if (srcMutation != undefined) {
       this.populateList_();
-    }
-    // TODO(kmh287, #7379) Mutually exclusive with [src]?
-    const localData = mutations['localdata'];
-    if (localData != undefined) {
-      const items = isArray(localData) ? localData : [localData];
+    } else if (stateMutation != undefined) {
+      const items = isArray(stateMutation) ? stateMutation : [stateMutation];
       templatesFor(this.win).findAndRenderTemplateArray(
           this.element, items).then(this.rendered_.bind(this));
+    }
+    if (srcMutation != undefined && stateMutation != undefined) {
+      user().warn('amp-list', '[src] and [state] mutated simultaneously.' +
+          'The [state] mutation will be dropped.');
     }
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -63,6 +63,13 @@ export class AmpList extends AMP.BaseElement {
     if (mutations['src'] != undefined) {
       this.populateList_();
     }
+    // TODO(kmh287, #7379) Mutually exclusive with [src]?
+    const localData = mutations['localdata'];
+    if (localData != undefined) {
+      const items = isArray(localData) ? localData : [localData];
+      templatesFor(this.win).findAndRenderTemplateArray(
+          this.element, items).then(this.rendered_.bind(this));
+    }
   }
 
   /** @override */

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -70,7 +70,7 @@ export class AmpList extends AMP.BaseElement {
           this.element, items).then(this.rendered_.bind(this));
     }
     if (srcMutation != undefined && stateMutation != undefined) {
-      user().warn('amp-list', '[src] and [state] mutated simultaneously.' +
+      user().warn('AMP-LIST', '[src] and [state] mutated simultaneously.' +
           'The [state] mutation will be dropped.');
     }
   }

--- a/extensions/amp-list/0.1/validator-amp-list.protoascii
+++ b/extensions/amp-list/0.1/validator-amp-list.protoascii
@@ -47,6 +47,7 @@ tags: {  # <amp-list>
   attrs: { name: "template" }
   # <amp-bind>
   attrs: { name: "[src]" }
+  attrs: { name: "[state]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-list"
   amp_layout: {


### PR DESCRIPTION
WIP

Allow binding to `[localdata]` (open to suggestions for different names) for amp-list. Whenever the bound expression changes, the amp-list will re-render with the new value. The value can be either a single object (list with one item) or an array of items.

/to @choumx as per our conversation