### PR TITLE
Stop overriding extractCreativeAndSignature in impls

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -18,13 +18,11 @@ import {
   additionalDimensions,
   addCsiSignalsToAmpAnalyticsConfig,
   extractAmpAnalyticsConfig,
-  extractGoogleAdCreativeAndSignature,
   EXPERIMENT_ATTRIBUTE,
   googleAdUrl,
   mergeExperimentIds,
 } from '../utils';
 import {createElementWithAttributes} from '../../../../src/dom';
-import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
 import {
   installExtensionsService,
 } from '../../../../src/service/extensions-impl';
@@ -67,50 +65,6 @@ function noopMethods(impl, doc, sandbox) {
 }
 
 describe('Google A4A utils', () => {
-
-  describe('#extractGoogleAdCreativeAndSignature', () => {
-    it('should return body and signature', () => {
-      const creative = 'some test data';
-      const headerData = {
-        'X-AmpAdSignature': 'AQAB',
-      };
-      const headers = {
-        has: h => { return h in headerData; },
-        get: h => { return headerData[h]; },
-      };
-      return expect(extractGoogleAdCreativeAndSignature(creative, headers))
-          .to.eventually.deep.equal({
-            creative,
-            signature: base64UrlDecodeToBytes('AQAB'),
-          });
-    });
-
-    it('should return body and signature and size', () => {
-      const creative = 'some test data';
-      const headerData = {
-        'X-AmpAdSignature': 'AQAB',
-      };
-      const headers = {
-        has: h => { return h in headerData; },
-        get: h => { return headerData[h]; },
-      };
-      return expect(extractGoogleAdCreativeAndSignature(creative, headers))
-          .to.eventually.deep.equal({
-            creative,
-            signature: base64UrlDecodeToBytes('AQAB'),
-          });
-    });
-
-    it('should return null when no signature header is present', () => {
-      const creative = 'some test data';
-      const headers = {
-        has: unused => { return false; },
-        get: h => { throw new Error('Tried to get ' + h); },
-      };
-      return expect(extractGoogleAdCreativeAndSignature(creative, headers))
-          .to.eventually.deep.equal({creative, signature: null});
-    });
-  });
 
   //TODO: Add tests for other utils functions.
 

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -29,15 +29,11 @@ import {
   viewerForDoc,
   viewportForDoc,
 } from '../../../src/services';
-import {base64UrlDecodeToBytes} from '../../../src/utils/base64';
 import {domFingerprint} from '../../../src/utils/dom-fingerprint';
 import {
   isExperimentOn,
   toggleExperiment,
 } from '../../../src/experiments';
-
-/** @const {string} */
-const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
 
 /** @type {string}  */
 const AMP_ANALYTICS_HEADER = 'X-AmpAnalytics';
@@ -272,27 +268,6 @@ export function truncAndTimeUrl(baseUrl, parameters, startTime) {
   return buildUrl(
       baseUrl, parameters, MAX_URL_LENGTH - 10, {name: 'trunc', value: '1'})
     + '&dtd=' + elapsedTimeWithCeiling(Date.now(), startTime);
-}
-
-/**
- * @param {!ArrayBuffer} creative
- * @param {!../../../src/service/xhr-impl.FetchResponseHeaders} responseHeaders
- * @return {!Promise<!../../../extensions/amp-a4a/0.1/amp-a4a.AdResponseDef>}
- */
-export function extractGoogleAdCreativeAndSignature(
-    creative, responseHeaders) {
-  let signature = null;
-  try {
-    if (responseHeaders.has(AMP_SIGNATURE_HEADER)) {
-      signature =
-        base64UrlDecodeToBytes(dev().assertString(
-            responseHeaders.get(AMP_SIGNATURE_HEADER)));
-    }
-  } finally {
-    return Promise.resolve(/** @type {
-          !../../../extensions/amp-a4a/0.1/amp-a4a.AdResponseDef} */ (
-          {creative, signature}));
-  }
 }
 
 /**

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -78,7 +78,7 @@ const METADATA_STRING_NO_QUOTES =
 /** @type {string} */
 export const DEFAULT_SAFEFRAME_VERSION = '1-0-9';
 
-/** @const {string} */
+/** @const {string} @visibleForTesting */
 export const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
 
 /** @const {string} */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -79,7 +79,7 @@ const METADATA_STRING_NO_QUOTES =
 export const DEFAULT_SAFEFRAME_VERSION = '1-0-9';
 
 /** @const {string} */
-const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
+export const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
 
 /** @const {string} */
 const CREATIVE_SIZE_HEADER = 'X-CreativeSize';
@@ -1099,8 +1099,8 @@ export class AmpA4A extends AMP.BaseElement {
         // Decoding error; do nothing
       }
     }
-    return Promise.resolve(
-        /** @type {!AdResponseDef} */ ({responseArrayBuffer, signature}));
+    return Promise.resolve(/** @type {!AdResponseDef} */ (
+        {creative: responseArrayBuffer, signature}));
   }
 
   /**

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -184,20 +184,6 @@ describe('integration test: a4a', () => {
     });
   });
 
-  it('should fall back to 3p when extractCreative throws', () => {
-    sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature').throws(
-        new Error('Testing extractCreativeAndSignature error'));
-    // TODO(tdrl) Currently layoutCallback rejects, even though something *is*
-    // rendered.  This should be fixed in a refactor, and we should change this
-    // .catch to a .then.
-    return fixture.addElement(a4aElement).catch(error => {
-      expect(error.message).to.contain.string(
-          'Testing extractCreativeAndSignature error');
-      expect(error.message).to.contain.string('amp-a4a:');
-      expectRenderedInXDomainIframe(a4aElement, TEST_URL);
-    });
-  });
-
   it('should fall back to 3p when extractCreative returns empty sig', () => {
     const extractCreativeAndSignatureStub =
         sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature');

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import {
-    MockA4AImpl,
-    SIGNATURE_HEADER,
-    TEST_URL,
-} from './utils';
+import {AMP_SIGNATURE_HEADER} from '../amp-a4a';
+import {MockA4AImpl, TEST_URL} from './utils';
 import {Xhr} from '../../../../src/service/xhr-impl';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
@@ -110,7 +107,7 @@ describe('integration test: a4a', () => {
     }
     // Expect ad request.
     headers = {};
-    headers[SIGNATURE_HEADER] = validCSSAmp.signature;
+    headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
     mockResponse = {
       arrayBuffer: () => utf8Encode(validCSSAmp.reserialized),
       bodyUsed: false,
@@ -154,7 +151,7 @@ describe('integration test: a4a', () => {
   });
 
   it('should fall back to 3p when no signature is present', () => {
-    delete headers[SIGNATURE_HEADER];
+    delete headers[AMP_SIGNATURE_HEADER];
     return fixture.addElement(a4aElement).then(unusedElement => {
       expectRenderedInXDomainIframe(a4aElement, TEST_URL);
     });
@@ -220,7 +217,7 @@ describe('integration test: a4a', () => {
 
   it('should collapse slot when creative response has code 204', () => {
     headers = {};
-    headers[SIGNATURE_HEADER] = validCSSAmp.signature;
+    headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
     mockResponse = {
       arrayBuffer: () => utf8Encode(validCSSAmp.reserialized),
       bodyUsed: false,
@@ -258,7 +255,7 @@ describe('integration test: a4a', () => {
 
   it('should collapse slot when creative response.arrayBuffer is null', () => {
     headers = {};
-    headers[SIGNATURE_HEADER] = validCSSAmp.signature;
+    headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
     mockResponse = {
       arrayBuffer: () => null,
       bodyUsed: false,
@@ -284,7 +281,7 @@ describe('integration test: a4a', () => {
   it('should collapse slot when creative response.arrayBuffer() is empty',
       () => {
         headers = {};
-        headers[SIGNATURE_HEADER] = validCSSAmp.signature;
+        headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
         mockResponse = {
           arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
           bodyUsed: false,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2167,6 +2167,65 @@ describe('amp-a4a', () => {
     });
   });
 
+  describe('#extractCreativeAndSignature', () => {
+    it('should return body and signature', () => {
+      const creative = 'some test data';
+      const headerData = {
+        'X-AmpAdSignature': 'AQAB',
+      };
+      const headers = {
+        has: h => {
+          return h in headerData;
+        },
+        get: h => {
+          return headerData[h];
+        },
+      };
+      return expect(AmpA4A.prototype.extractCreativeAndSignature(
+          creative, headers))
+          .to.eventually.deep.equal({
+            creative,
+            signature: base64UrlDecodeToBytes('AQAB'),
+          });
+    });
+
+    it('should return body and signature and size', () => {
+      const creative = 'some test data';
+      const headerData = {
+        'X-AmpAdSignature': 'AQAB',
+      };
+      const headers = {
+        has: h => {
+          return h in headerData;
+        },
+        get: h => {
+          return headerData[h];
+        },
+      };
+      return expect(AmpA4A.prototype.extractCreativeAndSignature(
+          creative, headers))
+          .to.eventually.deep.equal({
+            creative,
+            signature: base64UrlDecodeToBytes('AQAB'),
+          });
+    });
+
+    it('should return null when no signature header is present', () => {
+      const creative = 'some test data';
+      const headers = {
+        has: unused => {
+          return false;
+        },
+        get: h => {
+          throw new Error('Tried to get ' + h);
+        },
+      };
+      return expect(AmpA4A.prototype.extractCreativeAndSignature(
+          creative, headers))
+          .to.eventually.deep.equal({creative, signature: null});
+    });
+  });
+
   describe('#extractSize', () => {
 
     it('should return a size', () => {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2213,7 +2213,7 @@ describe('amp-a4a', () => {
         has: unused => {
           return false;
         },
-        get: h => {
+        get: unused => {
           return undefined;
         },
       };

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {AMP_SIGNATURE_HEADER} from '../amp-a4a';
 import {MockA4AImpl, TEST_URL} from './utils';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
   AmpA4A,
+  AMP_SIGNATURE_HEADER,
   RENDERING_TYPE_HEADER,
   DEFAULT_SAFEFRAME_VERSION,
   SAFEFRAME_VERSION_HEADER,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import {
-  MockA4AImpl,
-  TEST_URL,
-  SIGNATURE_HEADER,
-} from './utils';
+import {AMP_SIGNATURE_HEADER} from '../amp-a4a';
+import {MockA4AImpl, TEST_URL} from './utils';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
   AmpA4A,
@@ -111,7 +108,7 @@ describe('amp-a4a', () => {
       catch: callback => callback(),
     };
     headers = {};
-    headers[SIGNATURE_HEADER] = validCSSAmp.signature;
+    headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
   });
 
   afterEach(() => {
@@ -258,7 +255,7 @@ describe('amp-a4a', () => {
 
     it('for SafeFrame rendering case', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       // If rendering type is safeframe, we SHOULD attach a SafeFrame.
       headers[RENDERING_TYPE_HEADER] = 'safeframe';
       a4a.buildCallback();
@@ -276,7 +273,7 @@ describe('amp-a4a', () => {
       sandbox.stub(platform, 'isIos').returns(true);
       a4a = new MockA4AImpl(a4aElement);
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       // Ensure no rendering type header (ios on safari will default to
       // safeframe).
       delete headers[RENDERING_TYPE_HEADER];
@@ -296,7 +293,7 @@ describe('amp-a4a', () => {
 
     it('for cached content iframe rendering case', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
@@ -350,7 +347,7 @@ describe('amp-a4a', () => {
 
     it('should reset state to null on non-FIE unlayoutCallback', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
@@ -461,7 +458,7 @@ describe('amp-a4a', () => {
     let a4a;
     beforeEach(() => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       // If rendering type is safeframe, we SHOULD attach a SafeFrame.
       headers[RENDERING_TYPE_HEADER] = 'safeframe';
       xhrMock.withArgs(TEST_URL, {
@@ -540,7 +537,7 @@ describe('amp-a4a', () => {
             it(`should not attach a NameFrame when header is ${headerVal}`,
                 () => {
                   // Make sure there's no signature, so that we go down the 3p iframe path.
-                  delete headers[SIGNATURE_HEADER];
+                  delete headers[AMP_SIGNATURE_HEADER];
                   // If rendering type is anything but nameframe, we SHOULD NOT
                   // attach a NameFrame.
                   headers[RENDERING_TYPE_HEADER] = headerVal;
@@ -710,7 +707,7 @@ describe('amp-a4a', () => {
 
     it('should set height/width on iframe matching header value', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       headers['X-CreativeSize'] = '320x50';
       xhrMock.withArgs(TEST_URL, {
         mode: 'cors',
@@ -746,7 +743,7 @@ describe('amp-a4a', () => {
   describe('#onLayoutMeasure', () => {
     it('resumeCallback calls onLayoutMeasure', () => {
       // Force non-FIE
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
@@ -801,7 +798,7 @@ describe('amp-a4a', () => {
     });
     it('resumeCallback w/ measure required no onLayoutMeasure', () => {
       // Force non-FIE
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
@@ -1243,7 +1240,7 @@ describe('amp-a4a', () => {
       it('should process safeframe version header properly', () => {
         headers[SAFEFRAME_VERSION_HEADER] = '1-2-3';
         headers[RENDERING_TYPE_HEADER] = 'safeframe';
-        delete headers[SIGNATURE_HEADER];
+        delete headers[AMP_SIGNATURE_HEADER];
         xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
         return createIframePromise().then(fixture => {
           setupForAdTesting(fixture);
@@ -1322,7 +1319,7 @@ describe('amp-a4a', () => {
     it('should ignore invalid safeframe version header', () => {
       headers[SAFEFRAME_VERSION_HEADER] = 'some-bad-item';
       headers[RENDERING_TYPE_HEADER] = 'safeframe';
-      delete headers[SIGNATURE_HEADER];
+      delete headers[AMP_SIGNATURE_HEADER];
       xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
@@ -2217,7 +2214,7 @@ describe('amp-a4a', () => {
           return false;
         },
         get: h => {
-          throw new Error('Tried to get ' + h);
+          return undefined;
         },
       };
       return expect(AmpA4A.prototype.extractCreativeAndSignature(

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -15,13 +15,6 @@
  */
 
 import {AmpA4A} from '../amp-a4a';
-import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-
-/** @type {string} @private */
-export const SIGNATURE_HEADER = 'X-TestSignatureHeader';
-
-/** @type {string} @private */
-export const SIZE_HEADER = 'X-CreativeSize';
 
 /** @type {string} @private */
 export const TEST_URL = 'http://iframe.localhost:' + location.port +
@@ -34,18 +27,6 @@ export class MockA4AImpl extends AmpA4A {
 
   updatePriority() {
     // Do nothing.
-  }
-
-  extractCreativeAndSignature(responseArrayBuffer, responseHeaders) {
-    const sizeArr = responseHeaders.has(SIZE_HEADER) ?
-        responseHeaders.get(SIZE_HEADER).split('x') : null;
-    const size = sizeArr ? {width: sizeArr[0], height: sizeArr[1]} : null;
-    return Promise.resolve({
-      creative: responseArrayBuffer,
-      signature: responseHeaders.has(SIGNATURE_HEADER) ?
-          base64UrlDecodeToBytes(responseHeaders.get(SIGNATURE_HEADER)) : null,
-      size,
-    });
   }
 
   getFallback() {

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -28,7 +28,6 @@ import {
 import {isExperimentOn} from '../../../src/experiments';
 import {
   additionalDimensions,
-  extractGoogleAdCreativeAndSignature,
   googleAdUrl,
   isGoogleAdsA4AValidEnvironment,
   isReportingEnabled,
@@ -204,7 +203,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   }
 
   /** @override */
-  extractCreativeAndSignature(responseText, responseHeaders) {
+  extractSize(responseHeaders) {
     setGoogleLifecycleVarsFromHeaders(responseHeaders, this.lifecycleReporter_);
     this.ampAnalyticsConfig_ = extractAmpAnalyticsConfig(this, responseHeaders);
     this.qqid_ = responseHeaders.get(QQID_HEADER);
@@ -212,11 +211,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       // Load amp-analytics extensions
       this.extensions_./*OK*/loadExtension('amp-analytics');
     }
-    return extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
-  }
-
-  /** @override */
-  extractSize(unusedResponseHeaders) {
     return this.size_;
   }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -27,8 +27,6 @@ import {AmpAdUIHandler} from '../../../amp-ad/0.1/amp-ad-ui'; // eslint-disable-
 import {
   AmpAdXOriginIframeHandler,    // eslint-disable-line no-unused-vars
 } from '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
-import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-import {utf8Encode} from '../../../../src/utils/bytes';
 import {createIframePromise} from '../../../../testing/iframe';
 import {upgradeOrRegisterElement} from '../../../../src/custom-element';
 import {
@@ -310,7 +308,7 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
     });
   });
 
-  describe('#extractCreativeAndSignature', () => {
+  describe('#extractSize', () => {
     let loadExtensionSpy;
 
     beforeEach(() => {
@@ -330,70 +328,35 @@ describes.sandboxed('amp-ad-network-adsense-impl', {}, () => {
       });
     });
 
-    it('without signature', () => {
-      return utf8Encode('some creative').then(creative => {
-        return impl.extractCreativeAndSignature(
-            creative,
-            {
-              get() { return undefined; },
-              has() { return false; },
-            }).then(adResponse => {
-              expect(adResponse).to.deep.equal(
-                  {creative, signature: null});
-              expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
-                  .called;
-            });
+    it('without analytics', () => {
+      impl.extractSize({
+        get() {
+          return undefined;
+        },
+        has() {
+          return false;
+        },
       });
-    });
-    it('with signature', () => {
-      return utf8Encode('some creative').then(creative => {
-        return impl.extractCreativeAndSignature(
-            creative,
-            {
-              get(name) {
-                return name == 'X-AmpAdSignature' ? 'AQAB' : undefined;
-              },
-              has(name) {
-                return name === 'X-AmpAdSignature';
-              },
-            }).then(adResponse => {
-              expect(adResponse).to.deep.equal(
-                  {creative, signature: base64UrlDecodeToBytes('AQAB')});
-              expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be
-                  .called;
-            });
-      });
+      expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be.called;
     });
     it('with analytics', () => {
-      return utf8Encode('some creative').then(creative => {
-        const url = ['https://foo.com?a=b', 'https://blah.com?lsk=sdk&sld=vj'];
-        return impl.extractCreativeAndSignature(
-            creative,
-            {
-              get(name) {
-                switch (name) {
-                  case 'X-AmpAnalytics':
-                    return JSON.stringify({url});
-                  case 'X-AmpAdSignature':
-                    return 'AQAB';
-                  default:
-                    return undefined;
-                }
-              },
-              has(name) {
-                return !!this.get(name);
-              },
-            }).then(adResponse => {
-              expect(adResponse).to.deep.equal(
-                  {
-                    creative,
-                    signature: base64UrlDecodeToBytes('AQAB'),
-                  });
-              expect(loadExtensionSpy.withArgs('amp-analytics')).to.be.called;
-            // exact value of ampAnalyticsConfig_ covered in
-            // ads/google/test/test-utils.js
-            });
+      const url = ['https://foo.com?a=b', 'https://blah.com?lsk=sdk&sld=vj'];
+      impl.extractSize({
+        get(name) {
+          switch (name) {
+            case 'X-AmpAnalytics':
+              return JSON.stringify({url});
+            default:
+              return undefined;
+          }
+        },
+        has(name) {
+          return !!this.get(name);
+        },
       });
+      expect(loadExtensionSpy.withArgs('amp-analytics')).to.be.called;
+      // exact value of ampAnalyticsConfig_ covered in
+      // ads/google/test/test-utils.js
     });
   });
 

--- a/extensions/amp-ad-network-cloudflare-impl/0.1/amp-ad-network-cloudflare-impl.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/amp-ad-network-cloudflare-impl.js
@@ -15,19 +15,9 @@
  */
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
-import {base64UrlDecodeToBytes} from '../../../src/utils/base64';
-import {dev} from '../../../src/log';
 import {startsWith} from '../../../src/string';
 import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
 import {NETWORKS} from './vendors';
-
-/**
- * Header that will contain Cloudflare generated signature
- *
- * @type {string}
- * @private
- */
-const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
 
 /**
  * This is a minimalistic AmpA4A implementation that primarily gets an Ad
@@ -122,29 +112,6 @@ export class AmpAdNetworkCloudflareImpl extends AmpA4A {
     }
 
     return url;
-  }
-
-  /**
-   * Extract creative and signature from a Cloudflare signed response.
-   *
-   * Note: Invalid A4A content will NOT have a signature, which will automatically
-   *   cause the A4A processing to render it within a cross domain frame.
-   *
-   * @override
-   */
-  extractCreativeAndSignature(responseText, responseHeaders) {
-    let signature = null;
-    try {
-      if (responseHeaders.has(AMP_SIGNATURE_HEADER)) {
-        signature =
-          base64UrlDecodeToBytes(dev().assertString(
-              responseHeaders.get(AMP_SIGNATURE_HEADER)));
-      }
-    } finally {
-      return Promise.resolve(/** @type {!../../../extensions/amp-a4a/0.1/amp-a4a.AdResponseDef} */
-        ({creative: responseText, signature})
-      );
-    }
   }
 }
 

--- a/extensions/amp-ad-network-cloudflare-impl/0.1/test/test-amp-ad-network-cloudflare-impl.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/test/test-amp-ad-network-cloudflare-impl.js
@@ -18,8 +18,6 @@ import {AmpAdNetworkCloudflareImpl} from '../amp-ad-network-cloudflare-impl';
 import {
   AmpAdXOriginIframeHandler, // eslint-disable-line no-unused-vars
 } from '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
-import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-import {utf8Encode} from '../../../../src/utils/bytes';
 import * as sinon from 'sinon';
 import {cloudflareIsA4AEnabled} from '../cloudflare-a4a-config';
 import {createElementWithAttributes} from '../../../../src/dom';
@@ -156,37 +154,6 @@ describe('amp-ad-network-cloudflare-impl', () => {
         height: '0',
         key: 'value',
         width: '0',
-      });
-    });
-  });
-
-  describe('#extractCreativeAndSignature', () => {
-    it('without signature', () => {
-      return utf8Encode('some creative').then(creative => {
-        return expect(cloudflareImpl.extractCreativeAndSignature(
-            creative,
-            {
-              get() { return undefined; },
-              has() { return false; },
-            })).to.eventually.deep.equal(
-            {creative, signature: null}
-          );
-      });
-    });
-    it('with signature', () => {
-      return utf8Encode('some creative').then(creative => {
-        return expect(cloudflareImpl.extractCreativeAndSignature(
-            creative,
-            {
-              get(name) {
-                return name == 'X-AmpAdSignature' ? 'AQAB' : undefined;
-              },
-              has(name) {
-                return name === 'X-AmpAdSignature';
-              },
-            })).to.eventually.deep.equal(
-            {creative, signature: base64UrlDecodeToBytes('AQAB')}
-          );
       });
     });
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -35,7 +35,6 @@ import {
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {
-  extractGoogleAdCreativeAndSignature,
   googleAdUrl,
   truncAndTimeUrl,
   googleBlockParameters,
@@ -348,7 +347,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  extractCreativeAndSignature(responseText, responseHeaders) {
+  extractSize(responseHeaders) {
     setGoogleLifecycleVarsFromHeaders(responseHeaders, this.lifecycleReporter_);
     this.ampAnalyticsConfig_ = extractAmpAnalyticsConfig(this, responseHeaders);
     this.qqid_ = responseHeaders.get(QQID_HEADER);
@@ -356,11 +355,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       // Load amp-analytics extensions
       this.extensions_./*OK*/loadExtension('amp-analytics');
     }
-    return extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
-  }
-
-  /** @override */
-  extractSize(responseHeaders) {
     // If the server returned a size, use that, otherwise use the size that we
     // sent in the ad request.
     let size = super.extractSize(responseHeaders);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -156,7 +156,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
       });
     });
 
-    it('without analytics', () => {
+    it('should not load amp-analytics without an analytics header', () => {
       expect(impl.extractSize({
         get() {
           return undefined;
@@ -167,7 +167,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
       })).to.deep.equal(size);
       expect(loadExtensionSpy.withArgs('amp-analytics')).to.not.be.called;
     });
-    it('with analytics', () => {
+    it('should load amp-analytics with an analytics header', () => {
       const url = ['https://foo.com?a=b', 'https://blah.com?lsk=sdk&sld=vj'];
       expect(impl.extractSize({
         get(name) {

--- a/extensions/amp-ad-network-gmossp-impl/0.1/amp-ad-network-gmossp-impl.js
+++ b/extensions/amp-ad-network-gmossp-impl/0.1/amp-ad-network-gmossp-impl.js
@@ -15,17 +15,7 @@
  */
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
-import {base64UrlDecodeToBytes} from '../../../src/utils/base64';
-import {dev} from '../../../src/log';
 import {startsWith} from '../../../src/string';
-
-/**
- * Header that will contain Cloudflare generated signature
- *
- * @type {string}
- * @private
- */
-const AMP_SIGNATURE_HEADER_ = 'X-AmpAdSignature';
 
 /**
  * GMOSSP base URL
@@ -62,26 +52,6 @@ export class AmpAdNetworkGmosspImpl extends AmpA4A {
     return this.element.getAttribute('src');
   }
 
-  /**
-   * Extract creative and signature from a GMOSSP signed response.
-   *
-   * @override
-   */
-  extractCreativeAndSignature(responseText, responseHeaders) {
-    let signature = null;
-    try {
-      if (responseHeaders.has(AMP_SIGNATURE_HEADER_)) {
-        signature =
-          base64UrlDecodeToBytes(dev().assertString(
-              responseHeaders.get(AMP_SIGNATURE_HEADER_)));
-      }
-    } finally {
-      return Promise.resolve(/** @type
-        {!../../../extensions/amp-a4a/0.1/amp-a4a.AdResponseDef} */
-        ({creative: responseText, signature})
-      );
-    }
-  }
 }
 
 AMP.registerElement('amp-ad-network-gmossp-impl',

--- a/extensions/amp-ad-network-gmossp-impl/0.1/test/test-amp-ad-network-gmossp-impl.js
+++ b/extensions/amp-ad-network-gmossp-impl/0.1/test/test-amp-ad-network-gmossp-impl.js
@@ -21,8 +21,6 @@ import {
 import {
   AmpAdXOriginIframeHandler, // eslint-disable-line no-unused-vars
 } from '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
-import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-import {utf8Encode} from '../../../../src/utils/bytes';
 import * as sinon from 'sinon';
 import {gmosspIsA4AEnabled} from '../gmossp-a4a-config';
 import {createElementWithAttributes} from '../../../../src/dom';
@@ -106,37 +104,6 @@ document.createElement('amp-ad-network-gmossp-impl');
     it('should be valid', () => {
       const base = 'https://sp.gmossp-sp.jp/ads/ssp.ad?';
       expect(gmosspImpl.getAdUrl().substring(0, base.length)).to.equal(base);
-    });
-  });
-
-  describe('#extractCreativeAndSignature', () => {
-    it('without signature', () => {
-      return utf8Encode('some creative').then(creative => {
-        return expect(gmosspImpl.extractCreativeAndSignature(
-            creative,
-            {
-              get: function() { return undefined; },
-              has() { return false; },
-            })).to.eventually.deep.equal(
-            {creative, signature: null}
-          );
-      });
-    });
-    it('with signature', () => {
-      return utf8Encode('some creative').then(creative => {
-        return expect(gmosspImpl.extractCreativeAndSignature(
-            creative,
-            {
-              get(name) {
-                return name == 'X-AmpAdSignature' ? 'AQAB' : undefined;
-              },
-              has(name) {
-                return name === 'X-AmpAdSignature';
-              },
-            })).to.eventually.deep.equal(
-            {creative, signature: base64UrlDecodeToBytes('AQAB')}
-          );
-      });
     });
   });
 });

--- a/extensions/amp-ad-network-triplelift-impl/0.1/amp-ad-network-triplelift-impl.js
+++ b/extensions/amp-ad-network-triplelift-impl/0.1/amp-ad-network-triplelift-impl.js
@@ -15,16 +15,6 @@
  */
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
-import {base64UrlDecodeToBytes} from '../../../src/utils/base64';
-import {dev} from '../../../src/log';
-
-/**
- * Header that will contain Cloudflare generated signature
- *
- * @type {string}
- * @private
- */
-const AMP_SIGNATURE_HEADER_ = 'X-AmpAdSignature';
 
 /**
  * TripleLift base URL
@@ -64,30 +54,6 @@ export class AmpAdNetworkTripleliftImpl extends AmpA4A {
   getAdUrl() {
     return this.element.getAttribute('src').replace(TRIPLELIFT_BASE_URL_,
         TRIPLELIFT_BASE_A4A_URL_);
-  }
-
-  /**
-   * Extract creative and signature from a Cloudflare signed response.
-   *
-   * Note: Invalid A4A content will NOT have a signature, which will
-   * automatically cause the A4A processing to fall through to the 3p ad flow.
-   *
-   * @override
-   */
-  extractCreativeAndSignature(responseText, responseHeaders) {
-    let signature = null;
-    try {
-      if (responseHeaders.has(AMP_SIGNATURE_HEADER_)) {
-        signature =
-          base64UrlDecodeToBytes(dev().assertString(
-              responseHeaders.get(AMP_SIGNATURE_HEADER_)));
-      }
-    } finally {
-      return Promise.resolve(/** @type
-        {!../../../extensions/amp-a4a/0.1/amp-a4a.AdResponseDef} */
-        ({creative: responseText, signature})
-      );
-    }
   }
 }
 

--- a/extensions/amp-ad-network-triplelift-impl/0.1/test/test-amp-ad-network-triplelift-impl.js
+++ b/extensions/amp-ad-network-triplelift-impl/0.1/test/test-amp-ad-network-triplelift-impl.js
@@ -21,8 +21,6 @@ import {
 import {
   AmpAdXOriginIframeHandler, // eslint-disable-line no-unused-vars
 } from '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
-import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-import {utf8Encode} from '../../../../src/utils/bytes';
 import * as sinon from 'sinon';
 import {tripleliftIsA4AEnabled} from '../triplelift-a4a-config';
 import {createElementWithAttributes} from '../../../../src/dom';
@@ -106,37 +104,6 @@ document.createElement('amp-ad-network-triplelift-impl');
     it('should be valid', () => {
       expect(tripleliftImpl.getAdUrl()).to.equal(
           'https://amp.3lift.com/_a4a/amp/auction?inv_code=ampforadstest_main_feed');
-    });
-  });
-
-  describe('#extractCreativeAndSignature', () => {
-    it('without signature', () => {
-      return utf8Encode('some creative').then(creative => {
-        return expect(tripleliftImpl.extractCreativeAndSignature(
-            creative,
-            {
-              get() { return undefined; },
-              has() { return false; },
-            })).to.eventually.deep.equal(
-            {creative, signature: null}
-          );
-      });
-    });
-    it('with signature', () => {
-      return utf8Encode('some creative').then(creative => {
-        return expect(tripleliftImpl.extractCreativeAndSignature(
-            creative,
-            {
-              get(name) {
-                return name == 'X-AmpAdSignature' ? 'AQAB' : undefined;
-              },
-              has(name) {
-                return name === 'X-AmpAdSignature';
-              },
-            })).to.eventually.deep.equal(
-            {creative, signature: base64UrlDecodeToBytes('AQAB')}
-          );
-      });
     });
   });
 });


### PR DESCRIPTION
`extractCreativeAndSignature` is now common to all impls except `fake-impl`. Network-specific behavior is now in `extractSize`. This will facilitate having two different signature schemes.

One of the PRs that #9040 is being split into. Related to #7618. Follow-up to #10127.