### PR TITLE
AdSense/Doubleclick Fast Fetch: Fix random experiment selection

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -80,10 +80,7 @@ export function adsenseIsA4AEnabled(win, element) {
     const experimentInfoMap = {};
     experimentInfoMap[ADSENSE_A4A_EXPERIMENT_NAME] = {
       isTrafficEligible: () => true,
-      branches: {
-        control: '2092615',
-        experiment: ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL,
-      },
+      branches: ['2092615', ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
     };
     // Note: Because the same experimentName is being used everywhere here,
     // randomlySelectUnsetExperiments won't add new IDs if

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -105,7 +105,7 @@ export function doubleclickIsA4AEnabled(win, element) {
     const experimentInfoMap = {};
     experimentInfoMap[DOUBLECLICK_A4A_EXPERIMENT_NAME] = {
       isTrafficEligible: () => true,
-      branches: ['2092613',  DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
+      branches: ['2092613', DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
     };
     // Note: Because the same experimentName is being used everywhere here,
     // randomlySelectUnsetExperiments won't add new IDs if

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -105,10 +105,7 @@ export function doubleclickIsA4AEnabled(win, element) {
     const experimentInfoMap = {};
     experimentInfoMap[DOUBLECLICK_A4A_EXPERIMENT_NAME] = {
       isTrafficEligible: () => true,
-      branches: {
-        control: '2092613',
-        experiment: DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL,
-      },
+      branches: ['2092613',  DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
     };
     // Note: Because the same experimentName is being used everywhere here,
     // randomlySelectUnsetExperiments won't add new IDs if


### PR DESCRIPTION
Fix type error (not sure why it was not enforced via check-types) causing client-side diverted experiment selection within AdSense/Doubleclick A4A configs to work improperly.