### PR TITLE
Fix render-delaying-extension false error report

### DIFF
--- a/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
@@ -98,7 +98,7 @@ describe('amp-3q-player', function() {
           }).then(() => {
             const p = listenOncePromise(player, VideoEvents.UNMUTED);
             sendFakeMessage(player, iframe, 'unmuted');
-            const successTimeout = timer.timeoutPromise(10, true);
+            const successTimeout = timer.promise(10);
             return Promise.race([p, successTimeout]);
           });
         });

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -234,8 +234,8 @@ export class AmpForm {
         EXTERNAL_DEPS.join(','));
     // Wait for an element to be built to make sure it is ready.
     const depPromises = toArray(depElements).map(el => el.whenBuilt());
-    return this.dependenciesPromise_ = Promise.race(
-        [Promise.all(depPromises), this.timer_.promise(2000)]);
+    return this.dependenciesPromise_ = this.waitOnPromisesOrTimeout_(promises,
+        2000);
   }
 
   /** @private */

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -233,7 +233,7 @@ export class AmpForm {
     const depElements = this.form_./*OK*/querySelectorAll(
         EXTERNAL_DEPS.join(','));
     // Wait for an element to be built to make sure it is ready.
-    const depPromises = toArray(depElements).map(el => el.whenBuilt());
+    const promises = toArray(depElements).map(el => el.whenBuilt());
     return this.dependenciesPromise_ = this.waitOnPromisesOrTimeout_(promises,
         2000);
   }

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -389,7 +389,7 @@ describe(TAG, () => {
           assert.fail('Should not have dispatch unmute message twice');
         });
         v.querySelector('video').dispatchEvent(new Event('volumechange'));
-        const successTimeout = timer.timeoutPromise(10, true);
+        const successTimeout = timer.promise(10);
         return Promise.race([p, successTimeout]);
       });
     });

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -285,7 +285,7 @@ describe('amp-youtube', function() {
           assert.fail('Should not have dispatch unmute message twice');
         });
         sendFakeInfoDeliveryMessage(yt, iframe, {muted: false});
-        const successTimeout = timer.timeoutPromise(10, true);
+        const successTimeout = timer.promise(10);
         return Promise.race([p, successTimeout]);
       });
     });

--- a/src/service/timer-impl.js
+++ b/src/service/timer-impl.js
@@ -145,7 +145,7 @@ export class Timer {
       this.cancel(timerKey);
     };
     opt_racePromise.then(cancel, cancel);
-    return Promise.race([delayPromise, opt_racePromise])
+    return Promise.race([delayPromise, opt_racePromise]);
   }
 
   /**

--- a/src/service/timer-impl.js
+++ b/src/service/timer-impl.js
@@ -128,8 +128,9 @@ export class Timer {
    * @template RESULT
    */
   timeoutPromise(delay, opt_racePromise, opt_message) {
+    let timerKey;
     const delayPromise = new Promise((_resolve, reject) => {
-      const timerKey = this.delay(() => {
+      timerKey = this.delay(() => {
         reject(user().createError(opt_message || 'timeout'));
       }, delay);
 
@@ -140,7 +141,11 @@ export class Timer {
     if (!opt_racePromise) {
       return delayPromise;
     }
-    return Promise.race([delayPromise, opt_racePromise]);
+    const cancel = () => {
+      this.cancel(timerKey);
+    };
+    opt_racePromise.then(cancel, cancel);
+    return Promise.race([delayPromise, opt_racePromise])
   }
 
   /**


### PR DESCRIPTION
render-delaying extensions use `#timeoutPromise`, but `#timeoutPromise` will always create an error once the timer completes. But, if the `racePromise` has completed, there's no need for the timeout.

Fixes https://github.com/ampproject/amphtml/issues/8011.