### PR TITLE
Improve logs for Sauce labs runs on Travis

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -56,6 +56,11 @@ module.exports = {
 
   mochaReporter: {
     output: 'minimal',
+    symbols: {
+      success : '✔',
+      error: '✖',
+      warning: '?',
+    },
   },
 
   port: 9876,

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -59,7 +59,7 @@ module.exports = {
     symbols: {
       success : '✔',
       error: '✖',
-      warning: '?',
+      info: '?',
     },
   },
 

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -47,6 +47,11 @@ module.exports = {
   reporters: process.env.TRAVIS ? ['super-dots', 'mocha'] : ['progress'],
 
   superDotsReporter: {
+    color: {
+      success : 'green',
+      failure : 'red',
+      ignore  : 'yellow'
+    },
     icon: {
       success : '✔',
       failure : '✖',
@@ -56,6 +61,11 @@ module.exports = {
 
   mochaReporter: {
     output: 'minimal',
+    colors: {
+      success: 'green',
+      error: 'red',
+      info: 'yellow',
+    },
     symbols: {
       success : '✔',
       error: '✖',

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -46,14 +46,6 @@ module.exports = {
 
   reporters: process.env.TRAVIS ? ['super-dots', 'mocha'] : ['progress'],
 
-  superDotsReporter: {
-    icon: {
-      success : '✔',
-      failure : '✖',
-      ignore  : '?',
-    },
-  },
-
   mochaReporter: {
     output: 'minimal',
   },

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -46,6 +46,14 @@ module.exports = {
 
   reporters: process.env.TRAVIS ? ['super-dots', 'mocha'] : ['progress'],
 
+  superDotsReporter: {
+    icon: {
+      success : '✔',
+      failure : '✖',
+      ignore  : '?',
+    },
+  },
+
   mochaReporter: {
     output: 'minimal',
   },

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -51,7 +51,8 @@ function getConfig() {
       throw new Error('Missing SAUCE_ACCESS_KEY Env variable');
     }
     return Object.assign({}, karmaDefault, {
-      reporters: ['dots', 'saucelabs'],
+      reporters: process.env.TRAVIS ?
+          ['super-dots', 'saucelabs', 'mocha'] : ['dots', 'saucelabs'],
       browsers: argv.oldchrome
           ? ['SL_Chrome_45']
           : [
@@ -215,7 +216,6 @@ gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
       'Started test responses server on localhost:31862'));
 
   new Karma(c, function(exitCode) {
-    console./*OK*/log('\n');
     server.emit('kill');
     if (exitCode) {
       var error = new Error(

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -220,7 +220,9 @@ gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
     if (exitCode) {
       var error = new Error(
           util.colors.red('Karma test failed (error code: ' + exitCode + ')'));
-      process.exit(1);
+      process.nextTick(function() {
+        process.exit(1);
+      });
     } else {
       done();
     }

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -220,7 +220,7 @@ gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
     if (exitCode) {
       var error = new Error(
           util.colors.red('Karma test failed (error code: ' + exitCode + ')'));
-      done(error);
+      process.exit(1);
     } else {
       done();
     }

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -218,11 +218,10 @@ gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
   new Karma(c, function(exitCode) {
     server.emit('kill');
     if (exitCode) {
-      var error = new Error(
-          util.colors.red('Karma test failed (error code: ' + exitCode + ')'));
-      process.nextTick(function() {
-        process.exit(1);
-      });
+      util.log(
+          util.colors.red('ERROR:'),
+          util.colors.yellow('Karma test failed with exit code', exitCode));
+      process.exit(exitCode);
     } else {
       done();
     }

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -45,6 +45,7 @@ describe.configure().retryOnSaucelabs().run('Rendering of amp-img', function() {
 
   it('should resize and load more elements', () => {
     const p = fixture.awaitEvent(AmpEvents.LOAD_START, 11).then(function() {
+      expect(1).to.equal(2);
       expect(fixture.doc.querySelectorAll('amp-img img[src]'))
           .to.have.length(11);
       fixture.iframe.height = 2000;

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -45,7 +45,6 @@ describe.configure().retryOnSaucelabs().run('Rendering of amp-img', function() {
 
   it('should resize and load more elements', () => {
     const p = fixture.awaitEvent(AmpEvents.LOAD_START, 11).then(function() {
-      expect(1).to.equal(2);
       expect(fixture.doc.querySelectorAll('amp-img img[src]'))
           .to.have.length(11);
       fixture.iframe.height = 2000;


### PR DESCRIPTION
This PR does the following:

- Exposes the actual number of integration tests that pass, fail, or are skipped using the `super-dots` reporter.
- Prints a human readable summary of the tests run, with failure reasons, using the `mocha` reporter in `minimal` mode.
- In case of test failures, no longer prints a meaningless call stack, but instead, cleanly exits the test runner with a `process.exit(exitCode)`.

Fixes #10482