### PR TITLE
WIP: Skip XHR processing

### DIFF
--- a/extensions/amp-form/0.1/form-verifiers.js
+++ b/extensions/amp-form/0.1/form-verifiers.js
@@ -220,13 +220,9 @@ export class AsyncVerifier extends FormVerifier {
    */
   maybeVerify_(afterVerify) {
     if (this.shouldVerify_()) {
-      const xhrConsumeErrors = this.doXhr_().then(() => {
-        return [];
-      }, error => {
-        // A 400 error response should be handled here.
-        return getResponseErrorData_(
-            /** @type {!../../../src/service/xhr-impl.FetchError} */ (error));
-      });
+      const xhrConsumeErrors = this.doXhr_().then(response => {
+        return response.json();
+      }).then(getResponseErrorData);
 
       const p = this.addToResolver_(xhrConsumeErrors)
           .then(errors => this.verify_(errors))
@@ -411,13 +407,11 @@ class VerificationGroup {
 }
 
 /**
- * @param {!../../../src/service/xhr-impl.FetchError} fetchError
+ * @param {!JSONType} fetchError
  * @return {!Array<VerificationErrorDef>}
  * @private
  */
-function getResponseErrorData_(fetchError) {
-  const json = /** @type {?VerificationErrorResponseDef} */ (
-      fetchError && fetchError.responseJson);
+function getResponseErrorData(json) {
   if (json && json.verifyErrors) {
     return json.verifyErrors;
   } else {

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -191,12 +191,12 @@ describes.repeated('', {
         preventDefault: sandbox.spy(),
       };
 
-      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
       sandbox.spy(form, 'checkValidity');
       ampForm.handleSubmitEvent_(event);
       expect(event.stopImmediatePropagation).to.be.called;
       expect(form.checkValidity).to.not.be.called;
-      expect(ampForm.xhr_.fetch).to.not.be.called;
+      expect(ampForm.xhr_.fetchJson).to.not.be.called;
       document.body.removeChild(form);
     });
 
@@ -210,7 +210,7 @@ describes.repeated('', {
         target: form,
         preventDefault: sandbox.spy(),
       };
-      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
       sandbox.stub(ampForm, 'analyticsEvent_');
       sandbox.spy(form, 'checkValidity');
       const errorRe =
@@ -232,7 +232,7 @@ describes.repeated('', {
       emailInput.setAttribute('required', '');
       form.appendChild(emailInput);
       const ampForm = new AmpForm(form);
-      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
       const event = {
         stopImmediatePropagation: sandbox.spy(),
         target: form,
@@ -271,7 +271,7 @@ describes.repeated('', {
         target: form,
         preventDefault: sandbox.spy(),
       };
-      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
       sandbox.spy(form, 'checkValidity');
       const submitErrorRe =
           /Only XHR based \(via action-xhr attribute\) submissions are support/;
@@ -291,7 +291,7 @@ describes.repeated('', {
       emailInput.setAttribute('required', '');
       form.appendChild(emailInput);
       const ampForm = new AmpForm(form);
-      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
       const event = {
         stopImmediatePropagation: sandbox.spy(),
         target: form,
@@ -330,7 +330,7 @@ describes.repeated('', {
         emailInput.setAttribute('required', '');
         form.appendChild(emailInput);
         sandbox.spy(form, 'checkValidity');
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
         const event = {
           stopImmediatePropagation: sandbox.spy(),
@@ -357,7 +357,7 @@ describes.repeated('', {
         ampForm.handleSubmitEvent_(event);
         expect(event.stopImmediatePropagation).to.be.called;
         expect(form.checkValidity).to.be.called;
-        expect(ampForm.xhr_.fetch).to.not.be.called;
+        expect(ampForm.xhr_.fetchJson).to.not.be.called;
 
         const showCall1 = validationBubble.show.getCall(0);
         expect(showCall1.args[0]).to.equal(emailInput);
@@ -371,7 +371,7 @@ describes.repeated('', {
         expect(showCall2.args[0]).to.equal(emailInput);
         expect(showCall2.args[1]).to.not.be.null;
         expect(showCall2.args[1]).to.not.equal(showCall1.args[0]);
-        expect(ampForm.xhr_.fetch).to.not.be.called;
+        expect(ampForm.xhr_.fetchJson).to.not.be.called;
 
         // Check bubble would hide when input becomes valid.
         emailInput.value = 'cool@bea.ns';
@@ -390,7 +390,7 @@ describes.repeated('', {
         emailInput.value = 'cool@bea.ns';
         ampForm.handleSubmitEvent_(event);
         return timer.promise(10).then(() => {
-          expect(ampForm.xhr_.fetch).to.have.been.called;
+          expect(ampForm.xhr_.fetchJson).to.have.been.called;
         });
       });
     });
@@ -405,7 +405,7 @@ describes.repeated('', {
         emailInput.setAttribute('required', '');
         form.appendChild(emailInput);
         sandbox.spy(form, 'checkValidity');
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
         const event = {
           stopImmediatePropagation: sandbox.spy(),
@@ -428,7 +428,7 @@ describes.repeated('', {
         return timer.promise(1).then(() => {
           expect(event.stopImmediatePropagation).to.not.be.called;
           expect(form.checkValidity).to.not.be.called;
-          expect(ampForm.xhr_.fetch).to.be.called;
+          expect(ampForm.xhr_.fetchJson).to.be.called;
         });
       });
     });
@@ -439,7 +439,7 @@ describes.repeated('', {
           env.win.document, asyncVerifyConfig));
 
       return formPromise.then(ampForm => {
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.reject({
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.reject({
           responseJson: {
             verifyErrors: [{name: 'name', message: 'This name is just wrong.'}],
           },
@@ -463,7 +463,7 @@ describes.repeated('', {
           env.win.document, asyncVerifyConfig));
 
       return formPromise.then(ampForm => {
-        const xhrStub = sandbox.stub(ampForm.xhr_, 'fetch');
+        const xhrStub = sandbox.stub(ampForm.xhr_, 'fetchJson');
         xhrStub.onCall(0).returns(new Promise((unusedResolve, reject) => {
           setTimeout(() => {
             reject({
@@ -513,7 +513,7 @@ describes.repeated('', {
         errorContainer.appendChild(errorTemplate);
         let renderedTemplate = document.createElement('div');
         renderedTemplate.innerText = 'Error: hello there';
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.reject({
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.reject({
           response: {},
           responseJson: {message: 'hello there'},
         }));
@@ -558,7 +558,7 @@ describes.repeated('', {
         const newRender = document.createElement('div');
         newRender.innerText = 'New Success: What What';
 
-        sandbox.stub(ampForm.xhr_, 'fetch')
+        sandbox.stub(ampForm.xhr_, 'fetchJson')
             .returns(Promise.resolve({
               json: () => {
                 return Promise.resolve({'message': 'What What'});
@@ -585,9 +585,9 @@ describes.repeated('', {
       });
     });
 
-    it('should call fetch with the xhr action and form data', () => {
+    it('should call fetchJson with the xhr action and form data', () => {
       return getAmpForm(getForm()).then(ampForm => {
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
         const event = {
           stopImmediatePropagation: sandbox.spy(),
           target: ampForm.form_,
@@ -596,10 +596,10 @@ describes.repeated('', {
         ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault).to.be.calledOnce;
         return timer.promise(1).then(() => {
-          expect(ampForm.xhr_.fetch).to.be.calledOnce;
-          expect(ampForm.xhr_.fetch).to.be.calledWith('https://example.com');
+          expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+          expect(ampForm.xhr_.fetchJson).to.be.calledWith('https://example.com');
 
-          const xhrCall = ampForm.xhr_.fetch.getCall(0);
+          const xhrCall = ampForm.xhr_.fetchJson.getCall(0);
           const config = xhrCall.args[1];
           expect(config.body).to.not.be.null;
           expect(config.method).to.equal('POST');
@@ -610,7 +610,7 @@ describes.repeated('', {
 
     it('should trigger amp-form-submit analytics event with form data', () => {
       return getAmpForm(getForm()).then(ampForm => {
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
         sandbox.stub(ampForm, 'analyticsEvent_');
         const event = {
           stopImmediatePropagation: sandbox.spy(),
@@ -624,10 +624,10 @@ describes.repeated('', {
         ampForm.handleSubmitEvent_(event);
         expect(event.preventDefault).to.be.calledOnce;
         return timer.promise(1).then(() => {
-          expect(ampForm.xhr_.fetch).to.be.calledOnce;
-          expect(ampForm.xhr_.fetch).to.be.calledWith('https://example.com');
+          expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+          expect(ampForm.xhr_.fetchJson).to.be.calledWith('https://example.com');
 
-          const xhrCall = ampForm.xhr_.fetch.getCall(0);
+          const xhrCall = ampForm.xhr_.fetchJson.getCall(0);
           const config = xhrCall.args[1];
           expect(config.body).to.not.be.null;
           expect(config.method).to.equal('POST');
@@ -656,7 +656,7 @@ describes.repeated('', {
         canonicalUrlField.setAttribute('data-amp-replace', 'CANONICAL_URL');
         form.appendChild(canonicalUrlField);
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
         sandbox.stub(ampForm, 'analyticsEvent_');
@@ -667,7 +667,7 @@ describes.repeated('', {
           'formFields[clientId]': sinon.match(/amp-.+/),
           'formFields[canonicalUrl]': 'https%3A%2F%2Fexample.com%2Famps.html',
         };
-        expect(ampForm.xhr_.fetch).to.have.not.been.called;
+        expect(ampForm.xhr_.fetchJson).to.have.not.been.called;
         expect(ampForm.urlReplacement_.expandInputValueSync)
               .to.not.have.been.called;
         expect(ampForm.urlReplacement_.expandInputValueAsync)
@@ -677,7 +677,7 @@ describes.repeated('', {
         expect(ampForm.urlReplacement_.expandInputValueAsync)
               .to.have.been.calledWith(canonicalUrlField);
         return timer.promise(10).then(() => {
-          expect(ampForm.xhr_.fetch).to.be.called;
+          expect(ampForm.xhr_.fetchJson).to.be.called;
           expect(clientIdField.value).to.match(/amp-.+/);
           expect(canonicalUrlField.value).to.equal(
                   'https%3A%2F%2Fexample.com%2Famps.html');
@@ -694,7 +694,7 @@ describes.repeated('', {
           getAmpForm(getForm(env.win.document, true, true, true));
       return formPromise.then(ampForm => {
         let fetchResolver;
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(new Promise(resolve => {
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(new Promise(resolve => {
           fetchResolver = resolve;
         }));
         const form = ampForm.form_;
@@ -712,7 +712,7 @@ describes.repeated('', {
         ampForm.handleSubmitEvent_(event);
         expect(ampForm.state_).to.equal('submitting');
         return timer.promise(1).then(() => {
-          expect(ampForm.xhr_.fetch.calledOnce).to.be.true;
+          expect(ampForm.xhr_.fetchJson.calledOnce).to.be.true;
           expect(button1.hasAttribute('disabled')).to.be.true;
           expect(button2.hasAttribute('disabled')).to.be.true;
 
@@ -721,7 +721,7 @@ describes.repeated('', {
           expect(event.preventDefault.called).to.be.true;
           expect(event.preventDefault).to.have.callCount(3);
           expect(event.stopImmediatePropagation).to.have.callCount(2);
-          expect(ampForm.xhr_.fetch.calledOnce).to.be.true;
+          expect(ampForm.xhr_.fetchJson.calledOnce).to.be.true;
           expect(form.className).to.contain('amp-form-submitting');
           expect(form.className).to.not.contain('amp-form-submit-error');
           expect(form.className).to.not.contain('amp-form-submit-success');
@@ -741,7 +741,7 @@ describes.repeated('', {
     it('should manage form state classes (submitting, success)', () => {
       return getAmpForm(getForm()).then(ampForm => {
         let fetchResolver;
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(new Promise(resolve => {
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(new Promise(resolve => {
           fetchResolver = resolve;
         }));
         sandbox.stub(ampForm, 'analyticsEvent_');
@@ -783,7 +783,7 @@ describes.repeated('', {
       return getAmpForm(getForm(env.win.document, true, true)).then(ampForm => {
         let fetchRejecter;
         sandbox.stub(ampForm, 'analyticsEvent_');
-        sandbox.stub(ampForm.xhr_, 'fetch')
+        sandbox.stub(ampForm.xhr_, 'fetchJson')
             .returns(new Promise((unusedResolve, reject) => {
               fetchRejecter = reject;
             }));
@@ -834,7 +834,7 @@ describes.repeated('', {
         return getAmpForm(getForm()).then(ampForm => {
           ampForm.method_ = 'GET';
           ampForm.form_.setAttribute('method', 'GET');
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
           const event = {
             stopImmediatePropagation: sandbox.spy(),
             target: ampForm.form_,
@@ -843,11 +843,11 @@ describes.repeated('', {
           ampForm.handleSubmitEvent_(event);
           expect(event.preventDefault).to.be.calledOnce;
           return timer.promise(1).then(() => {
-            expect(ampForm.xhr_.fetch).to.be.calledOnce;
-            expect(ampForm.xhr_.fetch).to.be.calledWith(
+            expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+            expect(ampForm.xhr_.fetchJson).to.be.calledWith(
                 'https://example.com?name=John%20Miller');
 
-            const xhrCall = ampForm.xhr_.fetch.getCall(0);
+            const xhrCall = ampForm.xhr_.fetchJson.getCall(0);
             const config = xhrCall.args[1];
             expect(config.body).to.be.undefined;
             expect(config.method).to.equal('GET');
@@ -861,7 +861,7 @@ describes.repeated('', {
           const form = ampForm.form_;
           ampForm.method_ = 'GET';
           form.setAttribute('method', 'GET');
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
           const fieldset = document.createElement('fieldset');
           const emailInput = document.createElement('input');
           emailInput.setAttribute('name', 'email');
@@ -885,42 +885,42 @@ describes.repeated('', {
           ampForm.handleSubmitEvent_(event);
           expect(event.preventDefault).to.be.calledOnce;
           return timer.promise(1).then(() => {
-            expect(ampForm.xhr_.fetch).to.be.calledOnce;
-            expect(ampForm.xhr_.fetch).to.be.calledWith(
+            expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+            expect(ampForm.xhr_.fetchJson).to.be.calledWith(
                 'https://example.com?name=John%20Miller&email=cool%40bea.ns');
 
             ampForm.setState_('submit-success');
-            ampForm.xhr_.fetch.reset();
+            ampForm.xhr_.fetchJson.reset();
             usernameInput.removeAttribute('disabled');
             usernameInput.value = 'coolbeans';
             emailInput.value = 'cool@bea.ns';
             ampForm.handleSubmitEvent_(event);
             return timer.promise(1).then(() => {
-              expect(ampForm.xhr_.fetch).to.be.calledOnce;
-              expect(ampForm.xhr_.fetch).to.be.calledWith(
+              expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+              expect(ampForm.xhr_.fetchJson).to.be.calledWith(
                   'https://example.com?name=John%20Miller&email=cool%40bea.ns&' +
                   'nickname=coolbeans');
 
               ampForm.setState_('submit-success');
-              ampForm.xhr_.fetch.reset();
+              ampForm.xhr_.fetchJson.reset();
               fieldset.disabled = true;
               ampForm.handleSubmitEvent_(event);
 
               return timer.promise(1).then(() => {
-                expect(ampForm.xhr_.fetch).to.be.calledOnce;
-                expect(ampForm.xhr_.fetch).to.be.calledWith(
+                expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+                expect(ampForm.xhr_.fetchJson).to.be.calledWith(
                     'https://example.com?name=John%20Miller');
 
                 ampForm.setState_('submit-success');
-                ampForm.xhr_.fetch.reset();
+                ampForm.xhr_.fetchJson.reset();
                 fieldset.removeAttribute('disabled');
                 usernameInput.removeAttribute('name');
                 emailInput.removeAttribute('required');
                 emailInput.value = '';
                 ampForm.handleSubmitEvent_(event);
                 return timer.promise(1).then(() => {
-                  expect(ampForm.xhr_.fetch).to.be.calledOnce;
-                  expect(ampForm.xhr_.fetch).to.be.calledWith(
+                  expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+                  expect(ampForm.xhr_.fetchJson).to.be.calledWith(
                       'https://example.com?name=John%20Miller&email=');
                 });
               });
@@ -935,7 +935,7 @@ describes.repeated('', {
           const form = ampForm.form_;
           ampForm.method_ = 'GET';
           form.setAttribute('method', 'GET');
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
           const otherNamesFS = document.createElement('fieldset');
           const otherName1Input = document.createElement('input');
@@ -1002,30 +1002,30 @@ describes.repeated('', {
           ampForm.handleSubmitEvent_(event);
           expect(event.preventDefault).to.be.calledOnce;
           return timer.promise(1).then(() => {
-            expect(ampForm.xhr_.fetch).to.be.calledOnce;
-            expect(ampForm.xhr_.fetch).to.be.calledWith(
+            expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+            expect(ampForm.xhr_.fetchJson).to.be.calledWith(
                 'https://example.com?name=John%20Miller&name=&name=&' +
                 'city=San%20Francisco');
 
             ampForm.setState_('submit-success');
-            ampForm.xhr_.fetch.reset();
+            ampForm.xhr_.fetchJson.reset();
             foodCB.checked = true;
             footballCB.checked = true;
             ampForm.handleSubmitEvent_(event);
             return timer.promise(1).then(() => {
-              expect(ampForm.xhr_.fetch).to.be.calledOnce;
-              expect(ampForm.xhr_.fetch).to.be.calledWith(
+              expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+              expect(ampForm.xhr_.fetchJson).to.be.calledWith(
                   'https://example.com?name=John%20Miller&name=&name=' +
                   '&interests=Football&interests=Food&city=San%20Francisco');
 
               ampForm.setState_('submit-success');
               femaleRadio.checked = true;
               otherName1Input.value = 'John Maller';
-              ampForm.xhr_.fetch.reset();
+              ampForm.xhr_.fetchJson.reset();
               ampForm.handleSubmitEvent_(event);
               return timer.promise(1).then(() => {
-                expect(ampForm.xhr_.fetch).to.be.calledOnce;
-                expect(ampForm.xhr_.fetch).to.be.calledWith(
+                expect(ampForm.xhr_.fetchJson).to.be.calledOnce;
+                expect(ampForm.xhr_.fetchJson).to.be.calledWith(
                     'https://example.com?name=John%20Miller&name=John%20Maller' +
                     '&name=&gender=Female&interests=Football&interests=Food&' +
                     'city=San%20Francisco');
@@ -1051,7 +1051,7 @@ describes.repeated('', {
           sandbox.spy(form, 'checkValidity');
           sandbox.spy(emailInput, 'checkValidity');
           sandbox.spy(fieldset, 'checkValidity');
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
           const event = {
             target: ampForm.form_,
@@ -1093,7 +1093,7 @@ describes.repeated('', {
           sandbox.spy(form, 'checkValidity');
           sandbox.spy(emailInput, 'checkValidity');
           sandbox.spy(fieldset, 'checkValidity');
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
           checkUserValidityAfterInteraction_(emailInput);
           expect(form.checkValidity).to.be.called;
@@ -1157,7 +1157,7 @@ describes.repeated('', {
           sandbox.spy(form, 'checkValidity');
           sandbox.spy(emailInput, 'checkValidity');
           sandbox.spy(fieldset, 'checkValidity');
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
 
           emailInput.value = 'cool@bea.ns';
           checkUserValidityAfterInteraction_(emailInput);
@@ -1177,7 +1177,7 @@ describes.repeated('', {
       const actions = actionServiceForDoc(form.ownerDocument);
       sandbox.stub(actions, 'installActionHandler');
       const ampForm = new AmpForm(form);
-      sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+      sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
       expect(actions.installActionHandler).to.be.calledWith(form);
       sandbox.spy(ampForm, 'handleSubmitAction_');
       ampForm.actionHandler_({method: 'anything'});
@@ -1198,7 +1198,7 @@ describes.repeated('', {
         form.appendChild(selector);
         sandbox.stub(selector, 'whenBuilt')
             .returns(new Promise(unusedResolve => {}));
-        sandbox.stub(ampForm.xhr_, 'fetch')
+        sandbox.stub(ampForm.xhr_, 'fetchJson')
             .returns(Promise.resolve());
         sandbox.spy(ampForm, 'handleSubmitAction_');
         ampForm.actionHandler_({method: 'submit'});
@@ -1222,7 +1222,7 @@ describes.repeated('', {
         sandbox.stub(selector, 'whenBuilt').returns(new Promise(resolve => {
           builtPromiseResolver_ = resolve;
         }));
-        sandbox.stub(ampForm.xhr_, 'fetch')
+        sandbox.stub(ampForm.xhr_, 'fetchJson')
             .returns(Promise.resolve());
         sandbox.spy(ampForm, 'handleSubmitAction_');
         ampForm.actionHandler_({method: 'submit'});
@@ -1257,11 +1257,11 @@ describes.repeated('', {
           canonicalUrlField.setAttribute('data-amp-replace', 'CANONICAL_URL');
           form.appendChild(canonicalUrlField);
           sandbox.stub(form, 'checkValidity').returns(true);
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
           ampForm.submit_();
-          expect(ampForm.xhr_.fetch).to.have.not.been.called;
+          expect(ampForm.xhr_.fetchJson).to.have.not.been.called;
           expect(ampForm.urlReplacement_.expandInputValueSync)
               .to.not.have.been.called;
           expect(ampForm.urlReplacement_.expandInputValueAsync)
@@ -1271,7 +1271,7 @@ describes.repeated('', {
           expect(ampForm.urlReplacement_.expandInputValueAsync)
               .to.have.been.calledWith(canonicalUrlField);
           return timer.promise(10).then(() => {
-            expect(ampForm.xhr_.fetch).to.be.called;
+            expect(ampForm.xhr_.fetchJson).to.be.called;
             expect(clientIdField.value).to.match(/amp-.+/);
             expect(canonicalUrlField.value).to.equal(
                 'https%3A%2F%2Fexample.com%2Famps.html');
@@ -1296,14 +1296,14 @@ describes.repeated('', {
           canonicalUrlField.value = 'CANONICAL_URL';
           form.appendChild(canonicalUrlField);
           sandbox.stub(form, 'checkValidity').returns(true);
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync')
               .returns(new Promise(resolve => {
                 expandAsyncStringResolvers.push(resolve);
               }));
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
           ampForm.submit_();
-          expect(ampForm.xhr_.fetch).to.have.not.been.called;
+          expect(ampForm.xhr_.fetchJson).to.have.not.been.called;
           expect(ampForm.urlReplacement_.expandInputValueSync)
               .to.not.have.been.called;
           expect(ampForm.urlReplacement_.expandInputValueAsync)
@@ -1313,7 +1313,7 @@ describes.repeated('', {
           expect(ampForm.urlReplacement_.expandInputValueAsync)
               .to.have.been.calledWith(canonicalUrlField);
           return timer.promise(210).then(() => {
-            expect(ampForm.xhr_.fetch).to.be.called;
+            expect(ampForm.xhr_.fetchJson).to.be.called;
             expect(clientIdField.value).to.equal('CLIENT_ID(form)');
             expect(canonicalUrlField.value).to.equal('CANONICAL_URL');
           });
@@ -1340,7 +1340,7 @@ describes.repeated('', {
           form.appendChild(canonicalUrlField);
           sandbox.stub(form, 'submit');
           sandbox.stub(form, 'checkValidity').returns(true);
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
           ampForm.handleSubmitAction_();
@@ -1379,7 +1379,7 @@ describes.repeated('', {
           form.appendChild(canonicalUrlField);
           sandbox.stub(form, 'submit');
           sandbox.stub(form, 'checkValidity').returns(true);
-          sandbox.stub(ampForm.xhr_, 'fetch')
+          sandbox.stub(ampForm.xhr_, 'fetchJson')
               .returns(Promise.resolve());
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
@@ -1414,7 +1414,7 @@ describes.repeated('', {
           form.appendChild(canonicalUrlField);
           sandbox.stub(form, 'submit');
           sandbox.stub(form, 'checkValidity').returns(true);
-          sandbox.stub(ampForm.xhr_, 'fetch')
+          sandbox.stub(ampForm.xhr_, 'fetchJson')
               .returns(Promise.resolve());
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
@@ -1451,7 +1451,7 @@ describes.repeated('', {
           form.appendChild(canonicalUrlField);
           sandbox.stub(form, 'submit');
           sandbox.stub(form, 'checkValidity').returns(true);
-          sandbox.stub(ampForm.xhr_, 'fetch')
+          sandbox.stub(ampForm.xhr_, 'fetchJson')
               .returns(Promise.resolve());
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
@@ -1509,7 +1509,7 @@ describes.repeated('', {
 
       describe('AMP-Redirect-To', () => {
         it('should redirect users if header is set', () => {
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(fetchResolvePromise);
           redirectToValue = 'https://google.com/';
           ampForm.handleSubmitAction_();
 
@@ -1519,7 +1519,7 @@ describes.repeated('', {
         });
 
         it('should fail to redirect to non-secure urls', () => {
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(fetchResolvePromise);
           redirectToValue = 'http://google.com/';
           ampForm.handleSubmitAction_();
 
@@ -1532,7 +1532,7 @@ describes.repeated('', {
         });
 
         it('should fail to redirect to non-absolute urls', () => {
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(fetchResolvePromise);
           redirectToValue = '/hello';
           ampForm.handleSubmitAction_();
 
@@ -1546,7 +1546,7 @@ describes.repeated('', {
 
         it('should fail to redirect to when target != _top', () => {
           ampForm.target_ = '_blank';
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(fetchResolvePromise);
           redirectToValue = 'http://google.com/';
           ampForm.handleSubmitAction_();
 
@@ -1559,7 +1559,7 @@ describes.repeated('', {
         });
 
         it('should redirect on error and header is set', () => {
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchRejectPromise);
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(fetchRejectPromise);
           redirectToValue = 'https://example2.com/hello';
           const logSpy = sandbox.spy(user(), 'error');
           ampForm.handleSubmitAction_();
@@ -1582,7 +1582,7 @@ describes.repeated('', {
           ampForm.xhrAction_ = null;
           sandbox.stub(form, 'submit');
           sandbox.stub(form, 'checkValidity').returns(true);
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
           ampForm.handleSubmitAction_();
           expect(form.submit).to.have.been.called;
         });
@@ -1595,7 +1595,7 @@ describes.repeated('', {
           ampForm.xhrAction_ = null;
           sandbox.stub(form, 'submit');
           sandbox.stub(form, 'checkValidity').returns(true);
-          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
           const event = {
             stopImmediatePropagation: sandbox.spy(),
             target: form,
@@ -1627,7 +1627,7 @@ describes.repeated('', {
         ampForm.xhrAction_ = null;
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
         sandbox.stub(ampForm, 'analyticsEvent_');
         ampForm.handleSubmitAction_();
         const expectedFormData = {
@@ -1663,7 +1663,7 @@ describes.repeated('', {
         form.appendChild(canonicalUrlField);
         sandbox.stub(form, 'submit');
         sandbox.stub(form, 'checkValidity').returns(true);
-        sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+        sandbox.stub(ampForm.xhr_, 'fetchJson').returns(Promise.resolve());
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
         sandbox.stub(ampForm, 'analyticsEvent_');

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -195,9 +195,11 @@ export class Xhr {
    *
    * @param {string} input
    * @param {?FetchInitDef=} opt_init
+   * @param {boolean=} opt_skipProcessing Disables any processing of the
+   *     response, including asserting the response is 2XX.
    * @return {!Promise<!JSONType>}
    */
-  fetchJson(input, opt_init) {
+  fetchJson(input, opt_init, opt_skipProcessing) {
     const init = setupInit(opt_init, 'application/json');
     if (init.method == 'POST' && !isFormData(init.body)) {
       // Assume JSON strict mode where only objects or arrays are allowed
@@ -211,8 +213,8 @@ export class Xhr {
       init.headers['Content-Type'] = 'application/json;charset=utf-8';
       init.body = JSON.stringify(init.body);
     }
-    return this.fetch(input, init)
-        .then(response => response.json());
+    const fetch = this.fetch(input, init, opt_skipProcessing);
+    return opt_skipProcessing ? fetch : fetch.then(response => response.json());
   }
 
   /**
@@ -224,12 +226,14 @@ export class Xhr {
    *
    * @param {string} input
    * @param {?FetchInitDef=} opt_init
+   * @param {boolean=} opt_skipProcessing Disables any processing of the
+   *     response, including asserting the response is 2XX.
    * @return {!Promise<string>}
    */
-  fetchText(input, opt_init) {
+  fetchText(input, opt_init, opt_skipProcessing) {
     const init = setupInit(opt_init, 'text/plain');
-    return this.fetch(input, init)
-        .then(response => response.text());
+    const fetch = this.fetch(input, init, opt_skipProcessing);
+    return opt_skipProcessing ? fetch : fetch.then(response => response.text());
   }
 
   /**
@@ -238,24 +242,30 @@ export class Xhr {
    *
    * @param {string} input
    * @param {?FetchInitDef=} opt_init
+   * @param {boolean=} opt_skipProcessing Disables any processing of the
+   *     response, including asserting the response is 2XX.
    * @return {!Promise<!Document>}
    */
-  fetchDocument(input, opt_init) {
+  fetchDocument(input, opt_init, opt_skipProcessing) {
     const init = setupInit(opt_init, 'text/html');
     init.responseType = 'document';
-    return this.fetch(input, init)
-        .then(response => response.document_());
+    const fetch = this.fetch(input, init, opt_skipProcessing);
+    return opt_skipProcessing ? fetch : fetch.then(response => {
+      return response.document_();
+    });
   }
 
   /**
    * @param {string} input URL
    * @param {?FetchInitDef=} opt_init Fetch options object.
+   * @param {boolean=} opt_skipProcessing Disables any processing of the
+   *     response, including asserting the response is 2XX.
    * @return {!Promise<!FetchResponse>}
    */
-  fetch(input, opt_init) {
+  fetch(input, opt_init, opt_skipProcessing) {
     const init = setupInit(opt_init);
-    return this.fetchAmpCors_(input, init).then(response =>
-        assertSuccess(response));
+    const fetch = this.fetchAmpCors_(input, init);
+    return opt_skipProcessing ? fetch : fetch.then(assertSuccess);
   }
 
   /**
@@ -270,8 +280,7 @@ export class Xhr {
    * @return {!Promise}
    */
   sendSignal(input, opt_init) {
-    return this.fetchAmpCors_(input, opt_init)
-        .then(response => assertSuccess(response));
+    return this.fetchAmpCors_(input, opt_init).then(assertSuccess);
   }
 
   /**
@@ -425,7 +434,7 @@ function isRetriable(status) {
  * @return {!Promise<!FetchResponse>}
  * @private Visible for testing
  */
-export function assertSuccess(response) {
+export function assertSuccess(response, jsonDecode) {
   return new Promise((resolve, reject) => {
     const status = response.status;
     if (status < 200 || status >= 300) {
@@ -433,18 +442,6 @@ export function assertSuccess(response) {
       const err = new FetchError(
           user().createError(`HTTP error ${status}`), response, retriable);
       const contentType = response.headers.get('Content-Type') || '';
-      if (contentType.split(';')[0] == 'application/json') {
-        response.json().then(json => {
-          err.responseJson = json;
-          reject(err);
-        }, () => {
-          // Ignore a failed json parsing and just throw the error without
-          // setting responseJson.
-          reject(err);
-        });
-      } else {
-        reject(err);
-      }
     } else {
       resolve(response);
     }
@@ -467,6 +464,9 @@ export class FetchResponse {
 
     /** @type {number} */
     this.status = this.xhr_.status;
+
+    /** @const {boolean} */
+    this.ok = this.status >= 200 && this.status < 300;
 
     /** @const {!FetchResponseHeaders} */
     this.headers = new FetchResponseHeaders(xhr);

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -44,25 +44,6 @@ import {utf8EncodeSync} from '../utils/bytes';
  */
 export let FetchInitDef;
 
-/**
- * A custom error that encapsulates an XHR error message
- * with the corresponding response data.
- */
-export class FetchError {
-  /**
-   * @param {!Error} error
-   * @param {!FetchResponse} response
-   * @param {boolean=} opt_retriable
-   * @param {?JSONType=} opt_responseJson
-   */
-  constructor(error, response, opt_retriable, opt_responseJson) {
-    this.error = error;
-    this.response = response;
-    this.retriable = opt_retriable;
-    this.responseJson = opt_responseJson;
-  }
-}
-
 
 /** @private @const {!Array<string>} */
 const allowedMethods_ = ['GET', 'POST'];
@@ -434,16 +415,15 @@ function isRetriable(status) {
  * @return {!Promise<!FetchResponse>}
  * @private Visible for testing
  */
-export function assertSuccess(response, jsonDecode) {
-  return new Promise((resolve, reject) => {
-    const status = response.status;
-    if (status < 200 || status >= 300) {
-      const retriable = isRetriable(status);
-      const err = new FetchError(
-          user().createError(`HTTP error ${status}`), response, retriable);
-      const contentType = response.headers.get('Content-Type') || '';
-    } else {
+export function assertSuccess(response) {
+  return new Promise(resolve => {
+    if (response.ok) {
       resolve(response);
+    } else {
+      const status = response.status;
+      const err = user().createError(`HTTP error ${status}`);
+      err.retriable = isRetriable(status);
+      throw err;
     }
   });
 }


### PR DESCRIPTION
Allow XHR fetches to skip 2XX assertion and any additional processing (basically, just return me the damn response).

This gives the caller access to needed data (response headers, status, body) if they explicitly need it. For the average caller, nothing changes.

This also removes `FetchError`. There's no telling how that "error" instance will be passed around, and anything that doesn't have a `#message` and `#stack` is a danger to our error reporting process.

Fixes #8017.
Fixes #9501.
Closes #7140.
/cc @taymonbeal 