### PR TITLE
Resources: promisable buildCallback

### DIFF
--- a/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
@@ -68,14 +68,12 @@ describe('amp-3q-player', function() {
           expect(iframe).to.not.be.null;
           expect(iframe.src).to.equal('https://playout.3qsdn.com/c8dbe7f4-7f7f-11e6-a407-0cc47a188158?autoplay=false&amp=true');
         });
-  })
-;
+  });
 
   it('requires data-id', () => {
     return get3QElement('').should.eventually.be.rejectedWith(
         /The data-id attribute is required/);
-  })
-;
+  });
 
   it('should forward events from amp-3q-player to the amp element', () => {
     return get3QElement(

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -91,7 +91,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
     });
 
     it('should fail without config', () => {
-      const anim = createAnim({}, null).then(() => {
+      return createAnim({}, null).then(() => {
         throw new Error('must have failed');
       }, reason => {
         expect(reason.message)

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -51,8 +51,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
     }
 
     win.document.body.appendChild(element);
-    element.build();
-    return element.implementation_;
+    return element.build().then(() => element.implementation_);
   }
 
 
@@ -86,30 +85,36 @@ describes.sandboxed('AmpAnimation', {}, () => {
       return createAnimInWindow(win, attrs, config);
     }
 
-    it('should load and parse config', () => {
-      const anim = createAnim({}, {duration: 1001});
+    it('should load and parse config', function* () {
+      const anim = yield createAnim({}, {duration: 1001});
       expect(anim.configJson_).to.deep.equal({duration: 1001});
     });
 
     it('should fail without config', () => {
-      expect(() => {
-        createAnim({}, null);
-      }).to.throw(/\"<script type=application\/json>\" must be present/);
+      const anim = createAnim({}, null).then(() => {
+        throw new Error('must have failed');
+      }, reason => {
+        expect(reason.message)
+            .to.match(/\"<script type=application\/json>\" must be present/);
+      });
     });
 
     it('should fail with malformed config', () => {
-      expect(() => {
-        createAnim({}, 'broken');
-      }).to.throw(/failed to parse animation script/);
+      return createAnim({}, 'broken').then(() => {
+        throw new Error('must have failed');
+      }, reason => {
+        expect(reason.message)
+            .to.match(/failed to parse animation script/);
+      });
     });
 
-    it('should default trigger to none', () => {
-      const anim = createAnim({}, {duration: 1001});
+    it('should default trigger to none', function* () {
+      const anim = yield createAnim({}, {duration: 1001});
       expect(anim.triggerOnVisibility_).to.be.false;
     });
 
-    it('should parse visibility trigger', () => {
-      const anim = createAnim({trigger: 'visibility'}, {duration: 1001});
+    it('should parse visibility trigger', function* () {
+      const anim = yield createAnim({trigger: 'visibility'}, {duration: 1001});
       expect(anim.triggerOnVisibility_).to.be.true;
 
       // Animation is made to be always in viewport via mutateElement.
@@ -126,21 +131,24 @@ describes.sandboxed('AmpAnimation', {}, () => {
     });
 
     it('should fail on invalid trigger', () => {
-      expect(() => {
-        createAnim({trigger: 'unknown'}, {duration: 1001});
-      }).to.throw(/Only allowed value for \"trigger\" is \"visibility\"/);
+      return createAnim({trigger: 'unknown'}, {duration: 1001}).then(() => {
+        throw new Error('must have failed');
+      }, reason => {
+        expect(reason.message)
+            .to.match(/Only allowed value for \"trigger\" is \"visibility\"/);
+      });
     });
 
-    it('should update visibility from viewer', () => {
-      const anim = createAnim({}, {duration: 1001});
+    it('should update visibility from viewer', function* () {
+      const anim = yield createAnim({}, {duration: 1001});
       expect(anim.visible_).to.be.false;
 
       viewer.setVisibilityState_('visible');
       expect(anim.visible_).to.be.true;
     });
 
-    it('should update visibility when paused', () => {
-      const anim = createAnim({}, {duration: 1001});
+    it('should update visibility when paused', function* () {
+      const anim = yield createAnim({}, {duration: 1001});
       viewer.setVisibilityState_('visible');
       expect(anim.visible_).to.be.true;
 
@@ -148,34 +156,32 @@ describes.sandboxed('AmpAnimation', {}, () => {
       expect(anim.visible_).to.be.false;
     });
 
-    it('should not activate w/o visibility trigger', () => {
-      const anim = createAnim({}, {duration: 1001});
+    it('should not activate w/o visibility trigger', function* () {
+      const anim = yield createAnim({}, {duration: 1001});
       const activateStub = sandbox.stub(anim, 'startAction_');
       viewer.setVisibilityState_('visible');
-      return anim.layoutCallback().then(() => {
-        expect(activateStub).to.not.be.called;
-      });
+      yield anim.layoutCallback();
+      expect(activateStub).to.not.be.called;
     });
 
-    it('should activate with visibility trigger', () => {
-      const anim = createAnim({trigger: 'visibility'}, {duration: 1001});
+    it('should activate with visibility trigger', function* () {
+      const anim = yield createAnim({trigger: 'visibility'}, {duration: 1001});
       const activateStub = sandbox.stub(anim, 'startAction_');
       viewer.setVisibilityState_('visible');
-      return anim.layoutCallback().then(() => {
-        expect(activateStub).to.be.calledOnce;
-      });
+      yield anim.layoutCallback();
+      expect(activateStub).to.be.calledOnce;
     });
 
-    it('should trigger animation, but not start when invisible', () => {
-      const anim = createAnim({trigger: 'visibility'}, {duration: 1001});
+    it('should trigger animation, but not start when invisible', function* () {
+      const anim = yield createAnim({trigger: 'visibility'}, {duration: 1001});
       const startStub = sandbox.stub(anim, 'startOrResume_');
       anim.activate();
       expect(anim.triggered_).to.be.true;
       expect(startStub).to.not.be.called;
     });
 
-    it('should trigger animation and start when visible', () => {
-      const anim = createAnim({trigger: 'visibility'}, {duration: 1001});
+    it('should trigger animation and start when visible', function* () {
+      const anim = yield createAnim({trigger: 'visibility'}, {duration: 1001});
       const startStub = sandbox.stub(anim, 'startOrResume_');
       viewer.setVisibilityState_('visible');
       anim.activate();
@@ -183,8 +189,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
       expect(startStub).to.be.calledOnce;
     });
 
-    it('should resume/pause when visibility changes', () => {
-      const anim = createAnim({trigger: 'visibility'}, {duration: 1001});
+    it('should resume/pause when visibility changes', function* () {
+      const anim = yield createAnim({trigger: 'visibility'}, {duration: 1001});
       const startStub = sandbox.stub(anim, 'startOrResume_');
       const pauseStub = sandbox.stub(anim, 'pause_');
       anim.activate();
@@ -201,8 +207,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
       expect(startStub).to.be.calledOnce;  // Doesn't chnage.
     });
 
-    it('should NOT resume/pause when visible, but not triggered', () => {
-      const anim = createAnim({trigger: 'visibility'}, {duration: 1001});
+    it('should NOT resume/pause when visible, but not triggered', function* () {
+      const anim = yield createAnim({trigger: 'visibility'}, {duration: 1001});
       const startStub = sandbox.stub(anim, 'startOrResume_');
       const pauseStub = sandbox.stub(anim, 'pause_');
       expect(anim.triggered_).to.be.false;
@@ -218,67 +224,63 @@ describes.sandboxed('AmpAnimation', {}, () => {
       expect(startStub).to.not.be.called;
     });
 
-    it('should create runner', () => {
-      const anim = createAnim({trigger: 'visibility'},
+    it('should create runner', function* () {
+      const anim = yield createAnim({trigger: 'visibility'},
           {duration: 1001, animations: []});
       anim.activate();
       anim.visible_ = true;
       runnerMock.expects('start').once();
       runnerMock.expects('finish').never();
-      return anim.startOrResume_().then(() => {
-        expect(anim.triggered_).to.be.true;
-        expect(anim.runner_).to.exist;
-      });
+      yield anim.startOrResume_();
+      expect(anim.triggered_).to.be.true;
+      expect(anim.runner_).to.exist;
     });
 
-    it('should finish animation and runner', () => {
-      const anim = createAnim({trigger: 'visibility'},
+    it('should finish animation and runner', function* () {
+      const anim = yield createAnim({trigger: 'visibility'},
           {duration: 1001, animations: []});
       anim.activate();
       anim.visible_ = true;
       runnerMock.expects('start').once();
       runnerMock.expects('finish').once();
-      return anim.startOrResume_().then(() => {
-        anim.finish_();
-        expect(anim.triggered_).to.be.false;
-        expect(anim.runner_).to.be.null;
-      });
+      yield anim.startOrResume_();
+      anim.finish_();
+      expect(anim.triggered_).to.be.false;
+      expect(anim.runner_).to.be.null;
     });
 
-    it('should pause/resume animation and runner', () => {
-      const anim = createAnim({trigger: 'visibility'},
+    it('should pause/resume animation and runner', function* () {
+      const anim = yield createAnim({trigger: 'visibility'},
           {duration: 1001, animations: []});
       anim.activate();
       anim.visible_ = true;
       runnerMock.expects('start').once();
       runnerMock.expects('pause').once();
-      return anim.startOrResume_().then(() => {
-        anim.pause_();
-        expect(anim.triggered_).to.be.true;
+      yield anim.startOrResume_();
+      anim.pause_();
+      expect(anim.triggered_).to.be.true;
 
-        runnerMock.expects('resume').once();
-        anim.startOrResume_();
-        expect(anim.triggered_).to.be.true;
-      });
+      runnerMock.expects('resume').once();
+      anim.startOrResume_();
+      expect(anim.triggered_).to.be.true;
     });
 
-    it('should finish when animation is complete', () => {
-      const anim = createAnim({trigger: 'visibility'},
+    it('should finish when animation is complete', function* () {
+      const anim = yield createAnim({trigger: 'visibility'},
           {duration: 1001, animations: []});
       anim.activate();
       anim.visible_ = true;
-      return anim.startOrResume_().then(() => {
-        expect(anim.triggered_).to.be.true;
-        expect(anim.runner_).to.exist;
+      yield anim.startOrResume_();
+      expect(anim.triggered_).to.be.true;
+      expect(anim.runner_).to.exist;
 
-        runner.setPlayState_(WebAnimationPlayState.FINISHED);
-        expect(anim.triggered_).to.be.false;
-        expect(anim.runner_).to.be.null;
-      });
+      runner.setPlayState_(WebAnimationPlayState.FINISHED);
+      expect(anim.triggered_).to.be.false;
+      expect(anim.runner_).to.be.null;
     });
 
-    it('should resize from ampdoc viewport', () => {
-      const anim = createAnim({}, {duration: 1001});
+    it('should resize from ampdoc viewport', function* () {
+      const anim = yield createAnim({}, {duration: 1001});
       const stub = sandbox.stub(anim, 'onResize_');
       const viewport = win.services.viewport.obj;
 
@@ -291,25 +293,25 @@ describes.sandboxed('AmpAnimation', {}, () => {
       expect(stub).to.be.calledOnce;
     });
 
-    it('should cancel running animation on resize and schedule restart', () => {
-      const anim = createAnim({trigger: 'visibility'},
-          {duration: 1001, animations: []});
-      anim.activate();
-      anim.visible_ = true;
-      return anim.startOrResume_().then(() => {
-        expect(anim.runner_).to.exist;
+    it('should cancel running animation on resize and schedule restart',
+        function* () {
+          const anim = yield createAnim({trigger: 'visibility'},
+              {duration: 1001, animations: []});
+          anim.activate();
+          anim.visible_ = true;
+          yield anim.startOrResume_();
+          expect(anim.runner_).to.exist;
 
-        runnerMock.expects('cancel').once();
-        anim.onResize_();
-        expect(anim.runner_).to.be.null;
-        expect(anim.triggered_).to.be.true;
-        expect(anim.restartPass_.isPending()).to.be.true;
-        anim.restartPass_.cancel();
-      });
-    });
+          runnerMock.expects('cancel').once();
+          anim.onResize_();
+          expect(anim.runner_).to.be.null;
+          expect(anim.triggered_).to.be.true;
+          expect(anim.restartPass_.isPending()).to.be.true;
+          anim.restartPass_.cancel();
+        });
 
-    it('should ignore not-triggered animation on resize', () => {
-      const anim = createAnim({trigger: 'visibility'},
+    it('should ignore not-triggered animation on resize', function* () {
+      const anim = yield createAnim({trigger: 'visibility'},
           {duration: 1001, animations: []});
       anim.visible_ = true;
       expect(anim.runner_).to.not.exist;
@@ -320,32 +322,32 @@ describes.sandboxed('AmpAnimation', {}, () => {
       expect(anim.restartPass_.isPending()).to.be.false;
     });
 
-    it('should cancel and NOT restart hidden animation on resize', () => {
-      const anim = createAnim({trigger: 'visibility'},
-          {duration: 1001, animations: []});
-      anim.activate();
-      anim.visible_ = true;
-      return anim.startOrResume_().then(() => {
-        expect(anim.runner_).to.exist;
+    it('should cancel and NOT restart hidden animation on resize',
+        function* () {
+          const anim = yield createAnim({trigger: 'visibility'},
+              {duration: 1001, animations: []});
+          anim.activate();
+          anim.visible_ = true;
+          yield anim.startOrResume_();
+          expect(anim.runner_).to.exist;
 
-        anim.visible_ = false;
-        runnerMock.expects('cancel').once();
-        anim.onResize_();
-        expect(anim.runner_).to.be.null;
-        expect(anim.triggered_).to.be.true;
-        expect(anim.restartPass_.isPending()).to.be.false;
-      });
-    });
+          anim.visible_ = false;
+          runnerMock.expects('cancel').once();
+          anim.onResize_();
+          expect(anim.runner_).to.be.null;
+          expect(anim.triggered_).to.be.true;
+          expect(anim.restartPass_.isPending()).to.be.false;
+        });
 
-    it('should ignore start when not triggered', () => {
-      const anim = createAnim({trigger: 'visibility'},
+    it('should ignore start when not triggered', function* () {
+      const anim = yield createAnim({trigger: 'visibility'},
           {duration: 1001, animations: []});
       anim.visible_ = true;
       expect(anim.startOrResume_()).to.be.null;
     });
 
-    it('should ignore start when not triggered', () => {
-      const anim = createAnim({trigger: 'visibility'},
+    it('should ignore start when not triggered', function* () {
+      const anim = yield createAnim({trigger: 'visibility'},
           {duration: 1001, animations: []});
       anim.activate();
       anim.visible_ = false;
@@ -356,8 +358,10 @@ describes.sandboxed('AmpAnimation', {}, () => {
       let anim;
 
       beforeEach(() => {
-        anim = createAnim({}, {duration: 1001});
-        anim.visible_ = true;
+        return createAnim({}, {duration: 1001}).then(a => {
+          anim = a;
+          anim.visible_ = true;
+        });
       });
 
       it('should trigger activate via start', () => {
@@ -541,18 +545,18 @@ describes.sandboxed('AmpAnimation', {}, () => {
       return createAnimInWindow(embed.win, attrs, config);
     }
 
-    it('should update visibility from embed', () => {
-      const anim = createAnim({}, {duration: 1001});
+    it('should update visibility from embed', function* () {
+      const anim = yield createAnim({}, {duration: 1001});
       expect(anim.visible_).to.be.false;
 
       embed.setVisible_(true);
       expect(anim.visible_).to.be.true;
     });
 
-    it('should find target in the embed only via selector', () => {
+    it('should find target in the embed only via selector', function* () {
       const parentWin = env.ampdoc.win;
       const embedWin = embed.win;
-      const anim = createAnim({},
+      const anim = yield createAnim({},
           {duration: 1001, selector: '#target1', keyframes: {}});
       const targetInDoc = parentWin.document.createElement('div');
       targetInDoc.setAttribute('id', 'target1');
@@ -567,10 +571,10 @@ describes.sandboxed('AmpAnimation', {}, () => {
       });
     });
 
-    it('should find target in the embed only via target', () => {
+    it('should find target in the embed only via target', function* () {
       const parentWin = env.ampdoc.win;
       const embedWin = embed.win;
-      const anim = createAnim({},
+      const anim = yield createAnim({},
           {duration: 1001, target: 'target1', keyframes: {}});
       const targetInDoc = parentWin.document.createElement('div');
       targetInDoc.setAttribute('id', 'target1');
@@ -585,8 +589,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
       });
     });
 
-    it('should take resize from embed\'s window', () => {
-      const anim = createAnim({}, {duration: 1001});
+    it('should take resize from embed\'s window', function* () {
+      const anim = yield createAnim({}, {duration: 1001});
       const stub = sandbox.stub(anim, 'onResize_');
       embed.win.eventListeners.fire({type: 'resize'});
       expect(stub).to.be.calledOnce;

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -1452,6 +1452,8 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     it('should block AMP elements', () => {
       const r1 = resources.getResourceForElement(amp1);
       const r2 = resources.getResourceForElement(amp2);
+      sandbox.stub(r1, 'whenBuilt', () => Promise.resolve());
+      sandbox.stub(r2, 'whenBuilt', () => Promise.resolve());
       sandbox.stub(r1, 'isDisplayed', () => true);
       sandbox.stub(r2, 'isDisplayed', () => true);
       let runner;

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -1011,23 +1011,25 @@ describe('SlideScroll', () => {
         // Layout happens asynchronously after attaching to DOM, so we can
         // test pre-layoutCallback logic now.
         iframe.addElement(ampSlideScroll);
-        const impl = ampSlideScroll.implementation_;
-        const showSlideSpy = sandbox.spy(impl, 'showSlide_');
-        const satisfiesTrust = () => true;
+        return ampSlideScroll.build().then(() => {
+          const impl = ampSlideScroll.implementation_;
+          const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+          const satisfiesTrust = () => true;
 
-        const args = {'index': '3'};
-        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-        expect(showSlideSpy).to.not.have.been.called;
+          const args = {'index': '3'};
+          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+          expect(showSlideSpy).to.not.have.been.called;
 
-        impl.mutatedAttributesCallback({slide: 2});
-        expect(showSlideSpy).to.not.have.been.called;
+          impl.mutatedAttributesCallback({slide: 2});
+          expect(showSlideSpy).to.not.have.been.called;
 
-        impl.onLayoutMeasure();
-        ampSlideScroll.layoutCallback();
+          impl.onLayoutMeasure();
+          ampSlideScroll.layoutCallback();
 
-        // Should show the last slide index requested before layout.
-        expect(showSlideSpy).to.have.been.calledWith(2);
-        expect(showSlideSpy).to.be.calledOnce;
+          // Should show the last slide index requested before layout.
+          expect(showSlideSpy).to.have.been.calledWith(2);
+          expect(showSlideSpy).to.be.calledOnce;
+        });
       });
     });
 
@@ -1036,37 +1038,39 @@ describe('SlideScroll', () => {
         const {iframe, ampSlideScroll} = obj;
 
         iframe.addElement(ampSlideScroll);
-        const impl = ampSlideScroll.implementation_;
-        const showSlideSpy = sandbox.spy(impl, 'showSlide_');
-        const satisfiesTrust = () => true;
+        return ampSlideScroll.build().then(() => {
+          const impl = ampSlideScroll.implementation_;
+          const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+          const satisfiesTrust = () => true;
 
-        // Test that showSlide_ due to goToSlide(index=1) is not called before layout.
-        let args = {'index': '1'};
-        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-        expect(showSlideSpy).to.not.have.been.called;
+          // Test that showSlide_ due to goToSlide(index=1) is not called before layout.
+          let args = {'index': '1'};
+          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+          expect(showSlideSpy).to.not.have.been.called;
 
-        // Test that showSlide_ is called after layout.
-        impl.onLayoutMeasure();
-        ampSlideScroll.layoutCallback();
+          // Test that showSlide_ is called after layout.
+          impl.onLayoutMeasure();
+          ampSlideScroll.layoutCallback();
 
-        expect(showSlideSpy).to.have.been.calledWith(1);
-        expect(showSlideSpy).to.be.calledOnce;
+          expect(showSlideSpy).to.have.been.calledWith(1);
+          expect(showSlideSpy).to.be.calledOnce;
 
-        // Unlayout
-        showSlideSpy.reset();
-        impl.unlayoutCallback();
+          // Unlayout
+          showSlideSpy.reset();
+          impl.unlayoutCallback();
 
-        // Test that showSlide_ due to goToSlide(index=4) is not called before layout.
-        args = {'index': '4'};
-        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-        expect(showSlideSpy).to.not.have.been.called;
+          // Test that showSlide_ due to goToSlide(index=4) is not called before layout.
+          args = {'index': '4'};
+          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+          expect(showSlideSpy).to.not.have.been.called;
 
-        // Test that showSlide_ is called after layout.
-        impl.onLayoutMeasure();
-        ampSlideScroll.layoutCallback();
+          // Test that showSlide_ is called after layout.
+          impl.onLayoutMeasure();
+          ampSlideScroll.layoutCallback();
 
-        expect(showSlideSpy).to.have.been.calledWith(4);
-        expect(showSlideSpy).to.be.calledOnce;
+          expect(showSlideSpy).to.have.been.calledWith(4);
+          expect(showSlideSpy).to.be.calledOnce;
+        });
       });
     });
   });

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -91,11 +91,11 @@ describes.realWin('amp-selector', {
       impl.keyDownHandler_(event);
     }
 
-    it('should build properly', () => {
+    it('should build properly', function* () {
       let ampSelector = getSelector({});
       let impl = ampSelector.implementation_;
       let initSpy = sandbox.spy(impl, 'init_');
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.isMultiple_).to.be.false;
       expect(initSpy).to.be.calledOnce;
 
@@ -111,7 +111,7 @@ describes.realWin('amp-selector', {
       });
       impl = ampSelector.implementation_;
       initSpy = sandbox.spy(impl, 'init_');
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.be.calledOnce;
 
@@ -127,19 +127,19 @@ describes.realWin('amp-selector', {
       });
       impl = ampSelector.implementation_;
       initSpy = sandbox.spy(impl, 'init_');
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.be.calledOnce;
     });
 
-    it('should init properly for single select', () => {
+    it('should init properly for single select', function* () {
 
       let ampSelector = getSelector({});
       let impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
       let setInputsSpy = sandbox.spy(impl, 'setInputs_');
       let initSpy = sandbox.spy(impl, 'init_');
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.isMultiple_).to.be.false;
       expect(initSpy).to.have.been.calledOnce;
       expect(impl.selectedOptions_.length).to.equal(0);
@@ -155,7 +155,7 @@ describes.realWin('amp-selector', {
       impl = ampSelector.implementation_;
       setInputsSpy = sandbox.spy(impl, 'setInputs_');
       initSpy = sandbox.spy(impl, 'init_');
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.isMultiple_).to.be.false;
       expect(initSpy).to.have.been.calledOnce;
       expect(impl.selectedOptions_.length).to.equal(1);
@@ -165,7 +165,7 @@ describes.realWin('amp-selector', {
       expect(setInputsSpy).to.have.been.calledOnce;
     });
 
-    it('should init properly for multiselect', () => {
+    it('should init properly for multiselect', function* () {
       const ampSelector = getSelector({
         attributes: {
           multiple: true,
@@ -178,14 +178,14 @@ describes.realWin('amp-selector', {
       const impl = ampSelector.implementation_;
       const initSpy = sandbox.spy(impl, 'init_');
       const setInputsSpy = sandbox.spy(impl, 'setInputs_');
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.have.been.calledOnce;
       expect(impl.selectedOptions_.length).to.equal(2);
       expect(setInputsSpy).to.have.been.calledOnce;
     });
 
-    it('should init properly for selector with disabled options', () => {
+    it('should init properly for selector with disabled options', function* () {
       const ampSelector = getSelector({
         attributes: {
           multiple: true,
@@ -199,7 +199,7 @@ describes.realWin('amp-selector', {
       const impl = ampSelector.implementation_;
       const initSpy = sandbox.spy(impl, 'init_');
       const setInputsSpy = sandbox.spy(impl, 'setInputs_');
-      ampSelector.build();
+      yield ampSelector.build();
 
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.have.been.calledOnce;
@@ -209,7 +209,7 @@ describes.realWin('amp-selector', {
     });
 
 
-    it('should setSelection for single select', () => {
+    it('should setSelection for single select', function* () {
       const ampSelector = getSelector({
         config: {
           count: 5,
@@ -221,7 +221,7 @@ describes.realWin('amp-selector', {
       const initSpy = sandbox.spy(impl, 'init_');
       const setInputsSpy = sandbox.spy(impl, 'setInputs_');
       const clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
-      ampSelector.build();
+      yield ampSelector.build();
 
       expect(impl.isMultiple_).to.be.false;
       expect(initSpy).to.have.been.calledOnce;
@@ -240,7 +240,7 @@ describes.realWin('amp-selector', {
 
     });
 
-    it('should setSelection for multi select', () => {
+    it('should setSelection for multi select', function* () {
       const ampSelector = getSelector({
         attributes: {
           multiple: true,
@@ -254,8 +254,7 @@ describes.realWin('amp-selector', {
       const impl = ampSelector.implementation_;
       const initSpy = sandbox.spy(impl, 'init_');
       const setInputsSpy = sandbox.spy(impl, 'setInputs_');
-      ampSelector.build();
-
+      yield ampSelector.build();
 
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.have.been.calledOnce;
@@ -276,7 +275,7 @@ describes.realWin('amp-selector', {
     });
 
 
-    it('should clearSelection', () => {
+    it('should clearSelection', function* () {
       const ampSelector = getSelector({
         attributes: {
           multiple: true,
@@ -290,7 +289,7 @@ describes.realWin('amp-selector', {
       const impl = ampSelector.implementation_;
       const initSpy = sandbox.spy(impl, 'init_');
       const setInputsSpy = sandbox.spy(impl, 'setInputs_');
-      ampSelector.build();
+      yield ampSelector.build();
 
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.have.been.calledOnce;
@@ -311,10 +310,10 @@ describes.realWin('amp-selector', {
 
     });
 
-    it('should setInputs properly', () => {
+    it('should setInputs properly', function* () {
       let ampSelector = getSelector({});
       let impl = ampSelector.implementation_;
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.inputs_.length).to.equal(0);
 
       ampSelector = getSelector({
@@ -324,7 +323,7 @@ describes.realWin('amp-selector', {
       });
 
       impl = ampSelector.implementation_;
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.inputs_.length).to.equal(0);;
 
       ampSelector = getSelector({
@@ -337,7 +336,7 @@ describes.realWin('amp-selector', {
         },
       });
       impl = ampSelector.implementation_;
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.inputs_.length).to.equal(0);
 
       ampSelector = getSelector({
@@ -350,7 +349,7 @@ describes.realWin('amp-selector', {
         },
       });
       impl = ampSelector.implementation_;
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.inputs_.length).to.equal(1);
       expect(impl.selectedOptions_).to.include.members([impl.options_[1]]);
 
@@ -371,7 +370,7 @@ describes.realWin('amp-selector', {
         },
       });
       impl = ampSelector.implementation_;
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.inputs_.length).to.equal(2);
       expect(impl.selectedOptions_).to.include.members([
         impl.options_[0],
@@ -388,7 +387,7 @@ describes.realWin('amp-selector', {
       ]);
     });
 
-    it('should not create hidden inputs for disabled options', () => {
+    it('should not create hidden inputs for disabled options', function* () {
       const ampSelector = getSelector({
         attributes: {
           name: 'muti_select',
@@ -401,7 +400,7 @@ describes.realWin('amp-selector', {
         },
       });
       const impl = ampSelector.implementation_;
-      ampSelector.build();
+      yield ampSelector.build();
       expect(impl.inputs_.length).to.equal(0);
 
       impl.setSelection_(impl.options_[3]);
@@ -409,7 +408,7 @@ describes.realWin('amp-selector', {
       expect(impl.inputs_.length).to.equal(0);
     });
 
-    it('should handle clicks', () => {
+    it('should handle clicks', function* () {
       let ampSelector = getSelector({
         attributes: {
           name: 'single_select',
@@ -421,7 +420,7 @@ describes.realWin('amp-selector', {
       });
       let impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
-      ampSelector.build();
+      yield ampSelector.build();
       let clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       let setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
@@ -464,7 +463,7 @@ describes.realWin('amp-selector', {
 
       impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
-      ampSelector.build();
+      yield ampSelector.build();
       clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
@@ -507,7 +506,7 @@ describes.realWin('amp-selector', {
 
       impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
-      ampSelector.build();
+      yield ampSelector.build();
       clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
@@ -520,7 +519,7 @@ describes.realWin('amp-selector', {
       expect(clearSelectionSpy).to.not.have.been.called;
     });
 
-    it('should handle keyboard selection', () => {
+    it('should handle keyboard selection', function* () {
       let ampSelector = getSelector({
         attributes: {
           name: 'single_select',
@@ -532,7 +531,7 @@ describes.realWin('amp-selector', {
       });
       let impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
-      ampSelector.build();
+      yield ampSelector.build();
       let clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       let setSelectionSpy = sandbox.spy(impl, 'setSelection_');
       keyPress(ampSelector, KeyCodes.ENTER, impl.options_[3]);
@@ -559,7 +558,7 @@ describes.realWin('amp-selector', {
 
       impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
-      ampSelector.build();
+      yield ampSelector.build();
       clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
@@ -594,7 +593,7 @@ describes.realWin('amp-selector', {
 
       impl = ampSelector.implementation_;
       impl.mutateElement = fn => fn();
-      ampSelector.build();
+      yield ampSelector.build();
       clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
       setSelectionSpy = sandbox.spy(impl, 'setSelection_');
 
@@ -776,8 +775,8 @@ describes.realWin('amp-selector', {
             multiple: true,
           },
         });
-        expect(() => ampSelector.build())
-            .to.throw(/not supported for multiple selection amp-selector​​​/);
+        return expect(ampSelector.build()).to.eventually.be.rejectedWith(
+            /not supported for multiple selection amp-selector​​​/);
       });
 
       it('should ONLY change selection in `select` mode', () => {
@@ -807,7 +806,7 @@ describes.realWin('amp-selector', {
     });
 
     describe('clear action',() => {
-      it('should clear selection of a single select', () => {
+      it('should clear selection of a single select', function* () {
         const ampSelector = getSelector({
           attributes: {
             id: 'ampSelector',
@@ -818,7 +817,7 @@ describes.realWin('amp-selector', {
           },
         });
         ampSelector.children[1].setAttribute('selected', '');
-        ampSelector.build();
+        yield ampSelector.build();
 
         const button = win.document.createElement('button');
         button.setAttribute('on', 'tap:ampSelector.clear');
@@ -829,7 +828,7 @@ describes.realWin('amp-selector', {
         expect(ampSelector.children[1].hasAttribute('selected')).to.be.false;
       });
 
-      it('should clear selection of a multiselect', () => {
+      it('should clear selection of a multiselect', function* () {
         const ampSelector = getSelector({
           attributes: {
             id: 'ampSelector',
@@ -841,7 +840,7 @@ describes.realWin('amp-selector', {
         });
         ampSelector.children[0].setAttribute('selected', '');
         ampSelector.children[3].setAttribute('selected', '');
-        ampSelector.build();
+        yield ampSelector.build();
 
         const button = win.document.createElement('button');
         button.setAttribute('on', 'tap:ampSelector.clear');

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -320,6 +320,11 @@ export class BaseElement {
    * class set on it.
    *
    * This callback is executed early after the element has been attached to DOM.
+   *
+   * This callback can either immediately return or return a promise if the
+   * build steps are asynchronous.
+   *
+   * @return {!Promise|undefined}
    */
   buildCallback() {
     // Subclasses may override.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -780,7 +780,8 @@ function createBaseCustomElementClass(win) {
           }
         }
       }, reason => {
-        this.signals_.rejectSignal(CommonSignals.BUILT, reason);
+        this.signals_.rejectSignal(CommonSignals.BUILT,
+            /** @type {!Error} */ (reason));
         reportError(reason, this);
         throw reason;
       });

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -485,6 +485,9 @@ function createBaseCustomElementClass(win) {
       /** @private {boolean} */
       this.built_ = false;
 
+      /** @private {?Promise} */
+      this.buildingPromise_ = null;
+
       /** @type {string} */
       this.readyState = 'loading';
 
@@ -744,41 +747,48 @@ function createBaseCustomElementClass(win) {
      *
      * This method can only be called on a upgraded element.
      *
+     * @return {?Promise}
      * @final @this {!Element}
      */
     build() {
       assertNotTemplate(this);
-      if (this.isBuilt()) {
-        return;
-      }
       dev().assert(this.isUpgraded(), 'Cannot build unupgraded element');
-      try {
-        this.implementation_.buildCallback();
+      if (this.buildingPromise_) {
+        return this.buildingPromise_;
+      }
+      return this.buildingPromise_ = new Promise((resolve, reject) => {
+        const promise = this.implementation_.buildCallback();
+        if (promise) {
+          promise.then(resolve, reject);
+        } else {
+          resolve();
+        }
+      }).then(() => {
         this.preconnect(/* onLayout */false);
         this.built_ = true;
         this.classList.remove('i-amphtml-notbuilt');
         this.classList.remove('amp-notbuilt');
         this.signals_.signal(CommonSignals.BUILT);
-      } catch (e) {
-        this.signals_.rejectSignal(CommonSignals.BUILT, e);
-        reportError(e, this);
-        throw e;
-      }
-      if (this.built_ && this.isInViewport_) {
-        this.updateInViewport_(true);
-      }
-      if (this.actionQueue_) {
-        // Only schedule when the queue is not empty, which should be
-        // the case 99% of the time.
-        Services.timerFor(this.ownerDocument.defaultView)
-            .delay(this.dequeueActions_.bind(this), 1);
-      }
-      if (!this.getPlaceholder()) {
-        const placeholder = this.createPlaceholder();
-        if (placeholder) {
-          this.appendChild(placeholder);
+        if (this.isInViewport_) {
+          this.updateInViewport_(true);
         }
-      }
+        if (this.actionQueue_) {
+          // Only schedule when the queue is not empty, which should be
+          // the case 99% of the time.
+          Services.timerFor(this.ownerDocument.defaultView)
+              .delay(this.dequeueActions_.bind(this), 1);
+        }
+        if (!this.getPlaceholder()) {
+          const placeholder = this.createPlaceholder();
+          if (placeholder) {
+            this.appendChild(placeholder);
+          }
+        }
+      }, reason => {
+        this.signals_.rejectSignal(CommonSignals.BUILT, reason);
+        reportError(reason, this);
+        throw reason;
+      });
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -756,13 +756,8 @@ function createBaseCustomElementClass(win) {
       if (this.buildingPromise_) {
         return this.buildingPromise_;
       }
-      return this.buildingPromise_ = new Promise((resolve, reject) => {
-        const promise = this.implementation_.buildCallback();
-        if (promise) {
-          promise.then(resolve, reject);
-        } else {
-          resolve();
-        }
+      return this.buildingPromise_ = new Promise(resolve => {
+        resolve(this.implementation_.buildCallback());
       }).then(() => {
         this.preconnect(/* onLayout */false);
         this.built_ = true;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -331,6 +331,7 @@ export class Resource {
       dev().error(TAG, 'failed to build:', this.debugid, reason);
       this.isBuilding_ = false;
       this.blacklisted_ = true;
+      throw reason;
     });
   }
 

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -143,6 +143,9 @@ export class Resource {
     this.isPlaceholder_ = element.hasAttribute('placeholder');
 
     /** @private {boolean} */
+    this.isBuilding_ = false;
+
+    /** @private {boolean} */
     this.blacklisted_ = false;
 
     /** @private {!AmpElement|undefined|null} */
@@ -277,6 +280,22 @@ export class Resource {
   }
 
   /**
+   * Returns whether the resource has been fully built.
+   * @return {boolean}
+   */
+  isBuilt() {
+    return this.element.isBuilt();
+  }
+
+  /**
+   * Returns whether the resource is currently being built.
+   * @return {boolean}
+   */
+  isBuilding() {
+    return this.isBuilding_;
+  }
+
+  /**
    * Returns whether the resource has been blacklisted.
    * @return {boolean}
    */
@@ -287,29 +306,32 @@ export class Resource {
   /**
    * Requests the resource's element to be built. See {@link AmpElement.build}
    * for details.
+   * @return {?Promise}
    */
   build() {
-    if (this.blacklisted_ || !this.element.isUpgraded()
-        || !this.resources_.grantBuildPermission()) {
-      return;
+    if (this.isBuilding_ ||
+        this.blacklisted_ ||
+        !this.element.isUpgraded() ||
+        !this.resources_.grantBuildPermission()) {
+      return null;
     }
-    try {
-      this.element.build();
-    } catch (e) {
-      dev().error(TAG, 'failed to build:', this.debugid, e);
+    this.isBuilding_ = true;
+    return this.element.build().then(() => {
+      this.isBuilding_ = false;
+      if (this.hasBeenMeasured()) {
+        this.state_ = ResourceState.READY_FOR_LAYOUT;
+        this.element.updateLayoutBox(this.layoutBox_);
+      } else {
+        this.state_ = ResourceState.NOT_LAID_OUT;
+      }
+      // TODO(dvoytenko, #7389): cleanup once amp-sticky-ad signals are
+      // in PROD.
+      this.element.dispatchCustomEvent(AmpEvents.BUILT);
+    }, reason => {
+      dev().error(TAG, 'failed to build:', this.debugid, reason);
+      this.isBuilding_ = false;
       this.blacklisted_ = true;
-      return;
-    }
-
-    if (this.hasBeenMeasured()) {
-      this.state_ = ResourceState.READY_FOR_LAYOUT;
-      this.element.updateLayoutBox(this.layoutBox_);
-    } else {
-      this.state_ = ResourceState.NOT_LAID_OUT;
-    }
-    // TODO(dvoytenko, #7389): cleanup once amp-sticky-ad signals are
-    // in PROD.
-    this.element.dispatchCustomEvent(AmpEvents.BUILT);
+    });
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -304,6 +304,15 @@ export class Resource {
   }
 
   /**
+   * Returns promise that resolves when the element has been built.
+   * @return {!Promise}
+   */
+  whenBuilt() {
+    // TODO(dvoytenko): merge with the standard BUILT signal.
+    return this.element.signals().whenSignal('res-built');
+  }
+
+  /**
    * Requests the resource's element to be built. See {@link AmpElement.build}
    * for details.
    * @return {?Promise}
@@ -324,6 +333,8 @@ export class Resource {
       } else {
         this.state_ = ResourceState.NOT_LAID_OUT;
       }
+      // TODO(dvoytenko): merge with the standard BUILT signal.
+      this.element.signals().signal('res-built');
       // TODO(dvoytenko, #7389): cleanup once amp-sticky-ad signals are
       // in PROD.
       this.element.dispatchCustomEvent(AmpEvents.BUILT);
@@ -331,6 +342,7 @@ export class Resource {
       dev().error(TAG, 'failed to build:', this.debugid, reason);
       this.isBuilding_ = false;
       this.blacklisted_ = true;
+      this.element.signals().rejectSignal('res-built', reason);
       throw reason;
     });
   }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -570,7 +570,7 @@ export class Resources {
         // Remove resource before build to remove it from the pending list
         // in either case the build succeed or throws an error.
         this.pendingBuildResources_.splice(i--, 1);
-        this.buildResourceUnsafe_(resource, /* schedulePass */ true);
+        this.buildResourceUnsafe_(resource, scheduleWhenBuilt);
       }
     }
   }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -668,7 +668,7 @@ export class Resources {
         return;
       }
       if (resource.getState() != ResourceState.LAYOUT_SCHEDULED) {
-        promises.push(resource.element.whenBuilt().then(() => {
+        promises.push(resource.whenBuilt().then(() => {
           resource.measure();
           if (!resource.isDisplayed()) {
             return;
@@ -1837,7 +1837,7 @@ export class Resources {
   scheduleLayoutOrPreloadForSubresources_(parentResource, layout, subElements) {
     this.discoverResourcesForArray_(parentResource, subElements, resource => {
       if (resource.getState() == ResourceState.NOT_BUILT) {
-        resource.element.whenBuilt().then(() => {
+        resource.whenBuilt().then(() => {
           this.measureAndScheduleIfAllowed_(resource, layout,
               parentResource.getPriority());
         });

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -42,8 +42,9 @@ describes.realWin('amp-pixel', {amp: true}, env => {
       pixel.setAttribute('referrerpolicy', referrerPolicy);
     }
     win.document.body.appendChild(pixel);
-    pixel.build();
+    const buildPromise = pixel.build();
     implementation = pixel.implementation_;
+    return buildPromise;
   }
 
   /**
@@ -125,11 +126,14 @@ describes.realWin('amp-pixel', {amp: true}, env => {
 
   it('should throw for referrerpolicy with value other than ' +
       'no-referrer', () => {
-    expect(() => {
-      createPixel(
-          'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?',
-          'origin');
-    }).to.throw(/referrerpolicy/);
+    return createPixel(
+        'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?',
+        'origin')
+        .then(() => {
+          throw new Error('must have failed.');
+        }, reason => {
+          expect(reason.message).to.match(/referrerpolicy/);
+        });
   });
 });
 

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1742,7 +1742,7 @@ describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
     const toggle = sandbox.spy(element, 'toggleLoading_');
     container.appendChild(element);
     return element.buildingPromise_.then(() => {
-      return element.layoutCallback()
+      return element.layoutCallback();
     }).then(() => {
       expect(toggle).to.be.calledOnce;
       expect(toggle.firstCall.args[0]).to.equal(false);

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -246,7 +246,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
   it('Element - should only add classes on first attachedCallback', () => {
     const element = new ElementClass();
-    sandbox.stub(element, 'build');
+    const buildPromise = Promise.resolve();
+    const buildStub = sandbox.stub(element, 'build', () => buildPromise);
 
     expect(element).to.not.have.class('i-amphtml-element');
     expect(element).to.not.have.class('i-amphtml-notbuilt');
@@ -262,16 +263,19 @@ describes.realWin('CustomElement', {amp: true}, env => {
     element.classList.remove('amp-notbuilt');
 
     element.attachedCallback();
-
-    expect(element).to.not.have.class('i-amphtml-element');
-    expect(element).to.not.have.class('i-amphtml-notbuilt');
-    expect(element).to.not.have.class('amp-notbuilt');
+    return buildPromise.then(() => {
+      expect(buildStub).to.be.called;
+      expect(element).to.not.have.class('i-amphtml-element');
+      expect(element).to.not.have.class('i-amphtml-notbuilt');
+      expect(element).to.not.have.class('amp-notbuilt');
+    });
   });
 
   it('Element - should reset on 2nd attachedCallback when requested', () => {
     clock.tick(1);
     const element = new ElementClass();
-    sandbox.stub(element, 'build');
+    const buildPromise = Promise.resolve();
+    const buildStub = sandbox.stub(element, 'build', () => buildPromise);
     container.appendChild(element);
 
     sandbox.stub(element, 'reconstructWhenReparented', () => true);
@@ -280,10 +284,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
     element.signals().signal('render-start');
     element.signals().signal('load-end');
     element.attachedCallback();
-    expect(element.layoutCount_).to.equal(0);
-    expect(element.isFirstLayoutCompleted_).to.be.false;
-    expect(element.signals().get('render-start')).to.be.null;
-    expect(element.signals().get('load-end')).to.be.null;
+    return buildPromise.then(() => {
+      expect(buildStub).to.be.called;
+      expect(element.layoutCount_).to.equal(0);
+      expect(element.isFirstLayoutCompleted_).to.be.false;
+      expect(element.signals().get('render-start')).to.be.null;
+      expect(element.signals().get('load-end')).to.be.null;
+    });
   });
 
   it('Element - should NOT reset on 2nd attachedCallback w/o request', () => {
@@ -331,10 +338,12 @@ describes.realWin('CustomElement', {amp: true}, env => {
     });
     const errorStub = sandbox.stub(element, 'dispatchCustomEventForTesting');
     container.appendChild(element);
-    element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
-    expect(element.layoutWidth_).to.equal(111);
-    expect(element.implementation_.layoutWidth_).to.equal(111);
-    expect(errorStub).to.be.calledWith(AmpEvents.ERROR, 'intentional');
+    return element.buildingPromise_.then(() => {
+      element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
+      expect(element.layoutWidth_).to.equal(111);
+      expect(element.implementation_.layoutWidth_).to.equal(111);
+      expect(errorStub).to.be.calledWith(AmpEvents.ERROR, 'intentional');
+    });
   });
 
   it('StubElement - upgrade after attached', () => {
@@ -517,13 +526,14 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
     clock.tick(1);
     container.appendChild(element);
-
-    expect(element.isBuilt()).to.equal(true);
-    expect(element).to.not.have.class('i-amphtml-notbuilt');
-    expect(element).to.not.have.class('amp-notbuilt');
-    expect(testElementBuildCallback).to.be.calledOnce;
-    expect(element.signals().get('built')).to.be.ok;
-    return element.whenBuilt();  // Should eventually resolve.
+    return element.buildingPromise_.then(() => {
+      expect(element.isBuilt()).to.equal(true);
+      expect(element).to.not.have.class('i-amphtml-notbuilt');
+      expect(element).to.not.have.class('amp-notbuilt');
+      expect(testElementBuildCallback).to.be.calledOnce;
+      expect(element.signals().get('built')).to.be.ok;
+      return element.whenBuilt();  // Should eventually resolve.
+    });
   });
 
   it('should anticipate build errors', () => {
@@ -544,9 +554,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
     expect(testElementCreatePlaceholderCallback).to.have.not.been.called;
 
     container.appendChild(element);
-
-    expect(element.isBuilt()).to.equal(true);
-    expect(testElementCreatePlaceholderCallback).to.be.calledOnce;
+    return element.buildingPromise_.then(() => {
+      expect(element.isBuilt()).to.equal(true);
+      expect(testElementCreatePlaceholderCallback).to.be.calledOnce;
+    });
   });
 
   it('Element - build does not create a placeholder when one exists' , () => {
@@ -557,8 +568,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
     expect(testElementCreatePlaceholderCallback).to.have.not.been.called;
 
     container.appendChild(element);
-    expect(element.isBuilt()).to.equal(true);
-    expect(testElementCreatePlaceholderCallback).to.have.not.been.called;
+    return element.buildingPromise_.then(() => {
+      expect(element.isBuilt()).to.equal(true);
+      expect(testElementCreatePlaceholderCallback).to.have.not.been.called;
+    });
   });
 
   it('Element - buildCallback cannot be called twice', () => {
@@ -568,17 +581,31 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
     container.appendChild(element);
 
-    expect(element.isBuilt()).to.equal(true);
-    expect(testElementBuildCallback).to.be.calledOnce;
-    expect(testElementPreconnectCallback).to.have.not.been.called;
+    return element.buildingPromise_.then(() => {
+      expect(element.isBuilt()).to.equal(true);
+      expect(testElementBuildCallback).to.be.calledOnce;
+      expect(testElementPreconnectCallback).to.have.not.been.called;
 
-    // Call again.
-    element.build();
-    expect(element.isBuilt()).to.equal(true);
+      // Call again.
+      return element.build().then(() => {
+        expect(element.isBuilt()).to.equal(true);
+        expect(testElementBuildCallback).to.be.calledOnce;
+        expect(testElementPreconnectCallback).to.have.not.been.called;
+        clock.tick(1);
+        expect(testElementPreconnectCallback).to.be.calledOnce;
+      });
+    });
+  });
+
+  it('Element - build is repeatable', () => {
+    const element = new ElementClass();
+    expect(element.isBuilt()).to.equal(false);
+    expect(testElementBuildCallback).to.have.not.been.called;
+
+    container.appendChild(element);
+    const buildingPromise = element.buildingPromise_;
+    expect(element.build()).to.equal(buildingPromise);
     expect(testElementBuildCallback).to.be.calledOnce;
-    expect(testElementPreconnectCallback).to.have.not.been.called;
-    clock.tick(1);
-    expect(testElementPreconnectCallback).to.be.calledOnce;
   });
 
   it('Element - build NOT allowed when in template', () => {
@@ -723,22 +750,23 @@ describes.realWin('CustomElement', {amp: true}, env => {
     const element = new ElementClass();
     element.setAttribute('layout', 'fill');
     container.appendChild(element);
-    element.build();
-    expect(element.isBuilt()).to.equal(true);
-    expect(testElementLayoutCallback).to.have.not.been.called;
-    clock.tick(1);
-    expect(testElementPreconnectCallback).to.be.calledOnce;
-    expect(testElementPreconnectCallback.getCall(0).args[0]).to.be.false;
+    return element.build().then(() => {
+      expect(element.isBuilt()).to.equal(true);
+      expect(testElementLayoutCallback).to.have.not.been.called;
+      clock.tick(1);
+      expect(testElementPreconnectCallback).to.be.calledOnce;
+      expect(testElementPreconnectCallback.getCall(0).args[0]).to.be.false;
 
-    const p = element.layoutCallback();
-    expect(testElementLayoutCallback).to.be.calledOnce;
-    expect(testElementPreconnectCallback).to.have.callCount(2);
-    expect(testElementPreconnectCallback.getCall(1).args[0]).to.be.true;
-    expect(element.signals().get('load-start')).to.be.ok;
-    expect(element.signals().get('load-end')).to.be.null;
-    return p.then(() => {
-      expect(element.readyState).to.equal('complete');
-      expect(element.signals().get('load-end')).to.be.ok;
+      const p = element.layoutCallback();
+      expect(testElementLayoutCallback).to.be.calledOnce;
+      expect(testElementPreconnectCallback).to.have.callCount(2);
+      expect(testElementPreconnectCallback.getCall(1).args[0]).to.be.true;
+      expect(element.signals().get('load-start')).to.be.ok;
+      expect(element.signals().get('load-end')).to.be.null;
+      return p.then(() => {
+        expect(element.readyState).to.equal('complete');
+        expect(element.signals().get('load-end')).to.be.ok;
+      });
     });
   });
 
@@ -747,20 +775,21 @@ describes.realWin('CustomElement', {amp: true}, env => {
         const element = new ElementClass();
         element.setAttribute('layout', 'fill');
         container.appendChild(element);
-
-        const p = element.layoutCallback();
-        expect(testElementLayoutCallback).to.be.calledOnce;
-        expect(testElementFirstLayoutCompleted).to.have.not.been.called;
-        return p.then(() => {
+        return element.buildingPromise_.then(() => {
+          const p = element.layoutCallback();
+          expect(testElementLayoutCallback).to.be.calledOnce;
+          expect(testElementFirstLayoutCompleted).to.have.not.been.called;
+          return p;
+        }).then(() => {
           expect(testElementFirstLayoutCompleted).to.be.calledOnce;
 
           // But not second time.
           const p2 = element.layoutCallback();
           expect(testElementLayoutCallback).to.have.callCount(2);
           expect(testElementFirstLayoutCompleted).to.be.calledOnce;
-          return p2.then(() => {
-            expect(testElementFirstLayoutCompleted).to.be.calledOnce;
-          });
+          return p2;
+        }).then(() => {
+          expect(testElementFirstLayoutCompleted).to.be.calledOnce;
         });
       });
 
@@ -768,14 +797,15 @@ describes.realWin('CustomElement', {amp: true}, env => {
     const element = new ElementClass();
     element.setAttribute('layout', 'fill');
     container.appendChild(element);
-    element.build();
-    expect(element.isBuilt()).to.equal(true);
-    expect(testElementLayoutCallback).to.have.not.been.called;
+    return element.build().then(() => {
+      expect(element.isBuilt()).to.equal(true);
+      expect(testElementLayoutCallback).to.have.not.been.called;
 
-    element.isInTemplate_ = true;
-    expect(() => {
-      element.layoutCallback();
-    }).to.throw(/Must never be called in template/);
+      element.isInTemplate_ = true;
+      expect(() => {
+        element.layoutCallback();
+      }).to.throw(/Must never be called in template/);
+    });
   });
 
   it('StubElement - layoutCallback should fail before attach', () => {
@@ -796,14 +826,15 @@ describes.realWin('CustomElement', {amp: true}, env => {
     element.resources_ = resources;
     resourcesMock.expects('upgraded').withExactArgs(element).once();
     element.upgrade(TestElement);
-    element.build();
-    expect(element.isUpgraded()).to.equal(true);
-    expect(element.isBuilt()).to.equal(true);
-    expect(testElementLayoutCallback).to.have.not.been.called;
+    return element.build().then(() => {
+      expect(element.isUpgraded()).to.equal(true);
+      expect(element.isBuilt()).to.equal(true);
+      expect(testElementLayoutCallback).to.have.not.been.called;
 
-    const p = element.layoutCallback();
-    expect(testElementLayoutCallback).to.be.calledOnce;
-    return p.then(() => {
+      const p = element.layoutCallback();
+      expect(testElementLayoutCallback).to.be.calledOnce;
+      return p;
+    }).then(() => {
       expect(element.readyState).to.equal('complete');
     });
   });
@@ -827,13 +858,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
     const handler = sandbox.spy();
     element.implementation_.executeAction = handler;
     container.appendChild(element);
-    element.build();
-
-    const inv = {};
-    element.enqueAction(inv);
-    expect(handler).to.be.calledOnce;
-    expect(handler.getCall(0).args[0]).to.equal(inv);
-    expect(handler.getCall(0).args[1]).to.equal(false);
+    return element.build().then(() => {
+      const inv = {};
+      element.enqueAction(inv);
+      expect(handler).to.be.calledOnce;
+      expect(handler.getCall(0).args[0]).to.equal(inv);
+      expect(handler.getCall(0).args[1]).to.equal(false);
+    });
   });
 
   it('should dequeue all actions after build', () => {
@@ -851,13 +882,15 @@ describes.realWin('CustomElement', {amp: true}, env => {
     expect(handler).to.have.not.been.called;
 
     container.appendChild(element);
-    clock.tick(10);
-    expect(handler).to.have.callCount(2);
-    expect(handler.getCall(0).args[0]).to.equal(inv1);
-    expect(handler.getCall(0).args[1]).to.equal(true);
-    expect(handler.getCall(1).args[0]).to.equal(inv2);
-    expect(handler.getCall(1).args[1]).to.equal(true);
-    expect(element.actionQueue_).to.equal(null);
+    return element.buildingPromise_.then(() => {
+      clock.tick(10);
+      expect(handler).to.have.callCount(2);
+      expect(handler.getCall(0).args[0]).to.equal(inv1);
+      expect(handler.getCall(0).args[1]).to.equal(true);
+      expect(handler.getCall(1).args[0]).to.equal(inv2);
+      expect(handler.getCall(1).args[1]).to.equal(true);
+      expect(element.actionQueue_).to.equal(null);
+    });
   });
 
   it('should NOT enqueue actions when in template', () => {
@@ -1087,28 +1120,31 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       // Built element receives unlayoutCallback.
       container.appendChild(element);
-      element.unlayoutCallback();
-      expect(testElementUnlayoutCallback).to.be.calledOnce;
-      expect(element.layoutCount_).to.equal(0);
+      return element.buildingPromise_.then(() => {
+        element.unlayoutCallback();
+        expect(testElementUnlayoutCallback).to.be.calledOnce;
+        expect(element.layoutCount_).to.equal(0);
+      });
     });
 
     it('should not reset layoutCount if relayout not requested', () => {
       const element = new ElementClass();
-      container.appendChild(element);
       element.implementation_.layoutCallback = () => {
         testElementLayoutCallback();
         element.layoutCount_++;
         return Promise.resolve();
       };
-
       element.implementation_.unlayoutCallback = () => {
         testElementUnlayoutCallback();
         return false;
       };
-      element.layoutCallback();
-      element.unlayoutCallback();
-      expect(testElementUnlayoutCallback).to.be.calledOnce;
-      expect(element.layoutCount_).to.equal(1);
+      container.appendChild(element);
+      return element.buildingPromise_.then(() => {
+        element.layoutCallback();
+        element.unlayoutCallback();
+        expect(testElementUnlayoutCallback).to.be.calledOnce;
+        expect(element.layoutCount_).to.equal(1);
+      });
     });
 
     it('StubElement', () => {
@@ -1121,7 +1157,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
   });
 
   describe('pauseCallback', () => {
-    it('Element', () => {
+    it('should pause upgraded element', () => {
       const element = new ElementClass();
 
       // Non-built element doesn't receive pauseCallback.
@@ -1130,11 +1166,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       // Built element receives pauseCallback.
       container.appendChild(element);
-      element.pauseCallback();
-      expect(testElementPauseCallback).to.be.calledOnce;
+      return element.buildingPromise_.then(() => {
+        element.pauseCallback();
+        expect(testElementPauseCallback).to.be.calledOnce;
+      });
     });
 
-    it('StubElement', () => {
+    it('should pause stub element', () => {
       const element = new StubElementClass();
 
       // Unupgraded document doesn't receive pauseCallback.
@@ -1144,7 +1182,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
   });
 
   describe('resumeCallback', () => {
-    it('Element', () => {
+    it('should resume upgraded element', () => {
       const element = new ElementClass();
 
       // Non-built element doesn't receive resumeCallback.
@@ -1153,11 +1191,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       // Built element receives resumeCallback.
       container.appendChild(element);
-      element.resumeCallback();
-      expect(testElementResumeCallback).to.be.calledOnce;
+      return element.buildingPromise_.then(() => {
+        element.resumeCallback();
+        expect(testElementResumeCallback).to.be.calledOnce;
+      });
     });
 
-    it('StubElement', () => {
+    it('should resume stub element', () => {
       const element = new StubElementClass();
 
       // Unupgraded document doesn't receive resumeCallback.
@@ -1203,28 +1243,33 @@ describes.realWin('CustomElement', {amp: true}, env => {
       const element = new ElementClass();
       element.setAttribute('layout', 'fill');
       container.appendChild(element);
-      expect(element.isBuilt()).to.equal(true);
-      expect(testElementViewportCallback).to.have.not.been.called;
+      return element.buildingPromise_.then(() => {
+        expect(element.isBuilt()).to.equal(true);
+        expect(testElementViewportCallback).to.have.not.been.called;
 
-      element.viewportCallback(true);
-      expect(element.implementation_.inViewport_).to.equal(true);
-      expect(testElementViewportCallback).to.be.calledOnce;
+        element.viewportCallback(true);
+        expect(element.implementation_.inViewport_).to.equal(true);
+        expect(testElementViewportCallback).to.be.calledOnce;
+      });
     });
 
     it('StubElement - should be called once upgraded', () => {
       const element = new StubElementClass();
       element.setAttribute('layout', 'fill');
       container.appendChild(element);
-      expect(element.isUpgraded()).to.equal(false);
-      expect(element.isBuilt()).to.equal(false);
+      expect(element.isUpgraded()).to.be.false;
+      expect(element.isBuilt()).to.be.false;
 
       element.viewportCallback(true);
-      expect(element.implementation_.inViewport_).to.equal(false);
+      expect(element.implementation_.inViewport_).to.be.false;
       expect(testElementViewportCallback).to.not.have.been.called;
 
       element.upgrade(TestElement);
-      expect(element.implementation_.inViewport_).to.equal(true);
-      expect(testElementViewportCallback).to.be.calledOnce;
+      expect(element.implementation_.inViewport_).to.be.false;
+      return element.buildingPromise_.then(() => {
+        expect(element.implementation_.inViewport_).to.be.true;
+        expect(testElementViewportCallback).to.be.calledOnce;
+      });
     });
 
     it('StubElement - should not upgrade before attach', () => {
@@ -1246,22 +1291,25 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(testElementViewportCallback).to.have.not.been.called;
 
       container.appendChild(element);
-      expect(element.isInViewport_).to.equal(true);
-      expect(testElementViewportCallback).to.be.calledOnce;
+      return element.buildingPromise_.then(() => {
+        expect(element.isInViewport_).to.equal(true);
+        expect(testElementViewportCallback).to.be.calledOnce;
+      });
     });
 
     it('Element - should NOT be called in template', () => {
       const element = new ElementClass();
       element.setAttribute('layout', 'fill');
       container.appendChild(element);
-      element.build();
-      expect(element.isBuilt()).to.equal(true);
-      expect(testElementViewportCallback).to.have.not.been.called;
+      return element.build().then(() => {
+        expect(element.isBuilt()).to.equal(true);
+        expect(testElementViewportCallback).to.have.not.been.called;
 
-      element.isInTemplate_ = true;
-      expect(() => {
-        element.viewportCallback(true);
-      }).to.throw(/Must never be called in template/);
+        element.isInTemplate_ = true;
+        expect(() => {
+          element.viewportCallback(true);
+        }).to.throw(/Must never be called in template/);
+      });
     });
   });
 });
@@ -1693,12 +1741,12 @@ describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
     stubInA4A(false);
     const toggle = sandbox.spy(element, 'toggleLoading_');
     container.appendChild(element);
-    return element.layoutCallback().then(() => {
+    return element.buildingPromise_.then(() => {
+      return element.layoutCallback()
+    }).then(() => {
       expect(toggle).to.be.calledOnce;
       expect(toggle.firstCall.args[0]).to.equal(false);
       expect(toggle.firstCall.args[1]).to.equal(true);
-    }, () => {
-      throw new Error('Should never happen.');
     });
   });
 
@@ -1709,8 +1757,10 @@ describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
       return Promise.reject();
     });
     container.appendChild(element);
-    return element.layoutCallback().then(() => {
-      throw new Error('Should never happen.');
+    return element.buildingPromise_.then(() => {
+      return element.layoutCallback();
+    }).then(() => {
+      throw new Error('Must have failed.');
     }, () => {
       expect(toggle).to.be.calledOnce;
       expect(toggle.firstCall.args[0]).to.equal(false);
@@ -1725,10 +1775,12 @@ describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
       return Promise.reject();
     });
     container.appendChild(element);
-    expect(element.layoutCount_).to.equal(0);
-    expect(element.isLoadingEnabled_()).to.equal(true);
-    return element.layoutCallback().then(() => {
-      throw new Error('Should never happen.');
+    return element.buildingPromise_.then(() => {
+      expect(element.layoutCount_).to.equal(0);
+      expect(element.isLoadingEnabled_()).to.equal(true);
+      return element.layoutCallback();
+    }).then(() => {
+      throw new Error('Must have failed.');
     }, () => {
       expect(element.layoutCount_).to.equal(1);
       expect(element.isLoadingEnabled_()).to.equal(false);
@@ -1743,8 +1795,9 @@ describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
     container.appendChild(element);
     element.prepareLoading_();
     element.toggleLoading_(true);
-    element.build();
-    return element.layoutCallback().then(() => {
+    return element.build().then(() => {
+      return element.layoutCallback();
+    }).then(() => {
       expect(vsyncTasks).to.have.length(2);
 
       // The first mutate started by toggleLoading_(true), but it must
@@ -1756,8 +1809,6 @@ describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
       // Second vsync should perform cleanup.
       vsyncTasks.shift()();
       expect(element.loadingContainer_).to.be.null;
-    }, () => {
-      throw new Error('Should never happen.');
     });
   });
 });

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -189,9 +189,10 @@ describes.realWin('extension-analytics', {
       parentEle = env.win.document.createElement('amp-test');
       parentEle.setAttribute('layout', 'nodisplay');
       env.win.document.body.appendChild(parentEle);
-      parentEle.build();
+      const buildPromise = parentEle.build();
       builder = new CustomEventReporterBuilder(parentEle);
       reporter = builder.track('test', 'fake.com').build();
+      return buildPromise;
     });
 
     it('replace eventType with new name', function* () {
@@ -270,7 +271,7 @@ describes.realWin('extension-analytics', {
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
         env.win.document.body.appendChild(parentEle);
-        parentEle.build();
+        return parentEle.build();
       });
 
       it('should insert analytics after LOAD_START', function* () {
@@ -328,7 +329,7 @@ describes.realWin('extension-analytics', {
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
         env.win.document.body.appendChild(parentEle);
-        parentEle.build();
+        return parentEle.build();
       });
 
       it('should insert and remove analytics', function* () {
@@ -362,7 +363,7 @@ describes.realWin('extension-analytics', {
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
         env.win.document.body.appendChild(parentEle);
-        parentEle.build();
+        return parentEle.build();
       });
 
       it('should NOT insert analytics when relayout', function* () {
@@ -411,7 +412,7 @@ describes.realWin('extension-analytics', {
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
         env.win.document.body.appendChild(parentEle);
-        parentEle.build();
+        return parentEle.build();
       });
 
       it('should insert analytics when relayout', function* () {

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -17,6 +17,7 @@
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {Resources} from '../../src/service/resources-impl';
 import {Resource, ResourceState} from '../../src/service/resource';
+import {Signals} from '../../src/utils/signals';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {Services} from '../../src/services';
 import * as sinon from 'sinon';
@@ -35,6 +36,7 @@ describe('Resource', () => {
     sandbox = sinon.sandbox.create();
 
     attributes = {};
+    const signals = new Signals();
     element = {
       ownerDocument: {defaultView: window},
       tagName: 'AMP-AD',
@@ -68,6 +70,7 @@ describe('Resource', () => {
       nodeType: 1,
       removeAttribute: () => {},
       setAttribute: () => {},
+      signals: () => signals,
     };
     elementMock = sandbox.mock(element);
 

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -113,17 +113,19 @@ describe('Resource', () => {
     elementMock.expects('build').never();
     elementMock.expects('updateLayoutBox').never();
 
-    resource.build();
+    expect(resource.build()).to.be.null;
     expect(resource.getState()).to.equal(ResourceState.NOT_BUILT);
   });
 
 
   it('should build after upgraded', () => {
+    const buildPromise = Promise.resolve();
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('build').once();
+    elementMock.expects('build').returns(buildPromise).once();
     elementMock.expects('updateLayoutBox').never();
-    resource.build();
-    expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
+    return resource.build().then(() => {
+      expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
+    });
   });
 
   it('should not build if permission is not granted', () => {
@@ -131,44 +133,52 @@ describe('Resource', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     sandbox.stub(resources, 'grantBuildPermission', () => permission);
     elementMock.expects('updateLayoutBox').never();
-    resource.build();
+    expect(resource.build()).to.be.null;
     expect(resource.getState()).to.equal(ResourceState.NOT_BUILT);
 
     permission = true;
-    resource.build();
-    expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
+    elementMock.expects('build').returns(Promise.resolve()).once();
+    return resource.build().then(() => {
+      expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
+    });
   });
 
   it('should blacklist on build failure', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('build').throws('Failed').once();
+    elementMock.expects('build')
+        .returns(Promise.reject(new Error('intentional'))).once();
     elementMock.expects('updateLayoutBox').never();
-    resource.build();
-    expect(resource.blacklisted_).to.equal(true);
-    expect(resource.getState()).to.equal(ResourceState.NOT_BUILT);
+    return resource.build().then(() => {
+      throw new Error('must have failed');
+    }, () => {
+      expect(resource.blacklisted_).to.equal(true);
+      expect(resource.getState()).to.equal(ResourceState.NOT_BUILT);
+    });
   });
 
   it('should mark as ready for layout if already measured', () => {
     const box = layoutRectLtwh(0, 0, 100, 200);
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('build').once();
+    elementMock.expects('build').returns(Promise.resolve()).once();
     elementMock.expects('updateLayoutBox')
         .withExactArgs(box)
         .once();
     const stub = sandbox.stub(resource, 'hasBeenMeasured').returns(true);
     resource.layoutBox_ = box;
-    resource.build(false);
-    expect(stub).to.be.calledOnce;
-    expect(resource.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
+    return resource.build().then(() => {
+      expect(stub).to.be.calledOnce;
+      expect(resource.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
+    });
   });
 
   it('should mark as not laid out if not yet measured', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('build').once();
+    elementMock.expects('build').returns(Promise.resolve()).once();
     const stub = sandbox.stub(resource, 'hasBeenMeasured').returns(false);
-    resource.build(false);
-    expect(stub.calledOnce).to.be.true;
-    expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
+    return resource.build().then(() => {
+      expect(stub.calledOnce).to.be.true;
+      expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
+    });
   });
 
   it('should allow to measure when not upgraded', () => {
@@ -202,42 +212,42 @@ describe('Resource', () => {
 
   it('should measure and update state', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('build').once();
-    resource.build();
-
-    elementMock.expects('getBoundingClientRect')
-        .returns({left: 11, top: 12, width: 111, height: 222})
-        .once();
-    elementMock.expects('updateLayoutBox')
-        .withExactArgs(sinon.match(data => {
-          return data.width == 111 && data.height == 222;
-        }))
-        .once();
-    resource.measure();
-    expect(resource.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
-    expect(resource.getLayoutBox().left).to.equal(11);
-    expect(resource.getLayoutBox().top).to.equal(12);
-    expect(resource.getLayoutBox().width).to.equal(111);
-    expect(resource.getLayoutBox().height).to.equal(222);
-    expect(resource.isFixed()).to.be.false;
+    elementMock.expects('build').returns(Promise.resolve()).once();
+    return resource.build().then(() => {
+      elementMock.expects('getBoundingClientRect')
+          .returns({left: 11, top: 12, width: 111, height: 222})
+          .once();
+      elementMock.expects('updateLayoutBox')
+          .withExactArgs(sinon.match(data => {
+            return data.width == 111 && data.height == 222;
+          }))
+          .once();
+      resource.measure();
+      expect(resource.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
+      expect(resource.getLayoutBox().left).to.equal(11);
+      expect(resource.getLayoutBox().top).to.equal(12);
+      expect(resource.getLayoutBox().width).to.equal(111);
+      expect(resource.getLayoutBox().height).to.equal(222);
+      expect(resource.isFixed()).to.be.false;
+    });
   });
 
   it('should update initial box only on first measure', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('build').once();
-    resource.build();
+    elementMock.expects('build').returns(Promise.resolve()).once();
+    return resource.build().then(() => {
+      element.getBoundingClientRect = () =>
+          ({left: 11, top: 12, width: 111, height: 222});
+      resource.measure();
+      expect(resource.getLayoutBox().top).to.equal(12);
+      expect(resource.getInitialLayoutBox().top).to.equal(12);
 
-    element.getBoundingClientRect = () =>
-        ({left: 11, top: 12, width: 111, height: 222});
-    resource.measure();
-    expect(resource.getLayoutBox().top).to.equal(12);
-    expect(resource.getInitialLayoutBox().top).to.equal(12);
-
-    element.getBoundingClientRect = () =>
-        ({left: 11, top: 22, width: 111, height: 222});
-    resource.measure();
-    expect(resource.getLayoutBox().top).to.equal(22);
-    expect(resource.getInitialLayoutBox().top).to.equal(12);
+      element.getBoundingClientRect = () =>
+          ({left: 11, top: 22, width: 111, height: 222});
+      resource.measure();
+      expect(resource.getLayoutBox().top).to.equal(22);
+      expect(resource.getInitialLayoutBox().top).to.equal(12);
+    });
   });
 
   it('should noop request measure when not built', () => {
@@ -362,11 +372,10 @@ describe('Resource', () => {
       element.parentElement = document.createElement('amp-iframe');
       element.parentElement.__AMP__RESOURCE = {};
       elementMock.expects('isUpgraded').returns(true).atLeast(1);
-      elementMock.expects('build').once();
-      resource = new Resource(1, element, resources);
-      resource.build();
-
+      elementMock.expects('build').returns(Promise.resolve()).once();
       rect = {left: 11, top: 12, width: 111, height: 222};
+      resource = new Resource(1, element, resources);
+      return resource.build();
     });
 
     it('should measure placeholder with stubbed parent', () => {

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -17,6 +17,7 @@
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {Resources} from '../../src/service/resources-impl';
 import {Resource, ResourceState} from '../../src/service/resource';
+import {Signals} from '../../src/utils/signals';
 import {VisibilityState} from '../../src/visibility-state';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {loadPromise} from '../../src/event-helper';
@@ -45,9 +46,11 @@ describe('Resources', () => {
   function createAmpElement() {
     const element = document.createElement('div');
     element.classList.add('i-amphtml-element');
+    const signals = new Signals();
+    element.signals = () => signals;
     element.whenBuilt = () => Promise.resolve();
     element.isBuilt = () => true;
-    element.build = () => {};
+    element.build = () => Promise.resolve();
     element.isUpgraded = () => true;
     element.updateLayoutBox = () => {};
     element.getPlaceholder = () => null;
@@ -403,14 +406,13 @@ describe('Resources', () => {
         () => layoutRectLtwh(0, 0, 100, 100));
     const resource = new Resource(1, element, resources);
     const measureSpy = sandbox.spy(resource, 'measure');
-    const buildSpy = sandbox.spy(resource.element, 'whenBuilt');
     const scheduleStub = sandbox.stub(resources, 'scheduleLayoutOrPreload_',
         () => resource.loadPromiseResolve_());
     const promise = resources.requireLayout(resource.element);
-    return Promise.all([promise, element.whenBuilt()]).then(() => {
+    resource.build();
+    return Promise.all([promise, resource.whenBuilt()]).then(() => {
       expect(scheduleStub).to.be.calledOnce;
       expect(measureSpy).to.be.calledOnce;
-      expect(buildSpy).to.be.calledTwice;  // 1 for scheduler + 1 for test.
     });
   });
 
@@ -423,6 +425,7 @@ describe('Resources', () => {
     const measureSpy = sandbox.spy(resource, 'measure');
     const scheduleStub = sandbox.stub(resources, 'scheduleLayoutOrPreload_');
     const promise = resources.requireLayout(resource.element);
+    resource.build();
     resource.loadPromiseResolve_();
     return Promise.all([promise, element.whenBuilt()]).then(() => {
       expect(scheduleStub).to.not.be.called;
@@ -438,7 +441,8 @@ describe('Resources', () => {
     const measureSpy = sandbox.spy(resource, 'measure');
     const scheduleStub = sandbox.stub(resources, 'scheduleLayoutOrPreload_');
     const promise = resources.requireLayout(resource.element);
-    return promise.then(() => {
+    resource.build();
+    return Promise.all([promise, resource.whenBuilt()]).then(() => {
       expect(scheduleStub).to.not.be.called;
       expect(measureSpy).to.be.calledOnce;
     });
@@ -453,6 +457,7 @@ describe('Resources', () => {
     const measureSpy = sandbox.spy(resource, 'measure');
     const scheduleStub = sandbox.stub(resources, 'scheduleLayoutOrPreload_');
     const promise = resources.requireLayout(resource.element);
+    resource.build();
     return promise.then(() => {
       expect(scheduleStub).to.not.be.called;
       expect(measureSpy).to.not.be.called;
@@ -491,8 +496,9 @@ describe('Resources', () => {
         parentResource, true, [element]);
     expect(measureSpy).to.not.be.called;
     expect(scheduleStub).to.not.be.called;
-    resource.build();
-    return element.whenBuilt().then(() => {
+    return resource.build().then(() => {
+      return element.whenBuilt();
+    }).then(() => {
       expect(measureSpy).to.be.calledOnce;
       expect(scheduleStub).to.be.calledOnce;
     });
@@ -751,6 +757,7 @@ describe('Resources pause/resume/unlayout scheduling', () => {
   let child2;
 
   function createElement() {
+    const signals = new Signals();
     return {
       ownerDocument: {defaultView: window},
       tagName: 'amp-test',
@@ -788,6 +795,9 @@ describe('Resources pause/resume/unlayout scheduling', () => {
       },
       getPriority() {
         return 0;
+      },
+      signals() {
+        return signals;
       },
     };
   }
@@ -937,6 +947,7 @@ describe('Resources schedulePreload', () => {
   let placeholder;
 
   function createElement() {
+    const signals = new Signals();
     return {
       ownerDocument: {defaultView: window},
       tagName: 'amp-test',
@@ -978,6 +989,9 @@ describe('Resources schedulePreload', () => {
       },
       getPriority() {
         return 0;
+      },
+      signals() {
+        return signals;
       },
     };
   }
@@ -1067,6 +1081,7 @@ describe('Resources schedulePreload', () => {
 describe('Resources discoverWork', () => {
 
   function createElement(rect) {
+    const signals = new Signals();
     return {
       ownerDocument: {defaultView: window},
       tagName: 'amp-test',
@@ -1093,6 +1108,9 @@ describe('Resources discoverWork', () => {
       unlayoutOnPause: () => true,
       togglePlaceholder: () => sandbox.spy(),
       getPriority: () => 1,
+      signals() {
+        return signals;
+      },
       fakeComputedStyle: {
         marginTop: '0px',
         marginRight: '0px',
@@ -1695,6 +1713,7 @@ describes.realWin('Resources scrollHeight', {
 describe('Resources changeSize', () => {
 
   function createElement(rect) {
+    const signals = new Signals();
     return {
       ownerDocument: {defaultView: window},
       tagName: 'amp-test',
@@ -1725,6 +1744,7 @@ describe('Resources changeSize', () => {
           (unused_overflown, unused_requestedHeight, unused_requestedWidth) => {
           },
       getPriority: () => 0,
+      signals: () => signals,
       fakeComputedStyle: {
         marginTop: '0px',
         marginRight: '0px',
@@ -2431,6 +2451,7 @@ describe('Resources changeSize', () => {
 describe('Resources mutateElement and collapse', () => {
 
   function createElement(rect, isAmp) {
+    const signals = new Signals();
     return {
       ownerDocument: {defaultView: window},
       tagName: isAmp ? 'amp-test' : 'div',
@@ -2462,6 +2483,7 @@ describe('Resources mutateElement and collapse', () => {
       pauseCallback: () => {},
       unlayoutCallback: () => {},
       getPriority: () => 0,
+      signals: () => signals,
     };
   }
 
@@ -2689,8 +2711,7 @@ describe('Resources mutateElement and collapse', () => {
 });
 
 
-describe('Resources.add/upgrade/remove', () => {
-  let sandbox;
+describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
   let resources;
   let parent;
   let parentResource;
@@ -2700,6 +2721,7 @@ describe('Resources.add/upgrade/remove', () => {
   let resource2;
 
   function createElement() {
+    const signals = new Signals();
     const element = {
       ownerDocument: {defaultView: window},
       tagName: 'amp-test',
@@ -2723,8 +2745,11 @@ describe('Resources.add/upgrade/remove', () => {
       getBoundingClientRect() {
         return layoutRectLtwh(0, 0, 0, 0);
       },
+      signals() {
+        return signals;
+      },
     };
-    element.build = sandbox.spy();
+    element.build = sandbox.stub().returns(Promise.resolve());
     return element;
   }
 
@@ -2736,9 +2761,20 @@ describe('Resources.add/upgrade/remove', () => {
     return [element, resource];
   }
 
+  function stubBuild(resource) {
+    const origBuild = resource.build;
+    sandbox.stub(resource, 'build', () => {
+      resource.buildPromise = origBuild.call(resource);
+      return resource.buildPromise;
+    });
+    return resource;
+  }
+
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-    resources = new Resources(new AmpDocSingle(window));
+    const infPromise = new Promise(() => {});
+    sandbox.stub(env.ampdoc, 'whenReady', () => infPromise);
+    resources = new Resources(env.ampdoc);
+    resources.isBuildOn_ = true;
     resources.pendingBuildResources_ = [];
     parent = createElementWithResource(1)[0];
     parentResource = parent['__AMP__RESOURCE'];
@@ -2749,7 +2785,6 @@ describe('Resources.add/upgrade/remove', () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
   });
 
   it('should enforce that viewport is ready for first add', () => {
@@ -2770,12 +2805,16 @@ describe('Resources.add/upgrade/remove', () => {
     resources.documentReady_ = false;
     resources.add(child1);
     resources.upgraded(child1);
-    expect(child1.build.called).to.be.false;
+    expect(child1.build).to.not.be.called;
     resources.documentReady_ = true;
     resources.add(child2);
+    const resource2 = stubBuild(Resource.forElementOptional(child2));
     resources.upgraded(child2);
-    expect(child2.build.calledOnce).to.be.true;
-    expect(schedulePassStub).to.be.calledOnce;
+    expect(child2.build).to.be.calledOnce;
+    expect(schedulePassStub).to.not.be.called;
+    return resource2.buildPromise.then(() => {
+      expect(schedulePassStub).to.be.calledOnce;
+    });
   });
 
   it('should not schedule pass when immediate build fails', () => {
@@ -2785,13 +2824,18 @@ describe('Resources.add/upgrade/remove', () => {
     child1.build = () => {
       // Emulate an error happening during an element build.
       child1BuildSpy();
-      throw new Error('child1-build-error');
+      return Promise.reject(new Error('child1-build-error'));
     };
     resources.documentReady_ = true;
     resources.add(child1);
+    const resource1 = stubBuild(Resource.forElementOptional(child1));
     resources.upgraded(child1);
-    expect(child1BuildSpy.calledOnce).to.be.true;
-    expect(schedulePassStub).to.not.be.called;
+    return resource1.buildPromise.then(() => {
+      throw new Error('must have failed');
+    }, () => {
+      expect(child1BuildSpy).to.be.calledOnce;
+      expect(schedulePassStub).to.not.be.called;
+    });
   });
 
   it('should add element to pending build when document is not ready', () => {
@@ -2811,9 +2855,18 @@ describe('Resources.add/upgrade/remove', () => {
   });
 
   describe('buildReadyResources_', () => {
-    it('should build ready resources and remove them from pending', () => {
-      sandbox.stub(resources, 'schedulePass');
+    let schedulePassStub;
+
+    beforeEach(() => {
+      schedulePassStub = sandbox.stub(resources, 'schedulePass');
+      resources.isBuildOn_ = true;
       resources.documentReady_ = false;
+      resource1 = stubBuild(resource1);
+      resource2 = stubBuild(resource2);
+      parentResource = stubBuild(parentResource);
+    });
+
+    it('should build ready resources and remove them from pending', () => {
       resources.pendingBuildResources_ = [resource1, resource2];
       resources.buildReadyResources_();
       expect(child1.build.called).to.be.false;
@@ -2827,20 +2880,22 @@ describe('Resources.add/upgrade/remove', () => {
       expect(child2.build.called).to.be.false;
       expect(resources.pendingBuildResources_.length).to.be.equal(1);
       expect(resources.pendingBuildResources_[0]).to.be.equal(resource2);
-      expect(resources.schedulePass.calledOnce).to.be.true;
+      return resource1.buildPromise.then(() => {
+        expect(resources.schedulePass.calledOnce).to.be.true;
 
-      child2.parentNode = parent;
-      parent.nextSibling = true;
-      resources.buildReadyResources_();
-      expect(child1.build.calledTwice).to.be.false;
-      expect(child2.build.called).to.be.true;
-      expect(resources.pendingBuildResources_.length).to.be.equal(0);
-      expect(resources.schedulePass.calledTwice).to.be.true;
+        child2.parentNode = parent;
+        parent.nextSibling = true;
+        resources.buildReadyResources_();
+        expect(child1.build.calledTwice).to.be.false;
+        expect(child2.build.called).to.be.true;
+        expect(resources.pendingBuildResources_.length).to.be.equal(0);
+        return resource2.buildPromise;
+      }).then(() => {
+        expect(resources.schedulePass.calledTwice).to.be.true;
+      });
     });
 
     it('should NOT build past the root node when pending', () => {
-      sandbox.stub(resources, 'schedulePass');
-      resources.documentReady_ = false;
       resources.pendingBuildResources_ = [resource1];
       resources.buildReadyResources_();
       expect(child1.build.called).to.be.false;
@@ -2857,7 +2912,6 @@ describe('Resources.add/upgrade/remove', () => {
     });
 
     it('should not try to build resources already being built', () => {
-      resources.documentReady_ = false;
       resources.pendingBuildResources_ = [resource1, resource2];
       resources.buildReadyResources_();
       expect(child1.build.called).to.be.false;
@@ -2876,6 +2930,7 @@ describe('Resources.add/upgrade/remove', () => {
         child1BuildSpy();
         resources.pendingBuildResources_.push(newResource);
         resources.buildReadyResources_();
+        return Promise.resolve();
       };
       resources.buildReadyResources_();
       expect(child1BuildSpy.called).to.be.true;
@@ -2894,37 +2949,49 @@ describe('Resources.add/upgrade/remove', () => {
     });
 
     it('should build everything pending when document is ready', () => {
-      const schedulePassStub = sandbox.stub(resources, 'schedulePass');
       resources.documentReady_ = true;
       resources.pendingBuildResources_ = [parentResource, resource1, resource2];
       const child1BuildSpy = sandbox.spy();
       child1.build = () => {
         // Emulate an error happening during an element build.
         child1BuildSpy();
-        throw new Error('child1-build-error');
+        return Promise.reject(new Error('child1-build-error'));
       };
       resources.buildReadyResources_();
       expect(child1BuildSpy.called).to.be.true;
       expect(child2.build.called).to.be.true;
       expect(parent.build.called).to.be.true;
       expect(resources.pendingBuildResources_.length).to.be.equal(0);
-      expect(schedulePassStub).to.be.calledOnce;
+      return Promise.all([
+        parentResource.buildPromise,
+        resource2.buildPromise,
+        resource1.buildPromise.then(() => {
+          throw new Error('must have failed');
+        }, () => {
+          // Ignore error.
+        }),
+      ]).then(() => {
+        expect(schedulePassStub).to.be.calledTwice;
+      });
     });
 
     it('should not schedule pass if all builds failed', () => {
-      const schedulePassStub = sandbox.stub(resources, 'schedulePass');
       resources.documentReady_ = true;
       resources.pendingBuildResources_ = [resource1];
       const child1BuildSpy = sandbox.spy();
       child1.build = () => {
         // Emulate an error happening during an element build.
         child1BuildSpy();
-        throw new Error('child1-build-error');
+        return Promise.reject(new Error('child1-build-error'));
       };
       resources.buildReadyResources_();
       expect(child1BuildSpy.called).to.be.true;
       expect(resources.pendingBuildResources_.length).to.be.equal(0);
-      expect(schedulePassStub).to.not.be.called;
+      return resource1.buildPromise.then(() => {
+        throw new Error('must have failed');
+      }, () => {
+        expect(schedulePassStub).to.not.be.called;
+      });
     });
   });
 

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -244,7 +244,8 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
           addElement: function(element) {
             const iWin = iframe.contentWindow;
             const p = onInsert(iWin).then(() => {
-              element.build(true);
+              return element.build();
+            }).then(() => {
               if (!element.getPlaceholder()) {
                 const placeholder = element.createPlaceholder();
                 if (placeholder) {


### PR DESCRIPTION
Closes #10704.
/cc @charliereams

TODO:

- [x] Tests

This change is aimed at improving cases like #10211 where we block element on some async process early enough that we don't want to receive any other callbacks. Generally, async `buildCallback` sounds like a natural and clear extension of the existing API. But let's discuss if (a) it's indeed a good idea, and (b) if we are ready to add it now. I have other approaches to solve this issue, but this one seems the most beneficial overall.
