### PR TITLE
Fix build shard name for master

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -308,7 +308,7 @@ const command = {
 
 function runAllCommands() {
   // Run different sets of independent tasks in parallel to reduce build time.
-  if (process.env.BUILD_SHARD == "pre_build_checks_and_unit_tests") {
+  if (process.env.BUILD_SHARD == "unit_tests") {
     command.testBuildSystem();
     command.cleanBuild();
     command.buildRuntime();


### PR DESCRIPTION
Leftover fix from #10792, which updated the shard names for PRs, but not for master.

#10785