### PR TITLE
Add variable substitution to amp-iframe on src

### DIFF
--- a/examples/iframe.var.substitution.amp.html
+++ b/examples/iframe.var.substitution.amp.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-iframe: variable substitution</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+
+  <style amp-custom>
+    .redBackground {
+      background-color: red;
+    }
+    button {
+      border: solid 1px black;
+    }
+    amp-iframe {
+      margin-top: 600px; /* iframes must not be in initial viewport as a rule */
+    }
+  </style>
+</head>
+
+<body>
+  <h2>amp-iframe (scroll down)</h2>
+
+  <amp-iframe width="500" height="281"
+      sandbox="allow-scripts allow-same-origin allow-popups" allowfullscreen frameborder="0"
+      src="https://player.vimeo.com/video/140261016?RANDOM">
+  </amp-iframe>
+</body>
+</html>

--- a/extensions/amp-iframe/0.1/src-vars-whitelist.js
+++ b/extensions/amp-iframe/0.1/src-vars-whitelist.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Whitelist for var substitution on iframe src url.
+ * @const {!Object<string, boolean>}
+ */
+export const SRC_AVAILABLE_VARS = {
+  'RANDOM': true,
+  'CANONICAL_URL': true,
+  'CANONICAL_HOST': true,
+  'CANONICAL_HOSTNAME': true,
+  'CANONICAL_PATH': true,
+  'AMPDOC_URL': true,
+  'AMPDOC_HOST': true,
+  'AMPDOC_HOSTNAME': true,
+  'SOURCE_URL': true,
+  'SOURCE_HOST': true,
+  'SOURCE_HOSTNAME': true,
+  'SOURCE_PATH': true,
+  'TIMESTAMP': true,
+  'TIMEZONE': true,
+  'VIEWPORT_HEIGHT': true,
+  'VIEWPORT_WIDTH': true,
+  'SCREEN_WIDTH': true,
+  'SCREEN_HEIGHT': true,
+  'AVAILABLE_SCREEN_HEIGHT': true,
+  'AVAILABLE_SCREEN_WIDTH': true,
+  'SCREEN_COLOR_DEPTH': true,
+  'DOCUMENT_CHARSET': true,
+  'DOCUMENT_REFERRER': true,
+  'BROWSER_LANGUAGE': true,
+  'AMP_VERSION': true,
+  'BACKGROUND_STATE': true,
+  'USER_AGENT': true,
+};

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -40,6 +40,11 @@ describes.realWin('amp-iframe', {
   },
 }, env => {
   describe('amp-iframe', () => {
+    const urlReplacements = {
+      DOCUMENT_REFERRER: 'somereferrer.com',
+      RANDOM: '0.12345',
+      TITLE: 'Test AMP Iframe Page',
+    };
     let iframeSrc;
     let clickableIframeSrc;
     let timer;
@@ -74,6 +79,18 @@ describes.realWin('amp-iframe', {
         }
       });
       setTrackingIframeTimeoutForTesting(20);
+
+      sandbox.stub(Services, 'urlReplacementsForDoc', () => ({
+        expandUrlSync: url =>
+          Object.keys(urlReplacements)
+              .reduce(
+              (changedUrl, key) =>
+                changedUrl.replace(
+                    new RegExp(key, 'g'),
+                    urlReplacements[key]
+                ), url
+              ),
+      }));
     });
 
     afterEach(() => {
@@ -728,5 +745,24 @@ describes.realWin('amp-iframe', {
           expect(impl.iframeSrc).to.contain(newSrc);
           expect(iframe.getAttribute('src')).to.contain(newSrc);
         });
+
+    it('should substitute variables in the src url', function* () {
+      const qs = 'rand1=RANDOM&title=TITLE&ref=DOCUMENT_REFERRER&rand2=RANDOM';
+      const substitutedQs =
+        `rand1=${urlReplacements.RANDOM}&` +
+        `title=${urlReplacements.TITLE}&` +
+        `ref=${urlReplacements.DOCUMENT_REFERRER}&` +
+        `rand2=${urlReplacements.RANDOM}`;
+      const originalUrl = `${iframeSrc}?${qs}`;
+      const substitutedUrl = `${iframeSrc}?${substitutedQs}`;
+      const ampIframe = createAmpIframe(env, {
+        src: originalUrl,
+        width: 100,
+        height: 100,
+      });
+      yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+      const impl = ampIframe.implementation_;
+      expect(impl.iframeSrc).to.contain(substitutedUrl);
+    });
   });
 });

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -41,7 +41,7 @@ limitations under the License.
 
 `amp-iframe` has several important differences from vanilla iframes that are designed to make it more secure and avoid AMP files that are dominated by a single iframe:
 
-- An `amp-iframe` may not appear close to the top of the document (except for iframes that use `placeholder` as described [below](#iframe-with-placeholder)). The iframe must be either 600 px away from the top or not within the first 75% of the viewport when scrolled to the top, whichever is smaller. 
+- An `amp-iframe` may not appear close to the top of the document (except for iframes that use `placeholder` as described [below](#iframe-with-placeholder)). The iframe must be either 600 px away from the top or not within the first 75% of the viewport when scrolled to the top, whichever is smaller.
 - By default, an amp-iframe is sandboxed (see [details](#sandbox)).
 - An `amp-iframe` must only request resources via HTTPS, from a data-URI, or via the `srcdoc` attribute.
 - An `amp-iframe` must not be in the same origin as the container unless they do not allow `allow-same-origin` in the `sandbox` attribute. See the ["Iframe origin policy"](../../spec/amp-iframe-origin-policy.md) doc for further details on allowed origins for iframes.
@@ -57,7 +57,7 @@ limitations under the License.
 </amp-iframe>
 ```
 
-Renders as: 
+Renders as:
 
 <amp-iframe width="200" height="100"
     sandbox="allow-scripts allow-same-origin"
@@ -224,6 +224,46 @@ We strongly recommend using [`amp-analytics`](../amp-analytics/amp-analytics.md)
 AMP only allows a single iframe that is used for analytics and tracking purposes, per page. To conserve resources, these iframes will be removed from the DOM 5 seconds after they loaded, which should be sufficient time to complete whatever work is needed to be done.
 
 Iframes are identified as tracking/analytics iframes if they appear to serve no direct user purpose such as being invisible or small.
+
+## Substitutions
+
+The `amp-iframe` allows all standard URL variable substitutions for `src`.
+See the [Substitutions Guide](../../spec/amp-var-substitutions.md) for more information.
+
+In the following example, a request might be made to something like `https://foo.com/pixel?0.8390278471201` where the RANDOM value is randomly generated upon each impression.
+
+```html
+<amp-iframe src="https://foo.com/pixel?RANDOM"></amp-iframe>
+```
+
+Allowed substitutions:
+  - `RANDOM`
+  - `CANONICAL_URL`
+  - `CANONICAL_HOST`
+  - `CANONICAL_HOSTNAME`
+  - `CANONICAL_PATH`
+  - `DOCUMENT_REFERRER`
+  - `AMPDOC_URL`
+  - `AMPDOC_HOST`
+  - `AMPDOC_HOSTNAME`
+  - `SOURCE_URL`
+  - `SOURCE_HOST`
+  - `SOURCE_HOSTNAME`
+  - `SOURCE_PATH`
+  - `TIMESTAMP`
+  - `TIMEZONE`
+  - `VIEWPORT_HEIGHT`
+  - `VIEWPORT_WIDTH`
+  - `SCREEN_WIDTH`
+  - `SCREEN_HEIGHT`
+  - `AVAILABLE_SCREEN_HEIGHT`
+  - `AVAILABLE_SCREEN_WIDTH`
+  - `SCREEN_COLOR_DEPTH`
+  - `DOCUMENT_CHARSET`
+  - `BROWSER_LANGUAGE`
+  - `AMP_VERSION`
+  - `BACKGROUND_STATE`
+  - `USER_AGENT`
 
 ## Guideline: Use existing AMP components over amp-iframe
 

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -46,6 +46,12 @@ The following table lists the features that enable variable substitutions, as we
     <td width="25%">None</td>
   </tr>
   <tr>
+    <td width="25%"><code>amp-iframe</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-iframe/amp-iframe.md#substitutions">Detailed documentation</a></td>
+    <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
+    <td width="25%">No</td>
+    <td width="25%">See whitelist in detailed documentation</td>
+  </tr>
+  <tr>
     <td width="25%"><code>amp-list</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-list/amp-list.md#substitutions">Detailed documentation</a></td>
     <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
     <td width="25%">No</td>

--- a/test/manual/amp-iframe-var-substitution.amp.html
+++ b/test/manual/amp-iframe-var-substitution.amp.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-iframe</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+
+    amp-iframe iframe {
+      margin: 30px;
+      padding: 30px;
+      border: 10px solid red;
+    }
+
+    h1 {
+      padding-bottom: 75vh;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>Scroll down to see an iframe. The src of the iframe should get variable substitution applied to it.</h1>
+  <amp-iframe width=300 height=300
+      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      layout="responsive"
+      frameborder="0"
+      src="https://www.w3.org/TR/page-visibility/?test=RANDOM&referrer=DOCUMENT_REFERRER">
+      <!-- a very long document -->
+  </amp-iframe>
+</body>
+</html>


### PR DESCRIPTION
Related to https://github.com/ampproject/amphtml/issues/6234
- Add variable substitution to amp-iframe's `src`
- Add tests (including manual html)
- Add /examples/iframe.var.substitution.amp.html
- Update amp-iframe and amp-var-substitution docs to reflect change