### PR TITLE
Revert "Establish golden version of blank page on Percy"

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -305,8 +305,6 @@ function runAllCommands() {
     command.testBuildSystem();
     command.cleanBuild();
     command.buildRuntime();
-    // Revert after a golden version of the blank page has been established.
-    command.runVisualDiffTests(/* opt_skip */ true);
     command.runVisualDiffTests();
     command.runJsonAndLintChecks();
     command.runDepAndTypeChecks();


### PR DESCRIPTION
Reverts ampproject/amphtml#10512

It's no longer needed, now that a golden version of the blank page test has been established on `master`. See https://percy.io/ampproject/amphtml/builds/290093.

Fixes #10164