### PR TITLE
Add a simple meta description tag to the AMP Validator Web UI.

### DIFF
--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -38,6 +38,8 @@
     .ampproject-warning { color: #FF9800; }
     .ampproject-error { color: #F44336; }
   </style>
+  <meta name="description"
+        content="AMP HTML Project Web Validator. Tests Accelerated Mobile Page (AMP) documents for valid markup.">
 </head>
 <body unresolved>
   <webui-mainpage></webui-mainpage>

--- a/validator/webui/index.html
+++ b/validator/webui/index.html
@@ -39,7 +39,7 @@
     .ampproject-error { color: #F44336; }
   </style>
   <meta name="description"
-        content="AMP HTML Project Web Validator. Tests Accelerated Mobile Page (AMP) documents for valid markup.">
+        content="AMP HTML Project Web Validator. Tests Accelerated Mobile Pages for valid markup.">
 </head>
 <body unresolved>
   <webui-mainpage></webui-mainpage>


### PR DESCRIPTION
Since there is no actual text on the document, search results currently show an ugly snippet of:

```Clear filter. {{e.message}}. {{e.category}}. line {{e.line}}, column
{{e.col}}. [[_charCounterStr]]. [[label]] [[errorMessage]]. [[_text]].
{{text}}. AMP AMP4ADS Validate.
```