### PR TITLE
Implement AMP.print() Action for Printing of Page

### DIFF
--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -51,6 +51,11 @@
 </div>
 
 <div class="button-set">
+  <h3>AMP.print()</h3>
+  <button on="tap:AMP.print">Print</button>
+</div>
+
+<div class="button-set">
   <h3>amp-img:</h3>
   <button on="tap:img-on-viewport.show">Show</button>
   <button on="tap:img-on-viewport.hide">Hide</button>

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -368,6 +368,10 @@ actions that apply to the whole document.
     <td>setState</td>
     <td>Updates <code>amp-bind</code>'s state. See <a href="../extensions/amp-bind/amp-bind.md#ampsetstate">details</a>.</td>
   </tr>
+  <tr>
+    <td>print</td>
+    <td>Opens the Print Dialog to print the current page.</td>
+  </tr>
 </table>
 
 ### `amp-access`

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -173,7 +173,9 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
-    self.print();
+    const node = invocation.target;
+    const win = (node.ownerDocument || node).defaultView;
+    win.print();
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -173,7 +173,7 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
-    window.print();
+    self.print();
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -100,6 +100,9 @@ export class StandardActions {
       case 'goBack':
         this.handleAmpGoBack_(invocation);
         return;
+      case 'print':
+        this.handleAmpPrint_(invocation);
+        return;
     }
     throw user().createError('Unknown AMP action ', invocation.method);
   }
@@ -160,6 +163,17 @@ export class StandardActions {
       return;
     }
     historyForDoc(this.ampdoc).goBack();
+  }
+
+  /**
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @private
+   */
+  handleAmpPrint_(invocation) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
+      return;
+    }
+    window.print();
   }
 
   /**

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -236,9 +236,9 @@ describes.sandboxed('StandardActions', {}, () => {
 
     it('should implement print', () => {
       const windowObj = {
-        print: () => {}
-      }
-      windowApi = windowObj;
+        print: () => {},
+      };
+      let windowApi = windowObj;
       const printStub = sandbox.stub(windowApi, 'print');
       const invocation = {method: 'print', satisfiesTrust: () => true};
       standardActions.handleAmpTarget(invocation);

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -233,6 +233,15 @@ describes.sandboxed('StandardActions', {}, () => {
         expect(spy).to.be.calledWith('{foo: 123}');
       });
     });
+
+    it('should implement print', () => {
+      installHistoryServiceForDoc(ampdoc);
+      const history = historyForDoc(ampdoc);
+      const printStub = sandbox.stub(history, 'print');
+      const invocation = {method: 'print', satisfiesTrust: () => true};
+      standardActions.handleAmpTarget(invocation);
+      expect(print).to.be.calledOnce;
+    });
   });
 
   describes.fakeWin('adoptEmbedWindow', {}, env => {

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -235,12 +235,14 @@ describes.sandboxed('StandardActions', {}, () => {
     });
 
     it('should implement print', () => {
-      installHistoryServiceForDoc(ampdoc);
-      const history = historyForDoc(ampdoc);
-      const printStub = sandbox.stub(history, 'print');
+      const windowObj = {
+        print: () => {}
+      }
+      windowApi = windowObj;
+      const printStub = sandbox.stub(windowApi, 'print');
       const invocation = {method: 'print', satisfiesTrust: () => true};
       standardActions.handleAmpTarget(invocation);
-      expect(print).to.be.calledOnce;
+      expect(printStub).to.be.calledOnce;
     });
   });
 

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -238,7 +238,7 @@ describes.sandboxed('StandardActions', {}, () => {
       const windowObj = {
         print: () => {},
       };
-      let windowApi = windowObj;
+      const windowApi = windowObj;
       const printStub = sandbox.stub(windowApi, 'print');
       const invocation = {method: 'print', satisfiesTrust: () => true};
       standardActions.handleAmpTarget(invocation);

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -235,12 +235,19 @@ describes.sandboxed('StandardActions', {}, () => {
     });
 
     it('should implement print', () => {
-      const windowObj = {
+      const windowApi = {
         print: () => {},
       };
-      const windowApi = windowObj;
       const printStub = sandbox.stub(windowApi, 'print');
-      const invocation = {method: 'print', satisfiesTrust: () => true};
+      const invocation = {
+        method: 'print',
+        satisfiesTrust: () => true,
+        target: {
+          ownerDocument: {
+            defaultView: windowApi,
+          },
+        },
+      };
       standardActions.handleAmpTarget(invocation);
       expect(printStub).to.be.calledOnce;
     });


### PR DESCRIPTION
### Description

This PR adds the ability to print the current page by exposing a new `AMP.print()` action in `standard-actions-impl.js`.

### Closes - #10191 

### Screenshot (done in Chrome)
![amp-print](https://user-images.githubusercontent.com/5924733/27977129-57660848-6337-11e7-80e4-c3980a1fea20.gif)
