### PR TITLE
Clean up test-bind-impl.js

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -262,9 +262,9 @@ export class Bind {
   /**
    * The current number of bindings.
    * @return {number}
-   * @private
+   * @visibleForTesting
    */
-  numberOfBindings_() {
+  numberOfBindings() {
     return this.boundElements_.reduce((number, boundElement) => {
       return number + boundElement.boundProperties.length;
     }, 0);
@@ -292,7 +292,7 @@ export class Bind {
     // Limit number of total bindings (unless in local manual testing).
     const limit = (getMode().localDev && !getMode().test)
         ? Number.POSITIVE_INFINITY
-        : this.maxNumberOfBindings_ - this.numberOfBindings_();
+        : this.maxNumberOfBindings_ - this.numberOfBindings();
     return this.scanNode_(node, limit).then(results => {
       const {
         boundElements, bindings, expressionToElements, limitExceeded,

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -22,91 +22,146 @@ import {chunkInstanceForTesting} from '../../../../src/chunk';
 import {toArray} from '../../../../src/types';
 import {user} from '../../../../src/log';
 
-////////////////////////////////////////////////////////////////////////////////
-// Curried test helpers
-////////////////////////////////////////////////////////////////////////////////
-
-function createElementWithBinding_(parent, env) {
-  /**
-   * @param {string} binding
-   * @param {string=} opt_tagName
-   * @param {boolean=} opt_isAmpElement
-   * @return {!Element}
-   */
-  return function(binding, opt_tagName, opt_isAmpElement) {
-    const tag = opt_tagName || 'p';
-    const div = env.win.document.createElement('div');
-    div.innerHTML = `<${tag} ${binding}></${tag}>`;
-    const newElement = div.firstElementChild;
-    if (opt_isAmpElement) {
-      newElement.className = 'i-amphtml-foo -amp-foo amp-foo';
-      newElement.mutatedAttributesCallback = () => {};
-    }
-    parent.appendChild(newElement);
-    return newElement;
-  };
+/**
+ * @param {!Object} env
+ * @param {!Element} container
+ * @param {string} binding
+ * @param {string=} opt_tagName
+ * @param {boolean=} opt_amp
+ * @return {!Element}
+ */
+function createElement(env, container, binding, opt_tagName, opt_amp) {
+  const tag = opt_tagName || 'p';
+  const div = env.win.document.createElement('div');
+  div.innerHTML = `<${tag} ${binding}></${tag}>`;
+  const newElement = div.firstElementChild;
+  if (opt_amp) {
+    newElement.className = 'i-amphtml-foo -amp-foo amp-foo';
+    newElement.mutatedAttributesCallback = () => {};
+  }
+  container.appendChild(newElement);
+  return newElement;
 }
 
-function onBindReady_(bind, env) {
-  /**
-   * @return {!Promise}
-   */
-  return function() {
-    return bind.initializePromiseForTesting().then(() => {
-      env.flushVsync();
+/**
+ * @param {!Object} env
+ * @param {!Bind} bind
+ * @return {!Promise}
+ */
+function onBindReady(env, bind) {
+  return bind.initializePromiseForTesting().then(() => {
+    env.flushVsync();
+  });
+}
+
+/**
+ * @param {!Object} env
+ * @param {!Bind} bind
+ * @param {!Object} state
+ * @param {boolean=} opt_isAmpStateMutation
+ * @return {!Promise}
+ */
+function onBindReadyAndSetState(env, bind, state, opt_isAmpStateMutation) {
+  return bind.initializePromiseForTesting().then(() => {
+    return bind.setState(
+        state, /* opt_skipEval */ undefined, opt_isAmpStateMutation);
+  }).then(() => {
+    env.flushVsync();
+    return bind.setStatePromiseForTesting();
+  });
+}
+
+/**
+ * @param {!Object} env
+ * @param {!Bind} bind
+ * @param {string} expression
+ * @param {!Object} scope
+ * @return {!Promise}
+ */
+function onBindReadyAndSetStateWithExpression(env, bind, expression, scope) {
+  return bind.setStateWithExpression(expression, scope).then(() => {
+    env.flushVsync();
+  });
+}
+
+/**
+ * @param {!Object} env
+ * @param {string} name
+ * @return {!Promise}
+ */
+function waitForEvent(env, name) {
+  return new Promise(resolve => {
+    function callback() {
+      resolve();
+      env.win.removeEventListener(name, callback);
+    };
+    env.win.addEventListener(name, callback);
+  });
+}
+
+describes.realWin('Bind in FIE', {
+  amp: {
+    ampdoc: 'fie',
+    runtimeOn: false,
+  },
+}, env => {
+  let bind;
+  let container;
+
+  beforeEach(() => {
+    // Make sure we have a chunk instance for testing.
+    chunkInstanceForTesting(env.ampdoc);
+
+    bind = new Bind(env.ampdoc, env.win);
+    container = env.embed.getBodyElement();
+  });
+
+  it('should scan for bindings when ampdoc is ready', () => {
+    createElement(env, container, '[text]="1+1"');
+    expect(bind.boundElements_.length).to.equal(0);
+    return onBindReady(env, bind).then(() => {
+      expect(bind.boundElements_.length).to.equal(1);
     });
-  };
-}
+  });
 
-function onBindReadyAndSetState_(bind, env) {
-  /**
-   * @param {!Object} state
-   * @param {boolean=} opt_isAmpStateMutation
-   * @return {!Promise}
-   */
-  return function(state, opt_isAmpStateMutation) {
-    return bind.initializePromiseForTesting().then(() => {
-      return bind.setState(
-          state, /* opt_skipEval */ undefined, opt_isAmpStateMutation);
-    }).then(() => {
-      env.flushVsync();
-      return bind.setStatePromiseForTesting();
+  describe('with Bind in parent window', () => {
+    let parentBind;
+    let parentContainer;
+
+    beforeEach(() => {
+      parentBind = new Bind(env.ampdoc);
+      parentContainer = env.ampdoc.getBody();
     });
-  };
-}
 
-function onBindReadyAndSetStateWithExpression_(bind, env) {
-  /**
-   * @param {string} expression
-   * @param {!Object} scope
-   * @return {!Promise}
-   */
-  return function(expression, scope) {
-    return bind.setStateWithExpression(expression, scope).then(() => {
-      env.flushVsync();
+    it('should only scan elements in provided window', () => {
+      createElement(env, container, '[text]="1+1"');
+      createElement(env, parentContainer, '[text]="2+2"');
+      return Promise.all([
+        onBindReady(env, bind),
+        onBindReady(env, parentBind),
+      ]).then(() => {
+        expect(bind.boundElements_.length).to.equal(1);
+        expect(parentBind.boundElements_.length).to.equal(1);
+      });
     });
-  };
-}
 
-function waitForEvent_(bind, env) {
-  /**
-   * @param {string} name
-   * @return {!Promise}
-   */
-  return function(name) {
-    return new Promise(resolve => {
-      function callback() {
-        resolve();
-        env.win.removeEventListener(name, callback);
-      };
-      env.win.addEventListener(name, callback);
+    it('should not be able to access variables from other windows', () => {
+      const element =
+          createElement(env, container, '[text]="foo + bar"');
+      const parentElement =
+          createElement(env, parentContainer, '[text]="foo + bar"');
+      const promises = [
+        onBindReadyAndSetState(env, bind, {foo: '123', bar: '456'}),
+        onBindReadyAndSetState(env, parentBind, {foo: 'ABC', bar: 'DEF'}),
+      ];
+      return Promise.all(promises).then(() => {
+        // `element` only sees `foo` and `parentElement` only sees `bar`.
+        expect(element.textContent).to.equal('123456');
+        expect(parentElement.textContent).to.equal('ABCDEF');
+      });
     });
-  };
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Unit tests
-////////////////////////////////////////////////////////////////////////////////
+  });
+});
 
 describes.realWin('Bind in shadow ampdoc', {
   amp: {
@@ -115,26 +170,20 @@ describes.realWin('Bind in shadow ampdoc', {
   },
 }, env => {
   let bind;
-  let parent;
-
-  let createElementWithBinding;
-  let onBindReady;
+  let container;
 
   beforeEach(() => {
     // Make sure we have a chunk instance for testing.
     chunkInstanceForTesting(env.ampdoc);
 
     bind = new Bind(env.ampdoc);
-    parent = env.ampdoc.getBody();
-
-    createElementWithBinding = createElementWithBinding_(parent, env);
-    onBindReady = onBindReady_(bind, env);
+    container = env.ampdoc.getBody();
   });
 
   it('should scan for bindings when ampdoc is ready', () => {
-    createElementWithBinding('[text]="1+1"');
+    createElement(env, container, '[text]="1+1"');
     expect(bind.boundElements_.length).to.equal(0);
-    return onBindReady().then(() => {
+    return onBindReady(env, bind).then(() => {
       expect(bind.boundElements_.length).to.equal(1);
     });
   });
@@ -147,49 +196,36 @@ describes.realWin('Bind in single ampdoc', {
   },
 }, env => {
   let bind;
-  let parent; // A connected <div> created by describes.
-
-  let createElementWithBinding;
-  let onBindReady;
-  let onBindReadyAndSetState;
-  let onBindReadyAndSetStateWithExpression;
-  let waitForEvent;
+  let container;
 
   beforeEach(() => {
     // Make sure we have a chunk instance for testing.
     chunkInstanceForTesting(env.ampdoc);
 
     bind = new Bind(env.ampdoc);
-    parent = env.win.document.getElementById('parent');
-
-    // TODO(choumx): Use better names in a follow-up PR.
-    createElementWithBinding = createElementWithBinding_(parent, env);
-    onBindReady = onBindReady_(bind, env);
-    onBindReadyAndSetState = onBindReadyAndSetState_(bind, env);
-    onBindReadyAndSetStateWithExpression =
-        onBindReadyAndSetStateWithExpression_(bind, env);
-    waitForEvent = waitForEvent_(bind, env);
+    // Connected <div> element created by describes.js.
+    container = env.win.document.getElementById('parent');
   });
 
   it('should scan for bindings when ampdoc is ready', () => {
-    createElementWithBinding('[text]="1+1"');
+    createElement(env, container, '[text]="1+1"');
     expect(bind.boundElements_.length).to.equal(0);
-    return onBindReady().then(() => {
+    return onBindReady(env, bind).then(() => {
       expect(bind.boundElements_.length).to.equal(1);
     });
   });
 
   it('should have same state after removing + re-adding a subtree', () => {
     for (let i = 0; i < 5; i++) {
-      createElementWithBinding('[text]="1+1"');
+      createElement(env, container, '[text]="1+1"');
     }
     expect(bind.boundElements_.length).to.equal(0);
-    return onBindReady().then(() => {
+    return onBindReady(env, bind).then(() => {
       expect(bind.boundElements_.length).to.equal(5);
-      return bind.removeBindingsForNode_(parent);
+      return bind.removeBindingsForNode_(container);
     }).then(() => {
       expect(bind.boundElements_.length).to.equal(0);
-      return bind.addBindingsForNode_(parent);
+      return bind.addBindingsForNode_(container);
     }).then(() => {
       expect(bind.boundElements_.length).to.equal(5);
     });
@@ -198,35 +234,35 @@ describes.realWin('Bind in single ampdoc', {
   it('should dynamically detect new bindings under dynamic tags', () => {
     const doc = env.win.document;
     const dynamicTag = doc.createElement('div');
-    parent.appendChild(dynamicTag);
-    return onBindReady().then(() => {
+    container.appendChild(dynamicTag);
+    return onBindReady(env, bind).then(() => {
       expect(bind.boundElements_.length).to.equal(0);
-      const elementWithBinding = createElementWithBinding('[text]="1+1"');
-      dynamicTag.appendChild(elementWithBinding);
+      const element = createElement(env, container, '[text]="1+1"');
+      dynamicTag.appendChild(element);
       dynamicTag.dispatchEvent(
           new Event(AmpEvents.TEMPLATE_RENDERED, {bubbles: true}));
-      return waitForEvent(BindEvents.RESCAN_TEMPLATE);
+      return waitForEvent(env, BindEvents.RESCAN_TEMPLATE);
     }).then(() => {
       expect(bind.boundElements_.length).to.equal(1);
     });
   });
 
   it('should NOT apply expressions on first load', () => {
-    const element = createElementWithBinding('[text]="1+1"');
+    const element = createElement(env, container, '[text]="1+1"');
     expect(element.textContent).to.equal('');
-    return onBindReady().then(() => {
+    return onBindReady(env, bind).then(() => {
       expect(element.textContent).to.equal('');
     });
   });
 
   it('should verify class bindings in dev mode', () => {
     window.AMP_MODE = {development: true, test: true};
-    createElementWithBinding('[class]="\'foo\'" class="foo"');
-    createElementWithBinding('[class]="\'foo\'" class=" foo "');
-    createElementWithBinding('[class]="\'\'"');
-    createElementWithBinding('[class]="\'bar\'" class="qux"'); // Error.
+    createElement(env, container, '[class]="\'foo\'" class="foo"');
+    createElement(env, container, '[class]="\'foo\'" class=" foo "');
+    createElement(env, container, '[class]="\'\'"');
+    createElement(env, container, '[class]="\'bar\'" class="qux"'); // Error
     const errorSpy = env.sandbox.spy(user(), 'createError');
-    return onBindReady().then(() => {
+    return onBindReady(env, bind).then(() => {
       expect(errorSpy).to.be.calledOnce;
       expect(errorSpy).calledWithMatch(/bar/);
     });
@@ -235,28 +271,28 @@ describes.realWin('Bind in single ampdoc', {
   it('should verify string attribute bindings in dev mode', () => {
     window.AMP_MODE = {development: true, test: true};
     // Only the initial value for [a] binding does not match.
-    createElementWithBinding('[text]="\'a\'" [class]="\'b\'" class="b"');
+    createElement(env, container, '[text]="\'a\'" [class]="\'b\'" class="b"');
     const errorSpy = env.sandbox.spy(user(), 'createError');
-    return onBindReady().then(() => {
+    return onBindReady(env, bind).then(() => {
       expect(errorSpy).to.be.calledOnce;
     });
   });
 
   it('should verify boolean attribute bindings in dev mode', () => {
     window.AMP_MODE = {development: true, test: true};
-    createElementWithBinding('[disabled]="true" disabled', 'button');
-    createElementWithBinding('[disabled]="false"', 'button');
-    createElementWithBinding('[disabled]="true"', 'button'); // Mismatch.
+    createElement(env, container, '[disabled]="true" disabled', 'button');
+    createElement(env, container, '[disabled]="false"', 'button');
+    createElement(env, container, '[disabled]="true"', 'button'); // Mismatch.
     const errorSpy = env.sandbox.spy(user(), 'createError');
-    return onBindReady().then(() => {
+    return onBindReady(env, bind).then(() => {
       expect(errorSpy).to.be.calledOnce;
     });
   });
 
   it('should skip digest if specified in setState()', () => {
-    const element = createElementWithBinding('[text]="1+1"');
+    const element = createElement(env, container, '[text]="1+1"');
     expect(element.textContent).to.equal('');
-    return onBindReady().then(() => {
+    return onBindReady(env, bind).then(() => {
       bind.setState({}, /* opt_skipDigest */ true);
       env.flushVsync();
       expect(element.textContent).to.equal('');
@@ -264,63 +300,65 @@ describes.realWin('Bind in single ampdoc', {
   });
 
   it('should support binding to string attributes', () => {
-    const element = createElementWithBinding('[text]="1+1"');
+    const element = createElement(env, container, '[text]="1+1"');
     expect(element.textContent).to.equal('');
-    return onBindReadyAndSetState({}).then(() => {
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(element.textContent).to.equal('2');
     });
   });
 
   it('should support binding to boolean attributes', () => {
-    const element = createElementWithBinding(
+    const element = createElement(env,
+        container,
         '[checked]="true" [disabled]="false" disabled',
         /* opt_tagName */ 'input');
     expect(element.getAttribute('checked')).to.equal(null);
     expect(element.getAttribute('disabled')).to.equal('');
-    return onBindReadyAndSetState({}).then(() => {
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(element.getAttribute('checked')).to.equal('');
       expect(element.getAttribute('disabled')).to.equal(null);
     });
   });
 
   it('should support binding to Node.textContent', () => {
-    const element = createElementWithBinding('[text]="\'a\' + \'b\' + \'c\'"');
+    const element = createElement(
+        env, container, '[text]="\'a\' + \'b\' + \'c\'"');
     expect(element.textContent).to.equal('');
-    return onBindReadyAndSetState({}).then(() => {
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(element.textContent).to.equal('abc');
     });
   });
 
   it('should support binding to CSS classes with strings', () => {
-    const element = createElementWithBinding('[class]="[\'abc\']"');
+    const element = createElement(env, container, '[class]="[\'abc\']"');
     expect(toArray(element.classList)).to.deep.equal([]);
-    return onBindReadyAndSetState({}).then(() => {
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(toArray(element.classList)).to.deep.equal(['abc']);
     });
   });
 
   it('should support binding to CSS classes with arrays', () => {
-    const element = createElementWithBinding('[class]="[\'a\',\'b\']"');
+    const element = createElement(env, container, '[class]="[\'a\',\'b\']"');
     expect(toArray(element.classList)).to.deep.equal([]);
-    return onBindReadyAndSetState({}).then(() => {
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(toArray(element.classList)).to.deep.equal(['a', 'b']);
     });
   });
 
   it('should support parsing exprs in `setStateWithExpression`', () => {
-    const element = createElementWithBinding('[text]="onePlusOne"');
+    const element = createElement(env, container, '[text]="onePlusOne"');
     expect(element.textContent).to.equal('');
     const promise = onBindReadyAndSetStateWithExpression(
-        '{"onePlusOne": one + one}', {one: 1});
+        env, bind, '{"onePlusOne": one + one}', {one: 1});
     return promise.then(() => {
       expect(element.textContent).to.equal('2');
     });
   });
 
   it('should ignore <amp-state> updates if specified in `setState`', () => {
-    const element = createElementWithBinding('[src]="foo"', 'amp-state');
+    const element = createElement(env, container, '[src]="foo"', 'amp-state');
     expect(element.getAttribute('src')).to.be.null;
-    const promise = onBindReadyAndSetState(
+    const promise = onBindReadyAndSetState(env, bind,
         {foo: '/foo'}, /* opt_isAmpStateMutation */ true);
     return promise.then(() => {
       // Should _not_ be updated if `opt_isAmpStateMutation` is true.
@@ -329,11 +367,11 @@ describes.realWin('Bind in single ampdoc', {
   });
 
   it('should support NOT override internal AMP CSS classes', () => {
-    const element = createElementWithBinding('[class]="[\'abc\']"',
-        /* opt_tagName */ undefined, /* opt_isAmpElement */ true);
+    const element = createElement(env, container, '[class]="[\'abc\']"',
+        /* opt_tagName */ undefined, /* opt_amp */ true);
     expect(toArray(element.classList)).to.deep.equal(
         ['i-amphtml-foo', '-amp-foo', 'amp-foo']);
-    return onBindReadyAndSetState({}).then(() => {
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(toArray(element.classList)).to.deep.equal(
           ['i-amphtml-foo', '-amp-foo', 'amp-foo', 'abc']);
     });
@@ -342,10 +380,10 @@ describes.realWin('Bind in single ampdoc', {
   it('should call mutatedAttributesCallback on AMP elements', () => {
     const binding = '[text]="1+1" [value]="\'4\'" value="4" '
         + 'checked [checked]="false" [disabled]="true" [multiple]="false"';
-    const element = createElementWithBinding(binding,
-        /* opt_tagName */ 'input', /* opt_isAmpElement */ true);
+    const element = createElement(env, container, binding,
+        /* opt_tagName */ 'input', /* opt_amp */ true);
     const spy = env.sandbox.spy(element, 'mutatedAttributesCallback');
-    return onBindReadyAndSetState({}).then(() => {
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(spy).calledWithMatch({
         checked: false,
         disabled: true,
@@ -362,9 +400,9 @@ describes.realWin('Bind in single ampdoc', {
 
   it('should support scope variable references', () => {
     const binding = '[text]="foo + bar + baz.qux.join(\',\')"';
-    const element = createElementWithBinding(binding);
+    const element = createElement(env, container, binding);
     expect(element.textContent).to.equal('');
-    return onBindReadyAndSetState({
+    return onBindReadyAndSetState(env, bind, {
       foo: 'abc',
       bar: 123,
       baz: {
@@ -377,8 +415,8 @@ describes.realWin('Bind in single ampdoc', {
 
   it('should NOT mutate elements if expression result is unchanged', () => {
     const binding = '[value]="1+1" [class]="\'abc\'" [text]="\'a\'+\'b\'"';
-    const element = createElementWithBinding(binding, 'input');
-    return onBindReadyAndSetState({}).then(() => {
+    const element = createElement(env, container, binding, 'input');
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(element.textContent.length).to.not.equal(0);
       expect(element.classList.length).to.not.equal(0);
       expect(element.attributes.length).to.not.equal(0);
@@ -399,16 +437,16 @@ describes.realWin('Bind in single ampdoc', {
   });
 
   it('should NOT evaluate expression if binding is NOT allowed', () => {
-    const element = createElementWithBinding('[invalidBinding]="1+1"');
-    return onBindReadyAndSetState({}).then(() => {
+    const element = createElement(env, container, '[invalidBinding]="1+1"');
+    return onBindReadyAndSetState(env, bind, {}).then(() => {
       expect(element.getAttribute('invalidbinding')).to.be.null;
     });
   });
 
   it('should rewrite attribute values regardless of result type', () => {
-    const withString = createElementWithBinding('[href]="foo"', 'a');
-    const withArray = createElementWithBinding('[href]="bar"', 'a');
-    return onBindReadyAndSetState({
+    const withString = createElement(env, container, '[href]="foo"', 'a');
+    const withArray = createElement(env, container, '[href]="bar"', 'a');
+    return onBindReadyAndSetState(env, bind, {
       foo: '?__amp_source_origin',
       bar: ['?__amp_source_origin'],
     }).then(() => {
@@ -421,11 +459,11 @@ describes.realWin('Bind in single ampdoc', {
     bind.setMaxNumberOfBindingsForTesting(2);
     const errorStub = env.sandbox.stub(user(), 'error');
 
-    const foo = createElementWithBinding('[text]="foo"');
-    const bar = createElementWithBinding('[text]="bar" [class]="baz"');
-    const qux = createElementWithBinding('[text]="qux"');
+    const foo = createElement(env, container, '[text]="foo"');
+    const bar = createElement(env, container, '[text]="bar" [class]="baz"');
+    const qux = createElement(env, container, '[text]="qux"');
 
-    return onBindReadyAndSetState({
+    return onBindReadyAndSetState(env, bind, {
       foo: 1, bar: 2, baz: 3, qux: 4,
     }).then(() => {
       expect(foo.textContent).to.equal('1');
@@ -436,62 +474,6 @@ describes.realWin('Bind in single ampdoc', {
 
       expect(errorStub).to.have.been.calledWith('amp-bind',
           sinon.match(/Maximum number of bindings reached/));
-    });
-  });
-
-  describes.realWin('in embedded window', {
-    amp: {
-      runtimeOn: false,
-    },
-  }, otherEnv => {
-    let otherBind;
-    let otherParent;
-
-    let otherElementWithBinding;
-    let onOtherBindReady;
-    let onOtherBindReadyAndSetState;
-
-    beforeEach(() => {
-      // `otherBind` mimics an adopted embed window of `bind` -- it shares an
-      // ampdoc service instance but has a different root node and var scope.
-      // @see Bind#adoptEmbedWindow
-      otherBind = new Bind(env.ampdoc, otherEnv.win);
-      otherParent = otherEnv.win.document.getElementById('parent');
-
-      // TODO(choumx): Better names in a follow-up PR.
-      otherElementWithBinding =
-          createElementWithBinding_(otherParent, otherEnv);
-      onOtherBindReady = onBindReady_(otherBind, otherEnv);
-      onOtherBindReadyAndSetState =
-          onBindReadyAndSetState_(otherBind, otherEnv);
-    });
-
-    it('should only scan the elements in the provided window', () => {
-      createElementWithBinding('[text]="1+1"');
-      otherElementWithBinding('[text]="2+2"');
-
-      expect(otherBind.boundElements_.length).to.equal(0);
-      return onOtherBindReady().then(() => {
-        // `otherBind` shouldn't detect the "1+1" binding.
-        expect(otherBind.boundElements_.length).to.equal(1);
-      });
-    });
-
-    it('should not be able to access variables from other windows', () => {
-      const element = createElementWithBinding('[text]="foo + bar"');
-      const otherElement =
-          otherElementWithBinding('[text]="foo + bar"');
-
-      const promises = [
-        onBindReadyAndSetState({foo: '123', bar: '456'}),
-        onOtherBindReadyAndSetState({foo: 'ABC', bar: 'DEF'}),
-      ];
-
-      return Promise.all(promises).then(() => {
-        // `element` only sees `foo` and `otherElement` only sees `bar`.
-        expect(element.textContent).to.equal('123456');
-        expect(otherElement.textContent).to.equal('ABCDEF');
-      });
     });
   });
 });

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -118,9 +118,9 @@ describes.realWin('Bind in FIE', {
 
   it('should scan for bindings when ampdoc is ready', () => {
     createElement(env, container, '[text]="1+1"');
-    expect(bind.boundElements_.length).to.equal(0);
+    expect(bind.numberOfBindings()).to.equal(0);
     return onBindReady(env, bind).then(() => {
-      expect(bind.boundElements_.length).to.equal(1);
+      expect(bind.numberOfBindings()).to.equal(1);
     });
   });
 
@@ -140,8 +140,8 @@ describes.realWin('Bind in FIE', {
         onBindReady(env, bind),
         onBindReady(env, parentBind),
       ]).then(() => {
-        expect(bind.boundElements_.length).to.equal(1);
-        expect(parentBind.boundElements_.length).to.equal(1);
+        expect(bind.numberOfBindings()).to.equal(1);
+        expect(parentBind.numberOfBindings()).to.equal(1);
       });
     });
 
@@ -182,9 +182,9 @@ describes.realWin('Bind in shadow ampdoc', {
 
   it('should scan for bindings when ampdoc is ready', () => {
     createElement(env, container, '[text]="1+1"');
-    expect(bind.boundElements_.length).to.equal(0);
+    expect(bind.numberOfBindings()).to.equal(0);
     return onBindReady(env, bind).then(() => {
-      expect(bind.boundElements_.length).to.equal(1);
+      expect(bind.numberOfBindings()).to.equal(1);
     });
   });
 });
@@ -209,9 +209,9 @@ describes.realWin('Bind in single ampdoc', {
 
   it('should scan for bindings when ampdoc is ready', () => {
     createElement(env, container, '[text]="1+1"');
-    expect(bind.boundElements_.length).to.equal(0);
+    expect(bind.numberOfBindings()).to.equal(0);
     return onBindReady(env, bind).then(() => {
-      expect(bind.boundElements_.length).to.equal(1);
+      expect(bind.numberOfBindings()).to.equal(1);
     });
   });
 
@@ -219,15 +219,15 @@ describes.realWin('Bind in single ampdoc', {
     for (let i = 0; i < 5; i++) {
       createElement(env, container, '[text]="1+1"');
     }
-    expect(bind.boundElements_.length).to.equal(0);
+    expect(bind.numberOfBindings()).to.equal(0);
     return onBindReady(env, bind).then(() => {
-      expect(bind.boundElements_.length).to.equal(5);
+      expect(bind.numberOfBindings()).to.equal(5);
       return bind.removeBindingsForNode_(container);
     }).then(() => {
-      expect(bind.boundElements_.length).to.equal(0);
+      expect(bind.numberOfBindings()).to.equal(0);
       return bind.addBindingsForNode_(container);
     }).then(() => {
-      expect(bind.boundElements_.length).to.equal(5);
+      expect(bind.numberOfBindings()).to.equal(5);
     });
   });
 
@@ -236,14 +236,14 @@ describes.realWin('Bind in single ampdoc', {
     const dynamicTag = doc.createElement('div');
     container.appendChild(dynamicTag);
     return onBindReady(env, bind).then(() => {
-      expect(bind.boundElements_.length).to.equal(0);
+      expect(bind.numberOfBindings()).to.equal(0);
       const element = createElement(env, container, '[text]="1+1"');
       dynamicTag.appendChild(element);
       dynamicTag.dispatchEvent(
           new Event(AmpEvents.TEMPLATE_RENDERED, {bubbles: true}));
       return waitForEvent(env, BindEvents.RESCAN_TEMPLATE);
     }).then(() => {
-      expect(bind.boundElements_.length).to.equal(1);
+      expect(bind.numberOfBindings()).to.equal(1);
     });
   });
 


### PR DESCRIPTION
Fixes #10168.

- Use describes in FIE mode instead of nested iframes.
- Don't use curried helper functions (less readable).

Add `?w=1` to diff URL for easier reading. 😄 