### PR TITLE
Hide placeholders behind fallback images on image load error

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -199,21 +199,10 @@ export class AmpImg extends BaseElement {
     this.getVsync().mutate(() => {
       this.img_.classList.add('i-amphtml-ghost');
       this.toggleFallback(true);
-      // Hide child placeholders, as browsers that don't support webp
+      // Hide placeholders, as browsers that don't support webp
       // Would show the placeholder underneath a transparent fallback
-      this.hideChildPlaceholders_();
+      this.togglePlaceholder(false);
     });
-  }
-
-  /**
-  * Private function to hide child placeholder elements of our amp-img
-  * @private
-  */
-  hideChildPlaceholders_() {
-    toArray(this.element.querySelectorAll('[placeholder]'))
-        .forEach(placeholderElement => {
-          toggle(placeholderElement);
-        });
   }
 };
 

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -15,8 +15,6 @@
  */
 
 import {BaseElement} from '../src/base-element';
-import {toggle} from '../src/style';
-import {toArray} from '../src/types';
 import {isLayoutSizeDefined} from '../src/layout';
 import {registerElement} from '../src/custom-element';
 import {srcsetFromElement} from '../src/srcset';

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -15,6 +15,8 @@
  */
 
 import {BaseElement} from '../src/base-element';
+import {toggle} from '../src/style';
+import {toArray} from '../src/types';
 import {isLayoutSizeDefined} from '../src/layout';
 import {registerElement} from '../src/custom-element';
 import {srcsetFromElement} from '../src/srcset';
@@ -197,7 +199,21 @@ export class AmpImg extends BaseElement {
     this.getVsync().mutate(() => {
       this.img_.classList.add('i-amphtml-ghost');
       this.toggleFallback(true);
+      // Hide child placeholders, as browsers that don't support webp
+      // Would show the placeholder underneath a transparent fallback
+      this.hideChildPlaceholders_();
     });
+  }
+
+  /**
+  * Private function to hide child placeholder elements of our amp-img
+  * @private
+  */
+  hideChildPlaceholders_() {
+    toArray(this.element.querySelectorAll('[placeholder]'))
+        .forEach(placeholderElement => {
+          toggle(placeholderElement);
+        });
   }
 };
 


### PR DESCRIPTION
closes #10646 

This will hide all of the child placeholder elements within an amp-image component, when the image fails to load. Please let me know if there is a case where this would lead to unexpected results. Also, let me know if you would like me to add the `test/manual` file I added for this fix

# Screenshot (Safari and Firefox)

<img width="1428" alt="screen shot 2017-07-28 at 1 32 10 pm" src="https://user-images.githubusercontent.com/1448289/28735286-6298ced6-7399-11e7-98a8-d919482052e9.png">
