### PR TITLE
Increase local timeout for amp-bind tests

### DIFF
--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -101,7 +101,7 @@ function waitForEvent(env, name) {
 
 describe('Bind', function() {
   // Give more than default 2000ms timeout for local testing.
-  const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 3000);
+  const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);
 
   describes.realWin('in FIE', {

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -21,6 +21,10 @@ import {batchedXhrFor} from '../../src/services';
 import * as sinon from 'sinon';
 
 describe.configure().skipSauceLabs().run('amp-bind', function() {
+  // Give more than default 2000ms timeout for local testing.
+  const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
+  this.timeout(TIMEOUT);
+
   let fixture;
   let sandbox;
   let numSetStates;


### PR DESCRIPTION
- Increase local timeout for unit tests from 3 to 4s and integration tests from 2 to 4s.

Motivation: https://github.com/ampproject/amphtml/issues/10404#issuecomment-315605905

/to @rsimha-amp /cc @blueyedgeek