### PR TITLE
getValueForExpr: add support for arrays

### DIFF
--- a/src/json.js
+++ b/src/json.js
@@ -19,7 +19,7 @@
  * {@link http://json.org/}.
  */
 
-import {isObject, isArray} from './types';
+import {isObject} from './types';
 
 
 // NOTE Type are changed to {*} because of
@@ -91,17 +91,11 @@ export function getValueForExpr(obj, expr) {
   let value = obj;
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i];
-    if (!part) {
-      value = undefined;
-      break;
-    }
-    if (isArray(value) && arrayHasKey(value, part)) {
-      value = value[part];
-      continue;
-    }
-    if (isObject(value) &&
-            value[part] !== undefined &&
-            hasOwnProperty(value, part)) {
+    if (part &&
+        value &&
+        value[part] !== undefined &&
+        hasOwnProperty(value, part)
+    ) {
       value = value[part];
       continue;
     }
@@ -154,13 +148,4 @@ function hasOwnProperty(obj, key) {
   }
   return Object.prototype.hasOwnProperty.call(
       /** @type {!Object} */ (obj), key);
-}
-
-/**
- * @param {*} arr
- * @param {string} key
- * @return {boolean}
- */
-function arrayHasKey(arr, key) {
-  return (('' + parseInt(key, 10)) === key) && (typeof arr[key] !== 'undefined');
 }

--- a/src/json.js
+++ b/src/json.js
@@ -19,7 +19,7 @@
  * {@link http://json.org/}.
  */
 
-import {isObject} from './types';
+import {isObject, isArray} from './types';
 
 
 // NOTE Type are changed to {*} because of
@@ -74,8 +74,8 @@ export function recreateNonProtoObject(obj) {
 /**
  * Returns a value from an object for a field-based expression. The expression
  * is a simple nested dot-notation of fields, such as `field1.field2`. If any
- * field in a chain does not exist or is not an object, the returned value will
- * be `undefined`.
+ * field in a chain does not exist or is not an object or array, the returned 
+ * value will be `undefined`.
  *
  * @param {!JsonObject} obj
  * @param {string} expr
@@ -95,13 +95,18 @@ export function getValueForExpr(obj, expr) {
       value = undefined;
       break;
     }
-    if (!isObject(value) ||
-            value[part] === undefined ||
-            !hasOwnProperty(value, part)) {
-      value = undefined;
-      break;
+    if (isArray(value) && arrayHasKey(value, part)) {
+      value = value[part];
+      continue;
     }
-    value = value[part];
+    if (isObject(value) &&
+            value[part] !== undefined &&
+            hasOwnProperty(value, part)) {
+      value = value[part];
+      continue;
+    }
+    value = undefined;
+    break;
   }
   return value;
 }
@@ -149,4 +154,13 @@ function hasOwnProperty(obj, key) {
   }
   return Object.prototype.hasOwnProperty.call(
       /** @type {!Object} */ (obj), key);
+}
+
+/**
+ * @param {*} arr
+ * @param {string} key
+ * @return {boolean}
+ */
+function arrayHasKey(arr, key) {
+  return (('' + parseInt(key, 10)) === key) && (typeof arr[key] !== 'undefined');
 }

--- a/src/json.js
+++ b/src/json.js
@@ -74,7 +74,7 @@ export function recreateNonProtoObject(obj) {
 /**
  * Returns a value from an object for a field-based expression. The expression
  * is a simple nested dot-notation of fields, such as `field1.field2`. If any
- * field in a chain does not exist or is not an object or array, the returned 
+ * field in a chain does not exist or is not an object or array, the returned
  * value will be `undefined`.
  *
  * @param {!JsonObject} obj

--- a/test/functional/test-json.js
+++ b/test/functional/test-json.js
@@ -84,6 +84,24 @@ describe('json', () => {
       expect(getValueForExpr(obj, 'num')).to.be.undefined;
       expect(getValueForExpr(obj, '__proto__')).to.be.undefined;
     });
+
+    it('should support array index', () => {
+      const child = {num: 1, str: 'A'};
+      const obj = {foo: [child]};
+      expect(getValueForExpr(obj, 'foo.0.num')).to.equal(1);
+      expect(getValueForExpr(obj, 'foo.0.str')).to.equal('A');
+      expect(getValueForExpr(obj, 'foo.0a.str')).to.be.undefined;
+      expect(getValueForExpr(obj, 'foo.1.num')).to.be.undefined;
+      expect(getValueForExpr(obj, 'foo.1.str')).to.be.undefined;
+    });
+
+    it('should only search in own properties of arrays', () => {
+      const arr = ['A'];
+      expect(getValueForExpr(arr, '0')).to.equal('A');
+      expect(getValueForExpr(arr, '1')).to.be.undefined;
+      expect(getValueForExpr(arr, 'concat')).to.be.undefined;
+      expect(getValueForExpr(arr, '__proto__')).to.be.undefined;
+    });
   });
 
   describe('recreateNonProtoObject', () => {


### PR DESCRIPTION
# getValueForExpr: add support for arrays

Solves #10613 by adding support for array indexes for the `items` attribute of `amp-list`.