### PR TITLE
added trim to amp-timeago title

### DIFF
--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -42,7 +42,7 @@ export class AmpTimeAgo extends AMP.BaseElement {
     this.datetime_ = this.element.getAttribute('datetime');
     this.locale_ = this.element.getAttribute('locale') ||
       this.win.document.documentElement.lang;
-    this.title_ = this.element.textContent;
+    this.title_ = this.element.textContent.trim();
 
     this.element.title = this.title_;
     this.element.textContent = '';


### PR DESCRIPTION
Spaces in the title of an html element aren't ignored. This results in ugly titles and tooltips if amp-timeago is written in multiple lines.
```html
<amp-timeago datetime="sometime" height="16">
    4. April 2017
</amp-timeago>
```
This would result is this title:
```
title="
    4. April 2017
"
```
Resulting in a popup like this:
![bildschirmfoto 2017-08-05 um 23 26 59](https://user-images.githubusercontent.com/1749936/28998860-a08fc1de-7a35-11e7-831b-5d07aa6ee727.png)
But I expect it to look like this:
![bildschirmfoto 2017-08-05 um 23 27 53](https://user-images.githubusercontent.com/1749936/28998863-bf5178ec-7a35-11e7-8a2c-2548636c9b98.png)
So I build this little fix.