### PR TITLE
Measure width/height for SVG elements

### DIFF
--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -1252,7 +1252,8 @@ class CssContextImpl {
    * @private
    */
   getElementSize_(target) {
-    return {width: target./*OK*/offsetWidth, height: target./*OK*/offsetHeight};
+    const b = target./*OK*/getBoundingClientRect();
+    return {width: b.width, height: b.height};
   }
 
   /** @override */


### PR DESCRIPTION
Apparently, `offsetWidth` is undefined, but `getBCR()` works correctly in all browsers.