### PR TITLE
Disable remote HTML usage for AdSense Delayed Fetch

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -21,6 +21,7 @@
  *   renderStartImplemented: (boolean|undefined),
  *   clientIdScope: (string|undefined),
  *   clientIdCookieName: (string|undefined),
+ *   remoteHTMLDisabled: (boolean|undefined),
  * }}
  */
 let AdNetworkConfigDef;
@@ -112,6 +113,7 @@ export const adConfig = {
     preconnect: 'https://googleads.g.doubleclick.net',
     clientIdScope: 'AMP_ECID_GOOGLE',
     clientIdCookieName: '_ga',
+    remoteHTMLDisabled: true,
   },
 
   adsnative: {

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -134,7 +134,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     // We always need the bootstrap.
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(
+        this.win, this.preconnect, this.element.getAttribute('type'),
+        this.config.remoteHTMLDisabled);
     if (typeof this.config.prefetch == 'string') {
       this.preconnect.preload(this.config.prefetch, 'script');
     } else if (this.config.prefetch) {
@@ -229,7 +231,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       // incrementLoadingAds().
       this.emitLifecycleEvent('adRequestStart');
       const iframe = getIframe(this.element.ownerDocument.defaultView,
-          this.element, undefined, opt_context);
+          this.element, this.element.getAttribute('type'), opt_context,
+          this.config.remoteHTMLDisabled);
       this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(
           this);
       return this.xOriginIframeHandler_.init(iframe);

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -90,6 +90,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
     /** @type {!../../../ads/google/a4a/performance.BaseLifecycleReporter} */
     this.lifecycleReporter = googleLifecycleReporterFactory(this);
+
+    /** @private {string} */
+    this.type_ = this.element.getAttribute('type');
   }
 
   /** @override */
@@ -118,9 +121,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     this.placeholder_ = this.getPlaceholder();
     this.fallback_ = this.getFallback();
 
-    const adType = this.element.getAttribute('type');
-    this.config = adConfig[adType];
-    user().assert(this.config, `Type "${adType}" is not supported in amp-ad`);
+    this.config = adConfig[this.type_];
+    user().assert(
+        this.config, `Type "${this.type_}" is not supported in amp-ad`);
 
     this.uiHandler = new AmpAdUIHandler(this);
 
@@ -135,8 +138,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     // We always need the bootstrap.
     preloadBootstrap(
-        this.win, this.preconnect, this.element.getAttribute('type'),
-        this.config.remoteHTMLDisabled);
+        this.win, this.preconnect, this.type_, this.config.remoteHTMLDisabled);
     if (typeof this.config.prefetch == 'string') {
       this.preconnect.preload(this.config.prefetch, 'script');
     } else if (this.config.prefetch) {
@@ -231,7 +233,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       // incrementLoadingAds().
       this.emitLifecycleEvent('adRequestStart');
       const iframe = getIframe(this.element.ownerDocument.defaultView,
-          this.element, this.element.getAttribute('type'), opt_context,
+          this.element, this.type_, opt_context,
           this.config.remoteHTMLDisabled);
       this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(
           this);

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -76,7 +76,10 @@ export class AmpAd extends AMP.BaseElement {
 
       // TODO(tdrl): Check amp-ad registry to see if they have this already.
       if (!a4aRegistry[type] ||
-          this.win.document.querySelector('meta[name=amp-3p-iframe-src]') ||
+          // Do not allow Fast Fetch if remote HTML specified and type allows.
+          (!(adConfig[type] || {}).remoteHTMLDisabled &&
+           this.win.document.querySelector('meta[name=amp-3p-iframe-src]')) ||
+          // Note that predicate execution may have side effects.
           !a4aRegistry[type](this.win, this.element)) {
         // Either this ad network doesn't support Fast Fetch, its Fast Fetch
         // implementation has explicitly opted not to handle this tag, or this

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -186,7 +186,6 @@ describe('amp-ad-3p-impl', () => {
       win.document.head.appendChild(meta);
       ad3p.onLayoutMeasure();
       return ad3p.layoutCallback().then(() => {
-        console.log(win.document.querySelector('iframe').src);
         expect(win.document.querySelector('iframe[src="' +
             `${remoteUrl}?$internalRuntimeVersion$"]`)).to.be.ok;
       });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -127,12 +127,6 @@ describe('amp-ad-3p-impl', () => {
       });
     });
 
-    it('should reject if no type attribute provided', () => {
-      ad3p.element.removeAttribute('type');
-      return expect(ad3p.layoutCallback())
-          .to.eventually.be.rejectedWith('type');
-    });
-
     it('should throw on position:fixed', () => {
       ad3p.element.style.position = 'fixed';
       ad3p.onLayoutMeasure();
@@ -207,16 +201,17 @@ describe('amp-ad-3p-impl', () => {
   });
 
   describe('preconnectCallback', () => {
-    it('should add preconnect and prefech to DOM header', () => {
+    it('should add preconnect and prefetch to DOM header', () => {
       ad3p.buildCallback();
       ad3p.preconnectCallback();
       return whenFirstVisible.then(() => {
         const fetches = win.document.querySelectorAll('link[rel=preload]');
         expect(fetches).to.have.length(2);
-        expect(fetches[0]).to.have.property('href',
-            'http://ads.localhost:9876/dist.3p/current/frame.max.html');
-        expect(fetches[1]).to.have.property('href',
-            'http://ads.localhost:9876/dist.3p/current/integration.js');
+        expect(Array.from(fetches).map(link => link.href).sort()).to
+            .jsonEqual([
+              'http://ads.localhost:9876/dist.3p/current/frame.max.html',
+              'http://ads.localhost:9876/dist.3p/current/integration.js',
+            ]);
 
         const preconnects =
             win.document.querySelectorAll('link[rel=preconnect]');
@@ -234,8 +229,9 @@ describe('amp-ad-3p-impl', () => {
       ad3p.buildCallback();
       ad3p.preconnectCallback();
       return whenFirstVisible.then(() => {
-        expect(win.document.querySelector('link[rel=preload]' +
-            `[href="${remoteUrl}?$internalRuntimeVersion$"]`)).to.be.ok;
+        expect(Array.from(win.document.querySelectorAll('link[rel=preload]'))
+            .some(link => link.href == `${remoteUrl}?$internalRuntimeVersion$`))
+            .to.be.true;
       });
     });
 
@@ -248,9 +244,10 @@ describe('amp-ad-3p-impl', () => {
       ad3p.buildCallback();
       ad3p.preconnectCallback();
       return whenFirstVisible.then(() => {
-        expect(win.document.querySelector('link[rel=preload]' +
-            '[href="http://ads.localhost:9876/dist.3p/current/frame.max.html"]'))
-            .to.be.ok;
+        expect(Array.from(win.document.querySelectorAll('link[rel=preload]'))
+            .some(link => link.href ==
+              'http://ads.localhost:9876/dist.3p/current/frame.max.html'))
+            .to.be.true;
       });
     });
   });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -18,6 +18,7 @@ import {AmpAd3PImpl} from '../amp-ad-3p-impl';
 import {createIframePromise} from '../../../../testing/iframe';
 import {stubService} from '../../../../testing/test-helper';
 import {createElementWithAttributes} from '../../../../src/dom';
+import {adConfig} from '../../../../ads/_config';
 import * as adCid from '../../../../src/ad-cid';
 import '../../../amp-ad/0.1/amp-ad';
 import '../../../amp-sticky-ad/1.0/amp-sticky-ad';
@@ -43,9 +44,16 @@ describe('amp-ad-3p-impl', () => {
   let sandbox;
   let ad3p;
   let win;
+  let registryBackup;
   const whenFirstVisible = Promise.resolve();
 
   beforeEach(() => {
+    registryBackup = Object.create(null);
+    Object.keys(adConfig).forEach(k => {
+      registryBackup[k] = adConfig[k];
+      delete adConfig[k];
+    });
+    adConfig['_ping_'] = {};
     sandbox = sinon.sandbox.create();
     return createIframePromise(true).then(iframe => {
       win = iframe.win;
@@ -64,6 +72,10 @@ describe('amp-ad-3p-impl', () => {
   });
 
   afterEach(() => {
+    Object.keys(registryBackup).forEach(k => {
+      adConfig[k] = registryBackup[k];
+    });
+    registryBackup = null;
     sandbox.restore();
   });
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -177,6 +177,34 @@ describe('amp-ad-3p-impl', () => {
         expect(data._context.container).to.equal('AMP-STICKY-AD');
       });
     });
+
+    it('should use custom path', () => {
+      const remoteUrl = 'https://example.com/boot/remote.html';
+      const meta = win.document.createElement('meta');
+      meta.setAttribute('name', 'amp-3p-iframe-src');
+      meta.setAttribute('content', remoteUrl);
+      win.document.head.appendChild(meta);
+      ad3p.onLayoutMeasure();
+      return ad3p.layoutCallback().then(() => {
+        console.log(win.document.querySelector('iframe').src);
+        expect(win.document.querySelector('iframe[src="' +
+            `${remoteUrl}?$internalRuntimeVersion$"]`)).to.be.ok;
+      });
+    });
+
+    it('should use default path if custom disabled', () => {
+      const meta = win.document.createElement('meta');
+      meta.setAttribute('name', 'amp-3p-iframe-src');
+      meta.setAttribute('content', 'https://example.com/boot/remote.html');
+      win.document.head.appendChild(meta);
+      ad3p.config.remoteHTMLDisabled = true;
+      ad3p.onLayoutMeasure();
+      return ad3p.layoutCallback().then(() => {
+        expect(win.document.querySelector('iframe[src="' +
+            'http://ads.localhost:9876/dist.3p/current/frame.max.html"]'))
+            .to.be.ok;
+      });
+    });
   });
 
   describe('preconnectCallback', () => {
@@ -195,6 +223,35 @@ describe('amp-ad-3p-impl', () => {
             win.document.querySelectorAll('link[rel=preconnect]');
         expect(preconnects[preconnects.length - 1]).to.have.property('href',
             'https://testsrc/');
+      });
+    });
+
+    it('should use remote html path for preload', () => {
+      const remoteUrl = 'https://example.com/boot/remote.html';
+      const meta = win.document.createElement('meta');
+      meta.setAttribute('name', 'amp-3p-iframe-src');
+      meta.setAttribute('content', remoteUrl);
+      win.document.head.appendChild(meta);
+      ad3p.buildCallback();
+      ad3p.preconnectCallback();
+      return whenFirstVisible.then(() => {
+        expect(win.document.querySelector('link[rel=preload]' +
+            `[href="${remoteUrl}?$internalRuntimeVersion$"]`)).to.be.ok;
+      });
+    });
+
+    it('should not use remote html path for preload if disabled', () => {
+      const meta = win.document.createElement('meta');
+      meta.setAttribute('name', 'amp-3p-iframe-src');
+      meta.setAttribute('content', 'https://example.com/boot/remote.html');
+      win.document.head.appendChild(meta);
+      ad3p.config.remoteHTMLDisabled = true;
+      ad3p.buildCallback();
+      ad3p.preconnectCallback();
+      return whenFirstVisible.then(() => {
+        expect(win.document.querySelector('link[rel=preload]' +
+            '[href="http://ads.localhost:9876/dist.3p/current/frame.max.html"]'))
+            .to.be.ok;
       });
     });
   });

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -16,6 +16,7 @@
 
 import {createIframePromise} from '../../../../testing/iframe';
 import {a4aRegistry} from '../../../../ads/_a4a-config';
+import {adConfig} from '../../../../ads/_config';
 import {AmpAd} from '../amp-ad';
 import {AmpAd3PImpl} from '../amp-ad-3p-impl';
 import {extensionsFor} from '../../../../src/services';
@@ -25,21 +26,31 @@ import * as sinon from 'sinon';
 
 describe('Ad loader', () => {
   let sandbox;
+  let a4aRegistryBackup;
   let registryBackup;
   const tagNames = ['amp-ad', 'amp-embed'];
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    registryBackup = Object.create(null);
+    a4aRegistryBackup = Object.create(null);
     Object.keys(a4aRegistry).forEach(k => {
-      registryBackup[k] = a4aRegistry[k];
+      a4aRegistryBackup[k] = a4aRegistry[k];
       delete a4aRegistry[k];
+    });
+    registryBackup = Object.create(null);
+    Object.keys(adConfig).forEach(k => {
+      registryBackup[k] = adConfig[k];
+      delete adConfig[k];
     });
   });
 
   afterEach(() => {
+    Object.keys(a4aRegistryBackup).forEach(k => {
+      a4aRegistry[k] = a4aRegistryBackup[k];
+    });
+    registryBackup = null;
     Object.keys(registryBackup).forEach(k => {
-      a4aRegistry[k] = registryBackup[k];
+      adConfig[k] = registryBackup[k];
     });
     registryBackup = null;
     sandbox.restore();
@@ -147,6 +158,33 @@ describe('Ad loader', () => {
           ampAdElement.setAttribute('type', 'zort');
           const upgraded = new AmpAd(ampAdElement).upgradeCallback();
           return expect(upgraded).to.eventually.be.instanceof(AmpAd3PImpl);
+        });
+      });
+
+      it('uses Fast Fetch if remote.html is used but disabled', () => {
+        return iframePromise.then(fixture => {
+          const meta = fixture.doc.createElement('meta');
+          meta.setAttribute('name', 'amp-3p-iframe-src');
+          meta.setAttribute('content', 'https://example.com/remote.html');
+          fixture.doc.head.appendChild(meta);
+          adConfig['zort'] = {remoteHTMLDisabled: true};
+          a4aRegistry['zort'] = function() {
+            return true;
+          };
+          ampAdElement.setAttribute('type', 'zort');
+          const zortInstance = {};
+          const zortConstructor = function() { return zortInstance; };
+          const extensions = extensionsFor(fixture.win);
+          const extensionsStub = sandbox.stub(extensions, 'loadElementClass')
+              .withArgs('amp-ad-network-zort-impl')
+              .returns(Promise.resolve(zortConstructor));
+          ampAd = new AmpAd(ampAdElement);
+          return ampAd.upgradeCallback().then(baseElement => {
+            expect(extensionsStub).to.be.calledAtLeastOnce;
+            expect(ampAdElement.getAttribute(
+                'data-a4a-upgrade-type')).to.equal('amp-ad-network-zort-impl');
+            expect(baseElement).to.equal(zortInstance);
+          });
         });
       });
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -40,7 +40,6 @@ describe('Ad loader', () => {
     registryBackup = Object.create(null);
     Object.keys(adConfig).forEach(k => {
       registryBackup[k] = adConfig[k];
-      delete adConfig[k];
     });
   });
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -40,7 +40,9 @@ describe('Ad loader', () => {
     registryBackup = Object.create(null);
     Object.keys(adConfig).forEach(k => {
       registryBackup[k] = adConfig[k];
+      delete adConfig[k];
     });
+    adConfig['_ping_'] = {};
   });
 
   afterEach(() => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -48,7 +48,7 @@ describe('Ad loader', () => {
     Object.keys(a4aRegistryBackup).forEach(k => {
       a4aRegistry[k] = a4aRegistryBackup[k];
     });
-    registryBackup = null;
+    a4aRegistryBackup = null;
     Object.keys(registryBackup).forEach(k => {
       adConfig[k] = registryBackup[k];
     });

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -63,9 +63,11 @@ function getFrameAttributes(parentWindow, element, opt_type, opt_context) {
  * @param {!AmpElement} parentElement
  * @param {string=} opt_type
  * @param {Object=} opt_context
+ * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
  * @return {!Element} The iframe.
  */
-export function getIframe(parentWindow, parentElement, opt_type, opt_context) {
+export function getIframe(
+    parentWindow, parentElement, opt_type, opt_context, opt_disallowCustom) {
   // Check that the parentElement is already in DOM. This code uses a new and
   // fast `isConnected` API and thus only used when it's available.
   dev().assert(
@@ -81,7 +83,8 @@ export function getIframe(parentWindow, parentElement, opt_type, opt_context) {
   }
   count[attributes['type']] += 1;
 
-  const baseUrl = getBootstrapBaseUrl(parentWindow);
+  const baseUrl = getBootstrapBaseUrl(
+      parentWindow, undefined, opt_type, opt_disallowCustom);
   const host = parseUrl(baseUrl).hostname;
   // This name attribute may be overwritten if this frame is chosen to
   // be the master frame. That is ok, as we will read the name off
@@ -150,17 +153,20 @@ export function addDataAndJsonAttributes_(element, attributes) {
 
 /**
  * Preloads URLs related to the bootstrap iframe.
- * @param {!Window} window
+ * @param {!Window} win
  * @param {!./preconnect.Preconnect} preconnect
+ * @param {string=} opt_type
+ * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
  */
-export function preloadBootstrap(window, preconnect) {
-  const url = getBootstrapBaseUrl(window);
+export function preloadBootstrap(
+    win, preconnect, opt_type, opt_disallowCustom) {
+  const url = getBootstrapBaseUrl(win, undefined, opt_type, opt_disallowCustom);
   preconnect.preload(url, 'document');
 
   // While the URL may point to a custom domain, this URL will always be
   // fetched by it.
-  const scriptUrl = getMode().localDev
-      ? getAdsLocalhost(window) + '/dist.3p/current/integration.js'
+  const scriptUrl = getMode(win).localDev
+      ? getAdsLocalhost(win) + '/dist.3p/current/integration.js'
       : `${urls.thirdParty}/$internalRuntimeVersion$/f.js`;
   preconnect.preload(scriptUrl, 'script');
 }
@@ -169,18 +175,21 @@ export function preloadBootstrap(window, preconnect) {
  * Returns the base URL for 3p bootstrap iframes.
  * @param {!Window} parentWindow
  * @param {boolean=} opt_strictForUnitTest
+ * @param {string=} opt_type
+ * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
  * @return {string}
  * @visibleForTesting
  */
-export function getBootstrapBaseUrl(parentWindow, opt_strictForUnitTest) {
+export function getBootstrapBaseUrl(
+    parentWindow, opt_strictForUnitTest, opt_type, opt_disallowCustom) {
   // The value is cached in a global variable called `bootstrapBaseUrl`;
   const bootstrapBaseUrl = parentWindow.bootstrapBaseUrl;
   if (bootstrapBaseUrl) {
     return bootstrapBaseUrl;
   }
-  return parentWindow.bootstrapBaseUrl =
-      getCustomBootstrapBaseUrl(parentWindow, opt_strictForUnitTest)
-          || getDefaultBootstrapBaseUrl(parentWindow);
+  return parentWindow.bootstrapBaseUrl = getCustomBootstrapBaseUrl(
+      parentWindow, opt_strictForUnitTest, opt_type, opt_disallowCustom) ||
+      getDefaultBootstrapBaseUrl(parentWindow);
 }
 
 export function setDefaultBootstrapBaseUrlForTesting(url) {
@@ -257,12 +266,19 @@ export function getRandom(win) {
  * Otherwise null.
  * @param {!Window} parentWindow
  * @param {boolean=} opt_strictForUnitTest
+ * @param {string=} opt_type
+ * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
  * @return {?string}
  */
-function getCustomBootstrapBaseUrl(parentWindow, opt_strictForUnitTest) {
+function getCustomBootstrapBaseUrl(
+    parentWindow, opt_strictForUnitTest, opt_type, opt_disallowCustom) {
   const meta = parentWindow.document
       .querySelector('meta[name="amp-3p-iframe-src"]');
   if (!meta) {
+    return null;
+  }
+  if (opt_disallowCustom) {
+    user().error(`3p iframe url disabled for ${opt_type || 'unknown'}`);
     return null;
   }
   const url = assertHttpsUrl(meta.getAttribute('content'), meta);

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -278,7 +278,8 @@ function getCustomBootstrapBaseUrl(
     return null;
   }
   if (opt_disallowCustom) {
-    user().error(`3p iframe url disabled for ${opt_type || 'unknown'}`);
+    user().error(
+        '3p-frame', `3p iframe url disabled for ${opt_type || 'unknown'}`);
     return null;
   }
   const url = assertHttpsUrl(meta.getAttribute('content'), meta);

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -30,6 +30,9 @@ let count = {};
 /** @type {string} */
 let overrideBootstrapBaseUrl;
 
+/** @const {string} */
+const TAG = '3p-frame';
+
 /**
  * Produces the attributes for the ad template.
  * @param {!Window} parentWindow
@@ -278,8 +281,7 @@ function getCustomBootstrapBaseUrl(
     return null;
   }
   if (opt_disallowCustom) {
-    user().error(
-        '3p-frame', `3p iframe url disabled for ${opt_type || 'unknown'}`);
+    user().error(TAG, `3p iframe url disabled for ${opt_type || 'unknown'}`);
     return null;
   }
   const url = assertHttpsUrl(meta.getAttribute('content'), meta);

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -168,7 +168,7 @@ export function preloadBootstrap(
 
   // While the URL may point to a custom domain, this URL will always be
   // fetched by it.
-  const scriptUrl = getMode(win).localDev
+  const scriptUrl = getMode().localDev
       ? getAdsLocalhost(win) + '/dist.3p/current/integration.js'
       : `${urls.thirdParty}/$internalRuntimeVersion$/f.js`;
   preconnect.preload(scriptUrl, 'script');


### PR DESCRIPTION
Allow for configuring if network supports remote HTML usage via remoteHTMLDisabled option and enable for AdSense.  Also ensure that Fast Fetch is allowed for such networks even if remote HTML is specified.