### PR TITLE
Alias JSON.parse with a type safe function.

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -39,6 +39,7 @@ import {
 } from './3p';
 import {urls} from '../src/config';
 import {endsWith} from '../src/string';
+import {parseJson} from '../src/json';
 import {parseUrl, getSourceUrl, isProxyOrigin} from '../src/url';
 import {dev, initLogConstructor, setReportError, user} from '../src/log';
 import {dict} from '../src/utils/object.js';
@@ -193,10 +194,10 @@ const AMP_EMBED_ALLOWED = {
 };
 
 
-/** @const {!Object} */
-const FALLBACK_CONTEXT_DATA = {
-  _context: {},
-};
+/** @const {!JsonObject} */
+const FALLBACK_CONTEXT_DATA = dict({
+  '_context': dict(),
+});
 
 
 // Need to cache iframeName as it will be potentially overwritten by
@@ -204,7 +205,7 @@ const FALLBACK_CONTEXT_DATA = {
 const iframeName = window.name;
 const data = getData(iframeName);
 
-window.context = data._context;
+window.context = data['_context'];
 
 // This should only be invoked after window.context is set
 initLogConstructor();
@@ -364,13 +365,13 @@ const defaultAllowedTypesInCustomFrame = [
 
 /**
  * Gets data encoded in iframe name attribute.
- * @return {!Object}
+ * @return {!JsonObject}
  */
 function getData(iframeName) {
   try {
     // TODO(bradfrizzell@): Change the data structure of the attributes
     //    to make it less terrible.
-    return JSON.parse(iframeName).attributes;
+    return parseJson(iframeName)['attributes'];
   } catch (err) {
     if (!getMode().test) {
       dev().info(
@@ -430,16 +431,16 @@ function isMaster() {
 window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
     opt_allowedEmbeddingOrigins) {
   try {
-    const location = parseUrl(data._context.location.href);
+    const location = parseUrl(data['_context']['location']['href']);
 
     ensureFramed(window);
     validateParentOrigin(window, location);
-    validateAllowedTypes(window, data.type, opt_allowed3pTypes);
+    validateAllowedTypes(window, data['type'], opt_allowed3pTypes);
     if (opt_allowedEmbeddingOrigins) {
       validateAllowedEmbeddingOrigins(window, opt_allowedEmbeddingOrigins);
     }
     installContext(window);
-    delete data._context;
+    delete data['_context'];
     manageWin(window);
     installEmbedStateListener();
     draw3p(window, data, opt_configCallback);
@@ -500,7 +501,7 @@ function installContextUsingStandardImpl(win) {
   // Define master related properties to be lazily read.
   Object.defineProperties(win.context, {
     master: {
-      get: () => masterSelection(win, data.type),
+      get: () => masterSelection(win, data['type']),
     },
     isMaster: {
       get: isMaster,
@@ -508,13 +509,13 @@ function installContextUsingStandardImpl(win) {
   });
 
   win.context.data = data;
-  win.context.location = parseUrl(data._context.location.href);
+  win.context.location = parseUrl(data['_context']['location']['href']);
   win.context.noContentAvailable = triggerNoContentAvailable;
   win.context.requestResize = triggerResizeRequest;
   win.context.renderStart = triggerRenderStart;
 
-  if (data.type === 'facebook' || data.type === 'twitter'
-    || data.type === 'github') {
+  const type = data['type'];
+  if (type === 'facebook' || type === 'twitter' || type === 'github') {
     // Only make this available to selected embeds until the
     // generic solution is available.
     win.context.updateDimensions = triggerDimensions;
@@ -783,7 +784,7 @@ export function parseFragment(fragment) {
     if (startsWith(json, '{%22')) {
       json = decodeURIComponent(json);
     }
-    return /** @type {!JsonObject} */ (json ? JSON.parse(json) : {});
+    return /** @type {!JsonObject} */ (json ? parseJson(json) : dict());
   } catch (err) {
     return null;
   }

--- a/3p/messaging.js
+++ b/3p/messaging.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {parseJson} from '../src/json';
+
 /**
  * Send messages to parent frame. These should not contain user data.
  * @param {string} type Type of messages
@@ -77,9 +79,8 @@ function startListening(win) {
       return;
     }
     // Parse JSON only once per message.
-    const data = /** @type {!Object} */ (
-        JSON.parse(event.data.substr(4)));
-    if (win.context.sentinel && data.sentinel != win.context.sentinel) {
+    const data = parseJson(event.data.substr(4));
+    if (win.context.sentinel && data['sentinel'] != win.context.sentinel) {
       return;
     }
     // Don't let other message handlers interpret our events.
@@ -88,7 +89,7 @@ function startListening(win) {
     }
     // Find all the listeners for this type.
     for (let i = 0; i < listeners.length; i++) {
-      if (listeners[i].type != data.type) {
+      if (listeners[i].type != data['type']) {
         continue;
       }
       const cb = listeners[i].cb;

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -23,6 +23,7 @@ import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isProxyOrigin} from '../../../src/url';
+import {parseJson} from '../../../src/json';
 import {
   resourcesForDoc,
   viewerForDoc,
@@ -456,9 +457,9 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
   }
   try {
     const analyticsConfig =
-      JSON.parse(responseHeaders.get(AMP_ANALYTICS_HEADER));
+        parseJson(responseHeaders.get(AMP_ANALYTICS_HEADER));
     dev().assert(Array.isArray(analyticsConfig['url']));
-    const urls = analyticsConfig.url;
+    const urls = analyticsConfig['url'];
     if (!urls.length) {
       return null;
     }

--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -156,6 +156,18 @@ requirement: {
 }
 
 requirement: {
+  type: BANNED_NAME
+  error_message: 'Use jsonParse instead. Usage in 3p ads can be whitelisted for now.'
+  value: 'JSON.parse'
+  whitelist: 'ads/adfox.js'
+  whitelist: 'ads/imedia.js'
+  whitelist: 'ads/kargo.js'
+  whitelist: 'ads/mads.js'
+  whitelist: 'ads/google/imaVideo.js'
+  whitelist: 'src/json.js' # Where jsonParse itself is implemented.
+}
+
+requirement: {
   type: RESTRICTED_METHOD_CALL
   error_message: 'postMessage must be called with a string or a JsonObject'
   value: 'Window.prototype.postMessage:function((string|?JsonObject), string)'

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -43,6 +43,7 @@ import {cryptoFor} from '../../../src/crypto';
 import {isExperimentOn} from '../../../src/experiments';
 import {setStyle} from '../../../src/style';
 import {assertHttpsUrl} from '../../../src/url';
+import {parseJson} from '../../../src/json';
 import {handleClick} from '../../../ads/alp/handler';
 import {
   getDefaultBootstrapBaseUrl,
@@ -1477,7 +1478,7 @@ export class AmpA4A extends AMP.BaseElement {
       return null;
     }
     try {
-      const metaDataObj = JSON.parse(
+      const metaDataObj = parseJson(
           creative.slice(metadataStart + metadataString.length, metadataEnd));
       const ampRuntimeUtf16CharOffsets =
         metaDataObj['ampRuntimeUtf16CharOffsets'];

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -21,6 +21,7 @@ import {dev, user} from '../../../src/log';
 import {removeFragment} from '../../../src/url';
 import {dict} from '../../../src/utils/object';
 import {tryFocus} from '../../../src/dom';
+import {parseJson} from '../../../src/json';
 
 class AmpAccordion extends AMP.BaseElement {
 
@@ -132,7 +133,7 @@ class AmpAccordion extends AMP.BaseElement {
               dev().assertString(this.sessionId_));
       return sessionStr
           ? /** @type {!JsonObject} */ (
-              JSON.parse(dev().assertString(sessionStr)))
+              dev().assert(parseJson(dev().assertString(sessionStr))))
           : dict();
     } catch (e) {
       dev().fine('AMP-ACCORDION', e.message, e.stack);

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -21,6 +21,7 @@ import {isExperimentOn} from '../../../src/experiments';
 import {isJsonScriptTag, openWindowDialog} from '../../../src/dom';
 import {urlReplacementsForDoc} from '../../../src/services';
 import {user} from '../../../src/log';
+import {parseJson} from '../../../src/json';
 
 const TAG = 'amp-ad-exit';
 
@@ -168,7 +169,7 @@ export class AmpAdExit extends AMP.BaseElement {
         'The amp-ad-exit config should ' +
         'be inside a <script> tag with type="application/json"');
     try {
-      const config = assertConfig(JSON.parse(child.textContent));
+      const config = assertConfig(parseJson(child.textContent));
       const userFilters = {};
       for (const name in config.filters) {
         userFilters[name] = createFilter(name, config.filters[name]);

--- a/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
+++ b/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
@@ -20,6 +20,7 @@ import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {resolveRelativeUrl} from '../../../src/url';
 import {utf8Decode} from '../../../src/utils/bytes';
+import {parseJson} from '../../../src/json';
 
 
 export class AmpAdNetworkFakeImpl extends AmpA4A {
@@ -69,7 +70,7 @@ export class AmpAdNetworkFakeImpl extends AmpA4A {
       }
       // Normal mode: the content is a JSON structure with two fieleds:
       // `creative` and `signature`.
-      const decoded = JSON.parse(deserialized);
+      const decoded = parseJson(deserialized);
       dev().info('AMP-AD-FAKE', 'Decoded response text =', decoded['creative']);
       dev().info('AMP-AD-FAKE', 'Decoded signature =', decoded['signature']);
       const encoder = new TextEncoder('utf-8');

--- a/extensions/amp-ad/0.1/a2a-listener.js
+++ b/extensions/amp-ad/0.1/a2a-listener.js
@@ -18,6 +18,7 @@ import {isExperimentOn} from '../../../src/experiments';
 import {user} from '../../../src/log';
 import {viewerForDoc} from '../../../src/services';
 import {isProxyOrigin} from '../../../src/url';
+import {parseJson} from '../../../src/json';
 
 /**
  * Sets up a special document wide listener that relays requests
@@ -50,13 +51,14 @@ export function handleMessageEvent(win, event) {
     return;
   }
   const origin = event.origin;
-  const nav = JSON.parse(data.substr(/* 'a2a;'.length */ 4));
+  const nav = parseJson(data.substr(/* 'a2a;'.length */ 4));
+  const url = nav['url'];
   const source = event.source;
   const activeElement = win.document.activeElement;
   // Check that the active element is an iframe.
   user().assert(activeElement.tagName == 'IFRAME',
       'A2A request with invalid active element %s %s %s',
-      activeElement, nav.url, origin);
+      activeElement, url, origin);
   let found = false;
   let sourceParent = source;
   const activeWindow = activeElement.contentWindow;
@@ -70,12 +72,12 @@ export function handleMessageEvent(win, event) {
   // Check that the active iframe contains the iframe that sent us
   // the message.
   user().assert(found,
-      'A2A request from invalid source win %s %s', nav.url, origin);
+      'A2A request from invalid source win %s %s', url, origin);
   // Check that the iframe is contained in an ad.
   user().assert(closestByTag(activeElement, 'amp-ad'),
-      'A2A request from non-ad frame %s %s', nav.url, origin);
+      'A2A request from non-ad frame %s %s', url, origin);
   // We only allow AMP shaped URLs.
-  user().assert(isProxyOrigin(nav.url), 'Invalid ad A2A URL %s %s',
-      nav.url, origin);
-  viewerForDoc(win.document).navigateTo(nav.url, 'ad-' + origin);
+  user().assert(isProxyOrigin(url), 'Invalid ad A2A URL %s %s',
+      url, origin);
+  viewerForDoc(win.document).navigateTo(url, 'ad-' + origin);
 }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -27,6 +27,7 @@ import {cryptoFor} from '../../../src/crypto';
 import {timerFor, viewerForDoc, xhrFor} from '../../../src/services';
 import {toggle} from '../../../src/style';
 import {isEnumValue} from '../../../src/types';
+import {parseJson} from '../../../src/json';
 import {Activity} from './activity-impl';
 import {Cid} from './cid-impl';
 import {
@@ -422,7 +423,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       if (children.length == 1) {
         const child = children[0];
         if (isJsonScriptTag(child)) {
-          inlineConfig = JSON.parse(children[0].textContent);
+          inlineConfig = parseJson(children[0].textContent);
         } else {
           user().error(TAG, 'The analytics config should ' +
               'be put in a <script> tag with type="application/json"');

--- a/extensions/amp-analytics/0.1/cid-impl.js
+++ b/extensions/amp-analytics/0.1/cid-impl.js
@@ -37,7 +37,7 @@ import {isIframed} from '../../../src/dom';
 import {getCryptoRandomBytesArray} from '../../../src/utils/bytes';
 import {viewerForDoc} from '../../../src/services';
 import {cryptoFor} from '../../../src/crypto';
-import {tryParseJson} from '../../../src/json';
+import {parseJson, tryParseJson} from '../../../src/json';
 import {timerFor} from '../../../src/services';
 import {user, rethrowAsync} from '../../../src/log';
 
@@ -371,7 +371,7 @@ function read(ampdoc) {
     if (!data) {
       return null;
     }
-    const item = JSON.parse(data);
+    const item = parseJson(data);
     return {
       time: item['time'],
       cid: item['cid'],

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {parseJson} from '../../../../src/json';
 
 const TAG = 'amp-viewer-messaging';
 export const APP = '__AMPHTML__';
@@ -50,7 +51,7 @@ export function parseMessage(message) {
 
   try {
     return /** @type {?Message} */ (
-      JSON.parse(/** @type {string} */ (message)));
+        /** @type {?} */ (parseJson(/** @type {string} */ (message))));
   } catch (e) {
     return null;
   }

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -17,6 +17,7 @@
 import {dev} from './log';
 import {dict} from './utils/object';
 import {internalListenImplementation} from './event-helper-listen';
+import {parseJson} from './json';
 
 
 /** @const */
@@ -86,7 +87,7 @@ export function serializeMessage(type, sentinel, data = dict(),
  * Returns null if it's not valid AMP message format.
  *
  * @param {*} message
- * @returns {?JsonObject}
+ * @returns {?JsonObject|undefined}
  */
 export function deserializeMessage(message) {
   if (!isAmpMessage(message)) {
@@ -95,7 +96,7 @@ export function deserializeMessage(message) {
   const startPos = message.indexOf('{');
   dev().assert(startPos != -1, 'JSON missing in %s', message);
   try {
-    return /** @type {!JsonObject} */ (JSON.parse(message.substr(startPos)));
+    return parseJson(message.substr(startPos));
   } catch (e) {
     dev().error('MESSAGING', 'Failed to parse message: ' + message, e);
     return null;

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -26,6 +26,7 @@ import {getCookie, setCookie} from './cookies';
 import {getServicePromise} from './service';
 import {getSourceOrigin, parseQueryString, parseUrl} from './url';
 import {user} from './log';
+import {parseJson} from './json';
 
 /** @const {string} */
 const TAG = 'experiments';
@@ -121,7 +122,7 @@ function enableExperimentsFromToken(win, token, crypto, keyInfo) {
           throw new Error('Failed to verify config signature');
         }
         const configStr = utf8DecodeSync(configBytes);
-        const config = JSON.parse(configStr);
+        const config = parseJson(configStr);
 
         const approvedOrigin = parseUrl(config['origin']).origin;
         const sourceOrigin = getSourceOrigin(win.location);

--- a/src/json.js
+++ b/src/json.js
@@ -107,18 +107,28 @@ export function getValueForExpr(obj, expr) {
 }
 
 /**
+ * Simple wrapper around JSON.parse that casts the return value
+ * to JsonObject.
+ * Create a new wrapper if an array return value is desired.
+ * @param {*} json JSON string to parse
+ * @return {?JsonObject|undefined} May be extend to parse arrays.
+ */
+export function parseJson(json) {
+  return /** @type {?JsonObject} */(JSON.parse(/** @type {string} */ (json)));
+}
+
+/**
  * Parses the given `json` string without throwing an exception if not valid.
  * Returns `undefined` if parsing fails.
  * Returns the `Object` corresponding to the JSON string when parsing succeeds.
  * @param {*} json JSON string to parse
- * @param {function(!Error)=} opt_onFailed Optional function that will be called with
- *     the error if parsing fails.
+ * @param {function(!Error)=} opt_onFailed Optional function that will be called
+ *     with the error if parsing fails.
  * @return {?JsonObject|undefined} May be extend to parse arrays.
  */
 export function tryParseJson(json, opt_onFailed) {
   try {
-    return /** @type {?JsonObject|undefined} */(
-        JSON.parse(/** @type {string} */ (json)));
+    return parseJson(json);
   } catch (e) {
     if (opt_onFailed) {
       opt_onFailed(e);

--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -27,7 +27,7 @@ import {
 } from '../layout-rect';
 import {isExperimentOn} from '../../src/experiments';
 import {serializeMessage} from '../../src/3p-frame-messaging';
-import {tryParseJson} from '../../src/json.js';
+import {parseJson, tryParseJson} from '../../src/json.js';
 
 /** @const @private */
 const TAG = 'POSITION_OBSERVER';
@@ -367,13 +367,12 @@ export class InaboxAmpDocPositionObserver extends AbstractPositionObserver {
         return;
       }
       // Parse JSON only once per message.
-      const data = /** @type {!Object} */ (
-      JSON.parse(event.data.substr(4)));
-      if (data.sentinel != sentinel) {
+      const data = parseJson(event.data.substr(4));
+      if (data['sentinel'] != sentinel) {
         return;
       }
 
-      if (data.type != POSITION_HIGH_FIDELITY) {
+      if (data['type'] != POSITION_HIGH_FIDELITY) {
         return;
       }
 

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -18,7 +18,7 @@ import {registerServiceBuilderForDoc} from '../service';
 import {getSourceOrigin} from '../url';
 import {dev} from '../log';
 import {dict} from '../utils/object';
-import {recreateNonProtoObject} from '../json';
+import {parseJson, recreateNonProtoObject} from '../json';
 import {viewerForDoc} from '../services';
 
 /** @const */
@@ -110,7 +110,7 @@ export class Storage {
   getStore_() {
     if (!this.storePromise_) {
       this.storePromise_ = this.binding_.loadBlob(this.origin_)
-          .then(blob => blob ? JSON.parse(atob(blob)) : {})
+          .then(blob => blob ? parseJson(atob(blob)) : {})
           .catch(reason => {
             dev().expectedError(TAG, 'Failed to load store: ', reason);
             return {};

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -21,6 +21,7 @@ import {
   getCorsUrl,
   parseUrl,
 } from '../url';
+import {parseJson} from '../json';
 import {isArray, isObject, isFormData} from '../types';
 import {utf8EncodeSync} from '../utils/bytes';
 import {ampdocServiceFor} from '../ampdoc';
@@ -522,7 +523,7 @@ export class FetchResponse {
    */
   json() {
     return /** @type {!Promise<!JsonObject>} */ (
-        this.drainText_().then(JSON.parse.bind(JSON)));
+        this.drainText_().then(parseJson));
   }
 
   /**


### PR DESCRIPTION
Replaces `JSON.parse` with `parseJson` which returns a `JsonObject` and hence enforces `@dict` treatment.

Part of #9876