### PR TITLE
Add type annotations to randomlySelectUnsetExperiments() input

### DIFF
--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -44,9 +44,9 @@ import {
  * @const {!Object<string,!../../../src/experiments.ExperimentInfo>}
  */
 export const PROFILING_BRANCHES = {
-  a4aProfilingRate: {
-    isTrafficEligible: () => true,
-    branches: ['unused', 'unused'],
+  'a4aProfilingRate': {
+    'isTrafficEligible': () => true,
+    'branches': ['unused', 'unused'],
   },
 };
 

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -28,6 +28,7 @@ import {
   EXPERIMENT_ATTRIBUTE,
 } from './utils';
 import {
+  ExperimentInfo,
   isExperimentOn,
   forceExperimentBranch,
   getExperimentBranch,
@@ -90,7 +91,8 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
       opt_sfgInternalBranches ? opt_sfgInternalBranches.experiment : null,
       MANUAL_EXPERIMENT_ID);
   if (!isSetFromUrl) {
-    const experimentInfoMap = {};
+    const experimentInfoMap =
+        /** @type {!Object<string, !ExperimentInfo>} */ ({});
     const branches = [
       internalBranches.control,
       internalBranches.experiment,

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -28,7 +28,7 @@ import {
   EXPERIMENT_ATTRIBUTE,
 } from './utils';
 import {
-  ExperimentInfo,
+  /* eslint no-unused-vars: 0 */ ExperimentInfo,
   isExperimentOn,
   forceExperimentBranch,
   getExperimentBranch,

--- a/ads/google/adsense-amp-auto-ads.js
+++ b/ads/google/adsense-amp-auto-ads.js
@@ -16,6 +16,7 @@
 
 
 import {
+  ExperimentInfo,
   randomlySelectUnsetExperiments,
   getExperimentBranch,
 } from '../../src/experiments';
@@ -53,7 +54,7 @@ const ADSENSE_AMP_AUTO_ADS_EXPERIMENT_INFO = {
  * @return {?string}
  */
 export function getAdSenseAmpAutoAdsExpBranch(win) {
-  const experiments = {};
+  const experiments = /** @type {!Object<string, !ExperimentInfo>} */ ({});
   experiments[ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME] =
       ADSENSE_AMP_AUTO_ADS_EXPERIMENT_INFO;
   randomlySelectUnsetExperiments(win, experiments);

--- a/ads/google/adsense-amp-auto-ads.js
+++ b/ads/google/adsense-amp-auto-ads.js
@@ -16,7 +16,7 @@
 
 
 import {
-  ExperimentInfo,
+  /* eslint no-unused-vars: 0 */ ExperimentInfo,
   randomlySelectUnsetExperiments,
   getExperimentBranch,
 } from '../../src/experiments';

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -27,7 +27,7 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 import {isGoogleAdsA4AValidEnvironment} from '../../../ads/google/a4a/utils';
 import {
-  ExperimentInfo,
+  /* eslint no-unused-vars: 0 */ ExperimentInfo,
   getExperimentBranch,
   forceExperimentBranch,
   randomlySelectUnsetExperiments,

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -27,6 +27,7 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 import {isGoogleAdsA4AValidEnvironment} from '../../../ads/google/a4a/utils';
 import {
+  ExperimentInfo,
   getExperimentBranch,
   forceExperimentBranch,
   randomlySelectUnsetExperiments,
@@ -77,7 +78,8 @@ export function adsenseIsA4AEnabled(win, element) {
         TAG, `url experiment selection ${urlExperimentId}: ${experimentId}.`);
   } else {
     // Not set via url so randomly set.
-    const experimentInfoMap = {};
+    const experimentInfoMap =
+        /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[ADSENSE_A4A_EXPERIMENT_NAME] = {
       isTrafficEligible: () => true,
       branches: ['2092615', ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -27,6 +27,7 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 import {isGoogleAdsA4AValidEnvironment} from '../../../ads/google/a4a/utils';
 import {
+  ExperimentInfo,
   getExperimentBranch,
   forceExperimentBranch,
   randomlySelectUnsetExperiments,
@@ -102,7 +103,8 @@ export function doubleclickIsA4AEnabled(win, element) {
         TAG, `url experiment selection ${urlExperimentId}: ${experimentId}.`);
   } else {
     // Not set via url so randomly set.
-    const experimentInfoMap = {};
+    const experimentInfoMap =
+        /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[DOUBLECLICK_A4A_EXPERIMENT_NAME] = {
       isTrafficEligible: () => true,
       branches: ['2092613', DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -27,7 +27,7 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 import {isGoogleAdsA4AValidEnvironment} from '../../../ads/google/a4a/utils';
 import {
-  ExperimentInfo,
+  /* eslint no-unused-vars: 0 */ ExperimentInfo,
   getExperimentBranch,
   forceExperimentBranch,
   randomlySelectUnsetExperiments,


### PR DESCRIPTION
Fixes #10580.

Verified that this would've caught the type error with a message like:

> found   : {branches: {control: string, experiment: DOUBLECLICK_EXPERIMENT_FEATURE$$module$extensions$amp_ad_network_doubleclick_impl$0_1$doubleclick_a4a_config<string>}, isTrafficEligible: function (): ?}
required: {branches: Array<string>, isTrafficEligible: function (Window): boolean}
    experimentInfoMap[DOUBLECLICK_A4A_EXPERIMENT_NAME] = {
    ^

/to @keithwrightbos @bradfrizzell 