### PR TITLE
[amp-sidebar 1.0][Toolbar] Added State classes to Sidebar 1.0's Toolbar, Removed toolbar-only

### DIFF
--- a/extensions/amp-sidebar/1.0/amp-sidebar-1.0.md
+++ b/extensions/amp-sidebar/1.0/amp-sidebar-1.0.md
@@ -41,7 +41,7 @@ limitations under the License.
 
 ## Overview
 `<amp-sidebar>` hides meta content intended for temporary access (navigation links, buttons, menus, etc.). `<amp-sidebar>` can be opened and closed by button taps, and tapping outside of amp-sidebar.
-However, optional attributes that accept media queries can be used to display meta content in other parts of the site. Child `<nav toolbar="(media query)" target="elementID">` elements allow
+However, optional attributes that accept media queries can be used to display meta content in other parts of the site. Child `<nav toolbar="(media query)" toolbar-target="elementID">` elements allow
 for content within the sidebar to be displayed on other parts of the main content.
 
 
@@ -114,22 +114,20 @@ Alternatively, pressing the escape key on the keyboard will also close the sideb
 
 ### Toolbar
 
-You can create a `toolbar` element that displays in the `<body>` by specifying the `toolbar` attribute with a media query and a `target` attribute with an element id on a `<nav>` element that is a child of  `<amp-sidebar>`. The `toolbar` duplicates the `<nav>` element and its children and appends the element into the `target` element.
+You can create a `toolbar` element that displays in the `<body>` by specifying the `toolbar` attribute with a media query and a `toolbar-target` attribute with an element id on a `<nav>` element that is a child of  `<amp-sidebar>`. The `toolbar` duplicates the `<nav>` element and its children and appends the element into the `toolbar-target` element.
 
 #### Behavior
 
-- The sidebar may implement toolbars by adding nav elements with the `toolbar` attribute and `target` attribute.
-- The nav element must be a child of `<amp-sidebar>` and follow this format: `<nav toolbar="(media-query)" target="elementID">`.
-    - For instance, this would be a valid use of toolbar: `<nav toolbar="(max-width: 1024px)" target="toolbar-target">`.
+- The sidebar may implement toolbars by adding nav elements with the `toolbar` attribute and `toolbar-target` attribute.
+- The nav element must be a child of `<amp-sidebar>` and follow this format: `<nav toolbar="(media-query)" toolbar-target="elementID">`.
+    - For instance, this would be a valid use of toolbar: `<nav toolbar="(max-width: 1024px)" toolbar-target="target-element">`.
 - The nav containing the toolbar attribute must only contain a single `<ul>` element, that contains `<li>` elements.
     - The `<li>` elements may contain any valid HTML elements (supported by AMP), or any of the AMP elements that `<amp-sidebar>` supports.
-- The nav element, or it's `<ul>`'s `<li>` elements, may also contain the attribute `toolbar-only`.
-    - The attribute `toolbar-only` will hide the elements with the attribute in the sidebar, but leave them shown in the toolbar.
-- Toolbar behavior is only applied while the `toolbar` attribute media-query is valid. Also, an element with the `target` attribute id must exist on the page for the toolbar to be applied.
+- Toolbar behavior is only applied while the `toolbar` attribute media-query is valid. Also, an element with the `toolbar-target` attribute id must exist on the page for the toolbar to be applied.
 
 *Example: Basic Toolbar*
 
-In the following example, we display a `toolbar` if the window width is less than or equal to 767px. The `toolbar` contains a search input element. The `toolbar` element will be appended to the `<div id="toolbar-target">` element.
+In the following example, we display a `toolbar` if the window width is less than or equal to 767px. The `toolbar` contains a search input element. The `toolbar` element will be appended to the `<div id="target-element">` element.
 
 ```html
 <amp-sidebar id="sidebar1" layout="nodisplay" side="right">
@@ -142,7 +140,7 @@ In the following example, we display a `toolbar` if the window width is less tha
     <li>Nav item 6</li>
   </ul>
 
-  <nav toolbar="(max-width: 767px)" target="toolbar-target">
+  <nav toolbar="(max-width: 767px)" toolbar-target="target-element">
     <ul>
       <li>
         <input placeholder="Search..."/>
@@ -151,15 +149,27 @@ In the following example, we display a `toolbar` if the window width is less tha
   </nav>
 </amp-sidebar>
 
-<div id="toolbar-target">
+<div id="target-element">
 </div>
 ```
 
-*Example: Display toolbar content only within the toolbar*
+## Styling Toolbar
 
-In the following example, we display a toolbar if the window width is greater than or equal to 0px. The toolbar contains a search input element. The `toolbar` element will be appended to the `<div id="toolbar-target">` element. However, with the `toolbar-only` attribute, the `<nav>` element and its children will be hidden inside the sidebar, but visible within the toolbar when the toolbar is displayed.
+The `toolbar` element within the `<amp-sidebar>` element, will have classes applied to the element depending if the `toolbar-target` element is shown or hidden. This is useful for applying different styles on the `toolbar` element and then `toolbar-target` element. The classes are `amp-sidebar-toolbar-target-shown`, and `amp-sidebar-toolbar-target-hidden`. The class `amp-sidebar-toolbar-target-shown` is applied to the `toolbar` element when the `toolbar-target` element is shown. The class `amp-sidebar-toolbar-target-hidden` is applied to the `toolbar` element when the `toolbar-target` element is hidden.
+
+*Example: Toolbar State Classes*
+
+In the following example, we display a `toolbar` if the window width is less than or equal to 767px. The `toolbar` contains a search input element. The `toolbar` element will be appended to the `<div id="target-element">` element. However, we added some custom styles to hide the `toolbar` element, when the `<div id="toolbar-target">` element is shown.
 
 ```html
+<style amp-custom="">
+
+  .amp-sidebar-toolbar-target-shown {
+      display: none;
+  }
+
+</style>
+
 <amp-sidebar id="sidebar1" layout="nodisplay" side="right">
   <ul>
     <li>Nav item 1</li>
@@ -170,7 +180,7 @@ In the following example, we display a toolbar if the window width is greater th
     <li>Nav item 6</li>
   </ul>
 
-  <nav toolbar="(min-width: 0px)" target="toolbar-target" toolbar-only>
+  <nav toolbar="(max-width: 767px)" toolbar-target="target-element">
     <ul>
       <li>
         <input placeholder="Search..."/>
@@ -179,40 +189,10 @@ In the following example, we display a toolbar if the window width is greater th
   </nav>
 </amp-sidebar>
 
-<div id="toolbar-target">
+<div id="target-element">
 </div>
 ```
 
-*Example: Display specific toolbar items only within the toolbar*
-
-In the following example, we display a toolbar if the window width is greater than or equal to 768px, or if the window width is less than or equal to 1024px. The toolbar contains two items, text representing a publisher's logo, and a search input element. The `toolbar` element will be appended to the `<div id="toolbar-target">` element. However, with the `toolbar-only` attribute, the `<li>` element and its children will be hidden inside the sidebar, but visible within the toolbar when the toolbar is displayed. Other elements that are a child of the `<nav>` element will be displayed inside the sidebar, and the toolbar when the toolbar is displayed.
-
-```html
-<amp-sidebar id="sidebar1" layout="nodisplay" side="right">
-  <ul>
-    <li>Nav item 1</li>
-    <li>Nav item 2</li>
-    <li>Nav item 3</li>
-    <li>Nav item 4</li>
-    <li>Nav item 5</li>
-    <li>Nav item 6</li>
-  </ul>
-
-  <nav toolbar="(min-width: 768px) and (max-width: 1024px)" target="toolbar-target">
-    <ul>
-      <li>
-        Publisher Logo
-      </li>
-      <li toolbar-only>
-        <input placeholder="Search..."/>
-      </li>
-    </ul>
-  </nav>
-</amp-sidebar>
-
-<div id="toolbar-target">
-</div>
-```
 
 
 {% call callout('Tip', type='success') %}
@@ -241,15 +221,11 @@ Optional attribute used to set ARIA label for the close button added for accessi
 
 ##### toolbar
 
-This attribute is present on child `<nav toolbar="(media-query)" target="elementID">` elements, and accepts a media query of when to show a toolbar. See the [Toolbar](#toolbar) section for more information on using toolbars.
+This attribute is present on child `<nav toolbar="(media-query)" toolbar-target="elementID">` elements, and accepts a media query of when to show a toolbar. See the [Toolbar](#toolbar) section for more information on using toolbars.
 
-##### target
+##### toolbar-target
 
-This attribute is present on child `<nav toolbar="(media-query)" target="elementID">`, and accepts an id of an element on the page.  The `target` attribute will place the toolbar into the specified id of the element on the page, without the default toolbar styling. See the [Toolbar](#toolbar) section for more information on using toolbars.
-
-##### toolbar-only
-
-This attribute is present on child `<nav toolbar="(media-query)" target="elementID">`, or children `<li>` elements of `<nav toolbar="(media-query)">` elements, and indicates that the element will only be shown in the toolbar, when the toolbar is shown. See the [Toolbar](#toolbar) section for more information on using toolbar.
+This attribute is present on child `<nav toolbar="(media-query)" toolbar-target="elementID">`, and accepts an id of an element on the page.  The `toolbar-target` attribute will place the toolbar into the specified id of the element on the page, without the default toolbar styling. See the [Toolbar](#toolbar) section for more information on using toolbars.
 
 ##### common attributes
 

--- a/extensions/amp-sidebar/1.0/test/test-toolbar.js
+++ b/extensions/amp-sidebar/1.0/test/test-toolbar.js
@@ -227,9 +227,8 @@
      });
    });
 
-   it('should hide <nav toolbar> elements with toolbar-only, \
-   inside the sidebar, but not inside the toolbar, for a matching \
-   window size for (min-width: 768px)', () => {
+   it('should add the "amp-sidebar-toolbar-target-shown" state class, \
+   for matching window size of (min-width: 768px)', () => {
      return getToolbars([{
        toolbarOnlyOnNav: true,
      }]).then(obj => {
@@ -238,19 +237,37 @@
          toolbars.forEach(toolbar => {
            toolbar.onLayoutChange();
          });
-         const toolbarNavElements =
+         const toolbarNavElementsWithState =
                 toArray(obj.ampdoc.getRootNode()
-                .querySelectorAll('nav[toolbar]'));
-         const hiddenToolbarNavElements =
-                toArray(obj.ampdoc.getRootNode()
-                .querySelectorAll('nav[style]'));
-         expect(toolbarNavElements.length).to.be.equal(2);
-         expect(hiddenToolbarNavElements.length).to.be.equal(1);
+                .querySelectorAll(
+                    'nav[toolbar].amp-sidebar-toolbar-target-shown'
+                ));
+         expect(toolbarNavElementsWithState.length).to.be.equal(1);
          expect(toolbars.length).to.be.equal(1);
        });
      });
    });
 
+   it('should add the "amp-sidebar-toolbar-target-hidden" state class, \
+   for non-matching window size of (min-width: 768px)', () => {
+     return getToolbars([{
+       toolbarOnlyOnNav: true,
+     }]).then(obj => {
+       const toolbars = obj.toolbars;
+       resizeIframeToWidth(obj.iframe, '0px', () => {
+         toolbars.forEach(toolbar => {
+           toolbar.onLayoutChange();
+         });
+         const toolbarNavElementsWithState =
+                toArray(obj.ampdoc.getRootNode()
+                .querySelectorAll(
+                    'nav[toolbar].amp-sidebar-toolbar-target-hidden'
+                ));
+         expect(toolbarNavElementsWithState.length).to.be.equal(1);
+         expect(toolbars.length).to.be.equal(1);
+       });
+     });
+   });
 
    it('toolbar should be in the hidden state \
    when it is not being displayed', () => {

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -49,22 +49,10 @@ export class Toolbar {
     /** @private {!boolean} **/
     this.toolbarShown_ = false;
 
-    /** @private {Array} */
-    this.toolbarOnlyElementsInSidebar_ = [];
+    // Default to toolbar target being hidden
+    this.toolbarDomElement_.classList
+        .add('amp-sidebar-toolbar-target-hidden');
 
-    // Find our tool-bar only elements
-    if (this.toolbarDomElement_.hasAttribute('toolbar-only')) {
-      this.toolbarOnlyElementsInSidebar_.push(this.toolbarDomElement_);
-    } else {
-      // Get our toolbar only elements
-      const toolbarOnlyQuery =
-        this.toolbarDomElement_.querySelectorAll('[toolbar-only]');
-      if (toolbarOnlyQuery.length > 0) {
-        // Check the nav's children for toolbar-only
-        this.toolbarOnlyElementsInSidebar_ =
-          toArray(toolbarOnlyQuery);
-      }
-    }
     this.buildCallback_();
   }
 
@@ -140,11 +128,10 @@ export class Toolbar {
         if (!this.toolbarTarget_.contains(this.toolbarClone_)) {
           this.toolbarTarget_.appendChild(this.toolbarClone_);
         }
-      }
-      if (this.toolbarOnlyElementsInSidebar_) {
-        this.toolbarOnlyElementsInSidebar_.forEach(element => {
-          toggle(element, false);
-        });
+        this.toolbarDomElement_.classList
+            .add('amp-sidebar-toolbar-target-shown');
+        this.toolbarDomElement_.classList
+            .remove('amp-sidebar-toolbar-target-hidden');
       }
       this.toolbarShown_ = true;
     });
@@ -164,11 +151,10 @@ export class Toolbar {
       // Hide the elements
       if (this.toolbarTarget_) {
         toggle(this.toolbarTarget_, false);
-      }
-      if (this.toolbarOnlyElementsInSidebar_) {
-        this.toolbarOnlyElementsInSidebar_.forEach(element => {
-          toggle(element, true);
-        });
+        this.toolbarDomElement_.classList
+            .add('amp-sidebar-toolbar-target-hidden');
+        this.toolbarDomElement_.classList
+            .remove('amp-sidebar-toolbar-target-shown');
       }
       this.toolbarShown_ = false;
     });

--- a/extensions/amp-sidebar/1.0/toolbar.js
+++ b/extensions/amp-sidebar/1.0/toolbar.js
@@ -15,7 +15,6 @@
  */
 
 import {toggle} from '../../../src/style';
-import {toArray} from '../../../src/types';
 import {user} from '../../../src/log';
 
 export class Toolbar {

--- a/test/manual/amp-sidebar-1.0.amp.html
+++ b/test/manual/amp-sidebar-1.0.amp.html
@@ -74,6 +74,10 @@ limitations under the License.
   background-color: transparent;
 }
 
+.amp-sidebar-toolbar-target-shown {
+  display: none;
+}
+
 .ampstart-hamburger-nav > ul {
   display: flex;
   justify-content: flex-start;
@@ -144,9 +148,9 @@ limitations under the License.
       </ul>
     </nav>
 
-    <!-- Toolbar One, basic usage, toolbar-only -->
+    <!-- Toolbar One, basic usage -->
     <!-- Could center with CSS justify-content: space-between, but trying to be minimal -->
-    <nav toolbar="(min-width: 0px)" toolbar-target="hamburger-toolbar" class="ampstart-hamburger-nav ampstart-navbar-bg" toolbar-only>
+    <nav toolbar="(min-width: 0px)" toolbar-target="hamburger-toolbar" class="ampstart-hamburger-nav ampstart-navbar-bg">
       <ul class="justify-center">
         <li role="button" aria-label="open sidebar" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger pl2">
           ☰
@@ -158,7 +162,7 @@ limitations under the License.
     </nav>
 
     <!-- Toolbar Two, min only  -->
-    <nav toolbar="(min-width: 931px)" toolbar-target="accordion-toolbar" toolbar-only class="ampstart-headerbar-nav ampstart-nav ampstart-navbar-bg">
+    <nav toolbar="(min-width: 931px)" toolbar-target="accordion-toolbar" class="ampstart-headerbar-nav ampstart-nav ampstart-navbar-bg">
       <ul class="list-reset center m0 p0 flex justify-center nowrap">
           <li class="ampstart-nav-item ampstart-nav-dropdown">
             <!-- Start Dropdown -->
@@ -207,9 +211,9 @@ limitations under the License.
         <a href="#" target="_blank" class="inline-block" aria-label="Link to AMP HTML pin trest"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="28.5" viewbox="0 0 43 51"><title>pinterest</title><path d="M-13.6-5c0-1.6.2-3 .8-4.4.5-1.4 1.2-2.6 2.2-3.6.9-1 2-1.9 3.2-2.6 1.2-.8 2.5-1.3 3.9-1.7 1.5-.4 2.9-.5 4.4-.5 2.2 0 4.3.4 6.2 1.4 1.9.9 3.5 2.3 4.7 4.1 1.2 1.9 1.8 3.9 1.8 6.2 0 1.4-.1 2.7-.4 4C13-.8 12.5.5 12 1.7c-.6 1.2-1.3 2.3-2.2 3.2C9 5.8 8 6.6 6.7 7.1c-1.2.6-2.5.9-4 .9-1 0-1.9-.3-2.9-.7-.9-.5-1.6-1.1-2-1.9-.1.5-.3 1.4-.6 2.4-.3 1.1-.4 1.7-.5 2-.1.3-.2.9-.4 1.6-.3.7-.4 1.2-.6 1.5-.1.3-.4.7-.7 1.3-.3.6-.6 1.2-1 1.7-.3.5-.7 1.1-1.3 1.8l-.3.1-.2-.2c-.2-2.2-.3-3.6-.3-4 0-1.3.2-2.8.5-4.4.3-1.7.8-3.7 1.4-6.2.6-2.5 1-3.9 1.1-4.4-.5-.9-.7-2.1-.7-3.6 0-1.2.4-2.3 1.1-3.3.8-1.1 1.7-1.6 2.8-1.6.9 0 1.6.3 2.1.9.4.6.7 1.3.7 2.2 0 .9-.3 2.3-1 4.1C-.7-.9-1 .4-1 1.3c0 .9.3 1.6 1 2.2.6.6 1.4.9 2.3.9.8 0 1.5-.2 2.2-.5.6-.4 1.2-.9 1.6-1.5.5-.6.9-1.3 1.2-2 .4-.8.6-1.5.8-2.4.2-.8.4-1.6.5-2.4.1-.7.1-1.4.1-2.1 0-2.5-.8-4.4-2.3-5.8-1.6-1.4-3.6-2.1-6.1-2.1-2.8 0-5.2 1-7.1 2.8-1.9 1.9-2.9 4.2-2.9 7.1 0 .6.1 1.2.3 1.8.2.6.4 1.1.6 1.4.2.3.4.7.5 1 .2.3.3.5.3.6 0 .4-.1.9-.3 1.6-.2.6-.5 1-.8 1 0 0-.1-.1-.4-.1-.7-.2-1.3-.6-1.9-1.2-.5-.6-1-1.3-1.3-2-.3-.8-.5-1.6-.7-2.4-.2-.7-.2-1.5-.2-2.2z" transform="translate(21.734 23.748)" class="ampstart-icon ampstart-icon-pinterest"></path></svg></a>
       </li>
     </ul>
-
+    
     <ul class="ampstart-sidebar-faq list-reset m0">
-      <li toolbar-only class="ampstart-faq-item"><a href="#" class="text-decoration-none">About</a></li>
+      <li class="ampstart-faq-item"><a href="#" class="text-decoration-none">About</a></li>
       <li class="ampstart-faq-item"><a href="#" class="text-decoration-none">Contact</a></li>
     </ul>
   </amp-sidebar>


### PR DESCRIPTION
* Added the state classes `amp-sidebar-toolbar-target-shown`, and `amp-sidebar-toolbar-target-hidden` to the original `<nav toolbar="" toolbar-target="">`, on show/hide of the toolbar target.
* Updated tests to ensure that this is working
* Removed the `toolbar-only` attribute, until we have a request for it, or more discussion otherwise.

# Screenshot

![screen shot 2017-07-24 at 11 27 15 am](https://user-images.githubusercontent.com/1448289/28538431-1a9b4dcc-7063-11e7-8433-5a280d4a2743.png)
