### PR TITLE
Refactor to make action args simpler

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -23,8 +23,9 @@ import {
   installServiceInEmbedScope,
 } from '../service';
 import {getMode} from '../mode';
-import {hasOwn, map} from '../utils/object';
+import {getValueForExpr} from '../json';
 import {isArray, isFiniteNumber} from '../types';
+import {map} from '../utils/object';
 import {timerFor} from '../services';
 import {vsyncFor} from '../services';
 
@@ -83,10 +84,20 @@ const WHITELISTED_INPUT_DATA_ = {
 };
 
 /**
- * A map of method argument keys to functions that generate the argument values
- * given a local scope object. The function allows argument values to reference
- * data in the event that generated the action.
- * @typedef {Object<string,function(!Object):string>}
+ * An expression arg value, e.g. `foo.bar` in `e:t.m(arg=foo.bar)`.
+ * @typedef {{expression: string}}
+ */
+let ActionInfoArgExpressionDef;
+
+/**
+ * An arg value.
+ * @typedef {(boolean|number|string|ActionInfoArgExpressionDef)}
+ */
+let ActionInfoArgValueDef;
+
+/**
+ * Map of arg names to their values, e.g. {arg: 123} in `e:t.m(arg=123)`.
+ * @typedef {Object<string, ActionInfoArgValueDef>}
  */
 let ActionInfoArgsDef;
 
@@ -405,8 +416,8 @@ export class ActionService {
     for (let i = 0; i < action.actionInfos.length; i++) {
       const actionInfo = action.actionInfos[i];
 
-      // Replace any variables in args with data in `event`.
-      const args = applyActionInfoArgs(actionInfo.args, event);
+      // Replace any expressions in args with data in `event`.
+      const args = dereferenceExprsInArgs(actionInfo.args, event);
 
       // Global target, e.g. `AMP`.
       const globalTarget = this.globalTargets_[actionInfo.target];
@@ -705,7 +716,7 @@ function tokenizeMethodArguments(toks, assertToken, assertAction) {
     // fragment and delegate to specific action handler.
     args = map();
     const value = toks.next().value;
-    args[OBJECT_STRING_ARGS_KEY] = () => value;
+    args[OBJECT_STRING_ARGS_KEY] = value;
     assertToken(toks.next(), [TokenType.SEPARATOR], ')');
   } else {
     // Key-value pairs. Format: key = value, ....
@@ -718,11 +729,11 @@ function tokenizeMethodArguments(toks, assertToken, assertAction) {
       } else if (type == TokenType.LITERAL || type == TokenType.ID) {
         // Key: "key = "
         assertToken(toks.next(), [TokenType.SEPARATOR], '=');
-        // Value is either a literal or a variable: "foo.bar.baz"
+        // Value is either a literal or an expression: "foo.bar.baz"
         tok = assertToken(toks.next(/* convertValue */ true),
             [TokenType.LITERAL, TokenType.ID]);
         const argValueTokens = [tok];
-        // Variables have one or more dereferences: ".identifier"
+        // Expressions have one or more dereferences: ".identifier"
         if (tok.type == TokenType.ID) {
           for (peek = toks.peek();
               peek.type == TokenType.SEPARATOR && peek.value == '.';
@@ -732,7 +743,7 @@ function tokenizeMethodArguments(toks, assertToken, assertAction) {
             argValueTokens.push(tok);
           }
         }
-        const argValue = getActionInfoArgValue(argValueTokens);
+        const argValue = argValueForTokens(argValueTokens);
         if (!args) {
           args = map();
         }
@@ -752,62 +763,49 @@ function tokenizeMethodArguments(toks, assertToken, assertAction) {
 }
 
 /**
- * Returns a function that generates a method argument value for a given token.
- * The function takes a single object argument `data`.
- * If the token is an identifier `foo`, the function returns `data[foo]`.
- * Otherwise, the function returns the token value.
  * @param {Array<!TokenDef>} tokens
- * @return {?function(!Object):string}
+ * @return {?ActionInfoArgValueDef}
  * @private
  */
-function getActionInfoArgValue(tokens) {
+function argValueForTokens(tokens) {
   if (tokens.length == 0) {
     return null;
-  }
-  if (tokens.length == 1) {
-    return () => tokens[0].value;
+  } else if (tokens.length == 1) {
+    return /** @type {(boolean|number|string)} */ (tokens[0].value);
   } else {
-    return data => {
-      let current = data;
-      // Traverse properties of `data` per token values.
-      for (let i = 0; i < tokens.length; i++) {
-        const value = String(tokens[i].value);
-        if (current && hasOwn(current, value)) {
-          current = current[value];
-        } else {
-          return null;
-        }
-      }
-      // Only allow dereferencing of primitives.
-      const type = typeof current;
-      if (type === 'string' || type === 'number' || type === 'boolean') {
-        return current;
-      } else {
-        return null;
-      }
-    };
+    const values = tokens.map(token => token.value);
+    const expression = values.join('.');
+    return /** @type {ActionInfoArgExpressionDef} */ ({expression});
   }
 }
 
 /**
- * Generates method arg values for each key in the given ActionInfoArgsDef
- * with the data in the given event.
+ * Dereferences expression args in `args` using data in `event`.
  * @param {?ActionInfoArgsDef} args
  * @param {?ActionEventDef} event
  * @return {?JsonObject}
- * @private Visible for testing only.
+ * @private
+ * @visibleForTesting
  */
-export function applyActionInfoArgs(args, event) {
+export function dereferenceExprsInArgs(args, event) {
   if (!args) {
     return args;
   }
-  const data = {};
+  const data = map();
   if (event && event.detail) {
     data['event'] = event.detail;
   }
   const applied = map();
   Object.keys(args).forEach(key => {
-    applied[key] = args[key].call(null, data);
+    let value = args[key];
+    if (typeof value == 'object' && value.expression) {
+      const expr =
+          /** @type {ActionInfoArgExpressionDef} */ (value).expression;
+      const exprValue = getValueForExpr(data, expr);
+      // If expr can't be found in data, use null instead of undefined.
+      value = (exprValue === undefined) ? null : exprValue;
+    }
+    applied[key] = value;
   });
   return applied;
 }

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -19,7 +19,7 @@ import {
   ActionService,
   DeferredEvent,
   OBJECT_STRING_ARGS_KEY,
-  applyActionInfoArgs,
+  dereferenceExprsInArgs,
   parseActionMap,
 } from '../../src/service/action-impl';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
@@ -149,7 +149,7 @@ describe('ActionService parseAction', () => {
     expect(a.event).to.equal('event1');
     expect(a.target).to.equal('target1');
     expect(a.method).to.equal('method1');
-    expect(a.args['key1']()).to.equal('value1');
+    expect(a.args['key1']).to.equal('value1');
   });
 
   it('should parse args in more than one action', () => {
@@ -158,11 +158,11 @@ describe('ActionService parseAction', () => {
     expect(a[0].event).to.equal('event1');
     expect(a[0].target).to.equal('target1');
     expect(a[0].method).to.equal('methodA');
-    expect(a[0].args['key1']()).to.equal('value1');
+    expect(a[0].args['key1']).to.equal('value1');
     expect(a[1].event).to.equal('event1');
     expect(a[1].target).to.equal('target2');
     expect(a[1].method).to.equal('methodB');
-    expect(a[1].args['keyA']()).to.equal('valueA');
+    expect(a[1].args['keyA']).to.equal('valueA');
   });
 
   it('should parse multiple event types with multiple actions', () => {
@@ -189,7 +189,7 @@ describe('ActionService parseAction', () => {
     expect(a['event1'][2].event).to.equal('event1');
     expect(a['event1'][2].target).to.equal('corge');
     expect(a['event1'][2].method).to.equal('secondMethod');
-    expect(a['event1'][2].args['keyA']()).to.equal('valueA');
+    expect(a['event1'][2].args['keyA']).to.equal('valueA');
 
     // action definitions for event2
     expect(a['event2'][0].event).to.equal('event2');
@@ -205,7 +205,7 @@ describe('ActionService parseAction', () => {
     expect(a['event2'][2].event).to.equal('event2');
     expect(a['event2'][2].target).to.equal('grault');
     expect(a['event2'][2].method).to.equal('fourthMethod');
-    expect(a['event2'][2].args['keyB']()).to.equal('valueB');
+    expect(a['event2'][2].args['keyB']).to.equal('valueB');
   });
 
   it('should parse with multiple args', () => {
@@ -213,8 +213,8 @@ describe('ActionService parseAction', () => {
     expect(a.event).to.equal('event1');
     expect(a.target).to.equal('target1');
     expect(a.method).to.equal('method1');
-    expect(a.args['key1']()).to.equal('value1');
-    expect(a.args['key2']()).to.equal('value2');
+    expect(a.args['key1']).to.equal('value1');
+    expect(a.args['key2']).to.equal('value2');
   });
 
   it('should parse with multiple args with whitespace', () => {
@@ -223,8 +223,8 @@ describe('ActionService parseAction', () => {
     expect(a.event).to.equal('event1');
     expect(a.target).to.equal('target1');
     expect(a.method).to.equal('method1');
-    expect(a.args['key1']()).to.equal('value1');
-    expect(a.args['key2']()).to.equal('value2');
+    expect(a.args['key1']).to.equal('value1');
+    expect(a.args['key2']).to.equal('value2');
   });
 
   it('should parse with no args', () => {
@@ -249,8 +249,8 @@ describe('ActionService parseAction', () => {
     expect(a.event).to.equal('event1');
     expect(a.target).to.equal('target1');
     expect(a.method).to.equal('method1');
-    expect(a.args['key1']()).to.equal('value1');
-    expect(a.args['key2']()).to.equal('value (2)\'');
+    expect(a.args['key1']).to.equal('value1');
+    expect(a.args['key2']).to.equal('value (2)\'');
   });
 
   it('should parse with single-quoted args', () => {
@@ -259,8 +259,8 @@ describe('ActionService parseAction', () => {
     expect(a.event).to.equal('event1');
     expect(a.target).to.equal('target1');
     expect(a.method).to.equal('method1');
-    expect(a.args['key1']()).to.equal('value1');
-    expect(a.args['key2']()).to.equal('value (2)"');
+    expect(a.args['key1']).to.equal('value1');
+    expect(a.args['key2']).to.equal('value (2)"');
   });
 
   it('should parse with args with trailing comma', () => {
@@ -269,23 +269,23 @@ describe('ActionService parseAction', () => {
     expect(a.event).to.equal('event1');
     expect(a.target).to.equal('target1');
     expect(a.method).to.equal('method1');
-    expect(a.args['key1']()).to.equal('value1');
+    expect(a.args['key1']).to.equal('value1');
     expect(Object.keys(a.args)).to.have.length(1);
   });
 
   it('should parse with boolean args', () => {
-    expect(parseAction('e:t.m(k=true)').args['k']()).to.equal(true);
-    expect(parseAction('e:t.m(k=false)').args['k']()).to.equal(false);
+    expect(parseAction('e:t.m(k=true)').args['k']).to.equal(true);
+    expect(parseAction('e:t.m(k=false)').args['k']).to.equal(false);
   });
 
   it('should parse with numeric args', () => {
-    expect(parseAction('e:t.m(k=123)').args['k']()).to.equal(123);
-    expect(parseAction('e:t.m(k=1.23)').args['k']()).to.equal(1.23);
-    expect(parseAction('e:t.m(k=.123)').args['k']()).to.equal(.123);
+    expect(parseAction('e:t.m(k=123)').args['k']).to.equal(123);
+    expect(parseAction('e:t.m(k=1.23)').args['k']).to.equal(1.23);
+    expect(parseAction('e:t.m(k=.123)').args['k']).to.equal(.123);
   });
 
   it('should parse with term semicolon', () => {
-    expect(parseAction('e:t.m(k=1); ').args['k']()).to.equal(1);
+    expect(parseAction('e:t.m(k=1); ').args['k']).to.equal(1);
   });
 
   it('should parse with args as a proto-less object', () => {
@@ -296,91 +296,62 @@ describe('ActionService parseAction', () => {
     expect(parseAction('true:t.m').event).to.equal('true');
     expect(parseAction('e:true.m').target).to.equal('true');
     expect(parseAction('e:t.true').method).to.equal('true');
-    expect(parseAction('e:t.m(true=1)').args['true']()).to.equal(1);
-    expect(parseAction('e:t.m(01=1)').args['01']()).to.equal(1);
+    expect(parseAction('e:t.m(true=1)').args['true']).to.equal(1);
+    expect(parseAction('e:t.m(01=1)').args['01']).to.equal(1);
   });
 
   it('should parse with object literal args', () => {
     const a = parseAction('e:t.m({"foo": {"bar": "qux"}})');
-    expect(a.args[OBJECT_STRING_ARGS_KEY]())
+    expect(a.args[OBJECT_STRING_ARGS_KEY])
         .to.equal('{"foo": {"bar": "qux"}}');
   });
 
-  it('should dereference vars in arg value identifiers', () => {
-    const data = {foo: {bar: 'baz'}};
+  it('should parse with expression args', () => {
     const a = parseAction('e:t.m(key1=foo.bar)');
-    expect(a.args['key1']()).to.equal(null);
-    expect(a.args['key1'](data)).to.equal('baz');
+    expect(a.args['key1']).to.deep.equal({expression: 'foo.bar'});
   });
 
-  it('should NOT dereference vars in identifiers without "." operator', () => {
-    const a = parseAction('e:t.m(key1=foo)');
-    expect(a.args['key1']({foo: 'bar'})).to.equal('foo');
-  });
-
-  it('should NOT dereference vars in arg value strings', () => {
-    const a = parseAction('e:t.m(key1="abc")');
-    expect(a.args['key1']()).to.equal('abc');
-    expect(a.args['key1']({foo: 'bar'})).to.equal('abc');
-    expect(() => {
-      parseAction('e:t.m(key1="abc".foo)');
-    }).to.throw(/Expected either/);
-  });
-
-  it('should NOT dereference vars in arg value booleans', () => {
-    const a = parseAction('e:t.m(key1=true)');
-    expect(a.args['key1']()).to.equal(true);
-    expect(a.args['key1']({true: 'bar'})).to.equal(true);
-    expect(() => {
-      parseAction('e:t.m(key1=true.bar)');
-    }).to.throw(/Expected either/);
-  });
-
-  it('should NOT dereference vars in arg value numerics', () => {
-    const a = parseAction('e:t.m(key1=123)');
-    expect(a.args['key1']()).to.equal(123);
-    expect(a.args['key1']({123: 'bar'})).to.equal(123);
-    expect(() => {
-      parseAction('e:t.m(key1=123.bar)');
-    }).to.throw(/Expected either/);
-  });
-
-  it('should return null for undefined references in arg values', () => {
+  it('should return null for undefined references in dereferenced arg', () => {
     const a = parseAction('e:t.m(key1=foo.bar)');
-    expect(a.args['key1'](null)).to.equal(null);
-    expect(a.args['key1']({})).to.equal(null);
-    expect(a.args['key1']({foo: null})).to.equal(null);
+    expect(dereferenceExprsInArgs(a.args, null)).to.deep.equal({key1: null});
+    expect(dereferenceExprsInArgs(a.args, {})).to.deep.equal({key1: null});
+    expect(dereferenceExprsInArgs(a.args, {foo: null}))
+        .to.deep.equal({key1: null});
   });
 
-  it('should NOT dereference non-primitives in arg values', () => {
+  it('should return null for non-primitives in dereferenced args', () => {
     const a = parseAction('e:t.m(key1=foo.bar)');
-    expect(a.args['key1']({foo: {bar: undefined}})).to.equal(null);
-    expect(a.args['key1']({foo: {bar: {}}})).to.equal(null);
-    expect(a.args['key1']({foo: {bar: []}})).to.equal(null);
-    expect(a.args['key1']({foo: {bar: () => {}}})).to.equal(null);
+    expect(dereferenceExprsInArgs(a.args, {foo: {bar: undefined}}))
+        .to.deep.equal({key1: null});
+    expect(dereferenceExprsInArgs(a.args, {foo: {bar: {}}}))
+        .to.deep.equal({key1: null});
+    expect(dereferenceExprsInArgs(a.args, {foo: {bar: []}}))
+        .to.deep.equal({key1: null});
+    expect(dereferenceExprsInArgs(a.args, {foo: {bar: () => {}}}))
+        .to.deep.equal({key1: null});
   });
 
-  it('should apply arg functions with no event', () => {
+  it('evaluated args should be proto-less objects', () => {
     const a = parseAction('e:t.m(key1=foo)');
-    expect(applyActionInfoArgs(a.args, null)).to.deep.equal({key1: 'foo'});
+    expect(dereferenceExprsInArgs(a.args, null).__proto__).to.be.undefined;
+    expect(dereferenceExprsInArgs(a.args, null).constructor).to.be.undefined;
   });
 
-  it('applied arg values should be proto-less objects', () => {
+  it('should dereference arg expressions', () => {
     const a = parseAction('e:t.m(key1=foo)');
-    expect(applyActionInfoArgs(a.args, null).__proto__).to.be.undefined;
-    expect(applyActionInfoArgs(a.args, null).constructor).to.be.undefined;
+    expect(dereferenceExprsInArgs(a.args, null)).to.deep.equal({key1: 'foo'});
   });
 
-  it('should apply arg value functions with an event with data', () => {
-    const a = parseAction('e:t.m(key1=event.foo)');
-    const event = createCustomEvent(window, 'MyEvent', {foo: 'bar'});
-    expect(applyActionInfoArgs(a.args, event)).to.deep.equal({key1: 'bar'});
-  });
-
-  it('should apply arg value functions with an event without data', () => {
+  it('should dereference arg expressions with an event without data', () => {
     const a = parseAction('e:t.m(key1=foo)');
     const event = createCustomEvent(window, 'MyEvent');
-    expect(applyActionInfoArgs(a.args, event)).to.deep.equal({key1: 'foo'});
+    expect(dereferenceExprsInArgs(a.args, event)).to.deep.equal({key1: 'foo'});
+  });
+
+  it('should dereference arg expressions with an event with data', () => {
+    const a = parseAction('e:t.m(key1=event.foo)');
+    const event = createCustomEvent(window, 'MyEvent', {foo: 'bar'});
+    expect(dereferenceExprsInArgs(a.args, event)).to.deep.equal({key1: 'bar'});
   });
 
   it('should parse empty to null', () => {


### PR DESCRIPTION
Instead of storing a closure per action argument to support dereferencing expressions (e.g. `foo.bar` in `e:t.m(arg=foo.bar)`), store expressions as structs `{expression: <expr>}` and use `json#getValueForExpr` at evaluation time.

IMO this is a cleaner and more readable approach.