### PR TITLE
Animations: install polyfill even with native support

### DIFF
--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -32,6 +32,7 @@ import {user, dev} from '../../../src/log';
 import {viewerForDoc} from '../../../src/services';
 
 const TAG = 'amp-animation';
+const POLYFILLED = '__AMP_WA';
 
 
 export class AmpAnimation extends AMP.BaseElement {
@@ -345,9 +346,7 @@ export class AmpAnimation extends AMP.BaseElement {
         opt_args || null);
 
     // Ensure polyfill is installed.
-    if (!this.win.Element.prototype.animate) {
-      installWebAnimations(this.win);
-    }
+    ensurePolyfillInstalled(this.win);
 
     const ampdoc = this.getAmpDoc();
     const readyPromise = this.embed_ ? this.embed_.whenReady() :
@@ -420,6 +419,16 @@ export class AmpAnimation extends AMP.BaseElement {
       this.runner_.scrollTick.bind(this.runner_), /* onScroll */
       this.runner_.updateScrollDuration.bind(this.runner_) /* onDurationChanged */
     );
+  }
+}
+
+/**
+ * @param {!Window} win
+ */
+function ensurePolyfillInstalled(win) {
+  if (!win[POLYFILLED]) {
+    win[POLYFILLED] = true;
+    installWebAnimations(win);
   }
 }
 


### PR DESCRIPTION
The problem is that native implementations often have some features missing. The polyfill feature-detects what's missing and adds it, while keeping the native implementation intact.