### PR TITLE
Increase amp-bind integration test timeout

### DIFF
--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -25,7 +25,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   let ampdoc;
   let sandbox;
 
-  this.timeout(5000);
+  this.timeout(10000);
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -25,8 +25,6 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   let ampdoc;
   let sandbox;
 
-  this.timeout(10000);
-
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
   });


### PR DESCRIPTION
These tests were passing previously as unit tests with 10s timeout, so this may fix timeouts on master.