### PR TITLE
Use os.environ.get() for build.py

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -133,12 +133,12 @@ def InstallNodeDependencies():
   logging.info('installing AMP Validator engine dependencies ...')
   subprocess.check_call(
       ['npm', 'install'],
-      stdout=(open(os.devnull, 'wb') if os.environ['TRAVIS'] else sys.stdout))
+      stdout=(open(os.devnull, 'wb') if os.environ.get('TRAVIS') else sys.stdout))
   logging.info('installing AMP Validator nodejs dependencies ...')
   subprocess.check_call(
       ['npm', 'install'],
       cwd='nodejs',
-      stdout=(open(os.devnull, 'wb') if os.environ['TRAVIS'] else sys.stdout))
+      stdout=(open(os.devnull, 'wb') if os.environ.get('TRAVIS') else sys.stdout))
   logging.info('... done')
 
 

--- a/validator/webui/build.py
+++ b/validator/webui/build.py
@@ -110,7 +110,7 @@ def InstallNodeDependencies():
   logging.info('installing AMP Validator webui dependencies ...')
   subprocess.check_call(
       ['npm', 'install'],
-      stdout=(open(os.devnull, 'wb') if os.environ['TRAVIS'] else sys.stdout))
+      stdout=(open(os.devnull, 'wb') if os.environ.get('TRAVIS') else sys.stdout))
   logging.info('... done')
 
 


### PR DESCRIPTION
Following #10479, using os.environ.get('TRAVIS') instead of accessing directly.