### PR TITLE
Add "What's allowed in AMP" video to spec page

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -22,7 +22,9 @@ AMP HTML is a subset of HTML for authoring content pages such as news articles i
 
 Being a subset of HTML, it puts some restrictions on the full set of tags and functionality available through HTML but it does not require the development of new rendering engines: existing user agents can render AMP HTML just like all other HTML.
 
-{{ youtube('Gv8A4CktajQ', 480, 270, caption='This video gives an overview of the limitations of AMP.') }}
+{% call callout('Watch', type='read') %}
+If you're primarily interested in what's allowed in AMP and what isn't, watch our [primer video on AMP's limitations](https://www.youtube.com/watch?v=Gv8A4CktajQ). 
+{% endcall %}
 
 Also, AMP HTML documents can be uploaded to a web server and served just like any other HTML document; no special configuration for the server is necessary. However, they are also designed to be optionally served through specialized AMP serving systems that proxy AMP documents. These documents serve them from their own origin and are allowed to apply transformations to the document that provide additional performance benefits. An incomplete list of optimizations such a serving system might do is:
 

--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -22,6 +22,8 @@ AMP HTML is a subset of HTML for authoring content pages such as news articles i
 
 Being a subset of HTML, it puts some restrictions on the full set of tags and functionality available through HTML but it does not require the development of new rendering engines: existing user agents can render AMP HTML just like all other HTML.
 
+{{ youtube('Gv8A4CktajQ', 480, 270, caption='This video gives an overview of the limitations of AMP.') }}
+
 Also, AMP HTML documents can be uploaded to a web server and served just like any other HTML document; no special configuration for the server is necessary. However, they are also designed to be optionally served through specialized AMP serving systems that proxy AMP documents. These documents serve them from their own origin and are allowed to apply transformations to the document that provide additional performance benefits. An incomplete list of optimizations such a serving system might do is:
 
 - Replace image references with images sized to the viewer’s viewport.

--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -306,9 +306,9 @@ Example:
 
 Font providers can be whitelisted if they support CSS-only integrations and serve over HTTPS. The following origins are currently allowed for font serving via link tags:
 
-- Fonts.com: https://fast.fonts.net
-- Google Fonts: https://fonts.googleapis.com
-- Font Awesome: https://maxcdn.bootstrapcdn.com
+- Fonts.com: `https://fast.fonts.net`
+- Google Fonts: `https://fonts.googleapis.com`
+- Font Awesome: `https://maxcdn.bootstrapcdn.com`
 
 IMPLEMENTERS NOTE: Adding to this list requires a change to the AMP Cache CSP rule.
 


### PR DESCRIPTION
The spec page is highly trafficked due to mostly people wanting to know what's allowed and what isn't in AMP. This PR embeds the latest Amplify video, which gives an overview over exactly that: https://www.youtube.com/watch?v=Gv8A4CktajQ