### PR TITLE
Add comment to applylayout method for SSR

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -226,15 +226,23 @@ export function upgradeElementInChildWindow(parentWin, childWin, name) {
 
 /**
  * Applies layout to the element. Visible for testing only.
+ * 
+ * \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  / _____|
+ *  \   \/    \/   / /  ^  \    |  |_)  |    |   \|  | |  | |   \|  | |  |  __
+ *   \            / /  /_\  \   |      /     |  . `  | |  | |  . `  | |  | |_ |
+ *    \    /\    / /  _____  \  |  |\  \----.|  |\   | |  | |  |\   | |  |__| |
+ *     \__/  \__/ /__/     \__\ | _| `._____||__| \__| |__| |__| \__|  \______|
  *
- * WARNING: The equivalent of this method is used for server-side
- * rendering (SSR) and any changes made to it must be made in coordination
- * with caches that implement SSR. For more info on SSR see bit.ly/amp-ssr.
+ * The equivalent of this method is used for server-side rendering (SSR) and
+ * any changes made to it must be made in coordination with caches that
+ * implement SSR. For more information on SSR see bit.ly/amp-ssr.
  *
  * @param {!Element} element
  * @return {!Layout}
  */
 export function applyLayout_(element) {
+    /*
+    
   // Check if the layout has already been done by the server.
   const completedLayoutAttr = element.getAttribute('i-amphtml-layout');
   if (completedLayoutAttr) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -241,9 +241,9 @@ export function upgradeElementInChildWindow(parentWin, childWin, name) {
  * @return {!Layout}
  */
 export function applyLayout_(element) {
-    /*
-    
-  // Check if the layout has already been done by the server.
+  // Check if the layout has already been done by server-side rendering. The
+  // document may be visible to the user if the boilerplate was removed so
+  // please take care in making changes here.
   const completedLayoutAttr = element.getAttribute('i-amphtml-layout');
   if (completedLayoutAttr) {
     const layout = /** @type {!Layout} */ (dev().assert(
@@ -258,6 +258,10 @@ export function applyLayout_(element) {
     return layout;
   }
 
+  // If the layout was already done by server-side rendering (SSR), then the code
+  // below will not run. Any changes below will necessitate a change to SSR and must
+  // be coordinated with caches that implement SSR. See bit.ly/amp-ssr.
+    
   // Parse layout from the element.
   const layoutAttr = element.getAttribute('layout');
   const widthAttr = element.getAttribute('width');

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -226,6 +226,11 @@ export function upgradeElementInChildWindow(parentWin, childWin, name) {
 
 /**
  * Applies layout to the element. Visible for testing only.
+ *
+ * WARNING: The equivalent of this method is used for server-side
+ * rendering (SSR) and any changes made to it must be made in coordination
+ * with caches that implement SSR. For more info on SSR see bit.ly/amp-ssr.
+ *
  * @param {!Element} element
  * @return {!Layout}
  */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -226,7 +226,7 @@ export function upgradeElementInChildWindow(parentWin, childWin, name) {
 
 /**
  * Applies layout to the element. Visible for testing only.
- * 
+ *
  * \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  / _____|
  *  \   \/    \/   / /  ^  \    |  |_)  |    |   \|  | |  | |   \|  | |  |  __
  *   \            / /  /_\  \   |      /     |  . `  | |  | |  . `  | |  | |_ |
@@ -261,7 +261,7 @@ export function applyLayout_(element) {
   // If the layout was already done by server-side rendering (SSR), then the code
   // below will not run. Any changes below will necessitate a change to SSR and must
   // be coordinated with caches that implement SSR. See bit.ly/amp-ssr.
-    
+
   // Parse layout from the element.
   const layoutAttr = element.getAttribute('layout');
   const widthAttr = element.getAttribute('width');


### PR DESCRIPTION
Issue #9531 showed that changes to applylayout can have adverse affects on caches that implement server-side rendering. Make this more obvious by adding a comment for applylayout in custom-element.js.