### PR TITLE
AMP Sidebar v1.0: Started Toolbar (Horizontal Menubar) For AMP Sidebar

### DIFF
--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -224,7 +224,9 @@
 </head>
 <body>
   <amp-sidebar id="sidebar" layout="nodisplay">
-    <nav>
+
+    <!-- Toolbar/sidebar elements -->
+    <nav toolbar="(max-width: 768px)">
       <ul>
         <li>
           <a href="#">
@@ -232,15 +234,19 @@
             <amp-img src="img/ampicon.png" width="15" height="15"></amp-img>
           </a>
         </li>
-        <li><a href="#">Link 1</a></li>
-        <li><a href="#">Link 2</a></li>
-        <li><a href="#">Link 3</a></li>
-        <li><a href="#">Link 4</a></li>
-        <li><a href="#section1">Section 1</a></li>
-        <li><a href="#section2">Section 2</a></li>
-        <li><a href="#section3">Section 3</a></li>
       </ul>
     </nav>
+
+    <!-- Sidebar only elements -->
+    <ul>
+      <li><a href="#">Link 1</a></li>
+      <li><a href="#">Link 2</a></li>
+      <li><a href="#">Link 3</a></li>
+      <li><a href="#">Link 4</a></li>
+      <li><a href="#section1">Section 1</a></li>
+      <li><a href="#section2">Section 2</a></li>
+      <li><a href="#section3">Section 3</a></li>
+    </ul>
   </amp-sidebar>
   <amp-app-banner layout="nodisplay" id="demo-app-banner-2134">
     <div class="content">

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -242,7 +242,7 @@
     </nav>
 
     <!-- Multiple / Complex Toolbars -->
-    <nav toolbar="(min-width: 0px) and (max-width: 767px)" toolbar-only>
+    <nav toolbar="(max-width: 767px)" toolbar-only>
       <input placeholder="Search..."/>
     </nav>
 

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -242,6 +242,9 @@
         </li>
         <li toolbar-only><a href="#">Toolbar Only Example</a></li>
       </ul>
+
+      <!-- Example Search Input field -->
+      <input placeholder="Search..."/>
     </nav>
 
     <!-- Sidebar only elements -->
@@ -273,6 +276,7 @@
     <button on="tap:sidebar.toggle" class="menu" title="Toggle Sidebar" >
       ☰
     </button>
+
     <span class="brand-logo toolbar-media-hide">
       PublisherLogo
     </span>

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -243,12 +243,20 @@
 
     <!-- Multiple / Complex Toolbars -->
     <nav toolbar="(max-width: 767px)" toolbar-only>
-      <input placeholder="Search..."/>
+      <ul>
+        <li>
+          <input placeholder="Search..."/>
+        </li>
+      </ul>
     </nav>
 
     <nav toolbar="(min-width: 375px) and (max-width: 767px)" toolbar-only>
-      <amp-img src="https://cdn-images-1.medium.com/max/800/1*JLegdtjFMNgqHgnxdd04fg.png"
+      <ul>
+        <li>
+          <amp-img src="https://cdn-images-1.medium.com/max/800/1*JLegdtjFMNgqHgnxdd04fg.png"
                width="40" height="34"></amp-img>
+       </li>
+     </ul>
     </nav>
 
     <!-- Sidebar only elements -->

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -17,6 +17,12 @@
       font-family: 'Open Sans';
     }
 
+    @media (min-width: 768px) {
+      .toolbar-media-hide {
+        display: none;
+      }
+    }
+
     .ad-container {
       display: flex;
       justify-content: center;
@@ -231,7 +237,7 @@
         <li>
           <a href="#">
             Home
-            <amp-img src="img/ampicon.png" width="15" height="15" toolbar-only></amp-img>
+            <amp-img src="img/ampicon.png" width="15" height="15"></amp-img>
           </a>
         </li>
         <li toolbar-only><a href="#">Toolbar Only Example</a></li>
@@ -267,7 +273,7 @@
     <button on="tap:sidebar.toggle" class="menu" title="Toggle Sidebar" >
       ☰
     </button>
-    <span class="brand-logo">
+    <span class="brand-logo toolbar-media-hide">
       PublisherLogo
     </span>
   </header>

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -17,12 +17,6 @@
       font-family: 'Open Sans';
     }
 
-    @media (min-width: 768px) {
-      .toolbar-media-hide {
-        display: none;
-      }
-    }
-
     .ad-container {
       display: flex;
       justify-content: center;
@@ -247,6 +241,16 @@
       <input placeholder="Search..."/>
     </nav>
 
+    <!-- Multiple / Complex Toolbars -->
+    <nav toolbar="(min-width: 0px) and (max-width: 767)" toolbar-only>
+      <input placeholder="Search..."/>
+    </nav>
+
+    <nav toolbar="(min-width: 375px) and (max-width: 767)" toolbar-only>
+      <amp-img src="https://cdn-images-1.medium.com/max/800/1*JLegdtjFMNgqHgnxdd04fg.png"
+               width="40" height="34"></amp-img>
+    </nav>
+
     <!-- Sidebar only elements -->
     <ul>
       <li><a href="#">Link 1</a></li>
@@ -277,7 +281,7 @@
       ☰
     </button>
 
-    <span class="brand-logo toolbar-media-hide">
+    <span class="brand-logo">
       PublisherLogo
     </span>
   </header>

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -225,7 +225,7 @@
 <body>
   <amp-sidebar id="sidebar" layout="nodisplay">
 
-    <!-- Toolbar/sidebar elements -->
+    <!-- Toolbar/sidebar elements, except with toolbar-only -->
     <nav toolbar="(min-width: 768px)">
       <ul>
         <li>
@@ -234,6 +234,7 @@
             <amp-img src="img/ampicon.png" width="15" height="15" toolbar-only></amp-img>
           </a>
         </li>
+        <li toolbar-only><a href="#">Toolbar Only Example</a></li>
       </ul>
     </nav>
 

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -235,10 +235,11 @@
           </a>
         </li>
         <li toolbar-only><a href="#">Toolbar Only Example</a></li>
+        <li>
+          <!-- Example Search Input field -->
+          <input placeholder="Search..."/>
+        </li>
       </ul>
-
-      <!-- Example Search Input field -->
-      <input placeholder="Search..."/>
     </nav>
 
     <!-- Multiple / Complex Toolbars -->

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -242,11 +242,11 @@
     </nav>
 
     <!-- Multiple / Complex Toolbars -->
-    <nav toolbar="(min-width: 0px) and (max-width: 767)" toolbar-only>
+    <nav toolbar="(min-width: 0px) and (max-width: 767px)" toolbar-only>
       <input placeholder="Search..."/>
     </nav>
 
-    <nav toolbar="(min-width: 375px) and (max-width: 767)" toolbar-only>
+    <nav toolbar="(min-width: 375px) and (max-width: 767px)" toolbar-only>
       <amp-img src="https://cdn-images-1.medium.com/max/800/1*JLegdtjFMNgqHgnxdd04fg.png"
                width="40" height="34"></amp-img>
     </nav>

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -201,16 +201,6 @@
       width: 150px;
     }
 
-    nav li {
-      list-style: none;
-      margin-bottom: 10px;
-    }
-
-    nav li a {
-      text-decoration: none;
-      color: #666666;
-    }
-
   </style>
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
@@ -243,6 +233,26 @@
     </nav>
 
     <!-- Multiple / Complex Toolbars -->
+    <nav toolbar="(min-width: 0px)" toolbar-only>
+      <ul>
+        <li>
+          <a href="#">Min Width Example</a>
+        </li>
+        <li>
+          <a href="#">Wrap Example</a>
+        </li>
+        <li>
+          <a href="#">Wrap Example</a>
+        </li>
+        <li>
+          <a href="#">Wrap Example</a>
+        </li>
+        <li>
+          <a href="#">Wrap Example</a>
+        </li>
+      </ul>
+    </nav>
+
     <nav toolbar="(max-width: 767px)" toolbar-only>
       <ul>
         <li>

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -226,12 +226,12 @@
   <amp-sidebar id="sidebar" layout="nodisplay">
 
     <!-- Toolbar/sidebar elements -->
-    <nav toolbar="(max-width: 768px)">
+    <nav toolbar="(min-width: 768px)">
       <ul>
         <li>
           <a href="#">
             Home
-            <amp-img src="img/ampicon.png" width="15" height="15"></amp-img>
+            <amp-img src="img/ampicon.png" width="15" height="15" toolbar-only></amp-img>
           </a>
         </li>
       </ul>

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -49,10 +49,11 @@
    transition: transform 233ms cubic-bezier(0,0,.21,1);
  }
 
- .i-amphtml-toolbar-container {
+ .i-amphtml-toolbar {
    z-index: 2147483646;
    width: 100%;
    position: fixed;
+   top: 0;
  }
 
  .i-amphtml-toolbar > ul {

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -49,6 +49,25 @@
    transition: transform 233ms cubic-bezier(0,0,.21,1);
  }
 
+ :not(amp-sidebar) > nav[toolbar] {
+   display: flex;
+   justify-content: flex-start;
+   align-items: center;
+ }
+
+ :not(amp-sidebar) > nav[toolbar] > ul {
+   display: flex;
+   justify-content: flex-start;
+   align-items: center;
+
+   padding: 0;
+   margin: 0;
+ }
+
+ :not(amp-sidebar) > nav[toolbar] > ul > li {
+   margin-bottom: 0;
+ }
+
  .i-amphtml-sidebar-mask {
    position: fixed !important;
    top: 0 !important;
@@ -60,31 +79,4 @@
    background-image: none !important;
    background-color: #000;
    z-index: 2147483646;
- }
-
- .i-amphtml-sidebar-toolbar {
-   display: none;
- }
-
- .i-amphtml-sidebar-toolbar[show] {
-   display: block;
- }
-
- .i-amphtml-sidebar-toolbar > nav[toolbar] {
-   display: flex;
-   justify-content: flex-start;
-   align-items: center;
- }
-
- .i-amphtml-sidebar-toolbar > nav[toolbar] > ul {
-   display: flex;
-   justify-content: flex-start;
-   align-items: center;
-
-   padding: 0;
-   margin: 0;
- }
-
- .i-amphtml-sidebar-toolbar > nav[toolbar] > ul > li {
-   margin-bottom: 0;
  }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -50,17 +50,25 @@
  }
 
   header[toolbar] nav[toolbar] {
-    display: inline-block;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
   }
 
   header[toolbar] nav[toolbar] ul {
-    padding-left: 0px;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+
+    padding: 0;
+    margin: 0;
   }
 
-  header[toolbar] nav[toolbar] li {
-    margin-bottom: 0px;
+  header[toolbar] nav[toolbar] ul li {
+    margin-bottom: 0;
+
+    margin-left: 5px;
+    margin-right: 5px;
   }
 
  .i-amphtml-sidebar-mask {

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -49,12 +49,35 @@
    transition: transform 233ms cubic-bezier(0,0,.21,1);
  }
 
- .i-amphtml-sidebar-toolbar > ul {
+ .i-amphtml-toolbar-container {
+ }
+
+ .i-amphtml-toolbar-placeholder {
+   visibility: hidden;
+ }
+
+ .i-amphtml-toolbar-placeholder > ul {
+   width: 100%;
    display: flex;
    justify-content: flex-start;
    flex-wrap: wrap;
    overflow: auto;
    list-style-type: none;
+
+   padding: 0;
+   margin: 0;
+ }
+
+ .i-amphtml-toolbar > ul {
+   display: flex;
+   justify-content: flex-start;
+   flex-wrap: wrap;
+   overflow: auto;
+   list-style-type: none;
+   position: fixed;
+   z-index: 2147483646;
+   background-color: white;
+   width: 100%;
 
    padding: 0;
    margin: 0;

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -66,9 +66,6 @@
 
   header[toolbar] nav[toolbar] ul li {
     margin-bottom: 0;
-
-    margin-left: 5px;
-    margin-right: 5px;
   }
 
  .i-amphtml-sidebar-mask {

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -50,22 +50,9 @@
  }
 
  .i-amphtml-toolbar-container {
- }
-
- .i-amphtml-toolbar-placeholder {
-   visibility: hidden;
- }
-
- .i-amphtml-toolbar-placeholder > ul {
+   z-index: 2147483646;
    width: 100%;
-   display: flex;
-   justify-content: flex-start;
-   flex-wrap: wrap;
-   overflow: auto;
-   list-style-type: none;
-
-   padding: 0;
-   margin: 0;
+   position: fixed;
  }
 
  .i-amphtml-toolbar > ul {
@@ -74,10 +61,6 @@
    flex-wrap: wrap;
    overflow: auto;
    list-style-type: none;
-   position: fixed;
-   z-index: 2147483646;
-   background-color: white;
-   width: 100%;
 
    padding: 0;
    margin: 0;

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -49,6 +49,20 @@
    transition: transform 233ms cubic-bezier(0,0,.21,1);
  }
 
+  header[toolbar] nav[toolbar] {
+    display: inline-block;
+  }
+
+  header[toolbar] nav[toolbar] ul {
+    padding-left: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+  }
+
+  header[toolbar] nav[toolbar] li {
+    margin-bottom: 0px;
+  }
+
  .i-amphtml-sidebar-mask {
    position: fixed !important;
    top: 0 !important;

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -49,23 +49,15 @@
    transition: transform 233ms cubic-bezier(0,0,.21,1);
  }
 
- :not(amp-sidebar) > nav[toolbar] {
+ .i-amphtml-sidebar-toolbar > ul {
    display: flex;
    justify-content: flex-start;
-   align-items: center;
- }
-
- :not(amp-sidebar) > nav[toolbar] > ul {
-   display: flex;
-   justify-content: flex-start;
-   align-items: center;
+   flex-wrap: wrap;
+   overflow: auto;
+   list-style-type: none;
 
    padding: 0;
    margin: 0;
- }
-
- :not(amp-sidebar) > nav[toolbar] > ul > li {
-   margin-bottom: 0;
  }
 
  .i-amphtml-sidebar-mask {

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -49,25 +49,6 @@
    transition: transform 233ms cubic-bezier(0,0,.21,1);
  }
 
-  header[toolbar] nav[toolbar] {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-  }
-
-  header[toolbar] nav[toolbar] ul {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-
-    padding: 0;
-    margin: 0;
-  }
-
-  header[toolbar] nav[toolbar] ul li {
-    margin-bottom: 0;
-  }
-
  .i-amphtml-sidebar-mask {
    position: fixed !important;
    top: 0 !important;
@@ -79,4 +60,31 @@
    background-image: none !important;
    background-color: #000;
    z-index: 2147483646;
+ }
+
+ .i-amphtml-sidebar-toolbar {
+   display: none;
+ }
+
+ .i-amphtml-sidebar-toolbar[show] {
+   display: block;
+ }
+
+ .i-amphtml-sidebar-toolbar nav[toolbar] {
+   display: flex;
+   justify-content: flex-start;
+   align-items: center;
+ }
+
+ .i-amphtml-sidebar-toolbar nav[toolbar] ul {
+   display: flex;
+   justify-content: flex-start;
+   align-items: center;
+
+   padding: 0;
+   margin: 0;
+ }
+
+ .i-amphtml-sidebar-toolbar nav[toolbar] ul li {
+   margin-bottom: 0;
  }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -70,13 +70,13 @@
    display: block;
  }
 
- .i-amphtml-sidebar-toolbar nav[toolbar] {
+ .i-amphtml-sidebar-toolbar > nav[toolbar] {
    display: flex;
    justify-content: flex-start;
    align-items: center;
  }
 
- .i-amphtml-sidebar-toolbar nav[toolbar] ul {
+ .i-amphtml-sidebar-toolbar > nav[toolbar] > ul {
    display: flex;
    justify-content: flex-start;
    align-items: center;
@@ -85,6 +85,6 @@
    margin: 0;
  }
 
- .i-amphtml-sidebar-toolbar nav[toolbar] ul li {
+ .i-amphtml-sidebar-toolbar > nav[toolbar] > ul > li {
    margin-bottom: 0;
  }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -45,8 +45,8 @@ export class AmpSidebar extends AMP.BaseElement {
     /** @private {?../../../src/service/viewport-impl.Viewport} */
     this.viewport_ = null;
 
-    /** @const @private {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = vsyncFor(this.win);
+    /** @const @public {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync = vsyncFor(this.win);
 
     /** @private {?Element} */
     this.maskElement_ = null;
@@ -221,7 +221,7 @@ export class AmpSidebar extends AMP.BaseElement {
       return;
     }
     this.viewport_.enterOverlayMode();
-    this.vsync_.mutate(() => {
+    this.vsync.mutate(() => {
       toggle(this.element, /* display */true);
       this.openMask_();
       if (this.isIosSafari_) {
@@ -229,7 +229,7 @@ export class AmpSidebar extends AMP.BaseElement {
       }
       this.element./*OK*/scrollTop = 1;
       // Start animation in a separate vsync due to display:block; set above.
-      this.vsync_.mutate(() => {
+      this.vsync.mutate(() => {
         this.element.setAttribute('open', '');
         this.element.setAttribute('aria-hidden', 'false');
         if (this.openOrCloseTimeOut_) {
@@ -258,7 +258,7 @@ export class AmpSidebar extends AMP.BaseElement {
       return;
     }
     this.viewport_.leaveOverlayMode();
-    this.vsync_.mutate(() => {
+    this.vsync.mutate(() => {
       this.closeMask_();
       this.element.removeAttribute('open');
       this.element.setAttribute('aria-hidden', 'true');
@@ -267,7 +267,7 @@ export class AmpSidebar extends AMP.BaseElement {
       }
       this.openOrCloseTimeOut_ = this.timer_.delay(() => {
         if (!this.isOpen_()) {
-          this.vsync_.mutate(() => {
+          this.vsync.mutate(() => {
             toggle(this.element, /* display */false);
             this.schedulePause(this.getRealChildren());
           });

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -127,7 +127,9 @@ export class AmpSidebar extends AMP.BaseElement {
           this.toolbarTarget_ = this.element.ownerDocument.createElement("header");
           this.element.parentElement.insertBefore(this.toolbarTarget_, this.element);
           if(!this.isToolbar_()) {
-            this.toolbarTarget_.style.display = 'none';
+            setStyles(this.toolbarTarget_, {
+              'display': 'none'
+            });
           }
 
           //Finally, find our tool-bar only elements
@@ -219,11 +221,15 @@ export class AmpSidebar extends AMP.BaseElement {
       this.toolbarClone_ = this.toolbarNav_.cloneNode(true);
       this.toolbarTarget_.appendChild(this.toolbarClone_);
       if(this.toolbarTarget_.style.display === 'none') {
-        this.toolbarTarget_.style.display = null;
+        setStyles(this.toolbarTarget_, {
+          'display': null
+        });
       }
       if(this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
-          element.style.display = 'none';
+          setStyles(element, {
+            'display': 'none'
+          });
         });
       }
       this.toolbarTarget_.setAttribute('toolbar', '');
@@ -233,7 +239,9 @@ export class AmpSidebar extends AMP.BaseElement {
       this.toolbarTarget_.removeChild(this.toolbarClone_);
       if(this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
-          element.style.display = null;
+          setStyles(element, {
+            'display': null
+          });
         });
       }
       this.toolbarTarget_.removeAttribute('toolbar');
@@ -241,6 +249,9 @@ export class AmpSidebar extends AMP.BaseElement {
       // Check if our target still has elements, if not, do not display it
       if(!this.toolbarTarget_.hasChildNodes()) {
         this.toolbarTarget_.style.display = 'none';
+        setStyles(this.toolbarTarget_, {
+          'display': 'none'
+        });
       }
     }
   }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -182,7 +182,7 @@ export class AmpSidebar extends AMP.BaseElement {
   onLayoutMeasure() {
     // Check our toolbars for changes
     this.toolbars_.forEach(toolbar => {
-      toolbar.onLayoutMeasure(() => this.close_());
+      toolbar.onLayoutChange(() => this.close_());
     });
   }
 

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -112,7 +112,7 @@ export class AmpSidebar extends AMP.BaseElement {
       .call(this.element.querySelectorAll('nav[toolbar]'), 0);
     toolbarElements.forEach(toolbarElement => {
       try {
-        this.toolbars_.push(new Toolbar(toolbarElement, this));
+        this.toolbars_.push(new Toolbar(toolbarElement, this.element));
       } catch (e) {
         user().error(TAG, 'Failed to instantiate toolbar', e);
       }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -112,7 +112,7 @@ export class AmpSidebar extends AMP.BaseElement {
       .call(this.element.querySelectorAll('nav[toolbar]'), 0);
     toolbarElements.forEach(toolbarElement => {
       try {
-        this.toolbars_.push(new Toolbar(toolbarElement, this.element));
+        this.toolbars_.push(new Toolbar(toolbarElement, this));
       } catch (e) {
         user().error(TAG, 'Failed to instantiate toolbar', e);
       }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -112,7 +112,7 @@ export class AmpSidebar extends AMP.BaseElement {
       .call(this.element.querySelectorAll('nav[toolbar]'), 0);
     toolbarElements.forEach(toolbarElement => {
       try {
-        this.toolbars_.push(new Toolbar(toolbarElement));
+        this.toolbars_.push(new Toolbar(toolbarElement, this));
       } catch (e) {
         user().error(TAG, 'Failed to instantiate toolbar', e);
       }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -122,13 +122,10 @@ export class AmpSidebar extends AMP.BaseElement {
           this.toolbarNav_ = navElement;
           this.toolbar_ = navElement.getAttribute('toolbar');
 
-          // Find or create a header element on the document for our toolbar
-          if (this.element.ownerDocument.getElementsByTagName('header').length > 0) {
-            this.toolbarHeader_ = this.element.ownerDocument.getElementsByTagName('header')[0];
-          } else {
-            this.toolbarHeader_ = this.element.ownerDocument.createElement("div");
-            this.element.ownerDocument.insertBefore(this.toolbarHeader_, this.element);
-          }
+          // Create a header element on the document for our toolbar
+          // TODO: Allow specifying a target for the toolbar
+          this.toolbarHeader_ = this.element.ownerDocument.createElement("header");
+          this.element.parentElement.insertBefore(this.toolbarHeader_, this.element);
 
           //Finally, find our tool-bar only elements
           if(this.toolbarNav_.hasAttribute('toolbar-only')) {

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -248,7 +248,6 @@ export class AmpSidebar extends AMP.BaseElement {
 
       // Check if our target still has elements, if not, do not display it
       if(!this.toolbarTarget_.hasChildNodes()) {
-        this.toolbarTarget_.style.display = 'none';
         setStyles(this.toolbarTarget_, {
           'display': 'none'
         });

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -182,7 +182,7 @@ export class AmpSidebar extends AMP.BaseElement {
   onLayoutMeasure() {
     // Check our toolbars for changes
     this.toolbars_.forEach(toolbar => {
-      toolbar.checkToolbar(() => this.close_());
+      toolbar.onLayoutMeasure(() => this.close_());
     });
   }
 

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -60,16 +60,16 @@ export class AmpSidebar extends AMP.BaseElement {
     this.toolbar_ = undefined;
 
     /** @private {?Element} */
-    this.toolbarNav_ = undefined;
+    this.toolbarNav_ = null;
 
     /** @private {?Element} */
-    this.toolbarClone_ = undefined;
+    this.toolbarClone_ = null;
 
     /** @private {?Element} */
-    this.toolbarTarget_ = undefined;
+    this.toolbarTarget_ = null;
 
     /** @private {?Array} */
-    this.toolbarOnlyElements_ = undefined;
+    this.toolbarOnlyElements_ = null;
 
     const platform = platformFor(this.win);
 
@@ -119,7 +119,7 @@ export class AmpSidebar extends AMP.BaseElement {
       this.element.getElementsByTagName('nav').length > 0
     ) {
       const childNavElements =
-        Array.from(this.element.getElementsByTagName('nav'));
+      Array.prototype.slice.call(this.element.getElementsByTagName('nav'), 0);
       childNavElements.some(navElement => {
         if (navElement.hasAttribute('toolbar')) {
           this.toolbarNav_ = navElement;
@@ -145,8 +145,8 @@ export class AmpSidebar extends AMP.BaseElement {
             this.toolbarNav_.getElementsByTagName('*').length > 0) {
             this.toolbarOnlyElements_ = [];
             // Check the nav's children for toolbar-only
-            Array.from(this.toolbarNav_
-              .getElementsByTagName('*')).forEach(element => {
+            Array.prototype.slice.call(this.toolbarNav_
+              .getElementsByTagName('*'), 0).forEach(element => {
                 if (element.hasAttribute('toolbar-only')) {
                   this.toolbarOnlyElements_.push(element);
                 }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -29,6 +29,9 @@ import {timerFor} from '../../../src/services';
 import {Toolbar} from './toolbar';
 
 /** @const */
+const TAG = 'amp-sidebar 1.0';
+
+/** @const */
 const ANIMATION_TIMEOUT = 550;
 
 /** @const */
@@ -57,8 +60,8 @@ export class AmpSidebar extends AMP.BaseElement {
     /** @private {?string} */
     this.side_ = null;
 
-    /** @private {?Array} */
-    this.toolbars_ = null;
+    /** @private {Array} */
+    this.toolbars_ = [];
 
     const platform = platformFor(this.win);
 
@@ -104,17 +107,16 @@ export class AmpSidebar extends AMP.BaseElement {
     }
 
     // Get the toolbar attribute from the child navs
-    if (this.element.hasChildNodes &&
-      this.element.querySelectorAll('nav[toolbar]').length > 0
-    ) {
-      this.toolbars_ = [];
-      const childNavElements =
-      Array.prototype.slice
-        .call(this.element.querySelectorAll('nav[toolbar]'), 0);
-      childNavElements.forEach(toolbarElement => {
+    const toolbarElements =
+    Array.prototype.slice
+      .call(this.element.querySelectorAll('nav[toolbar]'), 0);
+    toolbarElements.forEach(toolbarElement => {
+      try {
         this.toolbars_.push(new Toolbar(toolbarElement));
-      });
-    }
+      } catch (e) {
+        user().error(TAG, 'Failed to instantiate toolbar', e);
+      }
+    });
 
     if (this.isIosSafari_) {
       this.fixIosElasticScrollLeak_();
@@ -180,7 +182,7 @@ export class AmpSidebar extends AMP.BaseElement {
   onLayoutMeasure() {
     // Check our toolbars for changes
     this.toolbars_.forEach(toolbar => {
-      toolbar.checkToolbar(() => this.closeIfOpen_());
+      toolbar.checkToolbar(() => this.close_());
     });
   }
 
@@ -196,16 +198,6 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   isOpen_() {
     return this.element.hasAttribute('open');
-  }
-
-  /**
-   * Closes the sidebar if it is open
-   * @private
-   */
-  closeIfOpen_() {
-    if (this.isOpen_()) {
-      this.close_();
-    }
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -97,7 +97,7 @@ export class AmpSidebar extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     user().assert(isExperimentOn(this.win, 'amp-sidebar 1.0'),
-        `Experiment amp-sidebar 1.0 is disabled.`);
+        'Experiment amp-sidebar 1.0 is disabled.');
 
     this.side_ = this.element.getAttribute('side');
 
@@ -115,36 +115,42 @@ export class AmpSidebar extends AMP.BaseElement {
     }
 
     // Get the toolbar attribute from the nav
-    if(this.element.hasChildNodes && this.element.getElementsByTagName('nav').length > 0) {
-      const childNavElements = Array.from(this.element.getElementsByTagName('nav'));
-      childNavElements.some((navElement) => {
-        if(navElement.hasAttribute('toolbar')) {
+    if (this.element.hasChildNodes &&
+      this.element.getElementsByTagName('nav').length > 0
+    ) {
+      const childNavElements =
+        Array.from(this.element.getElementsByTagName('nav'));
+      childNavElements.some(navElement => {
+        if (navElement.hasAttribute('toolbar')) {
           this.toolbarNav_ = navElement;
           this.toolbar_ = navElement.getAttribute('toolbar');
 
           // Create a header element on the document for our toolbar
           // TODO: Allow specifying a target for the toolbar
-          this.toolbarTarget_ = this.element.ownerDocument.createElement("header");
-          this.element.parentElement.insertBefore(this.toolbarTarget_, this.element);
-          if(!this.isToolbar_()) {
+          this.toolbarTarget_ =
+            this.element.ownerDocument.createElement('header');
+          this.element.parentElement
+            .insertBefore(this.toolbarTarget_, this.element);
+          if (!this.isToolbar_()) {
             setStyles(this.toolbarTarget_, {
-              'display': 'none'
+              'display': 'none',
             });
           }
 
           //Finally, find our tool-bar only elements
-          if(this.toolbarNav_.hasAttribute('toolbar-only')) {
+          if (this.toolbarNav_.hasAttribute('toolbar-only')) {
             this.toolbarOnlyElements_ = [];
             this.toolbarOnlyElements_.push(this.toolbarNav_);
-          } else if(!this.toolbarNav_.hasAttribute('toolbar-only') &&
+          } else if (!this.toolbarNav_.hasAttribute('toolbar-only') &&
             this.toolbarNav_.getElementsByTagName('*').length > 0) {
             this.toolbarOnlyElements_ = [];
             // Check the nav's children for toolbar-only
-            Array.from(this.toolbarNav_.getElementsByTagName('*')).forEach(element => {
-              if(element.hasAttribute('toolbar-only')) {
-                this.toolbarOnlyElements_.push(element);
-              }
-            });
+            Array.from(this.toolbarNav_
+              .getElementsByTagName('*')).forEach(element => {
+                if (element.hasAttribute('toolbar-only')) {
+                  this.toolbarOnlyElements_.push(element);
+                }
+              });
           }
           return true;
         }
@@ -220,36 +226,38 @@ export class AmpSidebar extends AMP.BaseElement {
       // Add the toolbar elements
       this.toolbarClone_ = this.toolbarNav_.cloneNode(true);
       this.toolbarTarget_.appendChild(this.toolbarClone_);
-      if(this.toolbarTarget_.style.display === 'none') {
+      if (this.toolbarTarget_.style.display === 'none') {
         setStyles(this.toolbarTarget_, {
-          'display': null
+          'display': null,
         });
       }
-      if(this.toolbarOnlyElements_) {
+      if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
           setStyles(element, {
-            'display': 'none'
+            'display': 'none',
           });
         });
       }
       this.toolbarTarget_.setAttribute('toolbar', '');
-    } else if (!this.isToolbar_() && this.toolbarTarget_.hasAttribute('toolbar')) {
+    } else if (!this.isToolbar_() &&
+      this.toolbarTarget_.hasAttribute('toolbar')
+      ) {
       this.closeIfOpen_();
       // Remove the elements and the attribute
       this.toolbarTarget_.removeChild(this.toolbarClone_);
-      if(this.toolbarOnlyElements_) {
+      if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
           setStyles(element, {
-            'display': null
+            'display': null,
           });
         });
       }
       this.toolbarTarget_.removeAttribute('toolbar');
 
       // Check if our target still has elements, if not, do not display it
-      if(!this.toolbarTarget_.hasChildNodes()) {
+      if (!this.toolbarTarget_.hasChildNodes()) {
         setStyles(this.toolbarTarget_, {
-          'display': 'none'
+          'display': 'none',
         });
       }
     }
@@ -270,10 +278,11 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   isToolbar_() {
-    if(!this.toolbar_) {
+    if (!this.toolbar_) {
       return false;
     } else {
-      return this.element.ownerDocument.defaultView.matchMedia(this.toolbar_).matches;
+      return this.element.ownerDocument.defaultView
+        .matchMedia(this.toolbar_).matches;
     }
   }
 
@@ -282,7 +291,7 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   closeIfOpen_() {
-    if(this.isOpen_()) {
+    if (this.isOpen_()) {
       this.close_();
     }
   }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -58,7 +58,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.side_ = null;
 
     /** @private {?Array} */
-    this.toolbars_ = undefined;
+    this.toolbars_ = null;
 
     const platform = platformFor(this.win);
 

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -28,8 +28,6 @@
  /** @const */
  const TOOLBAR_MEDIA = '(min-width: 768px)';
 
- /** @const */
- const TOOLBAR_TARGET_CLASS = 'i-amphtml-sidebar-toolbar';
 
  adopt(window);
 
@@ -579,11 +577,10 @@
          toolbar: true,
        }).then(obj => {
          const sidebarElement = obj.ampSidebar;
-         const toolbarTargetElements = sidebarElement.ownerDocument
-               .getElementsByClassName(TOOLBAR_TARGET_CLASS);
-         expect(toolbarTargetElements.length).to.be.above(0);
-         expect(toolbarTargetElements[0]
-             .querySelectorAll('nav[toolbar]').length).to.be.above(0);
+         const toolbarNavElements = Array.prototype
+                .slice.call(sidebarElement.ownerDocument
+                .querySelectorAll('nav[toolbar]'), 0);
+         expect(toolbarNavElements.length).to.be.above(1);
        });
      });
 
@@ -592,9 +589,16 @@
          toolbar: true,
        }).then(obj => {
          const sidebarElement = obj.ampSidebar;
-         const toolbarTargetElements = sidebarElement.ownerDocument
-               .getElementsByClassName(TOOLBAR_TARGET_CLASS);
-         expect(toolbarTargetElements[0].hasAttribute('show')).to.be.false;
+         const toolbarNavElements = Array.prototype
+                .slice.call(sidebarElement.ownerDocument
+                .querySelectorAll('nav[toolbar]'), 0);
+         expect(toolbarNavElements.length).to.be.above(1);
+         expect(toolbarNavElements.some(navElement => {
+           if (navElement.parentElement.style.display == 'none') {
+             return true;
+           }
+           return false;
+         })).to.be.true;
        });
      });
    });

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -28,6 +28,9 @@
  /** @const */
  const TOOLBAR_MEDIA = '(min-width: 768px)';
 
+ /** @const */
+ const TOOLBAR_TARGET_CLASS = 'i-amphtml-sidebar-toolbar';
+
  adopt(window);
 
  describes.realWin('amp-sidebar 1.0 version', {
@@ -570,17 +573,17 @@
          expect(toolbarElements.length).to.be.equal(0);
        });
      });
-     it('should create a header element, \
+     it('should create a toolbar target element, \
      containing the navigation toolbar element', () => {
        return getAmpSidebar({
          toolbar: true,
        }).then(obj => {
          const sidebarElement = obj.ampSidebar;
-         const headerElements = sidebarElement.ownerDocument
-               .getElementsByTagName('header');
-         expect(headerElements.length).to.be.above(0);
-         expect(headerElements[0].querySelectorAll('nav[toolbar]').length)
-             .to.be.above(0);
+         const toolbarTargetElements = sidebarElement.ownerDocument
+               .getElementsByClassName(TOOLBAR_TARGET_CLASS);
+         expect(toolbarTargetElements.length).to.be.above(0);
+         expect(toolbarTargetElements[0]
+             .querySelectorAll('nav[toolbar]').length).to.be.above(0);
        });
      });
 
@@ -589,9 +592,9 @@
          toolbar: true,
        }).then(obj => {
          const sidebarElement = obj.ampSidebar;
-         const headerElements = sidebarElement.ownerDocument
-               .getElementsByTagName('header');
-         expect(headerElements[0].style.display).to.be.equal('none');
+         const toolbarTargetElements = sidebarElement.ownerDocument
+               .getElementsByClassName(TOOLBAR_TARGET_CLASS);
+         expect(toolbarTargetElements[0].hasAttribute('show')).to.be.false;
        });
      });
    });

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -59,16 +59,18 @@
          const anchor = iframe.doc.createElement('a');
          anchor.href = '#section1';
          ampSidebar.appendChild(anchor);
-         const navToolbar = iframe.doc.createElement('nav');
-         navToolbar.setAttribute('toolbar', TOOLBAR_MEDIA);
-         const toolbarList = iframe.doc.createElement('ul');
-         for (let i = 0; i < 3; i++) {
-           const li = iframe.doc.createElement('li');
-           li.innerHTML = 'Toolbar item ' + i;
-           toolbarList.appendChild(li);
+         if (options.toolbar) {
+           const navToolbar = iframe.doc.createElement('nav');
+           navToolbar.setAttribute('toolbar', TOOLBAR_MEDIA);
+           const toolbarList = iframe.doc.createElement('ul');
+           for (let i = 0; i < 3; i++) {
+             const li = iframe.doc.createElement('li');
+             li.innerHTML = 'Toolbar item ' + i;
+             toolbarList.appendChild(li);
+           }
+           navToolbar.appendChild(toolbarList);
+           ampSidebar.appendChild(navToolbar);
          }
-         navToolbar.appendChild(toolbarList);
-         ampSidebar.appendChild(navToolbar);
          if (options.side) {
            ampSidebar.setAttribute('side', options.side);
          }
@@ -557,9 +559,22 @@
      });
 
      // Tests for amp-sidebar 1.0
+     it('should not create toolbars without <nav toolbar />', () => {
+       return getAmpSidebar().then(obj => {
+         const sidebarElement = obj.ampSidebar;
+         const headerElements = sidebarElement.ownerDocument
+               .getElementsByTagName('header');
+         const toolbarElements = sidebarElement.ownerDocument
+               .querySelectorAll('*[toolbar]');
+         expect(headerElements.length).to.be.equal(0);
+         expect(toolbarElements.length).to.be.equal(0);
+       });
+     });
      it('should create a header element, \
      containing the navigation toolbar element', () => {
-       return getAmpSidebar().then(obj => {
+       return getAmpSidebar({
+         toolbar: true,
+       }).then(obj => {
          const sidebarElement = obj.ampSidebar;
          const headerElements = sidebarElement.ownerDocument
                .getElementsByTagName('header');
@@ -570,7 +585,9 @@
      });
 
      it('toolbar header should be hidden for the const TOOLBAR_MEDIA', () => {
-       return getAmpSidebar().then(obj => {
+       return getAmpSidebar({
+         toolbar: true,
+       }).then(obj => {
          const sidebarElement = obj.ampSidebar;
          const headerElements = sidebarElement.ownerDocument
                .getElementsByTagName('header');

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -580,7 +580,7 @@
                .getElementsByTagName('header');
          expect(headerElements.length).to.be.above(0);
          expect(headerElements[0].querySelectorAll('nav[toolbar]').length)
-          .to.be.above(0);
+            .to.be.above(0);
        });
      });
 

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -580,7 +580,7 @@
                .getElementsByTagName('header');
          expect(headerElements.length).to.be.above(0);
          expect(headerElements[0].querySelectorAll('nav[toolbar]').length)
-            .to.be.above(0);
+             .to.be.above(0);
        });
      });
 

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -25,6 +25,9 @@
  import * as sinon from 'sinon';
  import '../amp-sidebar';
 
+ /** @const */
+ const TOOLBAR_MEDIA = '(min-width: 768px)';
+
  adopt(window);
 
  describes.realWin('amp-sidebar 1.0 version', {
@@ -56,6 +59,16 @@
          const anchor = iframe.doc.createElement('a');
          anchor.href = '#section1';
          ampSidebar.appendChild(anchor);
+         const navToolbar = iframe.doc.createElement('nav');
+         navToolbar.setAttribute('toolbar', TOOLBAR_MEDIA);
+         const toolbarList = iframe.doc.createElement('ul');
+         for (let i = 0; i < 3; i++) {
+           const li = iframe.doc.createElement('li');
+           li.innerHTML = 'Toolbar item ' + i;
+           toolbarList.appendChild(li);
+         }
+         navToolbar.appendChild(toolbarList);
+         ampSidebar.appendChild(navToolbar);
          if (options.side) {
            ampSidebar.setAttribute('side', options.side);
          }
@@ -540,6 +553,28 @@
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
          expect(sidebarElement.style.display).to.equal('');
          expect(impl.schedulePause).to.have.not.been.called;
+       });
+     });
+
+     // Tests for amp-sidebar 1.0
+     it('should create a header element, \
+     containing the navigation toolbar element', () => {
+       return getAmpSidebar().then(obj => {
+         const sidebarElement = obj.ampSidebar;
+         const headerElements = sidebarElement.ownerDocument
+               .getElementsByTagName('header');
+         expect(headerElements.length).to.be.above(0);
+         expect(headerElements[0].querySelectorAll('nav[toolbar]').length)
+          .to.be.above(0);
+       });
+     });
+
+     it('toolbar header should be hidden for the const TOOLBAR_MEDIA', () => {
+       return getAmpSidebar().then(obj => {
+         const sidebarElement = obj.ampSidebar;
+         const headerElements = sidebarElement.ownerDocument
+               .getElementsByTagName('header');
+         expect(headerElements[0].style.display).to.be.equal('none');
        });
      });
    });

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -41,8 +41,8 @@ export class Toolbar {
     /** @private {!string} */
     this.toolbarMedia_ = this.toolbarDOMElement_.getAttribute('toolbar');
 
-    /** @private {Element|undefined} */
-    this.toolbarClone_ = undefined;
+    /** @private {?Element} */
+    this.toolbarClone_ = null;
 
     /** @private {Element|undefined} */
     this.targetElement_ = undefined;
@@ -80,9 +80,12 @@ export class Toolbar {
         .matchMedia(this.toolbarMedia_).matches;
 
     // Remove and add the toolbar dynamically
-    if (matchesMedia && this.attemptShow_()) {
-      onShowCallback();
-    } else if (!matchesMedia) {
+    if (matchesMedia) {
+      const showResponse = this.attemptShow_();
+      if (showResponse) {
+        showResponse.then(onShowCallback);
+      }
+    } else {
       this.hideToolbar_();
     }
   }
@@ -119,18 +122,16 @@ export class Toolbar {
   /**
    * Function to attempt to show the toolbar,
    * and hide toolbar-only element in the sidebar.
-   * Returns true, if the toolbar will be shown in the next sidebar mutate elemnt,
-   * false otherwise.
-   * @returns {boolean}
+   * @returns {Promise|undefined}
    * @private
    */
   attemptShow_() {
     if (this.isToolbarShown_()) {
-      return false;
+      return;
     }
 
     // Display the elements
-    this.vsync_.mutate(() => {
+    return this.vsync_.mutatePromise(() => {
       if (this.targetElement_) {
         toggle(this.targetElement_, true);
       }
@@ -141,20 +142,16 @@ export class Toolbar {
       }
       this.toolbarShown_ = true;
     });
-    return true;
   }
 
   /**
   * Function to hide the toolbar,
   * and show toolbar-only element in the sidebar.
-  * Returns true, if the toolbar will be hidden in the next sidebar mutate elemnt,
-  * false otherwise.
-   * @returns {boolean}
-   * @private
+  * @private
    */
   hideToolbar_() {
     if (!this.isToolbarShown_()) {
-      return false;
+      return;
     }
 
     this.vsync_.mutate(() => {
@@ -169,6 +166,5 @@ export class Toolbar {
       }
       this.toolbarShown_ = false;
     });
-    return true;
   }
 }

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -85,7 +85,6 @@ export class Toolbar {
    * @param {!Function} onChangeCallback - function called if toolbar changes on check
    */
   checkToolbar(onChangeCallback) {
-    console.log(this.toolbarMedia_);
     // Remove and add the toolbar dynamically
     if (this.isToolbarShown_() &&
       !this.toolbarTarget_.hasAttribute('toolbar')

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -17,30 +17,50 @@
 import {setStyles} from '../../../src/style';
 
 export class Toolbar {
-  /** @param {!Element} element */
-  constructor(element) {
+  /**
+  * @param {!Element} element
+  * @param {!BaseElement} baseElement
+  */
+  constructor(element, baseElement) {
     this.element = element;
 
     /** @private {?Element} */
-    this.sidebarElement_ = this.element.parentElement;
+    this.sidebarElement_ = baseElement;
 
-    /** @private {string|undefined} */
-    this.toolbarMedia_ = undefined;
+    /** @private {?string} */
+    this.toolbarMedia_ = this.element.getAttribute('toolbar');
 
     /** @private {?Element} */
     this.toolbarClone_ = null;
 
-    /** @private {?Element} */
-    this.toolbarTarget_ = null;
+    /** @private {Element|undefined} */
+    this.toolbarTarget_ = undefined;
 
-    /** @private {?Array} */
-    this.toolbarOnlyElements_ = null;
+    /** @private {Array} */
+    this.toolbarOnlyElements_ = [];
 
-    // Get our declared private variables
-    this.toolbarMedia_ = this.element.getAttribute('toolbar');
+    this.buildToolbar_();
 
-    // Create a header element on the document for our toolbar
-    // TODO: Allow specifying a target for the toolbar
+    //Finally, find our tool-bar only elements
+    if (this.element.hasAttribute('toolbar-only')) {
+      this.toolbarOnlyElements_.push(this.element);
+    } else if (!this.element.hasAttribute('toolbar-only') &&
+      this.element.querySelectorAll('*[toolbar-only]').length > 0) {
+      // Check the nav's children for toolbar-only
+      Array.prototype.slice.call(this.element
+          .querySelectorAll('*[toolbar-only]'), 0)
+          .forEach(toolbarOnlyElement => {
+            this.toolbarOnlyElements_.push(toolbarOnlyElement);
+          });
+    }
+  }
+
+  /**
+   * Private function to build the DOM element for the toolbar
+   * TODO: Allow specifying a target for the toolbar
+   * @private
+   */
+  buildToolbar_() {
     const fragment = this.sidebarElement_
       .ownerDocument.createDocumentFragment();
     this.toolbarTarget_ =
@@ -57,21 +77,6 @@ export class Toolbar {
     fragment.appendChild(this.toolbarTarget_);
     this.sidebarElement_.parentElement
         .insertBefore(fragment, this.sidebarElement_);
-
-    //Finally, find our tool-bar only elements
-    if (this.element.hasAttribute('toolbar-only')) {
-      this.toolbarOnlyElements_ = [];
-      this.toolbarOnlyElements_.push(this.element);
-    } else if (!this.element.hasAttribute('toolbar-only') &&
-      this.element.querySelectorAll('*[toolbar-only]').length > 0) {
-      this.toolbarOnlyElements_ = [];
-      // Check the nav's children for toolbar-only
-      Array.prototype.slice.call(this.element
-          .querySelectorAll('*[toolbar-only]'), 0)
-          .forEach(toolbarOnlyElement => {
-            this.toolbarOnlyElements_.push(toolbarOnlyElement);
-          });
-    }
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -22,12 +22,12 @@ const TOOLBAR_TARGET_CLASS = 'i-amphtml-sidebar-toolbar';
 export class Toolbar {
   /**
   * @param {!Element} element
-  * @param {!BaseElement} sidebar
+  * @param {!AMP.BaseElement} sidebar
   */
   constructor(element, sidebar) {
     this.element = element;
 
-    /** @private {!BaseElement} **/
+    /** @private {!AMP.BaseElement} **/
     this.sidebar_ = sidebar;
 
     /** @private {!Element} */
@@ -116,12 +116,12 @@ export class Toolbar {
    * @private
    */
   attemptShow_(onChangeCallback) {
-    if(this.isToolbarShown_()) {
+    if (this.isToolbarShown_()) {
       return;
     }
 
     // Display the elements
-    this.sidebar.mutateElement(() => {
+    this.sidebar_.mutateElement(() => {
       this.toolbarTarget_.setAttribute('show', '');
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
@@ -139,11 +139,11 @@ export class Toolbar {
    * @private
    */
   hideToolbar_(onChangeCallback) {
-    if(!this.isToolbarShown_()) {
+    if (!this.isToolbarShown_()) {
       return;
     }
 
-    this.sidebar.mutateElement(() => {
+    this.sidebar_.mutateElement(() => {
       // Hide the elements
       this.toolbarTarget_.removeAttribute('show');
       if (this.toolbarOnlyElements_) {

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -22,19 +22,16 @@ const TOOLBAR_ELEMENT_CLASS = 'i-amphtml-toolbar';
 /** @const */
 const TOOLBAR_CONTAINER_CLASS = 'i-amphtml-toolbar-container';
 
-/** @const */
-const TOOLBAR_PLACEHOLDER_CLASS = 'i-amphtml-toolbar-placeholder';
-
 export class Toolbar {
   /**
   * @param {!Element} element
-  * @param {!AMP.BaseElement} sidebar
+  * @param {!./amp-sidebar.AmpSidebar} sidebar
   */
   constructor(element, sidebar) {
     /** @private {!Element} */
     this.toolbarDOMElement_ = element;
 
-    /** @private {!AMP.BaseElement} **/
+    /** @private {!./amp-sidebar.AmpSidebar} **/
     this.sidebar_ = sidebar;
 
     /** @private {!Element} */
@@ -104,9 +101,6 @@ export class Toolbar {
     this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
     this.toolbarClone_.className = TOOLBAR_ELEMENT_CLASS;
     this.targetElement_.appendChild(this.toolbarClone_);
-    const toolbarPlaceholder = this.toolbarClone_.cloneNode(true);
-    toolbarPlaceholder.className = TOOLBAR_PLACEHOLDER_CLASS;
-    this.targetElement_.appendChild(toolbarPlaceholder);
     toggle(this.targetElement_, false);
     fragment.appendChild(this.targetElement_);
     this.sidebarElement_.parentElement
@@ -136,7 +130,7 @@ export class Toolbar {
     }
 
     // Display the elements
-    this.sidebar_.vsync_.mutate(() => {
+    this.sidebar_.vsync.mutate(() => {
       if (this.targetElement_) {
         toggle(this.targetElement_, true);
       }
@@ -163,7 +157,7 @@ export class Toolbar {
       return false;
     }
 
-    this.sidebar_.vsync_.mutate(() => {
+    this.sidebar_.vsync.mutate(() => {
       // Hide the elements
       if (this.targetElement_) {
         toggle(this.targetElement_, false);

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -46,6 +46,9 @@ export class Toolbar {
       this.element.ownerDocument.createElement('header');
     this.sidebarElement_.parentElement
       .insertBefore(this.toolbarTarget_, this.sidebarElement_);
+    //Place the elements into the target
+    this.toolbarClone_ = this.element.cloneNode(true);
+    this.toolbarTarget_.appendChild(this.toolbarClone_);
     if (!this.isToolbarShown_()) {
       setStyles(this.toolbarTarget_, {
         'display': 'none',
@@ -65,7 +68,6 @@ export class Toolbar {
           this.toolbarOnlyElements_.push(toolbarOnlyElement);
         });
     }
-    return true;
   }
 
   /**
@@ -83,18 +85,15 @@ export class Toolbar {
    * @param {!Function} onChangeCallback - function called if toolbar changes on check
    */
   checkToolbar(onChangeCallback) {
+    console.log(this.toolbarMedia_);
     // Remove and add the toolbar dynamically
     if (this.isToolbarShown_() &&
       !this.toolbarTarget_.hasAttribute('toolbar')
     ) {
-      // Add the toolbar elements
-      this.toolbarClone_ = this.element.cloneNode(true);
-      this.toolbarTarget_.appendChild(this.toolbarClone_);
-      if (this.toolbarTarget_.style.display === 'none') {
-        setStyles(this.toolbarTarget_, {
-          'display': null,
-        });
-      }
+      // Display the elements
+      setStyles(this.toolbarTarget_, {
+        'display': null,
+      });
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
           setStyles(element, {
@@ -107,8 +106,10 @@ export class Toolbar {
     } else if (!this.isToolbarShown_() &&
       this.toolbarTarget_.hasAttribute('toolbar')
       ) {
-      // Remove the elements and the attribute
-      this.toolbarTarget_.removeChild(this.toolbarClone_);
+      // Hide the elements
+      setStyles(this.toolbarTarget_, {
+        'display': 'none',
+      });
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
           setStyles(element, {
@@ -117,13 +118,6 @@ export class Toolbar {
         });
       }
       this.toolbarTarget_.removeAttribute('toolbar');
-
-      // Check if our target still has elements, if not, do not display it
-      if (!this.toolbarTarget_.hasChildNodes()) {
-        setStyles(this.toolbarTarget_, {
-          'display': 'none',
-        });
-      }
       onChangeCallback();
     }
   }

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -16,9 +16,6 @@
 
 import {toggle} from '../../../src/style';
 
-/** @const */
-const TOOLBAR_TARGET_CLASS = 'i-amphtml-sidebar-toolbar';
-
 export class Toolbar {
   /**
   * @param {!Element} element
@@ -36,8 +33,8 @@ export class Toolbar {
     /** @private {?string} */
     this.toolbarMedia_ = this.element.getAttribute('toolbar');
 
-    /** @private {?Element} */
-    this.toolbarClone_ = null;
+    /** @private {Element|undefined} */
+    this.toolbarClone_ = undefined;
 
     /** @private {Element|undefined} */
     this.toolbarTarget_ = undefined;
@@ -68,7 +65,7 @@ export class Toolbar {
    * Function called to check if we should show or hide the toolbar
    * @param {!Function} onChangeCallback - function called if toolbar changes on check
    */
-  checkToolbar(onChangeCallback) {
+  onLayoutMeasure(onChangeCallback) {
     // Get if we match the current toolbar media
     const matchesMedia = this.element.ownerDocument.defaultView
         .matchMedia(this.toolbarMedia_).matches;
@@ -91,7 +88,6 @@ export class Toolbar {
       .ownerDocument.createDocumentFragment();
     this.toolbarTarget_ =
       this.element.ownerDocument.createElement('header');
-    this.toolbarTarget_.className = TOOLBAR_TARGET_CLASS;
     //Place the elements into the target
     this.toolbarClone_ = this.element.cloneNode(true);
     this.toolbarTarget_.appendChild(this.toolbarClone_);
@@ -122,7 +118,9 @@ export class Toolbar {
 
     // Display the elements
     this.sidebar_.mutateElement(() => {
-      toggle(this.toolbarTarget_, true);
+      if(this.toolbarTarget_) {
+        toggle(this.toolbarTarget_, true);
+      }
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
           toggle(element, false);
@@ -145,7 +143,9 @@ export class Toolbar {
 
     this.sidebar_.mutateElement(() => {
       // Hide the elements
-      toggle(this.toolbarTarget_, false);
+      if(this.toolbarTarget_) {
+        toggle(this.toolbarTarget_, false);
+      }
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
           toggle(element, true);

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {setStyles} from '../../../src/style';
+import {toggle} from '../../../src/style';
 
 export class Toolbar {
   /**
@@ -35,6 +35,10 @@ export class Toolbar {
 
     /** @private {Element|undefined} */
     this.toolbarTarget_ = undefined;
+
+    /** @private {!boolean} **/
+    this.toolbarShown_ = false;
+    this.updateToolbarShown_();
 
     /** @private {Array} */
     this.toolbarOnlyElements_ = [];
@@ -69,9 +73,7 @@ export class Toolbar {
     this.toolbarClone_ = this.element.cloneNode(true);
     this.toolbarTarget_.appendChild(this.toolbarClone_);
     if (!this.isToolbarShown_()) {
-      setStyles(this.toolbarTarget_, {
-        'display': 'none',
-      });
+      toggle(this.toolbarTarget_, false);
     }
 
     fragment.appendChild(this.toolbarTarget_);
@@ -80,13 +82,25 @@ export class Toolbar {
   }
 
   /**
+   * Function to update the toolbar shown state
+   * @private
+   */
+  updateToolbarShown_() {
+    if (this.toolbarMedia_) {
+      this.toolbarShown_ = this.element.ownerDocument.defaultView
+          .matchMedia(this.toolbarMedia_).matches;
+    } else {
+      this.toolbarShown_ = false;
+    }
+  }
+
+  /**
    * Returns if the sidebar is currently in toolbar media query
    * @returns {boolean}
    * @private
    */
   isToolbarShown_() {
-    return this.element.ownerDocument.defaultView
-        .matchMedia(this.toolbarMedia_).matches;
+    return this.toolbarShown_;
   }
 
   /**
@@ -94,19 +108,18 @@ export class Toolbar {
    * @param {!Function} onChangeCallback - function called if toolbar changes on check
    */
   checkToolbar(onChangeCallback) {
+    //Update our shown state
+    this.updateToolbarShown_();
+
     // Remove and add the toolbar dynamically
     if (this.isToolbarShown_() &&
       !this.toolbarTarget_.hasAttribute('toolbar')
     ) {
       // Display the elements
-      setStyles(this.toolbarTarget_, {
-        'display': null,
-      });
+      toggle(this.toolbarTarget_, true);
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
-          setStyles(element, {
-            'display': 'none',
-          });
+          toggle(element, false);
         });
       }
       this.toolbarTarget_.setAttribute('toolbar', '');
@@ -115,14 +128,10 @@ export class Toolbar {
       this.toolbarTarget_.hasAttribute('toolbar')
       ) {
       // Hide the elements
-      setStyles(this.toolbarTarget_, {
-        'display': 'none',
-      });
+      toggle(this.toolbarTarget_, false);
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
-          setStyles(element, {
-            'display': null,
-          });
+          toggle(element, true);
         });
       }
       this.toolbarTarget_.removeAttribute('toolbar');

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -56,7 +56,7 @@ export class Toolbar {
 
     fragment.appendChild(this.toolbarTarget_);
     this.sidebarElement_.parentElement
-      .insertBefore(fragment, this.sidebarElement_);
+        .insertBefore(fragment, this.sidebarElement_);
 
     //Finally, find our tool-bar only elements
     if (this.element.hasAttribute('toolbar-only')) {
@@ -67,9 +67,10 @@ export class Toolbar {
       this.toolbarOnlyElements_ = [];
       // Check the nav's children for toolbar-only
       Array.prototype.slice.call(this.element
-        .querySelectorAll('*[toolbar-only]'), 0).forEach(toolbarOnlyElement => {
-          this.toolbarOnlyElements_.push(toolbarOnlyElement);
-        });
+          .querySelectorAll('*[toolbar-only]'), 0)
+          .forEach(toolbarOnlyElement => {
+            this.toolbarOnlyElements_.push(toolbarOnlyElement);
+          });
     }
   }
 
@@ -80,7 +81,7 @@ export class Toolbar {
    */
   isToolbarShown_() {
     return this.element.ownerDocument.defaultView
-      .matchMedia(this.toolbarMedia_).matches;
+        .matchMedia(this.toolbarMedia_).matches;
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -17,7 +17,13 @@
 import {toggle} from '../../../src/style';
 
 /** @const */
-const TOOLBAR_CLASS = 'i-amphtml-sidebar-toolbar';
+const TOOLBAR_ELEMENT_CLASS = 'i-amphtml-toolbar';
+
+/** @const */
+const TOOLBAR_CONTAINER_CLASS = 'i-amphtml-toolbar-container';
+
+/** @const */
+const TOOLBAR_PLACEHOLDER_CLASS = 'i-amphtml-toolbar-placeholder';
 
 export class Toolbar {
   /**
@@ -25,8 +31,8 @@ export class Toolbar {
   * @param {!AMP.BaseElement} sidebar
   */
   constructor(element, sidebar) {
-    /** @public {!Element} */
-    this.toolbarDOMElement = element;
+    /** @private {!Element} */
+    this.toolbarDOMElement_ = element;
 
     /** @private {!AMP.BaseElement} **/
     this.sidebar_ = sidebar;
@@ -35,7 +41,7 @@ export class Toolbar {
     this.sidebarElement_ = this.sidebar_.element;
 
     /** @private {!string} */
-    this.toolbarMedia_ = this.toolbarDOMElement.getAttribute('toolbar');
+    this.toolbarMedia_ = this.toolbarDOMElement_.getAttribute('toolbar');
 
     /** @private {Element|undefined} */
     this.toolbarClone_ = undefined;
@@ -52,12 +58,12 @@ export class Toolbar {
     this.buildToolbar_();
 
     //Finally, find our tool-bar only elements
-    if (this.toolbarDOMElement.hasAttribute('toolbar-only')) {
-      this.toolbarOnlyElementsInSidebar_.push(this.toolbarDOMElement);
+    if (this.toolbarDOMElement_.hasAttribute('toolbar-only')) {
+      this.toolbarOnlyElementsInSidebar_.push(this.toolbarDOMElement_);
     } else {
       // Get our toolbar only elements
       const toolbarOnlyQuery =
-        this.toolbarDOMElement.querySelectorAll('[toolbar-only]');
+        this.toolbarDOMElement_.querySelectorAll('[toolbar-only]');
       if (toolbarOnlyQuery.length > 0) {
         // Check the nav's children for toolbar-only
         this.toolbarOnlyElementsInSidebar_ =
@@ -92,11 +98,15 @@ export class Toolbar {
     const fragment = this.sidebarElement_
       .ownerDocument.createDocumentFragment();
     this.targetElement_ =
-      this.toolbarDOMElement.ownerDocument.createElement('header');
+      this.toolbarDOMElement_.ownerDocument.createElement('header');
+    this.targetElement_.className = TOOLBAR_CONTAINER_CLASS;
     //Place the elements into the target
-    this.toolbarClone_ = this.toolbarDOMElement.cloneNode(true);
-    this.toolbarClone_.className = TOOLBAR_CLASS;
+    this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
+    this.toolbarClone_.className = TOOLBAR_ELEMENT_CLASS;
     this.targetElement_.appendChild(this.toolbarClone_);
+    const toolbarPlaceholder = this.toolbarClone_.cloneNode(true);
+    toolbarPlaceholder.className = TOOLBAR_PLACEHOLDER_CLASS;
+    this.targetElement_.appendChild(toolbarPlaceholder);
     toggle(this.targetElement_, false);
     fragment.appendChild(this.targetElement_);
     this.sidebarElement_.parentElement
@@ -113,7 +123,10 @@ export class Toolbar {
   }
 
   /**
-   * Function to attempt to show the toolbar
+   * Function to attempt to show the toolbar,
+   * and hide toolbar-only element in the sidebar.
+   * Returns true, if the toolbar will be shown in the next sidebar mutate elemnt,
+   * false otherwise.
    * @returns {boolean}
    * @private
    */
@@ -123,7 +136,7 @@ export class Toolbar {
     }
 
     // Display the elements
-    this.sidebar_.mutateElement(() => {
+    this.sidebar_.vsync_.mutate(() => {
       if (this.targetElement_) {
         toggle(this.targetElement_, true);
       }
@@ -138,7 +151,10 @@ export class Toolbar {
   }
 
   /**
-   * Function to hide the toolbar
+  * Function to hide the toolbar,
+  * and show toolbar-only element in the sidebar.
+  * Returns true, if the toolbar will be hidden in the next sidebar mutate elemnt,
+  * false otherwise.
    * @returns {boolean}
    * @private
    */
@@ -147,7 +163,7 @@ export class Toolbar {
       return false;
     }
 
-    this.sidebar_.mutateElement(() => {
+    this.sidebar_.vsync_.mutate(() => {
       // Hide the elements
       if (this.targetElement_) {
         toggle(this.targetElement_, false);

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setStyles} from '../../../src/style';
+
+export class Toolbar {
+  /** @param {!Element} element */
+  constructor(element) {
+    /** @private {?Element} */
+    this.element_ = element;
+
+    /** @private {string|undefined} */
+    this.toolbarMedia_ = undefined;
+
+    /** @private {?Element} */
+    this.toolbarClone_ = null;
+
+    /** @private {?Element} */
+    this.toolbarTarget_ = null;
+
+    /** @private {?Array} */
+    this.toolbarOnlyElements_ = null;
+  }
+
+  /**
+   * Returns if the sidebar is currently in toolbar media query
+   * @returns {boolean}
+   */
+  isToolbarShown() {
+    return this.element.ownerDocument.defaultView
+      .matchMedia(this.toolbarMedia_).matches;
+  }
+
+  /**
+   * Function called to check if we should show or hide the toolbar
+   */
+  checkToolbar() {
+    // Remove and add the toolbar dynamically
+    if (this.isToolbar_() && !this.toolbarTarget_.hasAttribute('toolbar')) {
+      this.closeIfOpen_();
+      // Add the toolbar elements
+      this.toolbarClone_ = this.toolbarNav_.cloneNode(true);
+      this.toolbarTarget_.appendChild(this.toolbarClone_);
+      if (this.toolbarTarget_.style.display === 'none') {
+        setStyles(this.toolbarTarget_, {
+          'display': null,
+        });
+      }
+      if (this.toolbarOnlyElements_) {
+        this.toolbarOnlyElements_.forEach(element => {
+          setStyles(element, {
+            'display': 'none',
+          });
+        });
+      }
+      this.toolbarTarget_.setAttribute('toolbar', '');
+    } else if (!this.isToolbar_() &&
+      this.toolbarTarget_.hasAttribute('toolbar')
+      ) {
+      this.closeIfOpen_();
+      // Remove the elements and the attribute
+      this.toolbarTarget_.removeChild(this.toolbarClone_);
+      if (this.toolbarOnlyElements_) {
+        this.toolbarOnlyElements_.forEach(element => {
+          setStyles(element, {
+            'display': null,
+          });
+        });
+      }
+      this.toolbarTarget_.removeAttribute('toolbar');
+
+      // Check if our target still has elements, if not, do not display it
+      if (!this.toolbarTarget_.hasChildNodes()) {
+        setStyles(this.toolbarTarget_, {
+          'display': 'none',
+        });
+      }
+    }
+  }
+}

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -41,10 +41,10 @@ export class Toolbar {
 
     // Create a header element on the document for our toolbar
     // TODO: Allow specifying a target for the toolbar
+    const fragment = this.sidebarElement_
+      .ownerDocument.createDocumentFragment();
     this.toolbarTarget_ =
       this.element.ownerDocument.createElement('header');
-    this.sidebarElement_.parentElement
-      .insertBefore(this.toolbarTarget_, this.sidebarElement_);
     //Place the elements into the target
     this.toolbarClone_ = this.element.cloneNode(true);
     this.toolbarTarget_.appendChild(this.toolbarClone_);
@@ -53,6 +53,10 @@ export class Toolbar {
         'display': 'none',
       });
     }
+
+    fragment.appendChild(this.toolbarTarget_);
+    this.sidebarElement_.parentElement
+      .insertBefore(fragment, this.sidebarElement_);
 
     //Finally, find our tool-bar only elements
     if (this.element.hasAttribute('toolbar-only')) {

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -121,14 +121,16 @@ export class Toolbar {
     }
 
     // Display the elements
-    this.toolbarTarget_.setAttribute('show', '');
-    if (this.toolbarOnlyElements_) {
-      this.toolbarOnlyElements_.forEach(element => {
-        toggle(element, false);
-      });
-    }
-    this.toolbarShown_ = true;
-    onChangeCallback();
+    this.sidebar.mutateElement(() => {
+      this.toolbarTarget_.setAttribute('show', '');
+      if (this.toolbarOnlyElements_) {
+        this.toolbarOnlyElements_.forEach(element => {
+          toggle(element, false);
+        });
+      }
+      this.toolbarShown_ = true;
+      onChangeCallback();
+    });
   }
 
   /**
@@ -141,14 +143,16 @@ export class Toolbar {
       return;
     }
 
-    // Hide the elements
-    this.toolbarTarget_.removeAttribute('show');
-    if (this.toolbarOnlyElements_) {
-      this.toolbarOnlyElements_.forEach(element => {
-        toggle(element, true);
-      });
-    }
-    this.toolbarShown_ = false;
-    onChangeCallback();
+    this.sidebar.mutateElement(() => {
+      // Hide the elements
+      this.toolbarTarget_.removeAttribute('show');
+      if (this.toolbarOnlyElements_) {
+        this.toolbarOnlyElements_.forEach(element => {
+          toggle(element, true);
+        });
+      }
+      this.toolbarShown_ = false;
+      onChangeCallback();
+    });
   }
 }

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -19,7 +19,6 @@ import {setStyles} from '../../../src/style';
 export class Toolbar {
   /** @param {!Element} element */
   constructor(element) {
-    /** @private {?Element} */
     this.element = element;
 
     /** @private {?Element} */

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -19,15 +19,13 @@ import {toggle} from '../../../src/style';
 /** @const */
 const TOOLBAR_ELEMENT_CLASS = 'i-amphtml-toolbar';
 
-/** @const */
-const TOOLBAR_CONTAINER_CLASS = 'i-amphtml-toolbar-container';
-
 export class Toolbar {
   /**
   * @param {!Element} element
   * @param {!./amp-sidebar.AmpSidebar} sidebar
+  * @param {!../../../src/service/vsync-impl.Vsync} vsync
   */
-  constructor(element, sidebar) {
+  constructor(element, sidebar, vsync) {
     /** @private {!Element} */
     this.toolbarDOMElement_ = element;
 
@@ -36,6 +34,9 @@ export class Toolbar {
 
     /** @private {!Element} */
     this.sidebarElement_ = this.sidebar_.element;
+
+    /** @const @private {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync_ = vsync;
 
     /** @private {!string} */
     this.toolbarMedia_ = this.toolbarDOMElement_.getAttribute('toolbar');
@@ -96,7 +97,6 @@ export class Toolbar {
       .ownerDocument.createDocumentFragment();
     this.targetElement_ =
       this.toolbarDOMElement_.ownerDocument.createElement('header');
-    this.targetElement_.className = TOOLBAR_CONTAINER_CLASS;
     //Place the elements into the target
     this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
     this.toolbarClone_.className = TOOLBAR_ELEMENT_CLASS;
@@ -130,7 +130,7 @@ export class Toolbar {
     }
 
     // Display the elements
-    this.sidebar_.vsync.mutate(() => {
+    this.vsync_.mutate(() => {
       if (this.targetElement_) {
         toggle(this.targetElement_, true);
       }
@@ -157,7 +157,7 @@ export class Toolbar {
       return false;
     }
 
-    this.sidebar_.vsync.mutate(() => {
+    this.vsync_.mutate(() => {
       // Hide the elements
       if (this.targetElement_) {
         toggle(this.targetElement_, false);

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -95,7 +95,7 @@ export class Toolbar {
     //Place the elements into the target
     this.toolbarClone_ = this.element.cloneNode(true);
     this.toolbarTarget_.appendChild(this.toolbarClone_);
-
+    toggle(this.toolbarTarget_, false);
     fragment.appendChild(this.toolbarTarget_);
     this.sidebarElement_.parentElement
         .insertBefore(fragment, this.sidebarElement_);
@@ -122,7 +122,7 @@ export class Toolbar {
 
     // Display the elements
     this.sidebar_.mutateElement(() => {
-      this.toolbarTarget_.setAttribute('show', '');
+      toggle(this.toolbarTarget_, true);
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
           toggle(element, false);
@@ -145,7 +145,7 @@ export class Toolbar {
 
     this.sidebar_.mutateElement(() => {
       // Hide the elements
-      this.toolbarTarget_.removeAttribute('show');
+      toggle(this.toolbarTarget_, false);
       if (this.toolbarOnlyElements_) {
         this.toolbarOnlyElements_.forEach(element => {
           toggle(element, true);

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -118,7 +118,7 @@ export class Toolbar {
 
     // Display the elements
     this.sidebar_.mutateElement(() => {
-      if(this.toolbarTarget_) {
+      if (this.toolbarTarget_) {
         toggle(this.toolbarTarget_, true);
       }
       if (this.toolbarOnlyElements_) {
@@ -143,7 +143,7 @@ export class Toolbar {
 
     this.sidebar_.mutateElement(() => {
       // Hide the elements
-      if(this.toolbarTarget_) {
+      if (this.toolbarTarget_) {
         toggle(this.toolbarTarget_, false);
       }
       if (this.toolbarOnlyElements_) {

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -278,7 +278,7 @@
   </amp-app-banner>
 
   <header class="slot-fallback">
-      I Should be seen with any amopunt of toolbars
+      I Should be seen with any amount of toolbars
   </header>
 
   <!--

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -6,13 +6,7 @@
   <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-
   <style amp-custom>
-    body {
-      margin: 0;
-      font-family: 'Georgia', Serif;
-    }
-
     .brand-logo {
       font-family: 'Open Sans';
     }
@@ -24,16 +18,6 @@
 
     .content-container p {
       line-height: 24px;
-    }
-
-    header,
-    .article-body {
-      padding: 15px;
-    }
-
-    /* In the shadow-doc mode, the parent shell already has header and nav. */
-    .amp-shadow header {
-      display: none;
     }
 
     .lightbox {
@@ -196,11 +180,6 @@
       text-align: right;
       font-size: 14px;
     }
-
-    amp-sidebar {
-      width: 150px;
-    }
-
   </style>
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
@@ -215,44 +194,31 @@
 <body>
   <amp-sidebar id="sidebar" layout="nodisplay">
 
-    <!-- Toolbar/sidebar elements, except with toolbar-only -->
-    <nav toolbar="(min-width: 768px)">
+    <nav toolbar="(min-width: 0px)" toolbar-only>
       <ul>
         <li>
-          <a href="#">
-            Home
-            <amp-img src="img/ampicon.png" width="15" height="15"></amp-img>
-          </a>
+          <button on="tap:sidebar.toggle" class="menu" title="Toggle Sidebar" >
+            ☰
+          </button>
         </li>
-        <li toolbar-only><a href="#">Toolbar Only Example</a></li>
         <li>
-          <!-- Example Search Input field -->
-          <input placeholder="Search..."/>
+          <span class="brand-logo">
+            PublisherLogo
+          </span>
+        </li>
+        <li>
+          <a href="#">Wrap Example</a>
+        </li>
+        <li>
+          <a href="#">Wrap Example</a>
+        </li>
+        <li>
+          <a href="#">Wrap Example</a>
         </li>
       </ul>
     </nav>
 
     <!-- Multiple / Complex Toolbars -->
-    <nav toolbar="(min-width: 0px)" toolbar-only>
-      <ul>
-        <li>
-          <a href="#">Min Width Example</a>
-        </li>
-        <li>
-          <a href="#">Wrap Example</a>
-        </li>
-        <li>
-          <a href="#">Wrap Example</a>
-        </li>
-        <li>
-          <a href="#">Wrap Example</a>
-        </li>
-        <li>
-          <a href="#">Wrap Example</a>
-        </li>
-      </ul>
-    </nav>
-
     <nav toolbar="(max-width: 767px)" toolbar-only>
       <ul>
         <li>
@@ -268,6 +234,22 @@
                width="40" height="34"></amp-img>
        </li>
      </ul>
+    </nav>
+
+    <nav toolbar="(min-width: 768px)">
+      <ul>
+        <li>
+          <a href="#">
+            Home
+            <amp-img src="../../examples/img/ampicon.png" width="15" height="15"></amp-img>
+          </a>
+        </li>
+        <li toolbar-only><a href="#">Toolbar Only Example</a></li>
+        <li>
+          <!-- Example Search Input field -->
+          <input placeholder="Search..."/>
+        </li>
+      </ul>
     </nav>
 
     <!-- Sidebar only elements -->
@@ -295,14 +277,8 @@
     </div>
   </amp-app-banner>
 
-  <header>
-    <button on="tap:sidebar.toggle" class="menu" title="Toggle Sidebar" >
-      ☰
-    </button>
-
-    <span class="brand-logo">
-      PublisherLogo
-    </span>
+  <header class="slot-fallback">
+      I Should be seen with any amopunt of toolbars
   </header>
 
   <!--
@@ -319,8 +295,8 @@
     <article>
       <figure>
         <amp-img id="hero-img"
-            src="img/hero@1x.jpg"
-            srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+            src="../../examples/img/hero@1x.jpg"
+            srcset="../../examples/img/hero@1x.jpg 1x, ../../examples/img/hero@2x.jpg 2x"
             layout="responsive" width="360" placeholder
             alt="Picture of two chairs on a lake shore with big pine trees"
             title="Opens image in a lightbox"
@@ -334,8 +310,8 @@
 
         <div class="lightbox-content">
           <amp-img id="floating-headline-img"
-              src="img/hero@1x.jpg"
-              srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+              src="../../examples/img/hero@1x.jpg"
+              srcset="../../examples/img/hero@1x.jpg 1x, ../../examples/img/hero@2x.jpg 2x"
               alt="Two chairs on a lake shore with big pine trees"
               placeholder
               width="360" height="216" layout="responsive">
@@ -361,7 +337,7 @@
         </header>
 
         <div class="author">
-          <amp-img src="img/sample.jpg" id="author-avatar" placeholder
+          <amp-img src="../../examples/img/sample.jpg" id="author-avatar" placeholder
               height="50" width="50">
           </amp-img>
           <div class="byline">
@@ -437,8 +413,8 @@
 
           <figure>
             <amp-img class="full-bleed" placeholder
-                src="img/sea@1x.jpg"
-                srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
+                src="../../examples/img/sea@1x.jpg"
+                srcset="../../examples/img/sea@1x.jpg 1x, ../../examples/img/sea@2x.jpg 2x"
                 layout="responsive" width="360"
                 alt="Fusce pretium tempor justo, vitae consequat dolor maximus eget."
                 height="216">


### PR DESCRIPTION
Please see the [Design Doc](https://docs.google.com/document/d/1njeaTdy-bMNaTT0IB9TXjoW6Xlp-VqcQr1GrQ826Rn8/edit?usp=sharing) for context.

# Changes

- Adds the `toolbar` attribute that accepts media queries, to show toolbar at certain widths
- Adds the `toolbar-only` attribute to specify which elements should not be in the sidebar
- Adds CSS for header, nav, ul, and li to give nice toolbars
- Adds an example article implementing the features

# Issues

Search for "[Toolbar]" for all Sidebar v1.0 toolbar issues

closes #9981 
closes #9979 
closes #9980 
closes #9978 

Part of #9985

**Please Note:** Toolbar still needs a few more edge cases, and tests, before being completed

# Example Gif (Done in Chrome)
<details>
  <summary>Click to show! (May Take a While To Load)</summary>

![toolbar](https://user-images.githubusercontent.com/1448289/27102454-2cd1831a-503a-11e7-8b9c-5f7a25326c11.gif)

</details>
