### PR TITLE
Use default timeout for test-amp-bind.js

### DIFF
--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -24,8 +24,6 @@ describe.configure().retryOnSaucelabs().run('amp-bind', function() {
   let numSetStates;
   let numTemplated;
 
-  this.timeout(5000);
-
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     numSetStates = 0;


### PR DESCRIPTION
Fixes #9829.. hopefully. 🙏 

`test-amp-bind.js` seems less stable than other integration tests. Saucelabs occasionally seems overloaded which causes a bunch of timeouts, e.g. [this build where it even fails to start Safari 9](https://travis-ci.org/ampproject/amphtml/jobs/242183296). 

/to @rsimha-amp 