### PR TITLE
Add test to make sure window.context.data is the same data object passed into 3P extension code.

### DIFF
--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -19,12 +19,15 @@ import {dev} from '../src/log';
 
 /**
  * A fake ad network integration that is mainly used for testing
- * and demo purpose.
+ * and demo purposes. This implementation gets stripped out in compiled
+ * production code.
  * @param {!Window} global
  * @param {!Object} data
  */
 export function _ping_(global, data) {
-  global.dataAsParam = data; // for testing only. see #10628
+  // for testing only. see #10628
+  global.networkIntegrationDataParamForTesting = data;
+
   validateData(data, [], ['valid', 'adHeight', 'adWidth', 'enableIo', 'url']);
   global.document.getElementById('c').textContent = data.ping;
   global.ping = Object.create(null);

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -18,10 +18,13 @@ import {validateData} from '../3p/3p';
 import {dev} from '../src/log';
 
 /**
+ * A fake ad network integration that is mainly used for testing
+ * and demo purpose.
  * @param {!Window} global
  * @param {!Object} data
  */
 export function _ping_(global, data) {
+  global.dataAsParam = data; // for testing only. see #10628
   validateData(data, [], ['valid', 'adHeight', 'adWidth', 'enableIo', 'url']);
   global.document.getElementById('c').textContent = data.ping;
   global.ping = Object.create(null);

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -540,3 +540,6 @@ data.renderer;
 // zergnet.js
 window.zergnetWidgetId;
 data.zergid;
+
+// _ping_.js
+window.networkIntegrationDataParamForTesting;

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -73,7 +73,8 @@ function createIframeWithApis(fixture) {
 
     // make sure the context.data is the same instance as the data param passed
     // into the vendor function. see #10628
-    expect(context.data).to.equal(iframe.contentWindow.dataAsParam);
+    expect(context.data).to.equal(
+        iframe.contentWindow.networkIntegrationDataParamForTesting);
 
     expect(context.pageViewId).to.be.greaterThan(0);
     expect(context.startTime).to.be.a('number');

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -70,6 +70,11 @@ function createIframeWithApis(fixture) {
       customValue: '123',
       'other_value': 'foo',
     });
+
+    // make sure the context.data is the same instance as the data param passed
+    // into the vendor function. see #10628
+    expect(context.data).to.equal(iframe.contentWindow.dataAsParam);
+
     expect(context.pageViewId).to.be.greaterThan(0);
     expect(context.startTime).to.be.a('number');
     expect(context.container).to.be.defined;


### PR DESCRIPTION
closes #10628