### PR TITLE
Clean up `gulp test` logging for local development

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = {
     bundleDelay: 900,
   },
 
-  reporters: process.env.TRAVIS ? ['super-dots', 'mocha'] : ['progress'],
+  reporters: ['super-dots', 'mocha'],
 
   superDotsReporter: {
     color: {
@@ -87,9 +87,9 @@ module.exports = {
     '/test/': '/base/test/',
   },
 
-  // Can't import Karma constants config.LOG_ERROR & config.LOG_WARN,
-  // so we hard code the strings here. Hopefully they'll never change.
-  logLevel: process.env.TRAVIS ? 'ERROR' : 'WARN',
+  // Can't import the Karma constant config.LOG_ERROR, so we hard code it here.
+  // Hopefully it'll never change.
+  logLevel: 'ERROR',
 
   autoWatch: true,
 

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = {
     bundleDelay: 900,
   },
 
-  reporters: ['super-dots', 'mocha'],
+  reporters: process.env.TRAVIS ? ['super-dots', 'mocha'] : ['dots', 'mocha'],
 
   superDotsReporter: {
     color: {

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -51,7 +51,8 @@ function getConfig() {
       throw new Error('Missing SAUCE_ACCESS_KEY Env variable');
     }
     return Object.assign({}, karmaDefault, {
-      reporters: ['super-dots', 'saucelabs', 'mocha'],
+      reporters: process.env.TRAVIS ?
+          ['super-dots', 'saucelabs', 'mocha'] : ['dots', 'saucelabs', 'mocha'],
       browsers: argv.oldchrome
           ? ['SL_Chrome_45']
           : [

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -51,8 +51,7 @@ function getConfig() {
       throw new Error('Missing SAUCE_ACCESS_KEY Env variable');
     }
     return Object.assign({}, karmaDefault, {
-      reporters: process.env.TRAVIS ?
-          ['super-dots', 'saucelabs', 'mocha'] : ['dots', 'saucelabs'],
+      reporters: ['super-dots', 'saucelabs', 'mocha'],
       browsers: argv.oldchrome
           ? ['SL_Chrome_45']
           : [


### PR DESCRIPTION
This PR does the following:

- For local `gulp test` runs, replaces the `progress` reporter with `dots` followed by a `mocha` summary
- For local `gulp test --saucelabs` runs, follows up the run with a `mocha` summary
- Changes the log level for local development from `WARN` to `ERROR` to suppress the numerous karma webserver `WARN [web-server]: 404` messages

Fixes #10482