### PR TITLE
Add callouts for CORS + cleanup

### DIFF
--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -2,11 +2,6 @@
 
 [TOC]
 
-{% call callout('Important', type='caution') %}
-This extension is under active development, and the version number of the specification section should provide guidance to its evolution.
-{% endcall %}
-
-
 <!---
 Copyright 2015 The AMP HTML Authors. All Rights Reserved.
 
@@ -30,7 +25,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong>Availability</strong></td>
-    <td>In development</td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
@@ -112,7 +107,7 @@ Login Page is implemented and served by the Publisher and called by the AMP Runt
 
 Login Page is triggered when the Reader taps on the Login Link which can be placed by the Publisher anywhere in the document.
 
-## Specification v0.5
+## Specification v0.1
 
 ### Configuration
 

--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -1,6 +1,11 @@
-# <a name="amp-access-"></a> AMP Access Specification
+# <a name="amp-access-"></a> amp-access
 
-**This extension is under active development, and the version number of the specification section should provide guidance to its evolution.**
+[TOC]
+
+{% call callout('Important', type='caution') %}
+This extension is under active development, and the version number of the specification section should provide guidance to its evolution.
+{% endcall %}
+
 
 <!---
 Copyright 2015 The AMP HTML Authors. All Rights Reserved.
@@ -25,7 +30,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
+    <td>In development</td>
   </tr>
   <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -506,13 +506,20 @@ The URL of the remote endpoint that will return the JSON that will update this `
 
 The `src` attribute allows all standard URL variable substitutions. See the [Substitutions Guide](../../spec/amp-var-substitutions.md) for more info.
 
+{% call callout('Important', type='caution') %}
+The endpoint must implement the requirements specified in the [CORS Requests in AMP](../../spec/amp-cors-requests.md) spec.
+{% endcall %}
+
+
 **credentials** (optional)
 
 Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
-To send credentials, pass the value of "include". If this is set, the response must follow
-the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
 
-The support values are "omit" and "include". Default is "omit".
+* Supported values: `omit`, `include`
+* Default: `omit`
+
+To send credentials, pass the value of `include`. If this value is set, the response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
+
 
 ### Non-standard built-in functions
 

--- a/extensions/amp-call-tracking/amp-call-tracking.md
+++ b/extensions/amp-call-tracking/amp-call-tracking.md
@@ -23,10 +23,6 @@ limitations under the License.
     tracking. Executes a CORS request to substitute the number.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-call-tracking" src="https://cdn.ampproject.org/v0/amp-call-tracking-0.1.js">&lt;/script></code></td>
   </tr>
@@ -49,7 +45,9 @@ by a CORS endpoint.
   <a href="tel:123456789">+1 (23) 456-789</a>
 </amp-call-tracking>
 ```
-Note that every unique CORS endpoint will only be called once per page.
+{% call callout('Note', type='note') %}
+Each unique CORS endpoint is called only once per page.
+{% endcall %}
 
 ## Attributes
 
@@ -62,7 +60,7 @@ of a valid JSON object with the following fields:
 - `formattedPhoneNumber` (optional): Specifies the phone number to display. If not specified, the value in `phoneNumber` is used.
 
 {% call callout('Important', type='caution') %}
-Your XHR endpoint needs to follow and implement [CORS Requests in AMP spec](../../spec/amp-cors-requests.md).
+Your XHR endpoint must implement the requirements specified in the [CORS Requests in AMP](../../spec/amp-cors-requests.md) spec.
 {% endcall %}
 
 ## Validation

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -23,7 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>Stable with the following Experimental feature: <a href="#verification-experimental-">Verification</a></td>
+    <td>Stable with the following Experimental feature: <a href="#verification-(experimental)">Verification</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -84,7 +84,7 @@ An XHR request (sometimes called an AJAX request) is where the browser would mak
 The value for `action-xhr` can be the same or a different endpoint than `action` and has the same action requirements above.
 
 {% call callout('Important', type='caution') %}
-See [Security Considerations](#security-considerations) for notes on how to secure your forms endpoints.
+See the [Security Considerations](#security-considerations) section below for notes on how to secure your forms endpoints.
 {% endcall %}
 
 **other form attributes**
@@ -448,10 +448,13 @@ Note how `CANONICAL_HOSTNAME` above did not get replaced because it was not in t
 Substitutions will happen on every subsequent submission. Read more about [variable substitutions in AMP](../../spec/amp-var-substitutions.md).
 
 ## Security Considerations
-Your XHR endpoints need to follow and implement [CORS Requests in AMP spec](../../spec/amp-cors-requests.md).
+
+{% call callout('Important', type='caution') %}
+Your XHR endpoint must implement the requirements specified in the [CORS Requests in AMP](../../spec/amp-cors-requests.md) spec.
+{% endcall %}
 
 ### Protecting against XSRF
-In addition to following AMP CORS spec, please pay extra attention to [state changing requests note](../../spec/amp-cors-requests.md#note-on-state-changing-requests) to protect against [XSRF attacks](https://en.wikipedia.org/wiki/Cross-site_request_forgery) where an attacker can execute unauthorized commands using the current user session without the user knowledge.
+In addition to following the details in the AMP CORS spec, please pay extra attention to the section on ["Verifying state changing requests" ](../../spec/amp-cors-requests.md#verify-state-changing-requests) to protect against [XSRF attacks](https://en.wikipedia.org/wiki/Cross-site_request_forgery) where an attacker can execute unauthorized commands using the current user session without the user knowledge.
 
 In general, keep in mind the following points when accepting input from the user:
 

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a <a href="https://gist.github.com/">GitHub Gist</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-gist" src="https://cdn.ampproject.org/v0/amp-gist-0.1.js">&lt;/script></code></td>
   </tr>
@@ -39,9 +35,11 @@ limitations under the License.
   </tr>
 </table>
 
-## Examples
+## Behavior
 
-### Multiple files
+This extension creates an iframe and displays a [gist from GitHub](https://help.github.com/articles/about-gists/). 
+
+#### Example: Embedding multiple files
 
 ```html
 <amp-gist
@@ -51,7 +49,7 @@ limitations under the License.
 </amp-gist>
 ```
 
-### Single file
+#### Example: Embedding a single file
 
 ```html
 <amp-gist
@@ -62,26 +60,25 @@ limitations under the License.
 </amp-gist>
 ```
 
-## Behavior
-
-This extension creates an iframe and displays the gist from GitHub. **You must find the 
-height of the gist by inspecting it with your browser** (e.g. Chrome Developer Tools).
-
 ## Attributes
 
-These are the valid attributes for the `amp-gist` component:
+##### data-gistid (required)
 
-**data-gistid** (required)
 The ID of the gist to embed.
 
-**layout** (required)
-Currently only supports `fixed-height`
+##### layout (required)
 
-**height** (required)
+Currently only supports `fixed-height`.
+
+##### height(required)
+
 The height of the gist or gist file in pixels.
 
-**data-file** (optional)
-`data-file` is used for displaying only one file in a gist.
+**Note**: You must find the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools).
+
+##### data-file (optional)
+
+If specified, display only one file in a gist.
 
 ## Validation
 See [amp-gist rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-gist/0.1/validator-amp-gist.protoascii) in the AMP validator specification.

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -16,15 +16,13 @@ limitations under the License.
 
 # <a name="amp-list"></a> `amp-list`
 
+[TOC]
+
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
     <td>Fetches content dynamically from a CORS JSON endpoint and renders it
 using a supplied template.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -42,44 +40,82 @@ using a supplied template.</td>
 
 ## Usage
 
-The `amp-list` defines its data source using the following attributes:
+The `amp-list` component fetches dynamic content from a CORS JSON endpoint. The response from the endpoint contains an array, which is rendered in the specified template.  
 
-- `src` defines a CORS URL. The URL's protocol must be HTTPS.
-- `credentials` defines a `credentials` option as specified by the
-[Fetch API](https://fetch.spec.whatwg.org/). To send credentials, pass the
-value of "include". If this is set, the response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
+{% call callout('Important', type='caution') %}
+Your endpoint must implement the requirements specified in the [CORS Requests in AMP](../../spec/amp-cors-requests.md) spec.
+{% endcall %}
 
-The response is expected to contain the array that will be rendered. The path to the array
-is specified using the optional `items` attribute. This attribute contains the dot-notated path
-to the array within the response object. The default value is "items". To indicate that the
-response itself is an array, the "." value can be used. The array can be nested within the
-response and accessed using an expression like `items="field1.field2"`.
+You can specify a template in one of two ways:
 
-Thus, when `items="items"` is specified (the default) the response must be a JSON object that
-contains an array property called "items":
-```text
+- a `template` attribute that references an ID of an existing `template` element.
+- a `template` element nested directly inside the `amp-list` element.
+  
+For more details on templates, see [AMP HTML Templates](../../spec/amp-html-templates.md).
+
+In the following example, we retrieve JSON data that contains image URLs and titles, and render the content in a nested [amp-mustache template](https://www.ampproject.org/docs/reference/components/amp-mustache).
+
+```html
+<amp-list src="https://data.com/images.json"
+    width="300" height="200" layout="responsive">
+  <template type="amp-mustache">
+    <div>
+      <amp-img src="{{imageUrl}}" width="50" height="50"></amp-img>
+      {{title}}
+    </div>
+  </template>
+</amp-list>
+```
+
+JSON data:
+
+```json
 {
-  "items": [...]
+  "items": [
+    {
+      "title": "Image 01",
+      "imageUrl": "https://example.com/images/flowers.jpg"
+    },
+
+    {
+      "title": "Image 02",
+      "imageUrl": "https://example.com/images/sunset.jpg"
+    }
+  ]
 }
 ```
 
-The template can be specified in one of the following two ways:
+## Behavior
 
-- a `template` attribute that references an ID of an existing `template` element.
-- a `template` element nested directly inside of this `amp-list` element.
+The request is always made from the client, even if the document was served from the AMP Cache. Loading is triggered using normal AMP rules depending on how far the element is from
+the current viewport.
 
-For more details on templates, see [AMP HTML Templates](../../spec/amp-html-templates.md).
+If `amp-list` needs more space after loading, it requests the AMP runtime to update its
+height using the normal AMP flow. If the AMP runtime cannot satisfy the request for the new
+height, it will display the `overflow` element when available. Notice however, that the typical
+placement of `amp-list` elements at the bottom of the document almost always guarantees
+that the AMP runtime can resize them.
 
-Optionally, the `amp-list` element can contain an element with an `overflow` attribute. This
-element will be shown if the AMP Runtime cannot resize the `amp-list` element as requested.
+By default, `amp-list` adds a `list` ARIA role to the list element and a `listitem` role to item
+elements rendered via the template.
 
-Example: Using overflow
+### Specifying an overflow
+
+Optionally, the `amp-list` element can contain an element with an `overflow` attribute. This element is shown if the AMP Runtime cannot resize the `amp-list` element as requested.
+
+```css
+.list-overflow[overflow] {
+  position: absolute;
+  bottom: 0;
+}
+```
+
 ```html
 <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
     width=300 height=200 layout=responsive>
   <template type="amp-mustache">
     <div>
-      <amp-img src="{{imageUrl}}" width=50 height=50></amp-img>
+      <amp-img src="{{imageUrl}}" width="50" height="50"></amp-img>
       {{title}}
     </div>
   </template>
@@ -89,12 +125,45 @@ Example: Using overflow
 </amp-list>
 ```
 
-```css
-.list-overflow[overflow] {
-  position: absolute;
-  bottom: 0;
+## Attributes
+
+**src** (required)
+
+The URL of the remote endpoint that returns the JSON that will be rendered
+within this `amp-list`. This must be a CORS HTTP service. The URL's protocol must be HTTPS.
+
+{% call callout('Important', type='caution') %}
+Your endpoint must implement the requirements specified in the [CORS Requests in AMP](../../spec/amp-cors-requests.md) spec.
+{% endcall %}
+
+**credentials** (optional)
+
+Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
+
+* Supported values: `omit`, `include`
+* Default: `omit`
+
+To send credentials, pass the value of `include`. If this value is set, the response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
+
+**items** (optional)
+
+Defines the expression to locate the array to be rendered within the response. This is a dot-notated expression that navigates via fields of the JSON response.
+
+- The default value is `"items"`. The expected response: `{items: [...]}`.
+- If the response itself is the desired array, use the value of `"."`. The expected response is: `[...]`.
+- Nested navigation is permitted (e.g., `"field1.field2"`). The expected response is: `{field1: {field2: [...]}}`.
+
+
+When `items="items"` is specified (which, is the default) the response must be a JSON object that contains an array property called `"items"`:
+```text
+{
+  "items": [...]
 }
 ```
+
+**common attributes**
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Substitutions
 
@@ -107,48 +176,6 @@ For example:
 ```
 may make a request to something like `https://foo.com/list.json?0.8390278471201` where the RANDOM value is randomly generated upon each impression.
 
-## Behavior
-
-The request is always made from the client, even if the document was served from the AMP
-cache. Loading is triggered using normal AMP rules depending on how far the element is from
-the current viewport.
-
-If `amp-list` needs more space after loading, it requests the AMP runtime to update its
-height using the normal AMP flow. If the AMP runtime cannot satisfy the request for the new
-height, it will display the `overflow` element when available. Notice however, that the typical
-placement of `amp-list` elements at the bottom of the document almost always guarantees
-that the AMP runtime can resize them.
-
-By default, `amp-list` adds a `list` ARIA role to the list element and a `listitem` role to item
-elements rendered via the template.
-
-## Attributes
-
-**src** (required)
-
-The URL of the remote endpoint that will return the JSON that will be rendered
-within this `amp-list`. This must be a CORS HTTP service.
-
-**credentials** (optional)
-
-Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
-To send credentials, pass the value of "include". If this is set, the response must follow
-the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
-
-The support values are "omit" and "include". Default is "omit".
-
-**items**
-
-Defines the expression to locate the array to be rendered within the response. It's a dot-notated
-expression that navigates via fields of the JSON response. Notice:
-
-- The default value is "items". The expected response: `{items: [...]}`.
-- If the response itself is the desired array, use the value of ".". The expected response is: `[...]`.
-- Nested navigation is permitted (e.g., "field1.field2"). The expected response is: `{field1: {field2: [...]}}`.
-
-**common attributes**
-
-This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Validation
 

--- a/extensions/amp-user-notification/amp-user-notification.md
+++ b/extensions/amp-user-notification/amp-user-notification.md
@@ -16,6 +16,8 @@ limitations under the License.
 
 # <a name="amp-user-notification"></a> `amp-user-notification`
 
+[TOC]
+
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
@@ -69,13 +71,12 @@ the user.
 To close `amp-user-notification`, add an `on` attribute to a button with the
 following value scheme `on="event:idOfUserNotificationElement.dismiss"`
 (see example below). This user action also triggers the `GET` to the
-`data-dismiss-href` URL. Be very mindful of the browser caching the `GET` response; see details below in the `data-show-if-href` section. (We recommend
+`data-dismiss-href` URL. Be very mindful of the browser caching the `GET` response; see details below in the [`data-show-if-href`](#data-show-if-href-(optional)) section. (We recommend
 adding a unique value to the `GET` url like a timestamp as a query string field).
 
 When multiple `amp-user-notification` elements are on a page, only one is shown
 at a single time (Once one is dismissed the next one is shown).
-The order of the notifications being shown is currently not deterministic. (TODO:
-follow up task [#1229](https://github.com/ampproject/amphtml/issues/1229) to fix this).
+The order of the notifications being shown is currently not deterministic. 
 
 Example:
 
@@ -93,9 +94,9 @@ Example:
 
 ## Attributes
 
-**data-show-if-href** (optional)
+##### data-show-if-href (optional)
 
-When specified, AMP will make a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) GET request with credentials to this URL to determine whether the notification should be shown. AMP appends the `elementId` and `ampUserId` query string fields to the href provided
+When specified, AMP will make a CORS GET request with credentials to the specified URL to determine whether the notification should be shown. AMP appends the `elementId` and `ampUserId` query string fields to the href provided
 on the `data-show-if-href` attribute (see [#1228](https://github.com/ampproject/amphtml/issues/1228) on why this is a GET instead of a POST).
 
 As a best practice to not let the browser cache the GET response values, you should add
@@ -103,43 +104,52 @@ a [`TIMESTAMP` url replacement](https://github.com/ampproject/amphtml/blob/maste
 You can add it as a query string field (e.g., 
 `data-show-if-href="https://foo.com/api/show-api?timestamp=TIMESTAMP"`).
 
- - **CORS GET request** query string fields: `elementId`, `ampUserId`
+If the `data-show-if-href` attribute is not specified, AMP will only check if the notification with the specified ID has been "dismissed" by the user locally. If not, the notification will be shown.
 
-    Example:
-  ```text
-  https://foo.com/api/show-api?timestamp=1234567890&elementId=notification1&ampUserId=cid-value
-  ```
+{% call callout('Important', type='caution') %}
+For handling CORS requests and responses, see the [AMP CORS spec](../../spec/amp-cors-requests.md).
+{% endcall %}
 
- - **CORS GET response** JSON fields: `showNotification`. The response must contain a single JSON object with a `showNotification` field of type boolean. If this field is `true`, the notification will be shown, otherwise it will not be shown.
+**CORS GET request** query string fields: `elementId`, `ampUserId`
 
-    Example:
-    ```json
-    { "showNotification": true }
-    ```
+Example:
 
-If not specified, AMP will only check if the notification with the specified ID has been "dismissed" by the user locally. If not, the notification will be shown.
+```text
+https://foo.com/api/show-api?timestamp=1234567890&elementId=notification1&ampUserId=cid-value
+```
 
-**data-dismiss-href** (optional)
+**CORS GET response** JSON fields: `showNotification`. The response must contain a single JSON object with a `showNotification` field of type boolean. If this field is `true`, the notification will be shown, otherwise it won't.
 
-When specified, AMP will make a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) 
-POST request to this URL transmitting the `elementId` and
-`ampUserId` only when the user has explicitly agreed.
+Example:
+
+```json
+{ "showNotification": true }
+```
+
+##### data-dismiss-href (optional)
+
+When specified, AMP will make a CORS POST request to the specified URL transmitting the `elementId` and `ampUserId` only when the user has explicitly agreed.
+
+If this attribute is not specified, AMP will not send a request upon dismissal, and will only store the "dismissed" flag for the specified ID locally.
+
+{% call callout('Important', type='caution') %}
+For handling CORS requests and responses, see the [AMP CORS spec](../../spec/amp-cors-requests.md).
+{% endcall %}
+
+**POST request** JSON fields: `elementId`, `ampUserId`
 
 Use the `ampUserId` field to store that the user has seen the notification before, if you want to avoid showing it in the future. It's the same value that
 will be passed in future requests to `data-show-if-href`.
 
-  - **POST request** JSON fields: `elementId`, `ampUserId`
+Example:
 
-    Example:
-    ```json
-    { "elementId": "id-of-amp-user-notification", "ampUserId": "ampUserIdString" }
-    ```
+```json
+{ "elementId": "id-of-amp-user-notification", "ampUserId": "ampUserIdString" }
+```
+**POST response** should be a 200 HTTP code and no data is expected back.
 
-  - **POST response** should be a 200 HTTP code and no data is expected back.
 
-If not specified, AMP will not send a request upon dismissal, and will only store the "dismissed" flag for the specified ID locally.
-
-**data-persist-dismissal** (optional)
+##### data-persist-dismissal (optional)
 
 By default, this is set to `true`. If set to `false`, AMP will not remember the user's dismissal of the notification. The notification
 will always show if the `data-show-if-href` result is show notification. If no `data-show-if-href` is provided


### PR DESCRIPTION
Per https://github.com/ampproject/docs/issues/478, now that the CORS guide is cleaned up, want to also highlight/call-out information on CORS and the guidelines. This will mostly look like this (in the ampproject.org docs):
![selection_003](https://cloud.githubusercontent.com/assets/1012254/26511010/fe784e28-422d-11e7-8c12-0e61ed32271c.png)

In addition to adding callouts, I performed:

- Miscellaneous cleanup: removing of "stable" (that'll eventually happen to all stable elements), adding TOCs, styling improvements, etc.
- clean up and improve readability of amp-list

to: @cramforce 
cc: @pbakaus, @dvoytenko 