### PR TITLE
Don't run `gulp build` for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,13 @@ env:
     - NPM_CONFIG_PROGRESS="false"
 matrix:
   include:
-    - env: BUILD_SHARD="pre_build_checks_and_unit_tests"
+    - env: BUILD_SHARD="unit_tests"
+    - env: BUILD_SHARD="integration_tests"
       before_script:
         - pip install --user protobuf
         - gem install percy-capybara phantomjs poltergeist
         # Poltergeist requires an absolute path to find phantomjs. See #10305.
         - export PATH="`pwd`/node_modules/.bin:$PATH"
-    - env: BUILD_SHARD="integration_tests"
-      before_script:
-        - pip install --user protobuf
       addons:
         sauce_connect:
           username: "amphtml"

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -108,7 +108,8 @@ function getAdTypes() {
 /**
  * Run tests.
  */
-gulp.task('test', 'Runs tests', argv.nobuild ? [] : ['build'], function(done) {
+gulp.task('test', 'Runs tests',
+    argv.nobuild ? [] : (argv.unit ? ['css'] : ['build']), function(done) {
   if (!argv.integration && process.env.AMPSAUCE_REPO) {
     console./*OK*/info('Deactivated for ampsauce repo')
   }


### PR DESCRIPTION
This PR is a follow up to #10800, and does the following:

1. No longer calls `gulp build` before `gulp test --unit` (It's now sufficient to call `gulp css`)
2. Changes the dependencies of `gulp test --unit` from `build` to `css`
3. Renames the Travis build shards to `unit_tests` and `integration_tests`
4. Moves build tasks that require `gulp build` into the `integration_tests` shard, and keeps tasks that don't need it in the `unit_tests` shard. This way, we do just one `gulp build` for a PR on Travis.

Fixes #10785