### PR TITLE
Use same-width dot characters for progress indicators

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -53,9 +53,9 @@ module.exports = {
       ignore  : 'yellow'
     },
     icon: {
-      success : '✔',
-      failure : '✖',
-      ignore  : '?',
+      success : '⚫',
+      failure : '⚫',
+      ignore  : '⚪',
     },
   },
 
@@ -67,9 +67,9 @@ module.exports = {
       info: 'yellow',
     },
     symbols: {
-      success : '✔',
-      error: '✖',
-      info: '?',
+      success : '⚫',
+      error: '⚫',
+      info: '⚪',
     },
   },
 


### PR DESCRIPTION
This is a follow up to #10530, since some platforms display checks and crosses really badly. The color coding should make it plenty clear which tests passed / failed / were skipped.

#10482