### PR TITLE
Add trust levels to AMP actions

### DIFF
--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -121,6 +121,7 @@ describes.realWin('amp-ad-exit', {
         method: 'exit',
         args: {target: 'not-a-real-target'},
         event: makeClickEvent(1001),
+        satisfiesTrust: () => true,
       });
       expect(open).to.not.have.been.called;
     } catch (expected) {}
@@ -132,6 +133,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'simple'},
       event,
+      satisfiesTrust: () => true,
     });
     expect(event.preventDefault).to.have.been.called;
   });
@@ -143,12 +145,14 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'simple'},
       event: makeClickEvent(999),
+      satisfiesTrust: () => true,
     });
 
     element.implementation_.executeAction({
       method: 'exit',
       args: {target: 'twoSecondDelay'},
       event: makeClickEvent(1000),  // 1000 ms + 999 from the previous exit.
+      satisfiesTrust: () => true,
     });
 
     expect(open).to.not.have.been.called;
@@ -163,6 +167,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'simple'},
       event: makeClickEvent(1001),
+      satisfiesTrust: () => true,
     });
 
     expect(open).to.have.been.calledOnce;
@@ -177,6 +182,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'simple'},
       event: makeClickEvent(1001),
+      satisfiesTrust: () => true,
     });
 
     expect(open).to.have.been.calledTwice;
@@ -196,6 +202,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'tracking'},
       event: makeClickEvent(1001),
+      satisfiesTrust: () => true,
     });
 
     expect(open).to.have.been.calledOnce;
@@ -223,6 +230,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'tracking'},
       event: makeClickEvent(1001),
+      satisfiesTrust: () => true,
     });
 
     expect(open).to.have.been.calledOnce;
@@ -249,6 +257,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'tracking'},
       event: makeClickEvent(1001),
+      satisfiesTrust: () => true,
     });
 
     expect(open).to.have.been.calledOnce;
@@ -281,6 +290,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'tracking'},
       event: makeClickEvent(1001),
+      satisfiesTrust: () => true,
     });
 
     expect(open).to.have.been.calledOnce;
@@ -307,6 +317,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'variables'},
       event: makeClickEvent(1001, 101, 102),
+      satisfiesTrust: () => true,
     });
 
     const urlMatcher = sinon.match(new RegExp(
@@ -334,6 +345,7 @@ describes.realWin('amp-ad-exit', {
       method: 'exit',
       args: {target: 'customVars', _foo: 'foo', _bar: 'bar'},
       event: makeClickEvent(1001, 101, 102),
+      satisfiesTrust: () => true,
     });
 
     expect(open).to.have.been.calledWith(

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -363,7 +363,12 @@ describes.sandboxed('AmpAnimation', {}, () => {
       it('should trigger activate via start', () => {
         const startStub = sandbox.stub(anim, 'startOrResume_');
         const args = {};
-        anim.executeAction({method: 'activate', args});
+        const invocation = {
+          method: 'activate',
+          args,
+          satisfiesTrust: () => true,
+        };
+        anim.executeAction(invocation);
         expect(anim.triggered_).to.be.true;
         expect(startStub).to.be.calledOnce;
         expect(startStub).to.be.calledWith(args);
@@ -372,7 +377,12 @@ describes.sandboxed('AmpAnimation', {}, () => {
       it('should trigger start', () => {
         const startStub = sandbox.stub(anim, 'startOrResume_');
         const args = {};
-        anim.executeAction({method: 'start', args});
+        const invocation = {
+          method: 'start',
+          args,
+          satisfiesTrust: () => true,
+        };
+        anim.executeAction(invocation);
         expect(anim.triggered_).to.be.true;
         expect(startStub).to.be.calledOnce;
         expect(startStub).to.be.calledWith(args);
@@ -394,7 +404,12 @@ describes.sandboxed('AmpAnimation', {}, () => {
         const cancelStub = sandbox.stub(anim, 'cancel_');
         const startStub = sandbox.stub(anim, 'startOrResume_');
         const args = {};
-        anim.executeAction({method: 'restart', args});
+        const invocation = {
+          method: 'restart',
+          args,
+          satisfiesTrust: () => true,
+        };
+        anim.executeAction(invocation);
         expect(anim.triggered_).to.be.true;
         expect(cancelStub).to.be.calledOnce;
         expect(startStub).to.be.calledOnce;
@@ -405,38 +420,44 @@ describes.sandboxed('AmpAnimation', {}, () => {
         anim.triggered_ = true;
         return anim.startOrResume_().then(() => {
           runnerMock.expects('pause').once();
-          anim.executeAction({method: 'pause'});
+          anim.executeAction({method: 'pause', satisfiesTrust: () => true});
         });
       });
 
       it('should ignore pause before start', () => {
         runnerMock.expects('pause').never();
-        anim.executeAction({method: 'pause'});
+        anim.executeAction({method: 'pause', satisfiesTrust: () => true});
       });
 
       it('should trigger resume after start', () => {
         anim.triggered_ = true;
         return anim.startOrResume_().then(() => {
           runnerMock.expects('resume').once();
-          anim.executeAction({method: 'resume'});
+          anim.executeAction({method: 'resume', satisfiesTrust: () => true});
         });
       });
 
       it('should ignore resume before start', () => {
         runnerMock.expects('resume').never();
-        anim.executeAction({method: 'resume'});
+        anim.executeAction({method: 'resume', satisfiesTrust: () => true});
       });
 
       it('should toggle pause/resume after start', () => {
         anim.triggered_ = true;
         return anim.startOrResume_().then(() => {
           runnerMock.expects('pause').once();
-          anim.executeAction({method: 'togglePause'});
+          anim.executeAction({
+            method: 'togglePause',
+            satisfiesTrust: () => true,
+          });
 
           runnerMock.expects('getPlayState')
               .returns(WebAnimationPlayState.PAUSED);
           runnerMock.expects('resume').once();
-          anim.executeAction({method: 'togglePause'});
+          anim.executeAction({
+            method: 'togglePause',
+            satisfiesTrust: () => true,
+          });
         });
       });
 
@@ -444,36 +465,51 @@ describes.sandboxed('AmpAnimation', {}, () => {
         anim.triggered_ = true;
         return anim.startOrResume_().then(() => {
           runnerMock.expects('seekTo').withExactArgs(100).once();
-          anim.executeAction({method: 'seekTo', args: {time: 100}});
+          let invocation = {
+            method: 'seekTo',
+            args: {time: 100},
+            satisfiesTrust: () => true,
+          };
+          anim.executeAction(invocation);
 
           runnerMock.expects('seekTo').withExactArgs(200).once();
-          anim.executeAction({method: 'seekTo', args: {time: '200'}});
+          invocation = {
+            method: 'seekTo',
+            args: {time: 200},
+            satisfiesTrust: () => true,
+          };
+          anim.executeAction(invocation);
         });
       });
 
       it('should ignore seek-to before start', () => {
         runnerMock.expects('seekTo').never();
-        anim.executeAction({method: 'seekTo', args: {time: 100}});
+        const invocation = {
+          method: 'seekTo',
+          args: {time: 100},
+          satisfiesTrust: () => true,
+        };
+        anim.executeAction(invocation);
       });
 
       it('should trigger reverse after start', () => {
         anim.triggered_ = true;
         return anim.startOrResume_().then(() => {
           runnerMock.expects('reverse').once();
-          anim.executeAction({method: 'reverse'});
+          anim.executeAction({method: 'reverse', satisfiesTrust: () => true});
         });
       });
 
       it('should ignore reverse before start', () => {
         runnerMock.expects('reverse').never();
-        anim.executeAction({method: 'reverse'});
+        anim.executeAction({method: 'reverse', satisfiesTrust: () => true});
       });
 
       it('should trigger finish after start', () => {
         anim.triggered_ = true;
         return anim.startOrResume_().then(() => {
           runnerMock.expects('finish').once();
-          anim.executeAction({method: 'finish'});
+          anim.executeAction({method: 'finish', satisfiesTrust: () => true});
         });
       });
 
@@ -481,7 +517,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
         anim.triggered_ = true;
         return anim.startOrResume_().then(() => {
           runnerMock.expects('cancel').once();
-          anim.executeAction({method: 'cancel'});
+          anim.executeAction({method: 'cancel', satisfiesTrust: () => true});
         });
       });
     });

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -211,7 +211,7 @@ export class AmpSlideScroll extends BaseSlides {
       if (args) {
         this.showSlideWhenReady(args['index']);
       }
-    }, ActionTrust.LOW);
+    }, ActionTrust.MEDIUM); // TODO(choumx, #9699): LOW.
   }
 
   /** @override */

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../../../src/action-trust';
 import {Animation} from '../../../src/animation';
 import {BaseSlides} from './base-slides';
 import {actionServiceForDoc} from '../../../src/services';
@@ -210,7 +211,7 @@ export class AmpSlideScroll extends BaseSlides {
       if (args) {
         this.showSlideWhenReady(args['index']);
       }
-    });
+    }, ActionTrust.LOW);
   }
 
   /** @override */
@@ -589,8 +590,9 @@ export class AmpSlideScroll extends BaseSlides {
       const name = 'slideChange';
       const event =
           createCustomEvent(this.win, `slidescroll.${name}`, {index: newIndex});
+      this.action_.trigger(this.element, name, event, ActionTrust.MEDIUM);
+
       this.element.dispatchCustomEvent(name, {index: newIndex});
-      this.action_.trigger(this.element, name, event);
     }
   }
 

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -975,29 +975,30 @@ describe('SlideScroll', () => {
         const ampSlideScroll = obj.ampSlideScroll;
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+        const satisfiesTrust = () => true;
 
         let args = {'index': '123'};
-        impl.executeAction({method: 'goToSlide', args});
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
         expect(showSlideSpy).to.not.have.been.called;
 
         args = {'index': '5'};
-        impl.executeAction({method: 'goToSlide', args});
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
         expect(showSlideSpy).to.not.have.been.called;
 
         args = {'index': 'ssds11'};
-        impl.executeAction({method: 'goToSlide', args});
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
         expect(showSlideSpy).to.not.have.been.called;
 
         args = {'index': '-1'};
-        impl.executeAction({method: 'goToSlide', args});
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
         expect(showSlideSpy).to.not.have.been.called;
 
         args = {'index': '0'};
-        impl.executeAction({method: 'goToSlide', args});
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
         expect(showSlideSpy).to.have.been.calledWith(0);
 
         args = {'index': '4'};
-        impl.executeAction({method: 'goToSlide', args});
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
         expect(showSlideSpy).to.have.been.calledWith(4);
       });
     });
@@ -1012,9 +1013,10 @@ describe('SlideScroll', () => {
         iframe.addElement(ampSlideScroll);
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+        const satisfiesTrust = () => true;
 
         const args = {'index': '3'};
-        impl.executeAction({method: 'goToSlide', args});
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
         expect(showSlideSpy).to.not.have.been.called;
 
         impl.mutatedAttributesCallback({slide: 2});

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -193,8 +193,9 @@ export class AmpForm {
     this.verifier_ = getFormVerifier(
         this.form_, () => this.handleXhrVerify_());
 
+    // TODO(choumx, #9699): HIGH.
     this.actions_.installActionHandler(
-        this.form_, this.actionHandler_.bind(this), ActionTrust.HIGH);
+        this.form_, this.actionHandler_.bind(this), ActionTrust.MEDIUM);
     this.installEventHandlers_();
 
     /** @private {?Promise} */
@@ -349,7 +350,7 @@ export class AmpForm {
       event.preventDefault();
     }
     // Submits caused by user input have high trust.
-    this.submit_(ActionTrust.HIGH);
+    this.submit_(ActionTrust.MEDIUM); // TODO(choumx, #9699): HIGH.
   }
 
   /**

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1435,7 +1435,7 @@ describes.repeated('', {
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
 
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
           expect(ampForm.urlReplacement_.expandInputValueAsync)
               .to.not.have.been.called;
           expect(ampForm.urlReplacement_.expandInputValueSync)
@@ -1477,7 +1477,7 @@ describes.repeated('', {
           sandbox.stub(ampForm, 'handleXhrSubmitSuccess_');
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
           expect(ampForm.urlReplacement_.expandInputValueAsync)
               .to.not.have.been.called;
           expect(ampForm.urlReplacement_.expandInputValueSync)
@@ -1515,7 +1515,7 @@ describes.repeated('', {
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
 
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
           expect(ampForm.urlReplacement_.expandInputValueAsync)
               .to.not.have.been.called;
           expect(ampForm.urlReplacement_.expandInputValueSync)
@@ -1552,7 +1552,7 @@ describes.repeated('', {
           sandbox.stub(ampForm, 'handleXhrSubmitSuccess_');
           sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
           sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
           expect(ampForm.urlReplacement_.expandInputValueAsync)
               .to.not.have.been.called;
           expect(ampForm.urlReplacement_.expandInputValueSync)
@@ -1615,7 +1615,7 @@ describes.repeated('', {
         it('should redirect users if header is set', () => {
           sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
           redirectToValue = 'https://google.com/';
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
 
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             expect(env.win.top.location.href).to.be.equal(redirectToValue);
@@ -1625,7 +1625,7 @@ describes.repeated('', {
         it('should fail to redirect to non-secure urls', () => {
           sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
           redirectToValue = 'http://google.com/';
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
 
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             assert.fail('Submit should have failed.');
@@ -1638,7 +1638,7 @@ describes.repeated('', {
         it('should fail to redirect to non-absolute urls', () => {
           sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
           redirectToValue = '/hello';
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
 
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             assert.fail('Submit should have failed.');
@@ -1652,7 +1652,7 @@ describes.repeated('', {
           ampForm.target_ = '_blank';
           sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchResolvePromise);
           redirectToValue = 'http://google.com/';
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
 
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             assert.fail('Submit should have failed.');
@@ -1666,7 +1666,7 @@ describes.repeated('', {
           sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchRejectPromise);
           redirectToValue = 'https://example2.com/hello';
           const logSpy = sandbox.spy(user(), 'error');
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
 
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             expect(logSpy).to.be.calledOnce;
@@ -1687,7 +1687,7 @@ describes.repeated('', {
           sandbox.stub(form, 'submit');
           sandbox.stub(form, 'checkValidity').returns(true);
           sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
-          ampForm.handleSubmitAction_();
+          ampForm.handleSubmitAction_(/* invocation */ {});
           expect(form.submit).to.have.been.called;
         });
       });
@@ -1733,7 +1733,7 @@ describes.repeated('', {
         sandbox.stub(form, 'checkValidity').returns(true);
         sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
         sandbox.stub(ampForm, 'analyticsEvent_');
-        ampForm.handleSubmitAction_();
+        ampForm.handleSubmitAction_(/* invocation */ {});
         const expectedFormData = {
           'formId': 'registration',
           'formFields[name]': 'John Miller',
@@ -1772,7 +1772,7 @@ describes.repeated('', {
         sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
         sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
         sandbox.stub(ampForm, 'analyticsEvent_');
-        ampForm.handleSubmitAction_();
+        ampForm.handleSubmitAction_(/* invocation */ {});
 
         const expectedFormData = {
           'formId': 'registration',

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../../../src/action-trust';
 import {CSS} from '../../../build/amp-live-list-0.1.css';
 import {childElementByAttr} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
@@ -222,7 +223,8 @@ export class AmpLiveList extends AMP.BaseElement {
     this.curNumOfLiveItems_ = this.validateLiveListItems_(
         this.itemsSlot_, true);
 
-    this.registerAction('update', this.updateAction_.bind(this));
+    this.registerAction(
+        'update', this.updateAction_.bind(this), ActionTrust.LOW);
 
     if (!this.element.hasAttribute('aria-live')) {
       this.element.setAttribute('aria-live', 'polite');

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -223,8 +223,9 @@ export class AmpLiveList extends AMP.BaseElement {
     this.curNumOfLiveItems_ = this.validateLiveListItems_(
         this.itemsSlot_, true);
 
+    // TODO(choumx, #9699): LOW.
     this.registerAction(
-        'update', this.updateAction_.bind(this), ActionTrust.LOW);
+        'update', this.updateAction_.bind(this), ActionTrust.MEDIUM);
 
     if (!this.element.hasAttribute('aria-live')) {
       this.element.setAttribute('aria-live', 'polite');

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../../../src/action-trust';
 import {CSS} from '../../../build/amp-selector-0.1.css';
 import {KeyCodes} from '../../../src/utils/key-codes';
 import {actionServiceForDoc} from '../../../src/services';
@@ -291,7 +292,7 @@ export class AmpSelector extends AMP.BaseElement {
               targetOption: el.getAttribute('option'),
               selectedOptions: selectedValues,
             });
-        this.action_.trigger(this.element, name, selectEvent);
+        this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
       }
     });
   }

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -292,7 +292,9 @@ export class AmpSelector extends AMP.BaseElement {
               targetOption: el.getAttribute('option'),
               selectedOptions: selectedValues,
             });
-        this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
+        // TODO(choumx, #9699): HIGH.
+        this.action_.trigger(this.element, name, selectEvent,
+            ActionTrust.MEDIUM);
       }
     });
   }

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -468,7 +468,7 @@ describe('amp-user-notification', () => {
         }
         expect(el).to.have.class('amp-active');
         expect(stub2.calledOnce).to.be.false;
-        impl.executeAction({method: 'dismiss'});
+        impl.executeAction({method: 'dismiss', satisfiesTrust: () => true});
         expect(el).to.not.have.class('amp-active');
         expect(el).to.have.class('amp-hidden');
         expect(stub2.calledOnce).to.be.true;

--- a/src/action-trust.js
+++ b/src/action-trust.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Trust level of an action.
+ *
+ * Corresponds to degree of user intent, i.e. events triggered with strong
+ * user intent have high trust.
+ *
+ * @enum {number}
+ */
+export const ActionTrust = {
+  LOW: 1,
+  MEDIUM: 2,
+  HIGH: 3,
+};

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -528,19 +528,16 @@ export class BaseElement {
    * Registers the action handler for the method with the specified name.
    *
    * The handler is only invoked by events with trust equal to or greater than
-   * `opt_minTrust` (or ActionTrust.MEDIUM if not provided). Otherwise, a
-   * user error is thrown.
+   * `minTrust` (or ActionTrust.MEDIUM if not provided). Otherwise, a
+   * user error is logged.
    *
    * @param {string} method
    * @param {function(!./service/action-impl.ActionInvocation)} handler
-   * @param {ActionTrust=} opt_minTrust
+   * @param {ActionTrust} minTrust
    * @public
    */
-  registerAction(method, handler, opt_minTrust) {
+  registerAction(method, handler, minTrust = ActionTrust.MEDIUM) {
     this.initActionMap_();
-    // Default to ActionTrust.MEDIUM.
-    const minTrust =
-        (opt_minTrust !== undefined) ? opt_minTrust : ActionTrust.MEDIUM;
     this.actionMap_[method] = {handler, minTrust};
   }
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -218,7 +218,8 @@ export class ActionService {
       this.root_.addEventListener('click', event => {
         if (!event.defaultPrevented) {
           const element = dev().assertElement(event.target);
-          this.trigger(element, name, event, ActionTrust.HIGH);
+          // TODO(choumx, #9699): HIGH.
+          this.trigger(element, name, event, ActionTrust.MEDIUM);
         }
       });
       this.root_.addEventListener('keydown', event => {
@@ -228,21 +229,23 @@ export class ActionService {
           if (!event.defaultPrevented &&
               element.getAttribute('role') == 'button') {
             event.preventDefault();
-            this.trigger(element, name, event, ActionTrust.HIGH);
+            // TODO(choumx, #9699): HIGH.
+            this.trigger(element, name, event, ActionTrust.MEDIUM);
           }
         }
       });
     } else if (name == 'submit') {
       this.root_.addEventListener(name, event => {
         const element = dev().assertElement(event.target);
-        this.trigger(element, name, event, ActionTrust.HIGH);
+        // TODO(choumx, #9699): HIGH.
+        this.trigger(element, name, event, ActionTrust.MEDIUM);
       });
     } else if (name == 'change') {
       this.root_.addEventListener(name, event => {
         const element = dev().assertElement(event.target);
         // Only `change` events from <select> elements have high trust.
         const trust = element.tagName == 'SELECT'
-            ? ActionTrust.HIGH
+            ? ActionTrust.MEDIUM // TODO(choumx, #9699): HIGH.
             : ActionTrust.MEDIUM;
         this.addInputDetails_(event);
         this.trigger(element, name, event, trust);
@@ -342,8 +345,8 @@ export class ActionService {
    * @param {?ActionEventDef} event
    */
   execute(target, method, args, source, event) {
-    // Invocation of actions by the runtime has the highest trust of all!
-    const trust = ActionTrust.HIGH;
+    // Invocation of actions by the runtime has the highest trust of all.
+    const trust = ActionTrust.MEDIUM; // TODO(choumx, #9699): HIGH.
     this.invoke_(target, method, args, source, event, trust, null);
   }
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -139,7 +139,7 @@ export class ActionInvocation {
 
   /**
    * Returns true if the trigger event has a trust equal to or greater than
-   * `minimumTrust`. Otherwise, throws a user error and returns false.
+   * `minimumTrust`. Otherwise, logs a user error and returns false.
    * @param {ActionTrust} minimumTrust
    * @returns {boolean}
    */
@@ -317,11 +317,9 @@ export class ActionService {
    * Registers the action handler for a common method.
    * @param {string} name
    * @param {function(!ActionInvocation)} handler
-   * @param {ActionTrust=} opt_minTrust
+   * @param {ActionTrust} minTrust
    */
-  addGlobalMethodHandler(name, handler, opt_minTrust) {
-    const minTrust =
-        (opt_minTrust !== undefined) ? opt_minTrust : ActionTrust.MEDIUM;
+  addGlobalMethodHandler(name, handler, minTrust = ActionTrust.MEDIUM) {
     this.globalMethodHandlers_[name] = {handler, minTrust};
   }
 
@@ -354,9 +352,9 @@ export class ActionService {
    * Installs action handler for the specified element.
    * @param {!Element} target
    * @param {function(!ActionInvocation)} handler
-   * @param {ActionTrust=} opt_minTrust
+   * @param {ActionTrust} minTrust
    */
-  installActionHandler(target, handler, opt_minTrust) {
+  installActionHandler(target, handler, minTrust = ActionTrust.MEDIUM) {
     // TODO(dvoytenko, #7063): switch back to `target.id` with form proxy.
     const targetId = target.getAttribute('id') || '';
     const debugid = target.tagName + '#' + targetId;
@@ -372,8 +370,6 @@ export class ActionService {
     /** @const {Array<!ActionInvocation>} */
     const currentQueue = target[ACTION_QUEUE_];
 
-    const minTrust =
-        (opt_minTrust !== undefined) ? opt_minTrust : ActionTrust.MEDIUM;
     target[ACTION_HANDLER_] = {handler, minTrust};
 
     // Dequeue the current queue.
@@ -382,7 +378,8 @@ export class ActionService {
         // TODO(dvoytenko, #1260): dedupe actions.
         currentQueue.forEach(invocation => {
           try {
-            if (invocation.satisfiesTrust(minTrust)) {
+            if (invocation.satisfiesTrust(
+                /** @type {ActionTrust} */ (minTrust))) {
               handler(invocation);
             }
           } catch (e) {

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -87,9 +87,6 @@ export class StandardActions {
       case 'setState':
         this.handleAmpSetState_(invocation);
         return;
-      case 'navigateTo':
-        this.handleAmpNavigateTo_(invocation);
-        return;
       case 'goBack':
         this.handleAmpGoBack_(invocation);
         return;
@@ -122,19 +119,6 @@ export class StandardActions {
             + '"AMP.setState(foo=\'bar\')".');
       }
     });
-  }
-
-  /**
-   * @param {!./action-impl.ActionInvocation} invocation
-   * @private
-   */
-  handleAmpNavigateTo_(invocation) {
-    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
-      return;
-    }
-    const url = invocation.args['url'];
-    // TODO(choumx): Scope this correctly for FIE.
-    this.ampdoc.win.location = url;
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../action-trust';
 import {OBJECT_STRING_ARGS_KEY} from '../service/action-impl';
 import {Layout, getLayoutClass} from '../layout';
 import {actionServiceForDoc} from '../services';
@@ -84,29 +85,67 @@ export class StandardActions {
   handleAmpTarget(invocation) {
     switch (invocation.method) {
       case 'setState':
-        bindForDoc(invocation.target).then(bind => {
-          const args = invocation.args;
-          const objectString = args[OBJECT_STRING_ARGS_KEY];
-          if (objectString) {
-            // Object string arg.
-            const scope = Object.create(null);
-            const event = invocation.event;
-            if (event && event.detail) {
-              scope['event'] = event.detail;
-            }
-            bind.setStateWithExpression(objectString, scope);
-          } else {
-            user().error('AMP-BIND', 'Please use the object-literal syntax, '
-                + 'e.g. "AMP.setState({foo: \'bar\'})" instead of '
-                + '"AMP.setState(foo=\'bar\')".');
-          }
-        });
+        this.handleAmpSetState_(invocation);
+        return;
+      case 'navigateTo':
+        this.handleAmpNavigateTo_(invocation);
         return;
       case 'goBack':
-        historyForDoc(this.ampdoc).goBack();
+        this.handleAmpGoBack_(invocation);
         return;
     }
     throw user().createError('Unknown AMP action ', invocation.method);
+  }
+
+  /**
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @private
+   */
+  handleAmpSetState_(invocation) {
+    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
+      return;
+    }
+    bindForDoc(invocation.target).then(bind => {
+      const args = invocation.args;
+      const objectString = args[OBJECT_STRING_ARGS_KEY];
+      if (objectString) {
+        // Object string arg.
+        const scope = Object.create(null);
+        const event = invocation.event;
+        if (event && event.detail) {
+          scope['event'] = event.detail;
+        }
+        bind.setStateWithExpression(objectString, scope);
+      } else {
+        user().error('AMP-BIND', 'Please use the object-literal syntax, '
+            + 'e.g. "AMP.setState({foo: \'bar\'})" instead of '
+            + '"AMP.setState(foo=\'bar\')".');
+      }
+    });
+  }
+
+  /**
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @private
+   */
+  handleAmpNavigateTo_(invocation) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
+      return;
+    }
+    const url = invocation.args['url'];
+    // TODO(choumx): Scope this correctly for FIE.
+    this.ampdoc.win.location = url;
+  }
+
+  /**
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @private
+   */
+  handleAmpGoBack_(invocation) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
+      return;
+    }
+    historyForDoc(this.ampdoc).goBack();
   }
 
   /**
@@ -115,6 +154,9 @@ export class StandardActions {
    * @param {!./action-impl.ActionInvocation} invocation
    */
   handleHide(invocation) {
+    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
+      return;
+    }
     const target = dev().assertElement(invocation.target);
 
     this.resources_.mutateElement(target, () => {
@@ -132,6 +174,9 @@ export class StandardActions {
    * @param {!./action-impl.ActionInvocation} invocation
    */
   handleShow(invocation) {
+    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
+      return;
+    }
     const target = dev().assertElement(invocation.target);
     const ownerWindow = target.ownerDocument.defaultView;
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -126,7 +126,8 @@ export class StandardActions {
    * @private
    */
   handleAmpGoBack_(invocation) {
-    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
+    // TODO(choumx, #9699): HIGH.
+    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
       return;
     }
     historyForDoc(this.ampdoc).goBack();

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -154,9 +154,6 @@ export class StandardActions {
    * @param {!./action-impl.ActionInvocation} invocation
    */
   handleHide(invocation) {
-    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
-      return;
-    }
     const target = dev().assertElement(invocation.target);
 
     this.resources_.mutateElement(target, () => {
@@ -174,9 +171,6 @@ export class StandardActions {
    * @param {!./action-impl.ActionInvocation} invocation
    */
   handleShow(invocation) {
-    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
-      return;
-    }
     const target = dev().assertElement(invocation.target);
     const ownerWindow = target.ownerDocument.defaultView;
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -91,12 +91,15 @@ export class VideoManager {
    * @private
    */
   registerCommonActions_(video) {
-    // TODO(choumx): Muted play should only require LOW trust.
-    video.registerAction('play',
-        video.play.bind(video, /* isAutoplay */ false), ActionTrust.HIGH);
-    video.registerAction('pause', video.pause.bind(video), ActionTrust.LOW);
-    video.registerAction('mute', video.mute.bind(video), ActionTrust.LOW);
-    video.registerAction('unmute', video.unmute.bind(video), ActionTrust.HIGH);
+    // TODO(choumx, #9699): HIGH for unmuted play, LOW for muted play.
+    video.registerAction('play', video.play.bind(video, /* isAutoplay */ false),
+        ActionTrust.MEDIUM);
+    // TODO(choumx, #9699): LOW.
+    video.registerAction('pause', video.pause.bind(video), ActionTrust.MEDIUM);
+    video.registerAction('mute', video.mute.bind(video), ActionTrust.MEDIUM);
+    // TODO(choumx, #9699): HIGH.
+    video.registerAction('unmute', video.unmute.bind(video),
+        ActionTrust.MEDIUM);
   }
 
   /**

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../action-trust';
 import {listen, listenOncePromise} from '../event-helper';
 import {dev} from '../log';
 import {getMode} from '../mode';
@@ -86,15 +87,16 @@ export class VideoManager {
    * so they can be called using AMP Actions.
    * For example: <button on="tap:myVideo.play">
    *
-   *
    * @param {!../video-interface.VideoInterface} video
    * @private
    */
   registerCommonActions_(video) {
-    video.registerAction('play', video.play.bind(video, /*isAutoplay*/ false));
-    video.registerAction('pause', video.pause.bind(video));
-    video.registerAction('mute', video.mute.bind(video));
-    video.registerAction('unmute', video.unmute.bind(video));
+    // TODO(choumx): Muted play should only require LOW trust.
+    video.registerAction('play',
+        video.play.bind(video, /* isAutoplay */ false), ActionTrust.HIGH);
+    video.registerAction('pause', video.pause.bind(video), ActionTrust.LOW);
+    video.registerAction('mute', video.mute.bind(video), ActionTrust.LOW);
+    video.registerAction('unmute', video.unmute.bind(video), ActionTrust.HIGH);
   }
 
   /**

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from './action-trust'; /* eslint no-unused-vars: 0 */
 
 /**
  * VideoInterface defines a common video API which any AMP component that plays
@@ -104,9 +105,10 @@ export class VideoInterface {
    *
    * @param {string} unusedMethod
    * @param {function(!./service/action-impl.ActionInvocation)} unusedHandler
+   * @param {ActionTrust=} opt_minTrust
    * @public
    */
-  registerAction(unusedMethod, unusedHandler) {}
+  registerAction(unusedMethod, unusedHandler, opt_minTrust) {}
 }
 
 

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -105,10 +105,10 @@ export class VideoInterface {
    *
    * @param {string} unusedMethod
    * @param {function(!./service/action-impl.ActionInvocation)} unusedHandler
-   * @param {ActionTrust=} opt_minTrust
+   * @param {ActionTrust} minTrust
    * @public
    */
-  registerAction(unusedMethod, unusedHandler, opt_minTrust) {}
+  registerAction(unusedMethod, unusedHandler, minTrust) {}
 }
 
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../../src/action-trust';
 import {
   ActionService,
   DeferredEvent,
@@ -640,7 +641,7 @@ describe('Action method', () => {
     const target = document.createElement('form');
     action.installActionHandler(target, handlerSpy);
     action.invoke_(target, 'submit', /* args */ null,
-        'button', 'tap');
+        'button', 'tap', ActionTrust.HIGH);
     expect(handlerSpy).to.be.calledOnce;
     const callArgs = handlerSpy.getCall(0).args[0];
     expect(callArgs.target).to.be.equal(target);
@@ -790,8 +791,10 @@ describe('Action interceptor', () => {
   });
 
   it('should dequeue actions after handler set', () => {
-    action.invoke_(target, 'method1', /* args */ null, 'source1', 'event1');
-    action.invoke_(target, 'method2', /* args */ null, 'source2', 'event2');
+    action.invoke_(target, 'method1', /* args */ null, 'source1', 'event1',
+        ActionTrust.MEDIUM);
+    action.invoke_(target, 'method2', /* args */ null, 'source2', 'event2',
+        ActionTrust.MEDIUM);
 
     expect(Array.isArray(getQueue())).to.be.true;
     expect(getActionHandler()).to.be.undefined;
@@ -817,7 +820,8 @@ describe('Action interceptor', () => {
     expect(inv1.source).to.equal('source2');
     expect(inv1.event).to.equal('event2');
 
-    action.invoke_(target, 'method3', /* args */ null, 'source3', 'event3');
+    action.invoke_(target, 'method3', /* args */ null, 'source3', 'event3',
+        ActionTrust.MEDIUM);
     expect(handler).to.have.callCount(3);
     const inv2 = handler.getCall(2).args[0];
     expect(inv2.target).to.equal(target);

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -866,15 +866,34 @@ describe('Action common handler', () => {
     action.addGlobalMethodHandler('action1', action1);
     action.addGlobalMethodHandler('action2', action2);
 
-    action.invoke_(target, 'action1', /* args */ null, 'source1', 'event1');
+    action.invoke_(target, 'action1', /* args */ null, 'source1', 'event1',
+        ActionTrust.HIGH);
     expect(action1).to.be.calledOnce;
     expect(action2).to.have.not.been.called;
 
-    action.invoke_(target, 'action2', /* args */ null, 'source2', 'event2');
+    action.invoke_(target, 'action2', /* args */ null, 'source2', 'event2',
+        ActionTrust.HIGH);
     expect(action2).to.be.calledOnce;
     expect(action1).to.be.calledOnce;
 
     expect(target['__AMP_ACTION_QUEUE__']).to.not.exist;
+  });
+
+  it('should check trust before invoking action', () => {
+    const handler = sandbox.spy();
+    action.addGlobalMethodHandler('foo', handler, ActionTrust.HIGH);
+
+    action.invoke_(target, 'foo', /* args */ null, 'source1', 'event1',
+        ActionTrust.LOW);
+    expect(handler).to.not.be.called;
+
+    action.invoke_(target, 'foo', /* args */ null, 'source1', 'event1',
+        ActionTrust.MEDIUM);
+    expect(handler).to.not.be.called;
+
+    action.invoke_(target, 'foo', /* args */ null, 'source1', 'event1',
+        ActionTrust.HIGH);
+    expect(handler).to.be.calledOnce;
   });
 });
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -29,6 +29,20 @@ import {setParentWindow} from '../../src/service';
 import * as sinon from 'sinon';
 
 
+/**
+ * @return {!ActionService}
+ */
+function actionService() {
+  const win = {
+    document: {body: {}},
+    services: {
+      vsync: {obj: {}},
+    },
+  };
+  return new ActionService(new AmpDocSingle(win), document);
+}
+
+
 function createExecElement(id, enqueAction) {
   const execElement = document.createElement('amp-element');
   execElement.setAttribute('id', id);
@@ -468,23 +482,16 @@ describe('Action parseActionMap', () => {
 
 
 describes.sandboxed('Action adoptEmbedWindow', {}, () => {
-  let win;
   let action;
   let embedWin;
 
   beforeEach(() => {
-    win = {
-      document: {body: {}},
-      services: {
-        vsync: {obj: {}},
-      },
-    };
-    action = new ActionService(new AmpDocSingle(win), document);
+    action = actionService();
     embedWin = {
       frameElement: document.createElement('div'),
       document: document.implementation.createHTMLDocument(''),
     };
-    setParentWindow(embedWin, win);
+    setParentWindow(embedWin, action.ampdoc.win);
   });
 
   it('should create embedded action service', () => {
@@ -500,18 +507,11 @@ describes.sandboxed('Action adoptEmbedWindow', {}, () => {
 
 describe('Action findAction', () => {
   let sandbox;
-  let win;
   let action;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    win = {
-      document: {body: {}},
-      services: {
-        vsync: {obj: {}},
-      },
-    };
-    action = new ActionService(new AmpDocSingle(win), document);
+    action = actionService();
   });
 
   afterEach(() => {
@@ -570,20 +570,13 @@ describe('Action findAction', () => {
 
 describe('Action method', () => {
   let sandbox;
-  let win;
   let action;
   let onEnqueue;
   let targetElement, parent, child, execElement;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    win = {
-      document: {body: {}},
-      services: {
-        vsync: {obj: {}},
-      },
-    };
-    action = new ActionService(new AmpDocSingle(win), document);
+    action = actionService();
     onEnqueue = sandbox.spy();
     targetElement = document.createElement('target');
     const id = ('E' + Math.random()).replace('.', '');
@@ -636,21 +629,6 @@ describe('Action method', () => {
     expect(onEnqueue).to.have.not.been.called;
   });
 
-  it('should invoke on non-AMP but whitelisted element', () => {
-    const handlerSpy = sandbox.spy();
-    const target = document.createElement('form');
-    action.installActionHandler(target, handlerSpy);
-    action.invoke_(target, 'submit', /* args */ null,
-        'button', 'tap', ActionTrust.HIGH);
-    expect(handlerSpy).to.be.calledOnce;
-    const callArgs = handlerSpy.getCall(0).args[0];
-    expect(callArgs.target).to.be.equal(target);
-    expect(callArgs.method).to.be.equal('submit');
-    expect(callArgs.args).to.be.equal(null);
-    expect(callArgs.source).to.be.equal('button');
-    expect(callArgs.event).to.be.equal('tap');
-  });
-
   it('should not allow invoke on unresolved AMP element', () => {
     expect(() => {
       action.invoke_({tagName: 'amp-img'}, 'method1', /* args */ null,
@@ -679,23 +657,62 @@ describe('Action method', () => {
   });
 });
 
+describe('installActionHandler', () => {
+  let sandbox;
+  let action;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    action = actionService();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should invoke on non-AMP but whitelisted element', () => {
+    const handlerSpy = sandbox.spy();
+    const target = document.createElement('form');
+    action.installActionHandler(target, handlerSpy);
+    action.invoke_(target, 'submit', /* args */ null,
+        'button', 'tap', ActionTrust.HIGH);
+    expect(handlerSpy).to.be.calledOnce;
+    const callArgs = handlerSpy.getCall(0).args[0];
+    expect(callArgs.target).to.be.equal(target);
+    expect(callArgs.method).to.be.equal('submit');
+    expect(callArgs.args).to.be.equal(null);
+    expect(callArgs.source).to.be.equal('button');
+    expect(callArgs.event).to.be.equal('tap');
+  });
+
+  it('should check trust level before invoking action', () => {
+    const handlerSpy = sandbox.spy();
+    const target = document.createElement('form');
+    action.installActionHandler(target, handlerSpy, ActionTrust.HIGH);
+
+    action.invoke_(target, 'submit', /* args */ null,
+        'button', 'tap', ActionTrust.LOW);
+    expect(handlerSpy).to.not.be.called;
+
+    action.invoke_(target, 'submit', /* args */ null,
+        'button', 'tap', ActionTrust.MEDIUM);
+    expect(handlerSpy).to.not.be.called;
+
+    action.invoke_(target, 'submit', /* args */ null,
+        'button', 'tap', ActionTrust.HIGH);
+    expect(handlerSpy).to.be.calledOnce;
+  });
+});
 
 describe('Multiple handlers action method', () => {
   let sandbox;
-  let win;
   let action;
   let onEnqueue1, onEnqueue2;
   let targetElement, parent, child, execElement1, execElement2;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    win = {
-      document: {body: {}},
-      services: {
-        vsync: {obj: {}},
-      },
-    };
-    action = new ActionService(new AmpDocSingle(win), document);
+    action = actionService();
     onEnqueue1 = sandbox.spy();
     onEnqueue2 = sandbox.spy();
     targetElement = document.createElement('target');
@@ -733,7 +750,6 @@ describe('Multiple handlers action method', () => {
 
 describe('Action interceptor', () => {
   let sandbox;
-  let win;
   let clock;
   let action;
   let target;
@@ -741,13 +757,7 @@ describe('Action interceptor', () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     clock = sandbox.useFakeTimers();
-    win = {
-      document: {body: {}},
-      services: {
-        vsync: {obj: {}},
-      },
-    };
-    action = new ActionService(new AmpDocSingle(win), document);
+    action = actionService();
     target = document.createElement('target');
     target.setAttribute('id', 'amp-test-1');
   });
@@ -834,19 +844,12 @@ describe('Action interceptor', () => {
 
 describe('Action common handler', () => {
   let sandbox;
-  let win;
   let action;
   let target;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    win = {
-      document: {body: {}},
-      services: {
-        vsync: {obj: {}},
-      },
-    };
-    action = new ActionService(new AmpDocSingle(win), document);
+    action = actionService();
     target = document.createElement('target');
     target.setAttribute('id', 'amp-test-1');
 
@@ -877,17 +880,10 @@ describe('Action common handler', () => {
 
 
 describes.sandboxed('Action global target', {}, () => {
-  let win;
   let action;
 
   beforeEach(() => {
-    win = {
-      document: {body: {}},
-      services: {
-        vsync: {obj: {}},
-      },
-    };
-    action = new ActionService(new AmpDocSingle(win), document);
+    action = actionService();
   });
 
   it('should register global target', () => {

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -94,6 +94,16 @@ describe('BaseElement', () => {
     }).to.throw(/Method not found/);
   });
 
+  it('`this` context of handler should not be the holder', () => {
+    const handler = () => {
+      const holder = element.actionMap_['foo'];
+      expect(this).to.not.equal(holder);
+    };
+    element.registerAction('foo', handler);
+    const invocation = {method: 'foo', satisfiesTrust: () => true};
+    element.executeAction(invocation, false);
+  });
+
   it('should execute registered action', () => {
     const handler = sandbox.spy();
     element.registerAction('method1', handler);

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -110,6 +110,34 @@ describe('BaseElement', () => {
     expect(handler).to.be.calledOnce;
   });
 
+  it('should check trust before invocation', () => {
+    const handler = sandbox.spy();
+    const minTrust = 123;
+    element.registerAction('foo', handler, minTrust);
+    const activate = sandbox.stub(element, 'activate');
+
+    // Registered action.
+    element.executeAction({method: 'foo', satisfiesTrust: () => false}, false);
+    expect(handler).to.not.be.called;
+    element.executeAction({
+      method: 'foo',
+      satisfiesTrust: t => (t == minTrust),
+    }, false);
+    expect(handler).to.be.calledOnce;
+
+    // Unregistered action (activate).
+    element.executeAction({
+      method: 'activate',
+      satisfiesTrust: () => false,
+    }, false);
+    expect(activate).to.not.be.called;
+    element.executeAction({
+      method: 'activate',
+      satisfiesTrust: t => (t <= element.activationTrust()),
+    }, false);
+    expect(activate).to.be.calledOnce;
+  });
+
   it('should return correct layoutBox', () => {
     const resources = window.services.resources.obj;
     customElement.getResources = () => resources;

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -85,7 +85,7 @@ describe('BaseElement', () => {
   it('should register action', () => {
     const handler = () => {};
     element.registerAction('method1', handler);
-    expect(element.actionMap_['method1']).to.equal(handler);
+    expect(element.actionMap_['method1']).to.not.be.null;
   });
 
   it('should fail execution of unregistered action', () => {
@@ -97,14 +97,16 @@ describe('BaseElement', () => {
   it('should execute registered action', () => {
     const handler = sandbox.spy();
     element.registerAction('method1', handler);
-    element.executeAction({method: 'method1'}, false);
+    const invocation = {method: 'method1', satisfiesTrust: () => true};
+    element.executeAction(invocation, false);
     expect(handler).to.be.calledOnce;
   });
 
   it('should execute "activate" action without registration', () => {
     const handler = sandbox.spy();
     element.activate = handler;
-    element.executeAction({method: 'activate'}, false);
+    const invocation = {method: 'activate', satisfiesTrust: () => true};
+    element.executeAction(invocation, false);
     expect(handler).to.be.calledOnce;
   });
 

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -82,13 +82,15 @@ describes.sandboxed('StandardActions', {}, () => {
   describe('"hide" action', () => {
     it('should handle normal element', () => {
       const element = createElement();
-      standardActions.handleHide({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleHide(invocation);
       expectElementToHaveBeenHidden(element);
     });
 
     it('should handle AmpElement', () => {
       const element = createAmpElement();
-      standardActions.handleHide({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleHide(invocation);
       expectAmpElementToHaveBeenHidden(element);
     });
   });
@@ -97,21 +99,24 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should handle normal element (inline css)', () => {
       const element = createElement();
       element.style.display = 'none';
-      standardActions.handleShow({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleShow(invocation);
       expectElementToHaveBeenShown(element);
     });
 
     it('should handle normal element (hidden attribute)', () => {
       const element = createElement();
       element.setAttribute('hidden', '');
-      standardActions.handleShow({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleShow(invocation);
       expectElementToHaveBeenShown(element);
     });
 
     it('should handle AmpElement (inline css)', () => {
       const element = createAmpElement();
       element.style.display = 'none';
-      standardActions.handleShow({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleShow(invocation);
       expectAmpElementToHaveBeenShown(element);
     });
 
@@ -121,33 +126,38 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should show normal element when hidden (inline css)', () => {
       const element = createElement();
       element.style.display = 'none';
-      standardActions.handleToggle({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleToggle(invocation);
       expectElementToHaveBeenShown(element);
     });
 
     it('should show normal element when hidden (hidden attribute)', () => {
       const element = createElement();
       element.setAttribute('hidden', '');
-      standardActions.handleToggle({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleToggle(invocation);
       expectElementToHaveBeenShown(element);
     });
 
     it('should hide normal element when shown', () => {
       const element = createElement();
-      standardActions.handleToggle({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleToggle(invocation);
       expectElementToHaveBeenHidden(element);
     });
 
     it('should show AmpElement when hidden (inline css)', () => {
       const element = createAmpElement();
       element.style.display = 'none';
-      standardActions.handleToggle({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleToggle(invocation);
       expectAmpElementToHaveBeenShown(element);
     });
 
     it('should hide AmpElement when shown', () => {
       const element = createAmpElement();
-      standardActions.handleToggle({target: element});
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleToggle(invocation);
       expectAmpElementToHaveBeenHidden(element);
     });
   });
@@ -157,7 +167,8 @@ describes.sandboxed('StandardActions', {}, () => {
       installHistoryServiceForDoc(ampdoc);
       const history = historyForDoc(ampdoc);
       const goBackStub = sandbox.stub(history, 'goBack');
-      standardActions.handleAmpTarget({method: 'goBack'});
+      const invocation = {method: 'goBack', satisfiesTrust: () => true};
+      standardActions.handleAmpTarget(invocation);
       expect(goBackStub).to.be.calledOnce;
     });
 
@@ -172,11 +183,13 @@ describes.sandboxed('StandardActions', {}, () => {
       const args = {};
       args[OBJECT_STRING_ARGS_KEY] = '{foo: 123}';
 
-      standardActions.handleAmpTarget({
+      const invocation = {
         method: 'setState',
         args,
         target: ampdoc,
-      });
+        satisfiesTrust: () => true,
+      };
+      standardActions.handleAmpTarget(invocation);
       return bindForDoc(ampdoc).then(() => {
         expect(setStateWithExpressionSpy).to.be.calledOnce;
         expect(setStateWithExpressionSpy).to.be.calledWith('{foo: 123}');


### PR DESCRIPTION
Partial for #9699.

- Add new `ActionTrust` enum in `src/action-trust.js`
- All invocations must provide a trust and each action has a minimum trust
- Before executing an invocation, call new `satisfiesTrust()` method to `ActionInvocation`

This PR has no functional changes since all use `ActionTrust.MEDIUM`. Trust levels for existing actions will be added in a follow-up PR.