### PR TITLE
AMP A4A Experiment Cleanup

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -460,8 +460,7 @@ export class AmpA4A extends AMP.BaseElement {
   resumeCallback() {
     // FIE that was not destroyed on unlayoutCallback does not require a new
     // ad request.
-    if (!isExperimentOn(this.win, 'a4a-fie-unlayout-enabled') &&
-        this.friendlyIframeEmbed_) {
+    if (this.friendlyIframeEmbed_) {
       return;
     }
     this.protectedEmitLifecycleEvent_('resumeCallback');
@@ -1020,8 +1019,7 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override  */
   unlayoutCallback() {
-    if (!isExperimentOn(this.win, 'a4a-fie-unlayout-enabled') &&
-        this.friendlyIframeEmbed_) {
+    if (this.friendlyIframeEmbed_) {
       return false;
     }
     // Increment promiseId to cause any pending promise to cancel.
@@ -1204,49 +1202,47 @@ export class AmpA4A extends AMP.BaseElement {
       const currServiceName = serviceName;
       if (url) {
         // Delay request until document is not in a prerender state.
-        const firstVisiblePromise =
-          isExperimentOn(this.win, 'a4a-disable-cryptokey-viewer-check') ?
-          Promise.resolve() : viewerForDoc(this.getAmpDoc()).whenFirstVisible();
-        return firstVisiblePromise.then(() => xhrFor(this.win).fetchJson(url, {
-          mode: 'cors',
-          method: 'GET',
-          // Set ampCors false so that __amp_source_origin is not
-          // included in XHR CORS request allowing for keyset to be cached
-          // across pages.
-          ampCors: false,
-          credentials: 'omit',
-        }).then(res => res.json()).then(jwkSetObj => {
-          const result = {serviceName: currServiceName};
-          if (isObject(jwkSetObj) && Array.isArray(jwkSetObj.keys) &&
-              jwkSetObj.keys.every(isObject)) {
-            result.keys = jwkSetObj.keys;
-          } else {
-            user().error(TAG, this.element.getAttribute('type'),
-                `Invalid response from signing server ${currServiceName}`,
-                this.element);
-            result.keys = [];
-          }
-          return result;
-        })).then(jwkSet => {
-          return {
-            serviceName: jwkSet.serviceName,
-            keys: jwkSet.keys.map(jwk =>
-                this.crypto_.importPublicKey(jwkSet.serviceName, jwk)
-                .catch(err => {
-                  user().error(TAG, this.element.getAttribute('type'),
-                      `error importing keys for service: ${jwkSet.serviceName}`,
-                      err, this.element);
-                  return null;
-                })),
-          };
-        }).catch(err => {
-          user().error(
-              TAG, this.element.getAttribute('type'), err, this.element);
-          // TODO(a4a-team): This is a failure in the initial attempt to get
-          // the keys, probably b/c of a network condition.  We should
-          // re-trigger key fetching later.
-          return {serviceName: currServiceName, keys: []};
-        });
+        return viewerForDoc(this.getAmpDoc()).whenFirstVisible()
+          .then(() => xhrFor(this.win).fetchJson(url, {
+            mode: 'cors',
+            method: 'GET',
+            // Set ampCors false so that __amp_source_origin is not
+            // included in XHR CORS request allowing for keyset to be cached
+            // across pages.
+            ampCors: false,
+            credentials: 'omit',
+          }).then(res => res.json()).then(jwkSetObj => {
+            const result = {serviceName: currServiceName};
+            if (isObject(jwkSetObj) && Array.isArray(jwkSetObj.keys) &&
+                jwkSetObj.keys.every(isObject)) {
+              result.keys = jwkSetObj.keys;
+            } else {
+              user().error(TAG, this.element.getAttribute('type'),
+                  `Invalid response from signing server ${currServiceName}`,
+                  this.element);
+              result.keys = [];
+            }
+            return result;
+          })).then(jwkSet => {
+            return {
+              serviceName: jwkSet.serviceName,
+              keys: jwkSet.keys.map(jwk =>
+                  this.crypto_.importPublicKey(jwkSet.serviceName, jwk)
+                  .catch(err => {
+                    user().error(TAG, this.element.getAttribute('type'),
+                        `error importing keys for: ${jwkSet.serviceName}`,
+                        err, this.element);
+                    return null;
+                  })),
+            };
+          }).catch(err => {
+            user().error(
+                TAG, this.element.getAttribute('type'), err, this.element);
+            // TODO(a4a-team): This is a failure in the initial attempt to get
+            // the keys, probably b/c of a network condition.  We should
+            // re-trigger key fetching later.
+            return {serviceName: currServiceName, keys: []};
+          });
       } else {
         // The given serviceName does not have a corresponding URL in
         // _a4a-config.js.

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -34,7 +34,6 @@ import {Extensions} from '../../../../src/service/extensions-impl';
 import {Viewer} from '../../../../src/service/viewer-impl';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 import {cryptoFor} from '../../../../src/crypto';
-import {isExperimentOn, toggleExperiment} from '../../../../src/experiments';
 import {cancellation} from '../../../../src/error';
 import {
   data as validCSSAmp,
@@ -371,20 +370,6 @@ describe('amp-a4a', () => {
         expect(a4a.unlayoutCallback()).to.be.false;
         expect(a4a.friendlyIframeEmbed_).to.exist;
         expect(destroySpy).to.not.be.called;
-      });
-    });
-
-    it('should reset state to null on FIE unlayoutCallback if exp set', () => {
-      toggleExperiment(fixture.win, 'a4a-fie-unlayout-enabled', true, true);
-      a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      return a4a.layoutCallback().then(() => {
-        expect(a4a.friendlyIframeEmbed_).to.exist;
-        const destroySpy = sandbox.spy();
-        a4a.friendlyIframeEmbed_.destroy = destroySpy;
-        expect(a4a.unlayoutCallback()).to.be.true;
-        expect(a4a.friendlyIframeEmbed_).to.not.exist;
-        expect(destroySpy).to.be.calledOnce;
       });
     });
 
@@ -810,34 +795,6 @@ describe('amp-a4a', () => {
           a4a.resumeCallback();
           expect(onLayoutMeasureSpy).to.not.be.called;
           expect(a4a.fromResumeCallback).to.be.false;
-        });
-      });
-    });
-    it('resumeCallback does call onLayoutMeasure for FIE if exp set', () => {
-      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        const doc = fixture.doc;
-        const a4aElement = createA4aElement(doc);
-        const s = doc.createElement('style');
-        s.textContent = '.fixed {position:fixed;}';
-        doc.head.appendChild(s);
-        toggleExperiment(fixture.win, 'a4a-fie-unlayout-enabled', true, true);
-        const a4a = new MockA4AImpl(a4aElement);
-        const renderAmpCreativeSpy = sandbox.spy(a4a, 'renderAmpCreative_');
-        a4a.buildCallback();
-        a4a.onLayoutMeasure();
-        expect(a4a.adPromise_).to.be.ok;
-        return a4a.layoutCallback().then(() => {
-          expect(renderAmpCreativeSpy.calledOnce,
-              'renderAmpCreative_ called exactly once').to.be.true;
-          a4a.unlayoutCallback();
-          const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
-          sandbox.stub(AmpA4A.prototype, 'getResource').returns(
-            {'hasBeenMeasured': () => true, 'isMeasureRequested': () => false});
-          a4a.resumeCallback();
-          expect(onLayoutMeasureSpy).to.be.called;
-          expect(a4a.fromResumeCallback).to.be.true;
         });
       });
     });
@@ -2010,8 +1967,6 @@ describe('amp-a4a', () => {
         fixture = f;
         win = fixture.win;
         a4aElement = createA4aElement(fixture.doc);
-        toggleExperiment(
-          win, 'a4a-disable-cryptokey-viewer-check', false, true);
         return fixture;
       });
     });
@@ -2068,23 +2023,6 @@ describe('amp-a4a', () => {
       expect(xhrMockJson).to.not.be.called;
       firstVisibleResolve();
       return Promise.all(result).then(() => {
-        expect(xhrMockJson).to.be.calledOnce;
-      });
-    });
-
-    it('should not wait for first visible if exp disabled', () => {
-      toggleExperiment(win, 'a4a-disable-cryptokey-viewer-check', true, true);
-      expect(isExperimentOn(win, 'a4a-disable-cryptokey-viewer-check'))
-        .to.be.true;
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(result).to.be.instanceof(Array);
-      expect(result).to.have.lengthOf(1);  // Only one service.
-      return Promise.all(result).then(() => {
-        expect(viewerWhenVisibleMock).to.not.be.called;
         expect(xhrMockJson).to.be.calledOnce;
       });
     });


### PR DESCRIPTION
Clean up launched behavior change experiments:

- a4a-fie-unlayout-enabled which allowed for disabling feature change where AMP creatives are not removed within unlayoutCallback
- a4a-disable-cryptokey-viewer-check which allowed for disabling feature change where crypto public key fetch is delayed until page is not in a prerender state

/cc @ampproject/a4a 