### PR TITLE
Remove amp-bind from experiments.js

### DIFF
--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -204,13 +204,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8236',
   },
   {
-    id: 'amp-bind',
-    name: 'AMP extension for dynamic content',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7156',
-    spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
-        'amp-bind/amp-bind.md',
-  },
-  {
     id: 'web-worker',
     name: 'Web worker for background processing',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7156',


### PR DESCRIPTION
Fixes #7156. In two parts to avoid presubmit error.

/to @jridgewell 