### PR TITLE
[amp-sidebar 1.0] [Toolbar] Implemented toolbar's "target" attribute

### DIFF
--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -113,8 +113,11 @@ export class AmpSidebar extends AMP.BaseElement {
     toolbarElements.forEach(toolbarElement => {
       try {
         const toolbar = new Toolbar(toolbarElement, this.win, this.vsync_);
-        this.element.parentElement
-            .insertBefore(toolbar.build(), this.element);
+        const toolbarFragment = toolbar.build();
+        if (toolbarFragment) {
+          this.element.parentElement
+              .insertBefore(toolbar.build(), this.element);
+        }
         this.toolbars_.push(toolbar);
       } catch (e) {
         user().error(TAG, 'Failed to instantiate toolbar', e);

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -116,7 +116,7 @@ export class AmpSidebar extends AMP.BaseElement {
         const toolbarFragment = toolbar.build();
         if (toolbarFragment) {
           this.element.parentElement
-              .insertBefore(toolbar.build(), this.element);
+              .insertBefore(toolbarFragment, this.element);
         }
         this.toolbars_.push(toolbar);
       } catch (e) {

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -112,13 +112,7 @@ export class AmpSidebar extends AMP.BaseElement {
       .call(this.element.querySelectorAll('nav[toolbar]'), 0);
     toolbarElements.forEach(toolbarElement => {
       try {
-        const toolbar = new Toolbar(toolbarElement, this.win, this.vsync_);
-        const toolbarFragment = toolbar.build();
-        if (toolbarFragment) {
-          this.element.parentElement
-              .insertBefore(toolbarFragment, this.element);
-        }
-        this.toolbars_.push(toolbar);
+        this.toolbars_.push(new Toolbar(toolbarElement, this.win, this.vsync_));
       } catch (e) {
         user().error(TAG, 'Failed to instantiate toolbar', e);
       }

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -83,12 +83,7 @@
          }
          navToolbar.appendChild(toolbarList);
          toolbarContainerElement.appendChild(navToolbar);
-         const toolbar = new Toolbar(navToolbar, iframe.win, vsync);
-         const toolbarFragment = toolbar.build();
-         if (toolbarFragment) {
-           toolbarContainerElement.appendChild(toolbarFragment);
-         }
-         toolbars.push(toolbar);
+         toolbars.push(new Toolbar(navToolbar, iframe.win, vsync));
        });
 
        return {iframe, toolbarContainerElement, toolbars};
@@ -241,7 +236,6 @@
        });
      });
    });
-
 
    it('toolbar should be placed into a target, and hidden for a \
    non-matching window size for DEFAULT_TOOLBAR_MEDIA', () => {

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -25,7 +25,7 @@
  const DEFAULT_TOOLBAR_MEDIA = '(min-width: 768px)';
 
  /** @const */
- const TOOLBAR_CLASS = 'i-amphtml-toolbar';
+ const TOOLBAR_ELEMENT_CLASS = 'i-amphtml-toolbar';
 
 
  adopt(window);
@@ -111,7 +111,7 @@
        const toolbars = obj.toolbars;
        const toolbarElements = Array.prototype
               .slice.call(obj.toolbarContainerElement.ownerDocument
-              .getElementsByClassName(TOOLBAR_CLASS), 0);
+              .getElementsByClassName(TOOLBAR_ELEMENT_CLASS), 0);
        resizeIframeToWidth(obj.iframe, '1px', () => {
          expect(toolbarElements.length).to.be.above(0);
          toolbars.forEach(toolbar => {
@@ -128,8 +128,8 @@
      return getToolbars([{}]).then(obj => {
        const toolbars = obj.toolbars;
        const toolbarElements = Array.prototype
-              .slice.call(obj.toolbarContainerElement
-              .getElementsByClassName(TOOLBAR_CLASS), 0);
+              .slice.call(obj.toolbarContainerElement.ownerDocument
+              .getElementsByClassName(TOOLBAR_ELEMENT_CLASS), 0);
        resizeIframeToWidth(obj.iframe, '4000px', () => {
          expect(toolbarElements.length).to.be.above(0);
          toolbars.forEach(toolbar => {
@@ -146,8 +146,8 @@
      return getToolbars([{}]).then(obj => {
        const toolbars = obj.toolbars;
        const toolbarElements = Array.prototype
-              .slice.call(obj.toolbarContainerElement
-              .getElementsByClassName(TOOLBAR_CLASS), 0);
+              .slice.call(obj.toolbarContainerElement.ownerDocument
+              .getElementsByClassName(TOOLBAR_ELEMENT_CLASS), 0);
        resizeIframeToWidth(obj.iframe, '4000px', () => {
          expect(toolbarElements.length).to.be.above(0);
          toolbars.forEach(toolbar => {
@@ -164,8 +164,8 @@
      return getToolbars([{}]).then(obj => {
        const toolbars = obj.toolbars;
        const toolbarElements = Array.prototype
-              .slice.call(obj.toolbarContainerElement
-              .getElementsByClassName(TOOLBAR_CLASS), 0);
+              .slice.call(obj.toolbarContainerElement.ownerDocument
+              .getElementsByClassName(TOOLBAR_ELEMENT_CLASS), 0);
        resizeIframeToWidth(obj.iframe, '4000px', () => {
          toolbars.forEach(toolbar => {
            toolbar.onLayoutChange();
@@ -188,7 +188,7 @@
        const toolbars = obj.toolbars;
        const toolbarElements = Array.prototype
               .slice.call(obj.toolbarContainerElement.ownerDocument
-              .getElementsByClassName(TOOLBAR_CLASS), 0);
+              .getElementsByClassName(TOOLBAR_ELEMENT_CLASS), 0);
        resizeIframeToWidth(obj.iframe, '1px', () => {
          expect(toolbarElements.length).to.be.above(0);
          toolbars.forEach(toolbar => {

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -69,6 +69,12 @@
          if (toolbarObj.toolbarOnlyOnNav) {
            navToolbar.setAttribute('toolbar-only', '');
          }
+         if (toolbarObj.target) {
+           const toolbarTarget = iframe.doc.createElement('div');
+           toolbarTarget.setAttribute('id', toolbarObj.target);
+           iframe.win.document.body.appendChild(toolbarTarget);
+           navToolbar.setAttribute('target', toolbarObj.target);
+         }
          const toolbarList = iframe.doc.createElement('ul');
          for (let i = 0; i < 3; i++) {
            const li = iframe.doc.createElement('li');
@@ -78,7 +84,10 @@
          navToolbar.appendChild(toolbarList);
          toolbarContainerElement.appendChild(navToolbar);
          const toolbar = new Toolbar(navToolbar, iframe.win, vsync);
-         toolbarContainerElement.appendChild(toolbar.build());
+         const toolbarFragment = toolbar.build();
+         if (toolbarFragment) {
+           toolbarContainerElement.appendChild(toolbarFragment);
+         }
          toolbars.push(toolbar);
        });
 
@@ -178,6 +187,84 @@
      });
    });
 
+   it('toolbar header should be hidden for a \
+   non-matching window size for DEFAULT_TOOLBAR_MEDIA', () => {
+     return getToolbars([{}]).then(obj => {
+       const toolbars = obj.toolbars;
+       const toolbarElements = Array.prototype
+              .slice.call(obj.toolbarContainerElement.ownerDocument
+              .getElementsByClassName(TOOLBAR_CLASS), 0);
+       resizeIframeToWidth(obj.iframe, '1px', () => {
+         expect(toolbarElements.length).to.be.above(0);
+         toolbars.forEach(toolbar => {
+           toolbar.onLayoutChange();
+         });
+         expect(toolbarElements[0].parentElement.style.display)
+             .to.be.equal('none');
+       });
+     });
+   });
+
+   it('toolbar should be placed into a target, with the \
+   target attrbiute', () => {
+     const targetId = 'toolbar-target';
+     return getToolbars([{
+       target: targetId,
+     }]).then(obj => {
+       const toolbars = obj.toolbars;
+       const toolbarTargetElements = Array.prototype
+              .slice.call(obj.iframe.win.document.body
+              .querySelectorAll(`#${targetId} > nav[toolbar]`), 0);
+       expect(toolbars.length).to.be.equal(1);
+       expect(toolbarTargetElements.length).to.be.equal(1);
+     });
+   });
+
+   it('toolbar should be placed into a target, and shown for a \
+   matching window size for DEFAULT_TOOLBAR_MEDIA', () => {
+     const targetId = 'toolbar-target';
+     return getToolbars([{
+       target: targetId,
+     }]).then(obj => {
+       const toolbars = obj.toolbars;
+       const toolbarTargets = Array.prototype
+               .slice.call(obj.iframe.win.document.body
+               .querySelectorAll(`#${targetId}`), 0);
+       resizeIframeToWidth(obj.iframe, '4000px', () => {
+         toolbars.forEach(toolbar => {
+           toolbar.onLayoutChange();
+         });
+         expect(toolbars.length).to.be.equal(1);
+         expect(toolbarTargets.length).to.be.equal(1);
+         expect(toolbarTargets[0].style.display)
+             .to.be.equal('');
+       });
+     });
+   });
+
+
+   it('toolbar should be placed into a target, and hidden for a \
+   non-matching window size for DEFAULT_TOOLBAR_MEDIA', () => {
+     const targetId = 'toolbar-target';
+     return getToolbars([{
+       target: targetId,
+     }]).then(obj => {
+       const toolbars = obj.toolbars;
+       const toolbarTargets = Array.prototype
+               .slice.call(obj.iframe.win.document.body
+               .querySelectorAll(`#${targetId}`), 0);
+       resizeIframeToWidth(obj.iframe, '200px', () => {
+         toolbars.forEach(toolbar => {
+           toolbar.onLayoutChange();
+         });
+         expect(toolbars.length).to.be.equal(1);
+         expect(toolbarTargets.length).to.be.equal(1);
+         expect(toolbarTargets[0].style.display)
+             .to.be.equal('none');
+       });
+     });
+   });
+
    it('should hide <nav toolbar> elements with toolbar-only, \
    inside the sidebar, but not inside the toolbar, for a matching \
    window size for DEFAULT_TOOLBAR_MEDIA', () => {
@@ -201,6 +288,7 @@
        });
      });
    });
+
 
    it('toolbar should be in the hidden state \
    when it is not being displayed', () => {

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -104,7 +104,6 @@ export class Toolbar {
    */
   build() {
     this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
-    this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
     // Check for the target attribute on toolbar nav
     const targetId = this.toolbarDOMElement_.getAttribute('target');
     if (targetId &&
@@ -116,6 +115,7 @@ export class Toolbar {
       toggle(this.targetElement_, false);
       return;
     } else {
+      this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
       const fragment = this.win_
         .document.createDocumentFragment();
       this.targetElement_ =

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -104,8 +104,17 @@ export class Toolbar {
    */
   buildCallback_() {
     this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
+    // Addend "_toolbar" to ids on the toolbar clone
+    const idElementsInClone = Array.prototype.slice
+      .call(this.toolbarClone_.querySelectorAll('[id]'), 0);
+    idElementsInClone.forEach(element => {
+      element.id = `${element.id}_toolbar`;
+    });
     const targetId = this.toolbarDOMElement_.getAttribute('target');
-    const targetElement = this.win_.document.getElementById(targetId);
+    // Set the target element to the toolbar clone if it exists.
+    const targetElement =
+    this.win_.document.getElementById(`${targetId}_toolbar`) ||
+    this.win_.document.getElementById(targetId);
     this.targetElement_ = targetElement || this.createTargetElement_();
     this.targetElement_.appendChild(this.toolbarClone_);
     toggle(this.targetElement_, false);

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -110,6 +110,7 @@ export class Toolbar {
     this.targetElement_.appendChild(this.toolbarClone_);
     toggle(this.targetElement_, false);
 
+    // Check if the target element was created by us, or already inserted by the user
     if (!this.targetElement_.parentElement) {
       this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
       const fragment = this.win_

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -99,21 +99,33 @@ export class Toolbar {
 
   /**
    * Private function to build the DOM element for the toolbar, and return the built fragment
+   * @returns {Element|null}
    * @public
    */
   build() {
-    const fragment = this.win_
-      .document.createDocumentFragment();
-    this.targetElement_ =
-      this.win_.document.createElement('header');
-    this.targetElement_.classList.add(TOOLBAR_TARGET_CLASS);
-    //Place the elements into the target
     this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
     this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
-    this.targetElement_.appendChild(this.toolbarClone_);
-    toggle(this.targetElement_, false);
-    fragment.appendChild(this.targetElement_);
-    return fragment;
+    // Check for the target attribute on toolbar nav
+    const targetId = this.toolbarDOMElement_.getAttribute('target');
+    if (targetId &&
+      this.win_document.getElementById(targetId)
+    ) {
+      this.targetElement_ =
+        this.win_document.getElementById(targetId);
+      this.targetElement_.appendChild(this.toolbarClone_);
+      toggle(this.targetElement_, false);
+      return;
+    } else {
+      const fragment = this.win_
+        .document.createDocumentFragment();
+      this.targetElement_ =
+        this.win_.document.createElement('header');
+      this.targetElement_.classList.add(TOOLBAR_TARGET_CLASS);
+      this.targetElement_.appendChild(this.toolbarClone_);
+      toggle(this.targetElement_, false);
+      fragment.appendChild(this.targetElement_);
+      return fragment;
+    }
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -75,6 +75,7 @@ export class Toolbar {
           Array.prototype.slice.call(toolbarOnlyQuery, 0);
       }
     }
+    this.buildCallback_();
   }
 
   /**
@@ -98,34 +99,36 @@ export class Toolbar {
   }
 
   /**
-   * Private function to build the DOM element for the toolbar, and return the built fragment
-   * @returns {DocumentFragment|undefined}
-   * @public
+   * Private function to build the DOM element for the toolbar
+   * @private
    */
-  build() {
+  buildCallback_() {
     this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
-    // Check for the target attribute on toolbar nav
     const targetId = this.toolbarDOMElement_.getAttribute('target');
-    if (targetId &&
-      this.win_.document.getElementById(targetId)
-    ) {
-      this.targetElement_ =
-        this.win_.document.getElementById(targetId);
-      this.targetElement_.appendChild(this.toolbarClone_);
-      toggle(this.targetElement_, false);
-      return;
-    } else {
+    const targetElement = this.win_.document.getElementById(targetId);
+    this.targetElement_ = targetElement || this.createTargetElement_();
+    this.targetElement_.appendChild(this.toolbarClone_);
+    toggle(this.targetElement_, false);
+
+    if (!this.targetElement_.parentElement) {
       this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
       const fragment = this.win_
         .document.createDocumentFragment();
-      this.targetElement_ =
-        this.win_.document.createElement('header');
-      this.targetElement_.classList.add(TOOLBAR_TARGET_CLASS);
-      this.targetElement_.appendChild(this.toolbarClone_);
-      toggle(this.targetElement_, false);
       fragment.appendChild(this.targetElement_);
-      return fragment;
+      this.body_.appendChild(fragment);
     }
+  }
+
+  /**
+   * Returns a created element that can be used as the target if one does not exist
+   * @returns {Element}
+   * @private
+   */
+  createTargetElement_() {
+    const targetElement =
+      this.win_.document.createElement('header');
+    targetElement.classList.add(TOOLBAR_TARGET_CLASS);
+    return targetElement;
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -99,7 +99,7 @@ export class Toolbar {
 
   /**
    * Private function to build the DOM element for the toolbar, and return the built fragment
-   * @returns {Element|null}
+   * @returns {DocumentFragment|undefined}
    * @public
    */
   build() {
@@ -108,10 +108,10 @@ export class Toolbar {
     // Check for the target attribute on toolbar nav
     const targetId = this.toolbarDOMElement_.getAttribute('target');
     if (targetId &&
-      this.win_document.getElementById(targetId)
+      this.win_.document.getElementById(targetId)
     ) {
       this.targetElement_ =
-        this.win_document.getElementById(targetId);
+        this.win_.document.getElementById(targetId);
       this.targetElement_.appendChild(this.toolbarClone_);
       toggle(this.targetElement_, false);
       return;

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -48,8 +48,8 @@ limitations under the License.
   justify-content: center !important;
 }
 
-.transparent-bg {
-  background-color: transparent;
+.mrauto {
+  margin-right: auto;
 }
 
 .ampstart-headerbar-nav, .ampstart-headerbar-nav > ul.flex {
@@ -72,6 +72,12 @@ limitations under the License.
 
 .ampstart-hamburger-nav {
   background-color: #fff;
+}
+
+@media (min-width: 931px) {
+  .ampstart-headerbar-nav {
+    margin-left: -195px;
+  }
 }
 
 @media (max-width: 930px) {
@@ -119,14 +125,14 @@ limitations under the License.
     <!-- Toolbar One, basic usage, toolbar-only -->
     <!-- Could center with CSS justify-content: space-between, but trying to be minimal -->
     <nav toolbar="(min-width: 0px)" class="ampstart-hamburger-nav ampstart-navbar-bg" toolbar-only>
-      <ul>
+      <ul class="justify-center">
         <li role="button" aria-label="open sidebar" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger pl2">
           ☰
         </li>
-        <li>
+        <li class="mrauto">
           <amp-img src="https://ampstart.com/img/blog/logo.png" width="100" height="61.3" layout="fixed" class="my0 ml2" alt="The Blog"></amp-img>
         </li>
-        <li id="toolbar-nav-target">
+        <li id="toolbar-nav-target" class="mrauto">
         </li>
       </ul>
     </nav>

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -126,11 +126,13 @@ limitations under the License.
         <li>
           <amp-img src="https://ampstart.com/img/blog/logo.png" width="100" height="61.3" layout="fixed" class="my0 ml2" alt="The Blog"></amp-img>
         </li>
+        <li id="toolbar-nav-target">
+        </li>
       </ul>
     </nav>
 
     <!-- Toolbar Two, min only  -->
-    <nav toolbar="(min-width: 931px)" toolbar-only class="ampstart-headerbar-nav ampstart-nav ampstart-navbar-bg">
+    <nav toolbar="(min-width: 931px)" target="toolbar-nav-target" toolbar-only class="ampstart-headerbar-nav ampstart-nav ampstart-navbar-bg">
       <ul class="list-reset center m0 p0 flex justify-center nowrap">
           <li class="ampstart-nav-item ampstart-nav-dropdown">
             <!-- Start Dropdown -->

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -274,27 +274,9 @@ limitations under the License.
                 <label for="emailid" class="absolute top-0 right-0 bottom-0 left-0">Email</label>
               </div>
               <!-- End Input-->
-
-
-
-
-
-
-
-
-
-
               <!-- Start Submit -->
               <input type="submit" name="submit" value="SUBMIT" id="submit" class="ampstart-btn mb3 ampstart-btn-secondary">
               <!-- End Submit -->
-
-
-
-
-
-
-
-
             </fieldset>
           </form>
         </div>


### PR DESCRIPTION
closes #9982 

- Checks the <nav toolbar> for a target attribute
- If the target element exists, places the clone into the target
- Created a quick demo for the old test/manual to demonstrate things working

Tested in Chrome, Firefox, and Safari

# Example Gif
![502_ampstarttarget](https://user-images.githubusercontent.com/1448289/27706878-1c11bbea-5cc8-11e7-8e1c-c5afeb7a8e3a.gif)
