### PR TITLE
Fix broken link in amp-ima-video doc

### DIFF
--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -38,7 +38,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-ima/">Annotated code example for amp-ima-video</a></td>
+    <td><a href="https://ampbyexample.com/components/amp-ima-video/">Annotated code example for amp-ima-video</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Correct link to ABE example for amp-ima-video