### PR TITLE
Preconnecting for amp-img

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -65,6 +65,15 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override */
+  preconnectCallback(onLayout) {
+    // NOTE(@wassgha) the correct src url isn't determined until the element is
+    // laid out, thus assuming that hopefully all urls in the srcset/src
+    // belong to the same domain, we take the first url and pre-connect to it.
+    // If the image doesn't have an srcset, this connects to the src url.
+    this.preconnect.url(this.element.getAttribute('src'), onLayout);
+  }
+
+  /** @override */
   buildCallback() {
     this.isPrerenderAllowed_ = !this.element.hasAttribute('noprerender');
   }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -68,10 +68,21 @@ export class AmpImg extends BaseElement {
   preconnectCallback(onLayout) {
     // NOTE(@wassgha): since parseSrcset is computationally expensive and can
     // not be inside the `buildCallback`, we went with preconnecting to the
-    // `src` url if it exists.
+    // `src` url if it exists or the first srcset url.
     const src = this.element.getAttribute('src');
     if (src) {
       this.preconnect.url(src, onLayout);
+    } else {
+      const srcset = this.element.getAttribute('srcset');
+      if (!srcset) {
+        return;
+      }
+      // We try to find the first url in the srcset
+      const srcseturls = srcset.match(/https?:\/\/[^\s]+/);
+      // Connect to the first url if it exists
+      if (srcseturls) {
+        this.preconnect.url(srcseturls[0], onLayout);
+      }
     }
   }
 

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -66,11 +66,13 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   preconnectCallback(onLayout) {
-    // NOTE(@wassgha) the correct src url isn't determined until the element is
-    // laid out, thus assuming that hopefully all urls in the srcset/src
-    // belong to the same domain, we take the first url and pre-connect to it.
-    // If the image doesn't have an srcset, this connects to the src url.
-    this.preconnect.url(this.element.getAttribute('src'), onLayout);
+    // NOTE(@wassgha): since parseSrcset is computationally expensive and can
+    // not be inside the `buildCallback`, we went with preconnecting to the
+    // `src` url if it exists.
+    const src = this.element.getAttribute('src');
+    if (src) {
+      this.preconnect.url(src, onLayout);
+    }
   }
 
   /** @override */

--- a/src/srcset.js
+++ b/src/srcset.js
@@ -28,7 +28,6 @@ import {dev, user} from './log';
  */
 let SrcsetSourceDef;
 
-
 /**
  * Extracts `srcset` and fallbacks to `src` if not available.
  * @param {!Element} element

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -110,16 +110,19 @@ describe('amp-img', () => {
     });
   });
 
-  it('should not preconnect to the if src is not set', () => {
+  it('should preconnect to the the first srcset url if src is not set', () => {
     return getImg({
-      srcset: 'bad.jpg 2000w, /examples/img/sample.jpg 1000w',
+      srcset: 'http://google.com/bad.jpg 2000w, /examples/img/sample.jpg 1000w',
       width: 300,
       height: 200,
     }).then(ampImg => {
       const impl = ampImg.implementation_;
       sandbox.stub(impl.preconnect, 'url');
       impl.preconnectCallback(true);
-      expect(impl.preconnect.url.called).to.be.false;
+      expect(impl.preconnect.url.called).to.be.true;
+      expect(impl.preconnect.url).to.have.been.calledWith(
+          'http://google.com/bad.jpg'
+      );
     });
   });
 

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -82,6 +82,21 @@ describe('amp-img', () => {
     });
   });
 
+  it('should preconnect the src url', () => {
+    return getImg({
+      src: '/examples/img/sample.jpg',
+      width: 300,
+      height: 200,
+    }).then(ampImg => {
+      const impl = ampImg.implementation_;
+      sandbox.stub(impl.preconnect, 'url');
+      impl.preconnectCallback(true);
+      const preconnecturl = impl.preconnect.url;
+      expect(preconnecturl.called).to.be.true;
+      expect(preconnecturl).to.have.been.calledWith('/examples/img/sample.jpg');
+    });
+  });
+
   it('should load an img with srcset', () => {
     return getImg({
       srcset: 'bad.jpg 2000w, /examples/img/sample.jpg 1000w',
@@ -94,6 +109,20 @@ describe('amp-img', () => {
       expect(img.hasAttribute('referrerpolicy')).to.be.false;
     });
   });
+
+  it('should not preconnect to the if src is not set', () => {
+    return getImg({
+      srcset: 'bad.jpg 2000w, /examples/img/sample.jpg 1000w',
+      width: 300,
+      height: 200,
+    }).then(ampImg => {
+      const impl = ampImg.implementation_;
+      sandbox.stub(impl.preconnect, 'url');
+      impl.preconnectCallback(true);
+      expect(impl.preconnect.url.called).to.be.false;
+    });
+  });
+
 
   describe('#fallback on initial load', () => {
     let el;


### PR DESCRIPTION
This should speed up image loading a bit by pre-connecting to the image's source URL.

### Changes

- The source url list (srcset / src) is now parsed during `buildCallback` rather than `layoutCallback`
- Implemented `preconnectCallback` to pre-connect to the first URL in the srcset (we can't do better since the source url is determined after the element is laid out based on the width and height of the image, however this should be enough since URLs in the srcset should come from the same domain)

Closes #10212