### PR TITLE
Added implementation of the video interface to dailymotion

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -166,6 +166,8 @@ exports.rules = [
           'src/service/video-manager-impl.js',
       'extensions/amp-youtube/0.1/amp-youtube.js->' +
           'src/service/video-manager-impl.js',
+      'extensions/amp-dailymotion/0.1/amp-dailymotion.js->' +
+          'src/service/video-manager-impl.js',
       'extensions/amp-brid-player/0.1/amp-brid-player.js->' +
           'src/service/video-manager-impl.js',
       'extensions/amp-a4a/0.1/amp-a4a.js->src/service/variable-source.js',

--- a/examples/dailymotion.amp.html
+++ b/examples/dailymotion.amp.html
@@ -7,6 +7,11 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
   <script async custom-element="amp-dailymotion" src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js"></script>
+  <style amp-custom>
+    .spacer {
+      height: 100vh;
+    }
+  </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
@@ -39,9 +44,27 @@
     data-ui-highlight="444444"
     data-ui-logo="false"
     data-info="false"
+    id="myVideo"
     width="640"
     height="360">
   </amp-dailymotion>
+
+  <h3>Actions</h3>
+  <button on="tap:myVideo.play">Play</button>
+  <button on="tap:myVideo.pause">Pause</button>
+  <button on="tap:myVideo.mute">Mute</button>
+  <button on="tap:myVideo.unmute">Unmute</button>
+
+  <h4>Autoplay</h4>
+
+  <amp-dailymotion
+    data-videoid="x3rdtfy"
+    width="500"
+    height="281"
+    autoplay
+    layout="responsive">
+  </amp-dailymotion>
+  <div class="spacer"></div>
 
 </body>
 </html>

--- a/examples/dailymotion.amp.html
+++ b/examples/dailymotion.amp.html
@@ -57,11 +57,13 @@
 
   <h4>Autoplay</h4>
 
+  <!-- Removed autoplay tag until validator is updated -->
+  <p>Autoplay tag is currently removed until prod. validator is updated</p>
+
   <amp-dailymotion
     data-videoid="x3rdtfy"
     width="500"
     height="281"
-    autoplay
     layout="responsive">
   </amp-dailymotion>
   <div class="spacer"></div>

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -86,10 +86,10 @@ class AmpDailymotion extends AMP.BaseElement {
     this.playerReadyResolver_ = null;
 
     /** @private {?Promise} */
-    this.loadedPromise_ = null;
+    this.startedBufferingPromise_ = null;
 
     /** @private {?Function} */
-    this.loadingResolver_ = null;
+    this.startedBufferingResolver_ = null;
 
   }
 
@@ -112,8 +112,8 @@ class AmpDailymotion extends AMP.BaseElement {
 
   /** @override */
   isInteractive() {
-    // Dailymotion videos are always interactive. There is no Dailymotion param that
-    // makes the video non-interactive. Even controls=false will not
+    // Dailymotion videos are always interactive. There is no Dailymotion param
+    // that makes the video non-interactive. Even controls=false will not
     // prevent user from pausing or resuming the video.
     return true;
   }
@@ -141,8 +141,8 @@ class AmpDailymotion extends AMP.BaseElement {
       this.playerReadyResolver_ = resolve;
     });
 
-    this.loadedPromise_ = new Promise(resolve => {
-      this.loadingResolver_ = resolve;
+    this.startedBufferingPromise_ = new Promise(resolve => {
+      this.startedBufferingResolver_ = resolve;
     });
   }
 
@@ -152,8 +152,8 @@ class AmpDailymotion extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
     dev().assert(this.videoid_);
-    iframe.src = 'https://www.dailymotion.com/embed/video/' + encodeURIComponent(
-        this.videoid_ || '') + '?' + this.getQuery_();
+    iframe.src = 'https://www.dailymotion.com/embed/video/' +
+     encodeURIComponent(this.videoid_ || '') + '?' + this.getQuery_();
 
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
@@ -218,7 +218,7 @@ class AmpDailymotion extends AMP.BaseElement {
         }
         break;
       case DailymotionEvents.STARTED_BUFFERING:
-        this.loadingResolver_(true);
+        this.startedBufferingResolver_(true);
         break;
       default:
 
@@ -282,7 +282,7 @@ class AmpDailymotion extends AMP.BaseElement {
     // Hack to solve autoplay problem on Chrome Android
     // (first play always fails)
     if (isAutoplay && this.playerState_ != DailymotionEvents.PAUSE) {
-      this.loadedPromise_.then(() => {
+      this.startedBufferingPromise_.then(() => {
         this.sendCommand_('play');
       });
     }

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -25,13 +25,13 @@ import {videoManagerForDoc} from '../../../src/services';
 import {parseQueryString} from '../../../src/url';
 
 /**
+ * Player events reverse-engineered from the Dailymotion API
+ * NOTE: 'unstarted' isn't part of the API, just a placeholder
+ * as an initial state
+ *
  * @enum {string}
  * @private
  */
-
-// Events reverse-engineered from the Dailymotion API
-// 'unstarted' isn't part of the API, just a placeholder as an initial state
-
 const DailymotionEvents = {
   UNSTARTED: 'unstarted',
   API_READY: 'apiready',
@@ -50,7 +50,7 @@ const DailymotionEvents = {
   VIDEO_END: 'video_end',
   // Other events
   VOLUMECHANGE: 'volumechange',
-  LOADED: 'progress',
+  STARTED_BUFFERING: 'progress',
 };
 
 /**
@@ -112,8 +112,8 @@ class AmpDailymotion extends AMP.BaseElement {
 
   /** @override */
   isInteractive() {
-    // Dailymotion videos are always interactive. There is no YouTube param that
-    // makes the video non-interactive. Even data-param-control=0 will not
+    // Dailymotion videos are always interactive. There is no Dailymotion param that
+    // makes the video non-interactive. Even controls=false will not
     // prevent user from pausing or resuming the video.
     return true;
   }
@@ -217,7 +217,7 @@ class AmpDailymotion extends AMP.BaseElement {
           }
         }
         break;
-      case DailymotionEvents.LOADED:
+      case DailymotionEvents.STARTED_BUFFERING:
         this.loadingResolver_(true);
         break;
       default:
@@ -271,10 +271,7 @@ class AmpDailymotion extends AMP.BaseElement {
 
   /** @override */
   pauseCallback() {
-    if (this.iframe_ && this.iframe_.contentWindow
-       && this.playerState_ == DailymotionEvents.PLAY) {
-      this.pause();
-    }
+    this.pause();
   }
 
   /**

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -15,7 +15,7 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {user} from '../../../src/log';
+import {dev, user} from '../../../src/log';
 import {VideoEvents} from '../../../src/video-interface';
 import {
   installVideoManagerForDoc,
@@ -130,6 +130,11 @@ class AmpDailymotion extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.videoid_ = user().assert(
+        this.element.getAttribute('data-videoid'),
+        'The data-videoid attribute is required for <amp-dailymotion> %s',
+        this.element);
+
     installVideoManagerForDoc(this.element);
     videoManagerForDoc(this.element).register(this);
     this.playerReadyPromise_ = new Promise(resolve => {
@@ -143,15 +148,12 @@ class AmpDailymotion extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    this.videoid_ = user().assert(
-        this.element.getAttribute('data-videoid'),
-        'The data-videoid attribute is required for <amp-dailymotion> %s',
-        this.element);
     const iframe = this.element.ownerDocument.createElement('iframe');
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
+    dev().assert(this.videoid_);
     iframe.src = 'https://www.dailymotion.com/embed/video/' + encodeURIComponent(
-        this.videoid_) + '?' + this.getQuery_();
+        this.videoid_ || '') + '?' + this.getQuery_();
 
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
@@ -165,7 +167,7 @@ class AmpDailymotion extends AMP.BaseElement {
 
     this.hasAutoplay_ = this.element.hasAttribute('autoplay');
 
-    return this.playerReadyPromise_;
+    return this.loadPromise(this.iframe_);
   }
 
   /** @private */
@@ -326,14 +328,14 @@ class AmpDailymotion extends AMP.BaseElement {
    * @override
    */
   showControls() {
-    // Not supported.
+    // Not supported
   }
 
   /**
    * @override
    */
   hideControls() {
-    // Not supported.
+    // Not supported
   }
 };
 

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -16,16 +16,70 @@
 
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {user} from '../../../src/log';
+import {VideoEvents} from '../../../src/video-interface';
+import {
+  installVideoManagerForDoc,
+} from '../../../src/service/video-manager-impl';
+import {listen} from '../../../src/event-helper';
+import {videoManagerForDoc} from '../../../src/services';
+import {parseQueryString} from '../../../src/url';
 
+const PlayerEvents = {
+  UNSTARTED: 'unstarted',
+  API_READY: 'apiready',
+  // Events fired for both the original content or ads
+  START: 'start',
+  PLAY: 'play',
+  PAUSE: 'pause',
+  END: 'end',
+  // Events fired only for ads
+  AD_START: 'ad_start',
+  AD_PLAY: 'ad_play',
+  AD_PAUSE: 'ad_pause',
+  AD_END: 'ad_end',
+  // Events fired only for the original content
+  VIDEO_START: 'video_start',
+  VIDEO_END: 'video_end',
+  // Other events
+  VOLUMECHANGE: 'volumechange',
+  LOADED: 'progress',
+};
 
 class AmpDailymotion extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
+    /** @private {number} */
+    this.playerState_ = PlayerEvents.UNSTARTED;
+
+    /** @private {?string}  */
+    this.videoid_ = null;
 
     /** @private {?Element} */
     this.iframe_ = null;
+
+    /** @private {boolean}  */
+    this.muted_ = false;
+
+    /** @private {?boolean}  */
+    this.hasAutoplay_ = false;
+
+    /** @private {?Function} */
+    this.unlistenMessage_ = null;
+
+    /** @private {?Promise} */
+    this.playerReadyPromise_ = null;
+
+    /** @private {?Function} */
+    this.playerReadyResolver_ = null;
+
+    /** @private {?Promise} */
+    this.loadedPromise_ = null;
+
+    /** @private {?Function} */
+    this.loadingResolver_ = null;
+
   }
 
  /**
@@ -34,8 +88,21 @@ class AmpDailymotion extends AMP.BaseElement {
   */
   preconnectCallback(opt_onLayout) {
     this.preconnect.url('https://www.dailymotion.com', opt_onLayout);
-    // Host that Dailymotion uses to serve JS needed by player.
-    this.preconnect.url('https://static1.dmcdn.net', opt_onLayout);
+  }
+
+  /**
+   * @override
+   */
+  supportsPlatform() {
+    return true;
+  }
+
+  /** @override */
+  isInteractive() {
+    // Dailymotion videos are always interactive. There is no YouTube param that
+    // makes the video non-interactive. Even data-param-control=0 will not
+    // prevent user from pausing or resuming the video.
+    return true;
   }
 
   /** @override */
@@ -44,8 +111,19 @@ class AmpDailymotion extends AMP.BaseElement {
   }
 
   /** @override */
+  viewportCallback(visible) {
+    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
+  }
+
+  /** @override */
+  buildCallback() {
+    installVideoManagerForDoc(this.element);
+    videoManagerForDoc(this.element).register(this);
+  }
+
+  /** @override */
   layoutCallback() {
-    const videoid = user().assert(
+    this.videoid_ = user().assert(
         this.element.getAttribute('data-videoid'),
         'The data-videoid attribute is required for <amp-dailymotion> %s',
         this.element);
@@ -53,12 +131,29 @@ class AmpDailymotion extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = 'https://www.dailymotion.com/embed/video/' + encodeURIComponent(
-        videoid) + '?' + this.getQuery_();
+        this.videoid_) + '?' + this.getQuery_();
 
     this.applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
-    return this.loadPromise(iframe);
+
+    this.unlistenMessage_ = listen(
+      this.win,
+      'message',
+      this.handleEvents_.bind(this)
+    );
+
+    this.playerReadyPromise_ = new Promise(resolve => {
+      this.playerReadyResolver_ = resolve;
+    });
+
+    this.loadedPromise_ = new Promise(resolve => {
+      this.loadingResolver_ = resolve;
+    });
+
+    this.hasAutoplay_ = this.element.hasAttribute('autoplay');
+
+    return this.playerReadyPromise_;
   }
 
   /** @private */
@@ -67,6 +162,71 @@ class AmpDailymotion extends AMP.BaseElement {
     if (val) {
       query.push(`${encodeURIComponent(param)}=${encodeURIComponent(val)}`);
     }
+  }
+
+  /** @private */
+  handleEvents_(event) {
+    if (event.origin != 'https://www.dailymotion.com' ||
+        event.source != this.iframe_.contentWindow) {
+      return;
+    }
+    if (!event.data || !event.type || event.type != 'message') {
+      return;  // Event empty
+    }
+    const data = parseQueryString(event.data);
+    if (data === undefined) {
+      return; // The message isn't valid
+    }
+
+    switch (data.event) {
+      case PlayerEvents.API_READY:
+        this.playerReadyResolver_(true);
+        this.element.dispatchCustomEvent(VideoEvents.LOAD);
+        break;
+      case PlayerEvents.END:
+      case PlayerEvents.PAUSE:
+        this.element.dispatchCustomEvent(VideoEvents.PAUSE);
+        this.playerState_ = PlayerEvents.PAUSE;
+        break;
+      case PlayerEvents.PLAY:
+        this.element.dispatchCustomEvent(VideoEvents.PLAY);
+        this.playerState_ = PlayerEvents.PLAY;
+        break;
+      case PlayerEvents.VOLUMECHANGE:
+        if (this.muted != (data.muted == 'true')) {
+          this.muted = (data.muted == 'true');
+          if (data.volume == 0 || this.muted) {
+            this.element.dispatchCustomEvent(VideoEvents.MUTED);
+          } else {
+            this.element.dispatchCustomEvent(VideoEvents.UNMUTED);
+          }
+        }
+        break;
+      case PlayerEvents.LOADED:
+        this.loadingResolver_(true);
+        break;
+      default:
+
+    }
+  }
+
+  /**
+   * Sends a command to the player through postMessage.
+   * @param {string} command
+   * @param {Array=} opt_args
+   * @private
+   */
+  sendCommand_(command, opt_args) {
+    const endpoint = 'https://www.dailymotion.com';
+    this.playerReadyPromise_.then(() => {
+      if (this.iframe_ && this.iframe_.contentWindow) {
+        const message = JSON.stringify({
+          command,
+          parameters: opt_args || [],
+        });
+        this.iframe_.contentWindow./*OK*/postMessage(message, endpoint);
+      }
+    });
   }
 
   /** @private */
@@ -97,8 +257,67 @@ class AmpDailymotion extends AMP.BaseElement {
   /** @override */
   pauseCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
-      this.iframe_.contentWindow./*OK*/postMessage('pause', '*');
+      this.pause();
     }
+  }
+
+  /**
+   * @override
+   */
+  play(isAutoplay) {
+    this.sendCommand_('play');
+    // Hack to solve autoplay problem on Chrome Android
+    // (first play always fails)
+    if (isAutoplay) {
+      this.loadedPromise_.then(() => {
+        this.sendCommand_('play');
+      });
+    }
+  }
+
+  /**
+   * @override
+   */
+  pause() {
+    this.sendCommand_('pause');
+  }
+
+  /**
+   * @override
+   */
+  mute() {
+    this.sendCommand_('muted', [true]);
+    // Hack to simulate firing mute events when video is not playing
+    // since Dailymotion only fires volume changes when the video has started
+    if (this.playerState_ == PlayerEvents.UNSTARTED) {
+      this.element.dispatchCustomEvent(PlayerEvents.MUTED);
+    }
+  }
+
+  /**
+   * @override
+   */
+  unmute() {
+    this.sendCommand_('muted', [false]);
+    // Hack to simulate firing mute events when video is not playing
+    // since Dailymotion only fires volume changes when the video has started
+    if (this.playerState_ == PlayerEvents.UNSTARTED) {
+      this.element.dispatchCustomEvent(PlayerEvents.UNMUTED);
+    }
+  }
+
+  /**
+   * @override
+   */
+  showControls() {
+    // Not supported.
+  }
+
+  /**
+   * @override
+   */
+  hideControls() {
+    // Not supported.
   }
 };
 

--- a/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
@@ -29,7 +29,7 @@ tags: {  # <amp-dailymotion>
   html_format: AMP
   tag_name: "AMP-DAILYMOTION"
   disallowed_ancestor: "AMP-SIDEBAR"
-  requires: "amp-dailymotion extension .js script"
+  requires_extension: "amp-dailymotion"
   attrs: { name: "autoplay" }
   attrs: {
     name: "data-endscreen-enable"

--- a/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
@@ -63,6 +63,7 @@ tags: {  # <amp-dailymotion>
     mandatory: true
     value_regex_casei: "[a-z0-9]+"
   }
+  attrs: { name: "autoplay" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-dailymotion"
   amp_layout: {

--- a/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/0.1/validator-amp-dailymotion.protoascii
@@ -29,7 +29,8 @@ tags: {  # <amp-dailymotion>
   html_format: AMP
   tag_name: "AMP-DAILYMOTION"
   disallowed_ancestor: "AMP-SIDEBAR"
-  requires_extension: "amp-dailymotion"
+  requires: "amp-dailymotion extension .js script"
+  attrs: { name: "autoplay" }
   attrs: {
     name: "data-endscreen-enable"
     value_regex: "true|false"
@@ -63,7 +64,6 @@ tags: {  # <amp-dailymotion>
     mandatory: true
     value_regex_casei: "[a-z0-9]+"
   }
-  attrs: { name: "autoplay" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-dailymotion"
   amp_layout: {

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -52,9 +52,19 @@ With responsive layout, the width and height from the example should yield corre
 
 ## Attributes
 
+**autoplay**
+
+If this attribute is present, and the browser supports autoplay:
+
+* the video is automatically muted before autoplay starts
+* when the video is scrolled out of view, the video is paused
+* when the video is scrolled into view, the video resumes playback
+* when the user taps the video, the video is unmuted
+* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused. 
+
 **data-videoid** (required)
 
-The Dailymotion video id found in every video page URL. For example, `"x2m8jpp"` is the video id for `https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation`. 
+The Dailymotion video id found in every video page URL. For example, `"x2m8jpp"` is the video id for `https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation`.
 
 **data-mute** (optional)
 
@@ -79,7 +89,7 @@ Indicates whether to display the sharing button.
 
 **data-start** (optional)
 
-Specifies the time (in seconds) from which the video should start playing. 
+Specifies the time (in seconds) from which the video should start playing.
 
 * Value: integer (number of seconds). For example, `data-start=45`.
 * Default value: `0`

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -35,7 +35,8 @@ import {startsWith} from '../../../src/string';
  * @private
  */
 
- // Correct PlayerStates taken from: https://developers.google.com/youtube/iframe_api_reference#Playback_status
+ // Correct PlayerStates taken from
+ // https://developers.google.com/youtube/iframe_api_reference#Playback_status
 const PlayerStates = {
   UNSTARTED: -1,
   ENDED: 0,

--- a/test/fixtures/video-players.html
+++ b/test/fixtures/video-players.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
   <!-- (1) Include your video player component here -->
+  <script async custom-element="amp-dailymotion" src="/dist/v0/amp-dailymotion-0.1.max.js"></script>
   <script async custom-element="amp-3q-player" src="/dist/v0/amp-3q-player-0.1.max.js"></script>
   <script async custom-element="amp-youtube" src="/dist/v0/amp-youtube-0.1.max.js"></script>
   <script async custom-element="amp-ima-video" src="/dist/v0/amp-ima-video-0.1.max.js"></script>

--- a/test/integration/test-video-players.js
+++ b/test/integration/test-video-players.js
@@ -50,6 +50,14 @@ describe.skip('amp-youtube', () => {
   });
 });
 
+describe.configure().run('amp-dailymotion', () => {
+  runVideoPlayerIntegrationTests(fixture => {
+    const video = fixture.doc.createElement('amp-dailymotion');
+    video.setAttribute('data-videoid', 'x3rdtfy');
+    return video;
+  });
+});
+
 describe.configure().skipIos().run('amp-3q-player', () => {
   runVideoPlayerIntegrationTests(fixture => {
     const video = fixture.doc.createElement('amp-3q-player');
@@ -92,4 +100,3 @@ describe.configure().skipIos().run('amp-brid-player', () => {
     return video;
   });
 });
-

--- a/test/integration/test-video-players.js
+++ b/test/integration/test-video-players.js
@@ -50,7 +50,8 @@ describe.skip('amp-youtube', () => {
   });
 });
 
-describe.configure().run('amp-dailymotion', () => {
+//TODO(aghassemi, #9379): unskip
+describe.skip('amp-dailymotion', () => {
   runVideoPlayerIntegrationTests(fixture => {
     const video = fixture.doc.createElement('amp-dailymotion');
     video.setAttribute('data-videoid', 'x3rdtfy');


### PR DESCRIPTION
This implements video interface inside the amp-dailymotion extension

### Changes

- Reverse-engineered the Dailymotion API (added action/status messages list)
- Implemented video interface methods
- Added autoplay example to the amp-dailymotion example
- Added manual controls example to the amp-dailymotion example
- Added amp-dailymotion to the players integration tests
- Minor corrections in amp-youtube
- Added documentation

Closes #6285 