### PR TITLE
Slowly migrate AMP to a state where we can obfuscate all properties.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -90,7 +90,7 @@
       "objectsInObjects": false,
       "arraysInObjects": false
     }],
-    "object-shorthand": [2, "properties"],
+    "object-shorthand": [2, "properties", { "avoidQuotes": true }],
     "prefer-const": 2,
     "quotes": [2, "single", "avoid-escape"],
     "radix": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -90,7 +90,7 @@
       "objectsInObjects": false,
       "arraysInObjects": false
     }],
-    "object-shorthand": [2, "properties", { "avoidQuotes": true }],
+    "object-shorthand": [2, "properties"],
     "prefer-const": 2,
     "quotes": [2, "single", "avoid-escape"],
     "radix": 2,

--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -106,11 +106,11 @@ export class IframeMessagingClient {
       }
 
       const message = deserializeMessage(event.data);
-      if (!message || message.sentinel != this.sentinel_) {
+      if (!message || message['sentinel'] != this.sentinel_) {
         return;
       }
 
-      this.fireObservable_(message.type, message);
+      this.fireObservable_(message['type'], message);
     });
   }
 

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -760,7 +760,7 @@ export function ensureFramed(window) {
 /**
  * Expects the fragment to contain JSON.
  * @param {string} fragment Value of location.fragment
- * @return {?JSONType}
+ * @return {?JsonObject}
  * @visibleForTesting
  */
 export function parseFragment(fragment) {
@@ -772,7 +772,7 @@ export function parseFragment(fragment) {
     if (startsWith(json, '{%22')) {
       json = decodeURIComponent(json);
     }
-    return /** @type {!JSONType} */ (json ? JSON.parse(json) : {});
+    return /** @type {!JsonObject} */ (json ? JSON.parse(json) : {});
   } catch (err) {
     return null;
   }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -20,6 +20,7 @@ import {isCanary} from '../../../src/experiments';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
 import {documentInfoForDoc} from '../../../src/services';
 import {dev} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isProxyOrigin} from '../../../src/url';
 import {
@@ -452,7 +453,7 @@ export function additionalDimensions(win, viewportSize) {
  * @param {number=} opt_initTime The initialization time, in ms, of the
  *   lifecycle reporter.
  *   TODO(levitzky) Remove the above two params once AV numbers stabilize.
- * @return {?JSONType} config or null if invalid/missing.
+ * @return {?JsonObject} config or null if invalid/missing.
  */
 export function extractAmpAnalyticsConfig(
     a4a, responseHeaders, opt_deltaTime = -1, opt_initTime = -1) {
@@ -468,7 +469,7 @@ export function extractAmpAnalyticsConfig(
       return null;
     }
 
-    const config = /** @type {JSONType}*/ ({
+    const config = /** @type {JsonObject}*/ ({
       'transport': {'beacon': false, 'xhrpost': false},
       'triggers': {
         'continuousVisible': {
@@ -509,7 +510,7 @@ export function extractAmpAnalyticsConfig(
     opt_deltaTime = Math.round(opt_deltaTime);
 
     // Duscover and build visibility endpoints.
-    const requests = {};
+    const requests = dict();
     for (let idx = 1; idx <= urls.length; idx++) {
       // TODO: Ensure url is valid and not freeform JS?
       requests[`visibility${idx}`] = `${urls[idx - 1]}`;

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -94,19 +94,19 @@ export class InaboxMessagingHost {
    */
   processMessage(message) {
     const request = deserializeMessage(message.data);
-    if (!request || !request.sentinel) {
+    if (!request || !request['sentinel']) {
       dev().fine(TAG, 'Ignored non-AMP message:', message);
       return false;
     }
 
     const iframe =
-        this.getFrameElement_(message.source, request.sentinel);
+        this.getFrameElement_(message.source, request['sentinel']);
     if (!iframe) {
       dev().info(TAG, 'Ignored message from untrusted iframe:', message);
       return false;
     }
 
-    if (!this.msgObservable_.fire(request.type, this,
+    if (!this.msgObservable_.fire(request['type'], this,
         [iframe, request, message.source, message.origin])) {
       dev().warn(TAG, 'Unprocessed AMP message:', message);
       return false;

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -59,14 +59,30 @@ window.draw3p;
 window.AMP_TEST;
 window.AMP_TEST_IFRAME;
 window.AMP_TAG;
-window.AMP_CONFIG = {};
 window.AMP = {};
 
-window.AMP_CONFIG.thirdPartyUrl;
-window.AMP_CONFIG.thirdPartyFrameHost;
-window.AMP_CONFIG.thirdPartyFrameRegex;
-window.AMP_CONFIG.cdnUrl;
-window.AMP_CONFIG.errorReportingUrl;
+/** @constructor */
+function AmpConfigType() {}
+
+/* @public {string} */
+AmpConfigType.prototype.thirdPartyUrl;
+/* @public {string} */
+AmpConfigType.prototype.thirdPartyFrameHost;
+/* @public {string} */
+AmpConfigType.prototype.thirdPartyFrameRegex;
+/* @public {string} */
+AmpConfigType.prototype.cdnUrl;
+/* @public {string} */
+AmpConfigType.prototype.errorReportingUrl;
+/* @public {string} */
+AmpConfigType.prototype.localDev;
+/* @public {string} */
+AmpConfigType.prototype.v;
+/* @public {boolean} */
+AmpConfigType.prototype.canary;
+
+/** @type {!AmpConfigType}  */
+window.AMP_CONFIG;
 
 window.AMP_CONTEXT_DATA;
 

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -91,6 +91,25 @@ window.AMP_CONFIG;
 
 window.AMP_CONTEXT_DATA;
 
+/** @constructor @struct */
+function AmpViewerMessage() {}
+
+/** @public {string}  */
+AmpViewerMessage.prototype.app;
+/** @public {string}  */
+AmpViewerMessage.prototype.type;
+/** @public {number}  */
+AmpViewerMessage.prototype.requestid;
+/** @public {string}  */
+AmpViewerMessage.prototype.name;
+/** @public {*}  */
+AmpViewerMessage.prototype.data;
+/** @public {boolean|undefined}  */
+AmpViewerMessage.prototype.rsvp;
+/** @public {string|undefined}  */
+AmpViewerMessage.prototype.error;
+
+
 // amp-viz-vega related externs.
 /**
  * @typedef {{spec: function(!JsonObject, function())}}

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
+/**
+ * A type for Objects that can be JSON serialized or that come from
+ * JSON serialization. Requires the objects fields to be accessed with
+ * bracket notation object['name'] to make sure the fields do not get
+ * obfuscated.
+ * @constructor
+ * @dict
+ */
+function JsonObject() {}
+
 // Node.js global
 var process = {};
 process.env;
@@ -62,7 +72,7 @@ window.AMP_CONTEXT_DATA;
 
 // amp-viz-vega related externs.
 /**
- * @typedef {{spec: function(!JSONType, function())}}
+ * @typedef {{spec: function(!JsonObject, function())}}
  */
 let VegaParser;
 /**

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -24,6 +24,11 @@
  */
 function JsonObject() {}
 
+/**
+ * @typedef {?JsonObject|undefined|string|number|!Array<JsonValue>}
+ */
+var JsonValue;
+
 // Node.js global
 var process = {};
 process.env;

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -176,7 +176,7 @@ export class LaterpayVendor {
   }
 
   /**
-   * @return {!Promise<!JSONType>}
+   * @return {!Promise<!JsonObject>}
    */
   authorize() {
     return this.getPurchaseConfig_()

--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -34,7 +34,7 @@ import {parser} from './access-expr-impl';
  * - Boolean logic: `X = 1 OR Y = 1`, `X = 1 AND Y = 2`, `NOT X`, `NOT (X = 1)`.
  *
  * @param {string} expr
- * @param {!JSONType} data
+ * @param {!JsonObject} data
  * @return {boolean}
  */
 export function evaluateAccessExpr(expr, data) {

--- a/extensions/amp-access/0.1/access-vendor.js
+++ b/extensions/amp-access/0.1/access-vendor.js
@@ -25,7 +25,7 @@ export class AccessVendor {
   /**
    * Requests authorization from the vendor. Returns a promise that yields
    * a JSON authorization response.
-   * @return {!Promise<!JSONType>}
+   * @return {!Promise<!JsonObject>}
    */
   authorize() {}
 

--- a/extensions/amp-access/0.1/amp-access-client.js
+++ b/extensions/amp-access/0.1/amp-access-client.js
@@ -32,7 +32,7 @@ export class AccessClientAdapter {
 
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    * @param {!AccessTypeAdapterContextDef} context
    */
   constructor(ampdoc, configJson, context) {
@@ -69,7 +69,7 @@ export class AccessClientAdapter {
   }
 
   /**
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    * @return {number}
    */
   buildConfigAuthorizationTimeout_(configJson) {

--- a/extensions/amp-access/0.1/amp-access-other.js
+++ b/extensions/amp-access/0.1/amp-access-other.js
@@ -26,7 +26,7 @@ export class AccessOtherAdapter {
 
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    * @param {!AccessTypeAdapterContextDef} context
    */
   constructor(ampdoc, configJson, context) {
@@ -36,7 +36,7 @@ export class AccessOtherAdapter {
     /** @const @private {!AccessTypeAdapterContextDef} */
     this.context_ = context;
 
-    /** @private {?JSONType} */
+    /** @private {?JsonObject} */
     this.authorizationResponse_ =
         configJson['authorizationFallbackResponse'] || null;
 

--- a/extensions/amp-access/0.1/amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/amp-access-server-jwt.js
@@ -78,7 +78,7 @@ export class AccessServerJwtAdapter {
 
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    * @param {!AccessTypeAdapterContextDef} context
    */
   constructor(ampdoc, configJson, context) {
@@ -277,7 +277,7 @@ export class AccessServerJwtAdapter {
   }
 
   /**
-   * @return {!Promise<!JSONType>}
+   * @return {!Promise<!JsonObject>}
    * @private
    */
   authorizeOnClient_() {
@@ -289,7 +289,7 @@ export class AccessServerJwtAdapter {
   }
 
   /**
-   * @return {!Promise<!JSONType>}
+   * @return {!Promise<!JsonObject>}
    * @private
    */
   authorizeOnServer_() {

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -60,7 +60,7 @@ export class AccessServerAdapter {
 
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    * @param {!AccessTypeAdapterContextDef} context
    */
   constructor(ampdoc, configJson, context) {

--- a/extensions/amp-access/0.1/amp-access-vendor.js
+++ b/extensions/amp-access/0.1/amp-access-vendor.js
@@ -31,7 +31,7 @@ export class AccessVendorAdapter {
 
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    */
   constructor(ampdoc, configJson) {
     /** @const */
@@ -41,7 +41,7 @@ export class AccessVendorAdapter {
     this.vendorName_ = user().assert(configJson['vendor'],
         '"vendor" name must be specified');
 
-    /** @const @private {JSONType} */
+    /** @const @private {JsonObject} */
     this.vendorConfig_ = configJson[this.vendorName_];
 
     /** @const @private {boolean} */

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -115,7 +115,7 @@ export class AccessService {
     /** @const @private {!Object<string, string>} */
     this.loginConfig_ = this.buildConfigLoginMap_(configJson);
 
-    /** @const @private {!JSONType} */
+    /** @const @private {!JsonObject} */
     this.authorizationFallbackResponse_ =
         configJson['authorizationFallbackResponse'];
 
@@ -210,7 +210,7 @@ export class AccessService {
   }
 
   /**
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    * @return {!AccessTypeAdapterDef}
    * @private
    */
@@ -240,14 +240,14 @@ export class AccessService {
   }
 
   /**
-   * @return {!JSONType}
+   * @return {!JsonObject}
    */
   getAdapterConfig() {
     return this.adapter_.getConfig();
   }
 
   /**
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    * @return {!AccessType}
    */
   buildConfigType_(configJson) {
@@ -273,7 +273,7 @@ export class AccessService {
   }
 
   /**
-   * @param {!JSONType} configJson
+   * @param {!JsonObject} configJson
    * @return {?Object<string, string>}
    * @private
    */
@@ -547,7 +547,7 @@ export class AccessService {
   }
 
   /**
-   * @param {!JSONTypeDef} response
+   * @param {!JsonObjectDef} response
    * @return {!Promise}
    * @private
    */
@@ -562,7 +562,7 @@ export class AccessService {
 
   /**
    * @param {!Element} element
-   * @param {!JSONTypeDef} response
+   * @param {!JsonObjectDef} response
    * @return {!Promise}
    * @private
    */
@@ -603,7 +603,7 @@ export class AccessService {
   /**
    * Discovers and renders templates.
    * @param {!Element} element
-   * @param {!JSONTypeDef} response
+   * @param {!JsonObjectDef} response
    * @return {!Promise}
    * @private
    */
@@ -627,7 +627,7 @@ export class AccessService {
   /**
    * @param {!Element} element
    * @param {!Element} templateOrPrev
-   * @param {!JSONTypeDef} response
+   * @param {!JsonObjectDef} response
    * @return {!Promise}
    * @private
    */
@@ -947,7 +947,7 @@ let AccessTypeAdapterContextDef;
 class AccessTypeAdapterDef {
 
   /**
-   * @return {!JSONType}
+   * @return {!JsonObject}
    */
   getConfig() {}
 
@@ -957,7 +957,7 @@ class AccessTypeAdapterDef {
   isAuthorizationEnabled() {}
 
   /**
-   * @return {!Promise<!JSONType>}
+   * @return {!Promise<!JsonObject>}
    */
   authorize() {}
 

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -160,7 +160,7 @@ export class AccessService {
     /** @private {?Promise<string>} */
     this.readerIdPromise_ = null;
 
-    /** @private {?JSONType} */
+    /** @private {?JsonObject} */
     this.authResponse_ = null;
 
     /** @const @private {!SignInProtocol} */
@@ -494,7 +494,7 @@ export class AccessService {
   }
 
   /**
-   * @param {!JSONType} authResponse
+   * @param {!JsonObject} authResponse
    * @private
    */
   setAuthResponse_(authResponse) {

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -67,8 +67,8 @@ export class AmpAdExit extends AMP.BaseElement {
         isExperimentOn(this.win, 'amp-ad-exit'),
         'amp-ad-exit experiment is off.');
 
-    const target = this.targets_[args.target];
-    user().assert(target, `Exit target not found: '${args.target}'`);
+    const target = this.targets_[args['target']];
+    user().assert(target, `Exit target not found: '${args['target']}'`);
 
     event.preventDefault();
     if (!this.filter_(this.defaultFilters_, event) ||

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -102,7 +102,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
     /**
      * Config to generate amp-analytics element for active view reporting.
-     * @type {?JSONType}
+     * @type {?JsonObject}
      * @private
      */
     this.ampAnalyticsConfig_ = null;

--- a/extensions/amp-ad-network-cloudflare-impl/0.1/vendors.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/vendors.js
@@ -15,9 +15,9 @@
  */
 
 /**
- * @const {!JSONType}
+ * @const {!JsonObject}
  */
-export const NETWORKS = /** @type {!JSONType} */ ({
+export const NETWORKS = /** @type {!JsonObject} */ ({
   cloudflare: {
     base: 'https://firebolt.cloudflaredemo.com',
   },

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -182,7 +182,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     /**
      * Config to generate amp-analytics element for active view reporting.
-     * @type {?JSONType}
+     * @type {?JsonObject}
      * @private
      */
     this.ampAnalyticsConfig_ = null;

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -19,7 +19,7 @@ import {assertHttpsUrl, appendEncodedParamStringToUrl} from '../../../src/url';
 import {dev, rethrowAsync, user} from '../../../src/log';
 import {expandTemplate} from '../../../src/string';
 import {isArray, isObject} from '../../../src/types';
-import {hasOwn, map} from '../../../src/utils/object';
+import {dict, hasOwn, map} from '../../../src/utils/object';
 import {sendRequest, sendRequestUsingIframe} from './transport';
 import {urlReplacementsForDoc} from '../../../src/services';
 import {userNotificationManagerFor} from '../../../src/services';
@@ -96,12 +96,12 @@ export class AmpAnalytics extends AMP.BaseElement {
     /**
      * @private {JsonObject}
      */
-    this.config_ = /** @type {JsonObject} */ ({});
+    this.config_ = dict();
 
     /**
      * @private {JsonObject}
      */
-    this.remoteConfig_ = /** @type {JsonObject} */ ({});
+    this.remoteConfig_ = dict();
 
     /** @private {?./instrumentation.InstrumentationService} */
     this.instrumentation_ = null;
@@ -382,7 +382,7 @@ export class AmpAnalytics extends AMP.BaseElement {
   mergeConfigs_() {
     const inlineConfig = this.getInlineConfigNoInline();
     // Initialize config with analytics related vars.
-    const config = /** @type {!JsonObject} */ ({
+    const config = dict({
       'vars': {
         'requestCount': 0,
       },

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -64,7 +64,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     super(element);
 
     /**
-     * @const {!JSONType} Copied here for tests.
+     * @const {!JsonObject} Copied here for tests.
      * @private
      */
     this.predefinedConfig_ = ANALYTICS_CONFIG;
@@ -94,14 +94,14 @@ export class AmpAnalytics extends AMP.BaseElement {
     this.requests_ = {};
 
     /**
-     * @private {JSONType}
+     * @private {JsonObject}
      */
-    this.config_ = /** @type {JSONType} */ ({});
+    this.config_ = /** @type {JsonObject} */ ({});
 
     /**
-     * @private {JSONType}
+     * @private {JsonObject}
      */
-    this.remoteConfig_ = /** @type {JSONType} */ ({});
+    this.remoteConfig_ = /** @type {JsonObject} */ ({});
 
     /** @private {?./instrumentation.InstrumentationService} */
     this.instrumentation_ = null;
@@ -281,7 +281,7 @@ export class AmpAnalytics extends AMP.BaseElement {
    * Calls `AnalyticsGroup.addTrigger` and reports any errors. "NoInline" is
    * to avoid inlining this method so that `try/catch` does it veto
    * optimizations.
-   * @param {!JSONType} config
+   * @param {!JsonObject} config
    * @private
    */
   addTriggerNoInline_(config) {
@@ -377,12 +377,12 @@ export class AmpAnalytics extends AMP.BaseElement {
    * - Default config: Built-in config shared by all amp-analytics tags.
    *
    * @private
-   * @return {!JSONType}
+   * @return {!JsonObject}
    */
   mergeConfigs_() {
     const inlineConfig = this.getInlineConfigNoInline();
     // Initialize config with analytics related vars.
-    const config = /** @type {!JSONType} */ ({
+    const config = /** @type {!JsonObject} */ ({
       'vars': {
         'requestCount': 0,
       },
@@ -408,7 +408,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {!JSONType}
+   * @return {!JsonObject}
    */
   getInlineConfigNoInline() {
     if (this.element.CONFIG) {
@@ -436,7 +436,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       user().error(TAG, 'Analytics config could not be ' +
           'parsed. Is it in a valid JSON format?', er);
     }
-    return /** @type {!JSONType} */ (inlineConfig);
+    return /** @type {!JsonObject} */ (inlineConfig);
   }
 
   /**
@@ -496,7 +496,7 @@ export class AmpAnalytics extends AMP.BaseElement {
    * Callback for events that are registered by the config's triggers. This
    * method generates requests and sends them out.
    *
-   * @param {!JSONType} trigger JSON config block that resulted in this event.
+   * @param {!JsonObject} trigger JSON config block that resulted in this event.
    * @param {!Object} event Object with details about the event.
    * @return {!Promise} The request that was sent out.
    * @private
@@ -517,7 +517,7 @@ export class AmpAnalytics extends AMP.BaseElement {
    * Processes a request for an event callback and sends it out.
    *
    * @param {string} request The request to process.
-   * @param {!JSONType} trigger JSON config block that resulted in this event.
+   * @param {!JsonObject} trigger JSON config block that resulted in this event.
    * @param {!Object} event Object with details about the event.
    * @return {!Promise<string|undefined>} The request that was sent out.
    * @private
@@ -547,7 +547,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /**
    * @param {string} request The request to process.
-   * @param {!JSONType} trigger JSON config block that resulted in this event.
+   * @param {!JsonObject} trigger JSON config block that resulted in this event.
    * @param {!Object} event Object with details about the event.
    * @return {!Promise<string>} The request that was sent out.
    * @private
@@ -576,7 +576,7 @@ export class AmpAnalytics extends AMP.BaseElement {
   }
 
   /**
-   * @param {!JSONType} trigger JSON config block that resulted in this event.
+   * @param {!JsonObject} trigger JSON config block that resulted in this event.
    * @param {!Object} event Object with details about the event.
    * @return {!Promise<T>} Map of the resolved parameters.
    * @template T
@@ -602,13 +602,13 @@ export class AmpAnalytics extends AMP.BaseElement {
   }
 
   /**
-   * @param {!JSONType} trigger The config to use to determine sampling.
+   * @param {!JsonObject} trigger The config to use to determine sampling.
    * @return {!Promise<boolean>} Whether the request should be sampled in or
    * not based on sampleSpec.
    * @private
    */
   isSampledIn_(trigger) {
-    /** @const {!JSONType} */
+    /** @const {!JsonObject} */
     const spec = trigger['sampleSpec'];
     const resolve = Promise.resolve(true);
     const TAG = this.getName_();
@@ -633,7 +633,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /**
    * Checks if request for a trigger is enabled.
-   * @param {!JSONType} trigger The config to use to determine if trigger is
+   * @param {!JsonObject} trigger The config to use to determine if trigger is
    * enabled.
    * @param {!Object} event Object with details about the event.
    * @return {!Promise<boolean>} Whether trigger must be called.
@@ -716,7 +716,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /**
    * @param {string} request The full request string to send.
-   * @param {!JSONType} trigger
+   * @param {!JsonObject} trigger
    * @private
    */
   sendRequest_(request, trigger) {

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -83,7 +83,7 @@ export class EventTracker {
   /**
    * @param {!Element} unusedContext
    * @param {string} unusedEventType
-   * @param {!JSONType} unusedConfig
+   * @param {!JsonObject} unusedConfig
    * @param {function(!AnalyticsEvent)} unusedListener
    * @return {!UnlistenDef}
    * @abstract

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -448,7 +448,7 @@ export class InstrumentationService {
    * @private
    */
   isTimerSpecValid_(timerSpec) {
-    if (!timerSpec) {
+    if (!timerSpec || typeof timerSpec != 'object') {
       user().error(TAG, 'Bad timer specification');
       return false;
     } else if (!('interval' in timerSpec)) {

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -238,7 +238,7 @@ export class InstrumentationService {
   }
 
   /**
-   * @param {!JSONType} config Configuration for instrumentation.
+   * @param {!JsonObject} config Configuration for instrumentation.
    * @param {function(!AnalyticsEvent)} listener The callback to call when the event
    *  occurs.
    * @param {!Element} analyticsElement The element associated with the
@@ -299,7 +299,7 @@ export class InstrumentationService {
    * the conditions are met.
    * @param {function(!AnalyticsEvent)} callback The callback to call when the
    *   event occurs.
-   * @param {!JSONType} config Configuration for instrumentation.
+   * @param {!JsonObject} config Configuration for instrumentation.
    * @param {AnalyticsEventType} eventType Event type for which the callback is triggered.
    * @param {!Element} analyticsElement The element assoicated with the
    *   config.
@@ -311,7 +311,7 @@ export class InstrumentationService {
         'createVisibilityListener should be called with visible or hidden ' +
         'eventType');
     const shouldBeVisible = eventType == AnalyticsEventType.VISIBLE;
-    /** @const {!JSONType} */
+    /** @const {!JsonObject} */
     const spec = config['visibilitySpec'];
     if (spec) {
       if (!isVisibilitySpecValid(config)) {
@@ -357,7 +357,7 @@ export class InstrumentationService {
   /**
    * Register for a listener to be called when the boundaries specified in
    * config are reached.
-   * @param {!JSONType} config the config that specifies the boundaries.
+   * @param {!JsonObject} config the config that specifies the boundaries.
    * @param {function(!AnalyticsEvent)} listener
    * @private
    */
@@ -444,21 +444,21 @@ export class InstrumentationService {
   }
 
   /**
-   * @param {JSONType} timerSpec
+   * @param {JsonObject} timerSpec
    * @private
    */
   isTimerSpecValid_(timerSpec) {
     if (!timerSpec) {
       user().error(TAG, 'Bad timer specification');
       return false;
-    } else if (!timerSpec.hasOwnProperty('interval')) {
+    } else if (!('interval' in timerSpec)) {
       user().error(TAG, 'Timer interval specification required');
       return false;
     } else if (typeof timerSpec['interval'] !== 'number' ||
                timerSpec['interval'] < MIN_TIMER_INTERVAL_SECONDS_) {
       user().error(TAG, 'Bad timer interval specification');
       return false;
-    } else if (timerSpec.hasOwnProperty('maxTimerLength') &&
+    } else if (('maxTimerLength' in timerSpec) &&
               (typeof timerSpec['maxTimerLength'] !== 'number' ||
                   timerSpec['maxTimerLength'] <= 0)) {
       user().error(TAG, 'Bad maxTimerLength specification');
@@ -470,11 +470,11 @@ export class InstrumentationService {
 
   /**
    * @param {!function(!AnalyticsEvent)} listener
-   * @param {JSONType} timerSpec
+   * @param {JsonObject} timerSpec
    * @private
    */
   createTimerListener_(listener, timerSpec) {
-    const hasImmediate = timerSpec.hasOwnProperty('immediate');
+    const hasImmediate = 'immediate' in timerSpec;
     const callImmediate = hasImmediate ? Boolean(timerSpec['immediate']) : true;
     const intervalId = this.ampdoc.win.setInterval(
         listener.bind(null, this.createEventDepr_(AnalyticsEventType.TIMER)),
@@ -553,7 +553,7 @@ export class AnalyticsGroup {
    * Triggers registered on a group are automatically released when the
    * group is disposed.
    *
-   * @param {!JSONType} config
+   * @param {!JsonObject} config
    * @param {function(!AnalyticsEvent)} handler
    */
   addTrigger(config, handler) {

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -15,9 +15,9 @@
  */
 
 /**
- * @const {!JSONType}
+ * @const {!JsonObject}
  */
-export const ANALYTICS_CONFIG = /** @type {!JSONType} */ ({
+export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
 
   // Default parent configuration applied to all amp-analytics tags.
   'default': {

--- a/extensions/amp-analytics/0.1/visibility-impl.js
+++ b/extensions/amp-analytics/0.1/visibility-impl.js
@@ -98,7 +98,7 @@ export function isValidPercentage_(num) {
 
 /**
  * Checks and outputs information about visibilitySpecValidation.
- * @param {!JSONType} config Configuration for instrumentation.
+ * @param {!JsonObject} config Configuration for instrumentation.
  * @return {boolean} True if the spec is valid.
  * @private
  */

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -52,7 +52,7 @@ export class AmpAnimation extends AMP.BaseElement {
     /** @private {?../../../src/friendly-iframe-embed.FriendlyIframeEmbed} */
     this.embed_ = null;
 
-    /** @private {?JSONType} */
+    /** @private {?JsonObject} */
     this.configJson_ = null;
 
     /** @private {?./web-animations.WebAnimationRunner} */
@@ -291,7 +291,7 @@ export class AmpAnimation extends AMP.BaseElement {
   }
 
   /**
-   * @param {?JSONType=} opt_args
+   * @param {?JsonObject=} opt_args
    * @return {?Promise}
    * @private
    */
@@ -332,7 +332,7 @@ export class AmpAnimation extends AMP.BaseElement {
   }
 
   /**
-   * @param {?JSONType=} opt_args
+   * @param {?JsonObject=} opt_args
    * @return {!Promise<!./web-animations.WebAnimationRunner>}
    * @private
    */

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -150,10 +150,10 @@ export class AmpAnimation extends AMP.BaseElement {
 
   /**
    * Returns the animation spec.
-   * @return {?JSONType}
+   * @return {?JsonObject}
    */
   getAnimationSpec() {
-    return /** @type {?JSONType} */ (this.configJson_);
+    return /** @type {?JsonObject} */ (this.configJson_);
   }
 
   /** @override */

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -139,7 +139,7 @@ class AmpApesterMedia extends AMP.BaseElement {
   }
 
   /**
-   * @return {!Promise<!JSONType>}
+   * @return {!Promise<!JsonObject>}
    **/
   queryMedia_() {
     const url = this.buildUrl_();

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -406,7 +406,7 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
   }
 
   /**
-   * @param {!JSONType} manifestJson
+   * @param {!JsonObject} manifestJson
    * @private
    */
   parseManifest_(manifestJson) {

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -15,6 +15,7 @@
  */
 
 import {Layout} from '../../../src/layout';
+import {dict} from '../../../src/utils/object';
 import {user, dev, rethrowAsync} from '../../../src/log';
 import {platformFor} from '../../../src/services';
 import {viewerForDoc} from '../../../src/services';
@@ -268,9 +269,9 @@ export class AmpIosAppBanner extends AbstractAppBanner {
       openWindowDialog(this.win, openInAppUrl, '_top');
     } else {
       timerFor(this.win).delay(() => {
-        this.viewer_.sendMessage('navigateTo', {url: installAppUrl});
+        this.viewer_.sendMessage('navigateTo', dict({'url': installAppUrl}));
       }, OPEN_LINK_TIMEOUT);
-      this.viewer_.sendMessage('navigateTo', {url: openInAppUrl});
+      this.viewer_.sendMessage('navigateTo', dict({'url': openInAppUrl}));
     }
   }
 

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -66,7 +66,7 @@ export class AmpAutoAds extends AMP.BaseElement {
    * Tries to load an auto-ads configuration from the given URL. This uses a
    * non-credentialed request.
    * @param {string} configUrl
-   * @return {!Promise<!JSONType>}
+   * @return {!Promise<!JsonObject>}
    * @private
    */
   getConfig_(configUrl) {

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -211,7 +211,7 @@ export class Placement {
 
 /**
  * @param {!Window} win
- * @param {!JSONType} configObj
+ * @param {!JsonObject} configObj
  * @return {!Array<!Placement>}
  */
 export function getPlacementsFromConfigObj(win, configObj) {

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -192,7 +192,7 @@ class AmpDailymotion extends AMP.BaseElement {
       return; // The message isn't valid
     }
 
-    switch (data.event) {
+    switch (data['event']) {
       case DailymotionEvents.API_READY:
         this.playerReadyResolver_(true);
         this.element.dispatchCustomEvent(VideoEvents.LOAD);
@@ -208,8 +208,9 @@ class AmpDailymotion extends AMP.BaseElement {
         break;
       case DailymotionEvents.VOLUMECHANGE:
         if (this.playerState_ == DailymotionEvents.UNSTARTED
-           || this.muted_ != (data.volume == 0 || (data.muted == 'true'))) {
-          this.muted_ = (data.volume == 0 || (data.muted == 'true'));
+            || this.muted_ != (
+                data['volume'] == 0 || (data['muted'] == 'true'))) {
+          this.muted_ = (data['volume'] == 0 || (data['muted'] == 'true'));
           if (this.muted_) {
             this.element.dispatchCustomEvent(VideoEvents.MUTED);
           } else {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -291,8 +291,9 @@ export class AmpForm {
     const formDataForAnalytics = {};
     const formObject = this.getFormAsObject_();
 
+
     for (const k in formObject) {
-      if (formObject.hasOwnProperty(k)) {
+      if (Object.prototype.hasOwnProperty.call(formObject, k)) {
         formDataForAnalytics['formFields[' + k + ']'] = formObject[k].join(',');
       }
     }
@@ -620,7 +621,7 @@ export class AmpForm {
   /**
    * Triggers either a submit-success or submit-error action with response data.
    * @param {boolean} success
-   * @param {?JSONType} json
+   * @param {?JsonObject} json
    * @private
    */
   triggerAction_(success, json) {
@@ -653,11 +654,11 @@ export class AmpForm {
 
   /**
    * Returns form data as an object.
-   * @return {!JSONType}
+   * @return {!JsonObject}
    * @private
    */
   getFormAsObject_() {
-    const data = /** @type {!JSONType} */ ({});
+    const data = /** @type {!JsonObject} */ ({});
     const inputs = this.form_.elements;
     const submittableTagsRegex = /^(?:input|select|textarea)$/i;
     const unsubmittableTypesRegex = /^(?:button|image|file|reset)$/i;
@@ -701,7 +702,7 @@ export class AmpForm {
   }
 
   /**
-   * @param {!JSONType} data
+   * @param {!JsonObject} data
    * @private
    */
   renderTemplate_(data) {

--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -158,7 +158,7 @@ export class AmpViewerIntegration {
   setup_(messaging, viewer, origin) {
     messaging.setDefaultHandler((type, payload, awaitResponse) => {
       return viewer.receiveMessage(
-          type, /** @type {!JSONType} */ (payload), awaitResponse);
+          type, /** @type {!JsonObject} */ (payload), awaitResponse);
     });
 
     viewer.setMessageDeliverer(messaging.sendRequest.bind(messaging), origin);

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -27,15 +27,7 @@ export const MessageType = {
 };
 
 /**
- * @typedef {{
- *   app: string,
- *   type: string,
- *   requestid: number,
- *   name: string,
- *   data: *,
- *   rsvp: (boolean|undefined),
- *   error: (string|undefined),
- * }}
+ * @typedef {!AmpViewerMessage}
  */
 export let Message;
 
@@ -205,14 +197,14 @@ export class Messaging {
         this.waitingForResponse_[requestId] = {resolve, reject};
       });
     }
-    this.sendMessage_({
+    this.sendMessage_(/** @type {!AmpViewerMessage} */ ({
       app: APP,
       requestid: requestId,
       type: MessageType.REQUEST,
       name: messageName,
       data: messageData,
       rsvp: awaitResponse,
-    });
+    }));
     return promise;
   }
 
@@ -224,13 +216,13 @@ export class Messaging {
    * @private
    */
   sendResponse_(requestId, messageName, messageData) {
-    this.sendMessage_({
+    this.sendMessage_(/** @type {!AmpViewerMessage} */ ({
       app: APP,
       requestid: requestId,
       type: MessageType.RESPONSE,
       name: messageName,
       data: messageData,
-    });
+    }));
   }
 
   /**
@@ -243,14 +235,14 @@ export class Messaging {
     const errString = this.errorToString_(reason);
     this.logError_(
         TAG + ': sendResponseError_, Message name: ' + messageName, errString);
-    this.sendMessage_({
+    this.sendMessage_(/** @type {!AmpViewerMessage} */ ({
       app: APP,
       requestid: requestId,
       type: MessageType.RESPONSE,
       name: messageName,
       data: null,
       error: errString,
-    });
+    }));
   }
 
   /**

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -34,7 +34,7 @@ export class AmpVizVega extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @private {?JSONType} */
+    /** @private {?JsonObject} */
     this.data_ = null;
 
     /** @private {?string} */

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -84,7 +84,7 @@ export function serializeMessage(type, sentinel, data = {}, rtvVersion = null) {
  * Returns null if it's not valid AMP message format.
  *
  * @param {*} message
- * @returns {?JSONType}
+ * @returns {?JsonObject}
  */
 export function deserializeMessage(message) {
   if (!isAmpMessage(message)) {
@@ -93,7 +93,7 @@ export function deserializeMessage(message) {
   const startPos = message.indexOf('{');
   dev().assert(startPos != -1, 'JSON missing in %s', message);
   try {
-    return /** @type {!JSONType} */ (JSON.parse(message.substr(startPos)));
+    return /** @type {!JsonObject} */ (JSON.parse(message.substr(startPos)));
   } catch (e) {
     dev().error('MESSAGING', 'Failed to parse message: ' + message, e);
     return null;

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -70,7 +70,7 @@ export function triggerAnalyticsEvent(target, eventType, opt_vars) {
 /**
  * Method to create scoped analytics element for any element.
  * @param {!Element} parentElement
- * @param {!JSONType} config
+ * @param {!JsonObject} config
  * @param {boolean=} loadAnalytics
  * @return {!Element} created analytics element
  */

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -27,8 +27,8 @@ import {getValueForExpr} from './json';
  * @param {!Element} element
  * @param {string=} opt_expr Dot-syntax reference to subdata of JSON result
  *     to return. If not specified, entire JSON result is returned.
- * @return {!Promise<JSONType>} Resolved with JSON result or rejected if
- *     response is invalid.
+ * @return {!Promise<!JsonObject|!Array<JsonObject>>} Resolved with JSON
+ *     result or rejected if response is invalid.
  */
 export function fetchBatchedJsonFor(ampdoc, element, opt_expr) {
   const url = assertHttpsUrl(element.getAttribute('src'), element);

--- a/src/impression.js
+++ b/src/impression.js
@@ -109,7 +109,7 @@ export function doNotTrackImpression() {
  * Send the url to ad server and wait for its response
  * @param {!Window} win
  * @param {string} clickUrl
- * @return {!Promise<!JSONType>}
+ * @return {!Promise<!JsonObject>}
  */
 function invoke(win, clickUrl) {
   if (getMode().localDev && !getMode().test) {
@@ -124,7 +124,7 @@ function invoke(win, clickUrl) {
  * parse the response back from ad server
  * Set for analytics purposes
  * @param {!Window} win
- * @param {!Object} response
+ * @param {!JsonObject} response
  */
 function applyResponse(win, viewer, response) {
   const adLocation = response['location'];

--- a/src/json.js
+++ b/src/json.js
@@ -113,11 +113,12 @@ export function getValueForExpr(obj, expr) {
  * @param {*} json JSON string to parse
  * @param {function(!Error)=} opt_onFailed Optional function that will be called with
  *     the error if parsing fails.
- * @return {?JSONValueDef|undefined}
+ * @return {?JsonObject|undefined} May be extend to parse arrays.
  */
 export function tryParseJson(json, opt_onFailed) {
   try {
-    return JSON.parse(/** @type {string} */ (json));
+    return /** @type {?JsonObject|undefined} */(
+        JSON.parse(/** @type {string} */ (json)));
   } catch (e) {
     if (opt_onFailed) {
       opt_onFailed(e);

--- a/src/json.js
+++ b/src/json.js
@@ -55,8 +55,8 @@ let JSONValueDef;
 
 /**
  * Recreates objects with prototype-less copies.
- * @param {!JSONObjectDef} obj
- * @return {!JSONObjectDef}
+ * @param {!JsonObject} obj
+ * @return {!JsonObject}
  */
 export function recreateNonProtoObject(obj) {
   const copy = Object.create(null);
@@ -67,7 +67,7 @@ export function recreateNonProtoObject(obj) {
     const v = obj[k];
     copy[k] = isObject(v) ? recreateNonProtoObject(v) : v;
   }
-  return copy;
+  return /** @type {!JsonObject} */ (copy);
 }
 
 
@@ -77,9 +77,9 @@ export function recreateNonProtoObject(obj) {
  * field in a chain does not exist or is not an object, the returned value will
  * be `undefined`.
  *
- * @param {!JSONObjectDef} obj
+ * @param {!JsonObject} obj
  * @param {string} expr
- * @return {?JSONValueDef|undefined}
+ * @return {*}
  */
 export function getValueForExpr(obj, expr) {
   // The `.` indicates "the object itself".

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -656,7 +656,7 @@ class MultidocManager {
     /**
      * Posts message to the ampdoc.
      * @param {string} eventType
-     * @param {!JSONType} data
+     * @param {!JsonObject} data
      * @param {boolean} unusedAwaitResponse
      * @return {(!Promise<*>|undefined)}
      */
@@ -948,7 +948,7 @@ class MultidocManager {
       const viewer = viewerForDoc(shadowRoot.AMP.ampdoc);
       this.timer_.delay(() => {
         viewer.receiveMessage('broadcast',
-            /** @type {!JSONType} */ (data),
+            /** @type {!JsonObject} */ (data),
             /* awaitResponse */ false);
       }, 0);
     });

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -119,7 +119,7 @@ export class ActionInvocation {
   /**
    * @param {!Node} target
    * @param {string} method
-   * @param {?JSONType} args
+   * @param {?JsonObject} args
    * @param {?Element} source
    * @param {?ActionEventDef} event
    */
@@ -128,7 +128,7 @@ export class ActionInvocation {
     this.target = target;
     /** @const {string} */
     this.method = method;
-    /** @const {?JSONType} */
+    /** @const {?JsonObject} */
     this.args = args;
     /** @const {?Element} */
     this.source = source;
@@ -300,7 +300,7 @@ export class ActionService {
    * Triggers execution of the method on a target/method.
    * @param {!Element} target
    * @param {string} method
-   * @param {?JSONType} args
+   * @param {?JsonObject} args
    * @param {?Element} source
    * @param {?ActionEventDef} event
    */
@@ -405,7 +405,7 @@ export class ActionService {
   /**
    * @param {!Element} target
    * @param {string} method
-   * @param {?JSONType} args
+   * @param {?JsonObject} args
    * @param {?Element} source
    * @param {?ActionEventDef} event
    * @param {?ActionInfoDef} actionInfo
@@ -746,7 +746,7 @@ function getActionInfoArgValue(tokens) {
  * with the data in the given event.
  * @param {?ActionInfoArgsDef} args
  * @param {?ActionEventDef} event
- * @return {?JSONType}
+ * @return {?JsonObject}
  * @private Visible for testing only.
  */
 export function applyActionInfoArgs(args, event) {

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -782,7 +782,7 @@ export class HistoryBindingVirtual_ {
   }
 
   /**
-   * @param {!JSONType} data
+   * @param {!JsonObject} data
    * @private
    */
   onHistoryPopped_(data) {

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -21,7 +21,7 @@ import {
 } from '../service';
 import {getMode} from '../mode';
 import {dev} from '../log';
-import {map} from '../utils/object';
+import {dict, map} from '../utils/object';
 import {timerFor} from '../services';
 import {viewerForDoc} from '../services';
 
@@ -764,7 +764,7 @@ export class HistoryBindingVirtual_ {
     // Current implementation doesn't wait for response from viewer.
     this.updateStackIndex_(this.stackIndex_ + 1);
     return this.viewer_.sendMessageAwaitResponse(
-        'pushHistory', {stackIndex: this.stackIndex_}).then(() => {
+        'pushHistory', dict({'stackIndex': this.stackIndex_})).then(() => {
           return this.stackIndex_;
         });
   }
@@ -775,7 +775,7 @@ export class HistoryBindingVirtual_ {
       return Promise.resolve(this.stackIndex_);
     }
     return this.viewer_.sendMessageAwaitResponse(
-        'popHistory', {stackIndex: this.stackIndex_}).then(() => {
+        'popHistory', dict({'stackIndex': this.stackIndex_})).then(() => {
           this.updateStackIndex_(stackIndex - 1);
           return this.stackIndex_;
         });
@@ -811,10 +811,11 @@ export class HistoryBindingVirtual_ {
     }
     return this.viewer_.sendMessageAwaitResponse('getFragment', undefined,
         /* cancelUnsent */true).then(
-        hash => {
-          if (!hash) {
+        data => {
+          if (!data) {
             return '';
           }
+          let hash = dev().assertString(data);
           /* Strip leading '#'*/
           if (hash[0] == '#') {
             hash = hash.substr(1);
@@ -829,7 +830,8 @@ export class HistoryBindingVirtual_ {
       return Promise.resolve();
     }
     return /** @type {!Promise} */ (this.viewer_.sendMessageAwaitResponse(
-        'replaceHistory', {fragment}, /* cancelUnsent */true));
+        'replaceHistory', dict({'fragment': fragment}),
+        /* cancelUnsent */true));
   }
 }
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -23,7 +23,7 @@ import {whenDocumentComplete} from '../document-ready';
 import {getMode} from '../mode';
 import {isCanary} from '../experiments';
 import {throttle} from '../utils/rate-limit';
-import {map} from '../utils/object';
+import {dict, map} from '../utils/object';
 
 /**
  * Maximum number of tick events we allow to accumulate in the performance

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -33,11 +33,13 @@ import {map} from '../utils/object';
 const QUEUE_LIMIT = 50;
 
 /**
- * @typedef {{
+ * Fields:
+ * {{
  *   label: string,
  *   delta: (number|null|undefined),
  *   value: (number|null|undefined)
  * }}
+ * @typedef {!JsonObject}
  */
 let TickEventDef;
 
@@ -283,12 +285,12 @@ export class Performance {
   tick(label, opt_delta) {
     const value = (opt_delta == undefined) ? this.win.Date.now() : undefined;
 
-    const data = {
-      label,
-      value,
+    const data = dict({
+      'label': label,
+      'value': value,
       // Delta can negative, but will always be changed to 0.
-      delta: opt_delta != null ? Math.max(opt_delta, 0) : undefined,
-    };
+      'delta': opt_delta != null ? Math.max(opt_delta, 0) : undefined,
+    });
     if (this.isMessagingReady_ && this.isPerformanceTrackingOn_) {
       this.viewer_.sendMessage('tick', data);
     } else {
@@ -330,9 +332,9 @@ export class Performance {
    */
   flush() {
     if (this.isMessagingReady_ && this.isPerformanceTrackingOn_) {
-      this.viewer_.sendMessage('sendCsi', {
-        ampexp: this.ampexp_,
-      }, /* cancelUnsent */true);
+      this.viewer_.sendMessage('sendCsi', dict({
+        'ampexp': this.ampexp_,
+      }), /* cancelUnsent */true);
     }
   }
 
@@ -398,7 +400,7 @@ export class Performance {
    */
   prerenderComplete_(value) {
     if (this.viewer_) {
-      this.viewer_.sendMessage('prerenderComplete', {value},
+      this.viewer_.sendMessage('prerenderComplete', dict({'value': value}),
           /* cancelUnsent */true);
     }
   }

--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -351,7 +351,7 @@ export class InaboxAmpDocPositionObserver extends AbstractPositionObserver {
     const dataObject = tryParseJson(this.ampdoc_.win.name);
     let sentinel = null;
     if (dataObject) {
-      sentinel = dataObject._context.sentinel;
+      sentinel = dataObject['_context']['sentinel'];
     }
     const win = this.ampdoc_.win;
     object.type = SEND_POSITIONS_HIGH_FIDELITY;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -32,6 +32,7 @@ import {viewportForDoc} from '../services';
 import {vsyncFor} from '../services';
 import {isArray} from '../types';
 import {dev} from '../log';
+import {dict} from '../utils/object';
 import {reportError} from '../error';
 import {filterSplice} from '../utils/array';
 import {getSourceUrl} from '../url';
@@ -995,16 +996,16 @@ export class Resources {
     if (firstPassAfterDocumentReady) {
       this.firstPassAfterDocumentReady_ = false;
       const doc = this.win.document;
-      this.viewer_.sendMessage('documentLoaded', {
-        title: doc.title,
-        sourceUrl: getSourceUrl(this.ampdoc.getUrl()),
-        serverLayout: doc.documentElement.hasAttribute('i-amphtml-element'),
-        linkRels: documentInfoForDoc(this.ampdoc).linkRels,
-      }, /* cancelUnsent */true);
+      this.viewer_.sendMessage('documentLoaded', dict({
+        'title': doc.title,
+        'sourceUrl': getSourceUrl(this.ampdoc.getUrl()),
+        'serverLayout': doc.documentElement.hasAttribute('i-amphtml-element'),
+        'linkRels': documentInfoForDoc(this.ampdoc).linkRels,
+      }), /* cancelUnsent */true);
 
       this.scrollHeight_ = this.viewport_.getScrollHeight();
       this.viewer_.sendMessage('documentHeight',
-          {height: this.scrollHeight_}, /* cancelUnsent */true);
+          dict({'height': this.scrollHeight_}), /* cancelUnsent */true);
       dev().fine(TAG_, 'document height on load: ' + this.scrollHeight_);
     }
 
@@ -1036,7 +1037,7 @@ export class Resources {
         const measuredScrollHeight = this.viewport_.getScrollHeight();
         if (measuredScrollHeight != this.scrollHeight_) {
           this.viewer_.sendMessage('documentHeight',
-              {height: measuredScrollHeight}, /* cancelUnsent */true);
+              dict({'height': measuredScrollHeight}), /* cancelUnsent */true);
           this.scrollHeight_ = measuredScrollHeight;
           dev().fine(TAG_, 'document height changed: ' + this.scrollHeight_);
         }

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -17,6 +17,7 @@
 import {registerServiceBuilderForDoc} from '../service';
 import {getSourceOrigin} from '../url';
 import {dev} from '../log';
+import {dict} from '../utils/object';
 import {recreateNonProtoObject} from '../json';
 import {viewerForDoc} from '../services';
 
@@ -367,15 +368,14 @@ export class ViewerStorageBinding {
 
   /** @override */
   loadBlob(origin) {
-    return this.viewer_.sendMessageAwaitResponse('loadStore', {origin}).then(
-        response => response['blob']
-    );
+    return this.viewer_.sendMessageAwaitResponse('loadStore',
+        dict({'origin': origin})).then(response => response['blob']);
   }
 
   /** @override */
   saveBlob(origin, blob) {
     return /** @type {!Promise} */ (this.viewer_.sendMessageAwaitResponse(
-        'saveStore', {origin, blob}));
+        'saveStore', dict({'origin': origin, 'blob': blob})));
   }
 }
 

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -148,7 +148,7 @@ export class Storage {
   /** @private */
   broadcastReset_() {
     dev().fine(TAG, 'Broadcasted reset message');
-    this.viewer_.broadcast(/** @type {!JSONType} */ ({
+    this.viewer_.broadcast(/** @type {!JsonObject} */ ({
       'type': 'amp-storage-reset',
       'origin': this.origin_,
     }));

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -174,17 +174,17 @@ export class Storage {
  */
 export class Store {
   /**
-   * @param {!JSONType} obj
+   * @param {!JsonObject} obj
    * @param {number=} opt_maxValues
    */
   constructor(obj, opt_maxValues) {
-    /** @const {!JSONType} */
-    this.obj = /** @type {!JSONType} */ (recreateNonProtoObject(obj));
+    /** @const {!JsonObject} */
+    this.obj = /** @type {!JsonObject} */ (recreateNonProtoObject(obj));
 
     /** @private @const {number} */
     this.maxValues_ = opt_maxValues || MAX_VALUES_PER_ORIGIN;
 
-    /** @private @const {!Object<string, !JSONType>} */
+    /** @private @const {!Object<string, !JsonObject>} */
     this.values_ = this.obj['vv'] || Object.create(null);
     if (!this.obj['vv']) {
       this.obj['vv'] = this.values_;
@@ -214,7 +214,7 @@ export class Store {
       item['v'] = value;
       item['t'] = Date.now();
     } else {
-      this.values_[name] = /** @type {!JSONType} */ ({
+      this.values_[name] = dict({
         'v': value,
         't': Date.now(),
       });

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -64,7 +64,7 @@ export class BaseTemplate {
 
   /**
    * To be implemented by subclasses.
-   * @param {!JSONType} unusedData
+   * @param {!JsonObject} unusedData
    * @return {!Element}
    */
   render(unusedData) {
@@ -135,7 +135,7 @@ export class Templates {
   /**
    * Renders the specified template element using the supplied data.
    * @param {!Element} templateElement
-   * @param {!JSONType} data
+   * @param {!JsonObject} data
    * @return {!Promise<!Element>}
    */
   renderTemplate(templateElement, data) {
@@ -148,7 +148,7 @@ export class Templates {
    * Renders the specified template element using the supplied array of data
    * and returns an array of resulting elements.
    * @param {!Element} templateElement
-   * @param {!Array<!JSONType>} array
+   * @param {!Array<!JsonObject>} array
    * @return {!Promise<!Array<!Element>>}
    */
   renderTemplateArray(templateElement, array) {
@@ -168,7 +168,7 @@ export class Templates {
    * attribute  or as a child "template" element. When specified via "template"
    * attribute, the value indicates the ID of the template element.
    * @param {!Element} parent
-   * @param {!JSONType} data
+   * @param {!JsonObject} data
    * @return {!Promise<!Element>}
    */
   findAndRenderTemplate(parent, data) {
@@ -182,7 +182,7 @@ export class Templates {
    * attribute, the value indicates the ID of the template element. Returns
    * the array of the rendered elements.
    * @param {!Element} parent
-   * @param {!Array<!JSONType>} array
+   * @param {!Array<!JsonObject>} array
    * @return {!Promise<!Array<!Element>>}
    */
   findAndRenderTemplateArray(parent, array) {
@@ -328,7 +328,7 @@ export class Templates {
 
   /**
    * @param {!BaseTemplate} impl
-   * @param {!JSONType} data
+   * @param {!JsonObject} data
    * @private
    */
   render_(impl, data) {

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -112,7 +112,7 @@ export class Viewer {
     /** @private {number} */
     this.prerenderSize_ = 1;
 
-    /** @private {!Object<string, !Observable<!JSONType>>} */
+    /** @private {!Object<string, !Observable<!JsonObject>>} */
     this.messageObservables_ = map();
 
     /** @private {!Observable<boolean>} */
@@ -121,7 +121,7 @@ export class Viewer {
     /** @private {!Observable} */
     this.visibilityObservable_ = new Observable();
 
-    /** @private {!Observable<!JSONType>} */
+    /** @private {!Observable<!JsonObject>} */
     this.broadcastObservable_ = new Observable();
 
     /** @private {?function(string, *, boolean):(Promise<*>|undefined)} */
@@ -723,7 +723,7 @@ export class Viewer {
   /**
    * Adds a eventType listener for viewer events.
    * @param {string} eventType
-   * @param {function(!JSONType)} handler
+   * @param {function(!JsonObject)} handler
    * @return {!UnlistenDef}
    */
   onMessage(eventType, handler) {
@@ -738,7 +738,7 @@ export class Viewer {
   /**
    * Requests AMP document to receive a message from Viewer.
    * @param {string} eventType
-   * @param {!JSONType} data
+   * @param {!JsonObject} data
    * @param {boolean} unusedAwaitResponse
    * @return {(!Promise<*>|undefined)}
    * @export
@@ -754,7 +754,7 @@ export class Viewer {
     }
     if (eventType == 'broadcast') {
       this.broadcastObservable_.fire(
-          /** @type {!JSONType|undefined} */ (data));
+          /** @type {!JsonObject|undefined} */ (data));
       return Promise.resolve();
     }
     const observable = this.messageObservables_[eventType];
@@ -901,7 +901,7 @@ export class Viewer {
    * will attempt to deliver messages when the messaging channel has been
    * established, but it will not fail if the channel is timed out.
    *
-   * @param {!JSONType} message
+   * @param {!JsonObject} message
    */
   broadcast(message) {
     if (!this.messagingMaybePromise_) {
@@ -914,7 +914,7 @@ export class Viewer {
 
   /**
    * Registers receiver for the broadcast events.
-   * @param {function(!JSONType)} handler
+   * @param {function(!JsonObject)} handler
    * @return {!UnlistenDef}
    */
   onBroadcast(handler) {

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -26,6 +26,7 @@ import {
 } from '../service';
 import {layoutRectLtwh} from '../layout-rect';
 import {dev} from '../log';
+import {dict} from '../utils/object';
 import {numeric} from '../transition';
 import {onDocumentReady, whenDocumentReady} from '../document-ready';
 import {platformFor} from '../services';
@@ -447,7 +448,8 @@ export class Viewport {
    * @return {!Promise}
    */
   enterLightboxMode() {
-    this.viewer_.sendMessage('requestFullOverlay', {}, /* cancelUnsent */true);
+    this.viewer_.sendMessage('requestFullOverlay', dict(),
+        /* cancelUnsent */true);
     this.enterOverlayMode();
     this.hideFixedLayer();
     return this.binding_.updateLightboxMode(true);
@@ -458,7 +460,8 @@ export class Viewport {
    * @return {!Promise}
    */
   leaveLightboxMode() {
-    this.viewer_.sendMessage('cancelFullOverlay', {}, /* cancelUnsent */true);
+    this.viewer_.sendMessage('cancelFullOverlay', dict(),
+        /* cancelUnsent */true);
     this.showFixedLayer();
     this.leaveOverlayMode();
     return this.binding_.updateLightboxMode(false);
@@ -781,7 +784,8 @@ export class Viewport {
       this.scrollAnimationFrameThrottled_ = true;
       this.vsync_.measure(() => {
         this.scrollAnimationFrameThrottled_ = false;
-        this.viewer_.sendMessage('scroll', {scrollTop: this.getScrollTop()},
+        this.viewer_.sendMessage('scroll',
+            dict({'scrollTop': this.getScrollTop()}),
             /* cancelUnsent */true);
       });
     }

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -633,7 +633,7 @@ export class Viewport {
   }
 
   /**
-   * @param {!JSONType} data
+   * @param {!JsonObject} data
    * @private
    */
   viewerSetScrollTop_(data) {
@@ -642,7 +642,7 @@ export class Viewport {
   }
 
   /**
-   * @param {!JSONType} data
+   * @param {!JsonObject} data
    * @private
    */
   updateOnViewportEvent_(data) {

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -504,10 +504,10 @@ export class FetchResponse {
 
   /**
    * Drains the response and returns the JSON object.
-   * @return {!Promise<!JSONType>}
+   * @return {!Promise<!JsonObject>}
    */
   json() {
-    return /** @type {!Promise<!JSONType>} */ (
+    return /** @type {!Promise<!JsonObject>} */ (
         this.drainText_().then(JSON.parse.bind(JSON)));
   }
 

--- a/src/url-parse-query-string.js
+++ b/src/url-parse-query-string.js
@@ -24,10 +24,10 @@ const regex = /(?:^[#?]?|&)([^=&]+)(?:=([^&]*))?/g;
  * from `src/url.js`.
  *
  * @param {string} queryString
- * @return {!Object<string>}
+ * @return {!JsonObject}
  */
 export function parseQueryString_(queryString) {
-  const params = Object.create(null);
+  const params = /** @type {!JsonObject} */ (Object.create(null));
   if (!queryString) {
     return params;
   }

--- a/src/url.js
+++ b/src/url.js
@@ -268,7 +268,7 @@ export function assertAbsoluteHttpOrHttpsUrl(urlString) {
  * dependency.
  *
  * @param {string} queryString
- * @return {!Object<string>}
+ * @return {!JsonObject}
  */
 export function parseQueryString(queryString) {
   return parseQueryString_(queryString);

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -36,6 +36,13 @@ export function map(opt_initial) {
 }
 
 /**
+ * @return {!JsonObject}
+ */
+export function dict() {
+  return /** @type {!JsonObject} */ ({});
+}
+
+/**
  * Checks if the given key is a property in the map.
  *
  * @param {T}  obj a map like property.

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -45,7 +45,7 @@ export function map(opt_initial) {
  * @return {!JsonObject}
  */
 export function dict(opt_initial) {
-  return /** @type {!JsonObject} */ (map(obj_initial));
+  return /** @type {!JsonObject} */ (map(opt_initial));
 }
 
 /**

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -41,7 +41,7 @@ export function map(opt_initial) {
  */
 export function dict(opt_initial) {
   if (opt_initial) {
-     return /** @type {!JsonObject} */ (opt_initial);
+    return /** @type {!JsonObject} */ (opt_initial);
   }
   return /** @type {!JsonObject} */ ({});
 }

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -36,9 +36,13 @@ export function map(opt_initial) {
 }
 
 /**
+ * @param {!Object=} opt_initial
  * @return {!JsonObject}
  */
-export function dict() {
+export function dict(opt_initial) {
+  if (opt_initial) {
+     return /** @type {!JsonObject} */ (opt_initial);
+  }
   return /** @type {!JsonObject} */ ({});
 }
 

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -36,14 +36,16 @@ export function map(opt_initial) {
 }
 
 /**
+ * Returns a `map`, and will always return a at-dict like object.
+ * The JsonObject type is just a simple object that is a dict.
+ * See
+ * https://github.com/google/closure-compiler/wiki/@struct-and-@dict-Annotations
+ * for what a dict is type-wise.
  * @param {!Object=} opt_initial
  * @return {!JsonObject}
  */
 export function dict(opt_initial) {
-  if (opt_initial) {
-    return /** @type {!JsonObject} */ (opt_initial);
-  }
-  return /** @type {!JsonObject} */ ({});
+  return /** @type {!JsonObject} */ (map(obj_initial));
 }
 
 /**

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -636,10 +636,16 @@ describes.fakeWin('Get and update fragment', {}, env => {
         new HistoryBindingVirtual_(env.win, viewer));
     viewerMock.expects('hasCapability').withExactArgs('fragment').once()
         .returns(true);
-    viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
-        'replaceHistory', {fragment: 'fragment'}, true).once()
-        .returns(Promise.resolve());
-    return history.updateFragment('fragment').then(() => {});
+    let called = false;
+    viewer.sendMessageAwaitResponse = function(action, data) {
+      expect(action).to.equal('replaceHistory');
+      expect(data.fragment).to.equal('fragment');
+      called = true;
+      return Promise.resolve();
+    };
+    return history.updateFragment('fragment').then(() => {
+      expect(called).to.be.ok;
+    });
   });
 
   it('should NOT update fragment of the viewer on Virtual ' +

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -22,6 +22,7 @@ import {
   installHistoryServiceForDoc,
 } from '../../src/service/history-impl';
 import {historyForDoc} from '../../src/services';
+import {dict} from '../../src/utils/object';
 import {listenOncePromise} from '../../src/event-helper';
 import {installTimerService} from '../../src/service/timer-impl';
 import {timerFor} from '../../src/services';
@@ -411,7 +412,7 @@ describe('HistoryBindingVirtual', () => {
 
   it('should push new state to viewer and notify', () => {
     viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
-        'pushHistory', {stackIndex: 1}).once().returns(Promise.resolve());
+        'pushHistory', dict({stackIndex: 1})).once().returns(Promise.resolve());
     return history.push().then(stackIndex => {
       expect(stackIndex).to.equal(1);
       expect(history.stackIndex_).to.equal(1);

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -427,21 +427,17 @@ describes.realWin('performance', {amp: true}, env => {
       });
 
       it('should call the flush callback', () => {
-        const payload = {
-          ampexp: 'rtv-' + getMode(win).rtvVersion,
-        };
-        expect(viewerSendMessageStub.withArgs('sendCsi', payload,
-            /* cancelUnsent */true)).to.have.callCount(0);
+        expect(viewerSendMessageStub.withArgs('sendCsi')).to.have.callCount(0);
         // coreServicesAvailable calls flush once.
         return perf.coreServicesAvailable().then(() => {
-          expect(viewerSendMessageStub.withArgs('sendCsi', payload,
-              /* cancelUnsent */true)).to.have.callCount(1);
+          expect(viewerSendMessageStub.withArgs('sendCsi'))
+              .to.have.callCount(1);
           perf.flush();
-          expect(viewerSendMessageStub.withArgs('sendCsi', payload,
-              /* cancelUnsent */true)).to.have.callCount(2);
+          expect(viewerSendMessageStub.withArgs('sendCsi'))
+              .to.have.callCount(2);
           perf.flush();
-          expect(viewerSendMessageStub.withArgs('sendCsi', payload,
-              /* cancelUnsent */true)).to.have.callCount(3);
+          expect(viewerSendMessageStub.withArgs('sendCsi'))
+              .to.have.callCount(3);
         });
       });
     });
@@ -652,9 +648,9 @@ describes.realWin('performance with experiment', {amp: true}, env => {
     return perf.coreServicesAvailable().then(() => {
       viewerSendMessageStub.reset();
       perf.flush();
-      expect(viewerSendMessageStub).to.be.calledWith('sendCsi', {
-        ampexp: 'rtv-' + getMode(win).rtvVersion,
-      });
+      expect(viewerSendMessageStub.lastCall.args[0]).to.equal('sendCsi');
+      expect(viewerSendMessageStub.lastCall.args[1].ampexp).to.equal(
+          'rtv-' + getMode(win).rtvVersion);
     });
   });
 

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1567,8 +1567,9 @@ describes.realWin('Resources scrollHeight', {
     expect(resources.maybeChangeHeight_).to.equal(false);
     expect(resources.scrollHeight_).to.equal(200);
     expect(viewerSendMessageStub).to.be.calledOnce;
-    expect(viewerSendMessageStub).to.be.calledWith(
-        'documentHeight', {height: 200}, true);
+    expect(viewerSendMessageStub.lastCall.args[0]).to.equal('documentHeight');
+    expect(viewerSendMessageStub.lastCall.args[1].height).to.equal(200);
+    expect(viewerSendMessageStub.lastCall.args[2]).to.equal(true);
   });
 
   it('should not send scrollHeight to viewer if height is not changed', () => {

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -594,8 +594,8 @@ describes.fakeWin('Viewport', {}, env => {
     clock.tick(6);
     expect(viewport.scrollAnimationFrameThrottled_).to.be.false;
     expect(viewer.sendMessage).to.have.been.calledOnce;
-    expect(viewer.sendMessage).to.have.been.calledWith('scroll',
-        {scrollTop: 30}, true);
+    expect(viewer.sendMessage.lastCall.args[0]).to.equal('scroll');
+    expect(viewer.sendMessage.lastCall.args[1].scrollTop).to.equal(30);
     // scroll to 40
     viewport.getScrollTop = () => 40;
     viewport.sendScrollMessage_();
@@ -631,8 +631,8 @@ describes.fakeWin('Viewport', {}, env => {
     // call viewer.postScroll, raf for viewer.postScroll
     expect(changeEvent).to.equal(null);
     expect(viewer.sendMessage).to.have.callCount(1);
-    expect(viewer.sendMessage).to.have.been.calledWith('scroll',
-        {scrollTop: 34}, true);
+    expect(viewer.sendMessage.lastCall.args[0]).to.equal('scroll');
+    expect(viewer.sendMessage.lastCall.args[1].scrollTop).to.equal(34);
     binding.getScrollTop = () => 35;
     viewport.scroll_();
 


### PR DESCRIPTION
Uses the type system to ensure that objects that must be treated as non-obfuscateable are using bracket notation for property access.

This is a first PR of many. Part of #9876