### PR TITLE
amp-access-laterpay fixes

### DIFF
--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -10,7 +10,10 @@
     {
       "vendor": "laterpay",
       "laterpay": {
-        "articleTitleSelector": ".content-container > header > h1"
+        "articleTitleSelector": ".content-container > header > h1",
+        "localeMessages": {
+          "header": "LaterPay"
+        }
       }
     }
   </script>

--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>
-  <link rel="canonical" href="amps.html" >
+  <link rel="canonical" href="article-access-laterpay.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <!-- See https://github.com/ampproject/amp-publisher-sample -->
   <script id="amp-access" type="application/json">

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -28,9 +28,10 @@
 }
 
 .amp-access-laterpay ul {
+  width: 100%;
   margin: 0;
   padding: 0;
-  width: 100%;
+  margin-bottom: 40px;
 }
 
 .amp-access-laterpay li {
@@ -48,8 +49,13 @@
   width: 20px;
 }
 
-.amp-access-laterpay-metadata-container {
-  width: 90%;
+.amp-access-laterpay-header {
+  font-size: 1.2em;
+  margin-bottom: 40px;
+}
+
+.amp-access-laterpay-metadata {
+  width: 92%;
 }
 
 .amp-access-laterpay-title {
@@ -69,8 +75,26 @@
   margin-left: auto;
 }
 
+.amp-access-laterpay-price {
+  font-size: 1.5em;
+}
+
+.amp-access-laterpay-currency {
+  font-size: 0.7em;
+}
+
 .amp-access-laterpay-purchase-button {
   font-size: 1.1em;
   padding: 0.5em 0.8em;
   width: 70%;
+  padding: 0.5em 0.8em;
+  background-color: #8db444;
+  border-radius: 4px;
+  border: 0;
+  color: #fff;
+  width: 70%;
+}
+
+.amp-access-laterpay-already-purchased-link-container {
+  font-size: 0.9em;
 }

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -76,7 +76,8 @@ let PurchaseOptionDef;
  *   access: boolean,
  *   apl: string,
  *   premiumcontent: !PurchaseOptionDef,
- *   timepasses: Array<PurchaseOptionDef>=
+ *   timepasses: Array<PurchaseOptionDef>=,
+ *   subscriptions: Array<PurchaseOptionDef>=
  * }}
  */
 let PurchaseConfigDef;
@@ -306,6 +307,9 @@ export class LaterpayVendor {
     );
     this.purchaseConfig_.timepasses.forEach(timepass => {
       listContainer.appendChild(this.createPurchaseOption_(timepass));
+    });
+    this.purchaseConfig_.subscriptions.forEach(subscription => {
+      listContainer.appendChild(this.createPurchaseOption_(subscription));
     });
     const purchaseButton = this.createElement_('button');
     purchaseButton.className = TAG + '-purchase-button';

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -152,6 +152,9 @@ describes.fakeWin('LaterpayVendor', {
         premiumcontent: {
           price: {},
         },
+        subscriptions: [
+          {price: {}},
+        ],
         timepasses: [
           {price: {}},
         ],
@@ -167,8 +170,8 @@ describes.fakeWin('LaterpayVendor', {
       expect(container.querySelector('ul')).to.not.be.null;
     });
 
-    it('renders 2 purchase options', () => {
-      expect(container.querySelector('ul').childNodes.length).to.equal(2);
+    it('renders 3 purchase options', () => {
+      expect(container.querySelector('ul').childNodes.length).to.equal(3);
     });
 
   });
@@ -184,6 +187,9 @@ describes.fakeWin('LaterpayVendor', {
         premiumcontent: {
           price: {},
         },
+        subscriptions: [
+          {price: {}},
+        ],
         timepasses: [
           {price: {}},
         ],
@@ -216,6 +222,9 @@ describes.fakeWin('LaterpayVendor', {
         premiumcontent: {
           price: {},
         },
+        subscriptions: [
+          {price: {}},
+        ],
         timepasses: [
           {price: {}},
         ],


### PR DESCRIPTION
This PR implements a few smaller fixes to the LaterPay extension in order to prepare it for release.

These include:
- Adding support for LaterPay subscriptions (pretty much the same as timepasses)
- Fixing the canonical link in the HTML example so it makes more sense when testing it with a configuration setup on the LaterPay service
- Adding an example configurable locale message to make it more obvious how to use these
- Some tweaks to the default styling to make things a bit more readable and usable by default.

Most of these fixes are fairly small so I chose to bundle them up in this PR, but can break them up if necessary.