### PR TITLE
Fix race condition for legacy elements when version-lock is reloaded

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1058,10 +1058,7 @@ function maybeLoadCorrectVersion(win, fnOrStruct) {
   }
   // Mark the element as being replace, so that the loadExtension code
   // assumes it as not-present.
-  scriptInHead.removeAttribute('custom-element');
-  scriptInHead.setAttribute('i-amphtml-loaded-new-version', fnOrStruct.n);
-  Services.extensionsFor(win).loadExtension(fnOrStruct.n,
-      /* stubbing not needed, should have already happened. */ false);
+  Services.extensionsFor(win).reloadExtension(fnOrStruct.n, scriptInHead);
   return true;
 }
 

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -263,6 +263,25 @@ export class Extensions {
   }
 
   /**
+   * Reloads the new version of the extension.
+   * @param {string} extensionId
+   * @param {!Element} oldScriptElement
+   * @return {!Promise<!ExtensionDef>}
+   */
+  reloadExtension(extensionId, oldScriptElement) {
+    // "Disconnect" the old script element and extension record.
+    const holder = this.extensions_[extensionId];
+    if (holder) {
+      dev().assert(!holder.loaded && !holder.error);
+      delete this.extensions_[extensionId];
+    }
+    oldScriptElement.removeAttribute('custom-element');
+    oldScriptElement.setAttribute('i-amphtml-loaded-new-version', extensionId);
+    return this.loadExtension(extensionId,
+        /* stubbing not needed, should have already happened. */ false);
+  }
+
+  /**
    * Returns the promise that will be resolved with the extension element's
    * class when the extension has been loaded. If necessary, adds the extension
    * script to the page.

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -375,6 +375,7 @@ describes.fakeWin('runtime', {
     }
     const s1 = addExisting(1);
     const s2 = addExisting(4);
+    const s3 = addExisting(5);
     const bodyCallbacks = new Observable();
     sandbox.stub(dom, 'waitForBody', (unusedDoc, callback) => {
       bodyCallbacks.add(callback);
@@ -407,6 +408,12 @@ describes.fakeWin('runtime', {
       expect(amp).to.equal(win.AMP);
       progress += 'not expected 2';
     }, 'version123'));
+    // Add legacy element (5) and eagarly ask for its load as ElementStub does.
+    Services.extensionsFor(win).loadExtension('amp-test-element5', false);
+    win.AMP.push(regularExtension(amp => {
+      expect(amp).to.equal(win.AMP);
+      progress += '5';
+    }, 'version123'));
     runChunksForTesting(win.document);
     expect(progress).to.equal('');
 
@@ -417,19 +424,25 @@ describes.fakeWin('runtime', {
     expect(queueExtensions).to.have.length(0);
     expect(s1.getAttribute('custom-element')).to.be.null;
     expect(s2.getAttribute('custom-element')).to.be.null;
+    expect(s3.getAttribute('custom-element')).to.be.null;
     expect(s1.getAttribute('i-amphtml-loaded-new-version'))
         .to.equal('amp-test-element1');
     expect(s2.getAttribute('i-amphtml-loaded-new-version'))
         .to.equal('amp-test-element4');
+    expect(s3.getAttribute('i-amphtml-loaded-new-version'))
+        .to.equal('amp-test-element5');
     const inserted = win.document.head.querySelectorAll(
         '[i-amphtml-inserted]');
-    expect(inserted).to.have.length(2);
+    expect(inserted).to.have.length(3);
     expect(inserted[0].getAttribute('src')).to.equal(
         'https://cdn.ampproject.org/rtv/test-version' +
             '/v0/amp-test-element1-0.1.js');
     expect(inserted[1].getAttribute('src')).to.equal(
         'https://cdn.ampproject.org/rtv/test-version' +
             '/v0/amp-test-element4-0.1.js');
+    expect(inserted[2].getAttribute('src')).to.equal(
+        'https://cdn.ampproject.org/rtv/test-version' +
+            '/v0/amp-test-element5-0.1.js');
   });
 
   it('should be robust against errors in early extensions', () => {


### PR DESCRIPTION
The real problem is with `ExtensionHolder.scriptPresent === true` flag that's optimistically set by legacy element stub (`amp-video` in this case). The whole holding record must be simply dropped to fix the race.

Closes #10690
/cc @aghassemi 