### PR TITLE
Clean sticky-ad-early-load flag

### DIFF
--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -20,15 +20,11 @@ import {Layout} from '../../../src/layout';
 import {dev,user} from '../../../src/log';
 import {removeElement} from '../../../src/dom';
 import {toggle, computedStyle} from '../../../src/style';
-import {isExperimentOn} from '../../../src/experiments';
 import {
   setStyle,
   removeAlphaFromColor,
 } from '../../../src/style';
 import {whenUpgradedToCustomElement} from '../../../src/dom';
-
-/** @const */
-const EARLY_LOAD_EXPERIMENT = 'sticky-ad-early-load';
 
 class AmpStickyAd extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -140,14 +136,8 @@ class AmpStickyAd extends AMP.BaseElement {
    */
   onScroll_() {
     const scrollTop = this.viewport_.getScrollTop();
-    if (isExperimentOn(this.win, EARLY_LOAD_EXPERIMENT) && scrollTop > 1) {
-      this.display_();
-      return;
-    }
-
-    const viewportHeight = this.viewport_.getSize().height;
-    // Check user has scrolled at least one viewport from init position.
-    if (scrollTop > viewportHeight) {
+    if (scrollTop > 1) {
+      // Check greater than 1 because AMP set scrollTop to 1 in iOS.
       this.display_();
     }
   }

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -53,21 +53,16 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       expect(impl.scrollUnlisten_).to.be.function;
     });
 
-    it('should not build when scrollTop less than viewportHeight', () => {
+    it('should not build when scrollTop not greater than 1', () => {
       const scheduleLayoutSpy = sandbox.spy(impl, 'scheduleLayout');
       const removeOnScrollListenerSpy =
           sandbox.spy(impl, 'removeOnScrollListener_');
       const getScrollTopSpy = sandbox.spy();
-      const getSizeSpy = sandbox.spy();
       const getScrollHeightSpy = sandbox.spy();
 
       impl.viewport_.getScrollTop = function() {
         getScrollTopSpy();
-        return 20;
-      };
-      impl.viewport_.getSize = function() {
-        getSizeSpy();
-        return {height: 50};
+        return 1;
       };
       impl.viewport_.getScrollHeight = function() {
         getScrollHeightSpy();
@@ -78,7 +73,6 @@ describes.realWin('amp-sticky-ad 1.0 version', {
         setTimeout(resolve, 0);
       }).then(() => {
         expect(getScrollTopSpy).to.have.been.called;
-        expect(getSizeSpy).to.have.been.called;
         expect(scheduleLayoutSpy).to.not.have.been.called;
         expect(removeOnScrollListenerSpy).to.not.have.been.called;
       });

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -18,7 +18,6 @@
 import '../amp-sticky-ad';
 import '../../../amp-ad/0.1/amp-ad';
 import {poll} from '../../../../testing/iframe';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('amp-sticky-ad 1.0 version', {
   win: { /* window spec */
@@ -85,48 +84,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       });
     });
 
-    it('should build on enough scroll dist, one more viewport ahead', () => {
-      const scheduleLayoutSpy = sandbox.stub(impl, 'scheduleLayoutForAd_',
-          () => {});
-      const removeOnScrollListenerSpy =
-          sandbox.spy(impl, 'removeOnScrollListener_');
-      const getScrollTopSpy = sandbox.spy();
-      const getSizeSpy = sandbox.spy();
-      const getScrollHeightSpy = sandbox.spy();
-
-      impl.viewport_.getScrollTop = function() {
-        getScrollTopSpy();
-        return 100;
-      };
-      impl.viewport_.getSize = function() {
-        getSizeSpy();
-        return {height: 50};
-      };
-      impl.viewport_.getScrollHeight = function() {
-        getScrollHeightSpy();
-        return 300;
-      };
-      impl.deferMutate = function(callback) {
-        callback();
-      };
-      impl.vsync_.mutate = function(callback) {
-        callback();
-      };
-
-      impl.onScroll_();
-      expect(getScrollTopSpy).to.have.been.called;
-      expect(getSizeSpy).to.have.been.called;
-      expect(removeOnScrollListenerSpy).to.have.been.called;
-      // Layout on ad is called only after fixed layer is done.
-      expect(scheduleLayoutSpy).to.not.have.been.called;
-      expect(addToFixedLayerStub).to.have.been.calledOnce;
-      return addToFixedLayerPromise.then(() => {
-        expect(scheduleLayoutSpy).to.have.been.calledOnce;
-      });
-    });
-
-    it('experiment version, should display once user scroll', () => {
-      toggleExperiment(win, 'sticky-ad-early-load');
+    it('should display once user scroll', () => {
       const scheduleLayoutSpy = sandbox.stub(impl, 'scheduleLayoutForAd_',
           () => {});
       const removeOnScrollListenerSpy =
@@ -151,7 +109,6 @@ describes.realWin('amp-sticky-ad 1.0 version', {
 
       impl.onScroll_();
       expect(removeOnScrollListenerSpy).to.have.been.called;
-      toggleExperiment(win, 'sticky-ad-early-load');
       // Layout on ad is called only after fixed layer is done.
       expect(scheduleLayoutSpy).to.not.have.been.called;
       expect(addToFixedLayerStub).to.have.been.calledOnce;

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -213,12 +213,6 @@ const EXPERIMENTS = [
     name: 'Display jank meter',
   },
   {
-    id: 'sticky-ad-early-load',
-    name: 'Load sticky-ad early after user first scroll' +
-        'Only apply to 1.0 version',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7479',
-  },
-  {
     id: 'amp-fx-parallax',
     name: 'Amp extension for a parallax effect',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7801',


### PR DESCRIPTION
This feature has been out for a while. Clean the experiment flag. 
close #7479 