### PR TITLE
Add `blob:` to `script-src` CSP directive

### DIFF
--- a/examples/csp.amp.html
+++ b/examples/csp.amp.html
@@ -6,7 +6,7 @@
   <link rel="canonical" href="analytics.amp.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src * data: blob:; script-src https://cdn.ampproject.org/v0.js https://cdn.ampproject.org/v0/ https://cdn.ampproject.org/viewer/; object-src 'none'; style-src 'unsafe-inline' https://cdn.ampproject.org/rtv/ https://fast.fonts.net https://fonts.googleapis.com; report-uri https://csp-collector.appspot.com/csp/amp">
+  <meta http-equiv="Content-Security-Policy" content="default-src * data: blob:; script-src blob: https://cdn.ampproject.org/v0.js https://cdn.ampproject.org/v0/ https://cdn.ampproject.org/viewer/; object-src 'none'; style-src 'unsafe-inline' https://cdn.ampproject.org/rtv/ https://fast.fonts.net https://fonts.googleapis.com; report-uri https://csp-collector.appspot.com/csp/amp">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>


### PR DESCRIPTION
Partial for #9290.

Tested on Chrome 58, 60 and Safari 10.1, 10.2.