### PR TITLE
PWA: hide slots until ready to be shown by SD polyfill

### DIFF
--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -77,6 +77,16 @@ function createShadowRootPolyfill(hostElement) {
   const doc = hostElement.ownerDocument;
   /** @const {!Window} */
   const win = doc.defaultView;
+
+  // Host CSS polyfill.
+  hostElement.classList.add('i-amphtml-shadow-host-polyfill');
+  const hostStyle = doc.createElement('style');
+  hostStyle.textContent =
+      '.i-amphtml-shadow-host-polyfill>:not(i-amphtml-shadow-root)'
+      + '{display:none!important}';
+  hostElement.appendChild(hostStyle);
+
+  // Shadow root.
   const shadowRoot = /** @type {!ShadowRoot} */ (
       // Cast to ShadowRoot even though it is an Element
       // TODO(@dvoytenko) Consider to switch to a type union instead.

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -125,6 +125,22 @@ describes.sandboxed('shadow-embed', {}, () => {
                 expect(shadowRoot.tagName).to.equal('I-AMPHTML-SHADOW-ROOT');
                 expect(shadowRoot.id).to.match(/i-amphtml-sd-\d+/);
               });
+
+              it('should add host style for polyfill', () => {
+                const doc = hostElement.ownerDocument;
+                const win = doc.defaultView;
+                doc.body.appendChild(hostElement);
+                const slot = doc.createElement('div');
+                hostElement.appendChild(slot);
+                expect(win.getComputedStyle(slot).display).to.equal('block');
+                const shadowRoot = createShadowRoot(hostElement);
+                expect(hostElement).to.have.class(
+                    'i-amphtml-shadow-host-polyfill');
+                expect(win.getComputedStyle(slot).display).to.equal('none');
+                expect(win.getComputedStyle(shadowRoot).display)
+                    .to.not.equal('none');
+                doc.body.removeChild(hostElement);
+              });
             }
           });
 


### PR DESCRIPTION
Partial for #9761

With this, slot distribution is still not supported, but at least the non-distributed content is not shown and only the slot itself is displayed, which, at least, have a fallback story. E.g. it can open a link to the target feature, etc.

/cc @rowangray