### PR TITLE
amp-pinterest: render should always a promise

### DIFF
--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -232,7 +232,11 @@ export class PinWidget {
     this.pinId = '';
     try {
       this.pinId = this.pinUrl.split('/pin/')[1].split('/')[0];
-    } catch (err) { return; }
+    } catch (err) {
+      return Promise.reject(
+        user().createError('Invalid pinterest url: ' + this.pinUrl)
+      );
+    }
 
     return this.fetchPin()
       .then(this.renderPin.bind(this));


### PR DESCRIPTION
Fixes unnecessary error logging.
/to @muxin 