### PR TITLE
Add missing actions to "all elements" table

### DIFF
--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -200,6 +200,14 @@ Including: `input[type=radio]`, `input[type=checkbox]`, `input[type=range]`, and
     <td>hide</td>
     <td>Hides the target element.</td>
   </tr>
+  <tr>
+    <td>show</td>
+    <td>Shows the target element.</td>
+  </tr>
+  <tr>
+    <td>toggleVisibility</td>
+    <td>Toggles the visibility of the target element.</td>
+  </tr>
 </table>
 
 ### amp-image-lightbox


### PR DESCRIPTION
All elements get not only `show` but also `hide` and `toggleVisibility`, as documented in an earlier section of this file.