### PR TITLE
Ensure transitions do not affect fixed-layer top calculation

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -278,7 +278,7 @@ export class FixedLayer {
           setStyles(elements[i].element, {
             top: '',
             bottom: '-9999vh',
-            transitionDuration: '0s',
+            transition: 'none',
           });
         }
         // 2. Capture the `style.top` with this new `style.bottom` value. If
@@ -291,7 +291,7 @@ export class FixedLayer {
         for (let i = 0; i < elements.length; i++) {
           setStyles(elements[i].element, {
             bottom: '',
-            transitionDuration: '',
+            transition: '',
           });
         }
 

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -275,9 +275,11 @@ export class FixedLayer {
         // large value (to catch cases where sticky-tops are in a long way
         // down inside a scroller).
         for (let i = 0; i < elements.length; i++) {
-          const element = elements[i].element;
-          setStyle(element, 'top', '');
-          setStyle(element, 'bottom', '-9999vh');
+          setStyles(elements[i].element, {
+            top: '',
+            bottom: '-9999vh',
+            transitionDuration: '0s',
+          });
         }
         // 2. Capture the `style.top` with this new `style.bottom` value. If
         // this element has a non-auto top, this value will remain constant
@@ -287,7 +289,10 @@ export class FixedLayer {
         }
         // 3. Cleanup the `style.bottom`.
         for (let i = 0; i < elements.length; i++) {
-          setStyle(elements[i].element, 'bottom', '');
+          setStyles(elements[i].element, {
+            bottom: '',
+            transitionDuration: '',
+          });
         }
 
         for (let i = 0; i < elements.length; i++) {

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -187,18 +187,25 @@ describe('FixedLayer', () => {
         visibility: 'visible',
         _top: '',
         get top() {
+          if (elem.computedStyle.transitionDuration &&
+              elem.style.transitionDuration !== '' &&
+              elem.style.transitionDuration !== '0s') {
+            return this._oldTop;
+          }
           if (elem.style.bottom) {
             return elem.autoTop || this._top;
           }
           return this._top;
         },
         set top(val) {
+          this._oldTop = this._top;
           this._top = val;
         },
         bottom: '',
         zIndex: '',
         transform: '',
         position: '',
+        transitionDuration: '',
       },
       matches: () => true,
       compareDocumentPosition: other => {
@@ -707,6 +714,29 @@ describe('FixedLayer', () => {
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
       element5.computedStyle['position'] = 'sticky';
+      element5.computedStyle['top'] = '0px';
+      element5.autoTop = '0px';
+
+      expect(vsyncTasks).to.have.length(1);
+      const state = {};
+      vsyncTasks[0].measure(state);
+
+      expect(state['F0'].fixed).to.be.true;
+      expect(state['F0'].top).to.equal('0px');
+
+      expect(state['F4'].sticky).to.be.true;
+      expect(state['F4'].top).to.equal('0px');
+    });
+
+    it('should handle transitions', () => {
+      element1.computedStyle['position'] = 'fixed';
+      element1.computedStyle['transitionDuration'] = '1s';
+      element1.computedStyle['top'] = '0px';
+      element1.autoTop = '0px';
+      element1.offsetWidth = 10;
+      element1.offsetHeight = 10;
+      element5.computedStyle['position'] = 'sticky';
+      element5.computedStyle['transitionDuration'] = '1s';
       element5.computedStyle['top'] = '0px';
       element5.autoTop = '0px';
 

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -187,9 +187,9 @@ describe('FixedLayer', () => {
         visibility: 'visible',
         _top: '',
         get top() {
-          if (elem.computedStyle.transitionDuration &&
-              elem.style.transitionDuration !== '' &&
-              elem.style.transitionDuration !== '0s') {
+          if (elem.computedStyle.transition &&
+              elem.style.transition !== '' &&
+              elem.style.transition !== 'none') {
             return this._oldTop;
           }
           if (elem.style.bottom) {
@@ -205,7 +205,7 @@ describe('FixedLayer', () => {
         zIndex: '',
         transform: '',
         position: '',
-        transitionDuration: '',
+        transition: '',
       },
       matches: () => true,
       compareDocumentPosition: other => {
@@ -730,13 +730,13 @@ describe('FixedLayer', () => {
 
     it('should handle transitions', () => {
       element1.computedStyle['position'] = 'fixed';
-      element1.computedStyle['transitionDuration'] = '1s';
+      element1.computedStyle['transition'] = 'all .4s ease';
       element1.computedStyle['top'] = '0px';
       element1.autoTop = '0px';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
       element5.computedStyle['position'] = 'sticky';
-      element5.computedStyle['transitionDuration'] = '1s';
+      element5.computedStyle['transition'] = 'all .4s ease';
       element5.computedStyle['top'] = '0px';
       element5.autoTop = '0px';
 


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/10695.

Do any other CSS styles do something like this?