### PR TITLE
Simplify ActionTrust to two tiers

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -210,7 +210,7 @@ export class AmpSlideScroll extends BaseSlides {
       if (args) {
         this.showSlideWhenReady(args['index']);
       }
-    }, ActionTrust.MEDIUM); // TODO(choumx, #9699): LOW.
+    }, ActionTrust.HIGH);
   }
 
   /** @override */
@@ -595,7 +595,7 @@ export class AmpSlideScroll extends BaseSlides {
       const name = 'slideChange';
       const event =
           createCustomEvent(this.win, `slidescroll.${name}`, {index: newIndex});
-      this.action_.trigger(this.element, name, event, ActionTrust.MEDIUM);
+      this.action_.trigger(this.element, name, event, ActionTrust.HIGH);
 
       this.element.dispatchCustomEvent(name, {index: newIndex});
     }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -186,9 +186,8 @@ export class AmpForm {
     this.verifier_ = getFormVerifier(
         this.form_, () => this.handleXhrVerify_());
 
-    // TODO(choumx, #9699): HIGH.
     this.actions_.installActionHandler(
-        this.form_, this.actionHandler_.bind(this), ActionTrust.MEDIUM);
+        this.form_, this.actionHandler_.bind(this), ActionTrust.HIGH);
     this.installEventHandlers_();
 
     /** @private {?Promise} */
@@ -344,7 +343,7 @@ export class AmpForm {
       event.preventDefault();
     }
     // Submits caused by user input have high trust.
-    this.submit_(ActionTrust.MEDIUM); // TODO(choumx, #9699): HIGH.
+    this.submit_(ActionTrust.HIGH);
   }
 
   /**
@@ -605,7 +604,7 @@ export class AmpForm {
     const name = success ? FormState_.SUBMIT_SUCCESS : FormState_.SUBMIT_ERROR;
     const event =
         createCustomEvent(this.win_, `${TAG}.${name}`, {response: json});
-    this.actions_.trigger(this.form_, name, event, ActionTrust.MEDIUM);
+    this.actions_.trigger(this.form_, name, event, ActionTrust.HIGH);
   }
 
   /**

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -223,9 +223,8 @@ export class AmpLiveList extends AMP.BaseElement {
     this.curNumOfLiveItems_ = this.validateLiveListItems_(
         this.itemsSlot_, true);
 
-    // TODO(choumx, #9699): LOW.
     this.registerAction(
-        'update', this.updateAction_.bind(this), ActionTrust.MEDIUM);
+        'update', this.updateAction_.bind(this), ActionTrust.HIGH);
 
     if (!this.element.hasAttribute('aria-live')) {
       this.element.setAttribute('aria-live', 'polite');

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -294,9 +294,8 @@ export class AmpSelector extends AMP.BaseElement {
               targetOption: el.getAttribute('option'),
               selectedOptions: selectedValues,
             });
-        // TODO(choumx, #9699): HIGH.
         this.action_.trigger(this.element, name, selectEvent,
-            ActionTrust.MEDIUM);
+            ActionTrust.HIGH);
       }
     });
   }

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -374,7 +374,7 @@ actions that apply to the whole document.
   </tr>
   <tr>
     <td><code>navigateTo(url=STRING)</code></td>
-    <td>Navigates current window to given URL. Supports <a href="./amp-var-substitutions.md">standard URL subsitutions</a>. Can only be invoked via <code>tap</code> or <code>change</code> events.</td>
+    <td>Navigates current window to given URL. Supports <a href="./amp-var-substitutions.md">standard URL subsitutions</a>.</td>
   </tr>
   <tr>
     <td><code>goBack</code></td>

--- a/src/action-trust.js
+++ b/src/action-trust.js
@@ -24,6 +24,5 @@
  */
 export const ActionTrust = {
   LOW: 1,
-  MEDIUM: 2,
-  HIGH: 3,
+  HIGH: 100,
 };

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -502,7 +502,7 @@ export class BaseElement {
    * @return {ActionTrust}
    */
   activationTrust() {
-    return ActionTrust.MEDIUM;
+    return ActionTrust.HIGH;
   }
 
   /**
@@ -528,15 +528,14 @@ export class BaseElement {
    * Registers the action handler for the method with the specified name.
    *
    * The handler is only invoked by events with trust equal to or greater than
-   * `minTrust` (or ActionTrust.MEDIUM if not provided). Otherwise, a
-   * user error is logged.
+   * `minTrust`. Otherwise, a user error is logged.
    *
    * @param {string} method
    * @param {function(!./service/action-impl.ActionInvocation)} handler
    * @param {ActionTrust} minTrust
    * @public
    */
-  registerAction(method, handler, minTrust = ActionTrust.MEDIUM) {
+  registerAction(method, handler, minTrust = ActionTrust.HIGH) {
     this.initActionMap_();
     this.actionMap_[method] = {handler, minTrust};
   }

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -131,7 +131,6 @@ export function onDocumentFormSubmit_(e) {
     e.stopImmediatePropagation();
 
     const actions = Services.actionServiceForDoc(form);
-    // TODO(choumx, #9699): HIGH.
-    actions.execute(form, 'submit', /*args*/ null, form, e, ActionTrust.MEDIUM);
+    actions.execute(form, 'submit', /*args*/ null, form, e, ActionTrust.HIGH);
   }
 }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -220,24 +220,19 @@ export class ActionService {
     } else if (name == 'submit') {
       this.root_.addEventListener(name, event => {
         const element = dev().assertElement(event.target);
-        // TODO(choumx, #9699): HIGH.
-        this.trigger(element, name, event, ActionTrust.MEDIUM);
+        this.trigger(element, name, event, ActionTrust.HIGH);
       });
     } else if (name == 'change') {
       this.root_.addEventListener(name, event => {
         const element = dev().assertElement(event.target);
-        // Only `change` events from <select> elements have high trust.
-        const trust = element.tagName == 'SELECT'
-            ? ActionTrust.HIGH
-            : ActionTrust.MEDIUM;
         this.addInputDetails_(event);
-        this.trigger(element, name, event, trust);
+        this.trigger(element, name, event, ActionTrust.HIGH);
       });
     } else if (name == 'input-debounced') {
       const debouncedInput = debounce(this.ampdoc.win, event => {
         const target = dev().assertElement(event.target);
         this.trigger(target, name, /** @type {!ActionEventDef} */ (event),
-            ActionTrust.MEDIUM);
+            ActionTrust.HIGH);
       }, DEFAULT_DEBOUNCE_WAIT);
 
       this.root_.addEventListener('input', event => {
@@ -299,7 +294,7 @@ export class ActionService {
    * @param {function(!ActionInvocation)} handler
    * @param {ActionTrust} minTrust
    */
-  addGlobalMethodHandler(name, handler, minTrust = ActionTrust.MEDIUM) {
+  addGlobalMethodHandler(name, handler, minTrust = ActionTrust.HIGH) {
     this.globalMethodHandlers_[name] = {handler, minTrust};
   }
 
@@ -333,7 +328,7 @@ export class ActionService {
    * @param {function(!ActionInvocation)} handler
    * @param {ActionTrust} minTrust
    */
-  installActionHandler(target, handler, minTrust = ActionTrust.MEDIUM) {
+  installActionHandler(target, handler, minTrust = ActionTrust.HIGH) {
     // TODO(dvoytenko, #7063): switch back to `target.id` with form proxy.
     const targetId = target.getAttribute('id') || '';
     const debugid = target.tagName + '#' + targetId;

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -120,7 +120,7 @@ export class StandardActions {
    * @private
    */
   handleAmpSetState_(invocation) {
-    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
     Services.bindForDocOrNull(invocation.target).then(bind => {
@@ -167,8 +167,7 @@ export class StandardActions {
    * @private
    */
   handleAmpGoBack_(invocation) {
-    // TODO(choumx, #9699): HIGH.
-    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
     Services.historyForDoc(this.ampdoc).goBack();
@@ -193,7 +192,7 @@ export class StandardActions {
    * @param {!./action-impl.ActionInvocation} invocation
    */
   handleScrollTo(invocation) {
-    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
     const node = dev().assertElement(invocation.target);
@@ -219,7 +218,7 @@ export class StandardActions {
    * @param {!./action-impl.ActionInvocation} invocation
    */
   handleFocus(invocation) {
-    if (!invocation.satisfiesTrust(ActionTrust.MEDIUM)) {
+    if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
     const node = dev().assertElement(invocation.target);

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -182,15 +182,13 @@ export class VideoManager {
    * @private
    */
   registerCommonActions_(video) {
-    // TODO(choumx, #9699): HIGH for unmuted play, LOW for muted play.
-    video.registerAction('play', video.play.bind(video, /* isAutoplay */ false),
-        ActionTrust.MEDIUM);
-    // TODO(choumx, #9699): LOW.
-    video.registerAction('pause', video.pause.bind(video), ActionTrust.MEDIUM);
-    video.registerAction('mute', video.mute.bind(video), ActionTrust.MEDIUM);
-    // TODO(choumx, #9699): HIGH.
-    video.registerAction('unmute', video.unmute.bind(video),
-        ActionTrust.MEDIUM);
+    // Only require ActionTrust.LOW for video actions to defer to platform
+    // specific handling (e.g. user gesture requirement for unmuted playback).
+    video.registerAction('play',
+        video.play.bind(video, /* isAutoplay */ false), ActionTrust.LOW);
+    video.registerAction('pause', video.pause.bind(video), ActionTrust.LOW);
+    video.registerAction('mute', video.mute.bind(video), ActionTrust.LOW);
+    video.registerAction('unmute', video.unmute.bind(video), ActionTrust.LOW);
   }
 
   /**

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -666,10 +666,6 @@ describe('installActionHandler', () => {
     expect(handlerSpy).to.not.be.called;
 
     action.invoke_(target, 'submit', /* args */ null,
-        'button', 'tap', ActionTrust.MEDIUM);
-    expect(handlerSpy).to.not.be.called;
-
-    action.invoke_(target, 'submit', /* args */ null,
         'button', 'tap', ActionTrust.HIGH);
     expect(handlerSpy).to.be.calledOnce;
   });
@@ -773,9 +769,9 @@ describe('Action interceptor', () => {
 
   it('should dequeue actions after handler set', () => {
     action.invoke_(target, 'method1', /* args */ null, 'source1', 'event1',
-        ActionTrust.MEDIUM);
+        ActionTrust.HIGH);
     action.invoke_(target, 'method2', /* args */ null, 'source2', 'event2',
-        ActionTrust.MEDIUM);
+        ActionTrust.HIGH);
 
     expect(Array.isArray(getQueue())).to.be.true;
     expect(getActionHandler()).to.be.undefined;
@@ -802,7 +798,7 @@ describe('Action interceptor', () => {
     expect(inv1.event).to.equal('event2');
 
     action.invoke_(target, 'method3', /* args */ null, 'source3', 'event3',
-        ActionTrust.MEDIUM);
+        ActionTrust.HIGH);
     expect(handler).to.have.callCount(3);
     const inv2 = handler.getCall(2).args[0];
     expect(inv2.target).to.equal(target);
@@ -856,10 +852,6 @@ describe('Action common handler', () => {
 
     action.invoke_(target, 'foo', /* args */ null, 'source1', 'event1',
         ActionTrust.LOW);
-    expect(handler).to.not.be.called;
-
-    action.invoke_(target, 'foo', /* args */ null, 'source1', 'event1',
-        ActionTrust.MEDIUM);
     expect(handler).to.not.be.called;
 
     action.invoke_(target, 'foo', /* args */ null, 'source1', 'event1',


### PR DESCRIPTION
Fixes #10166 and #9953.

Discussed with @ericlindley-g.

- Reduce granularity of ActionTrust from three to two tiers.
- All current events and actions have/require "high" trust, which means that ActionTrust as a whole will effectively be a no-op for now (until we have low-trust events).