### PR TITLE
Allow embed to have services that its parent lacks

### DIFF
--- a/examples/a4a.amp.html
+++ b/examples/a4a.amp.html
@@ -82,10 +82,18 @@
     <div fallback></div>
   </amp-ad>
 
-  <h2>Doubleclick</h2>
-  <amp-ad width="320" height="50"
-      type="doubleclick"
-      data-slot="/4119129/mobile_ad_banner">
+  <h2>Regular ad</h2>
+  <amp-ad data-slot="/30497360/a4a/non_a4a_native"
+    height="250"
+    type="doubleclick"
+    width="300">
+  </amp-ad>
+
+  <h2>A4A ad</h2>
+  <amp-ad data-slot="/30497360/a4a/a4a_native"
+    height="250"
+    type="doubleclick"
+    width="300">
   </amp-ad>
 </body>
 </html>

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -568,30 +568,42 @@ describe('service', () => {
         expect(isEmbeddable(nonEmbeddable)).to.be.false;
       });
 
-      it('should adopt embeddable', () => {
-        adoptServiceForEmbed(embedWin, 'embeddable');
-        expect(embeddable.adoptEmbedWindow).to.be.calledOnce;
-        expect(embeddable.adoptEmbedWindow.args[0][0]).to.equal(embedWin);
+      describe('adoptServiceForEmbed()', () => {
+        it('should adopt embeddable', () => {
+          adoptServiceForEmbed(embedWin, 'embeddable');
+          expect(embeddable.adoptEmbedWindow).to.be.calledOnce;
+          expect(embeddable.adoptEmbedWindow.args[0][0]).to.equal(embedWin);
+        });
+
+        it('should refuse adopt of non-embeddable', () => {
+          expect(() => {
+            adoptServiceForEmbed(embedWin, 'nonEmbeddable');
+          }).to.throw(/implement EmbeddableService/);
+        });
+
+        it('should refuse adopt of unknown service', () => {
+          expect(() => {
+            adoptServiceForEmbed(embedWin, 'unknown');
+          }).to.throw(/unknown/);
+        });
       });
 
-      it('should refuse adopt of non-embeddable', () => {
-        expect(() => {
-          adoptServiceForEmbed(embedWin, 'nonEmbeddable');
-        }).to.throw(/required to implement EmbeddableService/);
-      });
+      describe('adoptServiceForServiceIfEmbeddable()', () => {
+        it('should adopt embeddable if embeddable', () => {
+          adoptServiceForEmbedIfEmbeddable(embedWin, 'embeddable');
+          expect(embeddable.adoptEmbedWindow).to.be.calledOnce;
+          expect(embeddable.adoptEmbedWindow.args[0][0]).to.equal(embedWin);
 
-      it('should adopt embeddable if embeddable', () => {
-        adoptServiceForEmbedIfEmbeddable(embedWin, 'embeddable');
-        expect(embeddable.adoptEmbedWindow).to.be.calledOnce;
-        expect(embeddable.adoptEmbedWindow.args[0][0]).to.equal(embedWin);
+          // Should not throw 'required to implement EmbeddableService' error.
+          adoptServiceForEmbedIfEmbeddable(embedWin, 'nonEmbeddable');
+        });
 
-        adoptServiceForEmbedIfEmbeddable(embedWin, 'nonEmbeddable'); // No-op.
-      });
-
-      it('should refuse adopt of unknown service', () => {
-        expect(() => {
-          adoptServiceForEmbed(embedWin, 'unknown');
-        }).to.throw(/unknown/);
+        it('should soft fail adopt of unknown service', () => {
+          // If the embed has an extension service that the parent doesn't,
+          // e.g. AmpFormService if parent lacks amp-form extension.
+          const adopted = adoptServiceForEmbedIfEmbeddable(embedWin, 'unknown');
+          expect(adopted).to.be.false;
+        });
       });
     });
   });


### PR DESCRIPTION
Partial for #9679.

- Avoid throwing dev error when FIE doc has an extension service that its parent doesn't, e.g. `AmpFormService` if the embed includes `amp-form`.
- Add A4A native/non-native examples from ABE to a4a.amp.html.

/to @lannka 