### PR TITLE
Fix ExperimentInfo literal type

### DIFF
--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -45,8 +45,8 @@ import {
  */
 export const PROFILING_BRANCHES = {
   'a4aProfilingRate': {
-    'isTrafficEligible': () => true,
-    'branches': ['unused', 'unused'],
+    isTrafficEligible: () => true,
+    branches: ['unused', 'unused'],
   },
 };
 


### PR DESCRIPTION
Shouldn't need to make ExperimentInfo keys string literals since it's a [record type](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#record-type). My mistake.

Context: https://github.com/ampproject/amphtml/pull/10582/files#r129449089

/to @dvoytenko