### PR TITLE
PWA: enable Shadow V1 with and w/o native CE

### DIFF
--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -269,11 +269,13 @@
   Slots spec is not implemented yet by any browser. Will use an older version via `<content>` tag.
   <slot name="slot1"></slot>
   -->
-  <content>
-    <div class="slot-fallback">
-      This is a slot fallback.
-    </div>
-  </content>
+  <slot name="slot1">
+    <content>
+      <div class="slot-fallback">
+        This is a slot fallback.
+      </div>
+    </content>
+  </slot>
 
   <main role="main">
     <article>

--- a/examples/pwa/pwa.js
+++ b/examples/pwa/pwa.js
@@ -85,15 +85,16 @@ class Shell {
   }
 
   /**
+   * @param {!Event} e
    */
   handleNavigate_(e) {
     if (e.defaultPrevented) {
       return false;
     }
-    if (event.button) {
+    if (e.button) {
       return false;
     }
-    let a = event.target;
+    let a = e.target;
     while (a) {
       if (a.tagName == 'A' && a.href) {
         break;

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -54,16 +54,9 @@ export function isShadowDomSupported() {
  */
 export function getShadowDomSupportedVersion(opt_elementClass) {
   if (shadowDomSupportedVersion === undefined) {
-
-    //TODO: Remove native CE check once WebReflection/document-register-element#96 is fixed.
-    if (!areNativeCustomElementsSupported()) {
-      shadowDomSupportedVersion = ShadowDomVersion.NONE;
-    } else {
-      shadowDomSupportedVersion =
-          getShadowDomVersion(opt_elementClass || Element);
-    }
+    shadowDomSupportedVersion =
+        getShadowDomVersion(opt_elementClass || Element);
   }
-
   return shadowDomSupportedVersion;
 }
 
@@ -73,24 +66,5 @@ function getShadowDomVersion(element) {
   } else if (!!element.prototype.createShadowRoot) {
     return ShadowDomVersion.V0;
   }
-
   return ShadowDomVersion.NONE;
-}
-
-function areNativeCustomElementsSupported() {
-  return isNative(self.document.registerElement) ||
-         isNative(self
-             .Object
-             .getOwnPropertyDescriptor(self, 'customElements')
-             .get);
-}
-
-/**
- * Returns `true` if the method is natively implemented by the browser
- * @visibleForTesting
- * @param {Function=} method
- * @return {boolean}
- */
-export function isNative(method) {
-  return !!method && method.toString().indexOf('[native code]') !== -1;
 }


### PR DESCRIPTION
The WebReflection/document-register-element#96 has been fixed and thus this protection is no longer required.