### PR TITLE
Switch to preload-as-fetch per change to spec and remove prefetch support

### DIFF
--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -187,11 +187,19 @@ export function warmupDynamic(e) {
   if (!link || !link.eventualUrl) {
     return;
   }
-  const linkRel = /*OK*/document.createElement('link');
-  linkRel.rel = 'preload';
-  linkRel.setAttribute('as', 'document');
-  linkRel.href = link.eventualUrl;
-  getHeadOrFallback(e.target.ownerDocument).appendChild(linkRel);
+  // Preloading with empty as and newly specced value `fetch` meaning the same
+  // thing. `document` would be the right value, but this is not yet supported
+  // in browsers.
+  const linkRel0 = /*OK*/document.createElement('link');
+  linkRel0.rel = 'preload';
+  linkRel0.href = link.eventualUrl;
+  const linkRel1 = /*OK*/document.createElement('link');
+  linkRel1.rel = 'preload';
+  linkRel1.as = 'fetch';
+  linkRel1.href = link.eventualUrl;
+  const head = getHeadOrFallback(e.target.ownerDocument);
+  head.appendChild(linkRel0);
+  head.appendChild(linkRel1);
 }
 
 /**

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -184,10 +184,7 @@ describe('amp-ad-3p-impl', () => {
       ad3p.buildCallback();
       ad3p.preconnectCallback();
       return whenFirstVisible.then(() => {
-        let fetches = win.document.querySelectorAll('link[rel=prefetch]');
-        if (!fetches.length) {
-          fetches = win.document.querySelectorAll('link[rel=preload]');
-        }
+        const fetches = win.document.querySelectorAll('link[rel=preload]');
         expect(fetches).to.have.length(2);
         expect(fetches[0]).to.have.property('href',
             'http://ads.localhost:9876/dist.3p/current/frame.max.html');

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -284,8 +284,7 @@ describe('3p-frame', () => {
     preloadBootstrap(window, preconnect);
     // Wait for visible promise
     return Promise.resolve().then(() => {
-      const fetches = document.querySelectorAll(
-          'link[rel=prefetch],link[rel=preload]');
+      const fetches = document.querySelectorAll('link[rel=preload]');
       expect(fetches).to.have.length(2);
       expect(fetches[0]).to.have.property('href',
           'http://ads.localhost:9876/dist.3p/current/frame.max.html');

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -307,10 +307,15 @@ describe('alp-handler', () => {
 
   it('should warmup dynamically', () => {
     warmupDynamic(event);
-    expect(win.document.head.appendChild).to.be.calledOnce;
-    const link = win.document.head.appendChild.lastCall.args[0];
-    expect(link.rel).to.equal('preload');
-    expect(link.href).to.equal(
+    expect(win.document.head.appendChild).to.be.callCount(2);
+    const link0 = win.document.head.appendChild.firstCall.args[0];
+    expect(link0.rel).to.equal('preload');
+    expect(link0.href).to.equal(
+        'https://cdn.ampproject.org/c/www.example.com/amp.html');
+    const link1 = win.document.head.appendChild.secondCall.args[0];
+    expect(link1.rel).to.equal('preload');
+    expect(link1.as).to.equal('fetch');
+    expect(link1.href).to.equal(
         'https://cdn.ampproject.org/c/www.example.com/amp.html');
   });
 

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -101,7 +101,7 @@ describe('preconnect', () => {
           iframe.doc.querySelector('link[rel=preconnect]')
               .getAttribute('referrerpolicy')).to.equal('origin');
       return visible.then(() => {
-        expect(iframe.doc.querySelectorAll('link[rel=prefetch]'))
+        expect(iframe.doc.querySelectorAll('link[rel=preload]'))
             .to.have.length(0);
         expect(open).to.have.not.been.called;
       });
@@ -126,8 +126,7 @@ describe('preconnect', () => {
           iframe.doc.querySelector('link[rel=preconnect]')
               .getAttribute('referrerpolicy')).to.equal('origin');
       return visible.then(() => {
-        expect(iframe.doc.querySelectorAll(
-            'link[rel=prefetch],link[rel=preload]'))
+        expect(iframe.doc.querySelectorAll('link[rel=preload]'))
             .to.have.length(0);
         expect(open).to.have.not.been.called;
       });
@@ -151,7 +150,7 @@ describe('preconnect', () => {
           .to.have.length(1);
       expect(iframe.doc.querySelector('link[rel=preconnect]').href)
           .to.equal('https://s.preconnect.com/');
-      expect(iframe.doc.querySelectorAll('link[rel=prefetch]'))
+      expect(iframe.doc.querySelectorAll('link[rel=preload]'))
           .to.have.length(0);
       expect(open).to.have.not.been.called;
       return visible.then(() => {
@@ -241,37 +240,7 @@ describe('preconnect', () => {
     });
   });
 
-  it('should prefetch', () => {
-    return getPreconnectIframe().then(iframe => {
-      preconnect.preload('https://a.prefetch.com/foo/bar');
-      preconnect.preload('https://a.prefetch.com/foo/bar');
-      preconnect.preload('https://a.prefetch.com/other');
-      preconnect.preload(javascriptUrlPrefix + ':alert()');
-      const fetches = iframe.doc.querySelectorAll(
-          'link[rel=prefetch]');
-      expect(fetches).to.have.length(0);
-      return visible.then(() => {
-        // Also preconnects.
-        expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
-            .to.have.length(1);
-        expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
-            .to.equal('https://a.prefetch.com/');
-        expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
-            .to.have.length(1);
-        expect(iframe.doc.querySelector('link[rel=preconnect]').href)
-            .to.equal('https://a.prefetch.com/');
-        // Actual prefetch
-        const fetches = iframe.doc.querySelectorAll(
-            'link[rel=prefetch]');
-        expect(fetches).to.have.length(2);
-        expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
-        expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
-        expect(fetches[0].getAttribute('referrerpolicy')).to.equal('origin');
-      });
-    });
-  });
-
-  it('should add links (prefetch or preload)', () => {
+  it('should add links if feature if detected', () => {
     // Don't stub preload support allow the test to run through the browser
     // default regardless of support or not.
     return getPreconnectIframe(/* detectFeatures */ true).then(iframe => {
@@ -279,54 +248,16 @@ describe('preconnect', () => {
       preconnect.preload('https://a.prefetch.com/foo/bar');
       preconnect.preload('https://a.prefetch.com/other', 'style');
       preconnect.preload(javascriptUrlPrefix + ':alert()');
-      // Actual prefetch
       const fetches = iframe.doc.querySelectorAll(
-          'link[rel=prefetch],link[rel=preload]');
+          'link[rel=preload]');
       expect(fetches).to.have.length(0);
       return visible.then(() => {
         expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
             .to.have.length(1);
         expect(iframe.doc.querySelector('link[rel=preconnect]').href)
             .to.equal('https://a.prefetch.com/');
-        // Actual prefetch
         const fetches = iframe.doc.querySelectorAll(
-            'link[rel=prefetch],link[rel=preload]');
-        expect(fetches).to.have.length(2);
-        expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
-        expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
-        expect(fetches[0].getAttribute('referrerpolicy')).to.equal('origin');
-      });
-    });
-  });
-
-  it('should prefetch when preload is not supported', () => {
-    preloadSupported = false;
-    return getPreconnectIframe().then(iframe => {
-      preconnect.preload('https://a.prefetch.com/foo/bar', 'script');
-      preconnect.preload('https://a.prefetch.com/foo/bar');
-      preconnect.preload('https://a.prefetch.com/other', 'style');
-      preconnect.preload(javascriptUrlPrefix + ':alert()');
-      const fetches = iframe.doc.querySelectorAll(
-          'link[rel=prefetch]');
-      expect(fetches).to.have.length(0);
-      return visible.then(() => {
-        // Also preconnects.
-        expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
-            .to.have.length(1);
-        expect(iframe.doc.querySelector('link[rel=dns-prefetch]').href)
-            .to.equal('https://a.prefetch.com/');
-        expect(iframe.doc.querySelectorAll('link[rel=preconnect]'))
-            .to.have.length(1);
-        expect(iframe.doc.querySelector('link[rel=preconnect]').href)
-            .to.equal('https://a.prefetch.com/');
-
-        const preloads = iframe.doc.querySelectorAll(
             'link[rel=preload]');
-        expect(preloads).to.have.length(0);
-
-        // Actual prefetch
-        const fetches = iframe.doc.querySelectorAll(
-            'link[rel=prefetch]');
         expect(fetches).to.have.length(2);
         expect(fetches[0].href).to.equal('https://a.prefetch.com/foo/bar');
         expect(fetches[1].href).to.equal('https://a.prefetch.com/other');
@@ -335,16 +266,13 @@ describe('preconnect', () => {
     });
   });
 
-  it('should preload when supported', () => {
+  it('should preload', () => {
     preloadSupported = true;
     return getPreconnectIframe().then(iframe => {
       preconnect.preload('https://a.prefetch.com/foo/bar', 'script');
       preconnect.preload('https://a.prefetch.com/foo/bar');
       preconnect.preload('https://a.prefetch.com/other', 'style');
       preconnect.preload(javascriptUrlPrefix + ':alert()');
-      const fetches = iframe.doc.querySelectorAll(
-          'link[rel=prefetch]');
-      expect(fetches).to.have.length(0);
       return visible.then(() => {
         // Also preconnects.
         expect(iframe.doc.querySelectorAll('link[rel=dns-prefetch]'))
@@ -355,15 +283,18 @@ describe('preconnect', () => {
             .to.have.length(1);
         expect(iframe.doc.querySelector('link[rel=preconnect]').href)
             .to.equal('https://a.prefetch.com/');
-        // Actual prefetch
-        const fetches = iframe.doc.querySelectorAll(
-            'link[rel=prefetch]');
-        expect(fetches).to.have.length(0);
+        // Actual preload
         const preloads = iframe.doc.querySelectorAll(
             'link[rel=preload]');
         expect(preloads).to.have.length(2);
         expect(preloads[0].href).to.equal('https://a.prefetch.com/foo/bar');
         expect(preloads[1].href).to.equal('https://a.prefetch.com/other');
+        const as = preloads[0].as;
+        expect(as == '' || as == 'fetch').to.be.ok;
+        preloads[0].as = 'not-valid';
+        if (preloads[0].as != 'not-valid') {
+          expect(as).to.equal('fetch');
+        }
       });
     });
   });


### PR DESCRIPTION
Per https://github.com/w3c/preload/issues/80 we should use `fetch` instead of and empty `as` attribute value. We feature detect the change using the newly defined behavior that invalid `as` values are not reflected.

Also removes falling back to `link-rel-prefetch` as it leads to double downloads and preload itself is now very widely supported.