### PR TITLE
Be forgiving with malformed query strings

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -655,6 +655,14 @@ var forbiddenTermsSrcInclusive = {
       'dist.3p/current/integration.js',
     ],
   },
+  'decodeURIComponent\\(': {
+    message: 'decodeURIComponent throws for malformed URL components. Please ' +
+        'use tryDecodeUriComponent from src/url.js',
+    whitelist: [
+      'src/url.js',
+      'src/utils/bytes.js',
+    ],
+  },
   // Super complicated regex that says "find any querySelector method call that
   // is passed as a variable anything that is not a string, or a string that
   // contains a space.

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -659,7 +659,15 @@ var forbiddenTermsSrcInclusive = {
     message: 'decodeURIComponent throws for malformed URL components. Please ' +
         'use tryDecodeUriComponent from src/url.js',
     whitelist: [
+      '3p/integration.js',
+      'dist.3p/current/integration.js',
+      'examples/pwa/pwa.js',
+      'validator/engine/parse-url.js',
+      'validator/engine/validator.js',
+      'validator/webui/webui.js',
+      'extensions/amp-pinterest/0.1/util.js',
       'src/url.js',
+      'src/url-try-decode-uri-component.js',
       'src/utils/bytes.js',
     ],
   },

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {isProxyOrigin, parseUrl} from './url';
+import {
+  isProxyOrigin,
+  parseUrl,
+  tryDecodeUriComponent,
+} from './url';
 import {endsWith} from './string';
 import {urls} from './config';
 
@@ -42,8 +46,9 @@ export function getCookie(win, name) {
     if (eq == -1) {
       continue;
     }
-    if (decodeURIComponent(cookie.substring(0, eq).trim()) == name) {
-      return decodeURIComponent(cookie.substring(eq + 1).trim());
+    if (tryDecodeUriComponent(cookie.substring(0, eq).trim()) == name) {
+      const value = cookie.substring(eq + 1).trim();
+      return tryDecodeUriComponent(value, value);
     }
   }
   return null;
@@ -53,7 +58,8 @@ export function getCookie(win, name) {
  * This method should not be inlined to prevent TryCatch deoptimization.
  * NoInline keyword at the end of function name also prevents Closure compiler
  * from inlining the function.
- * @private
+ * @param {!Window} win
+ * @return {string}
  */
 function tryGetDocumentCookieNoInline(win) {
   try {
@@ -62,6 +68,7 @@ function tryGetDocumentCookieNoInline(win) {
     // Act as if no cookie is available. Exceptions can be thrown when
     // AMP docs are opened on origins that do not allow setting
     // cookies such as null origins.
+    return '';
   }
 }
 

--- a/src/url-parse-query-string.js
+++ b/src/url-parse-query-string.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {tryDecodeUriComponent_} from './url-try-decode-uri-component';
+
 const regex = /(?:^[#?]?|&)([^=&]+)(?:=([^&]*))?/g;
 
 /**
@@ -34,8 +36,10 @@ export function parseQueryString_(queryString) {
 
   let match;
   while ((match = regex.exec(queryString))) {
-    const name = decodeURIComponent(match[1]).trim();
-    const value = match[2] ? decodeURIComponent(match[2]).trim() : '';
+    const name = tryDecodeUriComponent_(match[1], match[1]).trim();
+    const value = match[2] ?
+        tryDecodeUriComponent_(match[2], match[2]).trim() :
+        '';
     params[name] = value;
   }
   return params;

--- a/src/url-try-decode-uri-component.js
+++ b/src/url-try-decode-uri-component.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tries to decode a URI component, falling back to opt_fallback (or an empty
+ * string)
+ *
+ * DO NOT import the function from this file. Instead, import
+ * tryDecodeUriComponent from `src/url.js`.
+ *
+ * @param {string} component
+ * @param {string=} fallback
+ * @return {string}
+ */
+export function tryDecodeUriComponent_(component, fallback = '') {
+  try {
+    return decodeURIComponent(component);
+  } catch (e) {
+    return fallback;
+  }
+}

--- a/src/url.js
+++ b/src/url.js
@@ -20,6 +20,7 @@ import {getMode} from './mode';
 import {urls} from './config';
 import {isArray} from './types';
 import {parseQueryString_} from './url-parse-query-string';
+import {tryDecodeUriComponent_} from './url-try-decode-uri-component';
 
 /**
  * Cached a-tag to avoid memory allocation during URL parsing.
@@ -476,4 +477,16 @@ export function checkCorsUrl(url) {
   const query = parseQueryString(parsedUrl.search);
   user().assert(!(SOURCE_ORIGIN_PARAM in query),
       'Source origin is not allowed in %s', url);
+}
+
+/**
+ * Tries to decode a URI component, falling back to opt_fallback (or an empty
+ * string)
+ *
+ * @param {string} component
+ * @param {string=} opt_fallback
+ * @return {string}
+ */
+export function tryDecodeUriComponent(component, opt_fallback) {
+  return tryDecodeUriComponent_(component, opt_fallback);
 }


### PR DESCRIPTION
Also allows malformed cookies, falling back to the original value.

Fixes https://github.com/ampproject/amphtml/issues/10203.