### PR TITLE
remove amp-animation experiment check in position observer

### DIFF
--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -440,9 +440,6 @@ export class InaboxAmpDocPositionObserver extends AbstractPositionObserver {
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  */
 export function installPositionObserverServiceForDoc(ampdoc) {
-  dev().assert(isExperimentOn(ampdoc.win, 'amp-animation'),
-      'PositionObserver is experimental and used by amp-animation only for ' +
-      'now');
   registerServiceBuilderForDoc(ampdoc, 'position-observer', () => {
     if (getMode(ampdoc.win).runtime == 'inabox') {
       return new InaboxAmpDocPositionObserver(ampdoc);

--- a/src/service/position-observer-impl.js
+++ b/src/service/position-observer-impl.js
@@ -25,7 +25,6 @@ import {
   layoutRectFromDomRect,
   layoutRectLtwh,
 } from '../layout-rect';
-import {isExperimentOn} from '../../src/experiments';
 import {serializeMessage} from '../../src/3p-frame-messaging';
 import {parseJson, tryParseJson} from '../../src/json.js';
 import {getData} from '../../src/event-helper';


### PR DESCRIPTION
since position observer is now used for video docking. (also the dependency white list protects who can use position observer anyway)