### PR TITLE
Clean up node-style done callbacks in mocha it tests

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1850,13 +1850,13 @@ describe('amp-a4a', () => {
         })();
         stubVerifySignature.returns(Promise.resolve(false));
         return a4a.verifyCreativeSignature_('some_creative', 'some_sig')
-          .then(() => {
-            throw new Error('should have triggered rejection');
-          })
-          .catch(err => {
-            expect(stubVerifySignature).to.be.callCount(20);
-            expect(err).to.equal('No validation service could verify this key');
-          });
+        .then(() => {
+          throw new Error('should have triggered rejection');
+        })
+        .catch(err => {
+          expect(stubVerifySignature).to.be.callCount(20);
+          expect(err).to.equal('No validation service could verify this key');
+        });
       });
 
       it('properly handles multiple keys for one provider', () => {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1878,7 +1878,7 @@ describe('amp-a4a', () => {
           });
       });
 
-      it('properly stops verification at first valid key', done => {
+      it('properly stops verification at first valid key', () => {
         // Single provider where first key fails, second passes, and third
         // never calls verifySignature.
         const serviceName = 'test-service';
@@ -1896,16 +1896,17 @@ describe('amp-a4a', () => {
         const signature = 'some_signature';
         stubVerifySignature.onCall(0).returns(Promise.resolve(false));
         stubVerifySignature.onCall(1).returns(Promise.resolve(true));
-        a4a.verifyCreativeSignature_(creative, signature)
-          .then(verifiedCreative => {
-            expect(stubVerifySignature).to.be.calledTwice;
-            expect(verifiedCreative).to.equal(creative);
-            done();
-          });
+
         // From testing have found that need to yield prior to calling last
         // key info resolver to ensure previous keys have had a chance to
         // execute.
         setTimeout(() => {keyInfoResolver({}); }, 0);
+
+        return a4a.verifyCreativeSignature_(creative, signature)
+          .then(verifiedCreative => {
+            expect(stubVerifySignature).to.be.calledTwice;
+            expect(verifiedCreative).to.equal(creative);
+          });
       });
     });
   });

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -96,7 +96,7 @@ describes.fakeWin('LaterpayVendor', {
       });
     });
 
-    it('authorization fails due to lack of server config', done => {
+    it('authorization fails due to lack of server config', () => {
       accessServiceMock.expects('buildUrl')
         .returns(Promise.resolve('https://builturl'))
         .once();
@@ -109,11 +109,10 @@ describes.fakeWin('LaterpayVendor', {
         .once();
       return vendor.authorize().catch(err => {
         expect(err.message).to.exist;
-        done();
       });
     });
 
-    it('authorization response from server fails', done => {
+    it('authorization response from server fails', () => {
       accessServiceMock.expects('buildUrl')
         .returns(Promise.resolve('https://builturl'))
         .once();
@@ -130,7 +129,6 @@ describes.fakeWin('LaterpayVendor', {
       emptyContainerStub.returns(Promise.resolve());
       return vendor.authorize().then(err => {
         expect(err.access).to.be.false;
-        done();
       });
     });
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -217,31 +217,33 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should trigger render-start on message "bootstrap-loaded" if' +
-       ' render-start is NOT implemented', done => {
+       ' render-start is NOT implemented', () => {
       initPromise = iframeHandler.init(iframe);
       iframe.postMessageToParent({
         sentinel: 'amp3ptest' + testIndex,
         type: 'bootstrap-loaded',
       });
       const renderStartPromise = signals.whenSignal('render-start');
-      renderStartPromise.then(() => {
+      return renderStartPromise.then(() => {
         expect(renderStartedSpy).to.be.calledOnce;
-        done();
       });
     });
 
-    it('should trigger visibility on timeout', done => {
+    it('should trigger visibility on timeout', () => {
       const clock = sandbox.useFakeTimers();
       iframe.name = 'test_master';
       initPromise = iframeHandler.init(iframe);
-      iframe.onload = () => {
-        clock.tick(10000);
-        initPromise.then(() => {
-          expect(iframe.style.visibility).to.equal('');
-          expect(renderStartedSpy).to.not.be.called;
-          done();
-        });
-      };
+      return new Promise(resolve => {
+        iframe.onload = () => {
+          clock.tick(10000);
+          initPromise.then(() => {
+            resolve();
+          });
+        };
+      }).then(() => {
+        expect(iframe.style.visibility).to.equal('');
+        expect(renderStartedSpy).to.not.be.called;
+      });
     });
 
     it('should be immediately visible if it is A4A', () => {

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -52,7 +52,7 @@ describe('amp-font', function() {
     });
   }
 
-  it('should timeout while loading custom font', function(done) {
+  it('should timeout while loading custom font', function() {
     sandbox.stub(FontLoader.prototype, 'load')
         .returns(Promise.reject('mock rejection'));
     return getAmpFontIframe().then(iframe => {
@@ -60,18 +60,16 @@ describe('amp-font', function() {
           .to.have.class('comic-amp-font-missing');
       expect(iframe.doc.body)
           .to.not.have.class('comic-amp-font-loading');
-      done();
     });
   });
 
-  it('should load custom font', function(done) {
+  it('should load custom font', function() {
     sandbox.stub(FontLoader.prototype, 'load').returns(Promise.resolve());
     return getAmpFontIframe().then(iframe => {
       expect(iframe.doc.documentElement)
           .to.have.class('comic-amp-font-loaded');
       expect(iframe.doc.body)
           .to.not.have.class('comic-amp-font-loading');
-      done();
     });
   });
 

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -53,7 +53,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       expect(impl.scrollUnlisten_).to.be.function;
     });
 
-    it('should not build when scrollTop less than viewportHeight', done => {
+    it('should not build when scrollTop less than viewportHeight', () => {
       const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
       const removeOnScrollListenerSpy =
           sandbox.spy(impl, 'removeOnScrollListener_');
@@ -74,11 +74,14 @@ describes.realWin('amp-sticky-ad 1.0 version', {
         return 300;
       };
       impl.onScroll_();
-      expect(getScrollTopSpy).to.have.been.called;
-      expect(getSizeSpy).to.have.been.called;
-      expect(scheduleLayoutSpy).to.not.have.been.called;
-      expect(removeOnScrollListenerSpy).to.not.have.been.called;
-      done();
+      return new Promise(resolve => {
+        setTimeout(resolve, 0);
+      }).then(() => {
+        expect(getScrollTopSpy).to.have.been.called;
+        expect(getSizeSpy).to.have.been.called;
+        expect(scheduleLayoutSpy).to.not.have.been.called;
+        expect(removeOnScrollListenerSpy).to.not.have.been.called;
+      });
     });
 
     it('should build on enough scroll dist, one more viewport ahead', () => {

--- a/test/functional/inabox/test-position-observer.js
+++ b/test/functional/inabox/test-position-observer.js
@@ -46,7 +46,7 @@ describes.realWin('inabox-host:position-observer', {}, env => {
     };
   });
 
-  it('observe should work', done => {
+  it('observe should work', () => {
     let position1 = {
       viewport: layoutRectLtwh(0, 0, 200, 300),
       target: layoutRectLtwh(1, 2, 30, 40),
@@ -66,19 +66,22 @@ describes.realWin('inabox-host:position-observer', {}, env => {
     expect(callbackSpy21).to.be.calledWith(position2);
 
     win.scrollTo(10, 20);
-    setTimeout(() => {
-      position1 = {
-        viewport: layoutRectLtwh(10, 20, 200, 300),
-        target: layoutRectLtwh(11, 22, 30, 40),
-      };
-      position2 = {
-        viewport: layoutRectLtwh(10, 20, 200, 300),
-        target: layoutRectLtwh(13, 24, 30, 40),
-      };
+    return new Promise(resolve => {
+      setTimeout(() => {
+        position1 = {
+          viewport: layoutRectLtwh(10, 20, 200, 300),
+          target: layoutRectLtwh(11, 22, 30, 40),
+        };
+        position2 = {
+          viewport: layoutRectLtwh(10, 20, 200, 300),
+          target: layoutRectLtwh(13, 24, 30, 40),
+        };
+        resolve();
+      }, 100);
+    }).then(() => {
       expect(callbackSpy11).to.be.calledWith(position1);
       expect(callbackSpy12).to.be.calledWith(position1);
       expect(callbackSpy21).to.be.calledWith(position2);
-      done();
-    }, 100);
+    });
   });
 });

--- a/test/functional/test-3p-nameframe.js
+++ b/test/functional/test-3p-nameframe.js
@@ -28,7 +28,8 @@ describes.sandboxed('alt nameframe', {}, () => {
       iframe.src = 'http://localhost:9876/dist.3p/current/nameframe.max.html';
     });
 
-    it('should load remote nameframe and succeed w/ valid JSON', done => {
+    it('should load remote nameframe and succeed w/ valid JSON', () => {
+      let messageContent;
       iframe.name = JSON.stringify({
         creative: `<html>
                    <body>
@@ -39,11 +40,15 @@ describes.sandboxed('alt nameframe', {}, () => {
                    </body>
                    </html>`,
       });
-      win.addEventListener('message', content => {
-        expect(content.data.type).to.equal('creative rendered');
-        done();
-      });
       doc.body.appendChild(iframe);
+      return new Promise(resolve => {
+        win.addEventListener('message', content => {
+          messageContent = content;
+          resolve();
+        });
+      }).then(() => {
+        expect(messageContent.data.type).to.equal('creative rendered');
+      });
     });
 
     it('should fail if JSON is not paresable', done => {

--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -74,7 +74,7 @@ describes.realWin('font-stylesheet-timeout', {
         'link[rel="stylesheet"]')).to.equal(link);
   });
 
-  it('should time out if doc is not interactive', done => {
+  it('should time out if doc is not interactive', () => {
     readyState = 'loading';
     const link = addLink();
     fontStylesheetTimeout(win);
@@ -89,9 +89,12 @@ describes.realWin('font-stylesheet-timeout', {
     expect(after).to.not.equal(link);
     expect(after.href).to.equal(link.href);
     expect(after.media).to.equal('not-matching');
-    after.addEventListener('load', () => {
+    return new Promise(resolve => {
+      after.addEventListener('load', () => {
+        resolve();
+      });
+    }).then(() => {
       expect(after.media).to.equal('all');
-      done();
     });
   });
 

--- a/test/functional/test-style-installer.js
+++ b/test/functional/test-style-installer.js
@@ -82,7 +82,7 @@ describe('Styles', () => {
       expect(ampdoc.signals().get('render-start')).to.be.null;
     });
 
-    it('should wait for render delaying services', done => {
+    it('should wait for render delaying services', () => {
       expect(getStyle(doc.body, 'opacity')).to.equal('');
       expect(getStyle(doc.body, 'visibility')).to.equal('');
       expect(getStyle(doc.body, 'animation')).to.equal('');
@@ -92,26 +92,28 @@ describe('Styles', () => {
           .returns(Promise.resolve(['service1', 'service2']));
       styles.makeBodyVisible(doc, true);
       styles.makeBodyVisible(doc, true); // 2nd call should make no difference
-      setTimeout(() => {
+      return new Promise(resolve => {
+        setTimeout(resolve, 0);
+      }).then(() => {
         expect(getStyle(doc.body, 'opacity')).to.equal('1');
         expect(getStyle(doc.body, 'visibility')).to.equal('visible');
         expect(getStyle(doc.body, 'animation')).to.equal('none');
         expect(tickSpy.withArgs('mbv')).to.be.calledOnce;
         expect(schedulePassSpy.withArgs(1, true)).to.be.calledOnce;
         expect(ampdoc.signals().get('render-start')).to.be.ok;
-        done();
-      }, 0);
+      });
     });
 
-    it('should skip schedulePass if no render delaying services', done => {
+    it('should skip schedulePass if no render delaying services', () => {
       waitForServicesStub.withArgs(win).returns(Promise.resolve([]));
       styles.makeBodyVisible(doc, true);
-      setTimeout(() => {
+      return new Promise(resolve => {
+        setTimeout(resolve, 0);
+      }).then(() => {
         expect(tickSpy.withArgs('mbv')).to.be.calledOnce;
         expect(schedulePassSpy).to.not.be.calledWith(sinon.match.number, true);
         expect(ampdoc.signals().get('render-start')).to.be.ok;
-        done();
-      }, 0);
+      });
     });
   });
 

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -144,29 +144,27 @@ describes.fakeWin('Timer', {}, env => {
     });
   });
 
-  it('poll - resolves only when condition is true', done => {
+  it('poll - resolves only when condition is true', () => {
     const realTimer = new Timer(env.win);
     let predicate = false;
-    realTimer.poll(10, () => {
-      return predicate;
-    }).then(() => {
-      expect(predicate).to.be.true;
-      done();
-    });
     setTimeout(() => {
       predicate = true;
     }, 15);
+    return realTimer.poll(10, () => {
+      return predicate;
+    }).then(() => {
+      expect(predicate).to.be.true;
+    });
   });
 
-  it('poll - clears out interval when complete', done => {
+  it('poll - clears out interval when complete', () => {
     const realTimer = new Timer(env.win);
     const clearIntervalStub = sandbox.stub();
     env.win.clearInterval = clearIntervalStub;
-    realTimer.poll(111, () => {
+    return realTimer.poll(111, () => {
       return true;
     }).then(() => {
       expect(clearIntervalStub).to.have.been.calledOnce;
-      done();
     });
   });
 


### PR DESCRIPTION
This PR does a clean up of the antipattern where node-style done() follows an expect() in a mocha it test. All changes were verified by adding a failing assertion (expect(1).equals(2)) at the end and making sure it appears in the logs as the cause of the error.

Fixes #8966 