### PR TITLE
AMP Sidebar 1.0: Created basic docking functionality

### DIFF
--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -26,6 +26,10 @@
       line-height: 24px;
     }
 
+    .menu-right {
+      float: right;
+    }
+
     header,
     .article-body {
       padding: 15px;
@@ -242,6 +246,15 @@
       </ul>
     </nav>
   </amp-sidebar>
+
+  <amp-sidebar id="sidebar2" side="right" layout="nodisplay" dock="(min-width: 1024px)">
+    <nav>
+      <ul>
+        <li><a href="#">Testing Sidebar 2</a></li>
+      </ul>
+    </nav>
+  </amp-sidebar>
+
   <amp-app-banner layout="nodisplay" id="demo-app-banner-2134">
     <div class="content">
       <amp-img src="https://cdn-images-1.medium.com/max/800/1*JLegdtjFMNgqHgnxdd04fg.png"
@@ -263,6 +276,9 @@
     <span class="brand-logo">
       PublisherLogo
     </span>
+    <button on="tap:sidebar2.toggle" class="menu menu-right" title="Toggle Sidebar" >
+      ☰
+    </button>
   </header>
 
   <!--

--- a/examples/article.amp-sidebar-1.0.amp.html
+++ b/examples/article.amp-sidebar-1.0.amp.html
@@ -223,7 +223,7 @@
   <link rel="manifest" href="medium-manifest.json">
 </head>
 <body>
-  <amp-sidebar id="sidebar" layout="nodisplay">
+  <amp-sidebar id="sidebar" layout="nodisplay" dock="(min-width: 768px)">
     <nav>
       <ul>
         <li>

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -49,6 +49,11 @@
    transition: transform 233ms cubic-bezier(0,0,.21,1);
  }
 
+ amp-sidebar[docked] {
+  transform: translateX(0) !important;
+  display: block !important;
+ }
+
  .i-amphtml-sidebar-mask {
    position: fixed !important;
    top: 0 !important;

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -168,6 +168,9 @@ export class AmpSidebar extends AMP.BaseElement {
 
   /** @override */
   onLayoutMeasure() {
+    if (!this.document_.body) {
+      return;
+    }
     // Remove and add the docking dynamically
     if (this.isDocked_() && !this.element.hasAttribute('docked')) {
       this.closeIfOpen_();
@@ -175,15 +178,15 @@ export class AmpSidebar extends AMP.BaseElement {
 
       // use calc to get our space for sidebar to docked
       const borderCalc =
-        `calc(${this.element.offsetWidth}px)`;
-
+        `calc(${this.element.getBoundingClientRect().width}px)`;
+      const bodyElement = this.document_.body;
       if (this.side_ === 'right') {
-        setStyles(this.document_.body, {
+        setStyles(bodyElement, {
           'border-right-width': borderCalc,
           'border-right-style': 'solid',
         });
       } else {
-        setStyles(this.document_.body, {
+        setStyles(bodyElement, {
           'border-left-width': borderCalc,
           'border-left-style': 'solid',
         });

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -198,12 +198,17 @@ export class AmpSidebar extends AMP.BaseElement {
     } else if (!this.isDocked_() && this.element.hasAttribute('docked')) {
       this.close_();
       this.element.removeAttribute('docked');
-      setStyles(this.document_.body, {
-        'border-right-width': null,
-        'border-right-style': null,
-        'border-left-width': null,
-        'border-left-style': null,
-      });
+      if (this.side_ === 'right') {
+        setStyles(this.document_.body, {
+          'border-right-width': null,
+          'border-right-style': null,
+        });
+      } else {
+        setStyles(this.document_.body, {
+          'border-left-width': null,
+          'border-left-style': null,
+        });
+      }
     }
   }
 

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -173,7 +173,7 @@ export class AmpSidebar extends AMP.BaseElement {
     }
     // Remove and add the docking dynamically
     if (this.isDocked_() && !this.element.hasAttribute('docked')) {
-      this.closeIfOpen_();
+      this.close_();
       this.element.setAttribute('docked', '');
 
       // use calc to get our space for sidebar to docked
@@ -196,7 +196,7 @@ export class AmpSidebar extends AMP.BaseElement {
         padding-left: //body width + side-bar width
       */
     } else if (!this.isDocked_() && this.element.hasAttribute('docked')) {
-      this.closeIfOpen_();
+      this.close_();
       this.element.removeAttribute('docked');
       setStyles(this.document_.body, {
         'border-right-width': null,
@@ -214,16 +214,6 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   isOpen_() {
     return this.element.hasAttribute('open');
-  }
-
-  /**
-   * Closes the sidebar if it is open
-   * @private
-   */
-  closeIfOpen_() {
-    if (this.isOpen_()) {
-      this.close_();
-    }
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -178,7 +178,7 @@ export class AmpSidebar extends AMP.BaseElement {
 
       // use calc to get our space for sidebar to docked
       const borderCalc =
-        `calc(${this.element.getBoundingClientRect().width}px)`;
+        `calc(${this.element./*REVIEW*/offsetWidth}px)`;
       const bodyElement = this.document_.body;
       if (this.side_ === 'right') {
         setStyles(bodyElement, {


### PR DESCRIPTION
Please see the [Design Doc](https://docs.google.com/document/d/1njeaTdy-bMNaTT0IB9TXjoW6Xlp-VqcQr1GrQ826Rn8/edit?usp=sharing) for context.

# Completed tasks

- Implements Basic Docking (on both sides)
- Moves Body Border

Related to #9988

**This is still a work in progress, remaining TODO**
- Calculate body's border for left and right
- Get both sidebars to play nice with each other in all situations
- Add some show/hide FOUC styles to amp.css
- Implement tests

# Example Screenshots
![screen shot 2017-06-15 at 10 18 50 am](https://user-images.githubusercontent.com/1448289/27193596-42053378-51b4-11e7-8978-946648701f57.png)
![screen shot 2017-06-15 at 1 53 49 pm](https://user-images.githubusercontent.com/1448289/27201329-1e8dc428-51d2-11e7-88b4-d9fca7534565.png)



