### PR TITLE
Remove timer calls to prevent future flakiness

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -471,7 +471,7 @@ export class AmpForm {
    * Transition the form to the submit success state.
    * @param {!../../../src/service/xhr-impl.FetchResponse} response
    * @return {!Promise}
-   * @private
+   * @private visible for testing
    */
   handleXhrSubmitSuccess_(response) {
     return response.json().then(json => {

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1239,9 +1239,9 @@ describes.repeated('', {
       const form = getForm();
       document.body.appendChild(form);
       const actions = actionServiceForDoc(form.ownerDocument);
-      const ampForm = new AmpForm(form);
 
       sandbox.stub(actions, 'installActionHandler');
+      const ampForm = new AmpForm(form);
       const {promise, stub} = stubWithCalledPromise(
           sandbox, ampForm.xhr_, 'fetch');
       stub.returns(Promise.resolve());

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -45,9 +45,15 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
   return sandbox.stub(service, method);
 }
 
-export function whenCalled(stub, opt_callCount = 1) {
-  return poll(`Stub was called ${opt_callCount} times`,
-      () => stub.callCount === opt_callCount);
+/**
+ * Resolves a promise when a spy has been called a configurable number of times.
+ * @param {!Object} spy
+ * @param {number=} opt_callCount
+ * @return {!Promise}
+ */
+export function whenCalled(spy, opt_callCount = 1) {
+  return poll(`Spy was called ${opt_callCount} times`,
+      () => spy.callCount === opt_callCount);
 }
 
 /**

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {poll} from './iframe';
 import {xhrServiceForTesting} from '../src/service/xhr-impl';
 import {
   getService,
@@ -44,25 +45,9 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
   return sandbox.stub(service, method);
 }
 
-/**
- * Resolves a promise when the method stub is called for the first time.
- */
-export function stubWithCalledPromise(sandbox, object, method, opt_callMethod) {
-  const original = object[method];
-  let stub;
-  const promise = new Promise(resolve => {
-    stub = sandbox.stub();
-    const spy = sandbox.stub(object, method, () => {
-      const result = stub.apply(object, spy.lastCall.args);
-      if (opt_callMethod) {
-        original.apply(object, spy.lastCall.args);
-      }
-
-      resolve({value: result});
-      return result;
-    });
-  });
-  return {stub, promise};
+export function whenCalled(stub, opt_callCount = 1) {
+  return poll(`Stub was called ${opt_callCount} times`,
+      () => stub.callCount === opt_callCount);
 }
 
 /**

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -45,6 +45,27 @@ export function stubServiceForDoc(sandbox, ampdoc, serviceId, method) {
 }
 
 /**
+ * Resolves a promise when the method stub is called for the first time.
+ */
+export function stubWithCalledPromise(sandbox, object, method, opt_callMethod) {
+  const original = object[method];
+  let stub;
+  const promise = new Promise(resolve => {
+    stub = sandbox.stub();
+    const spy = sandbox.stub(object, method, () => {
+      const result = stub.apply(object, spy.lastCall.args);
+      if (opt_callMethod) {
+        original.apply(object, spy.lastCall.args);
+      }
+
+      resolve({value: result});
+      return result;
+    });
+  });
+  return {stub, promise};
+}
+
+/**
  * Asserts that the given element is only visible to screen readers.
  * @param {!Element} node
  */


### PR DESCRIPTION
No issue tracks this, I'm just trying to find a good way to simplify asynchronous tests without using `timer`. Hopefully if this is a good approach we can replace other usages of `timer` outside of `amp-form`'s tests.

`stubWithCalledPromise` looks kind of weird because `sandbox.stub` returns a `stub` instance when given two arguments, but strangely returns a `spy` instance when passed a third callback argument. This prevents us from using the stub api e.g. `stub.returns(Promise.resolve())` to adjust the behavior of the stub. `stubWithCalledPromise` allows us to use the three argument invocation to resolve the promise while still returning a `stub` instance.