### PR TITLE
Floating Pause Button on `amp-audio`

### DIFF
--- a/examples/amp-audio.amp.html
+++ b/examples/amp-audio.amp.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+    [fallback] {
+      display: block;
+      /* @alternative */ display: flex;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      justify-content: center;
+      align-items: center;
+      background: rgba(0, 0, 0, 0.5);
+      color: #fff;
+    }
+    .spacer {
+      height: 100vh;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>amp-audio</h1>
+
+  <amp-audio
+      id="myAudio"
+      src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"
+      height="50"
+      width="auto">
+    <div placeholder>
+      This is a placeholder
+    </div>
+    <div fallback>
+      This is a fallback
+    </div>
+  </amp-audio>
+  <h2>Autoplay</h2>
+  <amp-audio
+      id="myAudioAutoplay"
+      src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"
+      width="auto"
+      height="50"
+      autoplay>
+    <div fallback>
+      This is a fallback
+    </div>
+  </amp-audio>
+  <div class="spacer"></div>
+</body>
+</html>

--- a/examples/amp-audio.amp.html
+++ b/examples/amp-audio.amp.html
@@ -55,17 +55,18 @@
       This is a fallback
     </div>
   </amp-audio>
-  <h2>Floating mute button</h2>
+  <h2>Floating Controls</h2>
   <amp-audio
       id="myAudioAutoplay"
       src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"
       width="auto"
       height="50"
-      floating-mute-button>
+      floating-controls>
     <div fallback>
       This is a fallback
     </div>
   </amp-audio>
+  <div class="spacer"></div>
   <div class="spacer"></div>
 </body>
 </html>

--- a/examples/amp-audio.amp.html
+++ b/examples/amp-audio.amp.html
@@ -55,6 +55,17 @@
       This is a fallback
     </div>
   </amp-audio>
+  <h2>Floating mute button</h2>
+  <amp-audio
+      id="myAudioAutoplay"
+      src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"
+      width="auto"
+      height="50"
+      floating-mute-button>
+    <div fallback>
+      This is a fallback
+    </div>
+  </amp-audio>
   <div class="spacer"></div>
 </body>
 </html>

--- a/extensions/amp-audio/0.1/amp-audio.css
+++ b/extensions/amp-audio/0.1/amp-audio.css
@@ -20,7 +20,7 @@ amp-audio {
 /**
  * Floating Mute Button for amp-audio
  */
-i-amphtml-floating-mute-btn {
+.amp-audio-floating-mute-btn {
   display: block;
   position: fixed;
   bottom: 20px;
@@ -33,31 +33,39 @@ i-amphtml-floating-mute-btn {
   height: 48px;
 }
 
-
-i-amphtml-floating-mute-btn.unmute {
-  background-color: rgba(0,0,0,0.75);
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
-  animation: i-amphtml-fmb-pop-out .5s linear 1;
+[dir=rtl] .amp-audio-floating-mute-btn {
+  right: auto;
+  left: 20px;
 }
 
-i-amphtml-floating-mute-btn.unmute.active {
+.amp-audio-floating-mute-btn.sticky-ad-exists{
+  bottom: 100px;
+}
+
+.amp-audio-floating-mute-btn.unmute {
+  background-color: rgba(0,0,0,0.75);
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  animation: amp-audio-fmb-pop-out .5s linear 1;
+}
+
+.amp-audio-floating-mute-btn.unmute.active {
   background-color: rgba(100,100,100,0.75);
 }
 
-i-amphtml-floating-mute-btn.mute {
+.amp-audio-floating-mute-btn.mute {
   background-color: rgba(192, 57, 43, 0.85);
   background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
-  animation: i-amphtml-fmb-pop-in .5s linear 1;
+  animation: amp-audio-fmb-pop-in .5s linear 1;
 }
 
-i-amphtml-floating-mute-btn.mute.active {
+.amp-audio-floating-mute-btn.mute.active {
   background-color: rgba(231, 76, 60, 0.85);
 }
 
-@keyframes i-amphtml-fmb-pop-in {
+@keyframes amp-audio-fmb-pop-in {
   50%  {transform: scale(1.4);}
 }
 
-@keyframes i-amphtml-fmb-pop-out {
+@keyframes amp-audio-fmb-pop-out {
   50%  {transform: scale(1.2);}
 }

--- a/extensions/amp-audio/0.1/amp-audio.css
+++ b/extensions/amp-audio/0.1/amp-audio.css
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software'
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+amp-audio {
+}
+
+/**
+ * Floating Mute Button for amp-audio
+ */
+i-amphtml-floating-mute-btn {
+  display: block;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12), 0 3px 1px -2px rgba(0,0,0,0.2);
+  background-repeat: no-repeat;
+  background-position: center;
+  border-radius: 100%;
+  width: 48px;
+  height: 48px;
+}
+
+
+i-amphtml-floating-mute-btn.unmute {
+  background-color: rgba(0,0,0,0.75);
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  animation: i-amphtml-fmb-pop-out .5s linear 1;
+}
+
+i-amphtml-floating-mute-btn.unmute.active {
+  background-color: rgba(100,100,100,0.75);
+}
+
+i-amphtml-floating-mute-btn.mute {
+  background-color: rgba(192, 57, 43, 0.85);
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  animation: i-amphtml-fmb-pop-in .5s linear 1;
+}
+
+i-amphtml-floating-mute-btn.mute.active {
+  background-color: rgba(231, 76, 60, 0.85);
+}
+
+@keyframes i-amphtml-fmb-pop-in {
+  50%  {transform: scale(1.4);}
+}
+
+@keyframes i-amphtml-fmb-pop-out {
+  50%  {transform: scale(1.2);}
+}

--- a/extensions/amp-audio/0.1/amp-audio.css
+++ b/extensions/amp-audio/0.1/amp-audio.css
@@ -20,7 +20,7 @@ amp-audio {
 /**
  * Floating Pause Button for amp-audio
  */
-.amp-audio-floating-controls {
+amp-audio-floating-controls {
   display: block;
   position: fixed;
   bottom: 20px;
@@ -31,16 +31,16 @@ amp-audio {
   height: 48px;
 }
 
-[dir=rtl] .amp-audio-floating-controls {
+[dir=rtl] amp-audio-floating-controls {
   right: auto;
   left: 20px;
 }
 
-.amp-audio-floating-controls.sticky-ad-exists{
+amp-audio-floating-controls.sticky-ad-exists{
   bottom: 100px;
 }
 
-.amp-audio-floating-controls-inline {
+amp-audio-floating-controls > amp-audio-scroll-btn {
   width: 48px;
   height: 48px;
   left: 0px;
@@ -54,15 +54,15 @@ amp-audio {
   border-right: 1px solid rgba(255, 255, 255, 0.3);
 }
 
-.amp-audio-floating-controls-inline.top {
+amp-audio-floating-controls > amp-audio-scroll-btn.top {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><g id="arrow" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round"><g id="Artboard" stroke="#FFFFFF" stroke-width="5"><path d="M11.7777778,21.1165273 L11.7777778,3.5" id="Line" transform="translate(11.500000, 12.500000) rotate(-360.000000) translate(-11.500000, -12.500000) "></path><path d="M21.0625526,12.0609371 L12.1008403,3.09922482" id="Line-Copy" transform="translate(17.000000, 8.000000) rotate(-360.000000) translate(-17.000000, -8.000000) "></path><path d="M11.0625526,12.0609371 L2.10084034,3.09922482" id="Line-Copy" transform="translate(7.000000, 8.000000) scale(-1, 1) rotate(-360.000000) translate(-7.000000, -8.000000) "></path></g></g></svg>');
 }
 
-.amp-audio-floating-controls-inline.bottom {
+amp-audio-floating-controls > amp-audio-scroll-btn.bottom {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><g id="arrow" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round"><g id="Artboard" stroke="#FFFFFF" stroke-width="5"><path d="M12.7777778,20.1165273 L12.7777778,2.5" id="Line" transform="translate(12.500000, 11.500000) rotate(-180.000000) translate(-12.500000, -11.500000) "></path><path d="M11.0625526,20.0609371 L2.10084034,11.0992248" id="Line-Copy" transform="translate(7.000000, 16.000000) rotate(-180.000000) translate(-7.000000, -16.000000) "></path><path d="M21.0625526,20.0609371 L12.1008403,11.0992248" id="Line-Copy" transform="translate(17.000000, 16.000000) scale(-1, 1) rotate(-180.000000) translate(-17.000000, -16.000000) "></path></g></g></svg>');
 }
 
-.amp-audio-floating-controls-pause {
+amp-audio-floating-controls > amp-audio-pause-btn {
   background-repeat: no-repeat;
   width: 48px;
   height: 48px;
@@ -73,12 +73,12 @@ amp-audio {
   background-position: 10px center;
 }
 
-.amp-audio-floating-controls-pause.play {
+amp-audio-floating-controls > amp-audio-pause-btn.play {
   background-color: rgba(0,0,0,0.75);
   background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }
 
-.amp-audio-floating-controls-pause.pause {
+amp-audio-floating-controls > amp-audio-pause-btn.pause {
   background-color: rgba(192, 57, 43, 0.85);
   background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }

--- a/extensions/amp-audio/0.1/amp-audio.css
+++ b/extensions/amp-audio/0.1/amp-audio.css
@@ -18,54 +18,67 @@ amp-audio {
 }
 
 /**
- * Floating Mute Button for amp-audio
+ * Floating Pause Button for amp-audio
  */
-.amp-audio-floating-mute-btn {
+.amp-audio-floating-controls {
   display: block;
   position: fixed;
   bottom: 20px;
   right: 20px;
   box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12), 0 3px 1px -2px rgba(0,0,0,0.2);
-  background-repeat: no-repeat;
-  background-position: center;
-  border-radius: 100%;
-  width: 48px;
+  border-radius: 48px;
+  width: 96px;
   height: 48px;
 }
 
-[dir=rtl] .amp-audio-floating-mute-btn {
+[dir=rtl] .amp-audio-floating-controls {
   right: auto;
   left: 20px;
 }
 
-.amp-audio-floating-mute-btn.sticky-ad-exists{
+.amp-audio-floating-controls.sticky-ad-exists{
   bottom: 100px;
 }
 
-.amp-audio-floating-mute-btn.unmute {
+.amp-audio-floating-controls-inline {
+  width: 48px;
+  height: 48px;
+  left: 0px;
+  position: absolute;
   background-color: rgba(0,0,0,0.75);
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
-  animation: amp-audio-fmb-pop-out .5s linear 1;
+  background-repeat: no-repeat;
+  background-size: 16px 16px;
+  background-position: 18px center;
+  border-top-left-radius: 48px;
+  border-bottom-left-radius: 48px;
+  border-right: 1px solid rgba(255, 255, 255, 0.3);
 }
 
-.amp-audio-floating-mute-btn.unmute.active {
-  background-color: rgba(100,100,100,0.75);
+.amp-audio-floating-controls-inline.top {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><g id="arrow" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round"><g id="Artboard" stroke="#FFFFFF" stroke-width="5"><path d="M11.7777778,21.1165273 L11.7777778,3.5" id="Line" transform="translate(11.500000, 12.500000) rotate(-360.000000) translate(-11.500000, -12.500000) "></path><path d="M21.0625526,12.0609371 L12.1008403,3.09922482" id="Line-Copy" transform="translate(17.000000, 8.000000) rotate(-360.000000) translate(-17.000000, -8.000000) "></path><path d="M11.0625526,12.0609371 L2.10084034,3.09922482" id="Line-Copy" transform="translate(7.000000, 8.000000) scale(-1, 1) rotate(-360.000000) translate(-7.000000, -8.000000) "></path></g></g></svg>');
 }
 
-.amp-audio-floating-mute-btn.mute {
+.amp-audio-floating-controls-inline.bottom {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><g id="arrow" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round"><g id="Artboard" stroke="#FFFFFF" stroke-width="5"><path d="M12.7777778,20.1165273 L12.7777778,2.5" id="Line" transform="translate(12.500000, 11.500000) rotate(-180.000000) translate(-12.500000, -11.500000) "></path><path d="M11.0625526,20.0609371 L2.10084034,11.0992248" id="Line-Copy" transform="translate(7.000000, 16.000000) rotate(-180.000000) translate(-7.000000, -16.000000) "></path><path d="M21.0625526,20.0609371 L12.1008403,11.0992248" id="Line-Copy" transform="translate(17.000000, 16.000000) scale(-1, 1) rotate(-180.000000) translate(-17.000000, -16.000000) "></path></g></g></svg>');
+}
+
+.amp-audio-floating-controls-pause {
+  background-repeat: no-repeat;
+  width: 48px;
+  height: 48px;
+  border-top-right-radius: 48px;
+  border-bottom-right-radius: 48px;
+  right: 0px;
+  position: absolute;
+  background-position: 10px center;
+}
+
+.amp-audio-floating-controls-pause.play {
+  background-color: rgba(0,0,0,0.75);
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+}
+
+.amp-audio-floating-controls-pause.pause {
   background-color: rgba(192, 57, 43, 0.85);
   background-image: url('data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
-  animation: amp-audio-fmb-pop-in .5s linear 1;
-}
-
-.amp-audio-floating-mute-btn.mute.active {
-  background-color: rgba(231, 76, 60, 0.85);
-}
-
-@keyframes amp-audio-fmb-pop-in {
-  50%  {transform: scale(1.4);}
-}
-
-@keyframes amp-audio-fmb-pop-out {
-  50%  {transform: scale(1.2);}
 }

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -167,22 +167,19 @@ export class AmpAudio extends AMP.BaseElement {
       return;
     }
     const doc = this.element.ownerDocument;
-    const btn = doc.createElement('div');
-    btn.classList.add('amp-audio-floating-controls');
+    const btn = doc.createElement('amp-audio-floating-controls');
     // Pause/Play icon
-    const pauseBtn = doc.createElement('div');
-    pauseBtn.classList.add('amp-audio-floating-controls-pause');
+    const pauseBtn = doc.createElement('amp-audio-pause-btn');
     pauseBtn.classList.toggle('pause', audio.paused);
     pauseBtn.classList.toggle('play', !audio.paused);
     // Scroll to element icon
     // (Different icon based on whether the original element is above or
     // below the viewport)
-    const inlineBtn = doc.createElement('div');
+    const inlineBtn = doc.createElement('amp-audio-scroll-btn');
     const viewportTop = this.getViewport().getScrollTop();
     const isTop = viewportTop > this.element./*OK*/offsetTop;
     inlineBtn.classList.toggle('top', isTop);
     inlineBtn.classList.toggle('bottom', !isTop);
-    inlineBtn.classList.add('amp-audio-floating-controls-inline');
     btn.appendChild(pauseBtn);
     btn.appendChild(inlineBtn);
     this.element.ownerDocument.body.appendChild(btn);

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -25,6 +25,16 @@ import {
   parseFavicon,
   setMediaSession,
 } from '../../../src/mediasession-helper';
+import {isFiniteNumber} from '../../../src/types';
+import {removeElement} from '../../../src/dom.js';
+import {Animation} from '../../../src/animation';
+import * as tr from '../../../src/transition';
+import {
+  TapRecognizer,
+  DoubletapRecognizer,
+} from '../../../src/gesture-recognizers';
+import {Gestures} from '../../../src/gesture';
+import {CSS} from '../../../build/amp-audio-0.1.css';
 
 /**
  * Visible for testing only.
@@ -40,6 +50,15 @@ export class AmpAudio extends AMP.BaseElement {
 
     /** @private {!../../../src/mediasession-helper.MetadataDef} */
     this.metadata_ = EMPTY_METADATA;
+
+    /** @private {?Element} */
+    this.floatingMuteBtn_ = null;
+
+    /** @private {boolean} */
+    this.scrollListenerInstalled_ = false;
+
+    /** @private {?UnlistenDef} */
+    this.volumeChangeUnlistener_ = null;
   }
 
   /** @override */
@@ -98,6 +117,22 @@ export class AmpAudio extends AMP.BaseElement {
     };
 
     listen(this.audio_, 'playing', () => this.audioPlaying_());
+
+    if (!this.scrollListenerInstalled_) {
+      const scrollListener = () => {
+        const change = this.element.getIntersectionChangeEntry();
+        const ratio = change.intersectionRatio;
+        const visible = isFiniteNumber(ratio) && ratio != 0;
+        if (visible) {
+          this.removeFloatingMuteBtn_();
+        } else if (!this.audio_.paused) {
+          this.createFloatingMuteBtn_(this.audio_);
+        }
+      };
+      this.getViewport().onScroll(scrollListener);
+      this.scrollListenerInstalled_ = true;
+    }
+
     return this.loadPromise(audio);
   }
 
@@ -123,7 +158,88 @@ export class AmpAudio extends AMP.BaseElement {
         playHandler,
         pauseHandler
     );
+
+  /** @private */
+  createFloatingMuteBtn_(audio) {
+    if (this.floatingMuteBtn_) {
+      return;
+    }
+    const doc = this.element.ownerDocument;
+    const btn = doc.createElement('i-amphtml-floating-mute-btn');
+    this.element.ownerDocument.body.appendChild(btn);
+
+    // Button pops in
+    const anim = new Animation(btn);
+    anim.add(0, tr.setStyles(dev().assertElement(btn), {
+      'transform': tr.scale(tr.numeric(0, 1.5)),
+    }), 0.5);
+    anim.add(0.5, tr.setStyles(dev().assertElement(btn), {
+      'transform': tr.scale(tr.numeric(1.5, 1)),
+    }), 0.5);
+    anim.start(300);
+
+    const gestures = Gestures.get(btn);
+
+    // Single tap toggles audio mute/unmute
+    gestures.onGesture(TapRecognizer, () => {
+      audio.muted = !audio.muted;
+    });
+
+    // Double-tap scrolls back to the element's position on the page
+    gestures.onGesture(DoubletapRecognizer, () => {
+      this.getViewport().animateScrollIntoView(audio);
+    });
+
+    // Change style when button is clicked (provides feedback since gestures
+    // are a bit slow)
+    listen(dev().assertElement(btn),
+        'touchstart', () => {
+          btn.classList.toggle('active', true);
+        });
+    listen(dev().assertElement(btn),
+        'touchend', () => {
+          setTimeout(() => {
+            btn.classList.toggle('active', false);
+          }, 300);
+        });
+
+
+    // Style the button based on whether the audio is muted or not
+    this.volumeChangeUnlistener_ = listen(dev().assertElement(this.audio_),
+        'volumechange', () => {
+          btn.classList.toggle('mute', audio.muted);
+          btn.classList.toggle('unmute', !audio.muted);
+        });
+
+    btn.classList.toggle('mute', audio.muted);
+    btn.classList.toggle('unmute', !audio.muted);
+
+    this.floatingMuteBtn_ = btn;
+  }
+
+  /** @private */
+  removeFloatingMuteBtn_() {
+    if (!this.floatingMuteBtn_) {
+      return;
+    }
+    const btn = this.floatingMuteBtn_;
+
+    // Button pops out
+    const anim = new Animation(btn);
+    anim.add(0, tr.setStyles(dev().assertElement(btn), {
+      'transform': tr.scale(tr.numeric(1, 1.5)),
+    }), 0.5);
+    anim.add(0.5, tr.setStyles(dev().assertElement(btn), {
+      'transform': tr.scale(tr.numeric(1.5, 0)),
+    }), 0.5);
+    anim.start(300).thenAlways(() => {
+      removeElement(btn);
+    });
+
+    this.volumeChangeUnlistener_();
+
+    this.floatingMuteBtn_ = null;
   }
 }
 
-AMP.registerElement('amp-audio', AmpAudio);
+AMP.registerElement('amp-audio', AmpAudio, CSS);

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -59,6 +59,9 @@ export class AmpAudio extends AMP.BaseElement {
 
     /** @private {?UnlistenDef} */
     this.volumeChangeUnlistener_ = null;
+
+    /** @private {boolean} */
+    this.hasFmb_ = this.element.hasAttribute('floating-mute-button');
   }
 
   /** @override */
@@ -118,7 +121,8 @@ export class AmpAudio extends AMP.BaseElement {
 
     listen(this.audio_, 'playing', () => this.audioPlaying_());
 
-    if (!this.scrollListenerInstalled_) {
+    // Activate the floating mute button
+    if (!this.scrollListenerInstalled_ && this.hasFmb_) {
       const scrollListener = () => {
         const change = this.element.getIntersectionChangeEntry();
         const ratio = change.intersectionRatio;
@@ -165,8 +169,20 @@ export class AmpAudio extends AMP.BaseElement {
       return;
     }
     const doc = this.element.ownerDocument;
-    const btn = doc.createElement('i-amphtml-floating-mute-btn');
+    const btn = doc.createElement('div');
+    btn.classList.add('amp-audio-floating-mute-btn');
     this.element.ownerDocument.body.appendChild(btn);
+
+    // Different positioning based on page direction
+    const pageDir = doc.body.getAttribute('dir')
+                      || doc.documentElement.getAttribute('dir')
+                      || 'ltr';
+
+    btn.classList.toggle('rtl', pageDir != 'ltr');
+
+    // Raise the button if a sticky ad exists
+    const stickyadexists = doc.querySelector('amp-sticky-ad');
+    btn.classList.toggle('sticky-ad-exists', !!stickyadexists);
 
     // Button pops in
     const anim = new Animation(btn);

--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -177,4 +177,25 @@ describe('amp-audio', () => {
       expect(audio.getAttribute('aria-describedby')).to.equal('id3');
     });
   });
+
+  it('should show floating controls when out of view', () => {
+    return attachAndRun({
+      src: 'https://origin.com/audio.mp3',
+      'floating-controls': '',
+    }).then(a => {
+      const floatingControls = a.querySelector('.amp-audio-floating-controls');
+      expect(floatingControls).to.not.exist;
+      const visibilityStub = sandbox.stub(
+          a.implementation_.element,
+          'getIntersectionChangeEntry'
+      );
+      visibilityStub.onFirstCall().returns({
+        'intersectionRatio': 0,
+      });
+      // Trigger scroll event
+      iframe.getViewport().setScrollTop(10);
+      expect(floatingControls).to.exist;
+    });
+  });
+
 });

--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -193,7 +193,7 @@ describe('amp-audio', () => {
         'intersectionRatio': 0,
       });
       // Trigger scroll event
-      iframe.getViewport().setScrollTop(10);
+      iframe.doc.getViewport().setScrollTop(10);
       expect(floatingControls).to.exist;
     });
   });

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -59,6 +59,11 @@ For example:
 </amp-audio>
 ```
 
+The `amp-audio` component allows out-of-view controls through the `floating-controls` attribute. When set, it shows a floating
+pause button as soon as the `amp-audio` element is no longer visible, which creates a better user experience by providing
+minimal controls to the user without having to scroll back to the element.
+
+
 ## Attributes
 
 ##### src
@@ -69,6 +74,13 @@ Required if no `<source>` children are present. Must be HTTPS.
 
 If present, the attribute implies that the audio will start playing as soon as
 it is ready.
+
+##### floating-controls
+
+Optional. Adds a pause/scroll to element button that pops-in when the audio
+player is out of view, allowing the user to control the audio without having to
+scroll back to the element.
+
 
 ##### loop
 

--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -51,7 +51,7 @@ tags: {  # <amp-audio> for AMP (autoplay and fmb attributes allowed)
     value: ""
   }
   attrs: {
-    name: "floating-mute-button"
+    name: "floating-controls"
     value: ""
   }
   attr_lists: "amp-audio-common"

--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -41,13 +41,17 @@ attr_lists: { # amp-audio attributes that are common to both AMP and A4A format.
     blacklisted_value_regex: "__amp_source_origin"
   }
 }
-tags: {  # <amp-audio> for AMP (autoplay attribute allowed)
+tags: {  # <amp-audio> for AMP (autoplay and fmb attributes allowed)
   html_format: AMP
   tag_name: "AMP-AUDIO"
   disallowed_ancestor: "AMP-SIDEBAR"
   requires_extension: "amp-audio"
   attrs: {
     name: "autoplay"
+    value: ""
+  }
+  attrs: {
+    name: "floating-mute-button"
     value: ""
   }
   attr_lists: "amp-audio-common"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,7 +63,7 @@ declareExtension('amp-anim', '0.1', false);
 declareExtension('amp-animation', '0.1', false);
 declareExtension('amp-apester-media', '0.1', true);
 declareExtension('amp-app-banner', '0.1', true);
-declareExtension('amp-audio', '0.1', false);
+declareExtension('amp-audio', '0.1', true);
 declareExtension('amp-auto-ads', '0.1', false);
 declareExtension('amp-bind', '0.1', false);
 declareExtension('amp-brid-player', '0.1', false);


### PR DESCRIPTION
![fmb](https://user-images.githubusercontent.com/591655/28237090-0221c6f0-68ec-11e7-84bb-8ee7e0cdd3e2.jpg)


This is another weekend project of mine and one of multiple requested changes to the behavior of `amp-audio` proposed by John Pallett and @rudygalfi . It implements a floating pause button that pops in when the audio element is no longer in view (could be considered `amp-audio` 's equivalent for docking videos). I added a few visual and user experience changes to the proposed spec.

<p align="center"><img src="https://user-images.githubusercontent.com/591655/28237127-d70d18c4-68ec-11e7-9494-9caee33de7d1.gif" /></p>

### Changes

- Added an example page for `amp-audio`
- Implemented a floating pause button using `IntersectionObserver` to be activated when the `floating-controls` attribute is set
- Added CSS styling to `amp-audio` (used to display icons on the button)
- Added `pop-in` and `pop-out` animations when the button is displayed/hidden
- Implemented button to pause/play audio as well as a button to scroll back to the parent audio element 
- Different positioning based on page direction

### To-do

- Needs testing
- Needs documentation
- When two or more `amp-audio` elements are present the behavior is not tested
- Interaction with sticky ads and dockable videos not tested.
- Implement on soundcloud?

Related-to Great AMP Audio & Video Project