### PR TITLE
Ensure that viewport dimensions are updated when expanding/collapsing iframe

### DIFF
--- a/ads/inabox/frame-overlay-manager.js
+++ b/ads/inabox/frame-overlay-manager.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expandFrame, collapseFrame} from './frame-overlay-helper';
+
+
+/**
+ * Inabox host manager for full overlay frames.
+ */
+export class FrameOverlayManager {
+
+  /**
+   * @param {!Window} win
+   */
+  constructor(win) {
+    /** @private @const {!Window} */
+    this.win_ = win;
+
+    /** @private {boolean} */
+    this.isExpanded_ = false;
+
+    /** @private {boolean} */
+    this.viewportChangedSinceExpand_ = false;
+
+    // TODO(alanorozco): type
+    /** @private {?} */
+    this.collapsedRect_ = null;
+
+    this.listenToViewportChanges_();
+  }
+
+  /** @private */
+  listenToViewportChanges_() {
+    this.win_.addEventListener('resize', () => this.onWindowResize());
+  }
+
+  /** @visibleForTesting */
+  onWindowResize() {
+    if (this.isExpanded_) {
+      this.viewportChangedSinceExpand_ = true;
+    }
+  }
+
+  /**
+   * Expands an iframe to full overlay.
+   * @param {!HTMLIFrameElement} iframe
+   * @param {!Function} callback Gets executed when expanded with the new box
+   *  rect.
+   */
+  expandFrame(iframe, callback) {
+    expandFrame(this.win_, iframe, (collapsedRect, expandedRect) => {
+      this.isExpanded_ = true;
+      this.viewportChangedSinceExpand_ = false;
+      this.collapsedRect_ = collapsedRect;
+      callback(expandedRect);
+    });
+  }
+
+  /**
+   * Collapses an iframe back from full overlay.
+   * @param {!HTMLIFrameElement} iframe
+   * @param {!Function} callback Gets executed when collapsed with the new box
+   *  rect.
+   */
+  collapseFrame(iframe, callback) {
+    // There is a delay of one animation frame between collapsing and measuring
+    // the box rect. collapseFrame() takes a callback for each event.
+    //
+    // We know what the collapsed box was. If the viewport has not changed while
+    // expanded, we can immediately notify the consumer of the collapsed
+    // box rect since it should be the same. Otherwise, we wait for remeasure.
+    collapseFrame(this.win_, iframe, () => {
+      this.isExpanded_ = false;
+
+      if (!this.viewportChangedSinceExpand_) {
+        callback(this.collapsedRect_);
+      }
+    }, collapsedRect => {
+      this.collapsedRect_ = collapsedRect;
+
+      if (this.viewportChangedSinceExpand_) {
+        callback(this.collapsedRect_);
+      }
+    });
+  }
+}

--- a/ads/inabox/util.js
+++ b/ads/inabox/util.js
@@ -26,7 +26,7 @@
  * BATCHED. This means that using this can still cause layout thrashing if it's
  * being called more than once within the same frame. Use with caution.
  * @param {!Window} win
- * @param {{measure: (Function|undefined), mutate: !Function}} task
+ * @param {{measure: (Function|undefined), mutate: (Function|undefined)}} task
  * @param {!Object=} opt_state
  * @visibleForTesting
  */
@@ -36,7 +36,9 @@ export function restrictedVsync(win, task, opt_state) {
     if (task.measure) {
       task.measure(opt_state);
     }
-    task.mutate(opt_state);
+    if (task.mutate) {
+      task.mutate(opt_state);
+    }
   });
 }
 

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -42,6 +42,7 @@ export const MessageType = {
   FULL_OVERLAY_FRAME_RESPONSE: 'full-overlay-frame-response',
   CANCEL_FULL_OVERLAY_FRAME: 'cancel-full-overlay-frame',
   CANCEL_FULL_OVERLAY_FRAME_RESPONSE: 'cancel-full-overlay-frame-response',
+  CANCEL_FULL_OVERLAY_FRAME_REMEASURE: 'cancel-full-overlay-frame-remeasure',
 
   // For amp-inabox
   SEND_POSITIONS: 'send-positions',

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -42,7 +42,6 @@ export const MessageType = {
   FULL_OVERLAY_FRAME_RESPONSE: 'full-overlay-frame-response',
   CANCEL_FULL_OVERLAY_FRAME: 'cancel-full-overlay-frame',
   CANCEL_FULL_OVERLAY_FRAME_RESPONSE: 'cancel-full-overlay-frame-response',
-  CANCEL_FULL_OVERLAY_FRAME_REMEASURE: 'cancel-full-overlay-frame-remeasure',
 
   // For amp-inabox
   SEND_POSITIONS: 'send-positions',

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -98,71 +98,6 @@ export function resetFixedContainer(win, fixedContainer) {
 
 
 /**
- * An observable that triggers with a cached value on demand, as long as the
- * cahced value is valid.
- * @template T
- */
-class CachedValueObservable {
-
-  /**
-   * @param {T=} opt_initialValue
-   */
-  constructor(opt_initialValue) {
-    /** @type {!Observable<T>} */
-    this.observable_ = new Observable();
-
-    /** @type {?T} */
-    this.value_ = opt_initialValue || null;
-  }
-
-  /**
-   * @param {function(T)} handler
-   * @return {!UnlistenDef}
-   */
-  add(handler) {
-    return this.observable_.add(handler);
-  }
-
-  /**
-   * Invalidates cached value.
-   */
-  invalidateValue() {
-    this.value_ = null;
-  }
-
-  /**
-   * Sets cached value.
-   * @param {T} value
-   */
-  setValue(value) {
-    this.value_ = value;
-  }
-
-  /**
-   * @return {?T}
-   */
-  getValueOptional() {
-    return this.value_;
-  }
-
-  /**
-   * @param {T=} opt_value
-   */
-  fire(opt_value) {
-    const shouldExecute = !this.value_ !== !opt_value;
-
-    if (opt_value && !this.value_) {
-      this.setValue(dev().assert(opt_value));
-    }
-
-    if (shouldExecute) {
-      this.observable_.fire(dev().assert(this.value_));
-    }
-  }
-}
-
-
-/**
  * Implementation of ViewportBindingDef that works inside an non-scrollable
  * iframe box by listening to host doc for position and resize updates.
  *
@@ -207,25 +142,8 @@ export class ViewportBindingInabox {
      */
     this.boxRect_ = layoutRectLtwh(0, boxHeight + 1, boxWidth, boxHeight);
 
-    /**
-     * Keeps track of the iframe box rect when collapsed (full overlay mode) and
-     * fires observers if the rect is not stale.
-     * @private @const {!CachedValueObservable<!../layout-rect.LayoutRectDef>}
-     */
-    this.collapsedRectObservable_ = new CachedValueObservable(this.boxRect_);
-
-    /**
-     * @type {boolean}
-     * @visibleForTesting
-     */
-    this.inFullOverlayMode = false;
-
     /** @private @const {!../../3p/iframe-messaging-client.IframeMessagingClient} */
     this.iframeClient_ = iframeMessagingClientFor(win);
-
-    this.collapsedRectObservable_.add(collapsedBoxRect => {
-      this.updateBoxRect_(collapsedBoxRect);
-    });
 
     dev().fine(TAG, 'initialized inabox viewport');
   }
@@ -233,7 +151,6 @@ export class ViewportBindingInabox {
   /** @override */
   connect() {
     this.listenForPosition_();
-    this.listenForHostRemeasure_();
   }
 
   /** @private */
@@ -253,16 +170,6 @@ export class ViewportBindingInabox {
 
           this.updateBoxRect_(data.target);
 
-          // When the viewport changes it's possible that our cached rect for
-          // the collapsed frame box is stale, so we invalidate our cached
-          // value.
-          // TODO(alanorozco): Invalidate when using native InOb
-          if (this.inFullOverlayMode &&
-              isChanged(this.viewportRect_, oldViewportRect)) {
-
-            this.collapsedRectObservable_.invalidateValue();
-          }
-
           if (isResized(this.viewportRect_, oldViewportRect)) {
             this.resizeObservable_.fire();
           }
@@ -270,22 +177,6 @@ export class ViewportBindingInabox {
             this.scrollObservable_.fire();
           }
         });
-  }
-
-  /** @private */
-  listenForHostRemeasure_() {
-    this.iframeClient_.registerCallback(
-        MessageType.CANCEL_FULL_OVERLAY_FRAME_REMEASURE,
-        data => this.handleCollapseOverlayRemeasure(data.collapsedRect));
-  }
-
-  /**
-   * @param {!../layout-rect.LayoutRectDef} rect
-   * @visibleForTesting
-   */
-  handleCollapseOverlayRemeasure(rect) {
-    // Host has remeasured box after collapse
-    this.collapsedRectObservable_.fire(rect);
   }
 
   /** @override */
@@ -429,13 +320,8 @@ export class ViewportBindingInabox {
           MessageType.FULL_OVERLAY_FRAME_RESPONSE,
           response => {
             unlisten();
-
-            this.inFullOverlayMode = true;
-
             if (response.success) {
-              this.collapsedRectObservable_.setValue(response.collapsedRect);
-              this.updateBoxRect_(response.expandedRect);
-
+              this.updateBoxRect_(response.boxRect);
               resolve();
             } else {
               reject('Request to open lightbox rejected by host document');
@@ -453,16 +339,9 @@ export class ViewportBindingInabox {
       const unlisten = this.iframeClient_.makeRequest(
           MessageType.CANCEL_FULL_OVERLAY_FRAME,
           MessageType.CANCEL_FULL_OVERLAY_FRAME_RESPONSE,
-          () => {
+          response => {
             unlisten();
-
-            this.inFullOverlayMode = false;
-
-            // Fire cached collapsed rect observable. If our viewport changed
-            // in the meantime, our value will be stale and the observable
-            // won't fire. In this case, we'll wait for remeasure.
-            // (See message handler for CANCEL_FULL_OVERLAY_FRAME_REMEASURE)
-            this.collapsedRectObservable_.fire();
+            this.updateBoxRect_(response.boxRect);
             resolve();
           });
     });

--- a/test/functional/inabox/test-inabox-frame-overlay-manager.js
+++ b/test/functional/inabox/test-inabox-frame-overlay-manager.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FrameOverlayManager} from '../../../ads/inabox/frame-overlay-manager';
+import {
+  stubCollapseFrameForTesting,
+  stubExpandFrameForTesting,
+} from '../../../ads/inabox/frame-overlay-helper';
+import * as sinon from 'sinon';
+
+
+const NOOP = () => {};
+
+
+describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
+
+  let win;
+  let addEventListenerSpy;
+
+  let manager;
+
+  beforeEach(() => {
+    win = env.win;
+    addEventListenerSpy = sandbox.spy(win, 'addEventListener');
+
+    manager = new FrameOverlayManager(win);
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+    sandbox.restore();
+  });
+
+  it('should listen to window resize event', () => {
+    expect(addEventListenerSpy)
+        .to.have.been.calledWith('resize', sinon.match.any);
+  });
+
+  it('should expand frame and execute callback', () => {
+    const expandedRect = {a: 2, b: 3};
+    const iframe = {};
+
+    const expandFrame = sandbox.spy((win, iframe, onFinish) => {
+      onFinish({}, expandedRect);
+    });
+
+    const callback = sandbox.spy();
+
+    stubExpandFrameForTesting(expandFrame);
+
+    manager.expandFrame(iframe, callback);
+
+    expect(callback).to.have.been.calledWith(expandedRect);
+    expect(expandFrame).to.have.been.calledWith(win, iframe, sinon.match.any);
+  });
+
+  it('should collapse frame and execute callback with remeasured box', () => {
+    const remeasuredCollapsedRect = {a: 2, b: 3};
+    const iframe = {};
+
+    const collapseFrame = sandbox.spy((win, iframe, onFinish, onRemeasure) => {
+      onFinish();
+      onRemeasure(remeasuredCollapsedRect);
+    });
+
+    const callback = sandbox.spy();
+
+    stubCollapseFrameForTesting(collapseFrame);
+    stubExpandFrameForTesting((win, iframe, onFinish) => onFinish({}, {}));
+
+    manager.expandFrame(iframe, NOOP);
+    manager.onWindowResize();
+    manager.collapseFrame(iframe, callback);
+
+    expect(callback).to.have.been.calledWith(remeasuredCollapsedRect);
+    expect(collapseFrame)
+        .to.have.been.calledWith(win, iframe, sinon.match.any, sinon.match.any);
+  });
+
+  it('should collapse frame and execute callback with known box rect', () => {
+    const knownBoxRect = {a: 2, b: 3};
+
+    const iframe = {};
+
+    const collapseFrame = sandbox.spy((win, iframe, onFinish, onRemeasure) => {
+      onFinish();
+      onRemeasure({});
+    });
+
+    const callback = sandbox.spy();
+
+    stubCollapseFrameForTesting(collapseFrame);
+    stubExpandFrameForTesting((win, iframe, onFinish) =>
+        onFinish(knownBoxRect, {}));
+
+    manager.expandFrame(iframe, NOOP);
+    manager.collapseFrame(iframe, callback);
+
+    expect(callback).to.have.been.calledWith(knownBoxRect);
+    expect(collapseFrame)
+        .to.have.been.calledWith(win, iframe, sinon.match.any, sinon.match.any);
+  });
+});

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -16,10 +16,6 @@
 
 import {InaboxMessagingHost} from '../../../ads/inabox/inabox-messaging-host';
 import {deserializeMessage} from '../../../src/3p-frame-messaging';
-import {
-  stubCollapseFrameForTesting,
-  stubExpandFrameForTesting,
-} from '../../../ads/inabox/frame-overlay-helper';
 import * as sinon from 'sinon';
 
 describes.realWin('inabox-host:messaging', {}, env => {
@@ -171,11 +167,12 @@ describes.realWin('inabox-host:messaging', {}, env => {
 
 
     it('should accept request and expand', () => {
-      const expandFrame = sandbox.spy((win, iframe, onFinish) => {
-        onFinish();
-      });
+      const boxRect = {a: 1, b: 2}; // we don't care
 
-      stubExpandFrameForTesting(expandFrame);
+      const expandFrame = sandbox./*OK*/stub(
+          host.frameOverlayManager_, 'expandFrame', (iframe, callback) => {
+            callback(boxRect);
+          });
 
       host.processMessage({
         source: iframe1.contentWindow,
@@ -189,17 +186,19 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const message = deserializeMessage(
           iframePostMessageSpy.getCall(0).args[0]);
 
-      expect(expandFrame).calledWith(win, iframe1, sinon.match.any);
+      expect(expandFrame).calledWith(iframe1, sinon.match.any);
       expect(message.type).to.equal('full-overlay-frame-response');
       expect(message.success).to.be.true;
+      expect(message.boxRect).to.deep.equal(boxRect);
     });
 
     it('should accept reset request and collapse', () => {
-      const collapseFrame = sandbox.spy((win, iframe, onFinish) => {
-        onFinish();
-      });
+      const boxRect = {c: 1, d: 2}; // we don't care
 
-      stubCollapseFrameForTesting(collapseFrame);
+      const collapseFrame = sandbox./*OK*/stub(
+          host.frameOverlayManager_, 'collapseFrame', (iframe, callback) => {
+            callback(boxRect);
+          });
 
       host.processMessage({
         source: iframe1.contentWindow,
@@ -213,9 +212,10 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const message = deserializeMessage(
           iframePostMessageSpy.getCall(0).args[0]);
 
-      expect(collapseFrame).calledWith(win, iframe1, sinon.match.any);
+      expect(collapseFrame).calledWith(iframe1, sinon.match.any);
       expect(message.type).to.equal('cancel-full-overlay-frame-response');
       expect(message.success).to.be.true;
+      expect(message.boxRect).to.deep.equal(boxRect);
     });
 
   });

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -25,6 +25,9 @@ import {
   installIframeMessagingClient,
 } from '../../../src/inabox/inabox-iframe-messaging-client';
 
+
+const NOOP = () => {};
+
 describes.fakeWin('inabox-viewport', {amp: {}}, env => {
 
   let win;
@@ -35,8 +38,22 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
   let onResizeCallback;
   let measureSpy;
 
-  function stubIframeClientMakeRequest(callback) {
-    return sandbox./*OK*/stub(binding.iframeClient_, 'makeRequest', callback);
+  function stubIframeClientMakeRequest(
+      requestType, responseType, callback, opt_sync) {
+
+    return sandbox./*OK*/stub(
+        binding.iframeClient_, 'makeRequest', (req, res, cb) => {
+          expect(req).to.equal(requestType);
+          expect(res).to.equal(responseType);
+
+          if (opt_sync) {
+            callback(req, res, cb);
+          } else {
+            setTimeout(() => callback(req, res, cb), 10);
+          }
+
+          return NOOP;
+        });
   }
 
   beforeEach(() => {
@@ -66,9 +83,12 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
   });
 
   it('should work for size, layoutRect and position observer', () => {
-    stubIframeClientMakeRequest((req, res, cb) => {
-      positionCallback = cb;
-    });
+    stubIframeClientMakeRequest(
+        'send-positions',
+        'position',
+        (req, res, cb) => { positionCallback = cb; },
+        /* opt_sync */ true);
+
     onScrollCallback = sandbox.spy();
     onResizeCallback = sandbox.spy();
     binding.connect();
@@ -132,42 +152,157 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
         .to.deep.equal(layoutRectLtwh(20, 20, 100, 100));
   });
 
-  it('should center content and request resize on enter overlay mode', () => {
+  it('should center content, resize and remeasure on overlay mode', () => {
+    const allResourcesMock = Array(5).fill(undefined).map(() => ({
+      measure: sandbox.spy(),
+    }));
+
+    sandbox.stub(binding, 'getChildResources', () => allResourcesMock);
+
     const prepareContainer =
         sandbox.stub(binding, 'prepareFixedContainer_')
             .returns(Promise.resolve());
 
-    const makeRequest = stubIframeClientMakeRequest((req, res, callback) => {
-      expect(req).to.equal('full-overlay-frame');
-      expect(res).to.equal('full-overlay-frame-response');
-
-      callback({success: true});
-    });
+    const makeRequest = stubIframeClientMakeRequest(
+        'full-overlay-frame',
+        'full-overlay-frame-response',
+        (req, res, cb) => cb({
+          success: true,
+          expandedRect: {
+            left: 0,
+            top: 0,
+            right: 1000,
+            bottom: 2000,
+            width: 1000,
+            height: 2000,
+          },
+        }));
 
     return binding.updateLightboxMode(true).then(() => {
       expect(prepareContainer).to.be.calledOnce;
       expect(prepareContainer).to.be.calledBefore(makeRequest);
+
+      allResourcesMock.forEach(resource => {
+        expect(resource.measure).to.have.been.calledOnce;
+      });
     });
   });
 
-  it('should reset content and request resize on leave overlay mode', done => {
+  it('should reset content and request resize on leave overlay mode', () => {
     const resetContainer =
         sandbox.stub(binding, 'resetFixedContainer_')
             .returns(Promise.resolve());
 
-    const makeRequest = stubIframeClientMakeRequest((req, res, callback) => {
-      expect(req).to.equal('cancel-full-overlay-frame');
-      expect(res).to.equal('cancel-full-overlay-frame-response');
+    const makeRequest = stubIframeClientMakeRequest(
+        'cancel-full-overlay-frame',
+        'cancel-full-overlay-frame-response',
+        (req, res, cb) => cb({success: true}));
 
-      callback();
-    });
-
-    binding.updateLightboxMode(false).then(() => {
+    return binding.updateLightboxMode(false).then(() => {
       expect(resetContainer).to.be.calledOnce;
       expect(resetContainer).to.be.calledAfter(makeRequest);
-
-      done();
     });
+  });
+
+  it('should update box rect when expanding/collapsing', function*() {
+    const collapsedRect = {
+      left: 20,
+      top: 10,
+      bottom: 310,
+      right: 420,
+      width: 400,
+      height: 300,
+    };
+
+    const expandedRect = {
+      left: 20,
+      top: 10,
+      bottom: 310,
+      right: 420,
+      width: 400,
+      height: 300,
+    };
+
+    const updateBoxRectStub = sandbox.stub(binding, 'updateBoxRect_', NOOP);
+
+    const overlayRequestStub = stubIframeClientMakeRequest(
+        'full-overlay-frame',
+        'full-overlay-frame-response',
+        (req, res, cb) => cb({success: true, expandedRect, collapsedRect}));
+
+    sandbox.stub(binding, 'prepareFixedContainer_').returns(Promise.resolve());
+    sandbox.stub(binding, 'resetFixedContainer_').returns(Promise.resolve());
+
+    yield binding.updateLightboxMode(true);
+
+    expect(updateBoxRectStub).to.be.calledWith(expandedRect);
+
+    overlayRequestStub./*OK*/restore(); // need to re-stub
+    updateBoxRectStub.reset();
+
+    stubIframeClientMakeRequest(
+        'cancel-full-overlay-frame',
+        'cancel-full-overlay-frame-response',
+        (req, res, cb) => cb({success: true}));
+
+    yield binding.updateLightboxMode(false);
+
+    expect(updateBoxRectStub).to.be.calledWith(collapsedRect);
+  });
+
+  it('should wait for remeasure if viewport changed', function*() {
+    const collapsedRect = {
+      left: 20,
+      top: 10,
+      bottom: 310,
+      right: 420,
+      width: 400,
+      height: 300,
+    };
+
+    const positionRequestStub = stubIframeClientMakeRequest(
+        'send-positions',
+        'position',
+        (req, res, cb) => { positionCallback = cb; },
+        /* opt_sync */ true);
+
+    const updateBoxRectStub = sandbox.stub(binding, 'updateBoxRect_', NOOP);
+
+    sandbox.stub(binding, 'resetFixedContainer_').returns(Promise.resolve());
+
+    // connecting to keep track of `position` listener
+    binding.connect();
+    positionRequestStub./*OK*/restore(); // need to re-stub
+
+    // Execute position callback in full overlay mode to invalidate collapsed
+    // rect.
+    binding.inFullOverlayMode = true;
+
+    positionCallback({
+      viewport: {
+        left: 1111,
+        top: 2222,
+        myValuesDontReallyMatterHere: 123,
+      },
+    });
+
+    updateBoxRectStub.reset();
+
+    stubIframeClientMakeRequest(
+        'cancel-full-overlay-frame',
+        'cancel-full-overlay-frame-response',
+        (req, res, cb) => cb({success: true}));
+
+    // Execute collapse
+    yield binding.updateLightboxMode(false);
+
+    // Shouldn't have been called as our current collapsed viewport is stale
+    expect(updateBoxRectStub).to.not.have.been.called;
+
+    // Send remeasure message
+    binding.handleCollapseOverlayRemeasure(collapsedRect);
+
+    expect(updateBoxRectStub).to.be.calledWith(collapsedRect);
   });
 
   it('should center the fixed container properly', done => {


### PR DESCRIPTION
Uses known information about the frame collapsed state. Invalidates cached rect if the viewport changes.