### PR TITLE
Revert "Add missing methods to AmpContext tests"

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -29,9 +29,6 @@ export class AbstractAmpContext {
     dev().assert(!this.isAbstractImplementation_(),
         'Should not construct AbstractAmpContext instances directly');
 
-    /** @visibleForTesting */
-    this._ampInternalIsNewImpl = true;
-
     /** @protected {!Window} */
     this.win_ = win;
 

--- a/test/functional/test-amp-context.js
+++ b/test/functional/test-amp-context.js
@@ -71,20 +71,6 @@ describe('3p ampcontext.js', () => {
     expect(context.sentinel).to.equal('1-291921');
     expect(context.startTime).to.equal(0);
     expect(context.referrer).to.equal('baz.net');
-    expect(context.canary).to.equal(true);
-    expect(context.clientId).to.equal('a-client-id');
-    expect(context.hidden).to.equal(false);
-    expect(context.initialIntersection).to.deep.equal({
-      intersects: true,
-    });
-    expect(context.initialLayoutRect).to.deep.equal({
-      left: 10,
-      top: 20,
-      width: 400,
-      height: 300,
-    });
-    expect(context.sourceUrl).to.equal('www.example.com/mypage');
-    expect(context.tagName).to.equal('my-tag');
   });
 
   it('should add metadata to window.context using name as per A4A.', () => {
@@ -97,20 +83,6 @@ describe('3p ampcontext.js', () => {
     expect(context.sentinel).to.equal('1-291921');
     expect(context.startTime).to.equal(0);
     expect(context.referrer).to.equal('baz.net');
-    expect(context.canary).to.equal(true);
-    expect(context.clientId).to.equal('a-client-id');
-    expect(context.hidden).to.equal(false);
-    expect(context.initialIntersection).to.deep.equal({
-      intersects: true,
-    });
-    expect(context.initialLayoutRect).to.deep.equal({
-      left: 10,
-      top: 20,
-      width: 400,
-      height: 300,
-    });
-    expect(context.sourceUrl).to.equal('www.example.com/mypage');
-    expect(context.tagName).to.equal('my-tag');
   });
 
   it('should add metadata to window.context using window var.', () => {
@@ -123,20 +95,6 @@ describe('3p ampcontext.js', () => {
     expect(context.sentinel).to.equal('1-291921');
     expect(context.startTime).to.equal(0);
     expect(context.referrer).to.equal('baz.net');
-    expect(context.canary).to.equal(true);
-    expect(context.clientId).to.equal('a-client-id');
-    expect(context.hidden).to.equal(false);
-    expect(context.initialIntersection).to.deep.equal({
-      intersects: true,
-    });
-    expect(context.initialLayoutRect).to.deep.equal({
-      left: 10,
-      top: 20,
-      width: 400,
-      height: 300,
-    });
-    expect(context.sourceUrl).to.equal('www.example.com/mypage');
-    expect(context.tagName).to.equal('my-tag');
   });
 
   it('should set up only sentinel if no metadata provided.', () => {
@@ -371,21 +329,6 @@ function generateAttributes(opt_sentinel) {
     sentinel,
     startTime: 0,
     referrer: 'baz.net',
-    canary: true,
-    clientId: 'a-client-id',
-    hidden: false,
-    initialIntersection: {
-      // checking against arbitrary object, could benefit from stronger typing
-      intersects: true,
-    },
-    initialLayoutRect: {
-      left: 10,
-      top: 20,
-      width: 400,
-      height: 300,
-    },
-    sourceUrl: 'www.example.com/mypage',
-    tagName: 'my-tag',
   };
 
   return name;
@@ -405,21 +348,6 @@ function generateAttributesA4A(opt_sentinel) {
     sentinel,
     startTime: 0,
     referrer: 'baz.net',
-    canary: true,
-    clientId: 'a-client-id',
-    hidden: false,
-    initialIntersection: {
-      // checking against arbitrary object, could benefit from stronger typing
-      intersects: true,
-    },
-    initialLayoutRect: {
-      left: 10,
-      top: 20,
-      width: 400,
-      height: 300,
-    },
-    sourceUrl: 'www.example.com/mypage',
-    tagName: 'my-tag',
   };
 
   return attributes;

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -25,7 +25,7 @@ import {toggleExperiment} from '../../src/experiments';
 
 
 // TODO(@alanorozco): Inline this once 3p-use-ampcontext experiment is removed
-function createIframeWithApis(fixture, opt_checkForNewImpl) {
+function createIframeWithApis(fixture) {
   this.timeout(20000);
   let iframe;
   let ampAd;
@@ -61,10 +61,6 @@ function createIframeWithApis(fixture, opt_checkForNewImpl) {
           'http://localhost:' + location.port);
     }
 
-    if (opt_checkForNewImpl) {
-      expect(context._ampInternalIsNewImpl).to.be.true;
-    }
-
     expect(context.canonicalUrl).to.equal(
         'https://www.example.com/doubleclick.html');
     expect(context.clientId).to.be.defined;
@@ -80,19 +76,6 @@ function createIframeWithApis(fixture, opt_checkForNewImpl) {
     expect(context.computeInMasterFrame).to.be.defined;
     expect(context.location).to.be.defined;
     expect(context.sourceUrl).to.be.a('string');
-    expect(context.reportRenderedEntityIdentifier).to.be.defined;
-    expect(context.renderStart).to.be.defined;
-    expect(context.bootstrapLoaded).to.be.defined;
-    expect(context.updateDimensions).to.be.defined;
-    expect(context.isMaster).to.be.defined;
-    expect(context.onPageVisibilityChange).to.be.defined;
-    expect(context.observeIntersection).to.be.defined;
-    expect(context.requestResize).to.be.defined;
-    expect(context.onResizeSuccess).to.be.defined;
-    expect(context.onResizeDenied).to.be.defined;
-    expect(context.addContextToIframe).to.be.defined;
-    expect(context.noContentAvailable).to.be.defined;
-
   }).then(() => {
     // test iframe will send out render-start to amp-ad
     return poll('render-start message received', () => {
@@ -174,18 +157,13 @@ describes.realWin('3P Ad (with AmpContext experiment)', {
       return createFixture().then(f => {
         fixture = f;
         toggleExperiment(fixture.win, '3p-use-ampcontext', /* opt_on */ true,
-            /* opt_transientExperiment */ false);
+            /* opt_transientExperiment */ true);
         installPlatformService(fixture.win);
       });
     });
 
-    afterEach(() => {
-      toggleExperiment(fixture.win, '3p-use-ampcontext', /* opt_on */ false,
-            /* opt_transientExperiment */ false);
-    });
-
     it('create an iframe with APIs', function() {
-      return createIframeWithApis.call(this, fixture, true);
+      return createIframeWithApis.call(this, fixture);
     });
   });
 });


### PR DESCRIPTION
Reverts ampproject/amphtml#9682

Due to #9814