### PR TITLE
Do a full remeasure when fonts finished loading.

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -244,9 +244,8 @@ export class Resources {
       this.checkPendingChangeSize_(element);
     });
 
-    this.schedulePass();
-
     // Ensure that we attempt to rebuild things when DOM is ready.
+    let documentWasReady = false;
     this.ampdoc.whenReady().then(() => {
       this.documentReady_ = true;
       this.buildReadyResources_();
@@ -274,6 +273,13 @@ export class Resources {
         timerFor(this.win).promise(3100),
       ]).then(remeasure);
     });
+    if (this.win.document.fonts && this.win.document.fonts.ready) {
+      this.win.document.fonts.ready().then(() => {
+        this.relayoutAll_ = true;
+        this.schedulePass();
+      });
+    }
+    this.schedulePass();
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -244,8 +244,9 @@ export class Resources {
       this.checkPendingChangeSize_(element);
     });
 
+    this.schedulePass();
+
     // Ensure that we attempt to rebuild things when DOM is ready.
-    let documentWasReady = false;
     this.ampdoc.whenReady().then(() => {
       this.documentReady_ = true;
       this.buildReadyResources_();
@@ -272,14 +273,13 @@ export class Resources {
         loadPromise(this.win),
         timerFor(this.win).promise(3100),
       ]).then(remeasure);
+
+      // Remeasure the document when all fonts loaded.
+      if (this.win.document.fonts &&
+          this.win.document.fonts.status != 'loaded') {
+        this.win.document.fonts.ready.then(remeasure);
+      }
     });
-    if (this.win.document.fonts && this.win.document.fonts.ready) {
-      this.win.document.fonts.ready().then(() => {
-        this.relayoutAll_ = true;
-        this.schedulePass();
-      });
-    }
-    this.schedulePass();
   }
 
   /**

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -85,6 +85,14 @@ export class FakeWindow {
     Object.defineProperty(this.document, 'readyState', {
       get: () => this.readyState,
     });
+    Object.defineProperty(this.document.fonts, 'ready', {
+      get: () => Promise.resolve(),
+    });
+    let fontStatus = 'loaded';
+    Object.defineProperty(this.document.fonts, 'status', {
+      get: () => fontStatus,
+      set: val => fontStatus = val,
+    });
 
     EventListeners.intercept(this.document);
     EventListeners.intercept(this.document.documentElement);


### PR DESCRIPTION
Checks if fonts are loaded on document-ready and if not, schedules a remeasure when they did load.

Fixes #10276