### PR TITLE
Implements viewport.onResize()

### DIFF
--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -135,6 +135,9 @@ export class Viewport {
     /** @private @const {!Observable} */
     this.scrollObservable_ = new Observable();
 
+    /** @private @const {!Observable} */
+    this.resizeObservable_ = new Observable();
+
     /** @private {?Element|undefined} */
     this.viewportMeta_ = undefined;
 
@@ -448,6 +451,16 @@ export class Viewport {
   onScroll(handler) {
     return this.scrollObservable_.add(handler);
   }
+
+  /**
+   * Registers the handler for Resize events.
+   * @param {!function()} handler
+   * @return {!UnlistenDef}
+   */
+  onResize(handler) {
+    return this.resizeObservable_.add(handler);
+  }
+
 
   /**
    * Instruct the viewport to enter lightbox mode.
@@ -878,6 +891,7 @@ export class Viewport {
     const newSize = this.getSize();
     this.fixedLayer_.update().then(() => {
       this.changed_(!oldSize || oldSize.width != newSize.width, 0);
+      this.resizeObservable_.fire();
     });
   }
 }

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -468,6 +468,26 @@ describes.fakeWin('Viewport', {}, env => {
     });
   });
 
+  it('should dispatch onResize on width resize', () => {
+    let resizeEvent = null;
+    viewport.onResize(event => {
+      resizeEvent = event;
+    });
+    viewportSize.width = 112;
+    viewport.resize_();
+    expect(resizeEvent).to.not.equal(null);
+  });
+
+  it('should dispatch onResize on height resize', () => {
+    let resizeEvent = null;
+    viewport.onResize(event => {
+      resizeEvent = event;
+    });
+    viewportSize.height = 223;
+    viewport.resize_();
+    expect(resizeEvent).to.not.equal(null);
+  });
+
   it('should not do anything if padding is not changed', () => {
     const bindingMock = sandbox.mock(binding);
     viewerViewportHandler({paddingTop: 19});


### PR DESCRIPTION
This implements the `onResize()` callback in the viewport implementation (for some reason, most of the implementation is already existent, however the method itself wasn't implemented).
### Changes
- Adds a resizeObservable that fires `onResize`
- Added unit tests