### PR TITLE
Make poll timeouts same as Mocha timeout

### DIFF
--- a/test/integration/test-amp-carousel.js
+++ b/test/integration/test-amp-carousel.js
@@ -31,7 +31,8 @@ describe.skip('integration amp-carousel', () => {
   });
 
   it('should show the body in carousel test', () => {
-    return expectBodyToBecomeVisible(fixture.win);
+    return expectBodyToBecomeVisible(
+        fixture.win, window.ampTestRuntimeConfig.mochaTimeout);
   });
 
   it('should be present', () => {

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -21,7 +21,7 @@ import {
 import {AmpEvents} from '../../src/amp-events';
 
 describe.configure().retryOnSaucelabs().run('Rendering of amp-img', function() {
-  this.timeout(5000);
+  const timeout = window.ampTestRuntimeConfig.mochaTimeout;
 
   let fixture;
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe.configure().retryOnSaucelabs().run('Rendering of amp-img', function() {
   });
 
   it('should show the body in image test', () => {
-    return expectBodyToBecomeVisible(fixture.win);
+    return expectBodyToBecomeVisible(fixture.win, timeout);
   });
 
   it('should be present', () => {

--- a/test/integration/test-boilerplates.js
+++ b/test/integration/test-boilerplates.js
@@ -20,8 +20,9 @@ import {
 } from '../../testing/iframe.js';
 import {getStyle} from '../../src/style';
 
-describe.configure().retryOnSaucelabs().run('Old Opacity Boilerplate', () => {
+const timeout = window.ampTestRuntimeConfig.mochaTimeout;
 
+describe.configure().retryOnSaucelabs().run('Old Opacity Boilerplate', () => {
   let fixture;
   beforeEach(() => {
     return createFixtureIframe(
@@ -31,7 +32,7 @@ describe.configure().retryOnSaucelabs().run('Old Opacity Boilerplate', () => {
   });
 
   it('should show the body when opacity boilerplate is used', () => {
-    return expectBodyToBecomeVisible(fixture.win).then(() => {
+    return expectBodyToBecomeVisible(fixture.win, timeout).then(() => {
       expect(getStyle(fixture.win.document.body, 'opacity')).to.equal('1');
     });
   });
@@ -49,7 +50,7 @@ describe('New Visibility Boilerplate', () => {
   });
 
   it('should show the body in boilerplate test', () => {
-    return expectBodyToBecomeVisible(fixture.win).then(() => {
+    return expectBodyToBecomeVisible(fixture.win, timeout).then(() => {
       expect(getStyle(
           fixture.win.document.body, 'visibility')).to.equal('visible');
       // Firefox spells out the values when assigning none.

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -21,7 +21,10 @@ import {
 } from '../../testing/iframe.js';
 
 describe.configure().retryOnSaucelabs().run('error page', function() {
-  this.timeout(5000);
+  const timeout = 5000;
+
+  this.timeout(timeout);
+
   let fixture;
   beforeEach(() => {
     return createFixtureIframe('test/fixtures/errors.html', 1000, win => {
@@ -39,13 +42,13 @@ describe.configure().retryOnSaucelabs().run('error page', function() {
       }, () => {
         return new Error('Failed to find errors. HTML\n' +
             fixture.doc.documentElement./*TEST*/innerHTML);
-      });
+      }, timeout);
     });
   });
 
   it.configure().skipFirefox().skipEdge()
       .run('should show the body in error test', () => {
-        return expectBodyToBecomeVisible(fixture.win);
+        return expectBodyToBecomeVisible(fixture.win, timeout);
       });
 
   function shouldFail(id) {

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -222,7 +222,7 @@ export function runVideoPlayerIntegrationTests(
           if (opt_experiment) {
             toggleExperiment(fixture.win, opt_experiment, true);
           }
-          return expectBodyToBecomeVisible(fixture.win);
+          return expectBodyToBecomeVisible(fixture.win, TIMEOUT);
         })
         .then(() => {
           const video = createVideoElementFunc(fixture);

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -399,14 +399,15 @@ export function expectPostMessage(sourceWin, targetwin, msg) {
  */
 export function poll(description, condition, opt_onError, opt_timeout) {
   return new Promise((resolve, reject) => {
-    let start = Date.now();
+    const start = Date.now();
+    const end = opt_timeout || 1600;
     function poll() {
       const ret = condition();
       if (ret) {
         clearInterval(interval);
         resolve(ret);
       } else {
-        if (Date.now() - start > (opt_timeout || 1600)) {
+        if (Date.now() - start > end) {
           clearInterval(interval);
           if (opt_onError) {
             reject(opt_onError());
@@ -416,7 +417,7 @@ export function poll(description, condition, opt_onError, opt_timeout) {
         }
       }
     }
-    let interval = setInterval(poll, 8);
+    const interval = setInterval(poll, 8);
     poll();
   });
 }
@@ -447,15 +448,16 @@ export function pollForLayout(win, count, opt_timeout) {
 
 /**
  * @param {!Window} win
+ * @param {number=} opt_timeout
  * @return {!Promise}
  */
-export function expectBodyToBecomeVisible(win) {
+export function expectBodyToBecomeVisible(win, opt_timeout) {
   return poll('expect body to become visible', () => {
     return win && win.document && win.document.body && (
         (win.document.body.style.visibility == 'visible'
             && win.document.body.style.opacity != '0')
         || win.document.body.style.opacity == '1');
-  }, undefined, 5000);
+  }, undefined, opt_timeout || 5000);
 }
 
 /**


### PR DESCRIPTION
Bandaid for #10187.

- `expectBodyToBecomeVisible` always timed out at 5s and `poll` defaulted to 1.6s. Increase both in integration tests to match Mocha timeout for that test.
- Also increase timeout for `test-amp-img.js` because it sucks.

/to @rsimha-amp 