### PR TITLE
Article.amp.html redesign

### DIFF
--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -8,9 +8,14 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 
   <style amp-custom>
+    * {
+      outline: none;
+    }
+
     body {
       margin: 0;
       font-family: 'Georgia', Serif;
+      background: white;
     }
 
     .brand-logo {
@@ -24,11 +29,6 @@
 
     .content-container p {
       line-height: 24px;
-    }
-
-    header,
-    .article-body {
-      padding: 15px;
     }
 
     /* In the shadow-doc mode, the parent shell already has header and nav. */
@@ -72,9 +72,30 @@
     }
 
     figcaption {
-      color: #6f757a;
-      padding: 15px 0;
+      font-family: 'Roboto';
+      border-bottom: 1px solid #e2e2e2;
+      color: #6d6d6d;
+      margin-left: 20px;
+      margin-right: 20px;
       font-size: .9em;
+      padding: 15px;
+    }
+
+    figcaption::before {
+      content: '';
+      width: 24px;
+      height: 24px;
+      display: inline-block;
+      vertical-align: middle;
+      margin-right: 5px;
+    }
+
+    figcaption.image::before {
+      background-image: url('data:image/svg+xml,<svg fill="#a9a9a9" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="3.2"/><path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+    }
+
+    figcaption.video::before {
+      background-image: url('data:image/svg+xml,<svg fill="#a9a9a9" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z"/></svg>');
     }
 
     .author {
@@ -90,10 +111,22 @@
       border-width: 1px 0;
     }
 
-    .header-time {
+    .header-time, .header-author {
       color: #a8a3ae;
       font-family: 'Roboto';
       font-size: 12px;
+    }
+
+    .header-author {
+      border-right: 1px solid #d5d5d5;
+      padding-right: 10px;
+      margin-right: 10px;
+      display: inline-block;
+    }
+
+    .header-author b {
+      color: #2294dd;
+      font-weight: normal;
     }
 
     .author p {
@@ -113,20 +146,17 @@
       color: #6f757a;
     }
 
-    .standfirst {
-      color: #6f757a;
-    }
-
     .mailto {
       text-decoration: none;
     }
 
     #author-avatar {
-      margin: 10px;
-      border: 5px solid #fff;
-      width: 50px;
-      height: 50px;
+      width: 16px;
+      height: 16px;
       border-radius: 50%;
+      display: inline-block;
+      vertical-align: middle;
+      margin-right: 5px;
     }
 
     h1 {
@@ -161,11 +191,6 @@
       background-color: #f4f4f4;
     }
 
-    .slot-fallback {
-      padding: 16px;
-      background: yellow;
-    }
-
     amp-app-banner amp-img {
       background-color: transparent;
       margin-right: 15px
@@ -198,17 +223,79 @@
     }
 
     amp-sidebar {
-      width: 150px;
+      width: 200px;
+      background: white;
+    }
+
+    nav ul {
+      padding: 0px;
+      list-style: none;
     }
 
     nav li {
       list-style: none;
-      margin-bottom: 10px;
+      padding: 0px;
+      padding-left: 15px;
     }
 
     nav li a {
       text-decoration: none;
       color: #666666;
+      display: block;
+      padding: 10px;
+    }
+
+    nav li.active {
+      background: #f7f7f7;
+    }
+
+    nav li.active a {
+      color: black;
+      border-right: 3px solid black;
+    }
+
+    .article-body p {
+      padding-right: 15px;
+      padding-left: 15px;
+    }
+
+    header {
+      padding: 15px;
+    }
+
+    button.menu {
+      background: transparent;
+      border: none;
+      padding: 10px;
+      padding-right: 20px;
+    }
+
+    .jump-to {
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+
+    .jump-to ul, .jump-to ol {
+    }
+
+    .jump-to ul a, .jump-to ol a {
+        text-decoration: none;
+        color: #2294dd;
+    }
+
+    header#top-bar {
+      background: white;
+      border-bottom: 1px solid #e2e2e2;
+    }
+
+    header#article-desc {
+      background: rgb(250, 250, 250);
+      padding: 20px;
+    }
+
+    header#article-desc h1 {
+      margin-top: 0px;
+      padding-top: 0px;
     }
 
   </style>
@@ -226,10 +313,9 @@
   <amp-sidebar id="sidebar" layout="nodisplay">
     <nav>
       <ul>
-        <li>
+        <li class="active">
           <a href="#">
             Home
-            <amp-img src="img/ampicon.png" width="15" height="15"></amp-img>
           </a>
         </li>
         <li><a href="#">Link 1</a></li>
@@ -256,7 +342,7 @@
     </div>
   </amp-app-banner>
 
-  <header>
+  <header id="top-bar">
     <button on="tap:sidebar.toggle" class="menu" title="Toggle Sidebar" >
       ☰
     </button>
@@ -265,20 +351,19 @@
     </span>
   </header>
 
-  <!--
-  Slots spec is not implemented yet by any browser. Will use an older version via `<content>` tag.
-  <slot name="slot1"></slot>
-  -->
-  <slot name="slot1">
-    <content>
-      <div class="slot-fallback">
-        This is a slot fallback.
-      </div>
-    </content>
-  </slot>
-
   <main role="main">
     <article>
+      <header id="article-desc">
+        <h1 itemprop="headline">Lorem Ipsum</h1>
+        <div class="header-author">
+          <amp-img src="img/sample.jpg" id="author-avatar" placeholder
+            height="16" width="16">
+          </amp-img>
+           by <span itemscope itemtype="http://schema.org/Person"
+        itemprop="author"><b>Lorem Ipsum</b></span></div>
+        <time class="header-time" itemprop="datePublished"
+            datetime="2015-09-14 13:00">September 14, 2015</time>
+      </header>
       <figure>
         <amp-img id="hero-img"
             src="img/hero@1x.jpg"
@@ -289,6 +374,9 @@
             role="button" on="tap:headline-img-lightbox"
             height="216" tabindex="0">
         </amp-img>
+        <figcaption class='image'>
+          Fusce pretium tempor justo, vitae.
+        </figcaption>
       </figure>
 
       <amp-lightbox id="headline-img-lightbox" class="lightbox"
@@ -309,32 +397,13 @@
       </amp-lightbox>
 
       <div class="content-container">
-        <ul>
-          <li><a href="#section1">Section 1</a></li>
-          <li><a href="#section2">Section 2</a></li>
-        </ul>
-        <header>
-          <h1 itemprop="headline">Lorem Ipsum</h1>
-          <time class="header-time" itemprop="datePublished"
-              datetime="2015-09-14 13:00">September 14, 2015</time>
-          <p class="standfirst">
-            Fusce pretium tempor justo, vitae consequat dolor maximus eget.
-          </p>
-        </header>
-
-        <div class="author">
-          <amp-img src="img/sample.jpg" id="author-avatar" placeholder
-              height="50" width="50">
-          </amp-img>
-          <div class="byline">
-            <p>
-              by <span itemscope itemtype="http://schema.org/Person"
-              itemprop="author"><b>Lorem Ipsum</b>
-              <a class="mailto" href="mailto:lorem.ipsum@">
-              lorem.ipsum@</a></span>
-            </p>
-            <p class="brand">PublisherName News Reporter<p>
-          </div>
+        <div class="jump-to">
+          <h3>Jump To</h3>
+          <ol>
+            <li><a on="tap:section1.scrollTo('position' = 'center')" href="#section1">Section 1</a></li>
+            <li><a on="tap:section2.scrollTo('position' = 'center')" href="#section2">Section 2</a></li>
+            <li><a on="tap:section3.scrollTo('position' = 'center')" href="#section3">Section 3</a></li>
+          </ol>
         </div>
         <div class="article-body" itemprop="articleBody">
           <p>
@@ -389,9 +458,10 @@
               width="720"
               height="405"
               layout="responsive"
+              dock
               controls>
             </amp-video>
-            <figcaption>
+            <figcaption class='video'>
               Fusce pretium tempor justo, vitae consequat dolor maximus eget.
             </figcaption>
           </figure>
@@ -437,11 +507,10 @@
                 alt="Fusce pretium tempor justo, vitae consequat dolor maximus eget."
                 height="180">
             </amp-img>
-            <figcaption>
+            <figcaption class='image'>
               Fusce pretium tempor justo, vitae consequat dolor maximus eget.
             </figcaption>
           </figure>
-          <hr>
 
           <p>
             Cum sociis natoque penatibus et magnis dis parturient montes,

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>
   <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 
   <style amp-custom>
@@ -162,7 +162,6 @@
       justify-content: center;
       height: 226px;
       background: #f4f4f4;
-      margin-bottom: 20px;
     }
 
     hr {
@@ -292,9 +291,19 @@
        background: #1b1b1b;
        color: white;
      }
+
+     #lightbox-close-btn {
+       font-family: Helvetica, sans-serif;
+       color: white;
+       position: absolute;
+       top: 0px;
+       right: 0px;
+       padding: 20px;
+     }
   </style>
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+  <script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
   <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
@@ -366,7 +375,7 @@
             layout="responsive" width="360" placeholder
             alt="Picture of two chairs on a lake shore with big pine trees"
             title="Opens image in a lightbox"
-            role="button" on="tap:headline-img-lightbox"
+            role="button" on="tap:headline-image-lightbox"
             height="216" tabindex="0">
         </amp-img>
         <figcaption class='image'>
@@ -374,22 +383,7 @@
         </figcaption>
       </figure>
 
-      <amp-lightbox id="headline-img-lightbox" class="lightbox"
-          layout="nodisplay">
-
-        <div class="lightbox-content">
-          <amp-img id="floating-headline-img"
-              src="img/hero@1x.jpg"
-              srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
-              alt="Two chairs on a lake shore with big pine trees"
-              placeholder
-              width="360" height="216" layout="responsive">
-          </amp-img>
-          <p>
-            Fusce pretium tempor justo, vitae consequat dolor maximus eget.
-          </p>
-        </div>
-      </amp-lightbox>
+      <amp-image-lightbox id="headline-image-lightbox" layout="nodisplay"></amp-image-lightbox>
 
       <div class="content-container">
         <div class="jump-to">
@@ -498,12 +492,35 @@
                 src="img/sea@1x.jpg"
                 srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
                 layout="responsive" width="320"
+                on="tap:inline-img-lightbox"
                 alt="Fusce pretium tempor justo, vitae consequat dolor maximus eget."
                 height="180">
             </amp-img>
             <figcaption class='image'>
               Fusce pretium tempor justo, vitae consequat dolor maximus eget.
             </figcaption>
+            <amp-lightbox id="inline-img-lightbox" class="lightbox"
+                layout="nodisplay">
+
+              <div class="lightbox-content">
+                <div id="lightbox-close-btn"
+                  on="tap:inline-img-lightbox.close"
+                  role="button"
+                  tabindex="0">
+                  <h1>x</h1>
+                </div>
+                <amp-img id="floating-headline-img"
+                    src="img/sea@1x.jpg"
+                    srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
+                    alt="Image of a sea"
+                    placeholder
+                    width="360" height="216" layout="responsive">
+                </amp-img>
+                <p>
+                  Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+                </p>
+              </div>
+            </amp-lightbox>
           </figure>
 
           <p>

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -4,14 +4,10 @@
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>
   <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
-  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 
   <style amp-custom>
-    * {
-      outline: none;
-    }
-
     body {
       margin: 0;
       font-family: 'Georgia', Serif;
@@ -19,7 +15,7 @@
     }
 
     .brand-logo {
-      font-family: 'Open Sans';
+      font-family: 'Roboto', Arial, Helvetica, sans-serif;
     }
 
     .ad-container {
@@ -38,10 +34,6 @@
 
     .lightbox {
       background: #222;
-    }
-
-    .full-bleed {
-      margin: 0 -15px;
     }
 
     .lightbox-content {
@@ -72,7 +64,7 @@
     }
 
     figcaption {
-      font-family: 'Roboto';
+      font-family: 'Roboto', Arial, Helvetica, sans-serif;
       border-bottom: 1px solid #e2e2e2;
       color: #6d6d6d;
       margin-left: 20px;
@@ -113,7 +105,7 @@
 
     .header-time, .header-author {
       color: #a8a3ae;
-      font-family: 'Roboto';
+      font-family: 'Roboto', Arial, Helvetica, sans-serif;
       font-size: 12px;
     }
 
@@ -134,7 +126,7 @@
     }
 
     .byline {
-      font-family: 'Roboto';
+      font-family: 'Roboto', Arial, Helvetica, sans-serif;
       display: inline-block;
     }
 
@@ -275,9 +267,6 @@
       padding-right: 15px;
     }
 
-    .jump-to ul, .jump-to ol {
-    }
-
     .jump-to ul a, .jump-to ol a {
         text-decoration: none;
         color: #2294dd;
@@ -298,12 +287,18 @@
       padding-top: 0px;
     }
 
+    .slot-fallback {
+       padding: 16px;
+       background: #1b1b1b;
+       color: white;
+     }
   </style>
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
   <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
   <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js" data-amp-report-test="amp-app-banner.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
@@ -458,7 +453,6 @@
               width="720"
               height="405"
               layout="responsive"
-              dock
               controls>
             </amp-video>
             <figcaption class='video'>
@@ -500,7 +494,7 @@
           </p>
 
           <figure>
-            <amp-img class="full-bleed" placeholder
+            <amp-img placeholder
                 src="img/sea@1x.jpg"
                 srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
                 layout="responsive" width="320"
@@ -543,6 +537,17 @@
             torquent per conubia nostra, per inceptos himenaeos.
           </p>
         </div>
+        <!--
+          Slots spec is not implemented yet by any browser. Will use an older version via `<content>` tag.
+          <slot name="slot1"></slot>
+        -->
+        <slot name="slot1">
+          <content>
+            <div class="slot-fallback">
+              This is a slot fallback.
+            </div>
+          </content>
+        </slot>
       </div>
     </article>
   </main>


### PR DESCRIPTION
For people who are just starting with AMP and do not know yet about AMP Start, an intuitive way to demonstrate a working AMP page is to look at `article.amp.html` in `/examples`.

### Changes
- Refreshed the page's design making it more minimalistic
- Images and videos take the full width (used to have a margin)
- Better media captions with icons
- Better navigation menu
- Made use of the new `scrollTo` standard action in the "Jump To" section to get a nice animation when jumping to anchor links.

<br>


<img src="https://user-images.githubusercontent.com/591655/28760569-02217a10-755d-11e7-96d4-8a524f3644e0.png" width="45%" /> &nbsp;  <img src="https://user-images.githubusercontent.com/591655/28760598-27f4da3e-755d-11e7-8dd4-f192693f5b31.png" width="45%" />

<p align="center">Left: <b>Before</b>, Right: <b>After</b></p>

<img src="https://user-images.githubusercontent.com/591655/28760554-eaebc67a-755c-11e7-8b1f-9d8727a12fe8.png"  width="45%" /> &nbsp;  <img src="https://user-images.githubusercontent.com/591655/28760605-2aab2d5a-755d-11e7-9eee-119e6b6c3078.png" width="45%" />

<p align="center">Left: <b>Before</b>, Right: <b>After</b></p>

<img src="https://user-images.githubusercontent.com/591655/28763030-f617d8e6-756f-11e7-8254-342397669446.png" width="45%" /> &nbsp;  <img src="https://user-images.githubusercontent.com/591655/28763013-d9408ff6-756f-11e7-973d-2ac138bc86f4.png" width="45%" />

<p align="center">Left: <b>Before</b>, Right: <b>After</b></p>

