### PR TITLE
AMP Ad Fast Fetch: FIE do not remove creative in unlayoutCallback

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -446,6 +446,12 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override */
   resumeCallback() {
+    // FIE that was not destroyed on unlayoutCallback does not require a new
+    // ad request.
+    if (!isExperimentOn('a4a-fie-unlayout-enabled') &&
+        this.friendlyIframeEmbed_) {
+      return;
+    }
     this.protectedEmitLifecycleEvent_('resumeCallback');
     this.fromResumeCallback = true;
     // If layout of page has not changed, onLayoutMeasure will not be called
@@ -1000,6 +1006,10 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override  */
   unlayoutCallback() {
+    if (!isExperimentOn('a4a-fie-unlayout-enabled') &&
+        this.friendlyIframeEmbed_) {
+      return;
+    }
     // Increment promiseId to cause any pending promise to cancel.
     this.promiseId_++;
     this.adUrlsPromise_ = null;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -448,7 +448,7 @@ export class AmpA4A extends AMP.BaseElement {
   resumeCallback() {
     // FIE that was not destroyed on unlayoutCallback does not require a new
     // ad request.
-    if (!isExperimentOn('a4a-fie-unlayout-enabled') &&
+    if (!isExperimentOn(this.win, 'a4a-fie-unlayout-enabled') &&
         this.friendlyIframeEmbed_) {
       return;
     }
@@ -1006,9 +1006,9 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override  */
   unlayoutCallback() {
-    if (!isExperimentOn('a4a-fie-unlayout-enabled') &&
+    if (!isExperimentOn(this.win, 'a4a-fie-unlayout-enabled') &&
         this.friendlyIframeEmbed_) {
-      return;
+      return false;
     }
     // Increment promiseId to cause any pending promise to cancel.
     this.promiseId_++;


### PR DESCRIPTION
AMP creatives rendered via friendly iframe embed are not removed during unlayoutCallback allowing them to be immediately visible when the user swipes back to the publisher page within the viewer.  ResumeCallback does not call onLayoutMeasure in this case as its unnecessary.  Wrapped in a4a-fie-unlayout-enabled experiment allowing this feature to be disabled (default is enabled).

Closes #9153 