### PR TITLE
Laterpay badge

### DIFF
--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -35,7 +35,7 @@
 
 .amp-access-laterpay label {
   display: flex;
-  padding-left: 5px;
+  padding-right: 10px;
 }
 
 .amp-access-laterpay input {
@@ -44,9 +44,12 @@
 
 .amp-access-laterpay-container {
   padding: 16px;
+  padding-right: 24px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  border-radius: 12px;
+  box-shadow: 0 0 10px -1px rgba(0,0,0,.25);
 }
 
 .amp-access-laterpay-badge {

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -14,13 +14,6 @@
  * limitations under the License.
  */
 
-.amp-access-laterpay {
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
 @media (min-width: 420px) {
   .amp-access-laterpay {
     width: 420px;
@@ -48,6 +41,14 @@
 .amp-access-laterpay input {
   width: 20px;
 }
+
+.amp-access-laterpay-container {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 
 .amp-access-laterpay-header {
   font-size: 1.2em;

--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -49,6 +49,14 @@
   align-items: center;
 }
 
+.amp-access-laterpay-badge {
+  text-align: center;
+  color: #999;
+}
+
+.amp-access-laterpay-badge a {
+  color: #8db444;
+}
 
 .amp-access-laterpay-header {
   font-size: 1.2em;

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -332,6 +332,7 @@ export class LaterpayVendor {
         this.createAlreadyPurchasedLink_(this.purchaseConfig_.apl));
     this.renderTextBlock_('footer');
     dialogContainer.appendChild(this.innerContainer_);
+    dialogContainer.appendChild(this.createLaterpayBadge_());
     this.containerEmpty_ = false;
   }
 
@@ -348,6 +349,21 @@ export class LaterpayVendor {
     }
   }
 
+  /**
+   * @private
+   * @return {!Node}
+   */
+  createLaterpayBadge_() {
+    const a = this.createElement_('a');
+    a.href = 'https://laterpay.net';
+    a.target = '_blank';
+    a.textContent = 'LaterPay';
+    const el = this.createElement_('p');
+    el.className = TAG + '-badge';
+    el.textContent = 'Powered by ';
+    el.appendChild(a);
+    return el;
+  }
 
   /**
    * @param {!PurchaseOptionDef} option

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -119,6 +119,9 @@ export class LaterpayVendor {
     this.containerEmpty_ = true;
 
     /** @private {?Node} */
+    this.innerContainer_ = null;
+
+    /** @private {?Node} */
     this.selectedPurchaseOption_ = null;
 
     /** @private {?Node} */
@@ -289,6 +292,7 @@ export class LaterpayVendor {
     }
     return this.vsync_.mutatePromise(() => {
       this.containerEmpty_ = true;
+      this.innerContainer_ = null;
       removeChildren(this.getContainer_());
     });
   }
@@ -298,6 +302,8 @@ export class LaterpayVendor {
    */
   renderPurchaseOverlay_() {
     const dialogContainer = this.getContainer_();
+    this.innerContainer_ = this.createElement_('div');
+    this.innerContainer_.className = TAG + '-container';
     this.renderTextBlock_('header');
     const listContainer = this.createElement_('ul');
     this.purchaseConfig_.premiumcontent['tp_title'] =
@@ -320,11 +326,12 @@ export class LaterpayVendor {
     this.purchaseButtonListener_ = listen(purchaseButton, 'click', ev => {
       this.handlePurchase_(ev, this.selectedPurchaseOption_.value);
     });
-    dialogContainer.appendChild(listContainer);
-    dialogContainer.appendChild(purchaseButton);
-    dialogContainer.appendChild(
+    this.innerContainer_.appendChild(listContainer);
+    this.innerContainer_.appendChild(purchaseButton);
+    this.innerContainer_.appendChild(
         this.createAlreadyPurchasedLink_(this.purchaseConfig_.apl));
     this.renderTextBlock_('footer');
+    dialogContainer.appendChild(this.innerContainer_);
     this.containerEmpty_ = false;
   }
 
@@ -337,7 +344,7 @@ export class LaterpayVendor {
       const el = this.createElement_('p');
       el.className = TAG + '-' + area;
       el.textContent = this.i18n_[area];
-      this.getContainer_().appendChild(el);
+      this.innerContainer_.appendChild(el);
     }
   }
 

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -170,6 +170,7 @@ The structure created for the dialog looks as follows:
       Optional, appears if footer locale message is defined.
     </p>
   </div>
+  <p class="amp-access-laterpay-badge">Powered by <a href="https://laterpay.net" target="_blank">LaterPay</a></p>
 </div>
 ```
 

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -142,32 +142,34 @@ The structure created for the dialog looks as follows:
 
 ```html
 <div id="amp-access-laterpay-dialog" class="amp-access-laterpay">
-  <p class="amp-access-laterpay-header">
-    Optional, appears if header locale message is defined.
-  </p>
-  <ul>
-    <li>
-      <label>
-        <input name="purchaseOption" type="radio" />
-        <div class="amp-access-laterpay-metadata">
-          <span class="amp-access-laterpay-title">Purchase option title</span>
-          <p class="amp-access-laterpay-description">Purchase option description</p>
-        </div>
-      </label>
-      <p class="amp-access-laterpay-price-container">
-        <span class="amp-access-laterpay-price">0.15</span>
-        <sup class="amp-access-laterpay-currency">USD</sup>
-      </p>
-    </li>
-    <!-- ... more list items for other purchase options ... -->
-  </ul>
-  <button class="amp-access-laterpay-purchase-button">Buy Now</button>
-  <p class="amp-access-laterpay-already-purchased-container">
-    <a href="...">I already bought this</a>
-  </p>
-  <p class="amp-access-laterpay-footer">
-    Optional, appears if footer locale message is defined.
-  </p>
+  <div class="amp-access-laterpay-container">
+    <p class="amp-access-laterpay-header">
+      Optional, appears if header locale message is defined.
+    </p>
+    <ul>
+      <li>
+        <label>
+          <input name="purchaseOption" type="radio" />
+          <div class="amp-access-laterpay-metadata">
+            <span class="amp-access-laterpay-title">Purchase option title</span>
+            <p class="amp-access-laterpay-description">Purchase option description</p>
+          </div>
+        </label>
+        <p class="amp-access-laterpay-price-container">
+          <span class="amp-access-laterpay-price">0.15</span>
+          <sup class="amp-access-laterpay-currency">USD</sup>
+        </p>
+      </li>
+      <!-- ... more list items for other purchase options ... -->
+    </ul>
+    <button class="amp-access-laterpay-purchase-button">Buy Now</button>
+    <p class="amp-access-laterpay-already-purchased-container">
+      <a href="...">I already bought this</a>
+    </p>
+    <p class="amp-access-laterpay-footer">
+      Optional, appears if footer locale message is defined.
+    </p>
+  </div>
 </div>
 ```
 


### PR DESCRIPTION
Adds a "powered by laterpay" badge to the laterpay integration.

A new internal container was added to accommodate this. Styles and docs are updated accordingly.

The base style was also tweaked to be more consistent with the non AMP website integration we have and make the badge stand out a bit more.