### PR TITLE
Remove old AmpContext implementation

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -18,6 +18,7 @@ import {dev} from '../src/log';
 import {IframeMessagingClient} from './iframe-messaging-client';
 import {MessageType} from '../src/3p-frame-messaging';
 import {nextTick} from './3p';
+import {parseUrl} from '../src/url';
 import {tryParseJson} from '../src/json';
 import {isObject} from '../src/types';
 import {AmpEvents} from '../src/amp-events';
@@ -93,6 +94,9 @@ export class AbstractAmpContext {
 
     /** @type {?string} */
     this.tagName = null;
+
+    /** @type {?Object} */
+    this.data = null;
 
     this.findAndSetMetadata_();
 
@@ -250,7 +254,7 @@ export class AbstractAmpContext {
     this.hidden = context.hidden;
     this.initialLayoutRect = context.initialLayoutRect;
     this.initialIntersection = context.initialIntersection;
-    this.location = context.location;
+    this.location = parseUrl(context.location.href);
     this.mode = context.mode;
     this.pageViewId = context.pageViewId;
     this.referrer = context.referrer;

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -95,9 +95,6 @@ export class AbstractAmpContext {
     /** @type {?string} */
     this.tagName = null;
 
-    /** @type {?Object} */
-    this.data = null;
-
     this.findAndSetMetadata_();
 
     /** @protected {!IframeMessagingClient} */

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -25,14 +25,9 @@
 import './polyfills';
 import {
   IntegrationAmpContext,
-  masterSelection,
 } from './ampcontext-integration';
 import {installEmbedStateListener, manageWin} from './environment';
-import {isExperimentOn} from './3p';
-import {nonSensitiveDataPostMessage, listenParent} from './messaging';
 import {
-  computeInMasterFrame,
-  nextTick,
   register,
   run,
   setExperimentToggles,
@@ -45,7 +40,6 @@ import {dev, initLogConstructor, setReportError, user} from '../src/log';
 import {dict} from '../src/utils/object.js';
 import {getMode} from '../src/mode';
 import {startsWith} from '../src/string.js';
-import {AmpEvents} from '../src/amp-events';
 
 // 3P - please keep in alphabetic order
 import {facebook} from './facebook';
@@ -201,10 +195,7 @@ const FALLBACK_CONTEXT_DATA = dict({
 });
 
 
-// Need to cache iframeName as it will be potentially overwritten by
-// masterSelection, as per below.
-const iframeName = window.name;
-const data = getData(iframeName);
+const data = getData(window.name);
 
 window.context = data['_context'];
 
@@ -410,12 +401,6 @@ export function draw3p(win, data, configCallback) {
   }
 };
 
-/**
- * @return {boolean} Whether this is the master iframe.
- */
-function isMaster() {
-  return window.context.master == window;
-}
 
 /**
  * Draws an embed, optionally synchronously, to the DOM.
@@ -445,16 +430,7 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
     manageWin(window);
     installEmbedStateListener();
     draw3p(window, data, opt_configCallback);
-
-    if (isAmpContextExperimentOn()) {
-      window.context.bootstrapLoaded();
-    } else {
-      updateVisibilityState(window);
-
-      // Subscribe to page visibility updates.
-      nonSensitiveDataPostMessage('send-embed-state');
-      nonSensitiveDataPostMessage('bootstrap-loaded');
-    }
+    window.context.bootstrapLoaded();
   } catch (e) {
     const c = window.context || {mode: {test: false}};
     if (!c.mode.test) {
@@ -465,215 +441,12 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
 };
 
 
-/** @return {boolean} */
-function isAmpContextExperimentOn() {
-  return isExperimentOn('3p-use-ampcontext');
-}
-
-
 /**
  * Installs window.context API.
  * @param {!Window} win
  */
 function installContext(win) {
-  if (isAmpContextExperimentOn()) {
-    installContextUsingExperimentalImpl(win);
-    return;
-  }
-
-  installContextUsingStandardImpl(win);
-}
-
-
-/**
- * Installs window.context API.
- * @param {!Window} win
- */
-function installContextUsingExperimentalImpl(win) {
   win.context = new IntegrationAmpContext(win);
-}
-
-
-/**
- * Installs window.context using standard (to be deprecated) implementation.
- * @param {!Window} win
- */
-function installContextUsingStandardImpl(win) {
-  // Define master related properties to be lazily read.
-  Object.defineProperties(win.context, {
-    master: {
-      get: () => masterSelection(win, data['type']),
-    },
-    isMaster: {
-      get: isMaster,
-    },
-  });
-
-  win.context.data = data;
-  win.context.location = parseUrl(data['_context']['location']['href']);
-  win.context.noContentAvailable = triggerNoContentAvailable;
-  win.context.requestResize = triggerResizeRequest;
-  win.context.renderStart = triggerRenderStart;
-
-  const type = data['type'];
-  if (type === 'facebook' || type === 'twitter' || type === 'github') {
-    // Only make this available to selected embeds until the
-    // generic solution is available.
-    win.context.updateDimensions = triggerDimensions;
-  }
-
-  // This only actually works for ads.
-  const initialIntersection = win.context.initialIntersection;
-  win.context.observeIntersection = cb => {
-    const unlisten = observeIntersection(cb);
-    // Call the callback with the value that was transmitted when the
-    // iframe was drawn. Called in nextTick, so that callers don't
-    // have to specially handle the sync case.
-    nextTick(win, () => cb([initialIntersection]));
-    return unlisten;
-  };
-  win.context.onResizeSuccess = onResizeSuccess;
-  win.context.onResizeDenied = onResizeDenied;
-  win.context.reportRenderedEntityIdentifier =
-      reportRenderedEntityIdentifier;
-  win.context.computeInMasterFrame = computeInMasterFrame;
-  win.context.addContextToIframe = iframe => {
-    iframe.name = iframeName;
-  };
-  win.context.getHtml = getHtml;
-}
-
-
-function triggerNoContentAvailable() {
-  nonSensitiveDataPostMessage('no-content');
-}
-
-function triggerDimensions(width, height) {
-  nonSensitiveDataPostMessage('embed-size', dict({
-    'width': width,
-    'height': height,
-  }));
-}
-
-function triggerResizeRequest(width, height) {
-  nonSensitiveDataPostMessage('embed-size', dict({
-    'width': width,
-    'height': height,
-  }));
-}
-
-/**
- * @param {!JsonObject=} opt_data fields: width, height
- */
-function triggerRenderStart(opt_data) {
-  nonSensitiveDataPostMessage('render-start', opt_data);
-}
-
-/**
- * Id for getHtml postMessage.
- * @type {!number}
- */
-let currentMessageId = 0;
-
-/**
- * See readme for window.context.getHtml
- * @param {!string} selector - CSS selector of the node to take content from
- * @param {!Array<string>} attributes - tag attributes to be left in the stringified HTML
- * @param {!Function} callback
- */
-function getHtml(selector, attributes, callback) {
-  const messageId = currentMessageId++;
-  nonSensitiveDataPostMessage('get-html', dict({
-    'selector': selector,
-    'attributes': attributes,
-    'messageId': messageId,
-  }));
-
-  const unlisten = listenParent(window, 'get-html-result', data => {
-    if (data['messageId'] === messageId) {
-      callback(data['content']);
-      unlisten();
-    }
-  });
-}
-
-/**
- * Registers a callback for intersections of this iframe with the current
- * viewport.
- * The passed in array has entries that aim to be compatible with
- * the IntersectionObserver spec callback.
- * http://rawgit.com/slightlyoff/IntersectionObserver/master/index.html#callbackdef-intersectionobservercallback
- * @param {function(!Array<IntersectionObserverEntry>)} observerCallback
- * @returns {!function()} A function which removes the event listener that
- *    observes for intersection messages.
- */
-function observeIntersection(observerCallback) {
-  // Send request to received records.
-  nonSensitiveDataPostMessage('send-intersections');
-  return listenParent(window, 'intersection', data => {
-    observerCallback(data['changes']);
-  });
-}
-
-/**
- * Listens for events via postMessage and updates `context.hidden` based on
- * it and forwards the event to a custom event called `amp:visibilitychange`.
- * @param {!Window} global
- */
-function updateVisibilityState(global) {
-  listenParent(window, 'embed-state', function(data) {
-    global.context.hidden = data['pageHidden'];
-    dispatchVisibilityChangeEvent(global, data['pageHidden']);
-  });
-}
-
-
-function dispatchVisibilityChangeEvent(win, isHidden) {
-  const event = win.document.createEvent('Event');
-  event.data = {hidden: isHidden};
-  event.initEvent(AmpEvents.VISIBILITY_CHANGE, true, true);
-  win.dispatchEvent(event);
-}
-
-/**
- * Registers a callback for communicating when a resize request succeeds.
- * @param {function(number, number)} observerCallback
- * @returns {!function()} A function which removes the event listener that
- *    observes for resize status messages.
- */
-function onResizeSuccess(observerCallback) {
-  return listenParent(window, 'embed-size-changed', data => {
-    observerCallback(data['requestedHeight'], data['requestedWidth']);
-  });
-}
-
-/**
- * Registers a callback for communicating when a resize request is denied.
- * @param {function(number, number)} observerCallback
- * @returns {!function()} A function which removes the event listener that
- *    observes for resize status messages.
- */
-function onResizeDenied(observerCallback) {
-  return listenParent(window, 'embed-size-denied', data => {
-    observerCallback(data['requestedHeight'], data['requestedWidth']);
-  });
-}
-
-/**
- * Reports the "entity" that was rendered to this frame to the parent for
- * reporting purposes.
- * The entityId MUST NOT contain user data or personal identifiable
- * information. One example for an acceptable data item would be the
- * creative id of an ad, while the user's location would not be
- * acceptable.
- * @param {string} entityId See comment above for content.
- */
-function reportRenderedEntityIdentifier(entityId) {
-  user().assert(typeof entityId == 'string',
-      'entityId should be a string %s', entityId);
-  nonSensitiveDataPostMessage('entity-id', dict({
-    'id': entityId,
-  }));
 }
 
 /**

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -21,107 +21,6 @@ import {
 } from '../../testing/iframe';
 import {platformFor} from '../../src/services';
 import {installPlatformService} from '../../src/service/platform-impl';
-import {toggleExperiment} from '../../src/experiments';
-
-
-// TODO(@alanorozco): Inline this once 3p-use-ampcontext experiment is removed
-function createIframeWithApis(fixture) {
-  this.timeout(20000);
-  let iframe;
-  let ampAd;
-  let lastIO = null;
-  const platform = platformFor(fixture.win);
-  return pollForLayout(fixture.win, 1, 5500).then(() => {
-    // test amp-ad will create an iframe
-    return poll('frame to be in DOM', () => {
-      return fixture.doc.querySelector('iframe');
-    });
-  }).then(iframeElement => {
-    // test the created iframe will have correct src.
-    iframe = iframeElement;
-    expect(fixture.doc.querySelectorAll('iframe')).to.have.length(1);
-    ampAd = iframe.parentElement;
-    expect(iframe.src).to.match(/http\:\/\/localhost:9876\/dist\.3p\//);
-  }).then(() => {
-    // wait for iframe to load.
-    return poll('frame to load', () => {
-      return iframe.contentWindow && iframe.contentWindow.document &&
-          iframe.contentWindow.document.getElementById('c');
-    });
-  }).then(() => {
-    // wait for iframe to load.
-    return poll('3p JS to load.', () => iframe.contentWindow.context);
-  }).then(context => {
-    // test iframe is created with correct context info.
-    expect(context.hidden).to.be.false;
-    // In some browsers the referrer is empty. But in Chrome it works, so
-    // we always check there.
-    if (context.referrer !== '' || platform.isChrome()) {
-      expect(context.referrer).to.contain(
-          'http://localhost:' + location.port);
-    }
-
-    expect(context.canonicalUrl).to.equal(
-        'https://www.example.com/doubleclick.html');
-    expect(context.clientId).to.be.defined;
-    expect(context.pageViewId).to.be.greaterThan(0);
-    expect(context.startTime).to.be.a('number');
-    expect(context.container).to.be.defined;
-    expect(context.initialIntersection).to.be.defined;
-    // check for rootBounds as native IO doesn't support it with CORS
-    expect(context.initialLayoutRect).to.be.defined;
-    expect(context.initialLayoutRect.top).to.be.defined;
-    expect(context.initialIntersection.rootBounds).to.be.defined;
-    expect(context.isMaster).to.be.defined;
-    expect(context.computeInMasterFrame).to.be.defined;
-    expect(context.location).to.be.defined;
-    expect(context.sourceUrl).to.be.a('string');
-  }).then(() => {
-    // test iframe will send out render-start to amp-ad
-    return poll('render-start message received', () => {
-      return fixture.messages.filter(message => {
-        return message.type == 'render-start';
-      }).length;
-    });
-  }).then(() => {
-    // test amp-ad will respond to render-start
-    return poll('wait for visibility style to change', () => {
-      return iframe.style.visibility == '';
-    });
-  }).then(() => {
-    return ampAd.layoutCallback();
-  }).then(() => {
-    expect(iframe.offsetHeight).to.equal(250);
-    expect(iframe.offsetWidth).to.equal(300);
-    expect(iframe.contentWindow.ping.resizeSuccess).to.be.undefined;
-    iframe.contentWindow.context.requestResize(200, 50);
-    return poll('wait for embed-size to be received', () => {
-      return fixture.messages.filter(message => {
-        return message.type == 'embed-size';
-      }).length;
-    });
-  }).then(() => {
-    return poll('wait for attemptChangeSize', () => {
-      return iframe.contentWindow.ping.resizeSuccess != undefined;
-    });
-  }).then(() => {
-    lastIO = null;
-    iframe.contentWindow.context.observeIntersection(changes => {
-      lastIO = changes[changes.length - 1];
-    });
-    fixture.win.scrollTo(0, 1000);
-    fixture.win.document.body.dispatchEvent(new Event('scroll'));
-    return poll('wait for new IO entry', () => {
-      return lastIO != null;
-    });
-  });
-}
-
-
-function createFixture() {
-  return createFixtureIframe('test/fixtures/3p-ad.html', 3000, () => {});
-}
-
 
 describes.realWin('3P Ad', {
   amp: {
@@ -132,40 +31,104 @@ describes.realWin('3P Ad', {
     let fixture;
 
     beforeEach(() => {
-      return createFixture().then(f => {
-        fixture = f;
-        installPlatformService(fixture.win);
-      });
+      return createFixtureIframe('test/fixtures/3p-ad.html', 3000, () => {})
+          .then(f => {
+            fixture = f;
+            installPlatformService(fixture.win);
+          });
     });
 
     it('create an iframe with APIs', function() {
-      return createIframeWithApis.call(this, fixture);
-    });
-  });
-});
+      this.timeout(20000);
+      let iframe;
+      let ampAd;
+      let lastIO = null;
+      const platform = platformFor(fixture.win);
+      return pollForLayout(fixture.win, 1, 5500).then(() => {
+        // test amp-ad will create an iframe
+        return poll('frame to be in DOM', () => {
+          return fixture.doc.querySelector('iframe');
+        });
+      }).then(iframeElement => {
+        // test the created iframe will have correct src.
+        iframe = iframeElement;
+        expect(fixture.doc.querySelectorAll('iframe')).to.have.length(1);
+        ampAd = iframe.parentElement;
+        expect(iframe.src).to.match(/http\:\/\/localhost:9876\/dist\.3p\//);
+      }).then(() => {
+        // wait for iframe to load.
+        return poll('frame to load', () => {
+          return iframe.contentWindow && iframe.contentWindow.document &&
+              iframe.contentWindow.document.getElementById('c');
+        });
+      }).then(() => {
+        // wait for iframe to load.
+        return poll('3p JS to load.', () => iframe.contentWindow.context);
+      }).then(context => {
+        // test iframe is created with correct context info.
+        expect(context.hidden).to.be.false;
+        // In some browsers the referrer is empty. But in Chrome it works, so
+        // we always check there.
+        if (context.referrer !== '' || platform.isChrome()) {
+          expect(context.referrer).to.contain(
+              'http://localhost:' + location.port);
+        }
 
-
-describes.realWin('3P Ad (with AmpContext experiment)', {
-  amp: {
-    runtimeOn: true,
-  },
-}, () => {
-  describe.configure().retryOnSaucelabs().run('render an ad should', () => {
-    let fixture;
-
-    beforeEach(() => {
-      return createFixture().then(f => {
-        fixture = f;
-        toggleExperiment(fixture.win, '3p-use-ampcontext', /* opt_on */ true,
-            /* opt_transientExperiment */ true);
-        installPlatformService(fixture.win);
+        expect(context.canonicalUrl).to.equal(
+            'https://www.example.com/doubleclick.html');
+        expect(context.clientId).to.be.defined;
+        expect(context.pageViewId).to.be.greaterThan(0);
+        expect(context.startTime).to.be.a('number');
+        expect(context.container).to.be.defined;
+        expect(context.initialIntersection).to.be.defined;
+        // check for rootBounds as native IO doesn't support it with CORS
+        expect(context.initialLayoutRect).to.be.defined;
+        expect(context.initialLayoutRect.top).to.be.defined;
+        expect(context.initialIntersection.rootBounds).to.be.defined;
+        expect(context.isMaster).to.be.defined;
+        expect(context.computeInMasterFrame).to.be.defined;
+        expect(context.location).to.be.defined;
+        expect(context.sourceUrl).to.be.a('string');
+      }).then(() => {
+        // test iframe will send out render-start to amp-ad
+        return poll('render-start message received', () => {
+          return fixture.messages.filter(message => {
+            return message.type == 'render-start';
+          }).length;
+        });
+      }).then(() => {
+        // test amp-ad will respond to render-start
+        return poll('wait for visibility style to change', () => {
+          return iframe.style.visibility == '';
+        });
+      }).then(() => {
+        return ampAd.layoutCallback();
+      }).then(() => {
+        expect(iframe.offsetHeight).to.equal(250);
+        expect(iframe.offsetWidth).to.equal(300);
+        expect(iframe.contentWindow.ping.resizeSuccess).to.be.undefined;
+        iframe.contentWindow.context.requestResize(200, 50);
+        return poll('wait for embed-size to be received', () => {
+          return fixture.messages.filter(message => {
+            return message.type == 'embed-size';
+          }).length;
+        });
+      }).then(() => {
+        return poll('wait for attemptChangeSize', () => {
+          return iframe.contentWindow.ping.resizeSuccess != undefined;
+        });
+      }).then(() => {
+        lastIO = null;
+        iframe.contentWindow.context.observeIntersection(changes => {
+          lastIO = changes[changes.length - 1];
+        });
+        fixture.win.scrollTo(0, 1000);
+        fixture.win.document.body.dispatchEvent(new Event('scroll'));
+        return poll('wait for new IO entry', () => {
+          return lastIO != null;
+        });
       });
     });
-
-    it('create an iframe with APIs', function() {
-      return createIframeWithApis.call(this, fixture);
-    });
   });
 });
-
 


### PR DESCRIPTION
Side effect: a test (`test-3p-frame.js`) that could have prevented #10312 is now enabled for the new implementation.

