### PR TITLE
throw early if no tag_name can be found

### DIFF
--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -331,6 +331,9 @@ function buildSections(gitMetadata) {
 function getLastGitTag(gitMetadata) {
   return request(latestReleaseOptions).then(res => {
     var body = JSON.parse(res.body);
+    if (!body.tag_name) {
+      throw new Error('getLastGitTag: ' + body.message);
+    }
     gitMetadata.tag = body.tag_name;
     return gitMetadata;
   });


### PR DESCRIPTION
changelog generation sometimes fails silently because of auth errors 