### PR TITLE
FixedLayer: Calculate top: auto by mutating bottom

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -543,7 +543,8 @@ export class FixedLayer {
       } else if (this.committedPaddingTop_ === this.paddingTop_) {
         setStyle(element, 'top', state.top);
       } else {
-        setStyle(element, 'top', `calc(${state.top} - ${this.committedPaddingTop_}px)`);
+        setStyle(element, 'top',
+            `calc(${state.top} - ${this.committedPaddingTop_}px)`);
       }
     }
 

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -548,7 +548,7 @@ export class FixedLayer {
 
     // Update `top`. This is necessary to adjust position to the viewer's
     // paddingTop.
-    if (state.top) {
+    if (state.top && (state.fixed || state.sticky)) {
       if (state.fixed || !this.transfer_) {
         // Fixed positions always need top offsetting, as well as stickies on
         // non iOS Safari.

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -241,15 +241,15 @@ export class FixedLayer {
    * @return {!Promise}
    */
   update() {
-    if (this.elements_.length == 0) {
-      return Promise.resolve();
-    }
-
     // Some of the elements may no longer be in DOM.
     /** @type {!Array<!ElementDef>} */
     const toRemove = this.elements_.filter(
         fe => !this.ampdoc.contains(fe.element));
     toRemove.forEach(fe => this.removeElement_(fe.element));
+
+    if (this.elements_.length == 0) {
+      return Promise.resolve();
+    }
 
     // Next, the positioning-related properties will be measured. If a
     // potentially fixed/sticky element turns out to be actually fixed/sticky,
@@ -257,58 +257,50 @@ export class FixedLayer {
     let hasTransferables = false;
     return this.vsync_.runPromise({
       measure: state => {
-        const autoTops = [];
         const elements = this.elements_;
-        const styles = [];
+        const autoTops = [];
+        const win = this.ampdoc.win;
 
         // Notice that this code intentionally breaks vsync contract.
         // Unfortunately, there's no way to reliably test whether or not
         // `top` has been set to a non-auto value on all platforms. To work
         // this around, this code compares `offsetTop` values with and without
         // `style.top = auto`.
-
-        // 1. Set all style top to `auto` and calculate the auto-offset.
         for (let i = 0; i < elements.length; i++) {
-          const el = elements[i].element;
-          const style = computedStyle(this.ampdoc.win, el);
-          styles.push(style);
-          if (endsWith(style.position || '', 'sticky')) {
-            setStyle(el, 'position', 'fixed');
-          } else {
-            setStyle(el, 'top', 'auto');
-          }
+          const element = elements[i].element;
+          setStyle(element, 'top', '');
+          setStyle(element, 'bottom', '-9999vh');
+        }
+        for (let i = 0; i < elements.length; i++) {
+          autoTops.push(computedStyle(win, elements[i].element).top);
+        }
+        for (let i = 0; i < elements.length; i++) {
+          setStyle(elements[i].element, 'bottom', '');
         }
 
-        for (let i = 0; i < elements.length; i++) {
-          autoTops.push(elements[i].element./*OK*/offsetTop);
-        }
-
-        // 2. Reset style top.
-        for (let i = 0; i < elements.length; i++) {
-          setStyles(elements[i].element, {
-            top: '',
-            position: '',
-          });
-        }
-
-        // 3. Calculated fixed/sticky info.
         for (let i = 0; i < elements.length; i++) {
           const fe = elements[i];
-          const style = styles[i];
-          const element = fe.element;
-          const position = style.position || '';
+          const {element} = fe;
+          const style = computedStyle(win, element);
+
+          const {offsetWidth, offsetHeight, offsetTop} = element;
+          const {
+            position = '',
+            bottom,
+            opacity,
+            zIndex,
+            transform,
+          } = style;
+          let {top} = style;
+
           // Element is indeed fixed. Visibility is added to the test to
           // avoid moving around invisible elements.
           const isFixed = (
-            position == 'fixed' && (
-                fe.forceTransfer || (
-                    element./*OK*/offsetWidth > 0 &&
-                    element./*OK*/offsetHeight > 0
-                )
-              )
-            );
+              position == 'fixed' &&
+              (fe.forceTransfer || (offsetWidth > 0 && offsetHeight > 0)));
           // Element is indeed sticky.
           const isSticky = endsWith(position, 'sticky');
+
           if (!isFixed && !isSticky) {
             state[fe.id] = {
               fixed: false,
@@ -320,28 +312,15 @@ export class FixedLayer {
             continue;
           }
 
-          // Calculate top, assuming that it could implicitly be `auto`.
-          // `getComputedStyle().top` will return `auto` in Safari and the
-          // actual calculated value in all other browsers. To find out whether
-          // or not the `top` was actually set in CSS, this method compares
-          // `offsetTop` with `style.top = 'auto'` and without.
-          let top = style.top;
-          const currentOffsetTop = element./*OK*/offsetTop;
-          if (isSticky) {
-            if (top === 'auto' || parseInt(top, 10) !== autoTops[i]) {
-              top = '';
-            }
-          } else if (currentOffsetTop === autoTops[i]) {
-            if (currentOffsetTop ===
-                    this.committedPaddingTop_ + this.borderTop_) {
+          if (top === 'auto' || autoTops[i] !== top) {
+            if (isFixed &&
+                offsetTop === this.committedPaddingTop_ + this.borderTop_) {
               top = '0px';
             } else {
               top = '';
             }
           }
 
-          const bottom = style.bottom;
-          const opacity = parseFloat(style.opacity);
           // Transferability requires element to be fixed and top or bottom to
           // be styled with `0`. Also, do not transfer transparent
           // elements - that's a lot of work for no benefit.  Additionally,
@@ -354,7 +333,7 @@ export class FixedLayer {
           const isTransferrable = isFixed && (
               fe.forceTransfer || (
                   opacity > 0 &&
-                  element./*OK*/offsetHeight < 300 &&
+                  offsetHeight < 300 &&
                   (this.isAllowedCoord_(top) || this.isAllowedCoord_(bottom))));
           if (isTransferrable) {
             hasTransferables = true;
@@ -364,8 +343,8 @@ export class FixedLayer {
             sticky: isSticky,
             transferrable: isTransferrable,
             top,
-            zIndex: style.zIndex,
-            transform: style.transform,
+            zIndex,
+            transform,
           };
         }
       },
@@ -557,9 +536,17 @@ export class FixedLayer {
 
     // Update `top`. This is necessary to adjust position to the viewer's
     // paddingTop.
-    if (state.top && (state.fixed || (state.sticky && !this.transfer_))) {
-      setStyle(element, 'top', `calc(${state.top} + ${this.paddingTop_}px)`);
+    // TODO
+    if (state.top) {
+      if (state.fixed || !this.transfer_) {
+        setStyle(element, 'top', `calc(${state.top} + ${this.paddingTop_}px)`);
+      } else if (this.committedPaddingTop_ === this.paddingTop_) {
+        setStyle(element, 'top', state.top);
+      } else {
+        setStyle(element, 'top', `calc(${state.top} - ${this.committedPaddingTop_}px)`);
+      }
     }
+
     // Move element to the fixed layer.
     if (this.transfer_ && state.fixed && !oldFixed && state.transferrable) {
       this.transferToTransferLayer_(fe, index, state);

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -171,7 +171,7 @@ describe('FixedLayer', () => {
     const children = [];
     const elem = {
       id,
-      autoOffsetTop: 17,
+      autoTop: '',
       toString: () => {
         return id;
       },
@@ -185,10 +185,20 @@ describe('FixedLayer', () => {
       computedStyle: {
         opacity: '0.9',
         visibility: 'visible',
-        top: '',
+        _top: '',
+        get top() {
+          if (elem.style.bottom) {
+            return elem.autoTop || this._top;
+          }
+          return this._top;
+        },
+        set top(val) {
+          this._top = val;
+        },
         bottom: '',
         zIndex: '',
         transform: '',
+        position: '',
       },
       matches: () => true,
       compareDocumentPosition: other => {
@@ -231,13 +241,6 @@ describe('FixedLayer', () => {
     };
     Object.defineProperty(elem, 'offsetTop', {
       get: () => {
-        if (elem.overrideOffsetTop != null) {
-          return elem.overrideOffsetTop;
-        }
-        if (elem.style.top == 'auto' || elem.computedStyle.top == 'auto' ||
-                elem.computedStyle.top == '') {
-          return elem.autoOffsetTop;
-        }
         return parseFloat(elem.computedStyle.top);
       },
     });
@@ -557,8 +560,7 @@ describe('FixedLayer', () => {
       // See http://crbug.com/703816.
       element5.computedStyle['position'] = 'sticky';
       element5.computedStyle['top'] = '0px';
-      element5.autoOffsetTop = 12;
-      element5.overrideOffsetTop = 12;
+      element5.autoTop = '12px';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};
@@ -572,23 +574,7 @@ describe('FixedLayer', () => {
       // See http://crbug.com/703816.
       element5.computedStyle['position'] = 'sticky';
       element5.computedStyle['top'] = '0px';
-      element5.autoOffsetTop = 0;
-      element5.overrideOffsetTop = 0;
-
-      expect(vsyncTasks).to.have.length(1);
-      const state = {};
-      vsyncTasks[0].measure(state);
-
-      expect(state['F4'].sticky).to.be.true;
-      expect(state['F4'].top).to.equal('0px');
-    });
-
-    it('should work around top=0 for sticky when offset = 0', () => {
-      // See http://crbug.com/703816.
-      element5.computedStyle['position'] = 'sticky';
-      element5.computedStyle['top'] = '0px';
-      element5.autoOffsetTop = 0;
-      element5.overrideOffsetTop = 0;
+      element5.autoTop = '0px';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};
@@ -602,8 +588,7 @@ describe('FixedLayer', () => {
       // See http://crbug.com/703816.
       element5.computedStyle['position'] = 'sticky';
       element5.computedStyle['top'] = '0px';
-      element5.autoOffsetTop = 12;
-      element5.overrideOffsetTop = 11;
+      element5.autoTop = '12px';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};
@@ -615,12 +600,12 @@ describe('FixedLayer', () => {
 
     it('should collect for implicit top = auto, but not update top', () => {
       element1.computedStyle['position'] = 'fixed';
-      element1.computedStyle['top'] = '12px';
-      element1.autoOffsetTop = 12;
+      element1.computedStyle['top'] = '0px';
+      element1.autoTop = '12px';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
       element5.computedStyle['position'] = 'sticky';
-      element5.autoOffsetTop = 12;
+      element5.autoTop = '12px';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};
@@ -636,12 +621,12 @@ describe('FixedLayer', () => {
     it('should override implicit top = auto to 0 when equals padding', () => {
       element1.computedStyle['position'] = 'fixed';
       element1.computedStyle['top'] = '11px';
-      element1.autoOffsetTop = 11;
+      element1.autoTop = '0px';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
       element5.computedStyle['position'] = 'sticky';
       element5.computedStyle['top'] = '11px';
-      element5.autoOffsetTop = 11;
+      element5.autoTop = '11px';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};
@@ -658,12 +643,12 @@ describe('FixedLayer', () => {
       fixedLayer.borderTop_ = 1;
       element1.computedStyle['position'] = 'fixed';
       element1.computedStyle['top'] = '12px';
-      element1.autoOffsetTop = 12;
+      element1.autoTop = '0px';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
       element5.computedStyle['position'] = 'sticky';
       element5.computedStyle['top'] = '12px';
-      element5.autoOffsetTop = 12;
+      element5.autoTop = '12px';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};
@@ -679,12 +664,12 @@ describe('FixedLayer', () => {
     it('should override implicit top = auto to 0 w/transient padding', () => {
       element1.computedStyle['position'] = 'fixed';
       element1.computedStyle['top'] = '11px';
-      element1.autoOffsetTop = 11;
+      element1.autoTop = '0px';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
       element5.computedStyle['position'] = 'sticky';
       element5.computedStyle['top'] = '11px';
-      element5.autoOffsetTop = 11;
+      element5.autoTop = '11px';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};
@@ -718,19 +703,19 @@ describe('FixedLayer', () => {
     it('should always collect and update top = 0', () => {
       element1.computedStyle['position'] = 'fixed';
       element1.computedStyle['top'] = '0px';
-      element1.autoOffsetTop = 0;
+      element1.autoTop = '0px';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
       element5.computedStyle['position'] = 'sticky';
       element5.computedStyle['top'] = '0px';
-      element5.autoOffsetTop = 0;
+      element5.autoTop = '0px';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};
       vsyncTasks[0].measure(state);
 
       expect(state['F0'].fixed).to.be.true;
-      expect(state['F0'].top).to.equal('');
+      expect(state['F0'].top).to.equal('0px');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('0px');
@@ -776,7 +761,7 @@ describe('FixedLayer', () => {
       expect(fe.element.style.top).to.equal('calc(17px + 11px)');
     });
 
-    it('should not mutate element to sticky top if transfer needed', () => {
+    it('should add needed padding to sticky top if transferring', () => {
       const fe = fixedLayer.elements_[4];
       fixedLayer.transfer_ = true;
       fe.element.style.top = '';
@@ -786,7 +771,21 @@ describe('FixedLayer', () => {
       });
 
       expect(fe.stickyNow).to.be.true;
-      expect(fe.element.style.top).to.equal('');
+      expect(fe.element.style.top).to.equal('17px');
+    });
+
+    it('should not add unneeded padding to sticky top if transferring', () => {
+      const fe = fixedLayer.elements_[4];
+      fixedLayer.transfer_ = true;
+      fixedLayer.paddingTop_ = 0;
+      fe.element.style.top = '';
+      fixedLayer.mutateElement_(fe, 1, {
+        sticky: true,
+        top: '17px',
+      });
+
+      expect(fe.stickyNow).to.be.true;
+      expect(fe.element.style.top).to.equal('calc(17px - 11px)');
     });
 
     it('should mutate element to sticky with top', () => {


### PR DESCRIPTION
This uses a new approach to calculate if a fixed-position (or sticky-position) element is `top: auto` by mutating the `bottom` to a (very large) value. This should detect autos in any circumstance, fixing any false positives that were caught (causing bad transfers that are later removed). This is the root cause behind https://github.com/ampproject/amphtml/issues/10343 and https://github.com/ampproject/amphtml/issues/10413.

Fixes https://github.com/ampproject/amphtml/issues/10343
Fixes https://github.com/ampproject/amphtml/issues/10413.

Note that #10343 will still require an explicit `top: 0px` to transfer without flickering.