### PR TITLE
Significantly speed up gulp build --css-only

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -98,7 +98,9 @@ function compile(entryModuleFilenames, outputDir,
     var intermediateFilename = 'build/cc/' +
         entryModuleFilename.replace(/\//g, '_').replace(/^\./, '');
     if (!process.env.TRAVIS) {
-      util.log('Starting closure compiler for', entryModuleFilenames);
+      util.log(
+          'Starting closure compiler for',
+          util.colors.cyan(entryModuleFilenames));
     }
     // If undefined/null or false then we're ok executing the deletions
     // and mkdir.
@@ -340,8 +342,13 @@ function compile(entryModuleFilenames, outputDir,
         .pipe(gulp.dest(outputDir))
         .on('end', function() {
           if (!process.env.TRAVIS) {
-            util.log('Compiled', entryModuleFilename, 'to',
-                outputDir + '/' + outputFilename, 'via', intermediateFilename);
+            util.log(
+                'Compiled',
+                util.colors.cyan(entryModuleFilename),
+                'to',
+                outputDir + '/' + outputFilename,
+                'via',
+                intermediateFilename);
           }
           gulp.src(intermediateFilename + '.map')
               .pipe(rename(outputFilename + '.map'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -351,7 +351,9 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
  * @return {!Promise}
  */
 function compileCss() {
-  $$.util.log('Recompiling CSS in amp.css');
+  if (!process.env.TRAVIS) {
+    $$.util.log('Recompiling CSS in amp.css');
+  }
   return jsifyCssAsync('css/amp.css').then(function(css) {
     return toPromise(gulp.src('css/**.css')
           .pipe($$.file('css.js', 'export const cssText = ' +
@@ -370,7 +372,9 @@ function compileCss() {
  * @return {!Promise}
  */
 function copyCss() {
-  $$.util.log('Copying build/css/v0.css to dist/v0.css');
+  if (!process.env.TRAVIS) {
+    $$.util.log('Copying build/css/v0.css to dist/v0.css');
+  }
   fs.copySync('build/css/v0.css', 'dist/v0.css');
   return toPromise(gulp.src('build/css/amp-*.css')
       .pipe(gulp.dest('dist/v0')));
@@ -456,9 +460,6 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
       if (cssOnly) {
         return Promise.resolve();
       }
-      if (!process.env.TRAVIS) {
-        $$.util.log('Bundling ' + name);
-      }
       return buildExtensionJs(path, name, version, options);
     });
   } else {
@@ -478,6 +479,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
  * @return {!Promise}
  */
 function buildExtensionJs(path, name, version, options) {
+  if (!process.env.TRAVIS) {
+    $$.util.log('Bundling ' + name);
+  }
   var filename = options.filename || name + '.js';
   if (options.loadPriority && options.loadPriority != 'high') {
     throw new Error('Unsupported loadPriority: ' + options.loadPriority);
@@ -641,7 +645,9 @@ function checkTypes() {
  * @return {!Promise}
  */
 function thirdPartyBootstrap(input, outputName, shouldMinify) {
-  $$.util.log('Processing ' + input);
+  if (!process.env.TRAVIS) {
+    $$.util.log('Processing ' + input);
+  }
 
   if (!shouldMinify) {
     return toPromise(gulp.src(input)
@@ -776,7 +782,9 @@ function compileJs(srcDir, srcFilename, destDir, options) {
 
   if (options.watch) {
     bundler.on('update', function() {
-      $$.util.log('-> bundling ' + srcDir + '...');
+      if (!process.env.TRAVIS) {
+        $$.util.log('-> bundling ' + srcDir + '...');
+      }
       rebundle();
       // Touch file in unit test set. This triggers rebundling of tests because
       // karma only considers changes to tests files themselves re-bundle
@@ -795,7 +803,9 @@ function compileJs(srcDir, srcFilename, destDir, options) {
  */
 function buildExperiments(options) {
   options = options || {};
-  $$.util.log('Bundling experiments.html/js');
+  if (!process.env.TRAVIS) {
+    $$.util.log('Bundling experiments.html/js');
+  }
 
   var path = 'tools/experiments';
   var htmlPath = path + '/experiments.html';
@@ -818,7 +828,9 @@ function buildExperiments(options) {
   }
 
   // Build HTML.
-  $$.util.log('Processing ' + htmlPath);
+  if (!process.env.TRAVIS) {
+    $$.util.log('Processing ' + htmlPath);
+  }
   var html = fs.readFileSync(htmlPath, 'utf8');
   var minHtml = html.replace('/dist.tools/experiments/experiments.js',
       `https://${hostname}/v0/experiments.js`);
@@ -862,7 +874,9 @@ function buildLoginDone(options) {
  */
 function buildLoginDoneVersion(version, options) {
   options = options || {};
-  $$.util.log('Bundling amp-login-done.html/js');
+  if (!process.env.TRAVIS) {
+    $$.util.log('Bundling amp-login-done.html/js');
+  }
 
   var path = 'extensions/amp-access/' + version + '/';
   var htmlPath = path + 'amp-login-done.html';
@@ -885,7 +899,9 @@ function buildLoginDoneVersion(version, options) {
   }
 
   // Build HTML.
-  $$.util.log('Processing ' + htmlPath);
+  if (!process.env.TRAVIS) {
+    $$.util.log('Processing ' + htmlPath);
+  }
   var html = fs.readFileSync(htmlPath, 'utf8');
   var minHtml = html.replace(
       '../../../dist/v0/amp-login-done-' + version + '.max.js',
@@ -924,7 +940,9 @@ function buildLoginDoneVersion(version, options) {
  */
 function buildAlp(options) {
   options = options || {};
-  $$.util.log('Bundling alp.js');
+  if (!process.env.TRAVIS) {
+    $$.util.log('Bundling alp.js');
+  }
 
   return compileJs('./ads/alp/', 'install-alp.js', './dist/', {
     toName: 'alp.max.js',
@@ -943,7 +961,9 @@ function buildAlp(options) {
  */
 function buildExaminer(options) {
   options = options || {};
-  $$.util.log('Bundling examiner.js');
+  if (!process.env.TRAVIS) {
+    $$.util.log('Bundling examiner.js');
+  }
 
   return compileJs('./src/examiner/', 'examiner.js', './dist/', {
     toName: 'examiner.max.js',
@@ -961,7 +981,9 @@ function buildExaminer(options) {
  * @param {!Object} options
  */
 function buildSw(options) {
-  $$.util.log('Bundling sw.js');
+  if (!process.env.TRAVIS) {
+    $$.util.log('Bundling sw.js');
+  }
   var opts = Object.assign({}, options);
 
   return Promise.all([
@@ -993,7 +1015,9 @@ function buildSw(options) {
  * @param {!Object} options
  */
 function buildWebWorker(options) {
-  $$.util.log('Bundling ww.js');
+  if (!process.env.TRAVIS) {
+    $$.util.log('Bundling ww.js');
+  }
   var opts = Object.assign({}, options);
 
   return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -231,131 +231,129 @@ function polyfillsForTests() {
  */
 function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     opt_checkTypes) {
-  return compileCss().then(() => {
-    var promises = [
-      compileJs('./3p/', 'integration.js',
-          './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-        minifiedName: 'f.js',
-        checkTypes: opt_checkTypes,
+  var promises = [
+    compileJs('./3p/', 'integration.js',
+        './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
+      minifiedName: 'f.js',
+      checkTypes: opt_checkTypes,
+      watch: watch,
+      minify: shouldMinify,
+      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+      externs: ['ads/ads.extern.js',],
+      include3pDirectories: true,
+      includePolyfills: true,
+    }),
+    compileJs('./3p/', 'ampcontext-lib.js',
+        './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
+      minifiedName: 'ampcontext-v0.js',
+      checkTypes: opt_checkTypes,
+      watch: watch,
+      minify: shouldMinify,
+      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+      externs: ['ads/ads.extern.js',],
+      include3pDirectories: true,
+      includePolyfills: false,
+    }),
+    // For compilation with babel we start with the amp-babel entry point,
+    // but then rename to the amp.js which we've been using all along.
+    compileJs('./src/', 'amp-babel.js', './dist', {
+      toName: 'amp.js',
+      minifiedName: 'v0.js',
+      includePolyfills: true,
+      checkTypes: opt_checkTypes,
+      watch: watch,
+      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+      minify: shouldMinify,
+      // If there is a sync JS error during initial load,
+      // at least try to unhide the body.
+      wrapper: 'try{(function(){<%= contents %>})()}catch(e){' +
+          'setTimeout(function(){' +
+          'var s=document.body.style;' +
+          's.opacity=1;' +
+          's.visibility="visible";' +
+          's.animation="none";' +
+          's.WebkitAnimation="none;"},1000);throw e};'
+    }),
+    compileJs('./extensions/amp-viewer-integration/0.1/examples/',
+      'amp-viewer-host.js', './dist/v0/examples', {
+        toName: 'amp-viewer-host.max.js',
+        minifiedName: 'amp-viewer-host.js',
+        incudePolyfills: true,
         watch: watch,
-        minify: shouldMinify,
+        extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
+        compilationLevel: 'WHITESPACE_ONLY',
         preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-        externs: ['ads/ads.extern.js',],
-        include3pDirectories: true,
-        includePolyfills: true,
+        minify: false,
       }),
-      compileJs('./3p/', 'ampcontext-lib.js',
-          './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-        minifiedName: 'ampcontext-v0.js',
-        checkTypes: opt_checkTypes,
-        watch: watch,
-        minify: shouldMinify,
-        preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-        externs: ['ads/ads.extern.js',],
-        include3pDirectories: true,
-        includePolyfills: false,
-      }),
-      // For compilation with babel we start with the amp-babel entry point,
-      // but then rename to the amp.js which we've been using all along.
-      compileJs('./src/', 'amp-babel.js', './dist', {
-        toName: 'amp.js',
-        minifiedName: 'v0.js',
-        includePolyfills: true,
-        checkTypes: opt_checkTypes,
-        watch: watch,
-        preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-        minify: shouldMinify,
-        // If there is a sync JS error during initial load,
-        // at least try to unhide the body.
-        wrapper: 'try{(function(){<%= contents %>})()}catch(e){' +
-            'setTimeout(function(){' +
-            'var s=document.body.style;' +
-            's.opacity=1;' +
-            's.visibility="visible";' +
-            's.animation="none";' +
-            's.WebkitAnimation="none;"},1000);throw e};'
-      }),
-      compileJs('./extensions/amp-viewer-integration/0.1/examples/',
-        'amp-viewer-host.js', './dist/v0/examples', {
-          toName: 'amp-viewer-host.max.js',
-          minifiedName: 'amp-viewer-host.js',
-          incudePolyfills: true,
-          watch: watch,
-          extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
-          compilationLevel: 'WHITESPACE_ONLY',
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          minify: false,
-        }),
-    ];
+  ];
 
-    // We don't rerun type check for the shadow entry point for now.
-    if (!opt_checkTypes) {
-      if (!watch || argv.with_shadow) {
-        promises.push(
-          // Entry point for shadow runtime.
-          compileJs('./src/', 'amp-shadow-babel.js', './dist', {
-            toName: 'amp-shadow.js',
-            minifiedName: 'shadow-v0.js',
-            includePolyfills: true,
-            checkTypes: opt_checkTypes,
-            watch: watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-            wrapper: '<%= contents %>'
-          })
-        );
-      }
-
-      if (!watch || argv.with_inabox) {
-        promises.push(
-          // Entry point for inabox runtime.
-          compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
-            toName: 'amp-inabox.js',
-            minifiedName: 'amp4ads-v0.js',
-            includePolyfills: true,
-            extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
-            checkTypes: opt_checkTypes,
-            watch: watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-            wrapper: '<%= contents %>',
-          }),
-
-          // inabox-host
-          compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
-            toName: 'amp-inabox-host.js',
-            minifiedName: 'amp4ads-host-v0.js',
-            includePolyfills: false,
-            checkTypes: opt_checkTypes,
-            watch: watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-            wrapper: '<%= contents %>',
-          })
-        );
-      }
-
+  // We don't rerun type check for the shadow entry point for now.
+  if (!opt_checkTypes) {
+    if (!watch || argv.with_shadow) {
       promises.push(
-        thirdPartyBootstrap(
-            '3p/frame.max.html', 'frame.html', shouldMinify),
-        thirdPartyBootstrap(
-            '3p/nameframe.max.html', 'nameframe.html',shouldMinify)
+        // Entry point for shadow runtime.
+        compileJs('./src/', 'amp-shadow-babel.js', './dist', {
+          toName: 'amp-shadow.js',
+          minifiedName: 'shadow-v0.js',
+          includePolyfills: true,
+          checkTypes: opt_checkTypes,
+          watch: watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+          wrapper: '<%= contents %>'
+        })
       );
-
-      if (watch) {
-        $$.watch('3p/nameframe.max.html', function() {
-          thirdPartyBootstrap(
-              '3p/nameframe.max.html', 'nameframe.html', shouldMinify);
-        });
-        $$.watch('3p/frame.max.html', function() {
-          thirdPartyBootstrap(
-              '3p/frame.max.html', 'frame.html', shouldMinify);
-        });
-      }
-
-      return Promise.all(promises);
     }
-  });
+
+    if (!watch || argv.with_inabox) {
+      promises.push(
+        // Entry point for inabox runtime.
+        compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
+          toName: 'amp-inabox.js',
+          minifiedName: 'amp4ads-v0.js',
+          includePolyfills: true,
+          extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
+          checkTypes: opt_checkTypes,
+          watch: watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+          wrapper: '<%= contents %>',
+        }),
+
+        // inabox-host
+        compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
+          toName: 'amp-inabox-host.js',
+          minifiedName: 'amp4ads-host-v0.js',
+          includePolyfills: false,
+          checkTypes: opt_checkTypes,
+          watch: watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+          wrapper: '<%= contents %>',
+        })
+      );
+    }
+
+    promises.push(
+      thirdPartyBootstrap(
+          '3p/frame.max.html', 'frame.html', shouldMinify),
+      thirdPartyBootstrap(
+          '3p/nameframe.max.html', 'nameframe.html',shouldMinify)
+    );
+
+    if (watch) {
+      $$.watch('3p/nameframe.max.html', function() {
+        thirdPartyBootstrap(
+            '3p/nameframe.max.html', 'nameframe.html', shouldMinify);
+      });
+      $$.watch('3p/frame.max.html', function() {
+        thirdPartyBootstrap(
+            '3p/frame.max.html', 'frame.html', shouldMinify);
+      });
+    }
+
+    return Promise.all(promises);
+  }
 }
 
 /**
@@ -537,15 +535,17 @@ function build() {
       buildExtensions({bundleOnlyIfListedInFiles: true}),  // Only ones with CSS
     ]);
   }
-  return Promise.all([
-    polyfillsForTests(),
-    buildAlp(),
-    buildExaminer(),
-    buildSw(),
-    buildWebWorker(),
-    buildExtensions({bundleOnlyIfListedInFiles: true}),
-    compile(),
-  ]);
+  return compileCss().then(() => {
+    return Promise.all([
+      polyfillsForTests(),
+      buildAlp(),
+      buildExaminer(),
+      buildSw(),
+      buildWebWorker(),
+      buildExtensions({bundleOnlyIfListedInFiles: true}),
+      compile(),
+    ]);
+  });
 }
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,12 +184,12 @@ function declareExtensionVersionAlias(name, version, lastestVersion, hasCss) {
 
 
 /**
- * Logs a build step to the console, unless we are on Travis, where we don't.
+ * Logs a build step to the console, unless we are on Travis.
  * @param {string} stepName Name of an action, like 'Bundling' or 'Compiling'
  * @param {string} targetName Name of the target, like a filename or path
  */
 function logBuildStep(stepName, targetName) {
-  if(!process.env.TRAVIS) {
+  if (!process.env.TRAVIS) {
     $$.util.log(stepName, $$.util.colors.cyan(targetName));
   }
 }


### PR DESCRIPTION
Prior to this PR, `gulp build --css-only` would take ~ 1 minute to run, and end up building a bunch of js files in addition to compiling css.

After this PR, `gulp build --css-only` takes ~ 0.5 seconds to run (a 100x speed up), and the only output files in `build/` after running it are .css, and .css.js files.

Resulting speeds on my workstation:
`gulp build --css-only`: ~500ms
`gulp build`: ~1m 45s
`gulp dist --fortesting`: ~3m 30s

Fixes #9640 