### PR TITLE
Remove experimental flag from amp-access-laterpay

### DIFF
--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -16,7 +16,6 @@
 
 import {CSS} from '../../../build/amp-access-laterpay-0.1.css';
 import {dev, user} from '../../../src/log';
-import {isExperimentOn} from '../../../src/experiments';
 import {installStyles} from '../../../src/style-installer';
 import {installStylesForShadowRoot} from '../../../src/shadow-embed';
 import {getMode} from '../../../src/mode';
@@ -180,8 +179,6 @@ export class LaterpayVendor {
    * @return {!Promise<!JSONType>}
    */
   authorize() {
-    user().assert(isExperimentOn(this.ampdoc.win, TAG),
-        'Enable "amp-access-laterpay" experiment');
     return this.getPurchaseConfig_()
     .then(response => {
       if (response.status === 204) {

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -15,8 +15,6 @@
  */
 
 import {LaterpayVendor} from '../laterpay-impl';
-import {toggleExperiment} from '../../../../src/experiments';
-
 
 describes.fakeWin('LaterpayVendor', {
   amp: true,
@@ -54,21 +52,12 @@ describes.fakeWin('LaterpayVendor', {
 
     vendor = new LaterpayVendor(accessService);
     xhrMock = sandbox.mock(vendor.xhr_);
-    toggleExperiment(win, 'amp-access-laterpay', true);
   });
 
   afterEach(() => {
     articleTitle.parentNode.removeChild(articleTitle);
-    toggleExperiment(win, 'amp-access-laterpay', false);
     accessServiceMock.verify();
     xhrMock.verify();
-  });
-
-  it('should fail without experiment', () => {
-    toggleExperiment(win, 'amp-access-laterpay', false);
-    expect(() => {
-      vendor.authorize();
-    }).to.throw(/experiment/);
   });
 
   describe('authorize', () => {

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -21,7 +21,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Experimental</td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td class="col-fourty"><strong>Required Scripts</strong></td>


### PR DESCRIPTION
As mentioned in #9300 this removes the experimental flag for the amp-access-laterpay extension.