### PR TITLE
Doubleclick Fast Fetch: Send default safeframe version on ad request

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -20,7 +20,7 @@
 // Most other ad networks will want to put their A4A code entirely in the
 // extensions/amp-ad-network-${NETWORK_NAME}-impl directory.
 
-import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
+import {AmpA4A, DEFAULT_SAFEFRAME_VERSION} from '../../amp-a4a/0.1/amp-a4a';
 import {
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
@@ -136,7 +136,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       {name: 'adk', value: this.adKey_(sizeStr)},
       {name: 'gdfp_req', value: '1'},
       {name: 'impl', value: 'ifr'},
-      {name: 'sfv', value: 'A'},
+      {name: 'sfv', value: DEFAULT_SAFEFRAME_VERSION},
       {name: 'sz', value: sizeStr},
       {name: 'tfcd', value: tfcd == undefined ? null : tfcd},
       {name: 'u_sd', value: global.devicePixelRatio},

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -328,7 +328,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
         expect(url).to.match(new RegExp(
           '^https://securepubads\\.g\\.doubleclick\\.net/gampad/ads' +
           // Depending on how the test is run, it can get different results.
-          '\\?adk=[0-9]+&gdfp_req=1&impl=ifr&sfv=A&sz=320x50' +
+          '\\?adk=[0-9]+&gdfp_req=1&impl=ifr&sfv=\d+-\d+-\d+&sz=320x50' +
           '&u_sd=[0-9]+(&asnt=[0-9]+-[0-9]+)?(&art=2)?' +
           '&is_amp=3&amp_v=%24internalRuntimeVersion%24' +
           '&d_imp=1&dt=[0-9]+&ifi=[0-9]+&adf=[0-9]+' +

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -328,7 +328,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
         expect(url).to.match(new RegExp(
           '^https://securepubads\\.g\\.doubleclick\\.net/gampad/ads' +
           // Depending on how the test is run, it can get different results.
-          '\\?adk=[0-9]+&gdfp_req=1&impl=ifr&sfv=\d+-\d+-\d+&sz=320x50' +
+          '\\?adk=[0-9]+&gdfp_req=1&impl=ifr&sfv=\\d+-\\d+-\\d+&sz=320x50' +
           '&u_sd=[0-9]+(&asnt=[0-9]+-[0-9]+)?(&art=2)?' +
           '&is_amp=3&amp_v=%24internalRuntimeVersion%24' +
           '&d_imp=1&dt=[0-9]+&ifi=[0-9]+&adf=[0-9]+' +


### PR DESCRIPTION
Rather than sending placeholder value of 'A', send the default safeframe version as specified in AmpA4A.