### PR TITLE
[amp-sidebar 1.0][Toolbar] Refactored `toolbar-only` to `hidden-when-toolbar`

### DIFF
--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -65,8 +65,8 @@
          } else {
            navToolbar.setAttribute('toolbar', '(min-width: 768px)');
          }
-         if (toolbarObj.toolbarOnlyOnNav) {
-           navToolbar.setAttribute('toolbar-only', '');
+         if (toolbarObj.hiddenWhenToolbarOnNav) {
+           navToolbar.setAttribute('hidden-when-toolbar', '');
          }
          const toolbarTarget = ampdoc.win.document.createElement('div');
          if (toolbarObj.toolbarTarget) {
@@ -82,6 +82,9 @@
          const toolbarList = ampdoc.win.document.createElement('ul');
          for (let i = 0; i < 3; i++) {
            const li = ampdoc.win.document.createElement('li');
+           if (toolbarObj.hiddenWhenToolbarOnNavChild && i == 1) {
+             li.setAttribute('hidden-when-toolbar', '');
+           }
            li.innerHTML = 'Toolbar item ' + i;
            toolbarList.appendChild(li);
          }
@@ -227,11 +230,11 @@
      });
    });
 
-   it('should hide <nav toolbar> elements with toolbar-only, \
+   it('should hide <nav toolbar> elements with hidden-when-toolbar, \
    inside the sidebar, but not inside the toolbar, for a matching \
    window size for (min-width: 768px)', () => {
      return getToolbars([{
-       toolbarOnlyOnNav: true,
+       hiddenWhenToolbarOnNav: true,
      }]).then(obj => {
        const toolbars = obj.toolbars;
        resizeIframeToWidth(obj.iframe, '4000px', () => {
@@ -246,6 +249,31 @@
                 .querySelectorAll('nav[style]'));
          expect(toolbarNavElements.length).to.be.equal(2);
          expect(hiddenToolbarNavElements.length).to.be.equal(1);
+         expect(toolbars.length).to.be.equal(1);
+       });
+     });
+   });
+
+   it('should hide individual <nav toolbar> \
+   children elements with hidden-when-toolbar, \
+   inside the sidebar, but not inside the toolbar, for a matching \
+   window size for (min-width: 768px)', () => {
+     return getToolbars([{
+       hiddenWhenToolbarOnNavChild: true,
+     }]).then(obj => {
+       const toolbars = obj.toolbars;
+       resizeIframeToWidth(obj.iframe, '4000px', () => {
+         toolbars.forEach(toolbar => {
+           toolbar.onLayoutChange();
+         });
+         const toolbarNavChildElements =
+                toArray(obj.ampdoc.getRootNode()
+                .querySelectorAll('nav[toolbar] > ul > li'));
+         const hiddenToolbarNavChildElements =
+                toArray(obj.ampdoc.getRootNode()
+                .querySelectorAll('nav[toolbar] > ul > li[style]'));
+         expect(toolbarNavChildElements.length).to.be.equal(6);
+         expect(hiddenToolbarNavChildElements.length).to.be.equal(1);
          expect(toolbars.length).to.be.equal(1);
        });
      });

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -50,18 +50,18 @@ export class Toolbar {
     this.toolbarShown_ = false;
 
     /** @private {Array} */
-    this.toolbarOnlyElementsInSidebar_ = [];
+    this.hiddenWhenToolbarElementsInSidebar_ = [];
 
-    // Find our tool-bar only elements
-    if (this.toolbarDomElement_.hasAttribute('toolbar-only')) {
-      this.toolbarOnlyElementsInSidebar_.push(this.toolbarDomElement_);
+    // Find our hidden-when-toolbar only elements
+    if (this.toolbarDomElement_.hasAttribute('hidden-when-toolbar')) {
+      this.hiddenWhenToolbarElementsInSidebar_.push(this.toolbarDomElement_);
     } else {
       // Get our toolbar only elements
       const toolbarOnlyQuery =
-        this.toolbarDomElement_.querySelectorAll('[toolbar-only]');
+        this.toolbarDomElement_.querySelectorAll('[hidden-when-toolbar]');
       if (toolbarOnlyQuery.length > 0) {
-        // Check the nav's children for toolbar-only
-        this.toolbarOnlyElementsInSidebar_ =
+        // Check the nav's children for hidden-when-toolbar
+        this.hiddenWhenToolbarElementsInSidebar_ =
           toArray(toolbarOnlyQuery);
       }
     }
@@ -124,7 +124,7 @@ export class Toolbar {
 
   /**
    * Function to attempt to show the toolbar,
-   * and hide toolbar-only element in the sidebar.
+   * and hide hidden-when-toolbar elements in the sidebar.
    * @returns {Promise|undefined}
    * @private
    */
@@ -141,8 +141,8 @@ export class Toolbar {
           this.toolbarTarget_.appendChild(this.toolbarClone_);
         }
       }
-      if (this.toolbarOnlyElementsInSidebar_) {
-        this.toolbarOnlyElementsInSidebar_.forEach(element => {
+      if (this.hiddenWhenToolbarElementsInSidebar_) {
+        this.hiddenWhenToolbarElementsInSidebar_.forEach(element => {
           toggle(element, false);
         });
       }
@@ -152,7 +152,7 @@ export class Toolbar {
 
   /**
   * Function to hide the toolbar,
-  * and show toolbar-only element in the sidebar.
+  * and show hidden-when-toolbar elements in the sidebar.
   * @private
    */
   hideToolbar_() {
@@ -165,8 +165,8 @@ export class Toolbar {
       if (this.toolbarTarget_) {
         toggle(this.toolbarTarget_, false);
       }
-      if (this.toolbarOnlyElementsInSidebar_) {
-        this.toolbarOnlyElementsInSidebar_.forEach(element => {
+      if (this.hiddenWhenToolbarElementsInSidebar_) {
+        this.hiddenWhenToolbarElementsInSidebar_.forEach(element => {
           toggle(element, true);
         });
       }

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -144,9 +144,9 @@ limitations under the License.
       </ul>
     </nav>
 
-    <!-- Toolbar One, basic usage, toolbar-only -->
+    <!-- Toolbar One, basic usage, hidden-when-toolbar -->
     <!-- Could center with CSS justify-content: space-between, but trying to be minimal -->
-    <nav toolbar="(min-width: 0px)" toolbar-target="hamburger-toolbar" class="ampstart-hamburger-nav ampstart-navbar-bg" toolbar-only>
+    <nav toolbar="(min-width: 0px)" toolbar-target="hamburger-toolbar" class="ampstart-hamburger-nav ampstart-navbar-bg" hidden-when-toolbar>
       <ul class="justify-center">
         <li role="button" aria-label="open sidebar" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger pl2">
           ☰
@@ -158,7 +158,7 @@ limitations under the License.
     </nav>
 
     <!-- Toolbar Two, min only  -->
-    <nav toolbar="(min-width: 931px)" toolbar-target="accordion-toolbar" toolbar-only class="ampstart-headerbar-nav ampstart-nav ampstart-navbar-bg">
+    <nav toolbar="(min-width: 931px)" toolbar-target="accordion-toolbar" hidden-when-toolbar class="ampstart-headerbar-nav ampstart-nav ampstart-navbar-bg">
       <ul class="list-reset center m0 p0 flex justify-center nowrap">
           <li class="ampstart-nav-item ampstart-nav-dropdown">
             <!-- Start Dropdown -->
@@ -209,7 +209,7 @@ limitations under the License.
     </ul>
 
     <ul class="ampstart-sidebar-faq list-reset m0">
-      <li toolbar-only class="ampstart-faq-item"><a href="#" class="text-decoration-none">About</a></li>
+      <li hidden-when-toolbar class="ampstart-faq-item"><a href="#" class="text-decoration-none">About</a></li>
       <li class="ampstart-faq-item"><a href="#" class="text-decoration-none">Contact</a></li>
     </ul>
   </amp-sidebar>


### PR DESCRIPTION
closes #10432 

After discussion between @dvoytenko @camelburrito and I, we decided that `hidden-when-toolbar` would be a better attribute naming than `toolbar-only` to convey that they element within the sidebar would be hidden, when it is shown int he toolbar.

Separate PRs for Updating AMPHTML Docs and AMP By Example will be opened after this is merged.

# Screenshots

**Test and Code working**

![screen shot 2017-07-19 at 5 23 37 pm](https://user-images.githubusercontent.com/1448289/28395180-112cbf74-6ca7-11e7-9b03-96f853ca9ea8.png)
![screen shot 2017-07-19 at 5 23 21 pm](https://user-images.githubusercontent.com/1448289/28395181-112d9cd2-6ca7-11e7-8c40-c2339a0bf019.png)
