### PR TITLE
Relayout all after connecting element

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -152,12 +152,6 @@ export class Resources {
     /** @private {number} */
     this.relayoutTop_ = -1;
 
-    /**
-     * Any resources after this index will be remeasured.
-     * @private {number}
-     **/
-    this.relayoutIndex_ = Infinity;
-
     /** @private {time} */
     this.lastScrollTime_ = 0;
 
@@ -490,14 +484,14 @@ export class Resources {
     if (resource &&
         resource.getState() != ResourceState.NOT_BUILT &&
         !element.reconstructWhenReparented()) {
+      resource.requestMeasure();
       dev().fine(TAG_, 'resource reused:', resource.debugid);
     } else {
+      this.relayoutAll_ = true;
       // Create and add a new resource.
       resource = new Resource((++this.resourceIdCounter_), element, this);
       dev().fine(TAG_, 'resource added:', resource.debugid);
     }
-    this.relayoutIndex_ = Math.min(this.relayoutIndex_, this.resources_.length);
-    this.schedulePass(1000);
     this.resources_.push(resource);
   }
 
@@ -1040,7 +1034,6 @@ export class Resources {
     dev().fine(TAG_,
         'PASS: visible=', this.visible_,
         ', relayoutAll=', this.relayoutAll_,
-        ', relayoutIndex=', this.relayoutIndex_,
         ', relayoutTop=', this.relayoutTop_,
         ', viewportSize=', viewportSize.width, viewportSize.height,
         ', prerenderSize=', this.prerenderSize_);
@@ -1329,10 +1322,8 @@ export class Resources {
     // Ensure all resources layout phase complete; when relayoutAll is requested
     // force re-layout.
     const relayoutAll = this.relayoutAll_;
-    const relayoutIndex = this.relayoutIndex_;
-    const relayoutTop = this.relayoutTop_;
     this.relayoutAll_ = false;
-    this.relayoutIndex_ = Infinity;
+    const relayoutTop = this.relayoutTop_;
     this.relayoutTop_ = -1;
 
     // Phase 1: Build and relayout as needed. All mutations happen here.
@@ -1359,7 +1350,7 @@ export class Resources {
     // there's no way to optimize this. All reads happen here.
     let toUnload;
     if (relayoutCount > 0 || remeasureCount > 0 ||
-        relayoutAll || relayoutIndex < Infinity || relayoutTop != -1) {
+            relayoutAll || relayoutTop != -1) {
       for (let i = 0; i < this.resources_.length; i++) {
         const r = this.resources_[i];
         if (r.hasOwner() && !r.isMeasureRequested()) {
@@ -1367,11 +1358,10 @@ export class Resources {
           continue;
         }
         if (relayoutAll ||
-            r.getState() == ResourceState.NOT_LAID_OUT ||
-            !r.hasBeenMeasured() ||
-            r.isMeasureRequested() ||
-            i > relayoutIndex ||
-            relayoutTop != -1 && r.getLayoutBox().bottom >= relayoutTop) {
+                r.getState() == ResourceState.NOT_LAID_OUT ||
+                !r.hasBeenMeasured() ||
+                r.isMeasureRequested() ||
+                relayoutTop != -1 && r.getLayoutBox().bottom >= relayoutTop) {
           const wasDisplayed = r.isDisplayed();
           r.measure();
           if (wasDisplayed && !r.isDisplayed()) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -165,7 +165,7 @@ export class Resources {
     this.remeasurePass_ = new Pass(this.win, () => {
       this.relayoutAll_ = true;
       this.schedulePass();
-    }, 1000);
+    });
 
     /** @const {!TaskQueue} */
     this.exec_ = new TaskQueue();

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -487,6 +487,7 @@ export class Resources {
       resource.requestMeasure();
       dev().fine(TAG_, 'resource reused:', resource.debugid);
     } else {
+      this.relayoutAll_ = true;
       // Create and add a new resource.
       resource = new Resource((++this.resourceIdCounter_), element, this);
       dev().fine(TAG_, 'resource added:', resource.debugid);

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -566,13 +566,7 @@ describes.fakeWin('Resources startup', {
     win.eventListeners.fire({type: 'load'});
     win.document.eventListeners.fire({type: 'readystatechange'});
     return resources.ampdoc.whenReady().then(() => {
-      expect(resources.relayoutAll_).to.be.true;
-      // Reset to make sure it is set again on load.
-      resources.relayoutAll_ = false;
-      return loadPromise(win).then(() => {
-        // Skip a microtask.
-        return Promise.race([Promise.resolve()]);
-      });
+      return loadPromise(win);
     }).then(() => {
       expect(resources.relayoutAll_).to.be.true;
       expect(schedulePassStub).to.be.calledTwice;

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -20,6 +20,7 @@ import {Resource, ResourceState} from '../../src/service/resource';
 import {VisibilityState} from '../../src/visibility-state';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {loadPromise} from '../../src/event-helper';
+import {resourcesForDoc} from '../../src/services';
 import * as sinon from 'sinon';
 
 /*eslint "google-camelcase/google-camelcase": 0*/
@@ -554,7 +555,7 @@ describes.fakeWin('Resources startup', {
   beforeEach(() => {
     win = env.win;
     clock = sandbox.useFakeTimers();
-    resources = new Resources(new AmpDocSingle(win));
+    resources = resourcesForDoc(win.document.body);
     resources.relayoutAll_ = false;
     schedulePassStub = sandbox.stub(resources, 'schedulePass');
   });
@@ -569,7 +570,7 @@ describes.fakeWin('Resources startup', {
       return loadPromise(win);
     }).then(() => {
       expect(resources.relayoutAll_).to.be.true;
-      expect(schedulePassStub).to.be.calledTwice;
+      expect(schedulePassStub).to.have.been.called;
     });
   });
 
@@ -577,18 +578,28 @@ describes.fakeWin('Resources startup', {
     win.readyState = 'complete';
     win.document.eventListeners.fire({type: 'readystatechange'});
     return resources.ampdoc.whenReady().then(() => {
-      return;
       expect(resources.relayoutAll_).to.be.false;
       expect(schedulePassStub).to.not.be.called;
-      clock.tick(4000);
-      // Skip a microtask.
-      return Promise.resolve().then(() => {
-        return Promise.race([Promise.resolve()]);
-      }).then(() => {
-        expect(resources.relayoutAll_).to.be.true;
-        expect(schedulePassStub).to.be.calledOnce;
-      });
+      clock.tick(3100);
+    }).then(() => {
+      expect(resources.relayoutAll_).to.be.true;
+      expect(schedulePassStub).to.have.been.called;
     });
+  });
+
+  it('should run a full reload when a new element is connected', () => {
+    expect(resources.relayoutAll_).to.be.false;
+    expect(schedulePassStub).to.not.be.called;
+    const el = win.document.createElement('amp-img');
+    el.isBuilt = () => { return true; };
+    el.isUpgraded = () => { return true; };
+    el.isRelayoutNeeded = () => { return true; };
+    el.updateLayoutBox = () => {};
+    win.document.body.appendChild(el);
+    resources.add(el);
+    expect(resources.relayoutAll_).to.be.false;
+    clock.tick(1000);
+    expect(resources.relayoutAll_).to.be.true;
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/9397.

The issue is we never remeasure after a carousel is connected to DOM (which drastically changes the height of the page due to overflow hiding). This forces us to remeasure everything after an element is attached (and we set those styles when they're attached).

We could optionally (naively) optimize by setting a remeasure index. When we add an element, we set the remeasure index to `Math.min(current, newResourceIndex)`, and when we get to measuring we remeasure any resource that's greater than that index. Since document order is largely preserved (except reparenting, which will append the resource to the end and it'll still get remeasured), this could save a lot of remeasures when a far down element gets added.