### PR TITLE
Integrate AMP Start into ref docs

### DIFF
--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -450,3 +450,9 @@ In general, keep in mind the following points when accepting input from the user
     * non-XHR GET requests are not going to receive accurate origin/headers and backends won't be able to protect against XSRF with the above mechanism.
     * In general use XHR/non-XHR GET requests for navigational or information retrieval only.
 * non-XHR POST requests are not allowed in AMP documents. This is due to inconsistencies of setting `Origin` header on these requests across browsers. And the complications supporting it would introduce in protecting against XSRF. This might be reconsidered and introduced later, please file an issue if you think this is needed.
+
+## Styling
+
+{% call callout('Tip', type='success') %}
+Visit [AMP Start](https://ampstart.com/components#form-elements) for responsive, pre-styled AMP form elements that you can use in your AMP pages.
+{% endcall %}

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -134,6 +134,11 @@ The `amp-sidebar` component can be styled with standard CSS.
 - The height of the `amp-sidebar` may be set to adjust the height of the sidebar, if required. If the height exceeds 100vw, the sidebar will have a vertical scrollbar. The preset height of the sidebar is 100vw and can be overridden in CSS to make it shorter.
 - The current state of the sidebar is exposed via the `open` attribute that is set on the `amp-sidebar` tag when the side bar is open on the page.
 
+{% call callout('Tip', type='success') %}
+Visit [AMP Start](https://ampstart.com/components#navigation) for responsive, pre-styled navigation menus that you can use in your AMP pages.
+{% endcall %}
+
+
 ## UX considerations
 
 When using `<amp-sidebar>`, keep in mind that your users will often view your page on mobile in an AMP viewer, which may display a fixed-position header. In addition, browsers often display their own fixed header at the top of the page. Adding another fixed-position element at the top of the screen would take up a large amount of mobile screen space with content that gives the user no new information.

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -203,6 +203,10 @@ The following example creates a share button through WhatsApp by setting the `da
 
 By default, `amp-social-share` includes some popular pre-configured providers. Buttons for these providers are styled with the provider's official color and logo. The default width is 60px, and the default height is 44px.
 
+{% call callout('Tip', type='success') %}
+Visit [AMP Start](https://ampstart.com/components#links-and-sharing) for responsive, pre-styled share links that you can use in your AMP pages.
+{% endcall %}
+
 ### Custom Styles
 
 Sometimes you want to provide your own style. You can simply override the provided styles like the following:


### PR DESCRIPTION
Added callouts to applicable components so readers know about pre-styled AMP Start components.

(There'll be more integration with ampproject.org and AMP Start, but this is a basic start.)

to: @ericlindley-g 
cc/ @pbakaus

