### PR TITLE
Update sizer element if improperly set

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -352,11 +352,8 @@ export function applyLayout_(element) {
     setStyle(element, 'height', dev().assertString(height));
   } else if (layout == Layout.RESPONSIVE) {
     const sizer = element.ownerDocument.createElement('i-amphtml-sizer');
-    setStyles(sizer, {
-      display: 'block',
-      paddingTop:
-        ((getLengthNumeral(height) / getLengthNumeral(width)) * 100) + '%',
-    });
+    setStyle(sizer, 'paddingTop',
+        (getLengthNumeral(height) / getLengthNumeral(width) * 100) + '%');
     element.insertBefore(sizer, element.firstChild);
     element.sizerElement_ = sizer;
   } else if (layout == Layout.FILL) {
@@ -852,12 +849,15 @@ function createBaseCustomElementClass(win) {
      * @private
      */
     getSizer_() {
-      if (this.sizerElement_ === undefined &&
-          this.layout_ === Layout.RESPONSIVE) {
-        // Expect sizer to exist, just not yet discovered.
-        this.sizerElement_ = this.querySelector('i-amphtml-sizer');
+      if (this.sizerElement_ === undefined) {
+        if (this.layout_ === Layout.RESPONSIVE) {
+          // Expect sizer to exist, just not yet discovered.
+          this.sizerElement_ = this.querySelector('i-amphtml-sizer');
+        } else {
+          this.sizerElement_ = null;
+        }
       }
-      return this.sizerElement_ || null;
+      return this.sizerElement_;
     }
 
     /**
@@ -901,11 +901,15 @@ function createBaseCustomElementClass(win) {
         this.heightsList_ = heightsAttr ?
             parseSizeList(heightsAttr, /* allowPercent */ true) : null;
       }
-      if (this.heightsList_) {
-        const sizer = this.getSizer_();
-        if (sizer) {
+      const sizer = this.getSizer_();
+      if (sizer) {
+        if (this.heightsList_) {
           setStyle(sizer, 'paddingTop',
               this.heightsList_.select(this.ownerDocument.defaultView));
+        } else if (!sizer.hasAttribute('style')) {
+          const height = getLengthNumeral(this.getAttribute('height'));
+          const width = getLengthNumeral(this.getAttribute('width'));
+          setStyle(sizer, 'paddingTop', (height / width * 100) + '%');
         }
       }
     }

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -937,6 +937,22 @@ describes.realWin('CustomElement', {amp: true}, env => {
     expect(sizer.style.paddingTop).to.equal('99%');
   });
 
+  it('should update sizer if done improperly in SSR', () => {
+    const element1 = new ElementClass();
+    element1.setAttribute('i-amphtml-layout', 'responsive');
+    element1.setAttribute('layout', 'responsive');
+    element1.setAttribute('width', '200px');
+    element1.setAttribute('height', '200px');
+    container.appendChild(element1);
+
+    const sizer = doc.createElement('i-amphtml-sizer');
+    expect(element1.sizerElement_).to.be.undefined;
+    element1.appendChild(sizer);
+    element1.applySizesAndMediaQuery();
+    expect(element1.sizerElement_).to.equal(sizer);
+    expect(sizer.style.paddingTop).to.equal('100%');
+  });
+
   it('should NOT rediscover sizer after reset in SSR', () => {
     const element1 = new ElementClass();
     element1.setAttribute('i-amphtml-layout', 'responsive');


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/9397#issuecomment-319753157.

Now every call to `#applySizesAndMediaQuery` will see if the sizer has been properly set.