### PR TITLE
Fixes multisize creative centering.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -134,7 +134,7 @@ const BLOCK_SRA_COMBINERS_ = [
   },
   instances => {
     return {'prev_iu_szs': instances.map(instance =>
-      `${instance.size_.width}x${instance.size_.height}`).join()};
+      `${instance.initialSize_.width}x${instance.initialSize_.height}`).join()};
   },
   // Although declared at a block-level, this is actually page level so
   // return true if ANY indicate TFCD.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -441,8 +441,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     this.lifecycleReporter_.addPingsForVisibility(this.element);
 
-    // Force size of frame to match available space as min-height/width are
-    // set to 0 to ensure centering.
+    // Force size of frame to match creative or, if creative size is unknown,
+    // the slot. This ensures that the creative is centered in the former case,
+    // and not truncated in the latter.
     const size = this.returnedSize_ || this.getIntersectionElementLayoutBox();
     setStyles(dev().assertElement(this.iframe), {
       width: `${size.width}px`,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -438,12 +438,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     this.lifecycleReporter_.addPingsForVisibility(this.element);
 
-    // Force size of frame to match available space as min-height/width are
-    // set to 0 to ensure centering.
-    const size = this.getIntersectionElementLayoutBox();
     setStyles(dev().assertElement(this.iframe), {
-      width: `${size.width}px`,
-      height: `${size.height}px`,
+      width: `${this.size_.width}px`,
+      height: `${this.size_.height}px`,
     });
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -198,7 +198,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     /** @private {?string} */
     this.qqid_ = null;
 
-    /** @private {?({width, height}|../../../src/layout-rect.LayoutRectDef)} */
+    /** @private {?({width: number, height: number}|../../../src/layout-rect.LayoutRectDef)} */
     this.initialSize_ = null;
 
     /** @private {?{width: number, height: number}} */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -201,7 +201,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     /** @private {?({width, height}|../../../src/layout-rect.LayoutRectDef)} */
     this.initialSize_ = null;
 
-    /** @private {?{width, height}} */
+    /** @private {?{width: number, height: number}} */
     this.returnedSize_ = null;
 
     /** @private {?Element} */


### PR DESCRIPTION
Changes made in #10351 caused the creative to resize to the size of the slot rather than the creative, forcing the creative to appear left-top justified rather than centered when occupying a space smaller than the slot.