### PR TITLE
Run integration tests for PRs that change `test/integration`

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -377,8 +377,18 @@ function main(argv) {
   }
 
   if (process.env.BUILD_SHARD == "integration_tests") {
-    // The integration_tests shard can be skipped for PRs.
-    console.log(fileLogPrefix, 'Skipping integration_tests for PRs');
+    // Run the integration_tests shard for a PR only if it is modifying an
+    // integration test. Otherwise, the shard can be skipped.
+    if (buildTargets.has('INTEGRATION_TEST')) {
+      console.log(fileLogPrefix,
+          'Running integration_tests since this PR touches',
+          util.colors.cyan('test/integration'));
+      command.cleanBuild();
+      command.buildRuntimeMinified();
+      command.runIntegrationTests();
+    } else {
+      console.log(fileLogPrefix, 'Skipping integration_tests for this PR');
+    }
   }
 
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -381,16 +381,20 @@ function main(argv) {
     // integration test. Otherwise, the shard can be skipped.
     if (buildTargets.has('INTEGRATION_TEST')) {
       console.log(fileLogPrefix,
-          'Running integration_tests since this PR touches',
+          'Running the',
+          util.colors.cyan('integration_tests'),
+          'build shard since this PR touches',
           util.colors.cyan('test/integration'));
       command.cleanBuild();
       command.buildRuntimeMinified();
       command.runIntegrationTests();
     } else {
-      console.log(fileLogPrefix, 'Skipping integration_tests for this PR');
+      console.log(fileLogPrefix,
+          'Skipping the',
+          util.colors.cyan('integration_tests'),
+          'build shard for this PR');
     }
   }
-
 
   stopTimer('pr-check.js', startTime);
   return 0;

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -108,15 +108,6 @@ function getAdTypes() {
  * Run tests.
  */
 gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
-  if (argv.saucelabs && process.env.MAIN_REPO &&
-      // Sauce Labs does not work on Pull Requests directly.
-      // The @ampsauce bot builds these.
-      process.env.TRAVIS_PULL_REQUEST != 'false') {
-    console./*OK*/info('Deactivated for pull requests. ' +
-        'The @ampsauce bots build eligible PRs.');
-    return;
-  }
-
   if (!argv.integration && process.env.AMPSAUCE_REPO) {
     console./*OK*/info('Deactivated for ampsauce repo')
   }


### PR DESCRIPTION
If you have to edit an integration test today, the workflow is to test your changes locally, run the PR through Travis (where integration tests are not run), and then merge it to master (where integration tests are run on all platforms), and then hope they pass.

This PR will run integration tests as part of the PR check for only those PRs that touch `test/integration`. While it may slightly slow down Travis runs for those PRs, it gives you test results *before* your changes hit `master`.

Looking at the [history](https://github.com/ampproject/amphtml/commits/master/test/integration) of `test/integration`, it appears that we only have a small handful of changes per week going into this directory, so I don't expect it to have a huge impact on the Travis queue.

A good compromise, methinks.