### PR TITLE
Fix most amp-bind integration tests

### DIFF
--- a/test/fixtures/bind-carousel.html
+++ b/test/fixtures/bind-carousel.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-bind with amp-carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script src="/dist/amp.js"></script>
+  <script custom-element="amp-carousel" src="/dist/v0/amp-carousel-0.1.max.js"></script>
+  <script custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
+</head>
+
+<body>
+  <button on="tap:AMP.setState({selectedSlide: 1})" id="goToSlideOne">slide 1!</button>
+  <p id="slideNumber" [text]="selectedSlide">0</p>
+  <amp-carousel width="300" height="100" type="slides" id="carousel"
+      on="slideChange:AMP.setState({selectedSlide: event.index})" [slide]="selectedSlide">
+    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
+    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
+    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
+  </amp-carousel>
+</body>
+</html>

--- a/test/fixtures/bind-integrations.html
+++ b/test/fixtures/bind-integrations.html
@@ -18,7 +18,6 @@
   <script src="/dist/amp.js"></script>
   <script custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
   <script custom-element="amp-brightcove" src="/dist/v0/amp-brightcove-0.1.max.js"></script>
-  <script custom-element="amp-carousel" src="/dist/v0/amp-carousel-0.1.max.js"></script>
   <script custom-element="amp-iframe" src="/dist/v0/amp-iframe-0.1.max.js"></script>
   <script custom-element="amp-list" src="/dist/v0/amp-list-0.1.max.js"></script>
   <script custom-element="amp-live-list" src="/dist/v0/amp-live-list-0.1.max.js"></script>
@@ -49,15 +48,6 @@
   <p id="checkboxText" [text]="'Checked: ' + checkboxChange.checked" id="checkboxText">Unbound</p>
   <input type="radio" on="change:AMP.setState({radioChange: event})" id="radio">
   <p id="radioText" [text]="'Checked: ' + radioChange.checked" id="radioText">Unbound</p>
-
-  <p>CAROUSEL</p>
-  <button on="tap:AMP.setState({selectedSlide: 1})" id="goToSlide1Button">slide 1!</button>
-  <p id="slideNum" [text]="selectedSlide">0</p>
-  <amp-carousel width="300" height="100" type="slides"  id="carousel" on="slideChange:AMP.setState({selectedSlide: event.index})" [slide]="selectedSlide">
-    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
-    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
-    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
-  </amp-carousel>
 
   <p>AMP-IMG</p>
   <button on="tap:AMP.setState({imageSrc: 'http://www.google.com/image2'})" id="changeImgSrcButton"></button>

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import '../../extensions/amp-carousel/0.1/amp-carousel';
 import {createFixtureIframe} from '../../testing/iframe';
 import {batchedXhrFor, bindForDoc} from '../../src/services';
 import {ampdocServiceFor} from '../../src/ampdoc';
 import * as sinon from 'sinon';
 
-// TODO(choumx): Unskip once #9571 is fixed.
-describe.skip('amp-bind', function() {
+describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   let fixture;
   let ampdoc;
   let sandbox;
@@ -76,8 +74,8 @@ describe.skip('amp-bind', function() {
         waitForEvent('amp:bind:mutated'));
   }
 
-  describe('[text] and [class] integration', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('[text] and [class] integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-text-integration.html');
     });
@@ -103,8 +101,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('detecting bindings under dynamic tags', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('detecting bindings under dynamic tags', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -151,8 +149,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
+  // TODO(choumx): Unskip once #9571 is fixed.
   describe('input integration', () => {
-
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -191,39 +189,47 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-carousel integration', () => {
-
+  describe('with amp-carousel', () => {
     beforeEach(() => {
-      return setupWithFixture('test/fixtures/bind-integrations.html');
+      return setupWithFixture('test/fixtures/bind-carousel.html');
     });
 
     it('should update dependent bindings on carousel slide changes', () => {
-      const slideNum = fixture.doc.getElementById('slideNum');
+      const slideNumber = fixture.doc.getElementById('slideNumber');
+      expect(slideNumber.textContent).to.equal('0');
+
       const carousel = fixture.doc.getElementById('carousel');
-      const impl = carousel.implementation_;
-      expect(slideNum.textContent).to.equal('0');
-      impl.go(1, /* animate */ false);
+      const nextSlideButton =
+          carousel.querySelector('div.amp-carousel-button-next');
+      nextSlideButton.click();
+
       return waitForBindApplication().then(() => {
-        expect(slideNum.textContent).to.equal('1');
+        expect(slideNumber.textContent).to.equal('1');
       });
     });
 
     it('should change slides when the slide attribute binding changes', () => {
       const carousel = fixture.doc.getElementById('carousel');
+      const slides =
+          carousel.querySelectorAll('.i-amphtml-slide-item > amp-img');
+      const firstSlide = slides[0];
+      const secondSlide = slides[1];
+
+      expect(firstSlide.getAttribute('aria-hidden')).to.equal('false');
+      expect(secondSlide.getAttribute('aria-hidden')).to.be.equal('true');
+
       const button = fixture.doc.getElementById('goToSlide1Button');
-      const impl = carousel.implementation_;
-      // No previous slide as current slide is 0th side
-      expect(impl.hasPrev()).to.be.false;
       button.click();
+
       return waitForBindApplication().then(() => {
-        // Has previous slide since the index has changed
-        expect(impl.hasPrev()).to.be.true;
+        expect(secondSlide.getAttribute('aria-hidden')).to.be.equal('false');
+        expect(firstSlide.getAttribute('aria-hidden')).to.equal('true');
       });
     });
   });
 
-  describe('amp-img integration', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-img integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -289,8 +295,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-live-list integration', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-live-list integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -344,8 +350,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-selector integration', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-selector integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -389,8 +395,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-video integration', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-video integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -460,8 +466,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-youtube', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-youtube', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -477,8 +483,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-brightcove', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-brightcove', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -497,8 +503,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-iframe', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-iframe', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -521,8 +527,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-list', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-list', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -552,8 +558,8 @@ describe.skip('amp-bind', function() {
     });
   });
 
-  describe('amp-state', () => {
-
+  // TODO(choumx): Unskip once #9571 is fixed.
+  describe.skip('amp-state', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -39,24 +39,10 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   function setupWithFixture(fixtureLocation) {
     return createFixtureIframe(fixtureLocation).then(f => {
       fixture = f;
-      return waitForEvent('amp:bind:initialize');
+      return fixture.awaitEvent('amp:bind:initialize', 1);
     }).then(() => {
       const ampdocService = ampdocServiceFor(fixture.win);
       ampdoc = ampdocService.getAmpDoc(fixture.doc);
-    });
-  }
-
-  /**
-   * @param {string} name
-   * @return {!Promise}
-   */
-  function waitForEvent(name) {
-    return new Promise(resolve => {
-      function callback() {
-        resolve();
-        fixture.win.removeEventListener(name, callback);
-      };
-      fixture.win.addEventListener(name, callback);
     });
   }
 
@@ -65,17 +51,16 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     // Bind should be available, but need to wait for actions to resolve
     // service promise for bind and call setState.
     return bindForDoc(ampdoc).then(unusedBind =>
-        waitForEvent('amp:bind:setState'));
+        fixture.awaitEvent('amp:bind:setState', 1));
   }
 
   /** @return {!Promise} */
   function waitForAllMutations() {
     return bindForDoc(ampdoc).then(unusedBind =>
-        waitForEvent('amp:bind:mutated'));
+        fixture.awaitEvent('amp:bind:mutated', 1));
   }
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('[text] and [class] integration', () => {
+  describe('[text] and [class] integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-text-integration.html');
     });
@@ -101,8 +86,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('detecting bindings under dynamic tags', () => {
+  describe('detecting bindings under dynamic tags', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -149,7 +133,6 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
   describe('input integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
@@ -218,7 +201,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
       expect(firstSlide.getAttribute('aria-hidden')).to.equal('false');
       expect(secondSlide.getAttribute('aria-hidden')).to.be.equal('true');
 
-      const button = fixture.doc.getElementById('goToSlide1Button');
+      const button = fixture.doc.getElementById('goToSlideOne');
       button.click();
 
       return waitForBindApplication().then(() => {
@@ -228,8 +211,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('amp-img integration', () => {
+  describe('amp-img integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -295,8 +277,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('amp-live-list integration', () => {
+  describe('amp-live-list integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -350,8 +331,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('amp-selector integration', () => {
+  describe('amp-selector integration', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -466,8 +446,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('amp-youtube', () => {
+  describe('amp-youtube', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -483,8 +462,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('amp-brightcove', () => {
+  describe('amp-brightcove', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -503,8 +481,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('amp-iframe', () => {
+  describe('amp-iframe', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });
@@ -527,8 +504,7 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Unskip once #9571 is fixed.
-  describe.skip('amp-list', () => {
+  describe('amp-list', () => {
     beforeEach(() => {
       return setupWithFixture('test/fixtures/bind-integrations.html');
     });

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -65,9 +65,12 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
     // Counts the supported custom events.
     const events = {
       'amp:attached': 0,
+      'amp:bind:initialize': 0,
+      'amp:bind:setState': 0,
+      'amp:bind:mutated': 0,
       'amp:error': 0,
-      'amp:stubbed': 0,
       'amp:load:start': 0,
+      'amp:stubbed': 0,
     };
     const messages = [];
     let html = __html__[fixture];


### PR DESCRIPTION
Partial for #9571. Fix and un-skip a bunch of tests.

- Reworked `amp-carousel` test to not require internal APIs. Also, flakiness fixed by making sure it gets laid out.
- Fixed timeouts due to `amp:bind:initialize` event firing before the listener was added.

All un-skipped tests now pass locally on Firefox 53 on OS X. A few are left.

/to @kmh287 