### PR TITLE
Allow option attribute for children of amp-selector in templates

### DIFF
--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -108,6 +108,7 @@ const WHITELISTED_ATTRS = [
   'href',
   'on',
   'placeholder',
+  'option',
   /* Attributes added for amp-bind */
   // TODO(kmh287): Add more whitelisted attributes for bind?
   'text',


### PR DESCRIPTION
Even though this change is in #9553, I want to merge this piece specifically to allow the workaround in #9536 to work.