### PR TITLE
amp-state: Allow both `src` and script child

### DIFF
--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -24,8 +24,11 @@ describes.realWin('AmpState', {
   },
 }, env => {
   let ampState;
-  let fetchStub;
+  let fetchSpy;
+  let batchedJsonStub;
   let updateStub;
+
+  let stubFetchPromise;
 
   // Viewer-related vars.
   let viewer;
@@ -41,21 +44,20 @@ describes.realWin('AmpState', {
 
   beforeEach(() => {
     viewer = viewerForDoc(env.win.document);
-
     whenFirstVisiblePromise = new Promise(resolve => {
       whenFirstVisiblePromiseResolve = resolve;
     });
     env.sandbox.stub(viewer, 'whenFirstVisible', () => whenFirstVisiblePromise);
 
     ampState = getAmpState();
-
     const impl = ampState.implementation_;
 
-    // For simpler testing, stub the fetching and update call to Bind service.
-    // - `fetchStub should only be called when fetching remote JSON data
-    // - `updateStub` should only be called when parsing a child script
-    fetchStub = sandbox.stub(impl, 'fetchSrcAndUpdateState_');
-    updateStub = sandbox.stub(impl, 'updateState_');
+    stubFetchPromise = Promise.resolve({baz: 'qux'});
+
+    fetchSpy = env.sandbox.spy(impl, 'fetchSrcAndUpdateState_');
+    updateStub = env.sandbox.stub(impl, 'updateState_');
+    batchedJsonStub = env.sandbox.stub(impl, 'fetchBatchedJsonFor_');
+    batchedJsonStub.returns(stubFetchPromise);
   });
 
   it('should fetch json if `src` attribute exists', () => {
@@ -63,29 +65,54 @@ describes.realWin('AmpState', {
     ampState.build();
 
     // IMPORTANT: No CORS fetch should happen until viewer is visible.
-    expect(fetchStub).to.not.have.been.called;
+    expect(fetchSpy).to.not.have.been.called;
+    expect(batchedJsonStub).to.not.have.been.called;
     expect(updateStub).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
-      expect(fetchStub).calledWithExactly(/* isInit */ true);
-      expect(updateStub).to.not.have.been.called;
+      expect(fetchSpy).calledWithExactly(/* isInit */ true);
+      return stubFetchPromise;
+    }).then(() => {
+      expect(updateStub).calledWithMatch({baz: 'qux'});
     });
   });
 
-  it('should parse its child script if `src` attribute does not exist', () => {
+  it('should parse its child script', () => {
     ampState.innerHTML = '<script type="application/json">' +
         '{"foo": "bar"}</script>';
     ampState.build();
 
     // IMPORTANT: No parsing should happen until viewer is visible.
-    expect(fetchStub).to.not.have.been.called;
+    expect(fetchSpy).to.not.have.been.called;
+    expect(batchedJsonStub).to.not.have.been.called;
     expect(updateStub).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
-      expect(fetchStub).to.not.have.been.called;
+      expect(fetchSpy).to.not.have.been.called;
       expect(updateStub).calledWithMatch({foo: 'bar'});
+    });
+  });
+
+  it('should parse child and fetch `src` if both provided', () => {
+    ampState.innerHTML = '<script type="application/json">' +
+        '{"foo": "bar"}</script>';
+    ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
+    ampState.build();
+
+    // IMPORTANT: No fetching or parsing should happen until viewer is visible.
+    expect(fetchSpy).to.not.have.been.called;
+    expect(batchedJsonStub).to.not.have.been.called;
+    expect(updateStub).to.not.have.been.called;
+
+    whenFirstVisiblePromiseResolve();
+    return whenFirstVisiblePromise.then(() => {
+      expect(updateStub).calledWithMatch({foo: 'bar'});
+      expect(fetchSpy).calledWithExactly(/* isInit */ true);
+      return stubFetchPromise;
+    }).then(() => {
+      expect(updateStub).calledWithMatch({baz: 'qux'});
     });
   });
 
@@ -97,10 +124,14 @@ describes.realWin('AmpState', {
     const isVisibleStub = env.sandbox.stub(viewer, 'isVisible');
     isVisibleStub.returns(false);
     ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
-    expect(fetchStub).to.not.have.been.called;
+    expect(fetchSpy).to.not.have.been.called;
+    expect(batchedJsonStub).to.not.have.been.called;
 
     isVisibleStub.returns(true);
     ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
-    expect(fetchStub).calledWithExactly(/* isInit */ false);
+    expect(fetchSpy).calledWithExactly(/* isInit */ false);
+    return stubFetchPromise.then(() => {
+      expect(updateStub).calledWithMatch({baz: 'qux'});
+    });
   });
 });

--- a/extensions/amp-bind/0.1/test/validator-amp-bind.html
+++ b/extensions/amp-bind/0.1/test/validator-amp-bind.html
@@ -51,10 +51,37 @@
     <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://ampbyexample.com/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog'})">Click me</button>
   </div>
 
-  <amp-state id="myState">
+  <!-- amp-state with child script -->
+  <amp-state id="withChildScript">
     <script type="application/json">
       {
-        "myStateKey1": "myStateValue1"
+        "foo": "bar"
+      }
+    </script>
+  </amp-state>
+
+  <!-- amp-state with `src` attr -->
+  <amp-state id="withSrc" src="https://www.foo.com/data.json">
+  </amp-state>
+
+  <!-- amp-state with `src` and `credentials` attrs -->
+  <amp-state id="withSrcPlusCredentials" src="https://www.foo.com/data.json" credentials="omit">
+  </amp-state>
+
+  <!-- amp-state with child script and `src` attr -->
+  <amp-state id="withChildScriptAndSrc" src="https://www.foo.com/data.json">
+    <script type="application/json">
+      {
+        "foo": "bar"
+      }
+    </script>
+  </amp-state>
+
+  <!-- amp-state with child script and `src` and `credentials` attrs -->
+  <amp-state id="withChildScriptAndSrcPlusCredentials" src="https://www.foo.com/data.json" credentials="include">
+    <script type="application/json">
+      {
+        "foo": "bar"
       }
     </script>
   </amp-state>

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -29,7 +29,6 @@ tags: {  # <amp-state> (json)
   tag_name: "SCRIPT"
   spec_name: "amp-bind extension .json script"
   mandatory_parent: "AMP-STATE"
-  satisfies: "amp-bind extension .json script"
   requires: "amp-bind extension .js script"
   attrs: { name: "nonce" }
   attrs: {
@@ -46,39 +45,22 @@ tags: {  # <amp-state> (json)
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }
-tags: {  # <amp-state> with json child
+tags: {  # <amp-state>
   html_format: AMP
   tag_name: "AMP-STATE"
   spec_name: "amp-state"
   requires: "amp-bind extension .js script"
-  requires: "amp-bind extension .json script"
   disallowed_ancestor: "AMP-SIDEBAR"
+  attrs: {
+    name: "credentials"
+    also_requires_attr: "src"
+  }
   attrs: {
     name: "id"
     mandatory: true
   }
-  # <amp-bind>
-  attrs: { name: "[src]" }
-  child_tags: {
-    mandatory_num_child_tags: 1
-    first_child_tag_name_oneof: "SCRIPT"
-  }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
-}
-tags: {  # <amp-state> with src
-  html_format: AMP
-  tag_name: "AMP-STATE"
-  spec_name: "amp-state[src]"
-  requires: "amp-bind extension .js script"
-  disallowed_ancestor: "AMP-SIDEBAR"
-  attrs: {
-    name: "id"
-    mandatory: true
-  }
-  attrs: { name: "credentials" }
   attrs: {
     name: "src"
-    mandatory: true
     value_url: {
       allowed_protocol: "https"
       allow_relative: true  # Will be set to false at a future date.
@@ -88,7 +70,7 @@ tags: {  # <amp-state> with src
   # <amp-bind>
   attrs: { name: "[src]" }
   child_tags: {
-    mandatory_num_child_tags: 0
+    first_child_tag_name_oneof: "SCRIPT"
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }

--- a/extensions/amp-bind/0.1/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/0.1/validator-amp-bind.protoascii
@@ -53,7 +53,9 @@ tags: {  # <amp-state>
   disallowed_ancestor: "AMP-SIDEBAR"
   attrs: {
     name: "credentials"
-    also_requires_attr: "src"
+    trigger: {
+      also_requires_attr: "src"
+    }
   }
   attrs: {
     name: "id"


### PR DESCRIPTION
Fixes #8844. Code largely adapted from #8897.

- Allow an `<amp-state>` element to have both `src` attribute and a script child.

Note that this also allows an `<amp-state>` element to have neither and allows multiple script children. IIUC, there's [currently no good way to avoid those cases](https://github.com/ampproject/amphtml/pull/8897#discussion_r115376549) without code dupe.

/to @jridgewell @honeybadgerdontcare 
