### PR TITLE
Remove blacklisted resources from resource manager

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -145,9 +145,6 @@ export class Resource {
     /** @private {boolean} */
     this.isBuilding_ = false;
 
-    /** @private {boolean} */
-    this.blacklisted_ = false;
-
     /** @private {!AmpElement|undefined|null} */
     this.owner_ = undefined;
 
@@ -296,14 +293,6 @@ export class Resource {
   }
 
   /**
-   * Returns whether the resource has been blacklisted.
-   * @return {boolean}
-   */
-  isBlacklisted() {
-    return this.blacklisted_;
-  }
-
-  /**
    * Returns promise that resolves when the element has been built.
    * @return {!Promise}
    */
@@ -319,7 +308,6 @@ export class Resource {
    */
   build() {
     if (this.isBuilding_ ||
-        this.blacklisted_ ||
         !this.element.isUpgraded() ||
         !this.resources_.grantBuildPermission()) {
       return null;
@@ -341,7 +329,6 @@ export class Resource {
     }, reason => {
       dev().error(TAG, 'failed to build:', this.debugid, reason);
       this.isBuilding_ = false;
-      this.blacklisted_ = true;
       this.element.signals().rejectSignal('res-built', reason);
       throw reason;
     });

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -589,10 +589,7 @@ export class Resources {
     return promise.then(() => this.schedulePass(), error => {
       // Build failed: remove the resource. No other state changes are
       // needed.
-      const index = this.resources_.indexOf(resource);
-      if (index != -1) {
-        this.resources_.splice(index, 1);
-      }
+      this.removeResource_(resource);
       throw error;
     });
   }
@@ -620,9 +617,11 @@ export class Resources {
     if (index != -1) {
       this.resources_.splice(index, 1);
     }
-    resource.pauseOnRemove();
-    if (opt_disconnect) {
-      resource.disconnect();
+    if (resource.isBuilt()) {
+      resource.pauseOnRemove();
+      if (opt_disconnect) {
+        resource.disconnect();
+      }
     }
     this.cleanupTasks_(resource, /* opt_removePending */ true);
     dev().fine(TAG_, 'element removed:', resource.debugid);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -586,9 +586,15 @@ export class Resources {
     if (!promise || !schedulePass) {
       return promise;
     }
-    // TODO(dvoytenko): Consider removing "blacklisted" resources
-    // altogether from the list of resources.
-    return promise.then(() => this.schedulePass());
+    return promise.then(() => this.schedulePass(), error => {
+      // Build failed: remove the resource. No other state changes are
+      // needed.
+      const index = this.resources_.indexOf(resource);
+      if (index != -1) {
+        this.resources_.splice(index, 1);
+      }
+      throw error;
+    });
   }
 
   /**
@@ -1335,7 +1341,7 @@ export class Resources {
     let remeasureCount = 0;
     for (let i = 0; i < this.resources_.length; i++) {
       const r = this.resources_[i];
-      if (r.getState() == ResourceState.NOT_BUILT && !r.isBlacklisted()) {
+      if (r.getState() == ResourceState.NOT_BUILT && !r.isBuilding()) {
         this.buildOrScheduleBuildForResource_(r, /* checkForDupes */ true,
             /* scheduleWhenBuilt */ false);
       }

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -151,10 +151,12 @@ describe('Resource', () => {
     elementMock.expects('build')
         .returns(Promise.reject(new Error('intentional'))).once();
     elementMock.expects('updateLayoutBox').never();
-    return resource.build().then(() => {
+    const buildPromise = resource.build();
+    expect(resource.isBuilding()).to.be.true;
+    return buildPromise.then(() => {
       throw new Error('must have failed');
     }, () => {
-      expect(resource.blacklisted_).to.equal(true);
+      expect(resource.isBuilding()).to.be.false;
       expect(resource.getState()).to.equal(ResourceState.NOT_BUILT);
     });
   });


### PR DESCRIPTION
Partial for #10866.

The first step in retiring `Resource` class. Bits of state will be moved out this class to `CustomElement`, `Resources` manager, `Layers`, or completely removed.