### PR TITLE
Set Doubleclick correlator clear experiment to 2%

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -6,6 +6,7 @@
   "expAdsenseA4A": 0.01,
   "expDoubleclickA4A": 0.01,
   "a4aProfilingRate": 1,
+  "dbclk_a4a_viz_change": 0.02,
   "ad-type-custom": 1,
   "ios-embed-wrapper": 1,
   "amp-apester-media": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -5,6 +5,7 @@
   "canary": 0,
   "expAdsenseA4A": 0.01,
   "expDoubleclickA4A": 0.01,
+  "dbclk_a4a_viz_change": 0.02,
   "a4aProfilingRate": 0.1,
   "ad-type-custom": 1,
   "ios-embed-wrapper": 1,


### PR DESCRIPTION
See #10708 which added the experiment.  Set to 2% of production/canary traffic.