### PR TITLE
Fix visState integration tests, part 3

### DIFF
--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -99,6 +99,7 @@ describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
         resources = resourcesForDoc(win.document);
         doPass_ = resources.doPass;
         sandbox.stub(resources, 'doPass', doPass);
+        unselect = sandbox.stub(resources, 'unselectText');
 
         const img = win.document.createElement('amp-img');
         img.setAttribute('width', 100);
@@ -121,33 +122,24 @@ describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
         layoutCallback.returns(Promise.resolve());
         unlayoutCallback.returns(true);
         prerenderAllowed.returns(false);
-        unselect = sandbox.stub();
-        Object.defineProperty(win, 'getSelection', {
-          value: unselect,
-        });
       });
     });
 
     describe('from in the PRERENDER state', () => {
-      beforeEach(() => {
-        return waitForNextPass().then(setupSpys);
-      });
-
       describe('for prerenderable element', () => {
         beforeEach(() => {
           prerenderAllowed.returns(true);
           setupSpys();
         });
 
-        it.configure().skipSafari().run('does layout when going to PRERENDER',
-            () => {
-              return waitForNextPass().then(() => {
-                expect(layoutCallback).to.have.been.called;
-                expect(unlayoutCallback).not.to.have.been.called;
-                expect(pauseCallback).not.to.have.been.called;
-                expect(resumeCallback).not.to.have.been.called;
-              });
-            });
+        it('does layout when going to PRERENDER', () => {
+          return waitForNextPass().then(() => {
+            expect(layoutCallback).to.have.been.called;
+            expect(unlayoutCallback).not.to.have.been.called;
+            expect(pauseCallback).not.to.have.been.called;
+            expect(resumeCallback).not.to.have.been.called;
+          });
+        });
 
         it('calls layout when going to VISIBLE', () => {
           viewer.receiveMessage('visibilitychange',
@@ -196,6 +188,10 @@ describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
       });
 
       describe('for non-prerenderable element', () => {
+        beforeEach(() => {
+          setupSpys();
+        });
+
         it('does not call callbacks when going to PRERENDER', () => {
           return waitForNextPass().then(() => {
             expect(layoutCallback).not.to.have.been.called;


### PR DESCRIPTION
Seems I screwed up mocking `getSelection()`. It expects a return object with a `#removeAllRanges`, but I was returning a simple function (not an object). So, an error was being thrown in these tests, which cased the flake.

Closes https://github.com/ampproject/amphtml/issues/9757