### PR TITLE
Yieldbot ad, fix multi-size attribute console error

### DIFF
--- a/ads/yieldbot.js
+++ b/ads/yieldbot.js
@@ -23,10 +23,7 @@ import {rethrowAsync} from '../src/log';
  * @param {!Object} data
  */
 export function yieldbot(global, data) {
-  validateData(data, ['psn', 'ybSlot', 'slot'], [
-    'targeting', 'categoryExclusions', 'tagForChildDirectedTreatment',
-    'cookieOptions','overrideWidth', 'overrideHeight',
-  ]);
+  validateData(data, ['psn', 'ybSlot', 'slot']);
 
   global.ybotq = global.ybotq || [];
 
@@ -69,4 +66,3 @@ export function yieldbot(global, data) {
     });
   });
 }
-

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -1252,12 +1252,13 @@
       data-block-id="R-I-106712-3">
   </amp-ad>
 
-  <h2>Yieldbot 300x250</h2>
+  <h2>Yieldbot</h2>
   <amp-ad width="300" height="250"
       type="yieldbot"
       data-psn="1234"
       data-yb-slot="medrec"
       data-slot="/2476204/medium-rectangle"
+      data-multi-size="300x220,300x200"
       json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
   </amp-ad>
 

--- a/test/manual/amp-ad.yieldbot.amp.html
+++ b/test/manual/amp-ad.yieldbot.amp.html
@@ -21,12 +21,13 @@
   <ul>
       <li>See also, <a href="https://ui.yieldbot.com/documentation/tags/async_gpt_advanced#testing">Yieldbot Integration Testing</a></li>
   </ul>
-  <h2>Yieldbot 300x250</h2>
+  <h2>Yieldbot</h2>
   <amp-ad width="300" height="250"
           type="yieldbot"
           data-psn="1234"
           data-yb-slot="medrec"
           data-slot="/2476204/medium-rectangle"
+          data-multi-size="300x220,300x200"
           json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
   </amp-ad>
 </body>


### PR DESCRIPTION
Removes the Yieldbot `amp-ad` brittle dependency on the `doubleclick()` delegate data attributes.

- Removes Yieldbot optional data attributes; these were formerly all Doubleclick attributes
- Updates example and manual test to include optional data attribute for the `doubleclick()` delegate

Resolves #10550
