### PR TITLE
Add AMP.navigateTo action

### DIFF
--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -40,6 +40,11 @@
 <body>
 
 <div class="button-set">
+  <h3>AMP.navigateTo()</h3>
+  <button on="tap:AMP.navigateTo(url='http://google.com')">google.com</button>
+</div>
+
+<div class="button-set">
   <h3>amp-img:</h3>
   <button on="tap:img-on-viewport.show">Show</button>
   <button on="tap:img-on-viewport.hide">Hide</button>

--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -42,6 +42,12 @@
 <div class="button-set">
   <h3>AMP.navigateTo()</h3>
   <button on="tap:AMP.navigateTo(url='http://google.com')">google.com</button>
+
+  <select on="change:AMP.navigateTo(url=event.value)">
+    <option value="http://google.com">google.com</option>
+    <option value="http://yahoo.com">yahoo.com</option>
+    <option value="http://bing.com">bing.com</option>
+  </select>
 </div>
 
 <div class="button-set">

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from './action-trust';
 import {actionServiceForDoc} from './services';
 import {dev, user} from './log';
 import {
@@ -128,6 +129,9 @@ export function onDocumentFormSubmit_(e) {
     // handling of the event in cases were we are delegating to action service
     // to deliver the submission event.
     e.stopImmediatePropagation();
-    actionServiceForDoc(form).execute(form, 'submit', /*args*/ null, form, e);
+
+    const actions = actionServiceForDoc(form);
+    // TODO(choumx, #9699): HIGH.
+    actions.execute(form, 'submit', /*args*/ null, form, e, ActionTrust.MEDIUM);
   }
 }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -771,7 +771,7 @@ function getActionInfoArgValue(tokens) {
       let current = data;
       // Traverse properties of `data` per token values.
       for (let i = 0; i < tokens.length; i++) {
-        const value = tokens[i].value;
+        const value = String(tokens[i].value);
         if (current && hasOwn(current, value)) {
           current = current[value];
         } else {

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -23,8 +23,8 @@ import {
   installServiceInEmbedScope,
 } from '../service';
 import {getMode} from '../mode';
+import {hasOwn, map} from '../utils/object';
 import {isArray, isFiniteNumber} from '../types';
-import {map} from '../utils/object';
 import {timerFor} from '../services';
 import {vsyncFor} from '../services';
 
@@ -772,7 +772,7 @@ function getActionInfoArgValue(tokens) {
       // Traverse properties of `data` per token values.
       for (let i = 0; i < tokens.length; i++) {
         const value = tokens[i].value;
-        if (current && current.hasOwnProperty(value)) {
+        if (current && hasOwn(current, value)) {
           current = current[value];
         } else {
           return null;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -218,8 +218,7 @@ export class ActionService {
       this.root_.addEventListener('click', event => {
         if (!event.defaultPrevented) {
           const element = dev().assertElement(event.target);
-          // TODO(choumx, #9699): HIGH.
-          this.trigger(element, name, event, ActionTrust.MEDIUM);
+          this.trigger(element, name, event, ActionTrust.HIGH);
         }
       });
       this.root_.addEventListener('keydown', event => {
@@ -229,8 +228,7 @@ export class ActionService {
           if (!event.defaultPrevented &&
               element.getAttribute('role') == 'button') {
             event.preventDefault();
-            // TODO(choumx, #9699): HIGH.
-            this.trigger(element, name, event, ActionTrust.MEDIUM);
+            this.trigger(element, name, event, ActionTrust.HIGH);
           }
         }
       });
@@ -245,7 +243,7 @@ export class ActionService {
         const element = dev().assertElement(event.target);
         // Only `change` events from <select> elements have high trust.
         const trust = element.tagName == 'SELECT'
-            ? ActionTrust.MEDIUM // TODO(choumx, #9699): HIGH.
+            ? ActionTrust.HIGH
             : ActionTrust.MEDIUM;
         this.addInputDetails_(event);
         this.trigger(element, name, event, trust);
@@ -341,10 +339,9 @@ export class ActionService {
    * @param {?JSONType} args
    * @param {?Element} source
    * @param {?ActionEventDef} event
+   * @param {ActionTrust} trust
    */
-  execute(target, method, args, source, event) {
-    // Invocation of actions by the runtime has the highest trust of all.
-    const trust = ActionTrust.MEDIUM; // TODO(choumx, #9699): HIGH.
+  execute(target, method, args, source, event, trust) {
     this.invoke_(target, method, args, source, event, trust, null);
   }
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -19,11 +19,12 @@ import {OBJECT_STRING_ARGS_KEY} from '../service/action-impl';
 import {Layout, getLayoutClass} from '../layout';
 import {actionServiceForDoc, urlReplacementsForDoc} from '../services';
 import {bindForDoc} from '../services';
-import {dev, user} from '../log';
-import {registerServiceBuilderForDoc} from '../service';
-import {historyForDoc} from '../services';
-import {resourcesForDoc} from '../services';
 import {computedStyle, getStyle, toggle} from '../style';
+import {dev, user} from '../log';
+import {historyForDoc} from '../services';
+import {isProtocolValid} from '../url';
+import {registerServiceBuilderForDoc} from '../service';
+import {resourcesForDoc} from '../services';
 import {vsyncFor} from '../services';
 
 /**
@@ -136,6 +137,9 @@ export class StandardActions {
       return;
     }
     const url = invocation.args['url'];
+    if (!isProtocolValid(url)) {
+      return;
+    }
     const expandedUrl = this.urlReplacements_.expandUrlSync(url);
     const node = invocation.target;
     const win = (node.ownerDocument || node).defaultView;

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -87,6 +87,9 @@ export class StandardActions {
       case 'setState':
         this.handleAmpSetState_(invocation);
         return;
+      case 'navigateTo':
+        this.handleAmpNavigateTo_(invocation);
+        return;
       case 'goBack':
         this.handleAmpGoBack_(invocation);
         return;
@@ -119,6 +122,19 @@ export class StandardActions {
             + '"AMP.setState(foo=\'bar\')".');
       }
     });
+  }
+
+  /**
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @private
+   */
+  handleAmpNavigateTo_(invocation) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
+      return;
+    }
+    const win = invocation.target.ownerDocument.defaultView;
+    const url = invocation.args['url'];
+    win.location = url;
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -17,7 +17,7 @@
 import {ActionTrust} from '../action-trust';
 import {OBJECT_STRING_ARGS_KEY} from '../service/action-impl';
 import {Layout, getLayoutClass} from '../layout';
-import {actionServiceForDoc} from '../services';
+import {actionServiceForDoc, urlReplacementsForDoc} from '../services';
 import {bindForDoc} from '../services';
 import {dev, user} from '../log';
 import {registerServiceBuilderForDoc} from '../service';
@@ -54,6 +54,9 @@ export class StandardActions {
 
     /** @const @private {!./resources-impl.Resources} */
     this.resources_ = resourcesForDoc(ampdoc);
+
+    /** @const @private {!./url-replacements-impl.UrlReplacements} */
+    this.urlReplacements_ = urlReplacementsForDoc(ampdoc);
 
     this.installActions_(this.actions_);
   }
@@ -132,9 +135,10 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
-    const win = invocation.target.ownerDocument.defaultView;
     const url = invocation.args['url'];
-    win.location = url;
+    const expandedUrl = this.urlReplacements_.expandUrlSync(url);
+    const win = invocation.target.ownerDocument.defaultView;
+    win.location = expandedUrl;
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -137,7 +137,8 @@ export class StandardActions {
     }
     const url = invocation.args['url'];
     const expandedUrl = this.urlReplacements_.expandUrlSync(url);
-    const win = invocation.target.ownerDocument.defaultView;
+    const node = invocation.target;
+    const win = (node.ownerDocument || node).defaultView;
     win.location = expandedUrl;
   }
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -36,6 +36,9 @@ function isShowable(element) {
       || element.hasAttribute('hidden');
 }
 
+/** @const {string} */
+const TAG = 'STANDARD-ACTIONS';
+
 /**
  * This service contains implementations of some of the most typical actions,
  * such as hiding DOM elements.
@@ -138,6 +141,7 @@ export class StandardActions {
     }
     const url = invocation.args['url'];
     if (!isProtocolValid(url)) {
+      user().error(TAG, 'Cannot navigate to invalid protocol: ' + url);
       return;
     }
     const expandedUrl = this.urlReplacements_.expandUrlSync(url);
@@ -186,7 +190,7 @@ export class StandardActions {
 
     if (target.classList.contains(getLayoutClass(Layout.NODISPLAY))) {
       user().warn(
-          'STANDARD-ACTIONS',
+          TAG,
           'Elements with layout=nodisplay cannot be dynamically shown.',
           target);
 
@@ -198,7 +202,7 @@ export class StandardActions {
           !isShowable(target)) {
 
         user().warn(
-            'STANDARD-ACTIONS',
+            TAG,
             'Elements can only be dynamically shown when they have the ' +
             '"hidden" attribute set or when they were dynamically hidden.',
             target);

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -164,6 +164,9 @@ describes.sandboxed('StandardActions', {}, () => {
 
   describe('"AMP" global target', () => {
     it('should implement navigateTo', () => {
+      const expandUrlStub = sandbox.stub(standardActions.urlReplacements_,
+          'expandUrlSync', url => url);
+
       const win = {
         location: 'http://foo.com',
       };
@@ -183,11 +186,13 @@ describes.sandboxed('StandardActions', {}, () => {
       invocation.satisfiesTrust = () => false;
       standardActions.handleAmpTarget(invocation);
       expect(win.location).to.equal('http://foo.com');
+      expect(expandUrlStub).to.not.be.called;
 
       // Should succeed.
       invocation.satisfiesTrust = () => true;
       standardActions.handleAmpTarget(invocation);
       expect(win.location).to.equal('http://bar.com');
+      expect(expandUrlStub.calledOnce);
     });
 
     it('should implement goBack', () => {

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -163,6 +163,33 @@ describes.sandboxed('StandardActions', {}, () => {
   });
 
   describe('"AMP" global target', () => {
+    it('should implement navigateTo', () => {
+      const win = {
+        location: 'http://foo.com',
+      };
+      const invocation = {
+        method: 'navigateTo',
+        args: {
+          url: 'http://bar.com',
+        },
+        target: {
+          ownerDocument: {
+            defaultView: win,
+          },
+        },
+      };
+
+      // Should check trust and fail.
+      invocation.satisfiesTrust = () => false;
+      standardActions.handleAmpTarget(invocation);
+      expect(win.location).to.equal('http://foo.com');
+
+      // Should succeed.
+      invocation.satisfiesTrust = () => true;
+      standardActions.handleAmpTarget(invocation);
+      expect(win.location).to.equal('http://bar.com');
+    });
+
     it('should implement goBack', () => {
       installHistoryServiceForDoc(ampdoc);
       const history = historyForDoc(ampdoc);
@@ -173,10 +200,10 @@ describes.sandboxed('StandardActions', {}, () => {
     });
 
     it('should implement setState', () => {
-      const setStateWithExpressionSpy = sandbox.spy();
+      const spy = sandbox.spy();
       window.services.bind = {
         obj: {
-          setStateWithExpression: setStateWithExpressionSpy,
+          setStateWithExpression: spy,
         },
       };
 
@@ -191,8 +218,8 @@ describes.sandboxed('StandardActions', {}, () => {
       };
       standardActions.handleAmpTarget(invocation);
       return bindForDoc(ampdoc).then(() => {
-        expect(setStateWithExpressionSpy).to.be.calledOnce;
-        expect(setStateWithExpressionSpy).to.be.calledWith('{foo: 123}');
+        expect(spy).to.be.calledOnce;
+        expect(spy).to.be.calledWith('{foo: 123}');
       });
     });
   });

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -193,6 +193,12 @@ describes.sandboxed('StandardActions', {}, () => {
       standardActions.handleAmpTarget(invocation);
       expect(win.location).to.equal('http://bar.com');
       expect(expandUrlStub.calledOnce);
+
+      // Invalid protocols should fail.
+      invocation.args.url = /*eslint no-script-url: 0*/ 'javascript:alert(1)';
+      standardActions.handleAmpTarget(invocation);
+      expect(win.location).to.equal('http://bar.com');
+      expect(expandUrlStub.calledOnce);
     });
 
     it('should implement goBack', () => {


### PR DESCRIPTION
Fixes #8976, partial for #9699.

- Add new `AMP.navigateTo(url=)` action -- requires high trust and supports var subs.
- Upgrade `tap` and `change` (from `<select>`) events to high trust.
- Minor fix: require plumbing trust for `ActionService.execute()`.

Documentation changes in #9933.