### PR TITLE
Amp-analytics: Adding Nielsen marketing cloud config

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -56,7 +56,7 @@
       <option>colanalytics</option>
       <option>comscore</option>
       <option>cxense</option>
-      <option>dynatrace</option>      
+      <option>dynatrace</option>
       <option>euleriananalytics</option>
       <option>facebook-pixel</option>
       <option>gemius</option>
@@ -69,6 +69,7 @@
       <option>mediametrie</option>
       <option>mparticle</option>
       <option>mpulse</option>
+      <option>nielsen-marketing-cloud</option>
       <option>oewa</option>
       <option>oewadirect</option>
       <option>parsely</option>
@@ -620,6 +621,29 @@ For complete documentation and additional examples please see: https://marketing
 </script>
 </amp-analytics>
 <!-- End Nielsen example -->
+
+<!-- Nielsen Marketing Cloud example -->
+<amp-analytics type="nielsen-marketing-cloud" id="nielsen-marketing-cloud">
+  <script type="application/json">
+    {
+      "vars": {
+        "pubId": "123",
+        "siteId": "001"
+      },
+      "triggers": {
+        "trackAppEvent": {
+          "on": "click",
+          "selector": "#test1",
+          "request": "trackurl",
+          "extraUrlParams": {
+            "extraparam": "testclick"
+          }
+        }
+      }
+    }
+  </script>
+</amp-analytics>
+<!-- End Nielsen Marketing Cloud example -->
 
 <!-- OEWA example -->
 <amp-analytics type="oewa" id="oewa">

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -161,7 +161,9 @@
     "cloudapi": "https://cloudapi.imrworldwide.com/nmapi/v2/$apid/_client_id_/a?b=%7B%22devInfo%22%3A%7B%22devId%22%3A%22_client_id_%22%2C%22apn%22%3A%22$apn%22%2C%22apv%22%3A%22$apv%22%2C%22apid%22%3A%22$apid%22%7D%2C%22metadata%22%3A%7B%22static%22%3A%7B%22type%22%3A%22static%22%2C%22section%22%3A%22$section%22%2C%22assetid%22%3A%22_page_view_id_%22%2C%22segA%22%3A%22$segA%22%2C%22segB%22%3A%22$segB%22%2C%22segC%22%3A%22$segC%22%2C%22adModel%22%3A%220%22%2C%22dataSrc%22%3A%22cms%22%7D%2C%22content%22%3A%7B%7D%2C%22ad%22%3A%7B%7D%7D%2C%22event%22%3A%22playhead%22%2C%22position%22%3A%22_timestamp_%22%2C%22data%22%3A%7B%22hidden%22%3A%22_background_state_%22%2C%22blur%22%3A%22_background_state_%22%2C%22position%22%3A%22_timestamp_%22%7D%2C%22type%22%3A%22static%22%2C%22utc%22%3A%22_timestamp_%22%2C%22index%22%3A%223%22%7D",
   },
   "nielsen-marketing-cloud": {
-    "trackurl": "https://loadeu.exelator.com/load/?p=${pubId}&g=${siteId}&j=0"
+    "host": "loadeu.exelator.com",
+    "pathPrefix": "load/",
+    "trackurl": "https://loadeu.exelator.com/load/?p=$pubId&g=$siteId&j=0"
   },
   "parsely": {
     "host": "https://srv.pixel.parsely.com",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -160,6 +160,9 @@
     "session": "https://uaid-linkage.imrworldwide.com/cgi-bin/gn?prd=session&c13=asid,P$apid&sessionId=_client_id_,&pingtype=4&enc=false&c61=createtm,_timestamp_&rnd=_random_",
     "cloudapi": "https://cloudapi.imrworldwide.com/nmapi/v2/$apid/_client_id_/a?b=%7B%22devInfo%22%3A%7B%22devId%22%3A%22_client_id_%22%2C%22apn%22%3A%22$apn%22%2C%22apv%22%3A%22$apv%22%2C%22apid%22%3A%22$apid%22%7D%2C%22metadata%22%3A%7B%22static%22%3A%7B%22type%22%3A%22static%22%2C%22section%22%3A%22$section%22%2C%22assetid%22%3A%22_page_view_id_%22%2C%22segA%22%3A%22$segA%22%2C%22segB%22%3A%22$segB%22%2C%22segC%22%3A%22$segC%22%2C%22adModel%22%3A%220%22%2C%22dataSrc%22%3A%22cms%22%7D%2C%22content%22%3A%7B%7D%2C%22ad%22%3A%7B%7D%7D%2C%22event%22%3A%22playhead%22%2C%22position%22%3A%22_timestamp_%22%2C%22data%22%3A%7B%22hidden%22%3A%22_background_state_%22%2C%22blur%22%3A%22_background_state_%22%2C%22position%22%3A%22_timestamp_%22%7D%2C%22type%22%3A%22static%22%2C%22utc%22%3A%22_timestamp_%22%2C%22index%22%3A%223%22%7D",
   },
+  "nielsen-marketing-cloud": {
+    "trackurl": "https://loadeu.exelator.com/load/?p=${pubId}&g=${siteId}&j=0"
+  },
   "parsely": {
     "host": "https://srv.pixel.parsely.com",
     "basePrefix": "https://srv.pixel.parsely.com/plogger/?rand=_timestamp_&idsite=$apikey&url=_ampdoc_url_&urlref=_document_referrer_&screen=_screen_width_x_screen_height_%7C_available_screen_width_x_available_screen_height_%7C_screen_color_depth_&title=_title_&date=_timestamp_&ampid=_client_id_",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1022,6 +1022,29 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     },
   },
 
+  'nielsen-marketing-cloud': {
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true,
+    },
+    'vars': {
+      'pubId': '',
+      'siteId': '',
+    },
+    'requests': {
+      'host': 'loadeu.exelator.com',
+      'pathPrefix': 'load/',
+      'trackurl': 'https://${host}/${pathPrefix}?p=${pubId}&g=${siteId}&j=0',
+    },
+    'triggers': {
+      'defaultPageview': {
+        'on': 'visible',
+        'request': 'trackurl',
+      },
+    },
+  },
+
   'oewadirect': {
     'transport': {'beacon': false, 'xhrpost': false, 'image': true},
     'requests': {


### PR DESCRIPTION
Adding Nielsen marketing cloud into amp-analytics configuration so that AMP users can implement it with easy

Issue associated with the Pull Request: #10012 

- Configuration for tracking pageviews
- Configuration for tracking clicks
- Example of usage

Closes #10012.