### PR TITLE
Make local "gulp test" 100% green by changing the test timeout for local and travis runs

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -156,6 +156,7 @@ module.exports = {
   client: {
     mocha: {
       reporter: 'html',
+      // Allow tests to run for up to 5 seconds locally and on Travis.
       timeout: 5000,
     },
     captureConsole: false,

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -156,8 +156,7 @@ module.exports = {
   client: {
     mocha: {
       reporter: 'html',
-      // Longer timeout on Travis; fail quickly at local.
-      timeout: process.env.TRAVIS ? 10000 : 2000,
+      timeout: 5000,
     },
     captureConsole: false,
   },

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -157,6 +157,8 @@ module.exports = {
     mocha: {
       reporter: 'html',
       // Allow tests to run for up to 5 seconds locally and on Travis.
+      // TODO(rsimha-amp): Reduce local run timeout to 2s after large tests are
+      // removed from unit_tests. See #9404.
       timeout: 5000,
     },
     captureConsole: false,


### PR DESCRIPTION
Doing a local gulp test run of all mocha tests results in a bunch of timeout failures that do not repro on Travis because the test timeout for local runs is 2s while the timeout on Travis is 10s. This is bad for a few reasons:

- Local runs end up being flaky, so engineers do not trust them, and are reluctant to run gulp test before pushing their PRs
- Travis runs will pass tests even if they take an order of magnitude more time than they should (e.g. hypothetical unit test that takes 9s to pass)
- The bind tests are a specific case of tests that routinely time out with a 2s limit. They are fairly involved and include network calls, and so have a genuine reason to routinely take longer than 2s to run.

This PR unifies the time limit for Travis and Local gulp test runs to a 5 second limit. I tested this out locally by running all tests ("gulp test") multiple times over, and was able to see a 100% pass rate. All tests ran on my workstation in under 3 minutes.

Fixes #9472 
#9404 