### PR TITLE
Add DoubleClick options to the Criteo ad tag

### DIFF
--- a/ads/criteo.js
+++ b/ads/criteo.js
@@ -16,6 +16,7 @@
 
 import {computeInMasterFrame, loadScript} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
+import {tryParseJson} from '../src/json';
 
 /* global Criteo: false */
 
@@ -55,15 +56,20 @@ export function criteo(global, data) {
  */
 function setTargeting(global, data) {
   if (data.adserver === 'DFP') {
-    const dblParams = {
-      slot: data.slot,
-      targeting: Criteo.ComputeDFPTargetingForAMP(
-          data.cookiename || Criteo.PubTag.RTA.DefaultCrtgRtaCookieName,
-          data.varname || Criteo.PubTag.RTA.DefaultCrtgContentName),
-      width: data.width,
-      height: data.height,
-      type: 'criteo',
-    };
+    const dblParams = tryParseJson(data.doubleclick) || {};
+    dblParams['slot'] = data.slot;
+    dblParams['targeting'] = dblParams['targeting'] || {};
+    dblParams['width'] = data.width;
+    dblParams['height'] = data.height;
+    dblParams['type'] = 'criteo';
+
+    const targeting = Criteo.ComputeDFPTargetingForAMP(
+        data.cookiename || Criteo.PubTag.RTA.DefaultCrtgRtaCookieName,
+        data.varname || Criteo.PubTag.RTA.DefaultCrtgContentName);
+    for (const i in targeting) {
+      dblParams['targeting'][i] = targeting[i];
+    }
+
     doubleclick(global, dblParams);
   }
 }

--- a/ads/criteo.md
+++ b/ads/criteo.md
@@ -28,7 +28,8 @@ For configuration details and to generate your tags, please refer to [your publi
     data-tagtype=“rta”
     data-networkid=“76543”
     data-adserver=“DFP”
-    data-slot=“/0987654/rta_zone_amp”>
+    data-slot=“/0987654/rta_zone_amp”
+    data-doubleclick='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusions":["health"]}'>
 </amp-ad>
 ```
 
@@ -56,6 +57,7 @@ Supported parameters:
 - `data-networkid`: your Criteo network id. Required.
 - `data-varname`: `crtg_content` variable name to store RTA labels. Optional.
 - `data-cookiename`: `crtg_rta` RTA cookie name. Optional.
+- `data-doubleclick`: custom options to send to doubleclick. Optional. See [doubleclick documentation](google/doubleclick.md) for details.
 
 ### PuMP and Passback
 

--- a/ads/criteo.md
+++ b/ads/criteo.md
@@ -57,7 +57,7 @@ Supported parameters:
 - `data-networkid`: your Criteo network id. Required.
 - `data-varname`: `crtg_content` variable name to store RTA labels. Optional.
 - `data-cookiename`: `crtg_rta` RTA cookie name. Optional.
-- `data-doubleclick`: custom options to send to doubleclick. Optional. See [doubleclick documentation](google/doubleclick.md) for details.
+- `data-doubleclick`: custom options to send to doubleclick, in JSON format. Optional. See [doubleclick documentation](google/doubleclick.md) for details.
 
 ### PuMP and Passback
 


### PR DESCRIPTION
# Add DoubleClick options to the Criteo ad tag

Allows to set additional options when using doubleclick through the Criteo RTA ad tag (ex: `categoryExclusions`, `targeting`).

Usage example can be found in the updated documentation (uses a JSON `data-doubleclick` field).