### PR TITLE
Video-docking edge cases and bug fixes

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -703,6 +703,9 @@ i-amphtml-video-mask, i-amp-video-mask {
   z-index: 2;
   will-change: transform;
   transform: scale(0.6) translateX(20px) translateY(20px);
+  border-radius: 6px;
+  box-shadow: 0px 3px 9px 3px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 1s, border-radius 1s;
   /* Override fill-content */
   min-width: initial !important;
   min-height: initial !important;

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -18,7 +18,7 @@ import {ActionTrust} from '../../../src/action-trust';
 import {CSS} from '../../../build/amp-selector-0.1.css';
 import {KeyCodes} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
-import {closestBySelector, tryFocus} from '../../../src/dom';
+import {closestBySelector, tryFocus, isRTL} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 
@@ -344,12 +344,12 @@ export class AmpSelector extends AMP.BaseElement {
    * @param {!Event} event
    */
   navigationKeyDownHandler_(event) {
-    const isLtr = this.win.document.body.getAttribute('dir') != 'rtl';
+    const doc = this.win.document;
     let dir = 0;
     switch (event.keyCode) {
       case KeyCodes.LEFT_ARROW:
         // Left is considered 'previous' in LTR and 'next' in RTL.
-        dir = isLtr ? -1 : 1;
+        dir = isRTL(doc) ? 1 : -1;
         break;
       case KeyCodes.UP_ARROW:
         // Up is considered 'previous' in both LTR and RTL.
@@ -357,7 +357,7 @@ export class AmpSelector extends AMP.BaseElement {
         break;
       case KeyCodes.RIGHT_ARROW:
         // Right is considered 'next' in LTR and 'previous' in RTL.
-        dir = isLtr ? 1 : -1;
+        dir = isRTL(doc) ? -1 : 1;
         break;
       case KeyCodes.DOWN_ARROW:
         // Down is considered 'next' in both LTR and RTL.

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -16,7 +16,7 @@
 
 import {CSS} from '../../../build/amp-sidebar-0.1.css';
 import {KeyCodes} from '../../../src/utils/key-codes';
-import {closestByTag, tryFocus} from '../../../src/dom';
+import {closestByTag, tryFocus, isRTL} from '../../../src/dom';
 import {Layout} from '../../../src/layout';
 import {dev} from '../../../src/log';
 import {Services} from '../../../src/services';
@@ -87,11 +87,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.viewport_.addToFixedLayer(this.element, /* forceTransfer */ true);
 
     if (this.side_ != 'left' && this.side_ != 'right') {
-      const pageDir =
-          this.document_.body.getAttribute('dir') ||
-          this.documentElement_.getAttribute('dir') ||
-          'ltr';
-      this.side_ = (pageDir == 'rtl') ? 'right' : 'left';
+      this.side_ = isRTL(this.document_) ? 'right' : 'left';
       this.element.setAttribute('side', this.side_);
     }
 

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -19,7 +19,7 @@ import {Layout} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 import {KeyCodes} from '../../../src/utils/key-codes';
-import {closestByTag, tryFocus} from '../../../src/dom';
+import {closestByTag, tryFocus, isRTL} from '../../../src/dom';
 import {Services} from '../../../src/services';
 import {setStyles, toggle} from '../../../src/style';
 import {removeFragment, parseUrl} from '../../../src/url';
@@ -95,11 +95,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.viewport_.addToFixedLayer(this.element, /* forceTransfer */ true);
 
     if (this.side_ != 'left' && this.side_ != 'right') {
-      const pageDir =
-          this.document_.body.getAttribute('dir') ||
-          this.documentElement_.getAttribute('dir') ||
-          'ltr';
-      this.side_ = (pageDir == 'rtl') ? 'right' : 'left';
+      this.side_ = isRTL(this.document_) ? 'right' : 'left';
       this.element.setAttribute('side', this.side_);
     }
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -639,6 +639,18 @@ export function isJsonScriptTag(element) {
             element.getAttribute('type').toUpperCase() == 'APPLICATION/JSON';
 }
 
+/**
+ * Whether the page's direction is right to left or not.
+ * @param {!Document} doc
+ * @return {boolean}
+ */
+export function isRTL(doc) {
+  const dir = doc.body.getAttribute('dir')
+                 || doc.documentElement.getAttribute('dir')
+                 || 'ltr';
+  return dir == 'rtl';
+}
+
 
 /**
  * Escapes an ident (ID or a class name) to be used as a CSS selector.

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -389,6 +389,7 @@ class VideoEntry {
     /** @private {?PositionInViewportEntryDef} */
     this.dockLastPosition_ = null;
 
+    /** @private {boolean} */
     this.dockPreviouslyInView_ = false;
 
     this.hasDocking = element.hasAttribute(VideoAttributes.DOCK);
@@ -468,6 +469,11 @@ class VideoEntry {
         this.video.element,
         'video, iframe'
     );
+
+    // Just in case the video's size changed during layout
+    this.vsync_.measure(() => {
+      this.initialRect_ = this.video.element.getLayoutBox();
+    });
 
     this.updateVisibility();
     if (this.isVisible_) {

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -42,7 +42,6 @@ import {
 } from '../dom';
 import * as st from '../style';
 
-
 /**
  * @const {number} Percentage of the video that should be in viewport before it
  * is considered visible.
@@ -54,6 +53,8 @@ const VISIBILITY_PERCENT = 75;
  */
 const DOCK_SCALE = 0.6;
 const DOCK_CLASS = 'i-amphtml-dockable-video-minimizing';
+const DOCK_MARGIN = 20;
+
 
 /**
 * Minimization Positions
@@ -61,13 +62,13 @@ const DOCK_CLASS = 'i-amphtml-dockable-video-minimizing';
 * Internal states used to describe whether the video is inside the viewport
 * or minimizing starting from the bottom or minimizing starting from the top
 *
-* @enum {number}
+* @enum {string}
 */
 export const MinimizePositions = {
-  DEFAULT: -1,
-  INVIEW: 0,
-  TOP: 1,
-  BOTTOM: 2,
+  DEFAULT: 'default',
+  INVIEW: 'inview',
+  TOP: 'top',
+  BOTTOM: 'bottom',
 };
 
 
@@ -91,6 +92,9 @@ export class VideoManager {
     /** @private {?Array<!VideoEntry>} */
     this.entries_ = null;
 
+    /** @private {?VideoEntry} */
+    this.curDocked_ = null;
+
     /** @private {boolean} */
     this.scrollListenerInstalled_ = false;
 
@@ -112,7 +116,7 @@ export class VideoManager {
     }
 
     this.entries_ = this.entries_ || [];
-    const entry = new VideoEntry(this.ampdoc_, video);
+    const entry = new VideoEntry(this.ampdoc_, video, this);
     this.maybeInstallVisibilityObserver_(entry);
     this.maybeInstallPositionObserver_(entry);
     this.entries_.push(entry);
@@ -197,6 +201,7 @@ export class VideoManager {
         entry.video.element,
         PositionObserverFidelity.HIGH,
         newPos => {
+          entry.updateVisibility();
           entry.onDockableVideoPositionChanged(newPos);
         }
     );
@@ -241,6 +246,52 @@ export class VideoManager {
     return this.getEntryForVideo_(video).userInteractedWithAutoPlay();
   }
 
+  /**
+   * Undocks all docked videos except the currently docked video
+   */
+  undockAllExceptCurrent() {
+    for (let i = 0; i < this.entries_.length; i++) {
+      if (this.entries_[i] != this.curDocked_ && this.entries_[i].hasDocking) {
+        // undocks the video
+        this.entries_[i].unDockVideo_();
+        this.entries_[i].hasBeenInViewBefore = false;
+      }
+    }
+  }
+
+  /**
+   * Declares that the provided entry is the current docked video
+   * @param {VideoEntry} entry
+   */
+  registerDocked(entry) {
+    this.curDocked_ = entry;
+    this.undockAllExceptCurrent();
+  }
+
+  /**
+   * Undocks the currently docked video
+   */
+  unregisterDocked() {
+    this.curDocked_ = null;
+    this.undockAllExceptCurrent();
+  }
+
+  /**
+   * Returns whether there is currently a docked video or not
+   * @returns {boolean}
+   */
+  noDockedVid() {
+    return this.curDocked_ == null;
+  }
+
+  /**
+   * Returns the current docked video if it exists
+   * @returns {?VideoEntry}
+   */
+  curDockedVid() {
+    return this.curDocked_;
+  }
+
 }
 
 /**
@@ -250,14 +301,18 @@ class VideoEntry {
   /**
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
    * @param {!../video-interface.VideoInterface} video
+   * @param {!VideoManager} vidManager
    */
-  constructor(ampdoc, video) {
+  constructor(ampdoc, video, vidManager) {
 
     /** @private @const {!./ampdoc-impl.AmpDoc}  */
     this.ampdoc_ = ampdoc;
 
     /** @package @const {!../video-interface.VideoInterface} */
     this.video = video;
+
+    /** @private @const {!VideoManager} */
+    this.vidManager_ = vidManager;
 
     /** @private {?Element} */
     this.autoplayAnimation_ = null;
@@ -304,17 +359,22 @@ class VideoEntry {
     /** @private {Object} */
     this.initialRect_ = null;
 
-    /** @private {number} */
+    /** @private {string} */
     this.minimizePosition_ = MinimizePositions.DEFAULT;
 
     /** @private {number} */
-    this.inViewportHeight_ = 0;
+    this.visibleHeight_ = 0;
 
     /** @private {?Element} */
     this.internalElement_ = null;
 
     /** @private */
     this.muted_ = false;
+
+    /** @private {string} */
+    this.pageDir_ = 'ltr';
+
+    this.hasBeenInViewBefore = false;
 
     this.hasDocking = element.hasAttribute(VideoAttributes.DOCK);
 
@@ -344,6 +404,13 @@ class VideoEntry {
     }
     if (this.hasDocking) {
       this.dockableVideoBuilt_();
+      // Determine the docking side based on the page's direction
+      // TODO(@wassgha) Probably will be needed for more functionalities later
+      // but for now, only needed for video docking
+      const doc = this.ampdoc_.win.document;
+      this.pageDir_ = doc.body.getAttribute('dir')
+                     || doc.documentElement.getAttribute('dir')
+                     || 'ltr';
     }
   }
 
@@ -447,6 +514,14 @@ class VideoEntry {
       },
     });
 
+    // Re-measure initial position when the window resizes / orientation changes
+    const viewport = viewportForDoc(this.ampdoc_);
+    viewport.onResize(() => {
+      this.vsync_.measure(() => {
+        this.initialRect_ = this.video.element./*OK*/getBoundingClientRect();
+        this.initializeDocking_();
+      });
+    });
     // TODO(@wassgha) Add video element wrapper here
   }
 
@@ -557,11 +632,11 @@ class VideoEntry {
    */
   scrollMap_(min, max, reverse = false) {
     if (reverse) {
-      return mapRange(this.inViewportHeight_,
+      return mapRange(this.visibleHeight_,
           this.initialRect_.height, 0,
           min, max);
     } else {
-      return mapRange(this.inViewportHeight_,
+      return mapRange(this.visibleHeight_,
           0, this.initialRect_.height,
           min, max);
     }
@@ -595,22 +670,26 @@ class VideoEntry {
       || !this.initialRect_
       || !this.internalElement_
       || (this.getPlayingState() != PlayingStates.PLAYING_MANUAL
-          && !this.internalElement_.classList.contains(DOCK_CLASS))
+          && !this.internalElement_.classList.contains(DOCK_CLASS)
+      || (!this.vidManager_.noDockedVid()
+          && this.vidManager_.curDockedVid() != this))
     ) {
       return;
     }
 
     // Initialize docking width/height
-    if (this.minimizePosition_ != MinimizePositions.INVIEW) {
+    if (this.minimizePosition_ != MinimizePositions.INVIEW
+        && this.hasBeenInViewBefore) {
       this.vsync_.mutate(() => {
-        this.startDocking_();
+        this.vidManager_.registerDocked(this);
+        this.initializeDocking_();
       });
     }
 
     // Temporary fix until PositionObserver somehow tracks objects outside of
     // the viewport (forces the style to be what we want in the final state)
-    if (this.inViewportHeight_ == 0
-       && this.getPlayingState() == PlayingStates.PLAYING_MANUAL
+    if (!newPos.positionRect
+       && (!this.hasAutoplay || this.userInteractedWithAutoPlay())
        && this.minimizePosition_ != MinimizePositions.DEFAULT) {
       this.vsync_.mutate(() => {
         this.endDocking_();
@@ -623,8 +702,10 @@ class VideoEntry {
     //
     // Conditions for animating the video are:
     // 1. The video is out of view and it has been in-view at least once before
-    const outOfView = this.minimizePosition_ != MinimizePositions.INVIEW
-                      && this.minimizePosition_ != MinimizePositions.DEFAULT;
+    const inView = this.minimizePosition_ == MinimizePositions.INVIEW;
+    const outOfView = !inView
+                      && this.minimizePosition_ != MinimizePositions.DEFAULT
+                      && this.hasBeenInViewBefore;
     // 2. Is either manually playing or paused while docked (so that it is
     // undocked even when paused)
     const manPlaying = (this.getPlayingState() == PlayingStates.PLAYING_MANUAL);
@@ -636,10 +717,11 @@ class VideoEntry {
       this.vsync_.mutate(() => {
         this.animateDocking_();
       });
-    } else if (this.minimizePosition_ == MinimizePositions.INVIEW) {
+    } else if (inView && this.internalElement_.classList.contains(DOCK_CLASS)) {
       // Here undocking animations are done so we restore the element
       // inline by clearing all styles and removing the position:fixed
       this.vsync_.mutate(() => {
+        this.vidManager_.unregisterDocked();
         this.unDockVideo_();
       });
     }
@@ -653,6 +735,8 @@ class VideoEntry {
    * @private
    */
   updateDockableVideoPosition_(newPos) {
+    // TODO(@wassgha) Refactor when position observer starts reporting the
+    // relative position
     if (newPos.positionRect) {
 
       const docViewTop = newPos.viewportRect.top;
@@ -663,24 +747,24 @@ class VideoEntry {
 
       // Calculate height currently displayed
       if (elemTop <= docViewTop) {
-        this.inViewportHeight_ = elemBottom - docViewTop;
+        this.visibleHeight_ = elemBottom - docViewTop;
         this.minimizePosition_ = MinimizePositions.TOP;
       } else if (elemBottom >= docViewBottom) {
-        this.inViewportHeight_ = docViewBottom - elemTop;
+        this.visibleHeight_ = docViewBottom - elemTop;
         this.minimizePosition_ = MinimizePositions.BOTTOM;
       } else {
+        this.visibleHeight_ = elemBottom - elemTop;
         this.minimizePosition_ = MinimizePositions.INVIEW;
-        this.inViewportHeight_ = elemBottom - elemTop;
       }
+    } else if (this.minimizePosition_ == MinimizePositions.INVIEW
+                || this.minimizePosition_ == MinimizePositions.DEFAULT)
+    {
+      // Here we're just guessing, until #9208 is fixed
+      // (until position observer returns more information when out of view )
+      this.minimizePosition_ = MinimizePositions.TOP;
+      this.visibleHeight_ = 0;
     } else {
-      if (this.minimizePosition_ == MinimizePositions.INVIEW
-        || this.minimizePosition_ == MinimizePositions.DEFAULT)
-      {
-        // Here we're just guessing, until #9208 is fixed
-        // (until position observer returns more information when out of view )
-        this.minimizePosition_ = MinimizePositions.TOP;
-      }
-      this.inViewportHeight_ = 0;
+      this.visibleHeight_ = 0;
     }
   }
 
@@ -689,7 +773,7 @@ class VideoEntry {
    * so that we scale relative to the initial video's dimensions
    * @private
    */
-  startDocking_() {
+  initializeDocking_() {
     st.setStyles(dev().assertElement(this.internalElement_), {
       'height': st.px(this.initialRect_.height),
       'width': st.px(this.initialRect_.width),
@@ -703,23 +787,82 @@ class VideoEntry {
    * @private
    */
   animateDocking_() {
+    if (this.minimizePosition_ == MinimizePositions.INVIEW) {
+      return;
+    }
+
+    // Calculate space on top and bottom of the video to see if it is possible
+    // for the video to become hidden by scrolling to the top/bottom
+    const viewport = viewportForDoc(this.ampdoc_);
+    const spaceOnTop = this.video.element./*OK*/offsetTop;
+    const spaceOnBottom = viewport.getScrollHeight()
+                          - spaceOnTop
+                          - this.video.element./*OK*/offsetHeight;
+
+    // Don't minimize if video can never be hidden by scrolling to the bottom
+    if (this.minimizePosition_ == MinimizePositions.TOP
+        && spaceOnBottom < viewport.getHeight()) {
+      return;
+    }
+
+    // Don't minimize if video can never be hidden by scrolling to the top
+    if (this.minimizePosition_ == MinimizePositions.BOTTOM
+        && spaceOnTop < viewport.getHeight()) {
+      return;
+    }
+
     // Minimize the video
     this.video.hideControls();
     this.internalElement_.classList.add(DOCK_CLASS);
 
     const isTop = this.minimizePosition_ == MinimizePositions.TOP;
-    const offsetX = st.px(this.scrollMap_(this.initialRect_.left, 20, true));
+    const isLtr = this.pageDir_ == 'ltr';
+    // Different behavior based on whether the page is written left to right
+    // or right to left
+    let offsetX;
+    if (isLtr) {
+      const offsetRight = viewport.getWidth()
+                          - this.initialRect_.left
+                          - this.initialRect_.width;
+      const scaledWidth = DOCK_SCALE * this.initialRect_.width;
+      offsetX = st.px(
+          this.scrollMap_(
+              viewport.getWidth() - this.initialRect_.width - offsetRight,
+              viewport.getWidth() - scaledWidth - DOCK_MARGIN,
+              true
+          )
+      );
+    } else {
+      const offsetLeft = this.initialRect_.left;
+      offsetX = st.px(this.scrollMap_(offsetLeft, DOCK_MARGIN, true));
+    }
+
     // Different behavior based on whether the video got minimized
     // from the top or the bottom
-    const offsetY = st.px((isTop ? 1 : -1) * this.scrollMap_(0, 20, true));
-    const transform = st.scale(this.scrollMap_(DOCK_SCALE, 1)) + ' '
-                      + st.translate(offsetX, offsetY);
+    let offsetY;
+    if (isTop) {
+      offsetY = st.px(this.scrollMap_(0, DOCK_MARGIN, true));
+    } else {
+      const scaledHeight = DOCK_SCALE * this.initialRect_.height;
+      offsetY = st.px(
+          this.scrollMap_(
+              viewport.getHeight() - this.initialRect_.height,
+              viewport.getHeight() - scaledHeight - DOCK_MARGIN,
+              true
+          )
+      );
+    }
+
+    const transform = st.translate(offsetX, offsetY) + ' '
+                      + st.scale(this.scrollMap_(DOCK_SCALE, 1));
 
     st.setStyles(dev().assertElement(this.internalElement_), {
       'transform': transform,
-      'transformOrigin': isTop ? 'top left' : 'bottom left',
-      'bottom': isTop ? 'auto' : '0px',
-      'top': isTop ? '0px' : 'auto',
+      'transformOrigin': 'top left',
+      'bottom': 'auto',
+      'top': '0px',
+      'right': 'auto',
+      'left': '0px',
     });
 
     // TODO(@wassim) Make minimized video draggable
@@ -735,30 +878,50 @@ class VideoEntry {
    * @private
    */
   endDocking_() {
+    const viewport = viewportForDoc(this.ampdoc_);
     // Hide the controls.
     this.video.hideControls();
     this.internalElement_.classList.add(DOCK_CLASS);
 
     const isTop = this.minimizePosition_ == MinimizePositions.TOP;
+    const isLtr = this.pageDir_ == 'ltr';
+
+    // Different behavior based on whether the page is written left to right
+    // or right to left
+    let offsetX;
+    if (isLtr) {
+      const scaledWidth = DOCK_SCALE * this.initialRect_.width;
+      offsetX = st.px(viewport.getWidth() - scaledWidth - DOCK_MARGIN);
+    } else {
+      offsetX = st.px(DOCK_MARGIN);
+    }
+
+    // Different behavior based on whether the video got minimized
+    // from the top or the bottom
+    let offsetY;
+    if (isTop) {
+      offsetY = st.px(DOCK_MARGIN);
+    } else {
+      const scaledHeight = DOCK_SCALE * this.initialRect_.height;
+      offsetY = st.px(viewport.getHeight() - scaledHeight - DOCK_MARGIN);
+    }
+
+    const transform = st.translate(offsetX, offsetY) + ' '
+                      + st.scale(DOCK_SCALE);
+    st.setStyles(dev().assertElement(this.internalElement_), {
+      'transform': transform,
+      'transformOrigin': 'top left',
+      'bottom': 'auto',
+      'top': '0px',
+      'right': 'auto',
+      'left': '0px',
+    });
+    // Guessing until Refactor
     if (isTop) {
       this.minimizePosition_ = MinimizePositions.BOTTOM;
     } else {
       this.minimizePosition_ = MinimizePositions.TOP;
     }
-
-    const offsetX = st.px(20);
-    // Different behavior based on whether the video got minimized
-    // from the top or the bottom
-    const offsetY = st.px((isTop ? 1 : -1) * 20);
-    const transform = st.scale(DOCK_SCALE) + ' '
-                      + st.translate(offsetX, offsetY);
-
-    st.setStyles(dev().assertElement(this.internalElement_), {
-      'transform': transform,
-      'transformOrigin': isTop ? 'top left' : 'bottom left',
-      'bottom': isTop ? 'auto' : '0px',
-      'top': isTop ? '0px' : 'auto',
-    });
   }
 
   /**
@@ -769,6 +932,7 @@ class VideoEntry {
    */
   unDockVideo_() {
     // Restore the video inline
+    this.minimizePosition_ = MinimizePositions.DEFAULT;
     this.internalElement_.classList.remove(DOCK_CLASS);
     this.internalElement_.setAttribute('style', '');
     this.video.showControls();
@@ -833,17 +997,13 @@ class VideoEntry {
 
     // Measure if video is now in viewport and what percentage of it is visible.
     const measure = () => {
-      if (!this.video.isInViewport()) {
-        this.isVisible_ = false;
-        return;
-      }
-
       // Calculate what percentage of the video is in viewport.
       const change = this.video.element.getIntersectionChangeEntry();
       const visiblePercent = !isFiniteNumber(change.intersectionRatio) ? 0
           : change.intersectionRatio * 100;
-
       this.isVisible_ = visiblePercent >= VISIBILITY_PERCENT;
+      this.hasBeenInViewBefore = this.hasBeenInViewBefore
+                                 || visiblePercent == 100;
     };
 
     // Mutate if visibility changed from previous state

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -350,7 +350,7 @@ export function runVideoPlayerIntegrationTests(
         }).then(() => {
           expect(insideElement).to.have.class(DOCK_CLASS);
           expect(st.getStyle(insideElement, 'transform')).to.equal(
-              st.scale(DOCK_SCALE) + ' ' + st.translate(st.px(-20), st.px(20))
+              st.translate(st.px(300), st.px(680)) + ' ' + st.scale(DOCK_SCALE)
           );
         });
       });
@@ -394,7 +394,7 @@ export function runVideoPlayerIntegrationTests(
         }).then(() => {
           expect(insideElement).to.have.class(DOCK_CLASS);
           expect(st.getStyle(insideElement, 'transform')).to.equal(
-              st.scale(DOCK_SCALE) + ' ' + st.translate(st.px(-20), st.px(20))
+              st.translate(st.px(300), st.px(20)) + ' ' + st.scale(DOCK_SCALE)
           );
         });
       });

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -22,6 +22,7 @@ import {
   VideoInterface,
   VideoEvents,
   VideoAnalyticsEvents,
+  PlayingStates,
 } from '../../src/video-interface';
 import {supportsAutoplay} from '../../src/service/video-manager-impl';
 import {
@@ -379,6 +380,14 @@ export function runVideoPlayerIntegrationTests(
           video.querySelector('i-amphtml-video-mask').click();
           return poll('wait for mask to hide', () => {
             return !video.querySelector('i-amphtml-video-mask');
+          });
+        }).then(() => {
+          const vidManager = Services.videoManagerForDoc(
+              video.implementation_.getAmpDoc()
+          );
+          return poll('wait for video to be playing manually', () => {
+            const curState = vidManager.getPlayingState(video.implementation_);
+            return curState == PlayingStates.PLAYING_MANUAL;
           });
         }).then(() => {
           viewport.setScrollTop(FRAME_HEIGHT);

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -350,7 +350,7 @@ export function runVideoPlayerIntegrationTests(
         }).then(() => {
           expect(insideElement).to.have.class(DOCK_CLASS);
           expect(st.getStyle(insideElement, 'transform')).to.equal(
-              st.scale(DOCK_SCALE) + ' ' + st.translate(st.px(20), st.px(20))
+              st.scale(DOCK_SCALE) + ' ' + st.translate(st.px(-20), st.px(20))
           );
         });
       });
@@ -394,7 +394,7 @@ export function runVideoPlayerIntegrationTests(
         }).then(() => {
           expect(insideElement).to.have.class(DOCK_CLASS);
           expect(st.getStyle(insideElement, 'transform')).to.equal(
-              st.scale(DOCK_SCALE) + ' ' + st.translate(st.px(20), st.px(20))
+              st.scale(DOCK_SCALE) + ' ' + st.translate(st.px(-20), st.px(20))
           );
         });
       });


### PR DESCRIPTION
### Changes
- Fixed bug where video flickers before undocking
- Switched to using strings for the enumerable `MinimizePositions` (easier for debugging)
- Added direction (right/left) to `MinimizePositions` so now it takes one of `INLINE`, `TOP_LEFT`, `TOP_RIGHT`, `BOTTOM_LEFT` or `BOTTOM_RIGHT`
- Added a few shortcuts to leave methods early
- The docking position now changes corresponding to the page's language orientation (ex: if page language is left to right then video docks to the right to minimize the chance of hidden content)
- Added back `border-radius` and `box-shadow` with timed animations instead of scroll-bound
- Fixed bug where video wasn't docked in the right position when in landscape mode
- Videos now only start docking when there is enough space before and after the inline video to completely hide it (fixes cases where the video starts docking but can't finish since there is no more content to scroll)
- Prevent videos from docking when another video is docked
- Fix bug where video docking would break if the page size changes (especially when going to landscape mode)
- Docking margin is now a constant rather than being hard-coded
- Fixed bug where docking will only end when the video is playing
- Fixed bug where video would always be minimized and never go inline if the video's height is bigger than the viewport's (especially in landscape)
- No longer uses `top` and `bottom` in preparation for drag and drop (drag and drop will animate the `translate` transformation)
- Use `viewport.onResize()` instead of `viewport.onChanged`
- Use the new changes to `position-observer` instead of guessing (got rid of `endDocking` and now using a fake position based on `relativepos`)
- Added `dockingStates` in preparation for drag and drop (takes one of `INLINE`, `DOCKED` or `DOCKING`)
- Added `isRTL()` to `dom.js` and updated extensions to use it
- Switched from using `getBoundingClientRect` to `getLayoutBox` when remeasuring after orientation change/page resize
- Fixed flaky test
- Overall better readability and structure