### PR TITLE
Refactor form verifiers API.

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -655,27 +655,10 @@
 <form
   method="post"
   action-xhr="/form/verify-search-json/post"
+  verify-xhr="/form/verify-search-json/post"
   target="_blank"
   class="verification-form"
 >
-    <script type="application/json">
-    {
-      "verificationGroups": [
-        {
-          "name": "coolName",
-          "elements": ["name"]
-        },
-        {
-          "name": "fullAddress",
-          "elements": ["addressLine2", "city", "zip"]
-        },
-        {
-          "name": "validCarrier",
-          "elements": ["phone"]
-        }
-      ]
-    }
-    </script>
     <fieldset>
         <label>
             <span>Name</span>

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -149,22 +149,10 @@ export class AmpForm {
     this.target_ = this.form_.getAttribute('target');
 
     /** @const @private {?string} */
-    this.xhrAction_ = this.form_.getAttribute('action-xhr');
-    if (this.xhrAction_) {
-      assertHttpsUrl(this.xhrAction_, this.form_, 'action-xhr');
-      user().assert(!isProxyOrigin(this.xhrAction_),
-          'form action-xhr should not be on AMP CDN: %s',
-          this.form_);
-    }
+    this.xhrAction_ = this.getXhrUrl_('action-xhr');
 
     /** @const @private {?string} */
-    this.xhrVerify_ = this.form_.getAttribute('verify-xhr');
-    if (this.xhrVerify_) {
-      assertHttpsUrl(this.xhrVerify_, this.form_, 'verify-xhr');
-      user().assert(!isProxyOrigin(this.xhrVerify_),
-          'form verify-xhr should not be on AMP CDN: %s',
-          this.form_);
-    }
+    this.xhrVerify_ = this.getXhrUrl_('verify-xhr');
 
     /**
      * Indicates that the action will submit to canonical or not.
@@ -213,6 +201,23 @@ export class AmpForm {
 
     /** @private {?Promise} */
     this.renderTemplatePromise_ = null;
+  }
+
+  /**
+   * Gets and validates an attribute for form request URLs.
+   * @param {string} attribute
+   * @return {?string}
+   * @private
+   */
+  getXhrUrl_(attribute) {
+    const url = this.form_.getAttribute(attribute);
+    if (url) {
+      assertHttpsUrl(url, this.form_, attribute);
+      user().assert(!isProxyOrigin(url),
+          `form ${attribute} should not be on AMP CDN: %s`,
+          this.form_);
+    }
+    return url;
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -258,7 +258,7 @@ export class AmpForm {
       this.validator_.onBlur(e);
     }, true);
 
-    const cleanup = () => {
+    const afterVerifierCommit = () => {
       // Move from the VERIFYING state back to INITIAL
       if (this.state_ === FormState_.VERIFYING) {
         this.setState_(FormState_.INITIAL);
@@ -272,7 +272,7 @@ export class AmpForm {
           }, () => {
             checkUserValidityAfterInteraction_(dev().assertElement(e.target));
           })
-          .then(cleanup, cleanup);
+          .then(afterVerifierCommit, afterVerifierCommit);
     });
 
     this.form_.addEventListener('input', e => {
@@ -455,6 +455,7 @@ export class AmpForm {
 
   /**
    * Send a request to the form's action endpoint.
+   * @return {!Promise<!../../../src/service/xhr-impl.FetchResponse>}
    * @private
    */
   doActionXhr_() {
@@ -463,6 +464,7 @@ export class AmpForm {
 
   /**
    * Send a request to the form's verify endpoint.
+   * @return {!Promise<!../../../src/service/xhr-impl.FetchResponse>}
    * @private
    */
   doVerifyXhr_() {
@@ -475,6 +477,7 @@ export class AmpForm {
    * @param {string} url
    * @param {string} method
    * @param {!Object<string, string>=} opt_extraFields
+   * @return {!Promise<!../../../src/service/xhr-impl.FetchResponse>}
    * @private
    */
   doXhr_(url, method, opt_extraFields) {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -88,10 +88,6 @@ const UserValidityState = {
 };
 
 
-/** @typedef {!HTMLInputElement|!HTMLSelectElement|!HTMLTextAreaElement} */
-let FormFieldDef;
-
-
 /** @private @const {string} */
 const REDIRECT_TO_HEADER = 'AMP-Redirect-To';
 
@@ -161,6 +157,15 @@ export class AmpForm {
           this.form_);
     }
 
+    /** @const @private {?string} */
+    this.xhrVerify_ = this.form_.getAttribute('verify-xhr');
+    if (this.xhrVerify_) {
+      assertHttpsUrl(this.xhrVerify_, this.form_, 'verify-xhr');
+      user().assert(!isProxyOrigin(this.xhrVerify_),
+          'form verify-xhr should not be on AMP CDN: %s',
+          this.form_);
+    }
+
     /**
      * Indicates that the action will submit to canonical or not.
      * @private {boolean|undefined}
@@ -182,8 +187,8 @@ export class AmpForm {
     /** @const @private {!Array<!Element>} */
     this.submitButtons_ = toArray(submitButtons);
 
-    /** @private {?string} */
-    this.state_ = null;
+    /** @private {!FormState_} */
+    this.state_ = FormState_.INITIAL;
 
     const inputs = this.form_.elements;
     for (let i = 0; i < inputs.length; i++) {
@@ -242,27 +247,32 @@ export class AmpForm {
   installEventHandlers_() {
     this.form_.addEventListener(
         'submit', this.handleSubmitEvent_.bind(this), true);
+
     this.form_.addEventListener('blur', e => {
       checkUserValidityAfterInteraction_(dev().assertElement(e.target));
       this.validator_.onBlur(e);
     }, true);
+
+    const cleanup = () => {
+      // Move from the VERIFYING state back to INITIAL
+      if (this.state_ === FormState_.VERIFYING) {
+        this.setState_(FormState_.INITIAL);
+      }
+    };
     this.form_.addEventListener('change', e => {
-      const input = dev().assertElement(e.target);
-      this.verifier_.onCommit(input, updatedElements => {
-        updatedElements.forEach(updatedElement => {
-          checkUserValidityAfterInteraction_(updatedElement);
-        });
-        this.validator_.onBlur(e);
-        // Move from the VERIFYING state back to INITIAL
-        if (this.state_ === FormState_.VERIFYING) {
-          this.setState_(FormState_.INITIAL);
-        }
-      });
+      this.verifier_.onCommit()
+          .then(updatedElements => {
+            updatedElements.forEach(checkUserValidityAfterInteraction_);
+            this.validator_.onBlur(e);
+          }, () => {
+            checkUserValidityAfterInteraction_(dev().assertElement(e.target));
+          })
+          .then(cleanup, cleanup);
     });
+
     this.form_.addEventListener('input', e => {
       checkUserValidityAfterInteraction_(dev().assertElement(e.target));
       this.validator_.onInput(e);
-      this.verifier_.onMutate(dev().assertElement(e.target));
     });
   }
 
@@ -392,9 +402,8 @@ export class AmpForm {
     }
     this.setState_(FormState_.VERIFYING);
 
-    const verifyXhr = this.doVarSubs_(this.getVarSubsFields_())
-        .then(() => this.doXhr_({[FORM_VERIFY_PARAM]: true}));
-    return verifyXhr;
+    return this.doVarSubs_(this.getVarSubsFields_())
+        .then(() => this.doVerifyXhr_());
   }
 
   /**
@@ -402,15 +411,18 @@ export class AmpForm {
    * @private
    */
   handleXhrSubmit_(varSubsFields) {
-    this.cleanupRenderedTemplate_();
     this.setState_(FormState_.SUBMITTING);
 
     const p = this.doVarSubs_(varSubsFields)
         .then(() => {
           this.triggerFormSubmitInAnalytics_();
           this.actions_.trigger(this.form_, 'submit', /*event*/ null);
+
+          // After variable substitution
+          const values = this.getFormAsObject_();
+          this.renderTemplate_(values);
         })
-        .then(() => this.doXhr_())
+        .then(() => this.doActionXhr_())
         .then(response => this.handleXhrSubmitSuccess_(response),
             error => {
               return this.handleXhrSubmitFailure_(/** @type {!Error} */(error));
@@ -438,28 +450,49 @@ export class AmpForm {
 
   /**
    * Send a request to the form's action endpoint.
-   * @param {!Object<string, string>=} opt_extraValues
    * @private
    */
-  doXhr_(opt_extraValues) {
-    const isHeadOrGet = this.method_ == 'GET' || this.method_ == 'HEAD';
-    const values = this.getFormAsObject_(opt_extraValues);
-    this.renderTemplate_(values);
+  doActionXhr_() {
+    return this.doXhr_(dev().assertString(this.xhrAction_), this.method_);
+  }
 
+  /**
+   * Send a request to the form's verify endpoint.
+   * @private
+   */
+  doVerifyXhr_() {
+    return this.doXhr_(dev().assertString(this.xhrVerify_), this.method_,
+        {[FORM_VERIFY_PARAM]: true});
+  }
+
+  /**
+   * Send a request to a form endpoint.
+   * @param {string} url
+   * @param {string} method
+   * @param {!Object<string, string>=} opt_extraFields
+   * @private
+   */
+  doXhr_(url, method, opt_extraFields) {
     let xhrUrl, body;
+    const isHeadOrGet = method == 'GET' || method == 'HEAD';
+
     if (isHeadOrGet) {
-      xhrUrl = addParamsToUrl(dev().assertString(this.xhrAction_), values);
+      const values = this.getFormAsObject_();
+      if (opt_extraFields) {
+        deepMerge(values, opt_extraFields);
+      }
+      xhrUrl = addParamsToUrl(url, values);
     } else {
-      xhrUrl = this.xhrAction_;
+      xhrUrl = url;
       body = new FormData(this.form_);
-      for (const key in opt_extraValues) {
-        body.append(key, opt_extraValues[key]);
+      for (const key in opt_extraFields) {
+        body.append(key, opt_extraFields[key]);
       }
     }
 
-    return this.xhr_.fetch(dev().assertString(xhrUrl), {
+    return this.xhr_.fetch(xhrUrl, {
       body,
-      method: this.method_,
+      method,
       credentials: 'include',
       headers: {
         Accept: 'application/json',
@@ -477,7 +510,6 @@ export class AmpForm {
     return response.json().then(json => {
       this.triggerAction_(/* success */ true, json);
       this.analyticsEvent_('amp-form-submit-success');
-      this.cleanupRenderedTemplate_();
       this.setState_(FormState_.SUBMIT_SUCCESS);
       this.renderTemplate_(json || {});
       this.maybeHandleRedirect_(response);
@@ -501,7 +533,6 @@ export class AmpForm {
     return promise.then(responseJson => {
       this.triggerAction_(/* success */ false, responseJson);
       this.analyticsEvent_('amp-form-submit-error');
-      this.cleanupRenderedTemplate_();
       this.setState_(FormState_.SUBMIT_ERROR);
       this.renderTemplate_(responseJson || {});
       this.maybeHandleRedirect_(error.response);
@@ -614,11 +645,10 @@ export class AmpForm {
 
   /**
    * Returns form data as an object.
-   * @param {!Object<string, string>=} opt_extraFields
    * @return {!JSONType}
    * @private
    */
-  getFormAsObject_(opt_extraFields) {
+  getFormAsObject_() {
     const data = /** @type {!JSONType} */ ({});
     const inputs = this.form_.elements;
     const submittableTagsRegex = /^(?:input|select|textarea)$/i;
@@ -638,21 +668,20 @@ export class AmpForm {
       }
       data[input.name].push(input.value);
     }
-    if (opt_extraFields) {
-      deepMerge(data, opt_extraFields);
-    }
+
     return data;
   }
 
   /**
    * Adds proper classes for the state passed.
-   * @param {string} newState
+   * @param {!FormState_} newState
    * @private
    */
   setState_(newState) {
     const previousState = this.state_;
     this.form_.classList.remove(`amp-form-${previousState}`);
     this.form_.classList.add(`amp-form-${newState}`);
+    this.cleanupRenderedTemplate_(previousState);
     this.state_ = newState;
     this.submitButtons_.forEach(button => {
       if (newState == FormState_.SUBMITTING) {
@@ -707,10 +736,12 @@ export class AmpForm {
   }
 
   /**
+   * Removes the template for the passed state.
+   * @param {!FormState_} state
    * @private
    */
-  cleanupRenderedTemplate_() {
-    const container = this.form_./*OK*/querySelector(`[${this.state_}]`);
+  cleanupRenderedTemplate_(state) {
+    const container = this.form_./*OK*/querySelector(`[${state}]`);
     if (!container) {
       return;
     }
@@ -755,10 +786,8 @@ function reportValidity(state) {
  * @return {boolean} Whether the form is currently valid or not.
  */
 function checkUserValidityOnSubmission(form) {
-  const inputs = form.querySelectorAll('input,select,textarea,fieldset');
-  for (let i = 0; i < inputs.length; i++) {
-    checkUserValidity(inputs[i]);
-  }
+  const elements = form.querySelectorAll('input,select,textarea,fieldset');
+  iterateCursor(elements, element => checkUserValidity(element));
   return checkUserValidity(form);
 }
 

--- a/extensions/amp-form/0.1/form-verifiers.js
+++ b/extensions/amp-form/0.1/form-verifiers.js
@@ -100,6 +100,9 @@ export class FormVerifier {
     const form = this.form_;
     for (let i = 0; i < form.elements.length; i++) {
       const field = form.elements[i];
+      if (field.disabled) {
+        continue;
+      }
       switch (field.type) {
         case 'select-multiple':
         case 'select-one':

--- a/extensions/amp-form/0.1/form-verifiers.js
+++ b/extensions/amp-form/0.1/form-verifiers.js
@@ -15,17 +15,9 @@
  */
 
 import {LastAddedResolver} from '../../../src/utils/promise';
-import {dev, user} from '../../../src/log';
-import {
-  childElementByTag,
-  isJsonScriptTag,
-} from '../../../src/dom';
-import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
-import {tryParseJson} from '../../../src/json';
-
-/** @visibleForTesting */
-export const CONFIG_KEY = 'verificationGroups';
+import {iterateCursor} from '../../../src/dom';
+import {user} from '../../../src/log';
 
 export const FORM_VERIFY_EXPERIMENT = 'amp-form-verifiers';
 
@@ -40,12 +32,6 @@ export const FORM_VERIFY_PARAM = '__amp_form_verify';
  */
 let VerificationErrorDef;
 
-/**
- * @typedef {{
- *    verifyErrors:!Array<!VerificationErrorDef>
- *  }}
- */
-let VerificationErrorResponseDef;
 
 /**
  * Construct the correct form verifier based on whether
@@ -55,70 +41,13 @@ let VerificationErrorResponseDef;
  */
 export function getFormVerifier(form, xhr) {
   const win = form.ownerDocument.defaultView;
-  const configTag = getConfig_(form);
-  if (configTag) {
+  if (form.hasAttribute('verify-xhr')) {
     user().assert(isExperimentOn(win, FORM_VERIFY_EXPERIMENT),
         `Enable "${FORM_VERIFY_EXPERIMENT}" experiment to use form verifiers`);
-    const config = dev().assert(parseConfig_(configTag));
-    return new AsyncVerifier(form, config, xhr);
+    return new AsyncVerifier(form, xhr);
   } else {
-    return new DefaultVerifier(form, []);
+    return new DefaultVerifier(form);
   }
-}
-
-/**
- * @param {!HTMLFormElement} form
- * @return {?Element}
- * @private
- */
-function getConfig_(form) {
-  return childElementByTag(form, 'script');
-}
-
-/**
- * @param {!Element} script
- * @return {!Array<!VerificationGroup>}
- * @private
- */
-function parseConfig_(script) {
-  if (isJsonScriptTag(script)) {
-    const json = tryParseJson(script.textContent, () => {
-      throw user().createError(
-          'Failed to parse amp-form config. Is it valid JSON?');
-    });
-    const config = json && json[CONFIG_KEY];
-    if (!config || !config.length) {
-      throw user().createError('The amp-form verification config should ' +
-          `contain an array property ${CONFIG_KEY} with at least one element`);
-    }
-    return config.map(group => {
-      const form = dev().assertElement(script.parentElement);
-      return new VerificationGroup(group.elements.map(name => {
-        const element = form.elements[name];
-        if (!element) {
-          throw user().createError(
-              `Form %s has no element named "${name}" `, form);
-        } else if (!isSubmittable_(element)) {
-          throw user().createError('Verification elements must be one of ' +
-              submittableTagNames_.join(', '));
-        } else {
-          return element;
-        }
-      }));
-    });
-  } else {
-    throw user().createError('The amp-form verification config should ' +
-        'be put in a <script> tag with type="application/json"');
-  }
-}
-
-const submittableTagNames_ = ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
-/**
- * @param {!Element} element
- * @return {boolean}
- */
-function isSubmittable_(element) {
-  return submittableTagNames_.includes(element.tagName);
 }
 
 /**
@@ -133,30 +62,82 @@ function isSubmittable_(element) {
 export class FormVerifier {
   /**
    * @param {!HTMLFormElement} form
-   * @param {!Array<!VerificationGroup>} groups
    */
-  constructor(form, groups) {
+  constructor(form) {
     /** @protected @const */
     this.form_ = form;
-
-    /** @protected @const {!Array<!VerificationGroup>} */
-    this.groups_ = groups;
   }
-
-  /**
-   * Called when the user has modified the value in the input,
-   * e.g. the input's 'input' event
-   * @param {!Element} unusedInput
-   */
-  onMutate(unusedInput) {}
 
   /**
    * Called when the user has fully set a value to be verified,
    * e.g. the input's 'change' event
-   * @param {!Element} unusedInput
-   * @param {!function(!Array<!Element>)} unusedAfterVerify
+   * @return {!Promise<!Array<!Element>>}
    */
-  onCommit(unusedInput, unusedAfterVerify) {}
+  onCommit() {
+    this.clearVerificationErrors_();
+    if (this.isDirty_()) {
+      return this.verify_();
+    } else {
+      return Promise.resolve([]);
+    }
+  }
+
+  /**
+   * Sends the verify request if any group is ready to verify.
+   * @return {!Promise<!Array<!Element>>} The list of elements whose state
+   *    must change
+   * @protected
+   */
+  verify_() {
+    return Promise.resolve([]);
+  }
+
+  /**
+   * Checks if the form has been changed from its initial state.
+   * @private
+   */
+  isDirty_() {
+    const form = this.form_;
+    for (let i = 0; i < form.elements.length; i++) {
+      const field = form.elements[i];
+      switch (field.type) {
+        case 'select-multiple':
+        case 'select-one':
+          const options = field.options;
+          for (let j = 0; j < options.length; j++) {
+            if (options[j].selected !== options[j].defaultSelected) {
+              return true;
+            }
+          }
+          break;
+        case 'checkbox':
+        case 'radio':
+          if (field.checked !== field.defaultChecked) {
+            return true;
+          }
+          break;
+        default:
+          if (field.value !== field.defaultValue) {
+            return true;
+          }
+          break;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Removes all custom verification errors from the elements.
+   * @private
+   */
+  clearVerificationErrors_() {
+    const elements = this.form_.elements;
+    if (elements) {
+      iterateCursor(elements, e => {
+        e.setCustomValidity('');
+      });
+    }
+  }
 }
 
 /**
@@ -172,11 +153,10 @@ export class DefaultVerifier extends FormVerifier { }
 export class AsyncVerifier extends FormVerifier {
   /**
    * @param {!HTMLFormElement} form
-   * @param {!Array<!VerificationGroup>} groups
    * @param {function():Promise<!../../../src/service/xhr-impl.FetchResponse>} xhr
    */
-  constructor(form, groups, xhr) {
-    super(form, groups);
+  constructor(form, xhr) {
+    super(form);
 
     /** @protected @const*/
     this.doXhr_ = xhr;
@@ -184,56 +164,20 @@ export class AsyncVerifier extends FormVerifier {
     /** @protected {?LastAddedResolver} */
     this.xhrResolver_ = null;
 
-    /** @private {?Promise} */
-    this.xhrVerifyPromise_ = null;
-  }
-
-  /**
-   * Returns a promise that resolves when xhr verify finishes. the promise
-   * will be null if verify submit has not started.
-   * @visibleForTesting
-   */
-  xhrVerifyPromiseForTesting() {
-    return this.xhrVerifyPromise_;
+    /** @private {!Array<!VerificationErrorDef>} */
+    this.previousErrors_ = [];
   }
 
   /** @override */
-  onMutate(input) {
-    const group = this.getGroup_(input);
-    if (group) {
-      group.setDirty(true);
-      group.clearErrors();
-    }
-  }
+  verify_() {
+    const xhrConsumeErrors = this.doXhr_().then(() => {
+      return [];
+    }, error => {
+      return getResponseErrorData_(/** @type {!Error} */(error));
+    });
 
-  /** @override */
-  onCommit(input, afterVerify) {
-    if (this.isVerificationElement_(input)) {
-      this.maybeVerify_(afterVerify);
-    }
-  }
-
-  /**
-   * Sends the verify request if any group is ready to verify.
-   * @param {!function(!Array<!Element>)} afterVerify
-   * @private
-   */
-  maybeVerify_(afterVerify) {
-    if (this.shouldVerify_()) {
-      const xhrConsumeErrors = this.doXhr_().then(() => {
-        return [];
-      }, error => {
-        return getResponseErrorData_(/** @type {!Error} */(error));
-      });
-
-      const p = this.addToResolver_(xhrConsumeErrors)
-          .then(errors => this.verify_(errors))
-          .then(updatedElements => afterVerify(updatedElements));
-
-      if (getMode().test) {
-        this.xhrVerifyPromise_ = p;
-      }
-    }
+    return this.addToResolver_(xhrConsumeErrors)
+        .then(errors => this.applyErrors_(errors));
   }
 
   /**
@@ -246,9 +190,7 @@ export class AsyncVerifier extends FormVerifier {
   addToResolver_(promise) {
     if (!this.xhrResolver_) {
       this.xhrResolver_ = new LastAddedResolver();
-      const cleanup = () => {
-        this.xhrResolver_ = null;
-      };
+      const cleanup = () => this.xhrResolver_ = null;
       this.xhrResolver_.then(cleanup, cleanup);
     }
     return this.xhrResolver_.add(promise);
@@ -258,153 +200,46 @@ export class AsyncVerifier extends FormVerifier {
    * Set errors on elements that failed verification, and clear any
    * verification state for elements that passed verification.
    * @param {!Array<!VerificationErrorDef>} errors
+   * @return {!Array<!Element>} Updated elements e.g. elements with new errors,
+   *    and elements that previously had errors but were fixed. The form will
+   *    update their user-valid/user-invalid state.
    * @private
    */
-  verify_(errors) {
+  applyErrors_(errors) {
     const errorElements = [];
-    let updatedElements = [];
+
+    const previousErrors = this.previousErrors_;
+    this.previousErrors_ = errors;
 
     // Set the error message on each element that caused an error.
     for (let i = 0; i < errors.length; i++) {
       const error = errors[i];
+      const name = user().assertString(error.name,
+          'Verification errors must have a name property');
+      const message = user().assertString(error.message,
+          'Verification errors must have a message property');
       // If multiple elements share the same name, the first should be selected.
       // This matches the behavior of HTML5 validation, e.g. with radio buttons.
-      const element = this.form_./*OK*/querySelector(`[name="${error.name}"]`);
-      if (element && element.checkValidity()) {
-        element.setCustomValidity(error.message);
+      const element = user().assertElement(
+          this.form_./*OK*/querySelector(`[name="${name}"]`),
+          'Verification error name property must match a field name');
+
+      // Only put verification errors on elements that are client-side valid.
+      // This prevents errors from appearing on elements that have not been
+      // filled out yet.
+      if (element.checkValidity()) {
+        element.setCustomValidity(message);
         errorElements.push(element);
       }
     }
 
-    // Remove the dirty flag from the successful groups that have values.
-    for (let i = 0; i < this.groups_.length; i++) {
-      const group = this.groups_[i];
-      if (group.isFilledOut() && group.containsNone(errorElements)) {
-        group.setDirty(false);
-        updatedElements = updatedElements.concat(group.getElements());
-      }
-    }
+    // Create a list of form elements that had an error, but are now fixed.
+    const isFixed = previousError => errors.every(
+        error => previousError.name !== error.name);
+    const fixedElements = previousErrors.filter(isFixed)
+        .map(e => this.form_./*OK*/querySelector(`[name="${e.name}"]`));
 
-    return errorElements.concat(updatedElements);
-  }
-
-  /**
-   * Check if any group in the form needs to be verified.
-   * @return {boolean}
-   * @private
-   */
-  shouldVerify_() {
-    return this.groups_.some(group => group.shouldVerify());
-  }
-
-  /**
-   * Check if an element is a member of a verification group.
-   * @param {!Element} element
-   * @return {boolean}
-   * @private
-   */
-  isVerificationElement_(element) {
-    return !!this.getGroup_(element);
-  }
-
-  /**
-   * Get the group that contains the given element.
-   * @param {!Element} element
-   * @return {?VerificationGroup}
-   * @private
-   */
-  getGroup_(element) {
-    for (let i = 0; i < this.groups_.length; i++) {
-      const group = this.groups_[i];
-      if (group.contains(element)) {
-        return group;
-      }
-    }
-    return null;
-  }
-}
-
-/**
- * Encapsulates a list of related inputs and a "dirty" flag to
- * help determine when to send a verification request. Provides methods
- * for querying the state of the grouped elements.
- * @private
- */
-class VerificationGroup {
-  /**
-   * @param {!Array<!Element>} elements
-   */
-  constructor(elements) {
-    /** @private @const */
-    this.elements_ = elements;
-
-    /** @private */
-    this.dirty_ = false;
-  }
-
-  /**
-   * Get the list of elements in this verification group
-   * @return {!Array<!Element>}
-   */
-  getElements() {
-    return this.elements_;
-  }
-
-  /**
-   * Set the dirty flag to indicate if the user has changed the value since
-   * the last verification.
-   * @param {boolean} dirty
-   */
-  setDirty(dirty) {
-    this.dirty_ = dirty;
-  }
-
-  /**
-   * Get the dirty flag value.
-   * @return {boolean}
-   */
-  isDirty() {
-    return this.dirty_;
-  }
-
-  /**
-   * Check if this group contains the given element.
-   * @param {!Element} element
-   * @return {boolean}
-   */
-  contains(element) {
-    return this.elements_.includes(element);
-  }
-
-  /**
-   * Check if this group contains none of the given elements
-   * @param {!Array<!Element>} elements
-   * @return {boolean}
-   */
-  containsNone(elements) {
-    return !elements.some(element => this.contains(element));
-  }
-
-  /**
-   * Check if the group is eligible for verification.
-   */
-  shouldVerify() {
-    return this.isDirty() && this.isFilledOut();
-  }
-
-  /**
-   * Check if every required element in the group has a value,
-   * and that those values are valid.
-   */
-  isFilledOut() {
-    return this.elements_.every(element => element.checkValidity());
-  }
-
-  /**
-   * Clear the validity state of this group's elements.
-   */
-  clearErrors() {
-    this.elements_.forEach(element => element.setCustomValidity(''));
+    return errorElements.concat(fixedElements);
   }
 }
 
@@ -418,7 +253,8 @@ function getResponseErrorData_(error) {
   if (!response) {
     return Promise.resolve([]);
   }
-  return response.json().then(json => {
-    return json.verifyErrors || [];
-  }, () => []);
+
+  return response.json().then(
+      json => json.verifyErrors || [],
+      () => []);
 }

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -16,7 +16,6 @@
 
 import {
   AsyncVerifier,
-  CONFIG_KEY,
   FORM_VERIFY_EXPERIMENT,
   DefaultVerifier,
   getFormVerifier,
@@ -24,19 +23,6 @@ import {
 import {toggleExperiment} from '../../../../src/experiments';
 
 describes.fakeWin('amp-form async verification', {}, env => {
-  const DEFAULT_CONFIG = `{
-    "${CONFIG_KEY}": [
-      {
-        "name": "uniqueEmail",
-        "elements": ["email"]
-      },
-      {
-        "name": "fullAddress",
-        "elements": ["addressLine2", "city", "zip"]
-      }
-    ]
-  }`;
-
   function stubValidationMessage(input) {
     Object.defineProperty(input, 'validationMessage', {
       get: function() {
@@ -56,15 +42,12 @@ describes.fakeWin('amp-form async verification', {}, env => {
     });
   }
 
-  function getForm(doc, config = DEFAULT_CONFIG) {
+  function getForm(doc, opt_verifyXhr = true) {
     const form = doc.createElement('form');
     form.setAttribute('method', 'POST');
 
-    if (config) {
-      const script = doc.createElement('script');
-      script.setAttribute('type', 'application/json');
-      script.innerHTML = config;
-      form.appendChild(script);
+    if (opt_verifyXhr === true) {
+      form.setAttribute('verify-xhr', '');
     }
 
     const nameInput = doc.createElement('input');
@@ -119,63 +102,23 @@ describes.fakeWin('amp-form async verification', {}, env => {
       toggleExperiment(env.win, FORM_VERIFY_EXPERIMENT, true);
     });
 
-    it('returns a DefaultVerifier when no config is present', () => {
-      const emptyConfig = '';
-      const form = getForm(env.win.document, emptyConfig);
+    it('returns a DefaultVerifier without the verify-xhr attribute', () => {
+      const form = getForm(env.win.document, false);
       const verifier = getFormVerifier(form, () => {});
       expect(verifier instanceof DefaultVerifier).to.be.true;
     });
 
-    it('returns an AsyncVerifier when a config is present', () => {
+    it('returns an AsyncVerifier with the verify-xhr attribute', () => {
       const form = getForm(env.win.document);
       const verifier = getFormVerifier(form, () => {});
       expect(verifier instanceof AsyncVerifier).to.be.true;
     });
 
-    it('should throw if the experiment is disabled and has a config', () => {
+    it('should throw if the experiment is disabled with the verify-xhr ' +
+        'attribute present', () => {
       toggleExperiment(env.win, FORM_VERIFY_EXPERIMENT, false);
       const form = getForm(env.win.document);
       expect(() => getFormVerifier(form, () => {})).to.throw(/experiment/);
-    });
-
-    it('should throw if an element is not in the form', () => {
-      const form = getForm(env.win.document, `{
-        "${CONFIG_KEY}": [
-          {
-            "name": "failGroup",
-            "elements": ["idontexist"]
-          }
-        ]
-      }`);
-      expect(() => getFormVerifier(form)).to.throw('no element named');
-    });
-
-    it('should throw if an element is not an allowed input', () => {
-      const form = getForm(env.win.document, `{
-        "${CONFIG_KEY}": [
-          {
-            "name": "failGroup",
-            "elements": ["invalid"]
-          }
-        ]
-      }`);
-      const nonInput = document.createElement('fieldset');
-      nonInput.name = 'invalid';
-      form.appendChild(nonInput);
-      expect(() => getFormVerifier(form)).to.throw('must be one of');
-    });
-
-    it('should throw if the list of groups is not an array ' +
-        'with at least one element', () => {
-      const form = getForm(env.win.document, `{
-        "${CONFIG_KEY}": ""
-      }`);
-      expect(() => getFormVerifier(form)).to.throw('at least one');
-
-      const form2 = getForm(env.win.document, `{
-        "${CONFIG_KEY}": []
-      }`);
-      expect(() => getFormVerifier(form2)).to.throw('at least one');
     });
   });
 
@@ -186,50 +129,26 @@ describes.fakeWin('amp-form async verification', {}, env => {
       sandbox = env.sandbox;
     });
 
-    it('should not submit when no element in a group has a value', () => {
+    it('should not submit when no element has a value', () => {
       const xhrSpy = sandbox.spy(() => Promise.resolve());
       const form = getForm(env.win.document);
       const verifier = getFormVerifier(form, xhrSpy);
-      verifier.onCommit(form.email, () => {});
-      expect(xhrSpy).to.not.be.called;
+      return verifier.onCommit().then(() => {
+        expect(xhrSpy).to.not.be.called;
+      });
     });
 
-    it('should submit when a group\'s elements are filled out, ' +
-        'mutated, and committed', () => {
+    it('should submit when an element is filled out, mutated, ' +
+          'and committed', () => {
       const xhrSpy = sandbox.spy(() => Promise.resolve());
       const form = getForm(env.win.document);
       const verifier = getFormVerifier(form, xhrSpy);
 
       form.email.value = 'test@example.com';
-      verifier.onMutate(form.email);
 
-      return new Promise(resolve => {
-        const afterVerify = () => resolve();
-        verifier.onCommit(form.email, afterVerify);
+      return verifier.onCommit().then(() => {
+        expect(xhrSpy).to.be.calledOnce;
       });
-      expect(xhrSpy).to.be.calledOnce;
-    });
-
-    it('should not submit until all required fields in a group ' +
-        'have values', () => {
-      const xhrSpy = sandbox.spy(() => Promise.resolve());
-      const form = getForm(env.win.document);
-      const verifier = getFormVerifier(form, xhrSpy);
-
-      form.city.value = 'Mountain View';
-      verifier.onMutate(form.city);
-      verifier.onCommit(form.city, () => {});
-      expect(xhrSpy).to.not.be.called;
-
-      form.zip.value = '940';
-      verifier.onMutate(form.zip);
-      verifier.onCommit(form.zip, () => {});
-      expect(xhrSpy).to.not.be.called;
-
-      form.zip.value = '94043';
-      verifier.onMutate(form.zip);
-      verifier.onCommit(form.zip, () => {});
-      expect(xhrSpy).to.be.calledOnce;
     });
 
     it('should assign an error to elements that the server ' +
@@ -253,14 +172,10 @@ describes.fakeWin('amp-form async verification', {}, env => {
 
       form.city.value = 'Mountain View';
       form.zip.value = '94043';
-      verifier.onMutate(form.zip);
-      return new Promise(resolve => {
-        verifier.onCommit(form.zip, resolve);
-      }).then(() => {
+      return verifier.onCommit().then(() => {
         expect(form.zip.validity.customError).to.be.true;
         expect(form.zip.validationMessage).to.equal(errorMessage);
       });
-      expect(xhrSpy).to.not.be.called;
     });
 
     it('should clear errors when any sibling of an input with an error ' +
@@ -276,21 +191,21 @@ describes.fakeWin('amp-form async verification', {}, env => {
           });
         },
       };
-      const xhrSpy = sandbox.spy(() => Promise.reject({
-        response: errorResponse,
-      }));
-      const form = getForm(env.win.document);
-      const verifier = getFormVerifier(form, xhrSpy);
+      const xhrStub = sandbox.stub();
+      xhrStub.onCall(0).returns(Promise.reject({response: errorResponse}));
+      xhrStub.onCall(1).returns(Promise.resolve());
 
-      form.city.value = 'Mountain View';
+      const form = getForm(env.win.document);
+      const verifier = getFormVerifier(form, xhrStub);
+      form.city.value = 'Palo Alto';
       form.zip.value = '94043';
-      verifier.onMutate(form.zip);
-      return new Promise(resolve => {
-        verifier.onCommit(form.zip, resolve);
-      }).then(() => {
+
+      return verifier.onCommit().then(() => {
         expect(form.zip.validity.customError).to.be.true;
         expect(form.zip.validationMessage).to.equal(errorMessage);
-        verifier.onMutate(form.city);
+        form.city.value = 'Mountain View';
+        return verifier.onCommit();
+      }).then(() => {
         expect(form.zip.validity.customError).to.be.false;
         expect(form.zip.validationMessage).to.be.empty;
       });
@@ -321,10 +236,7 @@ describes.fakeWin('amp-form async verification', {}, env => {
 
       form.city.value = 'Mountain View';
       form.zip.value = '94043';
-      verifier.onMutate(form.zip);
-      return new Promise(resolve => {
-        verifier.onCommit(form.zip, resolve);
-      }).then(() => {
+      return verifier.onCommit().then(() => {
         expect(form.zip.validity.customError).to.be.true;
         expect(form.zip.validationMessage).to.equal(zipMessage);
         expect(form.email.validity.customError).to.be.false;


### PR DESCRIPTION
This implements the suggestions @dvoytenko gave for the form verification API.

- No config block, no verification groups
- Verification behavior is triggered by a `verify-xhr` attribute functioning similarly to `action-xhr`
- The verification request must be sent after every `change` event. The groups allowed us to limit the requests to only send when a group was complete

Closes #9696