### PR TITLE
Ensure that children of responsive elements cannot overflow element until build time.

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -153,6 +153,14 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
   position: relative;
 }
 
+/**
+ * Children of responsive elements should not be able to influence the height
+ * which they do when they are statically positioned.
+ */
+.i-amphtml-layout-responsive > :not(i-amphtml-sizer) {
+  position: absolute;
+}
+
 .i-amphtml-layout-fixed-height {
   display: block;
   position: relative;


### PR DESCRIPTION
Fixes #9397

This change is dangerous and might break things, but I think it is the right thing to do.

Children of `layout=responsive` elements should not be allowed to effect the height of the element. This should probably be extended to `fixed-height`.