### PR TITLE
Enabling whitelisted http urls to get feature to replace whitelisted URL parameters

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -24,7 +24,7 @@ import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
 } from '../service';
-import {isSecureUrl, parseUrl, removeFragment, parseQueryString,
+import {parseUrl, removeFragment, parseQueryString,
   addParamsToUrl} from '../url';
 import {viewerForDoc} from '../services';
 import {viewportForDoc} from '../services';
@@ -807,17 +807,11 @@ export class UrlReplacements {
     }
     if (whitelist) {
       const isAllowedOrigin = this.isAllowedOrigin_(url);
-      const isSecure = isSecureUrl(href);
       if (!isAllowedOrigin) {
         user().warn('URL', 'Ignoring link replacement', href,
             ' because the link does not go to the document\'s' +
             ' source, canonical, or whitelisted origin.');
-      }
-      if (!isSecure) {
-        user().warn('URL', 'Ignoring link replacement', href,
-            ' because it is only supported for secure links.');
-      }
-      if (isAllowedOrigin && isSecure) {
+      } else {
         href = this.expandSync(
             href,
             /* opt_bindings */ undefined,

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -128,7 +128,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
         querySelector: selector => {
           if (selector.startsWith('meta')) {
             return {
-              getAttribute: () => {return 'https://whitelisted.com https://greylisted.com';},
+              getAttribute: () => {return 'https://whitelisted.com https://greylisted.com http://example.com';},
               hasAttribute: () => {return true;},
             };
           } else {
@@ -1066,12 +1066,12 @@ describes.sandboxed('UrlReplacements', {}, () => {
       expect(a.href).to.equal('https://example.com/link?out=RANDOM');
     });
 
-    it('should not replace in http (non-secure)', () => {
+    it('should replace for http (non-secure) whitelisted origin', () => {
       canonical = 'http://example.com/link';
       a.href = 'http://example.com/link?out=QUERY_PARAM(foo)';
       a.setAttribute('data-amp-replace', 'QUERY_PARAM');
       urlReplacements.maybeExpandLink(a);
-      expect(a.href).to.equal('http://example.com/link?out=QUERY_PARAM(foo)');
+      expect(a.href).to.equal('http://example.com/link?out=bar');
     });
 
     it('should replace with canonical origin', () => {
@@ -1126,13 +1126,30 @@ describes.sandboxed('UrlReplacements', {}, () => {
       expect(a.href).to.equal('http://whitelisted.com/link?out=QUERY_PARAM(foo)&guid=123');
     });
 
-    it('should add URL parameters without replacing whitelisted'
-      + ' values for http URL\'s(non-secure)', () => {
-      a.href = 'http://whitelisted.com/link?out=QUERY_PARAM(foo)';
+    it('should add URL parameters and repalce whitelisted'
+      + ' values for http whitelisted URL\'s(non-secure)', () => {
+      a.href = 'http://example.com/link?out=QUERY_PARAM(foo)';
       a.setAttribute('data-amp-replace', 'CLIENT_ID');
       a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
-      urlReplacements.maybeExpandLink(a);
-      expect(a.href).to.equal('http://whitelisted.com/link?out=QUERY_PARAM(foo)&guid=123&c=CLIENT_ID(abc)');
+      // Get a cid, then proceed.
+      return urlReplacements.expandAsync('CLIENT_ID(abc)').then(() => {
+        urlReplacements.maybeExpandLink(a);
+        expect(a.href).to.equal(
+            'http://example.com/link?out=QUERY_PARAM(foo)&guid=123&c=test-cid(abc)');
+      });
+    });
+
+    it('should add URL parameters and not repalce whitelisted'
+      + ' values for non whitelisted http URL\'s(non-secure)', () => {
+      a.href = 'http://example2.com/link?out=QUERY_PARAM(foo)';
+      a.setAttribute('data-amp-replace', 'CLIENT_ID');
+      a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
+      // Get a cid, then proceed.
+      return urlReplacements.expandAsync('CLIENT_ID(abc)').then(() => {
+        urlReplacements.maybeExpandLink(a);
+        expect(a.href).to.equal(
+            'http://example2.com/link?out=QUERY_PARAM(foo)&guid=123&c=CLIENT_ID(abc)');
+      });
     });
 
     it('should append query parameters and repalce whitelisted values', () => {


### PR DESCRIPTION
Support for data-amp-replace for non secure URL's of links if they are whitelisted through amp-link-variable-allowed-origin.

Example:
Page Origin URL is `https://www.m.example.com`

Whitelisted origin added through
`<meta name="amp-link-variable-allowed-origin" content="http://www.example.com">
`

For below link on the page
`<a class="b-tile" href="http://example.com/link" data-amp-addparams="guid=123&c=CLIENT_ID(abc)" data-amp-replace="CLIENT_ID">Sample 1</a>`

The destination would be formed as 
`http://example.com/link?guid=123&c=^js=1^sfLMD=1388586297^dv=593e081a^cv=15555^sin=in^sbf=#40400000000010048002084^cos=1^
`

Before the this change
`http://example.com/link?guid=123&c=CLIENT_ID(abc)`


Closes https://github.com/ampproject/amphtml/issues/9732