### PR TITLE
Force to fetch from API if referrer is from proxy origin.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -457,6 +457,7 @@ var forbiddenTerms = {
       'dist.3p/current/integration.js',
       'src/service/viewer-impl.js',
       'src/error.js',
+      'src/window-interface.js',
     ],
   },
   'getUnconfirmedReferrerUrl': {

--- a/src/window-interface.js
+++ b/src/window-interface.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An interface to interact with browser window object.
+ * Mainly used to mock out read only APIs in test.
+ * See test-helper.js#mockWindowInterface
+ */
+export class WindowInterface {
+
+  static getDocumentReferrer(win) {
+    return win.document.referrer;
+  }
+}

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -23,6 +23,7 @@ import {
   registerServiceBuilderForDoc,
   resetServiceForTesting,
 } from '../src/service';
+import {WindowInterface} from '../src/window-interface';
 
 export function stubService(sandbox, win, serviceId, method) {
   // Register if not already registered.
@@ -56,6 +57,16 @@ export function mockServiceForDoc(sandbox, ampdoc, serviceId, methods) {
   const mock = {};
   methods.forEach(method => {
     mock[method] = sandbox.stub(impl, method);
+  });
+  return mock;
+}
+
+export function mockWindowInterface(sandbox) {
+  const methods = Object.getOwnPropertyNames(WindowInterface)
+      .filter(p => typeof WindowInterface[p] === 'function');
+  const mock = {};
+  methods.forEach(method => {
+    mock[method] = sandbox.stub(WindowInterface, method);
   });
   return mock;
 }


### PR DESCRIPTION
Also introduced `WindowInterface` for easy mocking read-only APIs.

/cc @dvoytenko @choumx `WindowInterface` was an idea we discussed in "test best practice" tech talk. if this looks good to you, we can gradually retire `fakeWin` and migrate to `WindowInterface`.
