### PR TITLE
Short circuit custom element polyfill installation.

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -35,7 +35,7 @@ import {getMode} from './mode';
   sure to not `install` it during dev since the `install` is done as a side
   effect in importing the module.
 */
-if (!getMode().localDev) {
+if (!getMode().localDev && !self['customElements']) {
   installCustomElements(self, 'auto');
 }
 installDOMTokenListToggle(self);

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -622,7 +622,9 @@ export function stubLegacyElements(win) {
 function installPolyfillsInChildWindow(childWin) {
   installDocContains(childWin);
   installDOMTokenListToggle(childWin);
-  installCustomElements(childWin, 'auto');
+  if (!self['customElements']) {
+    installCustomElements(childWin, 'auto');
+  }
 }
 
 


### PR DESCRIPTION
If custom element V1 APIs are available we should just use them. The polyfill does sophisticated checks that can be pretty slow and should (hopefully) be irrelevant to us.