### PR TITLE
[amp-sidebar 1.0] Un-version sidebar 1.0

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -49,6 +49,17 @@ amp-sidebar[side] {
   transition: transform 233ms cubic-bezier(0,0,.21,1);
 }
 
+.i-amphtml-toolbar > ul {
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  overflow: auto;
+  list-style-type: none;
+
+  padding: 0;
+  margin: 0;
+}
+
 .i-amphtml-sidebar-mask {
   position: fixed !important;
   top: 0 !important;

--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -55,7 +55,6 @@ amp-sidebar[side] {
   flex-wrap: wrap;
   overflow: auto;
   list-style-type: none;
-
   padding: 0;
   margin: 0;
 }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -120,7 +120,7 @@ export class AmpSidebar extends AMP.BaseElement {
       });
     }
 
-    if (this.isIos_ && Safari_) {
+    if (this.isIos_) {
       this.fixIosElasticScrollLeak_();
     }
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -191,10 +191,12 @@ export class AmpSidebar extends AMP.BaseElement {
 
   /** @override */
   onLayoutMeasure() {
-    // Check our toolbars for changes
-    this.toolbars_.forEach(toolbar => {
-      toolbar.onLayoutChange(() => this.onToolbarOpen_());
-    });
+    if (this.isToolbarExperimentEnabled_) {
+      // Check our toolbars for changes
+      this.toolbars_.forEach(toolbar => {
+        toolbar.onLayoutChange(() => this.onToolbarOpen_());
+      });
+    }
   }
 
   /**

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -15,16 +15,16 @@
  */
 
 import {CSS} from '../../../build/amp-sidebar-0.1.css';
+import {KeyCodes} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
+import {Services} from '../../../src/services';
+import {Toolbar} from './toolbar';
+import {closestByTag, tryFocus, isRTL} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
-import {KeyCodes} from '../../../src/utils/key-codes';
-import {closestByTag, tryFocus, isRTL} from '../../../src/dom';
-import {Services} from '../../../src/services';
-import {setStyles, toggle} from '../../../src/style';
 import {removeFragment, parseUrl} from '../../../src/url';
+import {setStyles, toggle} from '../../../src/style';
 import {toArray} from '../../../src/types';
-import {Toolbar} from './toolbar';
 
 /** @const */
 const TAG = 'amp-sidebar toolbar';

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -106,7 +106,7 @@ export class AmpSidebar extends AMP.BaseElement {
 
     if (this.isToolbarExperimentEnabled_) {
       const ampdoc = this.getAmpDoc();
-      // Get the toolbar attribute from the child navs
+      // Get the toolbar attribute from the child navs.
       const toolbarElements =
         toArray(this.element.querySelectorAll('nav[toolbar]'));
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -64,7 +64,10 @@ export class AmpSidebar extends AMP.BaseElement {
     const platform = Services.platformFor(this.win);
 
     /** @private @const {boolean} */
-    this.isIosSafari_ = platform.isIos() && platform.isSafari();
+    this.isIos_ = platform.isIos();
+
+    /** @private @const {boolean} */
+    this.isSafari_ = platform.isSafari();
 
     /** @private {number} */
     this.historyId_ = -1;
@@ -117,7 +120,7 @@ export class AmpSidebar extends AMP.BaseElement {
       });
     }
 
-    if (this.isIosSafari_) {
+    if (this.isIos_ && Safari_) {
       this.fixIosElasticScrollLeak_();
     }
 
@@ -182,16 +185,16 @@ export class AmpSidebar extends AMP.BaseElement {
   }
 
   /** @override */
+  activate() {
+    this.open_();
+  }
+
+  /** @override */
   onLayoutMeasure() {
     // Check our toolbars for changes
     this.toolbars_.forEach(toolbar => {
       toolbar.onLayoutChange(() => this.onToolbarOpen_());
     });
-  }
-
-  /** @override */
-  activate() {
-    this.open_();
   }
 
   /**
@@ -234,7 +237,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.viewport_.enterOverlayMode();
     this.vsync_.mutate(() => {
       toggle(this.element, /* display */true);
-      if (this.isIosSafari_) {
+      if (this.isIos_ && this.isSafari_) {
         this.compensateIosBottombar_();
       }
       this.element./*OK*/scrollTop = 1;

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -61,6 +61,9 @@ export class AmpSidebar extends AMP.BaseElement {
     /** @private {Array} */
     this.toolbars_ = [];
 
+    /** @private {boolean} */
+    this.isToolbarExperimentEnabled_ = isExperimentOn(this.win, TAG);
+
     const platform = Services.platformFor(this.win);
 
     /** @private @const {boolean} */
@@ -101,19 +104,16 @@ export class AmpSidebar extends AMP.BaseElement {
       this.element.setAttribute('side', this.side_);
     }
 
-    const ampdoc = this.getAmpDoc();
-    // Get the toolbar attribute from the child navs
-    const toolbarElements =
-      toArray(this.element.querySelectorAll('nav[toolbar]'));
-
-    if (toolbarElements.length > 0) {
-      user().assert(isExperimentOn(this.win, TAG),
-          `Experiment ${TAG} is disabled.`);
+    if (this.isToolbarExperimentEnabled_) {
+      const ampdoc = this.getAmpDoc();
+      // Get the toolbar attribute from the child navs
+      const toolbarElements =
+        toArray(this.element.querySelectorAll('nav[toolbar]'));
 
       toolbarElements.forEach(toolbarElement => {
         try {
           this.toolbars_.push(new Toolbar(toolbarElement, this.vsync_,
-          ampdoc));
+            ampdoc));
         } catch (e) {
           user().error(TAG, 'Failed to instantiate toolbar', e);
         }

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -36,114 +36,113 @@ describes.realWin('amp-sidebar 0.1 version', {
     extensions: ['amp-sidebar:0.1'],
   },
 }, () => {
-  describe('amp-sidebar', () => {
-    let sandbox;
-    let platform;
-    let timer;
+  let sandbox;
+  let platform;
+  let timer;
 
-    function getAmpSidebar(options) {
-      options = options || {};
-      return createIframePromise().then(iframe => {
-        const ampSidebar = iframe.doc.createElement('amp-sidebar');
-        const list = iframe.doc.createElement('ul');
-        for (let i = 0; i < 10; i++) {
-          const li = iframe.doc.createElement('li');
-          li.innerHTML = 'Menu item ' + i;
-          list.appendChild(li);
-        }
-        ampSidebar.appendChild(list);
-        const anchor = iframe.doc.createElement('a');
-        anchor.href = '#section1';
-        ampSidebar.appendChild(anchor);
-        if (options.toolbars) {
-           // Stub our sidebar operations, doing this here as it will
-           // Ease testing our media queries
-          const impl = ampSidebar.implementation_;
-          sandbox.stub(impl.vsync_,
-              'mutate', callback => {
-                callback();
-              });
-          sandbox.stub(impl.vsync_,
-              'mutatePromise', callback => {
-                callback();
-                return Promise.resolve();
-              });
-           // Create our individual toolbars
-          options.toolbars.forEach(toolbarObj => {
-            const navToolbar = iframe.doc.createElement('nav');
-
-             //Create/Set toolbar-target
-            const toolbarTarget = iframe.doc.createElement('div');
-            if (toolbarObj.toolbarTarget) {
-              toolbarTarget.setAttribute('id',
-                  toolbarObj.toolbarTarget);
-              navToolbar.setAttribute('toolbar-target',
-                  toolbarObj.toolbarTarget);
-            } else {
-              toolbarTarget.setAttribute('id', 'toolbar-target');
-              navToolbar.setAttribute('toolbar-target', 'toolbar-target');
-            }
-            iframe.win.document.body.appendChild(toolbarTarget);
-
-             // Set the toolbar media
-            if (toolbarObj.media) {
-              navToolbar.setAttribute('toolbar', toolbarObj.media);
-            } else {
-              navToolbar.setAttribute('toolbar', '(min-width: 768px)');
-            }
-            const toolbarList = iframe.doc.createElement('ul');
-            for (let i = 0; i < 3; i++) {
-              const li = iframe.doc.createElement('li');
-              li.innerHTML = 'Toolbar item ' + i;
-              toolbarList.appendChild(li);
-            }
-            navToolbar.appendChild(toolbarList);
-            ampSidebar.appendChild(navToolbar);
-          });
-        }
-        if (options.side) {
-          ampSidebar.setAttribute('side', options.side);
-        }
-        if (options.open) {
-          ampSidebar.setAttribute('open', '');
-        }
-        if (options.closeText) {
-          ampSidebar.setAttribute('data-close-button-aria-label',
-              options.closeText);
-        };
-        ampSidebar.setAttribute('id', 'sidebar1');
-        ampSidebar.setAttribute('layout', 'nodisplay');
-        return iframe.addElement(ampSidebar).then(() => {
-          timer = Services.timerFor(iframe.win);
-          if (options.toolbars) {
-            sandbox.stub(timer, 'delay', function(callback) {
+  function getAmpSidebar(options) {
+    options = options || {};
+    return createIframePromise().then(iframe => {
+      const ampSidebar = iframe.doc.createElement('amp-sidebar');
+      const list = iframe.doc.createElement('ul');
+      for (let i = 0; i < 10; i++) {
+        const li = iframe.doc.createElement('li');
+        li.innerHTML = 'Menu item ' + i;
+        list.appendChild(li);
+      }
+      ampSidebar.appendChild(list);
+      const anchor = iframe.doc.createElement('a');
+      anchor.href = '#section1';
+      ampSidebar.appendChild(anchor);
+      if (options.toolbars) {
+         // Stub our sidebar operations, doing this here as it will
+         // Ease testing our media queries
+        const impl = ampSidebar.implementation_;
+        sandbox.stub(impl.vsync_,
+            'mutate', callback => {
               callback();
             });
+        sandbox.stub(impl.vsync_,
+            'mutatePromise', callback => {
+              callback();
+              return Promise.resolve();
+            });
+         // Create our individual toolbars
+        options.toolbars.forEach(toolbarObj => {
+          const navToolbar = iframe.doc.createElement('nav');
+
+           //Create/Set toolbar-target
+          const toolbarTarget = iframe.doc.createElement('div');
+          if (toolbarObj.toolbarTarget) {
+            toolbarTarget.setAttribute('id',
+                toolbarObj.toolbarTarget);
+            navToolbar.setAttribute('toolbar-target',
+                toolbarObj.toolbarTarget);
+          } else {
+            toolbarTarget.setAttribute('id', 'toolbar-target');
+            navToolbar.setAttribute('toolbar-target', 'toolbar-target');
           }
-          return {iframe, ampSidebar};
+          iframe.win.document.body.appendChild(toolbarTarget);
+
+           // Set the toolbar media
+          if (toolbarObj.media) {
+            navToolbar.setAttribute('toolbar', toolbarObj.media);
+          } else {
+            navToolbar.setAttribute('toolbar', '(min-width: 768px)');
+          }
+          const toolbarList = iframe.doc.createElement('ul');
+          for (let i = 0; i < 3; i++) {
+            const li = iframe.doc.createElement('li');
+            li.innerHTML = 'Toolbar item ' + i;
+            toolbarList.appendChild(li);
+          }
+          navToolbar.appendChild(toolbarList);
+          ampSidebar.appendChild(navToolbar);
         });
-      });
-
-      it('should replace text to screen reader \
-      button in data-close-button-aria-label', () => {
-        return getAmpSidebar({'closeText':
-          'data-close-button-aria-label'}).then(obj => {
-            const sidebarElement = obj.ampSidebar;
-            const closeButton = sidebarElement.lastElementChild;
-            expect(closeButton.textContent)
-                .to.equal('data-close-button-aria-label');
+      }
+      if (options.side) {
+        ampSidebar.setAttribute('side', options.side);
+      }
+      if (options.open) {
+        ampSidebar.setAttribute('open', '');
+      }
+      if (options.closeText) {
+        ampSidebar.setAttribute('data-close-button-aria-label',
+            options.closeText);
+      };
+      ampSidebar.setAttribute('id', 'sidebar1');
+      ampSidebar.setAttribute('layout', 'nodisplay');
+      return iframe.addElement(ampSidebar).then(() => {
+        timer = Services.timerFor(iframe.win);
+        if (options.toolbars) {
+          sandbox.stub(timer, 'delay', function(callback) {
+            callback();
           });
+        }
+        return {iframe, ampSidebar};
       });
-    }
+    });
+  }
 
+  describe('amp-sidebar', () => {
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
       platform = Services.platformFor(window);
-      toggleExperiment(window, 'amp-sidebar toolbar', true);
     });
 
     afterEach(() => {
       sandbox.restore();
+    });
+
+    it('should replace text to screen reader \
+    button in data-close-button-aria-label', () => {
+      return getAmpSidebar({'closeText':
+        'data-close-button-aria-label'}).then(obj => {
+          const sidebarElement = obj.ampSidebar;
+          const closeButton = sidebarElement.lastElementChild;
+          expect(closeButton.textContent)
+              .to.equal('data-close-button-aria-label');
+        });
     });
 
     it('should open from left is side is not specified', () => {
@@ -608,8 +607,21 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(impl.schedulePause).to.have.not.been.called;
       });
     });
+  });
 
-     // Tests for amp-sidebar 1.0
+  describe('amp-sidebar - toolbars in amp-sidebar', () => {
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      platform = Services.platformFor(window);
+      toggleExperiment(window, 'amp-sidebar toolbar', true);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    // Tests for amp-sidebar 1.0
     it('should not create toolbars without <nav toolbar />', () => {
       return getAmpSidebar().then(obj => {
         const sidebarElement = obj.ampSidebar;

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -522,8 +522,8 @@ describes.realWin('amp-sidebar 0.1 version', {
           };
         });
         anchor.dispatchEvent ?
-             anchor.dispatchEvent(eventObj) :
-             anchor.fireEvent('onkeydown', eventObj);
+            anchor.dispatchEvent(eventObj) :
+            anchor.fireEvent('onkeydown', eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         expect(sidebarElement.style.display).to.equal('');
@@ -551,7 +551,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
+            document.createEventObject() : document.createEvent('Events');
         if (eventObj.initEvent) {
           eventObj.initEvent('click', true, true);
         }
@@ -567,8 +567,8 @@ describes.realWin('amp-sidebar 0.1 version', {
           };
         });
         anchor.dispatchEvent ?
-             anchor.dispatchEvent(eventObj) :
-             anchor.fireEvent('onkeydown', eventObj);
+            anchor.dispatchEvent(eventObj) :
+            anchor.fireEvent('onkeydown', eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         expect(sidebarElement.style.display).to.equal('');

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -463,7 +463,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
+            document.createEventObject() : document.createEvent('Events');
         if (eventObj.initEvent) {
           eventObj.initEvent('click', true, true);
         }

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -125,14 +125,14 @@ describes.realWin('amp-sidebar 0.1 version', {
       });
 
       it('should replace text to screen reader \
-       button in data-close-button-aria-label', () => {
+      button in data-close-button-aria-label', () => {
         return getAmpSidebar({'closeText':
-           'data-close-button-aria-label'}).then(obj => {
-             const sidebarElement = obj.ampSidebar;
-             const closeButton = sidebarElement.lastElementChild;
-             expect(closeButton.textContent)
-                 .to.equal('data-close-button-aria-label');
-           });
+          'data-close-button-aria-label'}).then(obj => {
+            const sidebarElement = obj.ampSidebar;
+            const closeButton = sidebarElement.lastElementChild;
+            expect(closeButton.textContent)
+                .to.equal('data-close-button-aria-label');
+          });
       });
     }
 
@@ -180,7 +180,7 @@ describes.realWin('amp-sidebar 0.1 version', {
     });
 
     it('should create an invisible close \
-     button for screen readers only', () => {
+    button for screen readers only', () => {
       return getAmpSidebar().then(obj => {
         const sidebarElement = obj.ampSidebar;
         const impl = sidebarElement.implementation_;
@@ -238,7 +238,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(historyPopSpy).to.have.not.been.called;
         expect(impl.historyId_).to.not.equal('-1');
 
-         // second call to open_() should be a no-op and not increase call counts.
+        // second call to open_() should be a no-op and not increase call counts.
         impl.open_();
         expect(impl.scheduleLayout).to.be.calledOnce;
         expect(historyPushSpy).to.be.calledOnce;
@@ -288,7 +288,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(historyPopSpy).to.be.calledOnce;
         expect(impl.historyId_).to.equal(-1);
 
-         // second call to close_() should be a no-op and not increase call counts.
+        // second call to close_() should be a no-op and not increase call counts.
         impl.close_();
         expect(impl.schedulePause).to.be.calledOnce;
         expect(historyPopSpy).to.be.calledOnce;
@@ -346,7 +346,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
+            document.createEventObject() : document.createEvent('Events');
         if (eventObj.initEvent) {
           eventObj.initEvent('keydown', true, true);
         }
@@ -354,7 +354,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         eventObj.which = KeyCodes.ESCAPE;
         const el = iframe.doc.documentElement;
         el.dispatchEvent ?
-             el.dispatchEvent(eventObj) : el.fireEvent('onkeydown', eventObj);
+            el.dispatchEvent(eventObj) : el.fireEvent('onkeydown', eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
         expect(sidebarElement.style.display).to.equal('none');
@@ -433,11 +433,11 @@ describes.realWin('amp-sidebar 0.1 version', {
           callback();
         });
         const compensateIosBottombarSpy =
-             sandbox.spy(impl, 'compensateIosBottombar_');
+            sandbox.spy(impl, 'compensateIosBottombar_');
         const initalChildrenCount = sidebarElement.children.length;
         impl.open_();
         expect(compensateIosBottombarSpy).to.be.calledOnce;
-         // 10 lis + one top padding element inserted
+        // 10 lis + one top padding element inserted
         expect(sidebarElement.children.length)
             .to.equal(initalChildrenCount + 1);
       });
@@ -477,8 +477,8 @@ describes.realWin('amp-sidebar 0.1 version', {
           };
         });
         anchor.dispatchEvent ?
-             anchor.dispatchEvent(eventObj) :
-             anchor.fireEvent('onkeydown', eventObj);
+            anchor.dispatchEvent(eventObj) :
+            anchor.fireEvent('onkeydown', eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
         expect(sidebarElement.style.display).to.equal('none');
@@ -507,7 +507,7 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
+            document.createEventObject() : document.createEvent('Events');
         if (eventObj.initEvent) {
           eventObj.initEvent('click', true, true);
         }
@@ -515,7 +515,7 @@ describes.realWin('amp-sidebar 0.1 version', {
           return {
             win: {
               location: {
-                 // Mocking navigating from example.com -> localhost:9876
+                // Mocking navigating from example.com -> localhost:9876
                 href: 'http://example.com',
               },
             },
@@ -559,8 +559,8 @@ describes.realWin('amp-sidebar 0.1 version', {
           return {
             win: {
               location: {
-                 // Mocking navigating from
-                 // /context.html?old=context -> /context.html
+                // Mocking navigating from
+                // /context.html?old=context -> /context.html
                 href: 'http://localhost:9876/context.html?old=context',
               },
             },
@@ -595,13 +595,13 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         const eventObj = document.createEventObject ?
-             document.createEventObject() : document.createEvent('Events');
+            document.createEventObject() : document.createEvent('Events');
         if (eventObj.initEvent) {
           eventObj.initEvent('click', true, true);
         }
         li.dispatchEvent ?
-             li.dispatchEvent(eventObj) :
-             li.fireEvent('onkeydown', eventObj);
+            li.dispatchEvent(eventObj) :
+            li.fireEvent('onkeydown', eventObj);
         expect(sidebarElement.hasAttribute('open')).to.be.true;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('false');
         expect(sidebarElement.style.display).to.equal('');

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -55,50 +55,7 @@ describes.realWin('amp-sidebar 0.1 version', {
       anchor.href = '#section1';
       ampSidebar.appendChild(anchor);
       if (options.toolbars) {
-         // Stub our sidebar operations, doing this here as it will
-         // Ease testing our media queries
-        const impl = ampSidebar.implementation_;
-        sandbox.stub(impl.vsync_,
-            'mutate', callback => {
-              callback();
-            });
-        sandbox.stub(impl.vsync_,
-            'mutatePromise', callback => {
-              callback();
-              return Promise.resolve();
-            });
-         // Create our individual toolbars
-        options.toolbars.forEach(toolbarObj => {
-          const navToolbar = iframe.doc.createElement('nav');
-
-           //Create/Set toolbar-target
-          const toolbarTarget = iframe.doc.createElement('div');
-          if (toolbarObj.toolbarTarget) {
-            toolbarTarget.setAttribute('id',
-                toolbarObj.toolbarTarget);
-            navToolbar.setAttribute('toolbar-target',
-                toolbarObj.toolbarTarget);
-          } else {
-            toolbarTarget.setAttribute('id', 'toolbar-target');
-            navToolbar.setAttribute('toolbar-target', 'toolbar-target');
-          }
-          iframe.win.document.body.appendChild(toolbarTarget);
-
-           // Set the toolbar media
-          if (toolbarObj.media) {
-            navToolbar.setAttribute('toolbar', toolbarObj.media);
-          } else {
-            navToolbar.setAttribute('toolbar', '(min-width: 768px)');
-          }
-          const toolbarList = iframe.doc.createElement('ul');
-          for (let i = 0; i < 3; i++) {
-            const li = iframe.doc.createElement('li');
-            li.innerHTML = 'Toolbar item ' + i;
-            toolbarList.appendChild(li);
-          }
-          navToolbar.appendChild(toolbarList);
-          ampSidebar.appendChild(navToolbar);
-        });
+        getToolbars(options, ampSidebar, iframe);
       }
       if (options.side) {
         ampSidebar.setAttribute('side', options.side);
@@ -121,6 +78,53 @@ describes.realWin('amp-sidebar 0.1 version', {
         }
         return {iframe, ampSidebar};
       });
+    });
+  }
+
+  function getToolbars(options, ampSidebar, iframe) {
+    // Stub our sidebar operations, doing this here as it will
+    // Ease testing our media queries
+    const impl = ampSidebar.implementation_;
+    sandbox.stub(impl.vsync_,
+        'mutate', callback => {
+          callback();
+        });
+    sandbox.stub(impl.vsync_,
+        'mutatePromise', callback => {
+          callback();
+          return Promise.resolve();
+        });
+    // Create our individual toolbars
+    options.toolbars.forEach(toolbarObj => {
+      const navToolbar = iframe.doc.createElement('nav');
+
+      //Create/Set toolbar-target
+      const toolbarTarget = iframe.doc.createElement('div');
+      if (toolbarObj.toolbarTarget) {
+        toolbarTarget.setAttribute('id',
+            toolbarObj.toolbarTarget);
+        navToolbar.setAttribute('toolbar-target',
+            toolbarObj.toolbarTarget);
+      } else {
+        toolbarTarget.setAttribute('id', 'toolbar-target');
+        navToolbar.setAttribute('toolbar-target', 'toolbar-target');
+      }
+      iframe.win.document.body.appendChild(toolbarTarget);
+
+      // Set the toolbar media
+      if (toolbarObj.media) {
+        navToolbar.setAttribute('toolbar', toolbarObj.media);
+      } else {
+        navToolbar.setAttribute('toolbar', '(min-width: 768px)');
+      }
+      const toolbarList = iframe.doc.createElement('ul');
+      for (let i = 0; i < 3; i++) {
+        const li = iframe.doc.createElement('li');
+        li.innerHTML = 'Toolbar item ' + i;
+        toolbarList.appendChild(li);
+      }
+      navToolbar.appendChild(toolbarList);
+      ampSidebar.appendChild(navToolbar);
     });
   }
 

--- a/extensions/amp-sidebar/0.1/test/test-toolbar.js
+++ b/extensions/amp-sidebar/0.1/test/test-toolbar.js
@@ -1,0 +1,323 @@
+
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {adopt} from '../../../../src/runtime';
+import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
+import {createIframePromise} from '../../../../testing/iframe';
+import {Services} from '../../../../src/services';
+import {toArray} from '../../../../src/types';
+import * as sinon from 'sinon';
+import {Toolbar} from '../toolbar';
+
+adopt(window);
+
+describe('amp-sidebar - toolbar', () => {
+  let sandbox;
+  let timer;
+  let vsync;
+
+  function getToolbars(options) {
+    options = options || {};
+    return createIframePromise().then(iframe => {
+      vsync = Services.vsyncFor(iframe.win);
+      timer = Services.timerFor(iframe.win);
+      const ampdoc = new AmpDocSingle(iframe.win);
+
+       // Create toolbar elements
+      const toolbarContainerElement =
+        ampdoc.win.document.createElement('div');
+      const toolbars = [];
+      ampdoc.win.document.body.appendChild(toolbarContainerElement);
+       // Stub our toolbar operations, doing this here as it will
+       // Ease testing our media queries
+      sandbox.stub(vsync,
+          'mutate', callback => {
+            callback();
+          });
+      sandbox.stub(vsync,
+          'mutatePromise', callback => {
+            callback();
+            return Promise.resolve();
+          });
+      sandbox.stub(timer, 'delay', function(callback) {
+        callback();
+      });
+
+       // Create our individual toolbars
+      options.forEach(toolbarObj => {
+        const navToolbar = ampdoc.win.document.createElement('nav');
+        if (toolbarObj.media) {
+          navToolbar.setAttribute('toolbar', toolbar.media);
+        } else {
+          navToolbar.setAttribute('toolbar', '(min-width: 768px)');
+        }
+        if (toolbarObj.toolbarOnlyOnNav) {
+          navToolbar.setAttribute('toolbar-only', '');
+        }
+        const toolbarTarget = ampdoc.win.document.createElement('div');
+        if (toolbarObj.toolbarTarget) {
+          toolbarTarget.setAttribute('id', toolbarObj.toolbarTarget);
+          navToolbar.setAttribute('toolbar-target', toolbarObj.toolbarTarget);
+        } else if (toolbarObj.toolbarTargetError) {
+          navToolbar.setAttribute('target', 'toolbar-target');
+        } else {
+          toolbarTarget.setAttribute('id', 'toolbar-target');
+          navToolbar.setAttribute('toolbar-target', 'toolbar-target');
+        }
+        ampdoc.win.document.body.appendChild(toolbarTarget);
+        const toolbarList = ampdoc.win.document.createElement('ul');
+        for (let i = 0; i < 3; i++) {
+          const li = ampdoc.win.document.createElement('li');
+          li.innerHTML = 'Toolbar item ' + i;
+          toolbarList.appendChild(li);
+        }
+        navToolbar.appendChild(toolbarList);
+        toolbarContainerElement.appendChild(navToolbar);
+        toolbars.push(new Toolbar(navToolbar, vsync, ampdoc));
+      });
+
+      return {iframe, ampdoc, toolbarContainerElement, toolbars};
+    });
+  }
+
+  function resizeIframeToWidth(iframeObject, width, callback) {
+    iframeObject.iframe.setAttribute('width', width);
+     // Force the browser to re-draw
+    iframeObject.win.innerWidth;
+    callback();
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('toolbar header should error if target element \
+   could not be found as it is required.', () => {
+    return getToolbars([{
+      targetError: true,
+    }]).then(() => {
+      expect(false).to.be.equal(true, 'Toolbar \
+       should not be created when the target element is not found');
+    }).catch(() => {
+      expect(true).to.be.ok;
+    });
+  });
+
+  it('toolbar header should be hidden for a \
+   non-matching window size for (min-width: 768px)', () => {
+    return getToolbars([{}]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '1024px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarElements =
+                toArray(obj.ampdoc.getRootNode()
+                .getElementsByClassName('i-amphtml-toolbar'));
+        resizeIframeToWidth(obj.iframe, '1px', () => {
+          toolbars.forEach(toolbar => {
+            toolbar.onLayoutChange();
+          });
+          expect(toolbarElements.length).to.be.above(0);
+          expect(toolbarElements[0].parentElement.style.display)
+              .to.be.equal('none');
+        });
+      });
+    });
+  });
+
+  it('toolbar header should be shown for a \
+   matching window size for (min-width: 768px)', () => {
+    return getToolbars([{}]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarElements =
+                toArray(obj.ampdoc.getRootNode()
+                .getElementsByClassName('i-amphtml-toolbar'));
+        expect(toolbarElements.length).to.be.above(0);
+        expect(toolbarElements[0].parentElement.style.display)
+            .to.be.equal('');
+      });
+    });
+  });
+
+  it('toolbar should be placed into a target, with the \
+   target attrbiute', () => {
+    const targetId = 'toolbar-target';
+    return getToolbars([{
+      'toolbar-target': targetId,
+    }]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '1024px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarQuery = `#${targetId} > nav[toolbar]`;
+        const toolbarTargetElements =
+                toArray(obj.ampdoc.getRootNode()
+                .querySelectorAll(toolbarQuery));
+        expect(toolbars.length).to.be.equal(1);
+        expect(toolbarTargetElements.length).to.be.equal(1);
+      });
+    });
+  });
+
+  it('toolbar should be placed into a target, and shown for a \
+   matching window size for (min-width: 768px)', () => {
+    const targetId = 'toolbar-target';
+    return getToolbars([{
+      'toolbar-target': targetId,
+    }]).then(obj => {
+      const toolbars = obj.toolbars;
+      const toolbarTargets =
+                toArray(obj.ampdoc.getRootNode()
+               .querySelectorAll(`#${targetId}`));
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        expect(toolbars.length).to.be.equal(1);
+        expect(toolbarTargets.length).to.be.equal(1);
+        expect(toolbarTargets[0].style.display)
+            .to.be.equal('');
+      });
+    });
+  });
+
+  it('toolbar should be placed into a target, and hidden for a \
+   non-matching window size for (min-width: 768px)', () => {
+    const targetId = 'toolbar-target';
+    return getToolbars([{
+      'toolbar-target': targetId,
+    }]).then(obj => {
+      const toolbars = obj.toolbars;
+      const toolbarTargets =
+                toArray(obj.ampdoc.getRootNode()
+               .querySelectorAll(`#${targetId}`));
+      resizeIframeToWidth(obj.iframe, '200px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        expect(toolbars.length).to.be.equal(1);
+        expect(toolbarTargets.length).to.be.equal(1);
+        expect(toolbarTargets[0].style.display)
+            .to.be.equal('none');
+      });
+    });
+  });
+
+  it('should add the "amp-sidebar-toolbar-target-shown" state class, \
+   for matching window size of (min-width: 768px)', () => {
+    return getToolbars([{
+      toolbarOnlyOnNav: true,
+    }]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarNavElementsWithState =
+                toArray(obj.ampdoc.getRootNode()
+                .querySelectorAll(
+                    'nav[toolbar].amp-sidebar-toolbar-target-shown'
+                ));
+        expect(toolbarNavElementsWithState.length).to.be.equal(1);
+        expect(toolbars.length).to.be.equal(1);
+      });
+    });
+  });
+
+  it('should add the "amp-sidebar-toolbar-target-hidden" state class, \
+   for non-matching window size of (min-width: 768px)', () => {
+    return getToolbars([{
+      toolbarOnlyOnNav: true,
+    }]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '0px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarNavElementsWithState =
+                toArray(obj.ampdoc.getRootNode()
+                .querySelectorAll(
+                    'nav[toolbar].amp-sidebar-toolbar-target-hidden'
+                ));
+        expect(toolbarNavElementsWithState.length).to.be.equal(1);
+        expect(toolbars.length).to.be.equal(1);
+      });
+    });
+  });
+
+  it('toolbar should be in the hidden state \
+   when it is not being displayed', () => {
+    return getToolbars([{}]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '1px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+          expect(toolbar.isToolbarShown_()).to.be.false;
+        });
+      });
+    });
+  });
+
+  it('toolbar should be in the shown state \
+   when it is being displayed', () => {
+    return getToolbars([{}]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+          expect(toolbar.isToolbarShown_()).to.be.true;
+        });
+      });
+    });
+  });
+
+  it('toolbar should not be able to be shown \
+   if already in the shown state', () => {
+    return getToolbars([{}]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+          expect(toolbar.attemptShow_()).to.be.undefined;
+        });
+      });
+    });
+  });
+
+  it('toolbar should be able to be shown \
+   if not in the shown state, and return a promise', () => {
+    return getToolbars([{}]).then(obj => {
+      const toolbars = obj.toolbars;
+      resizeIframeToWidth(obj.iframe, '1px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+          expect(toolbar).to.exist;
+        });
+      });
+    });
+  });
+});

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.html
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+  Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -27,11 +27,10 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
-  <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
   <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
 </head>
 <body>
-  <!-- Example of a valid amp-sidebar. -->
+  <!-- Valid: Example of amp-sidebar usage -->
   <amp-sidebar side="left" layout="nodisplay">
     <amp-accordion>
       <section>
@@ -43,14 +42,37 @@
         <p>Content</p>
       </section>
     </amp-accordion>
-    <amp-fit-text layout="fill"></amp-fit-text>
     <amp-img layout="fill" src="img"></amp-img>
   </amp-sidebar>
-  <!-- Invalid example: invalid children. -->
+  <!-- Valid: Example of amp-sidebar with toolbar usage -->
+  <amp-sidebar layout="nodisplay">
+    <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+      <ul>
+        <li>Nav item 1</li>
+        <li>Nav item 2</li>
+        <li>Nav item 3</li>
+      </ul>
+    </nav>
+    <amp-img layout="fill" src="img"></amp-img>
+  </amp-sidebar>
+  <!-- Invalid: more than one <ul> tag -->
+  <amp-sidebar layout="nodisplay">
+    <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+      <ul>
+        <li>Nav item 1</li>
+      </ul>
+      <ul>
+        <li>Nav item 2</li>
+        <li>Nav item 3</li>
+      </ul>
+    </nav>
+    <amp-img layout="fill" src="img"></amp-img>
+  </amp-sidebar>
+  <!-- Invalid: disallowed children -->
   <amp-sidebar layout="nodisplay">
     <amp-ad layout="fill" src="https://ad" type="ad"></amp-ad>
   </amp-sidebar>
-  <!-- Invalid example with invalid side value. -->
+  <!-- Invalid: incorrect side value -->
   <amp-sidebar side="center" layout="nodisplay"></amp-sidebar>
 </body>
 </html>

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
@@ -1,3 +1,4 @@
 FAIL
+amp-sidebar/1.0/test/validator-amp-sidebar.html:59:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
 amp-sidebar/0.1/test/validator-amp-sidebar.html:51:4 The tag 'amp-ad' may not appear as a descendant of tag 'amp-sidebar'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
 amp-sidebar/0.1/test/validator-amp-sidebar.html:54:2 The attribute 'side' in tag 'amp-sidebar' is set to the invalid value 'center'. (see https://www.ampproject.org/docs/reference/components/amp-sidebar) [AMP_TAG_PROBLEM]

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
@@ -1,4 +1,4 @@
 FAIL
-amp-sidebar/0.1/test/validator-amp-sidebar.html:59:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
-amp-sidebar/0.1/test/validator-amp-sidebar.html:51:4 The tag 'amp-ad' may not appear as a descendant of tag 'amp-sidebar'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
-amp-sidebar/0.1/test/validator-amp-sidebar.html:54:2 The attribute 'side' in tag 'amp-sidebar' is set to the invalid value 'center'. (see https://www.ampproject.org/docs/reference/components/amp-sidebar) [AMP_TAG_PROBLEM]
+amp-sidebar/0.1/test/validator-amp-sidebar.html:60:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
+amp-sidebar/0.1/test/validator-amp-sidebar.html:73:4 The tag 'amp-ad' may not appear as a descendant of tag 'amp-sidebar'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+amp-sidebar/0.1/test/validator-amp-sidebar.html:76:2 The attribute 'side' in tag 'amp-sidebar' is set to the invalid value 'center'. (see https://www.ampproject.org/docs/reference/components/amp-sidebar) [AMP_TAG_PROBLEM]

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
@@ -1,4 +1,4 @@
 FAIL
-amp-sidebar/1.0/test/validator-amp-sidebar.html:59:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
+amp-sidebar/0.1/test/validator-amp-sidebar.html:59:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
 amp-sidebar/0.1/test/validator-amp-sidebar.html:51:4 The tag 'amp-ad' may not appear as a descendant of tag 'amp-sidebar'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
 amp-sidebar/0.1/test/validator-amp-sidebar.html:54:2 The attribute 'side' in tag 'amp-sidebar' is set to the invalid value 'center'. (see https://www.ampproject.org/docs/reference/components/amp-sidebar) [AMP_TAG_PROBLEM]

--- a/extensions/amp-sidebar/0.1/toolbar.js
+++ b/extensions/amp-sidebar/0.1/toolbar.js
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {toggle} from '../../../src/style';
+import {user} from '../../../src/log';
+
+export class Toolbar {
+  /**
+  * @param {!Element} element
+  * @param {!../../../src/service/vsync-impl.Vsync} vsync
+  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+  */
+  constructor(element, vsync, ampdoc) {
+    /** @private {!Element} */
+    this.toolbarDomElement_ = element;
+
+    /** @private {number|undefined} */
+    this.height_ = undefined;
+
+    /** @const @private {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync_ = vsync;
+
+    /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampdoc_ = ampdoc;
+
+    /** @private {!string} */
+    this.toolbarMedia_ = this.toolbarDomElement_.getAttribute('toolbar');
+
+    /** @private {?Element} */
+    this.toolbarClone_ = null;
+
+    /** @private {Element|undefined} */
+    this.toolbarTarget_ = undefined;
+
+    /** @private {!boolean} **/
+    this.toolbarShown_ = false;
+
+    // Default to toolbar target being hidden
+    this.toolbarDomElement_.classList
+        .add('amp-sidebar-toolbar-target-hidden');
+
+    this.buildCallback_();
+  }
+
+  /**
+   * Function called to check if we should show or hide the toolbar
+   * @param {!Function} onShowCallback - function called if toolbar is shown on check
+   */
+  onLayoutChange(onShowCallback) {
+    // Get if we match the current toolbar media
+    const matchesMedia = this.ampdoc_.win
+        .matchMedia(this.toolbarMedia_).matches;
+
+    // Remove and add the toolbar dynamically
+    if (matchesMedia) {
+      const showResponse = this.attemptShow_();
+      if (showResponse) {
+        showResponse.then(onShowCallback);
+      }
+    } else {
+      this.hideToolbar_();
+    }
+  }
+
+  /**
+   * Private function to build the DOM element for the toolbar
+   * @private
+   */
+  buildCallback_() {
+    this.toolbarClone_ = this.toolbarDomElement_.cloneNode(true);
+    const targetId = user().assert(this.toolbarDomElement_
+        .getAttribute('toolbar-target'), '"toolbar-target" is required',
+        this.toolbarDomElement_);
+    // Set the target element to the toolbar clone if it exists.
+    this.ampdoc_.whenReady().then(() => {
+      const targetElement = this.ampdoc_.getElementById(targetId);
+      if (targetElement) {
+        this.toolbarTarget_ = targetElement;
+        this.toolbarClone_.classList.add('i-amphtml-toolbar');
+        toggle(this.toolbarTarget_, false);
+      } else {
+        // This error will be later rethrown as a user error and
+        // the side bar will continue to function w/o toolbar feature
+        throw new Error('Could not find the ' +
+        `toolbar-target element with an id: ${targetId}`);
+      }
+    });
+  }
+
+  /**
+   * Returns if the sidebar is currently in toolbar media query
+   * @returns {boolean}
+   * @private
+   */
+  isToolbarShown_() {
+    return this.toolbarShown_;
+  }
+
+  /**
+   * Function to attempt to show the toolbar,
+   * and hide toolbar-only element in the sidebar.
+   * @returns {Promise|undefined}
+   * @private
+   */
+  attemptShow_() {
+    if (this.isToolbarShown_()) {
+      return;
+    }
+
+    // Display the elements
+    return this.vsync_.mutatePromise(() => {
+      if (this.toolbarTarget_) {
+        toggle(this.toolbarTarget_, true);
+        if (!this.toolbarTarget_.contains(this.toolbarClone_)) {
+          this.toolbarTarget_.appendChild(this.toolbarClone_);
+        }
+        this.toolbarDomElement_.classList
+            .add('amp-sidebar-toolbar-target-shown');
+        this.toolbarDomElement_.classList
+            .remove('amp-sidebar-toolbar-target-hidden');
+      }
+      this.toolbarShown_ = true;
+    });
+  }
+
+  /**
+  * Function to hide the toolbar,
+  * and show toolbar-only element in the sidebar.
+  * @private
+   */
+  hideToolbar_() {
+    if (!this.isToolbarShown_()) {
+      return;
+    }
+
+    this.vsync_.mutate(() => {
+      // Hide the elements
+      if (this.toolbarTarget_) {
+        toggle(this.toolbarTarget_, false);
+        this.toolbarDomElement_.classList
+            .add('amp-sidebar-toolbar-target-hidden');
+        this.toolbarDomElement_.classList
+            .remove('amp-sidebar-toolbar-target-shown');
+      }
+      this.toolbarShown_ = false;
+    });
+  }
+}

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,11 +21,13 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>A sidebar provides a way to display meta content intended for temporary access (navigation links, buttons, menus, etc.).The sidebar can be revealed by a button tap while the main content remains visually underneath.</td>
+    <td>
+    A sidebar provides a way to display meta content intended for temporary access (navigation links, buttons, menus, etc.). The sidebar can be revealed by a button tap while the main content remains visually underneath.
+    </td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
-    <td><code>&lt;script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js">&lt;/script></code></td>
+    <td><code>&lt;script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-1.0.js">&lt;/script></code></td>
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
@@ -36,6 +38,12 @@ limitations under the License.
     <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-sidebar/">amp-sidebar example</a>.</td>
   </tr>
 </table>
+
+## Overview
+`<amp-sidebar>` hides meta content intended for temporary access (navigation links, buttons, menus, etc.). `<amp-sidebar>` can be opened and closed by button taps, and tapping outside of amp-sidebar.
+However, optional attributes that accept media queries can be used to display meta content in other parts of the site. Child `<nav toolbar="(media query)" toolbar-target="elementID">` elements allow
+for content within the sidebar to be displayed on other parts of the main content.
+
 
 ## Behavior
 
@@ -53,17 +61,17 @@ limitations under the License.
 - The width of the sidebar can be set and adjusted between 45px and 80vw using CSS.
 - Touch zoom is disabled on the `amp-sidebar` and it's mask when the sidebar is open.
 
-Example:
+*Example:*
 
 ```html
-<amp-sidebar id="sidebar1" layout="nodisplay" side="right">
+<amp-sidebar id="sidebar1" layout="nodisplay">
   <ul>
-    <li> Nav item 1</li>
-    <li> Nav item 2</li>
-    <li> Nav item 3</li>
-    <li> Nav item 4</li>
-    <li> Nav item 5</li>
-    <li> Nav item 6</li>
+    <li>Nav item 1</li>
+    <li>Nav item 2</li>
+    <li>Nav item 3</li>
+    <li>Nav item 4</li>
+    <li>Nav item 5</li>
+    <li>Nav item 6</li>
   </ul>
 </amp-sidebar>
 ```
@@ -95,7 +103,7 @@ If the user taps back on the partially-visible main content area, this closes th
 
 Alternatively, pressing the escape key on the keyboard will also close the sidebar.
 
-Example:
+*Example:*
 
 ```html
 <button class="hamburger" on='tap:sidebar1.toggle'></button>
@@ -103,6 +111,89 @@ Example:
 <button on='tap:sidebar1.open'>Open</button>
 <button on='tap:sidebar1.close'>x</button>
 ```
+
+### Toolbar
+
+You can create a `toolbar` element that displays in the `<body>` by specifying the `toolbar` attribute with a media query and a `toolbar-target` attribute with an element id on a `<nav>` element that is a child of  `<amp-sidebar>`. The `toolbar` duplicates the `<nav>` element and its children and appends the element into the `toolbar-target` element.
+
+#### Behavior
+
+- The sidebar may implement toolbars by adding nav elements with the `toolbar` attribute and `toolbar-target` attribute.
+- The nav element must be a child of `<amp-sidebar>` and follow this format: `<nav toolbar="(media-query)" toolbar-target="elementID">`.
+    - For instance, this would be a valid use of toolbar: `<nav toolbar="(max-width: 1024px)" toolbar-target="target-element">`.
+- The nav containing the toolbar attribute must only contain a single `<ul>` element, that contains `<li>` elements.
+    - The `<li>` elements may contain any valid HTML elements (supported by AMP), or any of the AMP elements that `<amp-sidebar>` supports.
+- Toolbar behavior is only applied while the `toolbar` attribute media-query is valid. Also, an element with the `toolbar-target` attribute id must exist on the page for the toolbar to be applied.
+
+*Example: Basic Toolbar*
+
+In the following example, we display a `toolbar` if the window width is less than or equal to 767px. The `toolbar` contains a search input element. The `toolbar` element will be appended to the `<div id="target-element">` element.
+
+```html
+<amp-sidebar id="sidebar1" layout="nodisplay" side="right">
+  <ul>
+    <li>Nav item 1</li>
+    <li>Nav item 2</li>
+    <li>Nav item 3</li>
+    <li>Nav item 4</li>
+    <li>Nav item 5</li>
+    <li>Nav item 6</li>
+  </ul>
+
+  <nav toolbar="(max-width: 767px)" toolbar-target="target-element">
+    <ul>
+      <li>
+        <input placeholder="Search..."/>
+      </li>
+    </ul>
+  </nav>
+</amp-sidebar>
+
+<div id="target-element">
+</div>
+```
+
+## Styling Toolbar
+
+The `toolbar` element within the `<amp-sidebar>` element, will have classes applied to the element depending if the `toolbar-target` element is shown or hidden. This is useful for applying different styles on the `toolbar` element and then `toolbar-target` element. The classes are `amp-sidebar-toolbar-target-shown`, and `amp-sidebar-toolbar-target-hidden`. The class `amp-sidebar-toolbar-target-shown` is applied to the `toolbar` element when the `toolbar-target` element is shown. The class `amp-sidebar-toolbar-target-hidden` is applied to the `toolbar` element when the `toolbar-target` element is hidden.
+
+*Example: Toolbar State Classes*
+
+In the following example, we display a `toolbar` if the window width is less than or equal to 767px. The `toolbar` contains a search input element. The `toolbar` element will be appended to the `<div id="target-element">` element. However, we added some custom styles to hide the `toolbar` element, when the `<div id="toolbar-target">` element is shown.
+
+```html
+<style amp-custom="">
+
+  .amp-sidebar-toolbar-target-shown {
+      display: none;
+  }
+
+</style>
+
+<amp-sidebar id="sidebar1" layout="nodisplay" side="right">
+  <ul>
+    <li>Nav item 1</li>
+    <li>Nav item 2</li>
+    <li>Nav item 3</li>
+    <li>Nav item 4</li>
+    <li>Nav item 5</li>
+    <li>Nav item 6</li>
+  </ul>
+
+  <nav toolbar="(max-width: 767px)" toolbar-target="target-element">
+    <ul>
+      <li>
+        <input placeholder="Search..."/>
+      </li>
+    </ul>
+  </nav>
+</amp-sidebar>
+
+<div id="target-element">
+</div>
+```
+
+
 
 {% call callout('Tip', type='success') %}
 See live demos at [AMP By Example](https://ampbyexample.com/components/amp-sidebar/).
@@ -122,9 +213,19 @@ Specifies the display layout of the sidebar, which must be `nodisplay`.
 
 This attribute is present when the sidebar is open.
 
+
 ##### data-close-button-aria-label
 
-An optional attribute used for accessibility to set the ARIA label for the close button.
+Optional attribute used to set ARIA label for the close button added for accessibility.
+
+
+##### toolbar
+
+This attribute is present on child `<nav toolbar="(media-query)" toolbar-target="elementID">` elements, and accepts a media query of when to show a toolbar. See the [Toolbar](#toolbar) section for more information on using toolbars.
+
+##### toolbar-target
+
+This attribute is present on child `<nav toolbar="(media-query)" toolbar-target="elementID">`, and accepts an id of an element on the page.  The `toolbar-target` attribute will place the toolbar into the specified id of the element on the page, without the default toolbar styling. See the [Toolbar](#toolbar) section for more information on using toolbars.
 
 ##### common attributes
 

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -27,7 +27,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
-    <td><code>&lt;script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-1.0.js">&lt;/script></code></td>
+    <td><code>&lt;script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -76,6 +76,27 @@ for content within the sidebar to be displayed on other parts of the main conten
 </amp-sidebar>
 ```
 
+*Example: Advanced usage of `amp-sidebar` with anchor links and smooth scrolling*
+
+In the following example, we use `amp-sidebar` to contain navigation links to other parts of the page. The links are assigned to element id that is on the page. By using the [`on`](../../spec/amp-actions-and-events.md) attribute, we can scroll smoothly to the elements, using the element id and `scrollTo`.
+
+```html
+<amp-sidebar id="sidebar1" layout="nodisplay">
+  <ul>
+    <li><a href="#idOne" on="tap:idOne.scrollTo">Nav item 1</a></li>
+    <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>
+    <li><a href="#idThree" on="tap:idThree.scrollTo">Nav item 3</a></li>
+  </ul>
+</amp-sidebar>
+
+<div id="idOne">
+</div>
+<div id="idTwo">
+</div>
+<div id="idThree">
+</div>
+```
+
 ### Opening and closing the sidebar
 
 To toggle, open, or close the sidebar when an element is tapped or clicked, set the [`on`](../../spec/amp-actions-and-events.md) action attribute on the element, and specify one of the following action methods:

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -63,37 +63,21 @@ for content within the sidebar to be displayed on other parts of the main conten
 
 *Example:*
 
+In the following example, we use `amp-sidebar` to contain navigation items. However, The second item, Nav Item 2, is assigned to element id that is on the page. By using the [`on`](../../spec/amp-actions-and-events.md) attribute, we can scroll smoothly to the element, using the element id and `scrollTo`.
+
 ```html
 <amp-sidebar id="sidebar1" layout="nodisplay">
   <ul>
     <li>Nav item 1</li>
-    <li>Nav item 2</li>
+    <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>
     <li>Nav item 3</li>
     <li>Nav item 4</li>
     <li>Nav item 5</li>
     <li>Nav item 6</li>
   </ul>
 </amp-sidebar>
-```
 
-*Example: Advanced usage of `amp-sidebar` with anchor links and smooth scrolling*
-
-In the following example, we use `amp-sidebar` to contain navigation links to other parts of the page. The links are assigned to element id that is on the page. By using the [`on`](../../spec/amp-actions-and-events.md) attribute, we can scroll smoothly to the elements, using the element id and `scrollTo`.
-
-```html
-<amp-sidebar id="sidebar1" layout="nodisplay">
-  <ul>
-    <li><a href="#idOne" on="tap:idOne.scrollTo">Nav item 1</a></li>
-    <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>
-    <li><a href="#idThree" on="tap:idThree.scrollTo">Nav item 3</a></li>
-  </ul>
-</amp-sidebar>
-
-<div id="idOne">
-</div>
 <div id="idTwo">
-</div>
-<div id="idThree">
 </div>
 ```
 

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -66,7 +66,7 @@ for content within the sidebar to be displayed on other parts of the main conten
 In the following example, we use `amp-sidebar` to contain navigation items. However, The second and fourth item, Nav Item 2 and Nav Item 4, are assigned to element id that is on the page. By using the [`on`](../../spec/amp-actions-and-events.md) attribute, we can scroll smoothly to the element, using the element id and `scrollTo`.
 
 ```html
-<amp-sidebar id="sidebar1" layout="nodisplay">
+<amp-sidebar id="sidebar1" layout="nodisplay" side="right">
   <ul>
     <li>Nav item 1</li>
     <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>
@@ -76,11 +76,6 @@ In the following example, we use `amp-sidebar` to contain navigation items. Howe
     <li>Nav item 6</li>
   </ul>
 </amp-sidebar>
-
-<div id="idTwo">
-</div>
-<div id="idFour">
-</div>
 ```
 
 ### Opening and closing the sidebar
@@ -158,10 +153,6 @@ In the following example, we display a `toolbar` if the window width is less tha
 
 <div id="target-element">
 </div>
-<div id="idTwo">
-</div>
-<div id="idFour">
-</div>
 ```
 
 ## Styling Toolbar
@@ -201,10 +192,6 @@ In the following example, we display a `toolbar` if the window width is less tha
 </amp-sidebar>
 
 <div id="target-element">
-</div>
-<div id="idTwo">
-</div>
-<div id="idFour">
 </div>
 ```
 

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -63,7 +63,7 @@ for content within the sidebar to be displayed on other parts of the main conten
 
 *Example:*
 
-In the following example, we use `amp-sidebar` to contain navigation items. However, The second item, Nav Item 2, is assigned to element id that is on the page. By using the [`on`](../../spec/amp-actions-and-events.md) attribute, we can scroll smoothly to the element, using the element id and `scrollTo`.
+In the following example, we use `amp-sidebar` to contain navigation items. However, The second and fourth item, Nav Item 2 and Nav Item 4, are assigned to element id that is on the page. By using the [`on`](../../spec/amp-actions-and-events.md) attribute, we can scroll smoothly to the element, using the element id and `scrollTo`.
 
 ```html
 <amp-sidebar id="sidebar1" layout="nodisplay">
@@ -71,13 +71,15 @@ In the following example, we use `amp-sidebar` to contain navigation items. Howe
     <li>Nav item 1</li>
     <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>
     <li>Nav item 3</li>
-    <li>Nav item 4</li>
+    <li><a href="#idFour" on="tap:idFour.scrollTo">Nav item 4</a></li>
     <li>Nav item 5</li>
     <li>Nav item 6</li>
   </ul>
 </amp-sidebar>
 
 <div id="idTwo">
+</div>
+<div id="idFour">
 </div>
 ```
 
@@ -117,7 +119,7 @@ Alternatively, pressing the escape key on the keyboard will also close the sideb
 <button on='tap:sidebar1.close'>x</button>
 ```
 
-### Toolbar
+### Toolbar (Experimental)
 
 You can create a `toolbar` element that displays in the `<body>` by specifying the `toolbar` attribute with a media query and a `toolbar-target` attribute with an element id on a `<nav>` element that is a child of  `<amp-sidebar>`. The `toolbar` duplicates the `<nav>` element and its children and appends the element into the `toolbar-target` element.
 
@@ -138,9 +140,9 @@ In the following example, we display a `toolbar` if the window width is less tha
 <amp-sidebar id="sidebar1" layout="nodisplay" side="right">
   <ul>
     <li>Nav item 1</li>
-    <li>Nav item 2</li>
+    <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>
     <li>Nav item 3</li>
-    <li>Nav item 4</li>
+    <li><a href="#idFour" on="tap:idFour.scrollTo">Nav item 4</a></li>
     <li>Nav item 5</li>
     <li>Nav item 6</li>
   </ul>
@@ -155,6 +157,10 @@ In the following example, we display a `toolbar` if the window width is less tha
 </amp-sidebar>
 
 <div id="target-element">
+</div>
+<div id="idTwo">
+</div>
+<div id="idFour">
 </div>
 ```
 
@@ -178,9 +184,9 @@ In the following example, we display a `toolbar` if the window width is less tha
 <amp-sidebar id="sidebar1" layout="nodisplay" side="right">
   <ul>
     <li>Nav item 1</li>
-    <li>Nav item 2</li>
+    <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>
     <li>Nav item 3</li>
-    <li>Nav item 4</li>
+    <li><a href="#idFour" on="tap:idFour.scrollTo">Nav item 4</a></li>
     <li>Nav item 5</li>
     <li>Nav item 6</li>
   </ul>
@@ -195,6 +201,10 @@ In the following example, we display a `toolbar` if the window width is less tha
 </amp-sidebar>
 
 <div id="target-element">
+</div>
+<div id="idTwo">
+</div>
+<div id="idFour">
 </div>
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,6 +109,7 @@ declareExtension('amp-reach-player', '0.1', false);
 declareExtension('amp-reddit', '0.1', false);
 declareExtension('amp-share-tracking', '0.1', false);
 declareExtension('amp-sidebar', '0.1', true);
+declareExtension('amp-sidebar', '1.0', true);
 declareExtension('amp-soundcloud', '0.1', false);
 declareExtension('amp-springboard-player', '0.1', false);
 declareExtension('amp-sticky-ad', '1.0', true);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,34 +16,34 @@
 
 checkMinVersion();
 
-var $$ = require('gulp-load-plugins')();
-var babel = require('babelify');
-var browserify = require('browserify');
-var buffer = require('vinyl-buffer');
-var closureCompile = require('./build-system/tasks/compile').closureCompile;
-var cleanupBuildDir = require('./build-system/tasks/compile').cleanupBuildDir;
-var jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
-var fs = require('fs-extra');
-var gulp = $$.help(require('gulp'));
-var lazypipe = require('lazypipe');
-var minimatch = require('minimatch');
-var minimist = require('minimist');
-var source = require('vinyl-source-stream');
-var touch = require('touch');
-var watchify = require('watchify');
-var internalRuntimeVersion = require('./build-system/internal-version').VERSION;
-var internalRuntimeToken = require('./build-system/internal-version').TOKEN;
+const $$ = require('gulp-load-plugins')();
+const babel = require('babelify');
+const browserify = require('browserify');
+const buffer = require('vinyl-buffer');
+const closureCompile = require('./build-system/tasks/compile').closureCompile;
+const cleanupBuildDir = require('./build-system/tasks/compile').cleanupBuildDir;
+const jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
+const fs = require('fs-extra');
+const gulp = $$.help(require('gulp'));
+const lazypipe = require('lazypipe');
+const minimatch = require('minimatch');
+const minimist = require('minimist');
+const source = require('vinyl-source-stream');
+const touch = require('touch');
+const watchify = require('watchify');
+const internalRuntimeVersion = require('./build-system/internal-version').VERSION;
+const internalRuntimeToken = require('./build-system/internal-version').TOKEN;
 
-var argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
+const argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
 
 require('./build-system/tasks');
 
-var hostname = argv.hostname || 'cdn.ampproject.org';
-var hostname3p = argv.hostname3p || '3p.ampproject.net';
+const hostname = argv.hostname || 'cdn.ampproject.org';
+const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 // All declared extensions.
-var extensions = {};
-var extensionAliasFilePath = {};
+const extensions = {};
+const extensionAliasFilePath = {};
 
 // Each extension and version must be listed individually here.
 declareExtension('amp-3q-player', '0.1', false);
@@ -109,7 +109,6 @@ declareExtension('amp-reach-player', '0.1', false);
 declareExtension('amp-reddit', '0.1', false);
 declareExtension('amp-share-tracking', '0.1', false);
 declareExtension('amp-sidebar', '0.1', true);
-declareExtension('amp-sidebar', '1.0', true);
 declareExtension('amp-soundcloud', '0.1', false);
 declareExtension('amp-springboard-player', '0.1', false);
 declareExtension('amp-sticky-ad', '1.0', true);
@@ -147,17 +146,17 @@ declareExtensionVersionAlias(
  *   or an extension options object.
  */
 function declareExtension(name, version, hasCssOrOptions) {
-  var hasCss = false;
-  var options = {};
+  let hasCss = false;
+  let options = {};
   if (typeof hasCssOrOptions == 'boolean') {
     hasCss = hasCssOrOptions;
   } else {
-    options = hasCssOrOptions
+    options = hasCssOrOptions;
   }
   extensions[name + '-' + version] = Object.assign({
-    name: name,
-    version: version,
-    hasCss: hasCss,
+    name,
+    version,
+    hasCss,
   }, options);
 }
 
@@ -192,7 +191,7 @@ function endBuildStep(stepName, targetName, startTime) {
   const executionTime = new Date(endTime - startTime);
   const secs = executionTime.getSeconds();
   const ms = executionTime.getMilliseconds().toString().padStart(3, '0');
-  var timeString = '(';
+  let timeString = '(';
   if (secs === 0) {
     timeString += ms + ' ms)';
   } else {
@@ -213,10 +212,10 @@ function endBuildStep(stepName, targetName, startTime) {
  * @return {!Promise}
  */
 function buildExtensions(options) {
-  var results = [];
-  for (var key in extensions) {
-    var e = extensions[key];
-    var o = Object.assign({}, options);
+  const results = [];
+  for (const key in extensions) {
+    const e = extensions[key];
+    let o = Object.assign({}, options);
     o = Object.assign(o, e);
     results.push(buildExtension(e.name, e.version, e.hasCss, o, e.extraGlobs));
   }
@@ -243,40 +242,40 @@ function polyfillsForTests() {
  */
 function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     opt_checkTypes) {
-  var promises = [
+  const promises = [
     compileJs('./3p/', 'integration.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-      minifiedName: 'f.js',
-      checkTypes: opt_checkTypes,
-      watch: watch,
-      minify: shouldMinify,
-      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-      externs: ['ads/ads.extern.js',],
-      include3pDirectories: true,
-      includePolyfills: true,
-    }),
+          minifiedName: 'f.js',
+          checkTypes: opt_checkTypes,
+          watch,
+          minify: shouldMinify,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: true,
+        }),
     compileJs('./3p/', 'ampcontext-lib.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-      minifiedName: 'ampcontext-v0.js',
-      checkTypes: opt_checkTypes,
-      watch: watch,
-      minify: shouldMinify,
-      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-      externs: ['ads/ads.extern.js',],
-      include3pDirectories: true,
-      includePolyfills: false,
-    }),
+          minifiedName: 'ampcontext-v0.js',
+          checkTypes: opt_checkTypes,
+          watch,
+          minify: shouldMinify,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: false,
+        }),
     compileJs('./3p/', 'iframe-transport-client-lib.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-      minifiedName: 'iframe-transport-client-v0.js',
-      checkTypes: opt_checkTypes,
-      watch: watch,
-      minify: shouldMinify,
-      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-      externs: ['ads/ads.extern.js',],
-      include3pDirectories: true,
-      includePolyfills: false,
-    }),
+          minifiedName: 'iframe-transport-client-v0.js',
+          checkTypes: opt_checkTypes,
+          watch,
+          minify: shouldMinify,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: false,
+        }),
     // For compilation with babel we start with the amp-babel entry point,
     // but then rename to the amp.js which we've been using all along.
     compileJs('./src/', 'amp-babel.js', './dist', {
@@ -284,7 +283,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
       minifiedName: 'v0.js',
       includePolyfills: true,
       checkTypes: opt_checkTypes,
-      watch: watch,
+      watch,
       preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
       minify: shouldMinify,
       // If there is a sync JS error during initial load,
@@ -295,19 +294,19 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
           's.opacity=1;' +
           's.visibility="visible";' +
           's.animation="none";' +
-          's.WebkitAnimation="none;"},1000);throw e};'
+          's.WebkitAnimation="none;"},1000);throw e};',
     }),
     compileJs('./extensions/amp-viewer-integration/0.1/examples/',
-      'amp-viewer-host.js', './dist/v0/examples', {
-        toName: 'amp-viewer-host.max.js',
-        minifiedName: 'amp-viewer-host.js',
-        incudePolyfills: true,
-        watch: watch,
-        extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
-        compilationLevel: 'WHITESPACE_ONLY',
-        preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-        minify: false,
-      }),
+        'amp-viewer-host.js', './dist/v0/examples', {
+          toName: 'amp-viewer-host.max.js',
+          minifiedName: 'amp-viewer-host.js',
+          incudePolyfills: true,
+          watch,
+          extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
+          compilationLevel: 'WHITESPACE_ONLY',
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: false,
+        }),
   ];
 
   // We don't rerun type check for the shadow entry point for now.
@@ -315,53 +314,53 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     if (!watch || argv.with_shadow) {
       promises.push(
         // Entry point for shadow runtime.
-        compileJs('./src/', 'amp-shadow-babel.js', './dist', {
-          toName: 'amp-shadow.js',
-          minifiedName: 'shadow-v0.js',
-          includePolyfills: true,
-          checkTypes: opt_checkTypes,
-          watch: watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          minify: shouldMinify,
-          wrapper: '<%= contents %>'
-        })
+          compileJs('./src/', 'amp-shadow-babel.js', './dist', {
+            toName: 'amp-shadow.js',
+            minifiedName: 'shadow-v0.js',
+            includePolyfills: true,
+            checkTypes: opt_checkTypes,
+            watch,
+            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+            minify: shouldMinify,
+            wrapper: '<%= contents %>',
+          })
       );
     }
 
     if (!watch || argv.with_inabox) {
       promises.push(
         // Entry point for inabox runtime.
-        compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
-          toName: 'amp-inabox.js',
-          minifiedName: 'amp4ads-v0.js',
-          includePolyfills: true,
-          extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
-          checkTypes: opt_checkTypes,
-          watch: watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          minify: shouldMinify,
-          wrapper: '<%= contents %>',
-        }),
+          compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
+            toName: 'amp-inabox.js',
+            minifiedName: 'amp4ads-v0.js',
+            includePolyfills: true,
+            extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
+            checkTypes: opt_checkTypes,
+            watch,
+            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+            minify: shouldMinify,
+            wrapper: '<%= contents %>',
+          }),
 
         // inabox-host
-        compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
-          toName: 'amp-inabox-host.js',
-          minifiedName: 'amp4ads-host-v0.js',
-          includePolyfills: false,
-          checkTypes: opt_checkTypes,
-          watch: watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          minify: shouldMinify,
-          wrapper: '<%= contents %>',
-        })
+          compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
+            toName: 'amp-inabox-host.js',
+            minifiedName: 'amp4ads-host-v0.js',
+            includePolyfills: false,
+            checkTypes: opt_checkTypes,
+            watch,
+            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+            minify: shouldMinify,
+            wrapper: '<%= contents %>',
+          })
       );
     }
 
     promises.push(
-      thirdPartyBootstrap(
-          '3p/frame.max.html', 'frame.html', shouldMinify),
-      thirdPartyBootstrap(
-          '3p/nameframe.max.html', 'nameframe.html',shouldMinify)
+        thirdPartyBootstrap(
+            '3p/frame.max.html', 'frame.html', shouldMinify),
+        thirdPartyBootstrap(
+            '3p/nameframe.max.html', 'nameframe.html',shouldMinify)
     );
 
     if (watch) {
@@ -386,26 +385,26 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
 function compileCss() {
   const startTime = Date.now();
   return jsifyCssAsync('css/amp.css')
-  .then(function(css) {
-    return toPromise(gulp.src('css/**.css')
-          .pipe($$.file('css.js', 'export const cssText = ' +
+      .then(function(css) {
+        return toPromise(gulp.src('css/**.css')
+            .pipe($$.file('css.js', 'export const cssText = ' +
               JSON.stringify(css)))
-          .pipe(gulp.dest('build'))
-          .on('end', function() {
-            mkdirSync('build');
-            mkdirSync('build/css');
-            fs.writeFileSync('build/css/v0.css', css);
-          }));
-  })
-  .then(() => {
-    endBuildStep('Recompiled CSS in', 'amp.css', startTime);
-  })
-  .then(() => {
-    return buildExtensions({
-      bundleOnlyIfListedInFiles: true,
-      compileOnlyCss: true
-    });
-  });
+            .pipe(gulp.dest('build'))
+            .on('end', function() {
+              mkdirSync('build');
+              mkdirSync('build/css');
+              fs.writeFileSync('build/css/v0.css', css);
+            }));
+      })
+      .then(() => {
+        endBuildStep('Recompiled CSS in', 'amp.css', startTime);
+      })
+      .then(() => {
+        return buildExtensions({
+          bundleOnlyIfListedInFiles: true,
+          compileOnlyCss: true,
+        });
+      });
 }
 
 /**
@@ -465,9 +464,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
   if (options.compileOnlyCss && !hasCss) {
     return Promise.resolve();
   }
-  var path = 'extensions/' + name + '/' + version;
-  var jsPath = path + '/' + name + '.js';
-  var jsTestPath = path + '/test/' + 'test-' + name + '.js';
+  const path = 'extensions/' + name + '/' + version;
+  const jsPath = path + '/' + name + '.js';
+  const jsTestPath = path + '/test/' + 'test-' + name + '.js';
   if (argv.files && options.bundleOnlyIfListedInFiles) {
     const passedFiles = Array.isArray(argv.files) ? argv.files : [argv.files];
     const shouldBundle = passedFiles.some(glob => {
@@ -482,7 +481,7 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
   // it to the destination and adds the CSS.
   if (options.watch) {
     // Do not set watchers again when we get called by the watcher.
-    var copy = Object.create(options);
+    const copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildExtension(name, version, hasCss, copy);
@@ -493,9 +492,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
     mkdirSync('build/css');
     const startTime = Date.now();
     return jsifyCssAsync(path + '/' + name + '.css').then(function(css) {
-      var jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
-      var jsName = 'build/' + name + '-' + version + '.css.js';
-      var cssName = 'build/css/' + name + '-' + version + '.css';
+      const jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
+      const jsName = 'build/' + name + '-' + version + '.css.js';
+      const cssName = 'build/css/' + name + '-' + version + '.css';
       fs.writeFileSync(jsName, jsCss, 'utf-8');
       fs.writeFileSync(cssName, css, 'utf-8');
       if (options.compileOnlyCss) {
@@ -503,9 +502,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
       }
       return buildExtensionJs(path, name, version, options);
     })
-    .then(() => {
-      endBuildStep('Recompiled CSS in', name, startTime);
-    });
+        .then(() => {
+          endBuildStep('Recompiled CSS in', name, startTime);
+        });
   } else {
     return buildExtensionJs(path, name, version, options);
   }
@@ -523,16 +522,16 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
  * @return {!Promise}
  */
 function buildExtensionJs(path, name, version, options) {
-  var filename = options.filename || name + '.js';
+  const filename = options.filename || name + '.js';
   if (options.loadPriority && options.loadPriority != 'high') {
     throw new Error('Unsupported loadPriority: ' + options.loadPriority);
   }
-  var priority = options.loadPriority ? 'p:"high",' : '';
+  const priority = options.loadPriority ? 'p:"high",' : '';
   return compileJs(path + '/', filename, './dist/v0', {
     watch: options.watch,
     preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
     minify: options.minify,
-    toName:  name + '-' + version + '.max.js',
+    toName: name + '-' + version + '.max.js',
     minifiedName: name + '-' + version + '.js',
     latestName: name + '-latest.js',
     extraGlobs: options.extraGlobs,
@@ -552,9 +551,9 @@ function buildExtensionJs(path, name, version, options) {
  * Writes the AMP config to file if AMP_TESTING_HOST is set.
  */
 function writeAmpConfig() {
-  var TESTING_HOST = process.env.AMP_TESTING_HOST;
+  const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (argv.fortesting && typeof TESTING_HOST == 'string') {
-    var AMP_CONFIG = {
+    let AMP_CONFIG = {
       thirdPartyFrameHost: TESTING_HOST,
       thirdPartyFrameRegex: TESTING_HOST,
       localDev: true,
@@ -621,7 +620,7 @@ function dist() {
  * Copy built extension to alias extension
  */
 function copyAliasExtensions() {
-  for (var key in extensionAliasFilePath) {
+  for (const key in extensionAliasFilePath) {
     fs.copySync('dist/v0/' + extensionAliasFilePath[key], 'dist/v0/' + key);
   }
 }
@@ -640,7 +639,7 @@ function checkTypes() {
     checkTypes: true,
     preventRemoveAndMakeDir: true,
   });*/
-  var compileSrcs = [
+  const compileSrcs = [
     './src/amp-babel.js',
     './src/amp-shadow.js',
     './src/inabox/amp-inabox.js',
@@ -651,7 +650,7 @@ function checkTypes() {
     './src/service-worker/kill.js',
     './src/web-worker/web-worker.js',
   ];
-  var extensionSrcs = Object.values(extensions).filter(function(extension) {
+  const extensionSrcs = Object.values(extensions).filter(function(extension) {
     return !extension.noTypeCheck;
   }).map(function(extension) {
     return './extensions/' + extension.name + '/' +
@@ -668,26 +667,26 @@ function checkTypes() {
           }),
       // Type check 3p/ads code.
       closureCompile(['./3p/integration.js'], './dist',
-        'integration-check-types.js', {
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: true,
-          checkTypes: true,
-        }),
+          'integration-check-types.js', {
+            externs: ['ads/ads.extern.js'],
+            include3pDirectories: true,
+            includePolyfills: true,
+            checkTypes: true,
+          }),
       closureCompile(['./3p/ampcontext-lib.js'], './dist',
-        'ampcontext-check-types.js', {
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: true,
-          checkTypes: true,
-        }),
+          'ampcontext-check-types.js', {
+            externs: ['ads/ads.extern.js'],
+            include3pDirectories: true,
+            includePolyfills: true,
+            checkTypes: true,
+          }),
       closureCompile(['./3p/iframe-transport-client-lib.js'], './dist',
-        'iframe-transport-client-check-types.js', {
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: true,
-          checkTypes: true,
-        }),
+          'iframe-transport-client-check-types.js', {
+            externs: ['ads/ads.extern.js'],
+            include3pDirectories: true,
+            includePolyfills: true,
+            checkTypes: true,
+          }),
     ]);
   });
 }
@@ -715,16 +714,16 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
   // actual frame host for the JS inside the frame.
   // But during testing we need a relative reference because the
   // version is not available on the absolute path.
-  var integrationJs = argv.fortesting
+  const integrationJs = argv.fortesting
       ? './f.js'
       : `https://${hostname3p}/${internalRuntimeVersion}/f.js`;
   // Convert default relative URL to absolute min URL.
-  var html = fs.readFileSync(input, 'utf8')
+  const html = fs.readFileSync(input, 'utf8')
       .replace(/\.\/integration\.js/g, integrationJs);
   return toPromise($$.file(outputName, html, {src: true})
       .pipe(gulp.dest('dist.3p/' + internalRuntimeVersion))
       .on('end', function() {
-        var aliasToLatestBuild = 'dist.3p/current-min';
+        const aliasToLatestBuild = 'dist.3p/current-min';
         if (fs.existsSync(aliasToLatestBuild)) {
           fs.unlinkSync(aliasToLatestBuild);
         }
@@ -745,7 +744,7 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
  * @param {Array<string>} files List of file paths to concatenate
  */
 function concatFiles(destFilePath, files) {
-  var all = files.map(function(filePath) {
+  const all = files.map(function(filePath) {
     return fs.readFileSync(filePath, 'utf-8');
   });
 
@@ -808,15 +807,15 @@ function compileJs(srcDir, srcFilename, destDir, options) {
         });
   }
 
-  var bundler = browserify(srcDir + srcFilename, {debug: true})
+  let bundler = browserify(srcDir + srcFilename, {debug: true})
       .transform(babel, {loose: argv.strictBabelTransform ? undefined : 'all'});
   if (options.watch) {
     bundler = watchify(bundler);
   }
 
-  var wrapper = options.wrapper || '<%= contents %>';
+  const wrapper = options.wrapper || '<%= contents %>';
 
-  var lazybuild = lazypipe()
+  const lazybuild = lazypipe()
       .pipe(source, srcFilename)
       .pipe(buffer)
       .pipe($$.replace, /\$internalRuntimeVersion\$/g, internalRuntimeVersion)
@@ -824,29 +823,29 @@ function compileJs(srcDir, srcFilename, destDir, options) {
       .pipe($$.wrap, wrapper)
       .pipe($$.sourcemaps.init.bind($$.sourcemaps), {loadMaps: true});
 
-  var lazywrite = lazypipe()
+  const lazywrite = lazypipe()
       .pipe($$.sourcemaps.write.bind($$.sourcemaps), './')
       .pipe(gulp.dest.bind(gulp), destDir);
 
-  var destFilename = options.toName || srcFilename;
+  const destFilename = options.toName || srcFilename;
   function rebundle() {
     const startTime = Date.now();
     return toPromise(bundler.bundle()
-      .on('error', function(err) {
-        if (err instanceof SyntaxError) {
-          console.error($$.util.colors.red('Syntax error:', err.message));
-        } else {
-          console.error($$.util.colors.red(err.message));
-        }
-      })
-      .pipe(lazybuild())
-      .pipe($$.rename(destFilename))
-      .pipe(lazywrite())
-      .on('end', function() {
-        appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
-      })).then(() => {
-        endBuildStep('Compiled', srcFilename, startTime);
-      });
+        .on('error', function(err) {
+          if (err instanceof SyntaxError) {
+            console.error($$.util.colors.red('Syntax error:', err.message));
+          } else {
+            console.error($$.util.colors.red(err.message));
+          }
+        })
+        .pipe(lazybuild())
+        .pipe($$.rename(destFilename))
+        .pipe(lazywrite())
+        .on('end', function() {
+          appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
+        })).then(() => {
+          endBuildStep('Compiled', srcFilename, startTime);
+        });
   }
 
   if (options.watch) {
@@ -879,10 +878,10 @@ function compileJs(srcDir, srcFilename, destDir, options) {
  */
 function buildExperiments(options) {
   options = options || {};
-  var path = 'tools/experiments';
-  var htmlPath = path + '/experiments.html';
-  var jsPath = path + '/experiments.js';
-  var watch = options.watch;
+  const path = 'tools/experiments';
+  const htmlPath = path + '/experiments.html';
+  const jsPath = path + '/experiments.js';
+  let watch = options.watch;
   if (watch === undefined) {
     watch = argv.watch || argv.w;
   }
@@ -892,7 +891,7 @@ function buildExperiments(options) {
   // it to the destination and adds the CSS.
   if (watch) {
     // Do not set watchers again when we get called by the watcher.
-    var copy = Object.create(options);
+    const copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildExperiments(copy);
@@ -900,17 +899,17 @@ function buildExperiments(options) {
   }
 
   // Build HTML.
-  var html = fs.readFileSync(htmlPath, 'utf8');
-  var minHtml = html.replace('/dist.tools/experiments/experiments.js',
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const minHtml = html.replace('/dist.tools/experiments/experiments.js',
       `https://${hostname}/v0/experiments.js`);
   gulp.src(htmlPath)
       .pipe($$.file('experiments.cdn.html', minHtml))
       .pipe(gulp.dest('dist.tools/experiments/'));
 
   // Build JS.
-  var js = fs.readFileSync(jsPath, 'utf8');
-  var builtName = 'experiments.max.js';
-  var minifiedName = 'experiments.js';
+  const js = fs.readFileSync(jsPath, 'utf8');
+  const builtName = 'experiments.max.js';
+  const minifiedName = 'experiments.js';
   return toPromise(gulp.src(path + '/*.js')
       .pipe($$.file(builtName, js))
       .pipe(gulp.dest('build/experiments/')))
@@ -920,7 +919,7 @@ function buildExperiments(options) {
               watch: false,
               minify: options.minify || argv.minify,
               includePolyfills: true,
-              minifiedName: minifiedName,
+              minifiedName,
               preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
               checkTypes: options.checkTypes,
             });
@@ -945,7 +944,7 @@ function buildWebPushPublisherFiles(options) {
  */
 function buildWebPushPublisherFilesVersion(version, options) {
   options = options || {};
-  var watch = options.watch;
+  let watch = options.watch;
   if (watch === undefined) {
     watch = argv.watch || argv.w;
   }
@@ -955,21 +954,21 @@ function buildWebPushPublisherFilesVersion(version, options) {
   // it to the destination and adds the CSS.
   if (watch) {
     // Do not set watchers again when we get called by the watcher.
-    var copy = Object.create(options);
+    const copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildWebPushPublisherFiles(version, copy);
     });
   }
 
-  var fileNames = ['amp-web-push-helper-frame', 'amp-web-push-permission-dialog'];
-  var promises = [];
+  const fileNames = ['amp-web-push-helper-frame', 'amp-web-push-permission-dialog'];
+  const promises = [];
 
   mkdirSync('dist');
   mkdirSync('dist/v0');
 
-  for (var i = 0; i < fileNames.length; i++) {
-    var fileName = fileNames[i];
+  for (let i = 0; i < fileNames.length; i++) {
+    const fileName = fileNames[i];
     promises.push(buildWebPushPublisherFile(version, fileName, watch, options));
   }
 
@@ -977,40 +976,40 @@ function buildWebPushPublisherFilesVersion(version, options) {
 }
 
 function buildWebPushPublisherFile(version, fileName, watch, options) {
-  var basePath = 'extensions/amp-web-push/' + version + '/';
-  var tempBuildDir = 'build/all/v0/';
-  var distDir = 'dist/v0';
+  const basePath = 'extensions/amp-web-push/' + version + '/';
+  const tempBuildDir = 'build/all/v0/';
+  const distDir = 'dist/v0';
 
   // Build Helper Frame JS
-  var js = fs.readFileSync(basePath + fileName + '.js', 'utf8');
-  var builtName = fileName + '.js';
-  var minifiedName = fileName + '.js';
+  const js = fs.readFileSync(basePath + fileName + '.js', 'utf8');
+  const builtName = fileName + '.js';
+  const minifiedName = fileName + '.js';
   return toPromise(gulp.src(basePath + '/*.js')
-    .pipe($$.file(builtName, js))
-    .pipe(gulp.dest(tempBuildDir)))
-    .then(function () {
-      return compileJs('./' + tempBuildDir, builtName, './' + distDir, {
-        watch: watch,
-        includePolyfills: true,
-        minify: options.minify || argv.minify,
-        minifiedName: minifiedName,
-        preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
-      });
-    })
-    .then(function () {
-      if (fs.existsSync(distDir + '/' + minifiedName)) {
+      .pipe($$.file(builtName, js))
+      .pipe(gulp.dest(tempBuildDir)))
+      .then(function() {
+        return compileJs('./' + tempBuildDir, builtName, './' + distDir, {
+          watch,
+          includePolyfills: true,
+          minify: options.minify || argv.minify,
+          minifiedName,
+          preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
+        });
+      })
+      .then(function() {
+        if (fs.existsSync(distDir + '/' + minifiedName)) {
         // Build Helper Frame HTML
-        var fileContents = fs.readFileSync(basePath + fileName + '.html', 'utf8');
-        fileContents = fileContents.replace(
-          '<!-- [GULP-MAGIC-REPLACE ' + fileName + '.js] -->',
-          '<script>' + fs.readFileSync(distDir + '/' + minifiedName, 'utf8') +
+          let fileContents = fs.readFileSync(basePath + fileName + '.html', 'utf8');
+          fileContents = fileContents.replace(
+              '<!-- [GULP-MAGIC-REPLACE ' + fileName + '.js] -->',
+              '<script>' + fs.readFileSync(distDir + '/' + minifiedName, 'utf8') +
           '</script>'
         );
 
-        fs.writeFileSync('dist/v0/' + fileName + '.html',
-          fileContents);
-      }
-    });
+          fs.writeFileSync('dist/v0/' + fileName + '.html',
+              fileContents);
+        }
+      });
 }
 
 
@@ -1030,10 +1029,10 @@ function buildLoginDone(options) {
  */
 function buildLoginDoneVersion(version, options) {
   options = options || {};
-  var path = 'extensions/amp-access/' + version + '/';
-  var htmlPath = path + 'amp-login-done.html';
-  var jsPath = path + 'amp-login-done.js';
-  var watch = options.watch;
+  const path = 'extensions/amp-access/' + version + '/';
+  const htmlPath = path + 'amp-login-done.html';
+  const jsPath = path + 'amp-login-done.js';
+  let watch = options.watch;
   if (watch === undefined) {
     watch = argv.watch || argv.w;
   }
@@ -1043,7 +1042,7 @@ function buildLoginDoneVersion(version, options) {
   // it to the destination and adds the CSS.
   if (watch) {
     // Do not set watchers again when we get called by the watcher.
-    var copy = Object.create(options);
+    const copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildLoginDoneVersion(version, copy);
@@ -1051,8 +1050,8 @@ function buildLoginDoneVersion(version, options) {
   }
 
   // Build HTML.
-  var html = fs.readFileSync(htmlPath, 'utf8');
-  var minHtml = html.replace(
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const minHtml = html.replace(
       '../../../dist/v0/amp-login-done-' + version + '.max.js',
       `https://${hostname}/v0/amp-login-done-` + version + '.js');
 
@@ -1063,10 +1062,10 @@ function buildLoginDoneVersion(version, options) {
       minHtml);
 
   // Build JS.
-  var js = fs.readFileSync(jsPath, 'utf8');
-  var builtName = 'amp-login-done-' + version + '.max.js';
-  var minifiedName = 'amp-login-done-' + version + '.js';
-  var latestName = 'amp-login-done-latest.js';
+  const js = fs.readFileSync(jsPath, 'utf8');
+  const builtName = 'amp-login-done-' + version + '.max.js';
+  const minifiedName = 'amp-login-done-' + version + '.js';
+  const latestName = 'amp-login-done-latest.js';
   return toPromise(gulp.src(path + '/*.js')
       .pipe($$.file(builtName, js))
       .pipe(gulp.dest('build/all/v0/')))
@@ -1075,9 +1074,9 @@ function buildLoginDoneVersion(version, options) {
           watch: false,
           includePolyfills: true,
           minify: options.minify || argv.minify,
-          minifiedName: minifiedName,
+          minifiedName,
           preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
-          latestName: latestName,
+          latestName,
         });
       });
 }
@@ -1122,7 +1121,7 @@ function buildExaminer(options) {
  * @param {!Object} options
  */
 function buildSw(options) {
-  var opts = Object.assign({}, options);
+  const opts = Object.assign({}, options);
   return Promise.all([
     // The service-worker script loaded by the browser.
     compileJs('./src/service-worker/', 'shell.js', './dist/', {
@@ -1152,7 +1151,7 @@ function buildSw(options) {
  * @param {!Object} options
  */
 function buildWebWorker(options) {
-  var opts = Object.assign({}, options);
+  const opts = Object.assign({}, options);
   return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {
     toName: 'ww.max.js',
     minifiedName: 'ww.js',
@@ -1169,7 +1168,7 @@ function buildWebWorker(options) {
  * errors from modules that e.g. use let.
  */
 function checkMinVersion() {
-  var majorVersion = Number(process.version.replace(/v/, '').split('.')[0]);
+  const majorVersion = Number(process.version.replace(/v/, '').split('.')[0]);
   if (majorVersion < 4) {
     $$.util.log('Please run AMP with node.js version 4 or newer.');
     $$.util.log('Your version is', process.version);
@@ -1180,7 +1179,7 @@ function checkMinVersion() {
 function mkdirSync(path) {
   try {
     fs.mkdirSync(path);
-  } catch(e) {
+  } catch (e) {
     if (e.code != 'EEXIST') {
       throw e;
     }
@@ -1196,7 +1195,7 @@ function patchWebAnimations() {
   // Copies web-animations-js into a new file that has an export.
   const patchedName = 'node_modules/web-animations-js/' +
       'web-animations.install.js';
-  var file = fs.readFileSync(
+  let file = fs.readFileSync(
       'node_modules/web-animations-js/' +
       'web-animations.min.js').toString();
   // Wrap the contents inside the install function.
@@ -1228,15 +1227,14 @@ gulp.task('dist', 'Build production binaries', dist, {
         'Great for profiling and debugging production code.',
     fortesting: 'Compiles with `getMode().test` set to true',
     minimal_set: 'Only compile files needed to load article.amp.html',
-  }
+  },
 });
 gulp.task('extensions', 'Build AMP Extensions', buildExtensions);
 gulp.task('watch', 'Watches for changes in files, re-build', watch, {
   options: {
     with_inabox: 'Also watch and build the amp-inabox.js binary.',
     with_shadow: 'Also watch and build the amp-shadow.js binary.',
-  }
+  },
 });
 gulp.task('build-experiments', 'Builds experiments.html/js', buildExperiments);
 gulp.task('build-login-done', 'Builds login-done.html/js', buildLoginDone);
-

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,34 +16,34 @@
 
 checkMinVersion();
 
-const $$ = require('gulp-load-plugins')();
-const babel = require('babelify');
-const browserify = require('browserify');
-const buffer = require('vinyl-buffer');
-const closureCompile = require('./build-system/tasks/compile').closureCompile;
-const cleanupBuildDir = require('./build-system/tasks/compile').cleanupBuildDir;
-const jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
-const fs = require('fs-extra');
-const gulp = $$.help(require('gulp'));
-const lazypipe = require('lazypipe');
-const minimatch = require('minimatch');
-const minimist = require('minimist');
-const source = require('vinyl-source-stream');
-const touch = require('touch');
-const watchify = require('watchify');
-const internalRuntimeVersion = require('./build-system/internal-version').VERSION;
-const internalRuntimeToken = require('./build-system/internal-version').TOKEN;
+var $$ = require('gulp-load-plugins')();
+var babel = require('babelify');
+var browserify = require('browserify');
+var buffer = require('vinyl-buffer');
+var closureCompile = require('./build-system/tasks/compile').closureCompile;
+var cleanupBuildDir = require('./build-system/tasks/compile').cleanupBuildDir;
+var jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
+var fs = require('fs-extra');
+var gulp = $$.help(require('gulp'));
+var lazypipe = require('lazypipe');
+var minimatch = require('minimatch');
+var minimist = require('minimist');
+var source = require('vinyl-source-stream');
+var touch = require('touch');
+var watchify = require('watchify');
+var internalRuntimeVersion = require('./build-system/internal-version').VERSION;
+var internalRuntimeToken = require('./build-system/internal-version').TOKEN;
 
-const argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
+var argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
 
 require('./build-system/tasks');
 
-const hostname = argv.hostname || 'cdn.ampproject.org';
-const hostname3p = argv.hostname3p || '3p.ampproject.net';
+var hostname = argv.hostname || 'cdn.ampproject.org';
+var hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 // All declared extensions.
-const extensions = {};
-const extensionAliasFilePath = {};
+var extensions = {};
+var extensionAliasFilePath = {};
 
 // Each extension and version must be listed individually here.
 declareExtension('amp-3q-player', '0.1', false);
@@ -146,17 +146,17 @@ declareExtensionVersionAlias(
  *   or an extension options object.
  */
 function declareExtension(name, version, hasCssOrOptions) {
-  let hasCss = false;
-  let options = {};
+  var hasCss = false;
+  var options = {};
   if (typeof hasCssOrOptions == 'boolean') {
     hasCss = hasCssOrOptions;
   } else {
-    options = hasCssOrOptions;
+    options = hasCssOrOptions
   }
   extensions[name + '-' + version] = Object.assign({
-    name,
-    version,
-    hasCss,
+    name: name,
+    version: version,
+    hasCss: hasCss,
   }, options);
 }
 
@@ -191,7 +191,7 @@ function endBuildStep(stepName, targetName, startTime) {
   const executionTime = new Date(endTime - startTime);
   const secs = executionTime.getSeconds();
   const ms = executionTime.getMilliseconds().toString().padStart(3, '0');
-  let timeString = '(';
+  var timeString = '(';
   if (secs === 0) {
     timeString += ms + ' ms)';
   } else {
@@ -212,10 +212,10 @@ function endBuildStep(stepName, targetName, startTime) {
  * @return {!Promise}
  */
 function buildExtensions(options) {
-  const results = [];
-  for (const key in extensions) {
-    const e = extensions[key];
-    let o = Object.assign({}, options);
+  var results = [];
+  for (var key in extensions) {
+    var e = extensions[key];
+    var o = Object.assign({}, options);
     o = Object.assign(o, e);
     results.push(buildExtension(e.name, e.version, e.hasCss, o, e.extraGlobs));
   }
@@ -242,40 +242,40 @@ function polyfillsForTests() {
  */
 function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     opt_checkTypes) {
-  const promises = [
+  var promises = [
     compileJs('./3p/', 'integration.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-          minifiedName: 'f.js',
-          checkTypes: opt_checkTypes,
-          watch,
-          minify: shouldMinify,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: true,
-        }),
+      minifiedName: 'f.js',
+      checkTypes: opt_checkTypes,
+      watch: watch,
+      minify: shouldMinify,
+      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+      externs: ['ads/ads.extern.js',],
+      include3pDirectories: true,
+      includePolyfills: true,
+    }),
     compileJs('./3p/', 'ampcontext-lib.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-          minifiedName: 'ampcontext-v0.js',
-          checkTypes: opt_checkTypes,
-          watch,
-          minify: shouldMinify,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: false,
-        }),
+      minifiedName: 'ampcontext-v0.js',
+      checkTypes: opt_checkTypes,
+      watch: watch,
+      minify: shouldMinify,
+      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+      externs: ['ads/ads.extern.js',],
+      include3pDirectories: true,
+      includePolyfills: false,
+    }),
     compileJs('./3p/', 'iframe-transport-client-lib.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-          minifiedName: 'iframe-transport-client-v0.js',
-          checkTypes: opt_checkTypes,
-          watch,
-          minify: shouldMinify,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: false,
-        }),
+      minifiedName: 'iframe-transport-client-v0.js',
+      checkTypes: opt_checkTypes,
+      watch: watch,
+      minify: shouldMinify,
+      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+      externs: ['ads/ads.extern.js',],
+      include3pDirectories: true,
+      includePolyfills: false,
+    }),
     // For compilation with babel we start with the amp-babel entry point,
     // but then rename to the amp.js which we've been using all along.
     compileJs('./src/', 'amp-babel.js', './dist', {
@@ -283,7 +283,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
       minifiedName: 'v0.js',
       includePolyfills: true,
       checkTypes: opt_checkTypes,
-      watch,
+      watch: watch,
       preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
       minify: shouldMinify,
       // If there is a sync JS error during initial load,
@@ -294,19 +294,19 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
           's.opacity=1;' +
           's.visibility="visible";' +
           's.animation="none";' +
-          's.WebkitAnimation="none;"},1000);throw e};',
+          's.WebkitAnimation="none;"},1000);throw e};'
     }),
     compileJs('./extensions/amp-viewer-integration/0.1/examples/',
-        'amp-viewer-host.js', './dist/v0/examples', {
-          toName: 'amp-viewer-host.max.js',
-          minifiedName: 'amp-viewer-host.js',
-          incudePolyfills: true,
-          watch,
-          extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
-          compilationLevel: 'WHITESPACE_ONLY',
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          minify: false,
-        }),
+      'amp-viewer-host.js', './dist/v0/examples', {
+        toName: 'amp-viewer-host.max.js',
+        minifiedName: 'amp-viewer-host.js',
+        incudePolyfills: true,
+        watch: watch,
+        extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
+        compilationLevel: 'WHITESPACE_ONLY',
+        preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+        minify: false,
+      }),
   ];
 
   // We don't rerun type check for the shadow entry point for now.
@@ -314,53 +314,53 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
     if (!watch || argv.with_shadow) {
       promises.push(
         // Entry point for shadow runtime.
-          compileJs('./src/', 'amp-shadow-babel.js', './dist', {
-            toName: 'amp-shadow.js',
-            minifiedName: 'shadow-v0.js',
-            includePolyfills: true,
-            checkTypes: opt_checkTypes,
-            watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-            wrapper: '<%= contents %>',
-          })
+        compileJs('./src/', 'amp-shadow-babel.js', './dist', {
+          toName: 'amp-shadow.js',
+          minifiedName: 'shadow-v0.js',
+          includePolyfills: true,
+          checkTypes: opt_checkTypes,
+          watch: watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+          wrapper: '<%= contents %>'
+        })
       );
     }
 
     if (!watch || argv.with_inabox) {
       promises.push(
         // Entry point for inabox runtime.
-          compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
-            toName: 'amp-inabox.js',
-            minifiedName: 'amp4ads-v0.js',
-            includePolyfills: true,
-            extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
-            checkTypes: opt_checkTypes,
-            watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-            wrapper: '<%= contents %>',
-          }),
+        compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
+          toName: 'amp-inabox.js',
+          minifiedName: 'amp4ads-v0.js',
+          includePolyfills: true,
+          extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
+          checkTypes: opt_checkTypes,
+          watch: watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+          wrapper: '<%= contents %>',
+        }),
 
         // inabox-host
-          compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
-            toName: 'amp-inabox-host.js',
-            minifiedName: 'amp4ads-host-v0.js',
-            includePolyfills: false,
-            checkTypes: opt_checkTypes,
-            watch,
-            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-            minify: shouldMinify,
-            wrapper: '<%= contents %>',
-          })
+        compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
+          toName: 'amp-inabox-host.js',
+          minifiedName: 'amp4ads-host-v0.js',
+          includePolyfills: false,
+          checkTypes: opt_checkTypes,
+          watch: watch,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: shouldMinify,
+          wrapper: '<%= contents %>',
+        })
       );
     }
 
     promises.push(
-        thirdPartyBootstrap(
-            '3p/frame.max.html', 'frame.html', shouldMinify),
-        thirdPartyBootstrap(
-            '3p/nameframe.max.html', 'nameframe.html',shouldMinify)
+      thirdPartyBootstrap(
+          '3p/frame.max.html', 'frame.html', shouldMinify),
+      thirdPartyBootstrap(
+          '3p/nameframe.max.html', 'nameframe.html',shouldMinify)
     );
 
     if (watch) {
@@ -385,26 +385,26 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
 function compileCss() {
   const startTime = Date.now();
   return jsifyCssAsync('css/amp.css')
-      .then(function(css) {
-        return toPromise(gulp.src('css/**.css')
-            .pipe($$.file('css.js', 'export const cssText = ' +
+  .then(function(css) {
+    return toPromise(gulp.src('css/**.css')
+          .pipe($$.file('css.js', 'export const cssText = ' +
               JSON.stringify(css)))
-            .pipe(gulp.dest('build'))
-            .on('end', function() {
-              mkdirSync('build');
-              mkdirSync('build/css');
-              fs.writeFileSync('build/css/v0.css', css);
-            }));
-      })
-      .then(() => {
-        endBuildStep('Recompiled CSS in', 'amp.css', startTime);
-      })
-      .then(() => {
-        return buildExtensions({
-          bundleOnlyIfListedInFiles: true,
-          compileOnlyCss: true,
-        });
-      });
+          .pipe(gulp.dest('build'))
+          .on('end', function() {
+            mkdirSync('build');
+            mkdirSync('build/css');
+            fs.writeFileSync('build/css/v0.css', css);
+          }));
+  })
+  .then(() => {
+    endBuildStep('Recompiled CSS in', 'amp.css', startTime);
+  })
+  .then(() => {
+    return buildExtensions({
+      bundleOnlyIfListedInFiles: true,
+      compileOnlyCss: true
+    });
+  });
 }
 
 /**
@@ -464,9 +464,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
   if (options.compileOnlyCss && !hasCss) {
     return Promise.resolve();
   }
-  const path = 'extensions/' + name + '/' + version;
-  const jsPath = path + '/' + name + '.js';
-  const jsTestPath = path + '/test/' + 'test-' + name + '.js';
+  var path = 'extensions/' + name + '/' + version;
+  var jsPath = path + '/' + name + '.js';
+  var jsTestPath = path + '/test/' + 'test-' + name + '.js';
   if (argv.files && options.bundleOnlyIfListedInFiles) {
     const passedFiles = Array.isArray(argv.files) ? argv.files : [argv.files];
     const shouldBundle = passedFiles.some(glob => {
@@ -481,7 +481,7 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
   // it to the destination and adds the CSS.
   if (options.watch) {
     // Do not set watchers again when we get called by the watcher.
-    const copy = Object.create(options);
+    var copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildExtension(name, version, hasCss, copy);
@@ -492,9 +492,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
     mkdirSync('build/css');
     const startTime = Date.now();
     return jsifyCssAsync(path + '/' + name + '.css').then(function(css) {
-      const jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
-      const jsName = 'build/' + name + '-' + version + '.css.js';
-      const cssName = 'build/css/' + name + '-' + version + '.css';
+      var jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
+      var jsName = 'build/' + name + '-' + version + '.css.js';
+      var cssName = 'build/css/' + name + '-' + version + '.css';
       fs.writeFileSync(jsName, jsCss, 'utf-8');
       fs.writeFileSync(cssName, css, 'utf-8');
       if (options.compileOnlyCss) {
@@ -502,9 +502,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
       }
       return buildExtensionJs(path, name, version, options);
     })
-        .then(() => {
-          endBuildStep('Recompiled CSS in', name, startTime);
-        });
+    .then(() => {
+      endBuildStep('Recompiled CSS in', name, startTime);
+    });
   } else {
     return buildExtensionJs(path, name, version, options);
   }
@@ -522,16 +522,16 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
  * @return {!Promise}
  */
 function buildExtensionJs(path, name, version, options) {
-  const filename = options.filename || name + '.js';
+  var filename = options.filename || name + '.js';
   if (options.loadPriority && options.loadPriority != 'high') {
     throw new Error('Unsupported loadPriority: ' + options.loadPriority);
   }
-  const priority = options.loadPriority ? 'p:"high",' : '';
+  var priority = options.loadPriority ? 'p:"high",' : '';
   return compileJs(path + '/', filename, './dist/v0', {
     watch: options.watch,
     preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
     minify: options.minify,
-    toName: name + '-' + version + '.max.js',
+    toName:  name + '-' + version + '.max.js',
     minifiedName: name + '-' + version + '.js',
     latestName: name + '-latest.js',
     extraGlobs: options.extraGlobs,
@@ -551,9 +551,9 @@ function buildExtensionJs(path, name, version, options) {
  * Writes the AMP config to file if AMP_TESTING_HOST is set.
  */
 function writeAmpConfig() {
-  const TESTING_HOST = process.env.AMP_TESTING_HOST;
+  var TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (argv.fortesting && typeof TESTING_HOST == 'string') {
-    let AMP_CONFIG = {
+    var AMP_CONFIG = {
       thirdPartyFrameHost: TESTING_HOST,
       thirdPartyFrameRegex: TESTING_HOST,
       localDev: true,
@@ -620,7 +620,7 @@ function dist() {
  * Copy built extension to alias extension
  */
 function copyAliasExtensions() {
-  for (const key in extensionAliasFilePath) {
+  for (var key in extensionAliasFilePath) {
     fs.copySync('dist/v0/' + extensionAliasFilePath[key], 'dist/v0/' + key);
   }
 }
@@ -639,7 +639,7 @@ function checkTypes() {
     checkTypes: true,
     preventRemoveAndMakeDir: true,
   });*/
-  const compileSrcs = [
+  var compileSrcs = [
     './src/amp-babel.js',
     './src/amp-shadow.js',
     './src/inabox/amp-inabox.js',
@@ -650,7 +650,7 @@ function checkTypes() {
     './src/service-worker/kill.js',
     './src/web-worker/web-worker.js',
   ];
-  const extensionSrcs = Object.values(extensions).filter(function(extension) {
+  var extensionSrcs = Object.values(extensions).filter(function(extension) {
     return !extension.noTypeCheck;
   }).map(function(extension) {
     return './extensions/' + extension.name + '/' +
@@ -667,26 +667,26 @@ function checkTypes() {
           }),
       // Type check 3p/ads code.
       closureCompile(['./3p/integration.js'], './dist',
-          'integration-check-types.js', {
-            externs: ['ads/ads.extern.js'],
-            include3pDirectories: true,
-            includePolyfills: true,
-            checkTypes: true,
-          }),
+        'integration-check-types.js', {
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: true,
+          checkTypes: true,
+        }),
       closureCompile(['./3p/ampcontext-lib.js'], './dist',
-          'ampcontext-check-types.js', {
-            externs: ['ads/ads.extern.js'],
-            include3pDirectories: true,
-            includePolyfills: true,
-            checkTypes: true,
-          }),
+        'ampcontext-check-types.js', {
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: true,
+          checkTypes: true,
+        }),
       closureCompile(['./3p/iframe-transport-client-lib.js'], './dist',
-          'iframe-transport-client-check-types.js', {
-            externs: ['ads/ads.extern.js'],
-            include3pDirectories: true,
-            includePolyfills: true,
-            checkTypes: true,
-          }),
+        'iframe-transport-client-check-types.js', {
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: true,
+          checkTypes: true,
+        }),
     ]);
   });
 }
@@ -714,16 +714,16 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
   // actual frame host for the JS inside the frame.
   // But during testing we need a relative reference because the
   // version is not available on the absolute path.
-  const integrationJs = argv.fortesting
+  var integrationJs = argv.fortesting
       ? './f.js'
       : `https://${hostname3p}/${internalRuntimeVersion}/f.js`;
   // Convert default relative URL to absolute min URL.
-  const html = fs.readFileSync(input, 'utf8')
+  var html = fs.readFileSync(input, 'utf8')
       .replace(/\.\/integration\.js/g, integrationJs);
   return toPromise($$.file(outputName, html, {src: true})
       .pipe(gulp.dest('dist.3p/' + internalRuntimeVersion))
       .on('end', function() {
-        const aliasToLatestBuild = 'dist.3p/current-min';
+        var aliasToLatestBuild = 'dist.3p/current-min';
         if (fs.existsSync(aliasToLatestBuild)) {
           fs.unlinkSync(aliasToLatestBuild);
         }
@@ -744,7 +744,7 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
  * @param {Array<string>} files List of file paths to concatenate
  */
 function concatFiles(destFilePath, files) {
-  const all = files.map(function(filePath) {
+  var all = files.map(function(filePath) {
     return fs.readFileSync(filePath, 'utf-8');
   });
 
@@ -807,15 +807,15 @@ function compileJs(srcDir, srcFilename, destDir, options) {
         });
   }
 
-  let bundler = browserify(srcDir + srcFilename, {debug: true})
+  var bundler = browserify(srcDir + srcFilename, {debug: true})
       .transform(babel, {loose: argv.strictBabelTransform ? undefined : 'all'});
   if (options.watch) {
     bundler = watchify(bundler);
   }
 
-  const wrapper = options.wrapper || '<%= contents %>';
+  var wrapper = options.wrapper || '<%= contents %>';
 
-  const lazybuild = lazypipe()
+  var lazybuild = lazypipe()
       .pipe(source, srcFilename)
       .pipe(buffer)
       .pipe($$.replace, /\$internalRuntimeVersion\$/g, internalRuntimeVersion)
@@ -823,29 +823,29 @@ function compileJs(srcDir, srcFilename, destDir, options) {
       .pipe($$.wrap, wrapper)
       .pipe($$.sourcemaps.init.bind($$.sourcemaps), {loadMaps: true});
 
-  const lazywrite = lazypipe()
+  var lazywrite = lazypipe()
       .pipe($$.sourcemaps.write.bind($$.sourcemaps), './')
       .pipe(gulp.dest.bind(gulp), destDir);
 
-  const destFilename = options.toName || srcFilename;
+  var destFilename = options.toName || srcFilename;
   function rebundle() {
     const startTime = Date.now();
     return toPromise(bundler.bundle()
-        .on('error', function(err) {
-          if (err instanceof SyntaxError) {
-            console.error($$.util.colors.red('Syntax error:', err.message));
-          } else {
-            console.error($$.util.colors.red(err.message));
-          }
-        })
-        .pipe(lazybuild())
-        .pipe($$.rename(destFilename))
-        .pipe(lazywrite())
-        .on('end', function() {
-          appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
-        })).then(() => {
-          endBuildStep('Compiled', srcFilename, startTime);
-        });
+      .on('error', function(err) {
+        if (err instanceof SyntaxError) {
+          console.error($$.util.colors.red('Syntax error:', err.message));
+        } else {
+          console.error($$.util.colors.red(err.message));
+        }
+      })
+      .pipe(lazybuild())
+      .pipe($$.rename(destFilename))
+      .pipe(lazywrite())
+      .on('end', function() {
+        appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
+      })).then(() => {
+        endBuildStep('Compiled', srcFilename, startTime);
+      });
   }
 
   if (options.watch) {
@@ -878,10 +878,10 @@ function compileJs(srcDir, srcFilename, destDir, options) {
  */
 function buildExperiments(options) {
   options = options || {};
-  const path = 'tools/experiments';
-  const htmlPath = path + '/experiments.html';
-  const jsPath = path + '/experiments.js';
-  let watch = options.watch;
+  var path = 'tools/experiments';
+  var htmlPath = path + '/experiments.html';
+  var jsPath = path + '/experiments.js';
+  var watch = options.watch;
   if (watch === undefined) {
     watch = argv.watch || argv.w;
   }
@@ -891,7 +891,7 @@ function buildExperiments(options) {
   // it to the destination and adds the CSS.
   if (watch) {
     // Do not set watchers again when we get called by the watcher.
-    const copy = Object.create(options);
+    var copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildExperiments(copy);
@@ -899,17 +899,17 @@ function buildExperiments(options) {
   }
 
   // Build HTML.
-  const html = fs.readFileSync(htmlPath, 'utf8');
-  const minHtml = html.replace('/dist.tools/experiments/experiments.js',
+  var html = fs.readFileSync(htmlPath, 'utf8');
+  var minHtml = html.replace('/dist.tools/experiments/experiments.js',
       `https://${hostname}/v0/experiments.js`);
   gulp.src(htmlPath)
       .pipe($$.file('experiments.cdn.html', minHtml))
       .pipe(gulp.dest('dist.tools/experiments/'));
 
   // Build JS.
-  const js = fs.readFileSync(jsPath, 'utf8');
-  const builtName = 'experiments.max.js';
-  const minifiedName = 'experiments.js';
+  var js = fs.readFileSync(jsPath, 'utf8');
+  var builtName = 'experiments.max.js';
+  var minifiedName = 'experiments.js';
   return toPromise(gulp.src(path + '/*.js')
       .pipe($$.file(builtName, js))
       .pipe(gulp.dest('build/experiments/')))
@@ -919,7 +919,7 @@ function buildExperiments(options) {
               watch: false,
               minify: options.minify || argv.minify,
               includePolyfills: true,
-              minifiedName,
+              minifiedName: minifiedName,
               preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
               checkTypes: options.checkTypes,
             });
@@ -944,7 +944,7 @@ function buildWebPushPublisherFiles(options) {
  */
 function buildWebPushPublisherFilesVersion(version, options) {
   options = options || {};
-  let watch = options.watch;
+  var watch = options.watch;
   if (watch === undefined) {
     watch = argv.watch || argv.w;
   }
@@ -954,21 +954,21 @@ function buildWebPushPublisherFilesVersion(version, options) {
   // it to the destination and adds the CSS.
   if (watch) {
     // Do not set watchers again when we get called by the watcher.
-    const copy = Object.create(options);
+    var copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildWebPushPublisherFiles(version, copy);
     });
   }
 
-  const fileNames = ['amp-web-push-helper-frame', 'amp-web-push-permission-dialog'];
-  const promises = [];
+  var fileNames = ['amp-web-push-helper-frame', 'amp-web-push-permission-dialog'];
+  var promises = [];
 
   mkdirSync('dist');
   mkdirSync('dist/v0');
 
-  for (let i = 0; i < fileNames.length; i++) {
-    const fileName = fileNames[i];
+  for (var i = 0; i < fileNames.length; i++) {
+    var fileName = fileNames[i];
     promises.push(buildWebPushPublisherFile(version, fileName, watch, options));
   }
 
@@ -976,40 +976,40 @@ function buildWebPushPublisherFilesVersion(version, options) {
 }
 
 function buildWebPushPublisherFile(version, fileName, watch, options) {
-  const basePath = 'extensions/amp-web-push/' + version + '/';
-  const tempBuildDir = 'build/all/v0/';
-  const distDir = 'dist/v0';
+  var basePath = 'extensions/amp-web-push/' + version + '/';
+  var tempBuildDir = 'build/all/v0/';
+  var distDir = 'dist/v0';
 
   // Build Helper Frame JS
-  const js = fs.readFileSync(basePath + fileName + '.js', 'utf8');
-  const builtName = fileName + '.js';
-  const minifiedName = fileName + '.js';
+  var js = fs.readFileSync(basePath + fileName + '.js', 'utf8');
+  var builtName = fileName + '.js';
+  var minifiedName = fileName + '.js';
   return toPromise(gulp.src(basePath + '/*.js')
-      .pipe($$.file(builtName, js))
-      .pipe(gulp.dest(tempBuildDir)))
-      .then(function() {
-        return compileJs('./' + tempBuildDir, builtName, './' + distDir, {
-          watch,
-          includePolyfills: true,
-          minify: options.minify || argv.minify,
-          minifiedName,
-          preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
-        });
-      })
-      .then(function() {
-        if (fs.existsSync(distDir + '/' + minifiedName)) {
+    .pipe($$.file(builtName, js))
+    .pipe(gulp.dest(tempBuildDir)))
+    .then(function () {
+      return compileJs('./' + tempBuildDir, builtName, './' + distDir, {
+        watch: watch,
+        includePolyfills: true,
+        minify: options.minify || argv.minify,
+        minifiedName: minifiedName,
+        preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
+      });
+    })
+    .then(function () {
+      if (fs.existsSync(distDir + '/' + minifiedName)) {
         // Build Helper Frame HTML
-          let fileContents = fs.readFileSync(basePath + fileName + '.html', 'utf8');
-          fileContents = fileContents.replace(
-              '<!-- [GULP-MAGIC-REPLACE ' + fileName + '.js] -->',
-              '<script>' + fs.readFileSync(distDir + '/' + minifiedName, 'utf8') +
+        var fileContents = fs.readFileSync(basePath + fileName + '.html', 'utf8');
+        fileContents = fileContents.replace(
+          '<!-- [GULP-MAGIC-REPLACE ' + fileName + '.js] -->',
+          '<script>' + fs.readFileSync(distDir + '/' + minifiedName, 'utf8') +
           '</script>'
         );
 
-          fs.writeFileSync('dist/v0/' + fileName + '.html',
-              fileContents);
-        }
-      });
+        fs.writeFileSync('dist/v0/' + fileName + '.html',
+          fileContents);
+      }
+    });
 }
 
 
@@ -1029,10 +1029,10 @@ function buildLoginDone(options) {
  */
 function buildLoginDoneVersion(version, options) {
   options = options || {};
-  const path = 'extensions/amp-access/' + version + '/';
-  const htmlPath = path + 'amp-login-done.html';
-  const jsPath = path + 'amp-login-done.js';
-  let watch = options.watch;
+  var path = 'extensions/amp-access/' + version + '/';
+  var htmlPath = path + 'amp-login-done.html';
+  var jsPath = path + 'amp-login-done.js';
+  var watch = options.watch;
   if (watch === undefined) {
     watch = argv.watch || argv.w;
   }
@@ -1042,7 +1042,7 @@ function buildLoginDoneVersion(version, options) {
   // it to the destination and adds the CSS.
   if (watch) {
     // Do not set watchers again when we get called by the watcher.
-    const copy = Object.create(options);
+    var copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildLoginDoneVersion(version, copy);
@@ -1050,8 +1050,8 @@ function buildLoginDoneVersion(version, options) {
   }
 
   // Build HTML.
-  const html = fs.readFileSync(htmlPath, 'utf8');
-  const minHtml = html.replace(
+  var html = fs.readFileSync(htmlPath, 'utf8');
+  var minHtml = html.replace(
       '../../../dist/v0/amp-login-done-' + version + '.max.js',
       `https://${hostname}/v0/amp-login-done-` + version + '.js');
 
@@ -1062,10 +1062,10 @@ function buildLoginDoneVersion(version, options) {
       minHtml);
 
   // Build JS.
-  const js = fs.readFileSync(jsPath, 'utf8');
-  const builtName = 'amp-login-done-' + version + '.max.js';
-  const minifiedName = 'amp-login-done-' + version + '.js';
-  const latestName = 'amp-login-done-latest.js';
+  var js = fs.readFileSync(jsPath, 'utf8');
+  var builtName = 'amp-login-done-' + version + '.max.js';
+  var minifiedName = 'amp-login-done-' + version + '.js';
+  var latestName = 'amp-login-done-latest.js';
   return toPromise(gulp.src(path + '/*.js')
       .pipe($$.file(builtName, js))
       .pipe(gulp.dest('build/all/v0/')))
@@ -1074,9 +1074,9 @@ function buildLoginDoneVersion(version, options) {
           watch: false,
           includePolyfills: true,
           minify: options.minify || argv.minify,
-          minifiedName,
+          minifiedName: minifiedName,
           preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
-          latestName,
+          latestName: latestName,
         });
       });
 }
@@ -1121,7 +1121,7 @@ function buildExaminer(options) {
  * @param {!Object} options
  */
 function buildSw(options) {
-  const opts = Object.assign({}, options);
+  var opts = Object.assign({}, options);
   return Promise.all([
     // The service-worker script loaded by the browser.
     compileJs('./src/service-worker/', 'shell.js', './dist/', {
@@ -1151,7 +1151,7 @@ function buildSw(options) {
  * @param {!Object} options
  */
 function buildWebWorker(options) {
-  const opts = Object.assign({}, options);
+  var opts = Object.assign({}, options);
   return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {
     toName: 'ww.max.js',
     minifiedName: 'ww.js',
@@ -1168,7 +1168,7 @@ function buildWebWorker(options) {
  * errors from modules that e.g. use let.
  */
 function checkMinVersion() {
-  const majorVersion = Number(process.version.replace(/v/, '').split('.')[0]);
+  var majorVersion = Number(process.version.replace(/v/, '').split('.')[0]);
   if (majorVersion < 4) {
     $$.util.log('Please run AMP with node.js version 4 or newer.');
     $$.util.log('Your version is', process.version);
@@ -1179,7 +1179,7 @@ function checkMinVersion() {
 function mkdirSync(path) {
   try {
     fs.mkdirSync(path);
-  } catch (e) {
+  } catch(e) {
     if (e.code != 'EEXIST') {
       throw e;
     }
@@ -1195,7 +1195,7 @@ function patchWebAnimations() {
   // Copies web-animations-js into a new file that has an export.
   const patchedName = 'node_modules/web-animations-js/' +
       'web-animations.install.js';
-  let file = fs.readFileSync(
+  var file = fs.readFileSync(
       'node_modules/web-animations-js/' +
       'web-animations.min.js').toString();
   // Wrap the contents inside the install function.
@@ -1227,14 +1227,14 @@ gulp.task('dist', 'Build production binaries', dist, {
         'Great for profiling and debugging production code.',
     fortesting: 'Compiles with `getMode().test` set to true',
     minimal_set: 'Only compile files needed to load article.amp.html',
-  },
+  }
 });
 gulp.task('extensions', 'Build AMP Extensions', buildExtensions);
 gulp.task('watch', 'Watches for changes in files, re-build', watch, {
   options: {
     with_inabox: 'Also watch and build the amp-inabox.js binary.',
     with_shadow: 'Also watch and build the amp-shadow.js binary.',
-  },
+  }
 });
 gulp.task('build-experiments', 'Builds experiments.html/js', buildExperiments);
 gulp.task('build-login-done', 'Builds login-done.html/js', buildLoginDone);

--- a/test/manual/amp-sidebar-toolbar.amp.html
+++ b/test/manual/amp-sidebar-toolbar.amp.html
@@ -32,7 +32,7 @@ limitations under the License.
 
 
 <script custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js" async=""></script>
-<script custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-1.0.js" async=""></script>
+<script custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js" async=""></script>
 <script custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js" async=""></script>
 <script custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js" async=""></script>
 <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async=""></script>
@@ -211,7 +211,7 @@ limitations under the License.
         <a href="#" target="_blank" class="inline-block" aria-label="Link to AMP HTML pin trest"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="28.5" viewbox="0 0 43 51"><title>pinterest</title><path d="M-13.6-5c0-1.6.2-3 .8-4.4.5-1.4 1.2-2.6 2.2-3.6.9-1 2-1.9 3.2-2.6 1.2-.8 2.5-1.3 3.9-1.7 1.5-.4 2.9-.5 4.4-.5 2.2 0 4.3.4 6.2 1.4 1.9.9 3.5 2.3 4.7 4.1 1.2 1.9 1.8 3.9 1.8 6.2 0 1.4-.1 2.7-.4 4C13-.8 12.5.5 12 1.7c-.6 1.2-1.3 2.3-2.2 3.2C9 5.8 8 6.6 6.7 7.1c-1.2.6-2.5.9-4 .9-1 0-1.9-.3-2.9-.7-.9-.5-1.6-1.1-2-1.9-.1.5-.3 1.4-.6 2.4-.3 1.1-.4 1.7-.5 2-.1.3-.2.9-.4 1.6-.3.7-.4 1.2-.6 1.5-.1.3-.4.7-.7 1.3-.3.6-.6 1.2-1 1.7-.3.5-.7 1.1-1.3 1.8l-.3.1-.2-.2c-.2-2.2-.3-3.6-.3-4 0-1.3.2-2.8.5-4.4.3-1.7.8-3.7 1.4-6.2.6-2.5 1-3.9 1.1-4.4-.5-.9-.7-2.1-.7-3.6 0-1.2.4-2.3 1.1-3.3.8-1.1 1.7-1.6 2.8-1.6.9 0 1.6.3 2.1.9.4.6.7 1.3.7 2.2 0 .9-.3 2.3-1 4.1C-.7-.9-1 .4-1 1.3c0 .9.3 1.6 1 2.2.6.6 1.4.9 2.3.9.8 0 1.5-.2 2.2-.5.6-.4 1.2-.9 1.6-1.5.5-.6.9-1.3 1.2-2 .4-.8.6-1.5.8-2.4.2-.8.4-1.6.5-2.4.1-.7.1-1.4.1-2.1 0-2.5-.8-4.4-2.3-5.8-1.6-1.4-3.6-2.1-6.1-2.1-2.8 0-5.2 1-7.1 2.8-1.9 1.9-2.9 4.2-2.9 7.1 0 .6.1 1.2.3 1.8.2.6.4 1.1.6 1.4.2.3.4.7.5 1 .2.3.3.5.3.6 0 .4-.1.9-.3 1.6-.2.6-.5 1-.8 1 0 0-.1-.1-.4-.1-.7-.2-1.3-.6-1.9-1.2-.5-.6-1-1.3-1.3-2-.3-.8-.5-1.6-.7-2.4-.2-.7-.2-1.5-.2-2.2z" transform="translate(21.734 23.748)" class="ampstart-icon ampstart-icon-pinterest"></path></svg></a>
       </li>
     </ul>
-    
+
     <ul class="ampstart-sidebar-faq list-reset m0">
       <li class="ampstart-faq-item"><a href="#" class="text-decoration-none">About</a></li>
       <li class="ampstart-faq-item"><a href="#" class="text-decoration-none">Contact</a></li>

--- a/test/manual/amp-sidebar-toolbar.amp.html
+++ b/test/manual/amp-sidebar-toolbar.amp.html
@@ -107,6 +107,10 @@ limitations under the License.
 }
 
 @media (max-width: 930px) {
+  .ampstart-toolbar-container .ampstart-headerbar-nav {
+      display: none;
+  }
+
   .ampstart-headerbar-nav > ul.flex {
     flex-direction: column;
     text-align: left;


### PR DESCRIPTION
closes #10770

By request of the validation team, and approval by @camelburrito and @dvoytenko , this PR will unversion sidebar.

`toolbar` will now live as a feature to `amp-sidebar`, and is hidden under the experimental flag, `amp-sidebar toolbar`. This PR does the following changes:

* Moves all approved code and tests from 1.0 into 0.1
* Adds an example for #10770 (By request of @camelburrito to be done in the same PR)
* Updates the test manual for amp-sidebar toolbar
* Removes amp-sidebar 1.0 from the gulp file.
* Hides toolbar features under the experimental flag

**History of toolbar.js to ensure it has not changed since PR was opened:** https://github.com/ampproject/amphtml/commits/master/extensions/amp-sidebar/1.0/toolbar.js

See the screenshots below showing it will not affect current users, but only experimental toolbar users:

<img width="1504" alt="screen shot 2017-08-03 at 6 33 00 pm" src="https://user-images.githubusercontent.com/1448289/28950598-37e6cd10-787a-11e7-8b21-65541f4d4818.png">
<img width="1504" alt="screen shot 2017-08-03 at 6 32 47 pm" src="https://user-images.githubusercontent.com/1448289/28950600-37e8d7ea-787a-11e7-8ba8-cb040749cf68.png">
<img width="1501" alt="screen shot 2017-08-03 at 6 32 08 pm" src="https://user-images.githubusercontent.com/1448289/28950599-37e8c372-787a-11e7-85b8-068cef1310a0.png">
<img width="1503" alt="screen shot 2017-08-03 at 6 31 53 pm" src="https://user-images.githubusercontent.com/1448289/28950601-37e8f23e-787a-11e7-97c0-637af6be6d6a.png">
<img width="1500" alt="screen shot 2017-08-03 at 6 31 46 pm" src="https://user-images.githubusercontent.com/1448289/28950602-37eba43e-787a-11e7-85fd-28d8ee61f2c6.png">