### PR TITLE
Multi-size will no longer block ad requests due to invalid multi-size data attributes

### DIFF
--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -76,8 +76,7 @@ function doubleClickWithGpt(global, data, gladeExperiment, url) {
       multiSizeDataStr,
       primaryWidth,
       primaryHeight,
-      (data.multiSizeValidation || 'true') == 'true',
-      true))) {
+      (data.multiSizeValidation || 'true') == 'true'))) {
     dimensions.unshift([primaryWidth, primaryHeight]);
   } else {
     dimensions = [[primaryWidth, primaryHeight]];

--- a/ads/google/test/test-utils.js
+++ b/ads/google/test/test-utils.js
@@ -35,36 +35,31 @@ describe('#getMultiSizeDimensions', () => {
 
   it('should return all sizes', () => {
     const actual = getMultiSizeDimensions(multiSizeDataStr, 300, 300,
-        /* Ignore lowerbound */ false,
-        /* Don't drop entire string on error */ false);
+        /* Ignore lowerbound */ false);
     verifyArray(actual, 0, multiSizes.length);
   });
 
   it('should return a smaller array', () => {
     const actual = getMultiSizeDimensions(multiSizeDataStr, 300, 250,
-        /* Ignore lowerbound */ false,
-        /* Don't drop entire string on error */ false);
+        /* Ignore lowerbound */ false);
     verifyArray(actual, 1, multiSizes.length);
   });
 
   it('should return an even smaller array', () => {
     const actual = getMultiSizeDimensions(multiSizeDataStr, 250, 250,
-        /* Ignore lowerbound */ false,
-        /* Don't drop entire string on error */ false);
+        /* Ignore lowerbound */ false);
     verifyArray(actual, 2, multiSizes.length);
   });
 
   it('should return an empty array', () => {
     const actual = getMultiSizeDimensions(multiSizeDataStr, 100, 50,
-        /* Ignore lowerbound */ false,
-        /* Don't drop entire string on error */ false);
+        /* Ignore lowerbound */ false);
     verifyArray(actual, 0, 0);
   });
 
   it('should return a smaller array due to lowerbound', () => {
     const actual = getMultiSizeDimensions(multiSizeDataStr, 300, 300,
-        /* Use lowerbound */ true,
-        /* Don't drop entire string on error */ false);
+        /* Use lowerbound */ true);
 
     verifyArray(actual, 0, multiSizes.length - 1);
   });
@@ -72,23 +67,14 @@ describe('#getMultiSizeDimensions', () => {
   it('should return a smaller array due to lowerbound + smaller primary size',
       () => {
         const actual = getMultiSizeDimensions(multiSizeDataStr, 300, 250,
-            /* Use lowerbound */ true,
-            /* Don't drop entire string on error */ false);
+            /* Use lowerbound */ true);
         verifyArray(actual, 1, multiSizes.length - 1);
       });
 
-  it('should return null', () => {
-    const actual = getMultiSizeDimensions(multiSizeDataStr, 300, 250,
-        /* Ignore lowerbound */ false,
-        /* Drop entire string on error */ true);
-    expect(actual).to.be.null;
-  });
-
-  it('should return null due to non-positive argument', () => {
+  it('should return all positive sizes', () => {
     const actual = getMultiSizeDimensions(
         '-1x300,' + multiSizeDataStr, 300, 300,
-        /* Ignore lowerbound */ false,
-        /* Drop entire string on error */ true);
-    expect(actual).to.be.null;
+        /* Ignore lowerbound */ false);
+    verifyArray(actual, 0, multiSizes.length);
   });
 });

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -28,19 +28,13 @@ import {user} from '../../src/log';
  * @param {boolean} multiSizeValidation A flag that if set to true will enforce
  *   the rule that ensures multi-size dimensions are no less than 2/3rds of
  *   their primary dimension's counterpart.
- * @param {boolean} strict If set to true, this indicates that a single
- *   malformed size should cause the entire multi-size data string to be
- *   abandoned. If set to false, then malformed sizes will be ignored, and the
- *   remainder of the string will be parsed for any additional sizes.
- *   Additionally, errors will only be reported if this flag is set to true.
  * @return {?Array<!Array<number>>} An array of dimensions.
  */
 export function getMultiSizeDimensions(
     multiSizeDataStr,
     primaryWidth,
     primaryHeight,
-    multiSizeValidation,
-    strict) {
+    multiSizeValidation) {
 
   const dimensions = [];
   const arrayOfSizeStrs = multiSizeDataStr.split(',');
@@ -51,11 +45,8 @@ export function getMultiSizeDimensions(
     const size = sizeStr.split('x');
 
     // Make sure that each size is specified in the form WxH.
-    if (strict && size.length != 2) {
+    if (size.length != 2) {
       user().error('AMP-AD', `Invalid multi-size data format '${sizeStr}'.`);
-      if (strict) {
-        return null;
-      }
       continue;
     }
 
@@ -68,11 +59,7 @@ export function getMultiSizeDimensions(
         h => isNaN(h) || h <= 0,
         badParams => badParams.map(badParam =>
             `Invalid ${badParam.dim} of ${badParam.val} ` +
-            'given for secondary size.').join(' '),
-        strict)) {
-      if (strict) {
-        return null;
-      }
+            'given for secondary size.').join(' '))) {
       continue;
     }
 
@@ -82,11 +69,7 @@ export function getMultiSizeDimensions(
         h => h > primaryHeight,
         badParams => badParams.map(badParam =>
             `Secondary ${badParam.dim} ${badParam.val} ` +
-            `can't be larger than the primary ${badParam.dim}.`).join(' '),
-        strict)) {
-      if (strict) {
-        return null;
-      }
+            `can't be larger than the primary ${badParam.dim}.`).join(' '))) {
       continue;
     }
 
@@ -103,11 +86,8 @@ export function getMultiSizeDimensions(
           h => h < minHeight,
           badParams => badParams.map(badParam =>
               `Secondary ${badParam.dim} ${badParam.val} is ` +
-              `smaller than 2/3rds of the primary ${badParam.dim}.`).join(' '),
-          strict)) {
-        if (strict) {
-          return null;
-        }
+              `smaller than 2/3rds of the primary ${badParam.dim}.`)
+          .join(' '))) {
         continue;
       }
     }
@@ -135,12 +115,10 @@ export function getMultiSizeDimensions(
  * @param {function((number|string)): boolean} heightCond
  * @param {function(!Array<{dim: string, val: (number|string)}>): string=}
  *   errorBuilder A function that will produce an informative error message.
- * @param {boolean=} reportError If true, indicates that an error message
- *   should be logged to the console.
  * @return {boolean}
  */
-function validateDimensions(width, height, widthCond, heightCond,
-    errorBuilder, reportError = false) {
+function validateDimensions(width, height, widthCond, heightCond, errorBuilder)
+{
   const badParams = [];
   if (widthCond(width)) {
     badParams.push({dim: 'width', val: width});
@@ -148,8 +126,8 @@ function validateDimensions(width, height, widthCond, heightCond,
   if (heightCond(height)) {
     badParams.push({dim: 'height', val: height});
   }
-  if (reportError && badParams.length) {
-    user().error('AMP-AD', errorBuilder(badParams));
+  if (badParams.length) {
+    user().warn('AMP-AD', errorBuilder(badParams));
   }
   return !badParams.length;
 }

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -87,7 +87,7 @@ export function getMultiSizeDimensions(
           badParams => badParams.map(badParam =>
               `Secondary ${badParam.dim} ${badParam.val} is ` +
               `smaller than 2/3rds of the primary ${badParam.dim}.`)
-          .join(' '))) {
+              .join(' '))) {
         continue;
       }
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -329,8 +329,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           multiSizeDataStr,
           this.initialSize_.width,
           this.initialSize_.height,
-          multiSizeValidation == 'true',
-          /* Use strict mode only in non-refresh case */ !this.isRefreshing);
+          multiSizeValidation == 'true');
       sizeStr += '|' + dimensions
           .map(dimension => dimension.join('x'))
           .join('|');

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1556,5 +1556,16 @@ describes.sandboxed('amp-ad-network-doubleclick-impl', {}, () => {
         expect(iframe.getAttribute('style')).to.match(/height: 50/);
       });
     });
+
+    it('should issue an ad request even with bad multi-size data attr', () => {
+      stubForAmpCreative();
+      sandbox.stub(impl, 'sendXhrRequest', mockSendXhrRequest);
+      impl.element.setAttribute('data-multi-size', '201x50');
+      impl.onLayoutMeasure();
+      return impl.layoutCallback().then(() => {
+        expect(impl.adUrl_).to.be.ok;
+        expect(impl.adUrl_.length).to.be.ok;
+      });
+    });
   });
 });


### PR DESCRIPTION
In earlier implementations, a malformed data-multi-size attribute would throw an error and abort any attempt to issue an ad request. This behavior has been relaxed so that an ad request is always issued. Invalid portions of the attribute will be dropped, or the entire attribute will be ignored if none of it can be salvaged.