### PR TITLE
Remove whitelisted link for PR 9434

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -111,10 +111,6 @@ function filterWhitelistedLinks(markdown) {
   filteredMarkdown =
       filteredMarkdown.replace(/https:\/\/cdn.ampproject.org(?!\/)/g, '');
 
-  // TODO(honeybadgerdontcare): Remove after PR #9434 is merged
-  filteredMarkdown =
-    filteredMarkdown.replace(/https:\/\/github.com\/ampproject\/amphtml\/blob\/master\/extensions\/amp-imgur\/0.1\/validator-amp-imgur.protoascii/g, '');
-
   return filteredMarkdown;
 }
 


### PR DESCRIPTION
Due to #9628 it is necessary to whitelist links in markdowns that would resolve once the PR is merged. Now that PR #9434 is merged, removing that whitelist.