### PR TITLE
Fix mechanism to detect the files in a PR

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -99,9 +99,9 @@ function timedExecOrDie(cmd) {
  */
 function filesInPr() {
   const branches = `master ${process.env.TRAVIS_PULL_REQUEST_SHA}`;
-  const commonAncestor = getStdout(`git merge-base ${branches}`);
+  const commonAncestors = getStdout(`git merge-base ${branches}`);
   const travisCommitRange  =
-      `${commonAncestor}...${process.env.TRAVIS_PULL_REQUEST_SHA}`;
+      `${commonAncestors[0]}...${process.env.TRAVIS_PULL_REQUEST_SHA}`;
   return getStdout(`git diff --name-only ${travisCommitRange}`);
 }
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -68,7 +68,7 @@ function stopTimer(functionName, startTime) {
  * @return {!Array<string>}
  */
 function getStdout(cmd) {
-  return child_process.execSync(cmd, {'encoding': 'utf-8'}).trim();
+  return child_process.execSync(cmd, {'encoding': 'utf-8'});
 }
 
 /**
@@ -100,12 +100,13 @@ function timedExecOrDie(cmd) {
 function filesInPr() {
   const branches = `master ${process.env.TRAVIS_PULL_REQUEST_SHA}`;
   const commonAncestor =
-      getStdout(`git merge-base --fork-point ${branches}`);
+      getStdout(`git merge-base --fork-point ${branches}`).trim();
   const travisCommitRange  =
       `${commonAncestor}...${process.env.TRAVIS_PULL_REQUEST_SHA}`;
   const files =
-      getStdout(`git diff --name-only ${travisCommitRange}`).split('\n');
-  const changeSummary = getStdout(`git diff --stat ${travisCommitRange}`);
+      getStdout(`git diff --name-only ${travisCommitRange}`).trim().split('\n');
+  const changeSummary =
+      getStdout(`git -c color.ui=always diff --stat ${travisCommitRange}`);
   console.log(fileLogPrefix, 'Changes in this PR:');
   console.log(changeSummary);
   return files;

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -99,9 +99,9 @@ function timedExecOrDie(cmd) {
  */
 function filesInPr() {
   const branches = `master ${process.env.TRAVIS_PULL_REQUEST_SHA}`;
-  const commonAncestors = getStdout(`git merge-base ${branches}`);
+  const commonAncestor = getStdout(`git merge-base --fork-point ${branches}`);
   const travisCommitRange  =
-      `${commonAncestors[0]}...${process.env.TRAVIS_PULL_REQUEST_SHA}`;
+      `${commonAncestor}...${process.env.TRAVIS_PULL_REQUEST_SHA}`;
   return getStdout(`git diff --name-only ${travisCommitRange}`);
 }
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -68,7 +68,16 @@ function stopTimer(functionName, startTime) {
  * @return {!Array<string>}
  */
 function getStdout(cmd) {
-  return child_process.execSync(cmd, {'encoding': 'utf-8'});
+  let p = child_process.spawnSync(
+      '/bin/sh',
+      ['-c', cmd],
+      {
+        'cwd': process.cwd(),
+        'env': process.env,
+        'stdio': 'pipe',
+        'encoding': 'utf-8'
+      });
+  return p.stdout;
 }
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -107,16 +107,11 @@ function timedExecOrDie(cmd) {
  * @return {!Array<string>}
  */
 function filesInPr() {
-  const branches = `master ${process.env.TRAVIS_PULL_REQUEST_SHA}`;
-  const commonAncestor =
-      getStdout(`git merge-base --fork-point ${branches}`).trim();
-  const travisCommitRange  =
-      `${commonAncestor}...${process.env.TRAVIS_PULL_REQUEST_SHA}`;
-  const files =
-      getStdout(`git diff --name-only ${travisCommitRange}`).trim().split('\n');
-  const changeSummary =
-      getStdout(`git -c color.ui=always diff --stat ${travisCommitRange}`);
-  console.log(fileLogPrefix, 'Changes in this PR:');
+  const files = getStdout(`git diff --name-only master`).trim().split('\n');
+  const changeSummary = getStdout(`git -c color.ui=always diff --stat master`);
+  console.log(fileLogPrefix,
+      'Testing the following changes at commit',
+      util.colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(changeSummary);
   return files;
 }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -164,7 +164,7 @@ function isDocFile(filePath) {
  * @return {boolean}
  */
 function isIntegrationTest(filePath) {
-  if (filePath.startsWith('test/integration/')) return true;
+  return filePath.startsWith('test/integration/');
 }
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -107,8 +107,10 @@ function timedExecOrDie(cmd) {
  * @return {!Array<string>}
  */
 function filesInPr() {
-  const files = getStdout(`git diff --name-only master`).trim().split('\n');
-  const changeSummary = getStdout(`git -c color.ui=always diff --stat master`);
+  const files =
+      getStdout(`git diff --name-only master...HEAD`).trim().split('\n');
+  const changeSummary =
+      getStdout(`git -c color.ui=always diff --stat master...HEAD`);
   console.log(fileLogPrefix,
       'Testing the following changes at commit',
       util.colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));


### PR DESCRIPTION
This PR updates the mechanism to detect the files contained in a PR. This is necessary because pushing a PR from a branch that wasn't recently synced to master could sometimes result in Travis counting *all* the files committed to master since the creation of that branch as being within the PR. This has resulted in all sorts of confusion stemming from errors in unrelated files.

Fixes #9778