### PR TITLE
Link to the Great First Issue label instead of milestones

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ If you are new to contributing to an open source project, Git/GitHub, etc. welco
 
 The [Getting Started End-to-End Guide](contributing/getting-started-e2e.md) provides step-by-step instructions for everything from creating a GitHub account to getting your code reviewed and merged.  Even if you've never contributed to an open source project before you'll soon be building AMP, making improvements and seeing your code live across the web.
 
-The community has created a list of [Great First Issues](https://github.com/ampproject/amphtml/milestone/25) specifically for new contributors to the project.  Feel free to find one that interests you and jump in!  Make sure to comment on the issue first so others know you are starting on it.
+The community has created a list of [Great First Issues](https://github.com/ampproject/amphtml/labels/Great%20First%20Issue) specifically for new contributors to the project.  Feel free to find one that interests you and jump in!  Make sure to comment on the issue first so others know you are starting on it.
 
 If you run into any problems we have plenty of people who are willing to help; see the [How to get help](contributing/getting-started-e2e.md#how-to-get-help) section of the Getting Started guide.
 

--- a/contributing/creating-great-first-issues.md
+++ b/contributing/creating-great-first-issues.md
@@ -2,7 +2,7 @@
 
 The AMP Project welcomes new contributors and we want to make it as easy as possible for them to contribute.  For many new contributors (who may not have open source/Git/AMP/etc. experience) it can be difficult to figure out how to get started.
 
-To help these new contributors get oriented we curate [Great First Issues](https://github.com/ampproject/amphtml/milestone/25).  A Great First Issue is a starter issue that a new contributor can use to get comfortable contributing to the AMP Project.
+To help these new contributors get oriented we curate [Great First Issues](https://github.com/ampproject/amphtml/labels/Great%20First%20Issue).  A Great First Issue is a starter issue that a new contributor can use to get comfortable contributing to the AMP Project.
 
 We depend on experienced members of the community to identify bugs/features that would provide this orientation and to then create a well-documented Great First Issue for them.
 
@@ -20,5 +20,5 @@ Keep these qualities in mind when creating your Great First Issues:
 ## How to create a Great First Issue
 
 * When you identify an issue that would make a Great First Issue, create a new issue using the [Great First Issues Template](great-first-issues-template.md) (inspired by Hoodie's [template](https://github.com/hoodiehq/camp/blob/gh-pages/ISSUE_TEMPLATE.md)).  Copy the [raw markdown](https://raw.githubusercontent.com/ampproject/amphtml/master/contributing/great-first-issues-template.md) into your issue and follow the guidance in the comments.
-* Add the issue to the [Great First Issues milestone](https://github.com/ampproject/amphtml/milestone/25).
+* Add the [Great First Issue label](https://github.com/ampproject/amphtml/labels/Great%20First%20Issue) and add the issue to the [Great First Issues milestone](https://github.com/ampproject/amphtml/milestone/25).  (The redundancy is intentional.  Most other open source projects use a label for tracking these types of issues, so we do too... but we also ensure every bug is triaged to the right milestone.)
 * If you come across a good candidate for a Great First Issue but are momentarily unable to spend the time filling out the template add the [GFI Candidate](https://github.com/ampproject/amphtml/labels/GFI%20Candidate) label to the issue.  The time spent converting GFI Candidates to Great First Issues will pay off for the AMP Project so please remember to come back to issues you labeled as a GFI Candidate.

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -47,7 +47,7 @@ If you're already familiar with Git/GitHub/etc. or you just want to know what co
 
 If you have a question or are unsure about something while following this end-to-end guide, you can get help from the AMP Project community in many ways:
 
-* If you are tackling a [Great First Issue](https://github.com/ampproject/amphtml/milestone/25) or other GitHub issue you can ask a question as a comment on the issue directly.  This works particularly well if the question is about how to make progress on that specific issue.
+* If you are tackling a [Great First Issue](https://github.com/ampproject/amphtml/labels/Great%20First%20Issue) or other GitHub issue you can ask a question as a comment on the issue directly.  This works particularly well if the question is about how to make progress on that specific issue.
 
 * The [#welcome-contributors](https://amphtml.slack.com/messages/welcome-contributors/) channel on Slack is a place for new contributors getting up to speed in the AMP Project to find help.  You should feel comfortable asking any question in there no matter how basic it may seem to you (e.g. problems getting Git set up, errors during a build, etc.).  If you haven't already signed up for our Slack, you'll need to [request an invitation](https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877).
 


### PR DESCRIPTION
As we start to publicize our GFIs more, I've found that sites that publicize/aggregate "Great First Issue" style issues prefer using labels to track these instead of milestones.

I've added the label and switched our documentation to prefer the label form; the milestone will remain so the GFIs can be marked as triaged but we will advertise the label instead of the milestone going forward.

/cc @adelinamart 