### PR TITLE
Tilt To Pan on amp-img (work in progress)

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -755,3 +755,39 @@ amp-accordion > section > :last-child {
 amp-accordion > section[expanded] > :last-child {
   display: block !important;
 }
+
+.i-amphtml-tilt-to-pan-expanded {
+  margin: 0px;
+  width: 100vw;
+  position: relative;
+  overflow: scroll;
+}
+
+.i-amphtml-tilt-to-pan-expanded img {
+  width: auto;
+  position: absolute;
+  backface-visibility: hidden;
+}
+
+.i-amphtml-tilt-to-pan, .i-amphtml-tilt-to-pan img {
+  transition: transform 0.05s linear,
+              width 0.25s linear,
+              height 0.25s linear;
+}
+
+amp-tilt-to-pan-indicator-container {
+    width: 100%;
+    height: 5px;
+    background: rgba(255, 255, 255, 0.6);
+    display: block;
+    position: absolute;
+    top: 0px;
+}
+
+amp-tilt-to-pan-indicator {
+    background: white;
+    height: 5px;
+    position: absolute;
+    transition: left 0.25s linear;
+    backface-visibility: hidden;
+}

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -278,13 +278,13 @@
   <main role="main">
     <article>
       <figure>
-        <amp-img id="hero-img"
+        <amp-img tilt-to-pan id="hero-img"
             src="img/hero@1x.jpg"
             srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
             layout="responsive" width="360" placeholder
             alt="Picture of two chairs on a lake shore with big pine trees"
             title="Opens image in a lightbox"
-            role="button" on="tap:headline-img-lightbox"
+            role="button"
             height="216" tabindex="0">
         </amp-img>
       </figure>
@@ -321,7 +321,7 @@
         </header>
 
         <div class="author">
-          <amp-img src="img/sample.jpg" id="author-avatar" placeholder
+          <amp-img tilt-to-pan src="img/sample.jpg" id="author-avatar" placeholder
               height="50" width="50">
           </amp-img>
           <div class="byline">
@@ -428,7 +428,7 @@
           </p>
 
           <figure>
-            <amp-img class="full-bleed" placeholder
+            <amp-img tilt-to-pan class="full-bleed" placeholder
                 src="img/sea@1x.jpg"
                 srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
                 layout="responsive" width="320"


### PR DESCRIPTION
**DO NOT MERGE, PROOF OF CONCEPT, EXTREMELY MESSY CODE, WILL HURT YOUR EYES**

![tiltzoom](https://user-images.githubusercontent.com/591655/27514384-f2c69090-593d-11e7-8458-174b13185d9f.jpg)


This is just a weekend project that is far from being complete. There are no set specifications and is open to discussion if the team determines that this is a useful feature.

This adds the ability to expand images to fullscreen and use the phone's accelerometer to pan through the image. Provides an alternative to the `google-vrview-image` (smoother transitions, no on-screen controls, fullscreen view) built into `amp-img`. Useful for portrait only articles as well as 360 panorama images. Currently only goes into the tilt-to-pan after tapping the image.

<p align="center"><img width="100%" src="https://user-images.githubusercontent.com/591655/27518350-b1d1e300-5992-11e7-8f87-67684b6baf9f.gif"></p>

### Changes
- Added `tilt-to-pan` attribute to `amp-img`
- Implemented accelerometer controlled zoom
- Implemented fullscreen view
- Implemented pan indicator on the top

### To-do
- Determine demand for this feature
- Determine whether this should be part of the `amp-lightbox`, part of `amp-img` or a separate extension that does the same role as `amp-lightbox`
- Write tests
- Animate the scroll to element when going fullscreen
- Scroll back to the initial position when going out of fullscreen
- Take the element to actual fullscreen with `requestFullscreen()` instead of simulated fullscreen
- Provide properties for `tilt-to-pan` (ex. `on-tap`, `always`, etc.)
- Determine behavior inside the amp viewer
- Determine behavior when device goes to landscape
