### PR TITLE
Rename PLAY -> PLAYING for IMA as well

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -1028,7 +1028,7 @@ const VideoEvents = {
    *
    * @event play
    */
-  PLAY: 'play',
+  PLAYING: 'playing',
 
   /**
    * pause


### PR DESCRIPTION
`IMA` had a copy of VideoEvents enum due to dependency import restrictions.
