### PR TITLE
Pass credentials in call tracking request

### DIFF
--- a/extensions/amp-call-tracking/0.1/amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/amp-call-tracking.js
@@ -35,15 +35,16 @@ let cachedResponsePromises_ = {};
  */
 function fetch_(win, url) {
   if (!(url in cachedResponsePromises_)) {
-    cachedResponsePromises_[url] = Services.xhrFor(win).fetchJson(url)
+    cachedResponsePromises_[url] = Services.xhrFor(win)
+        .fetchJson(url, {credentials: 'include'})
         .then(res => res.json());
   }
   return cachedResponsePromises_[url];
 }
 
 
-/** Visible for testing. */
-export function clearResponseCache() {
+/** @visibleForTesting */
+export function clearResponseCacheForTesting() {
   cachedResponsePromises_ = {};
 }
 

--- a/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-call-tracking';
-import {clearResponseCache} from '../amp-call-tracking';
+import {clearResponseCacheForTesting} from '../amp-call-tracking';
 import {createIframePromise} from '../../../../testing/iframe';
 import {Services} from '../../../../src/services';
 import * as sinon from 'sinon';
@@ -49,7 +49,7 @@ describe('amp-call-tracking', () => {
   function mockXhrResponse(iframe, url, response) {
     xhrMock
         .expects('fetchJson')
-        .withArgs(url)
+        .withArgs(url, sandbox.match(init => init.credentials == 'include'))
         .returns(Promise.resolve({
           json() {
             return Promise.resolve(response);
@@ -69,7 +69,7 @@ describe('amp-call-tracking', () => {
   });
 
   afterEach(() => {
-    clearResponseCache();
+    clearResponseCacheForTesting();
 
     xhrMock.verify();
     sandbox.restore();


### PR DESCRIPTION
Bonus: Properly annotate a testing-only function.

/cc @jasti 