### PR TITLE
Rename describes.js functions

### DIFF
--- a/ads/google/a4a/test/test-google-data-reporter.js
+++ b/ads/google/a4a/test/test-google-data-reporter.js
@@ -93,7 +93,7 @@ describe('#getLifecycleReporter', () => {
   });
 });
 
-describes.fakeWin('#setGoogleLifecycleVarsFromHeaders', {amp: true}, env => {
+describes.unit('#setGoogleLifecycleVarsFromHeaders', {amp: true}, env => {
   const headerData = {};
   const headerMock = {
     get: h => { return h in headerData ? headerData[h] : null; },
@@ -129,7 +129,7 @@ describes.fakeWin('#setGoogleLifecycleVarsFromHeaders', {amp: true}, env => {
 });
 
 describes.sandboxed('#googleLifecycleReporterFactory', {}, () => {
-  describes.fakeWin('default parameters', {amp: true}, env => {
+  describes.unit('default parameters', {amp: true}, env => {
     let mockReporter;
     let emitPingStub;
     beforeEach(() => {

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -35,7 +35,7 @@ function expectMatchesAll(address, matchList) {
 }
 
 describe('BaseLifecycleReporter', () => {
-  describes.fakeWin('', {}, env => {
+  describes.unit('', {}, env => {
     let doc;
     beforeEach(() => {
       doc = env.win.document;

--- a/ads/google/a4a/test/test-traffic-experiments.js
+++ b/ads/google/a4a/test/test-traffic-experiments.js
@@ -48,7 +48,7 @@ import * as sinon from 'sinon';
 
 describe('all-traffic-experiments-tests', () => {
 
-  describes.realWin('#googleAdsIsA4AEnabled', {
+  describes.functional('#googleAdsIsA4AEnabled', {
     amp: {
       runtimeOn: true,
       ampdoc: 'single',

--- a/ads/google/test/test-adsense-amp-auto-ads.js
+++ b/ads/google/test/test-adsense-amp-auto-ads.js
@@ -24,7 +24,7 @@ import {
   toggleExperiment,
 } from '../../../src/experiments';
 
-describes.realWin('adsense-amp-auto-ads', {}, env => {
+describes.functional('adsense-amp-auto-ads', {}, env => {
   let win;
   let sandbox;
   let accurateRandomStub;

--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -172,7 +172,7 @@ function getJsTestExtensionFile(name) {
 
 import {${className}} from '../${name}';
 
-describes.realWin('${name}', {
+describes.functional('${name}', {
   amp: {
     extensions: ['${name}'],
   }

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -158,7 +158,7 @@ module.exports = {
     mocha: {
       reporter: 'html',
       // Longer timeout on Travis; fail quickly at local.
-      timeout: process.env.TRAVIS ? 10000 : 2000,
+      timeout: process.env.TRAVIS ? 10000 : 5000,
     },
     captureConsole: false,
   },

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -18,7 +18,7 @@ import {LaterpayVendor} from '../laterpay-impl';
 
 const TAG = 'amp-access-laterpay';
 
-describes.fakeWin('LaterpayVendor', {
+describes.unit('LaterpayVendor', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {

--- a/extensions/amp-access/0.1/test/test-amp-access-client.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-client.js
@@ -20,7 +20,7 @@ import * as sinon from 'sinon';
 import * as mode from '../../../../src/mode';
 
 
-describes.realWin('AccessClientAdapter', {
+describes.functional('AccessClientAdapter', {
   amp: true,
 }, env => {
   let win;

--- a/extensions/amp-access/0.1/test/test-amp-access-other.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-other.js
@@ -17,7 +17,7 @@
 import {AccessOtherAdapter} from '../amp-access-other';
 
 
-describes.realWin('AccessOtherAdapter', {amp: true}, env => {
+describes.functional('AccessOtherAdapter', {amp: true}, env => {
   let ampdoc;
   let validConfig;
   let context;

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -22,7 +22,7 @@ import * as lolex from 'lolex';
 import * as sinon from 'sinon';
 
 
-describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
+describes.functional('AccessServerJwtAdapter', {amp: true}, env => {
   let win;
   let ampdoc;
   let clock;

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -19,7 +19,7 @@ import {removeFragment} from '../../../../src/url';
 import * as lolex from 'lolex';
 
 
-describes.realWin('AccessServerAdapter', {amp: true}, env => {
+describes.functional('AccessServerAdapter', {amp: true}, env => {
   let win;
   let document;
   let ampdoc;

--- a/extensions/amp-access/0.1/test/test-amp-access-vendor.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-vendor.js
@@ -18,7 +18,7 @@ import {AccessVendor} from '../access-vendor';
 import {AccessVendorAdapter} from '../amp-access-vendor';
 
 
-describes.realWin('AccessVendorAdapter', {amp: true}, env => {
+describes.functional('AccessVendorAdapter', {amp: true}, env => {
   let ampdoc;
   let validConfig;
 

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -29,7 +29,7 @@ import {toggleExperiment} from '../../../../src/experiments';
 import * as sinon from 'sinon';
 
 
-describes.fakeWin('AccessService', {
+describes.unit('AccessService', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -352,7 +352,7 @@ describes.fakeWin('AccessService', {
 });
 
 
-describes.fakeWin('AccessService adapter context', {
+describes.unit('AccessService adapter context', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -461,7 +461,7 @@ describes.fakeWin('AccessService adapter context', {
 });
 
 
-describes.fakeWin('AccessService authorization', {
+describes.unit('AccessService authorization', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -768,7 +768,7 @@ describes.fakeWin('AccessService authorization', {
 });
 
 
-describes.fakeWin('AccessService applyAuthorizationToElement_', {
+describes.unit('AccessService applyAuthorizationToElement_', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -912,7 +912,7 @@ describes.fakeWin('AccessService applyAuthorizationToElement_', {
 });
 
 
-describes.fakeWin('AccessService pingback', {
+describes.unit('AccessService pingback', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -1252,7 +1252,7 @@ describes.fakeWin('AccessService pingback', {
 });
 
 
-describes.fakeWin('AccessService login', {
+describes.unit('AccessService login', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -1611,7 +1611,7 @@ describes.fakeWin('AccessService login', {
 });
 
 
-describes.fakeWin('AccessService analytics', {
+describes.unit('AccessService analytics', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {

--- a/extensions/amp-access/0.1/test/test-signin.js
+++ b/extensions/amp-access/0.1/test/test-signin.js
@@ -19,7 +19,7 @@ import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
 
 
-describes.realWin('SignInProtocol', {amp: true}, env => {
+describes.functional('SignInProtocol', {amp: true}, env => {
 
   const ORIGIN = 'https://example.com';
   const AUTHORITY = 'https://authority.example.net';

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -63,7 +63,7 @@ const EXIT_CONFIG = {
   },
 };
 
-describes.realWin('amp-ad-exit', {
+describes.functional('amp-ad-exit', {
   amp: {
     ampdoc: 'single',
     extensions: ['amp-ad-exit'],

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-integration.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-integration.js
@@ -22,7 +22,7 @@ import {
 
 // Still under construction.
 describes.sandboxed('A4A integration', {}, () => {
-  describes.realWin('doubleclick', {allowExternalResources: false}, env => {
+  describes.functional('doubleclick', {allowExternalResources: false}, env => {
     // Note: May need a separate realWin test for checking cross-domain
     // rendering, including SafeFrame and NameFrame.
     let fixture;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -38,7 +38,7 @@ function createAmpAd(win) {
   return new AmpAd3PImpl(ampAdElement);
 }
 
-describes.realWin('amp-ad-3p-impl', {
+describes.functional('amp-ad-3p-impl', {
   amp: {
     canonicalUrl: 'https://canonical.url',
   },

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -19,7 +19,7 @@ import {AmpAdUIHandler} from '../amp-ad-ui';
 import {BaseElement} from '../../../../src/base-element';
 import * as adHelper from '../../../../src/ad-helper';
 
-describes.realWin('amp-ad-ui handler', {
+describes.functional('amp-ad-ui handler', {
   amp: {
     ampdoc: 'single',
   },

--- a/extensions/amp-ad/0.1/test/test-concurrent-load.js
+++ b/extensions/amp-ad/0.1/test/test-concurrent-load.js
@@ -24,7 +24,7 @@ import {installTimerService} from '../../../../src/service/timer-impl';
 import {macroTask} from '../../../../testing/yield';
 import * as lolex from 'lolex';
 
-describes.realWin('concurrent-load', {}, env => {
+describes.functional('concurrent-load', {}, env => {
 
   describe('getAmpAdRenderOutsideViewport', () => {
     it('should return null if ' +

--- a/extensions/amp-analytics/0.1/test/test-analytics-root.js
+++ b/extensions/amp-analytics/0.1/test/test-analytics-root.js
@@ -30,7 +30,7 @@ import {
 } from '../visibility-manager';
 
 
-describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
+describes.functional('AmpdocAnalyticsRoot', {amp: 1}, env => {
   let win;
   let ampdoc;
   let resources, viewport;
@@ -402,7 +402,7 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
 });
 
 
-describes.realWin('EmbedAnalyticsRoot', {
+describes.functional('EmbedAnalyticsRoot', {
   amp: {ampdoc: 'fie'},
 }, env => {
   let win;

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -27,7 +27,7 @@ import {Signals} from '../../../../src/utils/signals';
 import * as sinon from 'sinon';
 
 
-describes.realWin('Events', {amp: 1}, env => {
+describes.functional('Events', {amp: 1}, env => {
   let win;
   let ampdoc;
   let root;

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -35,7 +35,7 @@ import {
 } from '../../../../src/service/resources-impl';
 import {Services} from '../../../../src/services';
 
-describes.realWin('InstrumentationService', {amp: 1}, env => {
+describes.functional('InstrumentationService', {amp: 1}, env => {
   let win;
   let ampdoc;
   let service;
@@ -234,7 +234,7 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
 });
 
 
-describes.realWin('InstrumentationService in FIE', {
+describes.functional('InstrumentationService in FIE', {
   amp: {ampdoc: 'fie'},
 }, env => {
   let win;

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -64,7 +64,7 @@ class IntersectionObserverStub {
 }
 
 
-describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
+describes.unit('VisibilityManagerForDoc', {amp: true}, env => {
   let win;
   let ampdoc;
   let clock;
@@ -618,7 +618,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 });
 
 
-describes.realWin('EmbedAnalyticsRoot', {
+describes.functional('EmbedAnalyticsRoot', {
   amp: {ampdoc: 'fie'},
 }, env => {
   let parentWin;
@@ -834,7 +834,7 @@ describes.realWin('EmbedAnalyticsRoot', {
 });
 
 
-describes.realWin('VisibilityManager integrated', {amp: true}, env => {
+describes.functional('VisibilityManager integrated', {amp: true}, env => {
   let win, doc;
   let ampdoc;
   let viewer;

--- a/extensions/amp-anim/0.1/test/test-amp-anim.js
+++ b/extensions/amp-anim/0.1/test/test-amp-anim.js
@@ -16,7 +16,7 @@
 
 import {AmpAnim} from '../amp-anim';
 
-describes.realWin('amp-anim', {
+describes.functional('amp-anim', {
   amp: {
     ampdoc: 'single',
     extensions: ['amp-anim'],

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -56,7 +56,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
   }
 
 
-  describes.realWin('in top-level doc', {
+  describes.functional('in top-level doc', {
     amp: {
       ampdoc: 'single',
       extensions: ['amp-animation'],
@@ -524,7 +524,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
   });
 
 
-  describes.realWin('in FIE', {
+  describes.functional('in FIE', {
     amp: {
       ampdoc: 'fie',
       extensions: ['amp-animation'],

--- a/extensions/amp-animation/0.1/test/test-keyframes-extractor.js
+++ b/extensions/amp-animation/0.1/test/test-keyframes-extractor.js
@@ -18,7 +18,7 @@ import {extractKeyframes} from '../keyframes-extractor';
 import {poll} from '../../../../testing/iframe';
 
 
-describes.realWin('extractKeyframes', {amp: 1}, env => {
+describes.functional('extractKeyframes', {amp: 1}, env => {
   let win, doc;
 
   beforeEach(() => {

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -27,7 +27,7 @@ import {user} from '../../../../src/log';
 import * as sinon from 'sinon';
 
 
-describes.realWin('MeasureScanner', {amp: 1}, env => {
+describes.functional('MeasureScanner', {amp: 1}, env => {
   let win, doc;
   let vsync;
   let resources;

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -24,7 +24,7 @@ import {
 } from '../amp-app-banner';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 
-describes.realWin('amp-app-banner', {amp: true}, () => {
+describes.functional('amp-app-banner', {amp: true}, () => {
 
   let vsync;
   let platform;

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -25,7 +25,7 @@ import {
   AdSenseAmpAutoAdsHoldoutBranches,
 } from '../../../../ads/google/adsense-amp-auto-ads';
 
-describes.realWin('ad-network-config', {
+describes.functional('ad-network-config', {
   amp: {
     canonicalUrl: 'https://foo.bar/baz',
     runtimeOn: true,

--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -19,7 +19,7 @@ import {AdStrategy} from '../ad-strategy';
 import {PlacementState, getPlacementsFromConfigObj} from '../placement';
 import {AdTracker} from '../ad-tracker';
 
-describes.realWin('amp-strategy', {
+describes.functional('amp-strategy', {
   amp: {
     runtimeOn: true,
     ampdoc: 'single',

--- a/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
@@ -229,7 +229,7 @@ describe('ad-tracker', () => {
   });
 });
 
-describes.realWin('getExistingAds', {}, env => {
+describes.functional('getExistingAds', {}, env => {
   let win;
   let doc;
 

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -27,7 +27,7 @@ import {
   AdSenseAmpAutoAdsHoldoutBranches,
 } from '../../../../ads/google/adsense-amp-auto-ads';
 
-describes.realWin('amp-auto-ads', {
+describes.functional('amp-auto-ads', {
   amp: {
     runtimeOn: true,
     ampdoc: 'single',

--- a/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
@@ -19,7 +19,7 @@ import {waitForChild} from '../../../../src/dom';
 import {Services} from '../../../../src/services';
 import {AnchorAdStrategy} from '../anchor-ad-strategy';
 
-describes.realWin('anchor-ad-strategy', {
+describes.functional('anchor-ad-strategy', {
   amp: {
     runtimeOn: true,
     ampdoc: 'single',

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -18,7 +18,7 @@ import {AdTracker} from '../ad-tracker';
 import {Services} from '../../../../src/services';
 import {PlacementState, getPlacementsFromConfigObj} from '../placement';
 
-describes.realWin('placement', {
+describes.functional('placement', {
   amp: {
     runtimeOn: true,
     ampdoc: 'single',

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -17,7 +17,7 @@
 import '../amp-bind';
 import {Services} from '../../../../src/services';
 
-describes.realWin('AmpState', {
+describes.functional('AmpState', {
   amp: {
     runtimeOn: true,
     extensions: ['amp-bind:0.1'],

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -104,7 +104,7 @@ describe('Bind', function() {
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);
 
-  describes.realWin('in FIE', {
+  describes.functional('in FIE', {
     amp: {
       ampdoc: 'fie',
       runtimeOn: false,
@@ -168,7 +168,7 @@ describe('Bind', function() {
     });
   }); // in FIE
 
-  describes.realWin('in shadow ampdoc', {
+  describes.functional('in shadow ampdoc', {
     amp: {
       ampdoc: 'shadow',
       runtimeOn: false,
@@ -194,7 +194,7 @@ describe('Bind', function() {
     });
   }); // in shadow ampdoc
 
-  describes.realWin('in single ampdoc', {
+  describes.functional('in single ampdoc', {
     amp: {
       ampdoc: 'single',
       runtimeOn: false,

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -18,7 +18,7 @@ import '../amp-carousel';
 import {createIframePromise} from '../../../../testing/iframe';
 import * as sinon from 'sinon';
 
-describes.realWin('test-scrollable-carousel', {ampCss: true}, env => {
+describes.functional('test-scrollable-carousel', {ampCss: true}, env => {
   let sandbox;
   let win;
 

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -25,7 +25,7 @@ import {registerExtendedTemplate} from
 /** @const {number} */
 const RENDER_TIMEOUT = 15000;
 
-describes.realWin('AmpForm Integration', {
+describes.functional('AmpForm Integration', {
   amp: {
     runtimeOn: true,
     ampdoc: 'single',

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -44,7 +44,7 @@ describes.repeated('', {
   'shadow ampdoc': {ampdoc: 'shadow'},
 }, (name, variant) => {
 
-  describes.realWin('amp-form', {
+  describes.functional('amp-form', {
     amp: {
       runtimeOn: false,
       ampdoc: variant.ampdoc,
@@ -1452,7 +1452,7 @@ describes.repeated('', {
       });
     });
 
-    describes.fakeWin('XHR', {
+    describes.unit('XHR', {
       amp: {
         ampdoc: 'single',
       },

--- a/extensions/amp-form/0.1/test/test-form-validators.js
+++ b/extensions/amp-form/0.1/test/test-form-validators.js
@@ -26,7 +26,7 @@ import {
 import {ValidationBubble} from '../validation-bubble';
 
 
-describes.realWin('form-validators', {amp: true}, env => {
+describes.functional('form-validators', {amp: true}, env => {
   let sandbox;
   const emailTypeValidationMsg = 'Yo! That email does not look so.. email-y';
 

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -22,7 +22,7 @@ import {
 } from '../form-verifiers';
 import {toggleExperiment} from '../../../../src/experiments';
 
-describes.fakeWin('amp-form async verification', {}, env => {
+describes.unit('amp-form async verification', {}, env => {
   function stubValidationMessage(input) {
     Object.defineProperty(input, 'validationMessage', {
       get() {

--- a/extensions/amp-form/0.1/test/test-validation-bubble.js
+++ b/extensions/amp-form/0.1/test/test-validation-bubble.js
@@ -16,7 +16,7 @@
 
 import {ValidationBubble} from '../validation-bubble';
 
-describes.realWin('validation-bubble', {amp: true}, env => {
+describes.functional('validation-bubble', {amp: true}, env => {
   it('should append a dom element to the document', () => {
     const ampdoc = env.ampdoc;
     const document = ampdoc.getRootNode();

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -25,7 +25,7 @@ import {loadPromise} from '../../../../src/event-helper';
 import {installTimerService} from '../../../../src/service/timer-impl';
 
 
-describes.realWin('amp-install-serviceworker', {
+describes.functional('amp-install-serviceworker', {
   amp: {
     runtimeOn: false,
     ampdoc: 'single',
@@ -266,7 +266,7 @@ describes.realWin('amp-install-serviceworker', {
 });
 
 
-describes.fakeWin('url rewriter', {
+describes.unit('url rewriter', {
   win: {
     location: 'https://example.com/thisdoc.amp.html',
   },

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -18,7 +18,7 @@ import {liveListManagerForDoc, LiveListManager} from '../live-list-manager';
 import {Services} from '../../../../src/services';
 
 
-describes.fakeWin('LiveListManager', {amp: true}, env => {
+describes.unit('LiveListManager', {amp: true}, env => {
   const jitterOffset = 1000;
   let win, doc;
   let ampdoc;

--- a/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
@@ -19,7 +19,7 @@ import {adopt} from '../../../../src/runtime';
 
 adopt(window);
 
-describes.realWin('amp-pinterest', {
+describes.functional('amp-pinterest', {
   amp: {
     runtimeOn: false,
     ampdoc: 'single',

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -17,7 +17,7 @@
 import '../amp-selector';
 import {KeyCodes} from '../../../../src/utils/key-codes';
 
-describes.realWin('amp-selector', {
+describes.functional('amp-selector', {
   win: { /* window spec */
     location: '...',
     historyOff: false,

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -21,7 +21,7 @@ import {Services} from '../../../../src/services';
 import {toggleExperiment} from '../../../../src/experiments';
 import * as bytes from '../../../../src/utils/bytes';
 
-describes.fakeWin('amp-share-tracking', {
+describes.unit('amp-share-tracking', {
   amp: {
     ampdoc: 'single',
     extensions: ['amp-share-tracking'],

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -25,7 +25,7 @@ import '../amp-sidebar';
 
 adopt(window);
 
-describes.realWin('amp-sidebar 0.1 version', {
+describes.functional('amp-sidebar 0.1 version', {
   win: { /* window spec */
     location: '...',
     historyOff: false,

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -30,7 +30,7 @@
 
  adopt(window);
 
- describes.realWin('amp-sidebar 1.0 version', {
+ describes.functional('amp-sidebar 1.0 version', {
    win: { /* window spec */
      location: '...',
      historyOff: false,

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -20,7 +20,7 @@ import '../../../amp-ad/0.1/amp-ad';
 import {poll} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';
 
-describes.realWin('amp-sticky-ad 1.0 version', {
+describes.functional('amp-sticky-ad 1.0 version', {
   win: { /* window spec */
     location: '...',
     historyOff: false,
@@ -328,7 +328,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
 });
 
 
-describes.realWin('amp-sticky-ad 1.0 with real ad child', {
+describes.functional('amp-sticky-ad 1.0 with real ad child', {
   win: { /* window spec */
     location: '...',
     historyOff: false,

--- a/extensions/amp-timeago/0.1/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/0.1/test/test-amp-timeago.js
@@ -15,7 +15,7 @@
  */
 import '../amp-timeago';
 
-describes.realWin('amp-timeago', {
+describes.functional('amp-timeago', {
   amp: {
     extensions: ['amp-timeago'],
   },

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -21,7 +21,7 @@ import {
 import {getServiceForDoc} from '../../../../src/service';
 
 
-describes.realWin('amp-user-notification', {
+describes.functional('amp-user-notification', {
   amp: {
     ampdoc: 'single',
     extensions: ['amp-user-notification'],

--- a/extensions/amp-viewer-integration/0.1/test/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-amp-viewer-integration.js
@@ -62,7 +62,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
     });
 
 
-    describes.realWin('amp-viewer-integration', {
+    describes.functional('amp-viewer-integration', {
       amp: {
         location: 'https://cdn.ampproject.org/c/s/www.example.com/path',
         params: {

--- a/extensions/amp-viewer-integration/0.1/test/test-amp-webview-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-amp-webview-viewer-integration.js
@@ -53,7 +53,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
     });
   });
 
-  describes.fakeWin('webview window init', {
+  describes.unit('webview window init', {
     amp: {
       params: {
         webview: '1',

--- a/extensions/amp-viewer-integration/0.1/test/test-touch-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-touch-handler.js
@@ -52,7 +52,7 @@ function fakeTouchEvent(type) {
   };
 }
 
-describes.fakeWin('TouchHandler', {}, env => {
+describes.unit('TouchHandler', {}, env => {
   describe('TouchHandler Unit Tests', function() {
     let win;
     let sandbox;

--- a/test/functional/3p/test-iframe-messaging-client.js
+++ b/test/functional/3p/test-iframe-messaging-client.js
@@ -17,7 +17,7 @@
 import {IframeMessagingClient} from '../../../3p/iframe-messaging-client';
 import {serializeMessage} from '../../../src/3p-frame-messaging';
 
-describes.realWin('iframe-messaging-client', {}, env => {
+describes.functional('iframe-messaging-client', {}, env => {
 
   let win;
   let client;

--- a/test/functional/ads/test-csa.js
+++ b/test/functional/ads/test-csa.js
@@ -50,7 +50,7 @@ function getAds(type) {
   }
 }
 
-describes.fakeWin('amp-ad-csa-impl', {}, () => {
+describes.unit('amp-ad-csa-impl', {}, () => {
   let sandbox;
   let win;
 

--- a/test/functional/inabox/test-inabox-frame-overlay-manager.js
+++ b/test/functional/inabox/test-inabox-frame-overlay-manager.js
@@ -25,7 +25,7 @@ import * as sinon from 'sinon';
 const NOOP = () => {};
 
 
-describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
+describes.unit('inabox-host:FrameOverlayManager', {}, env => {
 
   let win;
   let addEventListenerSpy;

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -18,7 +18,7 @@ import {InaboxMessagingHost} from '../../../ads/inabox/inabox-messaging-host';
 import {deserializeMessage} from '../../../src/3p-frame-messaging';
 import * as sinon from 'sinon';
 
-describes.realWin('inabox-host:messaging', {}, env => {
+describes.functional('inabox-host:messaging', {}, env => {
 
   let win;
   let host;

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -28,7 +28,7 @@ import {
 
 const NOOP = () => {};
 
-describes.fakeWin('inabox-viewport', {amp: {}}, env => {
+describes.unit('inabox-viewport', {amp: {}}, env => {
 
   let win;
   let binding;

--- a/test/functional/inabox/test-position-observer.js
+++ b/test/functional/inabox/test-position-observer.js
@@ -17,7 +17,7 @@
 import {PositionObserver} from '../../../ads/inabox/position-observer';
 import {layoutRectLtwh} from '../../../src/layout-rect';
 
-describes.realWin('inabox-host:position-observer', {}, env => {
+describes.functional('inabox-host:position-observer', {}, env => {
 
   let win;
   let observer;

--- a/test/functional/test-3p-nameframe.js
+++ b/test/functional/test-3p-nameframe.js
@@ -15,7 +15,7 @@
  */
 
 describes.sandboxed('alt nameframe', {}, () => {
-  describes.realWin('nameframe', {allowExternalResources: true}, env => {
+  describes.functional('nameframe', {allowExternalResources: true}, env => {
     let fixture;
     let win;
     let doc;

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -914,7 +914,7 @@ describes.sandboxed('Action global target', {}, () => {
 });
 
 
-describes.fakeWin('Core events', {amp: true}, env => {
+describes.unit('Core events', {amp: true}, env => {
   let sandbox;
   let window;
   let document;

--- a/test/functional/test-ad-cid.js
+++ b/test/functional/test-ad-cid.js
@@ -24,7 +24,7 @@ import {installTimerService} from '../../src/service/timer-impl';
 import {getAdCid} from '../../src/ad-cid';
 import * as lolex from 'lolex';
 
-describes.realWin('ad-cid', {}, env => {
+describes.functional('ad-cid', {}, env => {
   const cidScope = 'cid-in-ads-test';
   const config = adConfig['_ping_'];
   let sandbox;

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -19,7 +19,7 @@ import {
 } from '../../src/service/url-replacements-impl';
 import {VariableSource} from '../../src/service/variable-source';
 
-describes.realWin('amp-pixel', {amp: true}, env => {
+describes.functional('amp-pixel', {amp: true}, env => {
   let win;
   let whenFirstVisiblePromise, whenFirstVisibleResolver;
   let pixel;
@@ -134,7 +134,7 @@ describes.realWin('amp-pixel', {amp: true}, env => {
 });
 
 
-describes.realWin('amp-pixel in embed', {
+describes.functional('amp-pixel in embed', {
   amp: {
     ampdoc: 'fie',
   },

--- a/test/functional/test-analytics.js
+++ b/test/functional/test-analytics.js
@@ -26,7 +26,7 @@ import {Services} from '../../src/services';
 import * as sinon from 'sinon';
 
 
-describes.realWin('analytics', {
+describes.functional('analytics', {
   amp: true,
 }, env => {
   let sandbox;

--- a/test/functional/test-anchor-click-interceptor.js
+++ b/test/functional/test-anchor-click-interceptor.js
@@ -22,7 +22,7 @@ import {
 } from '../../src/service/url-replacements-impl';
 import {createElementWithAttributes} from '../../src/dom';
 
-describes.realWin('anchor-click-interceptor', {amp: true}, env => {
+describes.functional('anchor-click-interceptor', {amp: true}, env => {
 
   let doc;
   let ampdoc;

--- a/test/functional/test-batched-xhr.js
+++ b/test/functional/test-batched-xhr.js
@@ -28,7 +28,7 @@ describes.sandboxed('BatchedXhr', {}, () => {
     };
   }
 
-  describes.fakeWin('#fetch', getPolyfillWin(), env => {
+  describes.unit('#fetch', getPolyfillWin(), env => {
     const TEST_OBJECT = {a: {b: [{c: 2}, {d: 4}]}};
     const TEST_RESPONSE = JSON.stringify(TEST_OBJECT);
     const mockXhr = {
@@ -87,7 +87,7 @@ describes.sandboxed('BatchedXhr', {}, () => {
     });
   });
 
-  describes.fakeWin('#fetchJson', getPolyfillWin(), env => {
+  describes.unit('#fetchJson', getPolyfillWin(), env => {
     const TEST_OBJECT = {a: {b: [{c: 2}, {d: 4}]}};
     const TEST_RESPONSE = JSON.stringify(TEST_OBJECT);
     const mockXhr = {
@@ -136,7 +136,7 @@ describes.sandboxed('BatchedXhr', {}, () => {
     });
   });
 
-  describes.realWin('#fetchDocument', getPolyfillWin(), env => {
+  describes.functional('#fetchDocument', getPolyfillWin(), env => {
     const TEST_CONTENT = '<b>Hello, world';
     const TEST_RESPONSE_TEXT = '<!doctype html><html><body>' + TEST_CONTENT;
     let xhr;
@@ -181,7 +181,7 @@ describes.sandboxed('BatchedXhr', {}, () => {
     });
   });
 
-  describes.fakeWin('#fetchText', getPolyfillWin(), env => {
+  describes.unit('#fetchText', getPolyfillWin(), env => {
     const TEST_RESPONSE = 'Hello, world!';
     const mockXhr = {
       status: 200,

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -88,7 +88,7 @@ describe('chunk', () => {
     });
   }
 
-  describes.fakeWin('visible no amp', {
+  describes.unit('visible no amp', {
     amp: false,
   }, env => {
 
@@ -101,7 +101,7 @@ describe('chunk', () => {
     basicTests(env);
   });
 
-  describes.fakeWin('invisible no amp', {
+  describes.unit('invisible no amp', {
     amp: false,
   }, env => {
 
@@ -127,7 +127,7 @@ describe('chunk', () => {
     basicTests(env);
   });
 
-  describes.fakeWin('with viewer', {
+  describes.unit('with viewer', {
     amp: true,
   }, env => {
 
@@ -288,7 +288,7 @@ describe('chunk', () => {
     });
   });
 
-  describes.realWin('realWin', {
+  describes.functional('realWin', {
     amp: true,
   }, env => {
     beforeEach(() => {
@@ -299,7 +299,7 @@ describe('chunk', () => {
     basicTests(env);
   });
 
-  describes.realWin('realWin noIdleCallback', {
+  describes.functional('realWin noIdleCallback', {
     amp: true,
   }, env => {
     beforeEach(() => {

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -687,7 +687,7 @@ describe('getProxySourceOrigin', () => {
   });
 });
 
-describes.realWin('cid', {amp: true}, env => {
+describes.functional('cid', {amp: true}, env => {
   let cid;
   let win;
   let ampdoc;
@@ -755,7 +755,7 @@ describes.realWin('cid', {amp: true}, env => {
   });
 });
 
-describes.fakeWin('cid optout:', {amp: true}, env => {
+describes.unit('cid optout:', {amp: true}, env => {
   let storageGetStub;
   let storageSetStub;
   let viewerSendMessageStub;

--- a/test/functional/test-crypto.js
+++ b/test/functional/test-crypto.js
@@ -24,7 +24,7 @@ import {
 } from '../../src/service/extensions-impl';
 import {Services} from '../../src/services';
 
-describes.realWin('crypto-impl', {}, env => {
+describes.functional('crypto-impl', {}, env => {
 
   let win;
   let crypto;

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -35,7 +35,7 @@ import {
   upgradeOrRegisterElement,
 } from '../../src/custom-element';
 
-describes.realWin('CustomElement register', {amp: 1}, env => {
+describes.functional('CustomElement register', {amp: 1}, env => {
 
   class ConcreteElement extends BaseElement {}
 
@@ -71,7 +71,7 @@ describes.realWin('CustomElement register', {amp: 1}, env => {
 });
 
 
-describes.realWin('CustomElement', {amp: true}, env => {
+describes.functional('CustomElement', {amp: true}, env => {
   let win, doc;
   let resources;
   let resourcesMock;
@@ -1267,7 +1267,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 });
 
 
-describes.realWin('CustomElement Service Elements', {amp: true}, env => {
+describes.functional('CustomElement Service Elements', {amp: true}, env => {
   let win, doc;
   let StubElementClass;
   let element;
@@ -1426,7 +1426,7 @@ describes.realWin('CustomElement Service Elements', {amp: true}, env => {
 });
 
 
-describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
+describes.functional('CustomElement Loading Indicator', {amp: true}, env => {
   let win, doc;
   let ElementClass;
   let clock;
@@ -1727,7 +1727,7 @@ describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
 });
 
 
-describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
+describes.functional('CustomElement Overflow Element', {amp: true}, env => {
   let win, doc;
   let ElementClass;
   let element;

--- a/test/functional/test-document-click.js
+++ b/test/functional/test-document-click.js
@@ -30,7 +30,7 @@ describes.sandboxed('ClickHandler', {}, () => {
     };
   });
 
-  describes.fakeWin('non-embed', {
+  describes.unit('non-embed', {
     win: {
       location: 'https://www.google.com/some-path?hello=world#link',
     },
@@ -353,7 +353,7 @@ describes.sandboxed('ClickHandler', {}, () => {
     });
   });
 
-  describes.realWin('fie embed', {
+  describes.functional('fie embed', {
     amp: {
       ampdoc: 'fie',
     },

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -905,7 +905,7 @@ describes.sandboxed('DOM', {}, env => {
   });
 });
 
-describes.realWin('DOM', {
+describes.functional('DOM', {
   amp: { /* amp spec */
     ampdoc: 'single',
   },

--- a/test/functional/test-element-service.js
+++ b/test/functional/test-element-service.js
@@ -140,7 +140,7 @@ describe('getElementServiceIfAvailable()', () => {
 });
 
 
-describes.realWin('in single ampdoc', {
+describes.functional('in single ampdoc', {
   amp: {
     ampdoc: 'single',
   },
@@ -330,7 +330,7 @@ describes.realWin('in single ampdoc', {
   });
 });
 
-describes.fakeWin('in embed scope', {amp: true}, env => {
+describes.unit('in embed scope', {amp: true}, env => {
   let win;
   let embedWin;
   let nodeInEmbedWin;

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -32,7 +32,7 @@ import {
 import * as sinon from 'sinon';
 
 
-describes.fakeWin('installErrorReporting', {}, env => {
+describes.unit('installErrorReporting', {}, env => {
   let win;
   let rejectedPromiseError;
   let rejectedPromiseEvent;

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -432,7 +432,7 @@ describe('toggleExperiment', () => {
   });
 });
 
-describes.realWin('meta override', {}, env => {
+describes.functional('meta override', {}, env => {
 
   let win;
 
@@ -468,7 +468,7 @@ describes.realWin('meta override', {}, env => {
   });
 });
 
-describes.fakeWin('url override', {}, env => {
+describes.unit('url override', {}, env => {
 
   let win;
 
@@ -806,7 +806,7 @@ describe('experiment branch tests', () => {
   });
 });
 
-describes.realWin('isExperimentOnForOriginTrial', {amp: true}, env => {
+describes.functional('isExperimentOnForOriginTrial', {amp: true}, env => {
 
   let win;
   let sandbox;

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -31,7 +31,7 @@ import {macroTask} from '../../testing/yield';
 import * as sinon from 'sinon';
 
 
-describes.realWin('extension-analytics', {
+describes.functional('extension-analytics', {
   amp: true,
 }, env => {
   let timer;

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -33,7 +33,7 @@ import {loadPromise} from '../../src/event-helper';
 
 
 describes.sandboxed('Extensions', {}, () => {
-  describes.fakeWin('registerExtension', {}, env => {
+  describes.unit('registerExtension', {}, env => {
     let windowApi;
     let extensions;
 
@@ -294,7 +294,7 @@ describes.sandboxed('Extensions', {}, () => {
     });
   });
 
-  describes.realWin('loadExtension', {
+  describes.functional('loadExtension', {
     amp: true,
     fakeRegisterElement: true,
   }, env => {
@@ -380,7 +380,7 @@ describes.sandboxed('Extensions', {}, () => {
     });
   });
 
-  describes.realWin('installExtensionsInChildWindow', {amp: true}, env => {
+  describes.functional('installExtensionsInChildWindow', {amp: true}, env => {
     let parentWin;
     let extensions;
     let extensionsMock;

--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -19,7 +19,7 @@ import {
 } from '../../src/font-stylesheet-timeout';
 
 
-describes.realWin('font-stylesheet-timeout', {
+describes.functional('font-stylesheet-timeout', {
   amp: true,
 }, env => {
   let clock;

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -28,7 +28,7 @@ import {parseUrl} from '../../src/url';
 import * as sinon from 'sinon';
 
 
-describes.fakeWin('History', {
+describes.unit('History', {
   win: {
     location: '#first',
   },
@@ -460,7 +460,7 @@ describe('HistoryBindingVirtual', () => {
   });
 });
 
-describes.fakeWin('Local Hash Navigation', {
+describes.unit('Local Hash Navigation', {
   win: {
     location: '#first',
   },
@@ -531,7 +531,7 @@ describes.fakeWin('Local Hash Navigation', {
   });
 });
 
-describes.fakeWin('Get and update fragment', {}, env => {
+describes.unit('Get and update fragment', {}, env => {
 
   let sandbox;
   let history;

--- a/test/functional/test-jank-meter.js
+++ b/test/functional/test-jank-meter.js
@@ -18,7 +18,7 @@ import {JankMeter} from '../../src/service/jank-meter';
 import * as lolex from 'lolex';
 
 
-describes.realWin('jank-meter', {}, env => {
+describes.functional('jank-meter', {}, env => {
 
   let win;
   let clock;

--- a/test/functional/test-layout-delay-meter.js
+++ b/test/functional/test-layout-delay-meter.js
@@ -19,7 +19,7 @@ import {Services} from '../../src/services';
 import {installPerformanceService} from '../../src/service/performance-impl';
 import * as lolex from 'lolex';
 
-describes.realWin('layout-delay-meter', {
+describes.functional('layout-delay-meter', {
   amp: {
     ampdoc: 'single',
   },

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -21,7 +21,7 @@ import * as lolex from 'lolex';
 import * as sinon from 'sinon';
 
 
-describes.realWin('performance', {amp: true}, env => {
+describes.functional('performance', {amp: true}, env => {
   let sandbox;
   let perf;
   let clock;
@@ -621,7 +621,7 @@ describes.realWin('performance', {amp: true}, env => {
   });
 });
 
-describes.realWin('performance with experiment', {amp: true}, env => {
+describes.functional('performance with experiment', {amp: true}, env => {
 
   let win;
   let perf;

--- a/test/functional/test-polyfill-array-includes.js
+++ b/test/functional/test-polyfill-array-includes.js
@@ -16,7 +16,7 @@
 
 import {install} from '../../src/polyfills/array-includes';
 
-describes.fakeWin('Array.includes', {}, env => {
+describes.unit('Array.includes', {}, env => {
 
   beforeEach(() => {
     env.win.Array = Array;

--- a/test/functional/test-polyfill-domtokenlist-toggle.js
+++ b/test/functional/test-polyfill-domtokenlist-toggle.js
@@ -19,7 +19,7 @@ import {toArray} from '../../src/types';
 import * as sinon from 'sinon';
 
 
-describes.fakeWin('DOMTokenList.toggle on non-IE', {
+describes.unit('DOMTokenList.toggle on non-IE', {
   win: {
     navigator: {
       userAgent: 'Chrome',
@@ -56,7 +56,7 @@ describes.fakeWin('DOMTokenList.toggle on non-IE', {
 
 });
 
-describes.fakeWin('DOMTokenList.toggle On IE', {
+describes.unit('DOMTokenList.toggle On IE', {
   win: {
     navigator: {
       userAgent: 'MSIE',

--- a/test/functional/test-position-observer.js
+++ b/test/functional/test-position-observer.js
@@ -19,7 +19,7 @@ import {
   PositionObserverFidelity,
 } from '../../src/service/position-observer-impl';
 
-describes.realWin('PositionObserver', {amp: 1}, env => {
+describes.functional('PositionObserver', {amp: 1}, env => {
   let win;
   let ampdoc;
   beforeEach(() => {

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -541,7 +541,7 @@ describe('Resources', () => {
   });
 });
 
-describes.fakeWin('Resources startup', {
+describes.unit('Resources startup', {
   win: {
     readyState: 'loading',
   },
@@ -645,7 +645,7 @@ describes.fakeWin('Resources startup', {
   });
 });
 
-describes.realWin('getElementLayoutBox', {}, env => {
+describes.functional('getElementLayoutBox', {}, env => {
   let win;
   let sandbox;
   let resources;
@@ -1637,7 +1637,7 @@ describe('Resources discoverWork', () => {
   });
 });
 
-describes.realWin('Resources scrollHeight', {
+describes.functional('Resources scrollHeight', {
   amp: {
     runtimeOn: true,
   },

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -42,7 +42,7 @@ import * as shadowembed from '../../src/shadow-embed';
 import * as dom from '../../src/dom';
 import * as sinon from 'sinon';
 
-describes.fakeWin('runtime', {
+describes.unit('runtime', {
   location: 'https://cdn.ampproject.org/c/s/www.example.com/path',
 }, env => {
   let win;
@@ -738,7 +738,7 @@ describes.fakeWin('runtime', {
 });
 
 
-describes.realWin('runtime multidoc', {
+describes.functional('runtime multidoc', {
   amp: {ampdoc: 'multi'},
 }, env => {
   let win;

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -436,7 +436,7 @@ describes.sandboxed('shadow-embed', {}, () => {
     });
   });
 
-  describes.fakeWin('ShadowDomWriterStreamer', {amp: true}, env => {
+  describes.unit('ShadowDomWriterStreamer', {amp: true}, env => {
     let win;
     let writer;
     let onBodySpy, onBodyChunkSpy;
@@ -528,7 +528,7 @@ describes.sandboxed('shadow-embed', {}, () => {
     });
   });
 
-  describes.fakeWin('ShadowDomWriterBulk', {amp: true}, env => {
+  describes.unit('ShadowDomWriterBulk', {amp: true}, env => {
     let win;
     let writer;
     let onBodySpy, onBodyChunkSpy;

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -253,7 +253,7 @@ describes.sandboxed('StandardActions', {}, () => {
     });
   });
 
-  describes.fakeWin('adoptEmbedWindow', {}, env => {
+  describes.unit('adoptEmbedWindow', {}, env => {
     let embedWin;
     let embedActions;
     let hideStub;

--- a/test/functional/test-style-installer.js
+++ b/test/functional/test-style-installer.js
@@ -114,7 +114,7 @@ describe('Styles', () => {
     });
   });
 
-  describes.realWin('installStyles', {}, env => {
+  describes.functional('installStyles', {}, env => {
     let win;
     let doc;
 

--- a/test/functional/test-template.js
+++ b/test/functional/test-template.js
@@ -22,7 +22,7 @@ import {
 import {resetServiceForTesting} from '../../src/service';
 import {Services} from '../../src/services';
 
-describes.fakeWin('Template', {}, env => {
+describes.unit('Template', {}, env => {
   let templates;
   let doc;
   let win;
@@ -261,7 +261,7 @@ describes.fakeWin('Template', {}, env => {
 });
 
 
-describes.fakeWin('BaseTemplate', {}, env => {
+describes.unit('BaseTemplate', {}, env => {
 
   let templateElement;
   let win;

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -17,7 +17,7 @@
 import {Timer} from '../../src/service/timer-impl';
 import * as sinon from 'sinon';
 
-describes.fakeWin('Timer', {}, env => {
+describes.unit('Timer', {}, env => {
 
   let sandbox;
   let windowMock;

--- a/test/functional/test-variable-source.js
+++ b/test/functional/test-variable-source.js
@@ -84,7 +84,7 @@ describe('VariableSource', () => {
     });
   });
 
-  describes.fakeWin('getTimingData', {}, env => {
+  describes.unit('getTimingData', {}, env => {
     let win;
 
     beforeEach(() => {

--- a/test/functional/test-video-manager.js
+++ b/test/functional/test-video-manager.js
@@ -39,7 +39,7 @@ describe('Fake Video Player Integration Tests', () => {
   });
 });
 
-describes.fakeWin('VideoManager', {
+describes.unit('VideoManager', {
   amp: {
     ampdoc: 'single',
   },

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -43,7 +43,7 @@ import * as sinon from 'sinon';
 const NOOP = () => {};
 
 
-describes.fakeWin('Viewport', {}, env => {
+describes.unit('Viewport', {}, env => {
   let clock;
   let viewport;
   let binding;
@@ -842,7 +842,7 @@ describes.fakeWin('Viewport', {}, env => {
     bindingMock.verify();
   });
 
-  describes.realWin('top-level styles', {amp: 1}, env => {
+  describes.functional('top-level styles', {amp: 1}, env => {
     let win;
     let root;
 
@@ -1226,7 +1226,7 @@ describe('Viewport META', () => {
 });
 
 
-describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
+describes.functional('ViewportBindingNatural', {ampCss: true}, env => {
   let binding;
   let win;
   let ampdoc;
@@ -1388,7 +1388,7 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
   });
 });
 
-describes.realWin('ViewportBindingNaturalIosEmbed', {ampCss: true}, env => {
+describes.functional('ViewportBindingNaturalIosEmbed', {ampCss: true}, env => {
   let binding;
   let win;
 
@@ -1626,7 +1626,7 @@ describes.realWin('ViewportBindingNaturalIosEmbed', {ampCss: true}, env => {
 });
 
 
-describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
+describes.functional('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
   let win;
   let binding;
   let child;
@@ -1844,7 +1844,7 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
 
 describe('createViewport', () => {
 
-  describes.fakeWin('in Android', {
+  describes.unit('in Android', {
     win: {navigator: {userAgent: 'Android'}},
   }, env => {
     let win;
@@ -1879,7 +1879,7 @@ describe('createViewport', () => {
     });
   });
 
-  describes.fakeWin('in iOS', {
+  describes.unit('in iOS', {
     win: {navigator: {userAgent: 'iPhone'}},
   }, env => {
     let win;

--- a/test/functional/test-web-components.js
+++ b/test/functional/test-web-components.js
@@ -35,7 +35,7 @@ describe('web components', () => {
   });
 });
 
-describes.realWin('Web Components spec', {}, env => {
+describes.functional('Web Components spec', {}, env => {
   let win;
 
   beforeEach(() => {

--- a/test/functional/test-yield.js
+++ b/test/functional/test-yield.js
@@ -17,7 +17,7 @@
 import * as lolex from 'lolex';
 import {macroTask} from '../../testing/yield';
 
-describes.realWin('yield', {}, env => {
+describes.functional('yield', {}, env => {
 
   let win;
   let clock;

--- a/test/functional/utils/test-dom-fingerprint.js
+++ b/test/functional/utils/test-dom-fingerprint.js
@@ -20,7 +20,7 @@ import {
 } from '../../../src/utils/dom-fingerprint';
 
 
-describes.realWin('domFingerprint', {}, env => {
+describes.functional('domFingerprint', {}, env => {
   let body;
   let div1;
   let ampAd;

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -123,7 +123,7 @@ function createFixture() {
 }
 
 
-describes.realWin('3P Ad', {
+describes.functional('3P Ad', {
   amp: {
     runtimeOn: true,
   },
@@ -145,7 +145,7 @@ describes.realWin('3P Ad', {
 });
 
 
-describes.realWin('3P Ad (with AmpContext experiment)', {
+describes.functional('3P Ad (with AmpContext experiment)', {
   amp: {
     runtimeOn: true,
   },


### PR DESCRIPTION
Partial for #10478.

- `describes.fakeWin` -> `describes.unit`
- `describes.realWin` -> `describes.functional`
- Add "tl;dr" section to docs