### PR TITLE
amp-bind: Only fallback for nodes in top window

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -148,7 +148,8 @@ export class AmpState extends AMP.BaseElement {
     const id = user().assert(this.element.id, '<amp-state> must have an id.');
     const state = Object.create(null);
     state[id] = json;
-    Services.bindForDoc(this.element).then(bind => {
+    Services.bindForDocOrNull(this.element).then(bind => {
+      dev().assert(bind, 'Bind service can not be found.');
       bind.setState(state,
           /* opt_skipEval */ isInit, /* opt_isAmpStateMutation */ !isInit);
     });

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -139,29 +139,9 @@ export function getElementServiceIfAvailableForDoc(
 }
 
 /**
- * Returns a promise for a service in the closest embed scope of `nodeOrDoc`.
- * If no embed-scope service is found, falls back to top-level service.
- * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
- * @param {string} id of the service.
- * @param {string} extension Name of the custom element that provides
- *     the implementation of this service.
- * @return {!Promise<!Object>}
- */
-export function getElementServiceForDocInEmbedScope(
-    nodeOrDoc, id, extension) {
-  return getElementServiceIfAvailableForDocInEmbedScope(
-      nodeOrDoc, id, extension)
-      .then(service => {
-        if (service) {
-          return service;
-        }
-        // Fallback to ampdoc.
-        return getElementServiceForDoc(nodeOrDoc, id, extension);
-      });
-}
-
-/**
- * Same as `getElementServiceForDocInEmbedScope` but without top-level fallback.
+ * Returns a promise for service for the given id in the embed scope of
+ * a given node, if it exists. Otherwise, falls back to ampdoc scope IFF
+ * the given node is in the top-level window.
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @param {string} id of the service.
  * @param {string} extension Name of the custom element that provides
@@ -184,6 +164,9 @@ export function getElementServiceIfAvailableForDocInEmbedScope(
     // a promise from the wrong service holder which would never resolve.
     if (win !== topWin) {
       return getElementServicePromiseOrNull(win, id, extension);
+    } else {
+      // Fallback to ampdoc IFF the given node is _not_ FIE.
+      return getElementServiceIfAvailableForDoc(nodeOrDoc, id, extension);
     }
   }
   return /** @type {!Promise<?Object>} */ (Promise.resolve(null));

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -123,7 +123,8 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
       return;
     }
-    Services.bindForDoc(invocation.target).then(bind => {
+    Services.bindForDocOrNull(invocation.target).then(bind => {
+      user().assert(bind, 'AMP-BIND is not installed.');
       const args = invocation.args;
       const objectString = args[OBJECT_STRING_ARGS_KEY];
       if (objectString) {

--- a/src/services.js
+++ b/src/services.js
@@ -25,9 +25,9 @@ import {
 import {
   getElementService,
   getElementServiceForDoc,
-  getElementServiceForDocInEmbedScope,
   getElementServiceIfAvailable,
   getElementServiceIfAvailableForDoc,
+  getElementServiceIfAvailableForDocInEmbedScope,
 } from './element-service';
 
 export class Services {
@@ -124,11 +124,12 @@ export class Services {
 
   /**
    * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
-   * @return {!Promise<!../extensions/amp-bind/0.1/bind-impl.Bind>}
+   * @return {!Promise<?../extensions/amp-bind/0.1/bind-impl.Bind>}
    */
-  static bindForDoc(nodeOrDoc) {
-    return /** @type {!Promise<!../extensions/amp-bind/0.1/bind-impl.Bind>} */ (
-        getElementServiceForDocInEmbedScope(nodeOrDoc, 'bind', 'amp-bind'));
+  static bindForDocOrNull(nodeOrDoc) {
+    return /** @type {!Promise<?../extensions/amp-bind/0.1/bind-impl.Bind>} */ (
+        getElementServiceIfAvailableForDocInEmbedScope(
+            nodeOrDoc, 'bind', 'amp-bind'));
   }
 
   /**

--- a/test/functional/test-element-service.js
+++ b/test/functional/test-element-service.js
@@ -24,7 +24,6 @@ import {
   getElementServiceIfAvailable,
   getElementServiceForDoc,
   getElementServiceIfAvailableForDoc,
-  getElementServiceForDocInEmbedScope,
   getElementServiceIfAvailableForDocInEmbedScope,
 } from '../../src/element-service';
 import {
@@ -377,38 +376,23 @@ describes.fakeWin('in embed scope', {amp: true}, env => {
     });
   });
 
-  it('should return null if win is top window', () => {
+  it('should return ampdoc-scope service if node in top window', () => {
     markElementScheduledForTesting(win, 'amp-foo');
-    // Use `registerServiceBuilder` since `installServiceInEmbedScope` will
-    // fail for top windows.
-    registerServiceBuilder(win, 'foo', () => service);
+    registerServiceBuilderForDoc(nodeInTopWin, 'foo', () => service,
+        /* opt_instantiate */ true);
     return getElementServiceIfAvailableForDocInEmbedScope(
         nodeInTopWin, 'foo', 'amp-foo').then(returned => {
-          expect(returned).to.be.null;
+          expect(returned).to.equal(service);
         });
   });
 
-  it('"if available" should not fall back to top window\'s service', () => {
+  it('should NOT return ampdoc-scope service if node in embed window', () => {
     markElementScheduledForTesting(win, 'amp-foo');
-    // Use `registerServiceBuilder` since `installServiceInEmbedScope` will
-    // fail for top windows.
-    registerServiceBuilder(win, 'foo', () => service,
+    registerServiceBuilderForDoc(nodeInTopWin, 'foo', () => service,
         /* opt_instantiate */ true);
     return getElementServiceIfAvailableForDocInEmbedScope(
         nodeInEmbedWin, 'foo', 'amp-foo').then(returned => {
           expect(returned).to.be.null;
-        });
-  });
-
-  it('should fall back to top window\'s service', () => {
-    markElementScheduledForTesting(win, 'amp-foo');
-    // Use `registerServiceBuilder` since `installServiceInEmbedScope` will
-    // fail for top windows.
-    registerServiceBuilderForDoc(env.ampdoc, 'foo', () => service,
-        /* opt_instantiate */ true);
-    return getElementServiceForDocInEmbedScope(
-        nodeInEmbedWin, 'foo', 'amp-foo').then(returned => {
-          expect(returned).to.equal(service);
         });
   });
 });

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -272,7 +272,7 @@ describes.sandboxed('StandardActions', {}, () => {
         satisfiesTrust: () => true,
       };
       standardActions.handleAmpTarget(invocation);
-      return Services.bindForDoc(ampdoc).then(() => {
+      return Services.bindForDocOrNull(ampdoc).then(() => {
         expect(spy).to.be.calledOnce;
         expect(spy).to.be.calledWith('{foo: 123}');
       });


### PR DESCRIPTION
Realized this while prepping for today's design review. 😢 

Verified locally for amp-bind in only-embed, only-parent, and both-embed-and-parent.