### PR TITLE
Cleaner video docking implementation (phase 1)

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -277,6 +277,7 @@ var forbiddenTerms = {
       // TODO(@zhouyx, #9213) Remove this item.
       'extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js',
       'extensions/amp-animation/0.1/scrollbound-scene.js',
+      'src/service/video-manager-impl.js',
     ],
   },
   'initLogConstructor|setReportError': {

--- a/css/amp.css
+++ b/css/amp.css
@@ -684,6 +684,31 @@ i-amphtml-video-mask, i-amp-video-mask {
   100% {transform: translateY(0);}
 }
 
+
+/**
+ * Video Docking
+ */
+
+.i-amphtml-dockable-video {
+  padding: 0px;
+  margin:0px;
+  background: darkgray;
+}
+
+.i-amphtml-dockable-video > video.i-amphtml-dockable-video-minimizing,
+.i-amphtml-dockable-video > iframe.i-amphtml-dockable-video-minimizing {
+  position: fixed;
+  height: auto;
+  overflow: hidden;
+  z-index: 2;
+  will-change: transform;
+  transform: scale(0.6) translateX(20px) translateY(20px);
+  /* Override fill-content */
+  min-width: initial !important;
+  min-height: initial !important;
+  margin: initial !important;
+}
+
 /**
  * amp-accordion to avoid FOUC.
  */

--- a/examples/amp-video.amp.html
+++ b/examples/amp-video.amp.html
@@ -35,8 +35,8 @@
   <amp-video
       id="myVideo"
       src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-      width="358"
-      height="204"
+      width="720"
+      height="405"
       layout="responsive"
       controls>
     <div placeholder>
@@ -56,8 +56,8 @@
   <amp-video
     autoplay
     src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-    width="358"
-    height="204"
+    width="720"
+    height="405"
     layout="responsive"
     controls>
   </amp-video>

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -191,7 +191,7 @@
       font-size: 8px;
       background: #fff;
     }
-    }
+
     amp-app-banner .actions {
       text-align: right;
       font-size: 14px;
@@ -379,6 +379,38 @@
             ac molestie nulla porttitor ac. Donec porta risus ut enim
             pellentesque, id placerat elit ornare.
           </p>
+
+          <figure>
+            <amp-video
+              autoplay
+              src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+              width="720"
+              height="405"
+              layout="responsive"
+              controls>
+            </amp-video>
+            <figcaption>
+              Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+            </figcaption>
+          </figure>
+
+          <p>
+            Sed pharetra semper fringilla. Nulla fringilla, neque eget
+            varius suscipit, mi turpis congue odio, quis dignissim nisi
+            nulla at erat. Duis non nibh vel erat vehicula hendrerit eget
+            vel velit. Donec congue augue magna, nec eleifend dui porttitor
+            sed. Cras orci quam, dignissim nec elementum ac, bibendum et purus.
+            Ut elementum mi eget felis ultrices tempus. Maecenas nec sodales
+            ex. Phasellus ultrices, purus non egestas ullamcorper, felis
+            lorem ultrices nibh, in tristique mauris justo sed ante.
+            Nunc commodo purus feugiat metus bibendum consequat. Duis
+            finibus urna ut ligula auctor, sed vehicula ex aliquam.
+            Sed sed augue auctor, porta turpis ultrices, cursus diam.
+            In venenatis aliquet porta. Sed volutpat fermentum quam,
+            ac molestie nulla porttitor ac. Donec porta risus ut enim
+            pellentesque, id placerat elit ornare.
+          </p>
+
           <p id="section1">
             Curabitur convallis, urna quis pulvinar feugiat, purus diam
             posuere turpis, sit amet tincidunt purus justo et mi. Donec
@@ -399,9 +431,9 @@
             <amp-img class="full-bleed" placeholder
                 src="img/sea@1x.jpg"
                 srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
-                layout="responsive" width="360"
+                layout="responsive" width="320"
                 alt="Fusce pretium tempor justo, vitae consequat dolor maximus eget."
-                height="216">
+                height="180">
             </amp-img>
             <figcaption>
               Fusce pretium tempor justo, vitae consequat dolor maximus eget.

--- a/src/style.js
+++ b/src/style.js
@@ -190,7 +190,7 @@ export function translate(x, opt_y) {
   if (typeof opt_y == 'number') {
     opt_y = px(opt_y);
   }
-  return `translate(${x},${opt_y})`;
+  return `translate(${x}, ${opt_y})`;
 }
 
 

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Maps a value in a first range to its equivalent in a second range
+ * Ex.: 5 in the range [0,10] gives 60 in the range[40,80]
+ *
+ * NOTE: lower/upper bounds on the source range are detected automatically,
+ * however the bounds on the target range are not altered (thus the target
+ * range could be decreasing).
+ * Ex1: 8 in the range [0, 10] gives 2 in the range [10, 0]
+ * Ex2: also, 8 in the range [10, 0] gives 2 in the range [10, 0]
+ *
+ * NOTE: Input value is enforced to be bounded inside the source range
+ * Ex1: -2 in the range [0, 10] is interpreted as 0 and thus gives 40 in [40,80]
+ * Ex2: 19 in the range [0, 5] is interpreted as 5 and thus gives 80 in [40,80]
+ *
+ * @param {number} val the value in the source range
+ * @param {number} min1 the lower bound of the source range
+ * @param {number} max1 the upper bound of the source range
+ * @param {number} min2 the lower bound of the target range
+ * @param {number} max2 the upper bound of the target range
+ * @return {!number} the equivalent value in the target range
+ */
+export function mapRange(val, min1, max1, min2, max2) {
+
+  let max1Bound = max1;
+  let min1Bound = min1;
+  if (min1 > max1) {
+    max1Bound = min1;
+    min1Bound = max1;
+  }
+
+  if (val < min1Bound) {
+    val = min1Bound;
+  } else if (val > max1Bound) {
+    val = max1Bound;
+  }
+
+  return (val - min1) * (max2 - min2) / (max1 - min1) + min2;
+};

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -142,6 +142,13 @@ export const VideoAttributes = {
    *
    */
   AUTOPLAY: 'autoplay',
+  /**
+   * dock
+   *
+   * Setting the `dock` attribute on the component makes the video minimize
+   * to the corner when scrolled out of view and has been interacted with.
+   */
+  DOCK: 'dock',
 };
 
 

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -74,8 +74,8 @@ describe('Style', () => {
   });
 
   it('translate', () => {
-    expect(st.translate(101, 201)).to.equal('translate(101px,201px)');
-    expect(st.translate('101vw,201em')).to.equal('translate(101vw,201em)');
+    expect(st.translate(101, 201)).to.equal('translate(101px, 201px)');
+    expect(st.translate('101vw, 201em')).to.equal('translate(101vw, 201em)');
     expect(st.translate(101)).to.equal('translate(101px)');
     expect(st.translate('101vw')).to.equal('translate(101vw)');
   });

--- a/test/functional/test-video-manager.js
+++ b/test/functional/test-video-manager.js
@@ -405,6 +405,9 @@ function createFakeVideoPlayerClass(win) {
 
     /** @override */
     layoutCallback() {
+      const iframe = this.element.ownerDocument.createElement('iframe');
+      this.element.appendChild(iframe);
+
       return Promise.resolve().then(() => {
         this.element.dispatchCustomEvent(VideoEvents.LOAD);
       });

--- a/test/functional/utils/test-math.js
+++ b/test/functional/utils/test-math.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  mapRange,
+} from '../../../src/utils/math';
+
+describes.sandboxed('mapRange', {}, () => {
+
+  it('should map a number to the corrent value', () => {
+    expect(mapRange(5, 0, 10, 40, 80)).to.equal(60);
+    expect(mapRange(5, 0, 10, 10, 20)).to.equal(15);
+  });
+
+  it('should automatically detect source range bounds order', () => {
+    expect(mapRange(5, 10, 0, 40, 80)).to.equal(60);
+    expect(mapRange(8, 10, 0, 10, 20)).to.equal(12);
+  });
+
+  it('should accept decreasing target ranges', () => {
+    expect(mapRange(8, 0, 10, 10, 0)).to.equal(2);
+  });
+
+  it('should constrain input to the source range', () => {
+    expect(mapRange(-2, 0, 10, 10, 20)).to.equal(10);
+    expect(mapRange(50, 0, 10, 10, 20)).to.equal(20);
+    expect(mapRange(19, 0, 5, 40, 80)).to.equal(80);
+  });
+
+});

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -25,10 +25,20 @@ import {
   expectBodyToBecomeVisible,
   poll,
 } from '../../testing/iframe';
+import * as st from '../../src/style';
 
 export function runVideoPlayerIntegrationTests(
     createVideoElementFunc, opt_experiment) {
+
+  /**
+   * @const {number} Height of the fixture iframe
+   */
+  const FRAME_HEIGHT = 1000;
+
   const TIMEOUT = 20000;
+  const DOCK_SCALE = 0.6;
+  const DOCK_CLASS = 'i-amphtml-dockable-video-minimizing';
+
   let fixtureGlobal;
   let videoGlobal;
 
@@ -60,7 +70,7 @@ export function runVideoPlayerIntegrationTests(
 
     it('should support mute, play, pause, unmute actions', function() {
       return getVideoPlayer({outsideView: false, autoplay: false}).then(r => {
-    // Create a action buttons
+        // Create a action buttons
         const playButton = createButton(r, 'play');
         const pauseButton = createButton(r, 'pause');
         const muteButton = createButton(r, 'mute');
@@ -92,15 +102,189 @@ export function runVideoPlayerIntegrationTests(
       return button;
     }
 
-// Although these tests are not about autoplay, we can ony run them in
-// browsers that do support autoplay, this is because a synthetic click
-// event will not be considered a user-action and mobile browsers that
-// don't support muted autoplay will block it. In real life, the click
-// would be considered a user-initiated action, but no way to do that in a
-// scripted test environment.
+    // Although these tests are not about autoplay, we can ony run them in
+    // browsers that do support autoplay, this is because a synthetic click
+    // event will not be considered a user-action and mobile browsers that
+    // don't support muted autoplay will block it. In real life, the click
+    // would be considered a user-initiated action, but no way to do that in a
+    // scripted test environment.
     before(function() {
       this.timeout(TIMEOUT);
-  // Skip autoplay tests if browser does not support autoplay.
+      // Skip autoplay tests if browser does not support autoplay.
+      return supportsAutoplay(window, false).then(supportsAutoplay => {
+        if (!supportsAutoplay) {
+          this.skip();
+        }
+      });
+    });
+
+    afterEach(cleanUp);
+  });
+
+  describe.configure().retryOnSaucelabs().run('Video Docking', function() {
+    this.timeout(TIMEOUT);
+
+    describe('General Behavior', () => {
+      it('should have class when attribute is set (autoplay)', function() {
+        return getVideoPlayer(
+            {
+              outsideView: false,
+              autoplay: true,
+              dock: true,
+            }
+        ).then(r => {
+          return poll('checking class list', () => {
+            return r.video.classList.contains('i-amphtml-dockable-video');
+          }, undefined, TIMEOUT);
+        });
+      });
+
+      it('should have class when attribute is set (no-autoplay)', function() {
+        return getVideoPlayer(
+            {
+              outsideView: false,
+              autoplay: false,
+              dock: true,
+            }
+        ).then(r => {
+          return poll('checking class list', () => {
+            return r.video.classList.contains('i-amphtml-dockable-video');
+          }, undefined, TIMEOUT);
+        });
+      });
+    });
+
+    describe('without-autoplay', () => {
+      it('should minimize when out of viewport', function() {
+        let viewport;
+        let video;
+        let insideElement;
+        return getVideoPlayer(
+            {
+              outsideView: true,
+              autoplay: false,
+              dock: true,
+            }
+        ).then(r => {
+          video = r.video;
+          const playButton = createButton(r, 'play');
+          playButton.click();
+          return listenOncePromise(video, VideoEvents.PLAY);
+        }).then(() => {
+          viewport = video.implementation_.getViewport();
+          // scroll to the bottom, make video fully visible
+          viewport.scrollIntoView(video);
+          return poll('wait for scroll', () => {
+            return video.querySelector('video, iframe')
+             && viewport.getScrollTop() != 0;
+          }, undefined, TIMEOUT);
+        }).then(() => {
+          viewport.setScrollTop(0);
+          return poll('waiting for scroll', () => {
+            return viewport.getScrollTop() == 0;
+          }, undefined, TIMEOUT);
+        }).then(() => {
+          return poll('checking class list', () => {
+            insideElement = video.querySelector('video, iframe');
+            const classes = insideElement.classList;
+            return classes.contains(DOCK_CLASS);
+          }, undefined, TIMEOUT);
+        }).then(() => {
+          expect(insideElement).to.have.class(DOCK_CLASS);
+          expect(st.getStyle(insideElement, 'transform')).to.equal(
+              st.scale(DOCK_SCALE) + ' ' + st.translate(st.px(20), st.px(20))
+          );
+        });
+      });
+    });
+
+    describe('with-autoplay', () => {
+      it('should minimize when out of viewport', function() {
+        let viewport;
+        let video;
+        let insideElement;
+        return getVideoPlayer(
+            {
+              outsideView: false,
+              autoplay: true,
+              dock: true,
+            }
+        ).then(r => {
+          video = r.video;
+          viewport = video.implementation_.getViewport();
+          return listenOncePromise(video, VideoEvents.PLAY);
+        }).then(() => {
+          return poll('wait for mask', () => {
+            return !!video.querySelector('i-amphtml-video-mask');
+          }, undefined, TIMEOUT);
+        }).then(() => {
+          video.querySelector('i-amphtml-video-mask').click();
+          return poll('wait for mask to hide', () => {
+            return !video.querySelector('i-amphtml-video-mask');
+          });
+        }).then(() => {
+          viewport.setScrollTop(FRAME_HEIGHT);
+          return poll('wait for video/iframe', () => {
+            return !!video.querySelector('video, iframe');
+          }, undefined, TIMEOUT);
+        }).then(() => {
+          return poll('wait for minimization', () => {
+            insideElement = video.querySelector('video, iframe');
+            const classes = insideElement.classList;
+            return classes.contains(DOCK_CLASS);
+          }, undefined, TIMEOUT);
+        }).then(() => {
+          expect(insideElement).to.have.class(DOCK_CLASS);
+          expect(st.getStyle(insideElement, 'transform')).to.equal(
+              st.scale(DOCK_SCALE) + ' ' + st.translate(st.px(20), st.px(20))
+          );
+        });
+      });
+
+      it('should only minimize when video is manually playing', function() {
+        let viewport;
+        let video;
+        return getVideoPlayer(
+            {
+              outsideView: false,
+              autoplay: true,
+              dock: true,
+            }
+        ).then(r => {
+          video = r.video;
+          viewport = r.video.implementation_.getViewport();
+          return listenOncePromise(video, VideoEvents.PLAY);
+        }).then(() => {
+          viewport.setScrollTop(FRAME_HEIGHT);
+          return poll('wait for video/iframe', () => {
+            return !!video.querySelector('video, iframe');
+          }, undefined, TIMEOUT);
+        }).then(() => {
+          return poll('check for class', () => {
+            const insideElement = video.querySelector('video, iframe');
+            const classes = insideElement.classList;
+            return !classes.contains(DOCK_CLASS);
+          }, undefined, TIMEOUT);
+        });
+      });
+    });
+
+    function createButton(r, action) {
+      const button = r.fixture.doc.createElement('button');
+      button.setAttribute('on', 'tap:myVideo.' + action);
+      r.fixture.doc.body.appendChild(button);
+      return button;
+    }
+
+    // Although these tests are not about autoplay, we can ony run them in
+    // browsers that do support autoplay, this is because a synthetic click
+    // event will not be considered a user-action and mobile browsers that
+    // don't support muted autoplay will block it. In real life, the click
+    // would be considered a user-initiated action, but no way to do that in a
+    // scripted test environment.
+    before(function() {
+      this.timeout(TIMEOUT);
+      // Skip autoplay tests if browser does not support autoplay.
       return supportsAutoplay(window, false).then(supportsAutoplay => {
         if (!supportsAutoplay) {
           this.skip();
@@ -126,7 +310,7 @@ export function runVideoPlayerIntegrationTests(
           const p = listenOncePromise(r.video, VideoEvents.PLAY).then(() => {
             return Promise.reject('should not have autoplayed');
           });
-      // we have to wait to ensure play is NOT called.
+          // we have to wait to ensure play is NOT called.
           return Promise.race([timer.promise(1000), p]);
         });
       });
@@ -138,12 +322,12 @@ export function runVideoPlayerIntegrationTests(
           video = r.video;
           viewport = video.implementation_.getViewport();
 
-      // scroll to the bottom, make video fully visible
+          // scroll to the bottom, make video fully visible
           const p = listenOncePromise(video, VideoEvents.PLAY);
           viewport.scrollIntoView(video);
           return p;
         }).then(() => {
-      // scroll back to top, make video not visible
+          // scroll back to top, make video not visible
           const p = listenOncePromise(video, VideoEvents.PAUSE);
           viewport.setScrollTop(0);
           return p;
@@ -152,7 +336,7 @@ export function runVideoPlayerIntegrationTests(
     });
 
     describe('Animated Icon', () => {
-  // TODO(amphtml): Unskip when #8385 is fixed.
+      // TODO(amphtml): Unskip when #8385 is fixed.
       it.skip('should create an animated icon overlay', () => {
         let video;
         let viewport;
@@ -165,11 +349,11 @@ export function runVideoPlayerIntegrationTests(
         }).then(() => {
           icon = video.querySelector('i-amphtml-video-eq');
           expect(icon).to.exist;
-      // animation should be paused since video is not played yet
+          // animation should be paused since video is not played yet
           expect(isAnimationPaused(icon)).to.be.true;
 
           viewport = video.implementation_.getViewport();
-      // scroll to the bottom, make video fully visible so it autoplays
+          // scroll to the bottom, make video fully visible so it autoplays
           viewport.scrollIntoView(video);
 
           return waitForAnimationPlay(icon).then(() => {
@@ -201,7 +385,7 @@ export function runVideoPlayerIntegrationTests(
 
     before(function() {
       this.timeout(TIMEOUT);
-  // Skip autoplay tests if browser does not support autoplay.
+      // Skip autoplay tests if browser does not support autoplay.
       return supportsAutoplay(window, false).then(supportsAutoplay => {
         if (!supportsAutoplay) {
           this.skip();
@@ -216,7 +400,7 @@ export function runVideoPlayerIntegrationTests(
     options = options || {};
     const top = options.outsideView ? '100vh' : '0';
     let fixture;
-    return createFixtureIframe('test/fixtures/video-players.html', 1000)
+    return createFixtureIframe('test/fixtures/video-players.html', FRAME_HEIGHT)
         .then(f => {
           fixture = f;
           if (opt_experiment) {
@@ -229,14 +413,21 @@ export function runVideoPlayerIntegrationTests(
           if (options.autoplay) {
             video.setAttribute('autoplay', '');
           }
+
           video.setAttribute('id', 'myVideo');
+
+          if (options.dock) {
+            video.setAttribute('dock', '');
+          }
+
+          video.style.position = 'absolute';
+          video.style.top = top;
+
           video.setAttribute('controls', '');
           video.setAttribute('layout', 'fixed');
           video.setAttribute('width', '300px');
           video.setAttribute('height', '50vh');
 
-          video.style.position = 'absolute';
-          video.style.top = top;
 
           const sizer = fixture.doc.createElement('div');
           sizer.position = 'relative';


### PR DESCRIPTION
This is part of #8088 , implements simple scroll-bound docking of video elements when going out of the viewport.

<p align="center">
<img src="https://user-images.githubusercontent.com/591655/27311353-334537c0-5515-11e7-9cee-4e75327bc35e.gif" height="400px">
</p>


### Changes
- Added a autoplaying video to the article example
- Implemented a math tool that maps a value in a range to its equivalent in another range
- Fixed aspect ratio of videos in some example files
- Added `dock` attribute to the video interface
- Implemented a scroll-bound animation for minimizing videos
- Added integration tests
- In the styles helper, add the standard space between coordinates in the translate function (for consistency between reading and writing the attributes since the browser automatically adds a space between the coordinates).

### Changes on top of #10030
- Refactored and cleaned code
- More unit/integration tests
- Fixed multiple bugs
- Updated multiple comments

### In future PRs
- Create a container that houses all elements inside the amp component and minimizes it rather than minimizing the video/iframe only
- Use the new `PositionObserver`'s `visibleHeight` and `relativePos` rather than own logic
- Add controls
- Add gestures
- Better placeholder based on artwork/thumbnail
- Handle case when two or more videos are docked
- Handle case when video height is bigger than the viewport height

Closes #9702 , deprecates #10030