### PR TITLE
Move Design Review info to its own document & other improvements to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,10 @@ The AMP HTML project strongly encourages technical [contributions](https://www.a
 
 We hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about.
 
-- [Filing issues](#filing-issues)
+- [Reporting issues with AMP](#reporting-issues-with-amp)
   * [Bugs](#bugs)
-  * [Suggestions](#suggestions)
+  * [Questions about AMP](#questions-about-amp)
+  * [Suggestions and feature requests](#suggestions-and-feature-requests)
 - [Contributing code](#contributing-code)
   * [Tips for new open source contributors](#tips-for-new-open-source-contributors)
   * [How to contribute code](#how-to-contribute-code)
@@ -19,19 +20,21 @@ We hope you'll become an ongoing participant in our open source community but we
   * [Weekly design reviews](#weekly-design-reviews)
   * [See Also](#see-also)
 
-## Filing issues
+## Reporting issues with AMP
 
 ### Bugs
 
-If you find a bug in AMP, please [file an issue](https://github.com/ampproject/amphtml/issues/new).  Members of the community are regularly monitoring issues and will try to fix open bugs quickly.
+If you find a bug in AMP, please [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new).  Members of the community are regularly monitoring issues and will try to fix open bugs quickly according to our [prioritization guidelines](https://github.com/ampproject/amphtml/blob/master/contributing/issue-priorities.md).
 
 The best bug reports provide a detailed description of the issue (including screenshots if possible), step-by-step instructions for predictably reproducing the issue, and possibly even a working example that demonstrates the issue.
 
-If you want to learn more about our issues priorities and implementation guidelines check out [this document](https://github.com/ampproject/amphtml/blob/master/contributing/issue-priorities.md).
+### Questions about AMP
 
-Please note that questions about how to use AMP or other general questions about AMP should be asked on [Stack Overflow under the AMP HTML tag](http://stackoverflow.com/questions/tagged/amp-html) instead of filing an issue here.  Questions/issues related to Google Search should be asked on [Google's AMP forum](https://goo.gl/utQ1KZ).
+Questions about how to use AMP or other general questions about AMP should be asked on [Stack Overflow under the AMP HTML tag](http://stackoverflow.com/questions/tagged/amp-html) instead of filing an issue here.
 
-### Suggestions
+Questions and issues related to Google Search should be asked on [Google's AMP forum](https://goo.gl/utQ1KZ).
+
+### Suggestions and feature requests
 
 The AMP Project is meant to evolve with feedback.  The project and its users appreciate your thoughts on ways to improve the design or features.
 
@@ -105,42 +108,21 @@ We actively encourage ongoing participation by community members.
 
 ### Discussion channels
 
-Technical issues, designs, etc. are discussed on [GitHub issues](https://github.com/ampproject/amphtml/issues) and [pull requests](https://github.com/ampproject/amphtml/pulls),
- the [amphtml-discuss Google Group](https://groups.google.com/forum/#!forum/amphtml-discuss) and the [amphtml Slack](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877).
+Technical issues, designs, etc. are discussed using several different channels:
+
+- [GitHub issues](https://github.com/ampproject/amphtml/issues) and [pull requests](https://github.com/ampproject/amphtml/pulls)
+- [Slack](https://amphtml.slack.com) ([signup](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877))
+- the [amphtml-discuss Google Group](https://groups.google.com/forum/#!forum/amphtml-discuss)
 
 ### Weekly status updates
 
-GitHub issues labeled [Type: Weekly Status](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Weekly+Status%22) are used to track weekly updates from members of the community.  We encourage everyone who is actively contributing to AMP to add a comment to the relevant Weekly Status issue.
+Weekly updates from members of the community are tracked using [Weekly Status GitHub issues](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Weekly+Status%22).
+
+We encourage everyone who is actively contributing to AMP to add a comment to the relevant Weekly Status issue.
 
 ### Weekly design reviews
 
-The community holds weekly design reviews as video conferences via Google Hangouts on Wednesdays at [1pm Pacific](https://www.google.com/?#q=1pm+pacific+in+local+time).  If you have a design you would like to present but can never make this time (e.g. you are in a different time zone) please reach out on [Slack](https://amphtml.slack.com/messages/design-review/) ([sign up](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877)) and we will try to find a time that works for you.
-
-We use GitHub issues labeled [Type: Design Review](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Design+Review%22) to track design reviews.  The Design Review issue for a given week will have a link to the design docs being discussed that week as well as a link to the Hangout.  **When attending a design review please read through the design docs _before_ the review starts.**
-
-If the design for an issue/feature you are working on has a scope larger than you can cover in a discussion in the GitHub issue or one of the other discussion channels, consider bringing it to a design review:
-
-* Create a software design document in a shared Google Document open to public comments.
-  * A short design doc is fine as long as it covers your design in sufficient detail to allow for a review by other members of the community.
-  * Take a look at [Design docs - A design doc](https://medium.com/@cramforce/design-docs-a-design-doc-a152f4484c6b) for tips on putting together a good design doc.  [Phone call tracking in AMP](https://docs.google.com/document/d/1UDMYv0f2R9CvMUSBQhxjtkSnC4984t9dJeqwm_8WiAM/edit) and [New AMP Boilerplate](https://docs.google.com/document/d/1gZFaKvcDffceJNaI3bYfuYPtYU5u2y6UhE5wBPTsJ9w/edit) are examples of past AMP Project design docs.
-  * Add this license text to the top of your design doc before sharing it with anyone else in the community (updating the year if necessary):
-      ```
-      Copyright 2017 The AMP HTML Authors. All Rights Reserved.
-
-      Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-      See the License for the specific language governing permissions and limitations under the License.
-      ```
-
-* Perform a design pre-review with at least one [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md); you can request a pre-review in the [#design-review Slack channel](https://amphtml.slack.com/messages/design-review/).  It is fine to request a pre-review before your design doc is complete.
-
-* When your design is ready to be discussed at a design review add a comment on the appropriate Design Review GitHub issue.  Post a link to the design doc and a brief summary by **1pm Pacific Monday** on the week of your design review.
-
-* Update your design based on the feedback in the design review and any followup conversations in other channels.  Once your design is finalized, please provide a brief update at the start of a future design review (if you are able to attend) and submit a PDF version of your design doc in the [ampproject design-doc](https://github.com/ampproject/design-docs) repository.
+The community holds weekly engineering [design reviews](./contributing/design-reviews.md) via video conference.  We encourage everyone in the community to participate in these discussions and to bring their designs for new features and significant bug fixes to these reviews.
 
 ### See Also
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Questions and issues related to Google Search should be asked on [Google's AMP f
 
 The AMP Project is meant to evolve with feedback.  The project and its users appreciate your thoughts on ways to improve the design or features.
 
-To make a suggestion [file an issue](https://github.com/ampproject/amphtml/issues/new).
+To make a suggestion or feature request [file a GitHub issue](https://github.com/ampproject/amphtml/issues/new) describing your idea.
 
 If you are suggesting a feature that you are intending to implement, please see the [Contributing features](#contributing-features) section below for next steps.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can learn more at [ampproject.org](https://www.ampproject.org/) including [w
 
 ## We'd ❤️️ your help making AMP better!
 
-There are a lot of ways you can [contribute](CONTRIBUTING.md) to making AMP better! You can [report bugs and feature requests](CONTRIBUTING.md#filing-issues) or ideally become an [ongoing participant](CONTRIBUTING.md#ongoing-participation) in the AMP Project community and [contribute code to the open source project](CONTRIBUTING.md#contributing-code).
+There are a lot of ways you can [contribute](CONTRIBUTING.md) to making AMP better! You can [report bugs and feature requests](CONTRIBUTING.md#reporting-issues-with-amp) or ideally become an [ongoing participant](CONTRIBUTING.md#ongoing-participation) in the AMP Project community and [contribute code to the open source project](CONTRIBUTING.md#contributing-code).
 
 We enthusiastically welcome new contributors to the AMP Project **_even if you have no experience being part of an open source project_**.  We've got some [tips for new contributors](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#tips-for-new-open-source-contributors) and guides to getting started (both a [detailed version](contributing/getting-started-e2e.md) and a [TL;DR](contributing/getting-started-quick.md)).
 

--- a/contributing/design-reviews.md
+++ b/contributing/design-reviews.md
@@ -5,9 +5,9 @@ The AMP Project community holds weekly design reviews via [video conference](htt
 * [Upcoming design reviews](https://github.com/ampproject/amphtml/labels/Type%3A%20Design%20Review)
 * [Past design reviews](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Design+Review%22+is%3Aclosed)
 
-The Design Review GitHub issue for a given week will have links to the designs being discussed that week as well as a link to the Hangout.  **When attending a design review please read through the designs _before_ the review starts.**
+The GitHub issue for a given week's design review will have links to the designs being discussed that week.  When the design review is over the GitHub issue will include notes from the design review discussion.
 
-Notes from the design review discussion will be posted in the Design Review GitHub issue shortly after the design review has finished.
+**When attending a design review please read through the designs _before_ the review starts.**
 
 ## Bringing your design to a design review
 

--- a/contributing/design-reviews.md
+++ b/contributing/design-reviews.md
@@ -1,6 +1,6 @@
 # Design Reviews
 
-The AMP Project community holds weekly design reviews as video conferences via Google Hangouts on Wednesdays at [1pm Pacific](https://www.google.com/?#q=1pm+pacific+in+local+time).
+The AMP Project community holds weekly design reviews via [video conference](https://hangouts.google.com/hangouts/_/google.com/amp-eng-desrev) on Wednesdays at [1pm Pacific](https://www.google.com/?#q=1pm+pacific+in+local+time).
 
 * [Upcoming design reviews](https://github.com/ampproject/amphtml/labels/Type%3A%20Design%20Review)
 * [Past design reviews](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Design+Review%22+is%3Aclosed)

--- a/contributing/design-reviews.md
+++ b/contributing/design-reviews.md
@@ -1,0 +1,44 @@
+# Design Reviews
+
+The AMP Project community holds weekly design reviews as video conferences via Google Hangouts on Wednesdays at [1pm Pacific](https://www.google.com/?#q=1pm+pacific+in+local+time).
+
+* [Upcoming design reviews](https://github.com/ampproject/amphtml/labels/Type%3A%20Design%20Review)
+* [Past design reviews](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Design+Review%22+is%3Aclosed)
+
+The Design Review issue for a given week will have links to the designs being discussed that week as well as a link to the Hangout.  **When attending a design review please read through the designs _before_ the review starts.**
+
+For those who cannot attend the design reviews we will generally include notes from the discussion in the design review issue.
+
+## Bringing your design to a design review
+
+If the design for an issue/feature you are working on has a scope larger than you can cover in a discussion in the GitHub issue or one of the other discussion channels, consider bringing it to a design review.
+
+Note that the design review is optional and is not required for every new feature.
+
+* Create a software design document in a shared Google Document open to public comments.
+  * A short design doc is fine as long as it covers your design in sufficient detail to allow for a review by other members of the community.
+  * Take a look at [Design docs - A design doc](https://medium.com/@cramforce/design-docs-a-design-doc-a152f4484c6b) for tips on putting together a good design doc.  [Phone call tracking in AMP](https://docs.google.com/document/d/1UDMYv0f2R9CvMUSBQhxjtkSnC4984t9dJeqwm_8WiAM/edit) and [New AMP Boilerplate](https://docs.google.com/document/d/1gZFaKvcDffceJNaI3bYfuYPtYU5u2y6UhE5wBPTsJ9w/edit) are examples of past AMP Project design docs.
+  * Add this license text to the top of your design doc before sharing it with anyone else in the community (updating the year if necessary):
+      ```
+      Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+      Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+      See the License for the specific language governing permissions and limitations under the License.
+      ```
+
+* Perform a design pre-review with at least one [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md); you can request a pre-review in the [#design-review Slack channel](https://amphtml.slack.com/messages/design-review/) ([sign up](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877)).  It is fine to request a pre-review before your design doc is complete.
+
+* When your design is ready to be discussed at a design review add a comment on the appropriate Design Review GitHub issue.  Post a link to the design doc and a brief summary by **1pm Pacific Monday** on the week of your design review.
+
+* Update your design based on the feedback in the design review and any followup conversations in other channels.  Once your design is finalized, please provide a brief update at the start of a future design review (if you are able to attend) and submit a PDF version of your design doc in the [ampproject design-doc](https://github.com/ampproject/design-docs) repository.
+
+Although design documents are strongly encouraged, for some smaller features a well-documented design in its own GitHub issue may be sufficient for a design review.
+
+## Flexible design review time
+
+If you have a design you would like to present but can never make the 1pm Pacific design review (e.g. you are in a different time zone) please reach out in an upcoming design review issue or on [Slack](https://amphtml.slack.com/messages/design-review/) ([sign up](https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877)) and we will try to find a time that works for you.

--- a/contributing/design-reviews.md
+++ b/contributing/design-reviews.md
@@ -5,15 +5,17 @@ The AMP Project community holds weekly design reviews as video conferences via G
 * [Upcoming design reviews](https://github.com/ampproject/amphtml/labels/Type%3A%20Design%20Review)
 * [Past design reviews](https://github.com/ampproject/amphtml/issues?q=label%3A%22Type%3A+Design+Review%22+is%3Aclosed)
 
-The Design Review issue for a given week will have links to the designs being discussed that week as well as a link to the Hangout.  **When attending a design review please read through the designs _before_ the review starts.**
+The Design Review GitHub issue for a given week will have links to the designs being discussed that week as well as a link to the Hangout.  **When attending a design review please read through the designs _before_ the review starts.**
 
-For those who cannot attend the design reviews we will generally include notes from the discussion in the design review issue.
+Notes from the design review discussion will be posted in the Design Review GitHub issue shortly after the design review has finished.
 
 ## Bringing your design to a design review
 
 If the design for an issue/feature you are working on has a scope larger than you can cover in a discussion in the GitHub issue or one of the other discussion channels, consider bringing it to a design review.
 
-Note that the design review is optional and is not required for every new feature.
+Note that the design review is optional and is not required for every new feature or bug fix.
+
+The process for bringing a design to the design review is as follows:
 
 * Create a software design document in a shared Google Document open to public comments.
   * A short design doc is fine as long as it covers your design in sufficient detail to allow for a review by other members of the community.


### PR DESCRIPTION
This PR pulls the info about the weekly design review into its own doc so that it is easier to find/share.
I also made a few other minor improvements to CONTRIBUTING since I was making changes.

I also filed Issue #9845 to track some further improvements to CONTRIBUTING.

/cc @adewale