### PR TITLE
Ignore actions on disabled form controls

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -37,10 +37,6 @@ export const UPGRADE_TO_CUSTOMELEMENT_PROMISE =
 export const UPGRADE_TO_CUSTOMELEMENT_RESOLVER =
     '__AMP_UPG_RES';
 
-/** @const {string} */
-const DISABLED_PSEUDOCLASS_ = ':disabled';
-
-
 /**
  * Waits until the child element is constructed. Once the child is found, the
  * callback is executed.
@@ -840,5 +836,5 @@ export function isFullscreenElement(element) {
  * @see https://www.w3.org/TR/html5/forms.html#concept-fe-disabled
  */
 export function isEnabled(element) {
-  return !(element.disabled || matches(element, DISABLED_PSEUDOCLASS_));
+  return !(element.disabled || matches(element, ':disabled'));
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -37,6 +37,9 @@ export const UPGRADE_TO_CUSTOMELEMENT_PROMISE =
 export const UPGRADE_TO_CUSTOMELEMENT_RESOLVER =
     '__AMP_UPG_RES';
 
+/** @const {string} */
+const DISABLED_PSEUDOCLASS_ = ':disabled';
+
 
 /**
  * Waits until the child element is constructed. Once the child is found, the
@@ -826,4 +829,16 @@ export function isFullscreenElement(element) {
     }
   }
   return false;
+}
+
+/**
+ * Returns true if node is not disabled.
+ *
+ * IE8 can return false positives, see {@link matches}.
+ * @param {!Element} element
+ * @return {boolean}
+ * @see https://www.w3.org/TR/html5/forms.html#concept-fe-disabled
+ */
+export function isEnabled(element) {
+  return !(element.disabled || matches(element, DISABLED_PSEUDOCLASS_));
 }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -17,6 +17,7 @@
 import {ActionTrust} from '../action-trust';
 import {KeyCodes} from '../utils/key-codes';
 import {debounce} from '../utils/rate-limit';
+import {matches} from '../dom';
 import {dev, user} from '../log';
 import {
   registerServiceBuilderForDoc,
@@ -51,6 +52,9 @@ const DEFAULT_METHOD_ = 'activate';
 
 /** @const {number} */
 const DEFAULT_DEBOUNCE_WAIT = 300; // ms
+
+/** @const {string} */
+const DISABLED_PSEUDOCLASS_ = ':disabled';
 
 /** @const {!Object<string,!Array<string>>} */
 const ELEMENTS_ACTIONS_MAP_ = {
@@ -492,7 +496,8 @@ export class ActionService {
     let n = target;
     while (n) {
       const actionInfos = this.matchActionInfos_(n, actionEventType);
-      if (actionInfos) {
+      const isEnabled = !matches(n, DISABLED_PSEUDOCLASS_);
+      if (isEnabled && actionInfos) {
         return {node: n, actionInfos: dev().assert(actionInfos)};
       }
       n = n.parentElement;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -17,7 +17,7 @@
 import {ActionTrust} from '../action-trust';
 import {KeyCodes} from '../utils/key-codes';
 import {debounce} from '../utils/rate-limit';
-import {matches} from '../dom';
+import {isEnabled} from '../dom';
 import {dev, user} from '../log';
 import {
   registerServiceBuilderForDoc,
@@ -52,9 +52,6 @@ const DEFAULT_METHOD_ = 'activate';
 
 /** @const {number} */
 const DEFAULT_DEBOUNCE_WAIT = 300; // ms
-
-/** @const {string} */
-const DISABLED_PSEUDOCLASS_ = ':disabled';
 
 /** @const {!Object<string,!Array<string>>} */
 const ELEMENTS_ACTIONS_MAP_ = {
@@ -496,8 +493,7 @@ export class ActionService {
     let n = target;
     while (n) {
       const actionInfos = this.matchActionInfos_(n, actionEventType);
-      const isEnabled = !matches(n, DISABLED_PSEUDOCLASS_);
-      if (isEnabled && actionInfos) {
+      if (actionInfos && isEnabled(n)) {
         return {node: n, actionInfos: dev().assert(actionInfos)};
       }
       n = n.parentElement;

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -536,6 +536,36 @@ describe('Action findAction', () => {
 
     expect(action.findAction_(element, 'event3')).to.equal(null);
   });
+
+  it('should skip action on disabled elements', () => {
+    const parent = document.createElement('button');
+    parent.setAttribute('on', 'event1:action1');
+    parent.disabled = true;
+
+    expect(action.findAction_(parent, 'event1')).to.equal(null);
+  });
+
+  it('should skip parent action on descendants of disabled elements', () => {
+    const parent = document.createElement('button');
+    parent.setAttribute('on', 'event1:action1');
+    parent.disabled = true;
+    const element = document.createElement('div');
+    parent.appendChild(element);
+
+    expect(action.findAction_(element, 'event1')).to.equal(null);
+  });
+
+  it('should skip action on form control in a disabled fieldset', () => {
+    const parent = document.createElement('fieldset');
+    parent.setAttribute('on', 'event1:action1');
+    parent.disabled = true;
+    const element = document.createElement('button');
+    element.setAttribute('on', 'event2:action2');
+    parent.appendChild(element);
+
+    expect(action.findAction_(element, 'event1')).to.equal(null);
+    expect(action.findAction_(element, 'event2')).to.equal(null);
+  });
 });
 
 

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -903,6 +903,32 @@ describes.sandboxed('DOM', {}, env => {
       });
     });
   });
+
+  it('isEnabled', () => {
+    expect(dom.isEnabled(document)).to.be.true;
+
+    const a = document.createElement('button');
+    expect(dom.isEnabled(a)).to.be.true;
+
+    a.disabled = true;
+    expect(dom.isEnabled(a)).to.be.false;
+
+    a.disabled = false;
+    expect(dom.isEnabled(a)).to.be.true;
+
+    const b = document.createElement('fieldset');
+    b.appendChild(a);
+    expect(dom.isEnabled(a)).to.be.true;
+
+    b.disabled = true;
+    expect(dom.isEnabled(a)).to.be.false;
+
+    b.removeChild(a);
+    const c = document.createElement('legend');
+    c.appendChild(a);
+    b.appendChild(c);
+    expect(dom.isEnabled(a)).to.be.true;
+  });
 });
 
 describes.realWin('DOM', {


### PR DESCRIPTION
The action on a [disabled](https://www.w3.org/TR/html5/forms.html#concept-fe-disabled) form control is ignored during the action lookup on the tree.

  * When a `button` has action `event1` and is *disabled*, click on this button is blocked by DOM, click on a children element is not. This change prevents `event1` from firing.
  * A `button` inside a disabled `fieldset` has to be considered *disabled*. (This is why `:disabled` pseudo-class was used, since e.g. `el.disabled` does not take this into account.)

Potential problems:
  * Does not fix the problem on IE8 (and maybe others). I went with a permissive approach: rather allow action on a wrong place than cancel it on a correct place. (*enabled* means it does not match `:disabled`, cf. `:enabled` or `:not(:disabled)`)
  * Action propagation is not stopped, the event can fire on an ancestor. This is related to previous, it is difficult to reliably mark an element as *disabled* cross-platform.

cc: @choumx 
Fixes #10642