### PR TITLE
Whitelist check-links.js from cdn URL presubmit check

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -756,6 +756,7 @@ var forbiddenTermsSrcInclusive = {
       'tools/errortracker/errortracker.go',
       'validator/nodejs/index.js',
       'validator/webui/serve-standalone.go',
+      'build-system/tasks/check-links.js',
       'build-system/tasks/extension-generator/index.js',
     ],
   },


### PR DESCRIPTION
This didn't get caught by presubmit when the change went in, but is now causing presubmit failures in other PRs