### PR TITLE
Updated hashbang for python scripts.

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 #
 # Copyright 2015 The AMP HTML Authors. All Rights Reserved.
 #

--- a/validator/webui/build.py
+++ b/validator/webui/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 #
 # Copyright 2016 The AMP HTML Authors. All Rights Reserved.
 #


### PR DESCRIPTION
The build python scripts have hard-coded paths to the python environment, by changing them to `env` we allow scripts to be ran with other environments (like `setuptools` && `virtualenv`).

NOTE: The default protocol buffers library in openSUSE is throwing a "syntax" error. I had to change the script's hashbang path and use `virtualenv` with `pip` to get around the problem.