### PR TITLE
Stop resources for crawling build ancestors in SD polyfill

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -492,15 +492,17 @@ export function getDataParamsFromAttributes(element, opt_computeParamNameFunc,
  *  a. The element itself has a nextSibling.
  *  b. Any of the element ancestors has a nextSibling.
  * @param {!Element} element
+ * @param {?Node} opt_stopNode
  * @return {boolean}
  */
-export function hasNextNodeInDocumentOrder(element) {
+export function hasNextNodeInDocumentOrder(element, opt_stopNode) {
   let currentElement = element;
   do {
     if (currentElement.nextSibling) {
       return true;
     }
-  } while ((currentElement = currentElement.parentNode));
+  } while ((currentElement = currentElement.parentNode) &&
+            currentElement != opt_stopNode);
   return false;
 }
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -549,7 +549,8 @@ export class Resources {
     for (let i = 0; i < this.pendingBuildResources_.length; i++) {
       const resource = this.pendingBuildResources_[i];
       if (this.documentReady_ ||
-          hasNextNodeInDocumentOrder(resource.element)) {
+          hasNextNodeInDocumentOrder(
+              resource.element, this.ampdoc.getRootNode())) {
         // Remove resource before build to remove it from the pending list
         // in either case the build succeed or throws an error.
         this.pendingBuildResources_.splice(i--, 1);

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -629,6 +629,18 @@ describes.sandboxed('DOM', {}, env => {
       parent.appendChild(element);
       expect(dom.hasNextNodeInDocumentOrder(element)).to.be.true;
     });
+
+    it('should return false when ancestor with sibling with stop node', () => {
+      const element = document.createElement('div');
+      const parent = document.createElement('div');
+      const uncle = document.createElement('div');
+      const ancestor = document.createElement('div');
+      ancestor.appendChild(parent);
+      ancestor.appendChild(uncle);
+      parent.appendChild(element);
+      expect(dom.hasNextNodeInDocumentOrder(element)).to.be.true;
+      expect(dom.hasNextNodeInDocumentOrder(element, parent)).to.be.false;
+    });
   });
 
   describe('openWindowDialog', () => {

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -2690,6 +2690,24 @@ describe('Resources.add/upgrade/remove', () => {
       expect(resources.schedulePass.calledTwice).to.be.true;
     });
 
+    it('should NOT build past the root node when pending', () => {
+      sandbox.stub(resources, 'schedulePass');
+      resources.documentReady_ = false;
+      resources.pendingBuildResources_ = [resource1];
+      resources.buildReadyResources_();
+      expect(child1.build.called).to.be.false;
+      expect(resources.pendingBuildResources_.length).to.be.equal(1);
+      expect(resources.schedulePass.called).to.be.false;
+
+      child1.parentNode = parent;
+      parent.nextSibling = true;
+      sandbox.stub(resources.ampdoc, 'getRootNode', () => parent);
+      resources.buildReadyResources_();
+      expect(child1.build.called).to.be.false;
+      expect(resources.pendingBuildResources_.length).to.be.equal(1);
+      expect(resources.schedulePass.called).to.be.false;
+    });
+
     it('should not try to build resources already being built', () => {
       resources.documentReady_ = false;
       resources.pendingBuildResources_ = [resource1, resource2];


### PR DESCRIPTION
In SD, `topNode.parentNode == null`. Unfortunately, that's not the case for SD polyfill, where `topNode.parentNode == hostNode`. This is mostly benign right now. But as I'm preparing to stream shadow roots - this will be more problematic. So, it's best to fix right away.