### PR TITLE
Fix carousel not inline block bug in ie 11

### DIFF
--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -61,7 +61,8 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
     this.cells_.forEach(cell => {
       this.setAsOwner(cell);
-      cell.classList.add('amp-carousel-slide', 'amp-scrollable-carousel-slide');
+      cell.classList.add('amp-carousel-slide');
+      cell.classList.add('amp-scrollable-carousel-slide');
       this.container_.appendChild(cell);
     });
 


### PR DESCRIPTION
Fix https://github.com/ampproject/amphtml/issues/10206
IE does not support `classList.add` with multiple class names, so adding the class names separately solved this.