### PR TITLE
Additional cache urls

### DIFF
--- a/validator/chromeextension/content_script.js
+++ b/validator/chromeextension/content_script.js
@@ -19,7 +19,9 @@ globals.amphtmlRegex = new RegExp('(^\s*)amphtml(\s*$)');
 globals.ampCaches = [
   {
     'getAmpHref': function() {
-      if (window.location.pathname.startsWith('/c/s')) {
+      if (window.location.pathname.startsWith('/a/s') ||
+          window.location.pathname.startsWith('/c/s') ||
+          window.location.pathname.startsWith('/v/s')) {
         return 'https://' + window.location.pathname.slice(5);
       } else if (window.location.pathname.startsWith('/c')) {
         return 'http://' + window.location.pathname.slice(3);

--- a/validator/chromeextension/manifest.json
+++ b/validator/chromeextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
The chrome extension shouldn't try to validate amp cache urls which are of the form {cache domain}/c, {cache domain}/c/s, {cache domain}/a/s, and {cache domain}/v/s. Adding the last two to the extension.