### PR TITLE
Add Event constructor polyfill

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -208,6 +208,7 @@ exports.rules = [
       'src/polyfills.js->src/polyfills/object-assign.js',
       'src/polyfills.js->src/polyfills/promise.js',
       'src/polyfills.js->src/polyfills/array-includes.js',
+      'src/polyfills.js->src/polyfills/event.js',
       'src/service/extensions-impl.js->src/polyfills/document-contains.js',
       'src/service/extensions-impl.js->src/polyfills/domtokenlist-toggle.js',
     ],

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -1030,14 +1030,10 @@ describes.fakeWin('AccessService pingback', {
     service.reportViewToServer_ = sandbox.spy();
     const p = service.reportWhenViewed_(/* timeToView */ 2000);
     return Promise.resolve().then(() => {
-      let clickEvent;
-      if (document.createEvent) {
-        clickEvent = document.createEvent('MouseEvent');
-        clickEvent.initMouseEvent('click', true, true, window, 1);
-      } else {
-        clickEvent = document.createEventObject();
-        clickEvent.type = 'click';
-      }
+      const clickEvent = new MouseEvent(
+        'click',
+        {bubbles: true, cancelable: true, view: window, detail: 1}
+      );
       document.documentElement.dispatchEvent(clickEvent);
       return p;
     }).then(() => {}, () => {}).then(() => {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -959,13 +959,7 @@ export class Bind {
    */
   dispatchEventForTesting_(name) {
     if (getMode().test) {
-      let event;
-      if (typeof this.localWin_.Event === 'function') {
-        event = new Event(name, {bubbles: true, cancelable: true});
-      } else {
-        event = this.localWin_.document.createEvent('Event');
-        event.initEvent(name, /* bubbles */ true, /* cancelable */ true);
-      }
+      const event = new Event(name, {bubbles: true, cancelable: true});
       this.localWin_.dispatchEvent(event);
     }
   }

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -866,8 +866,10 @@ export class AmpLiveList extends AMP.BaseElement {
   }
 
   sendAmpDomUpdateEvent_() {
-    const event = this.win.document.createEvent('Event');
-    event.initEvent(AmpEvents.DOM_UPDATE, true, true);
+    const event = new this.win.Event(
+      AmpEvents.DOM_UPDATE,
+      {bubbles: true, cancelable: true}
+    );
     this.win.document.dispatchEvent(event);
   }
 }

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -866,7 +866,7 @@ export class AmpLiveList extends AMP.BaseElement {
   }
 
   sendAmpDomUpdateEvent_() {
-    const event = new this.win.Event(
+    const event = new Event(
       AmpEvents.DOM_UPDATE,
       {bubbles: true, cancelable: true}
     );

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -293,16 +293,14 @@ describes.realWin('amp-sidebar 0.1 version', {
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-        const eventObj = document.createEventObject ?
-            document.createEventObject() : document.createEvent('Events');
-        if (eventObj.initEvent) {
-          eventObj.initEvent('keydown', true, true);
-        }
+        const eventObj = new Event(
+          'keydown',
+          {bubbles: true, cancelable: true}
+        );
         eventObj.keyCode = KeyCodes.ESCAPE;
         eventObj.which = KeyCodes.ESCAPE;
         const el = iframe.doc.documentElement;
-        el.dispatchEvent ?
-            el.dispatchEvent(eventObj) : el.fireEvent('onkeydown', eventObj);
+        el.dispatchEvent(eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
         expect(sidebarElement.style.display).to.equal('none');
@@ -410,11 +408,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-        const eventObj = document.createEventObject ?
-            document.createEventObject() : document.createEvent('Events');
-        if (eventObj.initEvent) {
-          eventObj.initEvent('click', true, true);
-        }
+        const eventObj = new Event('click', {bubbles: true, cancelable: true});
         sandbox.stub(sidebarElement, 'getAmpDoc', () => {
           return {
             win: {
@@ -424,9 +418,7 @@ describes.realWin('amp-sidebar 0.1 version', {
             },
           };
         });
-        anchor.dispatchEvent ?
-            anchor.dispatchEvent(eventObj) :
-            anchor.fireEvent('onkeydown', eventObj);
+        anchor.dispatchEvent(eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
         expect(sidebarElement.style.display).to.equal('none');
@@ -453,11 +445,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-        const eventObj = document.createEventObject ?
-            document.createEventObject() : document.createEvent('Events');
-        if (eventObj.initEvent) {
-          eventObj.initEvent('click', true, true);
-        }
+        const eventObj = new Event('click', {bubbles: true, cancelable: true});
         sandbox.stub(sidebarElement, 'getAmpDoc', () => {
           return {
             win: {
@@ -468,9 +456,7 @@ describes.realWin('amp-sidebar 0.1 version', {
             },
           };
         });
-        anchor.dispatchEvent ?
-            anchor.dispatchEvent(eventObj) :
-            anchor.fireEvent('onkeydown', eventObj);
+        anchor.dispatchEvent(eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         expect(sidebarElement.style.display).to.equal('');
@@ -497,11 +483,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-        const eventObj = document.createEventObject ?
-            document.createEventObject() : document.createEvent('Events');
-        if (eventObj.initEvent) {
-          eventObj.initEvent('click', true, true);
-        }
+        const eventObj = new Event('click', {bubbles: true, cancelable: true});
         sandbox.stub(sidebarElement, 'getAmpDoc', () => {
           return {
             win: {
@@ -513,9 +495,7 @@ describes.realWin('amp-sidebar 0.1 version', {
             },
           };
         });
-        anchor.dispatchEvent ?
-            anchor.dispatchEvent(eventObj) :
-            anchor.fireEvent('onkeydown', eventObj);
+        anchor.dispatchEvent(eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         expect(sidebarElement.style.display).to.equal('');
@@ -541,14 +521,8 @@ describes.realWin('amp-sidebar 0.1 version', {
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-        const eventObj = document.createEventObject ?
-            document.createEventObject() : document.createEvent('Events');
-        if (eventObj.initEvent) {
-          eventObj.initEvent('click', true, true);
-        }
-        li.dispatchEvent ?
-            li.dispatchEvent(eventObj) :
-            li.fireEvent('onkeydown', eventObj);
+        const eventObj = new Event('click', {bubbles: true, cancelable: true});
+        li.dispatchEvent(eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         expect(sidebarElement.style.display).to.equal('');

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -331,16 +331,14 @@
          impl.open_();
          expect(sidebarElement.hasAttribute('open')).to.be.true;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
-         if (eventObj.initEvent) {
-           eventObj.initEvent('keydown', true, true);
-         }
+         const eventObj = new Event(
+           'keydown',
+           {bubbles: true, cancelable: true}
+         );
          eventObj.keyCode = KeyCodes.ESCAPE;
          eventObj.which = KeyCodes.ESCAPE;
          const el = iframe.doc.documentElement;
-         el.dispatchEvent ?
-             el.dispatchEvent(eventObj) : el.fireEvent('onkeydown', eventObj);
+         el.dispatchEvent(eventObj);
          expect(sidebarElement.hasAttribute('open')).to.be.false;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
          expect(sidebarElement.style.display).to.equal('none');
@@ -448,11 +446,7 @@
          impl.open_();
          expect(sidebarElement.hasAttribute('open')).to.be.true;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
-         if (eventObj.initEvent) {
-           eventObj.initEvent('click', true, true);
-         }
+         const eventObj = new Event('click', {bubbles: true, cancelable: true});
          sandbox.stub(sidebarElement, 'getAmpDoc', () => {
            return {
              win: {
@@ -462,9 +456,7 @@
              },
            };
          });
-         anchor.dispatchEvent ?
-             anchor.dispatchEvent(eventObj) :
-             anchor.fireEvent('onkeydown', eventObj);
+         anchor.dispatchEvent(eventObj);
          expect(sidebarElement.hasAttribute('open')).to.be.false;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
          expect(sidebarElement.style.display).to.equal('none');
@@ -492,11 +484,7 @@
          impl.open_();
          expect(sidebarElement.hasAttribute('open')).to.be.true;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
-         if (eventObj.initEvent) {
-           eventObj.initEvent('click', true, true);
-         }
+         const eventObj = new Event('click', {bubbles: true, cancelable: true});
          sandbox.stub(sidebarElement, 'getAmpDoc', () => {
            return {
              win: {
@@ -507,9 +495,7 @@
              },
            };
          });
-         anchor.dispatchEvent ?
-             anchor.dispatchEvent(eventObj) :
-             anchor.fireEvent('onkeydown', eventObj);
+         anchor.dispatchEvent(eventObj);
          expect(sidebarElement.hasAttribute('open')).to.be.true;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
          expect(sidebarElement.style.display).to.equal('');
@@ -536,11 +522,7 @@
          impl.open_();
          expect(sidebarElement.hasAttribute('open')).to.be.true;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
-         if (eventObj.initEvent) {
-           eventObj.initEvent('click', true, true);
-         }
+         const eventObj = new Event('click', {bubbles: true, cancelable: true});
          sandbox.stub(sidebarElement, 'getAmpDoc', () => {
            return {
              win: {
@@ -552,9 +534,7 @@
              },
            };
          });
-         anchor.dispatchEvent ?
-             anchor.dispatchEvent(eventObj) :
-             anchor.fireEvent('onkeydown', eventObj);
+         anchor.dispatchEvent(eventObj);
          expect(sidebarElement.hasAttribute('open')).to.be.true;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
          expect(sidebarElement.style.display).to.equal('');
@@ -580,14 +560,11 @@
          impl.open_();
          expect(sidebarElement.hasAttribute('open')).to.be.true;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
-         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
-         if (eventObj.initEvent) {
-           eventObj.initEvent('click', true, true);
-         }
-         li.dispatchEvent ?
-             li.dispatchEvent(eventObj) :
-             li.fireEvent('onkeydown', eventObj);
+         const eventObj = new Event(
+           'click',
+           {bubbles: true, cancelable: true}
+         );
+         li.dispatchEvent(eventObj);
          expect(sidebarElement.hasAttribute('open')).to.be.true;
          expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
          expect(sidebarElement.style.display).to.equal('');

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1109,9 +1109,7 @@ function createBaseCustomElementClass(win) {
      */
     dispatchCustomEvent(name, opt_data) {
       const data = opt_data || {};
-      // Constructors of events need to come from the correct window. Sigh.
-      const win = this.ownerDocument.defaultView;
-      const event = new win.Event(name, {bubbles: true, cancelable: true});
+      const event = new Event(name, {bubbles: true, cancelable: true});
       event.data = data;
       this.dispatchEvent(event);
     }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1111,9 +1111,8 @@ function createBaseCustomElementClass(win) {
       const data = opt_data || {};
       // Constructors of events need to come from the correct window. Sigh.
       const win = this.ownerDocument.defaultView;
-      const event = win.document.createEvent('Event');
+      const event = new win.Event(name, {bubbles: true, cancelable: true});
       event.data = data;
-      event.initEvent(name, /* bubbles */ true, /* cancelable */ true);
       this.dispatchEvent(event);
     }
 

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -16,17 +16,15 @@
 
 // Importing the document-register-element module has the side effect
 // of installing the custom elements polyfill if necessary.
-import installCustomElements from
-    'document-register-element/build/document-register-element.node';
-import {
-  install as installDOMTokenListToggle,
-} from './polyfills/domtokenlist-toggle';
+import installCustomElements from 'document-register-element/build/document-register-element.node';
+import {install as installDOMTokenListToggle} from './polyfills/domtokenlist-toggle';
 import {install as installDocContains} from './polyfills/document-contains';
 import {install as installMathSign} from './polyfills/math-sign';
 import {install as installObjectAssign} from './polyfills/object-assign';
 import {install as installPromise} from './polyfills/promise';
 import {install as installArrayIncludes} from './polyfills/array-includes';
 import {getMode} from './mode';
+import {install as installEvent} from './polyfills/event';
 
 /**
   Only install in closure binary and not in babel/browserify binary, since in
@@ -44,3 +42,4 @@ installObjectAssign(self);
 installPromise(self);
 installDocContains(self);
 installArrayIncludes(self);
+installEvent(self);

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -16,15 +16,17 @@
 
 // Importing the document-register-element module has the side effect
 // of installing the custom elements polyfill if necessary.
-import installCustomElements from 'document-register-element/build/document-register-element.node';
-import {install as installDOMTokenListToggle} from './polyfills/domtokenlist-toggle';
+import installCustomElements
+    from 'document-register-element/build/document-register-element.node';
+import {getMode} from './mode';
+import {install as installArrayIncludes} from './polyfills/array-includes';
 import {install as installDocContains} from './polyfills/document-contains';
+import {install as installDOMTokenListToggle}
+    from './polyfills/domtokenlist-toggle';
+import {install as installEvent} from './polyfills/event';
 import {install as installMathSign} from './polyfills/math-sign';
 import {install as installObjectAssign} from './polyfills/object-assign';
 import {install as installPromise} from './polyfills/promise';
-import {install as installArrayIncludes} from './polyfills/array-includes';
-import {getMode} from './mode';
-import {install as installEvent} from './polyfills/event';
 
 /**
   Only install in closure binary and not in babel/browserify binary, since in

--- a/src/polyfills/event.js
+++ b/src/polyfills/event.js
@@ -15,29 +15,36 @@
  */
 
 /**
+ *@constructor
+  */
+function Event(name, params) {
+  params = params || {bubbles: false, cancelable: false};
+  const evt = self.document.createEvent('Event');
+  evt.initEvent(
+      name,
+      params.bubbles,
+      params.cancelable
+  );
+  return evt;
+}
+
+/**
  * Sets the Event polyfill if it does not exist.
  * @param {!Window} win
  */
 export function install(win) {
   // win.Event is a function on Edge, Chrome, FF, Safari but
   // is an object on IE 11.
-  if (typeof win.Event === 'function') {
-    return;
+  if (typeof win.Event !== 'function') {
+
+    // supports >= IE 9. Below IE 9, window.Event.prototype is undefined
+    Event.prototype = win.Event.prototype;
+
+    win.Object.defineProperty(win, 'Event', {
+      configurable: false,
+      enumerable: false,
+      value: Event,
+      writable: false,
+    });
   }
-
-  function Event(name, params) {
-    params = params || {bubbles: false, cancelable: false};
-    const evt = win.document.createEvent('Event');
-    evt.initEvent(
-        name,
-        params.bubbles,
-        params.cancelable
-    );
-    return evt;
-  }
-
-  // supports >= IE 9. Below IE 9, window.Event.prototype is undefined
-  Event.prototype = win.Event.prototype;
-
-  win.Event = Event;
 }

--- a/src/polyfills/event.js
+++ b/src/polyfills/event.js
@@ -19,6 +19,8 @@
  * @param {!Window} win
  */
 export function install(win) {
+  // win.CustomEvent is a function on Edge, Chrome, FF, Safari but
+  // is an object on IE 11.
   if (typeof win.Event === 'function') {
     return false;
   }
@@ -35,6 +37,7 @@ export function install(win) {
     return evt;
   }
 
+  // supports >= IE 9. Below IE 9, window.Event.prototype is undefined
   Event.prototype = window.Event.prototype;
 
   win.Event = Event;

--- a/src/polyfills/event.js
+++ b/src/polyfills/event.js
@@ -27,7 +27,7 @@ export function install(win) {
 
   function Event(event, params) {
     params = params || {bubbles: false, cancelable: false, detail: undefined};
-    const evt = document.createEvent('Event');
+    const evt = win.document.createEvent('Event');
     evt.initCustomEvent(
       event,
       params.bubbles,
@@ -38,7 +38,7 @@ export function install(win) {
   }
 
   // supports >= IE 9. Below IE 9, window.Event.prototype is undefined
-  Event.prototype = window.Event.prototype;
+  Event.prototype = win.Event.prototype;
 
   win.Event = Event;
 }

--- a/src/polyfills/event.js
+++ b/src/polyfills/event.js
@@ -22,17 +22,16 @@ export function install(win) {
   // win.Event is a function on Edge, Chrome, FF, Safari but
   // is an object on IE 11.
   if (typeof win.Event === 'function') {
-    return false;
+    return;
   }
 
-  function Event(event, params) {
-    params = params || {bubbles: false, cancelable: false, detail: undefined};
+  function Event(name, params) {
+    params = params || {bubbles: false, cancelable: false};
     const evt = win.document.createEvent('Event');
-    evt.initCustomEvent(
-      event,
-      params.bubbles,
-      params.cancelable,
-      params.detail
+    evt.initEvent(
+        name,
+        params.bubbles,
+        params.cancelable
     );
     return evt;
   }

--- a/src/polyfills/event.js
+++ b/src/polyfills/event.js
@@ -19,7 +19,7 @@
  * @param {!Window} win
  */
 export function install(win) {
-  // win.CustomEvent is a function on Edge, Chrome, FF, Safari but
+  // win.Event is a function on Edge, Chrome, FF, Safari but
   // is an object on IE 11.
   if (typeof win.Event === 'function') {
     return false;

--- a/src/polyfills/event.js
+++ b/src/polyfills/event.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Sets the Event polyfill if it does not exist.
+ * @param {!Window} win
+ */
+export function install(win) {
+  if (typeof win.Event === 'function') {
+    return false;
+  }
+
+  function Event(event, params) {
+    params = params || {bubbles: false, cancelable: false, detail: undefined};
+    const evt = document.createEvent('Event');
+    evt.initCustomEvent(
+      event,
+      params.bubbles,
+      params.cancelable,
+      params.detail
+    );
+    return evt;
+  }
+
+  Event.prototype = window.Event.prototype;
+
+  win.Event = Event;
+}

--- a/src/polyfills/event.js
+++ b/src/polyfills/event.js
@@ -15,9 +15,16 @@
  */
 
 /**
- *@constructor
-  */
+ * @constructor
+ */
 function Event(name, params) {
+  if (!name) {
+    throw new TypeError(
+      "Failed to construct 'Event': 1 argument required but only 0 present",
+      'event.js',
+      20
+    );
+  }
   params = params || {bubbles: false, cancelable: false};
   const evt = self.document.createEvent('Event');
   evt.initEvent(

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -177,7 +177,7 @@ describe('BaseElement', () => {
       const timer = timerFor(element.win);
       target = document.createElement('div');
 
-      event1 = new Event('event1', {bubbles: false, cancelable: true})
+      event1 = new Event('event1', {bubbles: false, cancelable: true});
 
       event2 = new Event('event2', {bubbles: false, cancelable: true});
 

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -177,11 +177,9 @@ describe('BaseElement', () => {
       const timer = timerFor(element.win);
       target = document.createElement('div');
 
-      event1 = document.createEvent('Event');
-      event1.initEvent('event1', false, true);
+      event1 = new Event('event1', {bubbles: false, cancelable: true})
 
-      event2 = document.createEvent('Event');
-      event2.initEvent('event2', false, true);
+      event2 = new Event('event2', {bubbles: false, cancelable: true});
 
       event1Promise = listenOncePromise(element.element, 'event1');
       event1Promise = timer.timeoutPromise(TIMEOUT, event1Promise);

--- a/test/functional/test-event-helper.js
+++ b/test/functional/test-event-helper.js
@@ -28,8 +28,7 @@ import * as sinon from 'sinon';
 describe('EventHelper', () => {
 
   function getEvent(name, target) {
-    const event = document.createEvent('Event');
-    event.initEvent(name, true, true);
+    const event = new Event(name, {bubbles: true, cancelable: true});
     event.testTarget = target;
     return event;
   }

--- a/test/functional/test-polyfill-event.js
+++ b/test/functional/test-polyfill-event.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {install} from '../../src/polyfills/event.js';
+
+describes.fakeWin('Event', {}, env => {
+
+  beforeEach(() => {
+    env.win.Event = Object.create(self.Event.prototype);
+    env.win.Event.prototype = self.Event.prototype;
+    install(env.win);
+  });
+
+  it('should be a function', () => {
+    expect(env.win.Event).to.be.a('function');
+  });
+
+  it('should require a type argument', () => {
+    expect(() => new Event()).to.throw(TypeError);
+  });
+
+  it('should be configurable', () => {
+    const ev = new Event('event', {bubbles: true, cancelable: true});
+    expect(ev.bubbles).to.be.true;
+    expect(ev.cancelable).to.be.true;
+  });
+
+  it('should be able to be dispatched', () => {
+    const ev = new Event('event');
+    const elm = document.createElement('p');
+    expect(() => elm.dispatchEvent(ev)).to.not.throw();
+  });
+
+  it('should trigger listeners', () => {
+    const ev = new Event('event');
+    const elm = document.createElement('p');
+    let flag = false;
+    elm.addEventListener('event', () => {
+      flag = true;
+    });
+    elm.dispatchEvent(ev);
+    expect(flag).to.be.true;
+  });
+});

--- a/test/functional/test-polyfill-event.js
+++ b/test/functional/test-polyfill-event.js
@@ -19,7 +19,9 @@ import {install} from '../../src/polyfills/event.js';
 describes.fakeWin('Event', {}, env => {
 
   beforeEach(() => {
+    // makes the Event polyfill install by setting window.Event to an object
     env.win.Event = Object.create(self.Event.prototype);
+    // makes the prototype available for assignment
     env.win.Event.prototype = self.Event.prototype;
     install(env.win);
   });
@@ -32,16 +34,16 @@ describes.fakeWin('Event', {}, env => {
     expect(() => new env.win.Event()).to.throw(TypeError);
   });
 
+  it('should not bubble or be cancelable by default', () => {
+    const defaultEvent = new env.win.Event('event');
+    expect(defaultEvent.bubbles).to.be.false;
+    expect(defaultEvent.cancelable).to.be.false;
+  });
+
   it('should be configurable', () => {
     const ev = new env.win.Event('event', {bubbles: true, cancelable: true});
     expect(ev.bubbles).to.be.true;
     expect(ev.cancelable).to.be.true;
-  });
-
-  it('should be able to be dispatched', () => {
-    const ev = new env.win.Event('event');
-    const elm = document.createElement('p');
-    expect(() => elm.dispatchEvent(ev)).to.not.throw();
   });
 
   it('should trigger listeners', () => {

--- a/test/functional/test-polyfill-event.js
+++ b/test/functional/test-polyfill-event.js
@@ -29,23 +29,23 @@ describes.fakeWin('Event', {}, env => {
   });
 
   it('should require a type argument', () => {
-    expect(() => new Event()).to.throw(TypeError);
+    expect(() => new env.win.Event()).to.throw(TypeError);
   });
 
   it('should be configurable', () => {
-    const ev = new Event('event', {bubbles: true, cancelable: true});
+    const ev = new env.win.Event('event', {bubbles: true, cancelable: true});
     expect(ev.bubbles).to.be.true;
     expect(ev.cancelable).to.be.true;
   });
 
   it('should be able to be dispatched', () => {
-    const ev = new Event('event');
+    const ev = new env.win.Event('event');
     const elm = document.createElement('p');
     expect(() => elm.dispatchEvent(ev)).to.not.throw();
   });
 
   it('should trigger listeners', () => {
-    const ev = new Event('event');
+    const ev = new env.win.Event('event');
     const elm = document.createElement('p');
     let flag = false;
     elm.addEventListener('event', () => {

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -64,7 +64,7 @@ export class FakeWindow {
     this.DOMTokenList = window.DOMTokenList;
     /** @const */
     this.Math = window.Math;
-    /**@const */
+    /** @const */
     this.Event = window.Event;
 
     // Parent Window points to itself if spec.parent was not passed.

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -64,6 +64,8 @@ export class FakeWindow {
     this.DOMTokenList = window.DOMTokenList;
     /** @const */
     this.Math = window.Math;
+    /**@const */
+    this.Event = window.Event;
 
     // Parent Window points to itself if spec.parent was not passed.
     /** @const @type {!Window} */


### PR DESCRIPTION
- Fixes #9597.
- Implements a polyfill for the Event constructor for older browsers (IE 9+).
- Replaces usages of `document.createEvent` with `new Event`.

There is one location where I did not replace the usage of `document.createEvent`. It's in `test/functional/test-event-helper.js`, line 236. The test is creating a custom function to assign to `document.createEvent` so I've left it alone.
