### PR TITLE
Actions: Expose value property on radio/checkbox inputs

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -255,15 +255,15 @@ export class ActionService {
     const detail = /** @type {!JsonObject} */ (map());
     const target = event.target;
     const tagName = target.tagName;
+    const type = target.getAttribute('type');
 
     // Expose `value` property on HTMLInputElement and HTMLSelectElement.
     if (tagName == 'INPUT' || tagName == 'SELECT') {
-      detail['value'] = target.value
+      detail['value'] = (type == 'range') ? Number(target.value) : target.value;
     }
 
     // Expose HTMLInputElement properties based on type.
     if (tagName == 'INPUT') {
-      const type = target.getAttribute('type');
       if (type == 'checkbox' || type == 'radio') {
         detail['checked'] = target.checked;
       } else if (type == 'range') {

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -254,27 +254,25 @@ export class ActionService {
   addInputDetails_(event) {
     const detail = /** @type {!JsonObject} */ (map());
     const target = event.target;
-    switch (target.tagName) {
-      case 'INPUT':
-        const type = target.getAttribute('type');
-        // Some <input> elements have special properties for content values.
-        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties
-        if (type == 'checkbox' || type == 'radio') {
-          detail['checked'] = target.checked;
-        } else if (type == 'range') {
-          // TODO(choumx): min/max are also available on date pickers.
-          detail['min'] = Number(target.min);
-          detail['max'] = Number(target.max);
-          // TODO(choumx): HTMLInputElement.valueAsNumber instead?
-          detail['value'] = Number(target.value);
-        } else {
-          detail['value'] = target.value;
-        }
-        break;
-      case 'SELECT':
-        detail['value'] = target.value;
-        break;
+    const tagName = target.tagName;
+
+    // Expose `value` property on HTMLInputElement and HTMLSelectElement.
+    if (tagName == 'INPUT' || tagName == 'SELECT') {
+      detail['value'] = target.value
     }
+
+    // Expose HTMLInputElement properties based on type.
+    if (tagName == 'INPUT') {
+      const type = target.getAttribute('type');
+      if (type == 'checkbox' || type == 'radio') {
+        detail['checked'] = target.checked;
+      } else if (type == 'range') {
+        // TODO(choumx): min/max are also available on date pickers.
+        detail['min'] = Number(target.min);
+        detail['max'] = Number(target.max);
+      }
+    }
+
     if (Object.keys(detail).length > 0) {
       event.detail = detail;
     }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -255,21 +255,24 @@ export class ActionService {
     const detail = /** @type {!JsonObject} */ (map());
     const target = event.target;
     const tagName = target.tagName;
-    const type = target.getAttribute('type');
 
     // Expose `value` property on HTMLInputElement and HTMLSelectElement.
     if (tagName == 'INPUT' || tagName == 'SELECT') {
-      detail['value'] = (type == 'range') ? Number(target.value) : target.value;
-    }
+      const type = target.getAttribute('type');
 
-    // Expose HTMLInputElement properties based on type.
-    if (tagName == 'INPUT') {
-      if (type == 'checkbox' || type == 'radio') {
-        detail['checked'] = target.checked;
-      } else if (type == 'range') {
-        // TODO(choumx): min/max are also available on date pickers.
-        detail['min'] = Number(target.min);
-        detail['max'] = Number(target.max);
+      // TODO(blueyedgeek, #10729): Provide valueAsNumber instead of casting.
+      detail['value'] = (type == 'range') ? Number(target.value) : target.value;
+
+      // Expose HTMLInputElement properties based on type.
+      if (tagName == 'INPUT') {
+        if (type == 'checkbox' || type == 'radio') {
+          detail['checked'] = target.checked;
+        } else if (type == 'range') {
+          // TODO(choumx): Perhaps we shouldn't cast since min/max is also
+          // available on input[type="date|time|number"].
+          detail['min'] = Number(target.min);
+          detail['max'] = Number(target.max);
+        }
       }
     }
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1021,13 +1021,15 @@ describes.fakeWin('Core events', {amp: true}, env => {
     const handler = window.document.addEventListener.getCall(3).args[1];
     const element = document.createElement('input');
     element.setAttribute('type', 'checkbox');
+    element.setAttribute('value', 'foo')
     element.checked = true;
     const event = {target: element};
     handler(event);
     expect(action.trigger).to.have.been.calledWith(
         element,
         'change',
-        sinon.match(object => object.detail.checked));
+        sinon.match(object =>
+            object.detail.checked && object.detail.value == 'foo'));
   });
 
   it('should trigger change event for <input type="range"> elements', () => {

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1021,7 +1021,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     const handler = window.document.addEventListener.getCall(3).args[1];
     const element = document.createElement('input');
     element.setAttribute('type', 'checkbox');
-    element.setAttribute('value', 'foo')
+    element.setAttribute('value', 'foo');
     element.checked = true;
     const event = {target: element};
     handler(event);


### PR DESCRIPTION
Fixes #10758. 

- Expose `HTMLInputElement.value` on "checkbox" or "radio" input elements.