### PR TITLE
Tighten the types of JSON.stringify and postMessage.

### DIFF
--- a/3p/ampcontext-integration.js
+++ b/3p/ampcontext-integration.js
@@ -16,6 +16,7 @@
 import {AbstractAmpContext} from './ampcontext';
 import {computeInMasterFrame} from './3p';
 import {dev, user} from '../src/log';
+import {dict} from '../src/utils/object';
 
 
 /**
@@ -101,7 +102,7 @@ export class IntegrationAmpContext extends AbstractAmpContext {
   }
 
   /**
-   * @param {{width, height}=} opt_data
+   * @param {!JsonObject=} opt_data Fields: width, height
    */
   renderStart(opt_data) {
     this.client_.sendMessage('render-start', opt_data);
@@ -119,9 +120,9 @@ export class IntegrationAmpContext extends AbstractAmpContext {
    * @param {string} entityId See comment above for content.
    */
   reportRenderedEntityIdentifier(entityId) {
-    this.client_.sendMessage('entity-id', {
-      id: user().assertString(entityId),
-    });
+    this.client_.sendMessage('entity-id', dict({
+      'id': user().assertString(entityId),
+    }));
   }
 
   /**

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {dict} from '../src/utils/object';
 import {dev} from '../src/log';
 import {IframeMessagingClient} from './iframe-messaging-client';
 import {MessageType} from '../src/3p-frame-messaging';
@@ -178,7 +179,10 @@ export class AbstractAmpContext {
    *  @param {number} height The new height for the ad we are requesting.
    */
   requestResize(width, height) {
-    this.client_.sendMessage(MessageType.EMBED_SIZE, {width, height});
+    this.client_.sendMessage(MessageType.EMBED_SIZE, dict({
+      'width': width,
+      'height': height,
+    }));
   };
 
   /**

--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -79,7 +79,7 @@ export class IframeMessagingClient {
   /**
    *  Send a postMessage to Host Window
    *  @param {string} type The type of message to send.
-   *  @param {Object=} opt_payload The payload of message to send.
+   *  @param {JsonObject=} opt_payload The payload of message to send.
    */
   sendMessage(type, opt_payload) {
     this.hostWindow_.postMessage/*OK*/(

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -41,6 +41,7 @@ import {urls} from '../src/config';
 import {endsWith} from '../src/string';
 import {parseUrl, getSourceUrl, isProxyOrigin} from '../src/url';
 import {dev, initLogConstructor, setReportError, user} from '../src/log';
+import {dict} from '../src/utils/object.js';
 import {getMode} from '../src/mode';
 import {startsWith} from '../src/string.js';
 
@@ -546,15 +547,21 @@ function triggerNoContentAvailable() {
 }
 
 function triggerDimensions(width, height) {
-  nonSensitiveDataPostMessage('embed-size', {width, height});
+  nonSensitiveDataPostMessage('embed-size', dict({
+    'width': width,
+    'height': height,
+  }));
 }
 
 function triggerResizeRequest(width, height) {
-  nonSensitiveDataPostMessage('embed-size', {width, height});
+  nonSensitiveDataPostMessage('embed-size', dict({
+    'width': width,
+    'height': height,
+  }));
 }
 
 /**
- * @param {{width, height}=} opt_data
+ * @param {!JsonObject=} opt_data fields: width, height
  */
 function triggerRenderStart(opt_data) {
   nonSensitiveDataPostMessage('render-start', opt_data);
@@ -574,7 +581,11 @@ let currentMessageId = 0;
  */
 function getHtml(selector, attributes, callback) {
   const messageId = currentMessageId++;
-  nonSensitiveDataPostMessage('get-html', {selector, attributes, messageId});
+  nonSensitiveDataPostMessage('get-html', dict({
+    'selector': selector,
+    'attributes': attributes,
+    'messageId': messageId,
+  }));
 
   const unlisten = listenParent(window, 'get-html-result', data => {
     if (data.messageId === messageId) {
@@ -658,9 +669,9 @@ function onResizeDenied(observerCallback) {
 function reportRenderedEntityIdentifier(entityId) {
   user().assert(typeof entityId == 'string',
       'entityId should be a string %s', entityId);
-  nonSensitiveDataPostMessage('entity-id', {
-    id: entityId,
-  });
+  nonSensitiveDataPostMessage('entity-id', dict({
+    'id': entityId,
+  }));
 }
 
 /**

--- a/3p/messaging.js
+++ b/3p/messaging.js
@@ -17,15 +17,15 @@
 /**
  * Send messages to parent frame. These should not contain user data.
  * @param {string} type Type of messages
- * @param {*=} opt_object Data for the message.
+ * @param {!JsonObject=} opt_object Data for the message.
  */
 export function nonSensitiveDataPostMessage(type, opt_object) {
   if (window.parent == window) {
     return;  // Nothing to do.
   }
-  const object = opt_object || {};
-  object.type = type;
-  object.sentinel = window.context.sentinel;
+  const object = opt_object || /** @type {JsonObject} */ ({});
+  object['type'] = type;
+  object['sentinel'] = window.context.sentinel;
   window.parent./*OK*/postMessage(object,
       window.context.location.origin);
 }

--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -20,6 +20,7 @@ import {
 } from '../../src/url';
 import {closest, openWindowDialog} from '../../src/dom';
 import {dev} from '../../src/log';
+import {dict} from '../../src/utils/object';
 import {urls} from '../../src/config';
 import {isProxyOrigin, isLocalhostOrigin, parseUrl} from '../../src/url';
 import {startsWith} from '../../src/string';
@@ -149,9 +150,9 @@ function navigateTo(win, a, url) {
   const target = (a.target || '_top').toLowerCase();
   const a2aAncestor = getA2AAncestor(win);
   if (a2aAncestor) {
-    a2aAncestor.win./*OK*/postMessage('a2a;' + JSON.stringify({
-      url,
-    }), a2aAncestor.origin);
+    a2aAncestor.win./*OK*/postMessage('a2a;' + JSON.stringify(dict({
+      'url': url,
+    })), a2aAncestor.origin);
     return;
   }
   openWindowDialog(win, url, target);

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -21,6 +21,7 @@ import {
   MessageType,
 } from '../../src/3p-frame-messaging';
 import {dev} from '../../src/log';
+import {dict} from '../../src/utils/object';
 import {expandFrame, collapseFrame} from './frame-overlay-helper';
 
 /** @const */
@@ -153,7 +154,7 @@ export class InaboxMessagingHost {
           serializeMessage(
               MessageType.FULL_OVERLAY_FRAME_RESPONSE,
               request.sentinel,
-              {success: true}),
+              dict({'success': true})),
           origin);
     });
 
@@ -173,7 +174,7 @@ export class InaboxMessagingHost {
           serializeMessage(
               MessageType.CANCEL_FULL_OVERLAY_FRAME_RESPONSE,
               request.sentinel,
-              {success: true}),
+              dict({'success': true})),
           origin);
     });
 

--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -154,3 +154,26 @@ requirement: {
   error_message: 'Symbol is not allowed'
   value: 'Symbol'
 }
+
+requirement: {
+  type: RESTRICTED_METHOD_CALL
+  error_message: 'postMessage must be called with a string or a JsonObject'
+  value: 'Window.prototype.postMessage:function((string|?JsonObject), string)'
+  # Guaranteed same version call
+  whitelist: 'src/web-worker/web-worker.js'
+  # Allowing violations in ads code for now.
+  # We would have to fix this to property obfuscated the 3p frame code.
+  whitelist: 'ads/google/doubleclick.js'
+  whitelist: 'ads/google/imaVideo.js'
+}
+
+requirement: {
+  type: RESTRICTED_NAME_CALL
+  error_message: 'JSON.stringify must be called with a JsonObject'
+  # Unfortunately the Array is untyped, because the compiler doesn't check
+  # for the template type.
+  value: 'JSON.stringify:function((?JsonObject|AmpViewerMessage|string|number|boolean|undefined|Array),!Function=)'
+  # Allowing violations in ads code for now.
+  # We would have to fix this to property obfuscated the 3p frame code.
+  whitelist: 'ads/google/doubleclick.js'
+}

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -20,7 +20,7 @@ import {Layout} from '../../../src/layout';
 import {closest} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {removeFragment} from '../../../src/url';
-import {map} from '../../../src/utils/object';
+import {dict} from '../../../src/utils/object';
 import {tryFocus} from '../../../src/dom';
 
 class AmpAccordion extends AMP.BaseElement {
@@ -35,7 +35,7 @@ class AmpAccordion extends AMP.BaseElement {
     /** @private {?string} */
     this.sessionId_ = null;
 
-    /** @private {?Object<string,boolean>} */
+    /** @private {?JsonObject} */
     this.currentState_ = null;
 
     /** @private {boolean} */
@@ -113,23 +113,24 @@ class AmpAccordion extends AMP.BaseElement {
 
   /**
    * Get previous state from sessionStorage.
-   * @return {!Object}
+   * @return {!JsonObject}
    * @private
    */
   getSessionState_() {
     if (this.sessionOptOut_) {
-      return map();
+      return dict();
     }
     try {
       const sessionStr =
           this.win./*OK*/sessionStorage.getItem(
               dev().assertString(this.sessionId_));
       return sessionStr
-          ? /** @type {!Object} */ (JSON.parse(dev().assertString(sessionStr)))
-          : map();
+          ? /** @type {!JsonObject} */ (
+              JSON.parse(dev().assertString(sessionStr)))
+          : dict();
     } catch (e) {
       dev().fine('AMP-ACCORDION', e.message, e.stack);
-      return map();
+      return dict();
     }
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -26,6 +26,7 @@ import {
 } from '../../../src/iframe-helper';
 import {viewerForDoc} from '../../../src/services';
 import {dev} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {timerFor} from '../../../src/services';
 import {setStyle} from '../../../src/style';
 import {loadPromise} from '../../../src/event-helper';
@@ -122,9 +123,11 @@ export class AmpAdXOriginIframeHandler {
           this.positionObserver_.observe(
               dev().assertElement(this.iframe),
               PositionObserverFidelity.HIGH, pos => {
+                // Valid cast because it is an external object.
+                const posCast = /** @type {!JsonObject} */ (pos);
                 this.positionObserverHighFidelityApi_.send(
                     POSITION_HIGH_FIDELITY,
-                    pos);
+                    posCast);
               });
         });
     }
@@ -151,7 +154,10 @@ export class AmpAdXOriginIframeHandler {
 
           postMessageToWindows(
               this.iframe, [{win: source, origin}],
-              'get-html-result', {content, messageId}, true
+              'get-html-result', dict({
+                'content': content,
+                'messageId': messageId,
+              }), true
           );
         }, true, false));
 
@@ -385,7 +391,10 @@ export class AmpAdXOriginIframeHandler {
         this.iframe,
         [{win: source, origin}],
         success ? 'embed-size-changed' : 'embed-size-denied',
-        {requestedWidth, requestedHeight},
+        dict({
+          'requestedWidth': requestedWidth,
+          'requestedHeight': requestedHeight,
+        }),
         true);
   }
 
@@ -397,10 +406,10 @@ export class AmpAdXOriginIframeHandler {
     if (!this.embedStateApi_) {
       return;
     }
-    this.embedStateApi_.send('embed-state', {
-      inViewport,
-      pageHidden: !this.viewer_.isVisible(),
-    });
+    this.embedStateApi_.send('embed-state', dict({
+      'inViewport': inViewport,
+      'pageHidden': !this.viewer_.isVisible(),
+    }));
   }
 
   /**

--- a/extensions/amp-analytics/0.1/cid-impl.js
+++ b/extensions/amp-analytics/0.1/cid-impl.js
@@ -32,6 +32,7 @@ import {
   isProxyOrigin,
   parseUrl,
 } from '../../../src/url';
+import {dict} from '../../../src/utils/object';
 import {isIframed} from '../../../src/dom';
 import {getCryptoRandomBytesArray} from '../../../src/utils/bytes';
 import {viewerForDoc} from '../../../src/services';
@@ -315,10 +316,10 @@ export function viewerBaseCid(ampdoc, opt_data) {
           // For backward compatibility: #4029
           if (data && !tryParseJson(data)) {
             // TODO(dvoytenko, #9019): use this for reporting: dev().error('cid', 'invalid cid format');
-            return JSON.stringify({
-              time: Date.now(), // CID returned from old API is always fresh
-              cid: data,
-            });
+            return JSON.stringify(dict({
+              'time': Date.now(), // CID returned from old API is always fresh
+              'cid': data,
+            }));
           }
           return data;
         });
@@ -340,10 +341,10 @@ export function viewerBaseCid(ampdoc, opt_data) {
  * @return {string}
  */
 function createCidData(cidString) {
-  return JSON.stringify({
-    time: Date.now(),
-    cid: cidString,
-  });
+  return JSON.stringify(dict({
+    'time': Date.now(),
+    'cid': cidString,
+  }));
 }
 
 /**

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -389,8 +389,10 @@ export class BindExpression {
    * @private
    */
   memberAccessWarning_(target, member) {
-    user().warn(TAG, `Cannot read property ${JSON.stringify(member)} of ` +
-        `${JSON.stringify(target)}; returning null.`);
+    // Cast valid, because we don't care for the logging.
+    const stringified = JSON.stringify(/** @type {!JsonObject} */ (member));
+    user().warn(TAG, `Cannot read property ${stringified} of ` +
+        `${stringified}; returning null.`);
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -23,7 +23,7 @@ import {
 } from '../../../src/services';
 import {chunk, ChunkPriority} from '../../../src/chunk';
 import {dev, user} from '../../../src/log';
-import {deepMerge} from '../../../src/utils/object';
+import {dict, deepMerge} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {filterSplice} from '../../../src/utils/array';
 import {installServiceInEmbedScope} from '../../../src/service';
@@ -130,8 +130,8 @@ export class Bind {
     /** @const @private {!./bind-validator.BindValidator} */
     this.validator_ = new BindValidator();
 
-    /** @const @private {!Object} */
-    this.scope_ = Object.create(null);
+    /** @const @private {!JsonObject} */
+    this.scope_ = dict();
 
     /** @const @private {!../../../src/service/resources-impl.Resources} */
     this.resources_ = resourcesForDoc(ampdoc);
@@ -617,7 +617,7 @@ export class Bind {
         return;
       }
       const promise = this.resources_.mutateElement(element, () => {
-        const mutations = {};
+        const mutations = dict();
         let width, height;
 
         updates.forEach(update => {

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -16,6 +16,7 @@
 
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {VideoEvents} from '../../../src/video-interface';
 import {
   installVideoManagerForDoc,
@@ -229,17 +230,17 @@ class AmpDailymotion extends AMP.BaseElement {
   /**
    * Sends a command to the player through postMessage.
    * @param {string} command
-   * @param {Array=} opt_args
+   * @param {Array<boolean>=} opt_args
    * @private
    */
   sendCommand_(command, opt_args) {
     const endpoint = 'https://www.dailymotion.com';
     this.playerReadyPromise_.then(() => {
       if (this.iframe_ && this.iframe_.contentWindow) {
-        const message = JSON.stringify({
-          command,
-          parameters: opt_args || [],
-        });
+        const message = JSON.stringify(dict({
+          'command': command,
+          'parameters': opt_args || [],
+        }));
         this.iframe_.contentWindow./*OK*/postMessage(message, endpoint);
       }
     });

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -28,6 +28,7 @@ import {
 import {
   listen,
 } from '../../../src/event-helper';
+import {dict} from '../../../src/utils/object';
 import {removeElement} from '../../../src/dom';
 import {startsWith} from '../../../src/string';
 import {user} from '../../../src/log';
@@ -185,11 +186,11 @@ class AmpImaVideo extends AMP.BaseElement {
     if (this.iframe_ && this.iframe_.contentWindow)
     {
       this.playerReadyPromise_.then(() => {
-        this.iframe_.contentWindow./*OK*/postMessage(JSON.stringify({
+        this.iframe_.contentWindow./*OK*/postMessage(JSON.stringify(dict({
           'event': 'command',
           'func': command,
           'args': opt_args || '',
-        }), '*');
+        })), '*');
       });
     }
   }

--- a/extensions/amp-izlesene/0.1/amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/amp-izlesene.js
@@ -18,6 +18,7 @@
  import {getDataParamsFromAttributes} from '../../../src/dom';
  import {isLayoutSizeDefined} from '../../../src/layout';
  import {dev, user} from '../../../src/log';
+ import {dict} from '../../../src/utils/object';
 
  class AmpIzlesene extends AMP.BaseElement {
    constructor(element) {
@@ -91,7 +92,9 @@
   /** @override */
    pauseCallback() {
      if (this.iframe_ && this.iframe_.contentWindow) {
-       this.iframe_.contentWindow./*OK*/postMessage({command: 'pause'}, '*');
+       this.iframe_.contentWindow./*OK*/postMessage(dict({
+         'command': 'pause',
+       }), '*');
      }
    }
 };

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -17,6 +17,7 @@
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {addParamsToUrl} from '../../../src/url';
 import {getDataParamsFromAttributes} from '../../../src/dom';
+import {dict} from '../../../src/utils/object';
 import {user} from '../../../src/log';
 
 class AmpKaltura extends AMP.BaseElement {
@@ -98,10 +99,10 @@ class AmpKaltura extends AMP.BaseElement {
   /** @override */
   pauseCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
-      this.iframe_.contentWindow./*OK*/postMessage(JSON.stringify({
+      this.iframe_.contentWindow./*OK*/postMessage(JSON.stringify(dict({
         'method': 'pause' ,
         'value': '' ,
-      }) , '*');
+      })) , '*');
     }
   }
 

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -17,6 +17,7 @@
 import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
 import {tryParseJson} from '../../../src/json';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {dict} from '../../../src/utils/object';
 import {user} from '../../../src/log';
 import {
   installVideoManagerForDoc,
@@ -172,7 +173,9 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
   sendCommand_(command) {
     this.playerReadyPromise_.then(() => {
       if (this.iframe_ && this.iframe_.contentWindow) {
-        this.iframe_.contentWindow./*OK*/postMessage({cmd: command}, '*');
+        this.iframe_.contentWindow./*OK*/postMessage(dict({
+          'cmd': command,
+        }), '*');
       }
     });
   };

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -22,6 +22,7 @@ import {Layout} from '../../../src/layout';
 import {base64UrlEncodeFromBytes} from '../../../src/utils/base64';
 import {getCryptoRandomBytesArray} from '../../../src/utils/bytes';
 import {dev, user} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 
 /** @private @const {string} */
 const TAG = 'amp-share-tracking';
@@ -140,7 +141,7 @@ export class AmpShareTracking extends AMP.BaseElement {
     const postReq = {
       method: 'POST',
       credentials: 'include',
-      body: {},
+      body: dict(),
     };
     return xhrFor(this.win).fetchJson(vendorUrl, postReq)
         .then(res => res.json())

--- a/extensions/amp-soundcloud/0.1/amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/amp-soundcloud.js
@@ -29,6 +29,7 @@
  */
 
 import {Layout} from '../../../src/layout';
+import {dict} from '../../../src/utils/object';
 import {user} from '../../../src/log';
 
 
@@ -100,7 +101,7 @@ class AmpSoundcloud extends AMP.BaseElement {
   pauseCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
       this.iframe_.contentWindow./*OK*/postMessage(
-          JSON.stringify({method: 'pause'}),
+          JSON.stringify(dict({'method': 'pause'})),
           'https://w.soundcloud.com');
     }
   }

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -91,7 +91,7 @@ export class WindowPortEmulator {
   }
 
   /**
-   * @param {Object} data
+   * @param {JsonObject} data
    */
   postMessage(data) {
     this.target_./*OK*/postMessage(data, this.origin_);
@@ -251,7 +251,9 @@ export class Messaging {
    */
   sendMessage_(message) {
     this.port_./*OK*/postMessage(
-        this.isWebview_ ? JSON.stringify(message) : message);
+        this.isWebview_
+            ? JSON.stringify(message)
+            : message);
   }
 
   /**

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -26,6 +26,7 @@ import {
 import {setStyles} from '../../../src/style';
 import {addParamsToUrl} from '../../../src/url';
 import {isObject} from '../../../src/types';
+import {dict} from '../../../src/utils/object';
 import {VideoEvents} from '../../../src/video-interface';
 import {videoManagerForDoc} from '../../../src/services';
 import {startsWith} from '../../../src/string';
@@ -270,11 +271,11 @@ class AmpYoutube extends AMP.BaseElement {
   sendCommand_(command, opt_args) {
     this.playerReadyPromise_.then(() => {
       if (this.iframe_ && this.iframe_.contentWindow) {
-        const message = JSON.stringify({
+        const message = JSON.stringify(dict({
           'event': 'command',
           'func': command,
           'args': opt_args || '',
-        });
+        }));
         this.iframe_.contentWindow./*OK*/postMessage(message, '*');
       }
     });
@@ -317,9 +318,9 @@ class AmpYoutube extends AMP.BaseElement {
    * @private
    */
   listenToFrame_() {
-    this.iframe_.contentWindow./*OK*/postMessage(JSON.stringify({
+    this.iframe_.contentWindow./*OK*/postMessage(JSON.stringify(dict({
       'event': 'listening',
-    }), '*');
+    })), '*');
   }
 
   /** @private */

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -15,6 +15,7 @@
  */
 
 import {dev} from './log';
+import {dict} from './utils/object';
 import {internalListenImplementation} from './event-helper-listen';
 
 
@@ -66,15 +67,16 @@ export function listen(element, eventType, listener, opt_capture) {
  * 'amp-011481323099490{"type":"position","sentinel":"12345","foo":"bar"}'
  * @param {string} type
  * @param {string} sentinel
- * @param {Object=} data
+ * @param {JsonObject=} data
  * @param {?string=} rtvVersion
  * @returns {string}
  */
-export function serializeMessage(type, sentinel, data = {}, rtvVersion = null) {
+export function serializeMessage(type, sentinel, data = dict(),
+    rtvVersion = null) {
   // TODO: consider wrap the data in a "data" field. { type, sentinal, data }
   const message = data;
-  message.type = type;
-  message.sentinel = sentinel;
+  message['type'] = type;
+  message['sentinel'] = sentinel;
   return AMP_MESSAGE_PREFIX + (rtvVersion || '') + JSON.stringify(message);
 }
 

--- a/src/error.js
+++ b/src/error.js
@@ -72,7 +72,8 @@ let reportingBackoff = function(work) {
  */
 function tryJsonStringify(value) {
   try {
-    return JSON.stringify(value);
+    // Cast is fine, because we really don't care here. Just trying.
+    return JSON.stringify(/** @type {!JsonObject} */ (value));
   } catch (e) {
     return String(value);
   }

--- a/src/iframe-attributes.js
+++ b/src/iframe-attributes.js
@@ -20,23 +20,24 @@ import {viewerForDoc} from './services';
 import {getLengthNumeral} from './layout';
 import {getModeObject} from './mode-object';
 import {domFingerprint} from './utils/dom-fingerprint';
+import {dict} from './utils/object.js';
 
 /**
  * Produces the attributes for the ad template.
  * @param {!Window} parentWindow
  * @param {!AmpElement} element
  * @param {!string} sentinel
- * @param {!Object<string, string>=} attributes
- * @return {!Object}
+ * @param {!JsonObject=} attributes
+ * @return {!JsonObject}
  */
 export function getContextMetadata(
     parentWindow, element, sentinel, attributes) {
   const startTime = Date.now();
   const width = element.getAttribute('width');
   const height = element.getAttribute('height');
-  attributes = attributes ? attributes : {};
-  attributes.width = getLengthNumeral(width);
-  attributes.height = getLengthNumeral(height);
+  attributes = attributes ? attributes : dict();
+  attributes['width'] = getLengthNumeral(width);
+  attributes['height'] = getLengthNumeral(height);
   let locationHref = parentWindow.location.href;
   // This is really only needed for tests, but whatever. Children
   // see us as the logical origin, so telling them we are about:srcdoc
@@ -52,36 +53,36 @@ export function getContextMetadata(
   // TODO(alanorozco): Redesign data structure so that fields not exposed by
   // AmpContext are not part of this object.
   const layoutRect = element.getPageLayoutBox();
-  attributes._context = {
-    ampcontextVersion: '$internalRuntimeVersion$',
-    ampcontextFilepath: urls.cdn + '/$internalRuntimeVersion$' +
+  attributes['_context'] = dict({
+    'ampcontextVersion': '$internalRuntimeVersion$',
+    'ampcontextFilepath': urls.cdn + '/$internalRuntimeVersion$' +
         '/ampcontext-v0.js',
-    sourceUrl: docInfo.sourceUrl,
-    referrer,
-    canonicalUrl: docInfo.canonicalUrl,
-    pageViewId: docInfo.pageViewId,
-    location: {
-      href: locationHref,
+    'sourceUrl': docInfo.sourceUrl,
+    'referrer': referrer,
+    'canonicalUrl': docInfo.canonicalUrl,
+    'pageViewId': docInfo.pageViewId,
+    'location': {
+      'href': locationHref,
     },
-    startTime,
-    tagName: element.tagName,
-    mode: getModeObject(),
-    canary: isCanary(parentWindow),
-    hidden: !viewer.isVisible(),
-    initialLayoutRect: layoutRect ? {
-      left: layoutRect.left,
-      top: layoutRect.top,
-      width: layoutRect.width,
-      height: layoutRect.height,
+    'startTime': startTime,
+    'tagName': element.tagName,
+    'mode': getModeObject(),
+    'canary': isCanary(parentWindow),
+    'hidden': !viewer.isVisible(),
+    'initialLayoutRect': layoutRect ? {
+      'left': layoutRect.left,
+      'top': layoutRect.top,
+      'width': layoutRect.width,
+      'height': layoutRect.height,
     } : null,
-    initialIntersection: element.getIntersectionChangeEntry(),
-    domFingerprint: domFingerprint(element),
-    experimentToggles: experimentToggles(parentWindow),
-  };
-  attributes._context['sentinel'] = sentinel;
+    'initialIntersection': element.getIntersectionChangeEntry(),
+    'domFingerprint': domFingerprint(element),
+    'experimentToggles': experimentToggles(parentWindow),
+    'sentinel': sentinel,
+  });
   const adSrc = element.getAttribute('src');
   if (adSrc) {
-    attributes.src = adSrc;
+    attributes['src'] = adSrc;
   }
   return attributes;
 }

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -327,7 +327,7 @@ export function listenForOncePromise(iframe, typeOfMessages, opt_is3P) {
  * Posts a message to the iframe.
  * @param {!Element} iframe The iframe.
  * @param {string} type Type of the message.
- * @param {!Object} object Message payload.
+ * @param {!JsonObject} object Message payload.
  * @param {string} targetOrigin origin of the target.
  * @param {boolean=} opt_is3P set to true if the iframe is 3p.
  */
@@ -345,15 +345,15 @@ export function postMessage(iframe, type, object, targetOrigin, opt_is3P) {
  * @param {!Array<{win: !Window, origin: string}>} targets to send the message
  *     to, pairs of window and its origin.
  * @param {string} type Type of the message.
- * @param {!Object} object Message payload.
+ * @param {!JsonObject} object Message payload.
  * @param {boolean=} opt_is3P set to true if the iframe is 3p.
  */
 export function postMessageToWindows(iframe, targets, type, object, opt_is3P) {
   if (!iframe.contentWindow) {
     return;
   }
-  object.type = type;
-  object.sentinel = getSentinel_(iframe, opt_is3P);
+  object['type'] = type;
+  object['sentinel'] = getSentinel_(iframe, opt_is3P);
   let payload = object;
   if (opt_is3P) {
     // Serialize ourselves because that is much faster in Chrome.
@@ -439,7 +439,7 @@ export class SubscriptionApi {
   /**
    * Sends a message to all subscribed windows.
    * @param {string} type Type of the message.
-   * @param {!Object} data Message payload.
+   * @param {!JsonObject} data Message payload.
    */
   send(type, data) {
     // Remove clients that have been removed from the DOM.

--- a/src/intersection-observer-polyfill.js
+++ b/src/intersection-observer-polyfill.js
@@ -15,6 +15,7 @@
  */
 
 import {dev} from './log';
+import {dict} from './utils/object';
 import {layoutRectLtwh, rectIntersection, moveLayoutRect} from './layout-rect';
 import {SubscriptionApi} from './iframe-helper';
 
@@ -116,7 +117,7 @@ export class IntersectionObserverApi {
       for (let i = 0; i < entries.length; i++) {
         delete entries[i]['target'];
       }
-      this.subscriptionApi_.send('intersection', {changes: entries});
+      this.subscriptionApi_.send('intersection', dict({'changes': entries}));
     }, {threshold: DEFAULT_THRESHOLD});
     this.intersectionObserver_.tick(this.viewport_.getRect());
 

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -15,6 +15,7 @@
  */
 
 import {dev} from './log';
+import {dict} from './utils/object';
 import {layoutRectLtwh, rectIntersection, moveLayoutRect} from './layout-rect';
 import {SubscriptionApi} from './iframe-helper';
 import {timerFor} from './services';
@@ -270,7 +271,9 @@ export class IntersectionObserver {
       return;
     }
     // Note that SubscribeApi multicasts the update to all interested windows.
-    this.postMessageApi_.send('intersection', {changes: this.pendingChanges_});
+    this.postMessageApi_.send('intersection', dict({
+      'changes': this.pendingChanges_,
+    }));
     this.pendingChanges_.length = 0;
   }
 

--- a/src/service/crypto-impl.js
+++ b/src/service/crypto-impl.js
@@ -134,7 +134,7 @@ export class Crypto {
    * available using isCryptoAvailable before calling this function.
    *
    * @param {string} serviceName used to identify the signing service.
-   * @param {!Object} jwk An object which is hopefully an RSA JSON Web Key.  The
+   * @param {!JsonObject} jwk An object which is hopefully an RSA JSON Web Key.  The
    *     caller should verify that it is an object before calling this function.
    * @return {!Promise<!PublicKeyInfoDef>}
    */
@@ -153,11 +153,11 @@ export class Crypto {
           // We do the importKey first to allow the browser to check for
           // an invalid key.  This last check is in case the key is valid
           // but a different kind.
-          if (typeof jwk.n != 'string' || typeof jwk.e != 'string') {
+          if (typeof jwk['n'] != 'string' || typeof jwk['e'] != 'string') {
             throw new Error('missing fields in JSON Web Key');
           }
-          const mod = base64UrlDecodeToBytes(jwk.n);
-          const pubExp = base64UrlDecodeToBytes(jwk.e);
+          const mod = base64UrlDecodeToBytes(jwk['n']);
+          const pubExp = base64UrlDecodeToBytes(jwk['e']);
           const lenMod = lenPrefix(mod);
           const lenPubExp = lenPrefix(pubExp);
           const data = new Uint8Array(lenMod.length + lenPubExp.length);

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -47,6 +47,19 @@ import {getMode} from '../mode';
  */
 export let FetchInitDef;
 
+/**
+ * Special case for fetchJson
+ * @typedef {{
+ *   body: (!JsonObject|!FormData|undefined),
+ *   credentials: (string|undefined),
+ *   headers: (!Object|undefined),
+ *   method: (string|undefined),
+ *   requireAmpResponseSourceOrigin: (boolean|undefined),
+ *   ampCors: (boolean|undefined)
+ * }}
+ */
+export let FetchInitJsonDef;
+
 /** @private @const {!Array<string>} */
 const allowedMethods_ = ['GET', 'POST'];
 
@@ -195,7 +208,7 @@ export class Xhr {
    * See `fetchAmpCors_` for more detail.
    *
    * @param {string} input
-   * @param {?FetchInitDef=} opt_init
+   * @param {?FetchInitJsonDef=} opt_init
    * @param {boolean=} opt_allowFailure Allows non-2XX status codes to fulfill.
    * @return {!Promise<!FetchResponse>}
    */
@@ -211,7 +224,8 @@ export class Xhr {
       );
 
       init.headers['Content-Type'] = 'application/json;charset=utf-8';
-      init.body = JSON.stringify(init.body);
+      // Cast is valid, because we checked that it is not form data above.
+      init.body = JSON.stringify(/** @type {!JsonObject} */ (init.body));
     }
     return this.fetch(input, init);
   }


### PR DESCRIPTION
The new type limits the APIs to be used with `JsonObject` to enforce that objects being passed to them used quoted property names not subject to obfuscation.

Part of #9876
