### PR TITLE
Make bind integration tests less flaky (the remix)

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -894,6 +894,16 @@ export class AmpFormService {
     /** @const @private {!Promise} */
     this.whenInitialized_ = this.installStyles_(ampdoc)
         .then(() => this.installHandlers_(ampdoc));
+
+    // Dispatch a test-only event for integration tests.
+    if (getMode().test) {
+      this.whenInitialized_.then(() => {
+        const win = ampdoc.win;
+        const event = createCustomEvent(
+            win, 'amp:form-service:initialize', null, {bubbles: true});
+        win.dispatchEvent(event);
+      });
+    }
   }
 
   /**

--- a/test/fixtures/bind-brightcove.html
+++ b/test/fixtures/bind-brightcove.html
@@ -9,11 +9,6 @@
   <script async src="/dist/amp.js"></script>
   <script async custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
   <script async custom-element="amp-brightcove" src="/dist/v0/amp-brightcove-0.1.max.js"></script>
-  <style amp-custom>
-    amp-brightcove {
-      margin-top: 600px; /* iframes must not be in initial viewport as a rule */
-    }
-  </style>
 </head>
 <body>
   <!-- amp-brightcove -->

--- a/test/fixtures/bind-carousel.html
+++ b/test/fixtures/bind-carousel.html
@@ -16,9 +16,8 @@
   <p id="slideNumber" [text]="selectedSlide">0</p>
   <amp-carousel width="300" height="100" type="slides" id="carousel"
       on="slideChange:AMP.setState({selectedSlide: event.index})" [slide]="selectedSlide">
-    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
-    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
-    <amp-img src="http://www.google.com/image1" height="200" width="200"></amp-img>
+    <amp-img src="http://www.foo.com/image" height="200" width="200"></amp-img>
+    <amp-img src="http://www.foo.com/image" height="200" width="200"></amp-img>
   </amp-carousel>
 </body>
 </html>

--- a/test/fixtures/bind-iframe.html
+++ b/test/fixtures/bind-iframe.html
@@ -9,18 +9,13 @@
   <script async src="/dist/amp.js"></script>
   <script async custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
   <script async custom-element="amp-iframe" src="/dist/v0/amp-iframe-0.1.max.js"></script>
-  <style amp-custom>
-    amp-iframe {
-      margin-top: 600px; /* iframes must not be in initial viewport as a rule */
-    }
-  </style>
 </head>
-
 <body>
   <!-- amp-iframe -->
   <button id="iframeButton" on="tap:AMP.setState({iframe: 'https://giphy.com/embed/DKG1OhBUmxL4Q'})">Change amp-iframe</button>
   <amp-iframe width=100 height=100 id="ampIframe" sandbox="allow-scripts allow-same-origin allow-popups"
       src="https://player.vimeo.com/video/140261016" [src]="iframe">
+    <amp-img layout="fill" src="https://foo.com/foo.png" placeholder></amp-img>
   </amp-iframe>
 </body>
 </html>

--- a/test/fixtures/bind-list.html
+++ b/test/fixtures/bind-list.html
@@ -13,9 +13,9 @@
 
 <body>
   <!-- amp-list -->
-  <button id='listSrcButton' on="tap:AMP.setState({listSrc: 'https://www.google.com/bound.json'})">Change amp-list</button>
-  <button id='httpListSrcButton' on="tap:AMP.setState({listSrc: 'http://www.google.com/justhttp.json'})">Change amp-list</button>
-  <amp-list id='list' src="https://www.google.com/unbound.json" [src]=listSrc>
+  <button id="listSrcButton" on="tap:AMP.setState({listSrc: 'https://www.google.com/bound.json'})">Change amp-list</button>
+  <button id="httpListSrcButton" on="tap:AMP.setState({listSrc: 'http://www.google.com/justhttp.json'})">Change amp-list</button>
+  <amp-list id="list" width=100 height=100 src="https://www.google.com/unbound.json" [src]=listSrc>
   </amp-list>
 </body>
 </html>

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -95,7 +95,9 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   // TODO(choumx, #9759): Remove Chrome-only condition.
   describe.configure().ifChrome().run('with <amp-form>', () => {
     beforeEach(() => {
-      return setupWithFixture('test/fixtures/bind-form.html');
+      return setupWithFixture('test/fixtures/bind-form.html')
+          // Wait for AmpFormService to register <form> elements.
+          .then(() => fixture.awaitEvent('amp:form-service:initialize', 1));
     });
 
     it('should NOT allow invalid bindings or values', () => {

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -15,13 +15,11 @@
  */
 
 import {createFixtureIframe} from '../../testing/iframe';
-import {batchedXhrFor, bindForDoc} from '../../src/services';
-import {ampdocServiceFor} from '../../src/ampdoc';
+import {batchedXhrFor} from '../../src/services';
 import * as sinon from 'sinon';
 
 describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   let fixture;
-  let ampdoc;
   let sandbox;
   let numSetStates;
   let numTemplated;
@@ -53,24 +51,17 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
         fixture.awaitEvent('amp:bind:initialize', 1),
         fixture.awaitEvent('amp:load:start', loadStartsToExpect),
       ]);
-    }).then(() => {
-      const ampdocService = ampdocServiceFor(fixture.win);
-      ampdoc = ampdocService.getAmpDoc(fixture.doc);
     });
   }
 
   /** @return {!Promise} */
   function waitForBindApplication() {
-    // Bind should be available, but need to wait for actions to resolve
-    // service promise for bind and call setState.
-    return bindForDoc(ampdoc).then(unusedBind =>
-        fixture.awaitEvent('amp:bind:setState', ++numSetStates));
+    return fixture.awaitEvent('amp:bind:setState', ++numSetStates);
   }
 
   /** @return {!Promise} */
   function waitForTemplateRescan() {
-    return bindForDoc(ampdoc).then(unusedBind =>
-        fixture.awaitEvent('amp:bind:rescan-template', ++numTemplated));
+    return fixture.awaitEvent('amp:bind:rescan-template', ++numTemplated);
   }
 
   describe('with [text] and [class]', () => {
@@ -99,7 +90,8 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx, #9759): Remove Chrome-only condition.
+  // TODO(choumx, #9759): Seems like old browsers give up when hitting expected
+  // user errors due to illegal bindings in the form's template.
   describe.configure().ifChrome().run('with <amp-form>', () => {
     beforeEach(() => {
       // <form> is not an AMP element.
@@ -201,8 +193,8 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
     });
   });
 
-  // TODO(choumx): Flaky on Edge for some reason.
-  describe.configure().skipEdge().run('with <amp-carousel>', () => {
+  // TODO(choumx): Flaky on Edge/Firefox for some reason.
+  describe.configure().ifChrome().run('with <amp-carousel>', () => {
     beforeEach(() => {
       // One <amp-carousel> plus two <amp-img> elements.
       return setupWithFixture('test/fixtures/bind-carousel.html', 3);

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -69,6 +69,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
       'amp:bind:setState': 0,
       'amp:bind:rescan-template': 0,
       'amp:error': 0,
+      'amp:form-service:initialize': 0,
       'amp:load:start': 0,
       'amp:stubbed': 0,
     };


### PR DESCRIPTION
Fixes #9786.

- Wait for AMP element layout for all tests.
- Wait for `AmpFormService` registration for `with <amp-form>` tests.
- Remove crappy old code.
- Fix `bind-list.html` validation error which caused failures on some browsers.

Local saucelab runs are green with these changes.

/to @rsimha-amp /cc @camelburrito 