### PR TITLE
Added playlist support to amp-soundcloud

### DIFF
--- a/examples/soundcloud.amp.html
+++ b/examples/soundcloud.amp.html
@@ -12,17 +12,26 @@
 </head>
 <body>
 
-  <h2>Soundcloud</h2>
+  <h2>Soundcloud Classic</h2>
+
+  <amp-soundcloud height="166"
+    layout="fixed-height"
+    data-trackid="243169232"
+    data-color="336699"></amp-soundcloud>
+
+  <h2>Soundcloud Visual</h2>
 
   <amp-soundcloud height="450"
     layout="fixed-height"
     data-trackid="243169232"
     data-visual="true"></amp-soundcloud>
 
-  <amp-soundcloud height="166"
+  <h2>Soundcloud Playlist</h2>
+  <!-- Had to be Hamilton, sorry. -->
+  <amp-soundcloud height="450"
     layout="fixed-height"
-    data-trackid="243169232"
-    data-color="336699"></amp-soundcloud>
+    data-playlistid="173211206"
+    data-visual="true"></amp-soundcloud>
 
   </body>
 </html>

--- a/extensions/amp-soundcloud/0.1/amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/amp-soundcloud.js
@@ -61,10 +61,13 @@ class AmpSoundcloud extends AMP.BaseElement {
     const height = this.element.getAttribute('height');
     const color = this.element.getAttribute('data-color');
     const visual = this.element.getAttribute('data-visual');
-    const url = 'https://api.soundcloud.com/tracks/';
-    const trackid = user().assert(
-        (this.element.getAttribute('data-trackid')),
-        'The data-trackid attribute is required for <amp-soundcloud> %s',
+    const url = 'https://api.soundcloud.com/' + (
+      this.element.hasAttribute('data-trackid') ? 'tracks' : 'playlists'
+    ) + '/';
+    const mediaid = user().assert(
+        (this.element.getAttribute('data-trackid')
+         || this.element.getAttribute('data-playlistid')),
+        'data-trackid or data-playlistid is required for <amp-soundcloud> %s',
         this.element);
     const secret = this.element.getAttribute('data-secret-token');
 
@@ -74,7 +77,7 @@ class AmpSoundcloud extends AMP.BaseElement {
     iframe.setAttribute('scrolling', 'no');
 
     let src = 'https://w.soundcloud.com/player/?' +
-      'url=' + encodeURIComponent(url + trackid);
+      'url=' + encodeURIComponent(url + mediaid);
     if (secret) {
       // It's very important the entire thing is encoded, since it's part of
       // the `url` query param added above.

--- a/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
@@ -25,13 +25,18 @@ adopt(window);
 
 describe('amp-soundcloud', () => {
 
-  const embedUrl = 'https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F243169232';
+  const trackEmbedUrl = 'https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F243169232';
+  const playlistEmbedUrl = 'https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F173211206';
 
-  function getIns(trackid, opt_attrs) {
+  function getIns(mediaid, playlist, opt_attrs) {
     return createIframePromise().then(iframe => {
       doNotLoadExternalResourcesInTest(iframe.win);
       const ins = iframe.doc.createElement('amp-soundcloud');
-      ins.setAttribute('data-trackid', trackid);
+      if (playlist) {
+        ins.setAttribute('data-playlistid', mediaid);
+      } else {
+        ins.setAttribute('data-trackid', mediaid);
+      }
       ins.setAttribute('height', '237');
 
       if (opt_attrs) {
@@ -44,17 +49,26 @@ describe('amp-soundcloud', () => {
     });
   }
 
-  it('renders', () => {
+  it('renders track', () => {
     return getIns('243169232').then(ins => {
       const iframe = ins.firstChild;
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
-      expect(iframe.src).to.equal(embedUrl);
+      expect(iframe.src).to.equal(trackEmbedUrl);
+    });
+  });
+
+  it('renders playlist', () => {
+    return getIns('173211206', true).then(ins => {
+      const iframe = ins.firstChild;
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      expect(iframe.src).to.equal(playlistEmbedUrl);
     });
   });
 
   it('renders secret token', () => {
-    return getIns('243169232', {
+    return getIns('243169232', false, {
       'data-visual': true,
       'data-secret-token': 'c-af',
     }).then(ins => {
@@ -64,13 +78,13 @@ describe('amp-soundcloud', () => {
   });
 
   it('renders fixed-height', () => {
-    return getIns('243169232', {layout: 'fixed-height'}).then(ins => {
+    return getIns('243169232', false, {layout: 'fixed-height'}).then(ins => {
       expect(ins.className).to.match(/i-amphtml-layout-fixed-height/);
     });
   });
 
   it('ignores color in visual mode', () => {
-    return getIns('243169232', {
+    return getIns('243169232', false, {
       'data-visual': true,
       'data-color': '00FF00',
     }).then(ins => {

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -55,9 +55,13 @@ Classic Mode:
 
 ## Attributes
 
-**data-trackid** (required)
+**data-trackid** (required if `data-playlistid` is not defined)
 
-The ID of the track, an integer.
+The ID of a track, an integer.
+
+**data-playlistid** (required if `data-trackid` is not defined)
+
+The ID of a playlist, an integer.
 
 **data-secret-token** (optional)
 

--- a/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii
+++ b/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii
@@ -36,12 +36,17 @@ tags: {  # <amp-soundcloud>
     value_regex_casei: "([0-9a-f]{3}){1,2}"
   }
   attrs: {
+    name: "data-playlistid"
+    mandatory_oneof: "['data-trackid', 'data-playlistid']"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
     name: "data-secret-token"
     value_regex: "[A-Za-z0-9_-]+"
   }
   attrs: {
     name: "data-trackid"
-    mandatory: true
+    mandatory_oneof: "['data-trackid', 'data-playlistid']"
     value_regex: "[0-9]+"
   }
   attrs: {


### PR DESCRIPTION
Adds support for embedding soundcloud playlists using the `amp-soundcloud` component.

### Changes

- Adds `data-playlistid` attribute to `amp-soundcloud`
- Changes validator rules for `data-playlistid` and `data-trackid`
- Displays playlist when `data-playlistid` is present
- Adds integration test for the behavior
- Adds an example for the behavior
- Changes documentation for `amp-soundcloud`

Closes #2808 , Needs update to amp-by-example [#886](https://github.com/ampproject/amp-by-example/issues/886)