### PR TITLE
Update comment on use of suffix in Log class

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -64,6 +64,12 @@ export function setReportError(fn) {
 
 /**
  * Logging class.
+ *
+ * Use of sentinel string instead of a boolean to check user/dev errors
+ * because errors could be rethrown by some native code as a new error, and only a message would survive.
+ * Also, some browser don’t support a 5th error object argument in window.onerror. List of supporting browser can be found
+ * here: https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html
+ *
  * @final
  * @private Visible for testing only.
  */

--- a/src/log.js
+++ b/src/log.js
@@ -64,17 +64,16 @@ export function setReportError(fn) {
 
 /**
  * Logging class.
- *
- * Use of sentinel string instead of a boolean to check user/dev errors
- * because errors could be rethrown by some native code as a new error, and only a message would survive.
- * Also, some browser don’t support a 5th error object argument in window.onerror. List of supporting browser can be found
- * here: https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html
- *
  * @final
  * @private Visible for testing only.
  */
 export class Log {
   /**
+   * opt_suffix will be appended to error message to identify the type of the error message.
+   * We can't rely on the error object to pass along the type because
+   * some browsers do not have this param in its window.onerror API.
+   * See: https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html
+   *
    * @param {!Window} win
    * @param {function(!./mode.ModeDef):!LogLevel} levelFunc
    * @param {string=} opt_suffix


### PR DESCRIPTION
As I tried again to use boolean instead of string suffix to differentiate user() and dev() error, I confirm that it is impossible due to browser compatibility issue. 

Some browsers don’t support a 5th error object argument in window.onerror (https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror). 

The optimal use would be using message as we currently have. In cases where errors could be rethrown by some native code, only a message would survive.

List of supporting browser can be found here: https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html