### PR TITLE
Change default body content type for JSON posts.

### DIFF
--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -220,8 +220,7 @@ export class AmpUserNotification extends AMP.BaseElement {
             'ampUserId': this.ampUserId_,
           }),
           headers: {
-
-           'Content-Type': 'application/json;charset=utf-8',
+            'Content-Type': 'application/json;charset=utf-8',
           },
         });
   }

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -219,6 +219,10 @@ export class AmpUserNotification extends AMP.BaseElement {
             'elementId': this.elementId_,
             'ampUserId': this.ampUserId_,
           }),
+          headers: {
+
+           'Content-Type': 'application/json;charset=utf-8',
+          },
         });
   }
 

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -221,8 +221,9 @@ export class Xhr {
           'body must be of type object or array. %s',
           init.body
       );
-
-      init.headers['Content-Type'] = 'application/json;charset=utf-8';
+      // Content should be 'text/plain' to avoid CORS preflight.
+      init.headers['Content-Type'] = init.headers['Content-Type'] ||
+          'text/plain;charset=utf-8';
       // Cast is valid, because we checked that it is not form data above.
       init.body = JSON.stringify(/** @type {!JsonObject} */ (init.body));
     }

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -571,7 +571,7 @@ describe('XHR', function() {
           });
           expect(requests[0].requestHeaders).to.deep.equal({
             'Accept': 'application/json',
-            'Content-Type': 'application/json;charset=utf-8',
+            'Content-Type': 'text/plain;charset=utf-8',
             'Other': 'another',  // Not removed when other headers set.
           });
         });
@@ -583,6 +583,9 @@ describe('XHR', function() {
           body: {
             hello: 'world',
           },
+          headers: {
+            'Content-Type': 'application/json;charset=utf-8'
+          }
         }).then(res => res.json()).then(res => {
           expect(res.json).to.jsonEqual({
             hello: 'world',

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -584,8 +584,8 @@ describe('XHR', function() {
             hello: 'world',
           },
           headers: {
-            'Content-Type': 'application/json;charset=utf-8'
-          }
+            'Content-Type': 'application/json;charset=utf-8',
+          },
         }).then(res => res.json()).then(res => {
           expect(res.json).to.jsonEqual({
             hello: 'world',


### PR DESCRIPTION
`application/json` triggers preflight, which is rarely what we want. Changes the only uses of the status quo (that I found) to opt-into the old behavior.

CC @lannka @erwinmombay 