### PR TITLE
Add `@externs` tags to externs files.

### DIFF
--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/** @externs */
+
 // HACK. Define application types used in default AMP externs
 // that are not in the 3p code.
 /** @constructor */

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/** @externs */
+
 /**
  * A type for Objects that can be JSON serialized or that come from
  * JSON serialization. Requires the objects fields to be accessed with

--- a/build-system/amp.nti.extern.js
+++ b/build-system/amp.nti.extern.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-// Extern specifically for New Type Inference (NTI) type checking mode.
+/**
+ * @fileoverview Extern specifically for New Type Inference (NTI) type checking mode.
+ * @externs
+ */
 
 /**
  * TransitionDef function that accepts normtime, typically between 0 and 1 and

--- a/build-system/amp.oti.extern.js
+++ b/build-system/amp.oti.extern.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-// Extern specifically for Old Type Inference (OTI) type checking mode.
+/**
+ * @fileoverview Extern specifically for Old Type Inference (OTI) type checking mode.
+ * @externs
+ */
 
 /**
  * TransitionDef function that accepts normtime, typically between 0 and 1 and


### PR DESCRIPTION
This helps code quality tools such as [lgtm](https://lgtm.com) to identify them as not being code, avoiding false positives.

(For reference, all the externs bundled with the Closure compiler use the `@externs` tag, except for a few Node.js externs that appear to be third-party contributions.)