### PR TITLE
Support running randomized test runs for just a4a tests

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -126,13 +126,21 @@ gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
     c.files = [].concat(config.commonTestPaths, argv.files);
   } else if (argv.integration) {
     c.files = config.integrationTestPaths;
-  } else if (argv.randomize || argv.glob) {
+  } else if (argv.randomize || argv.glob || argv.a4a) {
     /** Randomize the order of the test running */
-    var testPaths = [
-      'test/**/*.js',
-      'ads/**/test/test-*.js',
-      'extensions/**/test/**/*.js',
-    ];
+    var testPaths;
+    if (argv.a4a) {
+      testPaths = [
+        'extensions/amp-a4a/**/test/**/*.js',
+        'extensions/amp-ad-network-*/**/test/**/*.js'
+      ];
+    } else {
+      testPaths = [
+        'test/**/*.js',
+        'ads/**/test/test-*.js',
+        'extensions/**/test/**/*.js',
+      ];
+    }
 
     var testFiles = [];
 

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -132,7 +132,8 @@ gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
     if (argv.a4a) {
       testPaths = [
         'extensions/amp-a4a/**/test/**/*.js',
-        'extensions/amp-ad-network-*/**/test/**/*.js'
+        'extensions/amp-ad-network-*/**/test/**/*.js',
+        'ads/google/a4a/test/*.js'
       ];
     } else {
       testPaths = [


### PR DESCRIPTION
Can now run 

```gulp test --a4a```

and all a4a tests will run, and all tests for all fast fetch networks, in randomized order (by file). 