### PR TITLE
Block amp-list render on amp-bind evaluation

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1131,6 +1131,11 @@ function enableCors(req, res, origin, opt_exposeHeaders) {
 }
 
 function assertCors(req, res, opt_validMethods, opt_exposeHeaders) {
+  // Allow disable CORS check (iframe fixtures have origin 'about:srcdoc').
+  if (req.query.cors == '0') {
+    return;
+  }
+
   const validMethods = opt_validMethods || ['GET', 'POST', 'OPTIONS'];
   const invalidMethod = req.method + ' method is not allowed. Use POST.';
   const invalidOrigin = 'Origin header is invalid.';

--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -13,7 +13,6 @@
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
 </head>
 <body>
-
   <button on="tap:AMP.setState({listSrc:'/list/fruit-data/get'})">Show Fruit</button>
   <button on="tap:AMP.setState({listSrc:'/list/vegetable-data/get'})">Show Vegetables</button>
 
@@ -29,11 +28,14 @@
     }]
   })">Show Other Foods</button>
 
+  <button on="tap:AMP.setState({foo: foo+1})">increment foo</button>
+
   <amp-list layout="responsive" src="/list/fruit-data/get" [src]="listSrc || '/list/fruit-data/get'" width="600" height="600" [state]="localState">
     <template type="amp-mustache">
       <strong>Product</strong>: {{name}}
       <strong>Quantity:</strong>: {{quantity}}
       <strong>Unit Price</strong>: ${{unitPrice}}
+      <strong>Foo</strong>: <span [text]="foo">?</span>
     </template>
   </amp-list>
 </body>

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -345,7 +345,8 @@ export class Bind {
     // Once all scans are complete, combine the bindings and ask web-worker to
     // evaluate expressions in a single RPC.
     return Promise.all(scanPromises).then(results => {
-      // `results[i]` is an array of bindings from the i'th scan -- combine.
+      // `results` is a 2D array where results[i] is an array of bindings.
+      // Flatten this into a 1D array of bindings via concat.
       const bindings = Array.prototype.concat.apply([], results);
       if (bindings.length == 0) {
         return bindings.length;
@@ -667,13 +668,13 @@ export class Bind {
    * @return {!Promise}
    */
   applyElements_(results, elements) {
-    const promises = this.boundElements_.map(boundElement => {
-      for (let i = 0; i < elements.length; i++) {
-        if (elements[i].contains(boundElement.element)) {
-          return this.applyBoundElement_(results, boundElement);
+    const promises = [];
+    this.boundElements_.forEach(boundElement => {
+      elements.forEach(element => {
+        if (element.contains(boundElement.element)) {
+          promises.push(this.applyBoundElement_(results, boundElement));
         }
-      }
-      return Promise.resolve();
+      });
     });
     return Promise.all(promises);
   }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -246,11 +246,8 @@ export class Bind {
         .then(numberOfBindingsAdded => {
           // Don't reevaluate/apply if there are no bindings.
           if (numberOfBindingsAdded > 0) {
-            return this.evaluate_()
-                .then(results => this.applyElement_(results, container))
-                .then(() => {
-                  this.dispatchEventForTesting_(BindEvents.RESCAN_TEMPLATE);
-                });
+            return this.evaluate_().then(results =>
+                this.applyElement_(results, container));
           }
         });
   }

--- a/extensions/amp-bind/0.1/test/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/test-bind-impl.js
@@ -237,10 +237,10 @@ describe('Bind', function() {
       expect(bind.numberOfBindings()).to.equal(0);
       return onBindReady(env, bind).then(() => {
         expect(bind.numberOfBindings()).to.equal(5);
-        return bind.removeBindingsForNode_(container);
+        return bind.removeBindingsForNodes_([container]);
       }).then(() => {
         expect(bind.numberOfBindings()).to.equal(0);
-        return bind.addBindingsForNode_(container);
+        return bind.addBindingsForNodes_([container]);
       }).then(() => {
         expect(bind.numberOfBindings()).to.equal(5);
       });

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -47,9 +47,6 @@ export class AmpList extends AMP.BaseElement {
 
     /** @const {!../../../src/service/template-impl.Templates} */
     this.templates_ = Services.templatesFor(this.win);
-
-    /** @const {!../../../src/service/timer-impl.Timer} */
-    this.timer_ = Services.timerFor(this.win);
   }
 
   /** @override */
@@ -167,17 +164,15 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   scanForBindings_(elements) {
-    const rescan = Services.bindForDocOrNull(this.element).then(bind => {
+    const forwardElements = () => elements;
+    return Services.bindForDocOrNull(this.element).then(bind => {
       if (bind) {
         return bind.rescanAndEvaluate(elements);
       } else {
         return Promise.resolve();
       }
-    });
-    const timeout = this.timer_.timeoutPromise(2000, rescan,
-        'Timed out waiting for amp-bind to process rendered template.');
-    // Forward rendered elements in returned promise.
-    return timeout.then(() => elements);
+    // Forward elements to chained promise on success or failure.
+    }).then(forwardElements, forwardElements);
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -168,8 +168,6 @@ export class AmpList extends AMP.BaseElement {
     return Services.bindForDocOrNull(this.element).then(bind => {
       if (bind) {
         return bind.rescanAndEvaluate(elements);
-      } else {
-        return Promise.resolve();
       }
     // Forward elements to chained promise on success or failure.
     }).then(forwardElements, forwardElements);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -33,11 +33,23 @@ export class AmpList extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
+    /** @const {!function(!Array<!Element>)} */
+    this.boundRendered_ = this.rendered_.bind(this);
+
+    /** @const {!function(!Array<!Element>):!Promise<!Array<!Element>>} */
+    this.boundScanForBindings_ = this.scanForBindings_.bind(this);
+
     /** @private {?Element} */
     this.container_ = null;
 
     /** @private {boolean} */
     this.fallbackDisplayed_ = false;
+
+    /** @const {!../../../src/service/template-impl.Templates} */
+    this.templates_ = Services.templatesFor(this.win);
+
+    /** @const {!../../../src/service/timer-impl.Timer} */
+    this.timer_ = Services.timerFor(this.win);
   }
 
   /** @override */
@@ -67,9 +79,9 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const populate = this.populateList_();
+    const fetch = this.fetchList_();
     if (this.getFallback()) {
-      populate.then(() => {
+      fetch.then(() => {
         // Hide in case fallback was displayed for a previous fetch.
         this.toggleFallbackInMutate_(false);
       }, unusedError => {
@@ -79,7 +91,7 @@ export class AmpList extends AMP.BaseElement {
         this.toggleFallbackInMutate_(true);
       });
     }
-    return populate;
+    return fetch;
   }
 
   /** @override */
@@ -87,11 +99,10 @@ export class AmpList extends AMP.BaseElement {
     const src = mutations['src'];
     const state = mutations['state'];
     if (src != undefined) {
-      this.populateList_();
+      this.fetchList_();
     } else if (state != undefined) {
       const items = isArray(state) ? state : [state];
-      Services.templatesFor(this.win).findAndRenderTemplateArray(
-          this.element, items).then(this.rendered_.bind(this));
+      this.renderItems_(items);
     }
     if (src != undefined && state != undefined) {
       user().warn('AMP-LIST', '[src] and [state] mutated simultaneously.' +
@@ -102,6 +113,7 @@ export class AmpList extends AMP.BaseElement {
   /**
    * Wraps `toggleFallback()` in a mutate context.
    * @param {boolean} state
+   * @private
    */
   toggleFallbackInMutate_(state) {
     if (state) {
@@ -124,18 +136,48 @@ export class AmpList extends AMP.BaseElement {
    * Request list data from `src` and return a promise that resolves when
    * the list has been populated with rendered list items.
    * @return {!Promise}
+   * @private
    */
-  populateList_() {
+  fetchList_() {
     const itemsExpr = this.element.getAttribute('items') || 'items';
-    return this.fetchItems_(itemsExpr).then(items => {
+    return this.fetch_(itemsExpr).then(items => {
       user().assert(isArray(items),
           'Response must contain an array at "%s". %s',
           itemsExpr, this.element);
-      return Services.templatesFor(this.win).findAndRenderTemplateArray(
-          this.element, items).then(this.rendered_.bind(this));
+      return this.renderItems_(items);
     }, error => {
       throw user().createError('Error fetching amp-list', error);
     });
+  }
+
+  /**
+   * @param {!Array} items
+   * @return {!Promise}
+   * @private
+   */
+  renderItems_(items) {
+    return this.templates_.findAndRenderTemplateArray(this.element, items)
+        .then(this.boundScanForBindings_)
+        .then(this.boundRendered_);
+  }
+
+  /**
+   * @param {!Array<!Element>} elements
+   * @return {!Promise<!Array<!Element>>}
+   * @private
+   */
+  scanForBindings_(elements) {
+    const rescan = Services.bindForDocOrNull(this.element).then(bind => {
+      if (bind) {
+        return bind.rescanAndEvaluate(elements);
+      } else {
+        return Promise.resolve();
+      }
+    });
+    const timeout = this.timer_.timeoutPromise(2000, rescan,
+        'Timed out waiting for amp-bind to process rendered template.');
+    // Forward rendered elements in returned promise.
+    return timeout.then(() => elements);
   }
 
   /**
@@ -151,9 +193,9 @@ export class AmpList extends AMP.BaseElement {
       this.container_.appendChild(element);
     });
 
-    const templatedEvent = createCustomEvent(this.win,
+    const event = createCustomEvent(this.win,
         AmpEvents.DOM_UPDATE, /* detail */ null, {bubbles: true});
-    this.container_.dispatchEvent(templatedEvent);
+    this.container_.dispatchEvent(event);
 
     // Change height if needed.
     this.getVsync().measure(() => {
@@ -168,8 +210,9 @@ export class AmpList extends AMP.BaseElement {
   /**
    * @param {string} itemsExpr
    * @visibleForTesting
+   * @private
    */
-  fetchItems_(itemsExpr) {
+  fetch_(itemsExpr) {
     return fetchBatchedJsonFor(this.getAmpDoc(), this.element, itemsExpr);
   }
 }

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {AmpEvents} from '../../../../src/amp-events';
 import {AmpList} from '../amp-list';
 import {Services} from '../../../../src/services';
 import * as sinon from 'sinon';
@@ -25,6 +24,7 @@ describe('amp-list component', () => {
   let element;
   let list;
   let listMock;
+  let bindStub;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -38,6 +38,9 @@ describe('amp-list component', () => {
     element.setAttribute('src', 'https://data.com/list.json');
     element.getAmpDoc = () => ampdoc;
     element.getFallback = () => null;
+
+    bindStub = sandbox.stub(Services, 'bindForDocOrNull')
+        .returns(Promise.resolve(null));
 
     list = new AmpList(element);
     list.buildCallback();
@@ -63,7 +66,7 @@ describe('amp-list component', () => {
     itemElement.style.height = newHeight + 'px';
     const fetchPromise = Promise.resolve(items);
     const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetchItems_').withExactArgs('items')
+    listMock.expects('fetch_').withExactArgs('items')
         .returns(fetchPromise).once();
     templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
         element, items)
@@ -106,6 +109,27 @@ describe('amp-list component', () => {
     });
   });
 
+  it('should call rescanAndEvaluate() if Bind is available', () => {
+    const fakeBind = {rescanAndEvaluate: sandbox.spy()};
+    bindStub.returns(Promise.resolve(fakeBind));
+
+    const items = [{title: 'Title1'}];
+    const itemElement = document.createElement('div');
+    const fetchPromise = Promise.resolve(items);
+    const rendered = [itemElement];
+    const renderPromise = Promise.resolve(rendered);
+    listMock.expects('fetch_').withExactArgs('items')
+        .returns(fetchPromise).once();
+    templatesMock.expects('findAndRenderTemplateArray').withArgs()
+        .returns(renderPromise).once();
+    return list.layoutCallback().then(() => {
+      return Promise.all([fetchPromise, renderPromise]);
+    }).then(() => {
+      expect(fakeBind.rescanAndEvaluate).to.have.been.calledOnce;
+      expect(fakeBind.rescanAndEvaluate).calledWithExactly(rendered);
+    });
+  });
+
   it('should reload data if the src attribute changes', () => {
     const initialItems = [
       {title: 'Title1'},
@@ -118,7 +142,7 @@ describe('amp-list component', () => {
     const itemElement3 = document.createElement('div');
     const fetchPromise = Promise.resolve(initialItems);
     const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetchItems_').withExactArgs('items')
+    listMock.expects('fetch_').withExactArgs('items')
         .returns(fetchPromise).once();
     templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
         element, initialItems)
@@ -132,12 +156,12 @@ describe('amp-list component', () => {
       expect(list.container_.contains(itemElement)).to.be.true;
       const newFetchPromise = Promise.resolve(newItems);
       const newRenderPromise = Promise.resolve([itemElement2, itemElement3]);
-      listMock.expects('fetchItems_').withExactArgs('items')
+      listMock.expects('fetch_').withExactArgs('items')
           .returns(newFetchPromise).once();
       templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
           element, newItems)
           .returns(newRenderPromise).once();
-      const spy = sandbox.spy(list, 'populateList_');
+      const spy = sandbox.spy(list, 'fetchList_');
       element.setAttribute('src', 'https://data2.com/list.json');
       list.mutatedAttributesCallback({'src': 'https://data2.com/list.json'});
       expect(spy).to.be.calledOnce;
@@ -145,7 +169,7 @@ describe('amp-list component', () => {
   });
 
   it('should fail to load b/c data is absent', () => {
-    listMock.expects('fetchItems_')
+    listMock.expects('fetch_')
         .returns(Promise.resolve({})).once();
     templatesMock.expects('findAndRenderTemplateArray').never();
     return expect(list.layoutCallback()).to.eventually.be
@@ -158,7 +182,7 @@ describe('amp-list component', () => {
     ];
     element.setAttribute('items', 'different');
     const itemElement = document.createElement('div');
-    listMock.expects('fetchItems_')
+    listMock.expects('fetch_')
         .returns(Promise.resolve(different)).once();
     templatesMock.expects('findAndRenderTemplateArray')
         .withExactArgs(element, different)
@@ -175,7 +199,7 @@ describe('amp-list component', () => {
     const itemElement = document.createElement('div');
     const fetchPromise = Promise.resolve(items);
     const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetchItems_').withExactArgs('items')
+    listMock.expects('fetch_').withExactArgs('items')
         .returns(fetchPromise).once();
     templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
         element, items)
@@ -197,7 +221,7 @@ describe('amp-list component', () => {
     itemElement.setAttribute('role', 'listitem1');
     const fetchPromise = Promise.resolve(items);
     const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetchItems_').withExactArgs('items')
+    listMock.expects('fetch_').withExactArgs('items')
         .returns(fetchPromise).once();
     templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
         element, items)
@@ -211,8 +235,8 @@ describe('amp-list component', () => {
   });
 
   it('should show placeholder on fetch failure (w/o fallback)', () => {
-    // Stub fetchItems_() to fail.
-    listMock.expects('fetchItems_').returns(Promise.reject()).once();
+    // Stub fetch_() to fail.
+    listMock.expects('fetch_').returns(Promise.reject()).once();
     listMock.expects('togglePlaceholder').never();
     return list.layoutCallback().catch(() => {});
   });
@@ -230,7 +254,7 @@ describe('amp-list component', () => {
 
     it('should hide fallback element on fetch success', () => {
       // Stub fetch and render to succeed.
-      listMock.expects('fetchItems_').returns(Promise.resolve([])).once();
+      listMock.expects('fetch_').returns(Promise.resolve([])).once();
       templatesMock.expects('findAndRenderTemplateArray')
           .returns(Promise.resolve([]));
       // Act as if a fallback is already displayed.
@@ -242,8 +266,8 @@ describe('amp-list component', () => {
     });
 
     it('should hide placeholder and display fallback on fetch failure', () => {
-      // Stub fetchItems_() to fail.
-      listMock.expects('fetchItems_').returns(Promise.reject()).once();
+      // Stub fetch_() to fail.
+      listMock.expects('fetch_').returns(Promise.reject()).once();
 
       listMock.expects('togglePlaceholder').withExactArgs(false).once();
       listMock.expects('toggleFallback').withExactArgs(true).once();

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AmpEvents} from '../../../../src/amp-events';
 import {AmpList} from '../amp-list';
 import {Services} from '../../../../src/services';
 import * as sinon from 'sinon';
@@ -93,7 +94,7 @@ describe('amp-list component', () => {
     const itemElement = document.createElement('div');
     const fetchPromise = Promise.resolve(items);
     const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetchItems_').withExactArgs('items')
+    listMock.expects('fetch_').withExactArgs('items')
         .returns(fetchPromise).once();
     templatesMock.expects('findAndRenderTemplateArray').withArgs()
         .returns(renderPromise).once();

--- a/test/fixtures/bind-list.html
+++ b/test/fixtures/bind-list.html
@@ -9,13 +9,21 @@
   <script async src="/dist/amp.js"></script>
   <script async custom-element="amp-bind" src="/dist/v0/amp-bind-0.1.max.js"></script>
   <script async custom-element="amp-list" src="/dist/v0/amp-list-0.1.max.js"></script>
+  <script async custom-element="amp-mustache" src="/dist/v0/amp-mustache-0.1.max.js"></script>
 </head>
 
 <body>
   <!-- amp-list -->
-  <button id="listSrcButton" on="tap:AMP.setState({listSrc: 'https://www.google.com/bound.json'})">Change amp-list</button>
-  <button id="httpListSrcButton" on="tap:AMP.setState({listSrc: 'http://www.google.com/justhttp.json'})">Change amp-list</button>
-  <amp-list id="list" width=100 height=100 src="https://www.google.com/unbound.json" [src]=listSrc>
+  <amp-state id="foo">
+    <script type="application/json">
+      {"bar": "Evaluated!"}
+    </script>
+  </amp-state>
+  <button id="button" on="tap:AMP.setState({src: 'https://foo.com/data.json'})">Set `src`</button>
+  <amp-list id="list" width=200 height=50 src="/list/fruit-data/get?cors=0" [src]="src">
+    <template type="amp-mustache">
+      <span class="foobar" [text]="foo.bar">?</span>
+    </template>
   </amp-list>
 </body>
 </html>

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -59,7 +59,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
   }
 
   /** @return {!Promise} */
-  function waitForBindApplication() {
+  function waitForSetState() {
     // Bind should be available, but need to wait for actions to resolve
     // service promise for bind and call setState.
     return fixture.awaitEvent(BindEvents.SET_STATE, ++numSetStates);
@@ -80,7 +80,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const button = fixture.doc.getElementById('changeTextButton');
       expect(textElement.textContent).to.equal('unbound');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(textElement.textContent).to.equal('hello world');
       });
     });
@@ -90,7 +90,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const button = fixture.doc.getElementById('changeTextClassButton');
       expect(textElement.className).to.equal('original');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(textElement.className).to.equal('new');
       });
     });
@@ -122,7 +122,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       submitButton.click();
 
       // The <amp-form> has on="submit-success:AMP.setState(...)".
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         // References to XHR JSON data should work on submit-success.
         expect(xhrText.textContent).to.equal('John Miller');
         // Illegal bindings/values should not be applied to DOM.
@@ -149,7 +149,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       // so it must be generated manually.
       range.value = 47;
       range.dispatchEvent(new Event('change', {bubbles: true}));
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(rangeText.textContent).to.equal('0 <= 47 <= 100');
       });
     });
@@ -159,7 +159,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const checkbox = fixture.doc.getElementById('checkbox');
       expect(checkboxText.textContent).to.equal('Unbound');
       checkbox.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(checkboxText.textContent).to.equal('Checked: true');
       });
     });
@@ -176,11 +176,11 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(checkbox.hasAttribute('checked')).to.be.false;
       expect(checkbox.checked).to.be.true;
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(checkbox.hasAttribute('checked')).to.be.false;
         expect(checkbox.checked).to.be.false;
         button.click();
-        return waitForBindApplication();
+        return waitForSetState();
       }).then(() => {
         // When Bind checks the box back to true, it adds the checked attr.
         expect(checkbox.hasAttribute('checked')).to.be.true;
@@ -193,7 +193,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const radio = fixture.doc.getElementById('radio');
       expect(radioText.textContent).to.equal('Unbound');
       radio.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(radioText.textContent).to.equal('Checked: true');
       });
     });
@@ -215,7 +215,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
           carousel.querySelector('div.amp-carousel-button-next');
       nextSlideButton.click();
 
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(slideNumber.textContent).to.equal('1');
       });
     });
@@ -233,7 +233,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const button = fixture.doc.getElementById('goToSlideOne');
       button.click();
 
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(secondSlide.getAttribute('aria-hidden')).to.be.equal('false');
         expect(firstSlide.getAttribute('aria-hidden')).to.equal('true');
       });
@@ -250,7 +250,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const img = fixture.doc.getElementById('image');
       expect(img.getAttribute('src')).to.equal('http://www.google.com/image1');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(img.getAttribute('src')).to
             .equal('http://www.google.com/image2');
       });
@@ -261,7 +261,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const img = fixture.doc.getElementById('image');
       expect(img.getAttribute('src')).to.equal('http://www.google.com/image1');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(img.getAttribute('src')).to
             .equal('http://www.google.com/image1');
       });
@@ -272,11 +272,11 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(img.getAttribute('src')).to.equal('http://www.google.com/image1');
       const ftpSrcButton = fixture.doc.getElementById('ftpSrcButton');
       ftpSrcButton.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(img.getAttribute('src')).to.equal('http://www.google.com/image1');
         const telSrcButton = fixture.doc.getElementById('telSrcButton');
         telSrcButton.click();
-        return waitForBindApplication();
+        return waitForSetState();
       }).then(() => {
         expect(img.getAttribute('src')).to
             .equal('http://www.google.com/image1');
@@ -288,7 +288,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const img = fixture.doc.getElementById('image');
       expect(img.getAttribute('alt')).to.equal('unbound');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(img.getAttribute('alt')).to.equal('hello world');
       });
     });
@@ -299,7 +299,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(img.getAttribute('height')).to.equal('200');
       expect(img.getAttribute('width')).to.equal('200');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(img.getAttribute('height')).to.equal('300');
         expect(img.getAttribute('width')).to.equal('300');
       });
@@ -320,7 +320,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
 
       const button = fixture.doc.getElementById('changeLiveListTextButton');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(liveListItem1.firstElementChild.textContent).to
             .equal('hello world');
       });
@@ -350,7 +350,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
         expect(liveListItems.children.length).to.equal(2);
         newItem = fixture.doc.getElementById('newItem');
         fixture.doc.getElementById('changeLiveListTextButton').click();
-        return waitForBindApplication();
+        return waitForSetState();
       }).then(() => {
         expect(existingItem.firstElementChild.textContent).to
             .equal('hello world');
@@ -376,7 +376,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(img3.hasAttribute('selected')).to.be.false;
       expect(selectionText.textContent).to.equal('None');
       img2.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(img1.hasAttribute('selected')).to.be.false;
         expect(img2.hasAttribute('selected')).to.be.true;
         expect(img3.hasAttribute('selected')).to.be.false;
@@ -396,7 +396,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(selectionText.textContent).to.equal('None');
       // Changes selection to 2
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(img1.hasAttribute('selected')).to.be.false;
         expect(img2.hasAttribute('selected')).to.be.true;
         expect(img3.hasAttribute('selected')).to.be.false;
@@ -416,7 +416,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(vid.getAttribute('src')).to
           .equal('https://www.google.com/unbound.webm');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(vid.getAttribute('src')).to
             .equal('https://www.google.com/bound.webm');
       });
@@ -428,7 +428,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(vid.getAttribute('src')).to
           .equal('https://www.google.com/unbound.webm');;
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(vid.getAttribute('src')).to
             .equal('https://www.google.com/unbound.webm');
       });
@@ -440,7 +440,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(vid.getAttribute('src')).to
           .equal('https://www.google.com/unbound.webm');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         // Only HTTPS is allowed
         expect(vid.getAttribute('src')).to
             .equal('https://www.google.com/unbound.webm');
@@ -452,7 +452,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const vid = fixture.doc.getElementById('video');
       expect(vid.getAttribute('alt')).to.equal('unbound');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(vid.getAttribute('alt')).to.equal('hello world');
       });
     });
@@ -465,10 +465,10 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const vid = fixture.doc.getElementById('video');
       expect(vid.hasAttribute('controls')).to.be.false;
       showControlsButton.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(vid.hasAttribute('controls')).to.be.true;
         hideControlsButton.click();
-        return waitForBindApplication();
+        return waitForSetState();
       }).then(() => {
         expect(vid.hasAttribute('controls')).to.be.false;
       });
@@ -485,7 +485,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const yt = fixture.doc.getElementById('youtube');
       expect(yt.getAttribute('data-videoid')).to.equal('unbound');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(yt.getAttribute('data-videoid')).to.equal('bound');
       });
     });
@@ -502,7 +502,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       const iframe = bc.querySelector('iframe');
       expect(iframe.src).to.not.contain('bound');
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(iframe.src).to.contain('bound');
       });
     });
@@ -522,7 +522,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
       expect(ampIframe.getAttribute('src')).to.not.contain(newSrc);
       expect(iframe.src).to.not.contain(newSrc);
       button.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(ampIframe.getAttribute('src')).to.contain(newSrc);
         expect(iframe.src).to.contain(newSrc);
       });
@@ -531,30 +531,24 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
 
   describe('with <amp-list>', () => {
     beforeEach(() => {
-      return setupWithFixture('test/fixtures/bind-list.html');
+      return setupWithFixture('test/fixtures/bind-list.html', 1);
     });
 
     it('should support binding to src', () => {
-      const button = fixture.doc.getElementById('listSrcButton');
       const list = fixture.doc.getElementById('list');
-      expect(list.getAttribute('src'))
-          .to.equal('https://www.google.com/unbound.json');
-      button.click();
-      return waitForBindApplication().then(() => {
-        expect(list.getAttribute('src'))
-            .to.equal('https://www.google.com/bound.json');
+      expect(list.getAttribute('src')).to.equal('/list/fruit-data/get?cors=0');
+      fixture.doc.getElementById('button').click();
+      return waitForSetState().then(() => {
+        expect(list.getAttribute('src')).to.equal('https://foo.com/data.json');
       });
     });
 
-    it('should NOT change src when new value uses an invalid protocol', () => {
-      const button = fixture.doc.getElementById('httpListSrcButton');
+    it('should evaluate bindings in template', () => {
       const list = fixture.doc.getElementById('list');
-      expect(list.getAttribute('src'))
-          .to.equal('https://www.google.com/unbound.json');
-      button.click();
-      return waitForBindApplication().then(() => {
-        expect(list.getAttribute('src'))
-            .to.equal('https://www.google.com/unbound.json');
+      return fixture.awaitEvent(AmpEvents.DOM_UPDATE, 1).then(() => {
+        list.querySelectorAll('span.foobar').forEach(span => {
+          expect(span.textContent).to.equal('Evaluated!');
+        });
       });
     });
   });
@@ -586,11 +580,11 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
           }));
       // Changes amp-state's src from .../first/source to .../second/source.
       changeAmpStateSrcButton.click();
-      return waitForBindApplication().then(() => {
+      return waitForSetState().then(() => {
         expect(ampState.getAttribute('src'))
             .to.equal('https://www.google.com/bind/second/source');
         // Wait for XHR to finish and for bind to re-apply bindings.
-        return waitForBindApplication();
+        return waitForSetState();
       }).then(() => {
         // bind applications caused by an amp-state mutation SHOULD NOT update
         // src attributes on amp-state elements.
@@ -598,7 +592,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
             .to.equal('https://www.google.com/bind/second/source');
         // Trigger a bind apply that isn't from an amp-state
         triggerBindApplicationButton.click();
-        return waitForBindApplication();
+        return waitForSetState();
       }).then(() => {
         // Now that a non-amp-state mutation has ocurred, the amp-state's src
         // attribute can be updated with the new src from the XHR.

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -37,6 +37,7 @@ describe.configure().skipSauceLabs().run('amp-bind', function() {
   });
 
   afterEach(() => {
+    fixture = null;
     sandbox.restore();
   });
 

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -67,6 +67,7 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
     // Counts the supported custom events.
     const events = {
       [AmpEvents.ATTACHED]: 0,
+      [AmpEvents.DOM_UPDATE]: 0,
       [AmpEvents.ERROR]: 0,
       [AmpEvents.LOAD_START]: 0,
       [AmpEvents.STUBBED]: 0,


### PR DESCRIPTION
Fixes #9862.

When rendering amp-list: if the template contains bindings, evaluate and apply the expression results before display. 

- Renders original template if amp-bind isn't installed (immediate) or if amp-bind fails (2s timeout).
- This, along with #9860, should satisfy the "amp-fresh" V2 FR.
- This was the original intent of #7376 but was postponed due to FOUC.

Tight coupling between amp-list and amp-bind feels dirty but can be refactored into an abstract processing pipeline for dynamic content once there's another extension like amp-bind.

TODO: Do the same thing for amp-live-list in a follow-up.