### PR TITLE
Update amp-gist validator to allow data-file attribute

### DIFF
--- a/extensions/amp-gist/0.1/test/test-amp-gist.js
+++ b/extensions/amp-gist/0.1/test/test-amp-gist.js
@@ -20,7 +20,6 @@ import {
 } from '../../../../testing/iframe';
 import '../amp-gist';
 import {adopt} from '../../../../src/runtime';
-import {toggleExperiment} from '../../../../src/experiments';
 
 adopt(window);
 
@@ -28,7 +27,6 @@ describe('amp-gist', () => {
 
   function getIns(gistid, opt_attrs) {
     return createIframePromise().then(iframe => {
-      toggleExperiment(iframe.win, 'amp-gist', true);
       doNotLoadExternalResourcesInTest(iframe.win);
       const ins = iframe.doc.createElement('amp-gist');
       ins.setAttribute('data-gistid', gistid);

--- a/extensions/amp-gist/0.1/test/test-amp-gist.js
+++ b/extensions/amp-gist/0.1/test/test-amp-gist.js
@@ -25,12 +25,15 @@ adopt(window);
 
 describe('amp-gist', () => {
 
-  function getIns(gistid, opt_attrs) {
+  function getIns(gistid, opt_attrs, file) {
     return createIframePromise().then(iframe => {
       doNotLoadExternalResourcesInTest(iframe.win);
       const ins = iframe.doc.createElement('amp-gist');
       ins.setAttribute('data-gistid', gistid);
       ins.setAttribute('height', '237');
+      if (file) {
+        ins.setAttribute('data-file', file);
+      }
 
       if (opt_attrs) {
         for (const attr in opt_attrs) {
@@ -43,6 +46,14 @@ describe('amp-gist', () => {
   }
 
   it('renders responsively', () => {
+    return getIns('b9bb35bc68df68259af94430f012425f').then(ins => {
+      const iframe = ins.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.className).to.match(/i-amphtml-fill-content/);
+    });
+  });
+
+  it('renders responsively with specific file', () => {
     return getIns('b9bb35bc68df68259af94430f012425f').then(ins => {
       const iframe = ins.querySelector('iframe');
       expect(iframe).to.not.be.null;

--- a/extensions/amp-gist/0.1/test/test-amp-gist.js
+++ b/extensions/amp-gist/0.1/test/test-amp-gist.js
@@ -25,7 +25,7 @@ adopt(window);
 
 describe('amp-gist', () => {
 
-  function getIns(gistid, opt_attrs, file) {
+  function getIns(gistid, file) {
     return createIframePromise().then(iframe => {
       doNotLoadExternalResourcesInTest(iframe.win);
       const ins = iframe.doc.createElement('amp-gist');
@@ -33,12 +33,6 @@ describe('amp-gist', () => {
       ins.setAttribute('height', '237');
       if (file) {
         ins.setAttribute('data-file', file);
-      }
-
-      if (opt_attrs) {
-        for (const attr in opt_attrs) {
-          ins.setAttribute(attr, opt_attrs[attr]);
-        }
       }
 
       return iframe.addElement(ins);
@@ -54,11 +48,12 @@ describe('amp-gist', () => {
   });
 
   it('renders responsively with specific file', () => {
-    return getIns('b9bb35bc68df68259af94430f012425f').then(ins => {
-      const iframe = ins.querySelector('iframe');
-      expect(iframe).to.not.be.null;
-      expect(iframe.className).to.match(/i-amphtml-fill-content/);
-    });
+    return getIns('b9bb35bc68df68259af94430f012425f', 'hello-world.html')
+        .then(ins => {
+          const iframe = ins.querySelector('iframe');
+          expect(iframe).to.not.be.null;
+          expect(iframe.className).to.match(/i-amphtml-fill-content/);
+        });
   });
 
   it('Rejects because data-gistid is missing', () => {

--- a/extensions/amp-gist/validator-amp-gist.protoascii
+++ b/extensions/amp-gist/validator-amp-gist.protoascii
@@ -28,10 +28,7 @@ tags: {  # <amp-gist>
   html_format: AMP
   tag_name: "AMP-GIST"
   requires_extension: "amp-gist"
-  attrs: {
-    name: "data-file"
-    value: ""
-  }
+  # data-file is allowed, but not required
   attrs: {
     name: "data-gistid"
     mandatory: true

--- a/extensions/amp-gist/validator-amp-gist.protoascii
+++ b/extensions/amp-gist/validator-amp-gist.protoascii
@@ -28,7 +28,6 @@ tags: {  # <amp-gist>
   html_format: AMP
   tag_name: "AMP-GIST"
   requires_extension: "amp-gist"
-  # data-file is allowed, but not required
   attrs: {
     name: "data-gistid"
     mandatory: true


### PR DESCRIPTION
The `amp-gist` component wasn't passing [amp-by-example](https://github.com/ampproject/amp-by-example) [validator tests on travis-ci](https://travis-ci.org/ampproject/amp-by-example/builds/243902984).

- Removed `data-file` attribute from `amp-gist` validator
- Added test to cover the `data-file` attribute

Closes #10001 

/cc @aghassemi @honeybadgerdontcare 