### PR TITLE
Run presubmit tests soon after building

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -359,14 +359,14 @@ function main(argv) {
     if (buildTargets.has('RUNTIME')) {
       command.cleanBuild();
       command.buildRuntime();
-      command.runLintChecks();
-      command.runDepAndTypeChecks();
-      command.runUnitTests();
       // Ideally, we'd run presubmit tests after `gulp dist`, as some checks run
       // through the dist/ folder. However, to speed up the Travis queue, we no
       // longer do a dist build for PRs, so this call won't cover dist/.
       // TODO(rsimha-amp): Move this once integration tests are enabled.
       command.runPresubmitTests();
+      command.runLintChecks();
+      command.runDepAndTypeChecks();
+      command.runUnitTests();
     }
     if (buildTargets.has('VALIDATOR_WEBUI')) {
       command.buildValidatorWebUI();


### PR DESCRIPTION
Exit pr-check.js early in case of presubmit failures.

Fixes #9500
Fixes #9387