### PR TITLE
Adds CLA & join project link to GFI template

### DIFF
--- a/contributing/great-first-issues-template.md
+++ b/contributing/great-first-issues-template.md
@@ -34,10 +34,11 @@ If this is a feature, change this to "The feature" and add a detailed descriptio
 Step-by-step instructions for the contributor to follow as they work through the bug.  Feel free to change any step that will make the steps more clear for this issue.  Make sure to replace the comment block below with the exact steps the contributor should follow.
 -->
 ### Step by step
-- [ ] Claim this issue by adding a comment below.  Please only claim this bug if you plan on starting work in the next day or so.
+- [ ] Claim this issue by adding a comment below.  Please only claim this bug if you plan on starting work in the next day or so.  (If you [join the AMP Project](https://goo.gl/forms/T65peVtfQfEoDWeD3) we'll be able to assign this issue to you after you've claimed it.)
 - [ ] If you aren't too familiar with Git/GitHub, see the [Getting Started End-to-End Guide](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md) for [an intro to Git & GitHub,](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#intro-to-git-and-github) and [how to get a copy of the code](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#get-a-copy-of-the-amphtml-code).  You can also refer to the [Quick Start Guide](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-quick.md) for the necessary setup steps with less explanation than the End-to-End guide.
 - [ ] Follow the instructions for [building AMP](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#building-amp-and-starting-a-local-server).
 - [ ] [Create a Git branch](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#create-a-git-branch) for making your changes.
+- [ ] [Sign the Contributor License Agreement](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#contributor-license-agreement) before creating a Pull Request.  (If you are contributing code on behalf of a corporation start this process as early as possible.)
 <!--
 Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run gulp test to see it fails, change a file and then run gulp test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
 -->


### PR DESCRIPTION
Adds a step in the GFI template to point out the need to sign a CLA (since this catches some new contributors by surprise) and adds a link to the form to optionally join the AMP Project.