### PR TITLE
Reassign old FE's `top` style after auto-top detection

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -309,7 +309,7 @@ export class FixedLayer {
               top: '',
               zIndex: '',
             };
-            return;
+            continue;
           }
 
           // Calculate top, assuming that it could implicitly be `auto`.

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -257,7 +257,9 @@ export class FixedLayer {
     let hasTransferables = false;
     return this.vsync_.runPromise({
       measure: state => {
-        const autoTopMap = {};
+        const autoTops = [];
+        const oldTops = [];
+        const elements = this.elements_;
 
         // Notice that this code intentionally breaks vsync contract.
         // Unfortunately, there's no way to reliably test whether or not
@@ -266,20 +268,24 @@ export class FixedLayer {
         // `style.top = auto`.
 
         // 1. Set all style top to `auto` and calculate the auto-offset.
-        this.elements_.forEach(fe => {
+        for (let i = 0; i < elements.length; i++) {
+          const fe = elements[i];
+          oldTops.push(getStyle(fe.element, 'top'));
           setStyle(fe.element, 'top', 'auto');
-        });
-        this.elements_.forEach(fe => {
-          autoTopMap[fe.id] = fe.element./*OK*/offsetTop;
-        });
+        }
+
+        for (let i = 0; i < elements.length; i++) {
+          autoTops.push(elements[i].element./*OK*/offsetTop);
+        }
 
         // 2. Reset style top.
-        this.elements_.forEach(fe => {
-          setStyle(fe.element, 'top', '');
-        });
+        for (let i = 0; i < elements.length; i++) {
+          setStyle(elements[i].element, 'top', oldTops[i]);
+        }
 
         // 3. Calculated fixed/sticky info.
-        this.elements_.forEach(fe => {
+        for (let i = 0; i < elements.length; i++) {
+          const fe = elements[i];
           const element = fe.element;
           const styles = computedStyle(this.ampdoc.win, element);
           const position = styles.position || '';
@@ -313,7 +319,7 @@ export class FixedLayer {
           // `offsetTop` with `style.top = 'auto'` and without.
           let top = styles.top;
           const currentOffsetTop = element./*OK*/offsetTop;
-          const isImplicitAuto = currentOffsetTop == autoTopMap[fe.id];
+          const isImplicitAuto = currentOffsetTop == autoTops[i];
           if ((top == 'auto' || isImplicitAuto) && top != '0px' ||
               // This is workaround for http://crbug.com/703816 in Chrome where
               // `getComputedStyle().top` returns `0px` instead of `auto`.
@@ -353,7 +359,7 @@ export class FixedLayer {
             zIndex: styles.zIndex,
             transform: styles.transform,
           };
-        });
+        }
       },
       mutate: state => {
         if (hasTransferables && this.transfer_) {

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -176,7 +176,7 @@ describe('FixedLayer', () => {
         return id;
       },
       style: {
-        top: '',
+        top: '15px',
         bottom: '',
         position: '',
         opacity: '0.9',
@@ -581,6 +581,7 @@ describe('FixedLayer', () => {
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('0px');
+      expect(element5.style['top']).to.equal('15px');
     });
 
     it('should NOT work around top=0 for sticky for non-implicit top', () => {
@@ -614,9 +615,11 @@ describe('FixedLayer', () => {
 
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].top).to.equal('');
+      expect(element1.style['top']).to.equal('15px');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('');
+      expect(element5.style['top']).to.equal('15px');
     });
 
     it('should override implicit top = auto to 0 when equals padding', () => {
@@ -635,9 +638,11 @@ describe('FixedLayer', () => {
 
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].top).to.equal('0px');
+      expect(element1.style['top']).to.equal('15px');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('0px');
+      expect(element5.style['top']).to.equal('15px');
     });
 
     it('should override implicit top = auto to 0 and padding + border', () => {
@@ -657,9 +662,11 @@ describe('FixedLayer', () => {
 
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].top).to.equal('0px');
+      expect(element1.style['top']).to.equal('15px');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('0px');
+      expect(element5.style['top']).to.equal('15px');
     });
 
     it('should override implicit top = auto to 0 w/transient padding', () => {
@@ -685,8 +692,10 @@ describe('FixedLayer', () => {
       vsyncTasks[0].measure(state);
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].top).to.equal('0px');
+      expect(element1.style['top']).to.equal('15px');
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('0px');
+      expect(element5.style['top']).to.equal('15px');
       expect(fixedLayer.paddingTop_).to.equal(22);
       expect(fixedLayer.committedPaddingTop_).to.equal(11);
 
@@ -695,8 +704,10 @@ describe('FixedLayer', () => {
       vsyncTasks[0].measure(state);
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].top).to.equal(''); // Reset completely.
+      expect(element1.style['top']).to.equal('15px');
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal(''); // Reset completely.
+      expect(element5.style['top']).to.equal('15px');
       expect(fixedLayer.paddingTop_).to.equal(22);
       expect(fixedLayer.committedPaddingTop_).to.equal(22);
     });
@@ -717,9 +728,11 @@ describe('FixedLayer', () => {
 
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].top).to.equal('0px');
+      expect(element1.style['top']).to.equal('15px');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('0px');
+      expect(element5.style['top']).to.equal('15px');
     });
 
     it('should mutate element to fixed without top', () => {
@@ -961,10 +974,12 @@ describe('FixedLayer', () => {
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].transferrable).to.be.true;
       expect(state['F0'].top).to.equal('0px');
+      expect(element1.style['top']).to.equal('15px');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].transferrable).to.be.false;
       expect(state['F4'].top).to.equal('0px');
+      expect(element5.style['top']).to.equal('15px');
     });
 
     it('should collect turn off transferrable with top != 0', () => {
@@ -982,18 +997,22 @@ describe('FixedLayer', () => {
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].transferrable).to.be.false;
       expect(state['F0'].top).to.equal('2px');
+      expect(element1.style['top']).to.equal('15px');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].transferrable).to.be.false;
       expect(state['F4'].top).to.equal('2px');
+      expect(element5.style['top']).to.equal('15px');
     });
 
     it('should collect turn on transferrable with bottom = 0', () => {
       element1.computedStyle['position'] = 'fixed';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
+      element1.computedStyle['top'] = '';
       element1.computedStyle['bottom'] = '0px';
       element5.computedStyle['position'] = 'sticky';
+      element5.computedStyle['top'] = '';
       element5.computedStyle['bottom'] = '0px';
 
       expect(vsyncTasks).to.have.length(1);
@@ -1035,8 +1054,12 @@ describe('FixedLayer', () => {
       element1.computedStyle['position'] = 'fixed';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
+      element1.style['top'] = '';
+      element1.computedStyle['top'] = '';
       element1.computedStyle['bottom'] = '2px';
       element5.computedStyle['position'] = 'sticky';
+      element5.style['top'] = '';
+      element5.computedStyle['top'] = '';
       element5.computedStyle['bottom'] = '2px';
 
       expect(vsyncTasks).to.have.length(1);
@@ -1045,9 +1068,11 @@ describe('FixedLayer', () => {
 
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].transferrable).to.be.false;
+      expect(element1.style['top']).to.equal('');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].transferrable).to.be.false;
+      expect(element1.style['top']).to.equal('');
     });
 
     it('should collect z-index', () => {


### PR DESCRIPTION
It's a problem with an interaction between https://github.com/ampproject/amphtml/pull/3352 (god, it's been here for a year!) and the `top` style we give top-positioned elements to avoid the Viewer Header.

#3352 introduced a "auto-top" detection for bottom-positioned elements. Here, auto-top means the `top` style is not actually set, but is effectively a pixel value because it's `bottom - offsetHeight (and padding, etc)`. So, we:

1. Set `style.top = auto`
2. get the "auto-top" offsetTop, but this isn't the issue
3. Set `style.top = ''` **Bug!**

The issue is that before step 1, `style.top` could be a calculated value (to offset for the Viewer Header). But we're resetting it to `''` afterwards.