### PR TITLE
Reinstitute the check to make sure yarn.lock is updated with package.json

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -367,9 +367,10 @@ function main(argv) {
         util.colors.cyan('yarn.lock'));
     console.error(fileLogPrefix, util.colors.yellow('NOTE:'),
         'To update', util.colors.cyan('yarn.lock'), 'after changing',
-        util.colors.cyan('package.json'), 'run',
-        util.colors.cyan('yarn install'), 'and include the change to',
-        util.colors.cyan('yarn.lock'), 'in your PR.');
+        util.colors.cyan('package.json') + ',', 'run',
+        '"' + util.colors.cyan('yarn install') + '"',
+        'and include the change to', util.colors.cyan('yarn.lock'),
+        'in your PR.');
     process.exit(1);
   }
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -359,12 +359,19 @@ function main(argv) {
     process.exit(1);
   }
 
-  //if (files.includes('package.json') ?
-        //!files.includes('yarn.lock') : files.includes('yarn.lock')) {
-    //console.error('pr-check.js - any update to package.json or yarn.lock ' +
-        //'must include the other file. Please update through yarn.');
-    //process.exit(1);
-  //}
+  // Make sure changes to package.json also update yarn.lock.
+  if (files.includes('package.json') && !files.includes('yarn.lock')) {
+    console.error(fileLogPrefix, util.colors.red('ERROR:'),
+        'Updates to', util.colors.cyan('package.json'),
+        'must be accompanied by a corresponding update to',
+        util.colors.cyan('yarn.lock'));
+    console.error(fileLogPrefix, util.colors.yellow('NOTE:'),
+        'To update', util.colors.cyan('yarn.lock'), 'after changing',
+        util.colors.cyan('package.json'), 'run',
+        util.colors.cyan('yarn install'), 'and include the change to',
+        util.colors.cyan('yarn.lock'), 'in your PR.');
+    process.exit(1);
+  }
 
   const sortedBuildTargets = [];
   for (const t of buildTargets) {

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -360,7 +360,7 @@ function main(argv) {
   }
 
   // Make sure changes to package.json also update yarn.lock.
-  if (files.includes('package.json') && !files.includes('yarn.lock')) {
+  if (files.indexOf('package.json') != -1 && files.indexOf('yarn.lock') == -1) {
     console.error(fileLogPrefix, util.colors.red('ERROR:'),
         'Updates to', util.colors.cyan('package.json'),
         'must be accompanied by a corresponding update to',

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "karma-fixture": "0.2.6",
     "karma-html2js-preprocessor": "0.1.0",
     "karma-mocha": "0.2.2",
-    "karma-mocha-reporter": "^2.2.3",
+    "karma-mocha-reporter": "2.2.3",
     "karma-safari-launcher": "0.1.1",
     "karma-sauce-launcher": "1.1.0",
     "karma-sinon-chai": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "karma-fixture": "0.2.6",
     "karma-html2js-preprocessor": "0.1.0",
     "karma-mocha": "0.2.2",
-    "karma-mocha-reporter": "2.2.3",
+    "karma-mocha-reporter": "^2.2.3",
     "karma-safari-launcher": "0.1.1",
     "karma-sauce-launcher": "1.1.0",
     "karma-sinon-chai": "1.2.3",


### PR DESCRIPTION
This PR makes sure `yarn.lock` is updated when `package.json` is updated. The reverse check is not necessary because it's legitimate to update `yarn.lock` without touching `package.json` while bringing the `yarn` install on Travis up to date.

Fixes #10673 
Related to #10671 