### PR TITLE
Add embedded demos of amp-list to doc

### DIFF
--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -34,7 +34,7 @@ using a supplied template.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-list/">Annotated code example for amp-list</a></td>
+    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-list/">amp-list example</a>.</td>
   </tr>
 </table>
 
@@ -53,35 +53,44 @@ You can specify a template in one of two ways:
   
 For more details on templates, see [AMP HTML Templates](../../spec/amp-html-templates.md).
 
-In the following example, we retrieve JSON data that contains image URLs and titles, and render the content in a nested [amp-mustache template](https://www.ampproject.org/docs/reference/components/amp-mustache).
+*Example: Displaying a dynamic list*
 
-```html
-<amp-list src="https://data.com/images.json"
-    width="300" height="200" layout="responsive">
-  <template type="amp-mustache">
-    <div>
-      <amp-img src="{{imageUrl}}" width="50" height="50"></amp-img>
-      {{title}}
-    </div>
-  </template>
-</amp-list>
-```
+In the following example, we retrieve JSON data that contains URLs and titles, and render the content in a nested [amp-mustache template](https://www.ampproject.org/docs/reference/components/amp-mustache).
 
-JSON data:
+<!--embedded example - displays in ampproject.org -->
+<div>
+<amp-iframe height="259"
+            layout="fixed-height"
+            sandbox="allow-scripts allow-forms allow-same-origin"
+            resizable
+            src="https://ampproject-b5f4c.firebaseapp.com/examples/amplist.basic.embed.html">
+  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
+  <div placeholder></div>
+</amp-iframe>
+</div>
+
+Here is the JSON file that we used:
 
 ```json
 {
-  "items": [
-    {
-      "title": "Image 01",
-      "imageUrl": "https://example.com/images/flowers.jpg"
-    },
-
-    {
-      "title": "Image 02",
-      "imageUrl": "https://example.com/images/sunset.jpg"
-    }
-  ]
+ "items": [
+   {
+     "title": "AMP YouTube Channel",
+     "url": "https://www.youtube.com/channel/UCXPBsjgKKG2HqsKBhWA4uQw"
+   },
+   {
+     "title": "AMPproject.org",
+     "url": "https://www.ampproject.org/"
+   },
+   {
+     "title": "AMP By Example",
+     "url": "https://ampbyexample.com/"
+   },
+   {
+     "title": "AMP Start",
+     "url": "https://ampstart.com/"
+   }
+ ]
 }
 ```
 
@@ -103,31 +112,36 @@ elements rendered via the template.
 
 Optionally, the `amp-list` element can contain an element with an `overflow` attribute. This element is shown if the AMP Runtime cannot resize the `amp-list` element as requested.
 
+*Example: Displaying an overflow when the list needs more space*
+
+In the following example, we display a list of images and titles. Because the amp-list content requires more space than available, the AMP Runtime displays the overflow element.
+
+<!--embedded example - displays in ampproject.org -->
+<div>
+<amp-iframe height="213"
+            layout="fixed-height"
+            sandbox="allow-scripts allow-forms allow-same-origin"
+            resizable
+            src="https://ampproject-b5f4c.firebaseapp.com/examples/amplist.overflow.embed.html?active-tab=preview&preview-height=213">
+  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
+  <div placeholder></div>
+</amp-iframe>
+</div>
+
+Here's the CSS for the `overflow`:
+
 ```css
 .list-overflow[overflow] {
   position: absolute;
   bottom: 0;
+  left: 0;
+  right: 0;
 }
-```
-
-```html
-<amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
-    width=300 height=200 layout=responsive>
-  <template type="amp-mustache">
-    <div>
-      <amp-img src="{{imageUrl}}" width="50" height="50"></amp-img>
-      {{title}}
-    </div>
-  </template>
-  <div overflow role=button aria-label="Show more" class="list-overflow">
-    Show more
-  </div>
-</amp-list>
 ```
 
 ## Attributes
 
-**src** (required)
+##### src (required)
 
 The URL of the remote endpoint that returns the JSON that will be rendered
 within this `amp-list`. This must be a CORS HTTP service. The URL's protocol must be HTTPS.
@@ -136,7 +150,7 @@ within this `amp-list`. This must be a CORS HTTP service. The URL's protocol mus
 Your endpoint must implement the requirements specified in the [CORS Requests in AMP](../../spec/amp-cors-requests.md) spec.
 {% endcall %}
 
-**credentials** (optional)
+##### credentials (optional)
 
 Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
 
@@ -145,7 +159,18 @@ Defines a `credentials` option as specified by the [Fetch API](https://fetch.spe
 
 To send credentials, pass the value of `include`. If this value is set, the response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
 
-**items** (optional)
+Here's an example that specifies including credentials to display personalized content in a list:
+
+```html
+<amp-list credentials="include"
+    src="<%host%>/json/product.json?clientId=CLIENT_ID(myCookieId)">
+  <template type="amp-mustache">
+    Your personal offer: ${{price}}
+  </template>
+</amp-list>
+```
+
+##### items (optional)
 
 Defines the expression to locate the array to be rendered within the response. This is a dot-notated expression that navigates via fields of the JSON response.
 
@@ -161,7 +186,7 @@ When `items="items"` is specified (which, is the default) the response must be a
 }
 ```
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 


### PR DESCRIPTION
Improved the documentation by adding embedded demos for amp-list.  Demos will display as source/preview tabs in ampproject.org.