### PR TITLE
JSON.stringify error objects

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -66,6 +66,19 @@ let reportingBackoff = function(work) {
 };
 
 /**
+ * Attempts to stringify a value, falling back to String.
+ * @param {*} value
+ * @return {string}
+ */
+function tryJsonStringify(value) {
+  try {
+    return JSON.stringify(value);
+  } catch (e) {
+    return String(value);
+  }
+}
+
+/**
  * The true JS engine, as detected by inspecting an Error stack. This should be
  * used with the userAgent to tell definitely. I.e., Chrome on iOS is really a
  * Safari JS engine.
@@ -93,9 +106,7 @@ export function reportError(error, opt_associatedElement) {
         isValidError = true;
       } else {
         const origError = error;
-        error = new Error(typeof origError == 'object' ?
-            JSON.stringify(origError) :
-            String(origError));
+        error = new Error(tryJsonStringify(origError));
         error.origError = origError;
       }
     } else {

--- a/src/error.js
+++ b/src/error.js
@@ -93,7 +93,9 @@ export function reportError(error, opt_associatedElement) {
         isValidError = true;
       } else {
         const origError = error;
-        error = new Error(String(origError));
+        error = new Error(typeof origError == 'object' ?
+            JSON.stringify(origError) :
+            String(origError));
         error.origError = origError;
       }
     } else {

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -188,7 +188,7 @@ export class Xhr {
 
   /**
    * Fetches a JSON response. Note this returns the response object, not the
-   * response's JSON. #fetchJson merely sets up the request to accept JSOn.
+   * response's JSON. #fetchJson merely sets up the request to accept JSON.
    *
    * See https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
    *
@@ -196,9 +196,10 @@ export class Xhr {
    *
    * @param {string} input
    * @param {?FetchInitDef=} opt_init
+   * @param {boolean=} opt_allowFailure Allows non-2XX status codes to fulfill.
    * @return {!Promise<!FetchResponse>}
    */
-  fetchJson(input, opt_init) {
+  fetchJson(input, opt_init, opt_allowFailure) {
     const init = setupInit(opt_init, 'application/json');
     if (init.method == 'POST' && !isFormData(init.body)) {
       // Assume JSON strict mode where only objects or arrays are allowed


### PR DESCRIPTION
Somewhere, something is reporting an object as an error, which turns
into “Error: [object Object]”. Instead, let’s stringify it and get some
answers.

Closes https://github.com/ampproject/amphtml/issues/9751.

/cc @cramforce to consider any privacy issues