### PR TITLE
Launching the amp-auto-ads-adsense-holdout holdout experiment to turn amp-auto-ads off for 5% of traffic

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -14,6 +14,7 @@
   "pump-early-frame": 1,
   "sticky-ad-early-load": 1,
   "amp-auto-ads": 1,
+  "amp-auto-ads-adsense-holdout": 0.1,
   "slidescroll-disable-css-snap": 1,
   "visibility-v3": 1,
   "as-use-attr-for-format": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,6 +13,7 @@
   "chunked-amp": 1,
   "sticky-ad-early-load": 1,
   "amp-auto-ads": 1,
+  "amp-auto-ads-adsense-holdout": 0.1,
   "slidescroll-disable-css-snap": 1,
   "visibility-v3": 1,
   "web-worker": 1,


### PR DESCRIPTION
This is to measure the uplift from amp-auto-ads for AdSense publishers.

The experiment is set to 10% and it has 2 branches, only one of which turns amp-auto-ads off, so this will result in 5% of pageviews not getting amp-auto-ads for the tagged pubs.