### PR TITLE
Remove amp-form-verifiers experiment now that validation rules are sh…

### DIFF
--- a/extensions/amp-form/0.1/form-verifiers.js
+++ b/extensions/amp-form/0.1/form-verifiers.js
@@ -15,11 +15,8 @@
  */
 
 import {LastAddedResolver} from '../../../src/utils/promise';
-import {isExperimentOn} from '../../../src/experiments';
 import {iterateCursor} from '../../../src/dom';
 import {user} from '../../../src/log';
-
-export const FORM_VERIFY_EXPERIMENT = 'amp-form-verifiers';
 
 export const FORM_VERIFY_PARAM = '__amp_form_verify';
 
@@ -40,10 +37,7 @@ let VerificationErrorDef;
  * @param {function():Promise<!../../../src/service/xhr-impl.FetchResponse>} xhr
  */
 export function getFormVerifier(form, xhr) {
-  const win = form.ownerDocument.defaultView;
   if (form.hasAttribute('verify-xhr')) {
-    user().assert(isExperimentOn(win, FORM_VERIFY_EXPERIMENT),
-        `Enable "${FORM_VERIFY_EXPERIMENT}" experiment to use form verifiers`);
     return new AsyncVerifier(form, xhr);
   } else {
     return new DefaultVerifier(form);

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -24,7 +24,7 @@ import {
   setCheckValiditySupportedForTesting,
 } from '../form-validators';
 import {
-  CONFIG_KEY
+  CONFIG_KEY,
 } from '../form-verifiers';
 import * as sinon from 'sinon';
 import '../../../amp-mustache/0.1/amp-mustache';
@@ -33,7 +33,6 @@ import {
 } from '../../../../src/service/cid-impl';
 import {Services} from '../../../../src/services';
 import '../../../amp-selector/0.1/amp-selector';
-import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
 import {whenCalled} from '../../../../testing/test-helper.js';
 import {AmpEvents} from '../../../../src/amp-events';

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -24,8 +24,7 @@ import {
   setCheckValiditySupportedForTesting,
 } from '../form-validators';
 import {
-  CONFIG_KEY,
-  FORM_VERIFY_EXPERIMENT,
+  CONFIG_KEY
 } from '../form-verifiers';
 import * as sinon from 'sinon';
 import '../../../amp-mustache/0.1/amp-mustache';
@@ -429,7 +428,6 @@ describes.repeated('', {
     });
 
     it('should allow verifying elements with a presubmit request', () => {
-      toggleExperiment(env.win, FORM_VERIFY_EXPERIMENT, true);
       const formPromise = getAmpForm(getVerificationForm(
           env.win.document));
       const fetchRejectPromise = Promise.reject({
@@ -461,7 +459,6 @@ describes.repeated('', {
     });
 
     it('should only use the more recent verify request', () => {
-      toggleExperiment(env.win, FORM_VERIFY_EXPERIMENT, true);
       const formPromise = getAmpForm(getVerificationForm(
           env.win.document, asyncVerifyConfig));
 

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -107,12 +107,6 @@ describes.fakeWin('amp-form async verification', {}, env => {
       const verifier = getFormVerifier(form, () => {});
       expect(verifier instanceof AsyncVerifier).to.be.true;
     });
-
-    it('should throw if the experiment is disabled with the verify-xhr ' +
-        'attribute present', () => {
-      const form = getForm(env.win.document);
-      expect(() => getFormVerifier(form, () => {})).to.throw(/experiment/);
-    });
   });
 
   describe('AsyncVerifier', () => {

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -16,7 +16,6 @@
 
 import {
   AsyncVerifier,
-  FORM_VERIFY_EXPERIMENT,
   DefaultVerifier,
   getFormVerifier,
 } from '../form-verifiers';
@@ -98,10 +97,6 @@ describes.fakeWin('amp-form async verification', {}, env => {
   }
 
   describe('getFormVerifier', () => {
-    beforeEach(() => {
-      toggleExperiment(env.win, FORM_VERIFY_EXPERIMENT, true);
-    });
-
     it('returns a DefaultVerifier without the verify-xhr attribute', () => {
       const form = getForm(env.win.document, false);
       const verifier = getFormVerifier(form, () => {});
@@ -116,7 +111,6 @@ describes.fakeWin('amp-form async verification', {}, env => {
 
     it('should throw if the experiment is disabled with the verify-xhr ' +
         'attribute present', () => {
-      toggleExperiment(env.win, FORM_VERIFY_EXPERIMENT, false);
       const form = getForm(env.win.document);
       expect(() => getFormVerifier(form, () => {})).to.throw(/experiment/);
     });
@@ -125,7 +119,6 @@ describes.fakeWin('amp-form async verification', {}, env => {
   describe('AsyncVerifier', () => {
     let sandbox;
     beforeEach(() => {
-      toggleExperiment(env.win, FORM_VERIFY_EXPERIMENT, true);
       sandbox = env.sandbox;
     });
 

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -19,7 +19,6 @@ import {
   DefaultVerifier,
   getFormVerifier,
 } from '../form-verifiers';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.fakeWin('amp-form async verification', {}, env => {
   function stubValidationMessage(input) {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -235,12 +235,6 @@ const EXPERIMENTS = [
     name: 'Use slot width/height attribute for AdSense size format',
   },
   {
-    id: 'amp-form-verifiers',
-    name: 'Asynchronous form verifiers',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/9174',
-    spec: 'https://github.com/ampproject/amphtml/issues/8736',
-  },
-  {
     id: 'input-debounced',
     name: 'A debounced input event for AMP actions',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/9413',


### PR DESCRIPTION
https://github.com/ampproject/amphtml/pull/10370 added validation rules, they are in prod now.

This removes the amp-form-verifiers experiment all together.