### PR TITLE
AMP Validator: Give more nuance to the dispatch_key field.

### DIFF
--- a/extensions/amp-access/validator-amp-access.protoascii
+++ b/extensions/amp-access/validator-amp-access.protoascii
@@ -37,7 +37,7 @@ tags: {  # amp-access (json)
     name: "id"
     mandatory: true
     value: "amp-access"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: { name: "nonce" }
   attrs: {

--- a/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii
+++ b/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii
@@ -48,7 +48,7 @@ tags: {  # amp-ad-exit config JSON
     name: "type"
     mandatory: true
     value: "application/json"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-ad-exit"
 }

--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -95,7 +95,7 @@ tags: {  # <amp-ad data-multi-size>
     name: "data-multi-size"
     mandatory: true
     value: ""
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: { name: "json" }
   attrs: {
@@ -166,7 +166,7 @@ tags: {  # <amp-embed data-multi-size>
     name: "data-multi-size"
     mandatory: true
     value: ""
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: { name: "json" }
   attrs: {

--- a/extensions/amp-analytics/validator-amp-analytics.protoascii
+++ b/extensions/amp-analytics/validator-amp-analytics.protoascii
@@ -36,7 +36,7 @@ tags: {  # amp-analytics (json)
     name: "type"
     mandatory: true
     value_casei: "application/json"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   cdata: {
     blacklisted_cdata_regex: {

--- a/extensions/amp-animation/validator-amp-animation.protoascii
+++ b/extensions/amp-animation/validator-amp-animation.protoascii
@@ -36,7 +36,7 @@ tags: {  # <amp-animation> (json)
     name: "type"
     mandatory: true
     value_casei: "application/json"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   cdata: {
     blacklisted_cdata_regex: {

--- a/extensions/amp-bind/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/validator-amp-bind.protoascii
@@ -34,7 +34,7 @@ tags: {  # <amp-state> (json)
     name: "type"
     mandatory: true
     value_casei: "application/json"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   cdata: {
     blacklisted_cdata_regex: {

--- a/extensions/amp-experiment/validator-amp-experiment.protoascii
+++ b/extensions/amp-experiment/validator-amp-experiment.protoascii
@@ -37,7 +37,7 @@ tags: {  # amp-experiment (json)
     name: "type"
     mandatory: true
     value_casei: "application/json"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   cdata: {
     blacklisted_cdata_regex: {

--- a/validator/testdata/feature_tests/amp_rtc.out
+++ b/validator/testdata/feature_tests/amp_rtc.out
@@ -1,2 +1,2 @@
 FAIL
-feature_tests/amp_rtc.html:44:2 The tag 'script' is disallowed except in specific forms. [CUSTOM_JAVASCRIPT_DISALLOWED]
+feature_tests/amp_rtc.html:44:2 The parent tag of tag 'script id=amp-rtc' is 'body', but it can only be 'head'. [DISALLOWED_HTML]

--- a/validator/testdata/feature_tests/runtime_in_body.html
+++ b/validator/testdata/feature_tests/runtime_in_body.html
@@ -1,0 +1,43 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+
+  This test demonstrates an error message selected via dispatch_key rules.
+
+  The <script> tag in the body is invalid only in it's location in the document.
+  Other forms of <script> tags are allowed in the body, but not the runtime tag.
+  We want to verify that the error message generated suggests a different
+  parent, not different attribute values.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+
+  <!-- This is a valid runtime script tag ag, but it's invalid because it is
+       found outside the <head>. The test demonstrates that the error message
+       is useful, suggesting placement in the document head. -->
+
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+
+</body>
+</html>

--- a/validator/testdata/feature_tests/runtime_in_body.out
+++ b/validator/testdata/feature_tests/runtime_in_body.out
@@ -1,0 +1,3 @@
+FAIL
+feature_tests/runtime_in_body.html:40:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+feature_tests/runtime_in_body.html:43:7 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]

--- a/validator/testdata/feature_tests/several_errors.out
+++ b/validator/testdata/feature_tests/several_errors.out
@@ -1,5 +1,5 @@
 FAIL
-feature_tests/several_errors.html:23:2 The attribute 'charset' may not appear in tag 'meta name= and content='. [DISALLOWED_HTML]
+feature_tests/several_errors.html:23:2 The attribute 'charset' in tag 'meta charset=utf-8' is set to the invalid value 'pick-a-key'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
 feature_tests/several_errors.html:26:2 The tag 'script' is disallowed except in specific forms. [CUSTOM_JAVASCRIPT_DISALLOWED]
 feature_tests/several_errors.html:32:2 The mandatory attribute 'height' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
 feature_tests/several_errors.html:34:2 The attribute 'width' in tag 'amp-ad' is set to the invalid value '100%'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_LAYOUT_PROBLEM]

--- a/validator/testdata/feature_tests/stylesheet_in_body.html
+++ b/validator/testdata/feature_tests/stylesheet_in_body.html
@@ -1,0 +1,44 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+
+  This test demonstrates an error message selected via dispatch_key rules.
+
+  The <link> tag in the body is invalid only in it's location in the document.
+  Other forms of <link> tags are allowed in the body, but not rel="stylesheet"
+  <link> tags. We want to verify that the error message generated suggests
+  a different parent, not different attribute values.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+  <!-- This is a valid font stylesheet tag, but it's invalid because it is
+       found outside the <head>. The test demonstrates that the error message
+       is useful, suggesting placement in the document head. -->
+
+  <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+
+</body>
+</html>

--- a/validator/testdata/feature_tests/stylesheet_in_body.out
+++ b/validator/testdata/feature_tests/stylesheet_in_body.out
@@ -1,0 +1,2 @@
+FAIL
+feature_tests/stylesheet_in_body.html:41:2 The parent tag of tag 'link rel=stylesheet for fonts' is 'body', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#custom-fonts) [DISALLOWED_HTML]

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,12 +20,12 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii) are always released together.
-min_validator_revision_required: 234
+min_validator_revision_required: 238
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 440
+spec_file_revision: 443
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 
@@ -191,7 +191,7 @@ tags: {
     name: "rel"
     value_casei: "canonical"
     mandatory: true
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   spec_url: "https://www.ampproject.org/docs/reference/spec#required-markup"
 }
@@ -215,7 +215,7 @@ tags: {
     name: "rel"
     value_casei: "manifest"
     mandatory: true
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
 }
@@ -240,7 +240,7 @@ tags: {
     name: "rel"
     mandatory: true
     value_casei: "stylesheet"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "type"
@@ -265,7 +265,7 @@ tags: {
     name: "itemprop"
     mandatory: true
     value_casei: "sameas"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "common-link-attrs"
   spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -309,7 +309,7 @@ tags: {
   mandatory_parent: "HEAD"
   unique: true
   attrs: {
-    dispatch_key: true
+    dispatch_key: NAME_DISPATCH
     name: "charset"
     mandatory: true
     value_casei: "utf-8"
@@ -339,7 +339,7 @@ tags: {
     name: "name"
     mandatory: true
     value: "viewport"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   spec_url: "https://www.ampproject.org/docs/reference/spec#required-markup"
 }
@@ -353,7 +353,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "x-ua-compatible"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -375,7 +375,7 @@ tags: {
     name: "name"
     value_casei: "apple-itunes-app"
     mandatory: true
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -394,7 +394,7 @@ tags: {
     name: "name"
     mandatory: true
     value_casei: "amp-experiments-opt-in"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -411,7 +411,7 @@ tags: {
     name: "name"
     mandatory: true
     value_casei: "amp-3p-iframe-src"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -433,7 +433,7 @@ tags: {
     name: "name"
     mandatory: true
     value_casei: "amp-experiment-token"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -451,7 +451,7 @@ tags: {
     name: "name"
     mandatory: true
     value_casei: "amp-link-variable-allowed-origin"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -469,7 +469,7 @@ tags: {
     name: "name"
     mandatory: true
     value_casei: "amp4ads-id"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -508,7 +508,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "content-type"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -526,7 +526,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "content-language"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -544,7 +544,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "pics-label"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -562,7 +562,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "imagetoolbar"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -580,7 +580,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "content-style-type"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -599,7 +599,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "content-script-type"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -617,7 +617,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "origin-trial"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -635,7 +635,7 @@ tags: {
     name: "http-equiv"
     mandatory: true
     value_casei: "resource-type"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "content"
@@ -660,7 +660,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP
     # is used for errors related to <style> tags missing the amp-custom
     # attribute rather than the boilerplate tagspec which doesn't have an
     # attribute and thus can't have a dispatch_key.
-    # dispatch_key: true
+    # dispatch_key: NAME_DISPATCH
   }
   attrs: { name: "nonce" }
   attrs: {  # This is a default, but it doesn't hurt.
@@ -750,7 +750,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP4ADS
     # is used for errors related to <style> tags missing the amp-custom
     # attribute rather than the boilerplate tagspec which doesn't have an
     # attribute and thus can't have a dispatch_key.
-    # dispatch_key: true
+    # dispatch_key: NAME_DISPATCH
   }
   attrs: { name: "nonce" }
   attrs: {  # This is a default, but it doesn't hurt.
@@ -870,7 +870,7 @@ tags: {
     name: "amp-boilerplate"
     mandatory: true
     value: ""
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   attrs: { name: "nonce" }
   cdata: {
@@ -890,7 +890,7 @@ tags: {
     name: "amp4ads-boilerplate"
     mandatory: true
     value: ""
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   attrs: { name: "nonce" }
   cdata: {
@@ -914,7 +914,7 @@ tags: {
     name: "amp-boilerplate"
     mandatory: true
     value: ""
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   attrs: { name: "nonce" }
   cdata {
@@ -2600,7 +2600,7 @@ tags {  # <form method=POST ...>
     name: "method"
     mandatory: true
     value_casei: "post"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: { name: "name" }
   attrs: { name: "novalidate" }
@@ -3020,7 +3020,7 @@ tags: {
     name: "src"
     mandatory: true
     value: "https://cdn.ampproject.org/v0.js"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "type"
@@ -3051,7 +3051,7 @@ tags: {
     name: "src"
     mandatory: true
     value: "https://cdn.ampproject.org/amp4ads-v0.js"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "type"
@@ -3074,7 +3074,7 @@ tags: {
     name: "type"
     mandatory: true
     value_casei: "application/ld+json"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   cdata: {
     blacklisted_cdata_regex: {
@@ -3100,7 +3100,7 @@ tags: {
     name: "id"
     mandatory: true
     value_casei: "amp-rtc"
-    dispatch_key: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   cdata: {
     blacklisted_cdata_regex: {

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -108,11 +108,21 @@ message AttrSpec {
   // If provided, a URL which links to the AMP HTML spec for this deprecation.
   optional string deprecation_url = 8;
 
+  enum DispatchKeyType {
+    // Indicates that the attribute does not form a dispatch key.
+    NONE_DISPATCH = 0;
+    // Indicates that the name of the attribute alone forms a dispatch key.
+    NAME_DISPATCH = 1;
+    // Indicates that the name + value of the attribute forms a dispatch key.
+    NAME_VALUE_DISPATCH = 2;
+    // Indicates that the name + value + mandatory parent forms a dispatch key.
+    NAME_VALUE_PARENT_DISPATCH = 3;
+  }
   // If set true, the TagSpec containing this AttrSpec will be evaluated first
   // for any encountered tag which matches the tag name and this attribute spec.
   // May only be set for an AttrSpec where mandatory=true and the value field
   // is set.
-  optional bool dispatch_key = 13;
+  optional DispatchKeyType dispatch_key = 13 [default = NONE_DISPATCH];
 
   // If set to true, the TagSpec containing this AttrSpec implicitly has this
   // attribute and the attribute is considered valid.

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -772,12 +772,17 @@ def DispatchKeyForTagSpecOrNone(tag_spec):
     a string indicating the dispatch key, or None.
   """
   for attr in tag_spec.attrs:
-    if attr.dispatch_key:
+    if attr.dispatch_key != attr.NONE_DISPATCH:
       mandatory_parent = tag_spec.mandatory_parent or ''
       attr_name = attr.name
       attr_value = attr.value_casei or attr.value.lower()
       assert attr_value is not None
-      return '%s\\0%s\\0%s' % (attr_name, attr_value, mandatory_parent)
+      if attr.dispatch_key == attr.NAME_DISPATCH:
+        return '%s' % attr_name
+      if attr.dispatch_key == attr.NAME_VALUE_DISPATCH:
+        return '%s\\0%s' % (attr_name, attr_value)
+      if attr.dispatch_key == attr.NAME_VALUE_PARENT_DISPATCH:
+        return '%s\\0%s\\0%s' % (attr_name, attr_value, mandatory_parent)
   return None
 
 


### PR DESCRIPTION
Give more nuance to the dispatch_key field. We now let you specify which components of the tag form the key, which allows for more specific targeting of tags to TagSpecs for producing more specific error messages.

Adddresses #9737 and other poor error messages.