### PR TITLE
Optimizations to speed up Travis PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,8 @@ env:
   global:
     - NPM_CONFIG_PROGRESS="false"
   matrix:
-    - BUILD_SHARD="pre_build_checks"
+    - BUILD_SHARD="pre_build_checks_and_unit_tests"
     - BUILD_SHARD="integration_tests"
-    - BUILD_SHARD="unit_tests"
 cache:
   yarn: true
   directories:

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -265,9 +265,9 @@ function runAllCommands() {
   if (process.env.BUILD_SHARD == "pre_build_checks_and_unit_tests") {
     command.testBuildSystem();
     command.cleanBuild();
+    command.buildRuntime();
     command.runLintChecks();
     command.runDepAndTypeChecks();
-    command.buildRuntime();
     command.runUnitTests();
     // command.testDocumentLinks() is skipped during push builds.
     command.buildValidatorWebUI();
@@ -358,9 +358,9 @@ function main(argv) {
 
     if (buildTargets.has('RUNTIME')) {
       command.cleanBuild();
+      command.buildRuntime();
       command.runLintChecks();
       command.runDepAndTypeChecks();
-      command.buildRuntime();
       command.runUnitTests();
       // Ideally, we'd run presubmit tests after `gulp dist`, as some checks run
       // through the dist/ folder. However, to speed up the Travis queue, we no

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -219,9 +219,6 @@ const command = {
   buildRuntime: function() {
     timedExecOrDie(`${gulp} build`);
   },
-  buildCSS: function() {
-    timedExecOrDie(`${gulp} build --css-only`);
-  },
   serveRuntime: function() {
     timedExecOrDie(`${gulp} dist --fortesting`);
   },
@@ -265,7 +262,7 @@ function runAllCommands() {
   if (process.env.BUILD_SHARD == "pre_build_checks_and_unit_tests") {
     command.testBuildSystem();
     command.cleanBuild();
-    command.buildCSS();
+    command.buildRuntime();
     command.runLintChecks();
     command.runDepAndTypeChecks();
     command.runUnitTests();
@@ -358,10 +355,15 @@ function main(argv) {
 
     if (buildTargets.has('RUNTIME')) {
       command.cleanBuild();
-      command.buildCSS();
+      command.buildRuntime();
       command.runLintChecks();
       command.runDepAndTypeChecks();
       command.runUnitTests();
+      // Ideally, we'd run presubmit tests after `gulp dist`, as some checks run
+      // through the dist/ folder. However, to speed up the Travis queue, we no
+      // longer do a dist build for PRs, so this call won't cover dist/.
+      // TODO(rsimha-amp): Move this once integration tests are enabled.
+      command.runPresubmitTests();
     }
     if (buildTargets.has('VALIDATOR_WEBUI')) {
       command.buildValidatorWebUI();
@@ -374,10 +376,6 @@ function main(argv) {
   if (process.env.BUILD_SHARD == "integration_tests") {
     // The integration_tests shard can be skipped for PRs.
     console.log(fileLogPrefix, 'Skipping integration_tests for PRs');
-    // Ideally, we'd run presubmit tests after `gulp dist`, as some checks run
-    // through the dist/ folder. However, to speed up the Travis queue, we no
-    // longer do a dist build for PRs, so this call won't cover dist/.
-    command.runPresubmitTests();
   }
 
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -216,10 +216,13 @@ const command = {
   runLintChecks: function() {
     timedExecOrDie(`${gulp} lint`);
   },
+  buildRuntimeCssOnly: function() {
+    timedExecOrDie(`${gulp} build --css-only`);
+  },
   buildRuntime: function() {
     timedExecOrDie(`${gulp} build`);
   },
-  serveRuntime: function() {
+  buildRuntimeMinified: function() {
     timedExecOrDie(`${gulp} dist --fortesting`);
   },
   runDepAndTypeChecks: function() {
@@ -262,9 +265,9 @@ function runAllCommands() {
   if (process.env.BUILD_SHARD == "pre_build_checks_and_unit_tests") {
     command.testBuildSystem();
     command.cleanBuild();
-    command.buildRuntime();
     command.runLintChecks();
     command.runDepAndTypeChecks();
+    command.buildRuntime();
     command.runUnitTests();
     // command.testDocumentLinks() is skipped during push builds.
     command.buildValidatorWebUI();
@@ -272,8 +275,8 @@ function runAllCommands() {
   }
   if (process.env.BUILD_SHARD == "integration_tests") {
     command.cleanBuild();
-    command.buildRuntime();
-    command.serveRuntime();
+    command.buildRuntimeCssOnly();
+    command.buildRuntimeMinified();
     command.runPresubmitTests();  // Needs runtime to be built and served.
     command.runVisualDiffTests();  // Only called during push builds.
     command.runIntegrationTests();
@@ -355,9 +358,9 @@ function main(argv) {
 
     if (buildTargets.has('RUNTIME')) {
       command.cleanBuild();
-      command.buildRuntime();
       command.runLintChecks();
       command.runDepAndTypeChecks();
+      command.buildRuntime();
       command.runUnitTests();
       // Ideally, we'd run presubmit tests after `gulp dist`, as some checks run
       // through the dist/ folder. However, to speed up the Travis queue, we no

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -374,12 +374,10 @@ function main(argv) {
   if (process.env.BUILD_SHARD == "integration_tests") {
     // The integration_tests shard can be skipped for PRs.
     console.log(fileLogPrefix, 'Skipping integration_tests for PRs');
-    // Presubmit needs to run after `gulp dist` as some checks run through the
-    // dist/ folder. In addition, we run presubmit even for PRs with just docs
-    // to check for the copyright at the top. However, to speed up the Travis
-    // queue, we no longer do a dist build for PRs.
-    // TODO(rsimha-amp, 9404): Enable this once integration_tests are enabled.
-    // command.runPresubmitTests();
+    // Ideally, we'd run presubmit tests after `gulp dist`, as some checks run
+    // through the dist/ folder. However, to speed up the Travis queue, we no
+    // longer do a dist build for PRs, so this call won't cover dist/.
+    command.runPresubmitTests();
   }
 
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -219,6 +219,9 @@ const command = {
   buildRuntime: function() {
     timedExecOrDie(`${gulp} build`);
   },
+  buildCSS: function() {
+    timedExecOrDie(`${gulp} build --css-only`);
+  },
   serveRuntime: function() {
     timedExecOrDie(`${gulp} dist --fortesting`);
   },
@@ -262,7 +265,7 @@ function runAllCommands() {
   if (process.env.BUILD_SHARD == "pre_build_checks_and_unit_tests") {
     command.testBuildSystem();
     command.cleanBuild();
-    command.buildRuntime();
+    command.buildCSS();
     command.runLintChecks();
     command.runDepAndTypeChecks();
     command.runUnitTests();
@@ -355,7 +358,7 @@ function main(argv) {
 
     if (buildTargets.has('RUNTIME')) {
       command.cleanBuild();
-      command.buildRuntime();
+      command.buildCSS();
       command.runLintChecks();
       command.runDepAndTypeChecks();
       command.runUnitTests();


### PR DESCRIPTION
Travis builds have become slow during busy periods of the day due to various reasons. This PR does the following:

- Reorganizes build tasks across fewer build shards
- Reduces the number of VMs used by PR and master builds to 2
- No longer does a full gulp dist for unit tests (Possible to do after #9404)
- Reduces the total CPU time used for PR builds to < 20 mins

Fixes #9500 
Fixes #9387