### PR TITLE
Clean up amp-ad-exit doc for publishing

### DIFF
--- a/extensions/amp-ad-exit/amp-ad-exit.md
+++ b/extensions/amp-ad-exit/amp-ad-exit.md
@@ -197,7 +197,7 @@ applies to navigation URLs and click tracking URLs.
 
 | Name | Value |
 | ---- | ----- |
-| RANDOM | A random float. See [RANDOM](../spec/amp-var-substitutions.md#random). |
+| RANDOM | A random float. See [RANDOM](../../spec/amp-var-substitutions.md#random). |
 | CLICK_X | The `x` coordinate of the click in the viewport. |
 | CLICK_Y | The `y` coordinate of the click in the viewport. |
 

--- a/extensions/amp-ad-exit/amp-ad-exit.md
+++ b/extensions/amp-ad-exit/amp-ad-exit.md
@@ -16,14 +16,16 @@ limitations under the License.
 
 # <a name="amp-ad-exit"></a> `amp-ad-exit`
 
+[TOC]
+
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Extension for configuring the behavior of ad exits.</td>
+    <td>Provides configurable behavior for ad exits for A4A (AMP for Ads).</td>
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>FILL THIS IN</td>
+    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -35,21 +37,19 @@ limitations under the License.
   </tr>
 </table>
 
-## <a name="overview"></a> Overview
+## Overview
 
-The amp-ad-exit element is configured with a JSON child script element and will
-expose an "exit" action to other elements in the creative. Elements can be
-annotated to exit when tapped, passing a target name and extra URL parameter
-values to insert. The exit action will perform these steps:
+The `amp-ad-exit` element is configured with a JSON child script element and 
+exposes an "exit" action to other elements in the [A4A (AMP for Ads)](../amp-a4a/amp-a4a-format.md) creative. Elements can be annotated to exit when tapped, passing a target name and extra URL parameter values to insert. The exit action performs these steps:
 
-1. parse the JSON config (if it hasn't yet been parsed)
-2. find the requested exit target
-3. determine whether the exit should be allowed by processing the click event through declared filters
-4. rewrite URL variables (see [Variable Substitution](#variable-substitution))
-5. ping any click tracking URLs
-6. perform the navigation by opening the target URL in a new tab
+1. Parse the JSON config (if it hasn't yet been parsed).
+2. Find the requested exit target.
+3. Determine whether the exit should be allowed by processing the click event through declared filters.
+4. Rewrite URL variables (see [Variable Substitution](#variable-substitution))
+5. Ping any click tracking URLs.
+6. Perform the navigation by opening the target URL in a new tab.
 
-## <a name="example"></a> Example
+## Example
 
 ```html
 <amp-ad-exit id="exit-api">
@@ -108,32 +108,35 @@ values to insert. The exit action will perform these steps:
 </div>
 ```
 
-## <a name="filters"></a> Filters
+## Filters
+
 Filters are specified in the `filters` section of the config. Targets reference
 filters by their property name in the `filters` section.
 
 There are two types of filters: location-based and time-based. Other filters (such as a confirmation prompt) could be added as needed. 
 
-`ClickLocationFilter` specifies the minimum distance a click must be from the edges of the creative or viewport (whichever is smaller).
+### clickLocation filter
 
-| Property | Value | Meaning
-| --- | --- | ---
-| `type` | `"clickLocation"` |
-| `top` | `number` | Distance in px from the top edge
-| `right` | `number` | Distance in px from the right edge
-| `bottom` | `number` | Distance in px from the bottom edge
-| `left` | `number` | Distance in px from the left edge
+The `clickLocation` filter type specifies the minimum distance a click must be from the edges of the creative or viewport (whichever is smaller).  The `clickLocation` filter requires the following properties:
 
-`ClickDelayFilter` specifies the time to wait before responding to clicks. amp-ad-exit imposes a minimum delay of 1 second on all exits.
+| Property | Value | Meaning |
+| -------- | ----- | ------- |
+| `top`    | `number` | Distance in px from the top edge. |
+| `right`  | `number` | Distance in px from the right edge. |
+| `bottom` | `number` | Distance in px from the bottom edge. |
+| `left`   | `number` | Distance in px from the left edge. |
 
-| Property | Value | Meaning
-| --- | --- | ---
-| `type` | `"clickDelay"` |
-| `delay` | `number` | Time in ms to reject any clicks after entering the viewport.
+### clickDelay filter
 
-Example:
+The `clickDelay` filter type specifies the time to wait before responding to clicks. The `amp-ad-exit` element imposes a minimum delay of 1 second on all exits. The `clickDelay` filter requires the following properties:
 
-``` javascript
+| Property | Value | Meaning |
+| ---------| ----- | ------- |
+| `delay`  | `number` | Time in ms to reject any clicks after entering the viewport. | 
+
+*Example: Using filters*
+
+```json
 {
   "targets": {
     "ad": {
@@ -164,16 +167,17 @@ Example:
 }
 ```
 
-## <a name="click-tracking-urls"></a> Click tracking URLs
-Navigation targets can be associated with click tracking URLs in the config.
-Before navigation, amp-ad-exit will attempt to ping the tracking URLs by using
+## Click tracking URLs
 
-1. navigator.sendBeacon, if available
+Navigation targets can be associated with click tracking URLs in the config.
+Before navigation, amp-ad-exit attempts to ping the tracking URLs by using:
+
+1. `navigator.sendBeacon`, if available
 2. image request
 
 You can override this behavior with a "transport" object on the config:
 
-``` javascript
+```json
 {
   "targets": { ... },
   "filters": { ... },
@@ -183,9 +187,9 @@ You can override this behavior with a "transport" object on the config:
 }
 ```
 
-## <a name="variable-substitution"></a> Variable Substitution
+## Variable Substitution
 
-URL variable substitution works like standard [AMP variable substitution](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md) with
+URL variable substitution works like standard [AMP variable substitution](../../spec/amp-var-substitutions.md) with
 custom variables and a limited set of platform variables. Variable substitution
 applies to navigation URLs and click tracking URLs.
 
@@ -193,7 +197,7 @@ applies to navigation URLs and click tracking URLs.
 
 | Name | Value |
 | ---- | ----- |
-| RANDOM | A random float. See [RANDOM](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md#random). |
+| RANDOM | A random float. See [RANDOM](../spec/amp-var-substitutions.md#random). |
 | CLICK_X | The `x` coordinate of the click in the viewport. |
 | CLICK_Y | The `y` coordinate of the click in the viewport. |
 
@@ -224,27 +228,31 @@ in the `exit` action invocation:
 By convention, user-defined variables should be in `_camelCase`. System
 variables are in `ALL_CAPS`.
 
-WARNING: Be careful with your variable names. Substitution works by simple
-string replacement. *Any* occurence of the variable in the URL will be
+{% call callout('Warning', type='caution') %}
+Be careful with your variable names. Substitution works by simple
+string replacement. *Any* occurrence of the variable in the URL will be
 replaced. For example, if you define a custom variable named "_b" with value
 "foo", `/?a_b_c=_b` will become `/?afoo_c=foo`.
+{% endcall %}
 
-## <a name="exit-action"></a> `exit` action
+## `exit` action
 
-amp-ad-exit exposes an `exit` action that other elements will reference in `on="tap:..."` attributes. The action accepts a "target" string parameter that must match a named `NavigationTarget` in the `ExitConfig`. Custom variables beggining with an underscore can also be passed in.
+The `amp-ad-exit` element exposes an `exit` action that other elements reference in `on="tap:..."` attributes. The action accepts a "target" string parameter that must match a named `NavigationTarget` in the `ExitConfig`. Custom variables beginning with an underscore can also be passed in.
 
 | Parameter name      | Parameter value type      | Meaning                    |
 | ------------------- | ------------------------- | -------------------------- |
 | `target`            | `string`                  | The name of a  `NavigationTarget` in the `ExitConfig` |
 | `_[a-zA-Z0-9_-]+` | `string\|boolean\|number` | Replace the URL parameter with this name and value into the final and tracking URLs. |
 
-## <a name="config"></a> Configuration spec
-See the `AmpAdExitConfig` typedef in config.js.
+## Configuration spec
+See the `AmpAdExitConfig` typedef in [config.js](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-exit/0.1/config.js).
 
 ## Attributes
 
-amp-ad-exit needs an `id` to be referenced by tappable elements.
+##### id
+
+An `id` is required so that `amp-exit` can be referenced by tappable elements. 
 
 ## Validation
-`amp-ad-exit` is only available for AMP4ADS documents. 
+The `amp-ad-exit` element is only available for [A4A (AMP for Ads)](../amp-a4a/amp-a4a-format.md) documents. 
 See [amp-ad-exit rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii) for the AMP validator specification.


### PR DESCRIPTION
Cleaned up formatting and wording for `amp-ad-exit` doc so that it can be imported and rendered on ampproject.org.

re: https://github.com/ampproject/docs/issues/564