### PR TITLE
Optimize validator test infra on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,6 @@ python:
 notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
-addons:
-  hosts:
-    - ads.localhost
-    - iframe.localhost
-    # Requested by some tests because they need a valid font host,
-    # but should not resolve in tests.
-    - fonts.googleapis.com
-  apt:
-    packages:
-    - protobuf-compiler
-    - python-protobuf
 before_install:
   - export CHROME_BIN=google-chrome
   - export DISPLAY=:99.0
@@ -44,8 +33,23 @@ env:
 matrix:
   include:
     - env: BUILD_SHARD="unit_tests"
+      addons:
+        hosts:
+          - ads.localhost
+          - iframe.localhost
+          # Requested by some tests because they need a valid font host,
+          # but should not resolve in tests.
+          - fonts.googleapis.com
+        apt:
+          packages:
+          - protobuf-compiler
+          - python-protobuf
     - env: BUILD_SHARD="integration_tests"
       addons:
+        apt:
+          packages:
+          - protobuf-compiler
+          - python-protobuf
         sauce_connect:
           username: "amphtml"
         jwt:

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -299,10 +299,10 @@ const command = {
     timedExecOrDie(`${gulp} presubmit`);
   },
   buildValidatorWebUI: function() {
-    timedExecOrDie('cd validator/webui && python build.py');
+    timedExecOrDie(`${gulp} validator-webui`);
   },
   buildValidator: function() {
-    timedExecOrDie('cd validator && python build.py');
+    timedExecOrDie(`${gulp} validator`);
   },
 };
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -409,12 +409,6 @@ function main(argv) {
         command.runUnitTests();
       }
     }
-    if (buildTargets.has('VALIDATOR_WEBUI')) {
-      command.buildValidatorWebUI();
-    }
-    if (buildTargets.has('VALIDATOR')) {
-      command.buildValidator();
-    }
   }
 
   if (process.env.BUILD_SHARD == "integration_tests") {
@@ -434,6 +428,12 @@ function main(argv) {
     } else {
       // Generates a blank Percy build to satisfy the required Github check.
       command.runVisualDiffTests(/* opt_mode */ 'skip');
+    }
+    if (buildTargets.has('VALIDATOR_WEBUI')) {
+      command.buildValidatorWebUI();
+    }
+    if (buildTargets.has('VALIDATOR')) {
+      command.buildValidator();
     }
   }
 

--- a/build-system/tasks/validator.js
+++ b/build-system/tasks/validator.js
@@ -26,4 +26,13 @@ function validator() {
   execSync('cd validator && python build.py')
 }
 
+/**
+ * Simple wrapper around the python based validator webui build.
+ */
+function validatorWebui() {
+  execSync('cd validator/webui && python build.py')
+}
+
 gulp.task('validator', 'Builds and tests the AMP validator.', validator);
+gulp.task('validator-webui', 'Builds and tests the AMP validator web UI.',
+    validatorWebui);

--- a/validator/build.py
+++ b/validator/build.py
@@ -581,7 +581,8 @@ def RunTests(out_dir, nodejs_cmd):
 def Main():
   """The main method, which executes all build steps and runs the tests."""
   logging.basicConfig(
-      format='[[%(filename)s %(funcName)s]] - %(message)s', level=logging.INFO)
+      format='[[%(filename)s %(funcName)s]] - %(message)s',
+      level=(logging.ERROR if os.environ.get('TRAVIS') else logging.INFO))
   nodejs_cmd = GetNodeJsCmd()
   CheckPrereqs()
   InstallNodeDependencies()

--- a/validator/webui/build.py
+++ b/validator/webui/build.py
@@ -158,8 +158,9 @@ def CreateWebuiAppengineDist(out_dir):
 
 def Main():
   """The main method, which executes all build steps and runs the tests."""
-  logging.basicConfig(format='[[%(filename)s %(funcName)s]] - %(message)s',
-                      level=logging.INFO)
+  logging.basicConfig(
+      format='[[%(filename)s %(funcName)s]] - %(message)s',
+      level=(logging.ERROR if os.environ.get('TRAVIS') else logging.INFO))
   nodejs_cmd = GetNodeJsCmd()
   CheckPrereqs()
   InstallNodeDependencies()


### PR DESCRIPTION
This PR does the following:
- Uses wrapper `gulp` tasks for `validator` and `validator/webui` tests in order to enable timing.
- Silences verbose `build.py` logs on Travis. (Errors, if any, are still printed. Local run behavior during development remains unchanged.)
- During PR runs, moves validator tests to the `integration_tests` shard for load balancing
- Fixes the `addons` section of `travis.yml` to include only those that are required by each shard. (This saves a considerable amount of build time when multiplied across all the PR runs in a given day.)

Fixes #10482 
Fixes #10833