### PR TITLE
Implement first paint and first contentful paint metrics based on new standard

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -76,6 +76,10 @@ window.vg;
 // IntersectionObserverEntry, but appears to have been omitted.
 IntersectionObserverEntry.prototype.rootBounds;
 
+// TODO (remove after we update closure compiler externs)
+window.PerformancePaintTiming;
+window.PerformanceObserver;
+
 // Externed explicitly because this private property is read across
 // binaries.
 Element.implementation_ = {};

--- a/extensions/amp-viewer-integration/TICKEVENTS.md
+++ b/extensions/amp-viewer-integration/TICKEVENTS.md
@@ -33,3 +33,4 @@ As an example if we executed `perf.tick('label')` we assume we have a counterpar
 | Make Body Visible | `mbv` | Make Body Visible Executes. |
 | On First Visible | `ofv` | The first time the page has been turned visible. |
 | First paint time | `fp` | The time on the first non-blank paint of the page. |
+| First contentful paint time | `fcp` | First paint with content. See https://github.com/WICG/paint-timing |

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -192,7 +192,6 @@ export class Performance {
         else if (entry.name == 'first-contentful-paint') {
           this.tickDelta('fcp', entry.startTime + entry.duration);
         }
-        console.info(entry);
       });
     });
 


### PR DESCRIPTION
Details are here https://github.com/WICG/paint-timing

This is currently in Chrome behind a flag. The legacy mechanism (only covering first-paint, not first-contentful-paint) is left intact until this reaches Chrome stable.

CC @spanicker @honeybadgerdontcare 