### PR TITLE
Forbid globals globally

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,6 @@
     "sinon": true,
     "sandbox": true,
     "context": false,
-    "global": false,
     "describes": true
   },
   "rules": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -61,7 +61,6 @@
     "no-extend-native": 2,
     "no-extra-bind": 2,
     "no-for-of-statement": 2,
-    "no-global": 2,
     "no-implicit-coercion": [2, { "boolean": false }],
     "no-implied-eval": 2,
     "no-iterator": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -62,6 +62,7 @@
     "no-extend-native": 2,
     "no-extra-bind": 2,
     "no-for-of-statement": 2,
+    "no-global": 2,
     "no-implicit-coercion": [2, { "boolean": false }],
     "no-implied-eval": 2,
     "no-iterator": 2,

--- a/3p/ampcontext-lib.js
+++ b/3p/ampcontext-lib.js
@@ -33,9 +33,9 @@ setReportError(() => {});
  */
 try {
   const windowContextCreated = new Event('amp-windowContextCreated');
-  self.context = new AmpContext(self);
+  window.context = new AmpContext(window);
   // Allows for pre-existence, consider validating correct window.context lib instance?
-  self.dispatchEvent(windowContextCreated);
+  window.dispatchEvent(windowContextCreated);
 } catch (err) {
   // do nothing with error
 }

--- a/3p/ampcontext-lib.js
+++ b/3p/ampcontext-lib.js
@@ -33,9 +33,9 @@ setReportError(() => {});
  */
 try {
   const windowContextCreated = new Event('amp-windowContextCreated');
-  window.context = new AmpContext(window);
+  self.context = new AmpContext(self);
   // Allows for pre-existence, consider validating correct window.context lib instance?
-  window.dispatchEvent(windowContextCreated);
+  self.dispatchEvent(windowContextCreated);
 } catch (err) {
   // do nothing with error
 }

--- a/3p/environment.js
+++ b/3p/environment.js
@@ -158,7 +158,7 @@ function instrumentIframeWindow(node, parent, win) {
  * @param {!Window} win
  */
 function installObserver(win) {
-  if (!window.MutationObserver) {
+  if (!win.MutationObserver) {
     return;
   }
   const observer = new MutationObserver(function(mutations) {
@@ -258,7 +258,7 @@ function minTime(time) {
 }
 
 export function installEmbedStateListener() {
-  listenParent(window, 'embed-state', function(data) {
+  listenParent(self, 'embed-state', function(data) {
     inViewport = data.inViewport;
   });
 };

--- a/3p/environment.js
+++ b/3p/environment.js
@@ -258,7 +258,7 @@ function minTime(time) {
 }
 
 export function installEmbedStateListener() {
-  listenParent(self, 'embed-state', function(data) {
+  listenParent(window, 'embed-state', function(data) {
     inViewport = data.inViewport;
   });
 };

--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -29,7 +29,7 @@ import {dashToUnderline} from '../src/string';
  * @param {function(!Object)} cb
  */
 function getFacebookSdk(global, cb) {
-  loadScript(global, 'https://connect.facebook.net/' + dashToUnderline(window.navigator.language) + '/sdk.js', () => {
+  loadScript(global, 'https://connect.facebook.net/' + dashToUnderline(global.navigator.language) + '/sdk.js', () => {
     cb(global.FB);
   });
 }

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -203,18 +203,18 @@ const FALLBACK_CONTEXT_DATA = dict({
 
 // Need to cache iframeName as it will be potentially overwritten by
 // masterSelection, as per below.
-const iframeName = self.name;
+const iframeName = window.name;
 const data = getData(iframeName);
 
-self.context = data['_context'];
+window.context = data['_context'];
 
 // This should only be invoked after window.context is set
 initLogConstructor();
 setReportError(console.error.bind(console));
 
 // Experiment toggles
-setExperimentToggles(self.context.experimentToggles);
-delete self.context.experimentToggles;
+setExperimentToggles(window.context.experimentToggles);
+delete window.context.experimentToggles;
 
 if (getMode().test || getMode().localDev) {
   register('_ping_', _ping_);
@@ -414,7 +414,7 @@ export function draw3p(win, data, configCallback) {
  * @return {boolean} Whether this is the master iframe.
  */
 function isMaster() {
-  return self.context.master == self;
+  return window.context.master == window;
 }
 
 /**
@@ -429,34 +429,34 @@ function isMaster() {
  * @param {!Array<string>=} opt_allowedEmbeddingOrigins List of domain suffixes
  *     that are allowed to embed this frame.
  */
-self.draw3p = function(opt_configCallback, opt_allowed3pTypes,
+window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
     opt_allowedEmbeddingOrigins) {
   try {
     const location = parseUrl(data['_context']['location']['href']);
 
-    ensureFramed(self);
-    validateParentOrigin(self, location);
-    validateAllowedTypes(self, data['type'], opt_allowed3pTypes);
+    ensureFramed(window);
+    validateParentOrigin(window, location);
+    validateAllowedTypes(window, data['type'], opt_allowed3pTypes);
     if (opt_allowedEmbeddingOrigins) {
-      validateAllowedEmbeddingOrigins(self, opt_allowedEmbeddingOrigins);
+      validateAllowedEmbeddingOrigins(window, opt_allowedEmbeddingOrigins);
     }
-    installContext(self);
+    installContext(window);
     delete data['_context'];
-    manageWin(self);
+    manageWin(window);
     installEmbedStateListener();
-    draw3p(self, data, opt_configCallback);
+    draw3p(window, data, opt_configCallback);
 
     if (isAmpContextExperimentOn()) {
-      self.context.bootstrapLoaded();
+      window.context.bootstrapLoaded();
     } else {
-      updateVisibilityState(self);
+      updateVisibilityState(window);
 
       // Subscribe to page visibility updates.
       nonSensitiveDataPostMessage('send-embed-state');
       nonSensitiveDataPostMessage('bootstrap-loaded');
     }
   } catch (e) {
-    const c = self.context || {mode: {test: false}};
+    const c = window.context || {mode: {test: false}};
     if (!c.mode.test) {
       lightweightErrorReport(e, c.canary);
       throw e;
@@ -589,7 +589,7 @@ function getHtml(selector, attributes, callback) {
     'messageId': messageId,
   }));
 
-  const unlisten = listenParent(self, 'get-html-result', data => {
+  const unlisten = listenParent(window, 'get-html-result', data => {
     if (data['messageId'] === messageId) {
       callback(data['content']);
       unlisten();
@@ -610,7 +610,7 @@ function getHtml(selector, attributes, callback) {
 function observeIntersection(observerCallback) {
   // Send request to received records.
   nonSensitiveDataPostMessage('send-intersections');
-  return listenParent(self, 'intersection', data => {
+  return listenParent(window, 'intersection', data => {
     observerCallback(data['changes']);
   });
 }
@@ -642,7 +642,7 @@ function dispatchVisibilityChangeEvent(win, isHidden) {
  *    observes for resize status messages.
  */
 function onResizeSuccess(observerCallback) {
-  return listenParent(self, 'embed-size-changed', data => {
+  return listenParent(window, 'embed-size-changed', data => {
     observerCallback(data['requestedHeight'], data['requestedWidth']);
   });
 }
@@ -654,7 +654,7 @@ function onResizeSuccess(observerCallback) {
  *    observes for resize status messages.
  */
 function onResizeDenied(observerCallback) {
-  return listenParent(self, 'embed-size-denied', data => {
+  return listenParent(window, 'embed-size-denied', data => {
     observerCallback(data['requestedHeight'], data['requestedWidth']);
   });
 }
@@ -821,6 +821,6 @@ function lightweightErrorReport(e, isCanary) {
       '?3p=1&v=' + encodeURIComponent('$internalRuntimeVersion$') +
       '&m=' + encodeURIComponent(e.message) +
       '&ca=' + (isCanary ? 1 : 0) +
-      '&r=' + encodeURIComponent(self.document.referrer) +
+      '&r=' + encodeURIComponent(window.document.referrer) +
       '&s=' + encodeURIComponent(e.stack || '');
 }

--- a/3p/messaging.js
+++ b/3p/messaging.js
@@ -23,14 +23,14 @@ import {getData} from '../src/event-helper';
  * @param {!JsonObject=} opt_object Data for the message.
  */
 export function nonSensitiveDataPostMessage(type, opt_object) {
-  if (window.parent == window) {
+  if (self.parent == self) {
     return;  // Nothing to do.
   }
   const object = opt_object || /** @type {JsonObject} */ ({});
   object['type'] = type;
-  object['sentinel'] = window.context.sentinel;
-  window.parent./*OK*/postMessage(object,
-      window.context.location.origin);
+  object['sentinel'] = self.context.sentinel;
+  self.parent./*OK*/postMessage(object,
+      self.context.location.origin);
 }
 
 /**

--- a/3p/messaging.js
+++ b/3p/messaging.js
@@ -23,14 +23,14 @@ import {getData} from '../src/event-helper';
  * @param {!JsonObject=} opt_object Data for the message.
  */
 export function nonSensitiveDataPostMessage(type, opt_object) {
-  if (self.parent == self) {
+  if (window.parent == window) {
     return;  // Nothing to do.
   }
   const object = opt_object || /** @type {JsonObject} */ ({});
   object['type'] = type;
-  object['sentinel'] = self.context.sentinel;
-  self.parent./*OK*/postMessage(object,
-      self.context.location.origin);
+  object['sentinel'] = window.context.sentinel;
+  window.parent./*OK*/postMessage(object,
+      window.context.location.origin);
 }
 
 /**

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -39,7 +39,7 @@ export function _ping_(global, data) {
         global.context.container == data.ad_container, 'wrong container');
   }
   if (data.valid && data.valid == 'true') {
-    const img = document.createElement('img');
+    const img = global.document.createElement('img');
     if (data.url) {
       img.setAttribute('src', data.url);
       img.setAttribute('width', data.width);
@@ -54,7 +54,7 @@ export function _ping_(global, data) {
       img.setAttribute('width', data.adWidth);
       width = Number(data.adWidth);
     }
-    document.body.appendChild(img);
+    global.document.body.appendChild(img);
     if (width || height) {
       global.context.renderStart({width, height});
     } else {

--- a/ads/adhese.js
+++ b/ads/adhese.js
@@ -36,7 +36,7 @@ export function adhese(global, data) {
     }
   }
   targetParam += '?t=' + Date.now();
-  writeScript(window, 'https://ads-' + encodeURIComponent(data['account']) +
+  writeScript(global, 'https://ads-' + encodeURIComponent(data['account']) +
       '.adhese.com/' + encodeURIComponent(data['requestType']) + '/sl' +
       encodeURIComponent(data['location']) +
       encodeURIComponent(data['position']) + '-' +

--- a/ads/adverticum.js
+++ b/ads/adverticum.js
@@ -29,7 +29,7 @@ export function adverticum(global, data) {
   d.id = zoneid;
   d.classList.add('goAdverticum');
 
-  document.getElementById('c').appendChild(d);
+  global.document.getElementById('c').appendChild(d);
   if (data['costumetargetstring']) {
     const s = global.document.createTextNode(data['costumetargetstring']);
     const v = global.document.createElement('var');
@@ -37,7 +37,7 @@ export function adverticum(global, data) {
     v.setAttribute('class', 'customtarget');
     setStyle(v, 'display', 'none');
     v.appendChild(s);
-    document.getElementById(zoneid).appendChild(v);
+    global.document.getElementById(zoneid).appendChild(v);
   }
   writeScript(global, '//ad.adverticum.net/g3.js');
 

--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -190,10 +190,10 @@ export function warmupDynamic(e) {
   // Preloading with empty as and newly specced value `fetch` meaning the same
   // thing. `document` would be the right value, but this is not yet supported
   // in browsers.
-  const linkRel0 = self.document.createElement('link');
+  const linkRel0 = window.document.createElement('link');
   linkRel0.rel = 'preload';
   linkRel0.href = link.eventualUrl;
-  const linkRel1 = self.document.createElement('link');
+  const linkRel1 = window.document.createElement('link');
   linkRel1.rel = 'preload';
   linkRel1.as = 'fetch';
   linkRel1.href = link.eventualUrl;

--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -169,7 +169,7 @@ export function warmupStatic(win) {
   // preconnects.
   new win.Image().src = `${urls.cdn}/preconnect.gif`;
   // Preload the primary AMP JS that is render blocking.
-  const linkRel = /*OK*/document.createElement('link');
+  const linkRel = win.document.createElement('link');
   linkRel.rel = 'preload';
   linkRel.setAttribute('as', 'script');
   linkRel.href = `${urls.cdn}/v0.js`;
@@ -190,10 +190,10 @@ export function warmupDynamic(e) {
   // Preloading with empty as and newly specced value `fetch` meaning the same
   // thing. `document` would be the right value, but this is not yet supported
   // in browsers.
-  const linkRel0 = /*OK*/document.createElement('link');
+  const linkRel0 = self.document.createElement('link');
   linkRel0.rel = 'preload';
   linkRel0.href = link.eventualUrl;
-  const linkRel1 = /*OK*/document.createElement('link');
+  const linkRel1 = self.document.createElement('link');
   linkRel1.rel = 'preload';
   linkRel1.as = 'fetch';
   linkRel1.href = link.eventualUrl;

--- a/ads/alp/install-alp.js
+++ b/ads/alp/install-alp.js
@@ -24,5 +24,5 @@ import {reportError} from '../../src/error';
 
 initLogConstructor();
 setReportError(reportError);
-installAlpClickHandler(self);
-warmupStatic(self);
+installAlpClickHandler(window);
+warmupStatic(window);

--- a/ads/alp/install-alp.js
+++ b/ads/alp/install-alp.js
@@ -24,5 +24,5 @@ import {reportError} from '../../src/error';
 
 initLogConstructor();
 setReportError(reportError);
-installAlpClickHandler(window);
-warmupStatic(window);
+installAlpClickHandler(self);
+warmupStatic(self);

--- a/ads/capirs.js
+++ b/ads/capirs.js
@@ -29,7 +29,7 @@ export function capirs(global, data) {
       init: () => {
         const block = global.document.createElement('div');
         block.id = 'x-' + Math.round(Math.random() * 1e8).toString(36);
-        document.body.appendChild(block);
+        global.document.body.appendChild(block);
 
         global['Adf']['banner']['ssp'](block.id, data['params'], {
           'begun-auto-pad': data['begunAutoPad'],
@@ -40,14 +40,14 @@ export function capirs(global, data) {
     block: {
       draw: feed => {
         const banner = feed['banners']['graph'][0];
-        window.context.renderStart({
+        global.context.renderStart({
           width: banner['width'],
           height: banner['height'],
         });
         const reportId = 'capirs-' + banner['banner_id'];
-        window.context.reportRenderedEntityIdentifier(reportId);
+        global.context.reportRenderedEntityIdentifier(reportId);
       },
-      unexist: window.context.noContentAvailable,
+      unexist: global.context.noContentAvailable,
     },
   };
 

--- a/ads/contentad.js
+++ b/ads/contentad.js
@@ -29,14 +29,14 @@ export function contentad(global, data) {
   global.url = data.url;
 
   /* Create div for ad to target */
-  const cadDiv = window.document.createElement('div');
+  const cadDiv = global.document.createElement('div');
   cadDiv.id = 'contentad' + global.wid;
-  window.document.body.appendChild(cadDiv);
+  global.document.body.appendChild(cadDiv);
 
   /* Pass Source URL */
-  let sourceUrl = window.context.sourceUrl;
+  let sourceUrl = global.context.sourceUrl;
   if (data.url) {
-    const domain = data.url || window.atob(data.d);
+    const domain = data.url || atob(data.d);
     sourceUrl = sourceUrl.replace(parseUrl(sourceUrl).host, domain);
   }
 

--- a/ads/criteo.js
+++ b/ads/criteo.js
@@ -27,7 +27,7 @@ export function criteo(global, data) {
   loadScript(global, 'https://static.criteo.net/js/ld/publishertag.js', () => {
     if (data.tagtype === 'rta') {
       // Make sure RTA is called only once
-      computeInMasterFrame(window, 'call-rta', resultCallback => {
+      computeInMasterFrame(global, 'call-rta', resultCallback => {
         const params = {
           networkid: data.networkid,
           cookiename:

--- a/ads/ezoic.js
+++ b/ads/ezoic.js
@@ -26,7 +26,7 @@ export function ezoic(global, data) {
   loadScript(global, 'https://g.ezoic.net/ezoic/ampad.js', () => {
     loadScript(global, 'https://www.googletagservices.com/tag/js/gpt.js', () => {
       global.googletag.cmd.push(() => {
-        new window.EzoicAmpAd(global,data).createAd();
+        new global.EzoicAmpAd(global,data).createAd();
       });
     });
   });

--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -233,7 +233,7 @@ function doubleClickWithGlade(global, data, gladeExperiment) {
     global.context.renderStart();
   });
 
-  window.glade = {correlator: getCorrelator(global)};
+  global.glade = {correlator: getCorrelator(global)};
   loadScript(global, 'https://securepubads.g.doubleclick.net/static/glade.js');
 }
 

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -320,7 +320,7 @@ export function imaVideo(global, data) {
   videoPlayer.setAttribute('poster', data.poster);
   videoPlayer.setAttribute('playsinline', true);
   if (data.src) {
-    const sourceElement = document.createElement('source');
+    const sourceElement = global.document.createElement('source');
     sourceElement.setAttribute('src', data.src);
     videoPlayer.appendChild(sourceElement);
   }
@@ -338,7 +338,7 @@ export function imaVideo(global, data) {
   wrapperDiv.appendChild(bigPlayDiv);
   global.document.getElementById('c').appendChild(wrapperDiv);
 
-  window.addEventListener('message', onMessage.bind(null, global));
+  global.addEventListener('message', onMessage.bind(null, global));
 
   /**
    * Set-up code that can't run until the IMA lib loads.
@@ -408,7 +408,7 @@ export function imaVideo(global, data) {
 }
 
 function htmlToElement(html) {
-  const template = document.createElement('template');
+  const template = self.document.createElement('template');
   template./*OK*/innerHTML = html;
   return template.content.firstChild;
 }
@@ -440,10 +440,10 @@ export function playAds(global) {
     try {
       adsManager.init(
           videoWidth, videoHeight, global.google.ima.ViewMode.NORMAL);
-      window.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
+      global.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
       adsManager.start();
     } catch (adError) {
-      window.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
+      global.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
       playVideo();
     }
   } else if (!adRequestFailed) {
@@ -451,7 +451,7 @@ export function playAds(global) {
     setTimeout(playAds.bind(null, global), 250);
   } else {
     // Ad request failed.
-    window.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
+    global.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
     playVideo();
   }
 }
@@ -490,7 +490,7 @@ export function onAdsManagerLoaded(global, adsManagerLoadedEvent) {
   if (muteAdsManagerOnLoaded) {
     adsManager.setVolume(0);
   }
-  window.parent./*OK*/postMessage({event: VideoEvents.LOAD}, '*');
+  global.parent./*OK*/postMessage({event: VideoEvents.LOAD}, '*');
 }
 
 /**
@@ -615,16 +615,16 @@ function onProgressClick(event) {
   clearInterval(hideControlsTimeout);
   onProgressMove(event);
   clearInterval(uiTicker);
-  document.addEventListener(mouseMoveEvent, onProgressMove);
-  document.addEventListener(mouseUpEvent, onProgressClickEnd);
+  self.document.addEventListener(mouseMoveEvent, onProgressMove);
+  self.document.addEventListener(mouseUpEvent, onProgressClickEnd);
 }
 
 /**
  * Detects the end of interaction on the progress bar.
  */
 function onProgressClickEnd() {
-  document.removeEventListener(mouseMoveEvent, onProgressMove);
-  document.removeEventListener(mouseUpEvent, onProgressClickEnd);
+  self.document.removeEventListener(mouseMoveEvent, onProgressMove);
+  self.document.removeEventListener(mouseUpEvent, onProgressClickEnd);
   uiTicker = setInterval(uiTickerClick, 500);
   videoPlayer.currentTime = videoPlayer.duration * seekPercent;
   // Reset hide controls timeout.
@@ -689,7 +689,7 @@ export function playVideo() {
   showControls();
   setStyle(playPauseDiv, 'line-height', '1.4em');
   playPauseNode.textContent = pauseChars;
-  window.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
+  self.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
   videoPlayer.play();
 }
 
@@ -708,7 +708,7 @@ export function pauseVideo(event) {
   }
   playPauseNode.textContent = playChar;
   setStyle(playPauseDiv, 'line-height', '');;
-  window.parent./*OK*/postMessage({event: VideoEvents.PAUSE}, '*');
+  self.parent./*OK*/postMessage({event: VideoEvents.PAUSE}, '*');
   if (event && event.type == 'webkitendfullscreen') {
     // Video was paused because we exited fullscreen.
     videoPlayer.removeEventListener('webkitendfullscreen', pauseVideo);
@@ -727,7 +727,7 @@ function onFullscreenClick(global) {
         global.document.webkitCancelFullScreen ||
         global.document.mozCancelFullScreen;
     if (cancelFullscreen) {
-      cancelFullscreen.call(document);
+      cancelFullscreen.call(global.document);
     }
   } else {
     // Try to enter fullscreen mode in the browser
@@ -739,8 +739,8 @@ function onFullscreenClick(global) {
         global.document.documentElement.webkitRequestFullScreen ||
         global.document.documentElement.mozRequestFullScreen;
     if (requestFullscreen) {
-      fullscreenWidth = window.screen.width;
-      fullscreenHeight = window.screen.height;
+      fullscreenWidth = global.screen.width;
+      fullscreenHeight = global.screen.height;
       requestFullscreen.call(global.document.documentElement);
     } else {
       // Figure out how to make iPhone fullscren work here - I've got nothing.
@@ -824,7 +824,7 @@ function onMessage(global, event) {
       case 'playVideo':
         if (adsActive) {
           adsManager.resume();
-          window.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
+          global.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
         } else if (playbackStarted) {
           playVideo();
         } else {
@@ -835,7 +835,7 @@ function onMessage(global, event) {
       case 'pauseVideo':
         if (adsActive) {
           adsManager.pause();
-          window.parent./*OK*/postMessage({event: VideoEvents.PAUSE}, '*');
+          global.parent./*OK*/postMessage({event: VideoEvents.PAUSE}, '*');
         } else if (playbackStarted) {
           pauseVideo(null);
         }
@@ -848,7 +848,7 @@ function onMessage(global, event) {
         } else {
           muteAdsManagerOnLoaded = true;
         }
-        window.parent./*OK*/postMessage({event: VideoEvents.MUTED}, '*');
+        global.parent./*OK*/postMessage({event: VideoEvents.MUTED}, '*');
         break;
       case 'unMute':
         videoPlayer.volume = 1;
@@ -858,7 +858,7 @@ function onMessage(global, event) {
         } else {
           muteAdsManagerOnLoaded = false;
         }
-        window.parent./*OK*/postMessage({event: VideoEvents.UNMUTED}, '*');
+        global.parent./*OK*/postMessage({event: VideoEvents.UNMUTED}, '*');
         break;
       case 'resize':
         if (msg.args && msg.args.width && msg.args.height) {

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -408,7 +408,7 @@ export function imaVideo(global, data) {
 }
 
 function htmlToElement(html) {
-  const template = self.document.createElement('template');
+  const template = window.document.createElement('template');
   template./*OK*/innerHTML = html;
   return template.content.firstChild;
 }
@@ -615,16 +615,16 @@ function onProgressClick(event) {
   clearInterval(hideControlsTimeout);
   onProgressMove(event);
   clearInterval(uiTicker);
-  self.document.addEventListener(mouseMoveEvent, onProgressMove);
-  self.document.addEventListener(mouseUpEvent, onProgressClickEnd);
+  window.document.addEventListener(mouseMoveEvent, onProgressMove);
+  window.document.addEventListener(mouseUpEvent, onProgressClickEnd);
 }
 
 /**
  * Detects the end of interaction on the progress bar.
  */
 function onProgressClickEnd() {
-  self.document.removeEventListener(mouseMoveEvent, onProgressMove);
-  self.document.removeEventListener(mouseUpEvent, onProgressClickEnd);
+  window.document.removeEventListener(mouseMoveEvent, onProgressMove);
+  window.document.removeEventListener(mouseUpEvent, onProgressClickEnd);
   uiTicker = setInterval(uiTickerClick, 500);
   videoPlayer.currentTime = videoPlayer.duration * seekPercent;
   // Reset hide controls timeout.
@@ -689,7 +689,7 @@ export function playVideo() {
   showControls();
   setStyle(playPauseDiv, 'line-height', '1.4em');
   playPauseNode.textContent = pauseChars;
-  self.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
+  window.parent./*OK*/postMessage({event: VideoEvents.PLAY}, '*');
   videoPlayer.play();
 }
 
@@ -708,7 +708,7 @@ export function pauseVideo(event) {
   }
   playPauseNode.textContent = playChar;
   setStyle(playPauseDiv, 'line-height', '');;
-  self.parent./*OK*/postMessage({event: VideoEvents.PAUSE}, '*');
+  window.parent./*OK*/postMessage({event: VideoEvents.PAUSE}, '*');
   if (event && event.type == 'webkitendfullscreen') {
     // Video was paused because we exited fullscreen.
     videoPlayer.removeEventListener('webkitendfullscreen', pauseVideo);

--- a/ads/imedia.js
+++ b/ads/imedia.js
@@ -26,7 +26,7 @@ export function imedia(global, data) {
   const mW = context.isMaster ? global : context.master;
 
   // create parent element
-  const parentElement = document.createElement('div');
+  const parentElement = global.document.createElement('div');
   parentElement.id = data.id;
   global.document.getElementById('c').appendChild(parentElement);
 

--- a/ads/inmobi.js
+++ b/ads/inmobi.js
@@ -30,7 +30,8 @@ export function inmobi(global, data) {
     onError: code => {
       if (code == 'nfr') {
         global.context.noContentAvailable();
-        document.getElementById('my-ad-slot').style./*OK*/display = 'none';
+        global.document.getElementById('my-ad-slot').style./*OK*/display =
+            'none';
       }
     },
     onSuccess: () => {
@@ -40,6 +41,7 @@ export function inmobi(global, data) {
 
   writeScript(global, 'https://cf.cdn.inmobi.com/ad/inmobi.secure.js', () => {
     global.document.write('<div id=\'my-ad-slot\'></div>');
-    global._inmobi.getNewAd(document.getElementById('my-ad-slot'), inmobiConf);
+    global._inmobi.getNewAd(global.document.getElementById('my-ad-slot'),
+        inmobiConf);
   });
 }

--- a/ads/ix.js
+++ b/ads/ix.js
@@ -86,8 +86,8 @@ function reportStats(siteID, slotID, dfpSlot, start, code) {
     const ts = start / 1000 >> 0;
     const ets = Date.now() / 1000 >> 0;
     let url = 'https://as-sec.casalemedia.com/headerstats?s=' + siteID;
-    if (typeof self.context.location.href !== 'undefined') {
-      url += '&u=' + encodeURIComponent(self.context.location.href);
+    if (typeof window.context.location.href !== 'undefined') {
+      url += '&u=' + encodeURIComponent(window.context.location.href);
     }
     let stats = '{"p":"display","d":"mobile","t":' + ts + ',';
     stats += '"sl":[{"s": "' + slotID + '",';

--- a/ads/ix.js
+++ b/ads/ix.js
@@ -86,8 +86,8 @@ function reportStats(siteID, slotID, dfpSlot, start, code) {
     const ts = start / 1000 >> 0;
     const ets = Date.now() / 1000 >> 0;
     let url = 'https://as-sec.casalemedia.com/headerstats?s=' + siteID;
-    if (typeof window.context.location.href !== 'undefined') {
-      url += '&u=' + encodeURIComponent(window.context.location.href);
+    if (typeof self.context.location.href !== 'undefined') {
+      url += '&u=' + encodeURIComponent(self.context.location.href);
     }
     let stats = '{"p":"display","d":"mobile","t":' + ts + ',';
     stats += '"sl":[{"s": "' + slotID + '",';

--- a/ads/kiosked.js
+++ b/ads/kiosked.js
@@ -26,11 +26,11 @@ export function kiosked(global, data) {
   if (data.hasOwnProperty('scriptid')) {
     scriptId = data['scriptid'];
   }
-  window.addEventListener('kioskedAdRender', function() {
+  global.addEventListener('kioskedAdRender', function() {
     global.context.renderStart();
   }, false);
 
-  window.addEventListener('kioskedAdNoFill', function() {
+  global.addEventListener('kioskedAdNoFill', function() {
     global.context.noContentAvailable();
   }, false);
 

--- a/ads/mads.js
+++ b/ads/mads.js
@@ -24,6 +24,6 @@ export function mads(global, data) {
   validateData(data, ['adrequest'], []);
 
   writeScript(global, 'https://eu2.madsone.com/js/tags.js', function() {
-    window.MADSAdrequest.adrequest(JSON.parse(data.adrequest));
+    global.MADSAdrequest.adrequest(JSON.parse(data.adrequest));
   });
 }

--- a/ads/mediaimpact.js
+++ b/ads/mediaimpact.js
@@ -54,11 +54,13 @@ export function mediaimpact(global, data) {
     view: 'm',
     async: true,
   };
-  loadScript(global, 'https://ec-ns.sascdn.com/diff/251/pages/amp_default.js', () => {
-    if (!global.document.getElementById('sas_' + data.slot.replace('sas_',''))) {
-      const adContainer = global.document.createElement('div');
-      adContainer.id = 'sas_' + data.slot.replace('sas_','');
-      global.document.body.appendChild(adContainer);
-    }
-  });
+  loadScript(global, 'https://ec-ns.sascdn.com/diff/251/pages/amp_default.js',
+      () => {
+        const id = 'sas_' + data.slot.replace('sas_','');
+        if (!global.document.getElementById(id)) {
+          const adContainer = global.document.createElement('div');
+          adContainer.id = id;
+          global.document.body.appendChild(adContainer);
+        }
+      });
 }

--- a/ads/mediaimpact.js
+++ b/ads/mediaimpact.js
@@ -40,7 +40,7 @@ export function mediaimpact(global, data) {
       global.context.noContentAvailable();
     }
   };
-  window.addEventListener('load', function() {
+  global.addEventListener('load', function() {
     asmi.sas.call(data.site + '/(' + data.page + ')',
         data.format,
         data.target + ';googleAMP=1;',
@@ -55,7 +55,7 @@ export function mediaimpact(global, data) {
     async: true,
   };
   loadScript(global, 'https://ec-ns.sascdn.com/diff/251/pages/amp_default.js', () => {
-    if (!document.getElementById('sas_' + data.slot.replace('sas_',''))) {
+    if (!global.document.getElementById('sas_' + data.slot.replace('sas_',''))) {
       const adContainer = global.document.createElement('div');
       adContainer.id = 'sas_' + data.slot.replace('sas_','');
       global.document.body.appendChild(adContainer);

--- a/ads/netletix.js
+++ b/ads/netletix.js
@@ -60,7 +60,7 @@ export function netletix(global, data) {
           })),
       data.ampSlotIndex);
 
-  window.addEventListener('message', event => {
+  global.addEventListener('message', event => {
     if (event.data.type &&
         startsWith(dev().assertString(event.data.type), 'nx-')) {
       switch (event.data.type) {

--- a/ads/plista.js
+++ b/ads/plista.js
@@ -30,7 +30,7 @@ export function plista(global, data) {
   div.setAttribute('data-display', 'plista_widget_' + data.widgetname);
   // container with id "c" is provided by amphtml
   global.document.getElementById('c').appendChild(div);
-  window.PLISTA = {
+  global.PLISTA = {
     publickey: data.publickey,
     widgets: [{
       name: data.widgetname,

--- a/ads/pulsepoint.js
+++ b/ads/pulsepoint.js
@@ -68,7 +68,7 @@ function headerBidding(global, data) {
         });
       },
     };
-    new window.PulsePointHeaderTag(hbConfig).init();
+    new global.PulsePointHeaderTag(hbConfig).init();
   });
 }
 

--- a/ads/relap.js
+++ b/ads/relap.js
@@ -23,12 +23,12 @@ import {loadScript, validateData} from '../3p/3p';
 export function relap(global, data) {
   validateData(data, [], ['token', 'url', 'anchorid']);
 
-  window.relapV6WidgetReady = function() {
-    window.context.renderStart();
+  global.relapV6WidgetReady = function() {
+    global.context.renderStart();
   };
 
-  window.relapV6WidgetNoSimilarPages = function() {
-    window.context.noContentAvailable();
+  global.relapV6WidgetNoSimilarPages = function() {
+    global.context.noContentAvailable();
   };
 
   const url = `https://relap.io/api/v6/head.js?token=${encodeURIComponent(data['token'])}&url=${encodeURIComponent(data['url'])}`;

--- a/ads/revcontent.js
+++ b/ads/revcontent.js
@@ -51,5 +51,5 @@ export function revcontent(global, data) {
 
   validateData(data, required, optional);
   global.data = data;
-  writeScript(window, endpoint);
+  writeScript(global, endpoint);
 }

--- a/ads/sklik.js
+++ b/ads/sklik.js
@@ -26,9 +26,9 @@ export function sklik(global, data) {
   loadScript(global, 'https://c.imedia.cz/js/amp.js', () => {
     const parentId = 'sklik_parent';
 
-    const parentElement = document.createElement('div');
+    const parentElement = global.document.createElement('div');
     parentElement.id = parentId;
-    window.document.body.appendChild(parentElement);
+    global.document.body.appendChild(parentElement);
 
     data.elm = parentId;
     data.url = global.context.canonicalUrl;

--- a/ads/yieldbot.js
+++ b/ads/yieldbot.js
@@ -40,7 +40,7 @@ export function yieldbot(global, data) {
 
         global.yieldbot.psn(data.psn);
         global.yieldbot.enableAsync();
-        if (window.context.isMaster) {
+        if (global.context.isMaster) {
           global.yieldbot.defineSlot(data.ybSlot, {sizes: dimensions});
           global.yieldbot.go();
         } else {

--- a/build-system/eslint-rules/no-global.js
+++ b/build-system/eslint-rules/no-global.js
@@ -20,6 +20,12 @@ var astUtils = require('eslint/lib/ast-utils');
 var GLOBALS = Object.create(null);
 GLOBALS.window = 'Use `self` instead.';
 GLOBALS.document = 'Reference it as `self.document` or similar instead.';
+GLOBALS.global = "This ain't node."
+
+var FIXES = Object.create(null);
+FIXES.window = 'self';
+FIXES.document = 'self.document';
+FIXES.global = 'self';
 
 module.exports = function(context) {
   return {
@@ -29,6 +35,9 @@ module.exports = function(context) {
         return;
       }
       if (!(/Expression/.test(node.parent.type))) {
+        return;
+      }
+      if (/test-/.test(context.getFilename())) {
         return;
       }
 
@@ -46,7 +55,15 @@ module.exports = function(context) {
       if (GLOBALS[name]) {
         message += ' ' + GLOBALS[name];
       }
-      context.report(node, message);
+      context.report({
+        node: node,
+        message: message,
+        fix: function(fixer) {
+          if (FIXES[name]) {
+            return fixer.replaceText(node, FIXES[name]);
+          }
+        }
+      });
     }
   };
 };

--- a/build-system/eslint-rules/no-global.js
+++ b/build-system/eslint-rules/no-global.js
@@ -37,6 +37,9 @@ module.exports = function(context) {
       if (!(/Expression/.test(node.parent.type))) {
         return;
       }
+      if (/test-/.test(context.getFilename())) {
+        return;
+      }
 
       if (node.parent.type === 'MemberExpression' &&
           node.parent.property === node) {

--- a/build-system/eslint-rules/no-global.js
+++ b/build-system/eslint-rules/no-global.js
@@ -37,9 +37,6 @@ module.exports = function(context) {
       if (!(/Expression/.test(node.parent.type))) {
         return;
       }
-      if (/test-/.test(context.getFilename())) {
-        return;
-      }
 
       if (node.parent.type === 'MemberExpression' &&
           node.parent.property === node) {

--- a/extensions/.eslintrc
+++ b/extensions/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-global": 2
+  }
+}

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -311,7 +311,7 @@ export class AmpA4A extends AMP.BaseElement {
         });
 
     /** @const {string} */
-    this.sentinel = generateSentinel(window);
+    this.sentinel = generateSentinel(this.win);
 
     /**
      * Used to indicate whether this slot should be collapsed or not. Marked

--- a/extensions/amp-access/0.1/amp-login-done.js
+++ b/extensions/amp-access/0.1/amp-login-done.js
@@ -29,6 +29,6 @@ import {onDocumentReady} from '../../../src/document-ready';
 initLogConstructor();
 setReportError(reportError);
 
-onDocumentReady(document, () => {
-  new LoginDoneDialog(window).start();
+onDocumentReady(self.document, () => {
+  new LoginDoneDialog(self).start();
 });

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -34,6 +34,7 @@ import {upgradeOrRegisterElement} from '../../../../src/custom-element';
 import {
   createElementWithAttributes,
   addAttributesToElement,
+  removeElement,
 } from '../../../../src/dom';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {
@@ -88,7 +89,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
       // amp-ad.
       const iframe = fixture.doc.createElement('iframe');
       element.appendChild(iframe);
-      document.body.appendChild(element);
+      fixture.doc.body.appendChild(element);
       impl = new AmpAdNetworkAdsenseImpl(element);
       impl.iframe = iframe;
       return fixture;
@@ -482,15 +483,9 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
       // IOb.
       expect(style.width).to.be.ok;
       expect(style.height).to.be.ok;
-      // We don't know the exact values by which the frame will be translated,
-      // as this can vary depending on whether we use the height/width
-      // attributes, or the actual size of the frame. To make this less of a
-      // hassle, we'll just match against regexp.
-      expect(style.transform).to.match(new RegExp(
-          'matrix\\(1, 0, 0, 1, -[0-9]+, -[0-9]+\\)'));
     }
 
-    afterEach(() => document.body.removeChild(impl.element));
+    afterEach(() => removeElement(impl.element));
 
     it('centers iframe in slot when height && width', () => {
       return createImplTag({

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -77,7 +77,7 @@ const DOUBLECLICK_BASE_URL =
 const PAGE_LEVEL_PARAMS_ = {
   'gdfp_req': '1',
   'sfv': DEFAULT_SAFEFRAME_VERSION,
-  'u_sd': window.devicePixelRatio,
+  'u_sd': self.devicePixelRatio,
 };
 
 /**
@@ -229,7 +229,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     return isGoogleAdsA4AValidEnvironment(this.win) &&
       this.isAmpAdElement() &&
       // Ensure not within remote.html iframe.
-      !document.querySelector('meta[name=amp-3p-iframe-src]');
+      !this.win.document.querySelector('meta[name=amp-3p-iframe-src]');
   }
 
   /**

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -70,8 +70,8 @@ export class AmpAd extends AMP.BaseElement {
         return new AmpAdCustom(this.element);
       }
 
-      window.ampAdSlotIdCounter = window.ampAdSlotIdCounter || 0;
-      const slotId = window.ampAdSlotIdCounter++;
+      this.win.ampAdSlotIdCounter = this.win.ampAdSlotIdCounter || 0;
+      const slotId = this.win.ampAdSlotIdCounter++;
       this.element.setAttribute('data-amp-slot-index', slotId);
 
       // TODO(tdrl): Check amp-ad registry to see if they have this already.

--- a/extensions/amp-crypto-polyfill/0.1/amp-crypto-polyfill.js
+++ b/extensions/amp-crypto-polyfill/0.1/amp-crypto-polyfill.js
@@ -23,4 +23,4 @@ export function installCryptoPolyfill(win) {
   });
 }
 
-installCryptoPolyfill(window);
+installCryptoPolyfill(self);

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -47,7 +47,7 @@ class AmpFacebookComments extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/' + dashToUnderline(window.navigator.language) + '/sdk.js', 'script');
+        'https://connect.facebook.net/' + dashToUnderline(this.win.navigator.language) + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -47,7 +47,7 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/' + dashToUnderline(window.navigator.language) + '/sdk.js', 'script');
+        'https://connect.facebook.net/' + dashToUnderline(this.win.navigator.language) + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -47,7 +47,7 @@ class AmpFacebook extends AMP.BaseElement {
     this.preconnect.url('https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
-        'https://connect.facebook.net/' + dashToUnderline(window.navigator.language) + '/sdk.js', 'script');
+        'https://connect.facebook.net/' + dashToUnderline(this.win.navigator.language) + '/sdk.js', 'script');
     preloadBootstrap(this.win, this.preconnect);
   }
 

--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -370,7 +370,7 @@ export function getFormValidator(form) {
  */
 function isReportValiditySupported(doc) {
   if (doc && reportValiditySupported === undefined) {
-    reportValiditySupported = !!document.createElement('form').reportValidity;
+    reportValiditySupported = !!doc.createElement('form').reportValidity;
   }
   return !!reportValiditySupported;
 }

--- a/extensions/amp-hulu/0.1/amp-hulu.js
+++ b/extensions/amp-hulu/0.1/amp-hulu.js
@@ -42,7 +42,7 @@ class AmpHulu extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const iframe = document.createElement('iframe');
+    const iframe = this.win.document.createElement('iframe');
     const src = this.getVideoIframeSrc_();
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -162,7 +162,7 @@ export class AmpIframe extends AMP.BaseElement {
      * @type {?string}
      **/
     this.iframeSrc = this.assertSource(
-        iframeSrc, window.location.href, this.sandbox_);
+        iframeSrc, this.win.location.href, this.sandbox_);
 
     /**
      * The element which will contain the iframe. This may be the amp-iframe
@@ -423,7 +423,7 @@ export class AmpIframe extends AMP.BaseElement {
       this.iframeSrc = this.transformSrc_(src);
       if (this.iframe_) {
         this.iframe_.src = this.assertSource(
-            this.iframeSrc, window.location.href, this.sandbox_);
+            this.iframeSrc, this.win.location.href, this.sandbox_);
       }
     }
   }

--- a/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
@@ -132,8 +132,8 @@ describe('amp-ima-video', () => {
         src: srcUrl,
         tag: adTagUrl,
       });
-      const mockGlobal = {};
-      mockGlobal.google = {
+      const global = iframe.win;
+      global.google = {
         ima: {
           ViewMode: {
             NORMAL: 'normal',
@@ -148,7 +148,7 @@ describe('amp-ima-video', () => {
       imaVideoObj.setAdsManagerForTesting(mockAdsManager);
       imaVideoObj.setVideoWidthAndHeightForTesting(100, 200);
 
-      imaVideoObj.playAds(mockGlobal);
+      imaVideoObj.playAds(global);
 
       expect(initSpy).to.be.calledWith(100, 200, 'normal');
       expect(startSpy).to.be.called;
@@ -214,24 +214,28 @@ describe('amp-ima-video', () => {
         tag: adTagUrl,
       });
       const mockAdsRenderingSettings = {};
-      const mockGlobal = {};
-      mockGlobal.google = {};
-      mockGlobal.google.ima = {};
-      mockGlobal.google.ima.AdsRenderingSettings = function() {
-        return mockAdsRenderingSettings;
-      };
-      mockGlobal.google.ima.UiElements = {
-        AD_ATTRIBUTION: 'adattr',
-        COUNTDOWN: 'countdown',
-      };
-      mockGlobal.google.ima.AdErrorEvent = {};
-      mockGlobal.google.ima.AdErrorEvent.Type = {
-        AD_ERROR: 'aderror',
-      };
-      mockGlobal.google.ima.AdEvent = {};
-      mockGlobal.google.ima.AdEvent.Type = {
-        CONTENT_PAUSE_REQUESTED: 'cpr',
-        CONTENT_RESUME_REQUESTED: 'crr',
+      const global = iframe.win;
+      global.google = {
+        ima: {
+          AdsRenderingSettings() {
+            return mockAdsRenderingSettings;
+          },
+          UiElements: {
+            AD_ATTRIBUTION: 'adattr',
+            COUNTDOWN: 'countdown',
+          },
+          AdErrorEvent: {
+            Type: {
+              AD_ERROR: 'aderror',
+            },
+          },
+          AdEvent: {
+            Type: {
+              CONTENT_PAUSE_REQUESTED: 'cpr',
+              CONTENT_RESUME_REQUESTED: 'crr',
+            },
+          },
+        },
       };
       const mockAdsManager = {
         addEventListener() {},
@@ -249,7 +253,7 @@ describe('amp-ima-video', () => {
       imaVideoObj.setVideoPlayerForTesting(mockVideoPlayer);
       imaVideoObj.setMuteAdsManagerOnLoadedForTesting(false);
 
-      imaVideoObj.onAdsManagerLoaded(mockGlobal, mockAdsManagerLoadedEvent);
+      imaVideoObj.onAdsManagerLoaded(global, mockAdsManagerLoadedEvent);
 
       expect(
           mockAdsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete)
@@ -277,24 +281,28 @@ describe('amp-ima-video', () => {
         tag: adTagUrl,
       });
       const mockAdsRenderingSettings = {};
-      const mockGlobal = {};
-      mockGlobal.google = {};
-      mockGlobal.google.ima = {};
-      mockGlobal.google.ima.AdsRenderingSettings = function() {
-        return mockAdsRenderingSettings;
-      };
-      mockGlobal.google.ima.UiElements = {
-        AD_ATTRIBUTION: 'adattr',
-        COUNTDOWN: 'countdown',
-      };
-      mockGlobal.google.ima.AdErrorEvent = {};
-      mockGlobal.google.ima.AdErrorEvent.Type = {
-        AD_ERROR: 'aderror',
-      };
-      mockGlobal.google.ima.AdEvent = {};
-      mockGlobal.google.ima.AdEvent.Type = {
-        CONTENT_PAUSE_REQUESTED: 'cpr',
-        CONTENT_RESUME_REQUESTED: 'crr',
+      const global = iframe.win;
+      global.google = {
+        ima: {
+          AdsRenderingSettings() {
+            return mockAdsRenderingSettings;
+          },
+          UiElements: {
+            AD_ATTRIBUTION: 'adattr',
+            COUNTDOWN: 'countdown',
+          },
+          AdErrorEvent: {
+            Type: {
+              AD_ERROR: 'aderror',
+            },
+          },
+          AdEvent: {
+            Type: {
+              CONTENT_PAUSE_REQUESTED: 'cpr',
+              CONTENT_RESUME_REQUESTED: 'crr',
+            },
+          },
+        },
       };
       const mockAdsManager = {
         addEventListener() {},
@@ -313,7 +321,7 @@ describe('amp-ima-video', () => {
       imaVideoObj.setVideoPlayerForTesting(mockVideoPlayer);
       imaVideoObj.setMuteAdsManagerOnLoadedForTesting(true);
 
-      imaVideoObj.onAdsManagerLoaded(mockGlobal, mockAdsManagerLoadedEvent);
+      imaVideoObj.onAdsManagerLoaded(global, mockAdsManagerLoadedEvent);
 
       expect(
           mockAdsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete)
@@ -433,8 +441,8 @@ describe('amp-ima-video', () => {
       imaVideoObj.setVideoPlayerForTesting(videoMock);
       const adsManagerMock = {};
       adsManagerMock.resize = function() {};
-      const mockGlobal = {};
-      mockGlobal.google = {
+      const global = iframe.win;
+      global.google = {
         ima: {
           ViewMode: {
             NORMAL: 'normal',
@@ -445,7 +453,7 @@ describe('amp-ima-video', () => {
       imaVideoObj.setAdsManagerDimensionsOnLoadForTesting(100, 200);
       imaVideoObj.setAdsManagerForTesting(adsManagerMock);
 
-      imaVideoObj.onContentPauseRequested(mockGlobal);
+      imaVideoObj.onContentPauseRequested(global);
 
       expect(resizeSpy).to.have.been.calledWith(100, 200, 'normal');
       expect(imaVideoObj.getPropertiesForTesting().adsManagerWidthOnLoad)

--- a/extensions/amp-pinterest/0.1/follow-button.js
+++ b/extensions/amp-pinterest/0.1/follow-button.js
@@ -49,7 +49,7 @@ export class FollowButton {
    */
   handleClick(event) {
     event.preventDefault();
-    openWindowDialog(window, this.href, 'pin' + Date.now(),
+    openWindowDialog(self, this.href, 'pin' + Date.now(),
         POP_FOLLOW);
     Util.log(`&type=button_follow&href=${this.href}`);
   }

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -52,9 +52,9 @@ export class PinWidget {
     const log = el.getAttribute('data-pin-log');
     if (href) {
       if (shouldPop) {
-        openWindowDialog(window, href, '_pinit', POP);
+        openWindowDialog(self, href, '_pinit', POP);
       } else {
-        openWindowDialog(window, `${href}?amp=1&guid=${Util.guid}`, '_blank');
+        openWindowDialog(self, `${href}?amp=1&guid=${Util.guid}`, '_blank');
       }
     }
     if (log) {

--- a/extensions/amp-pinterest/0.1/pinit-button.js
+++ b/extensions/amp-pinterest/0.1/pinit-button.js
@@ -63,7 +63,7 @@ export class PinItButton {
    */
   handleClick(event) {
     event.preventDefault();
-    openWindowDialog(window, this.href, '_pinit', POP);
+    openWindowDialog(self, this.href, '_pinit', POP);
     Util.log('&type=button_pinit');
   }
 

--- a/extensions/amp-pinterest/0.1/util.js
+++ b/extensions/amp-pinterest/0.1/util.js
@@ -34,7 +34,7 @@ function log(queryParams) {
   if (queryParams) {
     query = query + queryParams;
   }
-  query = query + '&via=' + encodeURIComponent(window.location.href);
+  query = query + '&via=' + encodeURIComponent(self.location.href);
   call.src = query;
 };
 

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -47,7 +47,7 @@ export class AmpTimeAgo extends AMP.BaseElement {
     this.element.title = this.title_;
     this.element.textContent = '';
 
-    const timeElement = document.createElement('time');
+    const timeElement = self.document.createElement('time');
     timeElement.setAttribute('datetime', this.datetime_);
     timeElement.textContent = timeago(this.datetime_, this.locale_);
     this.element.appendChild(timeElement);

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -107,8 +107,8 @@ export class AmpUserNotification extends AMP.BaseElement {
     this.urlReplacements_ = urlReplacementsForDoc(ampdoc);
     this.storagePromise_ = storageForDoc(ampdoc);
     if (!this.userNotificationManager_) {
-      installUserNotificationManager(window);
-      this.userNotificationManager_ = getService(window,
+      installUserNotificationManager(this.win);
+      this.userNotificationManager_ = getService(this.win,
           'userNotificationManager');
     }
 

--- a/extensions/amp-viewer-integration/0.1/test/viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/viewer-for-testing.js
@@ -47,10 +47,10 @@ export class ViewerForTesting {
     this.containerEl = containerEl;
 
     /** @type {Element} */
-    this.iframe = document.createElement('iframe');
+    this.iframe = self.document.createElement('iframe');
     this.iframe.setAttribute('id', 'AMP_DOC_' + id);
 
-    const isIos_ = /iPhone|iPad|iPod/i.test(window.navigator.userAgent);
+    const isIos_ = /iPhone|iPad|iPod/i.test(self.navigator.userAgent);
     if (this.viewportType_ == 'natural' && !isIos_) {
       this.iframe.setAttribute('scrolling', 'yes');
     } else {
@@ -82,15 +82,15 @@ export class ViewerForTesting {
       height: this.containerEl./*OK*/offsetHeight,
       visibilityState: this.visibilityState_,
       prerenderSize: 1,
-      origin: parseUrl(window.location.href).origin,
+      origin: parseUrl(self.location.href).origin,
       csi: 1,
       cap: 'foo,a2a',
     };
 
     let ampdocUrl = this.ampdocUrl + '#' + serializeQueryString(params);
 
-    if (window.location.hash && window.location.hash.length > 1) {
-      ampdocUrl += '&' + window.location.hash.substring(1);
+    if (self.location.hash && self.location.hash.length > 1) {
+      ampdocUrl += '&' + self.location.hash.substring(1);
     }
     const parsedUrl = parseUrl(ampdocUrl);
     const url = parsedUrl.href;
@@ -100,7 +100,7 @@ export class ViewerForTesting {
 
     // Listening for messages, hoping that I get a request for a handshake and
     // a notification that a document was loaded.
-    window.addEventListener('message', e => {
+    self.addEventListener('message', e => {
       this.log('message received', e, e.data);
       const target = this.iframe.contentWindow;
       const targetOrigin = this.frameOrigin_;

--- a/extensions/amp-viewer-integration/0.1/test/viewer-initiated-handshake-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/viewer-initiated-handshake-viewer-for-testing.js
@@ -51,13 +51,13 @@ export class WebviewViewerForTesting {
     this.containerEl = containerEl;
 
     /** @type {Window} */
-    this.win = window;
+    this.win = self;
 
     /** @type {Element} */
-    this.iframe = document.createElement('iframe');
+    this.iframe = self.document.createElement('iframe');
     this.iframe.setAttribute('id', 'AMP_DOC_' + id);
 
-    const isIos_ = /iPhone|iPad|iPod/i.test(window.navigator.userAgent);
+    const isIos_ = /iPhone|iPad|iPod/i.test(self.navigator.userAgent);
     if (this.viewportType_ == 'natural' && !isIos_) {
       this.iframe.setAttribute('scrolling', 'yes');
     } else {
@@ -86,15 +86,15 @@ export class WebviewViewerForTesting {
       height: this.containerEl./*OK*/offsetHeight,
       visibilityState: this.visibilityState_,
       prerenderSize: 1,
-      origin: parseUrl(window.location.href).origin,
+      origin: parseUrl(self.location.href).origin,
       csi: 1,
       cap: 'foo,a2a,handshakepoll',
     };
 
     let ampdocUrl = this.ampdocUrl + '#' + serializeQueryString(params);
 
-    if (window.location.hash && window.location.hash.length > 1) {
-      ampdocUrl += '&' + window.location.hash.substring(1);
+    if (self.location.hash && self.location.hash.length > 1) {
+      ampdocUrl += '&' + self.location.hash.substring(1);
     }
     const parsedUrl = parseUrl(ampdocUrl);
     const url = parsedUrl.href;
@@ -119,12 +119,12 @@ export class WebviewViewerForTesting {
     const listener = function(e) {
       if (this.isChannelOpen_(e)) {
         //stop polling
-        window.clearInterval(this.pollingIntervalIds_[intervalCtr]);
-        window.removeEventListener('message', listener, false);
+        self.clearInterval(this.pollingIntervalIds_[intervalCtr]);
+        self.removeEventListener('message', listener, false);
         this.completeHandshake_(e.data.requestid);
       }
     };
-    window.addEventListener('message', listener.bind(this));
+    self.addEventListener('message', listener.bind(this));
 
     const message = {
       app: APP,

--- a/extensions/amp-viewer-integration/0.1/test/webview-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/webview-viewer-for-testing.js
@@ -52,15 +52,15 @@ export class WebviewViewerForTesting {
     this.containerEl = containerEl;
 
     /** @type {Window} */
-    this.win = window;
+    this.win = self;
 
     this.messageHandlers_ = [];
 
     /** @type {Element} */
-    this.iframe = document.createElement('iframe');
+    this.iframe = self.document.createElement('iframe');
     this.iframe.setAttribute('id', 'AMP_DOC_' + id);
 
-    const isIos_ = /iPhone|iPad|iPod/i.test(window.navigator.userAgent);
+    const isIos_ = /iPhone|iPad|iPod/i.test(self.navigator.userAgent);
     if (this.viewportType_ == 'natural' && !isIos_) {
       this.iframe.setAttribute('scrolling', 'yes');
     } else {
@@ -95,7 +95,7 @@ export class WebviewViewerForTesting {
       height: this.containerEl./*OK*/offsetHeight,
       visibilityState: this.visibilityState_,
       prerenderSize: 1,
-      origin: parseUrl(window.location.href).origin,
+      origin: parseUrl(self.location.href).origin,
       csi: 1,
       cap: 'foo,a2a',
       webview: 1,
@@ -103,8 +103,8 @@ export class WebviewViewerForTesting {
 
     let ampdocUrl = this.ampdocUrl + '#' + serializeQueryString(params);
 
-    if (window.location.hash && window.location.hash.length > 1) {
-      ampdocUrl += '&' + window.location.hash.substring(1);
+    if (self.location.hash && self.location.hash.length > 1) {
+      ampdocUrl += '&' + self.location.hash.substring(1);
     }
     const parsedUrl = parseUrl(ampdocUrl);
     const url = parsedUrl.href;
@@ -131,7 +131,7 @@ export class WebviewViewerForTesting {
           JSON.stringify(message), '*', [channel.port2]);
       channel.port1.onmessage = function(e) {
         if (this.isChannelOpen_(e)) {
-          window.clearInterval(this.pollingIntervalIds_[intervalCtr]);
+          self.clearInterval(this.pollingIntervalIds_[intervalCtr]);
           const data = JSON.parse(e.data);
           this.completeHandshake_(channel, data.requestid);
         } else {

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-global": 2
+  }
+}

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-global": 2
-  }
-}

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -40,7 +40,7 @@ import stringify from 'json-stable-stringify';
 
 
 // All exposed describes.
-global.describes = describes;
+self.describes = describes;
 
 // Increase the before/after each timeout since certain times they have timedout
 // during the normal 2000 allowance.
@@ -48,7 +48,7 @@ const BEFORE_AFTER_TIMEOUT = 5000;
 
 // Needs to be called before the custom elements are first made.
 beforeTest();
-adopt(window);
+adopt(self);
 
 // Override AMP.extension to buffer extension installers.
 /**
@@ -57,13 +57,13 @@ adopt(window);
  * @param {function(!Object)} installer
  * @const
  */
-global.AMP.extension = function(name, version, installer) {
+self.AMP.extension = function(name, version, installer) {
   describes.bufferExtension(`${name}:${version}`, installer);
 };
 
 
 // Make amp section in karma config readable by tests.
-window.ampTestRuntimeConfig = parent.karma ? parent.karma.config.amp : {};
+self.ampTestRuntimeConfig = parent.karma ? parent.karma.config.amp : {};
 
 /**
  * Helper class to skip or retry tests under specific environment.
@@ -100,7 +100,7 @@ class TestConfig {
      */
     this.configTasks = [];
 
-    this.platform = platformFor(window);
+    this.platform = platformFor(self);
   }
 
   skipChrome() {
@@ -166,11 +166,11 @@ class TestConfig {
   }
 
   skipSauceLabs() {
-    return this.skip(() => window.ampTestRuntimeConfig.saucelabs);
+    return this.skip(() => self.ampTestRuntimeConfig.saucelabs);
   }
 
   retryOnSaucelabs() {
-    if (!window.ampTestRuntimeConfig.saucelabs) {
+    if (!self.ampTestRuntimeConfig.saucelabs) {
       return this;
     }
     this.configTasks.push(mocha => {
@@ -243,15 +243,15 @@ beforeEach(function() {
 
 function beforeTest() {
   activateChunkingForTesting();
-  window.AMP_MODE = undefined;
-  window.context = undefined;
-  window.AMP_CONFIG = {
+  self.AMP_MODE = undefined;
+  self.context = undefined;
+  self.AMP_CONFIG = {
     canary: 'testSentinel',
   };
-  window.AMP_TEST = true;
-  installDocService(window, /* isSingleDoc */ true);
-  const ampdoc = ampdocServiceFor(window).getAmpDoc();
-  installRuntimeServices(window);
+  self.AMP_TEST = true;
+  installDocService(self, /* isSingleDoc */ true);
+  const ampdoc = ampdocServiceFor(self).getAmpDoc();
+  installRuntimeServices(self);
   installAmpdocServices(ampdoc);
   resourcesForDoc(ampdoc).ampInitComplete();
 }
@@ -261,10 +261,10 @@ function beforeTest() {
 afterEach(function() {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   const cleanupTagNames = ['link', 'meta'];
-  if (!platformFor(window).isSafari()) {
+  if (!platformFor(self).isSafari()) {
     cleanupTagNames.push('iframe');
   }
-  const cleanup = document.querySelectorAll(cleanupTagNames.join(','));
+  const cleanup = self.document.querySelectorAll(cleanupTagNames.join(','));
   for (let i = 0; i < cleanup.length; i++) {
     try {
       const element = cleanup[i];
@@ -274,17 +274,17 @@ afterEach(function() {
       console./*OK*/log(e);
     }
   }
-  window.localStorage.clear();
-  window.ENABLE_LOG = false;
-  window.AMP_DEV_MODE = false;
-  window.context = undefined;
-  window.AMP_MODE = undefined;
+  self.localStorage.clear();
+  self.ENABLE_LOG = false;
+  self.AMP_DEV_MODE = false;
+  self.context = undefined;
+  self.AMP_MODE = undefined;
 
-  const forgotGlobal = !!global.sandbox;
+  const forgotGlobal = !!self.sandbox;
   if (forgotGlobal) {
     // The error will be thrown later to give possibly other sandboxes a
     // chance to restore themselves.
-    delete global.sandbox;
+    delete self.sandbox;
   }
   if (sandboxes.length > 0) {
     sandboxes.splice(0, sandboxes.length).forEach(sb => sb.restore());
@@ -293,13 +293,13 @@ afterEach(function() {
   if (forgotGlobal) {
     throw new Error('You forgot to clear global sandbox!');
   }
-  if (!/native/.test(window.setTimeout)) {
+  if (!/native/.test(self.setTimeout)) {
     throw new Error('You likely forgot to restore sinon timers ' +
         '(installed via sandbox.useFakeTimers).');
   }
   setDefaultBootstrapBaseUrlForTesting(null);
   resetAccumulatedErrorMessagesForTesting();
-  resetExperimentTogglesForTesting(window);
+  resetExperimentTogglesForTesting(self);
   setReportError(reportError);
 });
 
@@ -329,7 +329,7 @@ chai.Assertion.addMethod('class', function(className) {
 
 chai.Assertion.addProperty('visible', function() {
   const obj = this._obj;
-  const computedStyle = window.getComputedStyle(obj);
+  const computedStyle = self.getComputedStyle(obj);
   const visibility = computedStyle.getPropertyValue('visibility');
   const opacity = computedStyle.getPropertyValue('opacity');
   const isOpaque = parseInt(opacity, 10) > 0;
@@ -348,7 +348,7 @@ chai.Assertion.addProperty('visible', function() {
 
 chai.Assertion.addProperty('hidden', function() {
   const obj = this._obj;
-  const computedStyle = window.getComputedStyle(obj);
+  const computedStyle = self.getComputedStyle(obj);
   const visibility = computedStyle.getPropertyValue('visibility');
   const opacity = computedStyle.getPropertyValue('opacity');
   const tagName = obj.tagName.toLowerCase();
@@ -365,7 +365,7 @@ chai.Assertion.addProperty('hidden', function() {
 
 chai.Assertion.addMethod('display', function(display) {
   const obj = this._obj;
-  const value = window.getComputedStyle(obj).getPropertyValue('display');
+  const value = self.getComputedStyle(obj).getPropertyValue('display');
   const tagName = obj.tagName.toLowerCase();
   this.assert(
       value === display,

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -63,6 +63,7 @@ describe('alp-handler', () => {
       head: {
         appendChild: sandbox.spy(),
       },
+      createElement: document.createElement.bind(document),
     };
     win.document = doc;
     anchor = {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -304,7 +304,7 @@ if (getMode().localDev) {
  * Builds the expriments tbale.
  */
 function build() {
-  const table = document.getElementById('experiments-table');
+  const table = self.document.getElementById('experiments-table');
   EXPERIMENTS.forEach(function(experiment) {
     table.appendChild(buildExperimentRow(experiment));
   });
@@ -317,35 +317,35 @@ function build() {
  */
 function buildExperimentRow(experiment) {
 
-  const tr = document.createElement('tr');
+  const tr = self.document.createElement('tr');
   tr.id = 'exp-tr-' + experiment.id;
 
-  const tdId = document.createElement('td');
+  const tdId = self.document.createElement('td');
   tdId.appendChild(buildLinkMaybe(experiment.id, experiment.spec));
   tr.appendChild(tdId);
 
-  const tdName = document.createElement('td');
+  const tdName = self.document.createElement('td');
   tdName.appendChild(buildLinkMaybe(experiment.name, experiment.spec));
   tr.appendChild(tdName);
 
-  const tdOn = document.createElement('td');
+  const tdOn = self.document.createElement('td');
   tdOn.classList.add('button-cell');
   tr.appendChild(tdOn);
 
-  const button = document.createElement('button');
+  const button = self.document.createElement('button');
   tdOn.appendChild(button);
 
-  const buttonOn = document.createElement('div');
+  const buttonOn = self.document.createElement('div');
   buttonOn.classList.add('on');
   buttonOn.textContent = 'On';
   button.appendChild(buttonOn);
 
-  const buttonDefault = document.createElement('div');
+  const buttonDefault = self.document.createElement('div');
   buttonDefault.classList.add('default');
   buttonDefault.textContent = 'Default on';
   button.appendChild(buttonDefault);
 
-  const buttonOff = document.createElement('div');
+  const buttonOff = self.document.createElement('div');
   buttonOff.classList.add('off');
   buttonOff.textContent = 'Off';
   button.appendChild(buttonOff);
@@ -366,11 +366,11 @@ function buildExperimentRow(experiment) {
 function buildLinkMaybe(text, link) {
   let element;
   if (link) {
-    element = document.createElement('a');
+    element = self.document.createElement('a');
     element.setAttribute('href', link);
     element.setAttribute('target', '_blank');
   } else {
-    element = document.createElement('span');
+    element = self.document.createElement('span');
   }
   element.textContent = text;
   return element;
@@ -392,7 +392,7 @@ function update() {
  * @param {!ExperimentDef} experiment
  */
 function updateExperimentRow(experiment) {
-  const tr = document.getElementById('exp-tr-' + experiment.id);
+  const tr = self.document.getElementById('exp-tr-' + experiment.id);
   if (!tr) {
     return;
   }
@@ -411,9 +411,9 @@ function updateExperimentRow(experiment) {
  */
 function isExperimentOn_(id) {
   if (id == CANARY_EXPERIMENT_ID) {
-    return getCookie(window, 'AMP_CANARY') == '1';
+    return getCookie(self, 'AMP_CANARY') == '1';
   }
-  return isExperimentOn(window, id);
+  return isExperimentOn(self, id);
 }
 
 
@@ -434,7 +434,7 @@ function toggleExperiment_(id, name, opt_on) {
     if (id == CANARY_EXPERIMENT_ID) {
       const validUntil = Date.now() +
           COOKIE_MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
-      setCookie(window, 'AMP_CANARY',
+      setCookie(self, 'AMP_CANARY',
           (on ? '1' : '0'), (on ? validUntil : 0), {
             // Set explicit domain, so the cookie gets send to sub domains.
             domain: location.hostname,
@@ -443,7 +443,7 @@ function toggleExperiment_(id, name, opt_on) {
       // Reflect default experiment state.
       self.location.reload();
     } else {
-      toggleExperiment(window, id, on);
+      toggleExperiment(self, id, on);
     }
     update();
   });
@@ -456,12 +456,14 @@ function toggleExperiment_(id, name, opt_on) {
  * @param {function()} callback
  */
 function showConfirmation_(message, callback) {
-  const container = dev().assert(document.getElementById('popup-container'));
-  const messageElement = dev().assert(document.getElementById('popup-message'));
+  const container = dev().assert(
+      self.document.getElementById('popup-container'));
+  const messageElement = dev().assert(
+      self.document.getElementById('popup-message'));
   const confirmButton = dev().assert(
-      document.getElementById('popup-button-ok'));
+      self.document.getElementById('popup-button-ok'));
   const cancelButton = dev().assert(
-      document.getElementById('popup-button-cancel'));
+      self.document.getElementById('popup-button-cancel'));
   const unlistenSet = [];
   const closePopup = affirmative => {
     container.classList.remove('show');
@@ -512,7 +514,7 @@ function getAmpConfig() {
 
 // Start up.
 getAmpConfig().then(() => {
-  onDocumentReady(document, () => {
+  onDocumentReady(self.document, () => {
     build();
     update();
   });


### PR DESCRIPTION
Also adds `global` to the globally forbidden globals.

This’ll prevent #10112, #8514, and likely others.

I didn't do this when I first forbade globals because it seemed like too much work. But we're getting too many bugs.