### PR TITLE
PWA: API for shadow dom streaming

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -220,6 +220,7 @@ function compile(entryModuleFilenames, outputDir,
       'build-system/amp.extern.js',
       'third_party/closure-compiler/externs/intersection_observer.js',
       'third_party/closure-compiler/externs/shadow_dom.js',
+      'third_party/closure-compiler/externs/streams.js',
       'third_party/closure-compiler/externs/web_animations.js',
     ];
     if (options.externs) {

--- a/examples/pwa/pwa.js
+++ b/examples/pwa/pwa.js
@@ -27,10 +27,12 @@ function startsWith(string, prefix) {
 }
 
 class Shell {
-
-  constructor(win) {
+  constructor(win, useStreaming) {
     /** @private @const {!Window} */
     this.win = win;
+
+    /** @private @const {boolean} */
+    this.useStreaming_ = useStreaming;
 
     /** @private @const {!AmpViewer} */
     this.ampViewer_ = new AmpViewer(win,
@@ -149,8 +151,15 @@ class Shell {
     }
 
     // Fetch.
-    const url = this.resolveUrl_(path);
+    const url = this.resolveUrl_(path) + '?stream=1000';
     log('Fetch and render doc:', path, url);
+    // TODO(dvoytenko, #9490): Make `streamDocument` the only used API once
+    // streaming is graduated out of experimental.
+    if (this.useStreaming_) {
+      log('Streaming started: ', url);
+      return this.ampViewer_.showAsStream(url).then(
+          shadowDoc => streamDocument(url, shadowDoc.writer));
+    }
     return fetchDocument(url).then(doc => {
       log('Fetch complete: ', doc);
       this.ampViewer_.show(doc, url);
@@ -239,6 +248,37 @@ class AmpViewer {
   }
 
   /**
+   * @param {string} url
+   * @return {!Promise<!ShadowDoc>}
+   */
+  showAsStream(url) {
+    log('Show stream document:', url);
+
+    // Cleanup the existing document if any.
+    this.clear();
+
+    this.baseUrl_ = url;
+
+    this.host_ = this.win.document.createElement('div');
+    this.host_.classList.add('amp-doc-host');
+
+    const hostTemplate = this.win.document.getElementById('amp-slot-template');
+    if (hostTemplate) {
+      this.host_.appendChild(hostTemplate.content.cloneNode(true));
+    }
+
+    this.container.appendChild(this.host_);
+
+    return this.ampReadyPromise_.then(AMP => {
+      this.amp_ = AMP.attachShadowDocAsStream(this.host_, url, {});
+      this.win.document.title = this.amp_.title || '';
+      this.amp_.onMessage(this.onMessage_.bind(this));
+      this.amp_.setVisibilityState('visible');
+      return this.amp_;
+    });
+  }
+
+  /**
    * @param {string} src
    * @param {string=} customElement
    * @param {string=} customTemplate
@@ -276,7 +316,6 @@ class AmpViewer {
   /**
    */
   onMessage_(type, data, rsvp) {
-    log('received message:', type, data, rsvp);
   }
 }
 
@@ -329,6 +368,75 @@ function fetchDocument(url) {
 
 
 /**
+ * @param {string} url
+ * @param {!WritableStreamDefaultWriter} writer
+ * @return {!Promise}
+ */
+function streamDocument(url, writer) {
+  // Try native first.
+  if (window.fetch && window.TextDecoder && window.ReadableStream) {
+    return fetch(url).then(response => {
+      // This should be a lot simpler with transforming streams and pipes,
+      // but, TMK, these are not supported anywhere yet.
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      function readChunk() {
+        return reader.read().then(chunk => {
+          const text = decoder.decode(
+              chunk.value || new Uint8Array(),
+              {stream: !chunk.done});
+          if (text) {
+            writer.write(text);
+          }
+          if (chunk.done) {
+            writer.close();
+          } else {
+            return readChunk();
+          }
+        });
+      }
+      return readChunk();
+    });
+  }
+
+  // Polyfill via XHR.
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.setRequestHeader('Accept', 'text/html');
+    let pos = 0;
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState < /* STATUS_RECEIVED */ 2) {
+        return;
+      }
+      if (xhr.status < 100 || xhr.status > 599) {
+        xhr.onreadystatechange = null;
+        reject(new Error(`Unknown HTTP status ${xhr.status}`));
+        return;
+      }
+      if (xhr.readyState == /* COMPLETE */ 3 ||
+          xhr.readyState == /* COMPLETE */ 4) {
+        const s = xhr.responseText;
+        const chunk = s.substring(pos);
+        pos = s.length;
+        writer.write(chunk);
+        if (xhr.readyState == /* COMPLETE */ 4) {
+          writer.close().then(resolve);
+        }
+      }
+    };
+    xhr.onerror = () => {
+      reject(new Error('Network failure'));
+    };
+    xhr.onabort = () => {
+      reject(new Error('Request aborted'));
+    };
+    xhr.send();
+  });
+}
+
+
+/**
  * Parses the query string of an URL. This method returns a simple key/value
  * map. If there are duplicate keys the latest value is returned.
  * @param {string} queryString
@@ -363,4 +471,4 @@ function parseQueryString(queryString) {
 }
 
 
-var shell = new Shell(window);
+var shell = new Shell(window, /* useStreaming */ true);

--- a/examples/pwa/pwa.js
+++ b/examples/pwa/pwa.js
@@ -151,7 +151,7 @@ class Shell {
     }
 
     // Fetch.
-    const url = this.resolveUrl_(path) + '?stream=1000';
+    const url = this.resolveUrl_(path);
     log('Fetch and render doc:', path, url);
     // TODO(dvoytenko, #9490): Make `streamDocument` the only used API once
     // streaming is graduated out of experimental.

--- a/spec/amp-shadow-doc.md
+++ b/spec/amp-shadow-doc.md
@@ -1,0 +1,104 @@
+<!---
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# AMP Shadow Doc API
+
+## Overview
+
+AMP can be used in a shadow-doc mode where a single web page can open many AMP
+documents. This is especially useful for shell-style PWA documents.
+
+## Using shadow doc API
+
+The special runtime should be used in place of `v0.js`. It can be declared in the
+shell page as following:
+
+```html
+<script async src="https://cdn.ampproject.org/shadow-v0.js"></script>
+
+<!-- Wait for API to initialize -->
+<script>
+(window.AMP = window.AMP || []).push(function(AMP) {
+  // AMP APIs can be used now via "AMP" object.
+});
+</script>
+```
+
+## API
+
+### Fetching and attaching shadow docs
+
+There are currently two ways how one can attach a shadow doc: using a `Document` object, loaded, for instance, via XHR. Or using an experimental streaming API. Once streaming API graduates from experimental, the non-streaming API will be deprecated.
+
+Using the fully loaded `Document` object:
+```javascript
+fetchDocumentViaXhr(url).then(fetchedDoc => {
+  const shadowDoc = AMP.attachShadowDoc(hostElement, fetchedDoc, url, options);
+});
+```
+
+Using the streaming API:
+```javascript
+const shadowDoc = AMP.attachShadowDocAsStream(hostElement, url, options);
+fetch(url).then(response => {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  function readChunk() {
+    return reader.read().then(chunk => {
+      const text = decoder.decode(
+          chunk.value || new Uint8Array(),
+          {stream: !chunk.done});
+      if (text) {
+        shadowDoc.writer.write(text);
+      }
+      if (chunk.done) {
+        shadowDoc.writer.close();
+      } else {
+        return readChunk();
+      }
+    });
+  }
+  return readChunk();
+});
+```
+
+Notice, that XHR and Fetch API are only some of the sources of documents. Other sources could include local storage and other. AMP APIs assume a basic HTML streaming. The details of raw HTTP streaming are outside of AMP APIs, but examples below provide additional information and prototypes.
+
+#### Visibility state (`visibilityState`)
+The `options` argument is optional and can provide configuration parameters for AMP document. The most relevant of these options is `visibilityState`. By default it takes the value of "visible", but can be configured to "prerender" mode instead. Prerender mode can be used for minimal prerendering of the element. In this mode most of features are disabled, including analytics and ads. The mode can be later changed to "visibile" via `shadowDoc.setVisibilityState()` function.
+
+
+### Shadow-doc API
+
+Both `AMP.attachShadowDoc` and `AMP.attachShadowDocAsStream` return a `ShadowDoc` object that provides numerous ways for interracting with attached AMP documents. This object exposes the following methods and properties:
+
+- `shadowDoc.writer` - the writer that can be used to stream the AMP document. Only available for `attachShadowDocAsStream`.
+- `shadowDoc.url` - the URL used in the `attachShadowDoc` or `attachShadowDocAsStream`.
+- `shadowDoc.title` - the title of the AMP document.
+- `shadowDoc.canonicalUrl` - the canonical URL of the AMP document.
+- `shadowDoc.ampdoc` - the instance of the AMP document.
+- `shadowDoc.ampdoc.whenReady()` - returns a promise when the AMP document has been fully rendered.
+- `shadowDoc.setVisibilityState()` - changes the visibility state of the AMP document.
+- `shadowDoc.postMessage()` and `shadowDoc.onMessage()` - can be used to message with the AMP document.
+- `shadowDoc.close()` - closes the AMP document and frees the resources.
+
+
+## Examples and references
+
+See [pwa.js](../examples/pwa/pwa.js) for examples of uses of boths APIs.
+
+See [Combine AMP with PWA](https://www.ampproject.org/docs/guides/pwa-amp) and [Embed & use AMP as a data source](https://www.ampproject.org/docs/guides/pwa-amp/amp-in-pwa) guides.
+

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -781,7 +781,7 @@ class MultidocManager {
             // Append shallow body.
             const body = importShadowBody(
                 shadowRoot,
-                /** @type {!Element} */ (doc.body),
+                dev().assertElement(doc.body),
                 /* deep */ false);
             body.classList.add('amp-shadow');
             shadowRoot.appendChild(body);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -17,6 +17,12 @@
 import {BaseElement} from './base-element';
 import {BaseTemplate, registerExtendedTemplate} from './service/template-impl';
 import {CommonSignals} from './common-signals';
+import {
+  ShadowDomWriter,
+  createShadowRoot,
+  importShadowBody,
+  installStylesForShadowRoot,
+} from './shadow-embed';
 import {VisibilityState} from './visibility-state';
 import {
   addDocFactoryToExtension,
@@ -39,11 +45,6 @@ import {
   registerServiceBuilderForDoc,
 } from './service';
 import {childElementsByTag} from './dom';
-import {
-  createShadowRoot,
-  importShadowBody,
-  installStylesForShadowRoot,
-} from './shadow-embed';
 import {getMode} from './mode';
 import {
   hasRenderDelayingServices,
@@ -428,7 +429,7 @@ export function adoptShadowMode(global) {
         timerFor(global));
 
     /**
-     * Registers a shadow root document.
+     * Registers a shadow root document via a fully fetched document.
      * @param {!Element} hostElement
      * @param {!Document} doc
      * @param {string} url
@@ -436,6 +437,16 @@ export function adoptShadowMode(global) {
      * @return {!Object}
      */
     global.AMP.attachShadowDoc = manager.attachShadowDoc.bind(manager);
+
+    /**
+     * Registers a shadow root document via a stream.
+     * @param {!Element} hostElement
+     * @param {string} url
+     * @param {!Object<string, string>=} opt_initParams
+     * @return {!Object}
+     */
+    global.AMP.attachShadowDocAsStream =
+        manager.attachShadowDocAsStream.bind(manager);
   });
 }
 
@@ -591,16 +602,15 @@ class MultidocManager {
   }
 
   /**
-   * Implementation for `attachShadowDoc` function. Attaches the shadow doc and
-   * configures ampdoc for it.
+   * Attaches the shadow root and calls the supplied DOM builder.
    * @param {!Element} hostElement
-   * @param {!Document} doc
    * @param {string} url
-   * @param {!Object<string, string>=} opt_initParams
+   * @param {!Object<string, string>|undefined} initParams
+   * @param {function(!Object, !ShadowRoot, !./service/ampdoc-impl.AmpDocShadow):!Promise} builder
    * @return {!Object}
+   * @private
    */
-  attachShadowDoc(hostElement, doc, url, opt_initParams) {
-    dev().fine(TAG, 'Attach shadow doc:', doc);
+  attachShadowDoc_(hostElement, url, initParams, builder) {
     this.purgeShadowRoots_();
 
     setStyle(hostElement, 'visibility', 'hidden');
@@ -626,7 +636,7 @@ class MultidocManager {
         /* opt_isRuntimeCss */ true);
 
     // Instal doc services.
-    installAmpdocServices(ampdoc, opt_initParams || Object.create(null));
+    installAmpdocServices(ampdoc, initParams || Object.create(null));
     const viewer = viewerForDoc(ampdoc);
 
     /**
@@ -684,30 +694,13 @@ class MultidocManager {
       amp.resources = resourcesForDoc(ampdoc);
     }
 
-    // Install extensions.
-    const extensionIds = this.mergeShadowHead_(shadowRoot, doc);
-
-    // Apply all doc extensions.
-    installExtensionsInShadowDoc(this.extensions_, ampdoc, extensionIds);
-
-    // Append body.
-    if (doc.body) {
-      const body = importShadowBody(shadowRoot, doc.body);
-      body.classList.add('amp-shadow');
-      shadowRoot.appendChild(body);
-      shadowDocHasBody(ampdoc, body);
-    }
-
-    // Document is ready.
-    shadowDocReady(ampdoc);
-
-    // TODO(dvoytenko): find a better and more stable way to make content visible.
-    // E.g. integrate with dynamic classes. In shadow case specifically, we have
-    // to wait for stubbing to complete, which may take awhile due to importNode.
-    setTimeout(() => {
+    // Start building the shadow doc DOM.
+    builder(amp, shadowRoot, ampdoc).then(() => {
+      // Document is ready.
+      shadowDocReady(ampdoc);
       ampdoc.signals().signal(CommonSignals.RENDER_START);
       setStyle(hostElement, 'visibility', 'visible');
-    }, 50);
+    });
 
     // Store reference.
     if (!this.shadowRoots_.includes(shadowRoot)) {
@@ -716,6 +709,105 @@ class MultidocManager {
 
     dev().fine(TAG, 'Shadow root initialization is done:', shadowRoot, ampdoc);
     return amp;
+  }
+
+
+  /**
+   * Implementation for `attachShadowDoc` function. Attaches the shadow doc and
+   * configures ampdoc for it.
+   * @param {!Element} hostElement
+   * @param {!Document} doc
+   * @param {string} url
+   * @param {!Object<string, string>=} opt_initParams
+   * @return {!Object}
+   */
+  attachShadowDoc(hostElement, doc, url, opt_initParams) {
+    dev().fine(TAG, 'Attach shadow doc:', doc);
+    // TODO(dvoytenko, #9490): once stable, port full document case to emulated
+    // stream.
+    return this.attachShadowDoc_(
+        hostElement, url, opt_initParams,
+        (amp, shadowRoot, ampdoc) => {
+          // Install extensions.
+          const extensionIds = this.mergeShadowHead_(shadowRoot, doc);
+          installExtensionsInShadowDoc(this.extensions_, ampdoc, extensionIds);
+
+          // Append body.
+          if (doc.body) {
+            const body = importShadowBody(
+                shadowRoot, doc.body, /* deep */ true);
+            body.classList.add('amp-shadow');
+            shadowRoot.appendChild(body);
+            shadowDocHasBody(ampdoc, body);
+          }
+
+          // TODO(dvoytenko): find a better and more stable way to make content
+          // visible. E.g. integrate with dynamic classes. In shadow case
+          // specifically, we have to wait for stubbing to complete, which may
+          // take awhile due to importNode.
+          setTimeout(() => {
+            ampdoc.signals().signal(CommonSignals.RENDER_START);
+            setStyle(hostElement, 'visibility', 'visible');
+          }, 50);
+
+          return Promise.resolve();
+        });
+  }
+
+  /**
+   * Implementation for `attachShadowDocAsStream` function. Attaches the shadow
+   * doc and configures ampdoc for it.
+   * @param {!Element} hostElement
+   * @param {string} url
+   * @param {!Object<string, string>=} opt_initParams
+   * @return {!Object}
+   */
+  attachShadowDocAsStream(hostElement, url, opt_initParams) {
+    dev().fine(TAG, 'Attach shadow doc as stream');
+    return this.attachShadowDoc_(
+        hostElement, url, opt_initParams,
+        (amp, shadowRoot, ampdoc) => {
+          // Start streaming.
+          let renderStarted = false;
+          const writer = new ShadowDomWriter(this.win);
+          amp.writer = writer;
+          writer.onBody(doc => {
+            // Install extensions.
+            const extensionIds = this.mergeShadowHead_(shadowRoot, doc);
+            // Apply all doc extensions.
+            installExtensionsInShadowDoc(
+                this.extensions_, ampdoc, extensionIds);
+
+            // Append shallow body.
+            const body = importShadowBody(
+                shadowRoot,
+                /** @type {!Element} */ (doc.body),
+                /* deep */ false);
+            body.classList.add('amp-shadow');
+            shadowRoot.appendChild(body);
+            shadowDocHasBody(ampdoc, body);
+            return body;
+          });
+          writer.onBodyChunk(() => {
+            // TODO(dvoytenko): find a better and more stable way to make
+            // content visible. E.g. integrate with dynamic classes. In shadow
+            // case specifically, we have to wait for stubbing to complete,
+            // which may take awhile due to node importing.
+            if (!renderStarted) {
+              renderStarted = true;
+              setTimeout(() => {
+                ampdoc.signals().signal(CommonSignals.RENDER_START);
+                setStyle(hostElement, 'visibility', 'visible');
+              }, 50);
+            }
+          });
+          return new Promise(resolve => {
+            writer.onEnd(() => {
+              resolve();
+              amp.writer = null;
+            });
+          });
+        });
   }
 
   /**

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -20,12 +20,13 @@ import {dev} from './log';
 import {closestNode, escapeCssSelectorIdent} from './dom';
 import {extensionsFor} from './services';
 import {insertStyleElement} from './style-installer';
-import {setStyle} from './style';
 import {
   isShadowDomSupported,
   getShadowDomSupportedVersion,
   ShadowDomVersion,
 } from './web-components';
+import {setStyle} from './style';
+import {vsyncFor} from './services';
 
 /**
  * Used for non-composed root-node search. See `getRootNode`.
@@ -163,19 +164,26 @@ export function createShadowEmbedRoot(hostElement, extensionIds) {
  * Imports a body into a shadow root with the workaround for a polyfill case.
  * @param {!ShadowRoot} shadowRoot
  * @param {!Element} body
+ * @param {boolean} deep
  * @return {!Element}
  */
-export function importShadowBody(shadowRoot, body) {
+export function importShadowBody(shadowRoot, body, deep) {
   const doc = shadowRoot.ownerDocument;
   let resultBody;
   if (isShadowDomSupported()) {
-    resultBody = dev().assertElement(doc.importNode(body, true));
+    resultBody = dev().assertElement(doc.importNode(body, deep));
   } else {
     resultBody = doc.createElement('amp-body');
-    for (let n = body.firstChild; !!n; n = n.nextSibling) {
-      resultBody.appendChild(doc.importNode(n, true));
-    }
     setStyle(resultBody, 'display', 'block');
+    for (let i = 0; i < body.attributes.length; i++) {
+      resultBody.setAttribute(
+          body.attributes[0].name, body.attributes[0].value);
+    }
+    if (deep) {
+      for (let n = body.firstChild; !!n; n = n.nextSibling) {
+        resultBody.appendChild(doc.importNode(n, true));
+      }
+    }
   }
   setStyle(resultBody, 'position', 'relative');
   shadowRoot.appendChild(resultBody);
@@ -331,6 +339,145 @@ function getStylesheetRules(doc, css) {
   } finally {
     if (style.parentNode) {
       style.parentNode.removeChild(style);
+    }
+  }
+}
+
+
+/**
+ * Takes as an input a text stream, parses it and incrementally reconstructs
+ * it in the shadow root.
+ *
+ * See https://jakearchibald.com/2016/fun-hacks-faster-content/ for more
+ * details.
+ *
+ * @implements {WritableStreamDefaultWriter}
+ */
+export class ShadowDomWriter {
+  /**
+   * @param {!Window} win
+   */
+  constructor(win) {
+    /** @const @private {!Document} */
+    this.parser_ = win.document.implementation.createHTMLDocument('');
+    this.parser_.open();
+
+    /** @const @private */
+    this.vsync_ = vsyncFor(win);
+
+    /** @private @const */
+    this.boundMerge_ = this.merge_.bind(this);
+
+    /** @private {?function(!Document):!Element} */
+    this.onBody_ = null;
+
+    /** @private {?function()} */
+    this.onBodyChunk_ = null;
+
+    /** @private {?function()} */
+    this.onEnd_ = null;
+
+    /** @private {boolean} */
+    this.mergeScheduled_ = false;
+
+    /** @const @private {!Promise} */
+    this.success_ = Promise.resolve();
+
+    /** @private {boolean} */
+    this.eof_ = false;
+
+    /** @private {?Element} */
+    this.targetBody_ = null;
+  }
+
+  /**
+   * Sets the callback that will be called when body has been parsed.
+   *
+   * Unlike most of other nodes, `<body>` cannot be simply merged to support
+   * SD polyfill where the use of `<body>` element is not possible. The
+   * callback will be given the parsed document and it must return back
+   * the reconstructed `<body>` node in the target DOM where all children
+   * will be streamed into.
+   *
+   * @param {function(!Document):!Element} callback
+   */
+  onBody(callback) {
+    this.onBody_ = callback;
+  }
+
+  /**
+   * Sets the callback that will be called when new nodes have been merged
+   * into the target DOM.
+   * @param {function()} callback
+   */
+  onBodyChunk(callback) {
+    this.onBodyChunk_ = callback;
+  }
+
+  /**
+   * Sets the callback that will be called when the DOM has been fully
+   * constructed.
+   * @param {function()} callback
+   */
+  onEnd(callback) {
+    this.onEnd_ = callback;
+  }
+
+  /** @override */
+  write(chunk) {
+    if (this.eof_) {
+      throw new Error('closed already');
+    }
+    if (chunk) {
+      this.parser_.write(/** @type {string} */ (chunk));
+    }
+    this.schedule_();
+    return this.success_;
+  }
+
+  /** @override */
+  close() {
+    this.parser_.close();
+    this.eof_ = true;
+    this.schedule_();
+    return this.success_;
+  }
+
+  /** @private */
+  schedule_() {
+    dev().assert(this.onBody_ && this.onBodyChunk_ && this.onEnd_);
+    if (!this.mergeScheduled_) {
+      this.mergeScheduled_ = true;
+      this.vsync_.mutate(this.boundMerge_);
+    }
+  }
+
+  /** @private */
+  merge_() {
+    this.mergeScheduled_ = false;
+
+    // Body has been newly parsed.
+    if (!this.targetBody_ && this.parser_.body) {
+      this.targetBody_ = this.onBody_(this.parser_);
+    }
+
+    // Merge body children.
+    if (this.targetBody_) {
+      const inputBody = dev().assert(this.parser_.body);
+      const targetBody = dev().assert(this.targetBody_);
+      let transferCount = 0;
+      while (inputBody.firstChild) {
+        transferCount++;
+        targetBody.appendChild(inputBody.firstChild);
+      }
+      if (transferCount > 0) {
+        this.onBodyChunk_();
+      }
+    }
+
+    // EOF.
+    if (this.eof_) {
+      this.onEnd_();
     }
   }
 }

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -472,6 +472,7 @@ describes.fakeWin('runtime', {
       expect(win.AMP.viewport).to.be.a('object');
       // Single-doc mode does not create `attachShadowDoc`.
       expect(win.AMP.attachShadowDoc).to.not.exist;
+      expect(win.AMP.attachShadowDocAsStream).to.not.exist;
     });
 
     it('should register element without CSS', () => {
@@ -622,6 +623,7 @@ describes.fakeWin('runtime', {
       expect(win.AMP.win).to.equal(win);
 
       expect(win.AMP.attachShadowDoc).to.be.a('function');
+      expect(win.AMP.attachShadowDocAsStream).to.be.a('function');
 
       expect(win.AMP.viewer).to.not.exist;
       expect(win.AMP.viewport).to.not.exist;
@@ -1046,6 +1048,351 @@ describes.realWin('runtime multidoc', {
       amp.close();
       expect(viewer.getVisibilityState()).to.equal('inactive');
       expect(viewer.dispose).to.be.calledOnce;
+    });
+  });
+
+
+  describe.only('attachShadowDocAsStream', () => {
+    const docUrl = 'https://example.org/doc1';
+
+    let hostElement;
+    let ampdoc;
+    let shadowDoc;
+    let writer;
+
+    beforeEach(() => {
+      deactivateChunking();
+      hostElement = win.document.createElement('div');
+      const shadowRoot = shadowembed.createShadowRoot(hostElement);
+      ampdoc = new AmpDocShadow(win, docUrl, shadowRoot);
+
+      ampdocServiceMock.expects('installShadowDoc_')
+          .withExactArgs(
+              docUrl,
+              sinon.match(arg => arg == getShadowRoot(hostElement)))
+          .returns(ampdoc)
+          .atLeast(0);
+      ampdocServiceMock.expects('getAmpDoc')
+          .withExactArgs(sinon.match(arg => arg == getShadowRoot(hostElement)))
+          .returns(ampdoc)
+          .atLeast(0);
+    });
+
+    it('should install services and styles', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+
+      const shadowRoot = getShadowRoot(hostElement);
+
+      // URL is set.
+      expect(shadowRoot.AMP.url).to.equal(docUrl);
+
+      // Stylesheet has been installed.
+      expect(shadowRoot.querySelector('style[amp-runtime]')).to.exist;
+
+      // Doc services have been installed.
+      expect(ampdoc.services.action).to.exist;
+      expect(ampdoc.services.action.obj).to.exist;
+      expect(ampdoc.services.viewer).to.exist;
+      expect(ampdoc.services.viewer.obj).to.exist;
+
+      // Single-doc bidings have been installed.
+      expect(shadowDoc.ampdoc).to.equal(ampdoc);
+      expect(shadowDoc.viewer).to.not.exist;
+    });
+
+    it('should install doc services', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+
+      class Service1 {}
+      win.AMP.push({
+        n: 'amp-ext',
+        f: amp => {
+          amp.registerServiceForDoc('service1', Service1);
+        },
+      });
+
+      writer.write('<script custom-element="amp-ext" src=""></script>');
+      writer.write('<body>');
+
+      return ampdoc.whenBodyAvailable().then(() => {
+        return extensions.waitForExtension('amp-ext').then(() => {
+          // Factories have been applied.
+          expect(getServiceForDoc(ampdoc, 'service1'))
+              .to.be.instanceOf(Service1);
+        });
+      });
+    });
+
+    it('should pass init parameters to viewer', () => {
+      win.AMP.attachShadowDocAsStream(hostElement, docUrl, {
+        'test1': '12',
+      });
+      const viewer = getServiceForDoc(ampdoc, 'viewer');
+      expect(viewer.getParam('test1')).to.equal('12');
+    });
+
+    it('should update host visibility', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+
+      writer.write('<body><div>');
+
+      // Document is invisible at first.
+      expect(hostElement.style.visibility).to.equal('hidden');
+
+      return ampdoc.whenBodyAvailable().then(() => {
+        // After timeout the doc rendered is started.
+        expect(hostElement.style.visibility).to.equal('hidden');
+        return ampdoc.signals().whenSignal('render-start');
+      }).then(() => {
+        expect(hostElement.style.visibility).to.equal('visible');
+      });
+    });
+
+    it('should import body', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write('<body><child>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        const shadowRoot = getShadowRoot(hostElement);
+        const body = shadowRoot.querySelector('body') ||
+            shadowRoot.querySelector('amp-body');
+        expect(body).to.exist;
+        expect(body).to.have.class('amp-shadow');
+        expect(body.style.position).to.equal('relative');
+        env.flushVsync();
+        expect(body.querySelector('child')).to.exist;
+        expect(ampdoc.getBody()).to.exist;
+      });
+    });
+
+    it('should mark doc as ready', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write('<body><child>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        expect(ampdoc.isReady()).to.be.false;
+        writer.write('</child></body>');
+        writer.write('</html>');
+        writer.close();
+        return ampdoc.whenReady().then(() => {
+          expect(ampdoc.isReady()).to.be.true;
+        });
+      });
+    });
+
+    it('should read title element', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write('<title>test title</title><body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        expect(shadowDoc.title).to.equal('test title');
+        expect(getShadowRoot(hostElement).AMP.title).to.equal('test title');
+      });
+    });
+
+    it('should read canonical element', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write(
+          '<link rel="canonical" href="http://example.org/canonical"><body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        expect(shadowDoc.canonicalUrl).to.equal('http://example.org/canonical');
+      });
+    });
+
+    it('should import fonts', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+
+      writer.write(
+          '<link rel="stylesheet" href="http://example.org/font1"><body>');
+      writer.write(
+          '<link rel="stylesheet" href="http://example.org/font2"><body>');
+      const fontEl2 = win.document.createElement('link');
+      fontEl2.setAttribute('rel', 'stylesheet');
+      fontEl2.setAttribute('href', 'http://example.org/font2');
+      win.document.head.appendChild(fontEl2);
+
+      return ampdoc.whenBodyAvailable().then(() => {
+        expect(win.document.querySelector(
+            'link[href="http://example.org/font1"]')).to.exist;
+        // Duplicates are ignored.
+        expect(win.document.querySelectorAll(
+            'link[href="http://example.org/font2"]')).to.have.length(1);
+
+        const fontEl = win.document.querySelector(
+            'link[href="http://example.org/font1"]');
+        expect(fontEl.getAttribute('type')).to.equal('text/css');
+        expect(fontEl.getAttribute('rel')).to.equal('stylesheet');
+        fontEl.parentElement.removeChild(fontEl);
+      });
+    });
+
+    it('should ignore boilerplate style', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write('<style amp-boilerplate></style><body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        const shadowRoot = getShadowRoot(hostElement);
+        expect(shadowRoot.querySelector('style[amp-boilerplate]')).to.not.exist;
+      });
+    });
+
+    it('should import custom style', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write('<style amp-custom>.custom{}</style><body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        const shadowRoot = getShadowRoot(hostElement);
+        expect(shadowRoot.querySelector('style[amp-custom]')).to.exist;
+        expect(shadowRoot.querySelector('style[amp-custom]').textContent)
+            .to.contain('.custom');
+      });
+    });
+
+    it('should ignore runtime extension', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      extensionsMock.expects('loadExtension').never();
+      writer.write(
+          '<script src="https://cdn.ampproject.org/v0.js"></script>');
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable();
+    });
+
+    it('should ignore unknown script', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      extensionsMock.expects('loadExtension').never();
+      writer.write(
+          '<script data-id="unknown1"' +
+          ' src="https://cdn.ampproject.org/other.js"></script>');
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        expect(getShadowRoot(hostElement)
+            .querySelector('script[data-id="unknown1"]')).to.not.exist;
+        expect(win.document.querySelector('script[data-id="unknown1"]'))
+            .to.not.exist;
+      });
+    });
+
+    it('should import extension element', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      extensionsMock.expects('loadExtension')
+          .withExactArgs('amp-ext1')
+          .returns(Promise.resolve({
+            elements: {
+              'amp-ext1': function() {},
+            },
+          }))
+          .once();
+      writer.write(
+          '<script custom-element="amp-ext1" src=""></script>');
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        expect(win.document.querySelector('script[custom-element="amp-ext1"]'))
+            .to.not.exist;
+      });
+    });
+
+    it('should import extension template', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      extensionsMock.expects('loadExtension')
+          .withExactArgs('amp-ext1')
+          .returns(Promise.resolve({elements: {}}))
+          .once();
+      writer.write(
+          '<script custom-template="amp-ext1" src=""></script>');
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        expect(win.document.querySelector('script[custom-template="amp-ext1"]'))
+            .to.not.exist;
+      });
+    });
+
+    it('should import inline script', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write(
+          '<script type="application/json" data-id="test1">{}</script>');
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        expect(getShadowRoot(hostElement)
+            .querySelector('script[data-id="test1"]')).to.exist;
+        expect(getShadowRoot(hostElement).querySelector(
+            'script[data-id="test1"]').textContent).to.equal('{}');
+      });
+    });
+
+    it('should ignore inline script if javascript', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write(
+          '<script type="application/javascript" data-id="test1"></script>');
+      writer.write(
+          '<script data-id="test1"></script>');
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable(() => {
+        expect(getShadowRoot(hostElement)
+            .querySelector('script[data-id="test1"]')).to.not.exist;
+      });
+    });
+
+    it('should start as visible by default', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        const viewer = getServiceForDoc(ampdoc, 'viewer');
+        expect(viewer.getVisibilityState()).to.equal('visible');
+      });
+    });
+
+    it('should start as prerender when requested', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl, {
+        'visibilityState': 'prerender',
+      });
+      writer = shadowDoc.writer;
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        const viewer = getServiceForDoc(ampdoc, 'viewer');
+        expect(viewer.getVisibilityState()).to.equal('prerender');
+      });
+    });
+
+    it('should expose visibility method', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        const viewer = getServiceForDoc(ampdoc, 'viewer');
+        expect(shadowDoc.setVisibilityState).to.be.function;
+        expect(viewer.getVisibilityState()).to.equal('visible');
+
+        shadowDoc.setVisibilityState('inactive');
+        expect(viewer.getVisibilityState()).to.equal('inactive');
+      });
+    });
+
+    it('should expose close method and dispose services', () => {
+      shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
+      writer = shadowDoc.writer;
+      writer.write('<body>');
+      return ampdoc.whenBodyAvailable().then(() => {
+        const viewer = getServiceForDoc(ampdoc, 'viewer');
+        expect(shadowDoc.close).to.be.function;
+        expect(viewer.getVisibilityState()).to.equal('visible');
+
+        viewer.dispose = sandbox.spy();
+        shadowDoc.close();
+        expect(viewer.getVisibilityState()).to.equal('inactive');
+        expect(viewer.dispose).to.be.calledOnce;
+      });
     });
   });
 

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -1052,7 +1052,7 @@ describes.realWin('runtime multidoc', {
   });
 
 
-  describe.only('attachShadowDocAsStream', () => {
+  describe('attachShadowDocAsStream', () => {
     const docUrl = 'https://example.org/doc1';
 
     let hostElement;

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -15,8 +15,8 @@
  */
 
 import {AmpDocShadow} from '../../src/service/ampdoc-impl';
-import {ampdocServiceFor} from '../../src/ampdoc';
 import {
+  ShadowDomWriter,
   copyRuntimeStylesToShadowRoot,
   createShadowEmbedRoot,
   createShadowRoot,
@@ -26,6 +26,7 @@ import {
   isShadowRoot,
   scopeShadowCss,
 } from '../../src/shadow-embed';
+import {ampdocServiceFor} from '../../src/ampdoc';
 import {
   setShadowDomSupportedVersionForTesting,
   ShadowDomVersion,
@@ -34,16 +35,9 @@ import {extensionsFor} from '../../src/services';
 import * as sinon from 'sinon';
 
 
-describe('shadow-embed', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-  });
-
+describes.sandboxed('shadow-embed', {}, () => {
   afterEach(() => {
     setShadowDomSupportedVersionForTesting(undefined);
-    sandbox.restore();
   });
 
   it('should copy runtime styles from ampdoc', () => {
@@ -135,18 +129,22 @@ describe('shadow-embed', () => {
           });
 
           describe('importShadowBody', () => {
-            it('should import body with all children', () => {
-              const shadowRoot = createShadowRoot(hostElement);
-              const source = document.createElement('body');
-              const child1 = document.createElement('div');
+            let shadowRoot, source, child1, child2;
+
+            beforeEach(() => {
+              shadowRoot = createShadowRoot(hostElement);
+              source = document.createElement('body');
+              child1 = document.createElement('div');
               child1.id = 'child1';
-              const child2 = document.createElement('div');
+              child2 = document.createElement('div');
               child2.id = 'child2';
               source.appendChild(child1);
               source.appendChild(child2);
-              expect(shadowRoot.body).to.be.undefined;
+            });
 
-              const body = importShadowBody(shadowRoot, source);
+            it('should import body with all children', () => {
+              expect(shadowRoot.body).to.be.undefined;
+              const body = importShadowBody(shadowRoot, source, true);
               expect(shadowRoot.body).to.equal(body);
               expect(body.tagName).to.equal(
                   scenario == ShadowDomVersion.NONE ? 'AMP-BODY' : 'BODY');
@@ -158,6 +156,20 @@ describe('shadow-embed', () => {
               expect(body.children).to.have.length(2);
               expect(body.children[0].id).to.equal('child1');
               expect(body.children[1].id).to.equal('child2');
+            });
+
+            it('should import shallow body', () => {
+              expect(shadowRoot.body).to.be.undefined;
+              const body = importShadowBody(shadowRoot, source, false);
+              expect(shadowRoot.body).to.equal(body);
+              expect(body.tagName).to.equal(
+                  scenario == ShadowDomVersion.NONE ? 'AMP-BODY' : 'BODY');
+              expect(body.style.position).to.equal('relative');
+              if (scenario == ShadowDomVersion.NONE) {
+                expect(body.style.display).to.equal('block');
+              }
+              expect(shadowRoot.contains(body)).to.be.true;
+              expect(body.children).to.have.length(0);
             });
           });
         });
@@ -317,6 +329,98 @@ describe('shadow-embed', () => {
       expect(scope('body-x {}')).to.equal('#h body-x {}');
       expect(scope('body_x {}')).to.equal('#h body_x {}');
       expect(scope('body1 {}')).to.equal('#h body1 {}');
+    });
+  });
+
+  describes.fakeWin('ShadowDomWriter', {amp: true}, env => {
+    let win;
+    let writer;
+    let onBodySpy, onBodyChunkSpy;
+    let onBodyPromise, onBodyChunkPromiseResolver, onEndPromise;
+
+    beforeEach(() => {
+      win = env.win;
+      writer = new ShadowDomWriter(win);
+      onBodySpy = sandbox.spy();
+      onBodyChunkSpy = sandbox.spy();
+      onBodyPromise = new Promise(resolve => {
+        writer.onBody(parsedDoc => {
+          resolve(parsedDoc.body);
+          onBodySpy();
+          return win.document.body;
+        });
+      });
+      writer.onBodyChunk(() => {
+        if (onBodyChunkPromiseResolver) {
+          onBodyChunkPromiseResolver();
+          onBodyChunkPromiseResolver = null;
+        }
+        onBodyChunkSpy();
+      });
+      onEndPromise = new Promise(resolve => {
+        writer.onEnd(resolve);
+      });
+    });
+
+    function waitForNextBodyChunk() {
+      return new Promise(resolve => {
+        onBodyChunkPromiseResolver = resolve;
+      });
+    }
+
+    it('should complete when writer has been closed', () => {
+      writer.close();
+      return onEndPromise.then(() => {
+        expect(onBodySpy).to.be.calledOnce;
+        env.flushVsync();
+        expect(onBodyChunkSpy).to.not.be.called;
+      });
+    });
+
+    it('should resolve body as soon as available', () => {
+      writer.write('<body class="b">');
+      expect(onBodySpy).to.not.be.called;
+      return onBodyPromise.then(body => {
+        expect(body.getAttribute('class')).to.equal('b');
+        expect(onBodySpy).to.be.calledOnce;
+      });
+    });
+
+    it('should schedule body chunk', () => {
+      writer.write('<body>');
+      return onBodyPromise.then(() => {
+        expect(onBodySpy).to.be.calledOnce;
+        writer.write('<child>');
+        expect(onBodyChunkSpy).to.not.be.called;
+        return waitForNextBodyChunk().then(() => {
+          env.flushVsync();
+          expect(onBodySpy).to.be.calledOnce;
+          expect(onBodyChunkSpy).to.be.calledOnce;
+          expect(win.document.body.querySelector('child')).to.exist;
+
+          writer.write('</child><child2>');
+          return waitForNextBodyChunk().then(() => {
+            env.flushVsync();
+            expect(win.document.body.querySelector('child2')).to.exist;
+          });
+        });
+      });
+    });
+
+    it('should schedule several body chunks together', () => {
+      writer.write('<body>');
+      return onBodyPromise.then(() => {
+        expect(onBodySpy).to.be.calledOnce;
+        writer.write('<child></child>');
+        expect(onBodyChunkSpy).to.not.be.called;
+        const promise = waitForNextBodyChunk();
+        writer.write('<child2></child2>');
+        return promise.then(() => {
+          expect(onBodyChunkSpy).to.be.calledOnce;
+          expect(win.document.body.querySelector('child')).to.exist;
+          expect(win.document.body.querySelector('child2')).to.exist;
+        });
+      });
     });
   });
 });

--- a/third_party/closure-compiler/externs/streams.js
+++ b/third_party/closure-compiler/externs/streams.js
@@ -1,0 +1,38 @@
+// TODO(dvoytenko): Remove once Closure adds this extern.
+
+/*
+ * Copyright 2017 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * See https://streams.spec.whatwg.org/#default-writer-class
+ * @interface
+ */
+class WritableStreamDefaultWriter {
+
+  /**
+   * See https://streams.spec.whatwg.org/#default-writer-write
+   * @param {*} chunk
+   * @return {!Promise}
+   */
+  write(chunk) {}
+
+  /**
+   * See https://streams.spec.whatwg.org/#default-writer-close
+   * @return {!Promise}
+   */
+  close() {}
+}


### PR DESCRIPTION
This PR supersedes #9428. It creates an API for shadow doc streaming via the StreamWriter interface. It's still marked as experimental until I fully measure impact. At that point, the old codepath will be re-implemented via the streaming API.

In the end, the set of changes is very modest, but lots of tests.

Closes #9491.
Related to #9490.

/cc @bjalford