### PR TITLE
Add support for Criteo standalone ads

### DIFF
--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -225,24 +225,20 @@ data.url;
 // criteo.js
 var Criteo;
 Criteo.DisplayAd;
-Criteo.RenderAd;
 Criteo.Log.Debug;
 Criteo.CallRTA;
 Criteo.ComputeDFPTargetingForAMP;
-Criteo.ComputeStandaloneDFPTargeting;
 Criteo.PubTag = {};
+Criteo.PubTag.Adapters.AMP.Standalone;
 Criteo.PubTag.RTA = {};
 Criteo.PubTag.RTA.DefaultCrtgContentName;
 Criteo.PubTag.RTA.DefaultCrtgRtaCookieName
-Criteo.RequestBids;
-Criteo.GetBids;
 data.tagtype;
 data.networkid;
 data.cookiename;
 data.varname;
 data.zone;
 data.adserver;
-data.lineItemRanges
 
 // distroscale.js
 data.tid;

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -225,19 +225,24 @@ data.url;
 // criteo.js
 var Criteo;
 Criteo.DisplayAd;
+Criteo.RenderAd;
 Criteo.Log.Debug;
 Criteo.CallRTA;
 Criteo.ComputeDFPTargetingForAMP;
+Criteo.ComputeStandaloneDFPTargeting;
 Criteo.PubTag = {};
 Criteo.PubTag.RTA = {};
 Criteo.PubTag.RTA.DefaultCrtgContentName;
 Criteo.PubTag.RTA.DefaultCrtgRtaCookieName
+Criteo.RequestBids;
+Criteo.GetBids;
 data.tagtype;
 data.networkid;
 data.cookiename;
 data.varname;
 data.zone;
 data.adserver;
+data.lineItemRanges
 
 // distroscale.js
 data.tid;

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -229,6 +229,8 @@ Criteo.Log.Debug;
 Criteo.CallRTA;
 Criteo.ComputeDFPTargetingForAMP;
 Criteo.PubTag = {};
+Criteo.PubTag.Adapters = {};
+Criteo.PubTag.Adapters.AMP = {};
 Criteo.PubTag.Adapters.AMP.Standalone;
 Criteo.PubTag.RTA = {};
 Criteo.PubTag.RTA.DefaultCrtgContentName;

--- a/ads/criteo.js
+++ b/ads/criteo.js
@@ -101,7 +101,7 @@ function listenForCreativeRequests() {
           'creative': bid.creative,
           'displayUrl': bid.displayUrl,
         });
-        ev.source.postMessage(JSON.stringify(message), '*');
+        ev.source./*OK*/postMessage(JSON.stringify(message), '*');
       }
     }
   }, false);

--- a/ads/criteo.md
+++ b/ads/criteo.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Criteo
 
-Criteo support for AMP covers Real Time Audience (RTA), Publisher Marketplace (PuMP) and Passback technologies.
+Criteo support for AMP covers Real Time Audience (RTA), Standalone, Publisher Marketplace (PuMP) and Passback technologies.
 
 For configuration details and to generate your tags, please refer to [your publisher account](https://publishers.criteo.com) or contact publishers@criteo.com.
 
@@ -43,6 +43,20 @@ For configuration details and to generate your tags, please refer to [your publi
 </amp-ad>
 ```
 
+## Example - Standalone
+
+```html
+<amp-ad width=300 height=250
+    type="criteo"
+    data-tagtype="standalone"
+    data-timeout="700"
+    data-zone="497747"
+    data-slot="/2729856/AMP_Standalone_AdUnit"
+    data-adserver="DFP"
+    data-line-item-ranges="0..3:0.5">
+</amp-ad>
+```
+
 ## Configuration
 
 The ad size is based on the setup of your Criteo zone. The `width` and `height` attributes of the `amp-ad` tag should match that.
@@ -65,4 +79,16 @@ Supported parameters:
 
 - `data-tagtype`: identifies the used Criteo technology. Must be “passback”. Required.
 - `data-zone`: your Criteo zone identifier. Required.
+
+### Standalone
+
+Supported parameters:
+
+- `data-tagtype`: identifies the used Criteo technology. Must be "standalone". Required.
+- `data-adserver`: the name of your adserver. Required. Only "DFP" is supported at this stage.
+- `data-slot`: adserver (DFP) slot. Required.
+- `data-zone`: your Criteo zone identifier. Required.
+- `data-line-item-ranges`: your line item ranges. Required.
+- `data-timeout`: bid timeout override. Optional.
+- `data-doubleclick`: custom options to send to doubleclick, in JSON format. Optional. See [doubleclick documentation](google/doubleclick.md) for details.
 

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -524,6 +524,20 @@
       data-zone="314159">
   </amp-ad>
 
+  <h2>Criteo Standalone</h2>
+  <p>Due to ad targeting, the slot might not load ad.</p>
+
+  <amp-ad width="300" height="250"
+      type="criteo"
+      data-tagtype="standalone"
+      data-timeout="700"
+      data-zone="497747"
+      data-slot="/2729856/AMP_Standalone_AdUnit"
+      data-adserver="DFP"
+      data-line-item-ranges="0..3:0.5"
+      data-doubleclick='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusions":["health"],"tagForChildDirectedTreatment":1}'>
+  </amp-ad>
+
   <h2>Criteo RTA</h2>
   <p>Due to ad targeting, the slot might not load ad.</p>
 


### PR DESCRIPTION
# Ads: add support for Criteo standalone

Add support for standalone ads using CDB and DFP for Criteo.

Usage example can be found in the updated documentation and in the example file.