### PR TITLE
Fix script tag src

### DIFF
--- a/extensions/amp-a4a/amp-a4a-format.md
+++ b/extensions/amp-a4a/amp-a4a-format.md
@@ -458,7 +458,7 @@ SVG tags are not in the HTML5 namespace. They are listed below without section i
 4.10.8 `<button>`  
 #### 4.11 Scripting
 - Like a general AMP document, the creative's `<head>` tag must contain a
-  `<script async src="https://cdn.ampproject.org/v0.js"></script>` tag.
+  `<script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>` tag.
 - Unlike general AMP, `<noscript>` is prohibited.
   - _Rationale:_ Since AMP ads requires Javascript to be enabled to function
     at all, `<noscript>` blocks serve no purpose in an AMP ad and


### PR DESCRIPTION
In the `AMP Ad Format Rules` section, it is mentioned that the main script must be `https://cdn.ampproject.org/amp4ads-v0.js` instead of `https://cdn.ampproject.org/v0.js`.