### PR TITLE
Completely remove extractCreativeAndSignature and factor out SignatureVerifier interface

### DIFF
--- a/ads/google/a4a/docs/Network-Impl-Guide.md
+++ b/ads/google/a4a/docs/Network-Impl-Guide.md
@@ -41,7 +41,7 @@ All network communication via the AMP HTML runtime (resources or XHR) require SS
 
 ### AMP Ad Creative Signature
 
-In order for the AMP runtime to know that a creative is valid [AMP](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md), and thus receive preferential ad rendering, it must pass a client-side, validation check.  The creative must be sent by the ad network to a validation service which verifies the creative conforms to the [specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md).  If so, it will be rewritten by the validation service and the rewritten creative and a cryptographic signature will be returned to the ad network.  The rewritten creative and signature must be included in the response to the AMP runtime from the ad network. extractCreativeAndSignature will then parse out the creative and the signature from the ad response.  Lack of, or invalid signature will cause the runtime to treat it as a Legacy Ad, rendering it within a cross domain iframe and using delayed ad rendering.
+In order for the AMP runtime to know that a creative is valid [AMP](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md), and thus receive preferential ad rendering, it must pass a client-side, validation check.  The creative must be sent by the ad network to a validation service which verifies the creative conforms to the [specification](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md).  If so, it will be rewritten by the validation service and the rewritten creative and a cryptographic signature will be returned to the ad network.  The rewritten creative and signature must be included in the response to the AMP runtime from the ad network. The AMP runtime will then parse out the creative and the signature from the ad response.  Lack of, or invalid signature will cause the runtime to treat it as a Legacy Ad, rendering it within a cross domain iframe and using delayed ad rendering.
 
 Client side verification of the signature, and thus preferential rendering, requires a browser to have Web Crypto. However, if a browser does not have Web Crypto, Fast Fetch is still able to be used if the ad network permits it. In this case, the ad will simply be guaranteed to render in a cross-domain iframe.
 
@@ -79,7 +79,7 @@ Ad networks that want to add support for Fast Fetch within AMP must add the file
 
 *See Figure 1 Parts B and D*
 
-Implement class `AmpAdNetwork<TYPE>Impl`. This class must extend [AmpA4A](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/0.1/amp-a4a.js). This class must overwrite the super class methods **getAdUrl()** and **extractCreativeAndSignature()**.
+Implement class `AmpAdNetwork<TYPE>Impl`. This class must extend [AmpA4A](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/0.1/amp-a4a.js). This class must overwrite the super class method **getAdUrl()**.
 
 
 ``` javascript
@@ -87,17 +87,10 @@ getAdUrl() - must construct and return the ad url for ad request.
   // @return {string} - the ad url
 ```
 
-``` javascript
-extractCreativeAndSignature(responseText, responseHeaders)
-  // @param {!ArrayBuffer} responseText Response body from the ad request.
-  // @param {!Headers} responseHeaders Response headers from the ad request
-  // @return {Object} creativeParts Object must have a .creative and a .signature.
-``` 
-
 
 Examples of network implementations can be seen for [DoubleClick](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js) and [AdSense](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js). 
 
-Usage of getAdUrl and extractCreativeAndSignature can be seen within the this.adPromise_ promise chain in [amp-a4a.js](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/0.1/amp-a4a.js)
+Usage of getAdUrl can be seen within the this.adPromise_ promise chain in [amp-a4a.js](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/0.1/amp-a4a.js)
 
 ### `<TYPE>-a4a-config.js`
 
@@ -155,8 +148,6 @@ Please write thorough testing for your AMP ad network implementation.
 * File hierarchy created within amphtml/extensions
 
 * Custom `amp-ad-network-<TYPE>-impl.js` overwrites getAdUrl()
-
-* Custom `amp-ad-network-<TYPE>-impl.js` overwrites extractCreativeAndSignature()
 
 * `<TYPE>-a4a-config.js` implements <TYPE>IsA4AEnabled()
 

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -135,7 +135,6 @@ describe('GoogleAdLifecycleReporter', () => {
           urlBuilt: '1',
           adRequestStart: '2',
           adRequestEnd: '3',
-          extractCreativeAndSignature: '4',
           adResponseValidateStart: '5',
           renderFriendlyStart: '6',
           renderCrossDomainStart: '7',

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -15,17 +15,13 @@
  */
 
 import {Services} from '../../../src/services';
-import {
-  verifyHashVersion,
-  LegacySignatureVerifier,
-  PublicKeyInfoDef,
-} from './legacy-signature-verifier';
+import {signatureVerifierFor} from './legacy-signature-verifier';
+import {VerificationFailure} from './signature-verifier';
 import {
   is3pThrottled,
   getAmpAdRenderOutsideViewport,
   incrementLoadingAds,
 } from '../../amp-ad/0.1/concurrent-load';
-import {signingServerURLs} from '../../../ads/_a4a-config';
 import {createElementWithAttributes} from '../../../src/dom';
 import {cancellation, isCancellation} from '../../../src/error';
 import {
@@ -41,10 +37,7 @@ import {dev, user, duplicateErrorIfNecessary} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject, isEnumValue} from '../../../src/types';
-import {some} from '../../../src/utils/promise';
-import {base64UrlDecodeToBytes} from '../../../src/utils/base64';
 import {utf8Decode} from '../../../src/utils/bytes';
-import {endsWith} from '../../../src/string';
 import {isExperimentOn} from '../../../src/experiments';
 import {setStyle} from '../../../src/style';
 import {assertHttpsUrl} from '../../../src/url';
@@ -79,9 +72,6 @@ const METADATA_STRING_NO_QUOTES =
 /** @type {string} */
 export const DEFAULT_SAFEFRAME_VERSION = '1-0-9';
 
-/** @const {string} @visibleForTesting */
-export const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
-
 /** @const {string} */
 export const CREATIVE_SIZE_HEADER = 'X-CreativeSize';
 
@@ -114,12 +104,6 @@ const SHARED_IFRAME_PROPERTIES = dict({
   'marginheight': '0',
 });
 
-/** @typedef {{
- *    creative: ArrayBuffer,
- *    signature: ?Uint8Array,
- *  }} */
-export let AdResponseDef;
-
 /** @typedef {{width: number, height: number}} */
 export let SizeInfoDef;
 
@@ -130,27 +114,6 @@ export let SizeInfoDef;
     }} */
 let CreativeMetaDataDef;
 
-/**
- * A set of public keys for a single AMP signing service.  A single service may
- * return more than one key if, e.g., they're rotating keys and they serve
- * the current and upcoming keys.  A CryptoKeysDef stores one or more
- * (promises to) keys, in the order given by the return value from the
- * signing service.
- *
- * @typedef {{serviceName: string, keys: !Array<!Promise<!PublicKeyInfoDef>>}}
- */
-let CryptoKeysDef;
-
-/**
- * The public keys for all signing services.  This is an array of promises,
- * one per signing service, in the order given by the array returned by
- * #getSigningServiceNames().  Each entry resolves to the keys returned by
- * that service, represented by a `CryptoKeysDef` object.
- *
- * @typedef {Array<!Promise<!CryptoKeysDef>>}
- */
-let AllServicesCryptoKeysDef;
-
 /** @private */
 export const LIFECYCLE_STAGES = {
   // Note: Use strings as values here, rather than numbers, so that "0" does
@@ -159,7 +122,6 @@ export const LIFECYCLE_STAGES = {
   urlBuilt: '1',
   adRequestStart: '2',
   adRequestEnd: '3',
-  extractCreativeAndSignature: '4',
   adResponseValidateStart: '5',
   renderFriendlyStart: '6',  // TODO(dvoytenko): this signal and similar are actually "embed-create", not "render-start".
   renderCrossDomainStart: '7',
@@ -265,17 +227,13 @@ export class AmpA4A extends AMP.BaseElement {
     /** @private {boolean} whether creative has been verified as AMP */
     this.isVerifiedAmpCreative_ = false;
 
-    /** @private @const {!LegacySignatureVerifier} */
-    this.signatureVerifier_ = new LegacySignatureVerifier(this.win);
-
     /** @private {?ArrayBuffer} */
     this.creativeBody_ = null;
 
     /**
      * Initialize this with the slot width/height attributes, and override
-     * later with what the network implementation returns via
-     * extractCreativeAndSignature. Note: Either value may be 'auto' (i.e.,
-     * non-numeric).
+     * later with what the network implementation returns via extractSize.
+     * Note: Either value may be 'auto' (i.e., non-numeric).
      *
      * @private {?({width, height}|../../../src/layout-rect.LayoutRectDef)}
      */
@@ -382,16 +340,11 @@ export class AmpA4A extends AMP.BaseElement {
         });
 
     this.uiHandler = new AMP.AmpAdUIHandler(this);
-    if (!this.win.ampA4aValidationKeys) {
-      // Without the following variable assignment, there's no way to apply a
-      // type annotation to a win-scoped variable, so the type checker doesn't
-      // catch type errors here.  This no-op allows us to enforce some type
-      // expectations.  The const assignment will hopefully be optimized
-      // away by the compiler.  *fingers crossed*
-      /** @type {!AllServicesCryptoKeysDef} */
-      const forTypeSafety = this.getKeyInfoSets_();
-      this.win.ampA4aValidationKeys = forTypeSafety;
-    }
+    const verifier = signatureVerifierFor(this.win);
+    const visible = Services.viewerForDoc(this.getAmpDoc()).whenFirstVisible();
+    this.getSigningServiceNames().forEach(signingServiceName => {
+      verifier.loadKeyset(signingServiceName, visible);
+    });
   }
 
   /** @override */
@@ -523,7 +476,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   shouldInitializePromiseChain_() {
-    if (!this.signatureVerifier_.isAvailable()) {
+    if (!Services.cryptoFor(this.win).isPkcsAvailable()) {
       return false;
     }
     const slotRect = this.getIntersectionElementLayoutBox();
@@ -680,26 +633,10 @@ export class AmpA4A extends AMP.BaseElement {
             };
           });
         })
-        // This block returns the ad creative, signature, and size, if
-        // available; null otherwise.
-        /**
-         * @return {?Promise<{creativeParts: !AdResponseDef, size: ?SizeInfoDef}>}
-         */
-        .then(responseParts => {
-          checkStillCurrent();
-          if (!responseParts) {
-            return null;
-          }
-          this.protectedEmitLifecycleEvent_('extractCreativeAndSignature');
-          const size = this.extractSize(responseParts.headers);
-          return this.extractCreativeAndSignature(
-              responseParts.bytes, responseParts.headers)
-              .then(creativeParts => ({creativeParts, size}));
-        })
         // This block returns the ad creative if it exists and validates as AMP;
         // null otherwise.
         /** @return {!Promise<?ArrayBuffer>} */
-        .then(creativeData => {
+        .then(responseParts => {
           checkStillCurrent();
           // Keep a handle to the creative body so that we can render into
           // SafeFrame or NameFrame later, if necessary.  TODO(tdrl): Temporary,
@@ -708,34 +645,37 @@ export class AmpA4A extends AMP.BaseElement {
           // src cache issue.  If we decide to keep a SafeFrame-like solution,
           // we should restructure the promise chain to pass this info along
           // more cleanly, without use of an object variable outside the chain.
-          if (!creativeData) {
+          if (!responseParts) {
             return Promise.resolve();
           }
-          const {creativeParts, size} = creativeData;
+          const {bytes, headers} = responseParts;
+          const size = this.extractSize(responseParts.headers);
           this.creativeSize_ = size || this.creativeSize_;
           if (this.experimentalNonAmpCreativeRenderMethod_ !=
               XORIGIN_MODE.CLIENT_CACHE &&
-              creativeParts.creative) {
-            this.creativeBody_ = creativeParts.creative;
-          }
-          if (!creativeParts.signature) {
-            return Promise.resolve();
+              bytes) {
+            this.creativeBody_ = bytes;
           }
           this.protectedEmitLifecycleEvent_('adResponseValidateStart');
-          return this.verifyCreativeSignature_(
-              creativeParts.creative, creativeParts.signature)
-              .then(creative => {
-                if (creative) {
-                  return creative;
+          return signatureVerifierFor(this.win)
+              .verify(bytes, headers, (eventName, extraVariables) => {
+                this.protectedEmitLifecycleEvent_(eventName, extraVariables);
+              })
+              .then(failure => {
+                this.protectedEmitLifecycleEvent_('adResponseValidateEnd');
+                switch (failure) {
+                  case null:
+                    return bytes;
+                  case VerificationFailure.NO_FAULT:
+                    return null;
+                  // TODO(@taymonbeal, #9274): differentiate between these
+                  case VerificationFailure.KEY_NOT_FOUND:
+                  case VerificationFailure.SIGNATURE_MISMATCH:
+                    user().error(
+                        TAG, this.element.getAttribute('type'),
+                        'Signature verification failed');
+                    return null;
                 }
-
-                user().error(TAG, this.element.getAttribute('type'),
-                    'Unable to validate AMP creative against key providers');
-                // Attempt to re-fetch the keys in case our locally cached
-                // batch has expired.
-                this.win.ampA4aValidationKeys = this.getKeyInfoSets_();
-                return this.verifyCreativeSignature_(
-                    creativeParts.creative, creativeParts.signature);
               });
         })
         .then(creative => {
@@ -823,111 +763,6 @@ export class AmpA4A extends AMP.BaseElement {
         });
       });
     });
-  }
-
-  /**
-   * Attempts to validate the creative signature against every key currently in
-   * our possession. This should never be called before at least one key fetch
-   * attempt is made.
-   *
-   * @param {!ArrayBuffer} creative
-   * @param {!Uint8Array} signature
-   * @return {!Promise<!ArrayBuffer>} The creative.
-   */
-  verifyCreativeSignature_(creative, signature) {
-    if (getMode().localDev) {
-      // localDev mode allows "FAKESIG" signature for the "fake" network.
-      if (signature == 'FAKESIG' &&
-          this.element.getAttribute('type') == 'fake') {
-        return Promise.resolve(creative);
-      }
-    }
-
-    // For each signing service, we have exactly one Promise,
-    // keyInfoSetPromise, that holds an Array of Promises of signing keys.
-    // So long as any one of these signing services can verify the
-    // signature, then the creative is valid AMP.
-    /** @type {!AllServicesCryptoKeysDef} */
-    const keyInfoSetPromises = this.win.ampA4aValidationKeys;
-    // Track if verification found, as it will ensure that promises yet to
-    // resolve will "cancel" as soon as possible saving unnecessary resource
-    // allocation.
-    let verified = false;
-    return some(keyInfoSetPromises.map(keyInfoSetPromise => {
-      // Resolve Promise into an object containing a 'keys' field, which
-      // is an Array of Promises of signing keys.  *whew*
-      return keyInfoSetPromise.then(keyInfoSet => {
-        // As long as any one individual key of a particular signing
-        // service, keyInfoPromise, can verify the signature, then the
-        // creative is valid AMP.
-        if (verified) {
-          return Promise.reject('noop');
-        }
-        return some(keyInfoSet.keys.map(keyInfoPromise => {
-          // Resolve Promise into signing key.
-          return keyInfoPromise.then(keyInfo => {
-            if (verified) {
-              return Promise.reject('noop');
-            }
-            if (!keyInfo) {
-              return Promise.reject('Promise resolved to null key.');
-            }
-            const signatureVerifyStartTime = this.getNow_();
-            // If the key exists, try verifying with it.
-            return this.signatureVerifier_.verifySignature(
-                new Uint8Array(creative),
-                signature,
-                keyInfo)
-                .then(isValid => {
-                  if (isValid) {
-                    verified = true;
-                    this.protectedEmitLifecycleEvent_(
-                        'signatureVerifySuccess', {
-                          'met.delta.AD_SLOT_ID': Math.round(
-                              this.getNow_() - signatureVerifyStartTime),
-                          'signingServiceName.AD_SLOT_ID': keyInfo.serviceName,
-                        });
-                    return creative;
-                  }
-                  // Only report if signature is expected to match, given that
-                  // multiple key providers could have been specified.
-                  // Note: the 'keyInfo &&' check here is not strictly
-                  // necessary, because we checked that above.  But
-                  // Closure type compiler can't seem to recognize that, so
-                  // this guarantees it to the compiler.
-                  if (keyInfo && verifyHashVersion(signature, keyInfo)) {
-                    user().error(TAG, this.element.getAttribute('type'),
-                        'Key failed to validate creative\'s signature',
-                        keyInfo.serviceName, keyInfo.cryptoKey);
-                  }
-                  // Reject to ensure the some operation waits for other
-                  // possible providers to properly verify and resolve.
-                  return Promise.reject(
-                      `${keyInfo.serviceName} key failed to verify`);
-                },
-                err => {
-                  dev().error(
-                      TAG, this.element.getAttribute('type'),
-                      keyInfo.serviceName, err, this.element);
-                });
-          });
-        }))
-        // some() returns an array of which we only need a single value.
-            .then(returnedArray => returnedArray[0], () => {
-          // Rejection occurs if all keys for this provider fail to validate.
-              return Promise.reject(
-                  `All keys for ${keyInfoSet.serviceName} failed to verify`);
-            });
-      });
-    }))
-        .then(returnedArray => {
-          this.protectedEmitLifecycleEvent_('adResponseValidateEnd');
-          return returnedArray[0];
-        }, () => {
-      // rejection occurs if all providers fail to verify.
-          this.protectedEmitLifecycleEvent_('adResponseValidateEnd');
-          return Promise.reject('No validation service could verify this key');
-        });
   }
 
   /**
@@ -1178,36 +1013,6 @@ export class AmpA4A extends AMP.BaseElement {
   }
 
   /**
-   * Extracts creative and verification signature (if present) from
-   * XHR response body and header.
-   *
-   * In the returned value, the `creative` field should be an `ArrayBuffer`
-   * containing the utf-8 encoded bytes of the creative itself, while the
-   * `signature` field should be a `Uint8Array` containing the raw signature
-   * bytes.  The `signature` field may be null if no signature was available
-   * for this creative / the creative is not valid AMP.
-   *
-   * @param {!ArrayBuffer} responseArrayBuffer content as array buffer
-   * @param {!../../../src/service/xhr-impl.FetchResponseHeaders} responseHeaders
-   *   XHR service FetchResponseHeaders object containing the response
-   *   headers.
-   * @return {!Promise<!AdResponseDef>}
-   */
-  extractCreativeAndSignature(responseArrayBuffer, responseHeaders) {
-    let signature = null;
-    const headerValue = responseHeaders.get(AMP_SIGNATURE_HEADER);
-    if (headerValue) {
-      try {
-        signature = base64UrlDecodeToBytes(headerValue);
-      } catch (e) {
-        // Decoding error; do nothing
-      }
-    }
-    return Promise.resolve(/** @type {!AdResponseDef} */ (
-        {creative: responseArrayBuffer, signature}));
-  }
-
-  /**
    * Determine the desired size of the creative based on the HTTP response
    * headers. Must be less than or equal to the original size of the ad slot
    * along each dimension. May be overridden by network.
@@ -1305,76 +1110,6 @@ export class AmpA4A extends AMP.BaseElement {
    */
   getSigningServiceNames() {
     return getMode().localDev ? ['google', 'google-dev'] : ['google'];
-  }
-
-  /**
-   * Retrieves all public keys, as specified in _a4a-config.js.
-   * None of the (inner or outer) promises returned by this function can reject.
-   *
-   * @return {!AllServicesCryptoKeysDef}
-   * @private
-   */
-  getKeyInfoSets_() {
-    if (!this.signatureVerifier_.isAvailable()) {
-      return [];
-    }
-    return this.getSigningServiceNames().map(serviceName => {
-      dev().assert(getMode().localDev || !endsWith(serviceName, '-dev'));
-      const url = signingServerURLs[serviceName];
-      const currServiceName = serviceName;
-      if (url) {
-        // Delay request until document is not in a prerender state.
-        return Services.viewerForDoc(this.getAmpDoc()).whenFirstVisible()
-            .then(() => Services.xhrFor(this.win).fetchJson(url, {
-              mode: 'cors',
-              method: 'GET',
-            // Set ampCors false so that __amp_source_origin is not
-            // included in XHR CORS request allowing for keyset to be cached
-            // across pages.
-              ampCors: false,
-              credentials: 'omit',
-            }).then(res => res.json()).then(jwkSetObj => {
-              const result = {serviceName: currServiceName};
-              if (isObject(jwkSetObj) && Array.isArray(jwkSetObj.keys) &&
-                jwkSetObj.keys.every(isObject)) {
-                result.keys = jwkSetObj.keys;
-              } else {
-                user().error(TAG, this.element.getAttribute('type'),
-                    `Invalid response from signing server ${currServiceName}`,
-                    this.element);
-                result.keys = [];
-              }
-              return result;
-            })).then(jwkSet => {
-              return {
-                serviceName: jwkSet.serviceName,
-                keys: jwkSet.keys.map(jwk =>
-                  this.signatureVerifier_
-                      .importPublicKey(jwkSet.serviceName, jwk)
-                      .catch(err => {
-                        user().error(TAG, this.element.getAttribute('type'),
-                            `error importing keys for: ${jwkSet.serviceName}`,
-                            err, this.element);
-                        return null;
-                      })),
-              };
-            }).catch(err => {
-              user().error(
-                  TAG, this.element.getAttribute('type'), err, this.element);
-            // TODO(a4a-team): This is a failure in the initial attempt to get
-            // the keys, probably b/c of a network condition.  We should
-            // re-trigger key fetching later.
-              return {serviceName: currServiceName, keys: []};
-            });
-      } else {
-        // The given serviceName does not have a corresponding URL in
-        // _a4a-config.js.
-        const reason = `Signing service '${serviceName}' does not exist.`;
-        user().error(
-            TAG, this.element.getAttribute('type'), reason, this.element);
-        return Promise.resolve({serviceName: currServiceName, keys: []});
-      }
-    });
   }
 
   /**

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {signatureVerifierFor} from './legacy-signature-verifier';
-import {VerificationFailure} from './signature-verifier';
+import {VerificationStatus} from './signature-verifier';
 import {
   is3pThrottled,
   getAmpAdRenderOutsideViewport,
@@ -661,16 +661,16 @@ export class AmpA4A extends AMP.BaseElement {
               .verify(bytes, headers, (eventName, extraVariables) => {
                 this.protectedEmitLifecycleEvent_(eventName, extraVariables);
               })
-              .then(failure => {
+              .then(status => {
                 this.protectedEmitLifecycleEvent_('adResponseValidateEnd');
-                switch (failure) {
-                  case null:
+                switch (status) {
+                  case VerificationStatus.OK:
                     return bytes;
-                  case VerificationFailure.NO_FAULT:
+                  case VerificationStatus.UNVERIFIED:
                     return null;
                   // TODO(@taymonbeal, #9274): differentiate between these
-                  case VerificationFailure.KEY_NOT_FOUND:
-                  case VerificationFailure.SIGNATURE_MISMATCH:
+                  case VerificationStatus.ERROR_KEY_NOT_FOUND:
+                  case VerificationStatus.ERROR_SIGNATURE_MISMATCH:
                     user().error(
                         TAG, this.element.getAttribute('type'),
                         'Signature verification failed');

--- a/extensions/amp-a4a/0.1/legacy-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/legacy-signature-verifier.js
@@ -14,29 +14,279 @@
  * limitations under the License.
  */
 
+import {VerificationFailure} from './signature-verifier';
+import {signingServerURLs} from '../../../ads/_a4a-config';
+import {dev, user} from '../../../src/log';
+import {getMode} from '../../../src/mode';
 import {Services} from '../../../src/services';
+import {endsWith} from '../../../src/string';
+import {isArray, isObject} from '../../../src/types';
 import {base64UrlDecodeToBytes} from '../../../src/utils/base64';
+import {some} from '../../../src/utils/promise';
 
 /**
  * An object holding the public key and its hash.
  *
  * @typedef {{
- *   serviceName: string,
+ *   signingServiceName: string,
  *   hash: !Uint8Array,
  *   cryptoKey: !webCrypto.CryptoKey
  * }}
  */
-export let PublicKeyInfoDef;
+let PublicKeyInfoDef;
+
+/**
+ * A set of public keys for a single AMP signing service.  A single service may
+ * return more than one key if, e.g., they're rotating keys and they serve
+ * the current and upcoming keys.  A CryptoKeysDef stores one or more
+ * (promises to) keys, in the order given by the return value from the
+ * signing service.
+ *
+ * @typedef {{
+ *     signingServiceName: string,
+ *     keys: !Array<!Promise<!PublicKeyInfoDef>>,
+ * }}
+ */
+let CryptoKeysDef;
 
 /** @const {number} */
 const SIGNATURE_VERSION = 0x00;
 
+/** @const {string} */
+const TAG = 'amp-a4a';
+
+/** @const {string} @visibleForTesting */
+export const AMP_SIGNATURE_HEADER = 'X-AmpAdSignature';
+
+/**
+ * Returns the signature verifier for the given window. Lazily creates it if it
+ * doesn't already exist.
+ *
+ * This ensures that only one signature verifier exists per window, which allows
+ * multiple Fast Fetch ad slots on a page (even ones from different ad networks)
+ * to share the same cached public keys.
+ *
+ * @param {!Window} win
+ * @return {!./signature-verifier.ISignatureVerifier}
+ */
+export function signatureVerifierFor(win) {
+  const propertyName = 'AMP_FAST_FETCH_SIGNATURE_VERIFIER_';
+  return win[propertyName] ||
+      (win[propertyName] = new LegacySignatureVerifier(win));
+}
+
+/**
+ * @implements {./signature-verifier.ISignatureVerifier}
+ * @visibleForTesting
+ */
 export class LegacySignatureVerifier {
 
-  /** @param {!Window} win */
+  /**
+   * @param {!Window} win
+   */
   constructor(win) {
+    /** @private @const {!Window} */
+    this.win_ = win;
+
     /** @private @const {!../../../src/service/crypto-impl.Crypto} */
     this.crypto_ = Services.cryptoFor(win);
+
+    /**
+     * The public keys for all signing services.  This is an array of promises,
+     * one per signing service, in the order given by the array returned by
+     * #getSigningServiceNames().  Each entry resolves to the keys returned by
+     * that service, represented by a `CryptoKeysDef` object.
+     *
+     * @private @const {!Array<!Promise<!CryptoKeysDef>>}
+     */
+    this.keys_ = [];
+
+    /**
+     * Gets a notion of current time, in ms.  The value is not necessarily
+     * absolute, so should be used only for computing deltas.  When available,
+     * the performance system will be used; otherwise Date.now() will be
+     * returned.
+     *
+     * @private @const {function(): number}
+     */
+    this.getNow_ = (win.performance && win.performance.now) ?
+        win.performance.now.bind(win.performance) : Date.now;
+  }
+
+  /**
+   * Fetches and imports the public keyset for the named signing service.
+   * Hopefully, this will hit cache in many cases and not make an actual network
+   * round-trip. This method should be called as early as possible so that the
+   * network request and key imports can execute in parallel with other
+   * operations.
+   *
+   * @param {string} signingServiceName
+   * @param {!Promise<undefined>} waitFor a promise that must resolve before the
+   *     keys are fetched
+   */
+  loadKeyset(signingServiceName, waitFor) {
+    dev().assert(getMode().localDev || !endsWith(signingServiceName, '-dev'));
+    if (!this.isAvailable_()) {
+      return;
+    }
+    const url = signingServerURLs[signingServiceName];
+    if (url) {
+      // Delay request until document is not in a prerender state.
+      this.keys_.push(waitFor.then(() =>
+          Services.xhrFor(this.win_).fetchJson(url, {
+            mode: 'cors',
+            method: 'GET',
+            // Set ampCors false so that __amp_source_origin is not
+            // included in XHR CORS request allowing for keyset to be cached
+            // across pages.
+            ampCors: false,
+            credentials: 'omit',
+          })).then(res => res.json())
+          .then(jwkSetObj => {
+            if (jwkSetObj && isArray(jwkSetObj['keys']) &&
+                jwkSetObj['keys'].every(isObject)) {
+              return jwkSetObj['keys'];
+            } else {
+              user().error(
+                  TAG,
+                  `Invalid response from signing server ${signingServiceName}`);
+              return [];
+            }
+          }).then(jwks => ({
+            signingServiceName,
+            keys: jwks.map(jwk => this.importPublicKey_(signingServiceName, jwk)
+                .catch(err => {
+                  user().error(
+                      TAG, `error importing keys for: ${signingServiceName}`,
+                      err);
+                  return null;
+                })),
+          })).catch(err => {
+            user().error(TAG, err);
+            // TODO(a4a-team): This is a failure in the initial attempt to get
+            // the keys, probably b/c of a network condition.  We should
+            // re-trigger key fetching later.
+            return {signingServiceName, keys: []};
+          }));
+    } else {
+      // The given signingServiceName does not have a corresponding URL in
+      // _a4a-config.js.
+      const reason = `Signing service '${signingServiceName}' does not exist.`;
+      user().error(TAG, reason);
+      this.keys_.push(/** @type {!Promise<!CryptoKeysDef>} */ (Promise.resolve({
+        signingServiceName,
+        keys: [],
+      })));
+    }
+  }
+
+  /**
+   * Extracts a cryptographic signature from `headers` and verifies that it's
+   * the correct cryptographic signature for `creative`.
+   *
+   * As a precondition, `loadKeyset` must have already been called on the
+   * signing service that was used.
+   *
+   * @param {!ArrayBuffer} creative
+   * @param {!Headers} headers
+   * @param {function(string, !Object)} lifecycleCallback called for each AMP
+   *     lifecycle event triggered during verification
+   * @return {!Promise<?VerificationFailure>} resolves to `null` on success, or,
+   *     on failure, to a `VerificationFailure` indicating the cause
+   */
+  verify(creative, headers, lifecycleCallback) {
+    if (!this.isAvailable_()) {
+      return Promise.resolve(
+          /** @type {?VerificationFailure} */ (VerificationFailure.NO_FAULT));
+    }
+    const headerValue = headers.get(AMP_SIGNATURE_HEADER);
+    if (!headerValue) {
+      return Promise.resolve(
+          /** @type {?VerificationFailure} */ (VerificationFailure.NO_FAULT));
+    }
+    let signature;
+    try {
+      signature = base64UrlDecodeToBytes(headerValue);
+    } catch (e) {
+      return Promise.resolve(/** @type {?VerificationFailure} */ (
+          VerificationFailure.SIGNATURE_MISMATCH));
+    }
+    // For each signing service, we have exactly one Promise,
+    // keyInfoSetPromise, that holds an Array of Promises of signing keys.
+    // So long as any one of these signing services can verify the
+    // signature, then the creative is valid AMP.
+    // Track if verification found, as it will ensure that promises yet to
+    // resolve will "cancel" as soon as possible saving unnecessary resource
+    // allocation.
+    let verified = false;
+    return some(this.keys_.map(keyInfoSetPromise => {
+      // Resolve Promise into an object containing a 'keys' field, which
+      // is an Array of Promises of signing keys.  *whew*
+      return keyInfoSetPromise.then(keyInfoSet => {
+        // As long as any one individual key of a particular signing
+        // service, keyInfoPromise, can verify the signature, then the
+        // creative is valid AMP.
+        if (verified) {
+          return Promise.reject('noop');
+        }
+        return some(keyInfoSet.keys.map(keyInfoPromise => {
+          // Resolve Promise into signing key.
+          return keyInfoPromise.then(keyInfo => {
+            if (verified) {
+              return Promise.reject('noop');
+            }
+            if (!keyInfo) {
+              return Promise.reject('Promise resolved to null key.');
+            }
+            const signatureVerifyStartTime = this.getNow_();
+            // If the key exists, try verifying with it.
+            return this.verifySignature_(
+                new Uint8Array(creative),
+                signature,
+                keyInfo).then(
+                isValid => {
+                  if (isValid) {
+                    verified = true;
+                    lifecycleCallback('signatureVerifySuccess', {
+                      'met.delta.AD_SLOT_ID':
+                          Math.round(this.getNow_() - signatureVerifyStartTime),
+                      'signingServiceName.AD_SLOT_ID':
+                          keyInfo.signingServiceName,
+                    });
+                    return creative;
+                  }
+                    // Only report if signature is expected to match, given that
+                    // multiple key providers could have been specified.
+                    // Note: the 'keyInfo &&' check here is not strictly
+                    // necessary, because we checked that above.  But
+                    // Closure type compiler can't seem to recognize that, so
+                    // this guarantees it to the compiler.
+                  if (keyInfo && verifyHashVersion(signature, keyInfo)) {
+                    user().error(
+                        TAG, 'Key failed to validate creative\'s signature',
+                        keyInfo.signingServiceName, keyInfo.cryptoKey);
+                  }
+                    // Reject to ensure the some operation waits for other
+                    // possible providers to properly verify and resolve.
+                  return Promise.reject(
+                      `${keyInfo.signingServiceName} key failed to verify`);
+                },
+                err => {
+                  dev().error(TAG, keyInfo.signingServiceName, err);
+                });
+          });
+        // some() returns an array of which we only need a single value.
+        })).then(returnedArray => returnedArray[0], () => {
+          // Rejection occurs if all keys for this provider fail to validate.
+          return Promise.reject(
+              `All keys for ${keyInfoSet.signingServiceName} failed to verify`);
+        });
+      });
+    })).then(
+        () => null,
+        // rejection occurs if all providers fail to verify.
+        () => /** @type {?VerificationFailure} */ (
+            VerificationFailure.SIGNATURE_MISMATCH));
   }
 
   /**
@@ -44,21 +294,22 @@ export class LegacySignatureVerifier {
    *
    * @return {boolean}
    */
-  isAvailable() {
+  isAvailable_() {
     return this.crypto_.isPkcsAvailable();
   }
 
   /**
    * Convert a JSON Web Key object to a browser-native cryptographic key and
    * compute a hash for it.  The caller must verify that Web Cryptography is
-   * available using isPkcsAvailable before calling this function.
+   * available before calling this function.
    *
-   * @param {string} serviceName used to identify the signing service.
+   * @param {string} signingServiceName used to identify the signing service.
    * @param {!Object} jwk An object which is hopefully an RSA JSON Web Key.  The
    *     caller should verify that it is an object before calling this function.
    * @return {!Promise<!PublicKeyInfoDef>}
+   * @private
    */
-  importPublicKey(serviceName, jwk) {
+  importPublicKey_(signingServiceName, jwk) {
     return this.crypto_.importPkcsKey(jwk).then(cryptoKey => {
           // We do the importKey first to allow the browser to check for
           // an invalid key.  This last check is in case the key is valid
@@ -77,7 +328,7 @@ export class LegacySignatureVerifier {
           // control, so a collision would not help.
       return this.crypto_.sha1(data)
           .then(digest => ({
-            serviceName,
+            signingServiceName,
             cryptoKey,
                 // Hash is the first 4 bytes of the SHA-1 digest.
             hash: new Uint8Array(digest, 0, 4),
@@ -93,7 +344,7 @@ export class LegacySignatureVerifier {
    * @return {!Promise<!boolean>} whether the signature is valid for
    *     the public key.
    */
-  verifySignature(data, signature, publicKeyInfo) {
+  verifySignature_(data, signature, publicKeyInfo) {
     if (!verifyHashVersion(signature, publicKeyInfo)) {
       return Promise.resolve(false);
     }

--- a/extensions/amp-a4a/0.1/legacy-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/legacy-signature-verifier.js
@@ -227,13 +227,13 @@ export class LegacySignatureVerifier {
         // service, keyInfoPromise, can verify the signature, then the
         // creative is valid AMP.
         if (verified) {
-          return Promise.reject('noop');
+          return Promise.reject('redundant');
         }
         return some(keyInfoSet.keys.map(keyInfoPromise => {
           // Resolve Promise into signing key.
           return keyInfoPromise.then(keyInfo => {
             if (verified) {
-              return Promise.reject('noop');
+              return Promise.reject('redundant');
             }
             if (!keyInfo) {
               return Promise.reject('Promise resolved to null key.');
@@ -257,11 +257,8 @@ export class LegacySignatureVerifier {
                   }
                     // Only report if signature is expected to match, given that
                     // multiple key providers could have been specified.
-                    // Note: the 'keyInfo &&' check here is not strictly
-                    // necessary, because we checked that above.  But
-                    // Closure type compiler can't seem to recognize that, so
-                    // this guarantees it to the compiler.
-                  if (keyInfo && verifyHashVersion(signature, keyInfo)) {
+                  if (verifyHashVersion(
+                      signature, /** @type {!PublicKeyInfoDef} */ (keyInfo))) {
                     user().error(
                         TAG, 'Key failed to validate creative\'s signature',
                         keyInfo.signingServiceName, keyInfo.cryptoKey);
@@ -293,6 +290,7 @@ export class LegacySignatureVerifier {
    * Checks whether Web Cryptography is available in this context.
    *
    * @return {boolean}
+   * @visibleForTesting
    */
   isAvailable_() {
     return this.crypto_.isPkcsAvailable();
@@ -307,7 +305,7 @@ export class LegacySignatureVerifier {
    * @param {!Object} jwk An object which is hopefully an RSA JSON Web Key.  The
    *     caller should verify that it is an object before calling this function.
    * @return {!Promise<!PublicKeyInfoDef>}
-   * @private
+   * @visibleForTesting
    */
   importPublicKey_(signingServiceName, jwk) {
     return this.crypto_.importPkcsKey(jwk).then(cryptoKey => {
@@ -343,6 +341,7 @@ export class LegacySignatureVerifier {
    * @param {!PublicKeyInfoDef} publicKeyInfo the RSA public key.
    * @return {!Promise<!boolean>} whether the signature is valid for
    *     the public key.
+   * @visibleForTesting
    */
   verifySignature_(data, signature, publicKeyInfo) {
     if (!verifyHashVersion(signature, publicKeyInfo)) {

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Potential reasons why an attempt to verify a Fast Fetch signature might not
+ * succeed. Used for reporting errors to the ad network.
+ *
+ * @enum {number}
+ */
+export const VerificationFailure = {
+
+  /**
+   * A network connectivity failure, misbehaving signing service, or other
+   * factor beyond the ad network's control caused verification to fail.
+   */
+  NO_FAULT: 1,
+
+  /**
+   * The keypair ID provided by the ad network does not correspond to any public
+   * key offered by the signing service.
+   */
+  KEY_NOT_FOUND: 2,
+
+  /**
+   * The signature provided by the ad network is not the correct cryptographic
+   * signature for the given creative data and public key.
+   */
+  SIGNATURE_MISMATCH: 3,
+
+};
+
+/**
+ * A window-level object that encapsulates the logic for obtaining public keys
+ * from Fast Fetch signing services and cryptographically verifying signatures
+ * of AMP creatives.
+ *
+ * Unlike an AMP service, a signature verifier is **stateful**. It maintains a
+ * cache of all public keys that it has previously downloaded and imported.
+ *
+ * This interface is to facilitate the transition between the legacy Fast Fetch
+ * signature scheme and the new one specified in #7618.
+ *
+ * @interface
+ */
+export class ISignatureVerifier {
+  /**
+   * Fetches and imports the public keyset for the named signing service.
+   *
+   * @param {string} unusedSigningServiceName
+   * @param {!Promise<undefined>} unusedWaitFor a promise that must resolve
+   *     before the keys are fetched
+   */
+  loadKeyset(unusedSigningServiceName, unusedWaitFor) {}
+
+  /**
+   * Extracts a cryptographic signature from `headers` and verifies that it's
+   * the correct cryptographic signature for `creative`.
+   *
+   * As a precondition, `loadKeyset` must have already been called on the
+   * signing service that was used.
+   *
+   * @param {!ArrayBuffer} unusedCreative
+   * @param {!Headers} unusedHeaders
+   * @param {function(string, !Object)} unusedLifecycleCallback called for each
+   *     AMP lifecycle event triggered during verification
+   * @return {!Promise<?VerificationFailure>} resolves to `null` on success, or,
+   *     on failure, to a `VerificationFailure` indicating the cause
+   */
+  verify(unusedCreative, unusedHeaders, unusedLifecycleCallback) {}
+}

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -15,30 +15,35 @@
  */
 
 /**
- * Potential reasons why an attempt to verify a Fast Fetch signature might not
- * succeed. Used for reporting errors to the ad network.
+ * The result of an attempt to verify a Fast Fetch signature. The different
+ * error statuses are used for reporting errors to the ad network.
  *
  * @enum {number}
  */
-export const VerificationFailure = {
+export const VerificationStatus = {
+
+  /** Verification succeeded. */
+  OK: 0,
 
   /**
-   * A network connectivity failure, misbehaving signing service, or other
-   * factor beyond the ad network's control caused verification to fail.
+   * Verification failed because of a factor beyond the ad network's control,
+   * such as a network connectivity failure, unavailability of Web Cryptography
+   * in the current browsing context, or a misbehaving signing service.
    */
-  NO_FAULT: 1,
+  UNVERIFIED: 1,
 
   /**
-   * The keypair ID provided by the ad network does not correspond to any public
-   * key offered by the signing service.
+   * Verification failed because the keypair ID provided by the ad network did
+   * not correspond to any public key offered by the signing service.
    */
-  KEY_NOT_FOUND: 2,
+  ERROR_KEY_NOT_FOUND: 2,
 
   /**
-   * The signature provided by the ad network is not the correct cryptographic
-   * signature for the given creative data and public key.
+   * Verification failed because the signature provided by the ad network was
+   * not the correct cryptographic signature for the given creative data and
+   * public key.
    */
-  SIGNATURE_MISMATCH: 3,
+  ERROR_SIGNATURE_MISMATCH: 3,
 
 };
 
@@ -66,8 +71,8 @@ export class ISignatureVerifier {
   loadKeyset(unusedSigningServiceName, unusedWaitFor) {}
 
   /**
-   * Extracts a cryptographic signature from `headers` and verifies that it's
-   * the correct cryptographic signature for `creative`.
+   * Extracts a cryptographic signature from `headers` and attempts to verify
+   * that it's the correct cryptographic signature for `creative`.
    *
    * As a precondition, `loadKeyset` must have already been called on the
    * signing service that was used.
@@ -76,8 +81,7 @@ export class ISignatureVerifier {
    * @param {!Headers} unusedHeaders
    * @param {function(string, !Object)} unusedLifecycleCallback called for each
    *     AMP lifecycle event triggered during verification
-   * @return {!Promise<?VerificationFailure>} resolves to `null` on success, or,
-   *     on failure, to a `VerificationFailure` indicating the cause
+   * @return {!Promise<!VerificationStatus>}
    */
   verify(unusedCreative, unusedHeaders, unusedLifecycleCallback) {}
 }

--- a/extensions/amp-a4a/0.1/test/test-a4a-crypto.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-crypto.js
@@ -31,7 +31,7 @@ describe('A4A crypto', () => {
       'BPh0v2RwtwxNFytR9Ksrj_hwOYz_l81m8PnaBhMnkZorqF53bg' +
       'eJ8jvDx2_mBb';
   const pubExp = 'AQAB';
-  const serviceName = 'test-service';
+  const signingServiceName = 'test-service';
 
   const modulus1 =
       'vwx9LQrXHQmiVxxSK9IA_wq9Yu2TFDEQHk9b_rdYJe6fEEwron' +
@@ -73,14 +73,14 @@ describe('A4A crypto', () => {
 
   beforeEach(() => {
     verifier = new LegacySignatureVerifier(window);
-    pubKeyInfoPromise = verifier.importPublicKey(serviceName, {
+    pubKeyInfoPromise = verifier.importPublicKey_(signingServiceName, {
       kty: 'RSA',
       'n': modulus,
       'e': pubExp,
       alg: 'RS256',
       ext: true,
     });
-    pubKeyInfoPromise1 = verifier.importPublicKey(serviceName, {
+    pubKeyInfoPromise1 = verifier.importPublicKey_(signingServiceName, {
       kty: 'RSA',
       'n': modulus1,
       'e': pubExp1,
@@ -90,10 +90,10 @@ describe('A4A crypto', () => {
   });
 
   it('should resolve to a PublicKeyInfoDef object', () => {
-    if (!verifier.isAvailable()) { return; }
+    if (!verifier.isAvailable_()) { return; }
     return pubKeyInfoPromise.then(pubKeyInfo => {
       expect(pubKeyInfo).to.not.be.null;
-      expect(pubKeyInfo.serviceName).to.equal(serviceName);
+      expect(pubKeyInfo.signingServiceName).to.equal(signingServiceName);
       expect(pubKeyInfo.hash).to.not.be.null;
       expect(pubKeyInfo.hash.length).to.equal(4);
       expect(pubKeyInfo.cryptoKey).to.not.be.null;
@@ -102,29 +102,29 @@ describe('A4A crypto', () => {
 
   describe('verifySignature', function() {
     it('should validate with the correct key and signature', () => {
-      if (!verifier.isAvailable()) { return; }
+      if (!verifier.isAvailable_()) { return; }
       return pubKeyInfoPromise.then(pubKeyInfo =>
-          verifier.verifySignature(data, signature, pubKeyInfo)
+          verifier.verifySignature_(data, signature, pubKeyInfo)
               .then(isvalid => expect(isvalid).to.be.true));
     });
 
     it('should not validate with the correct key but wrong data', () => {
-      if (!verifier.isAvailable()) { return; }
+      if (!verifier.isAvailable_()) { return; }
       // Test with correct key, but wrong data.
       return pubKeyInfoPromise.then(pubKeyInfo =>
-          verifier.verifySignature(wrongData, signature, pubKeyInfo)
+          verifier.verifySignature_(wrongData, signature, pubKeyInfo)
               .then(isvalid => expect(isvalid).to.be.false));
     });
 
     it('should not validate with the correct key but modified signature',
         () => {
-          if (!verifier.isAvailable()) { return; }
+          if (!verifier.isAvailable_()) { return; }
           pubKeyInfoPromise.then(pubKeyInfo => {
             const arr = new Array(signature.length);
             for (let i = 0; i < signature.length ; i++) {
               const modifiedSig = signature.slice(0);
               modifiedSig[i] += 1;
-              arr[i] = verifier.verifySignature(data, modifiedSig, pubKeyInfo)
+              arr[i] = verifier.verifySignature_(data, modifiedSig, pubKeyInfo)
                  .then(isvalid => expect(isvalid).to.be.false);
             };
             return Promise.all(arr);
@@ -132,9 +132,9 @@ describe('A4A crypto', () => {
         });
 
     it('should not validate with wrong key', () => {
-      if (!verifier.isAvailable()) { return; }
+      if (!verifier.isAvailable_()) { return; }
       return pubKeyInfoPromise1.then(pubKeyInfo1 =>
-          verifier.verifySignature(data, signature, pubKeyInfo1)
+          verifier.verifySignature_(data, signature, pubKeyInfo1)
               .then(isvalid => expect(isvalid).to.be.false));
     });
   });

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AMP_SIGNATURE_HEADER} from '../amp-a4a';
+import {AMP_SIGNATURE_HEADER} from '../legacy-signature-verifier';
 import {FetchMock, networkFailure} from './fetch-mock';
 import {MockA4AImpl, TEST_URL} from './utils';
 import {createIframePromise} from '../../../../testing/iframe';

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -19,14 +19,19 @@ import {MockA4AImpl, TEST_URL} from './utils';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
   AmpA4A,
-  AMP_SIGNATURE_HEADER,
   RENDERING_TYPE_HEADER,
   DEFAULT_SAFEFRAME_VERSION,
   SAFEFRAME_VERSION_HEADER,
   protectFunctionWrapper,
   assignAdUrlToError,
 } from '../amp-a4a';
+import {
+  AMP_SIGNATURE_HEADER,
+  signatureVerifierFor,
+} from '../legacy-signature-verifier';
+import {VerificationFailure} from '../signature-verifier';
 import {FriendlyIframeEmbed} from '../../../../src/friendly-iframe-embed';
+import {utf8EncodeSync} from '../../../../src/utils/bytes';
 import {Signals} from '../../../../src/utils/signals';
 import {Extensions} from '../../../../src/service/extensions-impl';
 import {Viewer} from '../../../../src/service/viewer-impl';
@@ -35,8 +40,6 @@ import {
   data as validCSSAmp,
 } from './testdata/valid_css_at_rules_amp.reserialized';
 import {data as testFragments} from './testdata/test_fragments';
-import {base64UrlDecodeToBytes} from '../../../../src/utils/base64';
-import {utf8EncodeSync} from '../../../../src/utils/bytes';
 import {resetScheduledElementForTesting} from '../../../../src/custom-element';
 import {Services} from '../../../../src/services';
 import {incrementLoadingAds} from '../../../amp-ad/0.1/concurrent-load';
@@ -810,8 +813,6 @@ describe('amp-a4a', () => {
         const a4a = new MockA4AImpl(a4aElement);
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
         const updatePriorityStub = sandbox.stub(a4a, 'updatePriority');
-        const extractCreativeAndSignatureSpy = sandbox.spy(
-            a4a, 'extractCreativeAndSignature');
         const renderAmpCreativeSpy = sandbox.spy(a4a, 'renderAmpCreative_');
         const loadExtensionSpy =
             sandbox.spy(Extensions.prototype, 'loadExtension');
@@ -825,8 +826,6 @@ describe('amp-a4a', () => {
           expect(getAdUrlSpy.calledOnce, 'getAdUrl called exactly once')
               .to.be.true;
           expect(fetchMock.called('ad')).to.be.true;
-          expect(extractCreativeAndSignatureSpy.calledOnce,
-              'extractCreativeAndSignatureSpy called exactly once').to.be.true;
           expect(loadExtensionSpy.withArgs('amp-font')).to.be.calledOnce;
           return a4a.layoutCallback().then(() => {
             expect(renderAmpCreativeSpy.calledOnce,
@@ -916,8 +915,7 @@ describe('amp-a4a', () => {
         const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
         const updatePriorityStub = sandbox.stub(a4a, 'updatePriority');
         if (!isValidCreative) {
-          sandbox.stub(a4a, 'extractCreativeAndSignature').returns(
-              Promise.resolve({creative: utf8EncodeSync(adResponse.body)}));
+          delete adResponse.headers[AMP_SIGNATURE_HEADER];
         }
         if (opt_failAmpRender) {
           sandbox.stub(a4a, 'renderAmpCreative_').returns(
@@ -968,58 +966,6 @@ describe('amp-a4a', () => {
     });
     it('#layoutCallback AMP render fail, recover non-AMP', () => {
       return executeLayoutCallbackTest(true, true);
-    });
-    it('should not leak full response to rendered dom', () => {
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        adResponse.body = `<html amp>
-            <body>
-            <div class="forTest"></div>
-            <script class="hostile">
-            // Some hostile JavaScript
-            assert.fail('This code should never be executed!');
-            </script>
-            <noscript>${validCSSAmp.reserialized}</noscript>
-            <script type="application/json" amp-ad-metadata>
-            {
-               "bodyAttributes" : "",
-               "bodyUtf16CharOffsets" : [ 10, 1000000 ],
-               "cssUtf16CharOffsets" : [ 0, 0 ]
-            }
-            </script>
-            </body></html>`;
-        fetchMock.getOnce(
-            TEST_URL + '&__amp_source_origin=about%3Asrcdoc', () => adResponse,
-            {name: 'ad'});
-        const doc = fixture.doc;
-        const a4aElement = createA4aElement(doc);
-        const a4a = new MockA4AImpl(a4aElement);
-        // Return value from `#extractCreativeAndSignature` is a sub-doc of
-        // the full response.  To validate this test, comment out the following
-        // statement and verify that test fails, with full response spliced in
-        // to shadow doc.
-        sandbox.stub(a4a, 'extractCreativeAndSignature')
-            .returns(Promise.resolve({
-              creative: utf8EncodeSync(validCSSAmp.reserialized),
-              signature: base64UrlDecodeToBytes(validCSSAmp.signature),
-            }));
-        a4a.buildCallback();
-        a4a.onLayoutMeasure();
-        return a4a.layoutCallback().then(() => {
-          expect(a4a.isVerifiedAmpCreative_).to.be.true;
-          const friendlyIframe = a4aElement.getElementsByTagName('iframe')[0];
-          expect(friendlyIframe).to.be.ok;
-          expect(friendlyIframe.getAttribute('srcdoc')).to.be.ok;
-          expect(friendlyIframe.src).to.not.be.ok;
-          const frameDoc = friendlyIframe.contentDocument;
-          expect(frameDoc.querySelector('div[class=forTest]')).to.not.be.ok;
-          expect(frameDoc.querySelector('script[class=hostile]')).to.not.be.ok;
-          expect(frameDoc.querySelector('style[amp-custom]')).to.be.ok;
-          expect(frameDoc.body.innerHTML, 'body content')
-              .to.contain('Hello, world.');
-          expect(onCreativeRenderSpy.withArgs(true)).to.be.calledOnce;
-        });
-      });
     });
     it('should run end-to-end in the presence of an XHR error', () => {
       return createIframePromise().then(fixture => {
@@ -1648,7 +1594,7 @@ describe('amp-a4a', () => {
       });
     });
 
-    describe('verifyCreativeSignature_', () => {
+    describe('verifySignature_', () => {
       let stubVerifySignature;
       let a4a;
       beforeEach(() => {
@@ -1658,61 +1604,63 @@ describe('amp-a4a', () => {
           a4a = new MockA4AImpl(a4aElement);
           a4a.buildCallback();
           stubVerifySignature =
-              sandbox.stub(a4a.signatureVerifier_, 'verifySignature');
+              sandbox.stub(signatureVerifierFor(a4a.win), 'verifySignature_');
         });
       });
 
       it('properly handles all failures', () => {
-        // Single provider with first key fails but second key passes validation
-        a4a.win.ampA4aValidationKeys = (() => {
+        // Multiple providers with multiple keys each that all fail validation
+        signatureVerifierFor(a4a.win).keys_ = (() => {
           const providers = [];
           for (let i = 0; i < 10; i++) {
-            const serviceName = `test-service${i}`;
-            providers[i] = Promise.resolve({serviceName, keys: [
-              Promise.resolve({serviceName}),
-              Promise.resolve({serviceName}),
+            const signingServiceName = `test-service${i}`;
+            providers[i] = Promise.resolve({signingServiceName, keys: [
+              Promise.resolve({signingServiceName}),
+              Promise.resolve({signingServiceName}),
             ]});
           }
           return providers;
         })();
         stubVerifySignature.returns(Promise.resolve(false));
-        return a4a.verifyCreativeSignature_('some_creative', 'some_sig')
-            .then(() => {
-              throw new Error('should have triggered rejection');
-            })
-            .catch(err => {
+        const headers = new Headers();
+        headers.set(AMP_SIGNATURE_HEADER, 'some_sig');
+        return signatureVerifierFor(a4a.win).verify(
+            utf8EncodeSync('some_creative'), headers, () => {})
+            .then(failure => {
+              expect(failure).to.equal(VerificationFailure.SIGNATURE_MISMATCH);
               expect(stubVerifySignature).to.be.callCount(20);
-              expect(err).to.equal(
-                  'No validation service could verify this key');
             });
       });
 
       it('properly handles multiple keys for one provider', () => {
         // Single provider with first key fails but second key passes validation
-        const serviceName = 'test-service';
-        a4a.win.ampA4aValidationKeys = [
-          Promise.resolve({serviceName, keys: [
-            Promise.resolve({serviceName: '1'}),
-            Promise.resolve({serviceName: '2'}),
+        const signingServiceName = 'test-service';
+        signatureVerifierFor(a4a.win).keys_ = [
+          Promise.resolve({signingServiceName, keys: [
+            Promise.resolve({signingServiceName: '1'}),
+            Promise.resolve({signingServiceName: '2'}),
           ]}),
         ];
         const creative = 'some_creative';
+        const headers = new Headers();
+        headers.set(AMP_SIGNATURE_HEADER, 'some_sig');
         stubVerifySignature.onCall(0).returns(Promise.resolve(false));
         stubVerifySignature.onCall(1).returns(Promise.resolve(true));
-        return a4a.verifyCreativeSignature_(creative, 'some_sig')
-            .then(verifiedCreative => {
+        return signatureVerifierFor(a4a.win).verify(
+            utf8EncodeSync(creative), headers, () => {})
+            .then(failure => {
               expect(stubVerifySignature).to.be.calledTwice;
-              expect(verifiedCreative).to.equal(creative);
+              expect(failure).to.be.null;
             });
       });
 
       it('properly stops verification at first valid key', () => {
         // Single provider where first key fails, second passes, and third
         // never calls verifySignature.
-        const serviceName = 'test-service';
+        const signingServiceName = 'test-service';
         let keyInfoResolver;
-        a4a.win.ampA4aValidationKeys = [
-          Promise.resolve({serviceName, keys: [
+        signatureVerifierFor(a4a.win).keys_ = [
+          Promise.resolve({signingServiceName, keys: [
             Promise.resolve({}),
             Promise.resolve({}),
             new Promise(resolver => {
@@ -1721,7 +1669,8 @@ describe('amp-a4a', () => {
           ]}),
         ];
         const creative = 'some_creative';
-        const signature = 'some_signature';
+        const headers = new Headers();
+        headers.set(AMP_SIGNATURE_HEADER, 'some_signature');
         stubVerifySignature.onCall(0).returns(Promise.resolve(false));
         stubVerifySignature.onCall(1).returns(Promise.resolve(true));
 
@@ -1730,10 +1679,11 @@ describe('amp-a4a', () => {
         // execute.
         setTimeout(() => {keyInfoResolver({}); }, 0);
 
-        return a4a.verifyCreativeSignature_(creative, signature)
-            .then(verifiedCreative => {
+        return signatureVerifierFor(a4a.win).verify(
+            utf8EncodeSync(creative), headers, () => {})
+            .then(failure => {
               expect(stubVerifySignature).to.be.calledTwice;
-              expect(verifiedCreative).to.equal(creative);
+              expect(failure).to.be.null;
             });
       });
     });
@@ -1824,217 +1774,6 @@ describe('amp-a4a', () => {
     });
   });
 
-  describe('#getKeyInfoSets_', () => {
-    let fixture;
-    let win;
-    let a4aElement;
-    beforeEach(() => {
-      return createIframePromise().then(f => {
-        setupForAdTesting(f);
-        fixture = f;
-        win = fixture.win;
-        a4aElement = createA4aElement(fixture.doc);
-        return fixture;
-      });
-    });
-
-    function verifyIsKeyInfo(keyInfo) {
-      expect(keyInfo).to.be.ok;
-      expect(keyInfo).to.have.all.keys(
-          ['serviceName', 'hash', 'cryptoKey']);
-      expect(keyInfo.serviceName).to.be.a('string').and.not.to.equal('');
-      expect(keyInfo.hash).to.be.instanceOf(Uint8Array);
-    }
-
-    it('should fetch a single key', () => {
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(result).to.be.instanceof(Array);
-      expect(result).to.have.lengthOf(1);
-      return Promise.all(result).then(serviceInfos => {
-        expect(fetchMock.called('keyset')).to.be.true;
-        const serviceInfo = serviceInfos[0];
-        expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
-        expect(serviceInfo['serviceName']).to.equal('google');
-        expect(serviceInfo['keys']).to.be.an.instanceof(Array);
-        expect(serviceInfo['keys']).to.have.lengthOf(1);
-        const keyInfoPromise = serviceInfo['keys'][0];
-        expect(keyInfoPromise).to.be.an.instanceof(win.Promise);
-        return keyInfoPromise.then(keyInfo => {
-          verifyIsKeyInfo(keyInfo);
-        });
-      });
-    });
-
-    it('should wait for first visible', () => {
-      let firstVisibleResolve;
-      viewerWhenVisibleMock.returns(
-          new Promise(resolve => {
-            firstVisibleResolve = resolve;
-          }));
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(fetchMock.called('keyset')).to.be.false;
-      firstVisibleResolve();
-      return Promise.all(result).then(() => {
-        expect(fetchMock.called('keyset')).to.be.true;
-      });
-    });
-
-    it('should fetch multiple keys', () => {
-      // For our purposes, re-using the same key is fine.
-      keysetBody =
-          `{"keys":[${validCSSAmp.publicKey},${
-                                               validCSSAmp.publicKey
-                                             },${validCSSAmp.publicKey}]}`;
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(result).to.be.instanceof(Array);
-      expect(result).to.have.lengthOf(1);  // Only one service.
-      return Promise.all(result).then(serviceInfos => {
-        expect(fetchMock.called('keyset')).to.be.true;
-        expect(serviceInfos).to.have.lengthOf(1);  // Only one service.
-        const serviceInfo = serviceInfos[0];
-        expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
-        expect(serviceInfo['serviceName']).to.equal('google');
-        expect(serviceInfo['keys']).to.be.an.instanceof(Array);
-        expect(serviceInfo['keys']).to.have.lengthOf(3);
-        return Promise.all(serviceInfo['keys'].map(keyInfoPromise =>
-          keyInfoPromise.then(keyInfo => verifyIsKeyInfo(keyInfo))));
-      });
-    });
-
-    it('should fetch from multiple services', () => {
-      getSigningServiceNamesMock.returns(['google', 'google-dev']);
-      // For our purposes, we don't care what the key is, so long as it's valid.
-      fetchMock.getOnce(
-          'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
-          keysetBody, {name: 'dev-keyset'});
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(result).to.be.instanceof(Array);
-      expect(result).to.have.lengthOf(2);  // Two services.
-      return Promise.all(result).then(serviceInfos => {
-        expect(fetchMock.called('keyset')).to.be.true;
-        expect(fetchMock.called('dev-keyset')).to.be.true;
-        serviceInfos.map(serviceInfo => {
-          expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
-          expect(serviceInfo['serviceName']).to.have.string('google');
-          expect(serviceInfo['keys']).to.be.an.instanceof(Array);
-          expect(serviceInfo['keys']).to.have.lengthOf(1);
-          const keyInfoPromise = serviceInfo['keys'][0];
-          expect(keyInfoPromise).to.be.an.instanceof(win.Promise);
-          return keyInfoPromise.then(keyInfo => {
-            verifyIsKeyInfo(keyInfo);
-          });
-        });
-      });
-    });
-
-    it('Should gracefully handle malformed key responses', () => {
-      keysetBody = '{"keys":["invalid key data"]}';
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(result).to.be.instanceof(Array);
-      expect(result).to.have.lengthOf(1);  // Only one service.
-      return Promise.all(result).then(serviceInfos => {
-        expect(fetchMock.called('keyset')).to.be.true;
-        expect(serviceInfos[0]).to.have.all.keys(['serviceName', 'keys']);
-        expect(serviceInfos[0]['serviceName']).to.equal('google');
-        expect(serviceInfos[0]['keys']).to.be.an.instanceof(Array);
-        expect(serviceInfos[0]['keys']).to.be.empty;
-      });
-    });
-
-    it('should gracefully handle network errors in a single service', () => {
-      keysetBody = Promise.reject(networkFailure());
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(result).to.be.instanceof(Array);
-      expect(result).to.have.lengthOf(1);  // Only one service.
-      return result[0].then(serviceInfo => {
-        expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
-        expect(serviceInfo['serviceName']).to.equal('google');
-        expect(serviceInfo['keys']).to.be.an.instanceof(Array);
-        expect(serviceInfo['keys']).to.be.empty;
-      });
-    });
-
-    it('should handle success in one service and net error in another', () => {
-      getSigningServiceNamesMock.returns(['google', 'google-dev']);
-      fetchMock.getOnce(
-          'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
-          Promise.reject(networkFailure()), {name: 'dev-keyset'});
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(result).to.be.instanceof(Array);
-      expect(result).to.have.lengthOf(2);  // Two services.
-      return Promise.all(result.map(  // For each service...
-          serviceInfoPromise => serviceInfoPromise.then(serviceInfo => {
-            expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
-            const serviceName = serviceInfo.serviceName;
-            expect(serviceInfo['keys']).to.be.an.instanceof(Array);
-            if (serviceName == 'google') {
-              expect(serviceInfo['keys']).to.have.lengthOf(1);
-              const keyInfoPromise = serviceInfo['keys'][0];
-              expect(keyInfoPromise).to.be.an.instanceof(win.Promise);
-              return keyInfoPromise.then(keyInfo => {
-                verifyIsKeyInfo(keyInfo);
-              });
-            } else if (serviceName == 'google-dev') {
-              expect(serviceInfo['keys']).to.be.empty;
-            } else {
-              throw new Error(
-                  `Unexpected service name: ${serviceName} is neither ` +
-                  'google nor google-dev');
-            }
-          }))).then(() => {
-            expect(fetchMock.called('keyset')).to.be.true;
-            expect(fetchMock.called('dev-keyset')).to.be.true;
-          });
-    });
-
-    it('should return valid object on invalid service name', () => {
-      getSigningServiceNamesMock.returns(['fnord']);
-      expect(win.ampA4aValidationKeys).not.to.exist;
-      // Key fetch happens on A4A class construction.
-      const a4a = new MockA4AImpl(a4aElement);  // eslint-disable-line no-unused-vars
-      a4a.buildCallback();
-      const result = win.ampA4aValidationKeys;
-      expect(fetchMock.called('keyset')).to.be.false;
-      expect(result).to.be.instanceof(Array);
-      expect(result).to.have.lengthOf(1);
-      expect(result[0]).to.be.instanceof(Promise);
-      return result[0].then(serviceInfo => {
-        expect(serviceInfo).to.have.all.keys(['serviceName', 'keys']);
-        expect(serviceInfo['serviceName']).to.equal('fnord');
-        expect(serviceInfo['keys']).to.be.an.instanceof(Array);
-        expect(serviceInfo['keys']).to.be.empty;
-      });
-    });
-  });
-
   describe('#assignAdUrlToError', () => {
 
     it('should attach info to error correctly', () => {
@@ -2055,27 +1794,6 @@ describe('amp-a4a', () => {
       const error = new Error('foo');
       assignAdUrlToError(error, 'https://foo.com');
       expect(error.args).to.not.be.ok;
-    });
-  });
-
-  describe('#extractCreativeAndSignature', () => {
-    it('should return body and signature', () => {
-      const creative = 'some test data';
-      return expect(AmpA4A.prototype.extractCreativeAndSignature(
-          creative, new Headers({
-            'X-AmpAdSignature': 'AQAB',
-          })))
-          .to.eventually.deep.equal({
-            creative,
-            signature: base64UrlDecodeToBytes('AQAB'),
-          });
-    });
-
-    it('should return null when no signature header is present', () => {
-      const creative = 'some test data';
-      return expect(AmpA4A.prototype.extractCreativeAndSignature(
-          creative, new Headers()))
-          .to.eventually.deep.equal({creative, signature: null});
     });
   });
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1627,7 +1627,8 @@ describe('amp-a4a', () => {
         return signatureVerifierFor(a4a.win).verify(
             utf8EncodeSync('some_creative'), headers, () => {})
             .then(status => {
-              expect(status).to.equal(VerificationStatus.SIGNATURE_MISMATCH);
+              expect(status).to.equal(
+                  VerificationStatus.ERROR_SIGNATURE_MISMATCH);
               expect(stubVerifySignature).to.be.callCount(20);
             });
       });
@@ -1648,9 +1649,9 @@ describe('amp-a4a', () => {
         stubVerifySignature.onCall(1).returns(Promise.resolve(true));
         return signatureVerifierFor(a4a.win).verify(
             utf8EncodeSync(creative), headers, () => {})
-            .then(failure => {
+            .then(status => {
               expect(stubVerifySignature).to.be.calledTwice;
-              expect(failure).to.be.null;
+              expect(status).to.equal(VerificationStatus.OK);
             });
       });
 
@@ -1681,9 +1682,9 @@ describe('amp-a4a', () => {
 
         return signatureVerifierFor(a4a.win).verify(
             utf8EncodeSync(creative), headers, () => {})
-            .then(failure => {
+            .then(status => {
               expect(stubVerifySignature).to.be.calledTwice;
-              expect(failure).to.be.null;
+              expect(status).to.equal(VerificationStatus.OK);
             });
       });
     });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -29,7 +29,7 @@ import {
   AMP_SIGNATURE_HEADER,
   signatureVerifierFor,
 } from '../legacy-signature-verifier';
-import {VerificationFailure} from '../signature-verifier';
+import {VerificationStatus} from '../signature-verifier';
 import {FriendlyIframeEmbed} from '../../../../src/friendly-iframe-embed';
 import {utf8EncodeSync} from '../../../../src/utils/bytes';
 import {Signals} from '../../../../src/utils/signals';
@@ -1626,8 +1626,8 @@ describe('amp-a4a', () => {
         headers.set(AMP_SIGNATURE_HEADER, 'some_sig');
         return signatureVerifierFor(a4a.win).verify(
             utf8EncodeSync('some_creative'), headers, () => {})
-            .then(failure => {
-              expect(failure).to.equal(VerificationFailure.SIGNATURE_MISMATCH);
+            .then(status => {
+              expect(status).to.equal(VerificationStatus.SIGNATURE_MISMATCH);
               expect(stubVerifySignature).to.be.callCount(20);
             });
       });

--- a/extensions/amp-a4a/0.1/test/test-legacy-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-legacy-signature-verifier.js
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FetchMock, networkFailure} from './fetch-mock';
+import {
+  data as validCSSAmp,
+} from './testdata/valid_css_at_rules_amp.reserialized';
+import {LegacySignatureVerifier} from '../legacy-signature-verifier';
+
+describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
+
+  let fetchMock;
+  let keysetBody;
+  let verifier;
+  let result;
+
+  beforeEach(() => {
+    fetchMock = new FetchMock(env.win);
+    fetchMock.getOnce(
+        'https://cdn.ampproject.org/amp-ad-verifying-keyset.json',
+        () => keysetBody, {name: 'keyset'});
+    keysetBody = `{"keys":[${validCSSAmp.publicKey}]}`;
+    verifier = new LegacySignatureVerifier(env.win);
+    result = verifier.keys_;
+  });
+
+  afterEach(() => {
+    fetchMock./*OK*/restore();
+  });
+
+  function verifyIsKeyInfo(keyInfo) {
+    expect(keyInfo).to.be.ok;
+    expect(keyInfo).to.have.all.keys(
+        ['signingServiceName', 'hash', 'cryptoKey']);
+    expect(keyInfo.signingServiceName).to.be.a('string').and.not.to.equal('');
+    expect(keyInfo.hash).to.be.instanceOf(Uint8Array);
+  }
+
+  it('should fetch a single key', () => {
+    expect(result).to.be.empty;
+    verifier.loadKeyset('google', Promise.resolve());
+    expect(result).to.be.instanceof(Array);
+    expect(result).to.have.lengthOf(1);
+    return Promise.all(result).then(serviceInfos => {
+      expect(fetchMock.called('keyset')).to.be.true;
+      const serviceInfo = serviceInfos[0];
+      expect(serviceInfo).to.have.all.keys(['signingServiceName', 'keys']);
+      expect(serviceInfo['signingServiceName']).to.equal('google');
+      expect(serviceInfo['keys']).to.be.an.instanceof(Array);
+      expect(serviceInfo['keys']).to.have.lengthOf(1);
+      const keyInfoPromise = serviceInfo['keys'][0];
+      expect(keyInfoPromise).to.be.an.instanceof(env.win.Promise);
+      return keyInfoPromise.then(keyInfo => {
+        verifyIsKeyInfo(keyInfo);
+      });
+    });
+  });
+
+  it('should wait for promise', () => {
+    expect(result).to.be.empty;
+    let resolveWaitFor;
+    verifier.loadKeyset('google', new Promise(resolve => {
+      resolveWaitFor = resolve;
+    }));
+    expect(fetchMock.called('keyset')).to.be.false;
+    resolveWaitFor();
+    return Promise.all(result).then(() => {
+      expect(fetchMock.called('keyset')).to.be.true;
+    });
+  });
+
+  it('should fetch multiple keys', () => {
+    // For our purposes, re-using the same key is fine.
+    keysetBody =
+        `{"keys":[${validCSSAmp.publicKey},${
+                                               validCSSAmp.publicKey
+                                             },${validCSSAmp.publicKey}]}`;
+    expect(result).to.be.empty;
+    verifier.loadKeyset('google', Promise.resolve());
+    expect(result).to.be.instanceof(Array);
+    expect(result).to.have.lengthOf(1);  // Only one service.
+    return Promise.all(result).then(serviceInfos => {
+      expect(fetchMock.called('keyset')).to.be.true;
+      expect(serviceInfos).to.have.lengthOf(1);  // Only one service.
+      const serviceInfo = serviceInfos[0];
+      expect(serviceInfo).to.have.all.keys(['signingServiceName', 'keys']);
+      expect(serviceInfo['signingServiceName']).to.equal('google');
+      expect(serviceInfo['keys']).to.be.an.instanceof(Array);
+      expect(serviceInfo['keys']).to.have.lengthOf(3);
+      return Promise.all(serviceInfo['keys'].map(keyInfoPromise =>
+          keyInfoPromise.then(keyInfo => verifyIsKeyInfo(keyInfo))));
+    });
+  });
+
+  it('should fetch from multiple services', () => {
+    // For our purposes, we don't care what the key is, so long as it's valid.
+    fetchMock.getOnce(
+        'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
+        keysetBody, {name: 'dev-keyset'});
+    expect(result).to.be.empty;
+    verifier.loadKeyset('google', Promise.resolve());
+    verifier.loadKeyset('google-dev', Promise.resolve());
+    expect(result).to.be.instanceof(Array);
+    expect(result).to.have.lengthOf(2);  // Two services.
+    return Promise.all(result).then(serviceInfos => {
+      expect(fetchMock.called('keyset')).to.be.true;
+      expect(fetchMock.called('dev-keyset')).to.be.true;
+      serviceInfos.map(serviceInfo => {
+        expect(serviceInfo).to.have.all.keys(['signingServiceName', 'keys']);
+        expect(serviceInfo['signingServiceName']).to.have.string('google');
+        expect(serviceInfo['keys']).to.be.an.instanceof(Array);
+        expect(serviceInfo['keys']).to.have.lengthOf(1);
+        const keyInfoPromise = serviceInfo['keys'][0];
+        expect(keyInfoPromise).to.be.an.instanceof(env.win.Promise);
+        return keyInfoPromise.then(keyInfo => {
+          verifyIsKeyInfo(keyInfo);
+        });
+      });
+    });
+  });
+
+  it('Should gracefully handle malformed key responses', () => {
+    keysetBody = '{"keys":["invalid key data"]}';
+    expect(result).to.be.empty;
+    verifier.loadKeyset('google', Promise.resolve());
+    expect(result).to.be.instanceof(Array);
+    expect(result).to.have.lengthOf(1);  // Only one service.
+    return Promise.all(result).then(serviceInfos => {
+      expect(fetchMock.called('keyset')).to.be.true;
+      expect(serviceInfos[0]).to.have.all.keys(['signingServiceName', 'keys']);
+      expect(serviceInfos[0]['signingServiceName']).to.equal('google');
+      expect(serviceInfos[0]['keys']).to.be.an.instanceof(Array);
+      expect(serviceInfos[0]['keys']).to.be.empty;
+    });
+  });
+
+  it('should gracefully handle network errors in a single service', () => {
+    keysetBody = Promise.reject(networkFailure());
+    expect(result).to.be.empty;
+    verifier.loadKeyset('google', Promise.resolve());
+    expect(result).to.be.instanceof(Array);
+    expect(result).to.have.lengthOf(1);  // Only one service.
+    return result[0].then(serviceInfo => {
+      expect(serviceInfo).to.have.all.keys(['signingServiceName', 'keys']);
+      expect(serviceInfo['signingServiceName']).to.equal('google');
+      expect(serviceInfo['keys']).to.be.an.instanceof(Array);
+      expect(serviceInfo['keys']).to.be.empty;
+    });
+  });
+
+  it('should handle success in one service and net error in another', () => {
+    fetchMock.getOnce(
+        'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
+        Promise.reject(networkFailure()), {name: 'dev-keyset'});
+    expect(result).to.be.empty;
+    verifier.loadKeyset('google', Promise.resolve());
+    verifier.loadKeyset('google-dev', Promise.resolve());
+    expect(result).to.be.instanceof(Array);
+    expect(result).to.have.lengthOf(2);  // Two services.
+    return Promise.all(result.map(  // For each service...
+        serviceInfoPromise => serviceInfoPromise.then(serviceInfo => {
+          expect(serviceInfo).to.have.all.keys(['signingServiceName', 'keys']);
+          const signingServiceName = serviceInfo.signingServiceName;
+          expect(serviceInfo['keys']).to.be.an.instanceof(Array);
+          if (signingServiceName == 'google') {
+            expect(serviceInfo['keys']).to.have.lengthOf(1);
+            const keyInfoPromise = serviceInfo['keys'][0];
+            expect(keyInfoPromise).to.be.an.instanceof(env.win.Promise);
+            return keyInfoPromise.then(keyInfo => {
+              verifyIsKeyInfo(keyInfo);
+            });
+          } else if (signingServiceName == 'google-dev') {
+            expect(serviceInfo['keys']).to.be.empty;
+          } else {
+            throw new Error(
+                `Unexpected service name: ${signingServiceName} is neither ` +
+                    'google nor google-dev');
+          }
+        }))).then(() => {
+          expect(fetchMock.called('keyset')).to.be.true;
+          expect(fetchMock.called('dev-keyset')).to.be.true;
+        });
+  });
+
+  it('should return valid object on invalid service name', () => {
+    expect(result).to.be.empty;
+    verifier.loadKeyset('fnord', Promise.resolve());
+    expect(fetchMock.called('keyset')).to.be.false;
+    expect(result).to.be.instanceof(Array);
+    expect(result).to.have.lengthOf(1);
+    expect(result[0]).to.be.instanceof(Promise);
+    return result[0].then(serviceInfo => {
+      expect(serviceInfo).to.have.all.keys(['signingServiceName', 'keys']);
+      expect(serviceInfo['signingServiceName']).to.equal('fnord');
+      expect(serviceInfo['keys']).to.be.an.instanceof(Array);
+      expect(serviceInfo['keys']).to.be.empty;
+    });
+  });
+});

--- a/extensions/amp-a4a/0.1/test/test-legacy-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-legacy-signature-verifier.js
@@ -86,8 +86,7 @@ describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
     // For our purposes, re-using the same key is fine.
     keysetBody =
         `{"keys":[${validCSSAmp.publicKey},${
-                                               validCSSAmp.publicKey
-                                             },${validCSSAmp.publicKey}]}`;
+            validCSSAmp.publicKey},${validCSSAmp.publicKey}]}`;
     expect(result).to.be.empty;
     verifier.loadKeyset('google', Promise.resolve());
     expect(result).to.be.instanceof(Array);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -18,11 +18,14 @@ import {AmpAd} from '../../../amp-ad/0.1/amp-ad';
 import {AmpAd3PImpl} from '../../../amp-ad/0.1/amp-ad-3p-impl';
 import {
   AmpA4A,
-  AMP_SIGNATURE_HEADER,
   CREATIVE_SIZE_HEADER,
   RENDERING_TYPE_HEADER,
   XORIGIN_MODE,
 } from '../../../amp-a4a/0.1/amp-a4a';
+import {
+  AMP_SIGNATURE_HEADER,
+  signatureVerifierFor,
+} from '../../../amp-a4a/0.1/legacy-signature-verifier';
 import {createIframePromise} from '../../../../testing/iframe';
 import {
   installExtensionsService,
@@ -138,7 +141,7 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
     });
   });
 
-  describe('#extractCreativeAndSignature', () => {
+  describe('#extractSize', () => {
     let loadExtensionSpy;
     const size = {width: 200, height: 50};
 
@@ -1424,7 +1427,9 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
      * it has an AMP creative.
      */
     function stubForAmpCreative() {
-      sandbox.stub(impl, 'verifyCreativeSignature_', () => utf8Encode('foo'));
+      sandbox.stub(
+          signatureVerifierFor(impl.win), 'verify',
+          () => Promise.resolve(null));
     }
 
     function mockSendXhrRequest() {


### PR DESCRIPTION
This will facilitate the introduction of the new verifier in the next PR.

One of the PRs that #9040 is being split into. Related to #7618. Follow-up to #10594.