### PR TITLE
amp-carousel: optional aria-label for navigation buttons

### DIFF
--- a/examples/carousel.amp.html
+++ b/examples/carousel.amp.html
@@ -98,7 +98,7 @@
 
   </amp-carousel>
 
-  <amp-carousel width=auto height=300 controls>
+  <amp-carousel width=auto height=300 data-next-button-aria-label="Go Forward" data-previous-button-aria-label="Go Back" controls>
 
     <div>hello world</div>
 

--- a/examples/carousel.amp.html
+++ b/examples/carousel.amp.html
@@ -98,7 +98,7 @@
 
   </amp-carousel>
 
-  <amp-carousel width=auto height=300 data-previous-button-aria-label="Going Back" data-next-button-aria-label="Going Forward" controls>
+  <amp-carousel width=auto height=300 controls>
 
     <div>hello world</div>
 

--- a/examples/carousel.amp.html
+++ b/examples/carousel.amp.html
@@ -98,7 +98,7 @@
 
   </amp-carousel>
 
-  <amp-carousel width=auto height=300 controls>
+  <amp-carousel width=auto height=300 data-previous-button-aria-label="Going Back" data-next-button-aria-label="Going Forward" controls>
 
     <div>hello world</div>
 

--- a/examples/carousel.amp.html
+++ b/examples/carousel.amp.html
@@ -98,7 +98,7 @@
 
   </amp-carousel>
 
-  <amp-carousel width=auto height=300 data-next-button-aria-label="Go Forward" data-previous-button-aria-label="Go Back" controls>
+  <amp-carousel width=auto height=300 data-next-button-aria-label="Go to next slide" data-previous-button-aria-label="Go to previous slide" controls>
 
     <div>hello world</div>
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -72,9 +72,11 @@ export class BaseCarousel extends AMP.BaseElement {
     // TODO(erwinm): Does label need i18n support in the future? or provide
     // a way to be overridden.
     if (this.element.hasAttribute('data-previous-button-aria-label')) {
-        this.prevButton_.setAttribute('aria-label', this.element.getAttribute('data-previous-button-aria-label'));
+        this.prevButton_.setAttribute('aria-label',
+                                      this.element.getAttribute('data-previous-button-aria-label'));
     } else {
-        this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
+        this.prevButton_.setAttribute('aria-label', 
+                                      'Previous item in carousel');
     }
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
@@ -95,9 +97,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.classList.add('amp-carousel-button-next');
     this.nextButton_.setAttribute('role', 'button');
     if (this.element.hasAttribute('data-next-button-aria-label')) {
-        this.nextButton_.setAttribute('aria-label', this.element.getAttribute('data-next-button-aria-label'));
+        this.nextButton_.setAttribute('aria-label', 
+                                      this.element.getAttribute('data-next-button-aria-label'));
     } else {
-        this.nextButton_.setAttribute('aria-label', 'Previous item in carousel');
+        this.nextButton_.setAttribute('aria-label', 
+                                      'Previous item in carousel');
     }
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -71,7 +71,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.prevButton_.setAttribute('role', 'button');
     // TODO(erwinm): Does label need i18n support in the future? or provide
     // a way to be overridden.
-    this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
+    if (this.element.hasAttribute('data-previous-button-aria-label')) {
+        this.prevButton_.setAttribute('aria-label', this.element.getAttribute('data-previous-button-aria-label'));
+    } else {
+        this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
+    }
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
       if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {
@@ -90,7 +94,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.classList.add('amp-carousel-button');
     this.nextButton_.classList.add('amp-carousel-button-next');
     this.nextButton_.setAttribute('role', 'button');
-    this.nextButton_.setAttribute('aria-label', 'Next item in carousel');
+    if (this.element.hasAttribute('data-next-button-aria-label')) {
+        this.nextButton_.setAttribute('aria-label', this.element.getAttribute('data-next-button-aria-label'));
+    } else {
+        this.nextButton_.setAttribute('aria-label', 'Previous item in carousel');
+    }
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {
       if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {KeyCodes} from '../../../src/utils/key-codes';
+import {keyCodes} from '../../../src/utils/key-codes';
 import {timerFor} from '../../../src/services';
 
 /**
@@ -69,8 +69,6 @@ export class BaseCarousel extends AMP.BaseElement {
     this.prevButton_.classList.add('amp-carousel-button');
     this.prevButton_.classList.add('amp-carousel-button-prev');
     this.prevButton_.setAttribute('role', 'button');
-    // TODO(erwinm): Does label need i18n support in the future? or provide
-    // a way to be overridden.
     if (this.element.hasAttribute('data-previous-button-aria-label')) {
       this.prevButton_.setAttribute('aria-label',
         this.element.getAttribute('data-previous-button-aria-label'));
@@ -80,7 +78,7 @@ export class BaseCarousel extends AMP.BaseElement {
     }
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
-      if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {
+      if (event.keyCode == keyCodes.ENTER || event.keyCode == keyCodes.SPACE) {
         if (!event.defaultPrevented) {
           event.preventDefault();
           this.interactionPrev();
@@ -105,7 +103,7 @@ export class BaseCarousel extends AMP.BaseElement {
     }
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {
-      if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {
+      if (event.keyCode == keyCodes.ENTER || event.keyCode == keyCodes.SPACE) {
         if (!event.defaultPrevented) {
           event.preventDefault();
           this.interactionNext();

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Keycodes} from '../../../src/utils/keycodes';
-import {timerFor} from '../../../src/services';
+import {
+  Keycodes,
+} from '../../../src/utils/keycodes';
+import {
+  timerFor,
+} from '../../../src/services';
 
 /**
  * @abstract
@@ -72,11 +76,11 @@ export class BaseCarousel extends AMP.BaseElement {
     // TODO(erwinm): Does label need i18n support in the future? or provide
     // a way to be overridden.
     if (this.element.hasAttribute('data-previous-button-aria-label')) {
-        this.prevButton_.setAttribute('aria-label',
-                                      this.element.getAttribute('data-previous-button-aria-label'));
+      this.prevButton_.setAttribute('aria-label',
+        this.element.getAttribute('data-previous-button-aria-label'));
     } else {
-        this.prevButton_.setAttribute('aria-label', 
-                                      'Previous item in carousel');
+      this.prevButton_.setAttribute('aria-label',
+        'Previous item in carousel');
     }
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
@@ -97,11 +101,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.classList.add('amp-carousel-button-next');
     this.nextButton_.setAttribute('role', 'button');
     if (this.element.hasAttribute('data-next-button-aria-label')) {
-        this.nextButton_.setAttribute('aria-label', 
-                                      this.element.getAttribute('data-next-button-aria-label'));
+      this.nextButton_.setAttribute('aria-label',
+        this.element.getAttribute('data-next-button-aria-label'));
     } else {
-        this.nextButton_.setAttribute('aria-label', 
-                                      'Previous item in carousel');
+      this.nextButton_.setAttribute('aria-label',
+        'Previous item in carousel');
     }
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import {
-  Keycodes,
+  Keycodes
 } from '../../../src/utils/keycodes';
 import {
-  timerFor,
+  timerFor
 } from '../../../src/services';
 
 /**

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {keyCodes} from '../../../src/utils/key-codes';
+import {KeyCodes} from '../../../src/utils/key-codes';
 import {timerFor} from '../../../src/services';
 
 /**
@@ -78,7 +78,7 @@ export class BaseCarousel extends AMP.BaseElement {
     }
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
-      if (event.keyCode == keyCodes.ENTER || event.keyCode == keyCodes.SPACE) {
+      if (event.keyCode == KeyCodes.ENTER || event.keyCode == KeyCodes.SPACE) {
         if (!event.defaultPrevented) {
           event.preventDefault();
           this.interactionPrev();
@@ -103,7 +103,7 @@ export class BaseCarousel extends AMP.BaseElement {
     }
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {
-      if (event.keyCode == keyCodes.ENTER || event.keyCode == keyCodes.SPACE) {
+      if (event.keyCode == KeyCodes.ENTER || event.keyCode == KeyCodes.SPACE) {
         if (!event.defaultPrevented) {
           event.preventDefault();
           this.interactionNext();

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -71,11 +71,7 @@ export class BaseCarousel extends AMP.BaseElement {
     this.prevButton_.setAttribute('role', 'button');
     // TODO(erwinm): Does label need i18n support in the future? or provide
     // a way to be overridden.
-    if (this.element.hasAttribute('data-previous-button-aria-label')) {
-        this.prevButton_.setAttribute('aria-label', this.element.getAttribute('data-previous-button-aria-label'));
-    } else {
-        this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
-    }
+    this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
       if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {
@@ -94,12 +90,7 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.classList.add('amp-carousel-button');
     this.nextButton_.classList.add('amp-carousel-button-next');
     this.nextButton_.setAttribute('role', 'button');
-    if (this.element.hasAttribute('data-next-button-aria-label')) {
-        this.nextButton_.setAttribute('aria-label', this.element.getAttribute('data-next-button-aria-label'));
-    } else {
-        this.nextButton_.setAttribute('aria-label', 'Next item in carousel');
-    }
-    
+    this.nextButton_.setAttribute('aria-label', 'Next item in carousel');
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {
       if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -71,7 +71,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.prevButton_.setAttribute('role', 'button');
     // TODO(erwinm): Does label need i18n support in the future? or provide
     // a way to be overridden.
-    this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
+    if (this.element.hasAttribute('data-previous-button-aria-label')) {
+        this.prevButton_.setAttribute('aria-label', this.element.getAttribute('data-previous-button-aria-label'));
+    } else {
+        this.prevButton_.setAttribute('aria-label', 'Previous item in carousel');
+    }
     this.prevButton_.setAttribute('tabindex', 0);
     this.prevButton_.onkeydown = event => {
       if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {
@@ -90,7 +94,12 @@ export class BaseCarousel extends AMP.BaseElement {
     this.nextButton_.classList.add('amp-carousel-button');
     this.nextButton_.classList.add('amp-carousel-button-next');
     this.nextButton_.setAttribute('role', 'button');
-    this.nextButton_.setAttribute('aria-label', 'Next item in carousel');
+    if (this.element.hasAttribute('data-next-button-aria-label')) {
+        this.nextButton_.setAttribute('aria-label', this.element.getAttribute('data-next-button-aria-label'));
+    } else {
+        this.nextButton_.setAttribute('aria-label', 'Next item in carousel');
+    }
+    
     this.nextButton_.setAttribute('tabindex', 0);
     this.nextButton_.onkeydown = event => {
       if (event.keyCode == Keycodes.ENTER || event.keyCode == Keycodes.SPACE) {

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  Keycodes
-} from '../../../src/utils/keycodes';
-import {
-  timerFor
-} from '../../../src/services';
+import {KeyCodes} from '../../../src/utils/key-codes';
+import {timerFor} from '../../../src/services';
 
 /**
  * @abstract

--- a/extensions/amp-carousel/amp-carousel.md
+++ b/extensions/amp-carousel/amp-carousel.md
@@ -109,7 +109,7 @@ unless only a single child is present.
 Usage example:
 
 ```html
-<amp-carousel width="100" height="100" controls layout="responsive" type="slides">
+<amp-carousel width="100" height="100" data-next-button-aria-label="Go to next slide" data-previous-button-aria-label="Go to previous slide" controls layout="responsive" type="slides">
 ```
 
 **type**
@@ -139,6 +139,14 @@ attribute if present (minimum of 1000 ms; an error will be thrown if it's any lo
 **height** (required)
 
 The height of the carousel, in pixels.
+
+**data-next-button-aria-label**  (optional)
+- sets the aria-label for the amp-carousel-button-next
+- if no value is given, aria-label will default to 'Next item in carousel'
+
+**data-prev-button-aria-label**  (optional)
+- sets the aria-label for the amp-carousel-button-prev
+- if no value is given, aria-label will default to 'Previous item in carousel'
 
 **common attributes**
 


### PR DESCRIPTION
With these new attributes 'data-next-button-aria-label' and 'data-previous-button-aria-label' the aria-label can be set for each of these elements.

Closes #442 