### PR TITLE
Implements scrollTo, focus and blur standard actions

### DIFF
--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
-    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
     <style type="text/css">
     /* Styles for example */
     body {

--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -71,12 +71,11 @@
   <button on="tap:normal-element.show">Show</button>
   <button on="tap:normal-element.hide">Hide</button>
   <button on="tap:normal-element.toggleVisibility">Toggle Visibility</button>
-  <button on="tap:form.scrollTo">ScrollTo</button>
-  <button on="tap:form.scrollTo('position' = 'bottom')">ScrollTo Bottom</button>
-  <button on="tap:form.scrollTo('position' = 'center')">ScrollTo Center</button>
-  <button on="tap:form.scrollTo('duration' = 5000)">ScrollTo Slowly</button>
-  <button on="tap:name1.focus">Focus</button>
-  <button on="tap:name1.blur">Lose Focus</button>
+  <button on="tap:normal-element2.scrollTo">ScrollTo</button>
+  <button on="tap:normal-element2.scrollTo('position' = 'bottom')">ScrollTo Bottom</button>
+  <button on="tap:normal-element2.scrollTo('position' = 'center')">ScrollTo Center</button>
+  <button on="tap:normal-element2.scrollTo('duration' = 5000)">ScrollTo Slowly</button>
+  <button on="tap:input-element.focus">Focus</button>
 </div>
 
 <amp-img src="https://ampbyexample.com/img/amp.jpg" layout="responsive" width="1080" height="610" id="img-on-viewport"></amp-img>
@@ -88,37 +87,12 @@
 <div class="spacer">
 </div>
 
-<h4>Subscribe to our weekly Newsletter Form</h4>
-<form id="form" method="post"
-      action-xhr="/form/echo-json/post"
-      target="_blank">
-    <fieldset>
-        <input name="clientId" type="hidden" value="CLIENT_ID(poll)" data-amp-replace="CLIENT_ID">
-        <input name="canonicalUrl" type="hidden" value="RANDOM and CANONICAL_URL" data-amp-replace="CANONICAL_URL RANDOM">
-        <label>
-            <span>Your name</span>
-            <input type="text" name="name" id="name1" required>
-        </label>
-        <label>
-            <span>Your email</span>
-            <input type="email" name="email" id="email1" required>
-        </label>
-        <input type="submit" value="Subscribe">
-    </fieldset>
-    <div submitting>
-      <template type="amp-mustache">
-        Please wait, {{name}}.
-      </template>
-    </div>
-    <div submit-success>
-      Success! Thanks for subscribing! Please make sure to check your email
-      to confirm!
-    </div>
-    <div submit-error>
-      <amp-img width="32" height="32" src="/examples/x-icon.png"></amp-img>
-      Oops! We apologize, something went wrong. Please try again later.
-    </div>
-</form>
+<div id="normal-element2">
+  You have to scroll to see me.
+</div>
+
+
+<input type="text" id="input-element">
 
 <div class="spacer">
 </div>

--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -72,6 +72,8 @@
   <button on="tap:normal-element.hide">Hide</button>
   <button on="tap:normal-element.toggleVisibility">Toggle Visibility</button>
   <button on="tap:form.scrollTo">ScrollTo</button>
+  <button on="tap:form.scrollTo('position' = 'bottom')">ScrollTo Bottom</button>
+  <button on="tap:form.scrollTo('position' = 'center')">ScrollTo Center</button>
   <button on="tap:form.scrollTo('duration' = 5000)">ScrollTo Slowly</button>
   <button on="tap:name1.focus">Focus</button>
   <button on="tap:name1.blur">Lose Focus</button>
@@ -117,6 +119,9 @@
       Oops! We apologize, something went wrong. Please try again later.
     </div>
 </form>
+
+<div class="spacer">
+</div>
 
 
 </html>

--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
     <style type="text/css">
     /* Styles for example */
     body {
@@ -34,6 +35,9 @@
     #normal-element {
       background: #f0f0f0;
       padding: 10px;
+    }
+    .spacer {
+      height: 100vh;
     }
     </style>
 </head>
@@ -67,6 +71,10 @@
   <button on="tap:normal-element.show">Show</button>
   <button on="tap:normal-element.hide">Hide</button>
   <button on="tap:normal-element.toggleVisibility">Toggle Visibility</button>
+  <button on="tap:form.scrollTo">ScrollTo</button>
+  <button on="tap:form.scrollTo('duration' = 5000)">ScrollTo Slowly</button>
+  <button on="tap:name1.focus">Focus</button>
+  <button on="tap:name1.blur">Lose Focus</button>
 </div>
 
 <amp-img src="https://ampbyexample.com/img/amp.jpg" layout="responsive" width="1080" height="610" id="img-on-viewport"></amp-img>
@@ -74,5 +82,41 @@
 <div id="normal-element" hidden>
   I was initially hidden.
 </div>
+
+<div class="spacer">
+</div>
+
+<h4>Subscribe to our weekly Newsletter Form</h4>
+<form id="form" method="post"
+      action-xhr="/form/echo-json/post"
+      target="_blank">
+    <fieldset>
+        <input name="clientId" type="hidden" value="CLIENT_ID(poll)" data-amp-replace="CLIENT_ID">
+        <input name="canonicalUrl" type="hidden" value="RANDOM and CANONICAL_URL" data-amp-replace="CANONICAL_URL RANDOM">
+        <label>
+            <span>Your name</span>
+            <input type="text" name="name" id="name1" required>
+        </label>
+        <label>
+            <span>Your email</span>
+            <input type="email" name="email" id="email1" required>
+        </label>
+        <input type="submit" value="Subscribe">
+    </fieldset>
+    <div submitting>
+      <template type="amp-mustache">
+        Please wait, {{name}}.
+      </template>
+    </div>
+    <div submit-success>
+      Success! Thanks for subscribing! Please make sure to check your email
+      to confirm!
+    </div>
+    <div submit-error>
+      <amp-img width="32" height="32" src="/examples/x-icon.png"></amp-img>
+      Oops! We apologize, something went wrong. Please try again later.
+    </div>
+</form>
+
 
 </html>

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -207,9 +207,11 @@ For example, the following is possible in AMP.
     <td>Toggles the visibility of the target element.</td>
   </tr>
   <tr>
-    <td>`scrollTo(duration=INTEGER)`</td>
+    <td>`scrollTo(duration=INTEGER, position=STRING)`</td>
     <td>Scrolls the element into view with a smooth animation. If defined,
-    `duration` specifies the length of the animation in milliseconds.</td>
+    `duration` specifies the length of the animation in milliseconds. `position`
+    is optional and takes one of `top`, `center` and `bottom` defining where
+    in the viewport the element will be at the end of the scroll.</td>
   </tr>
   <tr>
     <td>`focus`</td>

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -89,7 +89,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>tap</td>
+    <td>`tap`</td>
     <td>Fired when the element is clicked/tapped.</td>
   </tr>
 </table>
@@ -142,7 +142,7 @@ For example, the following is possible in AMP.
     <th>Data</th>
   </tr>
   <tr>
-    <td>slideChange</td>
+    <td>`slideChange`</td>
     <td>Fired when the user manually changes the carousel's current slide. Does not fire on autoplay or the <code>goToSlide</code> action.</td>
     <td><code>event.index</code> : slide number</td>
   </tr>
@@ -156,7 +156,7 @@ For example, the following is possible in AMP.
     <th>Data</th>
   </tr>
   <tr>
-    <td>select</td>
+    <td>`select`</td>
     <td>Fired when the user manually selects an option.</td>
     <td><code>event.targetOption</code> : The <code>option</code> attribute value of the selected element</td>
   </tr>
@@ -170,17 +170,17 @@ For example, the following is possible in AMP.
     <th>Data</th>
   </tr>
   <tr>
-    <td>submit</td>
+    <td>`submit`</td>
     <td>Fired when the form is submitted.</td>
     <td></td>
   </tr>
   <tr>
-    <td>submit-success</td>
+    <td>`submit-success`</td>
     <td>Fired when the form submission response is success.</td>
     <td><code>event.response</code> : JSON response</td>
   </tr>
   <tr>
-    <td>submit-error</td>
+    <td>`submit-error`</td>
     <td>Fired when the form submission response is an error.</td>
     <td><code>event.response</code> : JSON response</td>
   </tr>
@@ -195,16 +195,29 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>hide</td>
+    <td>`hide`</td>
     <td>Hides the target element.</td>
   </tr>
   <tr>
-    <td>show</td>
+    <td>`show`</td>
     <td>Shows the target element.</td>
   </tr>
   <tr>
-    <td>toggleVisibility</td>
+    <td>`toggleVisibility`</td>
     <td>Toggles the visibility of the target element.</td>
+  </tr>
+  <tr>
+    <td>`scrollTo(duration=INTEGER)`</td>
+    <td>Scrolls the element into view with a smooth animation. If defined,
+    `duration` specifies the length of the animation in milliseconds.</td>
+  </tr>
+  <tr>
+    <td>`focus`</td>
+    <td>Makes the target element gain focus.</td>
+  </tr>
+  <tr>
+    <td>`blur`</td>
+    <td>Makes the target element lose focus (to be called after `focus`).</td>
   </tr>
 </table>
 
@@ -215,7 +228,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>goToSlide(index=INTEGER)</td>
+    <td>`goToSlide(index=INTEGER)`</td>
     <td>Advances the carousel to a specified slide index.</td>
   </tr>
 </table>
@@ -227,7 +240,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>open (default)</td>
+    <td>`open (default)`</td>
     <td>Opens the image lightbox with the source image being the one that triggered the action.</td>
   </tr>
 </table>
@@ -239,11 +252,11 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>open (default)</td>
+    <td>`open (default)`</td>
     <td>Opens the lightbox.</td>
   </tr>
   <tr>
-    <td>close</td>
+    <td>`close`</td>
     <td>Closes the lightbox.</td>
   </tr>
 </table>
@@ -255,7 +268,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>update (default)</td>
+    <td>`update (default)`</td>
     <td>Updates the DOM items to show updated content.</td>
   </tr>
 </table>
@@ -267,15 +280,15 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>open (default)</td>
+    <td>`open (default)`</td>
     <td>Opens the sidebar.</td>
   </tr>
   <tr>
-    <td>close</td>
+    <td>`close`</td>
     <td>Closes the sidebar.</td>
   </tr>
   <tr>
-    <td>toggle</td>
+    <td>`toggle`</td>
     <td>Toggles the state of the sidebar.</td>
   </tr>
 </table>
@@ -287,7 +300,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>(default)</td>
+    <td>`(default)`</td>
     <td>Updates the amp-state's data with the data contained in the event. Requires
       <a href="../extensions/amp-bind/amp-bind.md">amp-bind</a>.
     </td>
@@ -301,7 +314,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>dismiss (default)</td>
+    <td>`dismiss (default)`</td>
     <td>Hides the referenced user notification element.</td>
   </tr>
 </table>
@@ -313,19 +326,19 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>play</td>
+    <td>`play`</td>
     <td>Plays the video.</td>
   </tr>
   <tr>
-    <td>pause</td>
+    <td>`pause`</td>
     <td>Pauses the video.</td>
   </tr>
   <tr>
-    <td>mute</td>
+    <td>`mute`</td>
     <td>Mutes the video.</td>
   </tr>
   <tr>
-    <td>unmute</td>
+    <td>`unmute`</td>
     <td>Unmutes the video.</td>
   </tr>
 </table>
@@ -337,7 +350,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>submit</td>
+    <td>`submit`</td>
     <td>Submits the form.</td>
   </tr>
 </table>
@@ -357,19 +370,19 @@ actions that apply to the whole document.
     <th>Description</th>
   </tr>
   <tr>
-    <td>navigateTo(url=STRING)</td>
+    <td>`navigateTo(url=STRING)`</td>
     <td>Navigates current window to given URL. Supports <a href="./amp-var-substitutions.md">standard URL subsitutions</a>. Can only be invoked via <code>tap</code> or <code>change</code> events.</td>
   </tr>
   <tr>
-    <td>goBack</td>
+    <td>`goBack`</td>
     <td>Navigates back in history.</td>
   </tr>
   <tr>
-    <td>setState</td>
+    <td>`setState`</td>
     <td>Updates <code>amp-bind</code>'s state. See <a href="../extensions/amp-bind/amp-bind.md#ampsetstate">details</a>.</td>
   </tr>
   <tr>
-    <td>print</td>
+    <td>`print`</td>
     <td>Opens the Print Dialog to print the current page.</td>
   </tr>
 </table>

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -89,7 +89,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`tap`</td>
+    <td><code>tap</code></td>
     <td>Fired when the element is clicked/tapped.</td>
   </tr>
 </table>
@@ -142,7 +142,7 @@ For example, the following is possible in AMP.
     <th>Data</th>
   </tr>
   <tr>
-    <td>`slideChange`</td>
+    <td><code>slideChange</code></td>
     <td>Fired when the user manually changes the carousel's current slide. Does not fire on autoplay or the <code>goToSlide</code> action.</td>
     <td><code>event.index</code> : slide number</td>
   </tr>
@@ -156,7 +156,7 @@ For example, the following is possible in AMP.
     <th>Data</th>
   </tr>
   <tr>
-    <td>`select`</td>
+    <td><code>select</code></td>
     <td>Fired when the user manually selects an option.</td>
     <td><code>event.targetOption</code> : The <code>option</code> attribute value of the selected element</td>
   </tr>
@@ -170,17 +170,17 @@ For example, the following is possible in AMP.
     <th>Data</th>
   </tr>
   <tr>
-    <td>`submit`</td>
+    <td><code>submit</code></td>
     <td>Fired when the form is submitted.</td>
     <td></td>
   </tr>
   <tr>
-    <td>`submit-success`</td>
+    <td><code>submit-success</code></td>
     <td>Fired when the form submission response is success.</td>
     <td><code>event.response</code> : JSON response</td>
   </tr>
   <tr>
-    <td>`submit-error`</td>
+    <td><code>submit-error</code></td>
     <td>Fired when the form submission response is an error.</td>
     <td><code>event.response</code> : JSON response</td>
   </tr>
@@ -195,31 +195,32 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`hide`</td>
+    <td><code>hide</code></td>
     <td>Hides the target element.</td>
   </tr>
   <tr>
-    <td>`show`</td>
+    <td><code>show</code></td>
     <td>Shows the target element.</td>
   </tr>
   <tr>
-    <td>`toggleVisibility`</td>
+    <td><code>toggleVisibility</code></td>
     <td>Toggles the visibility of the target element.</td>
   </tr>
   <tr>
-    <td>`scrollTo(duration=INTEGER, position=STRING)`</td>
-    <td>Scrolls the element into view with a smooth animation. If defined,
-    `duration` specifies the length of the animation in milliseconds. `position`
-    is optional and takes one of `top`, `center` and `bottom` defining where
-    in the viewport the element will be at the end of the scroll.</td>
+    <td><code>scrollTo(duration=INTEGER, position=STRING)</code></td>
+    <td>Scrolls an element into view with a smooth animation. If defined,
+    <code>duration</code> specifies the length of the animation in milliseconds
+    (default is 500ms). <code>position</code> is optional and takes one of
+    <code>top</code>, <code>center</code> or <code>bottom</code> defining where
+    in the viewport the element will be at the end of the scroll (default is
+    <code>top</code>).</td>
   </tr>
   <tr>
-    <td>`focus`</td>
-    <td>Makes the target element gain focus.</td>
-  </tr>
-  <tr>
-    <td>`blur`</td>
-    <td>Makes the target element lose focus (to be called after `focus`).</td>
+    <td><code>focus</code></td>
+    <td>Makes the target element gain focus. To lose focus, <code>focus</code>
+    on another element (usually parent element). We strongly advise against
+    losing focus by focusing on <code>body</code>/<code>documentElement</code>
+    for accessibility reasons.</td>
   </tr>
 </table>
 
@@ -230,7 +231,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`goToSlide(index=INTEGER)`</td>
+    <td><code>goToSlide(index=INTEGER)</code></td>
     <td>Advances the carousel to a specified slide index.</td>
   </tr>
 </table>
@@ -242,7 +243,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`open (default)`</td>
+    <td><code>open (default)</code></td>
     <td>Opens the image lightbox with the source image being the one that triggered the action.</td>
   </tr>
 </table>
@@ -254,11 +255,11 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`open (default)`</td>
+    <td><code>open (default)</code></td>
     <td>Opens the lightbox.</td>
   </tr>
   <tr>
-    <td>`close`</td>
+    <td><code>close</code></td>
     <td>Closes the lightbox.</td>
   </tr>
 </table>
@@ -270,7 +271,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`update (default)`</td>
+    <td><code>update (default)</code></td>
     <td>Updates the DOM items to show updated content.</td>
   </tr>
 </table>
@@ -282,15 +283,15 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`open (default)`</td>
+    <td><code>open (default)</code></td>
     <td>Opens the sidebar.</td>
   </tr>
   <tr>
-    <td>`close`</td>
+    <td><code>close</code></td>
     <td>Closes the sidebar.</td>
   </tr>
   <tr>
-    <td>`toggle`</td>
+    <td><code>toggle</code></td>
     <td>Toggles the state of the sidebar.</td>
   </tr>
 </table>
@@ -302,7 +303,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`(default)`</td>
+    <td><code>(default)</code></td>
     <td>Updates the amp-state's data with the data contained in the event. Requires
       <a href="../extensions/amp-bind/amp-bind.md">amp-bind</a>.
     </td>
@@ -316,7 +317,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`dismiss (default)`</td>
+    <td><code>dismiss (default)</code></td>
     <td>Hides the referenced user notification element.</td>
   </tr>
 </table>
@@ -328,19 +329,19 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`play`</td>
+    <td><code>play</code></td>
     <td>Plays the video.</td>
   </tr>
   <tr>
-    <td>`pause`</td>
+    <td><code>pause</code></td>
     <td>Pauses the video.</td>
   </tr>
   <tr>
-    <td>`mute`</td>
+    <td><code>mute</code></td>
     <td>Mutes the video.</td>
   </tr>
   <tr>
-    <td>`unmute`</td>
+    <td><code>unmute</code></td>
     <td>Unmutes the video.</td>
   </tr>
 </table>
@@ -352,7 +353,7 @@ For example, the following is possible in AMP.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`submit`</td>
+    <td><code>submit</code></td>
     <td>Submits the form.</td>
   </tr>
 </table>
@@ -372,19 +373,19 @@ actions that apply to the whole document.
     <th>Description</th>
   </tr>
   <tr>
-    <td>`navigateTo(url=STRING)`</td>
+    <td><code>navigateTo(url=STRING)</code></td>
     <td>Navigates current window to given URL. Supports <a href="./amp-var-substitutions.md">standard URL subsitutions</a>. Can only be invoked via <code>tap</code> or <code>change</code> events.</td>
   </tr>
   <tr>
-    <td>`goBack`</td>
+    <td><code>goBack</code></td>
     <td>Navigates back in history.</td>
   </tr>
   <tr>
-    <td>`setState`</td>
+    <td><code>setState</code></td>
     <td>Updates <code>amp-bind</code>'s state. See <a href="../extensions/amp-bind/amp-bind.md#ampsetstate">details</a>.</td>
   </tr>
   <tr>
-    <td>`print`</td>
+    <td><code>print</code></td>
     <td>Opens the Print Dialog to print the current page.</td>
   </tr>
 </table>

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -88,7 +88,6 @@ export class StandardActions {
         'scrollTo', this.handleScrollTo.bind(this));
     actionService.addGlobalMethodHandler(
         'focus', this.handleFocus.bind(this));
-    actionService.addGlobalMethodHandler('blur', this.handleBlur.bind(this));
   }
 
   /**
@@ -226,18 +225,6 @@ export class StandardActions {
 
     // Set focus
     tryFocus(node);
-  }
-
-  /**
-   * Handles the `blur` action where given an element, we make it lose its focus
-   * @param {!./action-impl.ActionInvocation} invocation
-   */
-  handleBlur(invocation) {
-    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
-      return;
-    }
-    const node = invocation.target;
-    node.blur();
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -194,10 +194,21 @@ export class StandardActions {
     }
     const node = dev().assertElement(invocation.target);
 
-    // Animate scroll
-    const duration = invocation.args && invocation.args['duration'] ?
+    // Duration for scroll animation
+    const duration = invocation.args
+                     && invocation.args['duration']
+                     && invocation.args['duration'] >= 0 ?
                      invocation.args['duration'] : 500;
-    this.viewport_.animateScrollIntoView(node, duration);
+
+    // Position in the viewport at the end
+    const permittedPosVals = ['top','bottom','center'];
+    const pos = invocation.args
+                && invocation.args['position']
+                && (permittedPosVals.indexOf(invocation.args['position']) + 1) ?
+                invocation.args['position'] : 'top';
+
+    // Animate the scroll
+    this.viewport_.animateScrollIntoView(node, duration, 'ease-in', pos);
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -36,6 +36,10 @@ function isShowable(element) {
 /** @const {string} */
 const TAG = 'STANDARD-ACTIONS';
 
+/** @const {Array<string>} */
+const PERMITTED_POSITIONS = ['top','bottom','center'];
+
+
 /**
  * This service contains implementations of some of the most typical actions,
  * such as hiding DOM elements.
@@ -198,13 +202,12 @@ export class StandardActions {
     const duration = invocation.args
                      && invocation.args['duration']
                      && invocation.args['duration'] >= 0 ?
-                     invocation.args['duration'] : 500;
+                        invocation.args['duration'] : 500;
 
     // Position in the viewport at the end
-    const permittedPosVals = ['top','bottom','center'];
-    const pos = invocation.args
+    const pos = (invocation.args
                 && invocation.args['position']
-                && (permittedPosVals.indexOf(invocation.args['position']) + 1) ?
+                && PERMITTED_POSITIONS.includes(invocation.args['position'])) ?
                 invocation.args['position'] : 'top';
 
     // Animate the scroll

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -444,9 +444,9 @@ export class Viewport {
     }
     /** @const {!TransitionDef<number>} */
     const interpolate = numeric(curScrollTop, newScrollTop);
-    // TODO(erwinm): the duration should not be a constant and should
-    // be done in steps for better transition experience when things
-    // are closer vs farther.
+    // TODO(aghassemi): the duration should not be a constant and should
+    // be proportional to the distance to be scrolled for better transition
+    // experience when things are closer vs farther (#10463).
     return Animation.animate(this.ampdoc.getRootNode(), position => {
       this.binding_.setScrollTop(interpolate(position));
     }, duration, curve).then();

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -416,11 +416,28 @@ export class Viewport {
    * @param {!Element} element
    * @param {number=} duration
    * @param {string=} curve
+   * @param {string=} pos (takes one of 'top', 'bottom', 'center')
    * @return {!Promise}
    */
-  animateScrollIntoView(element, duration = 500, curve = 'ease-in') {
-    const elementTop = this.binding_.getLayoutRect(element).top;
-    const newScrollTop = Math.max(0, elementTop - this.paddingTop_);
+  animateScrollIntoView(element,
+                        duration = 500,
+                        curve = 'ease-in',
+                        pos = 'top') {
+    const elementRect = this.binding_.getLayoutRect(element);
+    let offset;
+    switch (pos) {
+      case 'bottom':
+        offset = -this.getHeight() + elementRect.height;
+        break;
+      case 'center':
+        offset = -this.getHeight() / 2 + elementRect.height / 2;
+        break;
+      default:
+        offset = 0;
+        break;
+    }
+    const calculatedScrollTop = elementRect.top - this.paddingTop_ + offset;
+    const newScrollTop = Math.max(0, calculatedScrollTop);
     const curScrollTop = this.getScrollTop();
     if (newScrollTop == curScrollTop) {
       return Promise.resolve();
@@ -430,8 +447,8 @@ export class Viewport {
     // TODO(erwinm): the duration should not be a constant and should
     // be done in steps for better transition experience when things
     // are closer vs farther.
-    return Animation.animate(this.ampdoc.getRootNode(), pos => {
-      this.binding_.setScrollTop(interpolate(pos));
+    return Animation.animate(this.ampdoc.getRootNode(), position => {
+      this.binding_.setScrollTop(interpolate(position));
     }, duration, curve).then();
   }
 

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -444,9 +444,9 @@ export class Viewport {
     }
     /** @const {!TransitionDef<number>} */
     const interpolate = numeric(curScrollTop, newScrollTop);
-    // TODO(aghassemi): the duration should not be a constant and should
+    // TODO(aghassemi, #10463): the duration should not be a constant and should
     // be proportional to the distance to be scrolled for better transition
-    // experience when things are closer vs farther (#10463).
+    // experience when things are closer vs farther.
     return Animation.animate(this.ampdoc.getRootNode(), position => {
       this.binding_.setScrollTop(interpolate(position));
     }, duration, curve).then();

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -26,6 +26,7 @@ describes.sandboxed('StandardActions', {}, () => {
   let standardActions;
   let mutateElementStub;
   let deferMutateStub;
+  let scrollStub;
   let ampdoc;
 
   function createElement() {
@@ -72,11 +73,20 @@ describes.sandboxed('StandardActions', {}, () => {
     expect(element.expand).to.be.calledOnce;
   }
 
+  function expectAmpElementToHaveBeenScrolledIntoView(element) {
+    expect(scrollStub).to.be.calledOnce;
+    expect(scrollStub.firstCall.args[0]).to.equal(element);
+  }
+
   beforeEach(() => {
     ampdoc = new AmpDocSingle(window);
     standardActions = new StandardActions(ampdoc);
     mutateElementStub = stubMutate('mutateElement');
     deferMutateStub = stubMutate('deferMutate');
+    scrollStub = sandbox.stub(
+        standardActions.viewport_,
+        'animateScrollIntoView');
+
   });
 
   describe('"hide" action', () => {
@@ -161,6 +171,65 @@ describes.sandboxed('StandardActions', {}, () => {
       expectAmpElementToHaveBeenHidden(element);
     });
   });
+
+  describe('"scrollTo" action', () => {
+    it('should handle normal element', () => {
+      const element = createElement();
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleScrollTo(invocation);
+      expectAmpElementToHaveBeenScrolledIntoView(element);
+    });
+
+    it('should handle AmpElement', () => {
+      const element = createAmpElement();
+      const invocation = {target: element, satisfiesTrust: () => true};
+      standardActions.handleScrollTo(invocation);
+      expectAmpElementToHaveBeenScrolledIntoView(element);
+    });
+  });
+
+  describe('"focus" action', () => {
+    it('should handle normal element', () => {
+      const element = createElement();
+      const invocation = {target: element, satisfiesTrust: () => true};
+      const focusStub = sandbox.stub(element, 'focus');
+      standardActions.handleFocus(invocation);
+      expect(focusStub).to.be.calledOnce;
+    });
+
+    it('should handle AmpElement', () => {
+      const element = createAmpElement();
+      const invocation = {target: element, satisfiesTrust: () => true};
+      const focusStub = sandbox.stub(element, 'focus');
+      standardActions.handleFocus(invocation);
+      expect(focusStub).to.be.calledOnce;
+    });
+  });
+
+  describe('"blur" action', () => {
+    it('should handle normal element', () => {
+      const element = createElement();
+      const invocation = {target: element, satisfiesTrust: () => true};
+      const focusStub = sandbox.stub(element, 'focus');
+      const blurStub = sandbox.stub(element, 'blur');
+      standardActions.handleFocus(invocation);
+      expect(focusStub).to.be.calledOnce;
+      standardActions.handleBlur(invocation);
+      expect(blurStub).to.be.calledOnce;
+    });
+
+    it('should handle AmpElement', () => {
+      const element = createAmpElement();
+      const invocation = {target: element, satisfiesTrust: () => true};
+      const focusStub = sandbox.stub(element, 'focus');
+      const blurStub = sandbox.stub(element, 'blur');
+      standardActions.handleFocus(invocation);
+      expect(focusStub).to.be.calledOnce;
+      standardActions.handleBlur(invocation);
+      expect(blurStub).to.be.calledOnce;
+    });
+  });
+
 
   describe('"AMP" global target', () => {
     it('should implement navigateTo', () => {
@@ -282,7 +351,7 @@ describes.sandboxed('StandardActions', {}, () => {
       expect(stub).to.be.calledOnce;
 
       // Global actions.
-      expect(embedActions.addGlobalMethodHandler).to.have.callCount(5);
+      expect(embedActions.addGlobalMethodHandler).to.have.callCount(6);
       expect(embedActions.addGlobalMethodHandler.args[0][0]).to.equal('hide');
       expect(embedActions.addGlobalMethodHandler.args[0][1]).to.be.function;
       expect(embedActions.addGlobalMethodHandler.args[1][0]).to.equal('show');

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -282,7 +282,7 @@ describes.sandboxed('StandardActions', {}, () => {
       expect(stub).to.be.calledOnce;
 
       // Global actions.
-      expect(embedActions.addGlobalMethodHandler).to.be.calledThrice;
+      expect(embedActions.addGlobalMethodHandler).to.have.callCount(5);
       expect(embedActions.addGlobalMethodHandler.args[0][0]).to.equal('hide');
       expect(embedActions.addGlobalMethodHandler.args[0][1]).to.be.function;
       expect(embedActions.addGlobalMethodHandler.args[1][0]).to.equal('show');
@@ -290,6 +290,14 @@ describes.sandboxed('StandardActions', {}, () => {
       expect(embedActions.addGlobalMethodHandler.args[2][0]).to
           .equal('toggleVisibility');
       expect(embedActions.addGlobalMethodHandler.args[2][1]).to.be.function;
+      expect(embedActions.addGlobalMethodHandler.args[3][0]).to
+          .equal('scrollTo');
+      expect(embedActions.addGlobalMethodHandler.args[3][1]).to.be.function;
+      expect(embedActions.addGlobalMethodHandler.args[4][0]).to
+          .equal('focus');
+      expect(embedActions.addGlobalMethodHandler.args[4][1]).to.be.function;
+      expect(embedActions.addGlobalMethodHandler.args[5][0]).to.equal('blur');
+      expect(embedActions.addGlobalMethodHandler.args[5][1]).to.be.function;
       embedActions.addGlobalMethodHandler.args[0][1]();
       expect(hideStub).to.be.calledOnce;
     });

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -206,31 +206,6 @@ describes.sandboxed('StandardActions', {}, () => {
     });
   });
 
-  describe('"blur" action', () => {
-    it('should handle normal element', () => {
-      const element = createElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
-      const focusStub = sandbox.stub(element, 'focus');
-      const blurStub = sandbox.stub(element, 'blur');
-      standardActions.handleFocus(invocation);
-      expect(focusStub).to.be.calledOnce;
-      standardActions.handleBlur(invocation);
-      expect(blurStub).to.be.calledOnce;
-    });
-
-    it('should handle AmpElement', () => {
-      const element = createAmpElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
-      const focusStub = sandbox.stub(element, 'focus');
-      const blurStub = sandbox.stub(element, 'blur');
-      standardActions.handleFocus(invocation);
-      expect(focusStub).to.be.calledOnce;
-      standardActions.handleBlur(invocation);
-      expect(blurStub).to.be.calledOnce;
-    });
-  });
-
-
   describe('"AMP" global target', () => {
     it('should implement navigateTo', () => {
       const expandUrlStub = sandbox.stub(standardActions.urlReplacements_,
@@ -351,7 +326,7 @@ describes.sandboxed('StandardActions', {}, () => {
       expect(stub).to.be.calledOnce;
 
       // Global actions.
-      expect(embedActions.addGlobalMethodHandler).to.have.callCount(6);
+      expect(embedActions.addGlobalMethodHandler).to.have.callCount(5);
       expect(embedActions.addGlobalMethodHandler.args[0][0]).to.equal('hide');
       expect(embedActions.addGlobalMethodHandler.args[0][1]).to.be.function;
       expect(embedActions.addGlobalMethodHandler.args[1][0]).to.equal('show');
@@ -365,8 +340,6 @@ describes.sandboxed('StandardActions', {}, () => {
       expect(embedActions.addGlobalMethodHandler.args[4][0]).to
           .equal('focus');
       expect(embedActions.addGlobalMethodHandler.args[4][1]).to.be.function;
-      expect(embedActions.addGlobalMethodHandler.args[5][0]).to.equal('blur');
-      expect(embedActions.addGlobalMethodHandler.args[5][1]).to.be.function;
       embedActions.addGlobalMethodHandler.args[0][1]();
       expect(hideStub).to.be.calledOnce;
     });


### PR DESCRIPTION
This adds an action to dynamically focus and scroll to elements as detailed in #7626

### Changes

- Added position parameter to `animateScrollIntoView` in `viewport-impl` specifying the final position of the element in the viewport after the scroll animation is over
- Implemented `scrollTo` action on all elements with configurable `duration` of animation and `position` inside the viewport
- Implemented `focus` action on all elements
- Implemented `blur` action on all elements
- Added example that implements the changes
- Made changes to standard action spec
- Added unit tests

Closes #7626