### PR TITLE
amp-bind: Embed scoping

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -133,7 +133,7 @@ export class AmpState extends AMP.BaseElement {
     const id = user().assert(this.element.id, '<amp-state> must have an id.');
     const state = Object.create(null);
     state[id] = json;
-    bindForDoc(this.getAmpDoc()).then(bind => {
+    bindForDoc(this.element).then(bind => {
       bind.setState(state,
           /* opt_skipEval */ isInit, /* opt_isAmpStateMutation */ !isInit);
     });

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -150,9 +150,10 @@ export class Bind {
     this.initializePromise_ = Promise.all([
       waitForBodyPromise(this.localWin_.document), // Wait for body.
       this.viewer_.whenFirstVisible(), // Don't initialize in prerender mode.
-    ]).then(() => this.initialize_(
-      dev().assertElement(this.localWin_.document.body)
-    ));
+    ]).then(() => {
+      const rootNode = dev().assertElement(this.localWin_.document.body);
+      return this.initialize_(rootNode);
+    });
 
     /**
      * @private {?Promise}

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -436,6 +436,9 @@ describes.realWin('Bind', {
     let onOtherBindReadyAndSetState;
 
     beforeEach(() => {
+      // `otherBind` mimics an adopted embed window of `bind` -- it shares an
+      // ampdoc service instance but has a different root node and var scope.
+      // @see Bind#adoptEmbedWindow
       otherBind = new Bind(env.ampdoc, otherEnv.win);
       otherParent = otherEnv.win.document.getElementById('parent');
 

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -450,7 +450,7 @@ describes.realWin('Bind', {
           onBindReadyAndSetState_(otherBind, otherEnv);
     });
 
-    it('should scan the elements in the provided window', () => {
+    it('should only scan the elements in the provided window', () => {
       createElementWithBinding('[text]="1+1"');
       otherElementWithBinding('[text]="2+2"');
 
@@ -467,14 +467,14 @@ describes.realWin('Bind', {
           otherElementWithBinding('[text]="foo + bar"');
 
       const promises = [
-        onBindReadyAndSetState({foo: '123'}),
-        onOtherBindReadyAndSetState({bar: '456'}),
+        onBindReadyAndSetState({foo: '123', bar: '456'}),
+        onOtherBindReadyAndSetState({foo: 'ABC', bar: 'DEF'}),
       ];
 
       return Promise.all(promises).then(() => {
         // `element` only sees `foo` and `otherElement` only sees `bar`.
-        expect(element.textContent).to.equal('123null');
-        expect(otherElement.textContent).to.equal('null456');
+        expect(element.textContent).to.equal('123456');
+        expect(otherElement.textContent).to.equal('ABCDEF');
       });
     });
   });

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -84,7 +84,7 @@ export class StandardActions {
   handleAmpTarget(invocation) {
     switch (invocation.method) {
       case 'setState':
-        bindForDoc(this.ampdoc).then(bind => {
+        bindForDoc(invocation.target).then(bind => {
           const args = invocation.args;
           const objectString = args[OBJECT_STRING_ARGS_KEY];
           if (objectString) {

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -31,19 +31,25 @@ let PendingMessageDef;
 /**
  * Invokes function named `method` with args `opt_args` on the web worker
  * and returns a Promise that will be resolved with the function's return value.
- * @note Currently only works in a single entry point.
+ *
+ * If `opt_localWin` is provided, method will be executed in a scope limited
+ * to other invocations with `opt_localWin`.
+ *
+ * @note Currently only works in a single entry point (amp-bind.js).
+ *
  * @param {!Window} win
  * @param {string} method
  * @param {!Array=} opt_args
+ * @param {!Window=} opt_localWin
  * @return {!Promise}
  */
-export function invokeWebWorker(win, method, opt_args) {
+export function invokeWebWorker(win, method, opt_args, opt_localWin) {
   if (!win.Worker) {
     return Promise.reject('Worker not supported in window.');
   }
   registerServiceBuilder(win, 'amp-worker', AmpWorker);
   const worker = getService(win, 'amp-worker');
-  return worker.sendMessage_(method, opt_args || []);
+  return worker.sendMessage_(method, opt_args || [], opt_localWin);
 }
 
 /**
@@ -65,6 +71,9 @@ class AmpWorker {
    * @param {!Window} win
    */
   constructor(win) {
+    /** @const @private {!Window} */
+    this.win_ = win;
+
     /** @const @private {!../service/xhr-impl.Xhr} */
     this.xhr_ = xhrFor(win);
 
@@ -103,6 +112,14 @@ class AmpWorker {
      * @private {number}
      */
     this.counter_ = 0;
+
+    /**
+     * Array of top-level and local windows passed into `invokeWebWorker`.
+     * Used to uniquely identify windows for scoping worker functions when
+     * a single worker is used for multiple windows (i.e. FIE).
+     * @const @private {!Array<!Window>}
+     */
+    this.windows_ = [win];
   }
 
   /**
@@ -112,14 +129,16 @@ class AmpWorker {
    * @return {!Promise}
    * @private
    */
-  sendMessage_(method, args) {
+  sendMessage_(method, args, opt_localWin) {
     return this.fetchPromise_.then(() => {
       return new Promise((resolve, reject) => {
         const id = this.counter_++;
         this.messages_[id] = {method, resolve, reject};
 
+        const scope = this.idForWindow_(opt_localWin || this.win_);
+
         /** @type {ToWorkerMessageDef} */
-        const message = {method, args, id};
+        const message = {method, args, scope, id};
         this.worker_./*OK*/postMessage(message);
       });
     });
@@ -155,6 +174,21 @@ class AmpWorker {
    */
   hasPendingMessages() {
     return Object.keys(this.messages_).length > 0;
+  }
+
+  /**
+   * Returns an identifier for `win`, unique for set of windows seen so far.
+   * @param {!Window} win
+   * @return {number}
+   * @private
+   */
+  idForWindow_(win) {
+    const index = this.windows_.indexOf(win);
+    if (index >= 0) {
+      return index;
+    } else {
+      return this.windows_.push(win) - 1;
+    }
   }
 
   /**

--- a/src/web-worker/web-worker-defines.js
+++ b/src/web-worker/web-worker-defines.js
@@ -18,6 +18,7 @@
  * @typedef {{
  *   method: string,
  *   args: !Array,
+ *   scope: number,
  *   id: number,
  * }}
  */

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -30,31 +30,36 @@ import {installWorkerErrorReporting} from '../worker-error-reporting';
 initLogConstructor();
 installWorkerErrorReporting('ww');
 
-/** @private {BindEvaluator} */
-let evaluator_;
+/**
+ * Element `i` contains the evaluator for scope `i`.
+ * @private {!Array<!BindEvaluator>}
+ */
+const evaluators_ = [];
 
 self.addEventListener('message', function(event) {
-  const {method, args, id} = /** @type {ToWorkerMessageDef} */ (event.data);
+  const {method, args, id, scope} =
+      /** @type {ToWorkerMessageDef} */ (event.data);
 
   let returnValue;
 
-  if (!evaluator_) {
-    evaluator_ = new BindEvaluator();
+  if (!evaluators_[scope]) {
+    evaluators_[scope] = new BindEvaluator();
   }
+  const evaluator = evaluators_[scope];
 
   switch (method) {
     case 'bind.addBindings':
-      returnValue = evaluator_.addBindings.apply(evaluator_, args);
+      returnValue = evaluator.addBindings.apply(evaluator, args);
       break;
     case 'bind.removeBindingsWithExpressionStrings':
-      const removeBindings = evaluator_.removeBindingsWithExpressionStrings;
-      returnValue = removeBindings.apply(evaluator_, args);
+      const removeBindings = evaluator.removeBindingsWithExpressionStrings;
+      returnValue = removeBindings.apply(evaluator, args);
       break;
     case 'bind.evaluateBindings':
-      returnValue = evaluator_.evaluateBindings.apply(evaluator_, args);
+      returnValue = evaluator.evaluateBindings.apply(evaluator, args);
       break;
     case 'bind.evaluateExpression':
-      returnValue = evaluator_.evaluateExpression.apply(evaluator_, args);
+      returnValue = evaluator.evaluateExpression.apply(evaluator, args);
       break;
     default:
       throw new Error(`Unrecognized method: ${method}`);

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -163,12 +163,21 @@ describes.sandboxed('StandardActions', {}, () => {
 
     it('should implement setState', () => {
       const setStateWithExpressionSpy = sandbox.spy();
-      const bind = {setStateWithExpression: setStateWithExpressionSpy};
-      window.services.bind = {obj: bind};
+      window.services.bind = {
+        obj: {
+          setStateWithExpression: setStateWithExpressionSpy
+        },
+      };
+
       const args = {};
       args[OBJECT_STRING_ARGS_KEY] = '{foo: 123}';
-      standardActions.handleAmpTarget({method: 'setState', args});
-      return bindForDoc(standardActions.ampdoc).then(() => {
+
+      standardActions.handleAmpTarget({
+        method: 'setState',
+        args,
+        target: ampdoc
+      });
+      return bindForDoc(ampdoc).then(() => {
         expect(setStateWithExpressionSpy).to.be.calledOnce;
         expect(setStateWithExpressionSpy).to.be.calledWith('{foo: 123}');
       });

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -165,7 +165,7 @@ describes.sandboxed('StandardActions', {}, () => {
       const setStateWithExpressionSpy = sandbox.spy();
       window.services.bind = {
         obj: {
-          setStateWithExpression: setStateWithExpressionSpy
+          setStateWithExpression: setStateWithExpressionSpy,
         },
       };
 
@@ -175,7 +175,7 @@ describes.sandboxed('StandardActions', {}, () => {
       standardActions.handleAmpTarget({
         method: 'setState',
         args,
-        target: ampdoc
+        target: ampdoc,
       });
       return bindForDoc(ampdoc).then(() => {
         expect(setStateWithExpressionSpy).to.be.calledOnce;

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -26,6 +26,8 @@ import * as sinon from 'sinon';
 describe('invokeWebWorker', () => {
   let sandbox;
   let fakeWin;
+
+  let ampWorker;
   let postMessageStub;
   let fakeWorker;
   let workerReadyPromise;
@@ -50,7 +52,7 @@ describe('invokeWebWorker', () => {
     installXhrService(fakeWin);
     sandbox.stub(xhrFor(fakeWin), 'fetchText', () => Promise.resolve());
 
-    const ampWorker = ampWorkerForTesting(fakeWin);
+    ampWorker = ampWorkerForTesting(fakeWin);
     workerReadyPromise = ampWorker.fetchPromiseForTesting();
   });
 
@@ -191,8 +193,6 @@ describe('invokeWebWorker', () => {
   });
 
   it('should clean up storage after message completion', () => {
-    const ampWorker = ampWorkerForTesting(fakeWin);
-
     invokeWebWorker(fakeWin, 'foo');
 
     return workerReadyPromise.then(() => {
@@ -205,6 +205,41 @@ describe('invokeWebWorker', () => {
       }});
 
       expect(ampWorker.hasPendingMessages()).to.be.false;
+    });
+  });
+
+  it('should send unique scope IDs per `opt_localWin` value', () => {
+    const scopeOne = {};
+    const scopeTwo = {};
+
+    // Sending.
+    invokeWebWorker(fakeWin, 'a'); // Default scope == 0.
+    invokeWebWorker(fakeWin, 'b', undefined, /* opt_localWin */ scopeOne);
+    invokeWebWorker(fakeWin, 'c', undefined, /* opt_localWin */ scopeTwo);
+    invokeWebWorker(fakeWin, 'd', undefined, /* opt_localWin */ scopeOne);
+    invokeWebWorker(fakeWin, 'e', undefined, /* opt_localWin */ fakeWin);
+
+    return workerReadyPromise.then(() => {
+      expect(postMessageStub).to.have.been.calledWithMatch({
+        method: 'a',
+        scope: 0,
+      });
+      expect(postMessageStub).to.have.been.calledWithMatch({
+        method: 'b',
+        scope: 1,
+      });
+      expect(postMessageStub).to.have.been.calledWithMatch({
+        method: 'c',
+        scope: 2,
+      });
+      expect(postMessageStub).to.have.been.calledWithMatch({
+        method: 'd',
+        scope: 1,
+      });
+      expect(postMessageStub).to.have.been.calledWithMatch({
+        method: 'e',
+        scope: 0,
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #7779, partial for #9395.

- `Bind` service implements `EmbeddableService`
- Add window-scoping of method invocations in `AmpWorker`

This allows FIE pages using `amp-bind` to share a Web Worker with the top-level window but have separate state scopes.