### PR TITLE
Add note on fixed pos elements have no inherent width

### DIFF
--- a/spec/amp-html-layout.md
+++ b/spec/amp-html-layout.md
@@ -126,7 +126,7 @@ Supported values for the `layout` attribute:
     </tr>
     <tr>
       <td><code>responsive</code></td>
-      <td>The element takes the space available to it and resizes its height automatically to the aspect ratio given by the <code>width</code> and <code>height</code> attributes. This layout works very well for most AMP elements, including <code>amp-img</code>, <code>amp-video</code>, etc.  The available space depends on the parent element and can also be customized using <code>max-width</code> CSS. The <code>width</code> and <code>height</code> attributes must be present.<br><em>Note</em>: Fixed positioned elements do not have an inherent width. Therefore, if the parent of a responsive element is a fixed position element, the responsive element will also have zero width.</td>
+      <td>The element takes the space available to it and resizes its height automatically to the aspect ratio given by the <code>width</code> and <code>height</code> attributes. This layout works very well for most AMP elements, including <code>amp-img</code>, <code>amp-video</code>, etc.  The available space depends on the parent element and can also be customized using <code>max-width</code> CSS. The <code>width</code> and <code>height</code> attributes must be present.</td>
     </tr>
   </tbody>
 </table>

--- a/spec/amp-html-layout.md
+++ b/spec/amp-html-layout.md
@@ -16,6 +16,8 @@ limitations under the License.
 
 # AMP HTML Layout System
 
+[TOC]
+
 ## Overview
 
 The main goal of the layout system is to ensure that AMP elements can express their layout
@@ -53,10 +55,6 @@ during rendering or scrolling or post download.
 If the element has been configured incorrectly, in PROD it will not be rendered at all and in DEV mode the runtime will render the element in the error state. Possible errors include invalid or unsupported
 values of `layout`, `width` and `height` attributes.
 
-
-
-
-
 ## Layout Attributes
 
 ### `width` and `height`
@@ -83,18 +81,55 @@ AMP provides a set of layouts that specify how an AMP component behaves in the d
 
 Supported values for the `layout` attribute:
 
-| Value          | Behavior  and  Requirements                              |
-| -------------- | -------------------------------------------------------- |
-| Not present    | If no value is specified, the layout for the component is inferred as follows: <ul><li> If <code>height</code> is present and <code>width</code> is absent or is set to <code>auto</code>, a <code>fixed-height</code> layout is assumed.</li><li>If <code>width</code> and <code>height</code> are present along with a <code>sizes</code> or <code>heights</code> attribute, a <code>responsive</code> layout is assumed.</li><li>If <code>width</code> and <code>height</code> are present, a  <code>fixed</code> layout is assumed.</li><li> if <code>width</code> and <code>height</code> are absent, a <code>container</code> layout is assumed.</li></ul> |
-| `container` | The element lets its children define its size, much like a normal HTML `div`. The component is assumed to not have specific layout itself but only act as a container; its children are rendered immediately.
-| `fill` | The element takes the space available to it&mdash;both width and height. In other words, the layout and size of a `fill` element matches its parent. |
-| `fixed` | The element has a fixed width and height with no responsiveness supported. The `width` and `height` attributes must be present. The only exceptions are the `amp-pixel` and `amp-audio` components. |
-| `fixed-height` |  The element takes the space available to it but keeps the height unchanged. This layout works well for elements such as `amp-carousel` that involves content positioned horizontally. The `height` attribute must be present. The `width` attribute must not be present or must be equal to `auto`. |
-| `flex-item` | The element and other elements in its parent with layout type `flex-item` take the parent container's remaining space when the parent is a flexible container (i.e., `display: flex`). The `width` and `height` attributes are not required. |
-| `nodisplay` | The element isn't displayed, and takes up zero space on the screen as if its display style was `none`. This layout can be applied to every AMP element.  It’s assumed that the element can display itself on user action (e.g., `amp-lightbox`). The `width` and `height` attributes are not required. |
-| `responsive` | The element takes the space available to it and resizes its height automatically to the aspect ratio given by the `width` and `height` attributes. This layout works very well for most AMP elements, including `amp-img`, `amp-video`, etc.  The available space depends on the parent element and can also be customized using `max-width` CSS. The `width` and `height` attributes must be present. |
-
-To find out which layouts are supported for a particular component, refer to the [reference documentation](https://www.ampproject.org/docs/reference/components) for that component. If a component does not support the specified value, AMP triggers a runtime error.
+<table>
+  <thead>
+    <tr>
+      <th width="30%">Value</th>
+      <th>Behavior  and  Requirements</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Not present</td>
+      <td>If no value is specified, the layout for the component is inferred as follows:
+        <ul>
+          <li>If <code>height</code> is present and <code>width</code> is absent or is set to <code>auto</code>, a <code>fixed-height</code> layout is assumed.</li>
+          <li>If <code>width</code> and <code>height</code> are present along with a <code>sizes</code> or <code>heights</code> attribute, a <code>responsive</code> layout is assumed.</li>
+          <li>If <code>width</code> and <code>height</code> are present, a  <code>fixed</code> layout is assumed.</li>
+          <li> if <code>width</code> and <code>height</code> are absent, a <code>container</code> layout is assumed.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>container</code></td>
+      <td>The element lets its children define its size, much like a normal HTML <code>div</code>. The component is assumed to not have specific layout itself but only act as a container; its children are rendered immediately.</td>
+    </tr>
+    <tr>
+      <td><code>fill</code></td>
+      <td>The element takes the space available to it&mdash;both width and height. In other words, the layout and size of a <code>fill</code> element matches its parent.</td>
+    </tr>
+    <tr>
+      <td><code>fixed</code></td>
+      <td>The element has a fixed width and height with no responsiveness supported. The <code>width</code> and <code>height</code> attributes must be present. The only exceptions are the <code>amp-pixel</code> and <code>amp-audio</code> components. </td>
+    </tr>
+    <tr>
+      <td><code>fixed-height</code></td>
+      <td>The element takes the space available to it but keeps the height unchanged. This layout works well for elements such as <code>amp-carousel</code> that involves content positioned horizontally. The <code>height</code> attribute must be present. The <code>width</code> attribute must not be present or must be equal to <code>auto</code>. </td>
+    </tr>
+    <tr>
+      <td><code>flex-item</code></td>
+      <td>The element and other elements in its parent with layout type <code>flex-item</code> take the parent container's remaining space when the parent is a flexible container (i.e., <code>display: flex</code>). The <code>width</code> and <code>height</code> attributes are not required.</td>
+    </tr>
+    <tr>
+      <td><code>nodisplay</code></td>
+      <td>The element isn't displayed, and takes up zero space on the screen as if its display style was <code>none</code>. This layout can be applied to every AMP element.  It’s assumed that the element can display itself on user action (e.g., <code>amp-lightbox</code>). The <code>width</code> and <code>height</code> attributes are not required.</td>
+    </tr>
+    <tr>
+      <td><code>responsive</code></td>
+      <td>The element takes the space available to it and resizes its height automatically to the aspect ratio given by the <code>width</code> and <code>height</code> attributes. This layout works very well for most AMP elements, including <code>amp-img</code>, <code>amp-video</code>, etc.  The available space depends on the parent element and can also be customized using <code>max-width</code> CSS. The <code>width</code> and <code>height</code> attributes must be present.<br><em>Note</em>: Fixed positioned elements do not have an inherent width. Therefore, if the parent of a responsive element is a fixed position element, the responsive element will also have zero width.</td>
+    </tr>
+  </tbody>
+</table>
 
 ### `sizes`
 
@@ -191,12 +226,65 @@ The following table describes the acceptable parameters, CSS classes, and styles
 1. Any CSS class marked prefixed with `-amp-` and elements prefixed with `i-amp-` are considered to be internal to AMP and their use in user stylesheets is not allowed. They are shown here simply for informational purposes.
 2. Even though `width` and `height` are specified in the table as required, the default rules may apply as is the case with `amp-pixel` and `amp-audio`.
 
-| Layout       | Width/Height Required? | Defines Size? | Additional Elements | CSS "display" |
-|--------------|------------------------|---------------|---------------------|---------------|
-| `container`    | No                     | No            | No | `block` |
-| `fill`         | No                     | Yes, parent's size. | No | `block` |
-| `fixed`        | Yes                    | Yes, specified by `width` and `height`. | No | `inline-block` |
-| `fixed-height` | `height` only; `width` can be `auto` | Yes, specified by the parent container and `height`. | No | `block` |
-| `flex-item`   | No                     | No            | Yes, based on parent container. | `block` |
-| `nodisplay`    | No                     | No | No | `none` |
-| `responsive`   | Yes                    | Yes, based on parent container and aspect ratio of `width:height`. | Yes, `i-amphtml-sizer`. | `block` |
+<table>
+  <thead>
+    <tr>
+      <th width="21%">Layout</th>
+      <th width="20%">Width/<br>Height Required?</th>
+      <th width="20%">Defines Size?</th>
+      <th width="20%">Additional Elements</th>
+      <th width="19%">CSS "display"</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>container</code></td>
+      <td>No</td>
+      <td>No</td>
+      <td>No</td>
+      <td><code>block</code></td>
+    </tr>
+    <tr>
+      <td><code>fill</code></td>
+      <td>No</td>
+      <td>Yes, parent's size.</td>
+      <td>No</td>
+      <td><code>block</code></td>
+    </tr>
+    <tr>
+      <td><code>fixed</code></td>
+      <td>Yes</td>
+      <td>Yes, specified by <code>width</code> and <code>height</code>.</td>
+      <td>No</td>
+      <td><code>inline-block</code></td>
+    </tr>
+    <tr>
+      <td><code>fixed-height</code></td>
+      <td><code>height</code> only; <code>width</code> can be <code>auto</code></td>
+      <td>Yes, specified by the parent container and <code>height</code>.</td>
+      <td>No</td>
+      <td><code>block</code></td>
+    </tr>
+    <tr>
+      <td><code>flex-item</code></td>
+      <td>No</td>
+      <td>No</td>
+      <td>Yes, based on parent container.</td>
+      <td><code>block</code></td>
+    </tr>
+    <tr>
+      <td><code>nodisplay</code></td>
+      <td>No</td>
+      <td>No</td>
+      <td>No</td>
+      <td><code>none</code></td>
+    </tr>
+    <tr>
+      <td><code>responsive</code></td>
+      <td>Yes</td>
+      <td>Yes, based on parent container and aspect ratio of <code>width:height</code>.</td>
+      <td>Yes, <code>i-amphtml-sizer</code>.</td>
+      <td><code>block</code></td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
Added note to "responsive" layout regarding if parent is fixed pos, then width will be zero.
Fixes: #10033 

I'll also add same note in other "Layouts" doc we have on ampproject.org.

Note: Also made tables presentable so that I can import this doc and have it render "nicely" for ampproject.org docs.

to: @cramforce 