### PR TITLE
Doc tidy - add TOC and headings for attributes

### DIFF
--- a/extensions/amp-3q-player/amp-3q-player.md
+++ b/extensions/amp-3q-player/amp-3q-player.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 With the `responsive` layout, the width and height in this should yield correct layouts for 16:9 aspect ratio videos:
@@ -44,11 +46,11 @@ With the `responsive` layout, the width and height in this should yield correct 
 
 ## Attributes
 
-**data-id** (required)
+##### data-id (required)
 
 The sdnPlayoutId from 3Q SDN.
 
-**autoplay** (optional)
+##### autoplay (optional)
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -58,7 +60,7 @@ If this attribute is present, and the browser supports autoplay:
 * when the user taps the video, the video is unmuted
 * if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-access-laterpay/amp-access-laterpay.md
+++ b/extensions/amp-access-laterpay/amp-access-laterpay.md
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+# `amp-access-laterpay`
+
 <table>
   <tr>
     <td class="col-fourty"><strong>Description</strong></td>
@@ -32,7 +34,6 @@ limitations under the License.
       <div>
         <code>&lt;script async custom-element="amp-access-laterpay" src="https://cdn.ampproject.org/v0/amp-access-laterpay-0.1.js">&lt;/script></code>
       </div>
-
     </td>
   </tr>
   <tr>
@@ -41,7 +42,7 @@ limitations under the License.
   </tr>
 </table>
 
-
+[TOC]
 
 ## Behavior
 

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The `amp-accordion` component allows you to display collapsible and expandable content sections. Each of the `amp-accordion` component’s immediate children is considered a section in the accordion. Each of these nodes must be a `<section>` tag.
@@ -68,11 +70,11 @@ To see more demos of the `amp-accordion`, visit [AMP By Example](https://ampbyex
 
 ## Attributes
 
-**disable-session-states**
+##### disable-session-states
 
 Set this attribute on the `<amp-accordion>` to opt out of preserving the collapsed/expanded state of the accordion.
 
-**expanded**
+#####  expanded
 
 Set this attribute on a `<section>` to display the section as expanded on page load.
 

--- a/extensions/amp-anim/amp-anim.md
+++ b/extensions/amp-anim/amp-anim.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The `amp-anim` component is almost identical to the `amp-img` element, but allows the AMP runtime to reduce CPU usage when the animation is off-screen. Like [other elements](https://www.ampproject.org/docs/guides/author-develop/responsive/placeholders), it supports an optional `placeholder` child, to display while the `src` file is loading:
@@ -50,29 +52,29 @@ In the future, additional functionality, such as animation playback control, cou
 
 ## Attributes
 
-**src**
+##### src
 
 Similar to the `src` attribute on the `img` tag. The value must be a URL that
 points to a publicly-cacheable image file. Cache providers may rewrite these
 URLs when ingesting AMP files to point to a cached version of the image.
 
-**srcset**
+##### srcset
 
 Same as `srcset` attribute on the `img` tag.
 
-**alt**
+##### alt
 
 A string of alternate text, similar to the `alt` attribute on `img`.
 
-**attribution**
+#####  attribution
 
 A string that indicates the attribution of the image. For example, `attribution="CC courtesy of Cats on Flicker"`.
 
-**height** and **width**
+##### height and width
 
 An explicit size of the image, which is used by the AMP runtime to determine the aspect ratio without fetching the image. 
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-animation/amp-animation.md
+++ b/extensions/amp-animation/amp-animation.md
@@ -35,10 +35,11 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Overview
 
 AMP Animations rely on [Web Animations API](https://www.w3.org/TR/web-animations/) to define and run animations in AMP documents.
-
 
 ## Format
 
@@ -94,7 +95,6 @@ and is comprised of:
 }
 ```
 
-
 ### Conditions
 
 Conditions can specify whether this animation component is included in the final animation. Currently, only `media` expression is supported.
@@ -114,7 +114,6 @@ for [CSS.supports](https://developer.mozilla.org/en-US/docs/Web/API/CSS/supports
 
 If value is specified for an animation component, the animation component will only be included if the
 supports condition will match the current environment.
-
 
 ### Variables
 

--- a/extensions/amp-apester-media/amp-apester-media.md
+++ b/extensions/amp-apester-media/amp-apester-media.md
@@ -33,6 +33,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Examples 
 
 Single Mode:
@@ -51,17 +53,15 @@ Playlist Mode:
 </amp-apester-media>
 ```
 
-## Required attributes
+## Attributes
 
-### Single Mode: 
-**data-apester-media-id**
+##### data-apester-media-id
 
-The ID of the media, a string.
+This attribute is required for single mode, and it represents the ID of the media (string value).
 
-### Playlist Mode: 
-**data-apester-channel-token**
+##### data-apester-channel-token
 
-The token of the channel, a string.
+This attribute is required for playlist mode, and it represents the token of the channel (string value).
 
 ## Validation
 

--- a/extensions/amp-app-banner/amp-app-banner.md
+++ b/extensions/amp-app-banner/amp-app-banner.md
@@ -39,6 +39,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 `amp-app-banner` is a wrapper and minimal UI for a cross-platform, fixed-position banner showing a call-to-action to install an app. Includes conditional logic to direct to the right app on the right platform, and to hide permanently if the user dismisses the banner.
 
@@ -134,17 +136,17 @@ Currently, the banner will be displayed always unless it was dismissed. Once dis
 
 ### Attributes on `amp-app-banner`
 
-**id** (Required)
+##### id (Required)
 
 A unique identifier for an amp-app-banner; used for persistence logic.
 
-**layout** (Required)
+##### layout (Required)
 
 The value must be `nodisplay`. 
 
 ### Attributes on `button` descendant element
 
-**open-button** (Required)
+##### open-button (Required)
 
 The click target for the banner to install the app, or open the deep-link if the app is already installed.
 

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The `amp-audio` component loads the audio resource specified by its `src` attribute at a time determined by the runtime. It can be controlled in much the same way as a standard HTML5 `audio` tag.

--- a/extensions/amp-brid-player/amp-brid-player.md
+++ b/extensions/amp-brid-player/amp-brid-player.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
@@ -53,7 +55,7 @@ Examples:
 
 ## Attributes
 
-**autoplay**
+##### autoplay
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -63,24 +65,23 @@ If this attribute is present, and the browser supports autoplay:
 * when the user taps the video, the video is unmuted
 * if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused. 
 
-
-**data-partner**
+##### data-partner
 
 The Brid.tv partner id.
 
-**data-player**
+##### data-player
 
 The Brid.tv player id. Specific to every partner.
 
-**data-video**
+##### data-video
 
 The Brid.tv video ID.
 
-**data-playlist**
+##### data-playlist
 
 The Brid.tv playlist ID. Embed must either have video or playlist attribute.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
@@ -54,33 +56,33 @@ Example:
 
 ## Attributes
 
-**data-account**
+##### data-account
 
 The Brightcove Video Cloud or Perform account id.
 
-**data-player** or **data-player-id**
+##### data-player or data-player-id
 
 The Brightcove player id. This is a GUID, shortid or "default". The default value is "default".
 
 `data-player` is preferred. `data-player-id` is also supported for backwards-compatibility.
 
-**data-embed**
+##### data-embed
 
 The Brightcove player id. This is a GUID or "default". The default value and most common value is "default".
 
-**data-video-id**
+##### data-video-id
 
 The Video Cloud video id. Most Video Cloud players will need this.
 
 This is not used for Perform players by default; use it if you have added a plugin that expects a `videoId` param in the query string.
 
-**data-playlist-id**
+##### data-playlist-id
 
 The Video Cloud playlist id. For AMP HTML uses a video id will normally be used instead. If both a playlist and a video are specified, the playlist takes precedence.
 
 This is not used for Perform players by default; use it if you have added a plugin that expects a `playlistId` param in the query string.
 
-**data-param-***
+##### data-param-*
 
 All `data-param-*` attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
 
@@ -89,7 +91,7 @@ Keys and values will be URI encoded. Keys will be camel cased.
 - `data-param-language="de"` becomes `&language=de`
 - `data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-call-tracking/amp-call-tracking.md
+++ b/extensions/amp-call-tracking/amp-call-tracking.md
@@ -32,6 +32,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Usage
 
 The `<amp-call-tracking>` tag must wrap a normal anchor tag that hyperlinks a
@@ -51,7 +53,7 @@ Each unique CORS endpoint is called only once per page.
 
 ## Attributes
 
-**config** (required)
+##### config (required)
 
 Defines a CORS URL. The URL's protocol must be HTTPS. The response must consist
 of a valid JSON object with the following fields:

--- a/extensions/amp-dailymotion/amp-dailymotion.md
+++ b/extensions/amp-dailymotion/amp-dailymotion.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 With responsive layout, the width and height from the example should yield correct layouts for 16:9 aspect ratio videos.
@@ -48,7 +50,7 @@ With responsive layout, the width and height from the example should yield corre
 
 ## Attributes
 
-**autoplay**
+##### autoplay
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -58,59 +60,59 @@ If this attribute is present, and the browser supports autoplay:
 * when the user taps the video, the video is unmuted
 * if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
 
-**data-videoid** (required)
+##### data-videoid (required)
 
 The Dailymotion video id found in every video page URL. For example, `"x2m8jpp"` is the video id for `https://www.dailymotion.com/video/x2m8jpp_dailymotion-spirit-movie_creation`.
 
-**data-mute** (optional)
+##### data-mute (optional)
 
 Indicates whether to mute the video.
 
 * Value: `"true"` or `"false"`
 * Default value: `"false"`
 
-**data-endscreen-enable** (optional)
+##### data-endscreen-enable (optional)
 
 Indicates whether to enable the end screen.
 
 * Value: `"true"` or `"false"`
 * Default value: `"true"`
 
-**data-sharing-enable** (optional)
+##### data-sharing-enable (optional)
 
 Indicates whether to display the sharing button.
 
 * Value: `"true"` or `"false"`
 * Default value: `"true"`
 
-**data-start** (optional)
+##### data-start (optional)
 
 Specifies the time (in seconds) from which the video should start playing.
 
 * Value: integer (number of seconds). For example, `data-start=45`.
 * Default value: `0`
 
-**data-ui-highlight** (optional)
+##### data-ui-highlight (optional)
 
 Change the default highlight color used in the controls.
 
 * Value: Hexadecimal color value (without the leading #). For example, `data-ui-highlight="e540ff"`.
 
-**data-ui-logo** (optional)
+##### data-ui-logo (optional)
 
 Indicates whether to display the Dailymotion logo.
 
 * Value: `"true"` or `"false"`
 * Default value: `"true"`
 
-**data-info** (optional)
+##### data-info (optional)
 
 Indicates whether to show video information (title and owner) on the start screen.
 
 * Value: `"true"` or `"false"`
 * Default value: `"true"`
 
-**data-param-*** (optional)
+##### data-param-* (optional)
 
 All data-param-* attributes are added as query parameters to the src value of the embedded Dailymotion iframe. You can use this attribute to pass custom values not explicitly declared.
 
@@ -120,7 +122,7 @@ Keys and values will be URI encoded.
 
 Please read [Dailymotion's video player documentation](https://developer.dailymotion.com/player#player-parameters) to know more about parameters and options.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-experiment/amp-experiment.md
+++ b/extensions/amp-experiment/amp-experiment.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 The `<amp-experiment>` element is used to conduct user experience experiments (such as [A/B testing and multivariate testing](https://en.wikipedia.org/wiki/A/B_testing)) on an AMP document. It provides hooks to define customizable variants and allocates traffic to each of the variants based on the configuration. For each page view, the variant allocation is also exposed to `amp-pixel` and `amp-analytics` so that the necessary data can be collected to perform statistical comparison across variants.
 

--- a/extensions/amp-facebook-comments/amp-facebook-comments.md
+++ b/extensions/amp-facebook-comments/amp-facebook-comments.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Overview
 
 You can use the `amp-facebook-comments` component to embed the [Facebook comments plugin](https://developers.facebook.com/docs/plugins/comments).
@@ -46,23 +48,23 @@ You can use the `amp-facebook-comments` component to embed the [Facebook comment
 ```
 ## Attributes
 
-**data-href** (required)
+##### data-href (required)
 
 The URL of the comments page. For example, `http://www.directlyrics.com/adele-25-complete-album-lyrics-news.html`.
 
-**data-numposts** (optional)
+##### data-numposts (optional)
 
 The number of comments to show.  For details, see the [Facebook comments documentation](https://developers.facebook.com/docs/plugins/comments).
 
-**data-order-by** (optional)
+##### data-order-by (optional)
 
 The order to use when displaying comments. For details, see the [Facebook comments documentation](https://developers.facebook.com/docs/plugins/comments).
 
-**data-colorscheme** (optional)
+##### data-colorscheme (optional)
 
 The color scheme. For details, see the [Facebook comments documentation](https://developers.facebook.com/docs/plugins/comments).
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-facebook-like/amp-facebook-like.md
+++ b/extensions/amp-facebook-like/amp-facebook-like.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Overview
 
 You can use the `amp-facebook-like` component to embed the [Facebook like button plugin](https://developers.facebook.com/docs/plugins/like-button).
@@ -46,45 +48,46 @@ You can use the `amp-facebook-like` component to embed the [Facebook like button
 ```
 ## Attributes
 
-**data-href** (required)
+##### data-href (required)
 
 The absolute URL of the page that will be liked. For example, `https://www.facebook.com/testesmegadivertidos/`.
 
-**data-action** (optional)
+##### data-action (optional)
 
 The verb to display on the button. Can be either `like` or `recommend`. The default is `like`.
 
-**data-colorscheme** (optional)
+##### data-colorscheme (optional)
 
 The color scheme used by the plugin for any text outside of the button itself. Can be `light` or `dark`. The default is `light`.
 
-**data-kd_site** (*aka data-kid_directed_site in facebook sdk*) (optional)
+##### data-kd_site  (optional)
 
-If your web site or online service, or a portion of your service, is directed to children under 13 you must enable this. The default is `false`.
+This attribute is also known as `data-kid_directed_site` in the Facebook SDK.
+If your web site or online service, or a portion of your service, is directed to children under 13 you must enable this attribute. The default is `false`.
 
-**data-layout** (optional)
+##### data-layout (optional)
 
 Selects one of the different layouts that are available for the plugin. Can be one of `standard`, `button_count`, `button` or `box_count`. The default is `standard`.
 
-**data-ref** (optional)
+##### data-ref (optional)
 
 A label for tracking referrals which must be less than 50 characters and can contain alphanumeric characters and some punctuation.
 
-**data-share** (optional)
+##### data-share (optional)
 
 Specifies whether to include a share button beside the Like button. This only works with the XFBML version. The default is `false`.
 
-**data-show_faces** (optional)
+#####data-show_faces (optional)
 
 Specifies whether to display profile photos below the button (standard layout only). You must not enable this on child-directed sites. The default is `false`.
 
-**data-size** (optional)
+##### data-size (optional)
 
 The size of the button, which can be one of two sizes, `large` or `small`. The default is `small`.
 
 For details, see the [Facebook comments documentation](https://developers.facebook.com/docs/plugins/like-button#settings).
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -76,11 +76,11 @@ Renders as:
 
 ## Attributes
 
-**data-href** (required)
+##### data-href (required)
 
 The URL of the Facebook post/video. For example, `https://www.facebook.com/zuck/posts/10102593740125791`.
 
-**data-embed-as** (optional)
+##### data-embed-as
 
 The value is either `post` or `video`.  The default is `post`.
 
@@ -88,7 +88,7 @@ Both posts and videos can be embedded as a post. Setting `data-embed-as="video"`
 
 Check out the documentation for differences between [post embeds](https://developers.facebook.com/docs/plugins/embedded-posts) and [video embeds](https://developers.facebook.com/docs/plugins/embedded-video-player).
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The `amp-fit-text` component expects its content to be text or other inline
@@ -61,15 +63,15 @@ For example:
 
 ## Attributes
 
-**min-font-size**
+##### min-font-size
 
 The minimum font size as an integer that the `amp-fit-text` can use.
 
-**max-font-size**
+##### max-font-size
 
 The maximum font size as an integer that the `amp-fit-text` can use.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-font/amp-font.md
+++ b/extensions/amp-font/amp-font.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The `amp-font` extension should be used for controlling timeouts on font loading.
@@ -70,23 +72,23 @@ The `amp-font` extension accepts the `layout` value:  `nodisplay`
 
 ## Attributes
 
-**font-family**
+##### font-family
 
 The font-family of the custom font being loaded.
 
-**timeout**
+##### timeout
 
 Time in milliseconds after which the we don't wait for the custom font to be available. This attribute is optional and it's default value is 3000. If the timeout is set to 0 then the amp-font loads the font if it is already in the cache, otherwise the font would not be loaded. If the timeout is has an invalid value then the timeout defaults to 3000.
 
-**on-load-add-class**
+##### on-load-add-class
 
 CSS class that would be added to the `document.documentElement`  after making sure that the custom font is available for display. This attribute is optional.
 
-**on-load-remove-class**
+##### on-load-remove-class
 
 CSS class that would be removed from the `document.documentElement` and `document.body` after making sure that the custom font is available for display. This attribute is optional.
 
-**on-error-add-class**
+##### on-error-add-class
 
 CSS class that would be added to the `document.documentElement`, if the timeout interval runs out before the font becomes available for use. This attribute is optional.
 
@@ -94,11 +96,11 @@ CSS class that would be added to the `document.documentElement`, if the timeout 
 
 CSS class that would be removed from the `document.documentElement` and `document.body` , if the timeout interval runs out before the font becomes available for use. This attribute is optional.
 
-**font-weight, font-style, font-variant**
+##### font-weight, font-style, font-variant
 
 The attributes above should all behave like they do on standard elements.
 
-**layout**
+##### layout
 
 Must be `nodisplay`.
 

--- a/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
+++ b/extensions/amp-fx-flying-carpet/amp-fx-flying-carpet.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 `amp-fx-flying-carpet` displays its children inside a container of fixed height. As the user scrolls the page, the flying carpet reveals more of it contents, sliding across its children as if peering through a window in the page.
@@ -49,11 +51,11 @@ The following requirements are imposed on `amp-fx-flying-carpet` positioning:
 
 ## Attributes
 
-**height**
+##### height
 
 The height of the flying carpet's "window".
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-fx-parallax/amp-fx-parallax.md
+++ b/extensions/amp-fx-parallax/amp-fx-parallax.md
@@ -22,8 +22,8 @@ limitations under the License.
     <td>An attribute that enables a 3D-perspective effect on an element.</td>
   </tr>
   <tr>
-    <td class="col-fourty" width="40%"><strong>Availability</strong></td>
-    <td>In development</td>
+    <td width="40%"><strong>Availability</strong></td>
+    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a></td>
   </tr>
   <tr>
     <td class="col-fourty"><strong>Required Script</strong></td>
@@ -34,6 +34,8 @@ limitations under the License.
     <td><a href="https://ampbyexample.com/components/amp-fx-parallax/">Annotated code example for amp-fx-parallax</a></td>
   </tr>
 </table>
+
+[TOC]
 
 ## Behavior
 
@@ -48,6 +50,6 @@ The `amp-fx-parallax` attribute causes an element to move as if it is nearer or 
 
 ## Attributes
 
-**amp-fx-parallax**
+##### amp-fx-parallax
 
 The factor to use when scrolling. A value greater than 1 scrolls the element upward when the user scrolls down the page. A value less than 1 scrolls the element downward when the user scrolls downward. A value of 1 behaves normally. A value of 0 effectively makes the element scroll fixed with the page.

--- a/extensions/amp-gfycat/amp-gfycat.md
+++ b/extensions/amp-gfycat/amp-gfycat.md
@@ -41,6 +41,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the Gfycat embedded in responsive layouts.
@@ -56,11 +58,11 @@ The `width` and `height` attributes determine the aspect ratio of the Gfycat emb
 
 ## Attributes
 
-**data-gfyid**
+##### data-gfyid
 
 The Gfycat ID found in any Gfycat url. For example, `TautWhoppingCougar` is the id in the following url: https://gfycat.com/TautWhoppingCougar.
 
-**width** and **height**
+##### width and height
 
 The width and height attributes are special for the Gfycat embed. These should be the actual width and height of the Gfycat. The system automatically adds space for the "chrome" that Gfycat adds around the GIF.
 
@@ -80,7 +82,8 @@ Example: Finding the actual width and height
         height='360' allowfullscreen>
 </iframe>
 ```
-**noautoplay**
+
+##### noautoplay
 
 By default, a video autoplays. You can turn off autoplay by setting the  `noautoplay` attribute.
 
@@ -95,7 +98,7 @@ Example: Turning off autoplay
   </amp-gfycat>
 ```
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 This extension creates an iframe and displays a [gist from GitHub](https://help.github.com/articles/about-gists/). 
@@ -70,7 +72,7 @@ The ID of the gist to embed.
 
 Currently only supports `fixed-height`.
 
-##### height(required)
+##### height (required)
 
 The height of the gist or gist file in pixels.
 

--- a/extensions/amp-google-vrview-image/amp-google-vrview-image.md
+++ b/extensions/amp-google-vrview-image/amp-google-vrview-image.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Overview
 
 See [Google VR View](https://developers.google.com/vr/concepts/vrview) for more details.
@@ -58,20 +60,20 @@ VR view supports mono and stereo 360 images. Note:
 
 ## Attributes
 
-**src**
+##### src
 
 The source URL of a stereo image. Must resolve to https. See notes above on what
 kind of image can be passed here.
 
-**stereo**
+##### stereo
 
 If specified, the image provided by the `src` attribute is considered to be a stereo
 image (see above), otherwise it's a mono image.
 
-**yaw**
+##### yaw
 
 Initial yaw of viewer, in degrees. Defaults to 0.
 
-**yaw-only**
+##### yaw-only
 
 Can be specified to restrict motion to yaw only.

--- a/extensions/amp-hulu/amp-hulu.md
+++ b/extensions/amp-hulu/amp-hulu.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 ```html
@@ -45,11 +47,11 @@ limitations under the License.
 
 ## Attributes
 
-**data-eid**
+##### data-eid
 
 The ID of the video. For example, `4Dk5F2PYTtrgciuvloH3UA` is the eid in the following URL: https://player.hulu.com/site/dash/mobile_embed.html?eid=4Dk5F2PYTtrgciuvloH3UA.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The typical scenario looks like this:
@@ -94,11 +96,11 @@ The `amp-image-lightbox` exposes the following actions you can use [AMP on-synta
 
 ## Attributes
 
-**layout**
+##### layout
 
 Must be set to `nodisplay`.
 
-**data-close-button-aria-label**
+##### data-close-button-aria-label
 
 Optional string used as ARIA label for close button.
 

--- a/extensions/amp-imgur/amp-imgur.md
+++ b/extensions/amp-imgur/amp-imgur.md
@@ -39,25 +39,27 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 This extension creates an iframe and displays the imgur post. 
 
 ## Attributes
 
-**data-imgur-id** (required)
+##### data-imgur-id (required)
 
 The ID of the imgur to embed.
 
-**layout** (required)
+##### layout (required)
 
 Currently only supports `responsive`.
 
-**width** (required)
+##### width (required)
 
 The width of the imgur.
 
-**height** (required)
+##### height (required)
 
 The width of the imgur.
 

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The `width` and `height` attributes are special for the Instagram embed.
@@ -60,17 +62,17 @@ When using non-responsive layout you will need to account for the extra space ad
 
 ## Attributes
 
-**data-shortcode**
+##### data-shortcode
 
 The instagram data-shortcode is found in every instagram photo URL.
 
 For example, in https://instagram.com/p/fBwFP, `fBwFP` is the data-shortcode.
 
-**data-captioned**
+##### data-captioned
 
 Include the Instagram caption.  `amp-instagram` will attept to resize to the correct hight including the caption.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-izlesene/amp-izlesene.md
+++ b/extensions/amp-izlesene/amp-izlesene.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 With responsive layout the width and height from the example should yield correct layouts for 16:9 aspect ratio videos:
@@ -44,25 +46,25 @@ With responsive layout the width and height from the example should yield correc
 
 ## Attributes
 
-**data-videoid** (required)
+##### data-videoid (required)
 
 The ID of the Izlesene video, which can be found in the Izlesene video page URL. For example, in https://www.izlesene.com/video/yayin-yok/7221390, the video ID is `7221390`.
 
-**data-param-showrel** (optional)
+##### data-param-showrel (optional)
 
 This is an optional attribute that indicates whether to show related content. This functionality is not available for iOS devices.
 
 * Accepted values: `1` or `0`
 * Default value: `1`
 
-**data-param-showreplay** (optional)
+##### data-param-showreplay (optional)
 
 This is an optional attribute that indicates whether to show the replay button at the end of the content.
 
 * Accepted values: `1` or `0`
 * Default value: `1`
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
@@ -64,19 +66,19 @@ Example:
 
 ## Attributes
 
-**data-player-id**
+##### data-player-id
 
 JW Platform player id. This is an 8-digit alphanumeric sequence that can be found in the [Players](https://dashboard.jwplayer.com/#/players) section in your JW Player Dashboard. (**Required**)
 
-**data-media-id**
+##### data-media-id
 
 The JW Platform media id. This is an 8-digit alphanumeric sequence that can be found in the [Content](https://dashboard.jwplayer.com/#/content) section in your JW Player Dashboard. (**Required if `data-playlist-id` is not defined.**)
 
-**data-playlist-id**
+##### data-playlist-id
 
 The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the [Playlists](https://dashboard.jwplayer.com/#/content/playlists) section in your JW Player Dashboard.  If both `data-playlist-id` and `data-media-id` are specified, `data-playlist-id` takes precedence.  (**Required if `data-media-id` is not defined.**)
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-kaltura-player/amp-kaltura-player.md
+++ b/extensions/amp-kaltura-player/amp-kaltura-player.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
@@ -53,20 +55,19 @@ Example:
 
 ## Attributes
 
-**data-partner**
+##### data-partner
 
 The Kaltura partner id. This attribute is mandatory.
 
-**data-uiconf**
+##### data-uiconf
 
 The Kaltura player id - uiconf id.
 
-**data-entryid**
+##### data-entryid
 
 The Kaltura entry id.
 
-
-**data-param-***
+##### data-param-*
 
 All `data-param-*` attributes will be added as query parameter to the player iframe src. This may be used to pass custom values through to player plugins, such as ad parameters or video ids for Perform players.
 
@@ -74,7 +75,7 @@ Keys and values will be URI encoded. Keys will be camel cased.
 
 - `data-param-streamerType="auto"` becomes `&flashvars[streamerType]=auto`
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The `amp-lightbox` component defines the child elements that will be displayed in a full-viewport overlay. It is triggered to take up the viewport when the user taps or clicks on an element with `on` attribute that targets `amp-lightbox` element’s `id`.
@@ -88,15 +90,15 @@ The `amp-lightbox` exposes the following actions you can use [AMP on-syntax to t
 
 ## Attributes
 
-**id** (required)
+##### id (required)
 
 A unique identifer for the lightbox.
 
-**layout**
+##### layout
 
 Must be set to `nodisplay`.
 
-**scrollable**
+##### scrollable
 
 When `scrollable` attribute is present, the content of the lightbox can scroll
 when overflowing the height of the lightbox.

--- a/extensions/amp-mustache/amp-mustache.md
+++ b/extensions/amp-mustache/amp-mustache.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Syntax
 
 Mustache is a logic-less template syntax. See [Mustache.js docs](https://github.com/janl/mustache.js/) for more details. Some of the core Mustache tags are:

--- a/extensions/amp-nexxtv-player/amp-nexxtv-player.md
+++ b/extensions/amp-nexxtv-player/amp-nexxtv-player.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 With the responsive layout, the width and height from the example should yield correct layouts for 16:9 aspect ratio videos:
@@ -50,15 +52,15 @@ With the responsive layout, the width and height from the example should yield c
 
 ## Attributes
 
-**data-mediaid** (required)
+##### data-mediaid (required)
 
 Represents the ID of the media you want to play.
 
-**data-client** (required)
+##### data-client (required)
 
 Your domain ID.
 
-**data-streamtype** (optional)
+##### data-streamtype (optional)
 
 Indicates the media streaming type, which can be one of the following:
 
@@ -70,24 +72,23 @@ Indicates the media streaming type, which can be one of the following:
 * `album`: An audio playlist.
 
 
-**data-seek-to** (optional)
+##### data-seek-to (optional)
 
 Indicates the starting point of your media (in seconds).  For example, video starting 1:30min.
 
-**data-mode** (optional)
+##### data-mode (optional)
 
 Indicates the data mode, which can be `static` (default) or `api`.
 
-**data-origin** (optional)
+##### data-origin (optional)
 
 Indicates the source from which the embedded domain media is played. By default this is set to `https://embed.nexx.cloud/`.
 
-**data-disable-ads** (optional)
+##### data-disable-ads (optional)
 
 Ads are enabled by default. Set value to 1 to disable.
 
-
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-o2-player/amp-o2-player.md
+++ b/extensions/amp-o2-player/amp-o2-player.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
@@ -54,27 +56,27 @@ Example:
 
 ## Attributes
 
-**data-pid** (required)
+##### data-pid (required)
 
 The Player ID for the O2Player.
 
-**data-bcid** (required)
+##### data-bcid (required)
 
 The Buyer Company ID (bcid) for the O2Player.
 
-**data-bid**
+##### data-bid
 
 The Playlist ID (bid) for the O2Player.
 
-**data-vid** 
+##### data-vid
 
 The Video ID (vid) for the O2Player.
 
-**data-macros**
+##### data-macros
 
 The macros for the O2Player.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
@@ -83,7 +85,6 @@ This element includes [common attributes](https://www.ampproject.org/docs/refere
 See [amp-o2-player rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-o2-player/validator-amp-o2-player.protoascii) in the AMP validator specification.
 
 The following lists validation errors specific to the `amp-o2-player` tag:
-
 
 <table>
   <tr>

--- a/extensions/amp-ooyala-player/amp-ooyala-player.md
+++ b/extensions/amp-ooyala-player/amp-ooyala-player.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 ```html
@@ -43,27 +45,27 @@ limitations under the License.
 
 ## Attributes
 
-**data-embedcode** (required)
+##### data-embedcode (required)
 
 The video embed code from [Backlot](https://backlot.ooyala.com).
 
-**data-playerid** (required)
+##### data-playerid (required)
 
 The ID of the player to load from [Backlot](https://backlot.ooyala.com).
 
-**data-pcode** (required)
+##### data-pcode (required)
 
 The provider code for the account owning the embed code and player.
 
-**data-playerversion** (optional)
+##### data-playerversion (optional)
 
 Specifies which version of the Ooyala player to use, V3 or V4. Defaults to V3.
 
-**data-config** (optional)
+##### data-config (optional)
 
 Specifies a skin.json config file URL for player V4.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-pinterest/amp-pinterest.md
+++ b/extensions/amp-pinterest/amp-pinterest.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Examples
 
 Use the `amp-pinterest` component to display a Pin It button, Pin widget, or Follow button.
@@ -75,22 +77,21 @@ Use the `amp-pinterest` component to display a Pin It button, Pin widget, or Fol
 </amp-pinterest>
 ```
 
-
 ## Pin It Button
 
-**data-do** (required)
+##### data-do (required)
 
 Must be set to `buttonPin`.
 
-**data-url** (required)
+##### data-url (required)
 
 Contains the fully-qualified URL intended to be pinned or re-made into a widget.
 
-**data-media** (required)
+##### data-media (required)
 
 Contains the fully-qualified URL of the image intended to be pinned. If the pin will eventually contain multimedia (such as YouTube), it should point to a high-resolution thumbnail.
 
-**data-description** (required)
+##### data-description (required)
 
 Contains the default description that appears in the pin create form; please choose carefully, since many Pinners will close the form without pinning if it doesn't make sense.
 
@@ -146,25 +147,25 @@ height=32 width=32
 
 ## Follow Button
 
-**data-do** (required)
+##### data-do (required)
 
 Must be set to `buttonFollow`.
 
-**data-href** (required)
+##### data-href (required)
 
 Contains the fully qualified Pinterest user profile url to follow.
 
-**data-label** (required)
+##### data-label (required)
 
 Contains the text to display on the follow button.
 
 ## Embedded Pin Widget
 
-**data-do** (required)
+##### data-do (required)
 
 Must be set to `embedPin`.
 
-**data-url** (required)
+##### data-url (required)
 
 Must contain the fully-qualified URL of the Pinterest resource to be shown as a widget.
 

--- a/extensions/amp-playbuzz/amp-playbuzz.md
+++ b/extensions/amp-playbuzz/amp-playbuzz.md
@@ -34,7 +34,9 @@ limitations under the License.
   </tr>
 </table>
 
-## Examples:
+[TOC]
+
+## Examples
 
 Playbuzz Item by plain url (without info, share-buttons, comments)
 
@@ -66,7 +68,7 @@ With optional parameters (info, share-buttons, comments):
 </amp-playbuzz>
 ```
 
-## Required Attributes
+## Required attributes
 ### One of the following is required:
 
 **src**
@@ -79,8 +81,9 @@ Can be any item URL taken from <a href="http://www.playbuzz.com">playbuzz.com</a
 The item id for the Playbuzz item.
 Can be taken from the item's embed code (at the item's page at playbuzz website)
 
-** in case both are present data-item will be used
-## Optional Attributes
+**Note**: If both attributes are present, `data-item` is used.
+
+## Optional attributes
 
 **data-item-info** (optional)
 

--- a/extensions/amp-reach-player/amp-reach-player.md
+++ b/extensions/amp-reach-player/amp-reach-player.md
@@ -39,6 +39,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
@@ -56,11 +58,11 @@ Example:
 
 ## Attributes
 
-**data-embed-id**
+##### data-embed-id
 
 The Reach player embed id found in the "players" section or in the generated embed itself.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-reddit/amp-reddit.md
+++ b/extensions/amp-reddit/amp-reddit.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Examples
 
 Use the `amp-reddit` component to embed a Reddit post or comment.
@@ -69,31 +71,31 @@ Use the `amp-reddit` component to embed a Reddit post or comment.
 
 ## Attributes
 
-**data-embedtype** (required)
+##### data-embedtype (required)
 
 The type of embed, either `post` or `comment`.
 
-**data-src** (required)
+##### data-src (required)
 
 The permamlink uri for the post or comment.
 
-**data-uuid**
+##### data-uuid
 
 The provided UUID for the comment embed. Supported when `data-embedtype` is `comment`. 
 
-**data-embedcreated**
+##### data-embedcreated
 
 The datetime string for the comment embed. Supported when `data-embedtype` is `comment`. 
 
-**data-embedparent**
+##### data-embedparent
 
  Indicates whether the parent comment should be included in the embed. Supported when `data-embedtype` is `comment`.
 
-**data-embedlive**
+##### data-embedlive
 
  Indicates whether the embedded comment should update if the original comment is updated. Supported when `data-embedtype` is `comment`.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-selector/amp-selector.md
+++ b/extensions/amp-selector/amp-selector.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 The AMP selector is a control that presents a list of options and lets the user choose one or many options; the contents of the options aren't just limited to text.
@@ -83,17 +85,17 @@ Example:
 
 ### Attributes on `<amp-selector>`
 
-**disabled, form, multiple, name**
+##### disabled, form, multiple, name
 
 The attributes above behave the same way as they do on a standard HTML [`<select>`](https://developer.mozilla.org/en/docs/Web/HTML/Element/select) element.
 
 ### Attributes on `<amp-selector>` options
 
-**option**
+##### option
 
 Indicates that the option is selectable.  If a value is specified, the contents of the value is submitted with the form.
 
-**disabled, selected**
+##### disabled, selected
 
 The attributes above behave the same way as they do on a standard HTML [`<option>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option) element.
 

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -69,20 +69,21 @@ Linkedin is one of the pre-configured providers, so you do not need to provide t
 
 ## Attributes
 
-**type** (__required__)
+##### type (required)
 
 Selects a provider type. This is required for both pre-configured and non-configured providers.
 
-**data-share-endpoint** (__required__ for non-configured providers)
+##### data-share-endpoint
+
+This attribute is **required for non-configured providers**.
 
 Some popular providers have pre-configured share endpoints. For details, see the [Pre-configured Providers](#pre-configured-providers) section.  For non-configured providers, you'll need to specify the share endpoint.
 
-**data-param-***
+##### data-param-*
 
 All `data-param-*` prefixed attributes are turned into URL parameters and passed to the share endpoint.
 
-
-## Pre-configured Providers
+## Pre-configured providers
 The `amp-social-share` component provides [some pre-configured providers](0.1/amp-social-share-config.js) that know their sharing endpoints as well as some default parameters.
 
 <table>
@@ -228,7 +229,6 @@ You can use [global AMP variables substitution](https://github.com/ampproject/am
     Share on Whatsapp
 </amp-social-share>
 ```
-
 
 ## Validation
 

--- a/extensions/amp-soundcloud/amp-soundcloud.md
+++ b/extensions/amp-soundcloud/amp-soundcloud.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Examples
 
 Visual Mode:
@@ -55,28 +57,29 @@ Classic Mode:
 
 ## Attributes
 
-**data-trackid** (required if `data-playlistid` is not defined)
+##### data-trackid 
 
-The ID of a track, an integer.
+This attribute is required if `data-playlistid` is not defined.  
+The value for this attribute is the ID of a track, an integer.
 
-**data-playlistid** (required if `data-trackid` is not defined)
+##### data-playlistid
 
-The ID of a playlist, an integer.
+This attribute is required if `data-trackid` is not defined.
+The value for this attribute is the ID of a playlist, an integer.
 
-**data-secret-token** (optional)
+##### data-secret-token (optional)
 
 The secret token of the track, if it is private.
 
-**data-visual** (optional)
+##### data-visual (optional)
 
 If set to `true`, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is `false`.
 
-**data-color** (optional)
+##### data-color (optional)
 
 This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., `data-color="e540ff"`).
 
-
-**width** and **height**
+##### width and height
 
 The layout for `amp-soundcloud` is set to `fixed-height` and it fills all of the available horizontal space. This is ideal for the "Classic" mode, but for "Visual" mode, it's recommended that the height is 300px, 450px or 600px, as per Soundcloud embed code. This will allow the clip's internal elements to resize properly on mobile.
 

--- a/extensions/amp-springboard-player/amp-springboard-player.md
+++ b/extensions/amp-springboard-player/amp-springboard-player.md
@@ -36,6 +36,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
@@ -54,31 +56,31 @@ The `width` and `height` attributes determine the aspect ratio of the player emb
 
 ## Attributes
 
-**data-site-id** (required)
+##### data-site-id (required)
 
 The SpringBoard site ID. Specific to every partner.
 
-**data-mode** (required)
+##### data-mode (required)
 
 The SpringBoard player mode: `video` or `playlist`.
 
-**data-content-id** (required)
+##### data-content-id (required)
 
 The SpringBoard player content ID (video or playlist ID).
 
-**data-player-id** (required)
+##### data-player-id (required)
 
 The Springboard player ID.
 
-**data-domain** (required)
+##### data-domain (required)
 
 The Springboard partner domain.
 
-**data-items** (required)
+##### data-items (required)
 
 The number of videos in the playlist.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-sticky-ad/amp-sticky-ad.md
+++ b/extensions/amp-sticky-ad/amp-sticky-ad.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 - There can be only one `<amp-sticky-ad>` in an AMP document. The `<amp-sticky-ad>` should only have one direct child: `<amp-ad>`. **Note**: Make sure you include any required scripts for the `<amp-ad>` component.
@@ -63,7 +65,7 @@ Example:
 
 ## Attributes
 
-**layout** (required)
+##### layout (required)
 
 Must be set to `nodisplay`.
 

--- a/extensions/amp-timeago/amp-timeago.md
+++ b/extensions/amp-timeago/amp-timeago.md
@@ -31,6 +31,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Behavior
 
 Provides fuzzy timestamps that you can use on your AMP pages. This component is based on <a href="https://github.com/hustcc/timeago.js">timeago.js</a>.
@@ -46,11 +48,11 @@ Example:
 
 ## Attributes
 
-**datetime** (required)
+##### datetime (required)
 
 An ISO datetime. E.g. 2017-03-10T01:00:00Z (UTC) *or* 2017-03-09T20:00:00-05:00 (specifying timezone offset).
 
-**locale** (optional)
+##### locale (optional)
 
 By default, the local is set to <code>en</code>; however, you can specify one of the following locales:
 
@@ -94,11 +96,11 @@ By default, the local is set to <code>en</code>; however, you can specify one of
   <li>zhTW (Taiwanese)</li>
 </ul>
 
-**cutoff** (optional)
+##### cutoff (optional)
 
 Display the original date if time distance is older than cutoff (seconds).
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 With responsive layout, the width and height from the example should yield correct layouts for 16:9 aspect ratio videos:
@@ -48,11 +50,11 @@ With responsive layout, the width and height from the example should yield corre
 
 ## Attributes
 
-**data-videoid** (required)
+##### data-videoid (required)
 
 The Vimeo video id found in every Vimeo video page URL For example, `27246366` is the video id for the following url: `https://vimeo.com/27246366`.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-vine/amp-vine.md
+++ b/extensions/amp-vine/amp-vine.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 A Vine simple embed has equal width and height:
@@ -47,11 +49,11 @@ A Vine simple embed has equal width and height:
 
 ## Attributes
 
-**data-vineid** (required)
+##### data-vineid (required)
 
 The ID of the Vine. In a URL like https://vine.co/v/MdKjXez002d, `MdKjXez002d` is the vineID.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 

--- a/extensions/amp-viz-vega/amp-viz-vega.md
+++ b/extensions/amp-viz-vega/amp-viz-vega.md
@@ -39,6 +39,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## What is Vega?
 Vega is a visualization grammar, a declarative format for creating and saving
 interactive visualization designs. Vega's runtime uses [D3](https://github.com/d3/d3)
@@ -124,7 +126,7 @@ to learn more and play with samples.
 
 ## Attributes
 
-**src**
+##### src
 
 This attribute can be used to load a Vega specification data file
 from a specified remote URL. The URL must use https scheme.
@@ -134,8 +136,7 @@ as the only child of `<amp-viz-vega>`.
 
 Only either `src` or `<script>` should be specified. Using both will result in error.
 
-
-**use-data-width** and **use-data-height**
+##### use-data-width and use-data-height
 
 To support responsive visualization, by default `<amp-viz-vega>` overrides `width`
 and `height` values defined in the Vega specification data with the actual width

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -35,6 +35,8 @@ limitations under the License.
   </tr>
 </table>
 
+[TOC]
+
 ## Example
 
 With the responsive layout, the width and height from the example should yield correct layouts for 16:9 aspect ratio videos:
@@ -48,7 +50,7 @@ With the responsive layout, the width and height from the example should yield c
 
 ## Attributes
 
-**autoplay**
+##### autoplay
 
 If this attribute is present, and the browser supports autoplay:
 
@@ -58,13 +60,13 @@ If this attribute is present, and the browser supports autoplay:
 * when the user taps the video, the video is unmuted
 * if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused. 
 
-**data-videoid**
+##### data-videoid
 
 The YouTube video id found in every YouTube video page URL.
 
 For example, in this URL: https://www.youtube.com/watch?v=Z1q71gFeRqM, `Z1q71gFeRqM` is the video id.
 
-**data-param-***
+##### data-param-*
 
 All `data-param-*` attributes will be added as query parameter to the YouTube iframe src. This may be used to pass custom values through to YouTube plugins, such as whether to show controls.
 
@@ -74,7 +76,7 @@ Keys and values will be URI encoded. Keys will be camel cased.
 
 See [YouTube Embedded Player Parameters](https://developers.google.com/youtube/player_parameters) for more parameter options for YouTube.
 
-**common attributes**
+##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 


### PR DESCRIPTION
While correcting the "availability" of `amp-fx-parallax`; I decided to add TOC for all other ref docs and correct the headings for Attributes + some minor wording corrections.

