### PR TITLE
Percy visual diffing of AMP pages served from localhost and using a locally built runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ matrix:
         - gem install poltergeist
       script:
         - node build-system/pr-check.js
-        - gulp serve
         - ruby build-system/tasks/visual-diff.rb
     - env: BUILD_SHARD="integration_tests"
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
   - sudo dpkg -i google-chrome*.deb
 before_script:
   - pip install --user protobuf
-script: node build-system/pr-check.js
 branches:
   only:
     - master
@@ -41,16 +40,25 @@ env:
 matrix:
   include:
     - env: BUILD_SHARD="pre_build_checks_and_unit_tests"
+      addons:
+        jwt:
+          secure: "Eh3dYL6SrN8DM9sguOMn6wXOc+3maFc/SChm81qZuRQd4p+XIuvQOQszAffsGAk+PPyTgFgulsk2CUVXH1VnW7dMx/KpVFK4spbRDUN+AEXRWAbfqoQf5ehIvm57FP5VQbWlB+PI5DldB1WzYB9Y4r5dXnSHTZCdD/avpbFj0PrBxut6jUnY70IUrhpu64Xf0RWkyyq8IV7246tVGHXBpeApMTTna29HeG0AhK21nxA2fsOovL1tGxwtN+cZqqUVJth1o81M7/N/Oth888WUTctjed5QxVZ3Y/ZiP4IAmUIKu84CuA8anKJP1Vpe62uHFw8wZz4cL8BbgszCIYywL7YavAlyisIkTdFQBdEJdaYWSjlxhrKTEEmcOXSYtZrIxLS2Vu3pyRvN2K3rjlVHGkENEfAmJRJCShCjoX2PPLX2DCobGc6scbN62T38+ECLgQEx2A0m1rhfCqU9BY+yRD67Ai9iaNlSfJg5GF6Ch1P+rXj/Mpu1aJMUWNXX+lgdX0kRGJearVuCsDrJw/HG32EhUhcAQ1CcnAzqMurY4wx/tLKJOeLxjnXPyEgeCiMPz7IVOYHYve2N284MujPdV+sij5MViNUqmu0HNEA66b0+ItTFn5fi2+4DTnJGq9qj2i8n/k8sbl4/S9701FcZzkOYhwo0ewAxz5+wmVsnWFc="
+          secure: "gorlvB2bjdW3i9AxUSoj3MvwllBxEBFI+7w4EpCmSRooHazn6SPNUfuvVuncDW75ZubkP1hHnUfLmmAbmuSLdW0SBEaj41j2mr/itpPLIL2YujGMC9dkEnh0dXykV8s2VL+nt5TY2zy0ebOg1QOY1ohmw0yse88BZSW35sJKFUSVYHhEly1q2DAwCGvWxKARMMTZuyqoJ1+z9ab/9ltpmUZ9NNBKIh/UucBgX9wJtYXJGZUTeMKLfphOdQ2QqswvJnxaz6xIq0zf/Hr1g9UYo5lvscrjgihiarUrEwCN804eRpeobwCkmiOM/YGgXvTtvWlHVGVLfKosqCbcb9Ho1ksz8IWCv6dyRQLzK+OwGvzpPyVBNP4r0QCg2T+WKHATMzFVuR1yxt+2vyZgDYKV5jnrUexL7aEoetXb8yU7GeiQoyRmE0ki3kXbGtMR+ml7jC10Wa57lpaCxZnbQR1Mqqc0Rm3n27OWOmI8KdHL8kkcKACIKicNDDvSUp5Vjry8Wtch1SOLVhc+o7DEIrQxaEpQfIYJjAOpv1HYjGR1hRNTkMw6vRiAbq93o3DYfndlreDAYpqfZ4e4G5ZSUKwdnn0RIsPm49oQJ36qW8UZVem/jnX/trU8sRSSSMTYUTpIZo0j+cm26jl1vpDUfujQWx/0weYASEeSdQ+PyTc/1Vw="
       before_script:
         - gem install percy-capybara
         - gem install phantomjs
         - gem install poltergeist
+      script:
+        - node build-system/pr-check.js
+        - gulp serve &
+        - ruby build-system/tasks/visual-diff.rb
     - env: BUILD_SHARD="integration_tests"
       addons:
         sauce_connect:
           username: "amphtml"
         jwt:
           secure: "Wze0F0vGL0UcxryOx1n/vcuD5LIMGyR+69Nc6IWLoRvZBbbIpFwVFhDE6rE9ranIXiA2Hc684N4sV8ASfNDF8RRSB+jyLov159qwgji2rBxIfQ/4kuDV2vYoAJvYMz8m42kwx5FV2VV9awqMMt8mwU3wYIrKIaVCxB34uV86KIlDlbrHxt17Bm5EIiUmwi9r1AAnW/63vVRUN264D77oB4j9UQ759PfD6BDwEt54O87KurNIaLseNCr1IvzfL8veEsZ3uTbLC1GtgHfR4IGgkS2YyN2QIk06VZWeRDEOalS3RcY0nDkbCmBywxIGObnrpEMzOpjBiOb2fxLoLvvpjlla5W84zJGfWE6q4T9IvkyHuDJE+sft5B+arjMIeA6PIeUhKdV27+6qqDEf7fILZ/U/Ekn9ds4zSV8hekAZPUyyPncOeyWppCIJ8sOeCrsebkRjH1BoX/d+FE+nP0bN/XkBpIi/nManx5FyS/kqjQWGKmvsFQfEWlSUaZi7XtEQEjvBizRkzvpJanSDaoiTDS2Keulmwii3XRId51FuGtnfDZFeggLaMTKGfBX9DlPkccwYAZe6vPNfYk1pNgEj6AtnifEhYVEO+aAuWhEnJ86od+1wDOL/h+a2XY6h8/gFBywsD95p7sXPfdVDCKgwagiBo+Hw5MNjztVF7lszg1A="
+      script: node build-system/pr-check.js
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
         - gem install poltergeist
       script:
         - node build-system/pr-check.js
-        - gulp serve &
+        - gulp serve
         - ruby build-system/tasks/visual-diff.rb
     - env: BUILD_SHARD="integration_tests"
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
-before_script:
-  - pip install --user protobuf
 script: node build-system/pr-check.js
 branches:
   only:
@@ -42,10 +40,13 @@ matrix:
   include:
     - env: BUILD_SHARD="pre_build_checks_and_unit_tests"
       before_script:
+        - pip install --user protobuf
         - gem install percy-capybara
         - gem install phantomjs
         - gem install poltergeist
     - env: BUILD_SHARD="integration_tests"
+      before_script:
+        - pip install --user protobuf
       addons:
         sauce_connect:
           username: "amphtml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
   - sudo dpkg -i google-chrome*.deb
 before_script:
   - pip install --user protobuf
-  - gem install percy-cli
 script: node build-system/pr-check.js
 branches:
   only:
@@ -42,6 +41,10 @@ env:
 matrix:
   include:
     - env: BUILD_SHARD="pre_build_checks_and_unit_tests"
+      before_script:
+        - gem install percy-capybara
+        - gem install phantomjs
+        - gem install poltergeist
     - env: BUILD_SHARD="integration_tests"
       addons:
         sauce_connect:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - sudo dpkg -i google-chrome*.deb
 before_script:
   - pip install --user protobuf
+script: node build-system/pr-check.js
 branches:
   only:
     - master
@@ -40,24 +41,16 @@ env:
 matrix:
   include:
     - env: BUILD_SHARD="pre_build_checks_and_unit_tests"
-      addons:
-        jwt:
-          secure: "Eh3dYL6SrN8DM9sguOMn6wXOc+3maFc/SChm81qZuRQd4p+XIuvQOQszAffsGAk+PPyTgFgulsk2CUVXH1VnW7dMx/KpVFK4spbRDUN+AEXRWAbfqoQf5ehIvm57FP5VQbWlB+PI5DldB1WzYB9Y4r5dXnSHTZCdD/avpbFj0PrBxut6jUnY70IUrhpu64Xf0RWkyyq8IV7246tVGHXBpeApMTTna29HeG0AhK21nxA2fsOovL1tGxwtN+cZqqUVJth1o81M7/N/Oth888WUTctjed5QxVZ3Y/ZiP4IAmUIKu84CuA8anKJP1Vpe62uHFw8wZz4cL8BbgszCIYywL7YavAlyisIkTdFQBdEJdaYWSjlxhrKTEEmcOXSYtZrIxLS2Vu3pyRvN2K3rjlVHGkENEfAmJRJCShCjoX2PPLX2DCobGc6scbN62T38+ECLgQEx2A0m1rhfCqU9BY+yRD67Ai9iaNlSfJg5GF6Ch1P+rXj/Mpu1aJMUWNXX+lgdX0kRGJearVuCsDrJw/HG32EhUhcAQ1CcnAzqMurY4wx/tLKJOeLxjnXPyEgeCiMPz7IVOYHYve2N284MujPdV+sij5MViNUqmu0HNEA66b0+ItTFn5fi2+4DTnJGq9qj2i8n/k8sbl4/S9701FcZzkOYhwo0ewAxz5+wmVsnWFc="
-          secure: "gorlvB2bjdW3i9AxUSoj3MvwllBxEBFI+7w4EpCmSRooHazn6SPNUfuvVuncDW75ZubkP1hHnUfLmmAbmuSLdW0SBEaj41j2mr/itpPLIL2YujGMC9dkEnh0dXykV8s2VL+nt5TY2zy0ebOg1QOY1ohmw0yse88BZSW35sJKFUSVYHhEly1q2DAwCGvWxKARMMTZuyqoJ1+z9ab/9ltpmUZ9NNBKIh/UucBgX9wJtYXJGZUTeMKLfphOdQ2QqswvJnxaz6xIq0zf/Hr1g9UYo5lvscrjgihiarUrEwCN804eRpeobwCkmiOM/YGgXvTtvWlHVGVLfKosqCbcb9Ho1ksz8IWCv6dyRQLzK+OwGvzpPyVBNP4r0QCg2T+WKHATMzFVuR1yxt+2vyZgDYKV5jnrUexL7aEoetXb8yU7GeiQoyRmE0ki3kXbGtMR+ml7jC10Wa57lpaCxZnbQR1Mqqc0Rm3n27OWOmI8KdHL8kkcKACIKicNDDvSUp5Vjry8Wtch1SOLVhc+o7DEIrQxaEpQfIYJjAOpv1HYjGR1hRNTkMw6vRiAbq93o3DYfndlreDAYpqfZ4e4G5ZSUKwdnn0RIsPm49oQJ36qW8UZVem/jnX/trU8sRSSSMTYUTpIZo0j+cm26jl1vpDUfujQWx/0weYASEeSdQ+PyTc/1Vw="
       before_script:
         - gem install percy-capybara
         - gem install phantomjs
         - gem install poltergeist
-      script:
-        - node build-system/pr-check.js
-        - ruby build-system/tasks/visual-diff.rb
     - env: BUILD_SHARD="integration_tests"
       addons:
         sauce_connect:
           username: "amphtml"
         jwt:
           secure: "Wze0F0vGL0UcxryOx1n/vcuD5LIMGyR+69Nc6IWLoRvZBbbIpFwVFhDE6rE9ranIXiA2Hc684N4sV8ASfNDF8RRSB+jyLov159qwgji2rBxIfQ/4kuDV2vYoAJvYMz8m42kwx5FV2VV9awqMMt8mwU3wYIrKIaVCxB34uV86KIlDlbrHxt17Bm5EIiUmwi9r1AAnW/63vVRUN264D77oB4j9UQ759PfD6BDwEt54O87KurNIaLseNCr1IvzfL8veEsZ3uTbLC1GtgHfR4IGgkS2YyN2QIk06VZWeRDEOalS3RcY0nDkbCmBywxIGObnrpEMzOpjBiOb2fxLoLvvpjlla5W84zJGfWE6q4T9IvkyHuDJE+sft5B+arjMIeA6PIeUhKdV27+6qqDEf7fILZ/U/Ekn9ds4zSV8hekAZPUyyPncOeyWppCIJ8sOeCrsebkRjH1BoX/d+FE+nP0bN/XkBpIi/nManx5FyS/kqjQWGKmvsFQfEWlSUaZi7XtEQEjvBizRkzvpJanSDaoiTDS2Keulmwii3XRId51FuGtnfDZFeggLaMTKGfBX9DlPkccwYAZe6vPNfYk1pNgEj6AtnifEhYVEO+aAuWhEnJ86od+1wDOL/h+a2XY6h8/gFBywsD95p7sXPfdVDCKgwagiBo+Hw5MNjztVF7lszg1A="
-      script: node build-system/pr-check.js
 cache:
   yarn: true
   directories:

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -373,12 +373,12 @@ function main(argv) {
       // through the dist/ folder. However, to speed up the Travis queue, we no
       // longer do a dist build for PRs, so this call won't cover dist/.
       // TODO(rsimha-amp): Move this once integration tests are enabled.
-      // command.runPresubmitTests();
-      // command.runJsonAndLintChecks();
-      // command.runDepAndTypeChecks();
+      command.runPresubmitTests();
+      command.runJsonAndLintChecks();
+      command.runDepAndTypeChecks();
       // Skip unit tests if the PR only contains changes to integration tests.
       if (buildTargets.has('RUNTIME')) {
-        // command.runUnitTests();
+        command.runUnitTests();
       }
     }
     if (buildTargets.has('VALIDATOR_WEBUI')) {

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -271,10 +271,8 @@ const command = {
         `${gulp} test --nobuild --saucelabs --integration --compiled`);
   },
   runVisualDiffTests: function() {
-    // This must only be run for push builds, since Travis hides the encrypted
-    // environment variables required by Percy during pull request builds.
-    // For now, this is warning-only.
-    timedExec(`${gulp} visual-diff`);
+    timedExecOrDie(`${gulp} serve`);
+    timedExec(`ruby build-system/tasks/visual-diff.rb`);
   },
   runPresubmitTests: function() {
     timedExecOrDie(`${gulp} presubmit`);
@@ -295,6 +293,7 @@ function runAllCommands() {
     command.buildRuntime();
     command.runJsonAndLintChecks();
     command.runDepAndTypeChecks();
+    command.runVisualDiffTests();
     command.runUnitTests();
     // command.testDocumentLinks() is skipped during push builds.
     command.buildValidatorWebUI();
@@ -304,7 +303,6 @@ function runAllCommands() {
     command.cleanBuild();
     command.buildRuntimeMinified();
     command.runPresubmitTests();  // Needs runtime to be built and served.
-    // command.runVisualDiffTests();  // Only called during push builds.
     command.runIntegrationTests();
   }
 }
@@ -385,6 +383,7 @@ function main(argv) {
       command.runDepAndTypeChecks();
       // Skip unit tests if the PR only contains changes to integration tests.
       if (buildTargets.has('RUNTIME')) {
+        command.runVisualDiffTests();
         command.runUnitTests();
       }
     }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -377,6 +377,7 @@ function main(argv) {
     if (buildTargets.has('RUNTIME') || buildTargets.has('INTEGRATION_TEST')) {
       command.cleanBuild();
       command.buildRuntime();
+      command.runVisualDiffTests();  // Temporary for testing.
       // Ideally, we'd run presubmit tests after `gulp dist`, as some checks run
       // through the dist/ folder. However, to speed up the Travis queue, we no
       // longer do a dist build for PRs, so this call won't cover dist/.

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -26,11 +26,12 @@
  */
 const exec = require('./exec.js').exec;
 const execOrDie = require('./exec.js').execOrDie;
+const extensionsVersions = require('./extensions-versions-config');
 const getStdout = require('./exec.js').getStdout;
 const path = require('path');
 const minimist = require('minimist');
+const resolve = require('path').resolve;
 const util = require('gulp-util');
-const extensionsVersions = require('./extensions-versions-config');
 
 const gulp = 'node_modules/gulp/bin/gulp.js';
 const fileLogPrefix = util.colors.yellow.bold('pr-check.js:');
@@ -270,6 +271,12 @@ const command = {
     timedExecOrDie(
         `${gulp} test --nobuild --saucelabs --integration --compiled`);
   },
+  runVisualDiffTests: function() {
+    // This must only be run for push builds, since Travis hides the encrypted
+    // environment variables required by Percy during pull request builds.
+    // For now, this is warning-only.
+    timedExec(`ruby ${resolve('tasks/visual-diff.rb')}`);
+  },
   runPresubmitTests: function() {
     timedExecOrDie(`${gulp} presubmit`);
   },
@@ -287,6 +294,7 @@ function runAllCommands() {
     command.testBuildSystem();
     command.cleanBuild();
     command.buildRuntime();
+    command.runVisualDiffTests();  // Only called during push builds.
     command.runJsonAndLintChecks();
     command.runDepAndTypeChecks();
     command.runUnitTests();

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -30,7 +30,6 @@ const extensionsVersions = require('./extensions-versions-config');
 const getStdout = require('./exec.js').getStdout;
 const minimist = require('minimist');
 const path = require('path');
-const resolve = require('path').resolve;
 const util = require('gulp-util');
 
 const gulp = 'node_modules/gulp/bin/gulp.js';
@@ -275,7 +274,7 @@ const command = {
     // This must only be run for push builds, since Travis hides the encrypted
     // environment variables required by Percy during pull request builds.
     // For now, this is warning-only.
-    timedExec(`ruby ${resolve('build-system/tasks/visual-diff.rb')}`);
+    timedExec(`ruby ${path.resolve('build-system/tasks/visual-diff.rb')}`);
   },
   runPresubmitTests: function() {
     timedExecOrDie(`${gulp} presubmit`);

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -275,7 +275,7 @@ const command = {
     // This must only be run for push builds, since Travis hides the encrypted
     // environment variables required by Percy during pull request builds.
     // For now, this is warning-only.
-    timedExec(`ruby ${resolve('tasks/visual-diff.rb')}`);
+    timedExec(`ruby ${resolve('build-system/tasks/visual-diff.rb')}`);
   },
   runPresubmitTests: function() {
     timedExecOrDie(`${gulp} presubmit`);

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -373,12 +373,12 @@ function main(argv) {
       // through the dist/ folder. However, to speed up the Travis queue, we no
       // longer do a dist build for PRs, so this call won't cover dist/.
       // TODO(rsimha-amp): Move this once integration tests are enabled.
-      command.runPresubmitTests();
-      command.runJsonAndLintChecks();
-      command.runDepAndTypeChecks();
+      // command.runPresubmitTests();
+      // command.runJsonAndLintChecks();
+      // command.runDepAndTypeChecks();
       // Skip unit tests if the PR only contains changes to integration tests.
       if (buildTargets.has('RUNTIME')) {
-        command.runUnitTests();
+        // command.runUnitTests();
       }
     }
     if (buildTargets.has('VALIDATOR_WEBUI')) {

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -270,10 +270,6 @@ const command = {
     timedExecOrDie(
         `${gulp} test --nobuild --saucelabs --integration --compiled`);
   },
-  runVisualDiffTests: function() {
-    timedExecOrDie(`${gulp} serve`);
-    timedExec(`ruby build-system/tasks/visual-diff.rb`);
-  },
   runPresubmitTests: function() {
     timedExecOrDie(`${gulp} presubmit`);
   },
@@ -293,7 +289,6 @@ function runAllCommands() {
     command.buildRuntime();
     command.runJsonAndLintChecks();
     command.runDepAndTypeChecks();
-    command.runVisualDiffTests();
     command.runUnitTests();
     // command.testDocumentLinks() is skipped during push builds.
     command.buildValidatorWebUI();
@@ -383,7 +378,6 @@ function main(argv) {
       command.runDepAndTypeChecks();
       // Skip unit tests if the PR only contains changes to integration tests.
       if (buildTargets.has('RUNTIME')) {
-        command.runVisualDiffTests();
         command.runUnitTests();
       }
     }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -28,8 +28,8 @@ const exec = require('./exec.js').exec;
 const execOrDie = require('./exec.js').execOrDie;
 const extensionsVersions = require('./extensions-versions-config');
 const getStdout = require('./exec.js').getStdout;
-const path = require('path');
 const minimist = require('minimist');
+const path = require('path');
 const resolve = require('path').resolve;
 const util = require('gulp-util');
 
@@ -377,7 +377,6 @@ function main(argv) {
     if (buildTargets.has('RUNTIME') || buildTargets.has('INTEGRATION_TEST')) {
       command.cleanBuild();
       command.buildRuntime();
-      command.runVisualDiffTests();  // Temporary for testing.
       // Ideally, we'd run presubmit tests after `gulp dist`, as some checks run
       // through the dist/ folder. However, to speed up the Travis queue, we no
       // longer do a dist build for PRs, so this call won't cover dist/.

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -48,8 +48,11 @@ function serve() {
       'SERVE_PORT': port,
       'SERVE_HOST': host,
       'SERVE_USEHTTPS': useHttps},
+  })
+  .once('exit', function () {
+    util.log(util.colors.green('Shutting down server'));
+    process.exit();
   });
-
   util.log(util.colors.yellow('Run `gulp build` then go to '
       + getHost() + '/examples/article.amp.html'
   ));

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/ruby
+#
+# Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Visual diff generator for AMP webpages using Percy.
+
+
+require 'percy/capybara/anywhere'
+require 'capybara/poltergeist'
+require 'phantomjs'
+require 'json'
+
+
+ENV['PERCY_DEBUG'] = '1'  # Enable debugging output.
+DEFAULT_WIDTHS = [375, 411]  # CSS widths: iPhone: 375, Pixel: 411.
+
+
+def loadConfigJson()
+  jsonFile = File.open(
+    File.join(
+      File.dirname(__FILE__),
+      '../../test/visual-diff/visual-tests.json'),
+    "r")
+  jsonContent = jsonFile.read
+end
+
+
+def generateSnapshot(server, assets_dir, assets_base_url, url, name)
+  Percy::Capybara::Anywhere.run(
+      server, assets_dir, assets_base_url) do |page|
+    page.driver.options[:phantomjs] = Phantomjs.path
+    page.driver.options[:js_errors] = false
+    page.visit(url)
+    Percy.config.default_widths = DEFAULT_WIDTHS
+    Percy::Capybara.snapshot(page, name: name)
+ end
+end
+
+
+def main()
+  configJson = loadConfigJson()
+  config = JSON.parse(configJson)
+  server = config["server"]
+  webpages = config["webpages"]
+  webpages.each do |webpage|
+    assets_base_url = webpage["assets_base_url"]
+    assets_dir = File.expand_path(
+        '../../../' + webpage["assets_dir"],
+        __FILE__)
+    url = webpage["url"]
+    name = webpage["name"]
+    generateSnapshot(server, assets_dir, assets_base_url, url, name)
+  end
+end
+
+
+main

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -31,8 +31,8 @@ HOST = 'localhost'
 PORT = '8000'
 
 
-def up?(server, port)
-  http = Net::HTTP.start(server, port, {open_timeout: 5, read_timeout: 5})
+def up(server, port)
+  http = Net::HTTP.start(server, port)
   response = http.head("/")
   response.code == "200"
 rescue SystemCallError
@@ -43,11 +43,10 @@ end
 def launchWebServer()
   webserverCmd = 'gulp serve --host ' + HOST + ' --port ' + PORT
   webserverUrl = 'http://' + HOST + ':' + PORT
-  puts 'Starting webserver at ' + webserverUrl + '...'
   webserver = fork do
     exec webserverCmd
   end
-  until up?(HOST, PORT)
+  until up(HOST, PORT)
     sleep(1)
   end
 end
@@ -64,7 +63,6 @@ end
 
 
 def generateSnapshot(server, assets_dir, assets_base_url, url, name)
-  puts 'Generating snapshot...'
   Percy::Capybara::Anywhere.run(
       server, assets_dir, assets_base_url) do |page|
     page.driver.options[:phantomjs] = Phantomjs.path

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -47,6 +47,19 @@ def launchWebServer()
 end
 
 
+# Checks if a webserver is up and running.
+#
+# Returns:
+# - true if the server returns an OK (200) response code.
+def isWebServerRunning()
+  http = Net::HTTP.start(HOST, PORT)
+  response = http.head("/")
+  response.code == "200"
+rescue SystemCallError
+  false
+end
+
+
 # Waits up to 10 seconds for the webserver to start up.
 #
 # Returns:
@@ -62,20 +75,10 @@ def waitForWebServer()
 end
 
 
-# Checks if a webserver is up and running.
-#
-# Returns:
-# - true if the server returns an OK (200) response code.
-def isWebServerRunning()
-  http = Net::HTTP.start(HOST, PORT)
-  response = http.head("/")
-  response.code == "200"
-rescue SystemCallError
-  false
-end
-
-
 # Closes the webserver process with the given process ID.
+#
+# Args:
+# - pid: Process ID of the webserver.
 def closeWebServer(pid)
   Process.kill('INT', pid)
   Process.wait(pid, Process::WNOHANG)

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -30,24 +30,11 @@ DEFAULT_WIDTHS = [375, 411]  # CSS widths: iPhone: 375, Pixel: 411.
 HOST = 'localhost'
 PORT = '8000'
 
-# Checks if a webserver is up and running.
-#
+
+# Launches a background AMP webserver for unminified js using gulp.
 #
 # Returns:
-# - true if the server returns an OK (200) response code
-def up
-  http = Net::HTTP.start(HOST, PORT)
-  response = http.head("/")
-  response.code == "200"
-rescue SystemCallError
-  false
-end
-
-
-# Launches a background AMP webserver for unminified js using gulp
-#
-# Returns:
-# - Process ID of server process
+# - Process ID of server process.
 def launchWebServer()
   webserverCmd = 'gulp serve --host ' + HOST + ' --port ' + PORT
   webserverUrl = 'http://' + HOST + ':' + PORT
@@ -63,15 +50,28 @@ end
 # Waits up to 10 seconds for the webserver to start up.
 #
 # Returns:
-# - Process ID of server process
+# - true if webserver is running.
 def waitForWebServer()
   tries = 0
-  until up()
+  until isWebServerRunning()
     sleep(1)
     tries += 1
     break if tries > 10
   end
-  up()
+  isWebServerRunning()
+end
+
+
+# Checks if a webserver is up and running.
+#
+# Returns:
+# - true if the server returns an OK (200) response code.
+def isWebServerRunning()
+  http = Net::HTTP.start(HOST, PORT)
+  response = http.head("/")
+  response.code == "200"
+rescue SystemCallError
+  false
 end
 
 
@@ -85,10 +85,10 @@ end
 # Loads the test config from a well-known json config file.
 def loadConfigJson()
   jsonFile = File.open(
-    File.join(
-      File.dirname(__FILE__),
-      '../../test/visual-diff/visual-tests.json'),
-    "r")
+      File.join(
+          File.dirname(__FILE__),
+          '../../test/visual-diff/visual-tests.json'),
+      "r")
   jsonContent = jsonFile.read
 end
 
@@ -97,10 +97,10 @@ end
 #
 # Args:
 # - server: URL of the webserver.
-# - assets_dir: Path to assets (images, etc.) used by the webpage
-# - assets_base_url: Base URL of assets on webserver
-# - url: Relative URL of page to be snapshotted
-# - name: Name of snapshot on Percy
+# - assets_dir: Path to assets (images, etc.) used by the webpage.
+# - assets_base_url: Base URL of assets on webserver.
+# - url: Relative URL of page to be snapshotted.
+# - name: Name of snapshot on Percy.
 def generateSnapshot(server, assets_dir, assets_base_url, url, name)
   Percy::Capybara::Anywhere.run(
       server, assets_dir, assets_base_url) do |page|

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -141,4 +141,6 @@ def main()
 end
 
 
-main
+if __FILE__ == $0
+  main()
+end

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -1,4 +1,12 @@
 {
   "_comment": "HTML file(s) used for visual diff tests. Paths relative to src.",
-  "webpage": "examples/amp-by-example.html"
+  "server": "http://localhost:8000",
+  "webpages": [
+    {
+      "assets_dir": "examples/amp-by-example",
+      "assets_base_url": "/",
+      "url": "examples/amp-by-example/amp-by-example.html",
+      "name": "Amp By Example"
+    }
+  ]
 }

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -1,6 +1,5 @@
 {
   "_comment": "HTML file(s) used for visual diff tests. Paths relative to src.",
-  "server": "http://localhost:8000",
   "webpages": [
     {
       "assets_dir": "examples/amp-by-example",


### PR DESCRIPTION
This PR adds a ruby script that starts up a local server for the AMP runtime, loads a test page from it, and grabs a snapshot via Percy. This will run on master, like before.

Visual diffing for PRs depends on making encrypted Percy tokens available on for PRs on Travis, and will come up in a separate PR.

#9469
Fixes #9928