### PR TITLE
Move custom middleware before Karma's builtin middleware.

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -170,7 +170,7 @@ module.exports = {
 
   // Import our gulp webserver as a Karma server middleware
   // So we instantly have all the custom server endpoints available
-  middleware: ['custom'],
+  beforeMiddleware: ['custom'],
   plugins: [
     'karma-browserify',
     'karma-chai',

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jison": "0.4.15",
     "jsdom": "9.2.1",
     "json-stable-stringify": "1.0.1",
-    "karma": "0.13.21",
+    "karma": "1.7.0",
     "karma-browserify": "5.1.1",
     "karma-chai": "0.1.0",
     "karma-chai-as-promised": "0.1.2",

--- a/test/integration/test-example-validation.js
+++ b/test/integration/test-example-validation.js
@@ -87,7 +87,7 @@ describe.configure().retryOnSaucelabs().run('example', function() {
 
   examples.forEach(filename => {
     it(filename + ' should validate', () => {
-      const url = '/examples/' + filename;
+      const url = '/base/examples/' + filename;
       return get(url).then(html => {
         /* global amp: false */
         const validationResult = amp.validator.validateString(html);


### PR DESCRIPTION
So the test can leverage the middleware to select the right binary (max/min) to serve.

/cc @kmh287 