### PR TITLE
Update trust levels for existing actions to spec

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -211,7 +211,7 @@ export class AmpSlideScroll extends BaseSlides {
       if (args) {
         this.showSlideWhenReady(args['index']);
       }
-    }, ActionTrust.MEDIUM); // TODO(choumx, #9699): LOW.
+    }, ActionTrust.LOW);
   }
 
   /** @override */

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -193,9 +193,8 @@ export class AmpForm {
     this.verifier_ = getFormVerifier(
         this.form_, () => this.handleXhrVerify_());
 
-    // TODO(choumx, #9699): HIGH.
     this.actions_.installActionHandler(
-        this.form_, this.actionHandler_.bind(this), ActionTrust.MEDIUM);
+        this.form_, this.actionHandler_.bind(this), ActionTrust.HIGH);
     this.installEventHandlers_();
 
     /** @private {?Promise} */
@@ -351,7 +350,7 @@ export class AmpForm {
       event.preventDefault();
     }
     // Submits caused by user input have high trust.
-    this.submit_(ActionTrust.MEDIUM); // TODO(choumx, #9699): HIGH.
+    this.submit_(ActionTrust.HIGH);
   }
 
   /**

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -223,9 +223,8 @@ export class AmpLiveList extends AMP.BaseElement {
     this.curNumOfLiveItems_ = this.validateLiveListItems_(
         this.itemsSlot_, true);
 
-    // TODO(choumx, #9699): LOW.
     this.registerAction(
-        'update', this.updateAction_.bind(this), ActionTrust.MEDIUM);
+        'update', this.updateAction_.bind(this), ActionTrust.LOW);
 
     if (!this.element.hasAttribute('aria-live')) {
       this.element.setAttribute('aria-live', 'polite');

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -292,9 +292,8 @@ export class AmpSelector extends AMP.BaseElement {
               targetOption: el.getAttribute('option'),
               selectedOptions: selectedValues,
             });
-        // TODO(choumx, #9699): HIGH.
         this.action_.trigger(this.element, name, selectEvent,
-            ActionTrust.MEDIUM);
+            ActionTrust.HIGH);
       }
     });
   }

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -58,12 +58,10 @@ You can listen to multiple events on an element by separating the two events wit
 
 Example: `on="submit-success:lightbox1;submit-error:lightbox2"`
 
-
 ## Multiple Actions For One Event
 You can execute multiple actions in sequence for the same event by separating the two actions with a comma ','.
 
 Example: `on="tap:target1.actionA,target2.actionB"`
-
 
 ## Globally defined Events and Actions
 Currently AMP defines `tap` event globally that you can listen to on any HTML element (including amp-elements).
@@ -80,6 +78,18 @@ For example, the following is possible in AMP.
 <button on="tap:warning-message.hide">Cool, thanks!</button>
 ```
 
+## Trust
+
+Each event has a "trust" level that corresponds to the user's intentionality
+behind that event. Each action has a "required trust" which is the minimum trust
+level of an event to trigger the action.
+
+For example, a medium-trust event  (e.g. `slideChange`) cannot trigger a
+high-required-trust action (e.g. `navigateTo`).
+
+See the tables below for the trust levels of each event and required trust for
+each action.
+
 ## Element Specific Events
 
 ### * - all elements
@@ -87,10 +97,12 @@ For example, the following is possible in AMP.
   <tr>
     <th>Event</th>
     <th>Description</th>
+    <th>Trust</th>
   </tr>
   <tr>
     <td>tap</td>
     <td>Fired when the element is clicked/tapped.</td>
+    <td>High</td>
   </tr>
 </table>
 
@@ -101,29 +113,40 @@ For example, the following is possible in AMP.
     <th>Description</th>
     <th>Elements</th>
     <th>Data</th>
+    <th>Trust</th>
   </tr>
   <!-- change -->
   <tr>
-    <td rowspan=3><code>change</code></td>
-    <td rowspan=3>Fired when the value of the element is changed and committed.</td>
+    <td rowspan=4><code>change</code></td>
+    <td rowspan=4>Fired when the value of the element is changed and committed.</td>
     <td>input[type="range"]</td>
     <td>
       <code>event.min</code> : The minimum value of the range<br>
       <code>event.value</code> : The current value of the range<br>
       <code>event.max</code> : The maximum value of the range<br>
     </td>
+    <td>Medium</td>
   </tr>
   <tr>
     <td>input[type="radio"], input[type="checkbox"]</td>
     <td>
       <code>event.checked</code> : If the element is checked
     </td>
+    <td>Medium</td>
   </tr>
   <tr>
-    <td>input[type="text"], select</td>
+    <td>input[type="text"]</td>
     <td>
       <code>event.value</code> : String of the text or selected option
     </td>
+    <td>Medium</td>
+  </tr>
+  <tr>
+    <td>select</td>
+    <td>
+      <code>event.value</code> : String of the text or selected option
+    </td>
+    <td>High</td>
   </tr>
   <!-- input-debounced -->
   <tr>
@@ -131,6 +154,7 @@ For example, the following is possible in AMP.
     <td>Fired when the value of the element is changed. This is similar to the standard <code>input</code> event, but it only fires when 300ms have passed after the value of the input has stopped changing.</td>
     <td>Elements that fire <code>input</code> event.</td>
     <td>Same as above.</td>
+    <td>Medium</td>
   </tr>
 </table>
 
@@ -140,11 +164,13 @@ For example, the following is possible in AMP.
     <th>Event</th>
     <th>Description</th>
     <th>Data</th>
+    <th>Trust</th>
   </tr>
   <tr>
     <td>slideChange</td>
     <td>Fired when the user manually changes the carousel's current slide. Does not fire on autoplay or the <code>goToSlide</code> action.</td>
     <td><code>event.index</code> : slide number</td>
+    <td>Medium</td>
   </tr>
 </table>
 
@@ -154,11 +180,13 @@ For example, the following is possible in AMP.
     <th>Event</th>
     <th>Description</th>
     <th>Data</th>
+    <th>Trust</th>
   </tr>
   <tr>
     <td>select</td>
     <td>Fired when the user manually selects an option.</td>
     <td><code>event.targetOption</code> : The <code>option</code> attribute value of the selected element</td>
+    <td>High</td>
   </tr>
 </table>
 
@@ -168,43 +196,51 @@ For example, the following is possible in AMP.
     <th>Event</th>
     <th>Description</th>
     <th>Data</th>
+    <th>Trust</th>
   </tr>
   <tr>
     <td>submit</td>
     <td>Fired when the form is submitted.</td>
     <td></td>
+    <td>High</td>
   </tr>
   <tr>
     <td>submit-success</td>
     <td>Fired when the form submission response is success.</td>
     <td><code>event.response</code> : JSON response</td>
+    <td>Medium</td>
   </tr>
   <tr>
     <td>submit-error</td>
     <td>Fired when the form submission response is an error.</td>
     <td><code>event.response</code> : JSON response</td>
+    <td>Medium</td>
   </tr>
 </table>
 
-
 ## Element Specific Actions
+
 ### * (all elements)
 <table>
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>hide</td>
     <td>Hides the target element.</td>
+    <td>Medium</td>
   </tr>
   <tr>
     <td>show</td>
     <td>Shows the target element.</td>
+    <td>Medium</td>
   </tr>
   <tr>
     <td>toggleVisibility</td>
     <td>Toggles the visibility of the target element.</td>
+    <td>Medium</td>
   </tr>
 </table>
 
@@ -213,10 +249,12 @@ For example, the following is possible in AMP.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>goToSlide(index=INTEGER)</td>
     <td>Advances the carousel to a specified slide index.</td>
+    <td>Low</td>
   </tr>
 </table>
 
@@ -225,10 +263,12 @@ For example, the following is possible in AMP.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>open (default)</td>
     <td>Opens the image lightbox with the source image being the one that triggered the action.</td>
+    <td>Medium</td>
   </tr>
 </table>
 
@@ -237,14 +277,17 @@ For example, the following is possible in AMP.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>open (default)</td>
     <td>Opens the lightbox.</td>
+    <td>Medium</td>
   </tr>
   <tr>
     <td>close</td>
     <td>Closes the lightbox.</td>
+    <td>Medium</td>
   </tr>
 </table>
 
@@ -253,10 +296,12 @@ For example, the following is possible in AMP.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>update (default)</td>
     <td>Updates the DOM items to show updated content.</td>
+    <td>Low</td>
   </tr>
 </table>
 
@@ -265,32 +310,22 @@ For example, the following is possible in AMP.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>open (default)</td>
     <td>Opens the sidebar.</td>
+    <td>Medium</td>
   </tr>
   <tr>
     <td>close</td>
     <td>Closes the sidebar.</td>
+    <td>Medium</td>
   </tr>
   <tr>
     <td>toggle</td>
     <td>Toggles the state of the sidebar.</td>
-  </tr>
-</table>
-
-### amp-state
-<table>
-  <tr>
-    <th>Action</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>(default)</td>
-    <td>Updates the amp-state's data with the data contained in the event. Requires
-      <a href="../extensions/amp-bind/amp-bind.md">amp-bind</a>.
-    </td>
+    <td>Medium</td>
   </tr>
 </table>
 
@@ -299,10 +334,12 @@ For example, the following is possible in AMP.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>dismiss (default)</td>
     <td>Hides the referenced user notification element.</td>
+    <td>Medium</td>
   </tr>
 </table>
 
@@ -311,22 +348,27 @@ For example, the following is possible in AMP.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>play</td>
     <td>Plays the video.</td>
+    <td>High</td>
   </tr>
   <tr>
     <td>pause</td>
     <td>Pauses the video.</td>
+    <td>Low</td>
   </tr>
   <tr>
     <td>mute</td>
     <td>Mutes the video.</td>
+    <td>Low</td>
   </tr>
   <tr>
     <td>unmute</td>
     <td>Unmutes the video.</td>
+    <td>High</td>
   </tr>
 </table>
 
@@ -335,10 +377,12 @@ For example, the following is possible in AMP.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>submit</td>
     <td>Submits the form.</td>
+    <td>High</td>
   </tr>
 </table>
 
@@ -355,18 +399,22 @@ actions that apply to the whole document.
   <tr>
     <th>Action</th>
     <th>Description</th>
+    <th>Required Trust</th>
   </tr>
   <tr>
     <td>navigateTo(url=STRING)</td>
     <td>Navigates current window to given URL. Supports <a href="./amp-var-substitutions.md">standard URL subsitutions</a>. Can only be invoked via <code>tap</code> or <code>change</code> events.</td>
+    <td>High</td>
   </tr>
   <tr>
     <td>goBack</td>
     <td>Navigates back in history.</td>
+    <td>High</td>
   </tr>
   <tr>
     <td>setState</td>
     <td>Updates <code>amp-bind</code>'s state. See <a href="../extensions/amp-bind/amp-bind.md#ampsetstate">details</a>.</td>
+    <td>Medium</td>
   </tr>
 </table>
 

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -131,7 +131,6 @@ export function onDocumentFormSubmit_(e) {
     e.stopImmediatePropagation();
 
     const actions = actionServiceForDoc(form);
-    // TODO(choumx, #9699): HIGH.
-    actions.execute(form, 'submit', /*args*/ null, form, e, ActionTrust.MEDIUM);
+    actions.execute(form, 'submit', /*args*/ null, form, e, ActionTrust.HIGH);
   }
 }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -235,8 +235,7 @@ export class ActionService {
     } else if (name == 'submit') {
       this.root_.addEventListener(name, event => {
         const element = dev().assertElement(event.target);
-        // TODO(choumx, #9699): HIGH.
-        this.trigger(element, name, event, ActionTrust.MEDIUM);
+        this.trigger(element, name, event, ActionTrust.HIGH);
       });
     } else if (name == 'change') {
       this.root_.addEventListener(name, event => {

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -155,8 +155,7 @@ export class StandardActions {
    * @private
    */
   handleAmpGoBack_(invocation) {
-    // TODO(choumx, #9699): HIGH.
-    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
     historyForDoc(this.ampdoc).goBack();

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -91,15 +91,12 @@ export class VideoManager {
    * @private
    */
   registerCommonActions_(video) {
-    // TODO(choumx, #9699): HIGH for unmuted play, LOW for muted play.
     video.registerAction('play', video.play.bind(video, /* isAutoplay */ false),
-        ActionTrust.MEDIUM);
-    // TODO(choumx, #9699): LOW.
-    video.registerAction('pause', video.pause.bind(video), ActionTrust.MEDIUM);
-    video.registerAction('mute', video.mute.bind(video), ActionTrust.MEDIUM);
-    // TODO(choumx, #9699): HIGH.
+        ActionTrust.HIGH);
+    video.registerAction('pause', video.pause.bind(video), ActionTrust.LOW);
+    video.registerAction('mute', video.mute.bind(video), ActionTrust.LOW);
     video.registerAction('unmute', video.unmute.bind(video),
-        ActionTrust.MEDIUM);
+        ActionTrust.HIGH);
   }
 
   /**


### PR DESCRIPTION
Fixes #9699.

Note that **this will remove functionality** by requiring high trust for some actions. Specifically, the actions:

- `AMP.goBack`
- `<video>.play` and `<video>.unmute`

...can no longer be triggered by the following medium-trust events:

- `change` (except from `<select>`)
- `slideChange`
- `submit-success`, `submit-error`
- `input-debounced`

We don't have any low trust events yet, so actions that require low trust have no effective change. 

See [this spreadsheet](https://docs.google.com/spreadsheets/d/1QnIxWMQLcNINaNGpHcMsSUt5_l9Q7_bvHVMwQfwyypg/edit#gid=0) for the canonical trust spec.