### PR TITLE
Remove dependency on WebCrypto for origin cookie generation.

### DIFF
--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -35,6 +35,7 @@ import {
 import {dict} from '../utils/object';
 import {isIframed} from '../dom';
 import {getCryptoRandomBytesArray} from '../utils/bytes';
+import {Services} from '../services';
 import {base64UrlEncodeFromBytes} from '../utils/base64';
 import {parseJson, tryParseJson} from '../json';
 import {user, rethrowAsync} from '../log';

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -35,7 +35,7 @@ import {
 import {dict} from '../utils/object';
 import {isIframed} from '../dom';
 import {getCryptoRandomBytesArray} from '../utils/bytes';
-import {Services} from '../services';
+import {base64UrlEncodeFromBytes} from '../utils/base64';
 import {parseJson, tryParseJson} from '../json';
 import {user, rethrowAsync} from '../log';
 import {ViewerCidApi} from './viewer-cid-api';
@@ -501,12 +501,9 @@ function getNewCidForCookie(win) {
   } else {
     // If our entropy is a pure random number, we can just directly turn it
     // into base 64
-    let string = '';
-    for (let i = 0; i < entropy.length; i++) {
-      // The replace removes the 0 padding.
-      string += btoa(entropy[i]).replace(/\=+$/, '');
-    }
-    return Promise.resolve(string);
+    return Promise.resolve(base64UrlEncodeFromBytes(entropy)
+        // Remove trailing padding
+        .replace(/\.+$/, ''));
   }
 }
 

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -569,11 +569,29 @@ describe('cid', () => {
       fakeWin.location.href =
           'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
       fakeWin.location.hostname = 'foo.abc.org';
+      fakeWin.crypto.getRandomValues = array => {
+        array[0] = 0;
+        array[1] = 2;
+        array[2] = 4;
+        array[3] = 8;
+        array[4] = 16;
+        array[5] = 32;
+        array[6] = 64;
+        array[7] = 128;
+        array[8] = 255;
+        array[9] = 7;
+        array[10] = 11;
+        array[11] = 22;
+        array[12] = 33;
+        array[13] = 66;
+        array[14] = 200;
+        array[15] = 39;
+      };
       return cid.get({scope: 'scope_name', createCookieIfNotPresent: true},
           hasConsent).then(c => {
             expect(c).to.exist;
             expect(c).to
-                .equal('amp-sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])');
+                .equal('amp-MAMgNAOAMTYMzINjQMTI4MjU1NwMTEMjIMzMNjYMjAwMzk');
             expect(fakeWin.document.cookie).to.equal(
                 'scope_name=' + encodeURIComponent(c) +
                 '; path=/' +
@@ -593,7 +611,7 @@ describe('cid', () => {
       }, hasConsent).then(c => {
         expect(c).to.exist;
         expect(c).to
-            .equal('amp-sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])');
+            .equal('amp-MQMgMwMAMAMAMAMAMAMAMAMAMAMAMAMTU');
         expect(fakeWin.document.cookie).to.equal(
             'cookie_name=' + encodeURIComponent(c) +
             '; path=/' +

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -590,8 +590,7 @@ describe('cid', () => {
       return cid.get({scope: 'scope_name', createCookieIfNotPresent: true},
           hasConsent).then(c => {
             expect(c).to.exist;
-            expect(c).to
-                .equal('amp-MAMgNAOAMTYMzINjQMTI4MjU1NwMTEMjIMzMNjYMjAwMzk');
+            expect(c).to.equal('amp-AAIECBAgQID_BwsWIULIJw');
             expect(fakeWin.document.cookie).to.equal(
                 'scope_name=' + encodeURIComponent(c) +
                 '; path=/' +
@@ -610,8 +609,7 @@ describe('cid', () => {
         cookieName: 'cookie_name',
       }, hasConsent).then(c => {
         expect(c).to.exist;
-        expect(c).to
-            .equal('amp-MQMgMwMAMAMAMAMAMAMAMAMAMAMAMAMTU');
+        expect(c).to.equal('amp-AQIDAAAAAAAAAAAAAAAADw');
         expect(fakeWin.document.cookie).to.equal(
             'cookie_name=' + encodeURIComponent(c) +
             '; path=/' +

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -590,6 +590,8 @@ describe('cid', () => {
       return cid.get({scope: 'scope_name', createCookieIfNotPresent: true},
           hasConsent).then(c => {
             expect(c).to.exist;
+            // Since various parties depend on the cookie values, please be careful
+            // about changing the format.
             expect(c).to.equal('amp-AAIECBAgQID_BwsWIULIJw');
             expect(fakeWin.document.cookie).to.equal(
                 'scope_name=' + encodeURIComponent(c) +


### PR DESCRIPTION
SubtleCrypto is going away for insecure origins. But we also don't really need it when not serving from a proxy. Instead produce a direct string from the entropy when that entropy was gathered with `getRandomValues`.