### PR TITLE
Handle full localhost urls in the link checker

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -102,7 +102,7 @@ function filterWhitelistedLinks(markdown) {
   var filteredMarkdown = markdown;
 
   // localhost links (not served on Travis)
-  filteredMarkdown = filteredMarkdown.replace(/http:\/\/localhost:8000/g, '');
+  filteredMarkdown = filteredMarkdown.replace(/http:\/\/localhost:8000(\/)?/g, '');
 
   // Links in script tags (illustrative, and not always valid)
   filteredMarkdown = filteredMarkdown.replace(/src="http.*?"/g, '');


### PR DESCRIPTION
Currently the link checker whitelists http://localhost:8000 only; it doesn't include the URL with a trailing slash or a path.  This fixes that.