### PR TITLE
Document `visual-tests.json` with detailed comments 

### DIFF
--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -1,12 +1,62 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Particulars of the webpages used in the AMP visual diff tests.
 {
-  "_comment": "HTML file(s) used for visual diff tests. Paths relative to src.",
+  // Path relative to amphtml/ that contains the assets for all test pages.
   "assets_dir": "examples/visual-tests",
+
+  // Path relative to webserver root where assets for all test pages are served.
   "assets_base_url": "/examples/visual-tests",
+
+  // List of webpages used in tests.
   "webpages": [
+    // Example of a webpage spec.
+    // {
+    //   // Path of webpage relative to webserver root.
+    //   "url": "examples/visual-tests/foo/foo.html",
+    //
+    //   // Name used to identify snapshots of webpage on Percy.
+    //   "name": "Foo test",
+    //
+    //   // CSS elements that must never appear on the webpage.
+    //   "forbidden_css": [
+    //     ".invalid-css-class",
+    //     ".another-invalid-css-class"
+    //   ],
+    //
+    //   // CSS elements that may initially appear on the page, but must
+    //   // eventually disappear.
+    //   "loading_incomplete_css": [
+    //     ".loading-in-progress-css-class",
+    //     ".another-loading-in-progress-css-class"
+    //   ],
+    //
+    //   // CSS elements that must eventually appear on the page.
+    //   "loading_complete_css": [
+    //     ".loading-complete-css-class",
+    //     ".another-loading-complete-css-class"
+    //   ]
+    // },
+
     {
       "url": "examples/visual-tests/amp-by-example/amp-by-example.html",
       "name": "Amp By Example"
     },
+
     {
       "url": "examples/visual-tests/article.amp/article.amp.html",
       "name": "AMP Article",
@@ -37,11 +87,14 @@
       ]
     }
   ],
+
+  // List of failing webpages. Move pages here if they fail, since visual tests
+  // block PRs from being merged. Move them back once failures are fixed.
   "failing_webpages": [
     {
+      // Fails due to https://github.com/ampproject/amphtml/issues/10377
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
-      "issue": "https://github.com/ampproject/amphtml/issues/10377",
       "forbidden_css": [
         ".comic-amp-font-loaded",
         ".comic-amp-bold-font-loaded"

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -16,6 +16,10 @@
 
 /**
  * Particulars of the webpages used in the AMP visual diff tests.
+ *
+ * Note: While the extension of this file is .json, the contents are pseudo-json
+ * due to the presence of detailed comments. Ruby's json parser natively
+ * supports comments in json files, and is capable of parsing this file.
  */
 {
   /**

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -14,43 +14,54 @@
  * limitations under the License.
  */
 
-// Particulars of the webpages used in the AMP visual diff tests.
+/**
+ * Particulars of the webpages used in the AMP visual diff tests.
+ */
 {
-  // Path relative to amphtml/ that contains the assets for all test pages.
+  /**
+   * Path relative to amphtml/ that contains the assets for all test pages.
+   */
   "assets_dir": "examples/visual-tests",
 
-  // Path relative to webserver root where assets for all test pages are served.
+  /**
+   * Path relative to webserver root where assets for all test pages are
+   * served.
+   */
   "assets_base_url": "/examples/visual-tests",
 
-  // List of webpages used in tests.
+  /**
+   * List of webpages used in tests.
+   */
   "webpages": [
-    // Example of a webpage spec.
-    // {
-    //   // Path of webpage relative to webserver root.
-    //   "url": "examples/visual-tests/foo/foo.html",
-    //
-    //   // Name used to identify snapshots of webpage on Percy.
-    //   "name": "Foo test",
-    //
-    //   // CSS elements that must never appear on the webpage.
-    //   "forbidden_css": [
-    //     ".invalid-css-class",
-    //     ".another-invalid-css-class"
-    //   ],
-    //
-    //   // CSS elements that may initially appear on the page, but must
-    //   // eventually disappear.
-    //   "loading_incomplete_css": [
-    //     ".loading-in-progress-css-class",
-    //     ".another-loading-in-progress-css-class"
-    //   ],
-    //
-    //   // CSS elements that must eventually appear on the page.
-    //   "loading_complete_css": [
-    //     ".loading-complete-css-class",
-    //     ".another-loading-complete-css-class"
-    //   ]
-    // },
+  /**
+   * Example of a webpage spec.
+   * {
+   *   // Path of webpage relative to webserver root.
+   *   "url": "examples/visual-tests/foo/foo.html",
+   *
+   *   // Name used to identify snapshots of webpage on Percy.
+   *   "name": "Foo test",
+   *
+   *   // CSS elements that must never appear on the webpage.
+   *   "forbidden_css": [
+   *     ".invalid-css-class",
+   *     ".another-invalid-css-class"
+   *   ],
+   *
+   *   // CSS elements that may initially appear on the page, but must
+   *   // eventually disappear.
+   *   "loading_incomplete_css": [
+   *     ".loading-in-progress-css-class",
+   *     ".another-loading-in-progress-css-class"
+   *   ],
+   *
+   *   // CSS elements that must eventually appear on the page.
+   *   "loading_complete_css": [
+   *     ".loading-complete-css-class",
+   *     ".another-loading-complete-css-class"
+   *   ]
+   * },
+   */
 
     {
       "url": "examples/visual-tests/amp-by-example/amp-by-example.html",
@@ -88,11 +99,15 @@
     }
   ],
 
-  // List of failing webpages. Move pages here if they fail, since visual tests
-  // block PRs from being merged. Move them back once failures are fixed.
+  /**
+   * List of failing webpages. Move pages here if they fail, since visual tests
+   * block PRs from being merged. Move them back once failures are fixed.
+   */
   "failing_webpages": [
     {
-      // Fails due to https://github.com/ampproject/amphtml/issues/10377
+      /**
+       * Fails due to https://github.com/ampproject/amphtml/issues/10377
+       */
       "url": "examples/visual-tests/font.amp.404/font.amp.html",
       "name": "Fonts 404",
       "forbidden_css": [


### PR DESCRIPTION
Ruby natively allows comments in json. Since `visual-tests.json` will only be parsed by `visual-diff.rb`, these comments should be parsed just fine.

Fixes #10535 