### PR TITLE
Move Table of Contents below intro

### DIFF
--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -13,6 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+# Getting Started End-to-end
+
+This end-to-end guide will show you how to contribute code to the AMP Project.  It covers everything from creating a GitHub account to getting your code reviewed and merged.
+
+This guide is intended for people who don't know much about Git/GitHub and the tools we use to build/test AMP (Node.js, Gulp, etc.).  The guide may look long, but it includes a lot of explanation so you can get a better understanding of how things work.
+
+If you're already familiar with Git/GitHub/etc. or you just want to know what commands to type in instead of what they're doing take a look at the much shorter [Quick Start Guide](getting-started-quick.md).
+
 - [How to get help](#how-to-get-help)
 - [Intro to Git and GitHub](#intro-to-git-and-github)
 - [Set up your GitHub account and Git](#set-up-your-github-account-and-git)
@@ -34,14 +43,6 @@ limitations under the License.
 - [See your changes in production](#see-your-changes-in-production)
 - [⚡⚡⚡... (Next steps)](#-next-steps)
 - [Other resources](#other-resources)
-
-# Getting Started End-to-end
-
-This end-to-end guide will show you how to contribute code to the AMP Project.  It covers everything from creating a GitHub account to getting your code reviewed and merged.
-
-This guide is intended for people who don't know much about Git/GitHub and the tools we use to build/test AMP (Node.js, Gulp, etc.).  The guide may look long, but it includes a lot of explanation so you can get a better understanding of how things work.
-
-If you're already familiar with Git/GitHub/etc. or you just want to know what commands to type in instead of what they're doing take a look at the much shorter [Quick Start Guide](getting-started-quick.md).
 
 # How to get help
 


### PR DESCRIPTION
This moves the Table of Contents below the intro paragraph.  The TOC is long and pushes a description of what this doc is way off the first screen.  Having the intro at the top helps people determine whether this doc will be useful to them (or if they should use the quick start guide instead).