### PR TITLE
Revert 10293 fix percy assets base url

### DIFF
--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -1,7 +1,7 @@
 {
   "_comment": "HTML file(s) used for visual diff tests. Paths relative to src.",
   "assets_dir": "examples/visual-tests",
-  "assets_base_url": "/examples/visual-tests",
+  "assets_base_url": "/",
   "webpages": [
     {
       "url": "examples/visual-tests/amp-by-example/amp-by-example.html",


### PR DESCRIPTION
Reason for revert: After this PR was landed, the percy snapshots on master appear to have gotten stuck in the "receiving" stage. See https://percy.io/ampproject/amphtml.