### PR TITLE
AdSense/Doubleclick Fast Fetch: allow for per network, external experiment selection

### DIFF
--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -111,6 +111,38 @@ describe('all-traffic-experiments-tests', () => {
       expect(isInternallyTriggeredExperiment(element)).to.be.false;
     });
 
+    it('should use AdSense specific A4A experiment from URL', () => {
+      element.setAttribute('type', 'adsense');
+      const externalBranches = {control: '12', experiment: '34'};
+      const internalBranches = {control: '56', experiment: '78'};
+      const externalDelayedBranches = {control: '90', experiment: '13'};
+
+      sandbox.win.location.search = '?exp=a4a:1,aa:2,da:0';
+
+      const renderViaA4a = googleAdsIsA4AEnabled(
+          sandbox.win, element, 'exp_name', externalBranches, internalBranches,
+          externalDelayedBranches);
+      expect(renderViaA4a).to.be.true;
+      expect(isInExperiment(element, '12')).to.be.false;
+      expect(isInExperiment(element, '34')).to.be.true;
+    });
+
+    it('should use Doubleclick specific A4A experiment from URL', () => {
+      element.setAttribute('type', 'doubleclick');
+      const externalBranches = {control: '12', experiment: '34'};
+      const internalBranches = {control: '56', experiment: '78'};
+      const externalDelayedBranches = {control: '90', experiment: '13'};
+
+      sandbox.win.location.search = '?exp=a4a:0,aa:1,da:2';
+
+      const renderViaA4a = googleAdsIsA4AEnabled(
+          sandbox.win, element, 'exp_name', externalBranches, internalBranches,
+          externalDelayedBranches);
+      expect(renderViaA4a).to.be.true;
+      expect(isInExperiment(element, '12')).to.be.false;
+      expect(isInExperiment(element, '34')).to.be.true;
+    });
+
     it('should enable the external A4A control from the URL', () => {
       const externalBranches = {control: '12', experiment: '34'};
       const internalBranches = {control: '56', experiment: '78'};

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -203,7 +203,8 @@ function maybeSetExperimentFromUrl(win, element, experimentName,
   let arg;
   let match;
   expKeys.forEach(key => arg = arg ||
-    (match = new RegExp(`(?:^|,)${key}:(-?\\d+)`).exec(expParam)) && match[1]);
+    ((match = new RegExp(`(?:^|,)${key}:(-?\\d+)`).exec(expParam)) &&
+      match[1]));
   if (!arg) {
     return false;
   }

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -203,7 +203,7 @@ function maybeSetExperimentFromUrl(win, element, experimentName,
   let arg;
   let match;
   expKeys.forEach(key => arg = arg ||
-    (match = new RegExp(`(?:^|,)${key}:(\\d+)`).exec(expParam)) && match[1]);
+    (match = new RegExp(`(?:^|,)${key}:(-?\\d+)`).exec(expParam)) && match[1]);
   if (!arg) {
     return false;
   }

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -185,48 +185,48 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
  * @return {boolean}  Whether the experiment state was set from a command-line
  *   parameter or not.
  */
- function maybeSetExperimentFromUrl(win, element, experimentName,
+function maybeSetExperimentFromUrl(win, element, experimentName,
      controlBranchId, treatmentBranchId, delayedControlId,
      delayedTreatmentBrandId, sfgControlId, sfgTreatmentId, manualId) {
-   const expParam = viewerForDoc(element).getParam('exp') ||
-       parseQueryString(win.location.search)['exp'];
-   if (!expParam) {
-     return false;
-   }
-   // Allow for per type experiment control with Doubleclick key set for 'da'
-   // and AdSense using 'aa'.  Fallbsck to 'a4a' if type specific is missing.
-   const expKeys = [
-     (element.getAttribute('type') || '').toLowerCase() == 'doubleclick' ?
-       'da' : 'aa',
-     'a4a',
-   ];
-   let arg;
-   let match;
-   expKeys.forEach(key => arg = arg ||
-     (match = new RegExp(`(?:^|,)${key}:(\\d+)`).exec(expParam)) && match[1]);
-   if (!arg) {
-     return false;
-   }
-   const argMapping = {
-     '-1': manualId,
-     '0': null,
-     '1': controlBranchId,
-     '2': treatmentBranchId,
-     '3': delayedControlId,
-     '4': delayedTreatmentBrandId,
-     '5': sfgControlId,
-     '6': sfgTreatmentId,
-   };
-   if (argMapping.hasOwnProperty(arg)) {
-     forceExperimentBranch(win, experimentName, argMapping[arg]);
-     return true;
-   } else {
-     dev().warn('A4A-CONFIG', 'Unknown a4a URL parameter: ', arg,
-         ' expected one of -1 (manual), 0 (not in experiment), 1 (control ' +
-         'branch), or 2 (a4a experiment branch)');
-     return false;
-   }
- }
+  const expParam = viewerForDoc(element).getParam('exp') ||
+    parseQueryString(win.location.search)['exp'];
+  if (!expParam) {
+    return false;
+  }
+  // Allow for per type experiment control with Doubleclick key set for 'da'
+  // and AdSense using 'aa'.  Fallbsck to 'a4a' if type specific is missing.
+  const expKeys = [
+    (element.getAttribute('type') || '').toLowerCase() == 'doubleclick' ?
+      'da' : 'aa',
+    'a4a',
+  ];
+  let arg;
+  let match;
+  expKeys.forEach(key => arg = arg ||
+    (match = new RegExp(`(?:^|,)${key}:(\\d+)`).exec(expParam)) && match[1]);
+  if (!arg) {
+    return false;
+  }
+  const argMapping = {
+    '-1': manualId,
+    '0': null,
+    '1': controlBranchId,
+    '2': treatmentBranchId,
+    '3': delayedControlId,
+    '4': delayedTreatmentBrandId,
+    '5': sfgControlId,
+    '6': sfgTreatmentId,
+  };
+  if (argMapping.hasOwnProperty(arg)) {
+    forceExperimentBranch(win, experimentName, argMapping[arg]);
+    return true;
+  } else {
+    dev().warn('A4A-CONFIG', 'Unknown a4a URL parameter: ', arg,
+        ' expected one of -1 (manual), 0 (not in experiment), 1 (control ' +
+        'branch), or 2 (a4a experiment branch)');
+    return false;
+  }
+}
 
 /**
  * Sets of experiment IDs can be attached to Elements via attributes.  In


### PR DESCRIPTION
Currently AdSense/Doubleclick external experiment selection is controlled by a single value (#exp=a4a:<some num>).  Allow for independently controlling AdSense (via 'aa') and Doubleclick (via 'da') keys with fallback to 'a4a'.

/cc @ampproject/a4a 