### PR TITLE
Added extra validation rules for RDFa rel and rev attributes

### DIFF
--- a/validator/testdata/feature_tests/rdfa.html
+++ b/validator/testdata/feature_tests/rdfa.html
@@ -18,7 +18,7 @@
   Test Description:
   Tests that we allow the global RDFa attributes (as used in schema.org).
 -->
-<html ⚡ prefix="dc:	http://purl.org/dc/terms/ schema: http://schema.org/">
+<html ⚡ prefix="dc: http://purl.org/dc/terms/ schema: http://schema.org/">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/validator/testdata/feature_tests/rdfa.html
+++ b/validator/testdata/feature_tests/rdfa.html
@@ -18,21 +18,79 @@
   Test Description:
   Tests that we allow the global RDFa attributes (as used in schema.org).
 -->
-<html ⚡ prefix="schema: http://schema.org/">
+<html ⚡ prefix="dc:	http://purl.org/dc/terms/ schema: http://schema.org/">
 <head>
   <meta charset="utf-8">
-  <link rel="canonical" href="./regular-html-version.html" />
-  <meta name="viewport" content="width=device-width,minimum-scale=1">
-  <meta property="schema:name" content="A Test Name">
-  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="canonical" href="./regular-html-version.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1" />
+  <meta property="dc:title" content="RDFa Example Page" />
+  <meta property="dc:creator" content="AMP HTML Authors" />
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
 <body>
-  <span typeof="schema:Person" resource="https://en.wikipedia.org/wiki/Buffy_Summers">
-    <span property="schema:givenName">Buffy</span>
-    <span property="schema:familyName">Summers</span>
-    <link property="schema:url" href="https://example.org/">
-    <meta property="schema:alternateName" content="The Vampire Slayer">
-  </span>
+
+  <div typeof="schema:TVSeries" about="Buffy-the-Vampire-Slayer">
+    <h1 property="schema:name">Buffy the Vampire Slayer</h1>
+    <ul>
+      <li><a property="schema:url" href="https://en.wikipedia.org/wiki/Buffy_the_Vampire_Slayer">Wikipedia Page</a></li>
+      <li>Start Date: <span property="schema:startDate" content="1997-03-10">March 10, 1997</span></li>
+      <li>End Date: <span property="schema:endDate" content="2003-05-20">May 20, 2003</span></li>
+      <li>Seasons: <span property="schema:numberOfSeasons">7</span></li>
+    </ul>
+
+
+    <h2>Cast</h2>
+    <ul>
+      <li rel="schema:actor" typeof="schema:PerformanceRole">
+        <span rel="schema:actor" resource="https://en.wikipedia.org/wiki/Nicholas_Brendon">Nicholas Brendon</span>
+        as <span property="schema:characterName">Xander Harris</span>
+      </li>
+      <li rel="schema:actor" typeof="schema:PerformanceRole">
+        <span rel="schema:actor" resource="https://en.wikipedia.org/wiki/Sarah_Michelle_Gellar">Sarah Michelle Gellar</span>
+        as <span property="schema:characterName">Buffy Summers</span>
+      </li>
+    </ul>
+  </div>
+
+
+  <h2>Actors</h2>
+  <div typeof="schema:Person" about="https://en.wikipedia.org/wiki/Sarah_Michelle_Gellar">
+    <span property="schema:givenName">Sarah Michelle</span>
+    <span property="schema:familyName">Gellar</span>
+    <link property="schema:url" href="https://en.wikipedia.org/wiki/Sarah_Michelle_Gellar" />
+    <meta property="schema:alternateName" content="Sarah Michelle Prinze" />
+    <meta rev="schema:creator" resource="https://example.org/Gellar.jpg" />
+  </div>
+  <div typeof="schema:Person" about="https://en.wikipedia.org/wiki/Nicholas_Brendon">
+    <span property="schema:givenName">Nicholas</span>
+    <span property="schema:familyName">Brendon</span>
+    <link property="schema:url" href="https://en.wikipedia.org/wiki/Nicholas_Brendon" />
+    <meta property="schema:alternateName" content="Nicholas Brendon Schultz" />
+    <meta rev="schema:creator" resource="https://example.org/Brendon.jpg" />
+  </div>
+
+
+  <h2>Photos</h2>
+  <div
+      typeof="schema:ImageObject" about="https://example.org/Gellar.jpg"
+      rev="schema:image" resource="https://en.wikipedia.org/wiki/Sarah_Michelle_Gellar">
+    <amp-img
+        src="https://example.org/Gellar.jpg"
+        property="schema:contentUrl"
+        alt="Self Portrait by Sarah" layout="fixed" height="320" width="200"></amp-img>
+    <span property="schema:name">Self Portrait</span> by
+  </div>
+
+  <div
+      typeof="schema:ImageObject" about="https://example.org/Brendon.jpg"
+      rev="schema:image" resource="https://en.wikipedia.org/wiki/Nicholas_Brendon">
+    <amp-img
+        src="https://example.org/Brendon.jpg"
+        property="schema:contentUrl"
+        alt="Self Portrait by Nicholas" layout="fixed" height="320" width="200"></amp-img>
+    <span property="schema:name">Self Portrait</span> by
+  </div>
+
 </body>
 </html>

--- a/validator/testdata/feature_tests/rdfa.html
+++ b/validator/testdata/feature_tests/rdfa.html
@@ -79,7 +79,7 @@
         src="https://example.org/Gellar.jpg"
         property="schema:contentUrl"
         alt="Self Portrait by Sarah" layout="fixed" height="320" width="200"></amp-img>
-    <span property="schema:name">Self Portrait</span> by
+    <span property="schema:name">Self Portrait</span>
   </div>
 
   <div
@@ -89,7 +89,7 @@
         src="https://example.org/Brendon.jpg"
         property="schema:contentUrl"
         alt="Self Portrait by Nicholas" layout="fixed" height="320" width="200"></amp-img>
-    <span property="schema:name">Self Portrait</span> by
+    <span property="schema:name">Self Portrait</span>
   </div>
 
 </body>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3319,6 +3319,23 @@ attr_lists: {
   attrs: { name: "inlist" }
   attrs: { name: "prefix" }
   attrs: { name: "property" }
+  attrs: {
+    name: "rel"
+    blacklisted_value_regex: "(^|\\s)("  # Values are space separated
+        "canonical|"
+        "components|"
+        "dns-prefetch|"
+        "import|"
+        "manifest|"
+        "preconnect|"
+        "preload|"
+        "prerender|"
+        "serviceworker|"
+        "stylesheet|"
+        "subresource"
+        ")(\\s|$)"
+  }
+  attrs: { name: "rev" }
   attrs: { name: "resource" }
   attrs: { name: "typeof" }
   attrs: { name: "vocab" }


### PR DESCRIPTION
RDFa support is not complete, this PR solves this issue.

Updated validator to:
- allow `rev` attribute on any HTML tag, with any value.
- allow `rel` attribute on any HTML tag, with a black list:

You can check the test markup in Google Strucutured Data Testing Tool and the AMP Validator and it will pass.

Fixes #9091

cc @Gregable, @jaygray0919