### PR TITLE
Ignore links in code for link checker

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -131,6 +131,9 @@ function filterWhitelistedLinks(markdown) {
   filteredMarkdown =
       filteredMarkdown.replace(/https:\/\/cdn.ampproject.org(?!\/)/g, '');
 
+  // Links inside a <code> block (illustrative, and not always valid)
+  filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/g, '');
+
   return filteredMarkdown;
 }
 


### PR DESCRIPTION
Link checker should ignore any links that are in `<code>`, like `<code>http://www.site.com/doc/amp</code>`.