### PR TITLE
Add cutoff option to amp-timeago

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -720,6 +720,9 @@ var forbiddenTermsSrcInclusive = {
   },
   '\\.getTime\\(\\)': {
     message: 'Unless you do weird date math (whitelist), use Date.now().',
+    whitelist: [
+      'extensions/amp-timeago/0.1/amp-timeago.js',
+    ],
   },
   '\\.expandStringSync\\(': {
     message: requiresReviewPrivacy,

--- a/examples/amp-timeago.amp.html
+++ b/examples/amp-timeago.amp.html
@@ -73,5 +73,8 @@
   <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="vi">Saturday 11 April 2017 00.37</amp-timeago>
   <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="zhCN">Saturday 11 April 2017 00.37</amp-timeago>
   <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="zhTW">Saturday 11 April 2017 00.37</amp-timeago>
+  <h1>Cutoff example (100 days)</h1>
+  <amp-timeago layout="fixed" width="320" height="20" datetime="2017-03-13T00:37:33.809Z" locale="en" cutoff="8640000">Monday 13 March 2017 00.37</amp-timeago>
+  <amp-timeago layout="fixed" width="320" height="20" datetime="2017-06-21T00:37:33.809Z" locale="en" cutoff="8640000">Wednesday 21 June 2017 00.37</amp-timeago>
 </body>
 </html>

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -32,6 +32,9 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
     /** @private {string} */
     this.title_ = '';
+
+    /** @private {string} */
+    this.cutoff_ = '';
   }
 
   /** @override */
@@ -43,13 +46,29 @@ export class AmpTimeAgo extends AMP.BaseElement {
     this.locale_ = this.element.getAttribute('locale') ||
       this.win.document.documentElement.lang;
     this.title_ = this.element.textContent;
+    this.cutoff_ = parseInt(this.element.getAttribute('cutoff'), 10);
 
     this.element.title = this.title_;
     this.element.textContent = '';
 
     const timeElement = document.createElement('time');
     timeElement.setAttribute('datetime', this.datetime_);
-    timeElement.textContent = timeago(this.datetime_, this.locale_);
+
+    if (this.cutoff_) {
+      const elDate = new Date(this.datetime_);
+      const secondsAgo = Math.floor((Date.now() - elDate.getTime()) / 1000);
+
+      if (secondsAgo > this.cutoff_) {
+        timeElement.textContent = this.title_;
+      }
+      else {
+        timeElement.textContent = timeago(this.datetime_, this.locale_);
+      }
+    }
+    else {
+      timeElement.textContent = timeago(this.datetime_, this.locale_);
+    }
+
     this.element.appendChild(timeElement);
   }
 

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -32,9 +32,6 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
     /** @private {string} */
     this.title_ = '';
-
-    /** @private {?number} */
-    this.cutoff_ = null;
   }
 
   /** @override */
@@ -54,11 +51,11 @@ export class AmpTimeAgo extends AMP.BaseElement {
     timeElement.setAttribute('datetime', this.datetime_);
 
     if (this.element.hasAttribute('cutoff')) {
-      this.cutoff_ = parseInt(this.element.getAttribute('cutoff'), 10);
+      const cutoff = parseInt(this.element.getAttribute('cutoff'), 10);
       const elDate = new Date(this.datetime_);
       const secondsAgo = Math.floor((Date.now() - elDate.getTime()) / 1000);
 
-      if (secondsAgo > this.cutoff_) {
+      if (secondsAgo > cutoff) {
         timeElement.textContent = this.title_;
       } else {
         timeElement.textContent = timeago(this.datetime_, this.locale_);

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -33,8 +33,8 @@ export class AmpTimeAgo extends AMP.BaseElement {
     /** @private {string} */
     this.title_ = '';
 
-    /** @private {string} */
-    this.cutoff_ = '';
+    /** @private {?number} */
+    this.cutoff_ = null;
   }
 
   /** @override */
@@ -46,7 +46,6 @@ export class AmpTimeAgo extends AMP.BaseElement {
     this.locale_ = this.element.getAttribute('locale') ||
       this.win.document.documentElement.lang;
     this.title_ = this.element.textContent;
-    this.cutoff_ = parseInt(this.element.getAttribute('cutoff'), 10);
 
     this.element.title = this.title_;
     this.element.textContent = '';
@@ -54,18 +53,17 @@ export class AmpTimeAgo extends AMP.BaseElement {
     const timeElement = document.createElement('time');
     timeElement.setAttribute('datetime', this.datetime_);
 
-    if (this.cutoff_) {
+    if (this.element.hasAttribute('cutoff')) {
+      this.cutoff_ = parseInt(this.element.getAttribute('cutoff'), 10);
       const elDate = new Date(this.datetime_);
       const secondsAgo = Math.floor((Date.now() - elDate.getTime()) / 1000);
 
       if (secondsAgo > this.cutoff_) {
         timeElement.textContent = this.title_;
-      }
-      else {
+      } else {
         timeElement.textContent = timeago(this.datetime_, this.locale_);
       }
-    }
-    else {
+    } else {
       timeElement.textContent = timeago(this.datetime_, this.locale_);
     }
 

--- a/extensions/amp-timeago/0.1/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/0.1/test/test-amp-timeago.js
@@ -43,7 +43,7 @@ describes.realWin('amp-timeago', {
     expect(timeElement.textContent).to.equal('2 days ago');
   });
 
-  it('should display original date when built', () => {
+  it('should display original date when older than cutoff', () => {
     const date = new Date('2017-01-01');
     element.setAttribute('datetime', date.toISOString());
     element.textContent = 'Sunday 1 January 2017';

--- a/extensions/amp-timeago/0.1/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/0.1/test/test-amp-timeago.js
@@ -27,10 +27,6 @@ describes.realWin('amp-timeago', {
   beforeEach(() => {
     win = env.win;
     element = win.document.createElement('amp-timeago');
-    const date = new Date();
-    date.setDate(date.getDate() - 2);
-    element.setAttribute('datetime', date.toISOString());
-    element.textContent = date.toString();
     element.setAttribute('layout', 'fixed');
     element.setAttribute('width', '160px');
     element.setAttribute('height', '20px');
@@ -38,8 +34,22 @@ describes.realWin('amp-timeago', {
   });
 
   it('should display 2 days ago when built', () => {
+    const date = new Date();
+    date.setDate(date.getDate() - 2);
+    element.setAttribute('datetime', date.toISOString());
+    element.textContent = date.toString();
     element.build();
     const timeElement = element.querySelector('time');
     expect(timeElement.textContent).to.equal('2 days ago');
+  });
+
+  it('should display original date when built', () => {
+    const date = new Date('2017-01-01');
+    element.setAttribute('datetime', date.toISOString());
+    element.textContent = 'Sunday 1 January 2017';
+    element.setAttribute('cutoff', '8640000');
+    element.build();
+    const timeElement = element.querySelector('time');
+    expect(timeElement.textContent).to.equal('Sunday 1 January 2017');
   });
 });

--- a/extensions/amp-timeago/0.1/test/validator-amp-timeago.html
+++ b/extensions/amp-timeago/0.1/test/validator-amp-timeago.html
@@ -30,9 +30,9 @@
   <body>
 
     <!-- valid -->
-    <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="en">Saturday 11 April 2017 00.37</amp-timeago>
+    <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="en" cutoff="8640000">Saturday 11 April 2017 00.37</amp-timeago>
 
-    <!-- valid, locale optional -->
+    <!-- valid, locale optional, cutoff optional -->
     <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z">Saturday 11 April 2017 00.37</amp-timeago>
 
     <!-- invalid, datetime is not ISO date format -->

--- a/extensions/amp-timeago/amp-timeago.md
+++ b/extensions/amp-timeago/amp-timeago.md
@@ -94,6 +94,10 @@ By default, the local is set to <code>en</code>; however, you can specify one of
   <li>zhTW (Taiwanese)</li>
 </ul>
 
+**cutoff** (optional)
+
+Display the original date if time distance is older than cutoff (seconds).
+
 **common attributes**
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/extensions/amp-timeago/validator-amp-timeago.protoascii
+++ b/extensions/amp-timeago/validator-amp-timeago.protoascii
@@ -36,7 +36,10 @@ tags: {  # <amp-timeago>
     value_regex: "\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?Z"
   }
   attrs: { name: "locale" }
-  attrs: { name: "cutoff" }
+  attrs: {
+    name: "cutoff"
+    value_regex: "\\d+"
+  }
   attr_lists: "extended-amp-global"
   cdata: {
     # Regex: \s*[\w.,:/+-]+(\s*[\w.,:/+-]+)*\s*

--- a/extensions/amp-timeago/validator-amp-timeago.protoascii
+++ b/extensions/amp-timeago/validator-amp-timeago.protoascii
@@ -29,6 +29,10 @@ tags: {  # <amp-timeago>
   tag_name: "AMP-TIMEAGO"
   requires_extension: "amp-timeago"
   attrs: {
+    name: "cutoff"
+    value_regex: "\\d+"
+  }
+  attrs: {
     name: "datetime"
     mandatory: true
     # Regex: \d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d(:[0-5]\d(\.\d+)?)?Z
@@ -36,10 +40,6 @@ tags: {  # <amp-timeago>
     value_regex: "\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?Z"
   }
   attrs: { name: "locale" }
-  attrs: {
-    name: "cutoff"
-    value_regex: "\\d+"
-  }
   attr_lists: "extended-amp-global"
   cdata: {
     # Regex: \s*[\w.,:/+-]+(\s*[\w.,:/+-]+)*\s*

--- a/extensions/amp-timeago/validator-amp-timeago.protoascii
+++ b/extensions/amp-timeago/validator-amp-timeago.protoascii
@@ -36,6 +36,7 @@ tags: {  # <amp-timeago>
     value_regex: "\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?Z"
   }
   attrs: { name: "locale" }
+  attrs: { name: "cutoff" }
   attr_lists: "extended-amp-global"
   cdata: {
     # Regex: \s*[\w.,:/+-]+(\s*[\w.,:/+-]+)*\s*


### PR DESCRIPTION
This pull request add a cutoff option to the amp-timeago component as discussed in #9415.

I've also made a tweak to presubmit-checks.js. Is it OK for amp-timeago to be whitelisted for the getTime() method?

Closes #9415.