### PR TITLE
amp-bind: Fix more integration tests

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1030,7 +1030,14 @@ export class Bind {
    */
   dispatchEventForTesting_(name) {
     if (getMode().test) {
-      this.localWin_.dispatchEvent(new Event(name));
+      let event;
+      if (typeof this.localWin_.Event === 'function') {
+        event = new Event(name, {bubbles: true, cancelable: true});
+      } else {
+        event = this.localWin_.document.createEvent('Event');
+        event.initEvent(name, /* bubbles */ true, /* cancelable */ true);
+      }
+      this.localWin_.dispatchEvent(event);
     }
   }
 }

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -183,7 +183,7 @@ export class BindValidator {
   rulesForTagAndProperty_(tag, property) {
     const globalRules = ownProperty(GLOBAL_PROPERTY_RULES, property);
     if (globalRules !== undefined) {
-      return globalRules;
+      return /** @type {PropertyRulesDef} */ (globalRules);
     }
     const tagRules = ownProperty(ELEMENT_RULES, tag);
     if (tagRules) {
@@ -191,7 +191,7 @@ export class BindValidator {
     }
     const ampPropertyRules = ownProperty(AMP_PROPERTY_RULES, property);
     if (startsWith(tag, 'AMP-') && ampPropertyRules !== undefined) {
-      return ampPropertyRules;
+      return /** @type {PropertyRulesDef} */ (ampPropertyRules);
     }
     return undefined;
   }

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {map} from '../../../src/utils/object';
+import {ownProperty} from '../../../src/utils/object';
 import {parseSrcset} from '../../../src/srcset';
 import {startsWith} from '../../../src/string';
 import {user} from '../../../src/log';
@@ -33,21 +33,21 @@ let PropertyRulesDef;
  * Property rules that apply to any and all tags.
  * @private {Object<string, ?PropertyRulesDef>}
  */
-const GLOBAL_PROPERTY_RULES = map({
+const GLOBAL_PROPERTY_RULES = {
   'text': null,
   'class': {
     blacklistedValueRegex: '(^|\\W)i-amphtml-',
   },
-});
+};
 
 /**
  * Property rules that apply to all AMP elements.
- * @private {Object<string, Object<string, ?PropertyRulesDef>>}
+ * @private {Object<string, ?PropertyRulesDef>}
  */
-const AMP_PROPERTY_RULES = map({
+const AMP_PROPERTY_RULES = {
   'width': null,
   'height': null,
-});
+};
 
 /**
  * Maps tag names to property names to PropertyRulesDef.
@@ -61,11 +61,11 @@ const ELEMENT_RULES = createElementRules_();
  * Map whose keys comprise all properties that contain URLs.
  * @private {Object<string, boolean>}
  */
-const URL_PROPERTIES = map({
+const URL_PROPERTIES = {
   'src': true,
   'srcset': true,
   'href': true,
-});
+};
 
 /**
  * BindValidator performs runtime validation of Bind expression results.
@@ -113,7 +113,7 @@ export class BindValidator {
     }
 
     // Validate URL(s) if applicable.
-    if (value && URL_PROPERTIES[property]) {
+    if (value && ownProperty(URL_PROPERTIES, property)) {
       let urls;
       if (property === 'srcset') {
         let srcset;
@@ -181,16 +181,15 @@ export class BindValidator {
    * @private
    */
   rulesForTagAndProperty_(tag, property) {
-    const globalPropertyRules = GLOBAL_PROPERTY_RULES[property];
-    if (globalPropertyRules !== undefined) {
-      return globalPropertyRules;
+    const globalRules = ownProperty(GLOBAL_PROPERTY_RULES, property);
+    if (globalRules !== undefined) {
+      return globalRules;
     }
-    const tagRules = ELEMENT_RULES[tag];
-    // hasOwnProperty() needed since nested objects are not prototype-less.
-    if (tagRules && tagRules.hasOwnProperty(property)) {
+    const tagRules = ownProperty(ELEMENT_RULES, tag);
+    if (tagRules) {
       return tagRules[property];
     }
-    const ampPropertyRules = AMP_PROPERTY_RULES[property];
+    const ampPropertyRules = ownProperty(AMP_PROPERTY_RULES, property);
     if (startsWith(tag, 'AMP-') && ampPropertyRules !== undefined) {
       return ampPropertyRules;
     }
@@ -204,7 +203,7 @@ export class BindValidator {
  */
 function createElementRules_() {
   // Initialize `rules` with tag-specific constraints.
-  const rules = map({
+  const rules = {
     'AMP-BRIGHTCOVE': {
       'data-account': null,
       'data-embed': null,
@@ -374,6 +373,6 @@ function createElementRules_() {
       'spellcheck': null,
       'wrap': null,
     },
-  });
+  };
   return rules;
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -966,6 +966,7 @@ function buildWebWorker(options) {
   return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {
     toName: 'ww.max.js',
     minifiedName: 'ww.js',
+    includePolyfills: true,
     watch: opts.watch,
     minify: opts.minify || argv.minify,
     preventRemoveAndMakeDir: opts.preventRemoveAndMakeDir,

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -51,7 +51,7 @@ export function hasOwn(obj, key) {
  * Returns obj[key] iff key is obj's own property (is not inherited).
  * Otherwise, returns undefined.
  *
- * @param {!Object} obj
+ * @param {Object} obj
  * @param {string} key
  * @return {*}
  */

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -48,6 +48,22 @@ export function hasOwn(obj, key) {
 }
 
 /**
+ * Returns obj[key] iff key is obj's own property (is not inherited).
+ * Otherwise, returns undefined.
+ *
+ * @param {!Object} obj
+ * @param {string} key
+ * @return {*}
+ */
+export function ownProperty(obj, key) {
+  if (hasOwn(obj, key)) {
+    return obj[key];
+  } else {
+    return undefined;
+  }
+}
+
+/**
  * @param {!Object} target
  * @param {!Object} source
  * @param {number} maxDepth The maximum depth for deep merge, beyond which

--- a/src/web-worker/web-worker-polyfills.js
+++ b/src/web-worker/web-worker-polyfills.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Directly imported into web-worker.js entry point so polyfills
+ *     can be used in top-level scope in module dependencies.
+ */
+
+import {install as installArrayIncludes} from '../polyfills/array-includes';
+import {install as installObjectAssign} from '../polyfills/object-assign';
+import {install as installMathSign} from '../polyfills/math-sign';
+
+installArrayIncludes(self);
+installObjectAssign(self);
+installMathSign(self);

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -27,6 +27,7 @@ import {FromWorkerMessageDef, ToWorkerMessageDef} from './web-worker-defines';
 import {initLogConstructor} from '../log';
 import {installWorkerErrorReporting} from '../worker-error-reporting';
 import {install as installArrayIncludes} from '../polyfills/array-includes';
+import {install as installObjectAssign} from '../polyfills/object-assign';
 import {install as installMathSign} from '../polyfills/math-sign';
 
 initLogConstructor();
@@ -34,6 +35,7 @@ installWorkerErrorReporting('ww');
 
 // Polyfills.
 installArrayIncludes(self);
+installObjectAssign(self);
 installMathSign(self);
 
 /**

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -24,11 +24,17 @@
 import '../../third_party/babel/custom-babel-helpers';
 import {BindEvaluator} from '../../extensions/amp-bind/0.1/bind-evaluator';
 import {FromWorkerMessageDef, ToWorkerMessageDef} from './web-worker-defines';
-import {initLogConstructor} from '../../src/log';
+import {initLogConstructor} from '../log';
 import {installWorkerErrorReporting} from '../worker-error-reporting';
+import {install as installArrayIncludes} from '../polyfills/array-includes';
+import {install as installMathSign} from '../polyfills/math-sign';
 
 initLogConstructor();
 installWorkerErrorReporting('ww');
+
+// Polyfills.
+installArrayIncludes(self);
+installMathSign(self);
 
 /**
  * Element `i` contains the evaluator for scope `i`.

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -22,21 +22,14 @@
  */
 
 import '../../third_party/babel/custom-babel-helpers';
+import './web-worker-polyfills';
 import {BindEvaluator} from '../../extensions/amp-bind/0.1/bind-evaluator';
 import {FromWorkerMessageDef, ToWorkerMessageDef} from './web-worker-defines';
 import {initLogConstructor} from '../log';
 import {installWorkerErrorReporting} from '../worker-error-reporting';
-import {install as installArrayIncludes} from '../polyfills/array-includes';
-import {install as installObjectAssign} from '../polyfills/object-assign';
-import {install as installMathSign} from '../polyfills/math-sign';
 
 initLogConstructor();
 installWorkerErrorReporting('ww');
-
-// Polyfills.
-installArrayIncludes(self);
-installObjectAssign(self);
-installMathSign(self);
 
 /**
  * Element `i` contains the evaluator for scope `i`.

--- a/test/functional/test-object.js
+++ b/test/functional/test-object.js
@@ -24,9 +24,9 @@ describe('Object', () => {
   });
 
   it('ownProperty', () => {
-    expect(object.ownProperty({}, '__proto__')).to.be.false;
-    expect(object.ownProperty({}, 'constructor')).to.be.false;
-    expect(object.ownProperty({foo: 'bar'}, 'foo')).to.be.true;
+    expect(object.ownProperty({}, '__proto__')).to.be.undefined;
+    expect(object.ownProperty({}, 'constructor')).to.be.undefined;
+    expect(object.ownProperty({foo: 'bar'}, 'foo')).to.equal('bar');
   });
 
   describe('map', () => {

--- a/test/functional/test-object.js
+++ b/test/functional/test-object.js
@@ -17,10 +17,16 @@
 import * as object from '../../src/utils/object';
 
 describe('Object', () => {
-  it('hasOwn works', () => {
+  it('hasOwn', () => {
     expect(object.hasOwn(object.map(), 'a')).to.be.false;
     expect(object.hasOwn(object.map({'a': 'b'}), 'b')).to.be.false;
     expect(object.hasOwn(object.map({'a': {}}), 'a')).to.be.true;
+  });
+
+  it('ownProperty', () => {
+    expect(object.ownProperty({}, '__proto__')).to.be.false;
+    expect(object.ownProperty({}, 'constructor')).to.be.false;
+    expect(object.ownProperty({foo: 'bar'}, 'foo')).to.be.true;
   });
 
   describe('map', () => {

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -19,8 +19,7 @@ import {batchedXhrFor, bindForDoc} from '../../src/services';
 import {ampdocServiceFor} from '../../src/ampdoc';
 import * as sinon from 'sinon';
 
-// TODO(choumx): Unskip once #9571 is fixed.
-describe.skip('amp-bind', function() {
+describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   let fixture;
   let ampdoc;
   let sandbox;
@@ -295,7 +294,8 @@ describe.skip('amp-bind', function() {
       });
     });
 
-    it('should change width and height when their bindings change', () => {
+    // TODO(choumx): Fix this final flaky test.
+    it.skip('should change width and height when their bindings change', () => {
       const button = fixture.doc.getElementById('changeImgDimensButton');
       const img = fixture.doc.getElementById('image');
       expect(img.getAttribute('height')).to.equal('200');

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -27,6 +27,8 @@ describe.skip('amp-bind', function() {
   let numSetStates;
   let numMutated;
 
+  this.timeout(5000);
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     numSetStates = 0;


### PR DESCRIPTION
Fixes all tests on Saucelabs (except for one). Partial for #9571. 

- Add missing polyfills (e.g. `Array.include`) to web worker.
- Remove use of polyfilled functions in top-level scope of modules.*
    - `map()` in bind-validator.js
    - `Array.includes` in bind-expression.js
- Add fallback for `Event` constructor.
- Add `ownProperty()` function to utils/object.js.

*May also be fixed by importing `web-worker-polyfills`, but I thought that looked weird.