### PR TITLE
[amp-sidebar 1.0][Toolbar] Removed default Behavior, and Enforced Target

### DIFF
--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -49,13 +49,6 @@
    transition: transform 233ms cubic-bezier(0,0,.21,1);
  }
 
- .i-amphtml-toolbar {
-   z-index: 2147483646;
-   width: 100%;
-   position: fixed;
-   top: 0;
- }
-
  .i-amphtml-toolbar > ul {
    display: flex;
    justify-content: flex-start;

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -106,7 +106,7 @@ export class AmpSidebar extends AMP.BaseElement {
     // Get the toolbar attribute from the child navs
     const toolbarElements =
     Array.prototype.slice
-      .call(this.element.querySelectorAll('nav[toolbar]'), 0);
+      .call(this.element.querySelectorAll('nav[toolbar][target]'), 0);
     toolbarElements.forEach(toolbarElement => {
       try {
         this.toolbars_.push(new Toolbar(toolbarElement, this.win, this.vsync_));

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -104,12 +104,14 @@ export class AmpSidebar extends AMP.BaseElement {
       this.element.setAttribute('side', this.side_);
     }
 
+    const ampDoc = this.getAmpDoc();
     // Get the toolbar attribute from the child navs
     const toolbarElements =
       toArray(this.element.querySelectorAll('nav[toolbar][toolbar-target]'));
     toolbarElements.forEach(toolbarElement => {
       try {
-        this.toolbars_.push(new Toolbar(toolbarElement, this.win, this.vsync_));
+        this.toolbars_.push(new Toolbar(toolbarElement, this.win,
+          this.vsync_, ampDoc));
       } catch (e) {
         user().error(TAG, 'Failed to instantiate toolbar', e);
       }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -106,7 +106,7 @@ export class AmpSidebar extends AMP.BaseElement {
 
     // Get the toolbar attribute from the child navs
     const toolbarElements =
-      toArray(this.element.querySelectorAll('nav[toolbar][target]'));
+      toArray(this.element.querySelectorAll('nav[toolbar][toolbar-target]'));
     toolbarElements.forEach(toolbarElement => {
       try {
         this.toolbars_.push(new Toolbar(toolbarElement, this.win, this.vsync_));

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -107,7 +107,7 @@ export class AmpSidebar extends AMP.BaseElement {
     const ampdoc = this.getAmpDoc();
     // Get the toolbar attribute from the child navs
     const toolbarElements =
-      toArray(ampdoc.getRootNode().querySelectorAll('nav[toolbar]'));
+      toArray(this.element.querySelectorAll('nav[toolbar]'));
     toolbarElements.forEach(toolbarElement => {
       try {
         this.toolbars_.push(new Toolbar(toolbarElement, this.vsync_,

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -104,14 +104,14 @@ export class AmpSidebar extends AMP.BaseElement {
       this.element.setAttribute('side', this.side_);
     }
 
-    const ampDoc = this.getAmpDoc();
+    const ampdoc = this.getAmpDoc();
     // Get the toolbar attribute from the child navs
     const toolbarElements =
-      toArray(this.element.querySelectorAll('nav[toolbar][toolbar-target]'));
+      toArray(ampdoc.getRootNode().querySelectorAll('nav[toolbar]'));
     toolbarElements.forEach(toolbarElement => {
       try {
-        this.toolbars_.push(new Toolbar(toolbarElement, this.win,
-          this.vsync_, ampDoc));
+        this.toolbars_.push(new Toolbar(toolbarElement, this.vsync_,
+          ampdoc));
       } catch (e) {
         user().error(TAG, 'Failed to instantiate toolbar', e);
       }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -23,6 +23,7 @@ import {closestByTag, tryFocus} from '../../../src/dom';
 import {Services} from '../../../src/services';
 import {setStyles, toggle} from '../../../src/style';
 import {removeFragment, parseUrl} from '../../../src/url';
+import {toArray} from '../../../src/types';
 import {Toolbar} from './toolbar';
 
 /** @const */
@@ -105,8 +106,7 @@ export class AmpSidebar extends AMP.BaseElement {
 
     // Get the toolbar attribute from the child navs
     const toolbarElements =
-    Array.prototype.slice
-      .call(this.element.querySelectorAll('nav[toolbar][target]'), 0);
+      toArray(this.element.querySelectorAll('nav[toolbar][target]'));
     toolbarElements.forEach(toolbarElement => {
       try {
         this.toolbars_.push(new Toolbar(toolbarElement, this.win, this.vsync_));

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -616,7 +616,7 @@
          const headerElements = sidebarElement.ownerDocument
                .getElementsByTagName('header');
          const toolbarElements = sidebarElement.ownerDocument
-               .querySelectorAll('[toolbar][toolbar-target]');
+               .querySelectorAll('[toolbar]');
          expect(headerElements.length).to.be.equal(0);
          expect(toolbarElements.length).to.be.equal(0);
          expect(sidebarElement.implementation_.toolbars_.length).to.be.equal(0);

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -25,6 +25,8 @@
  import '../amp-sidebar';
 
  /** @const */
+ const DEFAULT_TOOLBAR_TARGET = 'toolbar-target';
+ /** @const */
  const DEFAULT_TOOLBAR_MEDIA = '(min-width: 768px)';
 
 
@@ -73,9 +75,26 @@
                  return Promise.resolve();
                });
            // Create our individual toolbars
-           options.toolbars.forEach(() => {
+           options.toolbars.forEach(toolbarObj => {
              const navToolbar = iframe.doc.createElement('nav');
-             navToolbar.setAttribute('toolbar', DEFAULT_TOOLBAR_MEDIA);
+
+             //Create/Set toolbar target
+             const toolbarTarget = iframe.doc.createElement('div');
+             if (toolbarObj.target) {
+               toolbarTarget.setAttribute('id', toolbarObj.target);
+               navToolbar.setAttribute('target', toolbarObj.target);
+             } else {
+               toolbarTarget.setAttribute('id', DEFAULT_TOOLBAR_TARGET);
+               navToolbar.setAttribute('target', DEFAULT_TOOLBAR_TARGET);
+             }
+             iframe.win.document.body.appendChild(toolbarTarget);
+
+             // Set the toolbar media
+             if (toolbarObj.media) {
+               navToolbar.setAttribute('toolbar', toolbarObj.media);
+             } else {
+               navToolbar.setAttribute('toolbar', DEFAULT_TOOLBAR_MEDIA);
+             }
              const toolbarList = iframe.doc.createElement('ul');
              for (let i = 0; i < 3; i++) {
                const li = iframe.doc.createElement('li');
@@ -611,12 +630,12 @@
      it('should create a toolbar target element, \
      containing the navigation toolbar element', () => {
        return getAmpSidebar({
-         toolbars: [true],
+         toolbars: [{}],
        }).then(obj => {
          const sidebarElement = obj.ampSidebar;
          const toolbarNavElements = Array.prototype
                 .slice.call(sidebarElement.ownerDocument
-                .querySelectorAll('nav[toolbar]'), 0);
+                .querySelectorAll('nav[toolbar][target]'), 0);
          expect(toolbarNavElements.length).to.be.above(1);
          expect(sidebarElement.implementation_.toolbars_.length).to.be.equal(1);
        });
@@ -625,7 +644,7 @@
      it('should create multiple toolbar target elements, \
      containing the navigation toolbar element', () => {
        return getAmpSidebar({
-         toolbars: [true,
+         toolbars: [{},
            {
              media: '(min-width: 1024px)',
            },
@@ -634,7 +653,7 @@
          const sidebarElement = obj.ampSidebar;
          const toolbarNavElements = Array.prototype
                 .slice.call(sidebarElement.ownerDocument
-                .querySelectorAll('nav[toolbar]'), 0);
+                .querySelectorAll('nav[toolbar][target]'), 0);
          expect(toolbarNavElements.length).to.be.equal(4);
          expect(sidebarElement.implementation_.toolbars_.length).to.be.equal(2);
        });

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -72,14 +72,16 @@
            options.toolbars.forEach(toolbarObj => {
              const navToolbar = iframe.doc.createElement('nav');
 
-             //Create/Set toolbar target
+             //Create/Set toolbar-target
              const toolbarTarget = iframe.doc.createElement('div');
-             if (toolbarObj.target) {
-               toolbarTarget.setAttribute('id', toolbarObj.target);
-               navToolbar.setAttribute('target', toolbarObj.target);
+             if (toolbarObj.toolbarTarget) {
+               toolbarTarget.setAttribute('id',
+                   toolbarObj.toolbarTarget);
+               navToolbar.setAttribute('toolbar-target',
+                   toolbarObj.toolbarTarget);
              } else {
                toolbarTarget.setAttribute('id', 'toolbar-target');
-               navToolbar.setAttribute('target', 'toolbar-target');
+               navToolbar.setAttribute('toolbar-target', 'toolbar-target');
              }
              iframe.win.document.body.appendChild(toolbarTarget);
 
@@ -614,14 +616,14 @@
          const headerElements = sidebarElement.ownerDocument
                .getElementsByTagName('header');
          const toolbarElements = sidebarElement.ownerDocument
-               .querySelectorAll('*[toolbar]');
+               .querySelectorAll('[toolbar][toolbar-target]');
          expect(headerElements.length).to.be.equal(0);
          expect(toolbarElements.length).to.be.equal(0);
          expect(sidebarElement.implementation_.toolbars_.length).to.be.equal(0);
        });
      });
 
-     it('should create a toolbar element within the target', () => {
+     it('should create a toolbar element within the toolbar-target', () => {
        return getAmpSidebar({
          toolbars: [{}],
        }).then(obj => {

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -24,12 +24,6 @@
  import * as sinon from 'sinon';
  import '../amp-sidebar';
 
- /** @const */
- const DEFAULT_TOOLBAR_TARGET = 'toolbar-target';
- /** @const */
- const DEFAULT_TOOLBAR_MEDIA = '(min-width: 768px)';
-
-
  adopt(window);
 
  describes.realWin('amp-sidebar 1.0 version', {
@@ -84,8 +78,8 @@
                toolbarTarget.setAttribute('id', toolbarObj.target);
                navToolbar.setAttribute('target', toolbarObj.target);
              } else {
-               toolbarTarget.setAttribute('id', DEFAULT_TOOLBAR_TARGET);
-               navToolbar.setAttribute('target', DEFAULT_TOOLBAR_TARGET);
+               toolbarTarget.setAttribute('id', 'toolbar-target');
+               navToolbar.setAttribute('target', 'toolbar-target');
              }
              iframe.win.document.body.appendChild(toolbarTarget);
 
@@ -93,7 +87,7 @@
              if (toolbarObj.media) {
                navToolbar.setAttribute('toolbar', toolbarObj.media);
              } else {
-               navToolbar.setAttribute('toolbar', DEFAULT_TOOLBAR_MEDIA);
+               navToolbar.setAttribute('toolbar', '(min-width: 768px)');
              }
              const toolbarList = iframe.doc.createElement('ul');
              for (let i = 0; i < 3; i++) {
@@ -627,22 +621,18 @@
        });
      });
 
-     it('should create a toolbar target element, \
-     containing the navigation toolbar element', () => {
+     it('should create a toolbar element within the target', () => {
        return getAmpSidebar({
          toolbars: [{}],
        }).then(obj => {
          const sidebarElement = obj.ampSidebar;
-         const toolbarNavElements = Array.prototype
-                .slice.call(sidebarElement.ownerDocument
-                .querySelectorAll('nav[toolbar][target]'), 0);
-         expect(toolbarNavElements.length).to.be.above(1);
-         expect(sidebarElement.implementation_.toolbars_.length).to.be.equal(1);
+         expect(sidebarElement.implementation_.toolbars_.length)
+             .to.be.equal(1);
        });
      });
 
-     it('should create multiple toolbar target elements, \
-     containing the navigation toolbar element', () => {
+     it('should create multiple toolbar elements, \
+     within their respective containers', () => {
        return getAmpSidebar({
          toolbars: [{},
            {
@@ -651,11 +641,8 @@
          ],
        }).then(obj => {
          const sidebarElement = obj.ampSidebar;
-         const toolbarNavElements = Array.prototype
-                .slice.call(sidebarElement.ownerDocument
-                .querySelectorAll('nav[toolbar][target]'), 0);
-         expect(toolbarNavElements.length).to.be.equal(4);
-         expect(sidebarElement.implementation_.toolbars_.length).to.be.equal(2);
+         expect(sidebarElement.implementation_.toolbars_.length)
+             .to.be.equal(2);
        });
      });
    });

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -64,14 +64,14 @@
            navToolbar.setAttribute('toolbar-only', '');
          }
          const toolbarTarget = iframe.doc.createElement('div');
-         if (toolbarObj.target) {
-           toolbarTarget.setAttribute('id', toolbarObj.target);
-           navToolbar.setAttribute('target', toolbarObj.target);
-         } else if (toolbarObj.targetError) {
+         if (toolbarObj.toolbarTarget) {
+           toolbarTarget.setAttribute('id', toolbarObj.toolbarTarget);
+           navToolbar.setAttribute('toolbar-target', toolbarObj.toolbarTarget);
+         } else if (toolbarObj.toolbarTargetError) {
            navToolbar.setAttribute('target', 'toolbar-target');
          } else {
            toolbarTarget.setAttribute('id', 'toolbar-target');
-           navToolbar.setAttribute('target', 'toolbar-target');
+           navToolbar.setAttribute('toolbar-target', 'toolbar-target');
          }
          iframe.win.document.body.appendChild(toolbarTarget);
          const toolbarList = iframe.doc.createElement('ul');
@@ -161,7 +161,7 @@
    target attrbiute', () => {
      const targetId = 'toolbar-target';
      return getToolbars([{
-       target: targetId,
+       'toolbar-target': targetId,
      }]).then(obj => {
        const toolbars = obj.toolbars;
        resizeIframeToWidth(obj.iframe, '1024px', () => {
@@ -181,7 +181,7 @@
    matching window size for (min-width: 768px)', () => {
      const targetId = 'toolbar-target';
      return getToolbars([{
-       target: targetId,
+       'toolbar-target': targetId,
      }]).then(obj => {
        const toolbars = obj.toolbars;
        const toolbarTargets =
@@ -203,7 +203,7 @@
    non-matching window size for (min-width: 768px)', () => {
      const targetId = 'toolbar-target';
      return getToolbars([{
-       target: targetId,
+       'toolbar-target': targetId,
      }]).then(obj => {
        const toolbars = obj.toolbars;
        const toolbarTargets =

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -168,9 +168,10 @@
          toolbars.forEach(toolbar => {
            toolbar.onLayoutChange();
          });
+         const toolbarQuery = `#${targetId} > nav[toolbar][toolbar-target]`;
          const toolbarTargetElements =
                 toArray(obj.iframe.win.document.body
-                .querySelectorAll(`#${targetId} > nav[toolbar][target]`));
+                .querySelectorAll(toolbarQuery));
          expect(toolbars.length).to.be.equal(1);
          expect(toolbarTargetElements.length).to.be.equal(1);
        });
@@ -234,7 +235,7 @@
          });
          const toolbarNavElements =
                 toArray(obj.toolbarContainerElement.ownerDocument
-                .querySelectorAll('nav[toolbar][target]'));
+                .querySelectorAll('nav[toolbar][toolbar-target]'));
          const hiddenToolbarNavElements =
                 toArray(obj.toolbarContainerElement.ownerDocument
                 .querySelectorAll('nav[style]'));

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -16,6 +16,7 @@
  */
 
  import {adopt} from '../../../../src/runtime';
+ import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
  import {createIframePromise} from '../../../../testing/iframe';
  import {Services} from '../../../../src/services';
  import {toArray} from '../../../../src/types';
@@ -28,6 +29,7 @@
    let sandbox;
    let timer;
    let vsync;
+   let ampDoc;
 
    function getToolbars(options) {
      options = options || {};
@@ -82,7 +84,7 @@
          }
          navToolbar.appendChild(toolbarList);
          toolbarContainerElement.appendChild(navToolbar);
-         toolbars.push(new Toolbar(navToolbar, iframe.win, vsync));
+         toolbars.push(new Toolbar(navToolbar, iframe.win, vsync, ampDoc));
        });
 
        return {iframe, toolbarContainerElement, toolbars};
@@ -98,6 +100,7 @@
 
    beforeEach(() => {
      sandbox = sinon.sandbox.create();
+     ampDoc = new AmpDocSingle(window);
    });
 
    afterEach(() => {

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -22,6 +22,8 @@
  import {Toolbar} from '../toolbar';
 
  /** @const */
+ const DEFAULT_TOOLBAR_TARGET = 'toolbar-target';
+ /** @const */
  const DEFAULT_TOOLBAR_MEDIA = '(min-width: 768px)';
 
  /** @const */
@@ -69,12 +71,17 @@
          if (toolbarObj.toolbarOnlyOnNav) {
            navToolbar.setAttribute('toolbar-only', '');
          }
+         const toolbarTarget = iframe.doc.createElement('div');
          if (toolbarObj.target) {
-           const toolbarTarget = iframe.doc.createElement('div');
            toolbarTarget.setAttribute('id', toolbarObj.target);
-           iframe.win.document.body.appendChild(toolbarTarget);
            navToolbar.setAttribute('target', toolbarObj.target);
+         } else if (toolbarObj.targetError) {
+           navToolbar.setAttribute('target', DEFAULT_TOOLBAR_TARGET);
+         } else {
+           toolbarTarget.setAttribute('id', DEFAULT_TOOLBAR_TARGET);
+           navToolbar.setAttribute('target', DEFAULT_TOOLBAR_TARGET);
          }
+         iframe.win.document.body.appendChild(toolbarTarget);
          const toolbarList = iframe.doc.createElement('ul');
          for (let i = 0; i < 3; i++) {
            const li = iframe.doc.createElement('li');
@@ -103,6 +110,18 @@
 
    afterEach(() => {
      sandbox.restore();
+   });
+
+   it('toolbar header should error if target element \
+   could not be found as it is required.', () => {
+     return getToolbars([{
+       targetError: true,
+     }]).then(() => {
+       expect(false).to.be.equal(true, 'Toolbar \
+       should not be created when the target element is not found');
+     }).catch(() => {
+       expect(true).to.be.ok;
+     });
    });
 
    it('toolbar header should be hidden for a \

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -18,17 +18,9 @@
  import {adopt} from '../../../../src/runtime';
  import {createIframePromise} from '../../../../testing/iframe';
  import {Services} from '../../../../src/services';
+ import {toArray} from '../../../../src/types';
  import * as sinon from 'sinon';
  import {Toolbar} from '../toolbar';
-
- /** @const */
- const DEFAULT_TOOLBAR_TARGET = 'toolbar-target';
- /** @const */
- const DEFAULT_TOOLBAR_MEDIA = '(min-width: 768px)';
-
- /** @const */
- const TOOLBAR_ELEMENT_CLASS = 'i-amphtml-toolbar';
-
 
  adopt(window);
 
@@ -66,7 +58,7 @@
          if (toolbarObj.media) {
            navToolbar.setAttribute('toolbar', toolbar.media);
          } else {
-           navToolbar.setAttribute('toolbar', DEFAULT_TOOLBAR_MEDIA);
+           navToolbar.setAttribute('toolbar', '(min-width: 768px)');
          }
          if (toolbarObj.toolbarOnlyOnNav) {
            navToolbar.setAttribute('toolbar-only', '');
@@ -76,10 +68,10 @@
            toolbarTarget.setAttribute('id', toolbarObj.target);
            navToolbar.setAttribute('target', toolbarObj.target);
          } else if (toolbarObj.targetError) {
-           navToolbar.setAttribute('target', DEFAULT_TOOLBAR_TARGET);
+           navToolbar.setAttribute('target', 'toolbar-target');
          } else {
-           toolbarTarget.setAttribute('id', DEFAULT_TOOLBAR_TARGET);
-           navToolbar.setAttribute('target', DEFAULT_TOOLBAR_TARGET);
+           toolbarTarget.setAttribute('id', 'toolbar-target');
+           navToolbar.setAttribute('target', 'toolbar-target');
          }
          iframe.win.document.body.appendChild(toolbarTarget);
          const toolbarList = iframe.doc.createElement('ul');
@@ -125,55 +117,42 @@
    });
 
    it('toolbar header should be hidden for a \
-   non-matching window size for DEFAULT_TOOLBAR_MEDIA', () => {
+   non-matching window size for (min-width: 768px)', () => {
      return getToolbars([{}]).then(obj => {
        const toolbars = obj.toolbars;
-       const toolbarElements = Array.prototype
-              .slice.call(obj.toolbarContainerElement.ownerDocument
-              .getElementsByClassName(TOOLBAR_ELEMENT_CLASS), 0);
-       resizeIframeToWidth(obj.iframe, '1px', () => {
-         expect(toolbarElements.length).to.be.above(0);
+       resizeIframeToWidth(obj.iframe, '1024px', () => {
          toolbars.forEach(toolbar => {
            toolbar.onLayoutChange();
          });
-         expect(toolbarElements[0].parentElement.style.display)
-             .to.be.equal('none');
+         const toolbarElements =
+                toArray(obj.toolbarContainerElement.ownerDocument
+                .getElementsByClassName('i-amphtml-toolbar'));
+         resizeIframeToWidth(obj.iframe, '1px', () => {
+           toolbars.forEach(toolbar => {
+             toolbar.onLayoutChange();
+           });
+           expect(toolbarElements.length).to.be.above(0);
+           expect(toolbarElements[0].parentElement.style.display)
+               .to.be.equal('none');
+         });
        });
      });
    });
 
    it('toolbar header should be shown for a \
-   matching window size for DEFAULT_TOOLBAR_MEDIA', () => {
+   matching window size for (min-width: 768px)', () => {
      return getToolbars([{}]).then(obj => {
        const toolbars = obj.toolbars;
-       const toolbarElements = Array.prototype
-              .slice.call(obj.toolbarContainerElement.ownerDocument
-              .getElementsByClassName(TOOLBAR_ELEMENT_CLASS), 0);
        resizeIframeToWidth(obj.iframe, '4000px', () => {
-         expect(toolbarElements.length).to.be.above(0);
          toolbars.forEach(toolbar => {
            toolbar.onLayoutChange();
          });
+         const toolbarElements =
+                toArray(obj.toolbarContainerElement.ownerDocument
+                .getElementsByClassName('i-amphtml-toolbar'));
+         expect(toolbarElements.length).to.be.above(0);
          expect(toolbarElements[0].parentElement.style.display)
              .to.be.equal('');
-       });
-     });
-   });
-
-   it('toolbar header should be hidden for a \
-   non-matching window size for DEFAULT_TOOLBAR_MEDIA', () => {
-     return getToolbars([{}]).then(obj => {
-       const toolbars = obj.toolbars;
-       const toolbarElements = Array.prototype
-              .slice.call(obj.toolbarContainerElement.ownerDocument
-              .getElementsByClassName(TOOLBAR_ELEMENT_CLASS), 0);
-       resizeIframeToWidth(obj.iframe, '1px', () => {
-         expect(toolbarElements.length).to.be.above(0);
-         toolbars.forEach(toolbar => {
-           toolbar.onLayoutChange();
-         });
-         expect(toolbarElements[0].parentElement.style.display)
-             .to.be.equal('none');
        });
      });
    });
@@ -185,24 +164,29 @@
        target: targetId,
      }]).then(obj => {
        const toolbars = obj.toolbars;
-       const toolbarTargetElements = Array.prototype
-              .slice.call(obj.iframe.win.document.body
-              .querySelectorAll(`#${targetId} > nav[toolbar]`), 0);
-       expect(toolbars.length).to.be.equal(1);
-       expect(toolbarTargetElements.length).to.be.equal(1);
+       resizeIframeToWidth(obj.iframe, '1024px', () => {
+         toolbars.forEach(toolbar => {
+           toolbar.onLayoutChange();
+         });
+         const toolbarTargetElements =
+                toArray(obj.iframe.win.document.body
+                .querySelectorAll(`#${targetId} > nav[toolbar][target]`));
+         expect(toolbars.length).to.be.equal(1);
+         expect(toolbarTargetElements.length).to.be.equal(1);
+       });
      });
    });
 
    it('toolbar should be placed into a target, and shown for a \
-   matching window size for DEFAULT_TOOLBAR_MEDIA', () => {
+   matching window size for (min-width: 768px)', () => {
      const targetId = 'toolbar-target';
      return getToolbars([{
        target: targetId,
      }]).then(obj => {
        const toolbars = obj.toolbars;
-       const toolbarTargets = Array.prototype
-               .slice.call(obj.iframe.win.document.body
-               .querySelectorAll(`#${targetId}`), 0);
+       const toolbarTargets =
+                toArray(obj.iframe.win.document.body
+               .querySelectorAll(`#${targetId}`));
        resizeIframeToWidth(obj.iframe, '4000px', () => {
          toolbars.forEach(toolbar => {
            toolbar.onLayoutChange();
@@ -216,15 +200,15 @@
    });
 
    it('toolbar should be placed into a target, and hidden for a \
-   non-matching window size for DEFAULT_TOOLBAR_MEDIA', () => {
+   non-matching window size for (min-width: 768px)', () => {
      const targetId = 'toolbar-target';
      return getToolbars([{
        target: targetId,
      }]).then(obj => {
        const toolbars = obj.toolbars;
-       const toolbarTargets = Array.prototype
-               .slice.call(obj.iframe.win.document.body
-               .querySelectorAll(`#${targetId}`), 0);
+       const toolbarTargets =
+                toArray(obj.iframe.win.document.body
+               .querySelectorAll(`#${targetId}`));
        resizeIframeToWidth(obj.iframe, '200px', () => {
          toolbars.forEach(toolbar => {
            toolbar.onLayoutChange();
@@ -239,7 +223,7 @@
 
    it('should hide <nav toolbar> elements with toolbar-only, \
    inside the sidebar, but not inside the toolbar, for a matching \
-   window size for DEFAULT_TOOLBAR_MEDIA', () => {
+   window size for (min-width: 768px)', () => {
      return getToolbars([{
        toolbarOnlyOnNav: true,
      }]).then(obj => {
@@ -248,12 +232,12 @@
          toolbars.forEach(toolbar => {
            toolbar.onLayoutChange();
          });
-         const toolbarNavElements = Array.prototype
-                .slice.call(obj.toolbarContainerElement.ownerDocument
-                .querySelectorAll('nav[toolbar]'), 0);
-         const hiddenToolbarNavElements = Array.prototype
-                .slice.call(obj.toolbarContainerElement.ownerDocument
-                .querySelectorAll('nav[style]'), 0);
+         const toolbarNavElements =
+                toArray(obj.toolbarContainerElement.ownerDocument
+                .querySelectorAll('nav[toolbar][target]'));
+         const hiddenToolbarNavElements =
+                toArray(obj.toolbarContainerElement.ownerDocument
+                .querySelectorAll('nav[style]'));
          expect(toolbarNavElements.length).to.be.equal(2);
          expect(hiddenToolbarNavElements.length).to.be.equal(1);
          expect(toolbars.length).to.be.equal(1);

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -15,9 +15,7 @@
  */
 
 import {toggle} from '../../../src/style';
-
-/** @const */
-const TOOLBAR_ELEMENT_CLASS = 'i-amphtml-toolbar';
+import {toArray} from '../../../src/types';
 
 export class Toolbar {
   /**
@@ -27,7 +25,7 @@ export class Toolbar {
   */
   constructor(element, win, vsync) {
     /** @private {!Element} */
-    this.toolbarDOMElement_ = element;
+    this.toolbarDomElement_ = element;
 
     /** @private {!Window} **/
     this.win_ = win;
@@ -42,7 +40,7 @@ export class Toolbar {
     this.vsync_ = vsync;
 
     /** @private {!string} */
-    this.toolbarMedia_ = this.toolbarDOMElement_.getAttribute('toolbar');
+    this.toolbarMedia_ = this.toolbarDomElement_.getAttribute('toolbar');
 
     /** @private {?Element} */
     this.toolbarClone_ = null;
@@ -57,16 +55,16 @@ export class Toolbar {
     this.toolbarOnlyElementsInSidebar_ = [];
 
     // Find our tool-bar only elements
-    if (this.toolbarDOMElement_.hasAttribute('toolbar-only')) {
-      this.toolbarOnlyElementsInSidebar_.push(this.toolbarDOMElement_);
+    if (this.toolbarDomElement_.hasAttribute('toolbar-only')) {
+      this.toolbarOnlyElementsInSidebar_.push(this.toolbarDomElement_);
     } else {
       // Get our toolbar only elements
       const toolbarOnlyQuery =
-        this.toolbarDOMElement_.querySelectorAll('[toolbar-only]');
+        this.toolbarDomElement_.querySelectorAll('[toolbar-only]');
       if (toolbarOnlyQuery.length > 0) {
         // Check the nav's children for toolbar-only
         this.toolbarOnlyElementsInSidebar_ =
-          Array.prototype.slice.call(toolbarOnlyQuery, 0);
+          toArray(toolbarOnlyQuery);
       }
     }
     this.buildCallback_();
@@ -97,14 +95,13 @@ export class Toolbar {
    * @private
    */
   buildCallback_() {
-    this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
-    const targetId = this.toolbarDOMElement_.getAttribute('target');
+    this.toolbarClone_ = this.toolbarDomElement_.cloneNode(true);
+    const targetId = this.toolbarDomElement_.getAttribute('target');
     // Set the target element to the toolbar clone if it exists.
     const targetElement = this.win_.document.getElementById(targetId);
     if (targetElement) {
       this.targetElement_ = targetElement;
-      this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
-      this.targetElement_.appendChild(this.toolbarClone_);
+      this.toolbarClone_.classList.add('i-amphtml-toolbar');
       toggle(this.targetElement_, false);
     } else {
       throw new
@@ -136,6 +133,9 @@ export class Toolbar {
     return this.vsync_.mutatePromise(() => {
       if (this.targetElement_) {
         toggle(this.targetElement_, true);
+        if (!this.targetElement_.contains(this.toolbarClone_)) {
+          this.targetElement_.appendChild(this.toolbarClone_);
+        }
       }
       if (this.toolbarOnlyElementsInSidebar_) {
         this.toolbarOnlyElementsInSidebar_.forEach(element => {

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -22,8 +22,9 @@ export class Toolbar {
   * @param {!Element} element
   * @param {!Window} win
   * @param {!../../../src/service/vsync-impl.Vsync} vsync
+  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
   */
-  constructor(element, win, vsync) {
+  constructor(element, win, vsync, ampDoc) {
     /** @private {!Element} */
     this.toolbarDomElement_ = element;
 
@@ -38,6 +39,9 @@ export class Toolbar {
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = vsync;
+
+    /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampDoc_ = ampDoc;
 
     /** @private {!string} */
     this.toolbarMedia_ = this.toolbarDomElement_.getAttribute('toolbar');
@@ -98,15 +102,19 @@ export class Toolbar {
     this.toolbarClone_ = this.toolbarDomElement_.cloneNode(true);
     const targetId = this.toolbarDomElement_.getAttribute('toolbar-target');
     // Set the target element to the toolbar clone if it exists.
-    const targetElement = this.win_.document.getElementById(targetId);
-    if (targetElement) {
-      this.toolbarTarget_ = targetElement;
-      this.toolbarClone_.classList.add('i-amphtml-toolbar');
-      toggle(this.toolbarTarget_, false);
-    } else {
-      throw new Error('Could not find the ' +
-      `toolbar-target element with an id: ${targetId}`);
-    }
+    this.ampDoc_.whenReady().then(() => {
+      const targetElement = this.win_.document.getElementById(targetId);
+      if (targetElement) {
+        this.toolbarTarget_ = targetElement;
+        this.toolbarClone_.classList.add('i-amphtml-toolbar');
+        toggle(this.toolbarTarget_, false);
+      } else {
+        // This error will be later rethrown as a user error and
+        // the side bar will continue to function w/o toolbar feature
+        throw new Error('Could not find the ' +
+        `toolbar-target element with an id: ${targetId}`);
+      }
+    });
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -46,7 +46,7 @@ export class Toolbar {
     this.toolbarClone_ = null;
 
     /** @private {Element|undefined} */
-    this.targetElement_ = undefined;
+    this.toolbarTarget_ = undefined;
 
     /** @private {!boolean} **/
     this.toolbarShown_ = false;
@@ -96,16 +96,16 @@ export class Toolbar {
    */
   buildCallback_() {
     this.toolbarClone_ = this.toolbarDomElement_.cloneNode(true);
-    const targetId = this.toolbarDomElement_.getAttribute('target');
+    const targetId = this.toolbarDomElement_.getAttribute('toolbar-target');
     // Set the target element to the toolbar clone if it exists.
     const targetElement = this.win_.document.getElementById(targetId);
     if (targetElement) {
-      this.targetElement_ = targetElement;
+      this.toolbarTarget_ = targetElement;
       this.toolbarClone_.classList.add('i-amphtml-toolbar');
-      toggle(this.targetElement_, false);
+      toggle(this.toolbarTarget_, false);
     } else {
-      throw new
-        Error(`Could not find the target element with an id: ${targetId}`);
+      throw new Error('Could not find the ' +
+      `toolbar-target element with an id: ${targetId}`);
     }
   }
 
@@ -131,10 +131,10 @@ export class Toolbar {
 
     // Display the elements
     return this.vsync_.mutatePromise(() => {
-      if (this.targetElement_) {
-        toggle(this.targetElement_, true);
-        if (!this.targetElement_.contains(this.toolbarClone_)) {
-          this.targetElement_.appendChild(this.toolbarClone_);
+      if (this.toolbarTarget_) {
+        toggle(this.toolbarTarget_, true);
+        if (!this.toolbarTarget_.contains(this.toolbarClone_)) {
+          this.toolbarTarget_.appendChild(this.toolbarClone_);
         }
       }
       if (this.toolbarOnlyElementsInSidebar_) {
@@ -158,8 +158,8 @@ export class Toolbar {
 
     this.vsync_.mutate(() => {
       // Hide the elements
-      if (this.targetElement_) {
-        toggle(this.targetElement_, false);
+      if (this.toolbarTarget_) {
+        toggle(this.toolbarTarget_, false);
       }
       if (this.toolbarOnlyElementsInSidebar_) {
         this.toolbarOnlyElementsInSidebar_.forEach(element => {

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -16,23 +16,17 @@
 
 import {toggle} from '../../../src/style';
 import {toArray} from '../../../src/types';
+import {user} from '../../../src/log';
 
 export class Toolbar {
   /**
   * @param {!Element} element
-  * @param {!Window} win
   * @param {!../../../src/service/vsync-impl.Vsync} vsync
-  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
+  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
   */
-  constructor(element, win, vsync, ampDoc) {
+  constructor(element, vsync, ampdoc) {
     /** @private {!Element} */
     this.toolbarDomElement_ = element;
-
-    /** @private {!Window} **/
-    this.win_ = win;
-
-    /** @private {Element} */
-    this.body_ = this.win_.document.body;
 
     /** @private {number|undefined} */
     this.height_ = undefined;
@@ -41,7 +35,10 @@ export class Toolbar {
     this.vsync_ = vsync;
 
     /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc} */
-    this.ampDoc_ = ampDoc;
+    this.ampdoc_ = ampdoc;
+
+    /** @private {Element} */
+    this.body_ = this.ampdoc_.win.document.body;
 
     /** @private {!string} */
     this.toolbarMedia_ = this.toolbarDomElement_.getAttribute('toolbar');
@@ -80,7 +77,7 @@ export class Toolbar {
    */
   onLayoutChange(onShowCallback) {
     // Get if we match the current toolbar media
-    const matchesMedia = this.win_
+    const matchesMedia = this.ampdoc_.win
         .matchMedia(this.toolbarMedia_).matches;
 
     // Remove and add the toolbar dynamically
@@ -100,10 +97,12 @@ export class Toolbar {
    */
   buildCallback_() {
     this.toolbarClone_ = this.toolbarDomElement_.cloneNode(true);
-    const targetId = this.toolbarDomElement_.getAttribute('toolbar-target');
+    const targetId = user().assert(this.toolbarDomElement_
+        .getAttribute('toolbar-target'), '"toolbar-target" is required',
+        this.toolbarDomElement_);
     // Set the target element to the toolbar clone if it exists.
-    this.ampDoc_.whenReady().then(() => {
-      const targetElement = this.win_.document.getElementById(targetId);
+    this.ampdoc_.whenReady().then(() => {
+      const targetElement = this.ampdoc_.getElementById(targetId);
       if (targetElement) {
         this.toolbarTarget_ = targetElement;
         this.toolbarClone_.classList.add('i-amphtml-toolbar');

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -107,7 +107,8 @@ export class Toolbar {
       this.targetElement_.appendChild(this.toolbarClone_);
       toggle(this.targetElement_, false);
     } else {
-      throw new Error(`Could not find an element with the id: ${targetId}`);
+      throw new
+        Error(`Could not find the target element with an id: ${targetId}`);
     }
   }
 

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -103,14 +103,9 @@ export class Toolbar {
     const targetElement = this.win_.document.getElementById(targetId);
     if (targetElement) {
       this.targetElement_ = targetElement;
+      this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
       this.targetElement_.appendChild(this.toolbarClone_);
       toggle(this.targetElement_, false);
-      // Check if the target element was created by us, or already inserted by the user
-      this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
-      const fragment = this.win_
-        .document.createDocumentFragment();
-      fragment.appendChild(this.targetElement_);
-      this.body_.appendChild(fragment);
     } else {
       throw new Error(`Could not find an element with the id: ${targetId}`);
     }

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -17,9 +17,6 @@
 import {toggle} from '../../../src/style';
 
 /** @const */
-const TOOLBAR_TARGET_CLASS = 'i-amphtml-toolbar-target';
-
-/** @const */
 const TOOLBAR_ELEMENT_CLASS = 'i-amphtml-toolbar';
 
 export class Toolbar {
@@ -103,33 +100,20 @@ export class Toolbar {
     this.toolbarClone_ = this.toolbarDOMElement_.cloneNode(true);
     const targetId = this.toolbarDOMElement_.getAttribute('target');
     // Set the target element to the toolbar clone if it exists.
-    const targetElement =
-    this.win_.document.getElementById(`${targetId}_toolbar`) ||
-    this.win_.document.getElementById(targetId);
-    this.targetElement_ = targetElement || this.createTargetElement_();
-    this.targetElement_.appendChild(this.toolbarClone_);
-    toggle(this.targetElement_, false);
-
-    // Check if the target element was created by us, or already inserted by the user
-    if (!this.targetElement_.parentElement) {
+    const targetElement = this.win_.document.getElementById(targetId);
+    if (targetElement) {
+      this.targetElement_ = targetElement;
+      this.targetElement_.appendChild(this.toolbarClone_);
+      toggle(this.targetElement_, false);
+      // Check if the target element was created by us, or already inserted by the user
       this.toolbarClone_.classList.add(TOOLBAR_ELEMENT_CLASS);
       const fragment = this.win_
         .document.createDocumentFragment();
       fragment.appendChild(this.targetElement_);
       this.body_.appendChild(fragment);
+    } else {
+      throw new Error(`Could not find an element with the id: ${targetId}`);
     }
-  }
-
-  /**
-   * Returns a created element that can be used as the target if one does not exist
-   * @returns {Element}
-   * @private
-   */
-  createTargetElement_() {
-    const targetElement =
-      this.win_.document.createElement('header');
-    targetElement.classList.add(TOOLBAR_TARGET_CLASS);
-    return targetElement;
   }
 
   /**

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -37,9 +37,6 @@ export class Toolbar {
     /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc_ = ampdoc;
 
-    /** @private {Element} */
-    this.body_ = this.ampdoc_.win.document.body;
-
     /** @private {!string} */
     this.toolbarMedia_ = this.toolbarDomElement_.getAttribute('toolbar');
 

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -146,7 +146,7 @@ limitations under the License.
 
     <!-- Toolbar One, basic usage, toolbar-only -->
     <!-- Could center with CSS justify-content: space-between, but trying to be minimal -->
-    <nav toolbar="(min-width: 0px)" target="hamburger-toolbar" class="ampstart-hamburger-nav ampstart-navbar-bg" toolbar-only>
+    <nav toolbar="(min-width: 0px)" toolbar-target="hamburger-toolbar" class="ampstart-hamburger-nav ampstart-navbar-bg" toolbar-only>
       <ul class="justify-center">
         <li role="button" aria-label="open sidebar" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger pl2">
           ☰
@@ -158,7 +158,7 @@ limitations under the License.
     </nav>
 
     <!-- Toolbar Two, min only  -->
-    <nav toolbar="(min-width: 931px)" target="accordion-toolbar" toolbar-only class="ampstart-headerbar-nav ampstart-nav ampstart-navbar-bg">
+    <nav toolbar="(min-width: 931px)" toolbar-target="accordion-toolbar" toolbar-only class="ampstart-headerbar-nav ampstart-nav ampstart-navbar-bg">
       <ul class="list-reset center m0 p0 flex justify-center nowrap">
           <li class="ampstart-nav-item ampstart-nav-dropdown">
             <!-- Start Dropdown -->

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -146,7 +146,7 @@ limitations under the License.
 
     <!-- Toolbar One, basic usage, toolbar-only -->
     <!-- Could center with CSS justify-content: space-between, but trying to be minimal -->
-    <nav toolbar="(min-width: 0px)" class="ampstart-hamburger-nav ampstart-navbar-bg" target="hamburger-toolbar" toolbar-only>
+    <nav toolbar="(min-width: 0px)" target="hamburger-toolbar" class="ampstart-hamburger-nav ampstart-navbar-bg" toolbar-only>
       <ul class="justify-center">
         <li role="button" aria-label="open sidebar" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger pl2">
           ☰


### PR DESCRIPTION
* Removed default toolbar-target class
* Removed appending default toolbars to the end of the page
* Enforced a requirement for target to create toolbars
* Throw error if target element cannot be found
* Updated tests for the new requirement.

Tested that our test manual demo is still intact and working correctly after these changes.

@dvoytenko These mostly pertain to your requested changes, please let me know if this is looking correct 😄 