### PR TITLE
Add a `--quiet` mode to `gulp serve` and silence webserver logs on Travis

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -30,6 +30,7 @@ const host = process.env.SERVE_HOST;
 const port = process.env.SERVE_PORT;
 const useHttps = process.env.SERVE_USEHTTPS == 'true' ? true : false;
 const gulpProcess = process.env.SERVE_PROCESS_ID;
+const quiet = process.env.SERVE_QUIET == 'true' ? true : false;
 
 // Exit if the port is in use.
 process.on('uncaughtException', function(err) {
@@ -50,6 +51,12 @@ setInterval(function() {
   }
 }, 1000);
 
+// Determine webserver logging level.
+var logger = '';
+if (!quiet) {
+  logger = morgan('dev');
+}
+
 // Start gulp webserver
 gulp.src(process.cwd())
   .pipe(webserver({
@@ -57,6 +64,6 @@ gulp.src(process.cwd())
     host,
     directoryListing: true,
     https: useHttps,
-    middleware: [morgan('dev'), app],
+    middleware: [logger, app],
   }));
 

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -51,12 +51,6 @@ setInterval(function() {
   }
 }, 1000);
 
-// Determine webserver logging level.
-var logger = '';
-if (!quiet) {
-  logger = morgan('dev');
-}
-
 // Start gulp webserver
 gulp.src(process.cwd())
   .pipe(webserver({
@@ -64,6 +58,6 @@ gulp.src(process.cwd())
     host,
     directoryListing: true,
     https: useHttps,
-    middleware: [logger, app],
+    middleware: quiet ? [app] : [morgan('dev'), app]
   }));
 

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -23,6 +23,7 @@ var nodemon = require('nodemon');
 var host = argv.host || 'localhost';
 var port = argv.port || process.env.PORT || 8000;
 var useHttps = argv.https != undefined;
+var quiet = argv.quiet != undefined;
 
 /**
  * Starts a simple http server at the repository root
@@ -51,7 +52,8 @@ function serve() {
       'SERVE_PORT': port,
       'SERVE_HOST': host,
       'SERVE_USEHTTPS': useHttps,
-      'SERVE_PROCESS_ID': process.pid
+      'SERVE_PROCESS_ID': process.pid,
+      'SERVE_QUIET': quiet
     },
   })
   .once('exit', function () {
@@ -75,7 +77,8 @@ gulp.task(
       options: {
         'host': '  Hostname or IP address to bind to (default: localhost)',
         'port': '  Specifies alternative port (default: 8000)',
-        'https': '  Use HTTPS server (default: false)'
+        'https': '  Use HTTPS server (default: false)',
+        'quiet': '  Do not log HTTP requests (default: false)'
       }
     }
 );

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -64,9 +64,11 @@ function serve() {
   .once('quit', function () {
     util.log(util.colors.green('Shutting down server'));
   });
-  util.log(util.colors.yellow('Run `gulp build` then go to '
-      + getHost() + '/examples/article.amp.html'
-  ));
+  if (!quiet) {
+    util.log(util.colors.yellow('Run `gulp build` then go to '
+        + getHost() + '/examples/article.amp.html'
+    ));
+  }
 }
 
 gulp.task(

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -30,6 +30,7 @@ require 'phantomjs'
 
 ENV['PERCY_DEBUG'] = '0'
 ENV['PHANTOMJS_DEBUG'] = 'false'
+ENV['WEBSERVER_QUIET'] = '--quiet'
 # CSS widths: iPhone: 375, Pixel: 411, Macbook Pro 15": 1440.
 DEFAULT_WIDTHS = [375, 411, 1440]
 HOST = 'localhost'
@@ -46,7 +47,8 @@ def cyan(text); "\e[36m#{text}\e[0m"; end
 # Returns:
 # - Process ID of server process.
 def launchWebServer()
-  webserverCmd = "gulp serve --host #{HOST} --port #{PORT}"
+  webserverCmd =
+      "gulp serve --host #{HOST} --port #{PORT} #{ENV['WEBSERVER_QUIET']}"
   spawn(webserverCmd)
 end
 
@@ -126,38 +128,27 @@ def generateSnapshots(pagesToSnapshot)
       forbidden_css = webpage["forbidden_css"]
       loading_incomplete_css = webpage["loading_incomplete_css"]
       loading_complete_css = webpage["loading_complete_css"]
-      generateSnapshot(
-          page,
-          url,
-          name,
-          forbidden_css,
-          loading_incomplete_css,
-          loading_complete_css)
+      page.visit(url)
+      verifyCssElements(
+          page, forbidden_css, loading_incomplete_css, loading_complete_css)
+      Percy::Capybara.snapshot(page, name: name)
     end
   end
 end
 
 
-# Generates a percy snapshot for a given webpage.
+# Verifies that all CSS elements are as expected before taking a snapshot.
 #
 # Args:
 # - page: Page object used by Percy for snapshotting.
-# - url: Relative URL of page to be snapshotted.
-# - name: Name of snapshot on Percy.
 # - forbidden_css:
 #       Array of CSS elements that must not be found in the page.
 # - loading_incomplete_css:
 #       Array of CSS elements that must eventually be removed from the page.
 # - loading_complete_css:
 #       Array of CSS elements that must eventually appear on the page.
-def generateSnapshot(
-    page,
-    url,
-    name,
-    forbidden_css,
-    loading_incomplete_css,
-    loading_complete_css)
-  page.visit(url)
+def verifyCssElements(
+    page, forbidden_css, loading_incomplete_css, loading_complete_css)
   page.has_no_css?('.i-amphtml-loader-dot')  # Implicitly waits for page load.
   if forbidden_css
     forbidden_css.each do |css|
@@ -182,7 +173,6 @@ def generateSnapshot(
       end
     end
   end
-  Percy::Capybara.snapshot(page, name: name)
 end
 
 
@@ -191,12 +181,16 @@ def setDebuggingLevel()
   if ARGV.include? '--debug'
     ENV['PERCY_DEBUG'] = '1'
     ENV['PHANTOMJS_DEBUG'] = 'true'
+    ENV['WEBSERVER_QUIET'] = ''
   end
   if ARGV.include? '--percy_debug'
     ENV['PERCY_DEBUG'] = '1'
   end
   if ARGV.include? '--phantomjs_debug'
     ENV['PHANTOMJS_DEBUG'] = 'true'
+  end
+  if ARGV.include? '--webserver_debug'
+    ENV['WEBSERVER_QUIET'] = ''
   end
 end
 


### PR DESCRIPTION
The Travis logs are becoming more and more verbose as we add new visual diff tests. This PR adds a new `--quiet` mode to `gulp serve` and enables it by default for visual diff tests.

For local debugging of webserver logs with `visual-diff.rb`, use the `--webserver_debug` flag.

#10155