### PR TITLE
Stop stubbing fetch and fetchJson in A4A tests

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -62,7 +62,7 @@ import {A4AVariableSource} from './a4a-variable-source';
 import {getTimingDataAsync} from '../../../src/service/variable-source';
 import {getContextMetadata} from '../../../src/iframe-attributes';
 
-// Uncomment the next two lines when testing locally
+// Uncomment the next two lines when testing locally.
 // import '../../amp-ad/0.1/amp-ad-ui';
 // import '../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -62,6 +62,10 @@ import {A4AVariableSource} from './a4a-variable-source';
 import {getTimingDataAsync} from '../../../src/service/variable-source';
 import {getContextMetadata} from '../../../src/iframe-attributes';
 
+// Uncomment the next two lines when testing locally
+// import '../../amp-ad/0.1/amp-ad-ui';
+// import '../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
+
 /** @type {string} */
 const METADATA_STRING = '<script type="application/json" amp-ad-metadata>';
 

--- a/extensions/amp-a4a/0.1/test/fetch-mock.js
+++ b/extensions/amp-a4a/0.1/test/fetch-mock.js
@@ -52,7 +52,7 @@ export class FetchMock {
   /**
    * Unstubs the window object and restores the real `window.fetch`.
    */
-  restoreFetch() {
+  restore() {
     this.win_.fetch = this.realFetch_;
     this.routes_ = {};
   }
@@ -109,8 +109,8 @@ export class FetchMock {
     }
     route.called = true;
     return Promise.resolve(
-        typeof route.response == 'function' ? route.response() :
-                                                  route.response)
+        typeof route.response == 'function' ?
+            route.response() : route.response)
         .then(data => {
           if (data === null || typeof data == 'string') {
             return new Response(data);

--- a/extensions/amp-a4a/0.1/test/fetch-mock.js
+++ b/extensions/amp-a4a/0.1/test/fetch-mock.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @typedef {(?string|{
+ *     body: ?string,
+ *     status: (number|undefined),
+ *     headers: (!Object<string, string>|undefined),
+ * })}
+ */
+export let MockResponseData;
+
+/** @typedef {(!MockResponseData|!Promise<!MockResponseData>)} */
+export let MockResponseTiming;
+
+/** @typedef {(!MockResponseTiming|function(): !MockResponseTiming)} */
+export let MockResponse;
+
+export class FetchMock {
+
+  /** @param {!Window} win */
+  constructor(win) {
+    /** @private {!Window} */
+    this.win_ = win;
+    /** @private {function(!RequestInfo, !RequestInit=): !Promise<!Response>} */
+    this.realFetch_ = win.fetch;
+    /** @private {!Object<string, {response: !MockResponse, called: boolean}>} */
+    this.routes_ = {};
+    /** @private {!Object<string, {response: !MockResponse, called: boolean}>} */
+    this.names_ = {};
+
+    win.fetch = (input, init = undefined) => this.fetch_(input, init);
+  }
+
+  restore() {
+    this.win_.fetch = this.realFetch_;
+    this.routes_ = {};
+  }
+
+  /**
+   * @param {string} url
+   * @param {!MockResponse} response
+   * @param {{name: string}=} options
+   */
+  getOnce(url, response, options) {
+    if (url in this.routes_) {
+      throw new Error('route already defined for ' + url);
+    }
+    this.routes_[url] = {response, called: false};
+    if (options) {
+      this.names_[options.name] = this.routes_[url];
+    }
+  }
+
+  /**
+   * @param {string} name
+   * @return {boolean}
+   */
+  called(name) {
+    if (!(name in this.names_)) {
+      throw new Error('no route named ' + name);
+    }
+    return this.names_[name].called;
+  }
+
+  /**
+   * @param {!RequestInfo} input
+   * @param {(!RequestInit|undefined)} init
+   * @return {!Promise<!Response>}
+   */
+  fetch_(input, init) {
+    const url = new Request(input, init).url;
+    const route = this.routes_[url];
+    if (!route) {
+      throw new Error('no route defined for ' + url);
+    }
+    if (route.called) {
+      throw new Error('route called twice for ' + url);
+    }
+    route.called = true;
+    return Promise.resolve(
+        typeof route.response == 'function' ? route.response() :
+                                                  route.response)
+        .then(data => {
+          if (data === null || typeof data == 'string') {
+            return new Response(data);
+          } else {
+            const {body, status, headers} = data;
+            return new Response(body, {status, headers});
+          }
+        });
+  }
+}
+
+/**
+ * Returns an error representing a network failure. To simulate such a failure,
+ * use the return value from this function as the rejection value of a promise
+ * and use that promise as the `response` in an item of `entries` passed to
+ * `FetchMock.prototype.use`.
+ *
+ * @return {!Error}
+ */
+export function networkFailure() {
+  return new TypeError('Failed to fetch');
+}

--- a/extensions/amp-a4a/0.1/test/fetch-mock.js
+++ b/extensions/amp-a4a/0.1/test/fetch-mock.js
@@ -50,9 +50,9 @@ export class FetchMock {
   }
 
   /**
-   * Unstubs the window object and restore the real `window.fetch`.
+   * Unstubs the window object and restores the real `window.fetch`.
    */
-  restore() {
+  restoreFetch() {
     this.win_.fetch = this.realFetch_;
     this.routes_ = {};
   }

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -115,7 +115,7 @@ describe('integration test: a4a', () => {
   });
 
   afterEach(() => {
-    fetchMock.restoreFetch();
+    fetchMock./*OK*/restore();
     sandbox.restore();
     resetScheduledElementForTesting(window, 'amp-a4a');
     delete adConfig['mock'];

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -115,7 +115,7 @@ describe('integration test: a4a', () => {
   });
 
   afterEach(() => {
-    fetchMock.restore();
+    fetchMock.restoreFetch();
     sandbox.restore();
     resetScheduledElementForTesting(window, 'amp-a4a');
     delete adConfig['mock'];

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -15,15 +15,14 @@
  */
 
 import {AMP_SIGNATURE_HEADER} from '../amp-a4a';
+import {FetchMock, networkFailure} from './fetch-mock';
 import {MockA4AImpl, TEST_URL} from './utils';
-import {Xhr} from '../../../../src/service/xhr-impl';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
     data as validCSSAmp,
 } from './testdata/valid_css_at_rules_amp.reserialized';
 import {installCryptoService} from '../../../../src/service/crypto-impl';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
-import {FetchResponseHeaders} from '../../../../src/service/xhr-impl';
 import {adConfig} from '../../../../ads/_config';
 import {a4aRegistry} from '../../../../ads/_a4a-config';
 import {signingServerURLs} from '../../../../ads/_a4a-config';
@@ -31,7 +30,6 @@ import {
     resetScheduledElementForTesting,
     upgradeOrRegisterElement,
 } from '../../../../src/custom-element';
-import {utf8Encode} from '../../../../src/utils/bytes';
 import '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import {loadPromise} from '../../../../src/event-helper';
 import * as sinon from 'sinon';
@@ -81,51 +79,30 @@ function expectRenderedInXDomainIframe(element, src) {
 
 describe('integration test: a4a', () => {
   let sandbox;
-  let xhrMock;
   let fixture;
-  let mockResponse;
+  let fetchMock;
+  let adResponse;
   let a4aElement;
-  let headers;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    xhrMock = sandbox.stub(Xhr.prototype, 'fetch');
-    // Expect key set fetches for signing services.
-    const fetchJsonMock = sandbox.stub(Xhr.prototype, 'fetchJson');
-    for (const serviceName in signingServerURLs) {
-      fetchJsonMock.withArgs(signingServerURLs[serviceName],
-          {
-            mode: 'cors',
-            method: 'GET',
-            ampCors: false,
-            credentials: 'omit',
-          }).returns(Promise.resolve({
-            json() {
-              return Promise.resolve(
-                  {keys: [JSON.parse(validCSSAmp.publicKey)]});
-            },
-          }));
-    }
-    // Expect ad request.
-    headers = {};
-    headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
-    mockResponse = {
-      arrayBuffer: () => utf8Encode(validCSSAmp.reserialized),
-      bodyUsed: false,
-      headers: new FetchResponseHeaders({
-        getResponseHeader(name) {
-          return headers[name];
-        },
-      }),
-    };
-    xhrMock.withArgs(TEST_URL, {
-      mode: 'cors',
-      method: 'GET',
-      credentials: 'include',
-    }).onFirstCall().returns(Promise.resolve(mockResponse));
     adConfig['mock'] = {};
     a4aRegistry['mock'] = () => {return true;};
     return createIframePromise().then(f => {
       fixture = f;
+      fetchMock = new FetchMock(fixture.win);
+      for (const serviceName in signingServerURLs) {
+        fetchMock.getOnce(
+            signingServerURLs[serviceName],
+            `{"keys":[${validCSSAmp.publicKey}]}`);
+      }
+      fetchMock.getOnce(
+          TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+          {name: 'ad'});
+      adResponse = {
+        headers: {'AMP-Access-Control-Allow-Source-Origin': 'about:srcdoc'},
+        body: validCSSAmp.reserialized,
+      };
+      adResponse.headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
       installDocService(fixture.win, /* isSingleDoc */ true);
       installCryptoService(fixture.win);
       upgradeOrRegisterElement(fixture.win, 'amp-a4a', MockA4AImpl);
@@ -138,6 +115,7 @@ describe('integration test: a4a', () => {
   });
 
   afterEach(() => {
+    fetchMock.restore();
     sandbox.restore();
     resetScheduledElementForTesting(window, 'amp-a4a');
     delete adConfig['mock'];
@@ -151,7 +129,7 @@ describe('integration test: a4a', () => {
   });
 
   it('should fall back to 3p when no signature is present', () => {
-    delete headers[AMP_SIGNATURE_HEADER];
+    delete adResponse.headers[AMP_SIGNATURE_HEADER];
     return fixture.addElement(a4aElement).then(unusedElement => {
       expectRenderedInXDomainIframe(a4aElement, TEST_URL);
     });
@@ -160,14 +138,13 @@ describe('integration test: a4a', () => {
   it('should not send request if display none', () => {
     a4aElement.style.display = 'none';
     return fixture.addElement(a4aElement).then(element => {
-      expect(xhrMock).to.not.be.called;
+      expect(fetchMock.called('ad')).to.be.false;
       expect(element.querySelector('iframe')).to.not.be.ok;
     });
   });
 
   it('should fall back to 3p when the XHR fails', () => {
-    xhrMock.resetBehavior();
-    xhrMock.throws(new Error('Testing network error'));
+    adResponse = Promise.reject(networkFailure());
     // TODO(tdrl) Currently layoutCallback rejects, even though something *is*
     // rendered.  This should be fixed in a refactor, and we should change this
     // .catch to a .then.
@@ -181,96 +158,9 @@ describe('integration test: a4a', () => {
     });
   });
 
-  it('should fall back to 3p when extractCreative returns empty sig', () => {
-    const extractCreativeAndSignatureStub =
-        sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature');
-    extractCreativeAndSignatureStub.onFirstCall().returns({
-      creative: utf8Encode(validCSSAmp.reserialized),
-      signature: null,
-      size: null,
-    });
-    return fixture.addElement(a4aElement).then(unusedElement => {
-      expect(extractCreativeAndSignatureStub).to.be.calledOnce;
-      expectRenderedInXDomainIframe(a4aElement, TEST_URL);
-    });
-  });
-
-  it('should fall back to 3p when extractCreative returns empty creative',
-      () => {
-        sandbox.stub(MockA4AImpl.prototype, 'extractCreativeAndSignature')
-            .onFirstCall().returns({
-              creative: null,
-              signature: validCSSAmp.signature,
-              size: null,
-            })
-            .onSecondCall().throws(new Error(
-            'Testing extractCreativeAndSignature should not occur error'));
-        // TODO(tdrl) Currently layoutCallback rejects, even though something
-        // *is* rendered.  This should be fixed in a refactor, and we should
-        // change this .catch to a .then.
-        return fixture.addElement(a4aElement).catch(error => {
-          expect(error.message).to.contain.string('Key failed to validate');
-          expect(error.message).to.contain.string('amp-a4a:');
-          expectRenderedInXDomainIframe(a4aElement, TEST_URL);
-        });
-      });
-
   it('should collapse slot when creative response has code 204', () => {
-    headers = {};
-    headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
-    mockResponse = {
-      arrayBuffer: () => utf8Encode(validCSSAmp.reserialized),
-      bodyUsed: false,
-      headers: new FetchResponseHeaders({
-        getResponseHeader(name) {
-          return headers[name];
-        },
-      }),
-      status: 204,
-    };
-    xhrMock.withArgs(TEST_URL, {
-      mode: 'cors',
-      method: 'GET',
-      credentials: 'include',
-    }).onFirstCall().returns(Promise.resolve(mockResponse));
-    const forceCollapseStub =
-        sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
-    return fixture.addElement(a4aElement).then(() => {
-      expect(forceCollapseStub).to.be.calledOnce;
-    });
-  });
-
-  it('should NOT collapse slot when creative response is null', () => {
-    xhrMock.withArgs(TEST_URL, {
-      mode: 'cors',
-      method: 'GET',
-      credentials: 'include',
-    }).onFirstCall().returns(Promise.resolve(null));
-    const forceCollapseStub =
-        sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
-    return fixture.addElement(a4aElement).then(unusedElement => {
-      expect(forceCollapseStub).to.be.notCalled;
-    });
-  });
-
-  it('should collapse slot when creative response.arrayBuffer is null', () => {
-    headers = {};
-    headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
-    mockResponse = {
-      arrayBuffer: () => null,
-      bodyUsed: false,
-      headers: new FetchResponseHeaders({
-        getResponseHeader(name) {
-          return headers[name];
-        },
-      }),
-      status: 204,
-    };
-    xhrMock.withArgs(TEST_URL, {
-      mode: 'cors',
-      method: 'GET',
-      credentials: 'include',
-    }).onFirstCall().returns(Promise.resolve(mockResponse));
+    adResponse.status = 204;
+    adResponse.body = null;
     const forceCollapseStub =
         sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
     return fixture.addElement(a4aElement).then(() => {
@@ -280,23 +170,7 @@ describe('integration test: a4a', () => {
 
   it('should collapse slot when creative response.arrayBuffer() is empty',
       () => {
-        headers = {};
-        headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
-        mockResponse = {
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          bodyUsed: false,
-          headers: new FetchResponseHeaders({
-            getResponseHeader(name) {
-              return headers[name];
-            },
-          }),
-          status: 200,
-        };
-        xhrMock.withArgs(TEST_URL, {
-          mode: 'cors',
-          method: 'GET',
-          credentials: 'include',
-        }).onFirstCall().returns(Promise.resolve(mockResponse));
+        adResponse.body = '';
         const forceCollapseStub =
             sandbox.spy(MockA4AImpl.prototype, 'forceCollapse');
         return fixture.addElement(a4aElement).then(unusedElement => {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {FetchMock, networkFailure} from './fetch-mock';
 import {MockA4AImpl, TEST_URL} from './utils';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
@@ -27,7 +28,6 @@ import {
 } from '../amp-a4a';
 import {FriendlyIframeEmbed} from '../../../../src/friendly-iframe-embed';
 import {Signals} from '../../../../src/utils/signals';
-import {Xhr} from '../../../../src/service/xhr-impl';
 import {Extensions} from '../../../../src/service/extensions-impl';
 import {Viewer} from '../../../../src/service/viewer-impl';
 import {cancellation} from '../../../../src/error';
@@ -35,9 +35,8 @@ import {
   data as validCSSAmp,
 } from './testdata/valid_css_at_rules_amp.reserialized';
 import {data as testFragments} from './testdata/test_fragments';
-import {FetchResponseHeaders} from '../../../../src/service/xhr-impl';
 import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-import {utf8Encode} from '../../../../src/utils/bytes';
+import {utf8EncodeSync} from '../../../../src/utils/bytes';
 import {resetScheduledElementForTesting} from '../../../../src/custom-element';
 import {Services} from '../../../../src/services';
 import {incrementLoadingAds} from '../../../amp-ad/0.1/concurrent-load';
@@ -48,71 +47,58 @@ import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
 import * as sinon from 'sinon';
 
-function setupForAdTesting(fixture) {
-  installDocService(fixture.win, /* isSingleDoc */ true);
-  const doc = fixture.doc;
-  // TODO(a4a-cam@): This is necessary in the short term, until A4A is
-  // smarter about host document styling.  The issue is that it needs to
-  // inherit the AMP runtime style element in order for shadow DOM-enclosed
-  // elements to behave properly.  So we have to set up a minimal one here.
-  const ampStyle = doc.createElement('style');
-  ampStyle.setAttribute('amp-runtime', 'scratch-fortesting');
-  doc.head.appendChild(ampStyle);
-}
-
 describe('amp-a4a', () => {
   let sandbox;
-  let xhrMock;
-  let xhrMockJson;
+  let fetchMock;
   let getSigningServiceNamesMock;
   let viewerWhenVisibleMock;
-  let mockResponse;
+  let adResponse;
   let onCreativeRenderSpy;
-  let headers;
+  let keysetBody;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    xhrMock = sandbox.stub(Xhr.prototype, 'fetch');
-    xhrMockJson = sandbox.stub(Xhr.prototype, 'fetchJson');
+    fetchMock = null;
     getSigningServiceNamesMock = sandbox.stub(AmpA4A.prototype,
         'getSigningServiceNames');
     onCreativeRenderSpy =
         sandbox.spy(AmpA4A.prototype, 'onCreativeRender');
     getSigningServiceNamesMock.returns(['google']);
-    xhrMockJson.withArgs(
-        'https://cdn.ampproject.org/amp-ad-verifying-keyset.json',
-        {
-          mode: 'cors',
-          method: 'GET',
-          ampCors: false,
-          credentials: 'omit',
-        }).returns(Promise.resolve({
-          json() {
-            return Promise.resolve({keys: [JSON.parse(validCSSAmp.publicKey)]});
-          },
-        }));
     viewerWhenVisibleMock = sandbox.stub(Viewer.prototype, 'whenFirstVisible');
     viewerWhenVisibleMock.returns(Promise.resolve());
-    mockResponse = {
-      arrayBuffer() {
-        return utf8Encode(validCSSAmp.reserialized);
-      },
-      bodyUsed: false,
-      headers: new FetchResponseHeaders({
-        getResponseHeader(name) {
-          return headers[name];
-        },
-      }),
-      catch: callback => callback(),
+    adResponse = {
+      headers: {'AMP-Access-Control-Allow-Source-Origin': 'about:srcdoc'},
+      body: validCSSAmp.reserialized,
     };
-    headers = {};
-    headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
+    adResponse.headers[AMP_SIGNATURE_HEADER] = validCSSAmp.signature;
+    keysetBody = `{"keys":[${validCSSAmp.publicKey}]}`;
   });
 
   afterEach(() => {
+    if (fetchMock) {
+      fetchMock.restore();
+      fetchMock = null;
+    }
     sandbox.restore();
     resetScheduledElementForTesting(window, 'amp-a4a');
   });
+
+  function setupForAdTesting(fixture) {
+    expect(fetchMock).to.be.null;
+    fetchMock = new FetchMock(fixture.win);
+    fetchMock.getOnce(
+        'https://cdn.ampproject.org/amp-ad-verifying-keyset.json',
+        () => keysetBody, {name: 'keyset'});
+    installDocService(fixture.win, /* isSingleDoc */ true);
+    const doc = fixture.doc;
+    // TODO(a4a-cam@): This is necessary in the short term, until A4A is
+    // smarter about host document styling.  The issue is that it needs to
+    // inherit the AMP runtime style element in order for shadow DOM-enclosed
+    // elements to behave properly.  So we have to set up a minimal one here.
+    const ampStyle = doc.createElement('style');
+    ampStyle.setAttribute('amp-runtime', 'scratch-fortesting');
+    doc.head.appendChild(ampStyle);
+  }
 
   function createA4aElement(doc, opt_rect) {
     const element = createElementWithAttributes(doc, 'amp-a4a', {
@@ -235,27 +221,23 @@ describe('amp-a4a', () => {
     let a4aElement;
     let a4a;
     let fixture;
-    beforeEach(() => {
-      xhrMock.withArgs(TEST_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(f => {
-        fixture = f;
-        setupForAdTesting(fixture);
-        a4aElement = createA4aElement(fixture.doc);
-        a4a = new MockA4AImpl(a4aElement);
-        a4a.buildCallback();
-        return fixture;
-      });
-    });
+    beforeEach(() => createIframePromise().then(f => {
+      fixture = f;
+      setupForAdTesting(fixture);
+      fetchMock.getOnce(
+          TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+          {name: 'ad'});
+      a4aElement = createA4aElement(fixture.doc);
+      a4a = new MockA4AImpl(a4aElement);
+      a4a.buildCallback();
+      return fixture;
+    }));
 
     it('for SafeFrame rendering case', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[AMP_SIGNATURE_HEADER];
+      delete adResponse.headers[AMP_SIGNATURE_HEADER];
       // If rendering type is safeframe, we SHOULD attach a SafeFrame.
-      headers[RENDERING_TYPE_HEADER] = 'safeframe';
+      adResponse.headers[RENDERING_TYPE_HEADER] = 'safeframe';
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
@@ -271,10 +253,10 @@ describe('amp-a4a', () => {
       sandbox.stub(platform, 'isIos').returns(true);
       a4a = new MockA4AImpl(a4aElement);
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[AMP_SIGNATURE_HEADER];
+      delete adResponse.headers[AMP_SIGNATURE_HEADER];
       // Ensure no rendering type header (ios on safari will default to
       // safeframe).
-      delete headers[RENDERING_TYPE_HEADER];
+      delete adResponse.headers[RENDERING_TYPE_HEADER];
       fixture.doc.body.appendChild(a4aElement);
       a4a.buildCallback();
       a4a.onLayoutMeasure();
@@ -291,7 +273,7 @@ describe('amp-a4a', () => {
 
     it('for cached content iframe rendering case', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[AMP_SIGNATURE_HEADER];
+      delete adResponse.headers[AMP_SIGNATURE_HEADER];
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
@@ -345,7 +327,7 @@ describe('amp-a4a', () => {
 
     it('should reset state to null on non-FIE unlayoutCallback', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[AMP_SIGNATURE_HEADER];
+      delete adResponse.headers[AMP_SIGNATURE_HEADER];
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
@@ -393,20 +375,16 @@ describe('amp-a4a', () => {
     let a4aElement;
     let a4a;
     let fixture;
-    beforeEach(() => {
-      xhrMock.withArgs(TEST_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(f => {
-        fixture = f;
-        setupForAdTesting(fixture);
-        a4aElement = createA4aElement(fixture.doc);
-        a4a = new MockA4AImpl(a4aElement);
-        return fixture;
-      });
-    });
+    beforeEach(() => createIframePromise().then(f => {
+      fixture = f;
+      setupForAdTesting(fixture);
+      fetchMock.getOnce(
+          TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+          {name: 'ad'});
+      a4aElement = createA4aElement(fixture.doc);
+      a4a = new MockA4AImpl(a4aElement);
+      return fixture;
+    }));
 
     it('when unlayoutCallback called after adPromise', () => {
       a4a.buildCallback();
@@ -456,16 +434,14 @@ describe('amp-a4a', () => {
     let a4a;
     beforeEach(() => {
       // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[AMP_SIGNATURE_HEADER];
+      delete adResponse.headers[AMP_SIGNATURE_HEADER];
       // If rendering type is safeframe, we SHOULD attach a SafeFrame.
-      headers[RENDERING_TYPE_HEADER] = 'safeframe';
-      xhrMock.withArgs(TEST_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
+      adResponse.headers[RENDERING_TYPE_HEADER] = 'safeframe';
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         a4aElement = createA4aElement(doc);
         a4a = new MockA4AImpl(a4aElement);
@@ -482,7 +458,7 @@ describe('amp-a4a', () => {
         devErrLogSpy = sandbox.spy(dev(), 'error');
         // If rendering type is unknown, should fall back to cached content
         // iframe and generate an error.
-        headers[RENDERING_TYPE_HEADER] = 'random illegal value';
+        adResponse.headers[RENDERING_TYPE_HEADER] = 'random illegal value';
         a4a.onLayoutMeasure();
       });
 
@@ -493,7 +469,7 @@ describe('amp-a4a', () => {
           expect(devErrLogSpy).to.be.calledOnce;
           expect(devErrLogSpy.getCall(0).args[1]).to.have.string(
               'random illegal value');
-          expect(xhrMock).to.be.calledOnce;
+          expect(fetchMock.called('ad')).to.be.true;
         });
       });
     });
@@ -501,7 +477,7 @@ describe('amp-a4a', () => {
     describe('#renderViaNameFrame', () => {
       beforeEach(() => {
         // If rendering type is nameframe, we SHOULD attach a NameFrame.
-        headers[RENDERING_TYPE_HEADER] = 'nameframe';
+        adResponse.headers[RENDERING_TYPE_HEADER] = 'nameframe';
         a4a.onLayoutMeasure();
       });
 
@@ -511,7 +487,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifyNameFrameRender(a4aElement);
-          expect(xhrMock).to.be.calledOnce;
+          expect(fetchMock.called('ad')).to.be.true;
         });
       });
 
@@ -526,7 +502,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifyNameFrameRender(a4aElement);
-          expect(xhrMock).to.be.calledOnce;
+          expect(fetchMock.called('ad')).to.be.true;
         });
       });
 
@@ -535,10 +511,10 @@ describe('amp-a4a', () => {
             it(`should not attach a NameFrame when header is ${headerVal}`,
                 () => {
                   // Make sure there's no signature, so that we go down the 3p iframe path.
-                  delete headers[AMP_SIGNATURE_HEADER];
+                  delete adResponse.headers[AMP_SIGNATURE_HEADER];
                   // If rendering type is anything but nameframe, we SHOULD NOT
                   // attach a NameFrame.
-                  headers[RENDERING_TYPE_HEADER] = headerVal;
+                  adResponse.headers[RENDERING_TYPE_HEADER] = headerVal;
                   a4a.onLayoutMeasure();
                   return a4a.layoutCallback().then(() => {
                     // Force vsync system to run all queued tasks, so that
@@ -553,7 +529,7 @@ describe('amp-a4a', () => {
                       expect(unsafeChild.getAttribute('src')).to.have.string(
                           TEST_URL);
                     }
-                    expect(xhrMock).to.be.calledOnce;
+                    expect(fetchMock.called('ad')).to.be.true;
                   });
                 });
           });
@@ -562,7 +538,7 @@ describe('amp-a4a', () => {
     describe('#renderViaSafeFrame', () => {
       beforeEach(() => {
         // If rendering type is safeframe, we SHOULD attach a SafeFrame.
-        headers[RENDERING_TYPE_HEADER] = 'safeframe';
+        adResponse.headers[RENDERING_TYPE_HEADER] = 'safeframe';
         a4a.onLayoutMeasure();
       });
 
@@ -572,7 +548,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifySafeFrameRender(a4aElement, DEFAULT_SAFEFRAME_VERSION);
-          expect(xhrMock).to.be.calledOnce;
+          expect(fetchMock.called('ad')).to.be.true;
         });
       });
 
@@ -583,7 +559,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifySafeFrameRender(a4aElement, '1-2-3');
-          expect(xhrMock).to.be.calledOnce;
+          expect(fetchMock.called('ad')).to.be.true;
         });
       });
 
@@ -598,7 +574,7 @@ describe('amp-a4a', () => {
           // are actually completed before testing.
           a4a.vsync_.runScheduledTasks_();
           verifySafeFrameRender(a4aElement, DEFAULT_SAFEFRAME_VERSION);
-          expect(xhrMock).to.be.calledOnce;
+          expect(fetchMock.called('ad')).to.be.true;
         });
       });
 
@@ -608,7 +584,7 @@ describe('amp-a4a', () => {
                 () => {
                   // If rendering type is anything but safeframe, we SHOULD NOT attach a
                   // SafeFrame.
-                  headers[RENDERING_TYPE_HEADER] = headerVal;
+                  adResponse.headers[RENDERING_TYPE_HEADER] = headerVal;
                   a4a.onLayoutMeasure();
                   return a4a.layoutCallback().then(() => {
                     // Force vsync system to run all queued tasks, so that
@@ -625,7 +601,7 @@ describe('amp-a4a', () => {
                       expect(unsafeChild.getAttribute('src')).to.have.string(
                           TEST_URL);
                     }
-                    expect(xhrMock).to.be.calledOnce;
+                    expect(fetchMock.called('ad')).to.be.true;
                   });
                 });
           });
@@ -643,7 +619,7 @@ describe('amp-a4a', () => {
           // whether it's necessary or perhaps hazardous.  Feedback welcome.
           a4a.vsync_.runScheduledTasks_();
           expect(a4a.experimentalNonAmpCreativeRenderMethod_).to.be.null;
-          expect(xhrMock).to.be.calledOnce;
+          expect(fetchMock.called('ad')).to.be.true;
         });
       });
     });
@@ -652,26 +628,22 @@ describe('amp-a4a', () => {
   describe('cross-domain vs A4A', () => {
     let a4a;
     let a4aElement;
-    beforeEach(() => {
-      xhrMock.withArgs(TEST_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        const doc = fixture.doc;
-        a4aElement = createA4aElement(doc);
-        a4a = new MockA4AImpl(a4aElement);
-      });
-    });
+    beforeEach(() => createIframePromise().then(fixture => {
+      setupForAdTesting(fixture);
+      fetchMock.getOnce(
+          TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+          {name: 'ad'});
+      const doc = fixture.doc;
+      a4aElement = createA4aElement(doc);
+      a4a = new MockA4AImpl(a4aElement);
+    }));
     afterEach(() => {
-      expect(xhrMock).to.be.calledOnce;
+      expect(fetchMock.called('ad')).to.be.true;
     });
 
     ['nameframe', 'safeframe'].forEach(renderType => {
       it(`should not use ${renderType} if creative is A4A`, () => {
-        headers[RENDERING_TYPE_HEADER] = renderType;
+        adResponse.headers[RENDERING_TYPE_HEADER] = renderType;
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
@@ -684,7 +656,7 @@ describe('amp-a4a', () => {
 
       it(`should not use ${renderType} even if onLayoutMeasure called ` +
           'multiple times', () => {
-        headers[RENDERING_TYPE_HEADER] = renderType;
+        adResponse.headers[RENDERING_TYPE_HEADER] = renderType;
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         a4a.onLayoutMeasure();
@@ -702,38 +674,35 @@ describe('amp-a4a', () => {
         });
       });
     });
+  });
 
-    it('should set height/width on iframe matching header value', () => {
-      // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete headers[AMP_SIGNATURE_HEADER];
-      headers['X-CreativeSize'] = '320x50';
-      xhrMock.withArgs(TEST_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-        requireAmpResponseSourceOrigin: true,
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        const doc = fixture.doc;
-        const a4aElement = createA4aElement(doc);
-        a4aElement.setAttribute('width', 480);
-        a4aElement.setAttribute('height', 75);
-        a4aElement.setAttribute('type', 'doubleclick');
-        const a4a = new MockA4AImpl(a4aElement);
-        doc.body.appendChild(a4aElement);
-        a4a.buildCallback();
-        a4a.onLayoutMeasure();
-        const renderPromise = a4a.layoutCallback();
-        return renderPromise.then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
-          const child = a4aElement.querySelector('iframe[name]');
-          expect(child).to.be.ok;
-          expect(child.getAttribute('width')).to.equal('320');
-          expect(child.getAttribute('height')).to.equal('50');
-        });
+  it('should set height/width on iframe matching header value', () => {
+    // Make sure there's no signature, so that we go down the 3p iframe path.
+    delete adResponse.headers[AMP_SIGNATURE_HEADER];
+    adResponse.headers['X-CreativeSize'] = '320x50';
+    return createIframePromise().then(fixture => {
+      setupForAdTesting(fixture);
+      fetchMock.getOnce(
+          TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+          {name: 'ad'});
+      const doc = fixture.doc;
+      const a4aElement = createA4aElement(doc);
+      a4aElement.setAttribute('width', 480);
+      a4aElement.setAttribute('height', 75);
+      a4aElement.setAttribute('type', 'doubleclick');
+      const a4a = new MockA4AImpl(a4aElement);
+      doc.body.appendChild(a4aElement);
+      a4a.buildCallback();
+      a4a.onLayoutMeasure();
+      const renderPromise = a4a.layoutCallback();
+      return renderPromise.then(() => {
+        // Force vsync system to run all queued tasks, so that DOM mutations
+        // are actually completed before testing.
+        a4a.vsync_.runScheduledTasks_();
+        const child = a4aElement.querySelector('iframe[name]');
+        expect(child).to.be.ok;
+        expect(child.getAttribute('width')).to.equal('320');
+        expect(child.getAttribute('height')).to.equal('50');
       });
     });
   });
@@ -741,10 +710,12 @@ describe('amp-a4a', () => {
   describe('#onLayoutMeasure', () => {
     it('resumeCallback calls onLayoutMeasure', () => {
       // Force non-FIE
-      delete headers[AMP_SIGNATURE_HEADER];
-      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
+      delete adResponse.headers[AMP_SIGNATURE_HEADER];
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const s = doc.createElement('style');
@@ -770,9 +741,11 @@ describe('amp-a4a', () => {
       });
     });
     it('resumeCallback does not call onLayoutMeasure for FIE', () => {
-      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const s = doc.createElement('style');
@@ -796,10 +769,12 @@ describe('amp-a4a', () => {
     });
     it('resumeCallback w/ measure required no onLayoutMeasure', () => {
       // Force non-FIE
-      delete headers[AMP_SIGNATURE_HEADER];
-      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
+      delete adResponse.headers[AMP_SIGNATURE_HEADER];
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const s = doc.createElement('style');
@@ -825,13 +800,11 @@ describe('amp-a4a', () => {
       });
     });
     it('should run end-to-end and render in friendly iframe', () => {
-      xhrMock.withArgs(TEST_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
@@ -851,8 +824,7 @@ describe('amp-a4a', () => {
           expect(a4a.isVerifiedAmpCreative_).to.be.true;
           expect(getAdUrlSpy.calledOnce, 'getAdUrl called exactly once')
               .to.be.true;
-          expect(xhrMock.calledOnce,
-              'xhr.fetchTextAndHeaders called exactly once').to.be.true;
+          expect(fetchMock.called('ad')).to.be.true;
           expect(extractCreativeAndSignatureSpy.calledOnce,
               'extractCreativeAndSignatureSpy called exactly once').to.be.true;
           expect(loadExtensionSpy.withArgs('amp-font')).to.be.calledOnce;
@@ -892,9 +864,11 @@ describe('amp-a4a', () => {
       });
     });
     it('must not be position:fixed', () => {
-      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const s = doc.createElement('style');
@@ -907,9 +881,11 @@ describe('amp-a4a', () => {
       });
     });
     it('does not initialize promise chain 0 height/width', () => {
-      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const rect = layoutRectLtwh(0, 0, 200, 0);
         const a4aElement = createA4aElement(doc, rect);
@@ -929,13 +905,11 @@ describe('amp-a4a', () => {
       });
     });
     function executeLayoutCallbackTest(isValidCreative, opt_failAmpRender) {
-      xhrMock.withArgs(TEST_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
@@ -943,7 +917,7 @@ describe('amp-a4a', () => {
         const updatePriorityStub = sandbox.stub(a4a, 'updatePriority');
         if (!isValidCreative) {
           sandbox.stub(a4a, 'extractCreativeAndSignature').returns(
-              Promise.resolve({creative: mockResponse.arrayBuffer()}));
+              Promise.resolve({creative: utf8EncodeSync(adResponse.body)}));
         }
         if (opt_failAmpRender) {
           sandbox.stub(a4a, 'renderAmpCreative_').returns(
@@ -955,8 +929,7 @@ describe('amp-a4a', () => {
         return a4a.adPromise_.then(promiseResult => {
           expect(getAdUrlSpy.calledOnce, 'getAdUrl called exactly once')
               .to.be.true;
-          expect(xhrMock.calledOnce,
-              'xhr.fetchTextAndHeaders called exactly once').to.be.true;
+          expect(fetchMock.called('ad')).to.be.true;
           expect(a4a.isVerifiedAmpCreative_).to.equal(isValidCreative);
           if (isValidCreative) {
             expect(promiseResult).to.be.ok;
@@ -997,17 +970,9 @@ describe('amp-a4a', () => {
       return executeLayoutCallbackTest(true, true);
     });
     it('should not leak full response to rendered dom', () => {
-      xhrMock.withArgs(TEST_URL, {
-        mode: 'cors',
-        method: 'GET',
-        credentials: 'include',
-      }).onFirstCall().returns(Promise.resolve(mockResponse));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
-        const doc = fixture.doc;
-        const a4aElement = createA4aElement(doc);
-        const a4a = new MockA4AImpl(a4aElement);
-        const fullResponse = `<html amp>
+        adResponse.body = `<html amp>
             <body>
             <div class="forTest"></div>
             <script class="hostile">
@@ -1023,19 +988,20 @@ describe('amp-a4a', () => {
             }
             </script>
             </body></html>`;
-        mockResponse.arrayBuffer = () => {
-          return utf8Encode(fullResponse);
-        };
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
+        const doc = fixture.doc;
+        const a4aElement = createA4aElement(doc);
+        const a4a = new MockA4AImpl(a4aElement);
         // Return value from `#extractCreativeAndSignature` is a sub-doc of
         // the full response.  To validate this test, comment out the following
         // statement and verify that test fails, with full response spliced in
         // to shadow doc.
-        sandbox.stub(a4a, 'extractCreativeAndSignature').returns(
-            utf8Encode(validCSSAmp.reserialized).then(c => {
-              return {
-                creative: c,
-                signature: base64UrlDecodeToBytes(validCSSAmp.signature),
-              };
+        sandbox.stub(a4a, 'extractCreativeAndSignature')
+            .returns(Promise.resolve({
+              creative: utf8EncodeSync(validCSSAmp.reserialized),
+              signature: base64UrlDecodeToBytes(validCSSAmp.signature),
             }));
         a4a.buildCallback();
         a4a.onLayoutMeasure();
@@ -1056,9 +1022,11 @@ describe('amp-a4a', () => {
       });
     });
     it('should run end-to-end in the presence of an XHR error', () => {
-      xhrMock.onFirstCall().returns(Promise.reject(new Error('XHR Error')));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc',
+            Promise.reject(networkFailure()), {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
@@ -1082,9 +1050,11 @@ describe('amp-a4a', () => {
       });
     });
     it('should handle XHR error when resolves before layoutCallback', () => {
-      xhrMock.onFirstCall().returns(Promise.reject(new Error('XHR Error')));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc',
+            Promise.reject(networkFailure()), {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
@@ -1101,19 +1071,22 @@ describe('amp-a4a', () => {
       });
     });
     it('should handle XHR error when resolves after layoutCallback', () => {
-      let rejectXhr;
-      xhrMock.onFirstCall().returns(new Promise((unusedResolve, reject) => {
-        rejectXhr = reject;
-      }));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        let rejectXhr;
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc',
+            new Promise((unusedResolve, reject) => {
+              rejectXhr = reject;
+            }),
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         const layoutCallbackPromise = a4a.layoutCallback();
-        rejectXhr(new Error('XHR Error'));
+        rejectXhr(networkFailure());
         return layoutCallbackPromise.then(() => {
           // Verify iframe presence and lack of visibility hidden
           expect(a4aElement.querySelectorAll('iframe').length).to.equal(1);
@@ -1125,21 +1098,13 @@ describe('amp-a4a', () => {
       });
     });
     it('should collapse for 204 response code', () => {
-      xhrMock.onFirstCall().returns(Promise.resolve({
-        arrayBuffer() {
-          return utf8Encode(validCSSAmp.reserialized);
-        },
-        bodyUsed: false,
-        headers: new FetchResponseHeaders({
-          getResponseHeader(name) {
-            return headers[name];
-          },
-        }),
-        catch: callback => callback(),
-        status: 204,
-      }));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        adResponse.status = 204;
+        adResponse.body = null;
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
@@ -1182,20 +1147,12 @@ describe('amp-a4a', () => {
       });
     });
     it('should collapse for empty array buffer', () => {
-      xhrMock.onFirstCall().returns(Promise.resolve({
-        arrayBuffer() {
-          return utf8Encode('');
-        },
-        bodyUsed: false,
-        headers: new FetchResponseHeaders({
-          getResponseHeader(name) {
-            return headers[name];
-          },
-        }),
-        catch: callback => callback(),
-      }));
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        adResponse.body = '';
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
@@ -1236,19 +1193,21 @@ describe('amp-a4a', () => {
       });
 
       it('should process safeframe version header properly', () => {
-        headers[SAFEFRAME_VERSION_HEADER] = '1-2-3';
-        headers[RENDERING_TYPE_HEADER] = 'safeframe';
-        delete headers[AMP_SIGNATURE_HEADER];
-        xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
+        adResponse.headers[SAFEFRAME_VERSION_HEADER] = '1-2-3';
+        adResponse.headers[RENDERING_TYPE_HEADER] = 'safeframe';
+        delete adResponse.headers[AMP_SIGNATURE_HEADER];
         return createIframePromise().then(fixture => {
           setupForAdTesting(fixture);
+          fetchMock.getOnce(
+              TEST_URL + '&__amp_source_origin=about%3Asrcdoc',
+              () => adResponse, {name: 'ad'});
           const doc = fixture.doc;
           const a4aElement = createA4aElement(doc);
           const a4a = new MockA4AImpl(a4aElement);
           a4a.buildCallback();
           a4a.onLayoutMeasure();
           return a4a.adPromise_.then(() => {
-            expect(xhrMock).to.be.calledOnce;
+            expect(fetchMock.called('ad')).to.be.true;
             return a4a.layoutCallback().then(() => {
               verifySafeFrameRender(a4aElement, '1-2-3');
               // Verify preload to safeframe with header version.
@@ -1265,13 +1224,11 @@ describe('amp-a4a', () => {
       let getAdUrlSpy;
       let a4a;
       beforeEach(() => {
-        xhrMock.withArgs(TEST_URL, {
-          mode: 'cors',
-          method: 'GET',
-          credentials: 'include',
-        }).onFirstCall().returns(Promise.resolve(mockResponse));
         return createIframePromise().then(fixture => {
           setupForAdTesting(fixture);
+          fetchMock.getOnce(
+              TEST_URL + '&__amp_source_origin=about%3Asrcdoc',
+              () => adResponse, {name: 'ad'});
           const doc = fixture.doc;
           const a4aElement = createA4aElement(doc);
           a4a = new MockA4AImpl(a4aElement);
@@ -1315,19 +1272,21 @@ describe('amp-a4a', () => {
       });
     });
     it('should ignore invalid safeframe version header', () => {
-      headers[SAFEFRAME_VERSION_HEADER] = 'some-bad-item';
-      headers[RENDERING_TYPE_HEADER] = 'safeframe';
-      delete headers[AMP_SIGNATURE_HEADER];
-      xhrMock.onFirstCall().returns(Promise.resolve(mockResponse));
+      adResponse.headers[SAFEFRAME_VERSION_HEADER] = 'some-bad-item';
+      adResponse.headers[RENDERING_TYPE_HEADER] = 'safeframe';
+      delete adResponse.headers[AMP_SIGNATURE_HEADER];
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.adPromise_.then(() => {
-          expect(xhrMock).to.be.calledOnce;
+          expect(fetchMock.called('ad')).to.be.true;
           return a4a.layoutCallback().then(() => {
             verifySafeFrameRender(a4aElement, DEFAULT_SAFEFRAME_VERSION);
           });
@@ -1580,15 +1539,13 @@ describe('amp-a4a', () => {
     it('verify state reset', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         a4a.buildCallback();
-        xhrMock.withArgs(TEST_URL, {
-          mode: 'cors',
-          method: 'GET',
-          credentials: 'include',
-        }).returns(Promise.resolve(mockResponse));
         return a4a.onLayoutMeasure(() => {
           expect(a4a.adPromise_).to.not.be.null;
           expect(a4a.element.children).to.have.lengthOf(1);
@@ -1599,15 +1556,13 @@ describe('amp-a4a', () => {
     it('attemptChangeSize reverts', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
+        fetchMock.getOnce(
+            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
+            {name: 'ad'});
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         a4a.buildCallback();
-        xhrMock.withArgs(TEST_URL, {
-          mode: 'cors',
-          method: 'GET',
-          credentials: 'include',
-        }).returns(Promise.resolve(mockResponse));
         a4a.onLayoutMeasure();
         const attemptChangeSizeStub =
           sandbox.stub(AMP.BaseElement.prototype, 'attemptChangeSize');
@@ -1900,14 +1855,7 @@ describe('amp-a4a', () => {
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);
       return Promise.all(result).then(serviceInfos => {
-        expect(xhrMockJson).to.be.calledOnce;
-        expect(xhrMockJson).to.be.calledWith(
-            'https://cdn.ampproject.org/amp-ad-verifying-keyset.json', {
-              mode: 'cors',
-              method: 'GET',
-              ampCors: false,
-              credentials: 'omit',
-            });
+        expect(fetchMock.called('keyset')).to.be.true;
         const serviceInfo = serviceInfos[0];
         expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
         expect(serviceInfo['serviceName']).to.equal('google');
@@ -1932,27 +1880,19 @@ describe('amp-a4a', () => {
       const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
       a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
-      expect(xhrMockJson).to.not.be.called;
+      expect(fetchMock.called('keyset')).to.be.false;
       firstVisibleResolve();
       return Promise.all(result).then(() => {
-        expect(xhrMockJson).to.be.calledOnce;
+        expect(fetchMock.called('keyset')).to.be.true;
       });
     });
 
     it('should fetch multiple keys', () => {
       // For our purposes, re-using the same key is fine.
-      const testKey = JSON.parse(validCSSAmp.publicKey);
-      xhrMockJson.withArgs(
-          'https://cdn.ampproject.org/amp-ad-verifying-keyset.json', {
-            mode: 'cors',
-            method: 'GET',
-            ampCors: false,
-            credentials: 'omit',
-          }).returns(Promise.resolve({
-            json() {
-              return Promise.resolve({keys: [testKey, testKey, testKey]});
-            },
-          }));
+      keysetBody =
+          `{"keys":[${validCSSAmp.publicKey},${
+                                               validCSSAmp.publicKey
+                                             },${validCSSAmp.publicKey}]}`;
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
       const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
@@ -1961,14 +1901,7 @@ describe('amp-a4a', () => {
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);  // Only one service.
       return Promise.all(result).then(serviceInfos => {
-        expect(xhrMockJson).to.be.calledOnce;
-        expect(xhrMockJson).to.be.calledWith(
-            'https://cdn.ampproject.org/amp-ad-verifying-keyset.json', {
-              mode: 'cors',
-              method: 'GET',
-              ampCors: false,
-              credentials: 'omit',
-            });
+        expect(fetchMock.called('keyset')).to.be.true;
         expect(serviceInfos).to.have.lengthOf(1);  // Only one service.
         const serviceInfo = serviceInfos[0];
         expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
@@ -1983,19 +1916,9 @@ describe('amp-a4a', () => {
     it('should fetch from multiple services', () => {
       getSigningServiceNamesMock.returns(['google', 'google-dev']);
       // For our purposes, we don't care what the key is, so long as it's valid.
-      xhrMockJson.withArgs(
-          'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json', {
-            mode: 'cors',
-            method: 'GET',
-            ampCors: false,
-            credentials: 'omit',
-          }).returns(Promise.resolve({
-            json() {
-              return Promise.resolve({keys: [
-                JSON.parse(validCSSAmp.publicKey),
-              ]});
-            },
-          }));
+      fetchMock.getOnce(
+          'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
+          keysetBody, {name: 'dev-keyset'});
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
       const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
@@ -2004,7 +1927,8 @@ describe('amp-a4a', () => {
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(2);  // Two services.
       return Promise.all(result).then(serviceInfos => {
-        expect(xhrMockJson).to.be.calledTwice;
+        expect(fetchMock.called('keyset')).to.be.true;
+        expect(fetchMock.called('dev-keyset')).to.be.true;
         serviceInfos.map(serviceInfo => {
           expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
           expect(serviceInfo['serviceName']).to.have.string('google');
@@ -2020,17 +1944,7 @@ describe('amp-a4a', () => {
     });
 
     it('Should gracefully handle malformed key responses', () => {
-      xhrMockJson.withArgs(
-          'https://cdn.ampproject.org/amp-ad-verifying-keyset.json', {
-            mode: 'cors',
-            method: 'GET',
-            ampCors: false,
-            credentials: 'omit',
-          }).returns(Promise.resolve({
-            json() {
-              return Promise.resolve({keys: ['invalid key data']});
-            },
-          }));
+      keysetBody = '{"keys":["invalid key data"]}';
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
       const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
@@ -2039,14 +1953,7 @@ describe('amp-a4a', () => {
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);  // Only one service.
       return Promise.all(result).then(serviceInfos => {
-        expect(xhrMockJson).to.be.calledOnce;
-        expect(xhrMockJson).to.be.calledWith(
-            'https://cdn.ampproject.org/amp-ad-verifying-keyset.json', {
-              mode: 'cors',
-              method: 'GET',
-              ampCors: false,
-              credentials: 'omit',
-            });
+        expect(fetchMock.called('keyset')).to.be.true;
         expect(serviceInfos[0]).to.have.all.keys(['serviceName', 'keys']);
         expect(serviceInfos[0]['serviceName']).to.equal('google');
         expect(serviceInfos[0]['keys']).to.be.an.instanceof(Array);
@@ -2055,14 +1962,7 @@ describe('amp-a4a', () => {
     });
 
     it('should gracefully handle network errors in a single service', () => {
-      xhrMockJson.withArgs(
-          'https://cdn.ampproject.org/amp-ad-verifying-keyset.json', {
-            mode: 'cors',
-            method: 'GET',
-            ampCors: false,
-            credentials: 'omit',
-          }).returns(Promise.reject(
-              new TypeError('some random network error')));
+      keysetBody = Promise.reject(networkFailure());
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
       const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
@@ -2080,14 +1980,9 @@ describe('amp-a4a', () => {
 
     it('should handle success in one service and net error in another', () => {
       getSigningServiceNamesMock.returns(['google', 'google-dev']);
-      xhrMockJson.withArgs(
-          'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json', {
-            mode: 'cors',
-            method: 'GET',
-            ampCors: false,
-            credentials: 'omit',
-          }).returns(Promise.reject(
-              new TypeError('some random network error')));
+      fetchMock.getOnce(
+          'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
+          Promise.reject(networkFailure()), {name: 'dev-keyset'});
       expect(win.ampA4aValidationKeys).not.to.exist;
       // Key fetch happens on A4A class construction.
       const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
@@ -2115,7 +2010,8 @@ describe('amp-a4a', () => {
                   'google nor google-dev');
             }
           }))).then(() => {
-            expect(xhrMockJson).to.be.calledTwice;
+            expect(fetchMock.called('keyset')).to.be.true;
+            expect(fetchMock.called('dev-keyset')).to.be.true;
           });
     });
 
@@ -2126,7 +2022,7 @@ describe('amp-a4a', () => {
       const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
       a4a.buildCallback();
       const result = win.ampA4aValidationKeys;
-      expect(xhrMockJson).not.to.be.called;
+      expect(fetchMock.called('keyset')).to.be.false;
       expect(result).to.be.instanceof(Array);
       expect(result).to.have.lengthOf(1);
       expect(result[0]).to.be.instanceof(Promise);
@@ -2165,40 +2061,10 @@ describe('amp-a4a', () => {
   describe('#extractCreativeAndSignature', () => {
     it('should return body and signature', () => {
       const creative = 'some test data';
-      const headerData = {
-        'X-AmpAdSignature': 'AQAB',
-      };
-      const headers = {
-        has: h => {
-          return h in headerData;
-        },
-        get: h => {
-          return headerData[h];
-        },
-      };
       return expect(AmpA4A.prototype.extractCreativeAndSignature(
-          creative, headers))
-          .to.eventually.deep.equal({
-            creative,
-            signature: base64UrlDecodeToBytes('AQAB'),
-          });
-    });
-
-    it('should return body and signature and size', () => {
-      const creative = 'some test data';
-      const headerData = {
-        'X-AmpAdSignature': 'AQAB',
-      };
-      const headers = {
-        has: h => {
-          return h in headerData;
-        },
-        get: h => {
-          return headerData[h];
-        },
-      };
-      return expect(AmpA4A.prototype.extractCreativeAndSignature(
-          creative, headers))
+          creative, new Headers({
+            'X-AmpAdSignature': 'AQAB',
+          })))
           .to.eventually.deep.equal({
             creative,
             signature: base64UrlDecodeToBytes('AQAB'),
@@ -2207,16 +2073,8 @@ describe('amp-a4a', () => {
 
     it('should return null when no signature header is present', () => {
       const creative = 'some test data';
-      const headers = {
-        has: unused => {
-          return false;
-        },
-        get: unused => {
-          return undefined;
-        },
-      };
       return expect(AmpA4A.prototype.extractCreativeAndSignature(
-          creative, headers))
+          creative, new Headers()))
           .to.eventually.deep.equal({creative, signature: null});
     });
   });
@@ -2224,19 +2082,13 @@ describe('amp-a4a', () => {
   describe('#extractSize', () => {
 
     it('should return a size', () => {
-      expect(AmpA4A.prototype.extractSize({
-        get(name) {
-	  return {'X-CreativeSize': '320x50'}[name];
-        },
-      })).to.deep.equal({width: 320, height: 50});
+      expect(AmpA4A.prototype.extractSize(new Headers({
+        'X-CreativeSize': '320x50',
+      }))).to.deep.equal({width: 320, height: 50});
     });
 
     it('should return no size', () => {
-      expect(AmpA4A.prototype.extractSize({
-        get(unusedName) {
-	  return null;
-        },
-      })).to.be.null;
+      expect(AmpA4A.prototype.extractSize(new Headers())).to.be.null;
     });
   });
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -76,7 +76,7 @@ describe('amp-a4a', () => {
 
   afterEach(() => {
     if (fetchMock) {
-      fetchMock.restoreFetch();
+      fetchMock./*OK*/restore();
       fetchMock = null;
     }
     sandbox.restore();

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -76,7 +76,7 @@ describe('amp-a4a', () => {
 
   afterEach(() => {
     if (fetchMock) {
-      fetchMock.restore();
+      fetchMock.restoreFetch();
       fetchMock = null;
     }
     sandbox.restore();


### PR DESCRIPTION
Tests now directly stub `window.fetch` using a hand-rolled `FetchMock` class. This will facilitate refactoring of the keyset fetcher.

One of the PRs that #9040 is being split into. Related to #7618. Follow-up to #10269.