### PR TITLE
Remove amp-ad-exit experiment from configs.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -25,6 +25,5 @@
   "a4a-measure-get-ad-urls": 1,
   "ad-loader-v2": 1,
   "3p-use-ampcontext": 0,
-  "amp-ad-exit": 1,
   "amp-animation": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -23,7 +23,6 @@
   "pump-early-frame": 1,
   "a4a-measure-get-ad-urls": 0,
   "ad-loader-v2": 1,
-  "amp-ad-exit": 1,
   "3p-use-ampcontext": 0,
   "amp-animation": 1
 }


### PR DESCRIPTION
Remove reference to amp-ad-exit experiment from prod/canary configs. This was split from https://github.com/ampproject/amphtml/pull/10428.