### PR TITLE
Doubleclick Fast Fetch: Add support for data-override-height/width

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -62,7 +62,6 @@ import {tryParseJson} from '../../../src/json';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {extensionsFor, xhrFor} from '../../../src/services';
-import {isExperimentOn} from '../../../src/experiments';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {insertAnalyticsElement} from '../../../src/analytics';
 import {setStyles} from '../../../src/style';
@@ -282,8 +281,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       // dimensions in an array.
       const dimensions = getMultiSizeDimensions(
           multiSizeDataStr,
-          Number(this.element.getAttribute('width')),
-          Number(this.element.getAttribute('height')),
+          this.size_.width,
+          this.size_.height,
           multiSizeValidation == 'true');
       sizeStr += '|' + dimensions
           .map(dimension => dimension.join('x'))
@@ -309,16 +308,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @visibileForTesting
    */
   populateAdUrlState() {
-    const width = Number(this.element.getAttribute('width'));
-    const height = Number(this.element.getAttribute('height'));
-    // If dc-use-attr-for-format experiment is on, we want to make our attribute
-    // check to be more strict.
-    const useAttributesForSize =
-        isExperimentOn(this.win, 'dc-use-attr-for-format')
-        ? !isNaN(width) && width > 0 && !isNaN(height) && height > 0
-        : width && height;
-    this.size_ = useAttributesForSize
+    // Allow for pub to override height/width via override attribute.
+    const width = Number(this.element.getAttribute('data-override-width')) ||
+      Number(this.element.getAttribute('width'));
+    const height = Number(this.element.getAttribute('data-override-height')) ||
+      Number(this.element.getAttribute('height'));
+    this.size_ = width && height
         ? {width, height}
+        // width/height could be 'auto' in which case we fallback to measured.
         : this.getIntersectionElementLayoutBox();
     this.jsonTargeting_ =
       tryParseJson(this.element.getAttribute('json')) || {};
@@ -360,11 +357,20 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     let size = super.extractSize(responseHeaders);
     if (size) {
       this.size_ = size;
+      this.handleResize_(size.width, size.height);
     } else {
-      size = this.size_;
+      size = this.getSlotSize_();
     }
-    this.handleResize_(size.width, size.height);
     return size;
+  }
+
+  getSlotSize_() {
+    const width = Number(this.element.getAttribute('width'));
+    const height = Number(this.element.getAttribute('height'));
+    return width && height
+        ? {width, height}
+        // width/height could be 'auto' in which case we fallback to measured.
+        : this.getIntersectionElementLayoutBox();
   }
 
   /** @override */
@@ -436,9 +442,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     this.lifecycleReporter_.addPingsForVisibility(this.element);
 
+    // Force size of frame to match available space as min-height/width are
+    // set to 0 to ensure centering.
+    const size = this.getIntersectionElementLayoutBox();
     setStyles(dev().assertElement(this.iframe), {
-      width: `${this.size_.width}px`,
-      height: `${this.size_.height}px`,
+      width: `${size.width}px`,
+      height: `${size.height}px`,
     });
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -359,18 +359,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.size_ = size;
       this.handleResize_(size.width, size.height);
     } else {
-      size = this.getSlotSize_();
+      const width = Number(this.element.getAttribute('width'));
+      const height = Number(this.element.getAttribute('height'));
+      size = width && height
+          ? {width, height}
+          // width/height could be 'auto' in which case we fallback to measured.
+          : this.getIntersectionElementLayoutBox();
     }
     return size;
-  }
-
-  getSlotSize_() {
-    const width = Number(this.element.getAttribute('width'));
-    const height = Number(this.element.getAttribute('height'));
-    return width && height
-        ? {width, height}
-        // width/height could be 'auto' in which case we fallback to measured.
-        : this.getIntersectionElementLayoutBox();
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -433,20 +433,8 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
         // numbers, but we know that the values should be numeric.
         expect(url).to.match(/sz=[0-9]+x[0-9]+/));
     });
-    it('has correct format when dc-use-attr-for-format is on', () => {
-      toggleExperiment(window, 'dc-use-attr-for-format', true);
-      new AmpAd(element).upgradeCallback();
-      const width = impl.element.getAttribute('width');
-      const height = impl.element.getAttribute('height');
-      impl.onLayoutMeasure();
-      return impl.getAdUrl().then(url =>
-        // With exp dc-use-attr-for-format off, we can't test for specific
-        // numbers, but we know that the values should be numeric.
-        expect(url).to.match(new RegExp(`sz=${width}x${height}`)));
-    });
-    it('has correct format when width=auto and dc-use-attr-for-format is on',
+    it('has correct format when width == "auto"',
         () => {
-          toggleExperiment(window, 'dc-use-attr-for-format', true);
           element.setAttribute('width', 'auto');
           new AmpAd(element).upgradeCallback();
           expect(impl.element.getAttribute('width')).to.equal('auto');
@@ -454,6 +442,28 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           return impl.getAdUrl().then(url =>
               // Ensure that "auto" doesn't appear anywhere here:
               expect(url).to.match(/sz=[0-9]+x[0-9]+/));
+        });
+    it('has correct format with height/width override',
+        () => {
+          element.setAttribute('data-override-width', '123');
+          element.setAttribute('data-override-height', '456');
+          new AmpAd(element).upgradeCallback();
+          impl.onLayoutMeasure();
+          return impl.getAdUrl().then(url =>
+              // Ensure that "auto" doesn't appear anywhere here:
+              expect(url).to.contain('sz=123x456&'));
+        });
+    it('has correct format with height/width override and multiSize',
+        () => {
+          element.setAttribute('data-override-width', '123');
+          element.setAttribute('data-override-height', '456');
+          element.setAttribute('data-multi-size', '1x2,3x4');
+          element.setAttribute('data-multi-size-validation', 'false');
+          new AmpAd(element).upgradeCallback();
+          impl.onLayoutMeasure();
+          return impl.getAdUrl().then(url =>
+              // Ensure that "auto" doesn't appear anywhere here:
+              expect(url).to.contain('sz=123x456%7C1x2%7C3x4&'));
         });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -205,6 +205,18 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
         impl.size_ = {width: 200, height: 50};
         impl.iframe = impl.win.document.createElement('iframe');
         installExtensionsService(impl.win);
+        // Temporary fix for local test failure.
+        sandbox.stub(impl,
+            'getIntersectionElementLayoutBox', () => {
+              return {
+                top: 0,
+                bottom: 0,
+                left: 0,
+                right: 0,
+                width: 320,
+                height: 50,
+              };
+            });
       });
     });
 
@@ -454,8 +466,8 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
         });
     it('has correct format with height/width override and multiSize',
         () => {
-          element.setAttribute('width', 'auto');
-          element.setAttribute('height', 'auto');
+          element.setAttribute('data-override-width', '123');
+          element.setAttribute('data-override-height', '456');
           element.setAttribute('data-multi-size', '1x2,3x4');
           element.setAttribute('data-multi-size-validation', 'false');
           new AmpAd(element).upgradeCallback();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -450,10 +450,20 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           new AmpAd(element).upgradeCallback();
           impl.onLayoutMeasure();
           return impl.getAdUrl().then(url =>
-              // Ensure that "auto" doesn't appear anywhere here:
               expect(url).to.contain('sz=123x456&'));
         });
     it('has correct format with height/width override and multiSize',
+        () => {
+          element.setAttribute('width', 'auto');
+          element.setAttribute('height', 'auto');
+          element.setAttribute('data-multi-size', '1x2,3x4');
+          element.setAttribute('data-multi-size-validation', 'false');
+          new AmpAd(element).upgradeCallback();
+          impl.onLayoutMeasure();
+          return impl.getAdUrl().then(url =>
+              expect(url).to.contain('sz=123x456%7C1x2%7C3x4&'));
+        });
+    it('has correct format with auto height/width and multiSize',
         () => {
           element.setAttribute('data-override-width', '123');
           element.setAttribute('data-override-height', '456');
@@ -463,7 +473,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
           impl.onLayoutMeasure();
           return impl.getAdUrl().then(url =>
               // Ensure that "auto" doesn't appear anywhere here:
-              expect(url).to.contain('sz=123x456%7C1x2%7C3x4&'));
+              expect(url).to.match(/sz=[0-9]+x[0-9]+%7C1x2%7C3x4&/));
         });
   });
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -241,10 +241,6 @@ const EXPERIMENTS = [
     name: 'Use slot width/height attribute for AdSense size format',
   },
   {
-    id: 'dc-use-attr-for-format',
-    name: 'Use slot width/height attribute for DoubleClick size format',
-  },
-  {
     id: 'ad-loader-v1',
     name: 'New ad loader version 1',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8261',


### PR DESCRIPTION
Addresses #10332 and also removes unnecessary dc-use-attr-for-format experiment