### PR TITLE
Enable amp-ad-exit experiment in canary and prod.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -24,5 +24,6 @@
   "a4a-measure-get-ad-urls": 1,
   "amp-bind": 1,
   "ad-loader-v2": 1,
-  "3p-use-ampcontext": 1
+  "3p-use-ampcontext": 1,
+  "amp-ad-exit": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -22,5 +22,6 @@
   "pump-early-frame": 1,
   "a4a-measure-get-ad-urls": 0,
   "amp-bind": 1,
-  "ad-loader-v2": 1
+  "ad-loader-v2": 1,
+  "amp-ad-exit": 1
 }


### PR DESCRIPTION
Related to #9502