### PR TITLE
Fixed amp-carousel usage in container that may be unlayout-ed.

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -287,6 +287,12 @@ export class AmpSlideScroll extends BaseSlides {
   }
 
   /** @override */
+  unlayoutCallback() {
+    this.slideIndex_ = null;
+    return super.unlayoutCallback();
+  }
+
+  /** @override */
   updateViewportState(inViewport) {
     if (this.slideIndex_ !== null) {
       this.updateInViewport(

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -1030,5 +1030,44 @@ describe('SlideScroll', () => {
         expect(showSlideSpy).to.be.calledOnce;
       });
     });
+
+    it('should NOT call showSlide_ before re-layout', () => {
+      return getAmpSlideScroll(false, 5, false).then(obj => {
+        const {iframe, ampSlideScroll} = obj;
+
+        iframe.addElement(ampSlideScroll);
+        const impl = ampSlideScroll.implementation_;
+        const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+        const satisfiesTrust = () => true;
+
+        // Test that showSlide_ due to goToSlide(index=1) is not called before layout.
+        let args = {'index': '1'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        // Test that showSlide_ is called after layout.
+        impl.onLayoutMeasure();
+        ampSlideScroll.layoutCallback();
+
+        expect(showSlideSpy).to.have.been.calledWith(1);
+        expect(showSlideSpy).to.be.calledOnce;
+
+        // Unlayout
+        showSlideSpy.reset();
+        impl.unlayoutCallback();
+
+        // Test that showSlide_ due to goToSlide(index=4) is not called before layout.
+        args = {'index': '4'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        // Test that showSlide_ is called after layout.
+        impl.onLayoutMeasure();
+        ampSlideScroll.layoutCallback();
+
+        expect(showSlideSpy).to.have.been.calledWith(4);
+        expect(showSlideSpy).to.be.calledOnce;
+      });
+    });
   });
 });

--- a/test/manual/amp-slidescroll.amp.html
+++ b/test/manual/amp-slidescroll.amp.html
@@ -9,12 +9,16 @@
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
   <style amp-custom>
   /* AMP.CSS */
   html, body {
     overflow-x: hidden !important;
     height: auto !important;
   }
+
+  #lightbox-1 { width: 100%; height: 100%; background-color: black; }
+  #lightbox-1 .close { position: absolute; top: 0; left: 0; right: 0; margin: 5px; color: #ccc; text-align: center; z-index: 1; }
 
   /**
    * Margin:0 is currently needed for iOS viewer embeds.
@@ -120,6 +124,18 @@
     <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=80 height=60></amp-img>
   </amp-carousel>
 
+  <h1>Carousel in Lightbox</h1>
+  <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w100-h75-no" width=100 height=75 on="tap:lightbox-1,carousel-7.goToSlide(index=0)"></amp-img>
+  <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w100-h75-no" width=100 height=75 on="tap:lightbox-1,carousel-7.goToSlide(index=1)"></amp-img>
+  <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w100-h75-no" width=100 height=75 on="tap:lightbox-1,carousel-7.goToSlide(index=2)"></amp-img>
+  <amp-lightbox id="lightbox-1" layout=nodisplay>
+    <div class="close" on="tap:lightbox-1.close">Close</div>
+    <amp-carousel id="carousel-7" width=400 height=300 layout=fill type=slides controls>
+      <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no" width=400 height=300></amp-img>
+      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no" width=400 height=300></amp-img>
+      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no" width=400 height=300></amp-img>
+    </amp-carousel>
+  </amp-lightbox>
 </body>
 </html>
 


### PR DESCRIPTION
This PR fixes an issue where the amp-carousel goToSlide() function stops working when the amp-carousel is used in a container that may be unlayout-ed.

A typical use-case is when the amp-carousel is used inside amp-lightbox. amp-lightbox is unlayout-ed when the lightbox closes. When the lightbox is open using on="tag:lightbox,carousel.goToSlide(index=n)" on another element, the goToSlide() method is called when the carousel is not laid out yet. The issue is that when the amp-carousel is laid out for the second time, the amp-carousel is not in its initial state and the selected slide is not loaded. This PR fixes that issue.
