### PR TITLE
Insert an <amp-sticky-ad> from within <amp-auto-ads>

### DIFF
--- a/examples/auto-ads.amp.html
+++ b/examples/auto-ads.amp.html
@@ -3,9 +3,11 @@
   <head>
     <meta charset="utf-8">
     <title>AMP #0</title>
-    <link rel="canonical" href="amps.html" >
+    <link rel="canonical" href="http://amp.autoplaced.com" >
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script async custom-element="amp-auto-ads" src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"></script>
+    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>  
+    <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js"></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <style>

--- a/extensions/amp-auto-ads/0.1/ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/ad-tracker.js
@@ -161,6 +161,12 @@ export class AdTracker {
  * @return {!Array<!Element>}
  */
 export function getExistingAds(win) {
-  return [].slice.call(win.document.getElementsByTagName('AMP-AD')).concat(
-      [].slice.call(win.document.getElementsByTagName('AMP-A4A')));
+  return [].slice.call(win.document.getElementsByTagName('AMP-AD'))
+      .filter(ad => {
+        // Filters out AMP-STICKY-AD.
+        if (ad.parentElement && ad.parentElement.tagName == 'AMP-STICKY-AD') {
+          return false;
+        }
+        return true;
+      });
 }

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -16,6 +16,7 @@
 
 import {AdTracker, getExistingAds} from './ad-tracker';
 import {AdStrategy} from './ad-strategy';
+import {AnchorAdStrategy} from './anchor-ad-strategy';
 import {user} from '../../../src/log';
 import {xhrFor} from '../../../src/services';
 import {getAdNetworkConfig} from './ad-network-config';
@@ -43,7 +44,10 @@ export class AmpAutoAds extends AMP.BaseElement {
       return;
     }
 
-    this.getConfig_(adNetwork.getConfigUrl()).then(configObj => {
+    const configPromise = this.getConfig_(adNetwork.getConfigUrl());
+    const docPromise = this.getAmpDoc().whenReady();
+    Promise.all([configPromise, docPromise]).then(values => {
+      const configObj = values[0];
       if (!configObj) {
         return;
       }
@@ -54,6 +58,7 @@ export class AmpAutoAds extends AMP.BaseElement {
       const adTracker =
           new AdTracker(getExistingAds(this.win), adNetwork.getAdConstraints());
       new AdStrategy(placements, attributes, adTracker).run();
+      new AnchorAdStrategy(this.win, attributes, configObj).run();
     });
   }
 

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {createElementWithAttributes} from '../../../src/dom';
+import {user} from '../../../src/log';
+import {viewportForDoc} from '../../../src/services';
+
+/** @const */
+const TAG = 'amp-auto-ads';
+
+/** @const */
+const OPT_IN_STATUS_ANCHOR_ADS = 2;
+
+export class AnchorAdStrategy {
+  /**
+   * @param {!Window} win
+   * @param {!Object<string, string>} baseAttributes Any attributes that should
+   *     be added to any inserted ads.
+   * @param {!JSONType} configObj
+   */
+  constructor(win, baseAttributes, configObj) {
+    /** @const @private {!Window} */
+    this.win_ = win;
+
+    /** @const @private {!Object<string, string>} */
+    this.baseAttributes_ = baseAttributes;
+
+    /** @const @private {!JSONType} */
+    this.configObj_ = configObj;
+  }
+
+  /**
+   * @return {!Promise<boolean>} Resolves when the strategy is complete.
+   */
+  run() {
+    if (!this.isAnchorAdEnabled_()) {
+      return Promise.resolve(false);
+    }
+    if (this.hasExistingStickyAd_()) {
+      user().warn(TAG, 'exists <amp-sticky-ad>');
+      return Promise.resolve(false);
+    }
+    this.placeStickyAd_();
+    return Promise.resolve(true);
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  hasExistingStickyAd_() {
+    return this.win_.document.getElementsByTagName('AMP-STICKY-AD').length > 0;
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  isAnchorAdEnabled_() {
+    const optInStatus = this.configObj_['optInStatus'];
+    if (!optInStatus) {
+      return false;
+    }
+    for (let i = 0; i < optInStatus.length; i++) {
+      if (optInStatus[i] == OPT_IN_STATUS_ANCHOR_ADS) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  placeStickyAd_() {
+    const viewportWidth = viewportForDoc(this.win_.document).getWidth();
+    const attributes = Object.assign({}, this.baseAttributes_, {
+      'width': String(viewportWidth),
+      'height': '100',
+    });
+    const ampAd = createElementWithAttributes(
+        this.win_.document, 'amp-ad', attributes);
+    const stickyAd = createElementWithAttributes(
+        this.win_.document, 'amp-sticky-ad', {'layout': 'nodisplay'});
+    stickyAd.appendChild(ampAd);
+    this.win_.document.body.insertBefore(
+        stickyAd, this.win_.document.body.firstChild);
+  }
+}

--- a/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
@@ -243,8 +243,11 @@ describes.realWin('getExistingAds', {}, env => {
     doc.body.appendChild(ad1);
     const ad2 = doc.createElement('amp-ad');
     doc.body.appendChild(ad2);
-    const ad3 = doc.createElement('amp-a4a');
+    const ad3 = doc.createElement('amp-ad');
     doc.body.appendChild(ad3);
+    const ad4 = doc.createElement('amp-sticky-ad');
+    doc.body.appendChild(ad4);
+    ad4.appendChild(doc.createElement('amp-ad'));
 
     const ads = getExistingAds(win);
     expect(ads).to.have.lengthOf(3);

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import '../../../amp-ad/0.1/amp-ad';
 import {AmpAutoAds} from '../amp-auto-ads';
 import {
   toggleExperiment,
@@ -36,6 +37,7 @@ describes.realWin('amp-auto-ads', {
 }, env => {
 
   const AD_CLIENT = 'ca-pub-1234';
+  const OPT_IN_STATUS_ANCHOR_ADS = 2;
 
   let sandbox;
   let container;
@@ -131,6 +133,7 @@ describes.realWin('amp-auto-ads', {
           type: 1,
         },
       ],
+      optInStatus: [1],
     };
 
     xhr = xhrFor(env.win);
@@ -327,5 +330,72 @@ describes.realWin('amp-auto-ads', {
     expect(() => ampAutoAds.buildCallback())
         .to.throw(/Experiment is off​​​/);
     expect(xhr.fetchJson).not.to.have.been.called;
+  });
+
+  describe('Anchor Ad', () => {
+    it('should not insert anchor ad if not opted in', () => {
+      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsElem.setAttribute('type', 'adsense');
+      ampAutoAds.buildCallback();
+
+      return new Promise(resolve => {
+        setTimeout(() => {
+          expect(env.win.document.getElementsByTagName('AMP-STICKY-AD'))
+              .to.have.lengthOf(0);
+          resolve();
+        }, 500);
+      });
+    });
+
+    it('should insert three ads plus anchor ad', () => {
+      configObj['optInStatus'].push(OPT_IN_STATUS_ANCHOR_ADS);
+
+      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsElem.setAttribute('type', 'adsense');
+      ampAutoAds.buildCallback();
+
+      const bannerAdsPromise = new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor3.childNodes).to.have.lengthOf(0);
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          verifyAdElement(anchor1.childNodes[0]);
+          verifyAdElement(anchor2.childNodes[0]);
+          verifyAdElement(anchor4.childNodes[0]);
+          resolve();
+        });
+      });
+
+      const anchorAdPromise = new Promise(resolve => {
+        waitForChild(env.win.document.body, parent => {
+          return parent.firstChild.tagName == 'AMP-STICKY-AD';
+        }, () => {
+          resolve();
+        });
+      });
+
+      return Promise.all([bannerAdsPromise, anchorAdPromise]);
+    });
+
+    it('should insert anchor anchor ad only', () => {
+      configObj = {
+        optInStatus: [2],
+      };
+
+      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsElem.setAttribute('type', 'adsense');
+      ampAutoAds.buildCallback();
+
+      return new Promise(resolve => {
+        waitForChild(env.win.document.body, parent => {
+          return parent.firstChild.tagName == 'AMP-STICKY-AD';
+        }, () => {
+          resolve();
+        });
+      });
+    });
   });
 });

--- a/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../../../amp-ad/0.1/amp-ad';
+import {waitForChild} from '../../../../src/dom';
+import {viewportForDoc} from '../../../../src/services';
+import {AnchorAdStrategy} from '../anchor-ad-strategy';
+
+describes.realWin('anchor-ad-strategy', {
+  amp: {
+    runtimeOn: true,
+    ampdoc: 'single',
+    extensions: ['amp-ad'],
+  },
+}, env => {
+  let sandbox;
+  let configObj;
+  let attributes;
+
+  beforeEach(() => {
+    sandbox = env.sandbox;
+    const viewportMock = sandbox.mock(viewportForDoc(env.win.document));
+    viewportMock.expects('getWidth').returns(360).atLeast(1);
+
+    configObj = {
+      optInStatus: [1],
+    };
+
+    attributes = {
+      'data-ad-client': 'ca-pub-test',
+      'type': 'adsense',
+    };
+  });
+
+  describe('run', () => {
+    it('should insert sticky ad if opted in', () => {
+      configObj['optInStatus'].push(2);
+
+      const anchorAdStrategy = new AnchorAdStrategy(
+          env.win, attributes, configObj);
+
+      const strategyPromise = anchorAdStrategy.run().then(placed => {
+        expect(placed).to.equal(true);
+      });
+
+      const expectPromise = new Promise(resolve => {
+        waitForChild(env.win.document.body, parent => {
+          return parent.firstChild.tagName == 'AMP-STICKY-AD';
+        }, () => {
+          const stickyAd = env.win.document.body.firstChild;
+          expect(stickyAd.getAttribute('layout')).to.equal('nodisplay');
+          const ampAd = stickyAd.firstChild;
+          expect(ampAd.getAttribute('type')).to.equal('adsense');
+          expect(ampAd.getAttribute('width')).to.equal('360');
+          expect(ampAd.getAttribute('height')).to.equal('100');
+          expect(ampAd.getAttribute('data-ad-client')).to.equal('ca-pub-test');
+          resolve();
+        });
+      });
+
+      return Promise.all([strategyPromise, expectPromise]);
+    });
+
+    it('should not insert sticky ad if not opted in', () => {
+      const anchorAdStrategy = new AnchorAdStrategy(
+          env.win, attributes, configObj);
+
+      const strategyPromise = anchorAdStrategy.run().then(placed => {
+        expect(placed).to.equal(false);
+      });
+
+      const expectPromise = new Promise(resolve => {
+        setTimeout(() => {
+          expect(env.win.document.getElementsByTagName('AMP-STICKY-AD'))
+              .to.have.lengthOf(0);
+          resolve();
+        }, 500);
+      });
+
+      return Promise.all([strategyPromise, expectPromise]);
+    });
+
+    it('should not insert sticky ad if exists one', () => {
+      configObj['optInStatus'].push(2);
+
+      const existingStickyAd = env.win.document.createElement('amp-sticky-ad');
+      env.win.document.body.appendChild(existingStickyAd);
+
+      const anchorAdStrategy = new AnchorAdStrategy(
+          env.win, attributes, configObj);
+
+      const strategyPromise = anchorAdStrategy.run().then(placed => {
+        expect(placed).to.equal(false);
+      });
+
+      const expectPromise = new Promise(resolve => {
+        setTimeout(() => {
+          expect(env.win.document.getElementsByTagName('AMP-STICKY-AD'))
+              .to.have.lengthOf(1);
+          resolve();
+        }, 500);
+      });
+
+      return Promise.all([strategyPromise, expectPromise]);
+    });
+  });
+});


### PR DESCRIPTION
Inserts an &lt;amp-sticky-ad> from within &lt;amp-auto-ads> iff
(1) the returned configuration contains an anchor ad opt in status, and 
(2) there is no existing &lt;amp-sticky-ad> in the page.

See b/37065859.