### PR TITLE
Include a blank snapshot for Percy builds on master

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -280,11 +280,13 @@ const command = {
     timedExecOrDie(
         `${gulp} test --nobuild --saucelabs --integration --compiled`);
   },
-  runVisualDiffTests: function(opt_skip) {
+  runVisualDiffTests: function(opt_mode) {
     process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
     let cmd = 'ruby build-system/tasks/visual-diff.rb';
-    if (opt_skip) {
+    if (opt_mode === 'skip') {
       cmd += ' --skip';
+    } else if (opt_mode === 'master') {
+      cmd += ' --master';
     }
     timedExec(cmd);
   },
@@ -305,9 +307,7 @@ function runAllCommands() {
     command.testBuildSystem();
     command.cleanBuild();
     command.buildRuntime();
-    // Revert after a golden version of the blank page has been established.
-    command.runVisualDiffTests(/* opt_skip */ true);
-    command.runVisualDiffTests();
+    command.runVisualDiffTests(/* opt_mode */ 'master');
     command.runJsonAndLintChecks();
     command.runDepAndTypeChecks();
     command.runUnitTests();
@@ -404,7 +404,7 @@ function main(argv) {
       }
     } else {
       // Generates a blank Percy build to satisfy the required Github check.
-      command.runVisualDiffTests(/* opt_skip */ true);
+      command.runVisualDiffTests(/* opt_mode */ 'skip');
     }
     if (buildTargets.has('VALIDATOR_WEBUI')) {
       command.buildValidatorWebUI();

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -122,6 +122,10 @@ def generateSnapshots(pagesToSnapshot)
     page.driver.options[:js_errors] = true
     page.driver.options[:phantomjs_options] =
         ["--debug=#{ENV['PHANTOMJS_DEBUG']}"]
+    # Include a blank snapshot on master, to allow for PR builds to be skipped.
+    if ARGV.include? '--master'
+      Percy::Capybara.snapshot(page, name: 'Blank page')
+    end
     webpages.each do |webpage|
       url = webpage["url"]
       name = webpage["name"]


### PR DESCRIPTION
This fixes the problems we've been seeing with missing baselines. It turns out that on `master`, we must include regular snapshots _and_ the blank snapshots. Then, PR builds can take either just the regular snapshots, or just the blank snapshot, which are then compared against the most recent approved build on `master`.

Fixes #10164