### PR TITLE
Changing the amp-auto-ads ad height to 250px

### DIFF
--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -30,7 +30,7 @@ const TAG = 'amp-auto-ads';
  * TODO: Specify this via the configuration.
  * @const
  */
-const TARGET_AD_HEIGHT_PX = 100;
+const TARGET_AD_HEIGHT_PX = 250;
 
 /**
  * @enum {number}

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -547,7 +547,7 @@ describes.realWin('placement', {
       return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
-                anchor.firstChild, 100, undefined);
+                anchor.firstChild, 250, undefined);
             expect(placementState).to.equal(PlacementState.PLACED);
           });
     });
@@ -587,7 +587,7 @@ describes.realWin('placement', {
       return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
-                anchor.firstChild, 100, undefined);
+                anchor.firstChild, 250, undefined);
             expect(placementState).to.equal(PlacementState.RESIZE_FAILED);
           });
     });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "prepend-v0": "gulp prepend-global --prod node_modules/AMP_CONFIG.json --local --target dist/v0.js && gulp prepend-global --prod node_modules/AMP_CONFIG.json --local --target dist.3p/current-min/f.js"
   },
   "dependencies": {
+    "chalk": "^1.1.3",
     "document-register-element": "1.1.1",
+    "glob": "^7.1.2",
     "promise-pjs": "1.1.2",
     "web-animations-js": "2.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "prepend-v0": "gulp prepend-global --prod node_modules/AMP_CONFIG.json --local --target dist/v0.js && gulp prepend-global --prod node_modules/AMP_CONFIG.json --local --target dist.3p/current-min/f.js"
   },
   "dependencies": {
-    "chalk": "^1.1.3",
     "document-register-element": "1.1.1",
-    "glob": "^7.1.2",
     "promise-pjs": "1.1.2",
     "web-animations-js": "2.2.2"
   },


### PR DESCRIPTION
Changing the amp-auto-ads ad height from 100px to 250px. This is an interim solution until proper responsive sizing logic is available.