### PR TITLE
Increase timeouts for last few flaky tests

### DIFF
--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -22,6 +22,8 @@ import {poll} from '../../../../../testing/iframe';
 import {registerExtendedTemplate} from
     '../../../../../src/service/template-impl';
 
+/** @const {number} */
+const RENDER_TIMEOUT = 15000;
 
 describes.realWin('AmpForm Integration', {
   amp: {
@@ -145,7 +147,9 @@ describes.realWin('AmpForm Integration', {
     });
   });
 
-  describeChrome.run('Submit xhr-POST', () => {
+  describeChrome.run('Submit xhr-POST', function() {
+    this.timeout(RENDER_TIMEOUT);
+
     it('should submit and render success', () => {
       const form = getForm({
         id: 'form1',
@@ -207,7 +211,9 @@ describes.realWin('AmpForm Integration', {
     });
   });
 
-  describeChrome.run('Submit xhr-GET', () => {
+  describeChrome.run('Submit xhr-GET', function() {
+    this.timeout(RENDER_TIMEOUT);
+
     it('should submit and render success', () => {
       const form = getForm({
         id: 'form1',

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -19,7 +19,9 @@ import {
   withdrawRequest,
 } from '../../testing/test-helper';
 
-describe('amp-pixel', () => {
+describe('amp-pixel', function() {
+  this.timeout(15000);
+
   describes.integration('amp-pixel integration test', {
     body: `<amp-pixel src="${depositRequestUrl('has-referrer')}">`,
   }, env => {

--- a/test/integration/test-configuration.js
+++ b/test/integration/test-configuration.js
@@ -18,8 +18,6 @@ import {createFixtureIframe} from '../../testing/iframe.js';
 import {AmpEvents} from '../../src/amp-events';
 
 describe('Configuration', function() {
-  this.timeout(5000);
-
   let fixture;
   beforeEach(() => {
     return createFixtureIframe('test/fixtures/configuration.html', 500)

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -20,10 +20,11 @@ import {
   expectBodyToBecomeVisible,
 } from '../../testing/iframe.js';
 
-describe.configure().retryOnSaucelabs().run('error page', function() {
-  const timeout = 5000;
+/** @const {number} */
+const TIMEOUT = window.ampTestRuntimeConfig.mochaTimeout;
 
-  this.timeout(timeout);
+describe.configure().retryOnSaucelabs().run('error page', function() {
+  this.timeout(TIMEOUT);
 
   let fixture;
   beforeEach(() => {
@@ -42,13 +43,13 @@ describe.configure().retryOnSaucelabs().run('error page', function() {
       }, () => {
         return new Error('Failed to find errors. HTML\n' +
             fixture.doc.documentElement./*TEST*/innerHTML);
-      }, timeout);
+      }, TIMEOUT);
     });
   });
 
   it.configure().skipFirefox().skipEdge()
       .run('should show the body in error test', () => {
-        return expectBodyToBecomeVisible(fixture.win, timeout);
+        return expectBodyToBecomeVisible(fixture.win, TIMEOUT);
       });
 
   function shouldFail(id) {

--- a/test/integration/test-extensions-loading.js
+++ b/test/integration/test-extensions-loading.js
@@ -55,7 +55,9 @@ function testLoadOrderFixture(fixtureName, testElements) {
 }
 
 const t = describe.configure().retryOnSaucelabs();
-t.run('test extensions loading in multiple orders', () => {
+t.run('test extensions loading in multiple orders', function() {
+  this.timeout(15000);
+
   it('one extension, extension loads first, all scripts in header', () => {
     return testLoadOrderFixture(
         'test/fixtures/script-load-extension-head-v0-head.html',


### PR DESCRIPTION
I've seen these tests flake regularly over the last couple of weeks. E.g. https://travis-ci.org/ampproject/amphtml/jobs/252902865

If a 15s timeout doesn't cut it, let's start skipping on Saucelabs (we'll probably want to start selectively pruning integration tests anyway to improve build speed).

/to @rsimha-amp /cc @alanorozco 