### PR TITLE
Fix master: validator needs protobuf, and percy needs its gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
+before_script:
+  - pip install --user protobuf
+  - gem install percy-capybara phantomjs poltergeist
+  # Poltergeist requires an absolute path to find phantomjs. See #10305.
+  - export PATH="`pwd`/node_modules/.bin:$PATH"
 script: node build-system/pr-check.js
 branches:
   only:
@@ -39,14 +44,7 @@ env:
 matrix:
   include:
     - env: BUILD_SHARD="unit_tests"
-      before_script:
-        - pip install --user protobuf
     - env: BUILD_SHARD="integration_tests"
-      before_script:
-        - pip install --user protobuf
-        - gem install percy-capybara phantomjs poltergeist
-        # Poltergeist requires an absolute path to find phantomjs. See #10305.
-        - export PATH="`pwd`/node_modules/.bin:$PATH"
       addons:
         sauce_connect:
           username: "amphtml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ env:
 matrix:
   include:
     - env: BUILD_SHARD="unit_tests"
+      before_script:
+        - pip install --user protobuf
     - env: BUILD_SHARD="integration_tests"
       before_script:
         - pip install --user protobuf


### PR DESCRIPTION
Another leftover fix from #10792, which removed protobuf from the unit tests shard even though validator tests need it, and moved the percy gems to the integration tests shard, even though the unit tests shard runs these tests on master for load balancing.

#10785