### PR TITLE
ValueCommerce: add another ad server as preconnect

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -664,6 +664,7 @@ export const adConfig = {
     prefetch: 'https://amp.valuecommerce.com/amp_bridge.js',
     preconnect: [
       'https://ad.jp.ap.valuecommerce.com',
+      'https://ad.omks.valuecommerce.com',
     ],
     renderStartImplemented: true,
   },


### PR DESCRIPTION
This PR is intended for addition in the ad server list.

https://github.com/ampproject/amphtml/pull/6962

After our last PR, we added a new feature in our ad distribution using a different dedicated server.
The feature was released without amp support at this point.

By adding another value in preconnect array, we would like to provide amp-support to this as well.

Corporation name: ValueCommerce Co., Ltd.