### PR TITLE
Remove all deprecated .min .max usage in doc #9931

### DIFF
--- a/ads/README.md
+++ b/ads/README.md
@@ -248,7 +248,7 @@ If you're adding support for a new 3P ad service, changes to the following files
 
 ### Verify your examples
 
-To verify the examples that you have put in `/examples/ads.amp.html`, you will need to start a local gulp web server by running command `gulp`. Then visit `http://localhost:8000/examples/ads.amp.max.html?type=yournetwork` in your browser to make sure the examples load ads.
+To verify the examples that you have put in `/examples/ads.amp.html`, you will need to start a local gulp web server by running command `gulp`. Then visit `http://localhost:8000/examples/ads.amp.html?type=yournetwork` in your browser to make sure the examples load ads.
 
 Please consider having the example consistently load a fake ad (with ad targeting disabled). Not only it will be a more confident example for publishers to follow, but also for us to catch any regression bug during our releases.
 

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -747,7 +747,7 @@ function elementExtractor(tagName, type) {
       'gm');
 }
 
-// Data for example: http://localhost:8000/examples/bind/xhr.amp.max.html
+// Data for example: http://localhost:8000/examples/bind/xhr.amp.html
 app.use('/bind/form/get', (req, res) => {
   assertCors(req, res, ['GET']);
   res.json({
@@ -755,7 +755,7 @@ app.use('/bind/form/get', (req, res) => {
   });
 });
 
-// Data for example: http://localhost:8000/examples/bind/ecommerce.amp.max.html
+// Data for example: http://localhost:8000/examples/bind/ecommerce.amp.html
 app.use('/bind/ecommerce/sizes', (req, res) => {
   assertCors(req, res, ['GET']);
   setTimeout(() => {

--- a/build-system/tasks/make-golden.js
+++ b/build-system/tasks/make-golden.js
@@ -67,7 +67,7 @@ function doScreenshot(host, path, output, device, verbose, cb) {
 /**
  * Make a golden image of the url.
  * Ex:
- * `gulp make-golden --path=examples/everything.amp.max.html \
+ * `gulp make-golden --path=examples/everything.amp.html \
  *     --host=http://localhost:8000`
  *  @param {function} cb callback function
  */

--- a/examples/ads-legacy.amp.html
+++ b/examples/ads-legacy.amp.html
@@ -335,7 +335,7 @@
     data-nc="90577858-BidderTest">
   </amp-ad>
   <div>
-    <a href="openx.amp.max.html">See all OpenX examples</a>
+    <a href="openx.amp.html">See all OpenX examples</a>
   </div>
 
   <h2>SmartAdServer ad</h2>

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -959,7 +959,7 @@
       data-nc="90577858-BidderTest">
   </amp-ad>
   <div>
-    <a href="openx.amp.max.html">See all OpenX examples</a>
+    <a href="openx.amp.html">See all OpenX examples</a>
   </div>
 
   <h2>Outbrain widget</h2>

--- a/test/functional/test-extension-location.js
+++ b/test/functional/test-extension-location.js
@@ -48,7 +48,7 @@ describes.sandboxed('Extension Location', {}, () => {
     it('with remote mode', () => {
       window.AMP_MODE = {rtvVersion: '123'};
       const script = calculateExtensionScriptUrl({
-        pathname: 'examples/ads.amp.min.html',
+        pathname: 'examples/ads.amp.html',
         host: 'localhost:8000',
         protocol: 'http:',
       }, 'amp-ad', false);
@@ -79,7 +79,7 @@ describes.sandboxed('Extension Location', {}, () => {
     it('with remote mode', () => {
       window.AMP_MODE = {rtvVersion: '123'};
       const script = calculateEntryPointScriptUrl({
-        pathname: 'examples/ads.amp.min.html',
+        pathname: 'examples/ads.amp.html',
         host: 'localhost:8000',
         protocol: 'http:',
       }, 'sw', /* isLocalDev */ false);
@@ -90,7 +90,7 @@ describes.sandboxed('Extension Location', {}, () => {
     it('with remote mode & rtv', () => {
       window.AMP_MODE = {rtvVersion: '123'};
       const script = calculateEntryPointScriptUrl({
-        pathname: 'examples/ads.amp.min.html',
+        pathname: 'examples/ads.amp.html',
         host: 'localhost:8000',
         protocol: 'http:',
       }, 'ww', /* isLocalDev */ false, /* opt_rtv */ true);

--- a/test/manual/pre-render-load.html
+++ b/test/manual/pre-render-load.html
@@ -1,1 +1,1 @@
-<iframe src="/examples/article.amp.max.html#prerenderSize=1&visibilityState=prerender&viewerorigin=http://localhost:8000&log=4" width="100%" height=100%></iframe>
+<iframe src="/examples/article.amp.html#prerenderSize=1&visibilityState=prerender&viewerorigin=http://localhost:8000&log=4" width="100%" height=100%></iframe>

--- a/testing/screenshots/make-screenshot.js
+++ b/testing/screenshots/make-screenshot.js
@@ -24,7 +24,7 @@
  * ```
  * phantomjs --ssl-protocol=any --ignore-ssl-errors=true --load-images=true \
  *     make-screenshot.js "http://localhost:8000" \
- *     "/examples/everything.amp.max.html" \
+ *     "/examples/everything.amp.html" \
  *     "everything.png" "iPhone6+"
  * ```
  */


### PR DESCRIPTION
Removed all uses of localhost:8000/examples/***.max.html and .min.html files. Closes #9931 