### PR TITLE
Makes `data-vars-` attribute work in amp-ad.

### DIFF
--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -77,6 +77,10 @@ Use this attribute to load a script tag for the specified ad network. This can b
 
 Most ad networks require further configuration, which can be passed to the network by using HTML `data-` attributes. The parameter names are subject to standard data attribute dash to camel case conversion. For example, "data-foo-bar" is send to the ad for configuration as "fooBar".  See the documentation for the [ad network](#supported-ad-networks) on which attributes can be used.
 
+##### data-vars-foo-bar
+
+Attributes starting with `data-vars-` are reserved for [`amp-analytics` vars](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute). 
+
 ##### json (optional)
 
 Use this attribute to pass a configuration to the ad as an arbitrarily complex JSON object. The object is passed to the ad as-is with no mangling done on the names.

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -135,7 +135,10 @@ export function getIframe(
 export function addDataAndJsonAttributes_(element, attributes) {
   for (let i = 0; i < element.attributes.length; i++) {
     const attr = element.attributes[i];
-    if (attr.name.indexOf('data-') != 0) {
+    if (attr.name.indexOf('data-') != 0
+      // data-vars- is reserved for amp-analytics
+      // see https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute
+      || attr.name.indexOf('data-vars-') == 0) {
       continue;
     }
     attributes[dashToCamelCase(attr.name.substr(5))] = attr.value;

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -23,6 +23,7 @@ import {dict} from './utils/object';
 import {parseUrl, assertHttpsUrl} from './url';
 import {urls} from './config';
 import {setStyle} from './style';
+import {startsWith} from './string';
 
 /** @type {!Object<string,number>} Number of 3p frames on the for that type. */
 let count = {};
@@ -135,10 +136,10 @@ export function getIframe(
 export function addDataAndJsonAttributes_(element, attributes) {
   for (let i = 0; i < element.attributes.length; i++) {
     const attr = element.attributes[i];
-    if (attr.name.indexOf('data-') != 0
+    if (!startsWith(attr.name, 'data-')
       // data-vars- is reserved for amp-analytics
       // see https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute
-      || attr.name.indexOf('data-vars-') == 0) {
+      || startsWith(attr.name, 'data-vars-')) {
       continue;
     }
     attributes[dashToCamelCase(attr.name.substr(5))] = attr.value;

--- a/test/functional/test-3p-frame.js
+++ b/test/functional/test-3p-frame.js
@@ -117,6 +117,7 @@ describe('3p-frame', () => {
     div.setAttribute('data-foo', 'foo');
     div.setAttribute('data-bar', 'bar');
     div.setAttribute('foo', 'nope');
+    div.setAttribute('data-vars-bar', 'nope');
     let obj = {};
     addDataAndJsonAttributes_(div, obj);
     expect(obj).to.deep.equal({


### PR DESCRIPTION
Fixes #8852