### PR TITLE
AdSense Fast Fetch: include iu parameter based on data-ad-slot

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -170,6 +170,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       format,
       'w': this.size_.width,
       'h': this.size_.height,
+      'iu': this.element.getAttribute('data-ad-slot'),
       'adtest': adTestOn ? 'on' : null,
       adk,
       'bc': global.SVGElement && global.document.createElementNS ? '1' : null,

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -630,6 +630,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
       });
     });
     it('returns the right URL', () => {
+      element.setAttribute('data-ad-slot', 'some_slot');
       new AmpAd(element).upgradeCallback();
       return impl.getAdUrl().then(url => {
         [
@@ -639,6 +640,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
           /(\?|&)amp_v=%24internalRuntimeVersion%24(&|$)/,
           /(\?|&)client=ca-adsense(&|$)/,
           /(\?|&)format=\d+x\d+(&|$)/,
+          /(\?|&)iu=some_slot(&|$)/,
           /(\?|&)w=\d+(&|$)/,
           /(\?|&)h=\d+(&|$)/,
           /(\?|&)d_imp=1(&|$)/,


### PR DESCRIPTION
PR #9563 incorrectly removed the iu parameter from Fast Fetch AdSense requests based on data-ad-slot attribute.  Fix to re-add.