### PR TITLE
Allow all z-index to be overridable

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -321,7 +321,7 @@ i-amphtml-sizer {
   left: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
-  z-index: 1 !important;
+  z-index: 1;
 }
 
 .i-amphtml-notbuilt > [placeholder] {

--- a/extensions/amp-app-banner/0.1/amp-app-banner.css
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.css
@@ -22,7 +22,7 @@ amp-app-banner {
   max-height: 100px !important;
   box-sizing: border-box;
   background: #fff;
-  z-index: 13 !important;
+  z-index: 13;
   box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2) !important;
 }
 
@@ -34,7 +34,7 @@ i-amphtml-app-banner-top-padding {
   background: #fff;
   height: 4px;
   /** Must be above the dismiss button to cover bottom shadow */
-  z-index: 15 !important;
+  z-index: 15;
 }
 
 .amp-app-banner-dismiss-button {
@@ -48,7 +48,7 @@ i-amphtml-app-banner-top-padding {
   background-position: 9px center;
   background-color: #fff;
   background-repeat: no-repeat;
-  z-index: 14 !important;
+  z-index: 14;
   box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2);
   border: none;
   border-top-left-radius: 12px;

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
@@ -18,7 +18,6 @@
 /* Non-overridable properties */
 amp-image-lightbox {
   position: fixed !important;
-  z-index: 1000 !important;
   top: 0 !important;
   left: 0 !important;
   bottom: 0 !important;
@@ -34,6 +33,7 @@ amp-image-lightbox {
 
 /* Overridable properties */
 amp-image-lightbox {
+  z-index: 1000;
   background: rgba(0, 0, 0, 0.95);
   color: #f2f2f2;
 }
@@ -66,7 +66,7 @@ amp-image-lightbox {
 
 .i-amphtml-image-lightbox-caption {
   position: absolute !important;
-  z-index: 2 !important;
+  z-index: 2;
   bottom: 0 !important;
   left: 0 !important;
   right: 0 !important;

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -20,7 +20,7 @@
   left: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
-  z-index: 2147483642 !important;
+  z-index: 2147483642;
 }
 
 .i-amphtml-lbv-mask,

--- a/extensions/amp-lightbox/0.1/amp-lightbox.css
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.css
@@ -16,7 +16,7 @@
 amp-lightbox {
     display: none;
     position: fixed !important;
-    z-index: 1000 !important;
+    z-index: 1000;
     top: 0 !important;
     left: 0 !important;
     bottom: 0 !important;

--- a/extensions/amp-live-list/0.1/amp-live-list.css
+++ b/extensions/amp-live-list/0.1/amp-live-list.css
@@ -19,7 +19,7 @@ amp-live-list {
 
 amp-live-list > [update] {
   position: relative;
-  z-index: 1000 !important;
+  z-index: 1000;
 }
 
 /* Reset the `display: none` set in amp.css */

--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -25,7 +25,7 @@ amp-sidebar {
   outline: none;
   overflow-x: hidden !important;
   overflow-y: auto !important;
-  z-index: 2147483647 !important;
+  z-index: 2147483647;
   -webkit-overflow-scrolling: touch;
   will-change: transform;
 }
@@ -59,5 +59,5 @@ amp-sidebar[side] {
   /* Prevent someone from making this a full-sceen image */
   background-image: none !important;
   background-color: #000;
-  z-index: 2147483646 !important;
+  z-index: 2147483646;
 }

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
@@ -20,7 +20,7 @@ amp-sticky-ad {
   bottom: 0 !important;
   left: 0;
   width: 100% !important;
-  z-index: 11 !important;
+  z-index: 11;
   max-height: 100px !important;
   box-sizing: border-box;
   opacity: 1 !important;
@@ -37,7 +37,7 @@ amp-sticky-ad-top-padding {
   height: 4px;
   max-height: 5px !important;
   /** Must be above the dismiss button to cover bottom shadow */
-  z-index: 12 !important;
+  z-index: 12;
 }
 
 .i-amphtml-sticky-ad-layout {


### PR DESCRIPTION
Fixes #9487 

`!important` for `z-index` is pretty useless since z-index is relative to the stacking context and can be overridden anyway by putting the element in a relatively positioned parent with a different z-index anyway.

/to @lannka 
/cc @camelburrito 