### PR TITLE
Add per-page custom CSS waits for visual diff tests

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -142,12 +142,12 @@ def generateSnapshot(page, url, name, required_css, forbidden_css)
   page.visit(url)
   if required_css
     required_css.each do |css|
-      page.has_css?(css)
+      page.has_css?(css)  # Implicitly waits for the element to appear.
     end
   end
   if forbidden_css
     forbidden_css.each do |css|
-      page.has_no_css?(css)
+      page.has_no_css?(css)  # Implicitly waits for the element to disappear.
     end
   end
   Percy::Capybara.snapshot(page, name: name)

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -36,6 +36,11 @@ HOST = 'localhost'
 PORT = '8000'
 
 
+# Colorize logs.
+def red(text); "\e[31m#{text}\e[0m"; end
+def cyan(text); "\e[36m#{text}\e[0m"; end
+
+
 # Launches a background AMP webserver for unminified js using gulp.
 #
 # Returns:
@@ -153,14 +158,14 @@ def generateSnapshot(
   if loading_incomplete_indicators
     loading_incomplete_indicators.each do |indicator|
       if !page.has_no_css?(indicator)  # Implicitly waits for element to disappear.
-        puts "ERROR: page still has CSS element #{indicator}"
+        puts red("ERROR: ") + "page still has CSS element " + cyan("#{indicator}")
       end
     end
   end
   if loading_complete_indicators
     loading_complete_indicators.each do |indicator|
       if !page.has_css?(indicator)  # Implicitly waits for element to appear.
-        puts "ERROR: page does not yet have CSS element #{indicator}"
+        puts red("ERROR: ") + "page does not yet have CSS element " + cyan("#{indicator}")
       end
     end
   end
@@ -188,7 +193,7 @@ def main()
   setDebuggingLevel()
   pid = launchWebServer()
   if not waitForWebServer()
-    puts "Failed to start webserver"
+    puts red("ERROR: ") + "Failed to start webserver"
     closeWebServer(pid)
     exit(false)
   end

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -122,7 +122,9 @@ def generateSnapshots(pagesToSnapshot)
     webpages.each do |webpage|
       url = webpage["url"]
       name = webpage["name"]
-      generateSnapshot(page, url, name)
+      required_css = webpage["required_css"]
+      forbidden_css = webpage["forbidden_css"]
+      generateSnapshot(page, url, name, required_css, forbidden_css)
     end
   end
 end
@@ -134,9 +136,20 @@ end
 # - page: Page object used by Percy for snapshotting.
 # - url: Relative URL of page to be snapshotted.
 # - name: Name of snapshot on Percy.
-def generateSnapshot(page, url, name)
+# - required_css: Array of CSS elements that must be found in the page.
+# - forbidden_css: Array of CSS elements that must not be found in the page.
+def generateSnapshot(page, url, name, required_css, forbidden_css)
   page.visit(url)
-  page.has_no_css?('.i-amphtml-loader-dot')  # Implicitly waits for page load.
+  if required_css
+    required_css.each do |css|
+      page.has_css?(css)
+    end
+  end
+  if forbidden_css
+    forbidden_css.each do |css|
+      page.has_no_css?(css)
+    end
+  end
   Percy::Capybara.snapshot(page, name: name)
 end
 

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -128,16 +128,16 @@ def generateSnapshots(pagesToSnapshot)
     webpages.each do |webpage|
       url = webpage["url"]
       name = webpage["name"]
-      forbidden_indicators = webpage["forbidden_indicators"]
-      loading_incomplete_indicators = webpage["loading_incomplete_indicators"]
-      loading_complete_indicators = webpage["loading_complete_indicators"]
+      forbidden_css = webpage["forbidden_css"]
+      loading_incomplete_css = webpage["loading_incomplete_css"]
+      loading_complete_css = webpage["loading_complete_css"]
       generateSnapshot(
           page,
           url,
           name,
-          forbidden_indicators,
-          loading_incomplete_indicators,
-          loading_complete_indicators)
+          forbidden_css,
+          loading_incomplete_css,
+          loading_complete_css)
     end
   end
 end
@@ -149,41 +149,41 @@ end
 # - page: Page object used by Percy for snapshotting.
 # - url: Relative URL of page to be snapshotted.
 # - name: Name of snapshot on Percy.
-# - forbidden_indicators:
+# - forbidden_css:
 #       Array of CSS elements that must not be found in the page.
-# - loading_incomplete_indicators:
+# - loading_incomplete_css:
 #       Array of CSS elements that must eventually be removed from the page.
-# - loading_complete_indicators:
+# - loading_complete_css:
 #       Array of CSS elements that must eventually appear on the page.
 def generateSnapshot(
     page,
     url,
     name,
-    forbidden_indicators,
-    loading_incomplete_indicators,
-    loading_complete_indicators)
+    forbidden_css,
+    loading_incomplete_css,
+    loading_complete_css)
   page.visit(url)
   page.has_no_css?('.i-amphtml-loader-dot')  # Implicitly waits for page load.
-  if forbidden_indicators
-    forbidden_indicators.each do |indicator|
-      if page.has_css?(indicator)  # No implicit wait.
-        puts red("ERROR: ") + "page has CSS element " + cyan("#{indicator}")
+  if forbidden_css
+    forbidden_css.each do |css|
+      if page.has_css?(css)  # No implicit wait.
+        puts red("ERROR: ") + "page has CSS element " + cyan("#{css}")
       end
     end
   end
-  if loading_incomplete_indicators
-    loading_incomplete_indicators.each do |indicator|
-      if !page.has_no_css?(indicator)  # Implicitly waits for element to disappear.
+  if loading_incomplete_css
+    loading_incomplete_css.each do |css|
+      if !page.has_no_css?(css)  # Implicitly waits for element to disappear.
         puts red("ERROR: ") + "page still has CSS element "\
-            + cyan("#{indicator}")
+            + cyan("#{css}")
       end
     end
   end
-  if loading_complete_indicators
-    loading_complete_indicators.each do |indicator|
-      if !page.has_css?(indicator)  # Implicitly waits for element to appear.
+  if loading_complete_css
+    loading_complete_css.each do |css|
+      if !page.has_css?(css)  # Implicitly waits for element to appear.
         puts red("ERROR: ") + "page does not yet have CSS element "\
-            + cyan("#{indicator}")
+            + cyan("#{css}")
       end
     end
   end

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -107,6 +107,7 @@ end
 # - pagesToSnapshot: JSON object containing details about the pages to snapshot.
 def generateSnapshots(pagesToSnapshot)
   Percy.config.default_widths = DEFAULT_WIDTHS
+  Capybara.default_max_wait_time = 5
   server = "http://#{HOST}:#{PORT}"
   webpages = pagesToSnapshot["webpages"]
   assets_base_url = pagesToSnapshot["assets_base_url"]
@@ -151,12 +152,16 @@ def generateSnapshot(
   page.has_no_css?('.i-amphtml-loader-dot')  # Implicitly waits for page load.
   if loading_incomplete_indicators
     loading_incomplete_indicators.each do |indicator|
-      page.has_no_css?(indicator)  # Implicitly waits for element to disappear.
+      if !page.has_no_css?(indicator)  # Implicitly waits for element to disappear.
+        puts "ERROR: page still has CSS element #{indicator}"
+      end
     end
   end
   if loading_complete_indicators
     loading_complete_indicators.each do |indicator|
-      page.has_css?(indicator)  # Implicitly waits for element to appear.
+      if !page.has_css?(indicator)  # Implicitly waits for element to appear.
+        puts "ERROR: page does not yet have CSS element #{indicator}"
+      end
     end
   end
   Percy::Capybara.snapshot(page, name: name)

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -5,22 +5,41 @@
   "webpages": [
     {
       "url": "examples/visual-tests/amp-by-example/amp-by-example.html",
-      "name": "Amp By Example"
+      "name": "Amp By Example",
+      "forbidden_css": [".i-amphtml-loader-dot"]
     },
     {
       "url": "examples/visual-tests/article.amp/article.amp.html",
-      "name": "AMP Article"
+      "name": "AMP Article",
+      "forbidden_css": [".i-amphtml-loader-dot"]
     },
     {
       "url": "examples/visual-tests/font.amp/font.amp.html",
-      "name": "Fonts"
-    }
-  ],
-  "failing_webpages": [
+      "name": "Fonts",
+      "required_css": [
+        ".comic-amp-font-loaded",
+        ".comic-amp-bold-font-loaded"
+      ],
+      "forbidden_css": [
+        ".i-amphtml-loader-dot",
+        ".comic-amp-font-loading",
+        ".comic-amp-bold-font-loading"
+      ]
+    },
     {
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
-      "bug": "https://github.com/ampproject/amphtml/issues/10377"
+      "required_css": [
+        ".comic-amp-font-missing",
+        ".comic-amp-bold-font-missing"
+      ],
+      "forbidden_css": [
+        ".i-amphtml-loader-dot",
+        ".comic-amp-font-loading",
+        ".comic-amp-bold-font-loading"
+      ]
     }
+  ],
+  "failing_webpages": [
   ]
 }

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -26,6 +26,10 @@
     {
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
+      "forbidden_indicators": [
+        ".comic-amp-font-loaded",
+        ".comic-amp-bold-font-loaded"
+      ],
       "loading_incomplete_indicators": [
         ".comic-amp-font-loading",
         ".comic-amp-bold-font-loading"

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -22,10 +22,13 @@
         ".comic-amp-font-loaded",
         ".comic-amp-bold-font-loaded"
       ]
-    },
+    }
+  ],
+  "failing_webpages": [
     {
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
+      "issue": "https://github.com/ampproject/amphtml/issues/10377",
       "forbidden_indicators": [
         ".comic-amp-font-loaded",
         ".comic-amp-bold-font-loaded"
@@ -39,7 +42,5 @@
         ".comic-amp-bold-font-missing"
       ]
     }
-  ],
-  "failing_webpages": [
   ]
 }

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -22,7 +22,9 @@
         ".comic-amp-font-loaded",
         ".comic-amp-bold-font-loaded"
       ]
-    },
+    }
+  ],
+  "failing_webpages": [
     {
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
@@ -40,7 +42,5 @@
         ".comic-amp-bold-font-missing"
       ]
     }
-  ],
-  "failing_webpages": [
   ]
 }

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -5,38 +5,34 @@
   "webpages": [
     {
       "url": "examples/visual-tests/amp-by-example/amp-by-example.html",
-      "name": "Amp By Example",
-      "forbidden_css": [".i-amphtml-loader-dot"]
+      "name": "Amp By Example"
     },
     {
       "url": "examples/visual-tests/article.amp/article.amp.html",
-      "name": "AMP Article",
-      "forbidden_css": [".i-amphtml-loader-dot"]
+      "name": "AMP Article"
     },
     {
       "url": "examples/visual-tests/font.amp/font.amp.html",
       "name": "Fonts",
-      "required_css": [
-        ".comic-amp-font-loaded",
-        ".comic-amp-bold-font-loaded"
-      ],
-      "forbidden_css": [
-        ".i-amphtml-loader-dot",
+      "loading_incomplete_indicators": [
         ".comic-amp-font-loading",
         ".comic-amp-bold-font-loading"
+      ],
+      "loading_complete_indicators": [
+        ".comic-amp-font-loaded",
+        ".comic-amp-bold-font-loaded"
       ]
     },
     {
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
-      "required_css": [
-        ".comic-amp-font-missing",
-        ".comic-amp-bold-font-missing"
-      ],
-      "forbidden_css": [
-        ".i-amphtml-loader-dot",
+      "loading_incomplete_indicators": [
         ".comic-amp-font-loading",
         ".comic-amp-bold-font-loading"
+      ],
+      "loading_complete_indicators": [
+        ".comic-amp-font-missing",
+        ".comic-amp-bold-font-missing"
       ]
     }
   ],

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -14,11 +14,11 @@
     {
       "url": "examples/visual-tests/font.amp/font.amp.html",
       "name": "Fonts",
-      "loading_incomplete_indicators": [
+      "loading_incomplete_css": [
         ".comic-amp-font-loading",
         ".comic-amp-bold-font-loading"
       ],
-      "loading_complete_indicators": [
+      "loading_complete_css": [
         ".comic-amp-font-loaded",
         ".comic-amp-bold-font-loaded"
       ]
@@ -27,15 +27,15 @@
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
       "issue": "https://github.com/ampproject/amphtml/issues/10377",
-      "forbidden_indicators": [
+      "forbidden_css": [
         ".comic-amp-font-loaded",
         ".comic-amp-bold-font-loaded"
       ],
-      "loading_incomplete_indicators": [
+      "loading_incomplete_css": [
         ".comic-amp-font-loading",
         ".comic-amp-bold-font-loading"
       ],
-      "loading_complete_indicators": [
+      "loading_complete_css": [
         ".comic-amp-font-missing",
         ".comic-amp-bold-font-missing"
       ]

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -22,9 +22,7 @@
         ".comic-amp-font-loaded",
         ".comic-amp-bold-font-loaded"
       ]
-    }
-  ],
-  "failing_webpages": [
+    },
     {
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
@@ -42,5 +40,7 @@
         ".comic-amp-bold-font-missing"
       ]
     }
+  ],
+  "failing_webpages": [
   ]
 }


### PR DESCRIPTION
This should give tests the flexibility to add checks for the presence and absence of all kinds of CSS elements, and help ensure that a page has fully loaded before snapshotting. It's not the same as adding a global AMP "loaded" event, but this is a way to get what we want without adding a test-only workaround to the AMP runtime.

#10377
Related to #10156 