### PR TITLE
amp-bind: Fix embedding in FIF

### DIFF
--- a/extensions/amp-bind/0.1/amp-bind.js
+++ b/extensions/amp-bind/0.1/amp-bind.js
@@ -17,5 +17,10 @@
 import {AmpState} from './amp-state';
 import {Bind} from './bind-impl';
 
-AMP.registerServiceForDoc('bind', Bind);
-AMP.registerElement('amp-state', AmpState);
+/** @const {string} */
+const TAG = 'amp-bind';
+
+AMP.extension(TAG, '0.1', function(AMP) {
+  AMP.registerServiceForDoc('bind', Bind);
+  AMP.registerElement('amp-state', AmpState);
+});

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -20,7 +20,7 @@ import {viewerForDoc} from '../../../../src/services';
 describes.realWin('AmpState', {
   amp: {
     runtimeOn: true,
-    extensions: ['amp-state:0.1'],
+    extensions: ['amp-bind:0.1'],
   },
 }, env => {
   let ampState;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -219,7 +219,11 @@ export function copyElementToChildWindow(parentWin, childWin, name) {
  */
 export function upgradeElementInChildWindow(parentWin, childWin, name) {
   const toClass = getExtendedElements(parentWin)[name];
-  dev().assert(toClass, '%s is not stubbed yet', name);
+  // Some extensions unofficially register unstubbed elements, e.g. amp-bind.
+  // Can be changed to assert() once official support (#9143) is implemented.
+  if (!toClass) {
+    dev().warn(TAG_, '%s is not stubbed yet', name);
+  }
   dev().assert(toClass != ElementStub, '%s is not upgraded yet', name);
   upgradeOrRegisterElement(childWin, name, toClass);
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -27,6 +27,7 @@ import {VisibilityState} from './visibility-state';
 import {
   addDocFactoryToExtension,
   addElementToExtension,
+  addServiceToExtension,
   addShadowRootFactoryToExtension,
   installBuiltinElements,
   installExtensionsInShadowDoc,
@@ -530,6 +531,8 @@ function prepareAndRegisterServiceForDoc(global, extensions,
   const ampdocService = ampdocServiceFor(global);
   const ampdoc = ampdocService.getAmpDoc();
   registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory);
+
+  addServiceToExtension(extensions, name);
 }
 
 
@@ -548,6 +551,8 @@ function prepareAndRegisterServiceForDocShadowMode(global, extensions,
   addDocFactoryToExtension(extensions, ampdoc => {
     registerServiceForDoc(ampdoc, name, opt_ctor, opt_factory);
   }, name);
+
+  addServiceToExtension(extensions, name);
 }
 
 

--- a/src/service.js
+++ b/src/service.js
@@ -601,7 +601,8 @@ export function isEmbeddable(service) {
  */
 export function adoptServiceForEmbed(embedWin, serviceId) {
   const adopted = adoptServiceForEmbedIfEmbeddable(embedWin, serviceId);
-  dev().assert(adopted, `${serviceId} does not implement EmbeddableService.`);
+  dev().assert(adopted,
+      `${serviceId} required to implement EmbeddableService.`);
 }
 
 

--- a/src/service.js
+++ b/src/service.js
@@ -594,15 +594,14 @@ export function isEmbeddable(service) {
 
 
 /**
- * Asserts that the specified service implements `EmbeddableService` interface
- * and typecasts the instance to `EmbeddableService`.
- * @param {!Object} service
- * @return {!EmbeddableService}
+ * Adopts an embeddable (implements `EmbeddableService` interface) service
+ * in embed scope.
+ * @param {!Window} embedWin
+ * @param {string} serviceId
  */
-export function assertEmbeddable(service) {
-  dev().assert(isEmbeddable(service),
-      'required to implement EmbeddableService');
-  return /** @type {!EmbeddableService} */ (service);
+export function adoptServiceForEmbed(embedWin, serviceId) {
+  const adopted = adoptServiceForEmbedIfEmbeddable(embedWin, serviceId);
+  dev().assert(adopted, `${serviceId} does not implement EmbeddableService.`);
 }
 
 
@@ -611,13 +610,18 @@ export function assertEmbeddable(service) {
  * in embed scope.
  * @param {!Window} embedWin
  * @param {string} serviceId
+ * @return {boolean}
  */
-export function adoptServiceForEmbed(embedWin, serviceId) {
+export function adoptServiceForEmbedIfEmbeddable(embedWin, serviceId) {
   const frameElement = /** @type {!Node} */ (dev().assert(
       embedWin.frameElement,
       'frameElement not found for embed'));
   const service = getServiceForDoc(frameElement, serviceId);
-  assertEmbeddable(service).adoptEmbedWindow(embedWin);
+  if (isEmbeddable(service)) {
+    service.adoptEmbedWindow(embedWin);
+    return true;
+  }
+  return false;
 }
 
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -321,9 +321,7 @@ export class AmpDocSingle extends AmpDoc {
         waitForBodyPromise(this.win.document).then(() => this.getBody());
 
     /** @private @const {!Promise} */
-    this.readyPromise_ = isDocumentReady(this.win.document) ?
-        Promise.resolve() :
-        whenDocumentReady(this.win.document);
+    this.readyPromise_ = whenDocumentReady(this.win.document);
   }
 
   /** @override */

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -410,6 +410,12 @@ export class Extensions {
         // becomes necessary. This will require refactoring of extension
         // loader that can be resolved via the parent ampdoc.
 
+        // TODO(choumx): Similar to `adoptServicesForEmbed`, should there be
+        // a map of extension ID -> service? E.g. "cid" -> "amp-analytics".
+        if (extensionId == 'amp-bind') {
+          adoptServiceForEmbed(childWin, 'bind');
+        }
+
         // Adopt the custom element.
         const elementDef = extension.elements[extensionId];
         if (elementDef && elementDef.css) {
@@ -420,12 +426,15 @@ export class Extensions {
                 /* completeCallback */ resolve,
                 /* isRuntime */ false,
                 extensionId);
-          });
+          }).then(() => extension); // Forward `extension` to chained Promise.
         }
-      }).then(() => {
+        return extension;
+      }).then(extension => {
         // Notice that stubbing happens much sooner above
         // (see stubElementInChildWindow).
-        upgradeElementInChildWindow(topWin, childWin, extensionId);
+        Object.keys(extension.elements).forEach(element => {
+          upgradeElementInChildWindow(topWin, childWin, element);
+        });
       });
       promises.push(promise);
     });

--- a/src/services.js
+++ b/src/services.js
@@ -24,6 +24,7 @@ import {
 import {
   getElementService,
   getElementServiceForDoc,
+  getElementServiceForDocInEmbedScope,
   getElementServiceIfAvailable,
   getElementServiceIfAvailableForDoc,
 } from './element-service';
@@ -92,7 +93,7 @@ export function batchedXhrFor(window) {
  */
 export function bindForDoc(nodeOrDoc) {
   return /** @type {!Promise<!../extensions/amp-bind/0.1/bind-impl.Bind>} */ (
-      getElementServiceForDoc(nodeOrDoc, 'bind', 'amp-bind'));
+      getElementServiceForDocInEmbedScope(nodeOrDoc, 'bind', 'amp-bind'));
 }
 
 /**

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -16,8 +16,8 @@
 
 import {
   adoptServiceForEmbed,
+  adoptServiceForEmbedIfEmbeddable,
   assertDisposable,
-  assertEmbeddable,
   disposeServicesForDoc,
   getExistingServiceForDocInEmbedScope,
   getExistingServiceInEmbedScope,
@@ -568,12 +568,6 @@ describe('service', () => {
         expect(isEmbeddable(nonEmbeddable)).to.be.false;
       });
 
-      it('should assert embeddable interface', () => {
-        expect(assertEmbeddable(embeddable)).to.equal(embeddable);
-        expect(() => assertEmbeddable(nonEmbeddable))
-            .to.throw(/required to implement EmbeddableService/);
-      });
-
       it('should adopt embeddable', () => {
         adoptServiceForEmbed(embedWin, 'embeddable');
         expect(embeddable.adoptEmbedWindow).to.be.calledOnce;
@@ -584,6 +578,14 @@ describe('service', () => {
         expect(() => {
           adoptServiceForEmbed(embedWin, 'nonEmbeddable');
         }).to.throw(/required to implement EmbeddableService/);
+      });
+
+      it('should adopt embeddable if embeddable', () => {
+        adoptServiceForEmbedIfEmbeddable(embedWin, 'embeddable');
+        expect(embeddable.adoptEmbedWindow).to.be.calledOnce;
+        expect(embeddable.adoptEmbedWindow.args[0][0]).to.equal(embedWin);
+
+        adoptServiceForEmbedIfEmbeddable(embedWin, 'nonEmbeddable'); // No-op.
       });
 
       it('should refuse adopt of unknown service', () => {


### PR DESCRIPTION
Partial for #9395.

- Adds support for retrieving element services in embed scopes
- Adds `services` to `ExtensionDef` -- now an extension knows which services it registers
- Minor changes to `installExtensionsInChildWindow`