### PR TITLE
AmpAd Fast Fetch: Ensure separate pings are sent for AdSense vs Doubleclick SRA delay measurement

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -756,10 +756,11 @@ export class AmpA4A extends AMP.BaseElement {
     const type = this.element.getAttribute('type');
     const promiseId = this.promiseId_;
     // Only execute once per page, this includes potential pauseCallback flows.
-    if (this.win['a4a-measuring-ad-urls']) {
+    if ((type != 'adsense' & type != 'doubleclick') ||
+      this.win[`a4a-measuring-ad-urls-${type}`]) {
       return;
     }
-    this.win['a4a-measuring-ad-urls'] =
+    this.win[`a4a-measuring-ad-urls-${type}`] =
      resourcesForDoc(this.element).getMeasuredResources(this.win,
        r => {
          return r.element.tagName == 'AMP-AD' &&
@@ -782,8 +783,9 @@ export class AmpA4A extends AMP.BaseElement {
                'met.delta.AD_SLOT_ID': Math.round(Date.now() - startTime),
                'totalSlotCount.AD_SLOT_ID': adUrls.length,
                'totalUrlCount.AD_SLOT_ID': adUrls.filter(url => !!url).length,
+               'type.AD_SLOT_ID': type,
                'totalQueriedSlotCount.AD_SLOT_ID':
-                  this.win.document.querySelectorAll('amp-ad[type=doubleclick]')
+                  this.win.document.querySelectorAll(`amp-ad[type=${type}]`)
                     .length,
              });
        });

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -756,7 +756,7 @@ export class AmpA4A extends AMP.BaseElement {
     const type = this.element.getAttribute('type');
     const promiseId = this.promiseId_;
     // Only execute once per page, this includes potential pauseCallback flows.
-    if ((type != 'adsense' & type != 'doubleclick') ||
+    if ((type != 'adsense' && type != 'doubleclick') ||
       this.win[`a4a-measuring-ad-urls-${type}`]) {
       return;
     }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1502,6 +1502,98 @@ describe('amp-a4a', () => {
     // FAILURE cases here
   });
 
+  describe('SRA Ads Delay Measure', () => {
+    let fixture;
+    beforeEach(() => {
+      xhrMock.withArgs(TEST_URL, {
+        mode: 'cors',
+        method: 'GET',
+        credentials: 'include',
+      }).onFirstCall().returns(Promise.resolve(mockResponse));
+      return createIframePromise().then(f => {
+        setupForAdTesting(f);
+        fixture = f;
+        return fixture;
+      });
+    });
+    it('sends as expected', () => {
+      const win = fixture.win;
+      const a4a = new MockA4AImpl(createA4aElement(fixture.doc, win));
+      a4a.buildCallback();
+      const emitLifecycleEventSpy =
+        sandbox.spy(a4a, 'protectedEmitLifecycleEvent_');
+      a4a.onLayoutMeasure();
+      expect(a4a.adPromise_).to.be.ok;
+      return a4a.adPromise_.then(() => {
+        expect(win['a4a-measuring-ad-urls-adsense']).to.be.ok;
+        expect(win['a4a-measuring-ad-urls-doubleclick']).to.not.be.ok;
+        return win['a4a-measuring-ad-urls-adsense'].then(() => {
+          // TODO: get resources to include element so reported object can
+          // be verified.
+          expect(emitLifecycleEventSpy.withArgs(
+            'sraBuildRequestDelay',
+            {
+              'met.delta.AD_SLOT_ID': sinon.match.number,
+              'totalSlotCount.AD_SLOT_ID': 0,
+              'totalUrlCount.AD_SLOT_ID': 0,
+              'type.AD_SLOT_ID': 'adsense',
+              'totalQueriedSlotCount.AD_SLOT_ID': 0,
+            })).to.be.calledOnce;
+        });
+      });
+    });
+    it('does not execute if already present', () => {
+      const win = fixture.win;
+      win['a4a-measuring-ad-urls-adsense'] = true;
+      const a4aElement = createA4aElement(fixture.doc, win);
+      const a4a = new MockA4AImpl(a4aElement);
+      a4a.buildCallback();
+      const emitLifecycleEventSpy =
+        sandbox.spy(a4a, 'protectedEmitLifecycleEvent_');
+      a4a.onLayoutMeasure();
+      expect(a4a.adPromise_).to.be.ok;
+      return a4a.adPromise_.then(() => {
+        expect(emitLifecycleEventSpy).to.not.be.calledWith(
+          'sraBuildRequestDelay', sinon.match.object);
+      });
+    });
+    it('creates separate executions for doubleclick vs adsense', () => {
+      const win = fixture.win;
+      const adsenseA4a = new MockA4AImpl(createA4aElement(fixture.doc, win));
+      adsenseA4a.buildCallback();
+      const adSenseEmitLifecycleEventSpy =
+        sandbox.spy(adsenseA4a, 'protectedEmitLifecycleEvent_');
+      adsenseA4a.onLayoutMeasure();
+      expect(adsenseA4a.adPromise_).to.be.ok;
+      const doubleclickElement = createA4aElement(fixture.doc, win);
+      doubleclickElement.setAttribute('type', 'doubleclick');
+      const doubleclickA4a = new MockA4AImpl(doubleclickElement);
+      const doubleclickEmitLifecycleEventSpy =
+        sandbox.spy(doubleclickA4a, 'protectedEmitLifecycleEvent_');
+      doubleclickA4a.buildCallback();
+      doubleclickA4a.onLayoutMeasure();
+      expect(doubleclickA4a.adPromise_).to.be.ok;
+      return Promise.all(
+        [adsenseA4a.adPromise_, doubleclickA4a.adPromise_]).then(() => {
+          expect(win['a4a-measuring-ad-urls-adsense']).to.be.ok;
+          expect(win['a4a-measuring-ad-urls-doubleclick']).to.be.ok;
+          const checks = {adsense: adSenseEmitLifecycleEventSpy,
+            doubleclick: doubleclickEmitLifecycleEventSpy};
+          Object.keys(checks).forEach(type => {
+            expect(checks[type].withArgs(
+              'sraBuildRequestDelay',
+              {
+                'met.delta.AD_SLOT_ID': sinon.match.number,
+                'totalSlotCount.AD_SLOT_ID': 0,
+                'totalUrlCount.AD_SLOT_ID': 0,
+                'type.AD_SLOT_ID': type,
+                'totalQueriedSlotCount.AD_SLOT_ID': 0,
+              })).to.be.calledOnce;
+          });
+        });
+    });
+  });
+
   describe('#renderOutsideViewport', () => {
     let a4aElement;
     let a4a;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -297,7 +297,9 @@ export class Resources {
     return this.ampdoc.signals().whenSignal(READY_SCAN_SIGNAL_).then(() => {
       // Second, wait for any left-over elements to complete measuring.
       const measurePromiseArray = [];
+      console.log('resources', this.resources_);
       this.resources_.forEach(r => {
+        console.log(r.hasBeenMeasured(), r.hostWin == hostWin, r.hasOwner());
         if (!r.hasBeenMeasured() && r.hostWin == hostWin && !r.hasOwner()) {
           measurePromiseArray.push(this.ensuredMeasured_(r));
         }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -297,9 +297,7 @@ export class Resources {
     return this.ampdoc.signals().whenSignal(READY_SCAN_SIGNAL_).then(() => {
       // Second, wait for any left-over elements to complete measuring.
       const measurePromiseArray = [];
-      console.log('resources', this.resources_);
       this.resources_.forEach(r => {
-        console.log(r.hasBeenMeasured(), r.hostWin == hostWin, r.hasOwner());
         if (!r.hasBeenMeasured() && r.hostWin == hostWin && !r.hasOwner()) {
           measurePromiseArray.push(this.ensuredMeasured_(r));
         }


### PR DESCRIPTION
For tracking potential SRA delay from end of first ad url construction to construction of all blocks.  Ensure separate window objects are created for doubleclick vs adsense (currently they are mixed).