### PR TITLE
Doc cleanup + add examples

### DIFF
--- a/builtins/amp-pixel.md
+++ b/builtins/amp-pixel.md
@@ -48,7 +48,7 @@ In this basic example, the `amp-pixel` issues a simple GET request to the given 
 
 ##### src (required)
 
-A simple URL to a remote endpoint.
+A simple URL to a remote endpoint that must be `https` protocol.
 
 ##### referrerpolicy (optional)
 

--- a/builtins/amp-pixel.md
+++ b/builtins/amp-pixel.md
@@ -16,14 +16,12 @@ limitations under the License.
 
 # <a name="amp-pixel"></a> `amp-pixel`
 
+[TOC]
+
 <table>
   <tr>
     <td class="col-fourty"><strong>Description</strong></td>
-    <td>The <code>amp-pixel</code> element is meant to be used as a typical tracking pixel - to count page views.</td>
-  </tr>
-  <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
+    <td>Can be used as a typical tracking pixel to count pageviews.</td>
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
@@ -31,34 +29,51 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong>Examples</strong></td>
-    <td><a href="https://github.com/ampproject/amphtml/blob/master/examples/everything.amp.html">everything.amp.html</a></td>
+    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-pixel/">amp-pixel example</a>.</td>
   </tr>
 </table>
 
 ## Behavior
 
-The `amp-pixel` component behaves like a simple tracking pixel `img`. It takes a single URL, but provides variables that can be replaced by the component in the URL string when making the request. See the `src` attribute for more information.
+The `amp-pixel` component behaves like a simple tracking pixel `img`. It takes a single URL, but provides variables that can be replaced by the component in the URL string when making the request. See the [substitutions](#substitutions) section for further details.
+
+In this basic example, the `amp-pixel` issues a simple GET request to the given URL and ignores the result.
+
+```html
+<amp-pixel src="https://foo.com/tracker/foo"
+    layout="nodisplay"></amp-pixel>
+```
 
 ## Attributes
 
-**src** (required)
-The value is the URL of a remote endpoint.
+##### src (required)
 
-**referrerpolicy** (optional)
-Similar as the `referrerpolicy` on `<img>`, however `no-referrer` is the only accepted value. If `referrerpolicy=no-referrer` is provided, the `referrer` header in the HTTP request will be removed.
+A simple URL to a remote endpoint.
 
-A simple URL to send a GET request to when the tracking pixel is loaded.
+##### referrerpolicy (optional)
+
+This attribute is similar to the `referrerpolicy` attribute on `<img>`, however `no-referrer` is the only accepted value. If `referrerpolicy=no-referrer` is specified, the `referrer` header is removed from the HTTP request.
+
+```html
+<amp-pixel src="https://foo.com/tracker/foo"
+    layout="nodisplay"
+    referrerpolicy="no-referrer"></amp-pixel>
+```
+##### common attributes
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Substitutions
 
 The `amp-pixel` allows all standard URL variable substitutions.
-See [Substitutions Guide](../spec/amp-var-substitutions.md) for more info.
+See the [Substitutions Guide](../spec/amp-var-substitutions.md) for more information.
 
-For instance:
+In the following example, a request might be made to something like `https://foo.com/pixel?0.8390278471201` where the RANDOM value is randomly generated upon each impression.
+
 ```html
-<amp-pixel src="https://foo.com/pixel?RANDOM"></amp-pixel>
+<amp-pixel src="https://foo.com/pixel?RANDOM"
+    layout="nodisplay"></amp-pixel>
 ```
-may make a request to something like `https://foo.com/pixel?0.8390278471201` where the RANDOM value is randomly generated upon each impression.
 
 ## Styling
 

--- a/extensions/amp-3q-player/amp-3q-player.md
+++ b/extensions/amp-3q-player/amp-3q-player.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Embeds videos from <a href="https://www.3qsdn.com/en/">3Q SDN</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-3q-player" src="https://cdn.ampproject.org/v0/amp-3q-player-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -20,10 +20,6 @@ limitations under the License.
     <td>Allows publishers to easily integrate with the <a href="https://www.laterpay.net">LaterPay</a> micropayments platform. <code>amp-access-laterpay</code> is based on, and requires <a href="https://www.ampproject.org/docs/reference/components/amp-access">AMP Access</a>.</td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty"><strong>Required Scripts</strong></td>
     <td>
         <small>Notice that you need scripts for "amp-access-laterpay", "amp-access" and "amp-analytics".</small>

--- a/extensions/amp-access/amp-access.md
+++ b/extensions/amp-access/amp-access.md
@@ -24,10 +24,6 @@ limitations under the License.
     <td>AMP Access or “AMP paywall and subscription support” gives Publishers control over which content can be accessed by a Reader and with what restrictions, based on the Reader’s subscription status, number of views, and other factors.</td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
     <td>
       <div>

--- a/extensions/amp-anim/amp-anim.md
+++ b/extensions/amp-anim/amp-anim.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>A runtime-managed animated image, typically a GIF.</td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-apester-media/amp-apester-media.md
+++ b/extensions/amp-apester-media/amp-apester-media.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td> Displays a <a href="https://apester.com/">Apester</a> smart unit.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td> <code>&lt;script async custom-element="amp-apester-media" src="https://cdn.ampproject.org/v0/amp-apester-media-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-app-banner/amp-app-banner.md
+++ b/extensions/amp-app-banner/amp-app-banner.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>A wrapper and minimal UI for a cross-platform, fixed-position banner showing a call-to-action to install an app. Includes conditional logic to direct to the right app on the right platform, and to hide permanently if the user dismisses the banner.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td>
       <div>

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>A replacement for the HTML5 <code>audio</code> tag. The <code>amp-audio</code> component is only to be used for direct HTML5 audio file embeds.</td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>An <code>amp-brid-player</code> displays the Brid Player used in <a href="https://www.brid.tv/">Brid.tv</a> Video Platform.
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-brid-player" src="https://cdn.ampproject.org/v0/amp-brid-player-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>An <code>amp-brightcove</code> component displays the Brightcove Player as used in Brightcove's <a href="https://www.brightcove.com/en/online-video-platform">Video Cloud</a> or <a href="https://www.brightcove.com/en/perform">Perform</a> products.</td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td> Displays a <a href="http://www.dailymotion.com/">Dailymotion</a> video.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-dailymotion" src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-dynamic-css-classes/amp-dynamic-css-classes.md
+++ b/extensions/amp-dynamic-css-classes/amp-dynamic-css-classes.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Adds several dynamic CSS class names onto the <code>&lt;body></code> element.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-dynamic-css-classes" src="https://cdn.ampproject.org/v0/amp-dynamic-css-classes-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-experiment/amp-experiment.md
+++ b/extensions/amp-experiment/amp-experiment.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Conduct user experience experiments on an AMP document and collect corresponding data with <code>amp-pixel</code> or <code>amp-analytics</code>.</td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-facebook-comments/amp-facebook-comments.md
+++ b/extensions/amp-facebook-comments/amp-facebook-comments.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Embeds the Facebook comments plugin.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-facebook-comments" src="https://cdn.ampproject.org/v0/amp-facebook-comments-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-facebook-like/amp-facebook-like.md
+++ b/extensions/amp-facebook-like/amp-facebook-like.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Embeds the Facebook like button plugin.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-facebook-like" src="https://cdn.ampproject.org/v0/amp-facebook-like-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Expands or shrinks its font size to fit the content within the space given to it.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-font/amp-font.md
+++ b/extensions/amp-font/amp-font.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Trigger and monitor the loading of custom fonts on AMP pages.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-font" src="https://cdn.ampproject.org/v0/amp-font-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
+++ b/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>A flying carpet wraps its children in a unique full-screen scrolling container. In particular, this allows you to display a full-screen ad without taking up the entire viewport, making for a better user experience.</td>
   </tr>
   <tr>
-    <td class="col-fourty" width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-fx-flying-carpet" src="https://cdn.ampproject.org/v0/amp-fx-flying-carpet-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-gfycat/amp-gfycat.md
+++ b/extensions/amp-gfycat/amp-gfycat.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a <a href="https://gfycat.com/">Gfycat</a> video GIF.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-gfycat" src="https://cdn.ampproject.org/v0/amp-gfycat-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-hulu/amp-hulu.md
+++ b/extensions/amp-hulu/amp-hulu.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a simple embedded <a href="http://www.hulu.com">Hulu</a> video.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-hulu" src="https://cdn.ampproject.org/v0/amp-hulu-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -44,8 +44,7 @@ limitations under the License.
 
 ## Overview
 
-You can use the `amp-ima-video` component to embed an [IMA
-SDK](https://developers.google.com/interactive-media-ads/docs/sdks/html5/) enabled video player.
+You can use the `amp-ima-video` component to embed an [IMA SDK](https://developers.google.com/interactive-media-ads/docs/sdks/html5/) enabled video player.
 
 To embed a video, provide a source URL for your
 content video (`data-src`) and an ad tag (`data-tag`), which is a URL to a

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -26,7 +26,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>Experimental</td>
+    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -38,7 +38,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td>None</td>
+    <td><a href="https://ampbyexample.com/components/amp-ima/">Annotated code example for amp-ima-video</a></td>
   </tr>
 </table>
 

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -44,9 +44,8 @@ limitations under the License.
 
 ## Overview
 
-You can use the `amp-ima-video` component to embed an <a
-href="https://developers.google.com/interactive-media-ads/docs/sdks/html5/">IMA
-SDK</a> enabled video player.
+You can use the `amp-ima-video` component to embed an [IMA
+SDK](https://developers.google.com/interactive-media-ads/docs/sdks/html5/) enabled video player.
 
 To embed a video, provide a source URL for your
 content video (`data-src`) and an ad tag (`data-tag`), which is a URL to a

--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Allows for a “image lightbox” or similar experience where upon user interaction, an image expands to fill the viewport until it is closed again by the user.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -72,7 +72,7 @@ The `amp-image-lightbox-caption` class is also available to style the caption
 section.
 
 ## Actions
-The `amp-image-lightbox` exposes the following actions you can use [AMP on-syntax to trigger](../../../src/spec/amp-actions-and-events.md):
+The `amp-image-lightbox` exposes the following actions you can use [AMP on-syntax to trigger](../../spec/amp-actions-and-events.md):
 
 <table>
   <tr>

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays an Instagram embed.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-install-serviceworker/amp-install-serviceworker.md
+++ b/extensions/amp-install-serviceworker/amp-install-serviceworker.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Installs a <a href="https://developers.google.com/web/fundamentals/primers/service-worker/">ServiceWorker</a> for the current page.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-izlesene/amp-izlesene.md
+++ b/extensions/amp-izlesene/amp-izlesene.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays an embedded <a href="https://www.izlesene.com/">Izlesene</a> video.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-izlesene" src="https://cdn.ampproject.org/v0/amp-izlesene-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a cloud-hosted <a href="https://www.jwplayer.com/">JW Player</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-jwplayer" src="https://cdn.ampproject.org/v0/amp-jwplayer-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-kaltura-player/amp-kaltura-player.md
+++ b/extensions/amp-kaltura-player/amp-kaltura-player.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>An <code>amp-kaltura-player</code> component displays the Kaltura Player as used in Kaltura's <a href="https://corp.kaltura.com/">Video Platform</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-kaltura-player" src="https://cdn.ampproject.org/v0/amp-kaltura-player-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Allows for a “lightbox” or similar experience where upon user interaction, a component expands to fill the viewport until it is closed again by the user.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -306,7 +306,7 @@ reference point, and you can hook into this class to add transitions.
 (see Examples below)
 
 ## Actions
-The `amp-live-list` exposes the following actions you can use [AMP on-syntax to trigger](../../../src/spec/amp-actions-and-events.md):
+The `amp-live-list` exposes the following actions you can use [AMP on-syntax to trigger](../../spec/amp-actions-and-events.md):
 
 <table>
   <tr>

--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>A wrapper and minimal UI for content that updates live in the client instance as new content is available in the source document.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td>
       <div>

--- a/extensions/amp-mustache/amp-mustache.md
+++ b/extensions/amp-mustache/amp-mustache.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Allows rendering of <a href="https://github.com/janl/mustache.js/">Mustache.js</a>.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td>
       <div>

--- a/extensions/amp-nexxtv-player/amp-nexxtv-player.md
+++ b/extensions/amp-nexxtv-player/amp-nexxtv-player.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a media stream from the nexxOMNIA platform.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-nexxtv-player" src="https://cdn.ampproject.org/v0/amp-nexxtv-player-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-o2-player/amp-o2-player.md
+++ b/extensions/amp-o2-player/amp-o2-player.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays the AOL O2Player.</td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-o2-player" src="https://cdn.ampproject.org/v0/amp-o2-player-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-ooyala-player/amp-ooyala-player.md
+++ b/extensions/amp-ooyala-player/amp-ooyala-player.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays an <a href="https://www.ooyala.com/">Ooyala</a> video.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-ooyala-player" src="https://cdn.ampproject.org/v0/amp-ooyala-player-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-pinterest/amp-pinterest.md
+++ b/extensions/amp-pinterest/amp-pinterest.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a Pinterest widget, Pin It button, or Follow button.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-pinterest" src="https://cdn.ampproject.org/v0/amp-pinterest-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-playbuzz/amp-playbuzz.md
+++ b/extensions/amp-playbuzz/amp-playbuzz.md
@@ -25,10 +25,6 @@ limitations under the License.
     </td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-playbuzz" src="https://cdn.ampproject.org/v0/amp-playbuzz-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-reach-player/amp-reach-player.md
+++ b/extensions/amp-reach-player/amp-reach-player.md
@@ -24,10 +24,6 @@ limitations under the License.
     </td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-reach-player" src="https://cdn.ampproject.org/v0/amp-reach-player-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-reddit/amp-reddit.md
+++ b/extensions/amp-reddit/amp-reddit.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a Reddit comment or post embed.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-reddit" src="https://cdn.ampproject.org/v0/amp-reddit-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-selector/amp-selector.md
+++ b/extensions/amp-selector/amp-selector.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Represents a control that presents a menu of options and lets the user choose from it.</td>
   </tr>
   <tr>
-    <td class="col-fourty" width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td class="col-fourty" width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -16,14 +16,12 @@ limitations under the License.
 
 # <a name="amp-sidebar"></a> `amp-sidebar`
 
+[TOC]
+
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
     <td>A sidebar provides a way to display meta content intended for temporary access (navigation links, buttons, menus, etc.).The sidebar can be revealed by a button tap while the main content remains visually underneath.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -34,10 +32,8 @@ limitations under the License.
     <td>nodisplay</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Examples</strong></td>
-    <td>
-      <a href="https://ampbyexample.com/components/amp-sidebar/">Annotated code example for amp-sidebar</a>
-    </td>
+    <td class="col-fourty"><strong>Examples</strong></td>
+    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-sidebar/">amp-sidebar example</a>.</td>
   </tr>
 </table>
 
@@ -46,7 +42,7 @@ limitations under the License.
 - The `<amp-sidebar>` should be a direct child of the `<body>`.
 - The sidebar can only appear on the left or right side of a page.
 - The `<amp-sidebar>` may contain any valid HTML elements (supported by AMP).
-- The `<amp-sidebar>` may not contain any AMP Elements except for:
+- The `<amp-sidebar>` may contain any of the following AMP elements:
     - `<amp-accordion>`
     - `<amp-img>`
     - `<amp-fit-text>`
@@ -58,8 +54,9 @@ limitations under the License.
 - Touch zoom is disabled on the `amp-sidebar` and it's mask when the sidebar is open.
 
 Example:
+
 ```html
-<amp-sidebar id='sidebar1' layout='nodisplay'>
+<amp-sidebar id="sidebar1" layout="nodisplay" side="right">
   <ul>
     <li> Nav item 1</li>
     <li> Nav item 2</li>
@@ -67,55 +64,13 @@ Example:
     <li> Nav item 4</li>
     <li> Nav item 5</li>
     <li> Nav item 6</li>
-    <li> Nav item 7</li>
-    <li> Nav item 8</li>
-    <li> Nav item 9</li>
-    <li on="tap:sidebar1.close"> Close</li>
   </ul>
 </amp-sidebar>
 ```
 
-### Opening and Closing the Sidebar
-Setting the `on` attribute on one or more elements within the page and setting it's method to `toggle` will toggle the sidebar when the element is tapped or clicked. Setting the element's method to `open` or `close` will open or close the sidebar.Tapping back on the partially-visible main content area closes the sidebar.
+### Opening and closing the sidebar
 
-Alternatively pressing the escape key on the keyboard will also close the sidebar.
-
-Example:
-```html
-<button class="hamburger" on='tap:sidebar1.toggle'></button>
-<button on='tap:sidebar1'>Open</button>
-<button on='tap:sidebar1.open'>Open</button>
-<button on='tap:sidebar1.close'>x</button>
-```
-
-## Attributes
-
-**side**
-
-The `side` attribute may be set to `left` or `right` depending upon whether sidebar should open in the left or right side of the page. If a `side` is not set on the `amp-sidebar` then it will be inherited from the `body` tag's `dir` attribute (`ltr` => `left` , `rtl` => `right`) and if one does not exist then the `side` is defaulted to `left`.
-
-**open**
-
-The `open` attribute is present on the sidebar when it is open.
-
-**layout**
-
-The only permissible value for the `layout` attribute in `amp-sidebar` is `nodisplay`.
-
-**common attributes**
-
-This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
-
-## Styling
-
-The `amp-sidebar` component can be styled with standard CSS.
-
-- The `width` of the `amp-sidebar` may be set to adjust the width of the sidebar between the pre-set min(45px) and max(80vw) values.
-- The height of the `amp-sidebar` may be set to adjust the height of the sidebar if required. If the height exceeds 100vw then the sidebar will have a vertical scrollbar. The preset height of the sidebar is 100vw and can be overridden in CSS to make it shorter.
-- The current state of the sidebar is exposed via the `open` attribute that is set on the `amp-sidebar` tag when the side bar is open on the page.
-
-## Actions
-The `amp-sidebar` exposes the following actions you can use [AMP on-syntax to trigger](../../../src/spec/amp-actions-and-events.md):
+To toggle, open, or close the sidebar when an element is tapped or clicked, set the [`on`](../../spec/amp-actions-and-events.md) action attribute on the element, and specify one of the following action methods: 
 
 <table>
   <tr>
@@ -136,22 +91,53 @@ The `amp-sidebar` exposes the following actions you can use [AMP on-syntax to tr
   </tr>
 </table>
 
+If the user taps back on the partially-visible main content area, this closes the sidebar.
 
-### Examples
+Alternatively, pressing the escape key on the keyboard will also close the sidebar.
+
+Example:
 
 ```html
-<button on="tap:sidebar.open"> = </button>
-<amp-sidebar id="sidebar" layout="nodisplay">
-  <ul>
-    <li on="tap:sidebar.toggle">Toggle</li>
-    <li on="tap:sidebar.close">Close</li>
-  </ul>
-</amp-sidebar>
+<button class="hamburger" on='tap:sidebar1.toggle'></button>
+<button on='tap:sidebar1'>Open</button>
+<button on='tap:sidebar1.open'>Open</button>
+<button on='tap:sidebar1.close'>x</button>
 ```
+
+{% call callout('Tip', type='success') %}
+See live demos at [AMP By Example](https://ampbyexample.com/components/amp-sidebar/).
+{% endcall %}
+
+## Attributes
+
+##### side
+
+Indicates what side of the page the sidebar should open from, either `left` or `right`.  If a `side` is not specified, the `side` value will be inherited from the `body` tag's `dir` attribute (`ltr` => `left` , `rtl` => `right`); if no `dir` exists, the `side` defaults to `left`.
+
+##### layout
+
+Specifies the display layout of the sidebar, which must be `nodisplay`.
+
+##### open
+
+This attribute is present when the sidebar is open.
+
+##### common attributes
+
+This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
+## Styling
+
+The `amp-sidebar` component can be styled with standard CSS.
+
+-  The `width` of the `amp-sidebar` may be set to adjust the width between the pre-set min(45px) and max(80vw) values.
+- The height of the `amp-sidebar` may be set to adjust the height of the sidebar, if required. If the height exceeds 100vw, the sidebar will have a vertical scrollbar. The preset height of the sidebar is 100vw and can be overridden in CSS to make it shorter.
+- The current state of the sidebar is exposed via the `open` attribute that is set on the `amp-sidebar` tag when the side bar is open on the page.
+
 
 ## UX considerations
 
-When using `<amp-sidebar>`, bear in mind that your users will often view your page on mobile in an AMP viewer, which may display a fixed-position header. In addition, browsers often display their own fixed header at the top of the page. Adding another fixed-position element at the top of the screen would take up a large amount of mobile screen space with content that gives the user no new information.
+When using `<amp-sidebar>`, keep in mind that your users will often view your page on mobile in an AMP viewer, which may display a fixed-position header. In addition, browsers often display their own fixed header at the top of the page. Adding another fixed-position element at the top of the screen would take up a large amount of mobile screen space with content that gives the user no new information.
 
 For this reason, we recommend that affordances to open the sidebar are not placed in a fixed, full-width header.
 

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td> Displays a <a href="https://soundcloud.com/">Soundcloud</a> clip.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-springboard-player/amp-springboard-player.md
+++ b/extensions/amp-springboard-player/amp-springboard-player.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays the Springboard Player used in the <a href="http://publishers.springboardplatform.com">Springboard</a> Video Platform.
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-springboard-player" src="https://cdn.ampproject.org/v0/amp-springboard-player-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-timeago/amp-timeago.md
+++ b/extensions/amp-timeago/amp-timeago.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Provides fuzzy timestamps by formatting dates as `*** time ago` (for example, 3 hours ago).</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a Twitter Tweet.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-user-notification/amp-user-notification.md
+++ b/extensions/amp-user-notification/amp-user-notification.md
@@ -24,10 +24,6 @@ limitations under the License.
     <td>Displays a dismissable notification to the user. </td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td>
       <div>

--- a/extensions/amp-user-notification/amp-user-notification.md
+++ b/extensions/amp-user-notification/amp-user-notification.md
@@ -232,7 +232,7 @@ amp-user-notification.amp-active {
 ```
 
 ## Actions
-The `amp-user-notification` exposes the following actions that you can use [AMP on-syntax to trigger](../../../src/spec/amp-actions-and-events.md):
+The `amp-user-notification` exposes the following actions that you can use [AMP on-syntax to trigger](../../spec/amp-actions-and-events.md):
 
 <table>
   <tr>

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -16,23 +16,22 @@ limitations under the License.
 
 # <a name="amp-video"></a> `amp-video`
 
+[TOC]
+
 <table>
    <tr>
     <td class="col-fourty"><strong>Description</strong></td>
     <td>A replacement for the HTML5 <code>video</code> tag; only to be used for direct HTML5 video file embeds.</td>
   </tr>
-   <tr>
-    <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js">&lt;/script></code></td>
   </tr>
-
   <tr>
-    <td class="col-fourty"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-video/">Annotated code example for amp-video</a></td>
+    <td width="40%"><strong>Examples</strong></td>
+    <td>AMP By Example's:<ul>
+      <li><a href="https://ampbyexample.com/components/amp-video/">amp-video example</a></li>
+      <li><a href="https://ampbyexample.com/advanced/click-to-play_overlay_for_amp-video/">Click-to-play overlay for amp-video</a></td>
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
@@ -42,39 +41,43 @@ limitations under the License.
 
 ## Behavior
 
-The `amp-video` component loads the video resource specified by its `src` attribute lazily, at a time determined by the runtime. It can be controlled much the same way as a standard HTML5 `video` tag.
+The `amp-video` component loads the video resource specified by its `src` attribute lazily, at a time determined by the runtime. You can control an `amp-video` component much the same way as a standard HTML5 `<video>` tag.
 
-The `amp-video` component HTML accepts up to three unique types of HTML nodes as children - `source` tags, a placeholder for before the video starts, and a fallback if the browser doesn’t support HTML5 video.
+The `amp-video` component accepts up to three unique types of HTML nodes as children:
 
-`source` tag children can be used in the same way as the standard `video` tag, to specify different source files to play.
+- `source` tags: Just like in the HTML `<video>` tag, you can add `<source>` tag children to specify different source media files to play.
+-  a placeholder for before the video starts
+-  a fallback if the browser doesn’t support HTML5 video: One or zero immediate child nodes can have the `fallback` attribute. If present, this node and its children form the content that displays if HTML5 video is not supported on the user’s browser.
 
-One or zero immediate child nodes can have the `fallback` attribute. If present, this node and its children form the content that will be displayed if HTML5 video is not supported on the user’s browser.
+#### Example
 
-## Example
+<!--embedded example - displays in ampproject.org -->
+<div>
+<amp-iframe height="293"
+            layout="fixed-height"
+            sandbox="allow-scripts allow-forms allow-same-origin"
+            resizable
+            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampvideo.basic.embed.html">
+  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
+  <div placeholder></div> 
+</amp-iframe>
 
-```html
-<amp-video width=400 height=300 src="https://yourhost.com/videos/myvideo.mp4"
-    poster="myvideo-poster.jpg">
-  <div fallback>
-    <p>Your browser doesn’t support HTML5 video</p>
-  </div>
-  <source type="video/mp4" src="foo.mp4">
-  <source type="video/webm" src="foo.webm">
-</amp-video>
-```
+</div>
 
 ## Attributes
 
-**src**
+##### src
 
 Required if no `<source>` children are present. Must be HTTPS.
 
-**poster**
+##### poster
 
 The image for the frame to be displayed before video playback has started. By
-default the first frame is displayed.
+default, the first frame is displayed.
 
-**autoplay**
+Alternatively, you can present a click-to-play overlay. For details, see the [Click-to-Play overlay](#click-to-play-overlay) section below.
+
+##### autoplay
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -84,28 +87,27 @@ If this attribute is present, and the browser supports autoplay:
 * when the user taps the video, the video is unmuted
 * if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
 
-**controls**
+##### controls
 
-Similar to the `video` tag `controls` attribute - if present, the browser offers controls to allow the user to control video playback.
+This attribute is similar to the `controls` attribute in the HTML5 `video`. If this attribute is present, the browser offers controls to allow the user to control video playback.
 
-**loop**
+##### loop
 
-If present, will automatically loop the video back to the start upon reaching the end.
+If present, the video will automatically loop back to the start upon reaching the end.
 
-**muted (deprecated)**
+##### muted (deprecated)
 
-`muted` attribute is deprecated and no longer has any effect.
-`autoplay` attribute automatically controls the mute behavior.
+The `muted` attribute is deprecated and no longer has any effect. The `autoplay` attribute automatically controls the mute behavior.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Click-to-Play overlay
-Click-to-play is a common UX feature for video players on the web. `amp-video` supports
-the standard `play` AMP action, allowing you to implement click-to-play easily.
 
-Please see [Click-to-play overlay for amp-video on AmpByExample.com](https://ampbyexample.com/advanced/click-to-play_overlay_for_amp-video/) for a sample.
+Providing a click-to-play overlay is a common UX feature for video players on the web.  For example, you could display a custom play icon that the user can click, as well as include the title of the video, different sized poster images, and so on.  Because the `amp-video` component supports the standard `play` AMP action, you can easily implement click-to-play.
+
+For a detailed example, visit AMP By Example's  [Click-to-play overlay for amp-video](https://ampbyexample.com/advanced/click-to-play_overlay_for_amp-video/).
 
 ## Validation
 

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a <a href="https://vimeo.com">Vimeo</a> video.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-vimeo" src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -50,7 +50,7 @@ With responsive layout, the width and height from the example should yield corre
 
 **data-videoid** (required)
 
-The Vimeo video id found in every Vimeo video page URL For example, `27246366` is the video id for the following url: https://vimeo.com/27246366.
+The Vimeo video id found in every Vimeo video page URL For example, `27246366` is the video id for the following url: `https://vimeo.com/27246366`.
 
 **common attributes**
 

--- a/extensions/amp-vine/amp-vine.md
+++ b/extensions/amp-vine/amp-vine.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a Vine simple embed.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-0.1.js">&lt;/script></code></td>
   </tr>

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Displays a <a href="https://www.youtube.com/">YouTube</a> video.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js">&lt;/script></code></td>
   </tr>


### PR DESCRIPTION
- Added  embedded examples or inline code snippets for: amp-video, amp-pixel, amp-sidebar (re: https://github.com/ampproject/docs/issues/141)
- Corrected amp-izlesene's line endings so code format displays correctly (wasn't syntax highlighting)
- For all components with "availability = stable", removed that text.  Only have "availability" for components that are experimental or in development. 
- Also added text for amp-video `poster` - as alternative, use click-to-play UX per https://github.com/ampproject/docs/issues/27
- Corrected broken links that were flagged in checklinks test.
to: @pbakaus 