### PR TITLE
Let <amp-auto-ads> auto load <amp-ad> and <amp-sticky-ad>

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -717,6 +717,8 @@ var forbiddenTermsSrcInclusive = {
       'src/service/extensions-impl.js',
       'extensions/amp-ad/0.1/amp-ad.js',
       'extensions/amp-a4a/0.1/amp-a4a.js',
+      'extensions/amp-auto-ads/0.1/amp-auto-ads.js',
+      'extensions/amp-auto-ads/0.1/anchor-ad-strategy.js',
     ],
   },
   'reject\\(\\)': {

--- a/examples/auto-ads.amp.html
+++ b/examples/auto-ads.amp.html
@@ -6,8 +6,6 @@
     <link rel="canonical" href="http://amp.autoplaced.com" >
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script async custom-element="amp-auto-ads" src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"></script>
-    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>  
-    <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js"></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <style>

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -27,6 +27,8 @@ import {getPlacementsFromConfigObj} from './placement';
 /** @const */
 const TAG = 'amp-auto-ads';
 
+/** @const */
+const AD_TAG = 'amp-ad';
 
 export class AmpAutoAds extends AMP.BaseElement {
 
@@ -43,6 +45,8 @@ export class AmpAutoAds extends AMP.BaseElement {
     if (!adNetwork.isEnabled(this.win)) {
       return;
     }
+
+    Services.extensionsFor(this.win)./*OK*/loadElementClass(AD_TAG);
 
     const configPromise = this.getConfig_(adNetwork.getConfigUrl());
     const docPromise = this.getAmpDoc().whenReady();

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -22,6 +22,9 @@ import {Services} from '../../../src/services';
 const TAG = 'amp-auto-ads';
 
 /** @const */
+const STICKY_AD_TAG = 'amp-sticky-ad';
+
+/** @const */
 const OPT_IN_STATUS_ANCHOR_ADS = 2;
 
 export class AnchorAdStrategy {
@@ -53,6 +56,7 @@ export class AnchorAdStrategy {
       user().warn(TAG, 'exists <amp-sticky-ad>');
       return Promise.resolve(false);
     }
+    Services.extensionsFor(this.win_)./*OK*/loadElementClass(STICKY_AD_TAG);
     this.placeStickyAd_();
     return Promise.resolve(true);
   }

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -63,6 +63,10 @@ describes.realWin('amp-auto-ads', {
     toggleExperiment(env.win, 'amp-auto-ads', true);
     sandbox = env.sandbox;
 
+    const extensions = Services.extensionsFor(env.win);
+    sandbox.stub(extensions, 'loadElementClass',
+        () => Promise.resolve(() => {}));
+
     const viewportMock =
         sandbox.mock(Services.viewportForDoc(env.win.document));
     viewportMock.expects('getSize').returns(


### PR DESCRIPTION
The motivation is to simplify pubs opt in <amp-auto-ads>, so that only "<script async custom-element="amp-auto-ads" src="/dist/v0/amp-auto-ads-0.1.max.js"></script>" is needed in <head>.

Considering pubs may already have "<script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>" in <head>, it may cause confusion if asking pubs to insert both <script amp-auto-ads> and <script amp-ad>.
