### PR TITLE
add `dict-string-keys` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     "comma-dangle": [2, "always-multiline"],
     "computed-property-spacing": [2, "never"],
     "curly": 2,
+    "dict-string-keys": 2,
     "dot-location": [2, "property"],
     "enforce-private-props": 2,
     "todo-format": 0,

--- a/build-system/eslint-rules/dict-string-keys.js
+++ b/build-system/eslint-rules/dict-string-keys.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = function(context) {
+  return {
+    CallExpression: function(node) {
+      if (node.callee.name === 'dict') {
+        if (node.arguments[0]) {
+          var arg1 = node.arguments[0];
+          if (arg1.type !== 'ObjectExpression') {
+            context.report(node,
+                'calls to `dict` must have an Object Literal Expression as ' +
+                'the first argument');
+            return;
+          }
+
+          arg1.properties.forEach(function(prop) {
+            if (!prop.key.raw) {
+              context.report(node, 'Found: ' + prop.key.name + '. The keys ' +
+                  'of the Object Literal Expression passed into `dict` must ' +
+                  'have string keys');
+            }
+          });
+        }
+      }
+    }
+  };
+};

--- a/build-system/eslint-rules/dict-string-keys.js
+++ b/build-system/eslint-rules/dict-string-keys.js
@@ -27,16 +27,26 @@ module.exports = function(context) {
                 'the first argument');
             return;
           }
-
-          arg1.properties.forEach(function(prop) {
-            if (!prop.key.raw) {
-              context.report(node, 'Found: ' + prop.key.name + '. The keys ' +
-                  'of the Object Literal Expression passed into `dict` must ' +
-                  'have string keys');
-            }
-          });
+          checkNode(arg1, context);
         }
       }
     }
   };
 };
+
+function checkNode(node, context) {
+  if (node.type === 'ObjectExpression') {
+    node.properties.forEach(function(prop) {
+      if (!prop.key.raw) {
+        context.report(node, 'Found: ' + prop.key.name + '. The keys ' +
+            'of the Object Literal Expression passed into `dict` must ' +
+            'have string keys.');
+      }
+      checkNode(prop.value, context);
+    });
+  } else if (node.type === 'ArrayExpression') {
+    node.elements.forEach(function(elem) {
+      checkNode(elem, context);
+    });
+  }
+}

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1449,7 +1449,7 @@ export class AmpA4A extends AMP.BaseElement {
         name = `${this.safeframeVersion_};${creative.length};${creative}` +
             `${contextMetadata}`;
       }
-      return this.iframeRenderHelper_(dict({'src': srcPath, name}));
+      return this.iframeRenderHelper_(dict({'src': srcPath, 'name': name}));
     });
   }
 


### PR DESCRIPTION
enforces that the keys of the object passed into `dict` has to be
strings and should be quoted.

Fixes https://github.com/ampproject/amphtml/issues/10094