### PR TITLE
Prevent false resizing in a long document

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -49,6 +49,7 @@ const POST_TASK_PASS_DELAY_ = 1000;
 const MUTATE_DEFER_DELAY_ = 500;
 const FOCUS_HISTORY_TIMEOUT_ = 1000 * 60;  // 1min
 const FOUR_FRAME_DELAY_ = 70;
+const DOC_BOTTOM_OFFSET_LIMIT_ = 1000;
 
 
 /**
@@ -1096,7 +1097,8 @@ export class Resources {
     const scrollHeight = this.viewport_.getScrollHeight();
     const topOffset = viewportRect.height / 10;
     const bottomOffset = viewportRect.height / 10;
-    const docBottomOffset = scrollHeight * 0.85;
+    const maxDocBottomOffset = scrollHeight - DOC_BOTTOM_OFFSET_LIMIT_;
+    const docBottomOffset = Math.max(scrollHeight * 0.85, maxDocBottomOffset);
     const isScrollingStopped = (Math.abs(this.lastVelocity_) < 1e-2 &&
         now - this.lastScrollTime_ > MUTATE_DEFER_DELAY_ ||
         now - this.lastScrollTime_ > MUTATE_DEFER_DELAY_ * 2);

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -2249,6 +2249,47 @@ describe('Resources changeSize', () => {
       expect(overflowCallbackSpy).to.not.been.called;
     });
 
+    it('in viewport should change size if in the last 15% and ' +
+        'in the last 1000px', () => {
+      viewportRect.top = 9600;
+      viewportRect.bottom = 9800;
+      resource1.layoutBox_ = {top: 9650, left: 0, right: 100, bottom: 9700,
+        height: 50};
+      resources.scheduleChangeSize_(resource1, 111, 222,
+          {top: 1, right: 2, bottom: 3, left: 4}, false);
+
+      expect(vsyncSpy).to.be.calledOnce;
+      const marginsTask = vsyncSpy.lastCall.args[0];
+      marginsTask.measure({});
+
+      resources.mutateWork_();
+      expect(resources.requestsChangeSize_).to.be.empty;
+      expect(resource1.changeSize).to.be.calledOnce;
+      expect(overflowCallbackSpy).to.be.calledOnce;
+      expect(overflowCallbackSpy.firstCall.args[0]).to.equal(false);
+    });
+
+    it('in viewport should NOT change size if in the last 15% but NOT ' +
+        'in the last 1000px', () => {
+      viewportRect.top = 8600;
+      viewportRect.bottom = 8800;
+      resource1.layoutBox_ = {top: 8650, left: 0, right: 100, bottom: 8700,
+        height: 50};
+      resources.scheduleChangeSize_(resource1, 111, 222,
+          {top: 1, right: 2, bottom: 3, left: 4}, false);
+
+      expect(vsyncSpy).to.be.calledOnce;
+      const marginsTask = vsyncSpy.lastCall.args[0];
+      marginsTask.measure({});
+
+      resources.mutateWork_();
+      expect(resources.requestsChangeSize_).to.be.empty;
+      expect(resource1.changeSize).to.not.been.called;
+      expect(overflowCallbackSpy).to.be.calledOnce;
+      expect(overflowCallbackSpy).to.be.calledWith(true, 111, 222,
+          {top: 1, right: 2, bottom: 3, left: 4});
+    });
+
     it('in viewport should NOT change size and calls overflowCallback', () => {
       resources.scheduleChangeSize_(resource1, 111, 222,
           {top: 1, right: 2, bottom: 3, left: 4}, false);


### PR DESCRIPTION
- Limit resizing in the last 15% to 1000px.
- Add test for last 1000px.
- Add test for last 15% but not last 1000px.

Fixes #9565