### PR TITLE
Set `event.value` for most <input> elements

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -692,24 +692,24 @@ export class Bind {
         // Once the user interacts with these elements, the JS properties
         // underlying these attributes must be updated for the change to be
         // visible to the user.
-        const updateElementProperty =
+        const updateProperty =
             element.tagName == 'INPUT' && property in element;
         const oldValue = element.getAttribute(property);
 
-        let attributeChanged = false;
+        let mutated = false;
         if (typeof newValue === 'boolean') {
-          if (updateElementProperty && element[property] !== newValue) {
-            // Property value *must* be read before the attribute is changed.
+          if (updateProperty && element[property] !== newValue) {
+            // Property value _must_ be read before the attribute is changed.
             // Before user interaction, attribute updates affect the property.
             element[property] = newValue;
-            attributeChanged = true;
+            mutated = true;
           }
           if (newValue && oldValue !== '') {
             element.setAttribute(property, '');
-            attributeChanged = true;
+            mutated = true;
           } else if (!newValue && oldValue !== null) {
             element.removeAttribute(property);
-            attributeChanged = true;
+            mutated = true;
           }
         } else if (newValue !== oldValue) {
           // TODO(choumx): Perform in worker with URL API.
@@ -727,14 +727,14 @@ export class Bind {
           // Rewriting can fail due to e.g. invalid URL.
           if (rewrittenNewValue !== undefined) {
             element.setAttribute(property, rewrittenNewValue);
-            if (updateElementProperty) {
+            if (updateProperty) {
               element[property] = rewrittenNewValue;
             }
-            attributeChanged = true;
+            mutated = true;
           }
         }
 
-        if (attributeChanged) {
+        if (mutated) {
           return {name: property, value: newValue};
         }
         break;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -281,7 +281,7 @@ export class ActionService {
         break;
     }
     if (Object.keys(detail).length > 0) {
-      event['detail'] = detail;
+      event.detail = detail;
     }
   }
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -257,7 +257,7 @@ export class ActionService {
    * @param {!ActionEventDef} event
    */
   addInputDetails_(event) {
-    const detail = map();
+    const detail = /** @type {!JsonObject} */ (map());
     const target = event.target;
     switch (target.tagName) {
       case 'INPUT':
@@ -265,7 +265,7 @@ export class ActionService {
         // Some <input> elements have special properties for content values.
         // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties
         if (type == 'checkbox' || type == 'radio') {
-          detail['checked'] = !!target.checked;
+          detail['checked'] = target.checked;
         } else if (type == 'range') {
           // TODO(choumx): min/max are also available on date pickers.
           detail['min'] = Number(target.min);

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -995,7 +995,20 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(action.trigger).to.have.been.calledWith(element, 'change', event);
   });
 
-  it('should trigger change event with details for whitelisted inputs', () => {
+  it('should trigger change event for <input type="checkbox"> elements', () => {
+    const handler = window.document.addEventListener.getCall(3).args[1];
+    const element = document.createElement('input');
+    element.setAttribute('type', 'checkbox');
+    element.checked = true;
+    const event = {target: element};
+    handler(event);
+    expect(action.trigger).to.have.been.calledWith(
+        element,
+        'change',
+        sinon.match(object => object.detail.checked));
+  });
+
+  it('should trigger change event for <input type="range"> elements', () => {
     const handler = window.document.addEventListener.getCall(3).args[1];
     const element = document.createElement('input');
     element.setAttribute('type', 'range');
@@ -1007,14 +1020,26 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(action.trigger).to.have.been.calledWith(
         element,
         'change',
-        // Event doesn't seem to play well with sinon matchers
-        sinon.match(object => {
-          const detail = object.detail;
+        sinon.match(e => {
+          const detail = e.detail;
           return detail.min == 0 && detail.max == 10 && detail.value == 5;
         }));
   });
 
-  it('should trigger change event with details for select elements', () => {
+  it('should trigger change event for <input type="search"> elements', () => {
+    const handler = window.document.addEventListener.getCall(3).args[1];
+    const element = document.createElement('input');
+    element.setAttribute('type', 'search');
+    element.value = 'foo';
+    const event = {target: element};
+    handler(event);
+    expect(action.trigger).to.have.been.calledWith(
+        element,
+        'change',
+        sinon.match(e => e.detail.value == 'foo'));
+  });
+
+  it('should trigger change event with details for <select> elements', () => {
     const handler = window.document.addEventListener.getCall(3).args[1];
     const element = document.createElement('select');
     element.innerHTML =


### PR DESCRIPTION
Fixes #10135.

Instead of whitelisting specific input types, generalize by setting `value` for all input elements except `radio` and `checkbox`. 

As a follow-up, we should consider:
- Generalizing `.min` and `.max` for date pickers
- Expose `.valueAsNumber` and `.valueAsDate` instead of proactively casting `.value`

https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties

/to @cvializ