### PR TITLE
Add amp-selector clear action

### DIFF
--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -104,6 +104,8 @@ export class AmpSelector extends AMP.BaseElement {
     }
     this.kbSelectMode_ = kbSelectMode;
 
+    this.registerAction('clear', this.clearAllSelections_.bind(this));
+
     this.init_();
     if (!this.isDisabled_) {
       this.element.addEventListener('click', this.clickHandler_.bind(this));

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -805,5 +805,52 @@ describes.realWin('amp-selector', {
         expect(ampSelector.children[2].hasAttribute('selected')).to.be.false;
       });
     });
+
+    describe('clear action',() => {
+      it('should clear selection of a single select', () => {
+        const ampSelector = getSelector({
+          attributes: {
+            id: 'ampSelector',
+          },
+          config: {
+            count: 3,
+          },
+        });
+        ampSelector.build();
+        ampSelector.children[1].setAttribute('selected', '');
+
+        const button = win.document.createElement('button');
+        button.setAttribute('on', 'tap:ampSelector.clear');
+        win.document.body.append(button);
+
+        button.click();
+
+        expect(ampSelector.children[1].hasAttribute('selected')).to.be.false;
+      });
+
+      it('should clear selection of a multiselect', () => {
+        const ampSelector = getSelector({
+          attributes: {
+            id: 'ampSelector',
+            multiple: true,
+          },
+          config: {
+            count: 6,
+          },
+        });
+        ampSelector.build();
+        ampSelector.children[0].setAttribute('selected', '');
+        ampSelector.children[3].setAttribute('selected', '');
+
+        const button = win.document.createElement('button');
+        button.setAttribute('on', 'tap:ampSelector.clear');
+        win.document.body.append(button);
+
+        button.click();
+
+        expect(ampSelector.children[0].hasAttribute('selected')).to.be.false;
+        expect(ampSelector.children[3].hasAttribute('selected')).to.be.false;
+      });
+    });
   });
 });

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -814,14 +814,15 @@ describes.realWin('amp-selector', {
           },
           config: {
             count: 3,
+            selectedOptions: 1,
           },
         });
-        ampSelector.build();
         ampSelector.children[1].setAttribute('selected', '');
+        ampSelector.build();
 
         const button = win.document.createElement('button');
         button.setAttribute('on', 'tap:ampSelector.clear');
-        win.document.body.append(button);
+        win.document.body.appendChild(button);
 
         button.click();
 
@@ -838,13 +839,13 @@ describes.realWin('amp-selector', {
             count: 6,
           },
         });
-        ampSelector.build();
         ampSelector.children[0].setAttribute('selected', '');
         ampSelector.children[3].setAttribute('selected', '');
+        ampSelector.build();
 
         const button = win.document.createElement('button');
         button.setAttribute('on', 'tap:ampSelector.clear');
-        win.document.body.append(button);
+        win.document.body.appendChild(button);
 
         button.click();
 

--- a/extensions/amp-selector/amp-selector.md
+++ b/extensions/amp-selector/amp-selector.md
@@ -42,7 +42,7 @@ The AMP selector is a control that presents a list of options and lets the user 
 - Selectable options can be set by adding the `option` attribute to the element and assigning a value to the attribute (e.g., `<li option='value'></li>`).
 - Disabled options can be set by adding the `disabled` attribute to the element (e.g.,  `<li option='d' disabled></li>`).
 - Preselected options can be set by adding the `selected` attribute to the element (e.g.,  `<li option='b' selected></li>`).
-- To allow for multiple selections, add the `multiple` attribute to the `amp-selector` element.  By default, the `amp-selector` allows for one selection at a time. 
+- To allow for multiple selections, add the `multiple` attribute to the `amp-selector` element.  By default, the `amp-selector` allows for one selection at a time.
 - To disable the entire `amp-selector`, add the `disabled` attribute to the `amp-selector` element.
 - When an `amp-selector` contains a `name` attribute and the `amp-selector` is inside a `form` tag, if a submit event occurs on the form, the `amp-selector`behaves like a radio-button/checkbox group and submits the selected values (the ones assigned to the option) against the name of the `amp-selector`.
 
@@ -80,6 +80,24 @@ Example:
   </amp-carousel>
 </amp-selector>
 ```
+
+## Clearing selections
+To clear all selections when an element is tapped or clicked, set the [`on`](../../spec/amp-actions-and-events.md) action attribute on the element, and specify the AMP Selector `id` with the `clear` action method.
+
+Example:
+
+```html
+<button on="tap:mySelector.clear">Clear Selection</button>
+<amp-selector id="mySelector" layout="container" multiple>
+  <div>Option One</div>
+  <div>Option Two</div>
+  <div>Option Three</div>
+</amp-selector>
+```
+
+{% call callout('Tip', type='success') %}
+See live demos at [AMP By Example](https://ampbyexample.com/components/amp-selector/).
+{% endcall %}
 
 ## Attributes
 


### PR DESCRIPTION
- Closes Issue #10475
- Adds `clear` action to `amp-selector`
- Implements unit tests for `amp-selector`'s `clear` action
- Updates documentation for `amp-selector`

Reviewer: @aghassemi