### PR TITLE
Video-docking: Implement drag and drop

### DIFF
--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -1,28 +1,34 @@
-selector                                         |   z-index      |   file
----                                              |   ---          |   ---
-.i-amphtml-image-lightbox-container              |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.amp-video-eq                                    |   1            |   css/amp.css
-.i-amphtml-layout-size-defined > [fallback]      |   1            |   css/amp.css
-.i-amphtml-loading-container                     |   1            |   css/amp.css
-i-amphtml-video-mask                             |   1            |   css/amp.css
-.i-amphtml-layout-size-defined > [placeholder]   |   1            |   css/amp.css
-.i-amphtml-image-lightbox-viewer-image           |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-image-lightbox-viewer                 |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-loader-moving-line                    |   2            |   css/amp.css
-.i-amphtml-image-lightbox-caption                |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-element > [overflow]                  |   2            |   css/amp.css
-.amp-carousel-button                             |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
-amp-sticky-ad                                    |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
-amp-sticky-ad                                    |   11           |   extensions/amp-sticky-ad/0.1/amp-sticky-ad.css
-amp-sticky-ad-top-padding                        |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
-amp-app-banner                                   |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-.amp-app-banner-dismiss-button                   |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-i-amphtml-app-banner-top-padding                 |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-amp-user-notification                            |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
-.i-amphtml-jank-meter                            |   1000         |   css/amp.css
-amp-image-lightbox                               |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-amp-live-list > [update]                         |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
-amp-lightbox                                     |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
-.i-amphtml-image-lightbox-trans                  |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-lbv                                   |   2147483642   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
-amp-sidebar                                      |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+selector                                                                 |   z-index      |   file
+---                                                                      |   ---          |   ---
+.i-amphtml-image-lightbox-container                                      |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+ i-amp-video-mask                                                        |   1            |   css/amp.css
+.i-amphtml-lbv-top-bar                                                   |   1            |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+.i-amphtml-image-lightbox-viewer-image                                   |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-image-lightbox-viewer                                         |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.amp-video-eq                                                            |   1            |   css/amp.css
+.i-amphtml-layout-size-defined > [fallback]                              |   1            |   css/amp.css
+.i-amphtml-layout-size-defined > [placeholder]                           |   1            |   css/amp.css
+i-amphtml-video-mask                                                     |   1            |   css/amp.css
+.i-amphtml-loading-container                                             |   1            |   css/amp.css
+.i-amphtml-loader-moving-line                                            |   2            |   css/amp.css
+.i-amphtml-element > [overflow]                                          |   2            |   css/amp.css
+.i-amphtml-image-lightbox-caption                                        |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.amp-carousel-button                                                     |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
+amp-sticky-ad                                                            |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+amp-sticky-ad-top-padding                                                |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+amp-app-banner                                                           |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+.amp-app-banner-dismiss-button                                           |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+i-amphtml-app-banner-top-padding                                         |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+.i-amphtml-dockable-video > video.i-amphtml-dockable-video-minimizing    |   16           |   css/amp.css
+.i-amphtml-dockable-video > iframe.i-amphtml-dockable-video-minimizing   |   16           |   css/amp.css
+.i-amphtml-jank-meter                                                    |   1000         |   css/amp.css
+amp-user-notification                                                    |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
+amp-lightbox                                                             |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
+amp-live-list > [update]                                                 |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
+amp-image-lightbox                                                       |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-image-lightbox-trans                                          |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-lbv                                                           |   2147483642   |   extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+.i-amphtml-sidebar-mask                                                  |   2147483646   |   extensions/amp-sidebar/1.0/amp-sidebar.css
+.i-amphtml-sidebar-mask                                                  |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+amp-sidebar                                                              |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+amp-sidebar                                                              |   2147483647   |   extensions/amp-sidebar/1.0/amp-sidebar.css

--- a/css/amp.css
+++ b/css/amp.css
@@ -688,7 +688,7 @@ i-amphtml-video-mask, i-amp-video-mask {
 .i-amphtml-dockable-video {
   padding: 0px;
   margin:0px;
-  background: darkgray;
+  transition: background-color 1s;
 }
 
 .i-amphtml-dockable-video > video.i-amphtml-dockable-video-minimizing,
@@ -696,7 +696,7 @@ i-amphtml-video-mask, i-amp-video-mask {
   position: fixed;
   height: auto;
   overflow: hidden;
-  z-index: 2;
+  z-index: 16;
   will-change: transform;
   transform: scale(0.6) translateX(20px) translateY(20px);
   border-radius: 6px;


### PR DESCRIPTION
Implements dragging for docked videos.

<div align="center">
<img src="https://user-images.githubusercontent.com/591655/28144364-efdd66a2-671f-11e7-895c-281cf91a8f3b.gif" />
</div>

### Changes
- Viewport is now an instance variable
- Corrected JSDoc on video analytics
- Implemented drag & drop for all players (used a mask to capture events on iframe players)
- Video placeholder only appears when video docking starts (corrects bug where a dark line would appear over and under the video if the aspect ratio isn't correct)
- Changed minimized video's z-index

### To-do in next PRs
- Add minimized controls
- Show the draggable mask since docking starts (so that it absorbs `click` / `mouseover` events and hides the video controls)
- Call unlisteners for touch and mouse events when dragging is over
- Explore switching to `position: sticky` for cleaner code

Closes #9962, Checks off an item on #4154, Checks off two items on #8088