### PR TITLE
update minimum version of node from 4.0.0 to 6.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Fastish HTML",
   "main": "index.js",
   "engines": {
-    "node": "^4.0.0"
+    "node": "^6.10.3"
   },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
According http://node.green/ node has good support of ES6 since 6.10.3LTS (except the ES6 modules :-().

Updating the minimum version of node allows us to use ES6 features to simplify our gulp and server code.