### PR TITLE
Caching experiment toggles on window property

### DIFF
--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -32,7 +32,8 @@ export class AmpAutoAds extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    user().assert(isExperimentOn(self, 'amp-auto-ads'), 'Experiment is off');
+    user().assert(
+        isExperimentOn(this.win, 'amp-auto-ads'), 'Experiment is off');
 
     const type = this.element.getAttribute('type');
     user().assert(type, 'Missing type attribute');

--- a/src/error.js
+++ b/src/error.js
@@ -374,7 +374,7 @@ export function getErrorReportUrl(message, filename, line, col, error,
   url += `&jse=${detectedJsEngine}`;
 
   const exps = [];
-  const experiments = experimentTogglesOrNull();
+  const experiments = experimentTogglesOrNull(self);
   for (const exp in experiments) {
     const on = experiments[exp];
     exps.push(`${exp}=${on ? '1' : '0'}`);

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -551,7 +551,7 @@ describes.fakeWin('user error reporting', {amp: true}, env => {
   beforeEach(() => {
     win = env.win;
     analyticsEventSpy = sandbox.spy(analytics, 'triggerAnalyticsEvent');
-    toggleExperiment(window, 'user-error-reporting', true);
+    toggleExperiment(win, 'user-error-reporting', true);
   });
 
   it('should trigger triggerAnalyticsEvent with correct arguments', () => {


### PR DESCRIPTION
Currently each separate .js file on an AMP page maintains it's own experiment state, meaning a given experiment could be off according to amp-auto-ads.js while appearing on to amp-ads.js (for example).

This CL fixes this mismatch by storing the experiment state as a window property.

https://github.com/ampproject/amphtml/issues/10739