### PR TITLE
Skip visState tests on Edge and iOS

### DIFF
--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -22,7 +22,11 @@ import {getVendorJsPropertyName} from '../../src/style';
 import {whenUpgradedToCustomElement} from '../../src/dom';
 import {createCustomEvent} from '../../src/event-helper';
 
-describe.configure().retryOnSaucelabs().run('Viewer Visibility State', () => {
+const config = describe.configure();
+config.skipEdge();
+config.skipIos();
+config.retryOnSaucelabs();
+config.run('Viewer Visibility State', () => {
 
   function noop() {}
 


### PR DESCRIPTION
Testing on just Chrome, Firefox, and Safari should be enough.

Fix #9757.