### PR TITLE
Enabling dynamic queryparam addition to anchour links 

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -785,10 +785,10 @@ export class UrlReplacements {
       'CLIENT_ID': true,
       'QUERY_PARAM': true,
     };
-    const additionalURLParameters = element.getAttribute('data-amp-addparams');
+    const additionalUrlParameters = element.getAttribute('data-amp-addparams');
     const whitelist = this.getWhitelistForElement_(
         element, supportedReplacements);
-    if (!whitelist && !additionalURLParameters) {
+    if (!whitelist && !additionalUrlParameters) {
       return;
     }
     // ORIGINAL_HREF_PROPERTY has the value of the href "pre-replacement".
@@ -797,30 +797,35 @@ export class UrlReplacements {
     let href = dev().assertString(
         element[ORIGINAL_HREF_PROPERTY] || element.getAttribute('href'));
     const url = parseUrl(href);
-    if (!this.isAllowedOrigin_(url)) {
-      user().warn('URL', 'Ignoring link replacement', href,
-          ' because the link does not go to the document\'s' +
-          ' source, canonical, or whitelisted origin.');
-      return;
-    }
-    if (!isSecureUrl(href)) {
-      user().warn('URL', 'Ignoring link replacement', href,
-          ' because it is only supported for secure links.');
-      return;
-    }
     if (element[ORIGINAL_HREF_PROPERTY] == null) {
       element[ORIGINAL_HREF_PROPERTY] = href;
     }
-    if (additionalURLParameters) {
+    if (additionalUrlParameters) {
       href = addParamsToUrl(
         href,
-        parseQueryString(additionalURLParameters));
+        parseQueryString(additionalUrlParameters));
     }
-    return element.href = this.expandSync(
-        href,
-        /* opt_bindings */ undefined,
-        /* opt_collectVars */ undefined,
-        /* opt_whitelist */ whitelist);
+    if (whitelist) {
+      const isAllowedOrigin = this.isAllowedOrigin_(url);
+      const isSecure = isSecureUrl(href);
+      if (!isAllowedOrigin) {
+        user().warn('URL', 'Ignoring link replacement', href,
+            ' because the link does not go to the document\'s' +
+            ' source, canonical, or whitelisted origin.');
+      }
+      if (!isSecure) {
+        user().warn('URL', 'Ignoring link replacement', href,
+            ' because it is only supported for secure links.');
+      }
+      if (isAllowedOrigin && isSecure) {
+        href = this.expandSync(
+          href,
+          /* opt_bindings */ undefined,
+          /* opt_collectVars */ undefined,
+          /* opt_whitelist */ whitelist);
+      }
+    }
+    return element.href = href;
   }
 
   /**

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -785,9 +785,10 @@ export class UrlReplacements {
       'CLIENT_ID': true,
       'QUERY_PARAM': true,
     };
+    const additionalURLParameters = element.getAttribute('data-amp-addparams');
     const whitelist = this.getWhitelistForElement_(
         element, supportedReplacements);
-    if (!whitelist) {
+    if (!whitelist && !additionalURLParameters) {
       return;
     }
     // ORIGINAL_HREF_PROPERTY has the value of the href "pre-replacement".
@@ -810,7 +811,6 @@ export class UrlReplacements {
     if (element[ORIGINAL_HREF_PROPERTY] == null) {
       element[ORIGINAL_HREF_PROPERTY] = href;
     }
-    const additionalURLParameters = element.getAttribute('data-amp-addparams');
     if (additionalURLParameters) {
       href = addParamsToUrl(
         href,

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -1110,26 +1110,27 @@ describes.sandboxed('UrlReplacements', {}, () => {
       });
     });
 
-    it('should not add URL parameters for different origin', () => {
+    it('should add URL parameters for different origin', () => {
       a.href = 'https://example2.com/link';
       a.setAttribute('data-amp-addparams', 'guid=123');
       urlReplacements.maybeExpandLink(a);
-      expect(a.href).to.equal('https://example2.com/link');
+      expect(a.href).to.equal('https://example2.com/link?guid=123');
     });
 
-    it('should not add URL parameters for http URL\'s(non-secure)', () => {
+    it('should add URL parameters for http URL\'s(non-secure)', () => {
       a.href = 'http://whitelisted.com/link?out=QUERY_PARAM(foo)';
       a.setAttribute('data-amp-addparams', 'guid=123');
       urlReplacements.maybeExpandLink(a);
-      expect(a.href).to.equal('http://whitelisted.com/link?out=QUERY_PARAM(foo)');
+      expect(a.href).to.equal('http://whitelisted.com/link?out=QUERY_PARAM(foo)&guid=123');
     });
 
-    it('should append query parameters for whitelisted origin', () => {
-      a.href = 'https://whitelisted.com/link';
-      a.setAttribute('data-amp-addparams', 'guid=123');
+    it('should add URL parameters without replacing whitelisted'
+      + ' values for http URL\'s(non-secure)', () => {
+      a.href = 'http://whitelisted.com/link?out=QUERY_PARAM(foo)';
+      a.setAttribute('data-amp-replace', 'CLIENT_ID');
+      a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
       urlReplacements.maybeExpandLink(a);
-      expect(a.href).to.equal(
-          'https://whitelisted.com/link?guid=123');
+      expect(a.href).to.equal('http://whitelisted.com/link?out=QUERY_PARAM(foo)&guid=123&c=CLIENT_ID(abc)');
     });
 
     it('should append query parameters and repalce whitelisted values', () => {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -1110,11 +1110,11 @@ describes.sandboxed('UrlReplacements', {}, () => {
       });
     });
 
-    it('should not add URL parameters for unwhitelisted origin', () => {
-      a.href = 'https://example.com/link';
+    it('should not add URL parameters for different origin', () => {
+      a.href = 'https://example2.com/link';
       a.setAttribute('data-amp-addparams', 'guid=123');
       urlReplacements.maybeExpandLink(a);
-      expect(a.href).to.equal('https://example.com/link');
+      expect(a.href).to.equal('https://example2.com/link');
     });
 
     it('should not add URL parameters for http URL\'s(non-secure)', () => {
@@ -1124,7 +1124,15 @@ describes.sandboxed('UrlReplacements', {}, () => {
       expect(a.href).to.equal('http://whitelisted.com/link?out=QUERY_PARAM(foo)');
     });
 
-    it('should append the query parameters for whitelisted origin', () => {
+    it('should append query parameters for whitelisted origin', () => {
+      a.href = 'https://whitelisted.com/link';
+      a.setAttribute('data-amp-addparams', 'guid=123');
+      urlReplacements.maybeExpandLink(a);
+      expect(a.href).to.equal(
+          'https://whitelisted.com/link?guid=123');
+    });
+
+    it('should append query parameters and repalce whitelisted values', () => {
       a.href = 'https://whitelisted.com/link?out=QUERY_PARAM(foo)';
       a.setAttribute('data-amp-replace', 'QUERY_PARAM CLIENT_ID');
       a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');


### PR DESCRIPTION
- Providing option to add dynamic query parameters for source page attribution .This is done by enabling `data-amp-params` to get added with the anchour links href

https://github.com/ampproject/amphtml/issues/9673