### PR TITLE
Only error report request's origin for privacy

### DIFF
--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -181,8 +181,8 @@ export class Xhr {
       }
       return response;
     }, reason => {
-      user().assert(false, 'Fetch failed %s: %s', input,
-          reason && reason.message);
+      throw user().createExpectedError('XHR', `Failed fetching` +
+          ` (${targetOrigin}/...):`, reason && reason.message);
     });
   }
 


### PR DESCRIPTION
Since user private data can appear anywhere in the URL's request, let's
only report the origin of the request when an error happens.

Also converts this to an expected error, since there's really nothing we
can do about a network failure.

Fixes #7585.