### PR TITLE
Delay reading 'sandbox' attribute

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -86,7 +86,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     this.type_ = null;
 
     /** @private {!boolean} */
-    this.isSandbox_ = element.hasAttribute('sandbox');
+    this.isSandbox_ = false;
 
     /**
      * @private {Object<string, string>} A map of request names to the request
@@ -138,6 +138,8 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.isSandbox_ = this.element.hasAttribute('sandbox');
+
     this.element.setAttribute('aria-hidden', 'true');
 
     this.consentNotificationId_ = this.element


### PR DESCRIPTION
I was testing my other PR. Then I found reading `element.hasAttribute('sandbox')` too early (constructor) could lead to false result. Delay to `buildCallback`