### PR TITLE
Move extractSize to a separate hook

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -82,7 +82,6 @@ describe('Google A4A utils', () => {
           .to.eventually.deep.equal({
             creative,
             signature: base64UrlDecodeToBytes('AQAB'),
-            size: null,
           });
     });
 
@@ -90,7 +89,6 @@ describe('Google A4A utils', () => {
       const creative = 'some test data';
       const headerData = {
         'X-AmpAdSignature': 'AQAB',
-        'X-CreativeSize': '320x50',
       };
       const headers = {
         has: h => { return h in headerData; },
@@ -100,7 +98,6 @@ describe('Google A4A utils', () => {
           .to.eventually.deep.equal({
             creative,
             signature: base64UrlDecodeToBytes('AQAB'),
-            size: {width: 320, height: 50},
           });
     });
 

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -108,11 +108,7 @@ describe('Google A4A utils', () => {
         get: h => { throw new Error('Tried to get ' + h); },
       };
       return expect(extractGoogleAdCreativeAndSignature(creative, headers))
-          .to.eventually.deep.equal({
-            creative,
-            signature: null,
-            size: null,
-          });
+          .to.eventually.deep.equal({creative, signature: null});
     });
   });
 

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -39,9 +39,6 @@ import {
 /** @const {string} */
 const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
 
-/** @const {string} */
-const CREATIVE_SIZE_HEADER = 'X-CreativeSize';
-
 /** @type {string}  */
 const AMP_ANALYTICS_HEADER = 'X-AmpAnalytics';
 
@@ -284,25 +281,16 @@ export function truncAndTimeUrl(baseUrl, parameters, startTime) {
 export function extractGoogleAdCreativeAndSignature(
     creative, responseHeaders) {
   let signature = null;
-  let size = null;
   try {
     if (responseHeaders.has(AMP_SIGNATURE_HEADER)) {
       signature =
         base64UrlDecodeToBytes(dev().assertString(
             responseHeaders.get(AMP_SIGNATURE_HEADER)));
     }
-    if (responseHeaders.has(CREATIVE_SIZE_HEADER)) {
-      const sizeHeader = responseHeaders.get(CREATIVE_SIZE_HEADER);
-      dev().assert(new RegExp('[0-9]+x[0-9]+').test(sizeHeader));
-      const sizeArr = sizeHeader
-          .split('x')
-          .map(dim => Number(dim));
-      size = {width: sizeArr[0], height: sizeArr[1]};
-    }
   } finally {
     return Promise.resolve(/** @type {
           !../../../extensions/amp-a4a/0.1/amp-a4a.AdResponseDef} */ (
-          {creative, signature, size}));
+          {creative, signature}));
   }
 }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -78,6 +78,9 @@ const METADATA_STRING_NO_QUOTES =
 /** @type {string} */
 export const DEFAULT_SAFEFRAME_VERSION = '1-0-9';
 
+/** @const {string} */
+const CREATIVE_SIZE_HEADER = 'X-CreativeSize';
+
 /** @type {string} @visibleForTesting */
 export const RENDERING_TYPE_HEADER = 'X-AmpAdRender';
 
@@ -110,9 +113,11 @@ const SHARED_IFRAME_PROPERTIES = dict({
 /** @typedef {{
  *    creative: ArrayBuffer,
  *    signature: ?Uint8Array,
- *    size: ?{width: number, height: number}
  *  }} */
 export let AdResponseDef;
+
+/** @typedef {{width: number, height: number}} */
+export let SizeInfoDef;
 
 /** @typedef {{
       minifiedCreative: string,
@@ -649,20 +654,23 @@ export class AmpA4A extends AMP.BaseElement {
         // This block returns the ad creative and signature, if available; null
         // otherwise.
         /**
-         * @return {!Promise<?{AdResponseDef}>}
+         * @return {!Promise<?{creativeParts: !AdResponseDef, size: ?SizeInfoDef}>}
          */
         .then(responseParts => {
           checkStillCurrent();
           if (responseParts) {
             this.protectedEmitLifecycleEvent_('extractCreativeAndSignature');
           }
-          return responseParts && this.extractCreativeAndSignature(
-              responseParts.bytes, responseParts.headers);
+          return responseParts && {
+	    creativeParts: this.extractCreativeAndSignature(
+        responseParts.bytes, responseParts.headers),
+	    size: this.extractSize(responseParts.headers),
+	  };
         })
         // This block returns the ad creative if it exists and validates as AMP;
         // null otherwise.
         /** @return {!Promise<?ArrayBuffer>} */
-        .then(creativeParts => {
+        .then(creativeData => {
           checkStillCurrent();
           // Keep a handle to the creative body so that we can render into
           // SafeFrame or NameFrame later, if necessary.  TODO(tdrl): Temporary,
@@ -671,10 +679,11 @@ export class AmpA4A extends AMP.BaseElement {
           // src cache issue.  If we decide to keep a SafeFrame-like solution,
           // we should restructure the promise chain to pass this info along
           // more cleanly, without use of an object variable outside the chain.
-          if (!creativeParts) {
+          if (!creativeData) {
             return Promise.resolve();
           }
-          this.creativeSize_ = creativeParts.size || this.creativeSize_;
+	  const {creativeParts, size} = creativeData;
+          this.creativeSize_ = size || this.creativeSize_;
           if (this.experimentalNonAmpCreativeRenderMethod_ !=
               XORIGIN_MODE.CLIENT_CACHE &&
               creativeParts.creative) {
@@ -1074,6 +1083,29 @@ export class AmpA4A extends AMP.BaseElement {
   extractCreativeAndSignature(unusedResponseArrayBuffer,
       unusedResponseHeaders) {
     throw new Error('extractCreativeAndSignature not implemented!');
+  }
+
+ /**
+  * Determine the desired size of the creative based on the HTTP response
+  * headers. Must be less than or equal to the original size of the ad slot
+  * along each dimension. May be overridden by network.
+  *
+  * @param {!../../../src/service/xhr-impl.FetchResponseHeaders} responseHeaders
+  * @return {?SizeInfoDef}
+  */
+  extractSize(responseHeaders) {
+    const headerValue = responseHeaders.get(CREATIVE_SIZE_HEADER);
+    if (!headerValue) {
+      return null;
+    }
+    if (!(/[0-9]+x[0-9]+/.test(headerValue))) {
+      // TODO(@taymonbeal, #9274): replace this with real error reporting
+      user().error(TAG, `Invalid size header: ${headerValue}`);
+      return null;
+    }
+    const sizeArr = headerValue.split('x').map(Number);
+    return /** @type {?SizeInfoDef} */ (
+        {width: sizeArr[0], height: sizeArr[1]});
   }
 
   /**

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -663,9 +663,8 @@ export class AmpA4A extends AMP.BaseElement {
           }
           this.protectedEmitLifecycleEvent_('extractCreativeAndSignature');
           const size = this.extractSize(responseParts.headers);
-          return this
-              .extractCreativeAndSignature(
-                  responseParts.bytes, responseParts.headers)
+          return this.extractCreativeAndSignature(
+              responseParts.bytes, responseParts.headers)
               .then(creativeParts => ({creativeParts, size}));
         })
         // This block returns the ad creative if it exists and validates as AMP;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -652,7 +652,7 @@ export class AmpA4A extends AMP.BaseElement {
           });
         })
         // This block returns the ad creative, signature, and size, if
-        // available; nullotherwise.
+        // available; null otherwise.
         /**
          * @return {?Promise<{creativeParts: !AdResponseDef, size: ?SizeInfoDef}>}
          */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -651,8 +651,8 @@ export class AmpA4A extends AMP.BaseElement {
             };
           });
         })
-        // This block returns the ad creative and signature, if available; null
-        // otherwise.
+        // This block returns the ad creative, signature, and size, if
+        // available; nullotherwise.
         /**
          * @return {!Promise<?{creativeParts: !AdResponseDef, size: ?SizeInfoDef}>}
          */
@@ -662,10 +662,10 @@ export class AmpA4A extends AMP.BaseElement {
             this.protectedEmitLifecycleEvent_('extractCreativeAndSignature');
           }
           return responseParts && {
-	    creativeParts: this.extractCreativeAndSignature(
-        responseParts.bytes, responseParts.headers),
-	    size: this.extractSize(responseParts.headers),
-	  };
+            creativeParts: this.extractCreativeAndSignature(
+                responseParts.bytes, responseParts.headers),
+            size: this.extractSize(responseParts.headers),
+          };
         })
         // This block returns the ad creative if it exists and validates as AMP;
         // null otherwise.
@@ -682,7 +682,7 @@ export class AmpA4A extends AMP.BaseElement {
           if (!creativeData) {
             return Promise.resolve();
           }
-	  const {creativeParts, size} = creativeData;
+          const {creativeParts, size} = creativeData;
           this.creativeSize_ = size || this.creativeSize_;
           if (this.experimentalNonAmpCreativeRenderMethod_ !=
               XORIGIN_MODE.CLIENT_CACHE &&

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -654,7 +654,7 @@ export class AmpA4A extends AMP.BaseElement {
         // This block returns the ad creative, signature, and size, if
         // available; nullotherwise.
         /**
-         * @return {!Promise<?{creativeParts: !AdResponseDef, size: ?SizeInfoDef}>}
+         * @return {?Promise<{creativeParts: !AdResponseDef, size: ?SizeInfoDef}>}
          */
         .then(responseParts => {
           checkStillCurrent();

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2159,6 +2159,24 @@ describe('amp-a4a', () => {
     });
   });
 
+  describe('#extractSize', () => {
+
+    it('should return a size', () => {
+      expect(AmpA4A.prototype.extractSize({
+        get(name) {
+	  return {'X-CreativeSize': '320x50'}[name];
+        },
+      })).to.deep.equal({width: 320, height: 50});
+    });
+
+    it('should return no size', () => {
+      expect(AmpA4A.prototype.extractSize({
+        get(unusedName) {
+	  return null;
+        },
+      })).to.be.null;
+    });
+  });
   // TODO(tdrl): Other cases to handle for parsing JSON metadata:
   //   - Metadata tag(s) missing
   //   - JSON parse failure

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -206,11 +206,12 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       // Load amp-analytics extensions
       this.extensions_./*OK*/loadExtension('amp-analytics');
     }
-    return extractGoogleAdCreativeAndSignature(responseText, responseHeaders)
-        .then(adResponse => {
-          adResponse.size = this.size_;
-          return Promise.resolve(adResponse);
-        });
+    return extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
+  }
+
+  /** @override */
+  extractSize(unusedResponseHeaders) {
+    return this.size_;
   }
 
   /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -337,7 +337,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
               has() { return false; },
             }).then(adResponse => {
               expect(adResponse).to.deep.equal(
-                  {creative, signature: null, size: null});
+                  {creative, signature: null});
               expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
                   .called;
             });
@@ -356,8 +356,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
               },
             }).then(adResponse => {
               expect(adResponse).to.deep.equal(
-                  {creative, signature: base64UrlDecodeToBytes('AQAB'),
-                    size: null});
+                  {creative, signature: base64UrlDecodeToBytes('AQAB')});
               expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
                   .called;
             });
@@ -387,7 +386,6 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
                   {
                     creative,
                     signature: base64UrlDecodeToBytes('AQAB'),
-                    size: null,
                   });
               expect(loadExtensionSpy.withArgs('amp-analytics')).to.be.called;
             // exact value of ampAnalyticsConfig_ covered in

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -342,19 +342,21 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       // Load amp-analytics extensions
       this.extensions_./*OK*/loadExtension('amp-analytics');
     }
-    const adResponsePromise =
-        extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
-    return adResponsePromise.then(adResponse => {
-      // If the server returned a size, use that, otherwise use the size that
-      // we sent in the ad request.
-      if (adResponse.size) {
-        this.size_ = adResponse.size;
-      } else {
-        adResponse.size = this.size_;
-      }
-      this.handleResize_(adResponse.size.width, adResponse.size.height);
-      return Promise.resolve(adResponse);
-    });
+    return extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
+  }
+
+  /** @override */
+  extractSize(responseHeaders) {
+    // If the server returned a size, use that, otherwise use the size that we
+    // sent in the ad request.
+    let size = super.extractSize(responseHeaders);
+    if (size) {
+      this.size_ = size;
+    } else {
+      size = this.size_;
+    }
+    this.handleResize_(size.width, size.height);
+    return size;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -152,18 +152,21 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
 
     it('without signature', () => {
       const headers = {
-        get() { return undefined; },
-        has() { return false; },
+        get() {
+          return undefined;
+        },
+        has() {
+          return false;
+        },
       };
       return utf8Encode('some creative').then(creative => {
         return impl.extractCreativeAndSignature(creative, headers)
-	    .then(adResponse => {
-      expect(adResponse).to.deep.equal(
-                  {creative, signature: null});
-	      expect(impl.extractSize(headers)).to.deep.equal(size);
-      expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
-          .called;
-    });
+            .then(adResponse => {
+              expect(adResponse).to.deep.equal({creative, signature: null});
+              expect(impl.extractSize(headers)).to.deep.equal(size);
+              expect(loadExtensionSpy.withArgs('amp-analytics'))
+                  .to.not.be.called;
+            });
       });
     });
     it('with signature', () => {
@@ -177,13 +180,15 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           },
         };
         return impl.extractCreativeAndSignature(creative, headers)
-	    .then(adResponse => {
-      expect(adResponse).to.deep.equal(
-                  {creative, signature: base64UrlDecodeToBytes('AQAB')});
-	      expect(impl.extractSize(headers)).to.deep.equal(size);
-      expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
-          .called;
-    });
+            .then(adResponse => {
+              expect(adResponse).to.deep.equal({
+                creative,
+                signature: base64UrlDecodeToBytes('AQAB'),
+              });
+              expect(impl.extractSize(headers)).to.deep.equal(size);
+              expect(loadExtensionSpy.withArgs('amp-analytics'))
+                  .to.not.be.called;
+            });
       });
     });
     it('with analytics', () => {
@@ -205,17 +210,16 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           },
         };
         return impl.extractCreativeAndSignature(creative, headers)
-	    .then(adResponse => {
-      expect(adResponse).to.deep.equal(
-          {
-            creative,
-            signature: base64UrlDecodeToBytes('AQAB'),
-          });
-	      expect(impl.extractSize(headers)).to.deep.equal(size);
-      expect(loadExtensionSpy.withArgs('amp-analytics')).to.be.called;
-            // exact value of ampAnalyticsConfig covered in
-            // ads/google/test/test-utils.js
-    });
+            .then(adResponse => {
+              expect(adResponse).to.deep.equal({
+                creative,
+                signature: base64UrlDecodeToBytes('AQAB'),
+              });
+              expect(impl.extractSize(headers)).to.deep.equal(size);
+              expect(loadExtensionSpy.withArgs('amp-analytics')).to.be.called;
+              // exact value of ampAnalyticsConfig covered in
+              // ads/google/test/test-utils.js
+            });
       });
     });
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -151,69 +151,71 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
     });
 
     it('without signature', () => {
+      const headers = {
+        get() { return undefined; },
+        has() { return false; },
+      };
       return utf8Encode('some creative').then(creative => {
-        return impl.extractCreativeAndSignature(
-            creative,
-            {
-              get() { return undefined; },
-              has() { return false; },
-            }).then(adResponse => {
-              expect(adResponse).to.deep.equal(
-                  {creative, signature: null, size});
-              expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
-                  .called;
-            });
+        return impl.extractCreativeAndSignature(creative, headers)
+	    .then(adResponse => {
+      expect(adResponse).to.deep.equal(
+                  {creative, signature: null});
+	      expect(impl.extractSize(headers)).to.deep.equal(size);
+      expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
+          .called;
+    });
       });
     });
     it('with signature', () => {
       return utf8Encode('some creative').then(creative => {
-        return impl.extractCreativeAndSignature(
-            creative,
-            {
-              get(name) {
-                return name == 'X-AmpAdSignature' ? 'AQAB' : undefined;
-              },
-              has(name) {
-                return name === 'X-AmpAdSignature';
-              },
-            }).then(adResponse => {
-              expect(adResponse).to.deep.equal(
-              {creative, signature: base64UrlDecodeToBytes('AQAB'), size});
-              expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
-                  .called;
-            });
+        const headers = {
+          get(name) {
+            return name == 'X-AmpAdSignature' ? 'AQAB' : undefined;
+          },
+          has(name) {
+            return name === 'X-AmpAdSignature';
+          },
+        };
+        return impl.extractCreativeAndSignature(creative, headers)
+	    .then(adResponse => {
+      expect(adResponse).to.deep.equal(
+                  {creative, signature: base64UrlDecodeToBytes('AQAB')});
+	      expect(impl.extractSize(headers)).to.deep.equal(size);
+      expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
+          .called;
+    });
       });
     });
     it('with analytics', () => {
       return utf8Encode('some creative').then(creative => {
         const url = ['https://foo.com?a=b', 'https://blah.com?lsk=sdk&sld=vj'];
-        return impl.extractCreativeAndSignature(
+        const headers = {
+          get(name) {
+            switch (name) {
+              case 'X-AmpAnalytics':
+                return JSON.stringify({url});
+              case 'X-AmpAdSignature':
+                return 'AQAB';
+              default:
+                return undefined;
+            }
+          },
+          has(name) {
+            return !!this.get(name);
+          },
+        };
+        return impl.extractCreativeAndSignature(creative, headers)
+	    .then(adResponse => {
+      expect(adResponse).to.deep.equal(
+          {
             creative,
-            {
-              get(name) {
-                switch (name) {
-                  case 'X-AmpAnalytics':
-                    return JSON.stringify({url});
-                  case 'X-AmpAdSignature':
-                    return 'AQAB';
-                  default:
-                    return undefined;
-                }
-              },
-              has(name) {
-                return !!this.get(name);
-              },
-            }).then(adResponse => {
-              expect(adResponse).to.deep.equal(
-                  {
-                    creative,
-                    signature: base64UrlDecodeToBytes('AQAB'),
-                    size,
-                  });
-              expect(loadExtensionSpy.withArgs('amp-analytics')).to.be.called;
+            signature: base64UrlDecodeToBytes('AQAB'),
+          });
+	      expect(impl.extractSize(headers)).to.deep.equal(size);
+      expect(loadExtensionSpy.withArgs('amp-analytics')).to.be.called;
             // exact value of ampAnalyticsConfig covered in
             // ads/google/test/test-utils.js
-            });
+    });
       });
     });
   });


### PR DESCRIPTION
Determining the size of a Fast Fetch creative is now done through its own overridable method in `AmpA4A`. This will facilitate the deprecation of `extractCreativeAndSignature`, which in turn will facilitate having two different signature schemes controlled by a client-side experiment.

One of the PRs that #9040 is being split into. Related to #7618.