### PR TITLE
Add css waits for amp.article visual tests

### DIFF
--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -19,6 +19,9 @@
       "name": "AMP Article Access",
       "loading_complete_css": [
         ".login-section"
+      ],
+      "forbidden_css": [
+        ".article-body"
       ]
     },
     {

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -9,11 +9,17 @@
     },
     {
       "url": "examples/visual-tests/article.amp/article.amp.html",
-      "name": "AMP Article"
+      "name": "AMP Article",
+      "loading_complete_css": [
+        ".article-body"
+      ]
     },
     {
       "url": "examples/visual-tests/article-access.amp/article-access.amp.html",
-      "name": "AMP Article Access"
+      "name": "AMP Article Access",
+      "loading_complete_css": [
+        ".login-section"
+      ]
     },
     {
       "url": "examples/visual-tests/font.amp/font.amp.html",

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -20,7 +20,7 @@
       "loading_complete_css": [
         ".login-section"
       ],
-      "forbidden_css": [
+      "loading_incomplete_css": [
         ".article-body"
       ]
     },


### PR DESCRIPTION
This PR makes sure that the page added in #10511 is fully loaded before snapshotting.

There is currently some flakiness on Percy, most likely due to `article-access.amp.html` having started with a fully displayed article, and having not yet displayed the "login" prompt.

For example, see https://percy.io/ampproject/amphtml/builds/291191

#10155