### PR TITLE
Fix DFP A4A in PWA errors 

### DIFF
--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -147,7 +147,7 @@ export class GoogleAdLifecycleReporter extends BaseLifecycleReporter {
     this.slotId_ = slotId;
 
     /** @private {number} @const */
-    this.correlator_ = getCorrelator(win);
+    this.correlator_ = getCorrelator(win, /* opt_cid */ undefined, element);
 
     /** @private {string} @const */
     this.slotName_ = this.namespace_ + '.' + this.slotId_;

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -207,12 +207,12 @@ export function googlePageParameters(win, doc, startTime, output = 'html') {
   const referrerPromise = viewerForDoc(doc).getReferrerUrl();
   return getOrCreateAdCid(doc, 'AMP_ECID_GOOGLE', '_ga')
       .then(clientId => referrerPromise.then(referrer => {
-        const documentInfo = documentInfoForDoc(win.document);
+        const documentInfo = documentInfoForDoc(doc);
         // Read by GPT for GA/GPT integration.
         win.gaGlobal = win.gaGlobal ||
         {cid: clientId, hid: documentInfo.pageViewId};
         const screen = win.screen;
-        const viewport = viewportForDoc(win.document);
+        const viewport = viewportForDoc(doc);
         const viewportRect = viewport.getRect();
         const viewportSize = viewport.getSize();
         return {
@@ -398,12 +398,13 @@ function elapsedTimeWithCeiling(time, start) {
 /**
  * @param {!Window} win
  * @param {string=} opt_cid
+ * @param {(!Node|!../../../src/service/ampdoc-impl.AmpDoc)=} opt_nodeOrDoc
  * @return {number} The correlator.
  */
-export function getCorrelator(win, opt_cid) {
+export function getCorrelator(win, opt_cid, opt_nodeOrDoc) {
   if (!win.ampAdPageCorrelator) {
     win.ampAdPageCorrelator = makeCorrelator(
-        opt_cid, documentInfoForDoc(win.document).pageViewId);
+        opt_cid, documentInfoForDoc(opt_nodeOrDoc || win.document).pageViewId);
   }
   return win.ampAdPageCorrelator;
 }

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -71,7 +71,7 @@ app.get([
 app.use('/pwa', (req, res) => {
   let file;
   let contentType;
-  if (!req.url || req.url == '/') {
+  if (!req.url || req.path == '/') {
     // pwa.html
     contentType = 'text/html';
     file = '/examples/pwa/pwa.html';

--- a/examples/a4a.amp.html
+++ b/examples/a4a.amp.html
@@ -81,5 +81,11 @@
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
+
+  <h2>Doubleclick</h2>
+  <amp-ad width="320" height="50"
+      type="doubleclick"
+      data-slot="/4119129/mobile_ad_banner">
+  </amp-ad>
 </body>
 </html>

--- a/examples/pwa/pwa.html
+++ b/examples/pwa/pwa.html
@@ -82,19 +82,25 @@
     <section id="stream" class="stream">
       <article class="card">
         <a href="/pwa/examples/article.amp.html">
-          <h4>Lorem Ipsum</h4>
+          <h4>Article</h4>
           <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
         </a>
       </article>
       <article class="card">
         <a href="/pwa/examples/youtube.amp.html">
-          <h4>YouTube video</h4>
+          <h4>YouTube</h4>
           <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
         </a>
       </article>
       <article class="card">
         <a href="/pwa/examples/analytics.amp.html">
           <h4>Analytics</h4>
+          <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
+        </a>
+      </article>
+      <article class="card">
+        <a href="/pwa/examples/a4a.amp.html">
+          <h4>A4A</h4>
           <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
         </a>
       </article>

--- a/examples/pwa/pwa.js
+++ b/examples/pwa/pwa.js
@@ -102,11 +102,12 @@ class Shell {
     }
     if (a) {
       const url = new URL(a.href);
-      if (url.origin == this.win.location.origin &&
-              startsWith(url.pathname, '/pwa/') &&
-              url.pathname.indexOf('amp.html') != -1) {
+      const location = this.win.location;
+      if (url.origin == location.origin &&
+          startsWith(url.pathname, '/pwa/') &&
+          url.pathname.indexOf('amp.html') != -1) {
         e.preventDefault();
-        const newPage = url.pathname;
+        const newPage = url.pathname + location.search;
         log('Internal link to: ', newPage);
         if (newPage != this.currentPage_) {
           this.navigateTo(newPage);


### PR DESCRIPTION
Partial for #9679.

- Fix a few bugs in retrieving correct ampdoc-scope service in PWA.
- Also support using `?exp=a4a:-1` A4A toggle when using `localhost:8000/pwa` app.

/to @lannka