### PR TITLE
Fix lightbox caption overflow scroll in ios

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -88,6 +88,7 @@
 
 .i-amphtml-lbv-desc-box.overflow {
   overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch !important;
   background-color: rgba(0,0,0,0.7);
   top: 0 !important;
   padding-top: 50px !important;
@@ -108,8 +109,6 @@
 }
 
 .i-amphtml-lbv-desc-box.overflow .i-amphtml-lbv-desc-text {
-  position: absolute !important;
-  bottom: 0;
   padding-top: 0;
 }
 

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -228,19 +228,24 @@ export class AmpLightboxViewer extends AMP.BaseElement {
       this.descriptionBox_.classList.add('overflow');
       this.vsync_.run({
         measure: state => {
-          state.descBoxHeight = this.descriptionTextArea_./*OK*/scrollHeight;
-          state.descTextAreaHeight = this.descriptionBox_./*OK*/clientHeight;
+          state.descTextAreaHeight =
+              this.descriptionTextArea_./*OK*/scrollHeight;
+          state.descBoxHeight = this.descriptionBox_./*OK*/clientHeight;
         },
         mutate: state => {
-          if (state.descBoxHeight > state.descTextAreaHeight) {
-            setStyle(this.descriptionTextArea_, 'bottom', 'auto');
+          if (state.descTextAreaHeight < state.descBoxHeight) {
+            setStyle(this.descriptionTextArea_, 'position', 'absolute');
+            setStyle(this.descriptionTextArea_, 'bottom', '0');
           }
         },
       }, {});
     } else if (this.descriptionBox_.classList.contains('overflow')) {
-      this.descriptionBox_.classList.remove('overflow');
-      this.descriptionBox_.classList.add('standard');
-      setStyle(this.descriptionTextArea_, 'bottom', '');
+      this.vsync_.mutate(() => {
+        this.descriptionBox_.classList.remove('overflow');
+        this.descriptionBox_.classList.add('standard');
+        setStyle(this.descriptionTextArea_, 'position', '');
+        setStyle(this.descriptionTextArea_, 'bottom', '');
+      });
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/ampproject/amphtml/issues/10149

For some reason, setting `overflow-y: auto` on the container and `position: absolute; bottom: 0;` on the child **at the same time** is not making the container scrollable in ios. Separating the two mutates works.