### PR TITLE
Animation: normalize CSS expressions for fuller compatibility with polyfills

### DIFF
--- a/extensions/amp-animation/0.1/css-expr-ast.js
+++ b/extensions/amp-animation/0.1/css-expr-ast.js
@@ -31,7 +31,7 @@ const INFINITY_RE = /^(infinity|infinite)$/i;
  * @return {boolean}
  */
 export function isVarCss(css, normalize) {
-  return VAR_CSS_RE.test(css) || normalize && NORM_CSS_RE.test(css) || false;
+  return VAR_CSS_RE.test(css) || normalize && NORM_CSS_RE.test(css);
 }
 
 

--- a/extensions/amp-animation/0.1/css-expr-ast.js
+++ b/extensions/amp-animation/0.1/css-expr-ast.js
@@ -18,6 +18,7 @@ const FINAL_URL_RE = /^(data|https)\:/i;
 const DEG_TO_RAD = 2 * Math.PI / 360;
 const GRAD_TO_RAD = Math.PI / 200;
 const VAR_CSS_RE = /(calc|var|url|rand|width|height)\(/i;
+const NORM_CSS_RE = /\d(%|em|rem|vw|vh|vmin|vmax|s|deg|grad)/i;
 const INFINITY_RE = /^(infinity|infinite)$/i;
 
 
@@ -26,10 +27,11 @@ const INFINITY_RE = /^(infinity|infinite)$/i;
  * parsing and evaluation is heavy, but used relatively rarely. This method
  * can be used to avoid heavy parse/evaluate tasks.
  * @param {string} css
+ * @param {boolean} normalize
  * @return {boolean}
  */
-export function isVarCss(css) {
-  return VAR_CSS_RE.test(css);
+export function isVarCss(css, normalize) {
+  return VAR_CSS_RE.test(css) || normalize && NORM_CSS_RE.test(css) || false;
 }
 
 
@@ -124,32 +126,35 @@ export class CssNode {
    * for a non-variable nodes (`isConst() == true`). Otherwise, `calc()` method
    * is used to calculate the new value.
    * @param {!CssContext} context
+   * @param {boolean} normalize
    * @return {?CssNode}
    * @final
    */
-  resolve(context) {
-    if (this.isConst()) {
+  resolve(context, normalize) {
+    if (this.isConst(normalize)) {
       return this;
     }
-    return this.calc(context);
+    return this.calc(context, normalize);
   }
 
   /**
    * Whether the CSS node is a constant or includes variable components.
+   * @param {boolean} unusedNormalize
    * @return {boolean}
    * @protected
    */
-  isConst() {
+  isConst(unusedNormalize) {
     return true;
   }
 
   /**
    * Calculates the value of all variable components.
    * @param {!CssContext} unusedContext
+   * @param {boolean} unusedNormalize
    * @return {?CssNode}
    * @protected
    */
-  calc(unusedContext) {
+  calc(unusedContext, unusedNormalize) {
     return this;
   }
 }
@@ -213,15 +218,16 @@ export class CssConcatNode extends CssNode {
   }
 
   /** @override */
-  isConst() {
-    return this.array_.reduce((acc, node) => acc && node.isConst(), true);
+  isConst(normalize) {
+    return this.array_.reduce(
+        (acc, node) => acc && node.isConst(normalize), true);
   }
 
   /** @override */
-  calc(context) {
+  calc(context, normalize) {
     const resolvedArray = [];
     for (let i = 0; i < this.array_.length; i++) {
-      const resolved = this.array_[i].resolve(context);
+      const resolved = this.array_[i].resolve(context, normalize);
       if (resolved) {
         resolvedArray.push(resolved);
       } else {
@@ -298,12 +304,29 @@ export class CssNumericNode extends CssNode {
    */
   createSameUnits(unusedNum) {}
 
+  /** @override */
+  isConst(normalize) {
+    return normalize ? this.isNorm() : true;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isNorm() {
+    return true;
+  }
+
   /**
    * @param {!CssContext} unusedContext
    * @return {!CssNumericNode}
    */
   norm(unusedContext) {
     return this;
+  }
+
+  /** @override */
+  calc(context, normalize) {
+    return normalize ? this.norm(context) : this;
   }
 
   /**
@@ -363,6 +386,19 @@ export class CssPercentNode extends CssNumericNode {
   createSameUnits(num) {
     return new CssPercentNode(num);
   }
+
+  /** @override */
+  isNorm() {
+    return false;
+  }
+
+  /** @override */
+  norm(context) {
+    if (context.getDimension()) {
+      return new CssLengthNode(0, 'px').calcPercent(this.num_, context);
+    }
+    return this;
+  }
 }
 
 
@@ -384,8 +420,13 @@ export class CssLengthNode extends CssNumericNode {
   }
 
   /** @override */
+  isNorm() {
+    return (this.units_ == 'px');
+  }
+
+  /** @override */
   norm(context) {
-    if (this.units_ == 'px') {
+    if (this.isNorm()) {
       return this;
     }
 
@@ -450,8 +491,13 @@ export class CssAngleNode extends CssNumericNode {
   }
 
   /** @override */
+  isNorm() {
+    return (this.units_ == 'rad');
+  }
+
+  /** @override */
   norm() {
-    if (this.units_ == 'rad') {
+    if (this.isNorm()) {
       return this;
     }
     if (this.units_ == 'deg') {
@@ -483,8 +529,13 @@ export class CssTimeNode extends CssNumericNode {
   }
 
   /** @override */
+  isNorm() {
+    return (this.units_ == 'ms');
+  }
+
+  /** @override */
   norm() {
-    if (this.units_ == 'ms') {
+    if (this.isNorm()) {
       return this;
     }
     return new CssTimeNode(this.millis_(), 'ms');
@@ -546,21 +597,22 @@ export class CssFuncNode extends CssNode {
   }
 
   /** @override */
-  isConst() {
-    return this.args_.reduce((acc, node) => acc && node.isConst(), true);
+  isConst(normalize) {
+    return this.args_.reduce(
+        (acc, node) => acc && node.isConst(normalize), true);
   }
 
   /** @override */
-  calc(context) {
+  calc(context, normalize) {
     const resolvedArgs = [];
     for (let i = 0; i < this.args_.length; i++) {
       const node = this.args_[i];
       let resolved;
       if (this.dimensions_ && i < this.dimensions_.length) {
         resolved = context.withDimension(this.dimensions_[i],
-            () => node.resolve(context));
+            () => node.resolve(context, normalize));
       } else {
-        resolved = node.resolve(context);
+        resolved = node.resolve(context, normalize);
       }
       if (resolved) {
         resolvedArgs.push(resolved);
@@ -673,15 +725,15 @@ export class CssRandNode extends CssNode {
   }
 
   /** @override */
-  calc(context) {
+  calc(context, normalize) {
     // No arguments: return a random node between 0 and 1.
     if (this.left_ == null || this.right_ == null) {
       return new CssNumberNode(Math.random());
     }
 
     // Arguments: do a min/max random math.
-    let left = this.left_.resolve(context);
-    let right = this.right_.resolve(context);
+    let left = this.left_.resolve(context, normalize);
+    let right = this.right_.resolve(context, normalize);
     if (left == null || right == null) {
       return null;
     }
@@ -737,13 +789,13 @@ export class CssVarNode extends CssNode {
   }
 
   /** @override */
-  calc(context) {
+  calc(context, normalize) {
     const varNode = context.getVar(this.varName_);
     if (varNode) {
-      return varNode.resolve(context);
+      return varNode.resolve(context, normalize);
     }
     if (this.def_) {
-      return this.def_.resolve(context);
+      return this.def_.resolve(context, normalize);
     }
     return null;
   }
@@ -773,8 +825,8 @@ export class CssCalcNode extends CssNode {
   }
 
   /** @override */
-  calc(context) {
-    return this.expr_.resolve(context);
+  calc(context, normalize) {
+    return this.expr_.resolve(context, normalize);
   }
 }
 
@@ -809,7 +861,7 @@ export class CssCalcSumNode extends CssNode {
   }
 
   /** @override */
-  calc(context) {
+  calc(context, normalize) {
     /*
      * From spec:
      * At + or -, check that both sides have the same type, or that one side is
@@ -817,8 +869,8 @@ export class CssCalcSumNode extends CssNode {
      * type, resolve to that type. If one side is a <number> and the other is
      * an <integer>, resolve to <number>.
      */
-    let left = this.left_.resolve(context);
-    let right = this.right_.resolve(context);
+    let left = this.left_.resolve(context, normalize);
+    let right = this.right_.resolve(context, normalize);
     if (left == null || right == null) {
       return null;
     }
@@ -880,9 +932,9 @@ export class CssCalcProductNode extends CssNode {
   }
 
   /** @override */
-  calc(context) {
-    const left = this.left_.resolve(context);
-    const right = this.right_.resolve(context);
+  calc(context, normalize) {
+    const left = this.left_.resolve(context, normalize);
+    const right = this.right_.resolve(context, normalize);
     if (left == null || right == null) {
       return null;
     }

--- a/extensions/amp-animation/0.1/test/test-css-expr.js
+++ b/extensions/amp-animation/0.1/test/test-css-expr.js
@@ -364,6 +364,7 @@ describe('CSS parse', () => {
 
 
 describes.sandboxed('CSS resolve', {}, () => {
+  const normalize = true;
   let context;
   let contextMock;
 
@@ -376,8 +377,8 @@ describes.sandboxed('CSS resolve', {}, () => {
     contextMock.verify();
   });
 
-  function resolvedCss(node) {
-    const resolved = node.resolve(context);
+  function resolvedCss(node, opt_normalize) {
+    const resolved = node.resolve(context, opt_normalize);
     return resolved ? resolved.css() : null;
   }
 
@@ -409,14 +410,23 @@ describes.sandboxed('CSS resolve', {}, () => {
 
   it('should resolve a const concat node', () => {
     expect(ast.isVarCss('css1 css2')).to.be.false;
+    expect(ast.isVarCss('css1 10px')).to.be.false;
+    expect(ast.isVarCss('css1 10em')).to.be.false;
+    expect(ast.isVarCss('css1 css2', normalize)).to.be.false;
+    expect(ast.isVarCss('css1 10px', normalize)).to.be.false;
+    expect(ast.isVarCss('css1 10em', normalize)).to.be.true;
+    expect(ast.isVarCss('css1 10EM', normalize)).to.be.true;
     const node = new ast.CssConcatNode([
       new ast.CssPassthroughNode('css1'),
       new ast.CssPassthroughNode('css2'),
     ]);
     expect(node.isConst()).to.be.true;
+    expect(node.isConst(normalize)).to.be.true;
     expect(node.resolve(context)).to.equal(node);
+    expect(node.resolve(context, normalize)).to.equal(node);
     expect(node.css()).to.equal('css1 css2');
     expect(resolvedCss(node)).to.equal('css1 css2');
+    expect(resolvedCss(node, normalize)).to.equal('css1 css2');
   });
 
   it('should resolve a var concat node', () => {
@@ -424,71 +434,100 @@ describes.sandboxed('CSS resolve', {}, () => {
     expect(ast.isVarCss('var(--x) css2')).to.be.true;
     expect(ast.isVarCss('VAR(--x)')).to.be.true;
     expect(ast.isVarCss('Var(--x)')).to.be.true;
+    expect(ast.isVarCss('var(--x)', normalize)).to.be.true;
     contextMock.expects('getVar')
         .withExactArgs('--var1')
         .returns(new ast.CssPassthroughNode('val1'))
-        .once();
+        .twice();
     const node = new ast.CssConcatNode([
       new ast.CssPassthroughNode('css1'),
       new ast.CssVarNode('--var1'),
     ]);
     expect(node.isConst()).to.be.false;
+    expect(node.isConst(normalize)).to.be.false;
     expect(node.css()).to.equal('css1 var(--var1)');
     expect(resolvedCss(node)).to.equal('css1 val1');
+    expect(resolvedCss(node, normalize)).to.equal('css1 val1');
   });
 
   it('should resolve a null concat node', () => {
     contextMock.expects('getVar')
         .withExactArgs('--var1')
         .returns(null)
-        .once();
+        .twice();
     const node = new ast.CssConcatNode([
       new ast.CssPassthroughNode('css1'),
       new ast.CssVarNode('--var1'),
     ]);
     expect(node.isConst()).to.be.false;
+    expect(node.isConst(normalize)).to.be.false;
     expect(node.css()).to.equal('css1 var(--var1)');
     expect(resolvedCss(node)).to.be.null;
+    expect(resolvedCss(node, normalize)).to.be.null;
   });
 
   it('should resolve a number node', () => {
     expect(ast.isVarCss('11.5')).to.be.false;
+    expect(ast.isVarCss('11.5', normalize)).to.be.false;
     const node = new ast.CssNumberNode(11.5);
     expect(node.isConst()).to.be.true;
+    expect(node.isConst(normalize)).to.be.true;
     expect(node.css()).to.equal('11.5');
     expect(resolvedCss(node)).to.equal('11.5');
+    expect(resolvedCss(node, normalize)).to.equal('11.5');
     expect(node.createSameUnits(20.5).css()).to.equal('20.5');
   });
 
-  it('should resolve a percent node', () => {
+  it('should resolve a percent node w/o dimension', () => {
+    expect(ast.isVarCss('11.5%')).to.be.false;
+    expect(ast.isVarCss('11.5%', normalize)).to.be.true;
+    const node = new ast.CssPercentNode(11.5);
+    expect(node.isConst()).to.be.true;
+    expect(node.isConst(normalize)).to.be.false;
+    expect(node.css()).to.equal('11.5%');
+    expect(resolvedCss(node)).to.equal('11.5%');
+    expect(resolvedCss(node, normalize)).to.equal('11.5%');
+    expect(node.createSameUnits(20.5).css()).to.equal('20.5%');
+  });
+
+  it('should resolve a percent node w/dimension', () => {
+    contextMock.expects('getDimension').returns('w').twice();
+    contextMock.expects('getCurrentElementSize')
+        .returns({width: 110, height: 220});
     expect(ast.isVarCss('11.5%')).to.be.false;
     const node = new ast.CssPercentNode(11.5);
     expect(node.isConst()).to.be.true;
+    expect(node.isConst(normalize)).to.be.false;
     expect(node.css()).to.equal('11.5%');
     expect(resolvedCss(node)).to.equal('11.5%');
+    expect(resolvedCss(node, normalize)).to.equal('12.65px');
     expect(node.createSameUnits(20.5).css()).to.equal('20.5%');
   });
 
   describe('url', () => {
     it('should always consider as non-const', () => {
       expect(ast.isVarCss('url("https://acme.org")')).to.be.true;
+      expect(ast.isVarCss('url("https://acme.org")', normalize)).to.be.true;
     });
 
     it('should resolve an absolute HTTPS URL', () => {
       const node = new ast.CssUrlNode('https://acme.org/img');
       expect(node.isConst()).to.be.true;
+      expect(node.isConst(normalize)).to.be.true;
       expect(node.css()).to.equal('url("https://acme.org/img")');
     });
 
     it('should resolve an data URL', () => {
       const node = new ast.CssUrlNode('data:abc');
       expect(node.isConst()).to.be.true;
+      expect(node.isConst(normalize)).to.be.true;
       expect(node.css()).to.equal('url("data:abc")');
     });
 
     it('should resolve an empty URL', () => {
       const node = new ast.CssUrlNode('');
       expect(node.isConst()).to.be.true;
+      expect(node.isConst(normalize)).to.be.true;
       expect(node.css()).to.equal('');
     });
 
@@ -497,11 +536,13 @@ describes.sandboxed('CSS resolve', {}, () => {
           .expects('resolveUrl')
           .withExactArgs('http://acme.org/non-secure')
           .returns('broken')
-          .once();
+          .twice();
       const node = new ast.CssUrlNode('http://acme.org/non-secure');
       expect(node.isConst()).to.be.false;
+      expect(node.isConst(normalize)).to.be.false;
       expect(node.css()).to.equal('url("http://acme.org/non-secure")');
       expect(node.calc(context).css()).to.equal('url("broken")');
+      expect(node.calc(context, normalize).css()).to.equal('url("broken")');
     });
 
     it('should re-resolve a relative url', () => {
@@ -509,11 +550,14 @@ describes.sandboxed('CSS resolve', {}, () => {
           .expects('resolveUrl')
           .withExactArgs('/relative')
           .returns('https://acme.org/relative')
-          .once();
+          .twice();
       const node = new ast.CssUrlNode('/relative');
       expect(node.isConst()).to.be.false;
+      expect(node.isConst(normalize)).to.be.false;
       expect(node.css()).to.equal('url("/relative")');
       expect(node.calc(context).css())
+          .to.equal('url("https://acme.org/relative")');
+      expect(node.calc(context, normalize).css())
           .to.equal('url("https://acme.org/relative")');
     });
 
@@ -534,13 +578,24 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should always consider as const', () => {
       expect(ast.isVarCss('11.5px')).to.be.false;
       expect(ast.isVarCss('11.5em')).to.be.false;
+
+      expect(ast.isVarCss('11.5px', normalize)).to.be.false;
+      expect(ast.isVarCss('11.5em', normalize)).to.be.true;
+      expect(ast.isVarCss('11.5rem', normalize)).to.be.true;
+      expect(ast.isVarCss('11.5vh', normalize)).to.be.true;
+      expect(ast.isVarCss('11.5vw', normalize)).to.be.true;
+      expect(ast.isVarCss('11.5vmin', normalize)).to.be.true;
+      expect(ast.isVarCss('11.5vmax', normalize)).to.be.true;
+      expect(ast.isVarCss('11.5EM', normalize)).to.be.true;
     });
 
     it('should resolve a px-length node', () => {
       const node = new ast.CssLengthNode(11.5, 'px');
       expect(node.isConst()).to.be.true;
+      expect(node.isConst(normalize)).to.be.true;
       expect(node.css()).to.equal('11.5px');
       expect(resolvedCss(node)).to.equal('11.5px');
+      expect(resolvedCss(node, normalize)).to.equal('11.5px');
       expect(node.createSameUnits(20.5).css()).to.equal('20.5px');
       expect(node.norm()).to.equal(node);
       expect(node.norm().css()).to.equal('11.5px');
@@ -553,10 +608,12 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(resolvedCss(node)).to.equal('11.5em');
       expect(node.createSameUnits(20.5).css()).to.equal('20.5em');
 
-      contextMock.expects('getCurrentFontSize').returns(10).once();
+      contextMock.expects('getCurrentFontSize').returns(10).twice();
       const norm = node.norm(context);
       expect(norm).to.not.equal(node);
       expect(norm.css()).to.equal('115px');
+      expect(node.isConst(normalize)).to.be.false;
+      expect(resolvedCss(node, normalize)).to.equal('115px');
     });
 
     it('should resolve a rem-length node', () => {
@@ -566,17 +623,19 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(resolvedCss(node)).to.equal('11.5rem');
       expect(node.createSameUnits(20.5).css()).to.equal('20.5rem');
 
-      contextMock.expects('getRootFontSize').returns(2).once();
+      contextMock.expects('getRootFontSize').returns(2).twice();
       const norm = node.norm(context);
       expect(norm).to.not.equal(node);
       expect(norm.css()).to.equal('23px');
+      expect(node.isConst(normalize)).to.be.false;
+      expect(resolvedCss(node, normalize)).to.equal('23px');
     });
 
     describe('vw-length', () => {
       beforeEach(() => {
         contextMock.expects('getViewportSize')
             .returns({width: 200, height: 400})
-            .once();
+            .atLeast(1);
       });
 
       it('should resolve a vw-length node', () => {
@@ -586,6 +645,8 @@ describes.sandboxed('CSS resolve', {}, () => {
         expect(resolvedCss(node)).to.equal('11.5vw');
         expect(node.createSameUnits(20.5).css()).to.equal('20.5vw');
         expect(node.norm(context).css()).to.equal('23px');
+        expect(node.isConst(normalize)).to.be.false;
+        expect(resolvedCss(node, normalize)).to.equal('23px');
       });
 
       it('should resolve a vh-length node', () => {
@@ -595,6 +656,8 @@ describes.sandboxed('CSS resolve', {}, () => {
         expect(resolvedCss(node)).to.equal('11.5vh');
         expect(node.createSameUnits(20.5).css()).to.equal('20.5vh');
         expect(node.norm(context).css()).to.equal('46px');
+        expect(node.isConst(normalize)).to.be.false;
+        expect(resolvedCss(node, normalize)).to.equal('46px');
       });
 
       it('should resolve a vmin-length node', () => {
@@ -604,6 +667,8 @@ describes.sandboxed('CSS resolve', {}, () => {
         expect(resolvedCss(node)).to.equal('11.5vmin');
         expect(node.createSameUnits(20.5).css()).to.equal('20.5vmin');
         expect(node.norm(context).css()).to.equal('23px');
+        expect(node.isConst(normalize)).to.be.false;
+        expect(resolvedCss(node, normalize)).to.equal('23px');
       });
 
       it('should resolve a vmax-length node', () => {
@@ -613,6 +678,8 @@ describes.sandboxed('CSS resolve', {}, () => {
         expect(resolvedCss(node)).to.equal('11.5vmax');
         expect(node.createSameUnits(20.5).css()).to.equal('20.5vmax');
         expect(node.norm(context).css()).to.equal('46px');
+        expect(node.isConst(normalize)).to.be.false;
+        expect(resolvedCss(node, normalize)).to.equal('46px');
       });
     });
 
@@ -668,6 +735,11 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should always consider as const', () => {
       expect(ast.isVarCss('11.5rad')).to.be.false;
       expect(ast.isVarCss('11.5deg')).to.be.false;
+      expect(ast.isVarCss('11.5grad')).to.be.false;
+
+      expect(ast.isVarCss('11.5rad', normalize)).to.be.false;
+      expect(ast.isVarCss('11.5deg', normalize)).to.be.true;
+      expect(ast.isVarCss('11.5grad', normalize)).to.be.true;
     });
 
     it('should resolve a rad-angle node', () => {
@@ -678,6 +750,8 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(node.createSameUnits(20.5).css()).to.equal('20.5rad');
       expect(node.norm()).to.equal(node);
       expect(node.norm().css()).to.equal('11.5rad');
+      expect(node.isConst(normalize)).to.be.true;
+      expect(resolvedCss(node, normalize)).to.equal('11.5rad');
     });
 
     it('should resolve a deg-length node', () => {
@@ -691,6 +765,9 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(norm).to.not.equal(node);
       expect(norm.css()).to.match(/[\d\.]*rad/);
       expect(norm.num_).to.closeTo(0.2007, 1e-4);
+      expect(node.isConst(normalize)).to.be.false;
+      expect(node.calc(context, normalize).units_).to.equal('rad');
+      expect(node.calc(context, normalize).num_).to.closeTo(0.2007, 1e-4);
     });
 
     it('should resolve a grad-length node', () => {
@@ -704,13 +781,19 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(norm).to.not.equal(node);
       expect(norm.css()).to.match(/[\d\.]*rad/);
       expect(norm.num_).to.closeTo(0.1806, 1e-4);
+      expect(node.isConst(normalize)).to.be.false;
+      expect(node.calc(context, normalize).units_).to.equal('rad');
+      expect(node.calc(context, normalize).num_).to.closeTo(0.1806, 1e-4);
     });
   });
 
   describe('time', () => {
     it('should always consider as const', () => {
-      expect(ast.isVarCss('11.5s')).to.be.false;
       expect(ast.isVarCss('11.5ms')).to.be.false;
+      expect(ast.isVarCss('11.5s')).to.be.false;
+
+      expect(ast.isVarCss('11.5ms', normalize)).to.be.false;
+      expect(ast.isVarCss('11.5s', normalize)).to.be.true;
     });
 
     it('should resolve a milliseconds node', () => {
@@ -721,6 +804,8 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(node.createSameUnits(20.5).css()).to.equal('20.5ms');
       expect(node.norm()).to.equal(node);
       expect(node.norm().css()).to.equal('11.5ms');
+      expect(node.isConst(normalize)).to.be.true;
+      expect(resolvedCss(node, normalize)).to.equal('11.5ms');
     });
 
     it('should resolve a seconds node', () => {
@@ -733,6 +818,8 @@ describes.sandboxed('CSS resolve', {}, () => {
       const norm = node.norm(context);
       expect(norm).to.not.equal(node);
       expect(norm.css()).to.equal('11500ms');
+      expect(node.isConst(normalize)).to.be.false;
+      expect(resolvedCss(node, normalize)).to.equal('11500ms');
     });
   });
 
@@ -748,6 +835,8 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(node.css()).to.equal('rgb(201,202,203)');
       expect(resolvedCss(node)).to.equal('rgb(201,202,203)');
       expect(node.resolve(context)).to.equal(node);
+      expect(node.isConst(normalize)).to.be.true;
+      expect(resolvedCss(node, normalize)).to.equal('rgb(201,202,203)');
     });
 
     it('should resolve a var-arg function', () => {
@@ -755,7 +844,7 @@ describes.sandboxed('CSS resolve', {}, () => {
       contextMock.expects('getVar')
           .withExactArgs('--var1')
           .returns(new ast.CssNumberNode(11))
-          .once();
+          .twice();
       const node = new ast.CssFuncNode('rgb', [
         new ast.CssNumberNode(201),
         new ast.CssNumberNode(202),
@@ -764,6 +853,25 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(node.isConst()).to.be.false;
       expect(node.css()).to.equal('rgb(201,202,var(--var1))');
       expect(resolvedCss(node)).to.equal('rgb(201,202,11)');
+      expect(node.isConst(normalize)).to.be.false;
+      expect(resolvedCss(node, normalize)).to.equal('rgb(201,202,11)');
+    });
+
+    it('should norm function', () => {
+      contextMock.expects('getDimension').returns('w').atLeast(1);
+      contextMock.expects('getCurrentFontSize').returns(10).atLeast(1);
+      contextMock.expects('getCurrentElementSize')
+          .returns({width: 110, height: 220}).atLeast(1);
+      const node = new ast.CssFuncNode('xyz', [
+        new ast.CssLengthNode(11, 'px'),
+        new ast.CssLengthNode(11.5, 'em'),
+        new ast.CssPercentNode(11.5),
+      ]);
+      expect(node.isConst()).to.be.true;
+      expect(node.css()).to.equal('xyz(11px,11.5em,11.5%)');
+      expect(resolvedCss(node)).to.equal('xyz(11px,11.5em,11.5%)');
+      expect(node.isConst(normalize)).to.be.false;
+      expect(resolvedCss(node, normalize)).to.equal('xyz(11px,115px,12.65px)');
     });
 
     it('should push a dimension when specified', () => {
@@ -810,7 +918,7 @@ describes.sandboxed('CSS resolve', {}, () => {
       contextMock.expects('getVar')
           .withExactArgs('--var1')
           .returns(null)
-          .once();
+          .atLeast(1);
       const node = new ast.CssFuncNode('rgb', [
         new ast.CssNumberNode(201),
         new ast.CssNumberNode(202),
@@ -819,6 +927,8 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(node.isConst()).to.be.false;
       expect(node.css()).to.equal('rgb(201,202,var(--var1))');
       expect(resolvedCss(node)).to.be.null;
+      expect(node.isConst(normalize)).to.be.false;
+      expect(resolvedCss(node, normalize)).to.be.null;
     });
   });
 
@@ -843,6 +953,11 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(ast.isVarCss('translateX(10px)')).to.be.false;
       expect(ast.isVarCss('translateY(10px)')).to.be.false;
       expect(ast.isVarCss('translate3d(10px)')).to.be.false;
+
+      expect(ast.isVarCss('translate(10px)', normalize)).to.be.false;
+      expect(ast.isVarCss('translate(10%)', normalize)).to.be.true;
+      expect(ast.isVarCss('translate(10em)', normalize)).to.be.true;
+      expect(ast.isVarCss('translate(10EM)', normalize)).to.be.true;
     });
 
     it('should resolve 2d translate', () => {
@@ -850,7 +965,10 @@ describes.sandboxed('CSS resolve', {}, () => {
         new ast.CssPassthroughNode('X'),
         new ast.CssPassthroughNode('Y'),
       ]);
+      expect(node.isConst()).to.be.true;
       expect(node.calc(context).css()).to.equal('translate(Xw,Yh)');
+      expect(node.isConst(normalize)).to.be.true;
+      expect(node.calc(context, normalize).css()).to.equal('translate(Xw,Yh)');
     });
 
     it('should resolve abbreviated 2d translate', () => {
@@ -899,6 +1017,8 @@ describes.sandboxed('CSS resolve', {}, () => {
         new ast.CssPassthroughNode('X'),
         new ast.CssVarNode('--var1'),
       ]);
+      expect(node.isConst()).to.be.false;
+      expect(node.isConst(normalize)).to.be.false;
       expect(node.calc(context)).to.be.null;
     });
   });
@@ -971,6 +1091,8 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should always consider as non-const', () => {
       expect(ast.isVarCss('rand()')).to.be.true;
       expect(ast.isVarCss('rand(10px, 20px)')).to.be.true;
+      expect(ast.isVarCss('rand(10px, 20px)', normalize)).to.be.true;
+      expect(ast.isVarCss('rand(10em, 20em)', normalize)).to.be.true;
     });
 
     it('should always be a non-const and no css', () => {
@@ -1010,6 +1132,7 @@ describes.sandboxed('CSS resolve', {}, () => {
           new ast.CssTimeNode(10, 's'),
           new ast.CssTimeNode(20, 's'));
       expect(resolvedCss(node)).to.equal('12.5s');
+      expect(resolvedCss(node, normalize)).to.equal('12500ms');
     });
 
     it('should rand two same-unit values - percent', () => {
@@ -1017,6 +1140,11 @@ describes.sandboxed('CSS resolve', {}, () => {
           new ast.CssPercentNode(10),
           new ast.CssPercentNode(20));
       expect(resolvedCss(node)).to.equal('12.5%');
+
+      contextMock.expects('getDimension').returns('w').atLeast(1);
+      contextMock.expects('getCurrentElementSize')
+          .returns({width: 110, height: 220}).atLeast(1);
+      expect(resolvedCss(node, normalize)).to.equal('13.75px');
     });
 
     it('should resolve both parts', () => {
@@ -1080,6 +1208,9 @@ describes.sandboxed('CSS resolve', {}, () => {
   describe('var', () => {
     it('should always consider as non-const', () => {
       expect(ast.isVarCss('var(--x)')).to.be.true;
+      expect(ast.isVarCss('var(--x)', normalize)).to.be.true;
+      expect(ast.isVarCss('var(--x, 10px)', normalize)).to.be.true;
+      expect(ast.isVarCss('var(--x, 10em)', normalize)).to.be.true;
     });
 
     it('should resolve a var node', () => {
@@ -1091,6 +1222,22 @@ describes.sandboxed('CSS resolve', {}, () => {
       expect(node.isConst()).to.be.false;
       expect(node.css()).to.equal('var(--var1)');
       expect(resolvedCss(node)).to.equal('val1');
+    });
+
+    it('should resolve a var node and normalize', () => {
+      contextMock.expects('getDimension').returns('w').atLeast(1);
+      contextMock.expects('getCurrentElementSize')
+          .returns({width: 110, height: 220}).atLeast(1);
+      contextMock.expects('getVar')
+          .withExactArgs('--var1')
+          .returns(new ast.CssPercentNode(11.5))
+          .atLeast(1);
+      const node = new ast.CssVarNode('--var1');
+      expect(node.isConst()).to.be.false;
+      expect(node.isConst(normalize)).to.be.false;
+      expect(node.css()).to.equal('var(--var1)');
+      expect(resolvedCss(node)).to.equal('11.5%');
+      expect(resolvedCss(node, normalize)).to.equal('12.65px');
     });
 
     it('should resolve a var node with def', () => {
@@ -1147,6 +1294,9 @@ describes.sandboxed('CSS resolve', {}, () => {
   describe('calc', () => {
     it('should always consider as non-const', () => {
       expect(ast.isVarCss('calc()')).to.be.true;
+      expect(ast.isVarCss('calc()', normalize)).to.be.true;
+      expect(ast.isVarCss('calc(10px)', normalize)).to.be.true;
+      expect(ast.isVarCss('calc(10em)', normalize)).to.be.true;
     });
 
     it('should resolve a single-value calc', () => {
@@ -1165,6 +1315,20 @@ describes.sandboxed('CSS resolve', {}, () => {
         expect(node.isConst()).to.be.false;
         expect(node.css()).to.equal('10px + 20px');
         expect(resolvedCss(node)).to.equal('30px');
+      });
+
+      it('should add two same-unit values and normalize', () => {
+        const node = new ast.CssCalcSumNode(
+            new ast.CssLengthNode(10, 'em'),
+            new ast.CssLengthNode(20, 'em'),
+            '+');
+        expect(node.isConst()).to.be.false;
+        expect(node.css()).to.equal('10em + 20em');
+        expect(resolvedCss(node)).to.equal('30em');
+
+        contextMock.expects('getCurrentFontSize').returns(10).atLeast(1);
+        expect(node.isConst(normalize)).to.be.false;
+        expect(resolvedCss(node, normalize)).to.equal('300px');
       });
 
       it('should add two same-unit values - times', () => {

--- a/extensions/amp-animation/0.1/test/test-css-expr.js
+++ b/extensions/amp-animation/0.1/test/test-css-expr.js
@@ -409,9 +409,9 @@ describes.sandboxed('CSS resolve', {}, () => {
   });
 
   it('should resolve a const concat node', () => {
-    expect(ast.isVarCss('css1 css2')).to.be.false;
-    expect(ast.isVarCss('css1 10px')).to.be.false;
-    expect(ast.isVarCss('css1 10em')).to.be.false;
+    expect(ast.isVarCss('css1 css2', false)).to.be.false;
+    expect(ast.isVarCss('css1 10px', false)).to.be.false;
+    expect(ast.isVarCss('css1 10em', false)).to.be.false;
     expect(ast.isVarCss('css1 css2', normalize)).to.be.false;
     expect(ast.isVarCss('css1 10px', normalize)).to.be.false;
     expect(ast.isVarCss('css1 10em', normalize)).to.be.true;
@@ -430,10 +430,10 @@ describes.sandboxed('CSS resolve', {}, () => {
   });
 
   it('should resolve a var concat node', () => {
-    expect(ast.isVarCss('var(--x)')).to.be.true;
-    expect(ast.isVarCss('var(--x) css2')).to.be.true;
-    expect(ast.isVarCss('VAR(--x)')).to.be.true;
-    expect(ast.isVarCss('Var(--x)')).to.be.true;
+    expect(ast.isVarCss('var(--x)', false)).to.be.true;
+    expect(ast.isVarCss('var(--x) css2', false)).to.be.true;
+    expect(ast.isVarCss('VAR(--x)', false)).to.be.true;
+    expect(ast.isVarCss('Var(--x)', false)).to.be.true;
     expect(ast.isVarCss('var(--x)', normalize)).to.be.true;
     contextMock.expects('getVar')
         .withExactArgs('--var1')
@@ -467,7 +467,7 @@ describes.sandboxed('CSS resolve', {}, () => {
   });
 
   it('should resolve a number node', () => {
-    expect(ast.isVarCss('11.5')).to.be.false;
+    expect(ast.isVarCss('11.5', false)).to.be.false;
     expect(ast.isVarCss('11.5', normalize)).to.be.false;
     const node = new ast.CssNumberNode(11.5);
     expect(node.isConst()).to.be.true;
@@ -479,7 +479,7 @@ describes.sandboxed('CSS resolve', {}, () => {
   });
 
   it('should resolve a percent node w/o dimension', () => {
-    expect(ast.isVarCss('11.5%')).to.be.false;
+    expect(ast.isVarCss('11.5%', false)).to.be.false;
     expect(ast.isVarCss('11.5%', normalize)).to.be.true;
     const node = new ast.CssPercentNode(11.5);
     expect(node.isConst()).to.be.true;
@@ -494,7 +494,7 @@ describes.sandboxed('CSS resolve', {}, () => {
     contextMock.expects('getDimension').returns('w').twice();
     contextMock.expects('getCurrentElementSize')
         .returns({width: 110, height: 220});
-    expect(ast.isVarCss('11.5%')).to.be.false;
+    expect(ast.isVarCss('11.5%', false)).to.be.false;
     const node = new ast.CssPercentNode(11.5);
     expect(node.isConst()).to.be.true;
     expect(node.isConst(normalize)).to.be.false;
@@ -506,7 +506,7 @@ describes.sandboxed('CSS resolve', {}, () => {
 
   describe('url', () => {
     it('should always consider as non-const', () => {
-      expect(ast.isVarCss('url("https://acme.org")')).to.be.true;
+      expect(ast.isVarCss('url("https://acme.org")', false)).to.be.true;
       expect(ast.isVarCss('url("https://acme.org")', normalize)).to.be.true;
     });
 
@@ -576,8 +576,8 @@ describes.sandboxed('CSS resolve', {}, () => {
 
   describe('length', () => {
     it('should always consider as const', () => {
-      expect(ast.isVarCss('11.5px')).to.be.false;
-      expect(ast.isVarCss('11.5em')).to.be.false;
+      expect(ast.isVarCss('11.5px', false)).to.be.false;
+      expect(ast.isVarCss('11.5em', false)).to.be.false;
 
       expect(ast.isVarCss('11.5px', normalize)).to.be.false;
       expect(ast.isVarCss('11.5em', normalize)).to.be.true;
@@ -733,9 +733,9 @@ describes.sandboxed('CSS resolve', {}, () => {
 
   describe('angle', () => {
     it('should always consider as const', () => {
-      expect(ast.isVarCss('11.5rad')).to.be.false;
-      expect(ast.isVarCss('11.5deg')).to.be.false;
-      expect(ast.isVarCss('11.5grad')).to.be.false;
+      expect(ast.isVarCss('11.5rad', false)).to.be.false;
+      expect(ast.isVarCss('11.5deg', false)).to.be.false;
+      expect(ast.isVarCss('11.5grad', false)).to.be.false;
 
       expect(ast.isVarCss('11.5rad', normalize)).to.be.false;
       expect(ast.isVarCss('11.5deg', normalize)).to.be.true;
@@ -789,8 +789,8 @@ describes.sandboxed('CSS resolve', {}, () => {
 
   describe('time', () => {
     it('should always consider as const', () => {
-      expect(ast.isVarCss('11.5ms')).to.be.false;
-      expect(ast.isVarCss('11.5s')).to.be.false;
+      expect(ast.isVarCss('11.5ms', false)).to.be.false;
+      expect(ast.isVarCss('11.5s', false)).to.be.false;
 
       expect(ast.isVarCss('11.5ms', normalize)).to.be.false;
       expect(ast.isVarCss('11.5s', normalize)).to.be.true;
@@ -949,10 +949,10 @@ describes.sandboxed('CSS resolve', {}, () => {
     });
 
     it('should always consider as const', () => {
-      expect(ast.isVarCss('translate(10px)')).to.be.false;
-      expect(ast.isVarCss('translateX(10px)')).to.be.false;
-      expect(ast.isVarCss('translateY(10px)')).to.be.false;
-      expect(ast.isVarCss('translate3d(10px)')).to.be.false;
+      expect(ast.isVarCss('translate(10px)', false)).to.be.false;
+      expect(ast.isVarCss('translateX(10px)', false)).to.be.false;
+      expect(ast.isVarCss('translateY(10px)', false)).to.be.false;
+      expect(ast.isVarCss('translate3d(10px)', false)).to.be.false;
 
       expect(ast.isVarCss('translate(10px)', normalize)).to.be.false;
       expect(ast.isVarCss('translate(10%)', normalize)).to.be.true;
@@ -1040,8 +1040,8 @@ describes.sandboxed('CSS resolve', {}, () => {
     });
 
     it('should always consider as non-const', () => {
-      expect(ast.isVarCss('width()')).to.be.true;
-      expect(ast.isVarCss('height()')).to.be.true;
+      expect(ast.isVarCss('width()', false)).to.be.true;
+      expect(ast.isVarCss('height()', false)).to.be.true;
       expect(ast.isVarCss('width("")')).to.be.true;
       expect(ast.isVarCss('height("")')).to.be.true;
     });

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -1011,12 +1011,25 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
       expect(css.resolveCss(-1)).to.equal('-1');
       expect(css.resolveCss(Infinity)).to.equal('Infinity');
       expect(css.resolveCss('10px')).to.equal('10px');
-      expect(css.resolveCss('10em')).to.equal('10em');
-      expect(css.resolveCss('10vh')).to.equal('10vh');
+      expect(css.resolveCss('translateY(10px)')).to.equal('translateY(10px)');
       expect(css.resolveCss('rgb(0,0,0)')).to.equal('rgb(0,0,0)');
-      expect(css.resolveCss('translateY(10vh)'))
-          .to.equal('translateY(10vh)');
       expect(parseSpy).to.not.be.called;
+    });
+
+    it('should evaluate CSS for non-normalized values', () => {
+      target1.style.fontSize = '10px';
+      target1.style.width = '110px';
+      css.withTarget(target1, () => {
+        expect(css.resolveCss('10em')).to.equal('100px');
+        expect(css.resolveCss('translateX(10em)'))
+            .to.equal('translatex(100px)');
+        expect(css.resolveCss('translateX(10%)'))
+            .to.equal('translatex(11px)');
+      });
+      expect(css.resolveCss('10vh')).to.equal('15px');
+      expect(css.resolveCss('translateY(10vh)'))
+          .to.equal('translatey(15px)');
+      expect(parseSpy).to.be.called;
     });
 
     it('should evaluate CSS for complex values', () => {

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -850,17 +850,12 @@ export class MeasureScanner extends Scanner {
         newTiming.iterationStart, prevTiming.iterationStart);
 
     // Identifier CSS values.
-    const easing = newTiming.easing != null ?
-        this.css_.resolveCss(newTiming.easing) :
-        prevTiming.easing;
-    const direction = newTiming.direction != null ?
-        /** @type {!WebAnimationTimingDirection} */
-        (this.css_.resolveCss(newTiming.direction)) :
-        prevTiming.direction;
-    const fill = newTiming.fill != null ?
-        /** @type {!WebAnimationTimingFill} */
-        (this.css_.resolveCss(newTiming.fill)) :
-        prevTiming.fill;
+    const easing =
+        this.css_.resolveIdent(newTiming.easing, prevTiming.easing);
+    const direction = /** @type {!WebAnimationTimingDirection} */
+        (this.css_.resolveIdent(newTiming.direction, prevTiming.direction));
+    const fill = /** @type {!WebAnimationTimingFill} */
+        (this.css_.resolveIdent(newTiming.fill, prevTiming.fill));
 
     // Other.
     const ticker = newTiming.ticker != null ?
@@ -1047,20 +1042,9 @@ class CssContextImpl {
    * @protected
    */
   resolveCss(input) {
-    if (input == null || input === '') {
-      return '';
-    }
-    const inputCss = String(input);
-    if (typeof input == 'number') {
-      return inputCss;
-    }
-    // Test first if CSS contains any variable components. Otherwise, there's
-    // no need to spend cycles to parse/evaluate.
-    if (!isVarCss(inputCss)) {
-      return inputCss;
-    }
-    const result = this.resolveAsNode_(inputCss);
-    return result != null ? result.css() : '';
+    // Will always return a valid string, since the default value is `''`.
+    return dev().assertString(this.resolveCss_(
+        input, /* def */ '', /* normalize */ true));
   }
 
   /**
@@ -1081,6 +1065,15 @@ class CssContextImpl {
 
   /**
    * @param {*} input
+   * @param {string|undefined} def
+   * @return {string|undefined}
+   */
+  resolveIdent(input, def) {
+    return this.resolveCss_(input, def, /* normalize */ false);
+  }
+
+  /**
+   * @param {*} input
    * @param {number|undefined} def
    * @return {number|undefined}
    */
@@ -1089,7 +1082,7 @@ class CssContextImpl {
       if (typeof input == 'number') {
         return input;
       }
-      const node = this.resolveAsNode_(input);
+      const node = this.resolveAsNode_(input, /* normalize */ false);
       if (node) {
         return CssTimeNode.millis(node);
       }
@@ -1107,7 +1100,7 @@ class CssContextImpl {
       if (typeof input == 'number') {
         return input;
       }
-      const node = this.resolveAsNode_(input);
+      const node = this.resolveAsNode_(input, /* normalize */ false);
       if (node) {
         return CssNumberNode.num(node);
       }
@@ -1117,10 +1110,35 @@ class CssContextImpl {
 
   /**
    * @param {*} input
+   * @param {string|undefined} def
+   * @param {boolean} normalize
+   * @return {string|undefined}
+   * @private
+   */
+  resolveCss_(input, def, normalize) {
+    if (input == null || input === '') {
+      return def;
+    }
+    const inputCss = String(input);
+    if (typeof input == 'number') {
+      return inputCss;
+    }
+    // Test first if CSS contains any variable components. Otherwise, there's
+    // no need to spend cycles to parse/evaluate.
+    if (!isVarCss(inputCss, normalize)) {
+      return inputCss;
+    }
+    const result = this.resolveAsNode_(inputCss, normalize);
+    return result != null ? result.css() : def;
+  }
+
+  /**
+   * @param {*} input
+   * @param {boolean} normalize
    * @return {?./css-expr-ast.CssNode}
    * @private
    */
-  resolveAsNode_(input) {
+  resolveAsNode_(input, normalize) {
     if (input == null || input === '') {
       return null;
     }
@@ -1138,7 +1156,7 @@ class CssContextImpl {
     if (!node) {
       return null;
     }
-    return node.resolve(this);
+    return node.resolve(this, normalize);
   }
 
   /**
@@ -1164,7 +1182,8 @@ class CssContextImpl {
     if (rawValue == null || rawValue === '') {
       user().warn(TAG, `Variable not found: "${varName}"`);
     }
-    const result = this.resolveAsNode_(rawValue);
+    // No need to normalize vars - they will be normalized later.
+    const result = this.resolveAsNode_(rawValue, /* normalize */ false);
     this.varPath_.pop();
     return result;
   }


### PR DESCRIPTION
Currently polyfill normally errors on non-normalized or mixed expressions. See https://github.com/web-animations/web-animations-js/issues/149 for more details.
