### PR TITLE
amp-youtube: Autoplay animation to pause when video ends

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -34,7 +34,11 @@ import {startsWith} from '../../../src/string';
  * @enum {number}
  * @private
  */
+
+ // Correct PlayerStates taken from: https://developers.google.com/youtube/iframe_api_reference#Playback_status
 const PlayerStates = {
+  UNSTARTED: -1,
+  ENDED: 0,
   PLAYING: 1,
   PAUSED: 2,
 };
@@ -44,7 +48,7 @@ const PlayerStates = {
  * @private
  */
 const PlayerFlags = {
-  /* Config to tell YouTube to hide annotations by default*/
+  // Config to tell YouTube to hide annotations by default
   HIDE_ANNOTATION: 3,
 };
 
@@ -57,7 +61,7 @@ class AmpYoutube extends AMP.BaseElement {
   constructor(element) {
     super(element);
     /** @private {number} */
-    this.playerState_ = 0;
+    this.playerState_ = PlayerStates.UNSTARTED;
 
     /** @private {?string}  */
     this.videoid_ = null;
@@ -291,7 +295,8 @@ class AmpYoutube extends AMP.BaseElement {
     if (data.event == 'infoDelivery' &&
         data.info && data.info.playerState !== undefined) {
       this.playerState_ = data.info.playerState;
-      if (this.playerState_ == PlayerStates.PAUSED) {
+      if (this.playerState_ == PlayerStates.PAUSED ||
+          this.playerState_ == PlayerStates.ENDED) {
         this.element.dispatchCustomEvent(VideoEvents.PAUSE);
       } else if (this.playerState_ == PlayerStates.PLAYING) {
         this.element.dispatchCustomEvent(VideoEvents.PLAY);

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -173,7 +173,7 @@ describe('amp-youtube', function() {
       const iframe = yt.querySelector('iframe');
       expect(iframe).to.not.be.null;
 
-      expect(yt.implementation_.playerState_).to.equal(0);
+      expect(yt.implementation_.playerState_).to.equal(-1);
 
       sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 1});
 
@@ -273,6 +273,13 @@ describe('amp-youtube', function() {
       .then(() => {
         const p = listenOncePromise(yt, VideoEvents.PAUSE);
         sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 2});
+        return p;
+      })
+      .then(() => {
+        // Make sure pause is triggered when video stops
+        const p = listenOncePromise(yt, VideoEvents.PAUSE);
+        sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 1});
+        sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 0});
         return p;
       })
       .then(() => {


### PR DESCRIPTION
This fixes the bug where Youtube videos do not send a pause event when ended ( [https://github.com/ampproject/amphtml/issues/5776](#5776) ).

### Changes

- Changed example to use shorter video to see effect
- Changed initial state of videos to -1 (UNSTARTED) instead of 0 (ENDED) based on the Youtube API
- Added "ENDED" state (state 0)
- Added unit test for this behavior

Closes #5776 