### PR TITLE
Distinguish between element-provided and extension provided services

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -203,8 +203,8 @@ export function resourcesForDoc(nodeOrDoc) {
 export function shareTrackingForOrNull(win) {
   return (/** @type {
     !Promise<?{incomingFragment: string, outgoingFragment: string}>} */ (
-      getElementServiceIfAvailable(win, 'share-tracking',
-          'amp-share-tracking')));
+    getElementServiceIfAvailable(win, 'share-tracking', 'amp-share-tracking',
+        true)));
 }
 
 /**
@@ -261,7 +261,7 @@ export function userNotificationManagerFor(window) {
  */
 export function variantForOrNull(win) {
   return /** @type {!Promise<?Object<string>>} */ (
-      getElementServiceIfAvailable(win, 'variant', 'amp-experiment'));
+      getElementServiceIfAvailable(win, 'variant', 'amp-experiment', true));
 }
 
 /**


### PR DESCRIPTION
Extension-provided services are automatically registered by the
extension (eg, CID). Element-provided services are registered by an some
configuration element (not the extension script).

For extension-provided scripts, we can depend on a service promise if
the extension is registered (amp-analytics being registered guarantees
CID).

But for element-provided, we cannot depend on the service promise just
because the extension is included. Instead, we have to wait for the
`<body>` to be ready, and see if it's there (not guaranteed).

Fixes https://github.com/ampproject/amphtml/issues/9108.