### PR TITLE
Fix amp-bind in PWA

### DIFF
--- a/examples/pwa/pwa.html
+++ b/examples/pwa/pwa.html
@@ -104,6 +104,12 @@
           <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
         </a>
       </article>
+      <article class="card">
+        <a href="/pwa/examples/bind/basic.amp.html">
+          <h4>amp-bind</h4>
+          <div class="detail">Fusce pretium tempor justo, vitae consequat dolor maximus eget.</div>
+        </a>
+      </article>
     </section>
 
     <div id="doc-container" class="doc-container">

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -146,7 +146,7 @@ export class Bind {
      * @const @private {Promise}
      */
     this.initializePromise_ =
-        this.viewer_.whenFirstVisible().then(bodyPromise).then(body => {
+        this.viewer_.whenFirstVisible().then(() => bodyPromise).then(body => {
           return this.initialize_(body);
         });
 
@@ -244,7 +244,6 @@ export class Bind {
       rootNode.addEventListener(
           AmpEvents.TEMPLATE_RENDERED, this.boundOnTemplateRendered_);
     });
-    // Check default values against initial expression results in development.
     if (getMode().development) {
       // Check default values against initial expression results.
       promise = promise.then(() =>

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -105,7 +105,8 @@ export class Bind {
     /**
      * The window containing the document to scan.
      * May differ from the `ampdoc`'s window e.g. in FIE.
-     * @const @private {!Window} */
+     * @const @private {!Window}
+     */
     this.localWin_ = opt_win || ampdoc.win;
 
     /** @private {!Array<BoundElementDef>} */
@@ -135,15 +136,21 @@ export class Bind {
     /** @const @private {!../../../src/service/viewer-impl.Viewer} */
     this.viewer_ = viewerForDoc(this.ampdoc);
 
-    /**
+    const bodyReadyPromise = (opt_win)
+        ? waitForBodyPromise(opt_win.document)
+        : ampdoc.whenBodyAvailable();
+
+    /**c.
      * Resolved when the service finishes scanning the document for bindings.
      * @const @private {Promise}
      */
     this.initializePromise_ = Promise.all([
-      waitForBodyPromise(this.localWin_.document), // Wait for body.
+      bodyReadyPromise, // Don't scan for bindings until body is ready.
       this.viewer_.whenFirstVisible(), // Don't initialize in prerender mode.
     ]).then(() => {
-      const rootNode = dev().assertElement(this.localWin_.document.body);
+      const rootNode = (opt_win)
+          ? dev().assertElement(opt_win.document.body)
+          : ampdoc.getBody();
       return this.initialize_(rootNode);
     });
 

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -62,7 +62,7 @@ export function getElementServiceIfAvailable(win, id, extension, opt_element) {
   if (s) {
     return /** @type {!Promise<?Object>} */ (s);
   }
-  return elementServicePromiseOrNull(win, id, extension, opt_element);
+  return getElementServicePromiseOrNull(win, id, extension, opt_element);
 }
 
 /**
@@ -182,7 +182,7 @@ export function getElementServiceIfAvailableForDocInEmbedScope(
     const topWin = getTopWindow(win);
     // Don't return promise unless this is definitely FIE to avoid covfefe.
     if (win !== topWin) {
-      return elementServicePromiseOrNull(win, id, extension);
+      return getElementServicePromiseOrNull(win, id, extension);
     }
   }
   return /** @type {!Promise<?Object>} */ (Promise.resolve(null));
@@ -214,7 +214,7 @@ function assertService(service, id, extension) {
  * @return {!Promise<Object>}
  * @private
  */
-function elementServicePromiseOrNull(win, id, extension, opt_element) {
+function getElementServicePromiseOrNull(win, id, extension, opt_element) {
   // Microtask is necessary to ensure that window.ampExtendedElements has been
   // initialized.
   return Promise.resolve().then(() => {

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -21,6 +21,7 @@ import {
   getAmpdoc,
   getServicePromiseForDoc,
   getServicePromiseOrNullForDoc,
+  getTopWindow,
 } from './service';
 import {user} from './log';
 import * as dom from './dom';
@@ -173,10 +174,16 @@ export function getElementServiceIfAvailableForDocInEmbedScope(
   if (s) {
     return /** @type {!Promise<?Object>} */ (Promise.resolve(s));
   }
+  // Return embed-scope element service promise if scheduled.
   if (nodeOrDoc.nodeType) {
+    // In embeds, doc-scope services are window-scope.
     const win = /** @type {!Document} */ (
         nodeOrDoc.ownerDocument || nodeOrDoc).defaultView;
-    return elementServicePromiseOrNull(win, id, extension);
+    const topWin = getTopWindow(win);
+    // Don't return promise unless this is definitely FIE to avoid covfefe.
+    if (win !== topWin) {
+      return elementServicePromiseOrNull(win, id, extension);
+    }
   }
   return /** @type {!Promise<?Object>} */ (Promise.resolve(null));
 }

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -176,11 +176,12 @@ export function getElementServiceIfAvailableForDocInEmbedScope(
   }
   // Return embed-scope element service promise if scheduled.
   if (nodeOrDoc.nodeType) {
-    // In embeds, doc-scope services are window-scope.
     const win = /** @type {!Document} */ (
         nodeOrDoc.ownerDocument || nodeOrDoc).defaultView;
     const topWin = getTopWindow(win);
-    // Don't return promise unless this is definitely FIE to avoid covfefe.
+    // In embeds, doc-scope services are window-scope. But make sure to
+    // only do this for embeds (not the top window), otherwise we'd grab
+    // a promise from the wrong service holder which would never resolve.
     if (win !== topWin) {
       return getElementServicePromiseOrNull(win, id, extension);
     }

--- a/src/service.js
+++ b/src/service.js
@@ -14,6 +14,40 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview Registration and getter functions for AMP services.
+ *
+ * Invariant: Service getters never return null for registered services.
+ *
+ * Types of getters:
+ *   1. get win-service [promise]
+ *   2. get win-service or null if unregistered [promise]
+ *   3. get doc-service [promise]
+ *   4. get doc-service or null if unregistered [promise]
+ *   5. get win-service in embed (w/ optional fallback)
+ *   6. get doc-service in embed (w/ optional fallback)
+ *
+ * Types of element service getters (element-service.js):
+ *   a. get win-service
+ *   b. get win-service or null if unregistered
+ *   c. get doc-service
+ *   d. get doc-service or null if unregistered
+ *   e. get doc-service in embed
+ *   f. get doc-service in embed or null if unregistered
+ *
+ * TODO(choumx): Fix the following:
+ *   - Does the caller need to know if a service is window-scope or doc-scope?
+ *   - In embeds, doc-scope services are win-level, and need to use
+ *     `document.body` instead of AmpDoc.getBody(), etc.
+ *   - Need to be very careful when to allow/disallow FIE fallback.
+ *   - "Existing" and "orNull" are redundant, e.g. getExistingServiceOrNull.
+ *     Besides, "existing" is misleading since it will instantiate nonexistent
+ *     but registered services.
+ *   - "Promise" suffix inconsistently applied (i.e. getServicePromise,
+ *     getElementService)
+ *   - (4) doesn't exist.
+ */
+
 // Requires polyfills in immediate side effect.
 import './polyfills';
 import {dev} from './log';
@@ -68,36 +102,25 @@ export class EmbeddableService {
   adoptEmbedWindow(unusedEmbedWin) {}
 }
 
-/**
- * Returns a service or null with the given id.
- * @param {!Window} win
- * @param {string} id
- * @return {?Object} The service.
- */
-export function getExistingServiceOrNull(win, id) {
-  win = getTopWindow(win);
-  if (isServiceRegistered(win, id)) {
-    return getServiceInternal(win, id);
-  } else {
-    return null;
-  }
-}
 
 /**
  * Returns a service with the given id. Assumes that it has been registered
  * already.
  * @param {!Window} win
  * @param {string} id
+ * @param {boolean} opt_fallbackToTopWin
  * @return {!Object} The service.
  */
-export function getExistingServiceInEmbedScope(win, id) {
+export function getExistingServiceInEmbedScope(win, id, opt_fallbackToTopWin) {
   // First, try to resolve via local (embed) window.
   const local = getLocalExistingServiceForEmbedWinOrNull(win, id);
   if (local) {
     return local;
   }
-  // Fallback to top-level window.
-  return getService(win, id);
+  if (opt_fallbackToTopWin) {
+    return getService(win, id);
+  }
+  return null;
 }
 
 /**
@@ -105,9 +128,11 @@ export function getExistingServiceInEmbedScope(win, id) {
  * already.
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @param {string} id
+ * @param {boolean} opt_fallbackToTopWin
  * @return {!Object} The service.
  */
-export function getExistingServiceForDocInEmbedScope(nodeOrDoc, id) {
+export function getExistingServiceForDocInEmbedScope(
+    nodeOrDoc, id, opt_fallbackToTopWin) {
   // First, try to resolve via local (embed) window.
   if (nodeOrDoc.nodeType) {
     // If a node is passed, try to resolve via this node.
@@ -118,8 +143,10 @@ export function getExistingServiceForDocInEmbedScope(nodeOrDoc, id) {
       return local;
     }
   }
-  // Fallback to ampdoc.
-  return getServiceForDoc(nodeOrDoc, id);
+  if (opt_fallbackToTopWin) {
+    return getServiceForDoc(nodeOrDoc, id);
+  }
+  return null;
 }
 
 /**
@@ -134,13 +161,8 @@ export function installServiceInEmbedScope(embedWin, id, service) {
       'Service override can only be installed in embed window: %s', id);
   dev().assert(!getLocalExistingServiceForEmbedWinOrNull(embedWin, id),
       'Service override has already been installed: %s', id);
-  registerServiceInternal(
-      embedWin,
-      embedWin,
-      id,
-      () => service);
-  // Force service to build
-  getServiceInternal(embedWin, id);
+  registerServiceInternal(embedWin, embedWin, id, () => service);
+  getServiceInternal(embedWin, id); // Force service to build.
 }
 
 /**
@@ -161,21 +183,6 @@ function getLocalExistingServiceForEmbedWinOrNull(embedWin, id) {
 }
 
 /**
- * Returns a service for the given id and window (a per-window singleton).
- * Users should typically wrap this as a special purpose function (e.g.
- * `vsyncFor(win)`) for type safety and because the factory should not be
- * passed around.
- * @param {!Window} win
- * @param {string} id of the service.
- * @template T
- * @return {T}
- */
-export function getService(win, id) {
-  win = getTopWindow(win);
-  return getServiceInternal(win, id);
-}
-
-/**
  * Registers a service given a class to be used as implementation.
  * @param {!Window} win
  * @param {string} id of the service.
@@ -192,6 +199,7 @@ export function registerServiceBuilder(win,
     getServiceInternal(win, id);
   }
 }
+
 
 /**
  * Returns a service and registers it given a class to be used as
@@ -213,6 +221,23 @@ export function registerServiceBuilderForDoc(nodeOrDoc,
   }
 }
 
+
+/**
+ * Returns a service for the given id and window (a per-window singleton).
+ * Users should typically wrap this as a special purpose function (e.g.
+ * `vsyncFor(win)`) for type safety and because the factory should not be
+ * passed around.
+ * @param {!Window} win
+ * @param {string} id of the service.
+ * @template T
+ * @return {T}
+ */
+export function getService(win, id) {
+  win = getTopWindow(win);
+  return getServiceInternal(win, id);
+}
+
+
 /**
  * Returns a promise for a service for the given id and window. Also expects
  * an element that has the actual implementation. The promise resolves when
@@ -230,6 +255,22 @@ export function getServicePromise(win, id) {
 
 
 /**
+ * Returns a service or null with the given id.
+ * @param {!Window} win
+ * @param {string} id
+ * @return {?Object} The service.
+ */
+export function getExistingServiceOrNull(win, id) {
+  win = getTopWindow(win);
+  if (isServiceRegistered(win, id)) {
+    return getServiceInternal(win, id);
+  } else {
+    return null;
+  }
+}
+
+
+/**
  * Like getServicePromise but returns null if the service was never registered.
  * @param {!Window} win
  * @param {string} id of the service.
@@ -238,6 +279,7 @@ export function getServicePromise(win, id) {
 export function getServicePromiseOrNull(win, id) {
   return getServicePromiseOrNullInternal(win, id);
 }
+
 
 /**
  * Returns a service for the given id and ampdoc (a per-ampdoc singleton).
@@ -253,6 +295,7 @@ export function getServiceForDoc(nodeOrDoc, id) {
   return getServiceInternal(holder, id);
 }
 
+
 /**
  * Returns a promise for a service for the given id and ampdoc. Also expects
  * a service that has the actual implementation. The promise resolves when
@@ -263,8 +306,7 @@ export function getServiceForDoc(nodeOrDoc, id) {
  */
 export function getServicePromiseForDoc(nodeOrDoc, id) {
   return getServicePromiseInternal(
-      getAmpdocServiceHolder(nodeOrDoc),
-      id);
+      getAmpdocServiceHolder(nodeOrDoc), id);
 }
 
 
@@ -277,8 +319,7 @@ export function getServicePromiseForDoc(nodeOrDoc, id) {
  */
 export function getServicePromiseOrNullForDoc(nodeOrDoc, id) {
   return getServicePromiseOrNullInternal(
-      getAmpdocServiceHolder(nodeOrDoc),
-      id);
+      getAmpdocServiceHolder(nodeOrDoc), id);
 }
 
 /**

--- a/src/service.js
+++ b/src/service.js
@@ -115,7 +115,8 @@ export function getExistingServiceForDocInEmbedScope(
       return local;
     }
   }
-  if (opt_fallbackToTopWin) {
+  // If an ampdoc is passed or fallback is allowed, continue resolving.
+  if (!nodeOrDoc.nodeType || opt_fallbackToTopWin) {
     return getServiceForDoc(nodeOrDoc, id);
   }
   return null;

--- a/src/service.js
+++ b/src/service.js
@@ -80,8 +80,8 @@ export class EmbeddableService {
  * already.
  * @param {!Window} win
  * @param {string} id
- * @param {boolean} opt_fallbackToTopWin
- * @return {!Object} The service.
+ * @param {boolean=} opt_fallbackToTopWin
+ * @return {Object} The service.
  */
 export function getExistingServiceInEmbedScope(win, id, opt_fallbackToTopWin) {
   // First, try to resolve via local (embed) window.
@@ -100,8 +100,8 @@ export function getExistingServiceInEmbedScope(win, id, opt_fallbackToTopWin) {
  * already.
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @param {string} id
- * @param {boolean} opt_fallbackToTopWin
- * @return {!Object} The service.
+ * @param {boolean=} opt_fallbackToTopWin
+ * @return {Object} The service.
  */
 export function getExistingServiceForDocInEmbedScope(
     nodeOrDoc, id, opt_fallbackToTopWin) {

--- a/src/service.js
+++ b/src/service.js
@@ -18,34 +18,6 @@
  * @fileoverview Registration and getter functions for AMP services.
  *
  * Invariant: Service getters never return null for registered services.
- *
- * Types of getters:
- *   1. get win-service [promise]
- *   2. get win-service or null if unregistered [promise]
- *   3. get doc-service [promise]
- *   4. get doc-service or null if unregistered [promise]
- *   5. get win-service in embed (w/ optional fallback)
- *   6. get doc-service in embed (w/ optional fallback)
- *
- * Types of element service getters (element-service.js):
- *   a. get win-service
- *   b. get win-service or null if unregistered
- *   c. get doc-service
- *   d. get doc-service or null if unregistered
- *   e. get doc-service in embed
- *   f. get doc-service in embed or null if unregistered
- *
- * TODO(choumx): Fix the following:
- *   - Does the caller need to know if a service is window-scope or doc-scope?
- *   - In embeds, doc-scope services are win-level, and need to use
- *     `document.body` instead of AmpDoc.getBody(), etc.
- *   - Need to be very careful when to allow/disallow FIE fallback.
- *   - "Existing" and "orNull" are redundant, e.g. getExistingServiceOrNull.
- *     Besides, "existing" is misleading since it will instantiate nonexistent
- *     but registered services.
- *   - "Promise" suffix inconsistently applied (i.e. getServicePromise,
- *     getElementService)
- *   - (4) doesn't exist.
  */
 
 // Requires polyfills in immediate side effect.

--- a/src/services.js
+++ b/src/services.js
@@ -57,7 +57,8 @@ export function accessServiceForDocOrNull(nodeOrDoc) {
  */
 export function actionServiceForDoc(nodeOrDoc) {
   return /** @type {!./service/action-impl.ActionService} */ (
-      getExistingServiceForDocInEmbedScope(nodeOrDoc, 'action'));
+      getExistingServiceForDocInEmbedScope(
+          nodeOrDoc, 'action', /* opt_fallbackToTopWin */ true));
 }
 
 /**
@@ -232,7 +233,8 @@ export function timerFor(window) {
  */
 export function urlReplacementsForDoc(nodeOrDoc) {
   return /** @type {!./service/url-replacements-impl.UrlReplacements} */ (
-      getExistingServiceForDocInEmbedScope(nodeOrDoc, 'url-replace'));
+      getExistingServiceForDocInEmbedScope(
+          nodeOrDoc, 'url-replace', /* opt_fallbackToTopWin */ true));
 }
 
 /**

--- a/test/functional/test-element-service.js
+++ b/test/functional/test-element-service.js
@@ -363,8 +363,8 @@ describes.fakeWin('in embed scope', {amp: true}, env => {
     installServiceInEmbedScope(embedWin, 'foo', service);
     return getElementServiceIfAvailableForDocInEmbedScope(
         nodeInEmbedWin, 'foo', 'amp-foo').then(returned => {
-      expect(returned).to.equal(service);
-    });
+          expect(returned).to.equal(service);
+        });
   });
 
   it('should return service for scheduled element', () => {
@@ -384,8 +384,8 @@ describes.fakeWin('in embed scope', {amp: true}, env => {
     registerServiceBuilder(win, 'foo', () => service);
     return getElementServiceIfAvailableForDocInEmbedScope(
         nodeInTopWin, 'foo', 'amp-foo').then(returned => {
-      expect(returned).to.be.null;
-    });
+          expect(returned).to.be.null;
+        });
   });
 
   it('"if available" should not fall back to top window\'s service', () => {
@@ -396,8 +396,8 @@ describes.fakeWin('in embed scope', {amp: true}, env => {
         /* opt_instantiate */ true);
     return getElementServiceIfAvailableForDocInEmbedScope(
         nodeInEmbedWin, 'foo', 'amp-foo').then(returned => {
-      expect(returned).to.be.null;
-    });
+          expect(returned).to.be.null;
+        });
   });
 
   it('should fall back to top window\'s service', () => {
@@ -408,7 +408,7 @@ describes.fakeWin('in embed scope', {amp: true}, env => {
         /* opt_instantiate */ true);
     return getElementServiceForDocInEmbedScope(
         nodeInEmbedWin, 'foo', 'amp-foo').then(returned => {
-      expect(returned).to.equal(service);
-    });
+          expect(returned).to.equal(service);
+        });
   });
 });

--- a/test/functional/test-element-service.js
+++ b/test/functional/test-element-service.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {FakeWindow} from '../../testing/fake-dom';
 import {
   markElementScheduledForTesting,
   resetScheduledElementForTesting,
@@ -23,10 +24,15 @@ import {
   getElementServiceIfAvailable,
   getElementServiceForDoc,
   getElementServiceIfAvailableForDoc,
+  getElementServiceForDocInEmbedScope,
+  getElementServiceIfAvailableForDocInEmbedScope,
 } from '../../src/element-service';
 import {
+  installServiceInEmbedScope,
   registerServiceBuilder,
+  registerServiceBuilderForDoc,
   resetServiceForTesting,
+  setParentWindow,
 } from '../../src/service';
 
 describe('getElementServiceIfAvailable()', () => {
@@ -320,6 +326,89 @@ describes.realWin('in single ampdoc', {
       }).then(service => {
         expect(service).to.deep.equal({str: 'fake1'});
       });
+    });
+  });
+});
+
+describes.fakeWin('in embed scope', {amp: true}, env => {
+  let win;
+  let embedWin;
+  let nodeInEmbedWin;
+  let nodeInTopWin;
+  let service;
+
+  beforeEach(() => {
+    win = env.win;
+
+    embedWin = new FakeWindow();
+    setParentWindow(embedWin, win);
+
+    nodeInEmbedWin = {
+      nodeType: Node.ELEMENT_NODE,
+      ownerDocument: {
+        defaultView: embedWin,
+      },
+    };
+    nodeInTopWin = {
+      nodeType: Node.ELEMENT_NODE,
+      ownerDocument: {
+        defaultView: win,
+      },
+    };
+
+    service = {name: 'fake-service-object'};
+  });
+
+  it('should return existing service', () => {
+    installServiceInEmbedScope(embedWin, 'foo', service);
+    return getElementServiceIfAvailableForDocInEmbedScope(
+        nodeInEmbedWin, 'foo', 'amp-foo').then(returned => {
+      expect(returned).to.equal(service);
+    });
+  });
+
+  it('should return service for scheduled element', () => {
+    markElementScheduledForTesting(embedWin, 'amp-foo');
+    const promise = getElementServiceIfAvailableForDocInEmbedScope(
+        nodeInEmbedWin, 'foo', 'amp-foo');
+    installServiceInEmbedScope(embedWin, 'foo', service);
+    return promise.then(returned => {
+      expect(returned).to.equal(service);
+    });
+  });
+
+  it('should return null if win is top window', () => {
+    markElementScheduledForTesting(win, 'amp-foo');
+    // Use `registerServiceBuilder` since `installServiceInEmbedScope` will
+    // fail for top windows.
+    registerServiceBuilder(win, 'foo', () => service);
+    return getElementServiceIfAvailableForDocInEmbedScope(
+        nodeInTopWin, 'foo', 'amp-foo').then(returned => {
+      expect(returned).to.be.null;
+    });
+  });
+
+  it('"if available" should not fall back to top window\'s service', () => {
+    markElementScheduledForTesting(win, 'amp-foo');
+    // Use `registerServiceBuilder` since `installServiceInEmbedScope` will
+    // fail for top windows.
+    registerServiceBuilder(win, 'foo', () => service,
+        /* opt_instantiate */ true);
+    return getElementServiceIfAvailableForDocInEmbedScope(
+        nodeInEmbedWin, 'foo', 'amp-foo').then(returned => {
+      expect(returned).to.be.null;
+    });
+  });
+
+  it('should fall back to top window\'s service', () => {
+    markElementScheduledForTesting(win, 'amp-foo');
+    // Use `registerServiceBuilder` since `installServiceInEmbedScope` will
+    // fail for top windows.
+    registerServiceBuilderForDoc(env.ampdoc, 'foo', () => service,
+        /* opt_instantiate */ true);
+    return getElementServiceForDocInEmbedScope(
+        nodeInEmbedWin, 'foo', 'amp-foo').then(returned => {
+      expect(returned).to.equal(service);
     });
   });
 });

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -242,16 +242,25 @@ describe('service', () => {
         topService = getService(window, 'c');
       });
 
-      it('should return top service for top window', () => {
-        expect(getExistingServiceInEmbedScope(window, 'c'))
-            .to.equal(topService);
+      it('should not fall back to top window service by default', () => {
+        const service = getExistingServiceInEmbedScope(window, 'c');
+        expect(service).to.be.null;
       });
 
-      it('should return top service when not overriden', () => {
-        expect(getExistingServiceInEmbedScope(childWin, 'c'))
-            .to.equal(topService);
-        expect(getExistingServiceInEmbedScope(grandchildWin, 'c'))
-            .to.equal(topService);
+      it('should fall back top window service', () => {
+        const service = getExistingServiceInEmbedScope(
+            window, 'c', /* opt_fallbackToTopWin */ true);
+        expect(service).to.equal(topService);
+      });
+
+      it('should fall back to top service when not overriden', () => {
+        const childService = getExistingServiceInEmbedScope(
+            childWin, 'c', /* opt_fallbackToTopWin */ true);
+        expect(childService).to.equal(topService);
+
+        const grandchildService = getExistingServiceInEmbedScope(
+            grandchildWin, 'c', /* opt_fallbackToTopWin */ true);
+        expect(grandchildService).to.equal(topService);
       });
 
       it('should return overriden service', () => {
@@ -509,16 +518,28 @@ describe('service', () => {
         topService = getServiceForDoc(ampdoc, 'c');
       });
 
-      it('should return top service for ampdoc', () => {
-        expect(getExistingServiceForDocInEmbedScope(ampdoc, 'c'))
-            .to.equal(topService);
+      it('should not fall back to top ampdoc service with node', () => {
+        const service = getExistingServiceForDocInEmbedScope(node, 'c');
+        expect(service).to.be.null;
       });
 
-      it('should return top service when not overriden', () => {
-        expect(getExistingServiceForDocInEmbedScope(childWinNode, 'c'))
-            .to.equal(topService);
-        expect(getExistingServiceForDocInEmbedScope(grandChildWinNode, 'c'))
-            .to.equal(topService);
+      it('should fall back to top ampdoc service', () => {
+        const fromAmpdoc = getExistingServiceForDocInEmbedScope(ampdoc, 'c');
+        expect(fromAmpdoc).to.equal(topService);
+
+        const fromNodeWithFallback = getExistingServiceForDocInEmbedScope(
+            node, 'c', /* opt_fallbackToTopWin */ true);
+        expect(fromNodeWithFallback).to.equal(topService);
+      });
+
+      it('should fall back to top ampdoc service when not overriden', () => {
+        const childService = getExistingServiceForDocInEmbedScope(
+            childWinNode, 'c', /* opt_fallbackToTopWin */ true);
+        expect(childService).to.equal(topService);
+
+        const grandchildService = getExistingServiceForDocInEmbedScope(
+            grandChildWinNode, 'c', /* opt_fallbackToTopWin */ true);
+        expect(grandchildService).to.equal(topService);
       });
 
       it('should return overriden service', () => {
@@ -530,13 +551,17 @@ describe('service', () => {
         // Top-level service doesn't change.
         expect(getExistingServiceForDocInEmbedScope(ampdoc, 'c'))
             .to.equal(topService);
-        expect(getExistingServiceForDocInEmbedScope(node, 'c'))
+        expect(getExistingServiceForDocInEmbedScope(
+            node, 'c', /* opt_fallbackToTopWin */ true))
             .to.equal(topService);
 
         // Notice that only direct overrides are allowed for now. This is
         // arbitrary can change in the future to allow hierarchical lookup
         // up the window chain.
         expect(getExistingServiceForDocInEmbedScope(grandChildWinNode, 'c'))
+            .to.be.null;
+        expect(getExistingServiceForDocInEmbedScope(
+            grandChildWinNode, 'c', /* opt_fallbackToTopWin */ true))
             .to.equal(topService);
       });
     });

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -148,7 +148,7 @@ export let TestSpec;
 /**
  * An object specifying the configuration of an AmpFixture.
  *
- * - ampdoc: "single", "shadow", "multi", "none".
+ * - ampdoc: "single", "shadow", "multi", "none", "fie".
  *
  * @typedef {{
  *   runtimeOn: (boolean|undefined),


### PR DESCRIPTION
Fixes #9916.

- Scan `ampdoc.getBody()`, not `ampdoc.win.document.body` (doesn't work for shadow docs)
- Do *not* fallback to top window when retrieving the Bind element service (instead, fallback to ampdoc since it's a doc-scope service)
- Add relevant tests for `element-service.js` and `bind-impl.js`

This PR also requires passing a boolean `opt_fallbackToTopWin` to allow crossing FIE boundary when getting services. I think this is a safer default, e.g. for A4A.