### PR TITLE
Mark font server URLs as not intended to work

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -129,13 +129,14 @@ function filterWhitelistedLinks(markdown) {
 
   // Direct links to the https://cdn.ampproject.org domain (not a valid page)
   filteredMarkdown =
-      filteredMarkdown.replace(/https:\/\/cdn.ampproject.org(?!\/)/g, '');
+      filteredMarkdown.replace(/https:\/\/cdn\.ampproject\.org(?!\/)/g, '');
 
   // Links inside a <code> block (illustrative, and not always valid)
   filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/g, '');
 
   // Dailymotion link that is marked dead in Travis CI
-  filteredMarkdown = filteredMarkdown.replace(/https:\/\/developer.dailymotion.com\/player#player-parameters/g, '');
+  filteredMarkdown = filteredMarkdown.replace(
+      /https:\/\/developer\.dailymotion\.com\/player#player-parameters/g, '');
 
   // After all whitelisting is done, clean up any remaining empty blocks bounded
   // by backticks. Otherwise, `` will be treated as the start of a code block

--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -302,9 +302,9 @@ Example:
 
 Font providers can be whitelisted if they support CSS-only integrations and serve over HTTPS. The following origins are currently allowed for font serving via link tags:
 
-- Fonts.com: https://fast.fonts.net
-- Google Fonts: https://fonts.googleapis.com
-- Font Awesome: https://maxcdn.bootstrapcdn.com
+- Fonts.com: `https://fast.fonts.net`
+- Google Fonts: `https://fonts.googleapis.com`
+- Font Awesome: `https://maxcdn.bootstrapcdn.com`
 
 IMPLEMENTERS NOTE: Adding to this list requires a change to the AMP Cache CSP rule.
 


### PR DESCRIPTION
When changing `spec/amp-html-format.md` Trevis fails during `check-links` task. For example here: https://travis-ci.org/ampproject/amphtml/jobs/257735944#L757

<img width="589" alt="screenshot 2017-07-26 18 15 55" src="https://user-images.githubusercontent.com/68341/28631786-ba2d2e60-722e-11e7-9db6-db0ec80f8217.png">

These two font providers do not implement the root page and return 404 error.

**Changes:** All three font provider URLs are made non-clickable. Small improvements in `check-links` task.

Related-to #10644