### PR TITLE
Fix extern for integration test

### DIFF
--- a/third_party/closure-compiler/externs/web_animations.js
+++ b/third_party/closure-compiler/externs/web_animations.js
@@ -25,12 +25,13 @@
  * @extend {EventTarget}
  */
 class Animation {
-
-  /**
-   * Current time of the animation.
-   * @type {number}
-   */
-  get currentTime() {}
+  constructor() {
+    /**
+     * Current time of the animation.
+     * @type {number}
+     */
+    this.currentTime;
+  }
 
   /**
    * Starts or resumes playing of an animation, or begins the animation again


### PR DESCRIPTION
Apparently `get` properties are not ok for closure externs.