### PR TITLE
Make amp-img srcset select based on screen width.

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -174,7 +174,7 @@ export class AmpImg extends BaseElement {
     if (this.getLayoutWidth() <= 0) {
       return Promise.resolve();
     }
-    const src = this.srcset_.select(this.getLayoutWidth(), this.getDpr()).url;
+    const src = this.srcset_.select(this.win.screen.width, this.getDpr()).url;
     if (src == this.img_.getAttribute('src')) {
       return Promise.resolve();
     }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -174,7 +174,11 @@ export class AmpImg extends BaseElement {
     if (this.getLayoutWidth() <= 0) {
       return Promise.resolve();
     }
-    const src = this.srcset_.select(this.win.screen.width, this.getDpr()).url;
+    const src = this.srcset_.select(
+        // The width should never be 0, but we fall back to the screen width
+        // just in case.
+        this.getViewport().getWidth() || this.win.screen.width,
+        this.getDpr()).url;
     if (src == this.img_.getAttribute('src')) {
       return Promise.resolve();
     }

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -34,7 +34,7 @@ describe('amp-img', () => {
     sandbox.stub(BaseElement.prototype, 'getViewport', () => {
       return {
         getWidth: () => windowWidth,
-      }
+      };
     });
   });
 
@@ -200,7 +200,7 @@ describe('amp-img', () => {
         return {
           getWidth: () => windowWidth,
         };
-      }
+      };
     });
 
     it('should not display fallback if loading succeeds', () => {

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -129,28 +129,32 @@ describe('amp-img', () => {
     windowWidth = 3000;
     screenWidth = 300;
     return getImg({
-      srcset: 'large.jpg 2000w, small.jpg 1000w',
+      srcset: '/examples/img/sample.jpg?large 2000w, ' +
+          '/examples/img/small.jpg?small 1000w',
       width: 300,
       height: 200,
     }).then(ampImg => {
       const img = ampImg.querySelector('img');
       expect(img.tagName).to.equal('IMG');
-      expect(img.getAttribute('src')).to.equal('large.jpg');
+      expect(img.getAttribute('src')).to.equal(
+          '/examples/img/sample.jpg?large');
       expect(img.hasAttribute('referrerpolicy')).to.be.false;
     });
   });
 
-  it('should falls back to screen width for srcset', () => {
+  it('should fall back to screen width for srcset', () => {
     windowWidth = 0;
     screenWidth = 3000;
     return getImg({
-      srcset: 'large.jpg 2000w, small.jpg 1000w',
+      srcset: '/examples/img/sample.jpg?large 2000w, ' +
+          '/examples/img/small.jpg?small 1000w',
       width: 300,
       height: 200,
     }).then(ampImg => {
       const img = ampImg.querySelector('img');
       expect(img.tagName).to.equal('IMG');
-      expect(img.getAttribute('src')).to.equal('large.jpg');
+      expect(img.getAttribute('src')).to.equal(
+          '/examples/img/sample.jpg?large');
       expect(img.hasAttribute('referrerpolicy')).to.be.false;
     });
   });

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -22,9 +22,11 @@ import * as sinon from 'sinon';
 
 describe('amp-img', () => {
   let sandbox;
+  let screenWidth;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    screenWidth = 320;
   });
 
   afterEach(() => {
@@ -36,6 +38,9 @@ describe('amp-img', () => {
         .returns(true);
     return createIframePromise().then(iframe => {
       installImg(iframe.win);
+      Object.defineProperty(iframe.win.screen, 'width', {
+        get: () => screenWidth,
+      });
       const img = iframe.doc.createElement('amp-img');
       for (const key in attributes) {
         img.setAttribute(key, attributes[key]);
@@ -106,6 +111,20 @@ describe('amp-img', () => {
       const img = ampImg.querySelector('img');
       expect(img.tagName).to.equal('IMG');
       expect(img.getAttribute('src')).to.equal('/examples/img/sample.jpg');
+      expect(img.hasAttribute('referrerpolicy')).to.be.false;
+    });
+  });
+
+  it('should load larger image on larger screen', () => {
+    screenWidth = 3000;
+    return getImg({
+      srcset: 'large.jpg 2000w, small.jpg 1000w',
+      width: 300,
+      height: 200,
+    }).then(ampImg => {
+      const img = ampImg.querySelector('img');
+      expect(img.tagName).to.equal('IMG');
+      expect(img.getAttribute('src')).to.equal('large.jpg');
       expect(img.hasAttribute('referrerpolicy')).to.be.false;
     });
   });

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -23,10 +23,19 @@ import * as sinon from 'sinon';
 describe('amp-img', () => {
   let sandbox;
   let screenWidth;
+  let windowWidth;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     screenWidth = 320;
+    windowWidth = 320;
+    sandbox.stub(BaseElement.prototype, 'isInViewport')
+        .returns(true);
+    sandbox.stub(BaseElement.prototype, 'getViewport', () => {
+      return {
+        getWidth: () => windowWidth,
+      }
+    });
   });
 
   afterEach(() => {
@@ -34,13 +43,12 @@ describe('amp-img', () => {
   });
 
   function getImg(attributes, children) {
-    sandbox.stub(BaseElement.prototype, 'isInViewport')
-        .returns(true);
     return createIframePromise().then(iframe => {
       installImg(iframe.win);
       Object.defineProperty(iframe.win.screen, 'width', {
         get: () => screenWidth,
       });
+
       const img = iframe.doc.createElement('amp-img');
       for (const key in attributes) {
         img.setAttribute(key, attributes[key]);
@@ -103,6 +111,8 @@ describe('amp-img', () => {
   });
 
   it('should load an img with srcset', () => {
+    windowWidth = 320;
+    screenWidth = 4000;
     return getImg({
       srcset: 'bad.jpg 2000w, /examples/img/sample.jpg 1000w',
       width: 300,
@@ -116,6 +126,22 @@ describe('amp-img', () => {
   });
 
   it('should load larger image on larger screen', () => {
+    windowWidth = 3000;
+    screenWidth = 300;
+    return getImg({
+      srcset: 'large.jpg 2000w, small.jpg 1000w',
+      width: 300,
+      height: 200,
+    }).then(ampImg => {
+      const img = ampImg.querySelector('img');
+      expect(img.tagName).to.equal('IMG');
+      expect(img.getAttribute('src')).to.equal('large.jpg');
+      expect(img.hasAttribute('referrerpolicy')).to.be.false;
+    });
+  });
+
+  it('should falls back to screen width for srcset', () => {
+    windowWidth = 0;
     screenWidth = 3000;
     return getImg({
       srcset: 'large.jpg 2000w, small.jpg 1000w',
@@ -170,6 +196,11 @@ describe('amp-img', () => {
           },
         };
       };
+      impl.getViewport = function() {
+        return {
+          getWidth: () => windowWidth,
+        };
+      }
     });
 
     it('should not display fallback if loading succeeds', () => {


### PR DESCRIPTION
This aligns `amp-img` with regular `srcset` on `img` and makes src selection independent of layout. Eventually this would allow server side rendering the `amp-img` element.

The change tends to download larger images than the old algorithm. For a typical full-width is does not make a difference, though.

This change may need to be experiment guarded if we decide to go for it.

CC @honeybadgerdontcare 