### PR TITLE
Skip flaky video test

### DIFF
--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -505,7 +505,7 @@ export function runVideoPlayerIntegrationTests(
       });
 
       // TODO(aghassemi, #9379): Flaky on Safari 9.
-      it.configure().skipSafari().run('should play/pause when video ' +
+      it.skip('should play/pause when video ' +
           'enters/exits viewport', () => {
         let video;
         let viewport;


### PR DESCRIPTION
This test has been flaking  on ~50% of Travis builds since #10283 was merged AFAICT. 

> Chrome 59.0.3071 (Linux 0.0.0) Fake Video Player Integration Tests Autoplay play/pause should play/pause when video enters/exits viewport FAILED
	Error: timeout of 20000ms exceeded. Ensure the done() callback is being called in this test.

https://travis-ci.org/ampproject/amphtml/jobs/253791736

/to @cvializ /cc @alanorozco @aghassemi 