### PR TITLE
Automatic fullscreen videos on device roation

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -575,7 +575,7 @@ var forbiddenTerms = {
       'src/event-helper.js',
     ],
   },
-  '[A-Za-z]*Full[Ss]creen\\(': {
+  '([eE]xit|[eE]nter|[cC]ancel|[rR]equest)Full[Ss]creen\\(': {
     message: 'Use fullscreenEnter() and fullscreenExit() from dom.js instead.',
     whitelist: [
       'ads/google/imaVideo.js',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -575,6 +575,13 @@ var forbiddenTerms = {
       'src/event-helper.js',
     ],
   },
+  '[A-Za-z]*Full[Ss]creen\\(': {
+    message: 'Use fullscreenEnter() and fullscreenExit() from dom.js instead.',
+    whitelist: [
+      'ads/google/imaVideo.js',
+      'dist.3p/current/integration.js',
+    ],
+  },
 };
 
 var ThreePTermsMessage = 'The 3p bootstrap iframe has no polyfills loaded and' +

--- a/extensions/amp-3q-player/0.1/amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/amp-3q-player.js
@@ -219,14 +219,14 @@ class Amp3QPlayer extends AMP.BaseElement {
    * @override
    */
   fullscreenEnter() {
-    fullscreenEnter(this.iframe_);
+    fullscreenEnter(dev().assertElement(this.iframe_));
   }
 
   /**
    * @override
    */
   fullscreenExit() {
-    fullscreenExit(this.iframe_);
+    fullscreenExit(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-3q-player/0.1/amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/amp-3q-player.js
@@ -17,7 +17,12 @@
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {tryParseJson} from '../../../src/json';
 import {user, dev} from '../../../src/log';
-import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
+import {
+  removeElement,
+  fullscreenEnter,
+  fullscreenExit,
+  isFullscreenElement,
+} from '../../../src/dom';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
@@ -227,6 +232,11 @@ class Amp3QPlayer extends AMP.BaseElement {
    */
   fullscreenExit() {
     fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    return isFullscreenElement(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-3q-player/0.1/amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/amp-3q-player.js
@@ -17,7 +17,7 @@
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {tryParseJson} from '../../../src/json';
 import {user, dev} from '../../../src/log';
-import {removeElement} from '../../../src/dom';
+import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
@@ -213,6 +213,20 @@ class Amp3QPlayer extends AMP.BaseElement {
   /** @override */
   hideControls() {
     this.sdnPostMessage_('hideControlbar');
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    fullscreenEnter(this.iframe_);
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    fullscreenExit(this.iframe_);
   }
 
   /** @override */

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -15,7 +15,7 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {user} from '../../../src/log';
+import {user, dev} from '../../../src/log';
 import {
     installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
@@ -290,14 +290,14 @@ class AmpBridPlayer extends AMP.BaseElement {
    * @override
    */
   fullscreenEnter() {
-    fullscreenEnter(this.iframe_);
+    fullscreenEnter(dev().assertElement(this.iframe_));
   }
 
   /**
    * @override
    */
   fullscreenExit() {
-    fullscreenExit(this.iframe_);
+    fullscreenExit(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -22,7 +22,12 @@ import {
 import {VideoEvents} from '../../../src/video-interface';
 import {Services} from '../../../src/services';
 import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
-import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
+import {
+  removeElement,
+  fullscreenEnter,
+  fullscreenExit,
+  isFullscreenElement,
+} from '../../../src/dom';
 import {getData, listen} from '../../../src/event-helper';
 
 /**
@@ -298,6 +303,11 @@ class AmpBridPlayer extends AMP.BaseElement {
    */
   fullscreenExit() {
     fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    return isFullscreenElement(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -22,7 +22,7 @@ import {
 import {VideoEvents} from '../../../src/video-interface';
 import {Services} from '../../../src/services';
 import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
-import {removeElement} from '../../../src/dom';
+import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
 import {getData, listen} from '../../../src/event-helper';
 
 /**
@@ -284,6 +284,20 @@ class AmpBridPlayer extends AMP.BaseElement {
   /** @override */
   hideControls() {
     // Not supported.
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    fullscreenEnter(this.iframe_);
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    fullscreenExit(this.iframe_);
   }
 
   /** @override */

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -349,7 +349,7 @@ class AmpDailymotion extends AMP.BaseElement {
     if (platform.isSafari() || platform.isIos()) {
       this.sendCommand_('fullscreen', [true]);
     } else {
-      fullscreenEnter(this.iframe_);
+      fullscreenEnter(dev().assertElement(this.iframe_));
     }
   }
 
@@ -361,7 +361,7 @@ class AmpDailymotion extends AMP.BaseElement {
     if (platform.isSafari() || platform.isIos()) {
       this.sendCommand_('fullscreen', [false]);
     } else {
-      fullscreenExit(this.iframe_);
+      fullscreenExit(dev().assertElement(this.iframe_));
     }
   }
 

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -28,7 +28,11 @@ import {
     addParamsToUrl,
     addParamToUrl,
 } from '../../../src/url';
-import {getDataParamsFromAttributes} from '../../../src/dom';
+import {
+  getDataParamsFromAttributes,
+  fullscreenEnter,
+  fullscreenExit,
+} from '../../../src/dom';
 
 /**
  * Player events reverse-engineered from the Dailymotion API
@@ -335,6 +339,30 @@ class AmpDailymotion extends AMP.BaseElement {
    */
   hideControls() {
     // Not supported
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    const platform = Services.platformFor(this.win);
+    if (platform.isSafari() || platform.isIos()) {
+      this.sendCommand_('fullscreen', [true]);
+    } else {
+      fullscreenEnter(this.iframe_);
+    }
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    const platform = Services.platformFor(this.win);
+    if (platform.isSafari() || platform.isIos()) {
+      this.sendCommand_('fullscreen', [false]);
+    } else {
+      fullscreenExit(this.iframe_);
+    }
   }
 
   /** @override */

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -32,6 +32,7 @@ import {
   getDataParamsFromAttributes,
   fullscreenEnter,
   fullscreenExit,
+  isFullscreenElement,
 } from '../../../src/dom';
 
 /**
@@ -61,6 +62,7 @@ const DailymotionEvents = {
   // Other events
   VOLUMECHANGE: 'volumechange',
   STARTED_BUFFERING: 'progress',
+  FULLSCREEN_CHANGE: 'fullscreenchange',
 };
 
 /**
@@ -100,6 +102,9 @@ class AmpDailymotion extends AMP.BaseElement {
 
     /** @private {?Function} */
     this.startedBufferingResolver_ = null;
+
+    /** @private {boolean} */
+    this.isFullscreen_ = false;
 
   }
 
@@ -221,6 +226,9 @@ class AmpDailymotion extends AMP.BaseElement {
         break;
       case DailymotionEvents.STARTED_BUFFERING:
         this.startedBufferingResolver_(true);
+        break;
+      case DailymotionEvents.FULLSCREEN_CHANGE:
+        this.isFullscreen_ = data['fullscreen'] == 'true';
         break;
       default:
 
@@ -362,6 +370,16 @@ class AmpDailymotion extends AMP.BaseElement {
       this.sendCommand_('fullscreen', [false]);
     } else {
       fullscreenExit(dev().assertElement(this.iframe_));
+    }
+  }
+
+  /** @override */
+  isFullscreen() {
+    const platform = Services.platformFor(this.win);
+    if (platform.isSafari() || platform.isIos()) {
+      return this.isFullscreen_;
+    } else {
+      return isFullscreenElement(dev().assertElement(this.iframe_));
     }
   }
 

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -30,7 +30,7 @@ import {
   listen,
 } from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
-import {removeElement} from '../../../src/dom';
+import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
 import {user} from '../../../src/log';
 import {VideoEvents} from '../../../src/video-interface';
 import {Services} from '../../../src/services';
@@ -271,6 +271,22 @@ class AmpImaVideo extends AMP.BaseElement {
    */
   hideControls() {
     // Not supported.
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    // TODO(@aghassemi) Make internal <video> element go fullscreen instead
+    // using postMessages
+    fullscreenEnter(this.iframe_);
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    fullscreenExit(this.iframe_);
   }
 
   /** @override */

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -30,7 +30,12 @@ import {
   listen,
 } from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
-import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
+import {
+  removeElement,
+  fullscreenEnter,
+  fullscreenExit,
+  isFullscreenElement,
+} from '../../../src/dom';
 import {user, dev} from '../../../src/log';
 import {VideoEvents} from '../../../src/video-interface';
 import {Services} from '../../../src/services';
@@ -287,6 +292,13 @@ class AmpImaVideo extends AMP.BaseElement {
    */
   fullscreenExit() {
     fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    // TODO(@aghassemi, #10597) Report fullscreen status of internal <video>
+    // element rather than iframe
+    return isFullscreenElement(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -31,7 +31,7 @@ import {
 } from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
 import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
-import {user} from '../../../src/log';
+import {user, dev} from '../../../src/log';
 import {VideoEvents} from '../../../src/video-interface';
 import {Services} from '../../../src/services';
 
@@ -277,16 +277,16 @@ class AmpImaVideo extends AMP.BaseElement {
    * @override
    */
   fullscreenEnter() {
-    // TODO(@aghassemi) Make internal <video> element go fullscreen instead
+    // TODO(@aghassemi, #10597) Make internal <video> element go fullscreen instead
     // using postMessages
-    fullscreenEnter(this.iframe_);
+    fullscreenEnter(dev().assertElement(this.iframe_));
   }
 
   /**
    * @override
    */
   fullscreenExit() {
-    fullscreenExit(this.iframe_);
+    fullscreenExit(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -18,7 +18,7 @@ import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
 import {tryParseJson} from '../../../src/json';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {dict} from '../../../src/utils/object';
-import {user} from '../../../src/log';
+import {user, dev} from '../../../src/log';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
@@ -245,14 +245,14 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
    * @override
    */
   fullscreenEnter() {
-    fullscreenEnter(this.iframe_);
+    fullscreenEnter(dev().assertElement(this.iframe_));
   }
 
   /**
    * @override
    */
   fullscreenExit() {
-    fullscreenExit(this.iframe_);
+    fullscreenExit(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -22,7 +22,12 @@ import {user, dev} from '../../../src/log';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
-import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
+import {
+  removeElement,
+  fullscreenEnter,
+  fullscreenExit,
+  isFullscreenElement,
+} from '../../../src/dom';
 import {getData, listen} from '../../../src/event-helper';
 import {isObject} from '../../../src/types';
 import {VideoEvents} from '../../../src/video-interface';
@@ -253,6 +258,11 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
    */
   fullscreenExit() {
     fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    return isFullscreenElement(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -22,7 +22,7 @@ import {user} from '../../../src/log';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
-import {removeElement} from '../../../src/dom';
+import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
 import {getData, listen} from '../../../src/event-helper';
 import {isObject} from '../../../src/types';
 import {VideoEvents} from '../../../src/video-interface';
@@ -239,6 +239,20 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
   }
 
   hideControls() {
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    fullscreenEnter(this.iframe_);
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    fullscreenExit(this.iframe_);
   }
 
   /** @override */

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -17,7 +17,7 @@
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
-import {removeElement} from '../../../src/dom';
+import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
@@ -224,6 +224,20 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
 
   /** @override */
   hideControls() {
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    fullscreenEnter(this.iframe_);
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    fullscreenExit(this.iframe_);
   }
 
   /** @override */

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -17,7 +17,12 @@
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {tryParseJson} from '../../../src/json';
 import {user, dev} from '../../../src/log';
-import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
+import {
+  removeElement,
+  fullscreenEnter,
+  fullscreenExit,
+  isFullscreenElement,
+} from '../../../src/dom';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
@@ -238,6 +243,11 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
    */
   fullscreenExit() {
     fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    return isFullscreenElement(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -16,7 +16,7 @@
 
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {tryParseJson} from '../../../src/json';
-import {user} from '../../../src/log';
+import {user, dev} from '../../../src/log';
 import {removeElement, fullscreenEnter, fullscreenExit} from '../../../src/dom';
 import {
   installVideoManagerForDoc,
@@ -230,14 +230,14 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
    * @override
    */
   fullscreenEnter() {
-    fullscreenEnter(this.iframe_);
+    fullscreenEnter(dev().assertElement(this.iframe_));
   }
 
   /**
    * @override
    */
   fullscreenExit() {
-    fullscreenExit(this.iframe_);
+    fullscreenExit(dev().assertElement(this.iframe_));
   }
 
   /** @override */

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -284,14 +284,14 @@ class AmpVideo extends AMP.BaseElement {
    * @override
    */
   fullscreenEnter() {
-    fullscreenEnter(this.video_);
+    fullscreenEnter(dev().assertElement(this.video_));
   }
 
   /**
    * @override
    */
   fullscreenExit() {
-    fullscreenExit(this.video_);
+    fullscreenExit(dev().assertElement(this.video_));
   }
 
   /** @override */

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -14,7 +14,7 @@
   * limitations under the License.
   */
 
-import {elementByTag} from '../../../src/dom';
+import {elementByTag, fullscreenEnter, fullscreenExit} from '../../../src/dom';
 import {listen} from '../../../src/event-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {getMode} from '../../../src/mode';
@@ -182,9 +182,9 @@ class AmpVideo extends AMP.BaseElement {
     });
   }
 
-    /**
-     * @private
-     */
+  /**
+   * @private
+   */
   installEventHandlers_() {
     const video = dev().assertElement(this.video_);
     this.forwardEvents([VideoEvents.PLAYING, VideoEvents.PAUSE], video);
@@ -200,37 +200,37 @@ class AmpVideo extends AMP.BaseElement {
     });
   }
 
-    /** @override */
+  /** @override */
   pauseCallback() {
     if (this.video_) {
       this.video_.pause();
     }
   }
 
-    /** @private */
+  /** @private */
   isVideoSupported_() {
     return !!this.video_.play;
   }
 
-    // VideoInterface Implementation. See ../src/video-interface.VideoInterface
+  // VideoInterface Implementation. See ../src/video-interface.VideoInterface
 
-    /**
-     * @override
-     */
+  /**
+   * @override
+   */
   supportsPlatform() {
     return this.isVideoSupported_();
   }
 
-    /**
-     * @override
-     */
+  /**
+   * @override
+   */
   isInteractive() {
     return this.element.hasAttribute('controls');
   }
 
-    /**
-     * @override
-     */
+  /**
+   * @override
+   */
   play(unusedIsAutoplay) {
     const ret = this.video_.play();
 
@@ -245,39 +245,53 @@ class AmpVideo extends AMP.BaseElement {
     }
   }
 
-    /**
-     * @override
-     */
+  /**
+   * @override
+   */
   pause() {
     this.video_.pause();
   }
 
-    /**
-     * @override
-     */
+  /**
+   * @override
+   */
   mute() {
     this.video_.muted = true;
   }
 
-    /**
-     * @override
-     */
+  /**
+   * @override
+   */
   unmute() {
     this.video_.muted = false;
   }
 
-    /**
-     * @override
-     */
+  /**
+   * @override
+   */
   showControls() {
     this.video_.controls = true;
   }
 
-    /**
-     * @override
-     */
+  /**
+   * @override
+   */
   hideControls() {
     this.video_.controls = false;
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    fullscreenEnter(this.video_);
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    fullscreenExit(this.video_);
   }
 
   /** @override */

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -14,7 +14,12 @@
   * limitations under the License.
   */
 
-import {elementByTag, fullscreenEnter, fullscreenExit} from '../../../src/dom';
+import {
+  elementByTag,
+  fullscreenEnter,
+  fullscreenExit,
+  isFullscreenElement,
+} from '../../../src/dom';
 import {listen} from '../../../src/event-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {getMode} from '../../../src/mode';
@@ -292,6 +297,11 @@ class AmpVideo extends AMP.BaseElement {
    */
   fullscreenExit() {
     fullscreenExit(dev().assertElement(this.video_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    return isFullscreenElement(dev().assertElement(this.video_));
   }
 
   /** @override */

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -441,14 +441,14 @@ class AmpYoutube extends AMP.BaseElement {
    * @override
    */
   fullscreenEnter() {
-    fullscreenEnter(this.iframe_);
+    fullscreenEnter(dev().assertElement(this.iframe_));
   }
 
   /**
    * @override
    */
   fullscreenExit() {
-    fullscreenExit(this.iframe_);
+    fullscreenExit(dev().assertElement(this.iframe_));
   }
 
 

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -19,6 +19,7 @@ import {
   removeElement,
   fullscreenEnter,
   fullscreenExit,
+  isFullscreenElement,
 } from '../../../src/dom';
 import {tryParseJson} from '../../../src/json';
 import {getData, listen} from '../../../src/event-helper';
@@ -451,6 +452,10 @@ class AmpYoutube extends AMP.BaseElement {
     fullscreenExit(dev().assertElement(this.iframe_));
   }
 
+  /** @override */
+  isFullscreen() {
+    return isFullscreenElement(dev().assertElement(this.iframe_));
+  }
 
   /** @override */
   getCurrentTime() {

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-import {getDataParamsFromAttributes} from '../../../src/dom';
+import {
+  getDataParamsFromAttributes,
+  removeElement,
+  fullscreenEnter,
+  fullscreenExit,
+} from '../../../src/dom';
 import {tryParseJson} from '../../../src/json';
-import {removeElement} from '../../../src/dom';
 import {getData, listen} from '../../../src/event-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
@@ -432,6 +436,21 @@ class AmpYoutube extends AMP.BaseElement {
   hideControls() {
     // Not supported.
   }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    fullscreenEnter(this.iframe_);
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    fullscreenExit(this.iframe_);
+  }
+
 
   /** @override */
   getCurrentTime() {

--- a/src/dom.js
+++ b/src/dom.js
@@ -755,11 +755,14 @@ export function whenUpgradedToCustomElement(element) {
  * @param {Element} element
  */
 export function fullscreenEnter(element) {
-  const requestFs = element.webkitEnterFullscreen
+  const requestFs = element.requestFullscreen
+   || element.requestFullScreen
+   || element.webkitRequestFullscreen
    || element.webkitRequestFullScreen
-   || element.requestFullscreen
    || element.webkitEnterFullscreen
+   || element.webkitEnterFullScreen
    || element.msRequestFullscreen
+   || element.msRequestFullScreen
    || element.mozRequestFullscreen
    || element.mozRequestFullScreen;
   if (requestFs) {
@@ -770,16 +773,33 @@ export function fullscreenEnter(element) {
 /**
  * Replacement for `Document.exitFullscreen()` method.
  * https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen
- * @param {Document} doc
+ * @param {Element} element
  */
-export function fullscreenExit(doc) {
-  const exitFs = doc.webkitCancelFullScreen
-  || doc.cancelFullScreen
-  || doc.webkitExitFullscreen
-  || doc.exitFullscreen
-  || doc.mozCancelFullScreen
-  || doc.msExitFullscreen;
+export function fullscreenExit(element) {
+  let exitFs = element.cancelFullScreen
+               || element.exitFullscreen
+               || element.exitFullScreen
+               || element.webkitExitFullscreen
+               || element.webkitExitFullScreen
+               || element.webkitCancelFullScreen
+               || element.mozCancelFullScreen
+               || element.msExitFullscreen;
   if (exitFs) {
-    exitFs.call(doc);
+    exitFs.call(element);
+    return;
+  }
+  if (element.ownerDocument) {
+    exitFs = element.ownerDocument.cancelFullScreen
+             || element.ownerDocument.exitFullscreen
+             || element.ownerDocument.exitFullScreen
+             || element.ownerDocument.webkitExitFullscreen
+             || element.ownerDocument.webkitExitFullScreen
+             || element.ownerDocument.webkitCancelFullScreen
+             || element.ownerDocument.mozCancelFullScreen
+             || element.ownerDocument.msExitFullscreen;
+  }
+  if (exitFs) {
+    exitFs.call(element.ownerDocument);
+    return;
   }
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -752,7 +752,7 @@ export function whenUpgradedToCustomElement(element) {
 /**
  * Replacement for `Element.requestFullscreen()` method.
  * https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen
- * @param {Element} element
+ * @param {!Element} element
  */
 export function fullscreenEnter(element) {
   const requestFs = element.requestFullscreen
@@ -773,7 +773,7 @@ export function fullscreenEnter(element) {
 /**
  * Replacement for `Document.exitFullscreen()` method.
  * https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen
- * @param {Element} element
+ * @param {!Element} element
  */
 export function fullscreenExit(element) {
   let exitFs = element.cancelFullScreen

--- a/src/dom.js
+++ b/src/dom.js
@@ -803,3 +803,27 @@ export function fullscreenExit(element) {
     return;
   }
 }
+
+
+/**
+ * Replacement for `Document.fullscreenElement`.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenElement
+ * @param {!Element} element
+ * @return {boolean}
+ */
+export function isFullscreenElement(element) {
+  const isFullscreen = element.webkitDisplayingFullscreen;
+  if (isFullscreen) {
+    return true;
+  }
+  if (element.ownerDocument) {
+    const fullscreenElement = element.ownerDocument.fullscreenElement
+             || element.ownerDocument.webkitFullscreenElement
+             || element.ownerDocument.mozFullScreenElement
+             || element.webkitCurrentFullScreenElement;
+    if (fullscreenElement == element) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/dom.js
+++ b/src/dom.js
@@ -748,3 +748,38 @@ export function whenUpgradedToCustomElement(element) {
 
   return element[UPGRADE_TO_CUSTOMELEMENT_PROMISE];
 }
+
+/**
+ * Replacement for `Element.requestFullscreen()` method.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen
+ * @param {Element} element
+ */
+export function fullscreenEnter(element) {
+  const requestFs = element.webkitEnterFullscreen
+   || element.webkitRequestFullScreen
+   || element.requestFullscreen
+   || element.webkitEnterFullscreen
+   || element.msRequestFullscreen
+   || element.mozRequestFullscreen
+   || element.mozRequestFullScreen;
+  if (requestFs) {
+    requestFs.call(element);
+  }
+}
+
+/**
+ * Replacement for `Document.exitFullscreen()` method.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen
+ * @param {Document} doc
+ */
+export function fullscreenExit(doc) {
+  const exitFs = doc.webkitCancelFullScreen
+  || doc.cancelFullScreen
+  || doc.webkitExitFullscreen
+  || doc.exitFullscreen
+  || doc.mozCancelFullScreen
+  || doc.msExitFullscreen;
+  if (exitFs) {
+    exitFs.call(doc);
+  }
+}

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -17,7 +17,7 @@
 
 import {ActionTrust} from '../action-trust';
 import {VideoSessionManager} from './video-session-manager';
-import {removeElement, isRTL} from '../dom';
+import {removeElement, scopedQuerySelector, isRTL} from '../dom';
 import {listen, listenOncePromise} from '../event-helper';
 import {dev} from '../log';
 import {getMode} from '../mode';
@@ -38,11 +38,6 @@ import {
   PositionObserverFidelity,
   PositionInViewportEntryDef,
 } from './position-observer-impl';
-import {
-  scopedQuerySelector,
-  fullscreenEnter,
-  fullscreenExit,
-} from '../dom';
 import {layoutRectLtwh, RelativePositions} from '../layout-rect';
 import * as st from '../style';
 
@@ -247,8 +242,8 @@ export class VideoManager {
 
     // TODO(@wassgha) Check support status for orientation API and update
     // this as needed.
-    const screen = this.ampdoc_.win.screen;
-    const win = this.ampdoc_.win;
+    const win = this.ampdoc.win;
+    const screen = win.screen;
     const handleOrientationChange = () => {
       let isLandscape;
       if (screen && 'orientation' in screen) {
@@ -580,16 +575,11 @@ class VideoEntry {
    * @private
    */
   orientationChanged_(isLandscape) {
-    if (!viewerForDoc(this.ampdoc_).isVisible()) {
-      return;
-    }
     // Put the video in/out of fullscreen depending on orientation
     if (!isLandscape && this.isFullscreenByOrientationChange_) {
     	this.exitFullscreen_();
-    }
-    if (isLandscape
-        && this.isVisible_
-        && this.getPlayingState() == PlayingStates.PLAYING_MANUAL) {
+    } else if (this.getPlayingState() == PlayingStates.PLAYING_MANUAL
+               && this.isVisible_) {
     	this.enterFullscreen_();
     }
   }
@@ -599,7 +589,7 @@ class VideoEntry {
    * @private
    */
   enterFullscreen_() {
-    fullscreenEnter(this.internalElement_);
+    this.video.fullscreenEnter();
     this.isFullscreenByOrientationChange_ = true;
   }
 
@@ -608,7 +598,7 @@ class VideoEntry {
    * @private
    */
   exitFullscreen_() {
-    fullscreenExit(this.ampdoc_.win.document);
+    this.video.fullscreenExit();
     this.isFullscreenByOrientationChange_ = false;
   }
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -476,8 +476,8 @@ class VideoEntry {
         VideoAttributes.FULLSCREEN_ON_LANDSCAPE
     );
 
-    this.hasFullscreenOnLandscape = fsOnLandscapeAttr !== undefined
-      && (fsOnLandscapeAttr === '' || fsOnLandscapeAttr == 'always');
+    this.hasFullscreenOnLandscape = fsOnLandscapeAttr == ''
+                                    || fsOnLandscapeAttr == 'always';
 
     listenOncePromise(element, VideoEvents.LOAD)
         .then(() => this.videoLoaded());
@@ -581,6 +581,9 @@ class VideoEntry {
    * @private
    */
   orientationChanged_(isLandscape) {
+    if (!this.loaded_) {
+      return;
+    }
     // Put the video in/out of fullscreen depending on screen orientation
     if (!isLandscape && this.isFullscreenByOrientationChange_) {
     	this.exitFullscreen_();

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -167,6 +167,19 @@ export const VideoAttributes = {
    * to the corner when scrolled out of view and has been interacted with.
    */
   DOCK: 'dock',
+  /**
+   * auto-fullscreen
+   *
+   * If enabled, this automatically expands the currently visible video and
+   * playing to fullscreen when the user changes the device's orientation to
+   * landscape if the video was started following a user interaction
+   * (not autoplay)
+   *
+   * Dependent upon browser support of
+   * http://caniuse.com/#feat=screen-orientation
+   * and http://caniuse.com/#feat=fullscreen
+   */
+  AUTOFULLSCREEN: 'auto-fullscreen',
 };
 
 

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -119,6 +119,22 @@ export class VideoInterface {
   isInViewport() {}
 
   /**
+   * Enables fullscreen on the internal video element
+   * NOTE: While implementing, keep in mind that Safari/iOS do not allow taking
+   * any element other than <video> to fullscreen, if the player has an internal
+   * implementation of fullscreen (flash for example) then check
+   * if Services.platformFor(this.win).isSafari is true and use the internal
+   * implementation instead. If not, it is recommended to take the iframe
+   * to fullscreen using fullscreenEnter from dom.js
+   */
+  fullscreenEnter() {}
+
+  /**
+   * Quits fullscreen mode
+   */
+  fullscreenExit() {}
+
+  /**
    * Automatically comes from {@link ./base-element.BaseElement}
    *
    * @param {string} unusedMethod

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -135,6 +135,12 @@ export class VideoInterface {
   fullscreenExit() {}
 
   /**
+   * Returns whether the video is currently in fullscreen mode or not
+   * @return {boolean}
+   */
+  isFullscreen() {}
+
+  /**
    * Automatically comes from {@link ./base-element.BaseElement}
    *
    * @param {string} unusedMethod
@@ -184,7 +190,7 @@ export const VideoAttributes = {
    */
   DOCK: 'dock',
   /**
-   * auto-fullscreen
+   * fullscreen-on-landscape
    *
    * If enabled, this automatically expands the currently visible video and
    * playing to fullscreen when the user changes the device's orientation to
@@ -195,7 +201,7 @@ export const VideoAttributes = {
    * http://caniuse.com/#feat=screen-orientation
    * and http://caniuse.com/#feat=fullscreen
    */
-  AUTOFULLSCREEN: 'auto-fullscreen',
+  FULLSCREEN_ON_LANDSCAPE: 'fullscreen-on-landscape',
 };
 
 

--- a/test/functional/test-video-manager.js
+++ b/test/functional/test-video-manager.js
@@ -515,6 +515,12 @@ function createFakeVideoPlayerClass(win) {
     fullscreenExit() {
     }
 
+    /**
+     * @override
+     */
+    isFullscreen() {
+    }
+
     /** @override */
     getCurrentTime() {
       return this.currentTime_;

--- a/test/functional/test-video-manager.js
+++ b/test/functional/test-video-manager.js
@@ -503,6 +503,18 @@ function createFakeVideoPlayerClass(win) {
     hideControls() {
     }
 
+    /**
+     * @override
+     */
+    fullscreenEnter() {
+    }
+
+    /**
+     * @override
+     */
+    fullscreenExit() {
+    }
+
     /** @override */
     getCurrentTime() {
       return this.currentTime_;

--- a/test/manual/amp-video-auto-fullscreen.amp.html
+++ b/test/manual/amp-video-auto-fullscreen.amp.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <meta name="apple-mobile-web-app-title" content="AppTitle">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+    [fallback] {
+      display: block;
+      /* @alternative */ display: flex;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      justify-content: center;
+      align-items: center;
+      background: rgba(0, 0, 0, 0.5);
+      color: #fff;
+    }
+    .spacer {
+      height: 100vh;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>amp-video</h1>
+
+  <amp-video
+      id="myVideo"
+      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+      width="720"
+      height="405"
+      layout="responsive"
+      auto-fullscreen
+      controls>
+    <div placeholder>
+      This is a placeholder
+    </div>
+    <div fallback>
+      This is a fallback
+    </div>
+  </amp-video>
+  <h3>Actions</h3>
+  <button on="tap:myVideo.play">Play</button>
+  <button on="tap:myVideo.pause">Pause</button>
+  <button on="tap:myVideo.mute">Mute</button>
+  <button on="tap:myVideo.unmute">Unmute</button>
+
+  <h2>Autoplay</h2>
+  <amp-video
+    autoplay
+    auto-fullscreen
+    src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+    width="720"
+    height="405"
+    layout="responsive"
+    controls>
+  </amp-video>
+  <div class="spacer"></div>
+</body>
+</html>


### PR DESCRIPTION
Switching to landscape when watching a video is a strong indicator that the user wants to expand the video to fullscreen. This feature allows AMP pages to automatically put videos into fullscreen mode when an orientation change is detected.

<p align="center">
<img src="https://media.giphy.com/media/QqmCwXIhcIMz6/giphy.gif" height="400px">
</p>

### Changes

- Added `auto-fullscreen` attribute to the video interface
- Implemented an orientation change listener
- Implemented in/out of fullscreen on manually playing videos when the device rotation changes to landscape
- Added `fullscreenEnter` and `fullscreenExit` to the video interface and implemented it for all players (`amp-video` and `amp-dailymotion` have full support on iOS, other video players don't for now). Opened #10561 to check compatibility and implement any internal fullscreen API.

Closes #5380 , Checks-off an item on #4154 , Related-to #10561 , #10660