### PR TITLE
Remove need for <amp-auto-ads> tag in the body

### DIFF
--- a/ads/google/adsense-amp-auto-ads.js
+++ b/ads/google/adsense-amp-auto-ads.js
@@ -37,7 +37,9 @@ export const AdSenseAmpAutoAdsHoldoutBranches = {
 
 /** @const {!../../src/experiments.ExperimentInfo} */
 const ADSENSE_AMP_AUTO_ADS_EXPERIMENT_INFO = {
-  isTrafficEligible: win => !!win.document.querySelector('AMP-AUTO-ADS'),
+  isTrafficEligible: win => !!(
+      win.document.querySelector('meta[name="amp-auto-ads-setup"]') ||
+      win.document.querySelector('amp-auto-ads')),
   branches: [
     AdSenseAmpAutoAdsHoldoutBranches.CONTROL,
     AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT,

--- a/ads/google/test/test-adsense-amp-auto-ads.js
+++ b/ads/google/test/test-adsense-amp-auto-ads.js
@@ -64,6 +64,28 @@ describes.realWin('adsense-amp-auto-ads', {}, env => {
         .to.equal(AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
   });
 
+  it('should pick the control branch when experiment on and amp-auto-ads ' +
+      'setup element present.', () => {
+    const ampAutoAdsSetupNode = win.document.createElement('meta');
+    ampAutoAdsSetupNode.setAttribute('name', 'amp-auto-ads-setup');
+    win.document.head.appendChild(ampAutoAdsSetupNode);
+    toggleExperiment(win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, true);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.4);
+    expect(getAdSenseAmpAutoAdsExpBranch(win))
+        .to.equal(AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
+  });
+
+  it('should pick the experiment branch when experiment on and amp-auto-ads ' +
+      'setup element present.', () => {
+    const ampAutoAdsSetupNode = win.document.createElement('meta');
+    ampAutoAdsSetupNode.setAttribute('name', 'amp-auto-ads-setup');
+    win.document.head.appendChild(ampAutoAdsSetupNode);
+    toggleExperiment(win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, true);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.6);
+    expect(getAdSenseAmpAutoAdsExpBranch(win))
+        .to.equal(AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
+  });
+
   it('should not pick a branch when experiment off.', () => {
     const ampAutoAdsEl = win.document.createElement('amp-auto-ads');
     win.document.body.appendChild(ampAutoAdsEl);

--- a/examples/auto-ads.amp.html
+++ b/examples/auto-ads.amp.html
@@ -3,8 +3,9 @@
   <head>
     <meta charset="utf-8">
     <title>AMP #0</title>
-    <link rel="canonical" href="amps.html" >
+    <link rel="canonical" href="http://amp.autoplaced.com" >
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <meta name="amp-auto-ads-setup" type="adsense" data-ad-client="ca-pub-5439573510495356">
     <script async custom-element="amp-auto-ads" src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -49,7 +50,6 @@
     </style>
   </head>
   <body>
-    <amp-auto-ads type="adsense" data-ad-client="ca-pub-5439573510495356"></amp-auto-ads>
     <header>
       <amp-img layout="responsive" id="header-img" src="img/hero@2x.jpg" width="1200" height="900"></amp-img>
     </header>

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -33,31 +33,25 @@ describes.realWin('ad-network-config', {
   },
 }, env => {
 
-  let ampAutoAdsElem;
-  let document;
+  let ampdoc;
 
   beforeEach(() => {
-    document = env.win.document;
-    ampAutoAdsElem = document.createElement('amp-auto-ads');
-    env.win.document.body.appendChild(ampAutoAdsElem);
-  });
-
-  afterEach(() => {
-    env.win.document.body.removeChild(ampAutoAdsElem);
+    ampdoc = env.ampdoc;
   });
 
   describe('AdSense', () => {
 
     const AD_CLIENT = 'ca-pub-1234';
+    const setupParams = {};
 
     beforeEach(() => {
-      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+      setupParams['adClient'] = AD_CLIENT;
     });
 
     it('should report enabled when holdout experiment not on', () => {
       toggleExperiment(
           env.win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, false);
-      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      const adNetwork = getAdNetworkConfig(ampdoc, 'adsense', setupParams);
       expect(adNetwork.isEnabled(env.win)).to.equal(true);
     });
 
@@ -66,7 +60,7 @@ describes.realWin('ad-network-config', {
       forceExperimentBranch(env.win,
           ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
           AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
-      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      const adNetwork = getAdNetworkConfig(ampdoc, 'adsense', setupParams);
       expect(adNetwork.isEnabled(env.win)).to.equal(true);
     });
 
@@ -75,19 +69,19 @@ describes.realWin('ad-network-config', {
       forceExperimentBranch(env.win,
           ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
           AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
-      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      const adNetwork = getAdNetworkConfig(ampdoc, 'adsense', setupParams);
       expect(adNetwork.isEnabled(env.win)).to.equal(false);
     });
 
     it('should generate the config fetch URL', () => {
-      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      const adNetwork = getAdNetworkConfig(ampdoc, 'adsense', setupParams);
       expect(adNetwork.getConfigUrl()).to.equal(
           '//pagead2.googlesyndication.com/getconfig/ama?client=' +
           AD_CLIENT + '&plah=foo.bar&ama_t=amp');
     });
 
     it('should generate the attributes', () => {
-      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      const adNetwork = getAdNetworkConfig(ampdoc, 'adsense', setupParams);
       expect(adNetwork.getAttributes()).to.deep.equal({
         'type': 'adsense',
         'data-ad-client': 'ca-pub-1234',
@@ -95,11 +89,11 @@ describes.realWin('ad-network-config', {
     });
 
     it('should get the ad constraints', () => {
-      const viewportMock = sandbox.mock(viewportForDoc(env.win.document));
+      const viewportMock = sandbox.mock(viewportForDoc(ampdoc));
       viewportMock.expects('getSize').returns(
           {width: 320, height: 500}).atLeast(1);
 
-      const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+      const adNetwork = getAdNetworkConfig(ampdoc, 'adsense', setupParams);
       expect(adNetwork.getAdConstraints()).to.deep.equal({
         initialMinSpacing: 500,
         subsequentMinSpacing: [
@@ -112,6 +106,6 @@ describes.realWin('ad-network-config', {
   });
 
   it('should return null for unknown type', () => {
-    expect(getAdNetworkConfig('unknowntype', ampAutoAdsElem)).to.be.null;
+    expect(getAdNetworkConfig(ampdoc, 'unknowntype', {})).to.be.null;
   });
 });

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {AmpAutoAds} from '../amp-auto-ads';
+import {AmpAutoAdsElement, AmpAutoAdsService} from '../amp-auto-ads';
 import {
   toggleExperiment,
   forceExperimentBranch,
 } from '../../../../src/experiments';
-import {xhrFor} from '../../../../src/services';
+import {viewerForDoc, xhrFor} from '../../../../src/services';
 import {waitForChild} from '../../../../src/dom';
 import {viewportForDoc} from '../../../../src/services';
 import {
@@ -43,8 +43,6 @@ describes.realWin('amp-auto-ads', {
   let anchor2;
   let anchor3;
   let anchor4;
-  let ampAutoAds;
-  let ampAutoAdsElem;
   let xhr;
   let configObj;
 
@@ -97,9 +95,6 @@ describes.realWin('amp-auto-ads', {
     anchor4.id = 'anId4';
     container.appendChild(anchor4);
 
-    ampAutoAdsElem = env.win.document.createElement('amp-auto-ads');
-    env.win.document.body.appendChild(ampAutoAdsElem);
-
     configObj = {
       placements: [
         {
@@ -138,8 +133,6 @@ describes.realWin('amp-auto-ads', {
       return Promise.resolve(configObj);
     };
     sandbox.spy(xhr, 'fetchJson');
-
-    ampAutoAds = new AmpAutoAds(ampAutoAdsElem);
   });
 
   function verifyAdElement(adElement) {
@@ -148,180 +141,424 @@ describes.realWin('amp-auto-ads', {
     expect(adElement.getAttribute('data-ad-client')).to.equal(AD_CLIENT);
   }
 
-  it('should insert three ads on page using config', () => {
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    ampAutoAdsElem.setAttribute('type', 'adsense');
-    ampAutoAds.buildCallback();
+  describe('legacy <amp-auto-ads> setup', () => {
+    let ampAutoAdsElement;
+    let ampAutoAdsDomElem;
 
-    return new Promise(resolve => {
-      waitForChild(anchor4, parent => {
-        return parent.childNodes.length > 0;
-      }, () => {
-        expect(anchor1.childNodes).to.have.lengthOf(1);
-        expect(anchor2.childNodes).to.have.lengthOf(1);
-        expect(anchor3.childNodes).to.have.lengthOf(0);
-        expect(anchor4.childNodes).to.have.lengthOf(1);
-        verifyAdElement(anchor1.childNodes[0]);
-        verifyAdElement(anchor2.childNodes[0]);
-        verifyAdElement(anchor4.childNodes[0]);
-        resolve();
+    beforeEach(() => {
+      ampAutoAdsDomElem = env.win.document.createElement('amp-auto-ads');
+      env.win.document.body.appendChild(ampAutoAdsDomElem);
+
+      ampAutoAdsElement = new AmpAutoAdsElement(ampAutoAdsDomElem);
+    });
+
+    it('should insert three ads on page using config', () => {
+      ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsDomElem.setAttribute('type', 'adsense');
+      ampAutoAdsElement.buildCallback();
+
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor3.childNodes).to.have.lengthOf(0);
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          verifyAdElement(anchor1.childNodes[0]);
+          verifyAdElement(anchor2.childNodes[0]);
+          verifyAdElement(anchor4.childNodes[0]);
+          resolve();
+        });
       });
+    });
+
+    it('should insert ads on the page when in holdout experiment branch',
+        () => {
+          forceExperimentBranch(env.win,
+              ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+              AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
+
+          ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+          ampAutoAdsDomElem.setAttribute('type', 'adsense');
+          ampAutoAdsElement.buildCallback();
+
+          return new Promise(resolve => {
+            waitForChild(anchor4, parent => {
+              return parent.childNodes.length > 0;
+            }, () => {
+              expect(anchor1.childNodes).to.have.lengthOf(1);
+              expect(anchor2.childNodes).to.have.lengthOf(1);
+              expect(anchor3.childNodes).to.have.lengthOf(0);
+              expect(anchor4.childNodes).to.have.lengthOf(1);
+              verifyAdElement(anchor1.childNodes[0]);
+              verifyAdElement(anchor2.childNodes[0]);
+              verifyAdElement(anchor4.childNodes[0]);
+              resolve();
+            });
+          });
+        });
+
+    it('should not insert ads on the page when in holdout control branch',
+        () => {
+          forceExperimentBranch(env.win,
+              ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+              AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
+
+          ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+          ampAutoAdsDomElem.setAttribute('type', 'adsense');
+          ampAutoAdsElement.buildCallback();
+
+          return new Promise(resolve => {
+            setTimeout(() => {
+              expect(anchor1.childNodes).to.have.lengthOf(0);
+              expect(anchor2.childNodes).to.have.lengthOf(0);
+              expect(anchor3.childNodes).to.have.lengthOf(0);
+              expect(anchor4.childNodes).to.have.lengthOf(0);
+              resolve();
+            }, 500);
+          });
+        });
+
+    it('should insert ads with the config provided attributes', () => {
+      configObj.attributes = {
+        'bad-name': 'should be filtered',
+        'data-custom-att-1': 'val-1',
+        'data-custom-att-2': 'val-2',
+      };
+
+      ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsDomElem.setAttribute('type', 'adsense');
+      ampAutoAdsElement.buildCallback();
+
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor1.childNodes[0].getAttribute('data-custom-att-1'))
+              .to.equal('val-1');
+          expect(anchor1.childNodes[0].getAttribute('data-custom-att-2'))
+              .to.equal('val-2');
+
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes[0].getAttribute('data-custom-att-1'))
+              .to.equal('val-1');
+          expect(anchor2.childNodes[0].getAttribute('data-custom-att-2'))
+              .to.equal('val-2');
+
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          expect(anchor4.childNodes[0].getAttribute('data-custom-att-1'))
+              .to.equal('val-1');
+          expect(anchor4.childNodes[0].getAttribute('data-custom-att-2'))
+              .to.equal('val-2');
+          resolve();
+        });
+      });
+    });
+
+    it('should override ad network type with config provided attribute', () => {
+      configObj.attributes = {
+        'type': 'doubleclick',
+      };
+
+      ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsDomElem.setAttribute('type', 'adsense');
+      ampAutoAdsElement.buildCallback();
+
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor1.childNodes[0].getAttribute('type'))
+              .to.equal('doubleclick');
+
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes[0].getAttribute('type'))
+              .to.equal('doubleclick');
+
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          expect(anchor4.childNodes[0].getAttribute('type'))
+              .to.equal('doubleclick');
+          resolve();
+        });
+      });
+    });
+
+    it('should fetch a config from the correct URL', () => {
+      ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsDomElem.setAttribute('type', 'adsense');
+      ampAutoAdsElement.buildCallback();
+
+      return ampAutoAdsElement.layoutCallback().then(() => {
+        expect(xhr.fetchJson).to.have.been.calledWith(
+            '//pagead2.googlesyndication.com/getconfig/ama?client=' +
+            AD_CLIENT + '&plah=localhost&ama_t=amp', {
+              mode: 'cors',
+              method: 'GET',
+              credentials: 'omit',
+              requireAmpResponseSourceOrigin: false,
+            });
+        expect(xhr.fetchJson).to.be.calledOnce;
+      });
+    });
+
+    it('should throw an error if no type', () => {
+      ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+      expect(() => ampAutoAdsElement.buildCallback())
+          .to.throw(/Missing type attribute​​/);
+      expect(xhr.fetchJson).not.to.have.been.called;
+    });
+
+    it('should not try and fetch config if unknown type', () => {
+      ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsDomElem.setAttribute('type', 'unknowntype');
+
+      expect(() => ampAutoAdsElement.buildCallback())
+          .to.throw(/No AdNetworkConfig for type: unknowntype​​​/);
+
+      expect(xhr.fetchJson).not.to.have.been.called;
+    });
+
+    it('should not try and fetch config if experiment off', () => {
+      toggleExperiment(env.win, 'amp-auto-ads', false);
+      ampAutoAdsDomElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsDomElem.setAttribute('type', 'adsense');
+
+      expect(() => ampAutoAdsElement.buildCallback())
+          .to.throw(/Experiment is off​​​/);
+      expect(xhr.fetchJson).not.to.have.been.called;
     });
   });
 
-  it('should insert ads on the page when in holdout experiment branch', () => {
-    forceExperimentBranch(env.win,
-        ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
-        AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
+  describe('script tag setup', () => {
+    let ampAutoAdsService;
+    let ampAutoAdsSetupNode;
+    let bodyReadyResolve;
+    let viewer;
 
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    ampAutoAdsElem.setAttribute('type', 'adsense');
-    ampAutoAds.buildCallback();
+    beforeEach(() => {
+      ampAutoAdsSetupNode = env.win.document.createElement('meta');
+      ampAutoAdsSetupNode.setAttribute('name', 'amp-auto-ads-setup');
+      env.win.document.head.appendChild(ampAutoAdsSetupNode);
 
-    return new Promise(resolve => {
-      waitForChild(anchor4, parent => {
-        return parent.childNodes.length > 0;
-      }, () => {
-        expect(anchor1.childNodes).to.have.lengthOf(1);
-        expect(anchor2.childNodes).to.have.lengthOf(1);
-        expect(anchor3.childNodes).to.have.lengthOf(0);
-        expect(anchor4.childNodes).to.have.lengthOf(1);
-        verifyAdElement(anchor1.childNodes[0]);
-        verifyAdElement(anchor2.childNodes[0]);
-        verifyAdElement(anchor4.childNodes[0]);
-        resolve();
+      const ampdoc = env.ampdoc;
+      sandbox.stub(ampdoc, 'whenBodyAvailable').returns(new Promise(resolve => {
+        bodyReadyResolve = resolve;
+      }));
+      viewer = viewerForDoc(ampdoc);
+      sandbox.stub(viewer, 'onVisibilityChanged');
+      sandbox.stub(viewer, 'isVisible').returns(true);
+
+      ampAutoAdsService = new AmpAutoAdsService(ampdoc);
+    });
+
+    it('should insert three ads on page using config', () => {
+      ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsSetupNode.setAttribute('type', 'adsense');
+      bodyReadyResolve();
+
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor3.childNodes).to.have.lengthOf(0);
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          verifyAdElement(anchor1.childNodes[0]);
+          verifyAdElement(anchor2.childNodes[0]);
+          verifyAdElement(anchor4.childNodes[0]);
+          resolve();
+        });
       });
     });
-  });
 
-  it('should not insert ads on the page when in holdout control branch', () => {
-    forceExperimentBranch(env.win,
-        ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
-        AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
+    it('should only insert ads once the document is visible', done => {
+      viewer.isVisible.returns(false);
 
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    ampAutoAdsElem.setAttribute('type', 'adsense');
-    ampAutoAds.buildCallback();
+      ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsSetupNode.setAttribute('type', 'adsense');
+      bodyReadyResolve();
 
-    return new Promise(resolve => {
       setTimeout(() => {
         expect(anchor1.childNodes).to.have.lengthOf(0);
-        expect(anchor2.childNodes).to.have.lengthOf(0);
-        expect(anchor3.childNodes).to.have.lengthOf(0);
-        expect(anchor4.childNodes).to.have.lengthOf(0);
-        resolve();
-      }, 500);
+        viewer.isVisible.returns(true);
+        viewer.onVisibilityChanged.getCall(0).args[0]();
+
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor3.childNodes).to.have.lengthOf(0);
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          verifyAdElement(anchor1.childNodes[0]);
+          verifyAdElement(anchor2.childNodes[0]);
+          verifyAdElement(anchor4.childNodes[0]);
+          done();
+        });
+      }, 10);
     });
-  });
 
-  it('should insert ads with the config provided attributes', () => {
-    configObj.attributes = {
-      'bad-name': 'should be filtered',
-      'data-custom-att-1': 'val-1',
-      'data-custom-att-2': 'val-2',
-    };
+    it('should insert ads on the page when in holdout experiment branch',
+        () => {
+          forceExperimentBranch(env.win,
+              ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+              AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
 
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    ampAutoAdsElem.setAttribute('type', 'adsense');
-    ampAutoAds.buildCallback();
+          ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+          ampAutoAdsSetupNode.setAttribute('type', 'adsense');
+          bodyReadyResolve();
 
-    return new Promise(resolve => {
-      waitForChild(anchor4, parent => {
-        return parent.childNodes.length > 0;
-      }, () => {
-        expect(anchor1.childNodes).to.have.lengthOf(1);
-        expect(anchor1.childNodes[0].getAttribute('data-custom-att-1'))
-            .to.equal('val-1');
-        expect(anchor1.childNodes[0].getAttribute('data-custom-att-2'))
-            .to.equal('val-2');
-
-        expect(anchor2.childNodes).to.have.lengthOf(1);
-        expect(anchor2.childNodes[0].getAttribute('data-custom-att-1'))
-            .to.equal('val-1');
-        expect(anchor2.childNodes[0].getAttribute('data-custom-att-2'))
-            .to.equal('val-2');
-
-        expect(anchor4.childNodes).to.have.lengthOf(1);
-        expect(anchor4.childNodes[0].getAttribute('data-custom-att-1'))
-            .to.equal('val-1');
-        expect(anchor4.childNodes[0].getAttribute('data-custom-att-2'))
-            .to.equal('val-2');
-        resolve();
-      });
-    });
-  });
-
-  it('should override ad network type with config provided attribute', () => {
-    configObj.attributes = {
-      'type': 'doubleclick',
-    };
-
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    ampAutoAdsElem.setAttribute('type', 'adsense');
-    ampAutoAds.buildCallback();
-
-    return new Promise(resolve => {
-      waitForChild(anchor4, parent => {
-        return parent.childNodes.length > 0;
-      }, () => {
-        expect(anchor1.childNodes).to.have.lengthOf(1);
-        expect(anchor1.childNodes[0].getAttribute('type'))
-            .to.equal('doubleclick');
-
-        expect(anchor2.childNodes).to.have.lengthOf(1);
-        expect(anchor2.childNodes[0].getAttribute('type'))
-            .to.equal('doubleclick');
-
-        expect(anchor4.childNodes).to.have.lengthOf(1);
-        expect(anchor4.childNodes[0].getAttribute('type'))
-            .to.equal('doubleclick');
-        resolve();
-      });
-    });
-  });
-
-  it('should fetch a config from the correct URL', () => {
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    ampAutoAdsElem.setAttribute('type', 'adsense');
-    ampAutoAds.buildCallback();
-
-    return ampAutoAds.layoutCallback().then(() => {
-      expect(xhr.fetchJson).to.have.been.calledWith(
-          '//pagead2.googlesyndication.com/getconfig/ama?client=' +
-          AD_CLIENT + '&plah=localhost&ama_t=amp', {
-            mode: 'cors',
-            method: 'GET',
-            credentials: 'omit',
-            requireAmpResponseSourceOrigin: false,
+          return new Promise(resolve => {
+            waitForChild(anchor4, parent => {
+              return parent.childNodes.length > 0;
+            }, () => {
+              expect(anchor1.childNodes).to.have.lengthOf(1);
+              expect(anchor2.childNodes).to.have.lengthOf(1);
+              expect(anchor3.childNodes).to.have.lengthOf(0);
+              expect(anchor4.childNodes).to.have.lengthOf(1);
+              verifyAdElement(anchor1.childNodes[0]);
+              verifyAdElement(anchor2.childNodes[0]);
+              verifyAdElement(anchor4.childNodes[0]);
+              resolve();
+            });
           });
-      expect(xhr.fetchJson).to.be.calledOnce;
+        });
+
+    it('should not insert ads on the page when in holdout control branch',
+        () => {
+          forceExperimentBranch(env.win,
+              ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+              AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
+
+          ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+          ampAutoAdsSetupNode.setAttribute('type', 'adsense');
+          bodyReadyResolve();;
+
+          return new Promise(resolve => {
+            setTimeout(() => {
+              expect(anchor1.childNodes).to.have.lengthOf(0);
+              expect(anchor2.childNodes).to.have.lengthOf(0);
+              expect(anchor3.childNodes).to.have.lengthOf(0);
+              expect(anchor4.childNodes).to.have.lengthOf(0);
+              resolve();
+            }, 500);
+          });
+        });
+
+    it('should insert ads with the config provided attributes', () => {
+      configObj.attributes = {
+        'bad-name': 'should be filtered',
+        'data-custom-att-1': 'val-1',
+        'data-custom-att-2': 'val-2',
+      };
+
+      ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsSetupNode.setAttribute('type', 'adsense');
+      bodyReadyResolve();
+
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor1.childNodes[0].getAttribute('data-custom-att-1'))
+              .to.equal('val-1');
+          expect(anchor1.childNodes[0].getAttribute('data-custom-att-2'))
+              .to.equal('val-2');
+
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes[0].getAttribute('data-custom-att-1'))
+              .to.equal('val-1');
+          expect(anchor2.childNodes[0].getAttribute('data-custom-att-2'))
+              .to.equal('val-2');
+
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          expect(anchor4.childNodes[0].getAttribute('data-custom-att-1'))
+              .to.equal('val-1');
+          expect(anchor4.childNodes[0].getAttribute('data-custom-att-2'))
+              .to.equal('val-2');
+          resolve();
+        });
+      });
     });
-  });
 
-  it('should throw an error if no type', () => {
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    expect(() => ampAutoAds.buildCallback())
-        .to.throw(/Missing type attribute​​/);
-    expect(xhr.fetchJson).not.to.have.been.called;
-  });
+    it('should override ad network type with config provided attribute', () => {
+      configObj.attributes = {
+        'type': 'doubleclick',
+      };
 
-  it('should not try and fetch config if unknown type', () => {
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    ampAutoAdsElem.setAttribute('type', 'unknowntype');
+      ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsSetupNode.setAttribute('type', 'adsense');
+      bodyReadyResolve();
 
-    expect(() => ampAutoAds.buildCallback())
-        .to.throw(/No AdNetworkConfig for type: unknowntype​​​/);
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor1.childNodes[0].getAttribute('type'))
+              .to.equal('doubleclick');
 
-    expect(xhr.fetchJson).not.to.have.been.called;
-  });
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes[0].getAttribute('type'))
+              .to.equal('doubleclick');
 
-  it('should not try and fetch config if experiment off', () => {
-    toggleExperiment(env.win, 'amp-auto-ads', false);
-    ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    ampAutoAdsElem.setAttribute('type', 'adsense');
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          expect(anchor4.childNodes[0].getAttribute('type'))
+              .to.equal('doubleclick');
+          resolve();
+        });
+      });
+    });
 
-    expect(() => ampAutoAds.buildCallback())
-        .to.throw(/Experiment is off​​​/);
-    expect(xhr.fetchJson).not.to.have.been.called;
+    it('should fetch a config from the correct URL', done => {
+      ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsSetupNode.setAttribute('type', 'adsense');
+      bodyReadyResolve();
+
+      setTimeout(() => {
+        expect(xhr.fetchJson).to.have.been.calledWith(
+            '//pagead2.googlesyndication.com/getconfig/ama?client=' +
+            AD_CLIENT + '&plah=localhost&ama_t=amp', {
+              mode: 'cors',
+              method: 'GET',
+              credentials: 'omit',
+              requireAmpResponseSourceOrigin: false,
+            });
+        expect(xhr.fetchJson).to.be.calledOnce;
+        done();
+      }, 10);
+    });
+
+    it('should throw an error if no type', () => {
+      ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+      expect(() => ampAutoAdsService.runOnceIfDocVisible_())
+          .to.throw(/Missing type attribute​​/);
+      expect(xhr.fetchJson).not.to.have.been.called;
+    });
+
+    it('should not try and fetch config if unknown type', () => {
+      ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsSetupNode.setAttribute('type', 'unknowntype');
+
+      expect(() => ampAutoAdsService.runOnceIfDocVisible_())
+          .to.throw(/No AdNetworkConfig for type: unknowntype​​​/);
+
+      expect(xhr.fetchJson).not.to.have.been.called;
+    });
+
+    it('should not try and fetch config if experiment off', () => {
+      toggleExperiment(env.win, 'amp-auto-ads', false);
+      ampAutoAdsSetupNode.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsSetupNode.setAttribute('type', 'adsense');
+
+      expect(() => ampAutoAdsService.runOnceIfDocVisible_())
+          .to.throw(/Experiment is off​​​/);
+      expect(xhr.fetchJson).not.to.have.been.called;
+    });
   });
 });

--- a/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
+++ b/extensions/amp-auto-ads/0.1/validator-amp-auto-ads.protoascii
@@ -39,3 +39,19 @@ tags: {  # <amp-auto-ads>
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-auto-ads"
 }
+tags: {
+  html_format: AMP
+  tag_name: "META"
+  requires: "amp-auto-ads extension .js script"
+  satisfies: "amp-auto-ads"
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "name"
+    mandatory: true
+    value_casei: "amp-auto-ads-setup"
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+  }
+}


### PR DESCRIPTION
Enables amp-auto-ads to be configured with a single snippet, removing the need for an `<amp-auto-ads>` element in the `<body>`.
The old method of using an `<amp-auto-ads>` tag in the `<body>` still works after this change.

This is achieved by adding a service that can run amp-auto-ads and get the setup information from attributes on a meta tag.

The resulting single snippet that a publisher would need to provide would be of the form:
```html
<meta name="amp-auto-ads-setup" type="adsense" data-ad-client="ca-pub-5439573510495356">
<script async custom-element="amp-auto-ads" src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"></script>
```

Closes https://github.com/ampproject/amphtml/issues/9140