### PR TITLE
Update Promise PJs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "document-register-element": "1.5.0",
-    "promise-pjs": "1.1.2",
+    "promise-pjs": "1.1.3",
     "web-animations-js": "2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/10730.

A very interesting bug where promise adoption (an inner promise being
returned in side a `#then` block causes the outer to adopt the inner)
would not update the state of the outer promise if the inner was still
pending.

This only appeared when:

1. The outer promise was stored, and not used as a larger chain.
2. The inner promise was pending.
3. The outer promise has a `#then` block _after_ the inner promise
  resolved.

```js
var inner = new Promise(res => setTimeout(res, 0));
var outer = new Promise(res => res(inner));

// wait till after inner resolves
outer.then(() => {
  // I'll never be called. Whooops.
});