### PR TITLE
Should show amp-app-banner in non-embedded firefox ios

### DIFF
--- a/src/service/platform-impl.js
+++ b/src/service/platform-impl.js
@@ -53,7 +53,7 @@ export class Platform {
    */
   isSafari() {
     return /Safari/i.test(this.navigator_.userAgent) && !this.isChrome() &&
-        !this.isEdge();
+        !this.isEdge() && !this.isFirefox();
   }
 
   /**
@@ -70,7 +70,7 @@ export class Platform {
    * @return {boolean}
    */
   isFirefox() {
-    return /Firefox/i.test(this.navigator_.userAgent) && !this.isEdge();
+    return /Firefox|FxiOS/i.test(this.navigator_.userAgent) && !this.isEdge();
   }
 
   /**
@@ -109,7 +109,7 @@ export class Platform {
       return this.evalMajorVersion_(/(Chrome|CriOS)\/(\d+)/, 2);
     }
     if (this.isFirefox()) {
-      return this.evalMajorVersion_(/Firefox\/(\d+)/, 1);
+      return this.evalMajorVersion_(/(Firefox|FxiOS)\/(\d+)/, 2);
     }
     if (this.isIe()) {
       return this.evalMajorVersion_(/MSIE\s(\d+)/, 1);

--- a/test/functional/test-platform.js
+++ b/test/functional/test-platform.js
@@ -163,6 +163,18 @@ describe('Platform', () => {
         'Gecko/20100101 Firefox/40.1');
   });
 
+  it('Firefox ios', () => {
+    isIos = true;
+    isFirefox = true;
+    isWebKit = true;
+    majorVersion = 7;
+    iosVersion = '10.3.1';
+    iosMajorVersion = 10;
+    testUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X)' +
+        ' AppleWebKit/603.1.30 (KHTML, like Gecko) FxiOS/7.5b3349' +
+        ' Mobile/14E304 Safari/603.1.30');
+  });
+
   it('IE', () => {
     isIe = true;
     majorVersion = 10;


### PR DESCRIPTION
Fix https://github.com/ampproject/amphtml/issues/9566