### PR TITLE
Update to Index Exchange amp-ad tags to add render start

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -366,6 +366,7 @@ export const adConfig = {
       'https://js-sec.indexww.com/apl/amp.js',
     ],
     preconnect: 'https://as-sec.casalemedia.com',
+    renderStartImplemented: true,
   },
 
   kargo: {},

--- a/ads/ix.js
+++ b/ads/ix.js
@@ -57,6 +57,7 @@ export function ix(global, data) {
     global.IndexArgs = {
       ampCallback: callDoubleclick,
       ampSuccess: EVENT_SUCCESS,
+      ampError: EVENT_ERROR,
     };
 
     loadScript(global, 'https://js-sec.indexww.com/apl/amp.js', undefined, () => {

--- a/ads/ix.md
+++ b/ads/ix.md
@@ -34,7 +34,7 @@ For semantics of configuration, please contact your account manager at Index Exc
 
 If you use `remote.html` in your AMP pages, you must add `ix` into the array that outlines the list of acceptable types. For example, `['doubleclick']` should be changed to `['doubleclick', 'ix']`. If you do not use `remote.html`, this step is not required.
 
-Ad size are based on the `width` and `height` attributes of the `amp-ad` tag. Neither width and height override attributes nor multi-size ads are currently supported.
+Ad size is based on the `width` and `height` attributes of the `amp-ad` tag by default. Both width and height override attributes (`data-override-width` and `data-override-height`) and multi-size ads (via `data-multi-size`) are supported.
 
 __Required:__
 
@@ -45,13 +45,6 @@ __Optional:__
 
 - `data-ix-slot`
 - `data-ix-timeout`
-
-__Unsupported:__
-
-- `data-override-width`
-- `data-override-height`
-- `data-multi-size`
-- `data-multi-size-validation`
 
 Additional parameters including `json` will be passed through in the resulting call to DFP. For details please see the [Doubleclick documentation](https://github.com/ampproject/amphtml/blob/master/ads/google/doubleclick.md).
 


### PR DESCRIPTION
Add support for render start as well as update ix.md to reflect recent updates in our support for multi-size ad tags, due to changes in our external library.