### PR TITLE
Launch `fullscreen-on-lanscape` and re-structure validation rules for video-interface players

### DIFF
--- a/extensions/amp-3q-player/amp-3q-player.md
+++ b/extensions/amp-3q-player/amp-3q-player.md
@@ -60,6 +60,11 @@ If this attribute is present, and the browser supports autoplay:
 * when the user taps the video, the video is unmuted
 * if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
 
+##### fullscreen-on-landscape (optional)
+
+If this attribute is present, the video will automatically go to fullscreen when the
+device is rotated to landscape (Currently not supported on Safari iOS).
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/extensions/amp-3q-player/validator-amp-3q-player.protoascii
+++ b/extensions/amp-3q-player/validator-amp-3q-player.protoascii
@@ -29,14 +29,11 @@ tags: {  # <amp-3q-player>
   tag_name: "AMP-3Q-PLAYER"
   requires_extension: "amp-3q-player"
   attrs: {
-    name: "autoplay"
-    value: ""
-  }
-  attrs: {
     name: "data-id"
     mandatory: true
   }
   attr_lists: "extended-amp-global"
+  attr_lists: "implements-video-interface"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-3q-player/validator-amp-3q-player.protoascii
+++ b/extensions/amp-3q-player/validator-amp-3q-player.protoascii
@@ -24,16 +24,37 @@ tags: {  # amp-3q-player
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-3q-player>
-  html_format: AMP
-  tag_name: "AMP-3Q-PLAYER"
-  requires_extension: "amp-3q-player"
+
+attr_lists: { # <amp-3q-player> attributes that are common to both AMP & A4A.
+  name: "amp-3q-player-common"
   attrs: {
     name: "data-id"
     mandatory: true
   }
+}
+
+tags: {  # <amp-3q-player> for AMP
+  html_format: AMP
+  tag_name: "AMP-3Q-PLAYER"
+  requires_extension: "amp-3q-player"
   attr_lists: "extended-amp-global"
-  attr_lists: "implements-video-interface"
+  attr_lists: "amp-3q-player-common"
+  attr_lists: "implements-video-interface-amp"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FLEX_ITEM
+    supported_layouts: RESPONSIVE
+  }
+}
+
+tags: {  # <amp-3q-player> for A4A
+  html_format: AMP4ADS
+  tag_name: "AMP-3Q-PLAYER"
+  requires_extension: "amp-3q-player"
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-3q-player-common"
+  attr_lists: "implements-video-interface-amp4ads"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -55,7 +55,7 @@ Examples:
 
 ## Attributes
 
-##### autoplay
+##### autoplay (optional)
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -63,7 +63,12 @@ If this attribute is present, and the browser supports autoplay:
 * when the video is scrolled out of view, the video is paused
 * when the video is scrolled into view, the video resumes playback
 * when the user taps the video, the video is unmuted
-* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused. 
+* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+
+##### fullscreen-on-landscape (optional)
+
+If this attribute is present, the video will automatically go to fullscreen when the
+device is rotated to landscape (Currently not supported on Safari iOS).
 
 ##### data-partner
 

--- a/extensions/amp-brid-player/validator-amp-brid-player.protoascii
+++ b/extensions/amp-brid-player/validator-amp-brid-player.protoascii
@@ -31,7 +31,6 @@ tags: {  # <amp-brid-player>
   tag_name: "AMP-BRID-PLAYER"
   disallowed_ancestor: "AMP-SIDEBAR"
   requires_extension: "amp-brid-player"
-  attrs: { name: "autoplay" }
   attrs: {
     name: "data-partner"
     mandatory: true
@@ -53,6 +52,7 @@ tags: {  # <amp-brid-player>
     value_regex: "[0-9]+"
   }
   attr_lists: "extended-amp-global"
+  attr_lists: "implements-video-interface"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-brid-player"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-brid-player/validator-amp-brid-player.protoascii
+++ b/extensions/amp-brid-player/validator-amp-brid-player.protoascii
@@ -26,11 +26,8 @@ tags: {  # amp-brid-player
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-brid-player>
-  html_format: AMP
-  tag_name: "AMP-BRID-PLAYER"
-  disallowed_ancestor: "AMP-SIDEBAR"
-  requires_extension: "amp-brid-player"
+attr_lists: { # <amp-brid-player> attributes that are common to both AMP & A4A.
+  name: "amp-brid-player-common"
   attrs: {
     name: "data-partner"
     mandatory: true
@@ -51,8 +48,33 @@ tags: {  # <amp-brid-player>
     mandatory_oneof: "['data-playlist', 'data-video']"
     value_regex: "[0-9]+"
   }
+}
+tags: {  # <amp-brid-player> for AMP
+  html_format: AMP
+  tag_name: "AMP-BRID-PLAYER"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-brid-player"
   attr_lists: "extended-amp-global"
-  attr_lists: "implements-video-interface"
+  attr_lists: "amp-brid-player-common"
+  attr_lists: "implements-video-interface-amp"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-brid-player"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+tags: {  # <amp-brid-player> for A4A
+  html_format: AMP4ADS
+  tag_name: "AMP-BRID-PLAYER"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-brid-player"
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-brid-player-common"
+  attr_lists: "implements-video-interface-amp4ads"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-brid-player"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -50,7 +50,7 @@ With responsive layout, the width and height from the example should yield corre
 
 ## Attributes
 
-##### autoplay
+##### autoplay (optional)
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -59,6 +59,11 @@ If this attribute is present, and the browser supports autoplay:
 * when the video is scrolled into view, the video resumes playback
 * when the user taps the video, the video is unmuted
 * if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+
+##### fullscreen-on-landscape (optional)
+
+If this attribute is present, the video will automatically go to fullscreen when the
+device is rotated to landscape (Currently not supported on Safari iOS).
 
 ##### data-videoid (required)
 

--- a/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
@@ -30,7 +30,6 @@ tags: {  # <amp-dailymotion>
   tag_name: "AMP-DAILYMOTION"
   disallowed_ancestor: "AMP-SIDEBAR"
   requires_extension: "amp-dailymotion"
-  attrs: { name: "autoplay" }
   attrs: {
     name: "data-endscreen-enable"
     value_regex: "true|false"
@@ -65,6 +64,7 @@ tags: {  # <amp-dailymotion>
     value_regex_casei: "[a-z0-9]+"
   }
   attr_lists: "extended-amp-global"
+  attr_lists: "implements-video-interface"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-dailymotion"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
@@ -25,11 +25,8 @@ tags: {  # amp-dailymotion
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-dailymotion>
-  html_format: AMP
-  tag_name: "AMP-DAILYMOTION"
-  disallowed_ancestor: "AMP-SIDEBAR"
-  requires_extension: "amp-dailymotion"
+attr_lists: { # <amp-dailymotion> attributes that are common to both AMP & A4A.
+  name: "amp-dailymotion-common"
   attrs: {
     name: "data-endscreen-enable"
     value_regex: "true|false"
@@ -63,8 +60,33 @@ tags: {  # <amp-dailymotion>
     mandatory: true
     value_regex_casei: "[a-z0-9]+"
   }
+}
+tags: {  # <amp-dailymotion> for AMP
+  html_format: AMP
+  tag_name: "AMP-DAILYMOTION"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-dailymotion"
   attr_lists: "extended-amp-global"
-  attr_lists: "implements-video-interface"
+  attr_lists: "amp-dailymotion-common"
+  attr_lists: "implements-video-interface-amp"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-dailymotion"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: RESPONSIVE
+  }
+}
+
+tags: {  # <amp-dailymotion> for A4A
+  html_format: AMP4ADS
+  tag_name: "AMP-DAILYMOTION"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-dailymotion"
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-dailymotion-common"
+  attr_lists: "implements-video-interface-amp4ads"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-dailymotion"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -90,6 +90,21 @@ The URL of your video content. A relative URL or a URL that uses https protocol.
 An image for the frame to be displayed before video playback has started. By
 default, the first frame is displayed.
 
+##### autoplay (optional)
+
+If this attribute is present, and the browser supports autoplay:
+
+* the video is automatically muted before autoplay starts
+* when the video is scrolled out of view, the video is paused
+* when the video is scrolled into view, the video resumes playback
+* when the user taps the video, the video is unmuted
+* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+
+##### fullscreen-on-landscape (optional)
+
+If this attribute is present, the video will automatically go to fullscreen when the
+device is rotated to landscape (Currently not supported on Safari iOS).
+
 ##### common attributes
 
 This element includes

--- a/extensions/amp-ima-video/validator-amp-ima-video.protoascii
+++ b/extensions/amp-ima-video/validator-amp-ima-video.protoascii
@@ -47,6 +47,7 @@ tags: {  # <amp-ima-video>
     }
   }
   attr_lists: "extended-amp-global"
+  attr_lists: "implements-video-interface"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-ima-video"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-ima-video/validator-amp-ima-video.protoascii
+++ b/extensions/amp-ima-video/validator-amp-ima-video.protoascii
@@ -24,11 +24,9 @@ tags: {  # amp-ima-video
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-ima-video>
-  html_format: AMP
-  tag_name: "AMP-IMA-VIDEO"
-  disallowed_ancestor: "AMP-SIDEBAR"
-  requires_extension: "amp-ima-video"
+
+attr_lists: { # <amp-ima-video> attributes that are common to both AMP & A4A.
+  name: "amp-ima-video-common"
   # data-* is generally allowed, but it's not generally mandatory.
   attrs: {
     name: "data-src"
@@ -46,8 +44,34 @@ tags: {  # <amp-ima-video>
       allow_relative: true  # Will be set to false at a future date.
     }
   }
+}
+
+tags: {  # <amp-ima-video> for AMP
+  html_format: AMP
+  tag_name: "AMP-IMA-VIDEO"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-ima-video"
   attr_lists: "extended-amp-global"
-  attr_lists: "implements-video-interface"
+  attr_lists: "amp-ima-video-common"
+  attr_lists: "implements-video-interface-amp"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-ima-video"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+
+tags: {  # <amp-ima-video> for A4A
+  html_format: AMP4ADS
+  tag_name: "AMP-IMA-VIDEO"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-ima-video"
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-ima-video-common"
+  attr_lists: "implements-video-interface-amp4ads"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-ima-video"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-nexxtv-player/amp-nexxtv-player.md
+++ b/extensions/amp-nexxtv-player/amp-nexxtv-player.md
@@ -88,6 +88,21 @@ Indicates the source from which the embedded domain media is played. By default 
 
 Ads are enabled by default. Set value to 1 to disable.
 
+##### autoplay (optional)
+
+If this attribute is present, and the browser supports autoplay:
+
+* the video is automatically muted before autoplay starts
+* when the video is scrolled out of view, the video is paused
+* when the video is scrolled into view, the video resumes playback
+* when the user taps the video, the video is unmuted
+* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+
+##### fullscreen-on-landscape (optional)
+
+If this attribute is present, the video will automatically go to fullscreen when the
+device is rotated to landscape (Currently not supported on Safari iOS).
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/extensions/amp-nexxtv-player/validator-amp-nexxtv-player.protoascii
+++ b/extensions/amp-nexxtv-player/validator-amp-nexxtv-player.protoascii
@@ -58,6 +58,7 @@ tags: {  # <amp-nexxtv-player>
     value_regex: "album|audio|live|playlist|playlist-marked|video"
   }
   attr_lists: "extended-amp-global"
+  attr_lists: "implements-video-interface"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-nexxtv-player/validator-amp-nexxtv-player.protoascii
+++ b/extensions/amp-nexxtv-player/validator-amp-nexxtv-player.protoascii
@@ -24,11 +24,9 @@ tags: {  # amp-nexxtv-player
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-nexxtv-player>
-  html_format: AMP
-  tag_name: "AMP-NEXXTV-PLAYER"
-  disallowed_ancestor: "AMP-SIDEBAR"
-  requires_extension: "amp-nexxtv-player"
+
+attr_lists: { # <amp-nexxtv-player> attributes that are common to both AMP & A4A.
+  name: "amp-nexxtv-player-common"
   attrs: {
     name: "data-client"
     mandatory: true
@@ -57,8 +55,34 @@ tags: {  # <amp-nexxtv-player>
     name: "data-streamtype"
     value_regex: "album|audio|live|playlist|playlist-marked|video"
   }
+}
+
+tags: {  # <amp-nexxtv-player> for AMP
+  html_format: AMP
+  tag_name: "AMP-NEXXTV-PLAYER"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-nexxtv-player"
   attr_lists: "extended-amp-global"
-  attr_lists: "implements-video-interface"
+  attr_lists: "amp-nexxtv-player-common"
+  attr_lists: "implements-video-interface-amp"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+
+tags: {  # <amp-nexxtv-player> for A4A
+  html_format: AMP4ADS
+  tag_name: "AMP-NEXXTV-PLAYER"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-nexxtv-player"
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-nexxtv-player-common"
+  attr_lists: "implements-video-interface-amp4ads"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-ooyala-player/amp-ooyala-player.md
+++ b/extensions/amp-ooyala-player/amp-ooyala-player.md
@@ -65,6 +65,21 @@ Specifies which version of the Ooyala player to use, V3 or V4. Defaults to V3.
 
 Specifies a skin.json config file URL for player V4.
 
+##### autoplay (optional)
+
+If this attribute is present, and the browser supports autoplay:
+
+* the video is automatically muted before autoplay starts
+* when the video is scrolled out of view, the video is paused
+* when the video is scrolled into view, the video resumes playback
+* when the user taps the video, the video is unmuted
+* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+
+##### fullscreen-on-landscape (optional)
+
+If this attribute is present, the video will automatically go to fullscreen when the
+device is rotated to landscape (Currently not supported on Safari iOS).
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/extensions/amp-ooyala-player/validator-amp-ooyala-player.protoascii
+++ b/extensions/amp-ooyala-player/validator-amp-ooyala-player.protoascii
@@ -24,10 +24,9 @@ tags: {  # amp-ooyala-player
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-ooyala-player>
-  html_format: AMP
-  tag_name: "AMP-OOYALA-PLAYER"
-  requires_extension: "amp-ooyala-player"
+
+attr_lists: { # <amp-ooyala-player> attributes that are common to both AMP & A4A.
+  name: "amp-ooyala-player-common"
   attrs: {
     name: "data-embedcode"
     mandatory: true
@@ -40,8 +39,30 @@ tags: {  # <amp-ooyala-player>
     name: "data-playerid"
     mandatory: true
   }
+}
+
+tags: {  # <amp-ooyala-player> for AMP
+  html_format: AMP
+  tag_name: "AMP-OOYALA-PLAYER"
+  requires_extension: "amp-ooyala-player"
   attr_lists: "extended-amp-global"
-  attr_lists: "implements-video-interface"
+  attr_lists: "amp-ooyala-player-common"
+  attr_lists: "implements-video-interface-amp"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FLEX_ITEM
+    supported_layouts: RESPONSIVE
+  }
+}
+
+tags: {  # <amp-ooyala-player> for A4A
+  html_format: AMP4ADS
+  tag_name: "AMP-OOYALA-PLAYER"
+  requires_extension: "amp-ooyala-player"
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-ooyala-player-common"
+  attr_lists: "implements-video-interface-amp4ads"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-ooyala-player/validator-amp-ooyala-player.protoascii
+++ b/extensions/amp-ooyala-player/validator-amp-ooyala-player.protoascii
@@ -41,6 +41,7 @@ tags: {  # <amp-ooyala-player>
     mandatory: true
   }
   attr_lists: "extended-amp-global"
+  attr_lists: "implements-video-interface"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -71,14 +71,14 @@ The `amp-video` component accepts up to four unique types of HTML nodes as child
 
 Required if no `<source>` children are present. Must be HTTPS.
 
-##### poster
+##### poster (optional)
 
 The image for the frame to be displayed before video playback has started. By
 default, the first frame is displayed.
 
 Alternatively, you can present a click-to-play overlay. For details, see the [Click-to-Play overlay](#click-to-play-overlay) section below.
 
-##### autoplay
+##### autoplay (optional)
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -88,11 +88,16 @@ If this attribute is present, and the browser supports autoplay:
 * when the user taps the video, the video is unmuted
 * if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
 
-##### controls
+##### fullscreen-on-landscape (optional)
+
+If this attribute is present, the video will automatically go to fullscreen when the
+device is rotated to landscape (Currently not supported on Safari iOS).
+
+##### controls (optional)
 
 This attribute is similar to the `controls` attribute in the HTML5 `video`. If this attribute is present, the browser offers controls to allow the user to control video playback.
 
-##### loop
+##### loop (optional)
 
 If present, the video will automatically loop back to the start upon reaching the end.
 

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -41,10 +41,6 @@ tags: {  # <amp-video>
   attrs: { name: "artwork" }
   attrs: { name: "attribution" }
   attrs: {
-    name: "autoplay"
-    value: ""
-  }
-  attrs: {
     name: "controls"
     value: ""
   }
@@ -84,6 +80,7 @@ tags: {  # <amp-video>
   attrs: { name: "[preload]" }
   attrs: { name: "[src]" }
   attr_lists: "extended-amp-global"
+  attr_lists: "implements-video-interface"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-video"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -28,13 +28,9 @@ tags: {  # amp-video
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-video>
-  tag_name: "AMP-VIDEO"
-  disallowed_ancestor: "AMP-SIDEBAR"
-  # Typically we'd require the extension j/s, but for historical reasons
-  # many pages don't have it, so it ends up late loaded and we warn, instead
-  # of making this a validation error.
-  also_requires_tag_warning: "amp-video extension .js script"
+
+attr_lists: { # <amp-video> attributes that are common to both AMP & A4A.
+  name: "amp-video-common"
   attrs: { name: "album" }
   attrs: { name: "alt" }
   attrs: { name: "artist" }
@@ -79,8 +75,41 @@ tags: {  # <amp-video>
   attrs: { name: "[poster]" }
   attrs: { name: "[preload]" }
   attrs: { name: "[src]" }
+}
+
+tags: {  # <amp-video> for AMP
+  html_format: AMP
+  tag_name: "AMP-VIDEO"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  # Typically we'd require the extension j/s, but for historical reasons
+  # many pages don't have it, so it ends up late loaded and we warn, instead
+  # of making this a validation error.
+  also_requires_tag_warning: "amp-video extension .js script"
   attr_lists: "extended-amp-global"
-  attr_lists: "implements-video-interface"
+  attr_lists: "amp-video-common"
+  attr_lists: "implements-video-interface-amp"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-video"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+
+tags: {  # <amp-video> for A4A
+  html_format: AMP4ADS
+  tag_name: "AMP-VIDEO"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  # Typically we'd require the extension j/s, but for historical reasons
+  # many pages don't have it, so it ends up late loaded and we warn, instead
+  # of making this a validation error.
+  also_requires_tag_warning: "amp-video extension .js script"
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-video-common"
+  attr_lists: "implements-video-interface-amp4ads"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-video"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -50,7 +50,7 @@ With the responsive layout, the width and height from the example should yield c
 
 ## Attributes
 
-##### autoplay
+##### autoplay (optional)
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -58,9 +58,14 @@ If this attribute is present, and the browser supports autoplay:
 * when the video is scrolled out of view, the video is paused
 * when the video is scrolled into view, the video resumes playback
 * when the user taps the video, the video is unmuted
-* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused. 
+* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
 
-##### data-videoid
+##### fullscreen-on-landscape (optional)
+
+If this attribute is present, the video will automatically go to fullscreen when the
+device is rotated to landscape (Currently not supported on Safari iOS).
+
+##### data-videoid (required)
 
 The YouTube video id found in every YouTube video page URL.
 

--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -29,7 +29,6 @@ tags: {  # <amp-youtube>
   tag_name: "AMP-YOUTUBE"
   disallowed_ancestor: "AMP-SIDEBAR"
   requires_extension: "amp-youtube"
-  attrs: { name: "autoplay" }
   attrs: {
     name: "data-videoid"
     mandatory: true
@@ -38,6 +37,7 @@ tags: {  # <amp-youtube>
   # <amp-bind>
   attrs: { name: "[data-videoid]" }
   attr_lists: "extended-amp-global"
+  attr_lists: "implements-video-interface"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -25,10 +25,9 @@ tags: {  # amp-youtube
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-youtube>
-  tag_name: "AMP-YOUTUBE"
-  disallowed_ancestor: "AMP-SIDEBAR"
-  requires_extension: "amp-youtube"
+
+attr_lists: { # <amp-youtube> attributes that are common to both AMP & A4A.
+  name: "amp-youtube-common"
   attrs: {
     name: "data-videoid"
     mandatory: true
@@ -36,8 +35,34 @@ tags: {  # <amp-youtube>
   }
   # <amp-bind>
   attrs: { name: "[data-videoid]" }
+}
+
+tags: {  # <amp-youtube> for AMP
+  html_format: AMP
+  tag_name: "AMP-YOUTUBE"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-youtube"
   attr_lists: "extended-amp-global"
-  attr_lists: "implements-video-interface"
+  attr_lists: "amp-youtube-common"
+  attr_lists: "implements-video-interface-amp"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+
+tags: {  # <amp-youtube> for A4A
+  html_format: AMP4ADS
+  tag_name: "AMP-YOUTUBE"
+  disallowed_ancestor: "AMP-SIDEBAR"
+  requires_extension: "amp-youtube"
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-youtube-common"
+  attr_lists: "implements-video-interface-amp4ads"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3388,7 +3388,7 @@ attr_lists: {
 # Video Interface attributes for AMP. These attributes can be attached to any
 # element that implements the video interface
 attr_lists: {
-  name: "implements-video-interface-AMP"
+  name: "implements-video-interface-amp"
   attrs: {
     name: "autoplay"
     value: ""
@@ -3402,13 +3402,9 @@ attr_lists: {
 # Video Interface attributes for A4A. These attributes can be attached to any
 # element that implements the video interface
 attr_lists: {
-  name: "implements-video-interface-A4A"
+  name: "implements-video-interface-amp4ads"
   attrs: {
     name: "autoplay"
-    value: ""
-  }
-  attrs: {
-    name: "fullscreen-on-landscape"
     value: ""
   }
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3385,6 +3385,34 @@ attr_lists: {
   }
 }
 
+# Video Interface attributes for AMP. These attributes can be attached to any
+# element that implements the video interface
+attr_lists: {
+  name: "implements-video-interface-AMP"
+  attrs: {
+    name: "autoplay"
+    value: ""
+  }
+  attrs: {
+    name: "fullscreen-on-landscape"
+    value: ""
+  }
+}
+
+# Video Interface attributes for A4A. These attributes can be attached to any
+# element that implements the video interface
+attr_lists: {
+  name: "implements-video-interface-A4A"
+  attrs: {
+    name: "autoplay"
+    value: ""
+  }
+  attrs: {
+    name: "fullscreen-on-landscape"
+    value: ""
+  }
+}
+
 # Global attributes: These can be used in all tags.
 attr_lists: {
   name: "$GLOBAL_ATTRS"
@@ -4152,4 +4180,3 @@ error_formats {
   format: "CSS syntax error in tag '%1' - the property '%2' is disallowed "
           "unless the enclosing rule is prefixed with the '%3' qualification."
 }
-


### PR DESCRIPTION
### Changes
- Added attribute lists `implements-video-interface-AMP` and `implements-video-interface-A4A` to the validator for extensions implementing the video interface (currently contains `auto-fullscreen` and `autoplay`) and removed individual attributes from the players that used to have them
- Added documentation to reflect the changes
- As a result of the changes, some behaviors will change and we need to confirm whether they break anything ( @Gregable @powdercloud )  : 
  - Some video players will gain `autoplay`
  - Some video players will now be allowed in A4A (used to only have `html_format: AMP`)
  - Some video players will be restricted from having any value for `autoplay` (need to check whether any pages have `autoplay="true"`, etc..

Related-to #10030 , #8080 and  #9702 