### PR TITLE
Yieldbot ad, include multi-size dimensions in request

### DIFF
--- a/ads/yieldbot.js
+++ b/ads/yieldbot.js
@@ -16,6 +16,7 @@
 
 import {validateData, loadScript} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
+import {getMultiSizeDimensions} from '../ads/google/utils';
 import {rethrowAsync} from '../src/log';
 
 /**
@@ -72,38 +73,4 @@ export function yieldbot(global, data) {
       doubleclick(global, data);
     });
   });
-}
-
-/**
- * Parse a string of comma separated <code>WxH</code> values.
- * @param {string} multiSizeDataStr The amp-ad data attribute containing the multi-size dimensions.
- * @return {?Array<!Array<number>>} An array of dimensions.
- * @see https://github.com/ampproject/amphtml/blob/master/ads/google/doubleclick.md#multi-size-ad
- * @example data-multi-size="300x220,300x210,300x200"
- * @private
- */
-function getMultiSizeDimensions(multiSizeDataStr) {
-  const dimensions = [];
-
-  if (multiSizeDataStr) {
-    const arrayOfSizeStrs = multiSizeDataStr.split(',');
-
-    for (let idx = 0; idx < arrayOfSizeStrs.length; idx++) {
-      const sizeStr = arrayOfSizeStrs[idx];
-      const size = sizeStr.split('x');
-
-      if (size.length != 2) {
-        continue;
-      }
-      const width = Number(size[0]);
-      const height = Number(size[1]);
-
-      if (isNaN(width) || isNaN(height)) {
-        continue;
-      }
-
-      dimensions.push([width, height]);
-    }
-  }
-  return dimensions;
 }

--- a/ads/yieldbot.js
+++ b/ads/yieldbot.js
@@ -37,7 +37,10 @@ export function yieldbot(global, data) {
         let dimensions;
 
         if (multiSizeDataStr) {
-          dimensions = getMultiSizeDimensions(multiSizeDataStr);
+          dimensions = getMultiSizeDimensions(multiSizeDataStr,
+              primaryWidth,
+              primaryHeight,
+              false);
           dimensions.unshift([primaryWidth, primaryHeight]);
         } else {
           dimensions = [[primaryWidth, primaryHeight]];

--- a/ads/yieldbot.md
+++ b/ads/yieldbot.md
@@ -31,7 +31,7 @@ limitations under the License.
 
 ### With Doubleclick `amp-ad` data attributes
 
-To specify Doubleclick `amp-ad` data attributes, see [Doubleclick](./google/doubleclick.md) for details. Use the
+To specify Doubleclick `amp-ad` data attributes, `multi-size` for example, see [Doubleclick](./google/doubleclick.md) for details. Use the
 Doubleclick attributes as you would with an `<amp-ad type="doubleclick"/>` element.
 
 ```html
@@ -40,6 +40,7 @@ Doubleclick attributes as you would with an `<amp-ad type="doubleclick"/>` eleme
           data-psn="1234"
           data-yb-slot="medrec"
           data-slot="/2476204/medium-rectangle"
+          data-multi-size="300x220,300x200"
           json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
 </amp-ad>
 ```
@@ -63,8 +64,8 @@ For integration testing, the Yieldbot Platform can be set to always return a bid
 The Yieldbot `amp-ad` type can be tested with the following file:
 - [test/manual/amp-ad.yieldbot.amp.html](../test/manual/amp-ad.yieldbot.amp.html)
 
-When Yieldbot testing mode is enabled, a cookie (`ybotc__`) on the domain `i.yldbt.com` tells the Yieldbot ad server to always return a bid and when creative is requested, return a static integration testing creative.
+When Yieldbot testing mode is enabled, a cookie (`__ybot_test`) on the domain `.yldbt.com` tells the Yieldbot ad server to always return a bid and when creative is requested, return a static integration testing creative.
 
 - No ad serving metrics are impacted when integration testing mode is enabled.
-- The `ybotc__` cookie expires in 24 hours.
+- The `__ybot_test` cookie expires in 24 hours.
  - It is good practice to click "Stop testing" when testing is complete, to return to normal ad delivery.

--- a/test/manual/amp-ad.yieldbot.amp.html
+++ b/test/manual/amp-ad.yieldbot.amp.html
@@ -27,7 +27,7 @@
           data-psn="1234"
           data-yb-slot="medrec"
           data-slot="/2476204/medium-rectangle"
-          data-multi-size="300x220,300x200"
+          data-multi-size="300x220,300x210, 300x200,300NNN,300xNNN,"
           json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
   </amp-ad>
 </body>


### PR DESCRIPTION
The Yieldbot `amp-ad` is not including `data-multi-size` dimensions in bid requests. For example, the configuration below includes the Doubleclick [Multi-size Ad](https://github.com/ampproject/amphtml/blob/master/ads/google/doubleclick.md#multi-size-ad) data config; however, the Yieldbot `amp-ad` submits a bid request for the primary dimensions `300x250` only.

```
  <amp-ad width="300" height="250"
          type="yieldbot"
          data-psn="1234"
          data-yb-slot="medrec"
          data-slot="/2476204/medium-rectangle"
          data-multi-size="300x220,300x200"
          json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
  </amp-ad>
```

- Parses `data.multiSize` to include multi-size dimensions in the Yieldbot ad request
- **Note:**
  - Does ***not*** use the Doubleclick ad [utils.getMultiSizeDimensions(...)](https://github.com/ampproject/amphtml/blob/master/ads/google/utils.js#L38) function, but ***could*** if advisable
  - Was concerned about introducing dependencies where there does not appear to be a common code contribution pattern for unit testing such dependencies; and, concern for repeating logic unnecessary for the Yieldbot use case.
  - I can ask in a question issue separately about CI `amp-ad` unit tests

Fixes #10724 
