### PR TITLE
Revert "Use Docker containers in Travis (#9666)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
+sudo: required  # See http://docs.travis-ci.com/user/trusty-ci-environment/
 dist: trusty
-sudo: false  # See http://docs.travis-ci.com/user/trusty-ci-environment/
 node_js:
   - "4"
 python:
@@ -21,12 +21,11 @@ addons:
     - protobuf-compiler
     - python-protobuf
 before_install:
+  - export CHROME_BIN=google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-  - mkdir "${TRAVIS_BUILD_DIR}/chrome"
-  - dpkg -x google-chrome-stable_current_amd64.deb "${TRAVIS_BUILD_DIR}/chrome"
-  - export CHROME_BIN="${TRAVIS_BUILD_DIR}/chrome/opt/google/chrome/google-chrome"
+  - sudo dpkg -i google-chrome*.deb
 before_script:
   - pip install --user protobuf
   - gem install percy-cli


### PR DESCRIPTION
This reverts commit 98ecb9b72c34567a130a7fc8bc77dae5922b9768.

It turns out that while using Docker containers instead of VMs on Travis reduces VM startup time, it has significantly increased build and test time, increasing the overall PR check round trip from < 20 mins to > 30 mins.

Compare https://travis-ci.org/ampproject/amphtml/jobs/238464404 (Docker) against https://travis-ci.org/ampproject/amphtml/jobs/238462066 (VM).

Fixes #9651
