### PR TITLE
Properly type event.data

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -142,7 +142,7 @@ export class AbstractAmpContext {
    */
   onPageVisibilityChange(callback) {
     return this.client_.registerCallback(MessageType.EMBED_STATE, data => {
-      callback({hidden: data.pageHidden});
+      callback({hidden: data['pageHidden']});
     });
   }
 
@@ -194,7 +194,7 @@ export class AbstractAmpContext {
    */
   onResizeSuccess(callback) {
     this.client_.registerCallback(MessageType.EMBED_SIZE_CHANGED, obj => {
-      callback(obj.requestedHeight, obj.requestedWidth); });
+      callback(obj['requestedHeight'], obj['requestedWidth']); });
   };
 
   /**
@@ -206,7 +206,7 @@ export class AbstractAmpContext {
    */
   onResizeDenied(callback) {
     this.client_.registerCallback(MessageType.EMBED_SIZE_DENIED, obj => {
-      callback(obj.requestedHeight, obj.requestedWidth);
+      callback(obj['requestedHeight'], obj['requestedWidth']);
     });
   };
 

--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -20,6 +20,7 @@ import {
   serializeMessage,
   deserializeMessage,
 } from '../src/3p-frame-messaging';
+import {getData} from '../src/event-helper';
 import {getMode} from '../src/mode';
 import {dev} from '../src/log';
 
@@ -66,7 +67,7 @@ export class IframeMessagingClient {
    *   All future calls will overwrite any previously registered
    *   callbacks.
    * @param {string} messageType The type of the message.
-   * @param {function(Object)} callback The callback function to call
+   * @param {function(?JsonObject)} callback The callback function to call
    *   when a message with type messageType is received.
    */
   registerCallback(messageType, callback) {
@@ -105,7 +106,7 @@ export class IframeMessagingClient {
         return;
       }
 
-      const message = deserializeMessage(event.data);
+      const message = deserializeMessage(getData(event));
       if (!message || message['sentinel'] != this.sentinel_) {
         return;
       }
@@ -130,7 +131,7 @@ export class IframeMessagingClient {
 
   /**
    * @param {string} messageType
-   * @return {!Observable<Object>}
+   * @return {!Observable<?JsonObject>}
    */
   getOrCreateObservableFor_(messageType) {
     if (!(messageType in this.observableFor_)) {

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -589,8 +589,8 @@ function getHtml(selector, attributes, callback) {
   }));
 
   const unlisten = listenParent(window, 'get-html-result', data => {
-    if (data.messageId === messageId) {
-      callback(data.content);
+    if (data['messageId'] === messageId) {
+      callback(data['content']);
       unlisten();
     }
   });
@@ -610,7 +610,7 @@ function observeIntersection(observerCallback) {
   // Send request to received records.
   nonSensitiveDataPostMessage('send-intersections');
   return listenParent(window, 'intersection', data => {
-    observerCallback(data.changes);
+    observerCallback(data['changes']);
   });
 }
 
@@ -621,8 +621,8 @@ function observeIntersection(observerCallback) {
  */
 function updateVisibilityState(global) {
   listenParent(window, 'embed-state', function(data) {
-    global.context.hidden = data.pageHidden;
-    dispatchVisibilityChangeEvent(global, data.pageHidden);
+    global.context.hidden = data['pageHidden'];
+    dispatchVisibilityChangeEvent(global, data['pageHidden']);
   });
 }
 
@@ -642,7 +642,7 @@ function dispatchVisibilityChangeEvent(win, isHidden) {
  */
 function onResizeSuccess(observerCallback) {
   return listenParent(window, 'embed-size-changed', data => {
-    observerCallback(data.requestedHeight, data.requestedWidth);
+    observerCallback(data['requestedHeight'], data['requestedWidth']);
   });
 }
 
@@ -654,7 +654,7 @@ function onResizeSuccess(observerCallback) {
  */
 function onResizeDenied(observerCallback) {
   return listenParent(window, 'embed-size-denied', data => {
-    observerCallback(data.requestedHeight, data.requestedWidth);
+    observerCallback(data['requestedHeight'], data['requestedWidth']);
   });
 }
 

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -21,6 +21,7 @@ import {
   MessageType,
 } from '../../src/3p-frame-messaging';
 import {dev} from '../../src/log';
+import {getData} from '../../src/event-helper';
 import {dict} from '../../src/utils/object';
 import {expandFrame, collapseFrame} from './frame-overlay-helper';
 
@@ -90,11 +91,11 @@ export class InaboxMessagingHost {
    * {type: string, sentinel: string}. The allowed types are listed in the
    * REQUEST_TYPE enum.
    *
-   * @param message {!{data: *, source: !Window, origin: string}}
+   * @param {!MessageEvent} message
    * @return {boolean} true if message get successfully processed
    */
   processMessage(message) {
-    const request = deserializeMessage(message.data);
+    const request = deserializeMessage(getData(message));
     if (!request || !request['sentinel']) {
       dev().fine(TAG, 'Ignored non-AMP message:', message);
       return false;

--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -168,6 +168,22 @@ requirement: {
 }
 
 requirement: {
+  type: BANNED_PROPERTY_READ
+  error_message: 'Use eventHelper#getData to read the data property. OK to whitelist 3p ads for now.'
+  value: 'Event.prototype.data'
+  value: 'MessageEvent.prototype.data'
+  whitelist: 'src/event-helper.js' # getData is implemented here
+  whitelist: 'src/web-worker/amp-worker.js' # OK to use in version bound worker
+  whitelist: 'src/web-worker/web-worker.js' # OK to use in version bound worker
+
+  # 3p ads are OK
+  whitelist: 'ads/adfox.js'
+  whitelist: 'ads/google/imaVideo.js'
+  whitelist: 'ads/netletix.js'
+  whitelist: 'ads/yandex.js'
+}
+
+requirement: {
   type: RESTRICTED_METHOD_CALL
   error_message: 'postMessage must be called with a string or a JsonObject'
   value: 'Window.prototype.postMessage:function((string|?JsonObject), string)'

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -81,6 +81,8 @@ exports.rules = [
       '3p/**->src/observable.js',
       '3p/polyfills.js->src/polyfills/math-sign.js',
       '3p/polyfills.js->src/polyfills/object-assign.js',
+      '3p/messaging.js->src/event-helper.js',
+      '3p/iframe-messaging-client.js->src/event-helper.js',
     ],
   },
   {

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -712,6 +712,7 @@ var forbiddenTermsSrcInclusive = {
       'extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js',
       'extensions/amp-image-lightbox/0.1/amp-image-lightbox.js',
       'extensions/amp-analytics/0.1/transport.js',
+      'dist.3p/current/integration.js',
     ],
   },
   '\\.getTime\\(\\)': {

--- a/extensions/amp-ad/0.1/a2a-listener.js
+++ b/extensions/amp-ad/0.1/a2a-listener.js
@@ -15,6 +15,7 @@
 
 import {closestByTag} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
+import {getData} from '../../../src/event-helper';
 import {user} from '../../../src/log';
 import {viewerForDoc} from '../../../src/services';
 import {isProxyOrigin} from '../../../src/url';
@@ -45,7 +46,7 @@ export function setupA2AListener(win) {
  * @visibleForTesting
  */
 export function handleMessageEvent(win, event) {
-  const data = event.data;
+  const data = getData(event);
   // Only handle messages starting with the magic string.
   if (typeof data != 'string' || data.indexOf('a2a;') != 0) {
     return;

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -29,7 +29,7 @@ import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {timerFor} from '../../../src/services';
 import {setStyle} from '../../../src/style';
-import {loadPromise} from '../../../src/event-helper';
+import {getData, loadPromise} from '../../../src/event-helper';
 import {getHtml} from '../../../src/get-html';
 import {removeElement} from '../../../src/dom';
 import {getServiceForDoc} from '../../../src/service';
@@ -136,7 +136,7 @@ export class AmpAdXOriginIframeHandler {
     // iframe.
     listenForOncePromise(this.iframe, 'entity-id', true)
         .then(info => {
-          this.element_.creativeId = info.data.id;
+          this.element_.creativeId = info.data['id'];
         });
 
     this.unlisteners_.push(listenFor(this.iframe, 'get-html',
@@ -145,7 +145,9 @@ export class AmpAdXOriginIframeHandler {
             return;
           }
 
-          const {selector, attributes, messageId} = info;
+          const selector = info['selector'];
+          const attributes = info['attributes'];
+          const messageId = info['messageId'];
           let content = '';
 
           if (this.element_.hasAttribute('data-html-access-allowed')) {
@@ -164,7 +166,7 @@ export class AmpAdXOriginIframeHandler {
     // Install iframe resize API.
     this.unlisteners_.push(listenFor(this.iframe, 'embed-size',
         (data, source, origin) => {
-          this.handleResize_(data.height, data.width, source, origin);
+          this.handleResize_(data['height'], data['width'], source, origin);
         }, true, true));
 
     this.unlisteners_.push(this.viewer_.onVisibilityChanged(() => {
@@ -204,7 +206,7 @@ export class AmpAdXOriginIframeHandler {
       listenForOncePromise(this.iframe,
           ['render-start', 'no-content'], true).then(info => {
             const data = info.data;
-            if (data.type == 'render-start') {
+            if (data['type'] == 'render-start') {
               this.renderStart_(info);
               renderStartResolve();
             } else {
@@ -273,7 +275,7 @@ export class AmpAdXOriginIframeHandler {
 
   /**
    * callback functon on receiving render-start
-   * @param {!Object=} opt_info
+   * @param {{data: !JsonObject}=} opt_info
    * @private
    */
   renderStart_(opt_info) {
@@ -281,9 +283,9 @@ export class AmpAdXOriginIframeHandler {
     if (!opt_info) {
       return;
     }
-    const data = opt_info.data;
+    const data = getData(opt_info);
     this.handleResize_(
-        data.height, data.width, opt_info.source, opt_info.origin);
+        data['height'], data['width'], opt_info['source'], opt_info['origin']);
     if (this.baseInstance_.emitLifecycleEvent) {
       this.baseInstance_.emitLifecycleEvent('renderCrossDomainStart');
     }

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -23,7 +23,7 @@ import {VideoEvents} from '../../../src/video-interface';
 import {videoManagerForDoc} from '../../../src/services';
 import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
 import {removeElement} from '../../../src/dom';
-import {listen} from '../../../src/event-helper';
+import {getData, listen} from '../../../src/event-helper';
 
 /**
  * @implements {../../../src/video-interface.VideoInterface}
@@ -216,13 +216,14 @@ class AmpBridPlayer extends AMP.BaseElement {
 
   /** @private */
   handleBridMessages_(event) {
+    const eventData = /** @type {?string|undefined} */ (getData(event));
     if (event.origin !== 'https://services.brid.tv' ||
         event.source != this.iframe_.contentWindow ||
-        typeof event.data !== 'string' || event.data.indexOf('Brid') !== 0) {
+        typeof eventData !== 'string' || eventData.indexOf('Brid') !== 0) {
       return;
     }
 
-    const params = event.data.split('|');
+    const params = eventData.split('|');
 
     if (params[2] == 'trigger') {
       if (params[3] == 'ready') {

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -21,7 +21,7 @@ import {VideoEvents} from '../../../src/video-interface';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
-import {listen} from '../../../src/event-helper';
+import {getData, listen} from '../../../src/event-helper';
 import {videoManagerForDoc} from '../../../src/services';
 import {parseQueryString} from '../../../src/url';
 
@@ -185,10 +185,10 @@ class AmpDailymotion extends AMP.BaseElement {
         event.source != this.iframe_.contentWindow) {
       return;
     }
-    if (!event.data || !event.type || event.type != 'message') {
+    if (!getData(event) || !event.type || event.type != 'message') {
       return;  // Event empty
     }
-    const data = parseQueryString(event.data);
+    const data = parseQueryString(/** @type {string} */ (getData(event)));
     if (data === undefined) {
       return; // The message isn't valid
     }

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -62,7 +62,7 @@ class AmpFacebookComments extends AMP.BaseElement {
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(iframe, 'embed-size', data => {
-      this./*OK*/changeHeight(data.height);
+      this./*OK*/changeHeight(data['height']);
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -62,7 +62,7 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(iframe, 'embed-size', data => {
-      this.attemptChangeHeight(data.height).catch(() => {
+      this.attemptChangeHeight(data['height']).catch(() => {
         /* ignore failures */
       });
     }, /* opt_is3P */true);

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -62,7 +62,7 @@ class AmpFacebook extends AMP.BaseElement {
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(iframe, 'embed-size', data => {
-      this./*OK*/changeHeight(data.height);
+      this./*OK*/changeHeight(data['height']);
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -62,7 +62,7 @@ export class AmpGist extends AMP.BaseElement {
     this.applyFillContent(iframe);
     // Triggered by window.context.requestResize() inside the iframe.
     listenFor(iframe, 'embed-size', data => {
-      this./*OK*/changeHeight(data.height);
+      this./*OK*/changeHeight(data['height']);
     }, /* opt_is3P */true);
 
     this.element.appendChild(iframe);

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -26,11 +26,11 @@ import {
   toArray,
 } from '../../../src/types';
 import {
+  getData,
   listen,
 } from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
 import {removeElement} from '../../../src/dom';
-import {startsWith} from '../../../src/string';
 import {user} from '../../../src/log';
 import {VideoEvents} from '../../../src/video-interface';
 import {videoManagerForDoc} from '../../../src/services';
@@ -200,21 +200,19 @@ class AmpImaVideo extends AMP.BaseElement {
     if (event.source != this.iframe_.contentWindow) {
       return;
     }
-    if (!event.data ||
-        !(isObject(event.data) || startsWith(event.data, '{'))) {
-      return;  // Doesn't look like JSON.
-    }
+    const eventData = getData(event);
 
-    if (isObject(event.data)) {
-      if (event.data.event == VideoEvents.LOAD ||
-          event.data.event == VideoEvents.PLAY ||
-          event.data.event == VideoEvents.PAUSE ||
-          event.data.event == VideoEvents.MUTED ||
-          event.data.event == VideoEvents.UNMUTED) {
-        if (event.data.event == VideoEvents.LOAD) {
+    if (isObject(eventData)) {
+      const videoEvent = eventData['event'];
+      if (videoEvent == VideoEvents.LOAD ||
+          videoEvent == VideoEvents.PLAY ||
+          videoEvent == VideoEvents.PAUSE ||
+          videoEvent == VideoEvents.MUTED ||
+          videoEvent == VideoEvents.UNMUTED) {
+        if (videoEvent == VideoEvents.LOAD) {
           this.playerReadyResolver_(this.iframe_);
         }
-        this.element.dispatchCustomEvent(event.data.event);
+        this.element.dispatchCustomEvent(videoEvent);
       }
     }
   }

--- a/extensions/amp-imgur/0.1/amp-imgur.js
+++ b/extensions/amp-imgur/0.1/amp-imgur.js
@@ -32,7 +32,7 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
 import {tryParseJson} from '../../../src/json';
 import {isObject} from '../../../src/types';
-import {listen} from '../../../src/event-helper';
+import {getData, listen} from '../../../src/event-helper';
 import {startsWith} from '../../../src/string';
 
 export class AmpImgur extends AMP.BaseElement {
@@ -92,12 +92,14 @@ export class AmpImgur extends AMP.BaseElement {
         event.source != this.iframe_.contentWindow) {
       return;
     }
-    if (!event.data || !(isObject(event.data)) || startsWith(event.data, '{')) {
+    const eventData = getData(event);
+    if (!eventData || !(isObject(eventData))
+        || startsWith(/** @type {string} */ (eventData), '{')) {
       return;
     }
-    const data = isObject(event.data) ? event.data : tryParseJson(event.data);
-    if (data.message == 'resize_imgur') {
-      const height = data.height;
+    const data = isObject(eventData) ? eventData : tryParseJson(eventData);
+    if (data['message'] == 'resize_imgur') {
+      const height = data['height'];
       this.attemptChangeHeight(height).catch(() => {});
     }
   }

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -53,7 +53,7 @@ import {removeElement} from '../../../src/dom';
 import {user} from '../../../src/log';
 import {tryParseJson} from '../../../src/json';
 import {isObject} from '../../../src/types';
-import {listen} from '../../../src/event-helper';
+import {getData, listen} from '../../../src/event-helper';
 import {startsWith} from '../../../src/string';
 
 /*
@@ -195,15 +195,17 @@ class AmpInstagram extends AMP.BaseElement {
         event.source != this.iframe_.contentWindow) {
       return;
     }
-    if (!event.data || !(isObject(event.data) || startsWith(event.data, '{'))) {
+    const eventData = getData(event);
+    if (!eventData || !(isObject(eventData)
+        || startsWith(/** @type {string} */ (eventData), '{'))) {
       return;  // Doesn't look like JSON.
     }
-    const data = isObject(event.data) ? event.data : tryParseJson(event.data);
+    const data = isObject(eventData) ? eventData : tryParseJson(eventData);
     if (data === undefined) {
       return; // We only process valid JSON.
     }
-    if (data.type == 'MEASURE' && data.details) {
-      const height = data.details.height;
+    if (data['type'] == 'MEASURE' && data['details']) {
+      const height = data['details']['height'];
       this.getVsync().measure(() => {
         if (this.iframe_ && this.iframe_./*OK*/offsetHeight !== height) {
           // Height returned by Instagram includes header, so

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -23,7 +23,7 @@ import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
 import {removeElement} from '../../../src/dom';
-import {listen} from '../../../src/event-helper';
+import {getData, listen} from '../../../src/event-helper';
 import {isObject} from '../../../src/types';
 import {VideoEvents} from '../../../src/video-interface';
 import {videoManagerForDoc} from '../../../src/services';
@@ -182,22 +182,25 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
 
   // emitter
   handleNexxMessages_(event) {
-    if (!event.data || event.source !== this.iframe_.contentWindow) {
+    if (!getData(event) || event.source !== this.iframe_.contentWindow) {
       return;
     }
 
-    const data = isObject(event.data) ? event.data : tryParseJson(event.data);
-    if (data === undefined) {
+    /** @const {?JsonObject} */
+    const data = /** @type {?JsonObject} */ (isObject(getData(event))
+        ? getData(event)
+        : tryParseJson(getData(event)));
+    if (!data) {
       return;
     }
 
-    if (data.event == 'play') {
+    if (data['event'] == 'play') {
       this.element.dispatchCustomEvent(VideoEvents.PLAY);
-    } else if (data.event == 'pause') {
+    } else if (data['event'] == 'pause') {
       this.element.dispatchCustomEvent(VideoEvents.PAUSE);
-    } else if (data.event == 'mute') {
+    } else if (data['event'] == 'mute') {
       this.element.dispatchCustomEvent(VideoEvents.MUTED);
-    } else if (data.event == 'unmute') {
+    } else if (data['event'] == 'unmute') {
       this.element.dispatchCustomEvent(VideoEvents.UNMUTED);
     }
   }

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -22,7 +22,7 @@ import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
 import {isObject} from '../../../src/types';
-import {listen} from '../../../src/event-helper';
+import {getData, listen} from '../../../src/event-helper';
 import {VideoEvents} from '../../../src/video-interface';
 import {videoManagerForDoc} from '../../../src/services';
 
@@ -155,17 +155,20 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
 
   /** @private */
   handleOoyalaMessages_(event) {
-    const data = isObject(event.data) ? event.data : tryParseJson(event.data);
+    /** @const {?JsonObject|undefined} */
+    const data = /** @type {?JsonObject} */ (isObject(getData(event))
+        ? getData(event)
+        : tryParseJson(getData(event)));
     if (data === undefined) {
       return; // We only process valid JSON.
     }
-    if (data.data == 'playing') {
+    if (data['data'] == 'playing') {
       this.element.dispatchCustomEvent(VideoEvents.PLAY);
-    } else if (data.data == 'paused') {
+    } else if (data['data'] == 'paused') {
       this.element.dispatchCustomEvent(VideoEvents.PAUSE);
-    } else if (data.data == 'muted') {
+    } else if (data['data'] == 'muted') {
       this.element.dispatchCustomEvent('mute');
-    } else if (data.data == 'unmuted') {
+    } else if (data['data'] == 'unmuted') {
       this.element.dispatchCustomEvent('unmute');
     }
   }

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -65,7 +65,7 @@ class AmpTwitter extends AMP.BaseElement {
       // We only get the message if and when there is a tweet to display,
       // so hide the placeholder.
       this.togglePlaceholder(false);
-      this./*OK*/changeHeight(data.height);
+      this./*OK*/changeHeight(data['height']);
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;

--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -25,6 +25,7 @@ import {isIframed} from '../../../src/dom';
 import {listen, listenOnce} from '../../../src/event-helper';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {getData} from '../../../src/event-helper';
 import {getSourceUrl} from '../../../src/url';
 import {viewerForDoc} from '../../../src/services';
 
@@ -102,8 +103,9 @@ export class AmpViewerIntegration {
   webviewPreHandshakePromise_(source, origin) {
     return new Promise(resolve => {
       const unlisten = listen(this.win, 'message', e => {
-        dev().fine(TAG, 'AMPDOC got a pre-handshake message:', e.type, e.data);
-        const data = parseMessage(e.data);
+        dev().fine(TAG, 'AMPDOC got a pre-handshake message:', e.type,
+            getData(e));
+        const data = parseMessage(getData(e));
         if (!data) {
           return;
         }

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -15,6 +15,7 @@
  */
 
 import {parseJson} from '../../../../src/json';
+import {getData} from '../../../../src/event-helper';
 
 const TAG = 'amp-viewer-messaging';
 export const APP = '__AMPHTML__';
@@ -85,7 +86,7 @@ export class WindowPortEmulator {
   addEventListener(eventType, handler) {
     this.win.addEventListener('message', e => {
       if (e.origin == this.origin_ &&
-          e.source == this.target_ && e.data.app == APP) {
+          e.source == this.target_ && getData(e)['app'] == APP) {
         handler(e);
       }
     });
@@ -172,7 +173,7 @@ export class Messaging {
    * @private
    */
   handleMessage_(event) {
-    const message = parseMessage(event.data);
+    const message = parseMessage(getData(event));
     if (!message) {
       return;
     }

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -17,7 +17,7 @@
 import {getDataParamsFromAttributes} from '../../../src/dom';
 import {tryParseJson} from '../../../src/json';
 import {removeElement} from '../../../src/dom';
-import {listen} from '../../../src/event-helper';
+import {getData, listen} from '../../../src/event-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
 import {
@@ -287,26 +287,30 @@ class AmpYoutube extends AMP.BaseElement {
         event.source != this.iframe_.contentWindow) {
       return;
     }
-    if (!event.data || !(isObject(event.data) || startsWith(event.data, '{'))) {
+    if (!getData(event) || !(isObject(getData(event))
+        || startsWith(/** @type {string} */ (getData(event)), '{'))) {
       return;  // Doesn't look like JSON.
     }
-    const data = isObject(event.data) ? event.data : tryParseJson(event.data);
+    /** @const {?JsonObject} */
+    const data = /** @type {?JsonObject} */ (isObject(getData(event))
+        ? getData(event)
+        : tryParseJson(getData(event)));
     if (data === undefined) {
       return; // We only process valid JSON.
     }
-    if (data.event == 'infoDelivery' &&
-        data.info && data.info.playerState !== undefined) {
-      this.playerState_ = data.info.playerState;
+    if (data['event'] == 'infoDelivery' &&
+        data['info'] && data['info']['playerState'] !== undefined) {
+      this.playerState_ = data['info']['playerState'];
       if (this.playerState_ == PlayerStates.PAUSED ||
           this.playerState_ == PlayerStates.ENDED) {
         this.element.dispatchCustomEvent(VideoEvents.PAUSE);
       } else if (this.playerState_ == PlayerStates.PLAYING) {
         this.element.dispatchCustomEvent(VideoEvents.PLAY);
       }
-    } else if (data.event == 'infoDelivery' &&
-        data.info && data.info.muted !== undefined) {
-      if (this.muted_ != data.info.muted) {
-        this.muted_ = data.info.muted;
+    } else if (data['event'] == 'infoDelivery' &&
+        data['info'] && data['info']['muted'] !== undefined) {
+      if (this.muted_ != data['info']['muted']) {
+        this.muted_ = data['info']['muted'];
         const evt = this.muted_ ? VideoEvents.MUTED : VideoEvents.UNMUTED;
         this.element.dispatchCustomEvent(evt);
       }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -16,6 +16,7 @@
 
 import {ActionTrust} from './action-trust';
 import {Layout} from './layout';
+import {getData} from './event-helper';
 import {loadPromise} from './event-helper';
 import {preconnectForElement} from './preconnect';
 import {isArray} from './types';
@@ -617,7 +618,7 @@ export class BaseElement {
     events = isArray(events) ? events : [events];
     for (let i = 0; i < events.length; i++) {
       element.addEventListener(events[i], event => {
-        this.element.dispatchCustomEvent(events[i], event.data || {});
+        this.element.dispatchCustomEvent(events[i], getData(event) || {});
       });
     }
   }

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -16,6 +16,7 @@
 
 import PriorityQueue from './utils/priority-queue';
 import {dev} from './log';
+import {getData} from './event-helper';
 import {registerServiceBuilderForDoc, getServiceForDoc} from './service';
 import {makeBodyVisible} from './style-installer';
 import {viewerPromiseForDoc} from './services';
@@ -317,7 +318,7 @@ class Chunks {
     this.viewerPromise_ = viewerPromiseForDoc(ampDoc);
 
     this.win_.addEventListener('message', e => {
-      if (e.data == 'amp-macro-task') {
+      if (getData(e) == 'amp-macro-task') {
         this.execute_(/* idleDeadline */ null);
       }
     });

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -57,6 +57,14 @@ export function listen(element, eventType, listener, opt_capture) {
       element, eventType, listener, opt_capture);
 }
 
+/**
+ * Returns the data property of an event with the correct type.
+ * @param {!Event|{data: !JsonObject}} event
+ * @return {?JsonObject|string|undefined}
+ */
+export function getData(event) {
+  return /** @type {?JsonObject|string|undefined} */ (event.data);
+}
 
 /**
  * Listens for the specified event on the element and removes the listener

--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -28,6 +28,7 @@ import {
 import {isExperimentOn} from '../../src/experiments';
 import {serializeMessage} from '../../src/3p-frame-messaging';
 import {parseJson, tryParseJson} from '../../src/json.js';
+import {getData} from '../../src/event-helper';
 
 /** @const @private */
 const TAG = 'POSITION_OBSERVER';
@@ -362,12 +363,13 @@ export class InaboxAmpDocPositionObserver extends AbstractPositionObserver {
 
     this.ampdoc_.win.addEventListener('message', event => {
     // Cheap operations first, so we don't parse JSON unless we have to.
-      if (event.source != win.parent || typeof event.data != 'string' ||
-          event.data.indexOf('amp-') != 0) {
+      if (event.source != win.parent || typeof getData(event) != 'string' ||
+          dev().assertString(getData(event)).indexOf('amp-') != 0) {
         return;
       }
       // Parse JSON only once per message.
-      const data = parseJson(event.data.substr(4));
+      const data = parseJson(
+          dev().assertString(getData(event)).substr(4));
       if (data['sentinel'] != sentinel) {
         return;
       }


### PR DESCRIPTION
…to ensure the data is considered an external `JsonObject`. Forces the use of a `getData` function instead of accessing the `.data` property directly. The function returns the proper type.

Part of #9876