### PR TITLE
IMA Launch: Added support for source child elements.

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -319,18 +319,18 @@ export function imaVideo(global, data) {
   setStyle(videoPlayer, 'background-color', 'black');
   videoPlayer.setAttribute('poster', data.poster);
   videoPlayer.setAttribute('playsinline', true);
-  // Set video player source, first based on source child elements if present.
-  // If not, then based on data-src.
+  // Set video player source, first based on data-src then on source child
+  // elements.
+  if (data.src) {
+    const sourceElement = document.createElement('source');
+    sourceElement.setAttribute('src', data.src);
+    videoPlayer.appendChild(sourceElement);
+  }
   if (data.sources) {
     const sources = JSON.parse(data.sources);
-    sources.some(source => {
-      if (videoPlayer.canPlayType(source.type)) {
-        videoPlayer.setAttribute('src', source.src);
-        return true;
-      }
+    sources.forEach(source => {
+      videoPlayer.appendChild(htmlToElement(source));
     });
-  } else {
-    videoPlayer.setAttribute('src', data.src);
   }
 
 
@@ -408,6 +408,12 @@ export function imaVideo(global, data) {
     adRequestFailed = false;
     adsLoader.requestAds(adsRequest);
   });
+}
+
+function htmlToElement(html) {
+  var template = document.createElement('template');
+  template.innerHTML = html;
+  return template.content.firstChild;  
 }
 
 /**

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -412,7 +412,7 @@ export function imaVideo(global, data) {
 
 function htmlToElement(html) {
   const template = document.createElement('template');
-  template.innerHTML = html;
+  template./*REVIEW*/innerHTML = html;
   return template.content.firstChild;
 }
 

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -412,7 +412,7 @@ export function imaVideo(global, data) {
 
 function htmlToElement(html) {
   const template = document.createElement('template');
-  template./*REVIEW*/innerHTML = html;
+  template./*OK*/innerHTML = html;
   return template.content.firstChild;
 }
 

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -317,9 +317,22 @@ export function imaVideo(global, data) {
   setStyle(videoPlayer, 'width', '100%');
   setStyle(videoPlayer, 'height', '100%');
   setStyle(videoPlayer, 'background-color', 'black');
-  videoPlayer.setAttribute('src', data.src);
   videoPlayer.setAttribute('poster', data.poster);
   videoPlayer.setAttribute('playsinline', true);
+  // Set video player source, first based on source child elements if present.
+  // If not, then based on data-src.
+  if (data.sources) {
+    const sources = JSON.parse(data.sources);
+    sources.some(source => {
+      if (videoPlayer.canPlayType(source.type)) {
+        videoPlayer.setAttribute('src', source.src);
+        return true;
+      }
+    });
+  } else {
+    videoPlayer.setAttribute('src', data.src);
+  }
+
 
   contentDiv.appendChild(videoPlayer);
   wrapperDiv.appendChild(contentDiv);

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -411,9 +411,9 @@ export function imaVideo(global, data) {
 }
 
 function htmlToElement(html) {
-  var template = document.createElement('template');
+  const template = document.createElement('template');
   template.innerHTML = html;
-  return template.content.firstChild;  
+  return template.content.firstChild;
 }
 
 /**

--- a/examples/ima-video.amp.html
+++ b/examples/ima-video.amp.html
@@ -14,15 +14,24 @@
     </style>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <style>
+    #player-wrapper {
+        width: 640px;
+        height: 360px;
+        max-width: 90%;
+    }
+    </style>
 </head>
 <body>
     <h2>amp-ima-video</h2>
-    <amp-ima-video id="myVideo"
-        width="640" height="360" layout="responsive"
-        data-src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4"
-        data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator="
-        data-poster="/examples/img/ima-poster.png">
-    </amp-ima-video>
+    <div id="player-wrapper">
+        <amp-ima-video id="myVideo"
+            width="640" height="360" layout="responsive"
+            data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator="
+            data-poster="/examples/img/ima-poster.png">
+            <source src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4" type="video/mp4">
+        </amp-ima-video>
+    </div>
     <h3>Actions</h3>
     <button on="tap:myVideo.play">Play</button>
     <button on="tap:myVideo.pause">Pause</button>

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -81,7 +81,7 @@ class AmpImaVideo extends AMP.BaseElement {
         }
         const tmp = document.createElement('div');
         tmp.appendChild(source);
-        sources.push(tmp.innerHTML);
+        sources.push(tmp./*REVIEW*/innerHTML);
       });
       this.element.setAttribute('data-sources', JSON.stringify(sources));
     }

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -79,7 +79,7 @@ class AmpImaVideo extends AMP.BaseElement {
         if (!this.preconnectSource_) {
           this.preconnectSource_ = source.src;
         }
-        var tmp = document.createElement('div');
+        const tmp = document.createElement('div');
         tmp.appendChild(source);
         sources.push(tmp.innerHTML);
       });

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -79,9 +79,7 @@ class AmpImaVideo extends AMP.BaseElement {
         if (!this.preconnectSource_) {
           this.preconnectSource_ = source.src;
         }
-        const tmp = document.createElement('div');
-        tmp.appendChild(source);
-        sources.push(tmp./*REVIEW*/innerHTML);
+        sources.push(source./*OK*/outerHTML);
       });
       this.element.setAttribute('data-sources', JSON.stringify(sources));
     }

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -64,16 +64,29 @@ class AmpImaVideo extends AMP.BaseElement {
     assertHttpsUrl(this.element.getAttribute('data-tag'),
         'The data-tag attribute is required for <amp-video-ima> and must be ' +
             'https');
-    assertHttpsUrl(this.element.getAttribute('data-src'),
-        'The data-src attribute is required for <amp-video-ima> and must be ' +
-            'https');
+
+    // Set data-sources attribute based on source child elements.
+    const sourceElements = this.element.getElementsByTagName('source');
+    if (sourceElements.length > 0) {
+      const sources = [];
+      Array.from(sourceElements).forEach(source => {
+        sources.push({
+          'src': source.src,
+          'type': source.type,
+        });
+      });
+      this.element.setAttribute('data-sources', JSON.stringify(sources));
+    }
   }
 
   /** @override */
   preconnectCallback() {
     this.preconnect.preload(
         'https://imasdk.googleapis.com/js/sdkloader/ima3.js', 'script');
-    this.preconnect.url(this.element.getAttribute('data-src'));
+    const source = this.element.getAttribute('data-src');
+    if (source) {
+      this.preconnect.url(source);
+    }
     this.preconnect.url(this.element.getAttribute('data-tag'));
     preloadBootstrap(this.win, this.preconnect);
   }

--- a/extensions/amp-ima-video/0.1/validator-amp-ima-video.protoascii
+++ b/extensions/amp-ima-video/0.1/validator-amp-ima-video.protoascii
@@ -35,7 +35,7 @@ tags: {  # <amp-ima-video>
   # data-* is generally allowed, but it's not generally mandatory.
   attrs: {
     name: "data-src"
-    mandatory: true
+    mandatory: false
     value_url: {
       allowed_protocol: "https"
       allow_relative: true  # Will be set to false at a future date.

--- a/extensions/amp-ima-video/0.1/validator-amp-ima-video.protoascii
+++ b/extensions/amp-ima-video/0.1/validator-amp-ima-video.protoascii
@@ -35,7 +35,6 @@ tags: {  # <amp-ima-video>
   # data-* is generally allowed, but it's not generally mandatory.
   attrs: {
     name: "data-src"
-    mandatory: false
     value_url: {
       allowed_protocol: "https"
       allow_relative: true  # Will be set to false at a future date.

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -72,7 +72,7 @@ The URL for your VAST ad document.
 
 **data-src** (required if no `<source>` children are present)
 
-DEPRECATED Prefer `<source>` child elements. The URL of your video content.
+The URL of your video content.
 
 **data-poster** (optional)
 

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -66,13 +66,13 @@ VAST-compliant ad response (for examples, see
 
 ## Attributes
 
-**data-src** (required)
-
-The URL of your video content.
-
 **data-tag** (required)
 
 The URL for your VAST ad document.
+
+**data-src** (optional)
+
+The URL of your video content.
 
 **data-poster** (optional)
 

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -32,7 +32,7 @@ limitations under the License.
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-ima-video" src="https://cdn.ampproject.org/v0/amp-ima-video-0.1.js">&lt;/script></code></td>
   </tr>
-  <tr>
+  <tr
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
     <td>fixed, responsive</td>
   </tr>
@@ -44,8 +44,8 @@ limitations under the License.
 
 ## Overview
 
-You can use the `amp-ima-video` component to embed an <a
-href="https://developers.google.com/interactive-media-ads/docs/sdks/html5/">IMA
+You can use the `amp-ima-video` component to embed an
+<a href="https://developers.google.com/interactive-media-ads/docs/sdks/html5/">IMA
 SDK</a> enabled video player.
 
 To embed a video, provide a source URL for your

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -72,7 +72,7 @@ The URL for your VAST ad document.
 
 **data-src** (optional)
 
-The URL of your video content.
+DEPRECATED Prefer `<source>` child elements. The URL of your video content.
 
 **data-poster** (optional)
 

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -70,7 +70,7 @@ VAST-compliant ad response (for examples, see
 
 The URL for your VAST ad document.
 
-**data-src** (optional)
+**data-src** (required if no `<source>` children are present)
 
 DEPRECATED Prefer `<source>` child elements. The URL of your video content.
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3227,6 +3227,26 @@ tags: {  # <amp-pixel>
   }
 }
 
+tags: {
+  tag_name: "SOURCE"
+  spec_name: "amp-ima-video > source"
+  mandatory_parent: "AMP-IMA-VIDEO"
+  attrs: { name: "media" }
+  attrs: {
+    name: "src"
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  attrs: { name: "type" }
+  # <amp-bind>
+  attrs: { name: "[src]" }
+  attrs: { name: "[type]" }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-ima-video"
+}
+
 # AMP Layout attributes: implied for TagSpecs with amp_layout field
 # set. Note that while these attributes are defined as optional here,
 # depending on amp layout the validator will examine these fields and

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1548,6 +1548,25 @@ tags: {
   attrs: { name: "media" }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-video"
 }
+tags: {
+  tag_name: "SOURCE"
+  spec_name: "amp-ima-video > source"
+  mandatory_parent: "AMP-IMA-VIDEO"
+  attrs: { name: "media" }
+  attrs: {
+    name: "src"
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  attrs: { name: "type" }
+  # <amp-bind>
+  attrs: { name: "[src]" }
+  attrs: { name: "[type]" }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-ima-video"
+}
 # 4.7.8 The track element
 # We have two attr_list variants to encode the requirement that if
 # the attribute kind has the value 'subtitles', then the tag must
@@ -3225,26 +3244,6 @@ tags: {  # <amp-pixel>
     supported_layouts: FIXED
     supported_layouts: NODISPLAY
   }
-}
-
-tags: {
-  tag_name: "SOURCE"
-  spec_name: "amp-ima-video > source"
-  mandatory_parent: "AMP-IMA-VIDEO"
-  attrs: { name: "media" }
-  attrs: {
-    name: "src"
-    value_url: {
-      allowed_protocol: "https"
-      allow_relative: true  # Will be set to false at a future date.
-    }
-    blacklisted_value_regex: "__amp_source_origin"
-  }
-  attrs: { name: "type" }
-  # <amp-bind>
-  attrs: { name: "[src]" }
-  attrs: { name: "[type]" }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-ima-video"
 }
 
 # AMP Layout attributes: implied for TagSpecs with amp_layout field


### PR DESCRIPTION
* Adds support for child &lt;source&gt; elements, like so:
  ```
  <amp-video-ima>
    <source src="forrest_gump.mp4" type="video/mp4">
    <source src="forrest_gump.ogg" type="video/ogg">
  </amp-video-ima>
  ```
* Maintains support for the old data-src attribute.
* Updates sample to use &lt;source&gt; instead of data-src attribute.
* Fixes sample by adding wrapping div with style
* Fixes #8842 