### PR TITLE
Restore test timeouts for local and travis runs

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -156,10 +156,8 @@ module.exports = {
   client: {
     mocha: {
       reporter: 'html',
-      // Allow tests to run for up to 5 seconds locally and on Travis.
-      // TODO(rsimha-amp): Reduce local run timeout to 2s after large tests are
-      // removed from unit_tests. See #9404.
-      timeout: 5000,
+      // Longer timeout on Travis; fail quickly at local.
+      timeout: process.env.TRAVIS ? 10000 : 2000,
     },
     captureConsole: false,
   },


### PR DESCRIPTION
Now that bind tests have moved to integration/ with #9477, we can restore the Travis / Local timeouts.

#9404 