### PR TITLE
Remove use of .includes on strings

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -927,7 +927,7 @@ class ParserTokenizer {
     if (WHITESPACE_SET.indexOf(c) != -1) {
       newIndex++;
       for (; newIndex < this.str_.length; newIndex++) {
-        if (!WHITESPACE_SET.indexOf(this.str_.charAt(newIndex)) == -1) {
+        if (WHITESPACE_SET.indexOf(this.str_.charAt(newIndex)) == -1) {
           break;
         }
       }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -927,7 +927,7 @@ class ParserTokenizer {
     if (WHITESPACE_SET.indexOf(c) != -1) {
       newIndex++;
       for (; newIndex < this.str_.length; newIndex++) {
-        if (!WHITESPACE_SET.includes(this.str_.charAt(newIndex))) {
+        if (!WHITESPACE_SET.indexOf(this.str_.charAt(newIndex)) == -1) {
           break;
         }
       }


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/10014
Regression from https://github.com/ampproject/amphtml/pull/8743, `WHITESPACE_SET` similar to `SPECIAL_SET` is a string not an array.

@erwinmombay https://github.com/ampproject/amphtml/issues/6549 should have caught this (i.e. use of `includes` on `string`) in presubmit, maybe check doesn't work on `const` or something else is going on?

We can polyfill String.includes too if we like, not sure if it is worth the extra bytes.