### PR TITLE
Implemented MediaSessionAPI for `amp-audio`

### DIFF
--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -474,7 +474,6 @@
 
           <figure>
             <amp-audio
-              autoplay
               src="https://www.dl-sounds.com/wp-content/uploads/edd/2017/07/The-Horizon-preview.mp3"
               poster="https://images.pexels.com/photos/290101/pexels-photo-290101.jpeg?w=500&h=500&auto=compress&cs=tinysrgb"
               title="The Horizon"

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -308,6 +308,7 @@
   <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
   <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js" data-amp-report-test="amp-app-banner.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
@@ -470,6 +471,20 @@
             ac molestie nulla porttitor ac. Donec porta risus ut enim
             pellentesque, id placerat elit ornare.
           </p>
+
+          <figure>
+            <amp-audio
+              autoplay
+              src="https://www.dl-sounds.com/wp-content/uploads/edd/2017/07/The-Horizon-preview.mp3"
+              poster="https://images.pexels.com/photos/290101/pexels-photo-290101.jpeg?w=500&h=500&auto=compress&cs=tinysrgb"
+              title="The Horizon"
+              album="Royalty Free Music"
+              artist="Dl Sounds"
+              height="50"
+              width="auto"
+              controls>
+            </amp-video>
+          </figure>
 
           <p id="section1">
             Curabitur convallis, urna quis pulvinar feugiat, purus diam

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -17,6 +17,14 @@
 import {Layout} from '../../../src/layout';
 import {assertHttpsUrl} from '../../../src/url';
 import {dev} from '../../../src/log';
+import {listen} from '../../../src/event-helper';
+import {
+  EMPTY_METADATA,
+  parseSchemaImage,
+  parseOgImage,
+  parseFavicon,
+  setMediaSession,
+} from '../../../src/mediasession-helper';
 
 /**
  * Visible for testing only.
@@ -29,6 +37,9 @@ export class AmpAudio extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.audio_ = null;
+
+    /** @private {!../../../src/mediasession-helper.metadataDef} */
+    this.metadata_ = EMPTY_METADATA;
   }
 
   /** @override */
@@ -65,6 +76,28 @@ export class AmpAudio extends AMP.BaseElement {
     });
     this.element.appendChild(audio);
     this.audio_ = audio;
+
+    // Gather metadata
+    const doc = this.getAmpDoc().win.document;
+    const artist = this.element.getAttribute('artist');
+    const title = this.element.getAttribute('title')
+                  || this.element.getAttribute('aria-label')
+                  || doc.title;
+    const album = this.element.getAttribute('album');
+    const poster = this.element.getAttribute('poster')
+                   || parseSchemaImage(doc)
+                   || parseOgImage(doc)
+                   || parseFavicon(doc);
+    this.metadata_ = {
+      'title': title || '',
+      'artist': artist || '',
+      'album': album || '',
+      'artwork': [
+        {'src': poster || ''},
+      ],
+    };
+
+    listen(this.audio_, 'playing', () => this.audioPlaying_());
     return this.loadPromise(audio);
   }
 
@@ -73,6 +106,23 @@ export class AmpAudio extends AMP.BaseElement {
     if (this.audio_) {
       this.audio_.pause();
     }
+  }
+
+  audioPlaying_() {
+    const playHandler = () => {
+      this.audio_.play();
+    };
+    const pauseHandler = () => {
+      this.audio_.pause();
+    };
+
+    // Update the media session
+    setMediaSession(
+        this.getAmpDoc().win,
+        this.metadata_,
+        playHandler,
+        pauseHandler
+    );
   }
 }
 

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -38,7 +38,7 @@ export class AmpAudio extends AMP.BaseElement {
     /** @private {?Element} */
     this.audio_ = null;
 
-    /** @private {!../../../src/mediasession-helper.metadataDef} */
+    /** @private {!../../../src/mediasession-helper.MetadataDef} */
     this.metadata_ = EMPTY_METADATA;
   }
 

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -61,7 +61,7 @@ For example:
 
 ## Attributes
 
-##### src 
+##### src
 
 Required if no `<source>` children are present. Must be HTTPS.
 
@@ -81,6 +81,30 @@ If present, will mute the audio by default.
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
+
+## MediaSessionAPI Attributes
+
+`amp-audio` implements the MediaSessionAPI enabling developers to specify more information about the audio file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
+##### poster
+URL to a PNG/JPG/ICO image serving as the audio's artwork. If not present, the MediaSessionAPI Helper will use either the `image` field in the `schema.org` definition, the `og:image` or the website's `favicon`.
+##### artist
+(string) indicates the author of the audio
+##### album
+(string) indicates the album the audio was taken from
+##### title
+(string) part of the [common attributes](https://www.ampproject.org/docs/reference/common_attributes), doubles as the audio's name displayed in the MediaSession notification. If not provided, the MediaSessionAPI Helper will use either the `aria-label` attribute or fall back to the page's title.
+
+Example:
+
+```html
+<amp-audio width="400" height="300"
+  src="https://yourhost.com/audios/myaudio.mp3"
+  poster="https://yourhost.com/posters/poster.png"
+  title="Awesome music" artist="Awesome singer"
+  album="Amazing album">
+  <source type="audio/mpeg" src="foo.mp3">
+</amp-audio>
+```
 
 ## Validation
 

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -82,16 +82,24 @@ If present, will mute the audio by default.
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
-## MediaSessionAPI Attributes
+## Media Session Attributes
 
-`amp-audio` implements the MediaSessionAPI enabling developers to specify more information about the audio file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
+`amp-audio` implements the [Media Session API](https://developers.google.com/web/updates/2017/02/media-session) enabling developers to specify more information about the audio file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
+
 ##### poster
+
 URL to a PNG/JPG/ICO image serving as the audio's artwork. If not present, the MediaSessionAPI Helper will use either the `image` field in the `schema.org` definition, the `og:image` or the website's `favicon`.
+
 ##### artist
+
 (string) indicates the author of the audio
+
 ##### album
+
 (string) indicates the album the audio was taken from
+
 ##### title
+
 (string) part of the [common attributes](https://www.ampproject.org/docs/reference/common_attributes), doubles as the audio's name displayed in the MediaSession notification. If not provided, the MediaSessionAPI Helper will use either the `aria-label` attribute or fall back to the page's title.
 
 Example:

--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -26,9 +26,12 @@ tags: {  # amp-audio
 }
 attr_lists: { # amp-audio attributes that are common to both AMP and A4A format.
   name: "amp-audio-common"
+  attrs: { name: "album" }
+  attrs: { name: "artist" }
   attrs: { name: "controls" }
   attrs: { name: "loop"  value: "" }
   attrs: { name: "muted" value: "" }
+  attrs: { name: "poster" }
   attrs: {
     name: "src"
     value_url: {

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -72,7 +72,7 @@ class AmpVideo extends AMP.BaseElement {
     /** @private {?boolean}  */
     this.muted_ = false;
 
-    /** @private {!../../../src/video-interface.VideoMetaDef} */
+    /** @private {!../../../src/mediasession-helper.MetadataDef} */
     this.metadata_ = EMPTY_METADATA;
   }
 

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -109,16 +109,24 @@ The `muted` attribute is deprecated and no longer has any effect. The `autoplay`
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 
-## MediaSessionAPI Attributes
+## Media Session API Attributes
 
-`amp-video` implements the MediaSessionAPI enabling developers to specify more information about the video file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
+`amp-video` implements the [Media Session API](https://developers.google.com/web/updates/2017/02/media-session) enabling developers to specify more information about the video file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
+
 ##### poster
+
 URL to a PNG/JPG/ICO image serving as the video's artwork. If not present, the MediaSessionAPI Helper will use either the `image` field in the `schema.org` definition, the `og:image` or the website's `favicon`.
+
 ##### artist
+
 (string) indicates the author of the video file
+
 ##### album
+
 (string) indicates the album/collection the video was taken from
+
 ##### title
+
 (string) part of the [common attributes](https://www.ampproject.org/docs/reference/common_attributes), doubles as the video's name/title displayed in the MediaSession notification. If not provided, the MediaSessionAPI Helper will use either the `aria-label` attribute or fall back to the page's title.
 
 Example:

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -108,6 +108,31 @@ The `muted` attribute is deprecated and no longer has any effect. The `autoplay`
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
+
+## MediaSessionAPI Attributes
+
+`amp-video` implements the MediaSessionAPI enabling developers to specify more information about the video file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
+##### poster
+URL to a PNG/JPG/ICO image serving as the video's artwork. If not present, the MediaSessionAPI Helper will use either the `image` field in the `schema.org` definition, the `og:image` or the website's `favicon`.
+##### artist
+(string) indicates the author of the video file
+##### album
+(string) indicates the album/collection the video was taken from
+##### title
+(string) part of the [common attributes](https://www.ampproject.org/docs/reference/common_attributes), doubles as the video's name/title displayed in the MediaSession notification. If not provided, the MediaSessionAPI Helper will use either the `aria-label` attribute or fall back to the page's title.
+
+Example:
+
+```html
+<amp-audio width="400" height="300"
+  src="https://yourhost.com/audios/myaudio.mp3"
+  poster="https://yourhost.com/posters/poster.png"
+  title="Awesome music" artist="Awesome singer"
+  album="Amazing album">
+  <source type="audio/mpeg" src="foo.mp3">
+</amp-audio>
+```
+
 ## Click-to-Play overlay
 
 Providing a click-to-play overlay is a common UX feature for video players on the web.  For example, you could display a custom play icon that the user can click, as well as include the title of the video, different sized poster images, and so on.  Because the `amp-video` component supports the standard `play` AMP action, you can easily implement click-to-play.

--- a/src/mediasession-helper.js
+++ b/src/mediasession-helper.js
@@ -24,9 +24,9 @@ import {tryParseJson} from './json';
  *   artist: string,
  * }}
  */
-export let metadataDef;
+export let MetadataDef;
 
-/** @const {metadataDef} Dummy metadata used to fix a bug */
+/** @const {MetadataDef} Dummy metadata used to fix a bug */
 export const EMPTY_METADATA = {
   'title': '',
   'artist': '',
@@ -38,22 +38,22 @@ export const EMPTY_METADATA = {
 
 /**
  * Updates the Media Session API's metadata
- * @param {!Window} global
- * @param {!metadataDef} metadata
+ * @param {!Window} win
+ * @param {!MetadataDef} metadata
  * @param {function()=} playHandler
  * @param {function()=} pauseHandler
  */
-export function setMediaSession(global,
+export function setMediaSession(win,
                                 metadata,
                                 playHandler,
                                 pauseHandler) {
-  const navigator = global.navigator;
-  if ('mediaSession' in navigator && global.MediaMetadata) {
+  const navigator = win.navigator;
+  if ('mediaSession' in navigator && win.MediaMetadata) {
     // Clear mediaSession (required to fix a bug when switching between two
     // videos)
-    navigator.mediaSession.metadata = new global.MediaMetadata(EMPTY_METADATA);
+    navigator.mediaSession.metadata = new win.MediaMetadata(EMPTY_METADATA);
     // Add metadata
-    navigator.mediaSession.metadata = new global.MediaMetadata(metadata);
+    navigator.mediaSession.metadata = new win.MediaMetadata(metadata);
 
     navigator.mediaSession.setActionHandler('play', playHandler);
     navigator.mediaSession.setActionHandler('pause', pauseHandler);

--- a/src/mediasession-helper.js
+++ b/src/mediasession-helper.js
@@ -16,7 +16,17 @@
 
 import {tryParseJson} from './json';
 
-/** @const {./video-interface.VideoMetaDef} Dummy metadata used to fix a bug */
+/**
+ * @typedef {{
+ *   artwork: Array,
+ *   title: string,
+ *   album: string,
+ *   artist: string,
+ * }}
+ */
+export let metadataDef;
+
+/** @const {metadataDef} Dummy metadata used to fix a bug */
 export const EMPTY_METADATA = {
   'title': '',
   'artist': '',
@@ -28,23 +38,22 @@ export const EMPTY_METADATA = {
 
 /**
  * Updates the Media Session API's metadata
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
- * @param {!./video-interface.VideoMetaDef} metadata
+ * @param {!Window} global
+ * @param {!metadataDef} metadata
  * @param {function()=} playHandler
  * @param {function()=} pauseHandler
  */
-export function setMediaSession(ampdoc,
+export function setMediaSession(global,
                                 metadata,
                                 playHandler,
                                 pauseHandler) {
-  const win = ampdoc.win;
-  const navigator = win.navigator;
-  if ('mediaSession' in navigator && win.MediaMetadata) {
+  const navigator = global.navigator;
+  if ('mediaSession' in navigator && global.MediaMetadata) {
     // Clear mediaSession (required to fix a bug when switching between two
     // videos)
-    navigator.mediaSession.metadata = new win.MediaMetadata(EMPTY_METADATA);
+    navigator.mediaSession.metadata = new global.MediaMetadata(EMPTY_METADATA);
     // Add metadata
-    navigator.mediaSession.metadata = new win.MediaMetadata(metadata);
+    navigator.mediaSession.metadata = new global.MediaMetadata(metadata);
 
     navigator.mediaSession.setActionHandler('play', playHandler);
     navigator.mediaSession.setActionHandler('pause', pauseHandler);
@@ -57,11 +66,10 @@ export function setMediaSession(ampdoc,
 /**
  * Parses the schema.org json-ld formatted meta-data, looks for the page's
  * featured image and returns it
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Document} doc
  * @return {string|undefined}
  */
-export function parseSchemaImage(ampdoc) {
-  const doc = ampdoc.win.document;
+export function parseSchemaImage(doc) {
   const schema = doc.querySelector('script[type="application/ld+json"]');
   if (!schema) {
     // No schema element found
@@ -94,11 +102,10 @@ export function parseSchemaImage(ampdoc) {
 
 /**
  * Parses the og:image if it exists and returns it
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Document} doc
  * @return {string|undefined}
  */
-export function parseOgImage(ampdoc) {
-  const doc = ampdoc.win.document;
+export function parseOgImage(doc) {
   const metaTag = doc.querySelector('meta[property="og:image"]');
   if (metaTag) {
     return metaTag.getAttribute('content');
@@ -109,11 +116,10 @@ export function parseOgImage(ampdoc) {
 
 /**
  * Parses the website's Favicon and returns it
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Document} doc
  * @return {string|undefined}
  */
-export function parseFavicon(ampdoc) {
-  const doc = ampdoc.win.document;
+export function parseFavicon(doc) {
   const linkTag = doc.querySelector('link[rel="shortcut icon"]')
                   || doc.querySelector('link[rel="icon"]');
   if (linkTag) {

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -549,7 +549,7 @@ class VideoEntry {
 
     // Media Session API Variables
 
-    /** @private {!../video-interface.VideoMetaDef} */
+    /** @private {!../mediasession-helper.metadataDef} */
     this.metadata_ = EMPTY_METADATA;
 
     listenOncePromise(element, VideoEvents.LOAD)
@@ -593,7 +593,7 @@ class VideoEntry {
       };
       // Update the media session
       setMediaSession(
-          this.ampdoc_,
+          this.ampdoc_.win,
           this.metadata_,
           playHandler,
           pauseHandler
@@ -665,14 +665,18 @@ class VideoEntry {
     }
 
     if (this.video.getMetadata()) {
-      const mapped = map(this.video.getMetadata());
-      this.metadata_ = /** @type {!../video-interface.VideoMetaDef} */ (mapped);
+      this.metadata_ = map(
+          /** @type {!../mediasession-helper.metadataDef} */
+          (this.video.getMetadata())
+      );
     }
 
+    const doc = this.ampdoc_.win.document;
+
     if (!this.metadata_.artwork || this.metadata_.artwork.length == 0) {
-      const posterUrl = parseSchemaImage(this.ampdoc_)
-                        || parseOgImage(this.ampdoc_)
-                        || parseFavicon(this.ampdoc_);
+      const posterUrl = parseSchemaImage(doc)
+                        || parseOgImage(doc)
+                        || parseFavicon(doc);
 
       if (posterUrl) {
         this.metadata_.artwork = [{
@@ -686,7 +690,7 @@ class VideoEntry {
                     || this.video.element.getAttribute('aria-label')
                     || this.internalElement_.getAttribute('title')
                     || this.internalElement_.getAttribute('aria-label')
-                    || this.ampdoc_.win.document.title;
+                    || doc.title;
       if (title) {
         this.metadata_.title = title;
       }

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -549,7 +549,7 @@ class VideoEntry {
 
     // Media Session API Variables
 
-    /** @private {!../mediasession-helper.metadataDef} */
+    /** @private {!../mediasession-helper.MetadataDef} */
     this.metadata_ = EMPTY_METADATA;
 
     listenOncePromise(element, VideoEvents.LOAD)
@@ -666,7 +666,7 @@ class VideoEntry {
 
     if (this.video.getMetadata()) {
       this.metadata_ = map(
-          /** @type {!../mediasession-helper.metadataDef} */
+          /** @type {!../mediasession-helper.MetadataDef} */
           (this.video.getMetadata())
       );
     }

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -111,7 +111,7 @@ export class VideoInterface {
    * title (string): Name of the video
    * artist (string): Name of the video's author/artist
    * album (string): Name of the video's album if it exists
-   * @return {!./mediasession-helper.metadataDef|undefined} metadata
+   * @return {!./mediasession-helper.MetadataDef|undefined} metadata
    */
   getMetadata() {}
 

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -17,16 +17,6 @@
 import {ActionTrust} from './action-trust'; /* eslint no-unused-vars: 0 */
 
 /**
- * @typedef {{
- *   artwork: Array,
- *   title: string,
- *   album: string,
- *   artist: string,
- * }}
- */
-export let VideoMetaDef;
-
-/**
  * VideoInterface defines a common video API which any AMP component that plays
  * videos is expected to implement.
  *
@@ -121,7 +111,7 @@ export class VideoInterface {
    * title (string): Name of the video
    * artist (string): Name of the video's author/artist
    * album (string): Name of the video's album if it exists
-   * @return {!VideoMetaDef|undefined} metadata
+   * @return {!./mediasession-helper.metadataDef|undefined} metadata
    */
   getMetadata() {}
 

--- a/test/functional/test-mediasession-helper.js
+++ b/test/functional/test-mediasession-helper.js
@@ -105,15 +105,15 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
   });
 
   it('should parse the schema and find the image', () => {
-    expect(parseSchemaImage(ampdoc)).to.equal('http://example.com/image.png');
+    expect(parseSchemaImage(ampdoc.win.document)).to.equal('http://example.com/image.png');
   });
 
   it('should parse the og-image', () => {
-    expect(parseOgImage(ampdoc)).to.equal('http://example.com/og-image.png');
+    expect(parseOgImage(ampdoc.win.document)).to.equal('http://example.com/og-image.png');
   });
 
   it('should parse the favicon', () => {
-    expect(parseFavicon(ampdoc)).to.equal('http://example.com/favicon.ico');
+    expect(parseFavicon(ampdoc.win.document)).to.equal('http://example.com/favicon.ico');
   });
 
   it('should set the media session', () => {
@@ -131,7 +131,7 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
       ],
       'title': 'Some title',
     };
-    setMediaSession(ampdoc, fakeMetaData);
+    setMediaSession(ampdoc.win, fakeMetaData);
     const newMetaData = ampdoc.win.navigator.mediaSession.metadata;
     expect(newMetaData).to.deep.equal(fakeMetaData);
   });


### PR DESCRIPTION

![screenshot_20170802-232616](https://user-images.githubusercontent.com/591655/28909499-98b22bd2-77dd-11e7-8977-c35382efc34f.jpg)

### Changes
- Made `mediasession-helper` and its variables more generic and less tied to video
- Added `poster`, `album`, `artist` and `title` attributes to `amp-audio`
- Implemented the MediaSessionAPI updates when the audio starts playing
- Added an `amp-audio` component to `article.amp.html` that implements the MediaSessionAPI (since there's no `amp-audio` example).
- Validator changes for `amp-audio`