### PR TITLE
Filter bad first-paint values.

### DIFF
--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -31,7 +31,6 @@ describes.realWin('performance', {amp: true}, env => {
   let clock;
   let win;
   let ampdoc;
-  let hasLoadTimes;
 
   beforeEach(() => {
     win = env.win;
@@ -40,7 +39,6 @@ describes.realWin('performance', {amp: true}, env => {
     clock = lolex.install(win, 0, ['Date', 'setTimeout', 'clearTimeout']);
     installPerformanceService(env.win);
     perf = performanceFor(env.win);
-    hasLoadTimes = window.chrome && window.chrome.loadTimes;
   });
 
   describe('when viewer is not ready', () => {
@@ -260,7 +258,7 @@ describes.realWin('performance', {amp: true}, env => {
         return perf.coreServicesAvailable().then(() => {
           expect(flushSpy).to.have.callCount(3);
           expect(perf.isMessagingReady_).to.be.false;
-          const count = hasLoadTimes ? 5 : 4;
+          const count = 4;
           expect(perf.events_.length).to.equal(count);
         });
       });
@@ -566,16 +564,16 @@ describes.realWin('performance', {amp: true}, env => {
          'to be visible before before first viewport completion', () => {
         clock.tick(100);
         whenFirstVisibleResolve();
-        expect(tickSpy).to.have.callCount(hasLoadTimes ? 3 : 2);
+        expect(tickSpy).to.have.callCount(2);
         return viewer.whenFirstVisible().then(() => {
           clock.tick(400);
-          expect(tickSpy).to.have.callCount(hasLoadTimes ? 4 : 3);
+          expect(tickSpy).to.have.callCount(3);
           whenViewportLayoutCompleteResolve();
           return perf.whenViewportLayoutComplete_().then(() => {
-            expect(tickSpy).to.have.callCount(hasLoadTimes ? 4 : 3);
+            expect(tickSpy).to.have.callCount(3);
             expect(tickSpy.withArgs('ofv')).to.be.calledOnce;
             return whenFirstVisiblePromise.then(() => {
-              expect(tickSpy).to.have.callCount(hasLoadTimes ? 5 : 4);
+              expect(tickSpy).to.have.callCount(4);
               expect(tickSpy.withArgs('pc')).to.be.calledOnce;
               expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(400);
             });


### PR DESCRIPTION
Chrome sometimes reports 1 or 0, but those values are never realistic, so lets throw them away.

PR does some light refactoring for readability.