### PR TITLE
Remove development requirement for Sandbox mode

### DIFF
--- a/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
+++ b/extensions/amp-access-laterpay/0.1/amp-access-laterpay.css
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+.amp-access-laterpay {
+  position: relative;
+}
+
 @media (min-width: 420px) {
   .amp-access-laterpay {
     width: 420px;
@@ -50,6 +54,15 @@
   align-items: center;
   border-radius: 12px;
   box-shadow: 0 0 10px -1px rgba(0,0,0,.25);
+}
+
+.amp-access-laterpay-sandbox {
+  width: 112%;
+  padding: 15px 10px;
+  background-color: #f2902a;
+  color: #fff;
+  font-weight: bold;
+  text-align: center;
 }
 
 .amp-access-laterpay-badge {

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -41,6 +41,7 @@ const DEFAULT_MESSAGES = {
   payNowButton: 'Buy Now',
   defaultButton: 'Buy Now',
   alreadyPurchasedLink: 'I already bought this',
+  sandbox: 'Site in test mode. No payment required.',
 };
 
 /**
@@ -171,7 +172,7 @@ export class LaterpayVendor {
       this.laterpayConfig_.configUrl
     ) {
       return this.laterpayConfig_.configUrl;
-    } else if (getMode().development && this.laterpayConfig_.sandbox) {
+    } else if (this.laterpayConfig_.sandbox) {
       return SANDBOX_CONFIG_URL;
     } else {
       return CONFIG_URL;
@@ -304,6 +305,9 @@ export class LaterpayVendor {
     const dialogContainer = this.getContainer_();
     this.innerContainer_ = this.createElement_('div');
     this.innerContainer_.className = TAG + '-container';
+    if (this.laterpayConfig_.sandbox) {
+      this.renderTextBlock_('sandbox');
+    }
     this.renderTextBlock_('header');
     const listContainer = this.createElement_('ul');
     this.purchaseConfig_.premiumcontent['tp_title'] =


### PR DESCRIPTION
This was initially added so that implementors wouldn't accidentally deploy an AMP page on LaterPay's Sandbox mode, but the Sandbox payment workflow already warns users when they are in Sandbox mode, so this is
rather unnecessary.

This also adds a warning on this overlay to let the users know they are in development mode for our service.

For clarity, LaterPay's Sandbox environment is the environment we provide to our users while they are implementing and testing our product on their websites. It is the same as our Live environment but doesn't require actual payments (more here: https://connectormwi.laterpay.net/docs/regions-environments-locales.html#environments )