### PR TITLE
Launch Fast Fetch for Doubleclick

### DIFF
--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -20,23 +20,16 @@ import {
   isReportingEnabled,
 } from './utils';
 import {BaseLifecycleReporter, GoogleAdLifecycleReporter} from './performance';
-import {randomlySelectUnsetExperiments} from '../../../src/experiments';
 import {
-    parseExperimentIds,
-    isInManualExperiment,
-} from './traffic-experiments';
+  getExperimentBranch,
+  randomlySelectUnsetExperiments,
+} from '../../../src/experiments';
 import {
-    ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-    ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-    ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-    ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
+    ADSENSE_A4A_EXPERIMENT_NAME,
 } from '../../../extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config';
 import {
-    DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-    DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-    DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-    DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-} from '../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config';  // eslint-disable-line max-len
+  DOUBLECLICK_A4A_EXPERIMENT_NAME,
+} from '../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config'; // eslint-disable-line max-len
 
 /**
  * An experiment config for controlling profiling.  Profiling has no branches:
@@ -58,73 +51,21 @@ export const PROFILING_BRANCHES = {
 };
 
 /**
- * Set of namespaces that can be set for lifecycle reporters.
- *
- * @enum {string}
- */
-export const ReporterNamespace = {
-  A4A: 'a4a',
-  AMP: 'amp',
-};
-
-/**
- * Check whether the element is in an experiment branch that is eligible for
- * monitoring.
- *
- * @param {!AMP.BaseElement} ampElement
- * @param {!string} namespace
- * @returns {boolean}
- */
-function isInReportableBranch(ampElement, namespace) {
-  // Handle the possibility of multiple eids on the element.
-  const eids = parseExperimentIds(
-      ampElement.element.getAttribute(EXPERIMENT_ATTRIBUTE));
-  const reportableA4AEids = {
-    [ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment]: 1,
-    [ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment]: 1,
-    [ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment]: 1,
-    [ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment]: 1,
-    [DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment]: 1,
-    [DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment]: 1,
-    [DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment]: 1,
-    [DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment]: 1,
-  };
-  const reportableControlEids = {
-    [ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control]: 1,
-    [ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control]: 1,
-    [ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control]: 1,
-    [ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control]: 1,
-    [DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control]: 1,
-    [DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control]: 1,
-    [DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control]: 1,
-    [DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control]: 1,
-  };
-  switch (namespace) {
-    case ReporterNamespace.A4A:
-      return eids.some(x => { return x in reportableA4AEids; }) ||
-          isInManualExperiment(ampElement.element);
-    case ReporterNamespace.AMP:
-      return eids.some(x => { return x in reportableControlEids; });
-    default:
-      return false;
-  }
-}
-
-/**
  * @param {!AMP.BaseElement} ampElement The element on whose lifecycle this
  *    reporter will be reporting.
- * @param {string} namespace
  * @param {number|string} slotId A unique numeric identifier in the page for
  *    the given element's slot.
  * @return {!./performance.BaseLifecycleReporter}
  * @visibleForTesting
  */
-export function getLifecycleReporter(ampElement, namespace, slotId) {
-  randomlySelectUnsetExperiments(ampElement.win, PROFILING_BRANCHES);
+export function getLifecycleReporter(ampElement, slotId) {
+  const win = ampElement.win;
+  randomlySelectUnsetExperiments(win, PROFILING_BRANCHES);
   if (isReportingEnabled(ampElement) &&
-      isInReportableBranch(ampElement, namespace)) {
-    return new GoogleAdLifecycleReporter(ampElement.win, ampElement.element,
-      namespace, Number(slotId));
+      (!!getExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME) ||
+       !!getExperimentBranch(win, ADSENSE_A4A_EXPERIMENT_NAME))) {
+    return new GoogleAdLifecycleReporter(
+      win, ampElement.element, Number(slotId));
   } else {
     return new BaseLifecycleReporter();
   }
@@ -137,15 +78,11 @@ export function getLifecycleReporter(ampElement, namespace, slotId) {
  * generates no outputs.
  *
  * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A|!../../../extensions/amp-ad/0.1/amp-ad-3p-impl.AmpAd3PImpl} baseInstance
- * @param {string=} opt_namespace  CSI ping namespace.  For example, a key
- *   of #ReporterNamespace.
  * @return {!./performance.BaseLifecycleReporter}
  */
-export function googleLifecycleReporterFactory(baseInstance, opt_namespace) {
-  const namespace = opt_namespace || ReporterNamespace.A4A;
-  const reporter =
-      (getLifecycleReporter(baseInstance, namespace,
-          baseInstance.element.getAttribute('data-amp-slot-index')));
+export function googleLifecycleReporterFactory(baseInstance) {
+  const reporter = getLifecycleReporter(
+      baseInstance, baseInstance.element.getAttribute('data-amp-slot-index'));
   reporter.setPingParameters({
     's': 'AD_SLOT_NAMESPACE',
     'dt': 'NAV_TIMING(navigationStart)',

--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -128,11 +128,9 @@ export class GoogleAdLifecycleReporter extends BaseLifecycleReporter {
   /**
    * @param {!Window} win  Parent window object.
    * @param {!Element} element  Parent element object.
-   * @param {string} namespace  Namespace for page-level info.  (E.g.,
-   *   'amp' vs 'a4a'.)
    * @param {number} slotId
    */
-  constructor(win, element, namespace, slotId) {
+  constructor(win, element, slotId) {
     super();
 
     /** @private {!Window} @const */
@@ -142,7 +140,8 @@ export class GoogleAdLifecycleReporter extends BaseLifecycleReporter {
     this.element_ = element;
 
     /** @private {string} @const */
-    this.namespace_ = namespace;
+    this.namespace_ =
+      element.getAttribute('data-a4a-upgrade-type') ? 'a4a' : 'amp';
 
     /** @private {number} @const */
     this.slotId_ = slotId;

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -20,8 +20,6 @@ import {
   googleAdsIsA4AEnabled,
   isInExperiment,
   isInManualExperiment,
-  isExternallyTriggeredExperiment,
-  isInternallyTriggeredExperiment,
 } from '../traffic-experiments';
 import {toggleExperiment} from '../../../../src/experiments';
 import {installPlatformService} from '../../../../src/service/platform-impl';
@@ -79,30 +77,6 @@ function expectThereCanBeOnlyOne(element, id) {
   expect(isInExperiment(element, id),
       `expected ${id} to be in ${element.getAttribute(
           'data-experiment-id')}`).to.be.true;
-}
-
-/**
- * Checks that element's data-element-id contains the "is internally triggered"
- * experiment ID and that it does not contain the "is externally triggered"
- * eid.
- *
- * @param {!Element} element
- */
-function expectInternallyTriggered(element) {
-  expect(isInternallyTriggeredExperiment(element)).to.be.true;
-  expect(isExternallyTriggeredExperiment(element)).to.be.false;
-}
-
-/**
- * Checks that element's data-element-id contains the "is externally triggered"
- * experiment ID and that it does not contain the "is internally triggered"
- * eid.
- *
- * @param {!Element} element
- */
-function expectExternallyTriggered(element) {
-  expect(isInternallyTriggeredExperiment(element)).to.be.false;
-  expect(isExternallyTriggeredExperiment(element)).to.be.true;
 }
 
 describe('a4a_config', () => {
@@ -167,7 +141,6 @@ describe('a4a_config', () => {
         'googleAdsIsA4AEnabled').to.be.true;
     expect(win.document.cookie).to.be.null;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
-    expectInternallyTriggered(element);
   });
 
   it('should attach control ID and return false when control is on', () => {
@@ -177,7 +150,6 @@ describe('a4a_config', () => {
         .to.be.false;
     expect(win.document.cookie).to.be.null;
     expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.control);
-    expectInternallyTriggered(element);
   });
 
   it('should not attach ID and return false when selected out', () => {
@@ -263,7 +235,6 @@ describe('a4a_config', () => {
           'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
-      expectInternallyTriggered(element);
     });
 
     it('should fall back to client-side eid when param is empty', () => {
@@ -274,7 +245,6 @@ describe('a4a_config', () => {
           'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, INTERNAL_BRANCHES.experiment);
-      expectInternallyTriggered(element);
     });
 
     const externalIdTestCases = [
@@ -297,7 +267,6 @@ describe('a4a_config', () => {
             expect(win.document.cookie).to.be.null;
             if (testCase.expId) {
               expectThereCanBeOnlyOne(element, testCase.expId);
-              expectExternallyTriggered(element);
             } else {
               expect(element.getAttribute('data-experiment-id')).to.not.be.ok;
             }
@@ -431,7 +400,6 @@ describe('a4a_config hash param parsing', () => {
           'googleAdsIsA4AEnabled').to.be.true;
       expect(win.document.cookie).to.be.null;
       expectThereCanBeOnlyOne(element, EXTERNAL_BRANCHES.experiment);
-      expectExternallyTriggered(element);
     });
   });
 });

--- a/ads/google/a4a/test/test-google-data-reporter.js
+++ b/ads/google/a4a/test/test-google-data-reporter.js
@@ -57,7 +57,7 @@ describe('#getLifecycleReporter', () => {
     }, 0, 0)).to.be.instanceOf(BaseLifecycleReporter);
   });
 
-  it('should not reporter if in neither adsense or doubleclick exp', () => {
+  it('should not create reporter if not adsense or doubleclick exp', () => {
     forceExperimentBranch(win, 'a4aProfilingRate', 'unused');
     const element = doc.createElement('div');
     element.setAttribute('type', 'doubleclick');
@@ -80,11 +80,11 @@ describe('#getLifecycleReporter', () => {
     }, 0, 0)).to.be.instanceOf(GoogleAdLifecycleReporter);
   });
 
-  it('should create reporter for doubleclick', () => {
+  it('should create reporter for adsense', () => {
     forceExperimentBranch(win, 'a4aProfilingRate', 'unused');
     forceExperimentBranch(win, ADSENSE_A4A_EXPERIMENT_NAME, '1234');
     const element = doc.createElement('div');
-    element.setAttribute('type', 'doubleclick');
+    element.setAttribute('type', 'adsense');
     doc.body.appendChild(element);
     expect(getLifecycleReporter({
       win,

--- a/ads/google/a4a/test/test-google-data-reporter.js
+++ b/ads/google/a4a/test/test-google-data-reporter.js
@@ -26,219 +26,154 @@ import {
 } from '../performance';
 import {EXPERIMENT_ATTRIBUTE, QQID_HEADER} from '../utils';
 import {
-    ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-    ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-    ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-    ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-} from '../../../../extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config';  // eslint-disable-line max-len
+  ADSENSE_A4A_EXPERIMENT_NAME,
+} from '../../../../extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config'; // eslint-disable-line
 import {
-    DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-    DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-    DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-    DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-} from '../../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config';  // eslint-disable-line max-len
-
-/**
- * Construct a lifecycle reporter for an element with a given eid in one of
- * the reporting namespaces.  If eid is not specified, creates an element with
- * no eid.
- * @param {string} namespace
- * @param {string} ad type
- * @param {string=} opt_eid
- * @returns {*}
- */
-function buildElementWithEid(namespace, type, opt_eid) {
-  return createIframePromise(false).then(iframeFixture => {
-    const win = iframeFixture.win;
-    const doc = iframeFixture.doc;
-    const elem = doc.createElement('div');
-    elem.setAttribute('type', type);
-    if (opt_eid) {
-      elem.setAttribute(EXPERIMENT_ATTRIBUTE, opt_eid);
-    }
-    doc.body.appendChild(elem);
-    const pseudoAmpElement = {
-      win,
-      element: elem,
-    };
-    return getLifecycleReporter(pseudoAmpElement, namespace, 0, 0);
-  });
-}
+  DOUBLECLICK_A4A_EXPERIMENT_NAME,
+} from '../../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config'; // eslint-disable-line
+import {forceExperimentBranch} from '../../../../src/experiments';
 
 describe('#getLifecycleReporter', () => {
-  const EXPERIMENT_BRANCH_EIDS = [
-    ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
-    ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
-    ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
-    ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
-    DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
-    DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
-    DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
-    DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
-    '117152632',
-  ];
-  const CONTROL_BRANCH_EIDS = [
-    ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
-    ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
-    ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
-    ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
-    DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
-    DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
-    DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
-    DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
-  ];
 
-  ['adsense', 'doubleclick'].forEach(type => {
-    describe(`type = ${type}`, () => {
-      EXPERIMENT_BRANCH_EIDS.forEach(eid => {
-        it(`should return real reporter for a4a eid = ${eid}`, () => {
-          return buildElementWithEid('a4a', type, eid).then(reporter => {
-            expect(reporter).to.be.instanceOf(GoogleAdLifecycleReporter);
-          });
-        });
+  let win;
+  let doc;
 
-        it(`should return a null reporter for amp eid = ${eid}`, () => {
-          return buildElementWithEid('amp', type, eid).then(reporter => {
-            expect(reporter).to.be.instanceOf(BaseLifecycleReporter);
-          });
-        });
-
-        it(`should return null reporter for bogus namespace eid = ${eid}`,
-            () => {
-              return buildElementWithEid('fnord', type, eid).then(reporter => {
-                expect(reporter).to.be.instanceOf(BaseLifecycleReporter);
-              });
-            });
-
-        it(`should return null reporter for non-Google ad, eid = ${eid}`,
-            () => {
-              return buildElementWithEid('a4a', 'a9', eid).then(reporter => {
-                expect(reporter).to.be.instanceOf(BaseLifecycleReporter);
-              });
-            });
-      });
-
-      CONTROL_BRANCH_EIDS.forEach(eid => {
-        it(`should return null reporter for a4a eid = ${eid}`, () => {
-          return buildElementWithEid('a4a', type, eid).then(reporter => {
-            expect(reporter).to.be.instanceOf(BaseLifecycleReporter);
-          });
-        });
-
-        it(`should return a real reporter for amp eid = ${eid}`, () => {
-          return buildElementWithEid('amp', type, eid).then(reporter => {
-            expect(reporter).to.be.instanceOf(GoogleAdLifecycleReporter);
-          });
-        });
-
-        it(`should return null reporter for bogus namespace eid = ${eid}`,
-            () => {
-              return buildElementWithEid('fnord', type, eid).then(reporter => {
-                expect(reporter).to.be.instanceOf(BaseLifecycleReporter);
-              });
-            });
-
-        it(`should return null reporter for non-Google ad, eid = ${eid}`,
-            () => {
-              return buildElementWithEid('amp', 'a9', eid).then(reporter => {
-                expect(reporter).to.be.instanceOf(BaseLifecycleReporter);
-              });
-            });
-      });
-
-      for (const namespace in ['a4a', 'amp']) {
-        it(`should return null reporter for ${namespace} and no eid`, () => {
-          return buildElementWithEid(namespace, type).then(reporter => {
-            expect(reporter).to.be.instanceOf(BaseLifecycleReporter);
-          });
-        });
-      }
+  beforeEach(() => {
+    return createIframePromise(false).then(iframeFixture => {
+      win = iframeFixture.win;
+      doc = iframeFixture.doc;
     });
   });
 
-  describes.fakeWin('#setGoogleLifecycleVarsFromHeaders', {amp: true}, env => {
-    const headerData = {};
-    const headerMock = {
-      get: h => { return h in headerData ? headerData[h] : null; },
-    };
+  it('should not create reporter if sampling is not enabled', () => {
+    forceExperimentBranch(win, 'a4aProfilingRate', null);
+    forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, '1234');
+    const element = doc.createElement('div');
+    element.setAttribute('type', 'doubleclick');
+    doc.body.appendChild(element);
+    expect(getLifecycleReporter({
+      win,
+      element,
+    }, 0, 0)).to.be.instanceOf(BaseLifecycleReporter);
+  });
+
+  it('should not reporter if in neither adsense or doubleclick exp', () => {
+    forceExperimentBranch(win, 'a4aProfilingRate', 'unused');
+    const element = doc.createElement('div');
+    element.setAttribute('type', 'doubleclick');
+    doc.body.appendChild(element);
+    expect(getLifecycleReporter({
+      win,
+      element,
+    }, 0, 0)).to.be.instanceOf(BaseLifecycleReporter);
+  });
+
+  it('should create reporter for doubleclick', () => {
+    forceExperimentBranch(win, 'a4aProfilingRate', 'unused');
+    forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, '1234');
+    const element = doc.createElement('div');
+    element.setAttribute('type', 'doubleclick');
+    doc.body.appendChild(element);
+    expect(getLifecycleReporter({
+      win,
+      element,
+    }, 0, 0)).to.be.instanceOf(GoogleAdLifecycleReporter);
+  });
+
+  it('should create reporter for doubleclick', () => {
+    forceExperimentBranch(win, 'a4aProfilingRate', 'unused');
+    forceExperimentBranch(win, ADSENSE_A4A_EXPERIMENT_NAME, '1234');
+    const element = doc.createElement('div');
+    element.setAttribute('type', 'doubleclick');
+    doc.body.appendChild(element);
+    expect(getLifecycleReporter({
+      win,
+      element,
+    }, 0, 0)).to.be.instanceOf(GoogleAdLifecycleReporter);
+  });
+});
+
+describes.fakeWin('#setGoogleLifecycleVarsFromHeaders', {amp: true}, env => {
+  const headerData = {};
+  const headerMock = {
+    get: h => { return h in headerData ? headerData[h] : null; },
+  };
+  let mockReporter;
+  let emitPingStub;
+  beforeEach(() => {
+    const fakeElt = env.createAmpElement('div');
+    env.win.Math = Math;
+    env.win.document.body.appendChild(fakeElt);
+    mockReporter = new GoogleAdLifecycleReporter(env.win, fakeElt, 37);
+    mockReporter.setPingAddress('http://localhost:9876/');
+    emitPingStub = sandbox.stub(mockReporter, 'emitPing_');
+  });
+
+  it('should pick up qqid from headers', () => {
+    headerData[QQID_HEADER] = 'test_qqid';
+    expect(mockReporter.extraVariables_).to.be.empty;
+    setGoogleLifecycleVarsFromHeaders(headerMock, mockReporter);
+    mockReporter.sendPing('preAdThrottle');
+    expect(emitPingStub).to.be.calledOnce;
+    expect(emitPingStub).to.be.calledWithMatch(/[&?]qqid.37=test_qqid/);
+  });
+
+  it('should pick up rendering method from headers', () => {
+    headerData['X-AmpAdRender'] = 'fnord';
+    expect(mockReporter.extraVariables_).to.be.empty;
+    setGoogleLifecycleVarsFromHeaders(headerMock, mockReporter);
+    mockReporter.sendPing('preAdThrottle');
+    expect(emitPingStub).to.be.calledOnce;
+    expect(emitPingStub).to.be.calledWithMatch(/[&?]rm.37=fnord/);
+  });
+});
+
+describes.sandboxed('#googleLifecycleReporterFactory', {}, () => {
+  describes.fakeWin('default parameters', {amp: true}, env => {
     let mockReporter;
     let emitPingStub;
     beforeEach(() => {
-      const fakeElt = env.createAmpElement('div');
-      env.win.Math = Math;
+      const fakeElt = env.win.document.createElement('div');
+      fakeElt.setAttribute('data-amp-slot-index', '22');
+      fakeElt.setAttribute('type', 'doubleclick');
+      fakeElt.setAttribute(EXPERIMENT_ATTRIBUTE, '1234');
+      fakeElt.setAttribute('data-a4a-upgrade-type', 'foo');
+      forceExperimentBranch(env.win, DOUBLECLICK_A4A_EXPERIMENT_NAME, '1234');
       env.win.document.body.appendChild(fakeElt);
-      mockReporter = new GoogleAdLifecycleReporter(
-          env.win, fakeElt, 'test', 37);
+      env.win.ampAdPageCorrelator = 7777777;
+      const a4aContainer = {
+        element: fakeElt,
+        win: env.win,
+      };
+      mockReporter = googleLifecycleReporterFactory(a4aContainer);
+      expect(mockReporter).to.be.instanceOf(GoogleAdLifecycleReporter);
       mockReporter.setPingAddress('http://localhost:9876/');
       emitPingStub = sandbox.stub(mockReporter, 'emitPing_');
     });
 
-    it('should pick up qqid from headers', () => {
-      headerData[QQID_HEADER] = 'test_qqid';
-      expect(mockReporter.extraVariables_).to.be.empty;
-      setGoogleLifecycleVarsFromHeaders(headerMock, mockReporter);
-      mockReporter.sendPing('preAdThrottle');
+    it('should generate a ping with known parameters', () => {
+      const viewer = env.win.services.viewer.obj;
+      viewer.firstVisibleTime_ = viewer.lastVisibleTime_ = Date.now();
+      mockReporter.sendPing('renderFriendlyStart');
       expect(emitPingStub).to.be.calledOnce;
-      expect(emitPingStub).to.be.calledWithMatch(/[&?]qqid.37=test_qqid/);
-    });
-
-    it('should pick up rendering method from headers', () => {
-      headerData['X-AmpAdRender'] = 'fnord';
-      expect(mockReporter.extraVariables_).to.be.empty;
-      setGoogleLifecycleVarsFromHeaders(headerMock, mockReporter);
-      mockReporter.sendPing('preAdThrottle');
-      expect(emitPingStub).to.be.calledOnce;
-      expect(emitPingStub).to.be.calledWithMatch(/[&?]rm.37=fnord/);
-    });
-  });
-
-  describes.sandboxed('#googleLifecycleReporterFactory', {}, () => {
-    describes.fakeWin('default parameters', {amp: true}, env => {
-      let mockReporter;
-      let emitPingStub;
-      beforeEach(() => {
-        const fakeElt = env.win.document.createElement('div');
-        fakeElt.setAttribute('data-amp-slot-index', '22');
-        fakeElt.setAttribute('type', 'doubleclick');
-        fakeElt.setAttribute(EXPERIMENT_ATTRIBUTE,
-            DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment);
-        env.win.document.body.appendChild(fakeElt);
-        env.win.ampAdPageCorrelator = 7777777;
-        const a4aContainer = {
-          element: fakeElt,
-          win: env.win,
-        };
-        mockReporter = googleLifecycleReporterFactory(a4aContainer);
-        expect(mockReporter).to.be.instanceOf(GoogleAdLifecycleReporter);
-        mockReporter.setPingAddress('http://localhost:9876/');
-        emitPingStub = sandbox.stub(mockReporter, 'emitPing_');
-      });
-
-      it('should generate a ping with known parameters', () => {
-        const viewer = env.win.services.viewer.obj;
-        viewer.firstVisibleTime_ = viewer.lastVisibleTime_ = Date.now();
-        mockReporter.sendPing('renderFriendlyStart');
-        expect(emitPingStub).to.be.calledOnce;
-        const pingUrl = emitPingStub.firstCall.args[0];
-        const experimentId =
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment;
-        const expectedParams = [
-          's=a4a',
-          'c=7777777',
-          'slotId=22',
-          `rls=${encodeURIComponent('$internalRuntimeVersion$')}`,
-          'v_h=[0-9]+',
-          's_t=',  // SROLL_TOP not defined in test environment.
-          'stageName=renderFriendlyStart',
-          'stageIdx=6',
-          'met.a4a.22=renderFriendlyStart.[0-9]+',
-          `e.22=${experimentId}`,
-          'adt.22=doubleclick',
-          'met.a4a=firstVisibleTime.[0-9]+%2ClastVisibleTime.[0-9]+',
-        ];
-        expectedParams.forEach(p => {
-          expect(pingUrl, p).to.match(new RegExp(`[?&]${p}(&|$)`));
-        });
+      const pingUrl = emitPingStub.firstCall.args[0];
+      const experimentId = 1234;
+      const expectedParams = [
+        's=a4a',
+        'c=7777777',
+        'slotId=22',
+        `rls=${encodeURIComponent('$internalRuntimeVersion$')}`,
+        'v_h=[0-9]+',
+        's_t=',  // SROLL_TOP not defined in test environment.
+        'stageName=renderFriendlyStart',
+        'stageIdx=6',
+        'met.a4a.22=renderFriendlyStart.[0-9]+',
+        `e.22=${experimentId}`,
+        'adt.22=doubleclick',
+        'met.a4a=firstVisibleTime.[0-9]+%2ClastVisibleTime.[0-9]+',
+      ];
+      expectedParams.forEach(p => {
+        expect(pingUrl, p).to.match(new RegExp(`[?&]${p}(&|$)`));
       });
     });
   });

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -83,8 +83,7 @@ describe('GoogleAdLifecycleReporter', () => {
       const viewer = viewerForDoc(doc);
       const elem = doc.createElement('div');
       doc.body.appendChild(elem);
-      const reporter = new GoogleAdLifecycleReporter(
-          win, elem, 'test_foo', 42);
+      const reporter = new GoogleAdLifecycleReporter(win, elem, 42);
       reporter.setPingAddress('/');
       reporter.setPingParameters({
         's': 'AD_SLOT_NAMESPACE',
@@ -114,7 +113,7 @@ describe('GoogleAdLifecycleReporter', () => {
         expect(emitPingSpy).to.be.calledOnce;
         const arg = emitPingSpy.getCall(0).args[0];
         const expectations = [
-          /[&?]s=test_foo(&|$)/,
+          /[&?]s=amp(&|$)/,
           // In unit tests, internalRuntimeVersion is not substituted.  %24 ==
           // ASCII encoding of '$'.
           /[&?]rls=%24internalRuntimeVersion%24(&|$)/,
@@ -153,7 +152,7 @@ describe('GoogleAdLifecycleReporter', () => {
         count = 0;
         for (const k in stages) {
           const expectations = [
-            /[&?]s=test_foo(&|$)/,
+            /[&?]s=amp(&|$)/,
             // In unit tests, internalRuntimeVersion is not substituted.  %24 ==
             // ASCII encoding of '$'.
             /[&?]rls=%24internalRuntimeVersion%24(&|$)/,
@@ -182,8 +181,7 @@ describe('GoogleAdLifecycleReporter', () => {
           const elem = doc.createElement('div');
           elem.setAttribute('id', i);
           doc.body.appendChild(elem);
-          const reporter = new GoogleAdLifecycleReporter(win, elem, 'test_foo',
-              i + 1);
+          const reporter = new GoogleAdLifecycleReporter(win, elem, i + 1);
           reporter.setPingAddress('/');
           reporter.setPingParameters({
             's': 'AD_SLOT_NAMESPACE',
@@ -202,7 +200,7 @@ describe('GoogleAdLifecycleReporter', () => {
         const slotCounts = {};
         for (let i = 0; i < emitPingSpy.callCount; ++i) {
           const src = emitPingSpy.getCall(i).args[0];
-          expect(src).to.match(/[?&]s=test_foo(&|$)/);
+          expect(src).to.match(/[?&]s=amp(&|$)/);
           expect(src).to.match(/[?&]c=[0-9]+/);
           const corr = /[?&]c=([0-9]+)/.exec(src)[1];
           commonCorrelator = commonCorrelator || corr;
@@ -230,7 +228,7 @@ describe('GoogleAdLifecycleReporter', () => {
         const arg = emitPingSpy.getCall(0).args[0];
         const expectations = [
           // Be sure that existing ping not deleted by args.
-          /[&?]s=test_foo/,
+          /[&?]s=amp/,
           /zort=314159/,
           /gack=flubble/,
         ];
@@ -304,7 +302,7 @@ describe('GoogleAdLifecycleReporter', () => {
         const arg = emitPingSpy.getCall(0).args[0];
         const expectations = [
           // Be sure that existing ping not deleted by args.
-          /[&?]s=test_foo/,
+          /[&?]s=amp/,
           /zort=[0-9.]+/,
         ];
         expectMatchesAll(arg, expectations);
@@ -324,7 +322,7 @@ describe('GoogleAdLifecycleReporter', () => {
         const arg = emitPingSpy.getCall(0).args[0];
         const expectations = [
           // Be sure that existing ping not deleted by args.
-          /[&?]s=test_foo/,
+          /[&?]s=amp/,
         ];
         expectMatchesAll(arg, expectations);
       });
@@ -341,7 +339,7 @@ describe('GoogleAdLifecycleReporter', () => {
         const arg = emitPingSpy.getCall(0).args[0];
         const expectations = [
           // Be sure that existing ping not deleted by args.
-          /[&?]s=test_foo/,
+          /[&?]s=amp/,
           /zort=12345/,
         ];
         expectMatchesAll(arg, expectations);
@@ -359,7 +357,7 @@ describe('GoogleAdLifecycleReporter', () => {
         const arg = emitPingSpy.getCall(0).args[0];
         const expectations = [
           // Be sure that existing ping not deleted by args.
-          /[&?]s=test_foo/,
+          /[&?]s=amp/,
           /zort=12345/,
           /gax=99/,
           /flub=0/,

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -19,8 +19,6 @@ import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {
   addExperimentIdToElement,
   isInExperiment,
-  isExternallyTriggeredExperiment,
-  isInternallyTriggeredExperiment,
   validateExperimentIds,
   googleAdsIsA4AEnabled,
 } from '../traffic-experiments';
@@ -39,12 +37,12 @@ import {
   installDocumentStateService,
 } from '../../../../src/service/document-state';
 import {
-  DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-  DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-  DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-  DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
-  DOUBLECLICK_A4A_EXTERNAL_DELAYED_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-} from '../../../../extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js'; // eslint-disable-line
+  ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
+  ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
+  ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
+  ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH,
+  ADSENSE_A4A_EXTERNAL_DELAYED_EXPERIMENT_BRANCHES_PRE_LAUNCH,
+} from '../../../../extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js'; // eslint-disable-line
 import {EXPERIMENT_ATTRIBUTE} from '../utils';
 import * as sinon from 'sinon';
 
@@ -67,6 +65,7 @@ describe('all-traffic-experiments-tests', () => {
       sandbox.win = {
         location: {
           hostname: 'test.server.name.com',
+          origin: 'https://cdn.ampproject.org',
         },
         AMP_CONFIG: {
           testExperimentId: experimentFrequency,
@@ -107,8 +106,6 @@ describe('all-traffic-experiments-tests', () => {
       expect(isInExperiment(element, '34')).to.be.true;
       expect(isInExperiment(element, '56')).to.be.false;
       expect(isInExperiment(element, '78')).to.be.false;
-      expect(isExternallyTriggeredExperiment(element)).to.be.true;
-      expect(isInternallyTriggeredExperiment(element)).to.be.false;
     });
 
     it('should use AdSense specific A4A experiment from URL', () => {
@@ -158,8 +155,6 @@ describe('all-traffic-experiments-tests', () => {
       expect(isInExperiment(element, '34')).to.be.false;
       expect(isInExperiment(element, '56')).to.be.false;
       expect(isInExperiment(element, '78')).to.be.false;
-      expect(isExternallyTriggeredExperiment(element)).to.be.true;
-      expect(isInternallyTriggeredExperiment(element)).to.be.false;
     });
 
     it('should enable the internal A4A experiment', () => {
@@ -178,8 +173,6 @@ describe('all-traffic-experiments-tests', () => {
       expect(isInExperiment(element, '34')).to.be.false;
       expect(isInExperiment(element, '56')).to.be.false;
       expect(isInExperiment(element, '78')).to.be.true;
-      expect(isExternallyTriggeredExperiment(element)).to.be.false;
-      expect(isInternallyTriggeredExperiment(element)).to.be.true;
     });
 
     it('should enable the internal A4A control', () => {
@@ -198,8 +191,6 @@ describe('all-traffic-experiments-tests', () => {
       expect(isInExperiment(element, '34')).to.be.false;
       expect(isInExperiment(element, '56')).to.be.true;
       expect(isInExperiment(element, '78')).to.be.false;
-      expect(isExternallyTriggeredExperiment(element)).to.be.false;
-      expect(isInternallyTriggeredExperiment(element)).to.be.true;
     });
   });
 
@@ -354,14 +345,14 @@ describe('all-traffic-experiments-tests', () => {
 
     function expectCorrectBranchOnly(element, expectedBranchId) {
       const branchIds = [
-        DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
-        DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
-        DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
-        DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
-        DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
-        DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
-        DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
-        DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
+        ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
+        ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
+        ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
+        ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
+        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
+        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
+        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
+        ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
       ];
       for (const bId in branchIds) {
         expect(isInExperiment(element, bId)).to.equal(bId === expectedBranchId);
@@ -382,7 +373,7 @@ describe('all-traffic-experiments-tests', () => {
         hasLaunched: false,
         shouldServeFastFetch: false,
         branchId:
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
       },
       {
         branchType: 'experiment',
@@ -390,7 +381,7 @@ describe('all-traffic-experiments-tests', () => {
         hasLaunched: false,
         shouldServeFastFetch: true,
         branchId:
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
       },
       {
         adType: 'doubleclick',
@@ -405,7 +396,7 @@ describe('all-traffic-experiments-tests', () => {
         shouldServeFastFetch: true,
         branchType: 'control',
         branchId:
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
       },
       {
         adType: 'doubleclick',
@@ -413,7 +404,7 @@ describe('all-traffic-experiments-tests', () => {
         shouldServeFastFetch: false,
         branchType: 'experiment',
         branchId:
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
       },
       {
         adType: 'doubleclick',
@@ -430,7 +421,7 @@ describe('all-traffic-experiments-tests', () => {
         urlParam: '?exp=a4a:1',
         branchType: 'control',
         branchId:
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.control,
       },
       {
         adType: 'doubleclick',
@@ -439,7 +430,7 @@ describe('all-traffic-experiments-tests', () => {
         urlParam: '?exp=a4a:2',
         branchType: 'experiment',
         branchId:
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment,
       },
       {
         adType: 'doubleclick',
@@ -456,7 +447,7 @@ describe('all-traffic-experiments-tests', () => {
         urlParam: '?exp=a4a:1',
         branchType: 'control',
         branchId:
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.control,
       },
       {
         adType: 'doubleclick',
@@ -465,7 +456,7 @@ describe('all-traffic-experiments-tests', () => {
         urlParam: '?exp=a4a:2',
         branchType: 'experiment',
         branchId:
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH.experiment,
       },
       // TODO(jonkeller): Need AdSense tests also
     ];
@@ -487,14 +478,14 @@ describe('all-traffic-experiments-tests', () => {
           forceExperimentBranch(win, 'expDoubleclickA4A', test.branchId);
         }
         const external = test.hasLaunched ?
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH :
-          DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH;
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH :
+          ADSENSE_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH;
         const internal = test.hasLaunched ?
-          DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH :
-          DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH;
+          ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH :
+          ADSENSE_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH;
         expect(googleAdsIsA4AEnabled(win, element, 'expDoubleclickA4A',
             external, internal,
-            DOUBLECLICK_A4A_EXTERNAL_DELAYED_EXPERIMENT_BRANCHES_PRE_LAUNCH))
+            ADSENSE_A4A_EXTERNAL_DELAYED_EXPERIMENT_BRANCHES_PRE_LAUNCH))
             .to.equal(test.shouldServeFastFetch);
         expectCorrectBranchOnly(element, test.branchId);
         expect(win.document.cookie).to.be.null;

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -82,7 +82,6 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
     opt_sfgInternalBranches) {
   if (!isGoogleAdsA4AValidEnvironment(win)) {
     // Serving location doesn't qualify for A4A treatment
-    console.log('not valid env');
     return false;
   }
 
@@ -93,7 +92,6 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
       opt_sfgInternalBranches ? opt_sfgInternalBranches.control : null,
       opt_sfgInternalBranches ? opt_sfgInternalBranches.experiment : null,
       MANUAL_EXPERIMENT_ID);
-  console.log('isSetFromUrl:', isSetFromUrl);
   if (!isSetFromUrl) {
     const experimentInfoMap = {};
     const branches = [

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -140,6 +140,11 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
   }
 }
 
+/**
+ * @param {!Window} win
+ * @param {!Element} element Ad tag Element.
+ * @return {?string} experiment extracted from page url.
+ */
 export function extractUrlExperimentId(win, element) {
   const expParam = viewerForDoc(element).getParam('exp') ||
     parseQueryString(win.location.search)['exp'];
@@ -147,7 +152,7 @@ export function extractUrlExperimentId(win, element) {
     return null;
   }
   // Allow for per type experiment control with Doubleclick key set for 'da'
-  // and AdSense using 'aa'.  Fallbsck to 'a4a' if type specific is missing.
+  // and AdSense using 'aa'.  Fallback to 'a4a' if type specific is missing.
   const expKeys = [
     (element.getAttribute('type') || '').toLowerCase() == 'doubleclick' ?
       'da' : 'aa',
@@ -158,7 +163,7 @@ export function extractUrlExperimentId(win, element) {
   expKeys.forEach(key => arg = arg ||
     ((match = new RegExp(`(?:^|,)${key}:(-?\\d+)`).exec(expParam)) &&
       match[1]));
-  return arg ? Number(arg) : null;
+  return arg || null;
 }
 
 /**

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -82,6 +82,7 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
     opt_sfgInternalBranches) {
   if (!isGoogleAdsA4AValidEnvironment(win)) {
     // Serving location doesn't qualify for A4A treatment
+    console.log('not valid env');
     return false;
   }
 
@@ -92,20 +93,23 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
       opt_sfgInternalBranches ? opt_sfgInternalBranches.control : null,
       opt_sfgInternalBranches ? opt_sfgInternalBranches.experiment : null,
       MANUAL_EXPERIMENT_ID);
-  const experimentInfoMap = {};
-  const branches = [
-    internalBranches.control,
-    internalBranches.experiment,
-  ];
-  experimentInfoMap[experimentName] = {
-    isTrafficEligible: () => true,
-    branches,
-  };
-  // Note: Because the same experimentName is being used everywhere here,
-  // randomlySelectUnsetExperiments won't add new IDs if
-  // maybeSetExperimentFromUrl has already set something for this
-  // experimentName.
-  randomlySelectUnsetExperiments(win, experimentInfoMap);
+  console.log('isSetFromUrl:', isSetFromUrl);
+  if (!isSetFromUrl) {
+    const experimentInfoMap = {};
+    const branches = [
+      internalBranches.control,
+      internalBranches.experiment,
+    ];
+    experimentInfoMap[experimentName] = {
+      isTrafficEligible: () => true,
+      branches,
+    };
+    // Note: Because the same experimentName is being used everywhere here,
+    // randomlySelectUnsetExperiments won't add new IDs if
+    // maybeSetExperimentFromUrl has already set something for this
+    // experimentName.
+    randomlySelectUnsetExperiments(win, experimentInfoMap);
+  }
   if (isExperimentOn(win, experimentName)) {
     // Page is selected into the overall traffic experiment.
     // In other words, if A4A has not yet launched serve A4A Fast Fetch,

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -100,7 +100,8 @@ export function isGoogleAdsA4AValidEnvironment(win) {
   // around that, just say that we're A4A eligible if we're in local dev
   // mode, regardless of origin path.
   return supportsNativeCrypto &&
-      (isProxyOrigin(win.location) || getMode().localDev || getMode().test);
+      (isProxyOrigin(win.location) || getMode(win).localDev ||
+       getMode(win).test);
 }
 
 /**

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -63,7 +63,6 @@ import {A4AVariableSource} from './a4a-variable-source';
 // TODO(tdrl): Temporary.  Remove when we migrate to using amp-analytics.
 import {getTimingDataAsync} from '../../../src/service/variable-source';
 import {getContextMetadata} from '../../../src/iframe-attributes';
-import {isInExperiment} from '../../../ads/google/a4a/traffic-experiments';
 
 /** @type {string} */
 const METADATA_STRING = '<script type="application/json" amp-ad-metadata>';
@@ -335,16 +334,6 @@ export class AmpA4A extends AMP.BaseElement {
      */
     this.fromResumeCallback = false;
 
-
-    const type = (this.element.getAttribute('type') || 'notype').toLowerCase();
-    /**
-     * @private @const{boolean} whether request should only be sent when slot is
-     *    within renderOutsideViewport distance.
-     */
-    this.delayRequestEnabled_ =
-      (type == 'adsense' && isInExperiment(this.element, '117152655')) ||
-      (type == 'doubleclick' && isInExperiment(this.element, '117152665'));
-
     /** @private {string} */
     this.safeframeVersion_ = DEFAULT_SAFEFRAME_VERSION;
   }
@@ -595,6 +584,7 @@ export class AmpA4A extends AMP.BaseElement {
           checkStillCurrent();
           this.adUrl_ = adUrl;
           this.protectedEmitLifecycleEvent_('urlBuilt');
+          console.log('send request', adUrl);
           return adUrl && this.sendXhrRequest(adUrl);
         })
         // The following block returns either the response (as a {bytes, headers}
@@ -603,6 +593,7 @@ export class AmpA4A extends AMP.BaseElement {
         .then(fetchResponse => {
           checkStillCurrent();
           this.protectedEmitLifecycleEvent_('adRequestEnd');
+          console.log('response', fetchResponse);
           // If the response is null, we want to return null so that
           // unlayoutCallback will attempt to render via x-domain iframe,
           // assuming ad url or creative exist.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -403,6 +403,14 @@ export class AmpA4A extends AMP.BaseElement {
   }
 
   /**
+   * @return {boolean} whether ad request should be delayed until
+   *    renderOutsideViewport is met.
+   */
+  delayAdRequestEnabled() {
+    return false;
+  }
+
+  /**
    * Returns preconnect urls for A4A. Ad network should overwrite in their
    * Fast Fetch implementation and return an array of urls for the runtime to
    * preconnect to.
@@ -570,7 +578,7 @@ export class AmpA4A extends AMP.BaseElement {
           // renderOutsideViewport. Within render outside viewport will not
           // resolve if already within viewport thus the check for already
           // meeting the definition as opposed to waiting on the promise.
-          if (this.delayRequestEnabled_ &&
+          if (this.delayAdRequestEnabled() &&
               !this.getResource().renderOutsideViewport()) {
             return this.getResource().whenWithinRenderOutsideViewport();
           }
@@ -579,10 +587,7 @@ export class AmpA4A extends AMP.BaseElement {
         /** @return {!Promise<?string>} */
         .then(() => {
           checkStillCurrent();
-          if (this.delayRequestEnabled_) {
-            dev().info(TAG, 'ad request being built');
-          }
-          return /** @type {!Promise<?string>} */ (this.getAdUrl());
+          return /** @type {!Promise<?string>} */(this.getAdUrl());
         })
         // This block returns the (possibly empty) response to the XHR request.
         /** @return {!Promise<?Response>} */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -584,7 +584,6 @@ export class AmpA4A extends AMP.BaseElement {
           checkStillCurrent();
           this.adUrl_ = adUrl;
           this.protectedEmitLifecycleEvent_('urlBuilt');
-          console.log('send request', adUrl);
           return adUrl && this.sendXhrRequest(adUrl);
         })
         // The following block returns either the response (as a {bytes, headers}
@@ -593,7 +592,6 @@ export class AmpA4A extends AMP.BaseElement {
         .then(fetchResponse => {
           checkStillCurrent();
           this.protectedEmitLifecycleEvent_('adRequestEnd');
-          console.log('response', fetchResponse);
           // If the response is null, we want to return null so that
           // unlayoutCallback will attempt to render via x-domain iframe,
           // assuming ad url or creative exist.

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1276,10 +1276,9 @@ describe('amp-a4a', () => {
           setupForAdTesting(fixture);
           const doc = fixture.doc;
           const a4aElement = createA4aElement(doc);
-          a4aElement.setAttribute('data-experiment-id', '117152655');
           a4a = new MockA4AImpl(a4aElement);
-          expect(a4a.delayRequestEnabled_).to.be.true;
           getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+          sandbox.stub(a4a, 'delayAdRequestEnabled').returns(true);
         });
       });
       it('should not delay request when in viewport', () => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -26,7 +26,7 @@ import {
 import {isExperimentOn} from '../../../src/experiments';
 
 /** @const {!string}  @private */
-const ADSENSE_A4A_EXPERIMENT_NAME = 'expAdsenseA4A';
+export const ADSENSE_A4A_EXPERIMENT_NAME = 'expAdsenseA4A';
 
 // The following experiment IDs are used by Google-side servers to
 // understand what experiment is running and what mode the A4A code is

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -23,6 +23,7 @@
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {
   isInManualExperiment,
+  isInExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {isExperimentOn} from '../../../src/experiments';
 import {
@@ -128,6 +129,11 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   isValidElement() {
     return !!this.element.getAttribute('data-ad-client') &&
         isGoogleAdsA4AValidEnvironment(this.win) && this.isAmpAdElement();
+  }
+
+  /** @override */
+  delayAdRequestEnabled() {
+    return isInExperiment(this.element, '117152655');
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -44,6 +44,7 @@ import {
   ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
   AdSenseAmpAutoAdsHoldoutBranches,
 } from '../../../../ads/google/adsense-amp-auto-ads';
+import {EXPERIMENT_ATTRIBUTE} from '../../../../ads/google/a4a/utils';
 
 function createAdsenseImplElement(attributes, opt_doc, opt_tag) {
   const doc = opt_doc || document;
@@ -711,5 +712,27 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
                 .equal(String(Number(slotIdBefore) + 1));
           });
         });
+  });
+
+  describe('#delayAdRequestEnabled', () => {
+    let impl;
+    beforeEach(() => {
+      return createIframePromise().then(f => {
+        setupForAdTesting(f);
+        impl = new AmpAdNetworkAdsenseImpl(
+          createElementWithAttributes(f.doc, 'amp-ad', {
+            type: 'adsense',
+          }));
+      });
+    });
+
+    it('should return true if in experiment', () => {
+      impl.element.setAttribute(EXPERIMENT_ATTRIBUTE, '117152655');
+      expect(impl.delayAdRequestEnabled()).to.be.true;
+    });
+
+    it('should return false if not in experiment', () => {
+      expect(impl.delayAdRequestEnabled()).to.be.false;
+    });
   });
 });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -28,6 +28,10 @@ import {
   assignAdUrlToError,
 } from '../../amp-a4a/0.1/amp-a4a';
 import {
+  experimentFeatureEnabled,
+  DOUBLECLICK_EXPERIMENT_FEATURE,
+} from './doubleclick-a4a-config';
+import {
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {
@@ -210,8 +214,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     // TODO(keithwrightbos) - how can pub enable?
     /** @private @const {boolean} */
-    this.useSra_ = getMode().localDev && /(\?|&)force_sra=true(&|$)/.test(
-        this.win.location.search);
+    this.useSra_ = (getMode().localDev && /(\?|&)force_sra=true(&|$)/.test(
+        this.win.location.search)) ||
+        experimentFeatureEnabled(this.win, DOUBLECLICK_EXPERIMENT_FEATURE.SRA);
 
     const sraInitializer = this.initializeSraPromise_();
     /** @protected {?function(?../../../src/service/xhr-impl.FetchResponse)} */
@@ -230,6 +235,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.isAmpAdElement() &&
       // Ensure not within remote.html iframe.
       !document.querySelector('meta[name=amp-3p-iframe-src]');
+  }
+
+  /** @override */
+  delayAdRequestEnabled() {
+    return experimentFeatureEnabled(
+        this.win, DOUBLECLICK_EXPERIMENT_FEATURE.DELAYED_REQUEST);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -21,10 +21,13 @@
 // extensions/amp-ad-network-${NETWORK_NAME}-impl directory.
 
 import {
-  googleAdsIsA4AEnabled,
-  isInManualExperiment,
+  MANUAL_EXPERIMENT_ID,
+  extractUrlExperimentId,
+  addExperimentIdToElement,
 } from '../../../ads/google/a4a/traffic-experiments';
+import {isGoogleAdsA4AValidEnvironment} from '../../../ads/google/a4a/utils';
 import {EXPERIMENT_ATTRIBUTE} from '../../../ads/google/a4a/utils';
+import {dev} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {isProxyOrigin} from '../../../src/url';
 import {isExperimentOn} from '../../../src/experiments';
@@ -32,78 +35,36 @@ import {isExperimentOn} from '../../../src/experiments';
 /** @const {string} */
 const DOUBLECLICK_A4A_EXPERIMENT_NAME = 'expDoubleclickA4A';
 
-// The following experiment IDs are used by Google-side servers to
-// understand what experiment is running and what mode the A4A code is
-// running in.  In this experiment phase, we're testing 8 different
-// configurations, resulting from the Cartesian product of the following:
-//   - Traditional 3p iframe ad rendering (control) vs A4A rendering
-//     (experiment)
-//   - Experiment triggered by an external page, such as the Google Search
-//     page vs. triggered internally in the client code.
-//   - Doubleclick vs Adsense
-// The following two objects contain experiment IDs for the first two
-// categories for Doubleclick ads.  They are attached to the ad request by
-// ads/google/a4a/traffic-experiments.js#googleAdsIsA4AEnabled when it works
-// out whether a given ad request is in the overall experiment and, if so,
-// which branch it's on.
+/** @type {string} */
+const TAG = 'amp-ad-network-doubleclick-impl';
 
-// We would prefer the following constants to remain private, but we need to
-// refer to them directly in amp-ad-3p-impl.js and amp-a4a.js in order to check
-// whether we're in the experiment or not, for the purposes of enabling
-// debug traffic profiling.  Once we have debugged the a4a implementation and
-// can disable profiling again, we can return these constants to being
-// private to this file.
-/** @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches} */
-export const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH = {
-  control: '117152662',
-  experiment: '117152663',
+/** @const @enum{string} */
+export const DOUBLECLICK_EXPERIMENT_FEATURE = {
+  HOLDBACK_EXTERNAL: '2092620',
+  HOLDBACK_INTERNAL: '2092614',
+  DELAYED_REQUEST: '117152665',
+  SRA: '117152667',
 };
 
-export const DOUBLECLICK_A4A_EXTERNAL_DELAYED_EXPERIMENT_BRANCHES_PRE_LAUNCH = {
-  control: '117152664',
-  experiment: '117152665',
+/** @const @type {!Object<string,?string>} */
+const URL_EXPERIMENT_MAPPING = {
+  '-1': MANUAL_EXPERIMENT_ID,
+  '0': null,
+  // Holdback
+  '1': '2092619',
+  '2': DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_EXTERNAL,
+  // Delay Request
+  '3': '117152664',
+  '4': DOUBLECLICK_EXPERIMENT_FEATURE.DELAYED_REQUEST,
+  // SFG
+  '5': '21060540',
+  '6': '21060541',
+  // SRA
+  '7': '117152666',
+  '8': DOUBLECLICK_EXPERIMENT_FEATURE.SRA,
 };
 
-/**
- * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
- */
-export const DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH = {
-  control: '2092619',
-  experiment: '2092620',
-};
-
-/**
- * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
- */
-export const DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH = {
-  control: '117152680',
-  experiment: '117152681',
-};
-
-/**
- * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
- */
-export const DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH = {
-  control: '2092613',
-  experiment: '2092614',
-};
-
-/**
- * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
- */
-export const DOUBLECLICK_A4A_BETA_BRANCHES = {
-  control: '2077830',
-  experiment: '2077831',
-};
-
-/**
- * @const {!../../../ads/google/a4a/traffic-experiments.A4aExperimentBranches}
- */
-export const DOUBLECLICK_SFG_INTERNAL_EXPERIMENT_BRANCHES = {
-  control: '21060540',
-  experiment: '21060541',
-};
-
+/** @const {string} */
 export const BETA_ATTRIBUTE = 'data-use-beta-a4a-implementation';
 
 /**
@@ -112,34 +73,57 @@ export const BETA_ATTRIBUTE = 'data-use-beta-a4a-implementation';
  * @returns {boolean}
  */
 export function doubleclickIsA4AEnabled(win, element) {
-  if (element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
+  if (element.hasAttribute('useSameDomainRenderingUntilDeprecated') ||
+      !isGoogleAdsA4AValidEnvironment(win)) {
     return false;
   }
-  const a4aRequested = element.hasAttribute(BETA_ATTRIBUTE);
-  // Note: Under this logic, a4aRequested shortcuts googleAdsIsA4AEnabled and,
-  // therefore, carves out of the experiment branches.  Any publisher using this
-  // attribute will be excluded from the experiment altogether.
-  // TODO(tdrl): The "is this site eligible" logic has gotten scattered around
-  // and is now duplicated.  It should be cleaned up and factored into a single,
-  // shared location.
-  let externalBranches, internalBranches;
-  if (isExperimentOn(win, 'a4aFastFetchDoubleclickLaunched')) {
-    externalBranches = DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH;
-    internalBranches = DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_POST_LAUNCH;
+  if (element.hasAttribute(BETA_ATTRIBUTE)) {
+    addExperimentIdToElement('2077831', element);
+    dev().info(TAG, `beta forced a4a selection ${element}`);
+    return true;
+  }
+  // See if in holdback control/experiment.
+  let experimentId;
+  const urlExperimentId = extractUrlExperimentId(win, element);
+  if (urlExperimentId != undefined) {
+    experimentId = argMapping[urlExperimentId];
+    dev().info(
+      TAG, `url experiment selection ${urlExperimentId}: ${experimentId}`);
   } else {
-    externalBranches = DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH;
-    internalBranches = DOUBLECLICK_A4A_INTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH;
+    // Not set via url so randomly set.
+    const experimentInfoMap = {};
+    experimentInfoMap[DOUBLECLICK_A4A_EXPERIMENT_NAME] = {
+      isTrafficEligible: () => true,
+      branches: {
+        control: '2092613',
+        experiment: DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL
+      },
+    };
+    // Note: Because the same experimentName is being used everywhere here,
+    // randomlySelectUnsetExperiments won't add new IDs if
+    // maybeSetExperimentFromUrl has already set something for this
+    // experimentName.
+    randomlySelectUnsetExperiments(win, experimentInfoMap);
+    experimentId = getExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME);
+    dev().info(
+      TAG, `random experiment selection ${urlExperimentId}: ${experimentId}`);
   }
-  const enableA4A = googleAdsIsA4AEnabled(
-      win, element, DOUBLECLICK_A4A_EXPERIMENT_NAME,
-      externalBranches, internalBranches,
-      DOUBLECLICK_A4A_EXTERNAL_DELAYED_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-      DOUBLECLICK_SFG_INTERNAL_EXPERIMENT_BRANCHES) ||
-      (a4aRequested && (isProxyOrigin(win.location) ||
-       getMode(win).localDev || getMode(win).test));
-  if (enableA4A && a4aRequested && !isInManualExperiment(element)) {
-    element.setAttribute(EXPERIMENT_ATTRIBUTE,
-        DOUBLECLICK_A4A_BETA_BRANCHES.experiment);
+  if (experimentId) {
+    addExperimentIdToElement(experimentId, element);
   }
-  return enableA4A;
+  return
+    !experimentFeatureEnabled(
+      win, DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_EXTERNAL) &&
+    !experimentFeatureEnabled(
+      win, DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL)
+}
+
+/**
+ * @param {!Window} win
+ * @param {!DOUBLECLICK_EXPERIMENT_FEATURE} feature
+ * @return {boolean} whether feature is enabled
+ */
+export function experimentFeatureEnabled(win, feature) {
+  return getExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME) ==
+    dev().assertString(DOUBLECLICK_EXPERIMENT_FEATURE[feature]);
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -34,6 +34,10 @@ import {
   resetSraStateForTesting,
 } from '../amp-ad-network-doubleclick-impl';
 import {
+  DOUBLECLICK_A4A_EXPERIMENT_NAME,
+  DOUBLECLICK_EXPERIMENT_FEATURE,
+} from '../doubleclick-a4a-config';
+import {
   MANUAL_EXPERIMENT_ID,
 } from '../../../../ads/google/a4a/traffic-experiments';
 import {EXPERIMENT_ATTRIBUTE} from '../../../../ads/google/a4a/utils';
@@ -42,7 +46,10 @@ import {utf8Encode} from '../../../../src/utils/bytes';
 import {ampdocServiceFor} from '../../../../src/ampdoc';
 import {BaseElement} from '../../../../src/base-element';
 import {createElementWithAttributes} from '../../../../src/dom';
-import {toggleExperiment} from '../../../../src/experiments';
+import {
+  toggleExperiment,
+  forceExperimentBranch,
+} from '../../../../src/experiments';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {Xhr, FetchResponseHeaders} from '../../../../src/service/xhr-impl';
@@ -746,8 +753,8 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           for (let i = 0; i < instanceCount; i++) {
             const impl = createA4aSraInstance(network.networkId);
             doubleclickInstances.push(impl);
+            sandbox.stub(impl, 'isValidElement').returns(!invalid);
             if (invalid) {
-              sandbox.stub(impl, 'isValidElement').returns(false);
               impl.element.setAttribute('data-test-invalid', 'true');
             }
           }
@@ -874,5 +881,28 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
     it('should handle mixture of all possible scenarios', () => executeTest(
         [1234, 1234, 101, {networkId: 4567, instances: 2, xhrFail: true}, 202,
         {networkId: 8901, instances: 3, invalidInstances: 1}]));
+  });
+
+  describe('#delayAdRequestEnabled', () => {
+    let impl;
+    beforeEach(() => {
+      return createIframePromise().then(f => {
+        setupForAdTesting(f);
+        impl = new AmpAdNetworkDoubleclickImpl(
+          createElementWithAttributes(f.doc, 'amp-ad', {
+            type: 'doubleclick',
+          }));
+      });
+    });
+
+    it('should return true if in experiment', () => {
+      forceExperimentBranch(impl.win, DOUBLECLICK_A4A_EXPERIMENT_NAME,
+          DOUBLECLICK_EXPERIMENT_FEATURE.DELAYED_REQUEST);
+      expect(impl.delayAdRequestEnabled()).to.be.true;
+    });
+
+    it('should return false if not in experiment', () => {
+      expect(impl.delayAdRequestEnabled()).to.be.false;
+    });
   });
 });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -16,15 +16,17 @@
 
 import {
   doubleclickIsA4AEnabled,
-  DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH,
-  DOUBLECLICK_A4A_BETA_BRANCHES,
   BETA_ATTRIBUTE,
+  BETA_EXPERIMENT_ID,
+  DOUBLECLICK_A4A_EXPERIMENT_NAME,
+  DOUBLECLICK_EXPERIMENT_FEATURE,
+  URL_EXPERIMENT_MAPPING,
 } from '../doubleclick-a4a-config';
 import {
-  isInManualExperiment,
   isInExperiment,
 } from '../../../../ads/google/a4a/traffic-experiments';
 import {EXPERIMENT_ATTRIBUTE} from '../../../../ads/google/a4a/utils';
+import {forceExperimentBranch} from '../../../../src/experiments';
 import {parseUrl} from '../../../../src/url';
 import {createIframePromise} from '../../../../testing/iframe';
 import * as sinon from 'sinon';
@@ -62,7 +64,7 @@ describe('doubleclick-a4a-config', () => {
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_A4A_BETA_BRANCHES.experiment);
+          BETA_EXPERIMENT_ID);
     });
 
     it('should enable a4a when requested and in local dev', () => {
@@ -72,7 +74,7 @@ describe('doubleclick-a4a-config', () => {
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_A4A_BETA_BRANCHES.experiment);
+          BETA_EXPERIMENT_ID);
     });
 
     it('should not enable a4a, even if requested, when on bad origin', () => {
@@ -91,90 +93,60 @@ describe('doubleclick-a4a-config', () => {
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
     });
 
-    [-1, 0, 1, 2].forEach(expFlagValue => {
-      it(`exp flag=${expFlagValue} should set eid attribute`, () => {
-        mockWin.location = parseUrl(
-            'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:' +
-            String(expFlagValue));
-        const expectedEnabledState =
-            (expFlagValue == -1 || expFlagValue == 2);
-        const elem = testFixture.doc.createElement('div');
-        testFixture.doc.body.appendChild(elem);
-        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.equal(
-            expectedEnabledState);
-        if (expFlagValue == 0) {
-          expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
-        } else {
-          expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.be.ok;
-          expect(isInExperiment(elem,
-              DOUBLECLICK_A4A_BETA_BRANCHES.experiment)).to.be.false;
-          expect(isInExperiment(elem,
-              DOUBLECLICK_A4A_BETA_BRANCHES.control)).to.be.false;
-        }
-      });
-
-    });
-
-    [0, 1, 2].forEach(expFlagValue => {
-      it(`force a4a attribute should preempt exp flag=${expFlagValue}`, () => {
-        mockWin.location = parseUrl(
-            'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:' +
-            String(expFlagValue));
-        const elem = testFixture.doc.createElement('div');
-        elem.setAttribute(BETA_ATTRIBUTE, 'true');
-        testFixture.doc.body.appendChild(elem);
-        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
-        expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-            DOUBLECLICK_A4A_BETA_BRANCHES.experiment);
-      });
-    });
-
-    it('manual experiment should win over beta force a4a attribute', () => {
+    it('should honor beta over url experiment id', () => {
       mockWin.location = parseUrl(
-          'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:-1');
+          'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:2');
       const elem = testFixture.doc.createElement('div');
       elem.setAttribute(BETA_ATTRIBUTE, 'true');
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
-      expect(isInManualExperiment(elem)).to.be.true;
-      expect(isInExperiment(elem, DOUBLECLICK_A4A_BETA_BRANCHES.experiment))
-          .to.be.false;
-      expect(isInExperiment(elem, DOUBLECLICK_A4A_BETA_BRANCHES.control))
-          .to.be.false;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
+          BETA_EXPERIMENT_ID);
     });
 
-    it('should not switch on other slot on page', () => {
-      const doc = testFixture.doc;
-      mockWin.location = parseUrl(
-          'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:0');
-      const elem0 = doc.createElement('div');
-      elem0.setAttribute(BETA_ATTRIBUTE, 'true');
-      doc.body.appendChild(elem0);
-      const elem1 = doc.createElement('div');
-      doc.body.appendChild(elem1);
-      expect(doubleclickIsA4AEnabled(mockWin, elem0)).to.be.true;
-      expect(elem0.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_A4A_BETA_BRANCHES.experiment);
-      expect(doubleclickIsA4AEnabled(mockWin, elem1)).to.be.false;
-      expect(elem1.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+    Object.keys(URL_EXPERIMENT_MAPPING).forEach(expFlagValue => {
+      it(`exp flag=${expFlagValue} should set eid attribute`, () => {
+        mockWin.location = parseUrl(
+            'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:' +
+            String(expFlagValue));
+        const elem = testFixture.doc.createElement('div');
+        testFixture.doc.body.appendChild(elem);
+        // Enabled for all but holdback.
+        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.equal(
+            expFlagValue != 2);
+        if (expFlagValue == 0) {
+          expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+        } else {
+          expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.be.ok;
+          expect(isInExperiment(elem, URL_EXPERIMENT_MAPPING[expFlagValue]))
+              .to.be.true;
+          // Should not be in beta.
+          expect(isInExperiment(elem, BETA_EXPERIMENT_ID)).to.be.false;
+        }
+      });
     });
 
-    it('should not interfere with other slot on page', () => {
-      const doc = testFixture.doc;
+    it('should select random branch, holdback', () => {
       mockWin.location = parseUrl(
-          'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:2');
-      const elem0 = doc.createElement('div');
-      elem0.setAttribute(BETA_ATTRIBUTE, 'true');
-      doc.body.appendChild(elem0);
-      const elem1 = doc.createElement('div');
-      doc.body.appendChild(elem1);
-      expect(doubleclickIsA4AEnabled(mockWin, elem0)).to.be.true;
-      expect(elem0.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_A4A_BETA_BRANCHES.experiment);
-      expect(doubleclickIsA4AEnabled(mockWin, elem1)).to.be.true;
-      const experimentId =
-        DOUBLECLICK_A4A_EXTERNAL_EXPERIMENT_BRANCHES_PRE_LAUNCH.experiment;
-      expect(isInExperiment(elem1, experimentId)).to.be.true;
+          'https://cdn.ampproject.org/some/path/to/content.html');
+      forceExperimentBranch(mockWin, DOUBLECLICK_A4A_EXPERIMENT_NAME,
+          DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL);
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
+          DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL);
+    });
+
+    it('should select random branch, control', () => {
+      mockWin.location = parseUrl(
+          'https://cdn.ampproject.org/some/path/to/content.html');
+      forceExperimentBranch(
+          mockWin, DOUBLECLICK_A4A_EXPERIMENT_NAME, '2092613');
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal('2092613');
     });
   });
 });

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -28,7 +28,6 @@ import {isAdPositionAllowed, getAdContainer}
 import {adConfig} from '../../../ads/_config';
 import {
   googleLifecycleReporterFactory,
-  ReporterNamespace,
 } from '../../../ads/google/a4a/google-data-reporter';
 import {user, dev} from '../../../src/log';
 import {getIframe} from '../../../src/3p-frame';
@@ -90,8 +89,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     this.layoutPromise_ = null;
 
     /** @type {!../../../ads/google/a4a/performance.BaseLifecycleReporter} */
-    this.lifecycleReporter = googleLifecycleReporterFactory(
-        this, ReporterNamespace.AMP);
+    this.lifecycleReporter = googleLifecycleReporterFactory(this);
   }
 
   /** @override */


### PR DESCRIPTION
Make the default behavior for Doubleclick to use Fast Fetch where eligible (on AMP cache, not using remote HTML).  Restructure experiment framework accordingly and allow for SRA experimentation.

For CSI reporting, assumes that any experiment selection in AdSense/Doubleclick layers should trigger CSI reporting.

/cc @ampproject/a4a 