### PR TITLE
Document semantics of html_format being empty

### DIFF
--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -346,8 +346,8 @@ message TagSpec {
     AMP = 1;
     AMP4ADS = 2;
   }
-  // Specifies which amp html document formats we allow this TagSpec to
-  // validate.
+  // Specifies which AMP HTML document formats we allow this TagSpec to
+  // validate. If empty, then this TagSpec validates all formats.
   repeated HtmlFormat html_format = 21;
 
   // Use UPPER-CASE tag names only. If adding the same tag twice, then they must


### PR DESCRIPTION
Based on the engine code at the following location:

https://github.com/ampproject/amphtml/blob/master/validator/engine/validator.js#L3994

when the html_format list is empty, the current TagSpec is allowed to validate all AMP HTML formats.