### PR TITLE
Added fallback support to `amp-twitter`

### DIFF
--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -76,6 +76,8 @@ export function twitter(global, data) {
         // Not a deleted tweet
         twitterWidgetSandbox = el;
         resize(twitterWidgetSandbox);
+      } else {
+        global.context.noContentAvailable();
       }
     });
   });

--- a/examples/twitter.amp.html
+++ b/examples/twitter.amp.html
@@ -48,11 +48,31 @@
 
   <h2>Intentionally non-existing-tweet</h2>
   <amp-twitter width=390 height=330
-      layout="responsive"
+      layout="fixed"
       data-tweetid="1111111111111641653602164060160"
       data-cards="hidden">
       <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">A new approach to web performance.<br><br>Today we are starting the AMP Project to make mobile web content fast again.<a href="https://t.co/b091YOzo5s">https://t.co/b091YOzo5s</a></p>&mdash; Malte Ubl (@cramforce) <a href="https://twitter.com/cramforce/status/651762967147483136">October 7, 2015</a></blockquote>
   </amp-twitter>
 
+  <h2>Deleted tweet</h2>
+
+  <amp-twitter width=390 height=330
+      layout="fixed"
+      data-tweetid="882818033403789316"
+      data-cards="hidden">
+      <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">AMP test</p>&mdash; Gharbi Wassim (@wassgha) <a href="https://twitter.com/wassgha/status/882818033403789316">July 6, 2017</a></blockquote>
+  </amp-twitter>
+
+  <h2>Deleted tweet (with fallback)</h2>
+
+  <amp-twitter width=390 height=330
+      layout="fixed"
+      data-tweetid="882818033403789316"
+      data-cards="hidden">
+      <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">AMP test</p>&mdash; Gharbi Wassim (@wassgha) <a href="https://twitter.com/wassgha/status/882818033403789316">July 6, 2017</a></blockquote>
+      <div fallback>
+        An error occurred while retrieving the tweet. It might have been deleted.
+      </div>
+  </amp-twitter>
 </body>
 </html>

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -54,7 +54,7 @@ class AmpTwitter extends AMP.BaseElement {
 
   /** @override */
   firstLayoutCompleted() {
-    // Do not hide placeholder
+    // Do not hide the placeholder.
   }
 
   /** @override */
@@ -63,9 +63,16 @@ class AmpTwitter extends AMP.BaseElement {
     this.applyFillContent(iframe);
     listenFor(iframe, 'embed-size', data => {
       // We only get the message if and when there is a tweet to display,
-      // so hide the placeholder.
+      // so hide the placeholder
       this.togglePlaceholder(false);
       this./*OK*/changeHeight(data['height']);
+    }, /* opt_is3P */true);
+    listenFor(iframe, 'no-content', () => {
+      if (this.getFallback()) {
+        this.togglePlaceholder(false);
+        this.toggleFallback(true);
+      }
+      // else keep placeholder displayed since there's no fallback
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;


### PR DESCRIPTION
This adds the support for a `fallback` element inside `amp-twitter` that only appears when a tweet can not be loaded or was deleted.

### Changes

- Twitter iframe now emits a `no-content` `postMessage` when a tweet can't be loaded
- `amp-twitter` listens to `no-content` and toggles the fallback accordingly
- `amp-twitter` no longer shows the `placeholder` when a tweet can't be loaded (now as soon as the tweet finished retrieving, the placeholder is hidden regardless of whether the tweet was found or not)

Closes #9355 , Related-to [https://stackoverflow.com/questions/43975240/amp-twitter-fallback-when-tweet-deleted](https://stackoverflow.com/questions/43975240/amp-twitter-fallback-when-tweet-deleted)