### PR TITLE
Moves "Building an AMP Component" doc to GitHub

### DIFF
--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -101,103 +101,78 @@ AMP.registerElement('amp-my-element', AmpMyElement, CSS);
 
 #### upgradeCallback
 
-**Default**: Does nothing
-
-**Override**: Rarely.
-
-**[Vsync](https://github.com/ampproject/amphtml/blob/master/src/service/vsync-impl.js#L44) Context**: None
-
-**Usage**: If your extension provides different implementations
+- **Default**: Does nothing
+- **Override**: Rarely.
+- **[Vsync](https://github.com/ampproject/amphtml/blob/master/src/service/vsync-impl.js#L44) Context**: None
+- **Usage**: If your extension provides different implementations
 depending on a late runtime condition (e.g. type attribute on the
 element, platform)
-
-**Example Usage**: amp-ad, amp-app-banner
+- **Example Usage**: amp-ad, amp-app-banner
 
 #### buildCallback
 
-**Default**: Does nothing
-
-**Override**: Almost always
-
-**Vsync Context**: Mutate
-
-**Usage**: If your element has UI elements this is where you should
+- **Default**: Does nothing
+- **Override**: Almost always
+- **Vsync Context**: Mutate
+- **Usage**: If your element has UI elements this is where you should
 create your DOM structure and append it to the element. You can also
 read the attributes (e.g. width, height…) the user provided on your
 element in this callback.
-
-**Warning**: Don’t load remote resources during the buildCallback. This
+- **Warning**: Don’t load remote resources during the buildCallback. This
 only circumvents the AMP resources manager, but it will also lead to
 higher data charges for users because all these resources will be loaded
 before layouting needs to happen.
-
-**Warning 2**: Do the least needed work here, and don’t build DOM that
+- **Warning 2**: Do the least needed work here, and don’t build DOM that
 is not needed at this point.
 
 #### preconnectCallback
 
-**Default**: Does nothing.
-
-**Vsync Context**: None (Neither mutate nor measure)
-
-**Override**: Sometimes, if your element will be loading remote
+- **Default**: Does nothing.
+- **Vsync Context**: None (Neither mutate nor measure)
+- **Override**: Sometimes, if your element will be loading remote
 resources.
-
-**Usage**: Use to instruct AMP which hosts to preconnect to and which
+- **Usage**: Use to instruct AMP which hosts to preconnect to and which
 resources to preload/prefetch this allows AMP to delegate to the browser
 to get a performance boost by preconnecting, preloading and prefetching
 resources via preconnect service.
-
-**Example Usage**: [Instagram uses this to
+- **Example Usage**: [Instagram uses this to
 preconnect](https://github.com/ampproject/amphtml/blob/master/extensions/amp-instagram/0.1/amp-instagram.js#L46)
 to instagram hosts.
 
 #### createPlaceholderCallback
 
-**Default**: Does nothing.
-
-**Vsync Context**: Mutate
-
-**Override**: Sometimes. If your component provides a way to dynamically
+- **Default**: Does nothing.
+- **Vsync Context**: Mutate
+- **Override**: Sometimes. If your component provides a way to dynamically
 create a lightweight placeholder. This gets called only if the element
 doesn’t already have a publisher-provided placeholder (through [the
 placeholder
 attribute](https://github.com/ampproject/amphtml/blob/c44a48fbb1dbd0de0b5a9e20f8f69bb920705dde/spec/amp-html-layout.md#placeholder)).
-
-**Usage**: Create placeholder DOM and return it. For example,
+- **Usage**: Create placeholder DOM and return it. For example,
 amp-instagram uses this to create a placeholder dynamically by creating
 an amp-img placeholder instead of loading the iframe, leaving the iframe
 loading to layoutCallback.
-
-**Warning**: Only use amp-elements for creating placeholders that
+- **Warning**: Only use amp-elements for creating placeholders that
 require external resource loading. This allows runtime to create this
 early but still defer the resource loading and management to AMP
 resources manager. Don’t create or load heavyweight resources (e.g.
 iframe…).
-
-**Example Usage**: amp-instagram.
+- **Example Usage**: amp-instagram.
 
 #### onLayoutMeasure
 
-**Default**: Does nothing.
-
-**Vsync Context**: Measure.
-
-**Override**: Rarely.
-
-**Usage**: Use to measure layouts for your element.
-
-**Example Usage**: amp-iframe
+- **Default**: Does nothing.
+- **Vsync Context**: Measure.
+- **Override**: Rarely.
+- **Usage**: Use to measure layouts for your element.
+- **Example Usage**: amp-iframe
 
 #### layoutCallback
 
-**Default**: Does nothing.
-
-**Vsync Context**: Mutate
-
-**Override**: Almost always.
-
-**Usage**: Use this to actually render the final version of your
+- **Default**: Does nothing.
+- **Vsync Context**: Mutate
+- **Override**: Almost always.
+- **Usage**: Use this to actually render the final version of your
 element. If the element should load a video, this is where you load the
 video. This needs to return a promise that resolves when the element is
 considered “laid out” - usually this means load event has fired but can
@@ -211,85 +186,61 @@ sends to resolve the layoutCallback promise.
 
 #### firstLayoutCompleted
 
-**Default**: Hide element’s placeholder.
-
-**Vsync Context**: Mutate
-
-**Override**: Sometimes. If you’d like to override default behavior and
+- **Default**: Hide element’s placeholder.
+- **Vsync Context**: Mutate
+- **Override**: Sometimes. If you’d like to override default behavior and
 not hide the placeholder when the element is considered first laid out.
 Sometimes you wanna control when to hide the placeholder.
-
-**Example Usage**: amp-anim
+- **Example Usage**: amp-anim
 
 #### pauseCallback
 
-**Default**: Does nothing.
-
-**Vsync Context**: Mutate
-
-**Called**: When you swipe away from a document in a viewer. Called on
+- **Default**: Does nothing.
+- **Vsync Context**: Mutate
+- **Called**: When you swipe away from a document in a viewer. Called on
 children of lightbox when you close a lightbox instance, called on
 carousel children when the slide is not the active slide. And possibly
 other places.
-
-**Override**: Sometimes. Most likely if you’re building a player.
-
-**Usage**: Use to pause video, slideshow auto-advance...etc
-
-**Example Usage**: amp-video, amp-youtube
+- **Override**: Sometimes. Most likely if you’re building a player.
+- **Usage**: Use to pause video, slideshow auto-advance...etc
+- **Example Usage**: amp-video, amp-youtube
 
 #### resumeCallback
 
-**Default**: Does nothing.
-
-**Vsync Context**: Mutate
-
-**Override**: Sometimes.
-
-**Usage**: Use to restart the slideshow auto-advance.
-
-**Note**: This is not used widely yet because it’s not possible to
+- **Default**: Does nothing.
+- **Vsync Context**: Mutate
+- **Override**: Sometimes.
+- **Usage**: Use to restart the slideshow auto-advance.
+- **Note**: This is not used widely yet because it’s not possible to
 resume video playback for example on mobile.
 
 #### unlayoutOnPause
 
-**Default**: Returns false.
-
-**Vsync Context**: Mutate
-
-**Override**: If your element doesn’t provide a pausing mechanism,
+- **Default**: Returns false.
+- **Vsync Context**: Mutate
+- **Override**: If your element doesn’t provide a pausing mechanism,
 instead override this to unlayout the element when AMP tries to pause
 it.
-
-**Return**: True if you want unlayoutCallback to be called when paused.
-
-**Usage Example**: amp-brightcove
+- **Return**: True if you want unlayoutCallback to be called when paused.
+- **Usage Example**: amp-brightcove
 
 #### unlayoutCallback
 
-**Default**: Does nothing.
-
-**Vsync Context**: Mutate
-
-**Override**: Sometimes.
-
-**Usage**: Use to remove and unload heavyweight resources like iframes,
+- **Default**: Does nothing.
+- **Vsync Context**: Mutate
+- **Override**: Sometimes.
+- **Usage**: Use to remove and unload heavyweight resources like iframes,
 video, audio and others that your element has created.
-
-**Return**: **True** if your element need to re-layout.
-
-**Usage Example**: amp-iframe
+- **Return**: **True** if your element need to re-layout.
+- **Usage Example**: amp-iframe
 
 #### viewportCallback
 
-**Default**: Does nothing.
-
-**Override**: Rarely.
-
-**Usage**: Use if your element need to know when it comes into viewport
+- **Default**: Does nothing.
+- **Override**: Rarely.
+- **Usage**: Use if your element need to know when it comes into viewport
 and when it goes out of it for finer control.
-
-**Usage Example**: amp-carousel, amp-anim
+- **Usage Example**: amp-carousel, amp-anim
 
 ## Element styling
 

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -2,7 +2,7 @@
 
 ## A word on contributing
 
-We suggest opening an “Intent to Implement” GitHub issue for your
+We suggest opening an "Intent to Implement" GitHub issue for your
 extension as early as you can, so we can advise on next steps or provide
 early feedback on the implementation or naming. See [CONTRIBUTING.md
 for more details](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md).
@@ -12,9 +12,9 @@ for more details](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING
 AMP can be extended to allow more functionality and components through
 building open source extensions (aka custom elements). For example, AMP
 provides `amp-carousel`, `amp-sidebar` and `amp-access` as
-extensions. If you’d like to add an extension to support your company
+extensions. If you'd like to add an extension to support your company
 video player, rich embed or just a general UI component like a star
-rating viewer, you’d do this by building an extension.
+rating viewer, you'd do this by building an extension.
 
 ## Naming
 
@@ -33,15 +33,15 @@ The directory structure is below:
         -   test/
             -   **test-amp-my-element.js** (Unit test suite for your element)
             -   More test JS files (Optional)
-        -   **amp-my-element.js** (Contains your element’s implementation)
+        -   **amp-my-element.js** (Contains your element's implementation)
         -   **amp-my-element.css** (Optional)
         -   More JS files (Optional)
         -   validator-amp-my-element.protoascii (Validator rules)
     -   **amp-my-element.md** (Main usage documentation for your element)
     -   More documentation in .md files (Optional)
 
-In most cases you’ll only create the bolded files. If your element does
-not need custom CSS you don’t need to create the CSS file.
+In most cases you'll only create the bolded files. If your element does
+not need custom CSS you don't need to create the CSS file.
 
 ## Extend AMP.BaseElement
 
@@ -118,11 +118,11 @@ element, platform)
 create your DOM structure and append it to the element. You can also
 read the attributes (e.g. width, height…) the user provided on your
 element in this callback.
-- **Warning**: Don’t load remote resources during the buildCallback. This
+- **Warning**: Don't load remote resources during the buildCallback. This
 only circumvents the AMP resources manager, but it will also lead to
 higher data charges for users because all these resources will be loaded
 before layouting needs to happen.
-- **Warning 2**: Do the least needed work here, and don’t build DOM that
+- **Warning 2**: Do the least needed work here, and don't build DOM that
 is not needed at this point.
 
 #### preconnectCallback
@@ -145,7 +145,7 @@ to instagram hosts.
 - **Vsync Context**: Mutate
 - **Override**: Sometimes. If your component provides a way to dynamically
 create a lightweight placeholder. This gets called only if the element
-doesn’t already have a publisher-provided placeholder (through [the
+doesn't already have a publisher-provided placeholder (through [the
 placeholder
 attribute](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#placeholder)).
 - **Usage**: Create placeholder DOM and return it. For example,
@@ -155,7 +155,7 @@ loading to layoutCallback.
 - **Warning**: Only use amp-elements for creating placeholders that
 require external resource loading. This allows runtime to create this
 early but still defer the resource loading and management to AMP
-resources manager. Don’t create or load heavyweight resources (e.g.
+resources manager. Don't create or load heavyweight resources (e.g.
 iframe…).
 - **Example Usage**: amp-instagram.
 
@@ -175,9 +175,9 @@ iframe…).
 - **Usage**: Use this to actually render the final version of your
 element. If the element should load a video, this is where you load the
 video. This needs to return a promise that resolves when the element is
-considered “laid out” - usually this means load event has fired but can
+considered "laid out" - usually this means load event has fired but can
 be different from element to element. Note that load events usually are
-fired very early so if there’s another event that your element can
+fired very early so if there's another event that your element can
 listen to that have a better meaning of ready-ness, use that to resolve
 your promise instead - for example: [amp-youtube](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/amp-youtube.js) uses the
 playerready event that the underlying YT Player
@@ -185,9 +185,9 @@ iframe sends to resolve the layoutCallback promise.
 
 #### firstLayoutCompleted
 
-- **Default**: Hide element’s placeholder.
+- **Default**: Hide element's placeholder.
 - **Vsync Context**: Mutate
-- **Override**: Sometimes. If you’d like to override default behavior and
+- **Override**: Sometimes. If you'd like to override default behavior and
 not hide the placeholder when the element is considered first laid out.
 Sometimes you wanna control when to hide the placeholder.
 - **Example Usage**: amp-anim
@@ -200,7 +200,7 @@ Sometimes you wanna control when to hide the placeholder.
 children of lightbox when you close a lightbox instance, called on
 carousel children when the slide is not the active slide. And possibly
 other places.
-- **Override**: Sometimes. Most likely if you’re building a player.
+- **Override**: Sometimes. Most likely if you're building a player.
 - **Usage**: Use to pause video, slideshow auto-advance...etc
 - **Example Usage**: amp-video, amp-youtube
 
@@ -210,14 +210,14 @@ other places.
 - **Vsync Context**: Mutate
 - **Override**: Sometimes.
 - **Usage**: Use to restart the slideshow auto-advance.
-- **Note**: This is not used widely yet because it’s not possible to
+- **Note**: This is not used widely yet because it's not possible to
 resume video playback for example on mobile.
 
 #### unlayoutOnPause
 
 - **Default**: Returns false.
 - **Vsync Context**: Mutate
-- **Override**: If your element doesn’t provide a pausing mechanism,
+- **Override**: If your element doesn't provide a pausing mechanism,
 instead override this to unlayout the element when AMP tries to pause
 it.
 - **Return**: True if you want unlayoutCallback to be called when paused.
@@ -246,7 +246,7 @@ and when it goes out of it for finer control.
 You can write a stylesheet to style your element to provide a minimal
 visual appeal, your element structure should account for whether you
 want users (publishers and developers using your element) to customize
-the default styling you’re providing and allow for easy CSS classes
+the default styling you're providing and allow for easy CSS classes
 and/or well-structure DOM elements.
 
 Element styles are loaded when the element script itself is included in
@@ -270,7 +270,7 @@ AMP.registerElement('amp-carousel', CarouselSelector, CSS);
 ## Element usage documentation and tests
 
 Make sure to write pretty comprehensive unit tests for your element.
-Also don’t forget to write an .md file documenting how to use this
+Also don't forget to write an .md file documenting how to use this
 element along with its attributes requirements and examples.
 
 An extra step that you can do is to write a small AMP doc inside
@@ -288,7 +288,7 @@ and react to it, for example, by launching a lightbox to display a
 message.
 
 The other part of the event-system in AMP is actions. When listening to
-an event on an element usually you’d like to trigger an action (possibly
+an event on an element usually you'd like to trigger an action (possibly
 on other elements). For example, in the example above, the publisher is
 executing the `open` action on `lightbox`.
 
@@ -299,7 +299,7 @@ The syntax for using this on elements is as follow:
 </form>
 ```
 
-To fire events on your element use AMP’s action service and the
+To fire events on your element use AMP's action service and the
 `.trigger` method.
 
 ```javascript
@@ -363,7 +363,7 @@ current slide when the user moves to it.
   this.schedulePreload(nextSlide);
 ```
 
-It’s important to understand that the parent/owner element is
+It's important to understand that the parent/owner element is
 responsible for managing all of its children (except for placeholders,
 see below). This means you need to make sure your element updates
 whether the child is in viewport and when to schedule different phases
@@ -389,19 +389,19 @@ nested amp-elements that are placeholders.
 
 ## Allowing proper validations
 
-One of AMP’s features is that a document can be checked against
-validation rules to confirm it’s AMP-valid. When you implement your
+One of AMP's features is that a document can be checked against
+validation rules to confirm it's AMP-valid. When you implement your
 element, AMP validator needs to be updated to add rules for your element
 to keep documents using your element valid. In order to do that you need
-to file an issue on the GitHub repo select “Related to: Validator” and
+to file an issue on the GitHub repo select "Related to: Validator" and
 mention what rules the validator needs to validate. This usually
 includes
 
 -   Your element tag-name
 -   Required attributes for the element
--   Specific values that an attribute accept (e.g. `myattr=”TYPE1|TYPE2”`)
+-   Specific values that an attribute accept (e.g. `myattr="TYPE1|TYPE2"`)
 -   Layouts your element supports (see [Layout specs](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md) and [Layouts supported in your element](#layouts-supported-in-your-element))
--   If there are restrictions where your element can or can’t appear (e.g. disallowed_ancestory, mandatory_parent...)
+-   If there are restrictions where your element can or can't appear (e.g. disallowed_ancestory, mandatory_parent...)
 
 For more details take a look at [Contributing Component Validator
 Rules](https://github.com/ampproject/amphtml/blob/master/contributing/component-validator-rules.md).
@@ -412,29 +412,29 @@ Rules](https://github.com/ampproject/amphtml/blob/master/contributing/component-
 
 Another enabling feature of instant-web in AMP is support for
 prerendering in a way that does not consume loads of data and does not
-waste too much of the user’s device resources. AMP does this by strictly
+waste too much of the user's device resources. AMP does this by strictly
 controlling resource loading and rendering.
 
 If your extension is lightweight, it might be worth enabling
 pre-rendering of your elements so that users will be able to see it
 appear instantly when they click on an article.
 
-Sometimes fully pre-rendering the element isn’t an option because it is
+Sometimes fully pre-rendering the element isn't an option because it is
 heavyweight. Your element might want to opt into creating a dynamic
-placeholder for itself (in case a placeholder wasn’t provided by the
+placeholder for itself (in case a placeholder wasn't provided by the
 developer/publisher who is using your element). This allows elements to
 display content as fast as possible and allow prerendering that
 placeholder. Learn [more about placeholder
 elements](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#placeholder).
 
 NOTE: Make sure not to request external resources in the pre-render
-phase. Requests to the publisher’s origin itself are OK. If in doubt,
+phase. Requests to the publisher's origin itself are OK. If in doubt,
 please flag this in review.
 
-AMP will automatically call your element’s
+AMP will automatically call your element's
 [createPlaceholderCallback](#createplaceholdercallback) during
-build step if it didn’t detect a placeholder was provided. This allows
-you to create your own placeholder. Here’s an example of how
+build step if it didn't detect a placeholder was provided. This allows
+you to create your own placeholder. Here's an example of how
 `amp-instagram` element used this callback to create a dynamic
 placeholder of an `amp-img` element to avoid loading the heavyweight
 instagram iframe embed during pre-rendering and instead loads just the
@@ -519,7 +519,7 @@ the viewport. This will only happen if your element sets
 `unlayoutOnPause`. Carousel by default only pauses the elements that
 are outside its viewport.
 
-Here’s an example of how `amp-instagram` destroys the iframe it has
+Here's an example of how `amp-instagram` destroys the iframe it has
 embedded when `unlayoutCallback` is called.
 
 ```javascript
@@ -615,7 +615,7 @@ Most newly created elements are initially launched as
 This allows people to experiment with using the new element and provide
 the author(s) with feedback. It also provides the AMP Team with the
 opportunity to monitor for any potential errors. This is especially
-required if the validator hasn’t been updated yet to allow your newly
+required if the validator hasn't been updated yet to allow your newly
 created extension, otherwise people using it in production will
 invalidate all their AMP documents.
 
@@ -639,16 +639,16 @@ const EXPERIMENTS = [
 ```
 
 And then protecting your code with a check `isExperimentOn(win,
-‘amp-my-element’)` and only execute your code when it is on.
+'amp-my-element')` and only execute your code when it is on.
 
 ```javascript
-import {isExperimentOn} from ‘../src/experiments;
+import {isExperimentOn} from '../src/experiments';
 
 /** @const */
-const EXPERIMENT = ‘amp-my-element’;
+const EXPERIMENT = 'amp-my-element';
 
 /** @const */
-const TAG = ‘amp-my-element’;
+const TAG = 'amp-my-element';
 
 Class AmpMyElement extends AMP.BaseElement {
 
@@ -684,7 +684,7 @@ Class AmpMyElement extends AMP.BaseElement {
   }
 }
 
-AMP.registerElement(‘amp-my-element’, AmpMyElement, CSS);
+AMP.registerElement('amp-my-element', AmpMyElement, CSS);
 ```
 
 ### Enable experiment
@@ -744,7 +744,7 @@ for all checked in code. We use the following frameworks for testing:
 - [Sinon](http://sinonjs.org/), spies, stubs and mocks.
 
 For faster testing during development, consider using --files argument
-to only run your extensions’ tests.
+to only run your extensions' tests.
 
 ```shell
 $ gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
@@ -769,7 +769,7 @@ $ gulp check-types
   - [Teads](https://github.com/ampproject/amphtml/commit/654ade680d796527345af8ff298a41a7532ee074)
   - [EPlanning](https://github.com/ampproject/amphtml/commit/a007543518a07ff77d48297e76bd264cadf36f57)
   - [Taboola](https://github.com/ampproject/amphtml/commit/79a58e545939cca0b75e62b2e62147829c59602a)
-- Adding embeds that’s not iframe-based (requires JS SDK)
+- Adding embeds that's not iframe-based (requires JS SDK)
   - [amp-facebook](https://github.com/ampproject/amphtml/commit/6679db198d8b9d9c38854d93aa04801e8cf6999f)
 - Adding iframe based embeds
   - [amp-soundcloud](https://github.com/ampproject/amphtml/commit/2ac845641c8eea9e67f17a1d471cfb9bab459fd1)

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -4,8 +4,8 @@
 
 We suggest opening an “Intent to Implement” GitHub issue for your
 extension as early as you can, so we can advise on next steps or provide
-early feedback on the implementation or naming. See [*CONTRIBUTING.md
-for more details*](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md).
+early feedback on the implementation or naming. See [CONTRIBUTING.md
+for more details](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md).
 
 ## Getting Started
 
@@ -49,7 +49,7 @@ Almost all AMP extensions extend AMP.BaseElement, which provides some
 hookups and callbacks for you to override in order to implement and
 customize your element behavior. These callbacks are explained below in
 the BaseElement Callbacks section, and are also explained inline in the
-[*BaseElement*](https://github.com/ampproject/amphtml/blob/master/src/base-element.js#L26)
+[BaseElement](https://github.com/ampproject/amphtml/blob/master/src/base-element.js#L26)
 class.
 
 ### Element Class
@@ -102,12 +102,15 @@ AMP.registerElement('amp-my-element', AmpMyElement, CSS);
 #### upgradeCallback
 
 **Default**: Does nothing
+
 **Override**: Rarely.
-**[*Vsync*](https://github.com/ampproject/amphtml/blob/master/src/service/vsync-impl.js#L44)
-Context**: None
+
+**[Vsync](https://github.com/ampproject/amphtml/blob/master/src/service/vsync-impl.js#L44) Context**: None
+
 **Usage**: If your extension provides different implementations
 depending on a late runtime condition (e.g. type attribute on the
 element, platform)
+
 **Example Usage**: amp-ad, amp-app-banner
 
 #### buildCallback
@@ -145,8 +148,8 @@ resources to preload/prefetch this allows AMP to delegate to the browser
 to get a performance boost by preconnecting, preloading and prefetching
 resources via preconnect service.
 
-**Example Usage**: [*Instagram uses this to
-preconnect*](https://github.com/ampproject/amphtml/blob/master/extensions/amp-instagram/0.1/amp-instagram.js#L46)
+**Example Usage**: [Instagram uses this to
+preconnect](https://github.com/ampproject/amphtml/blob/master/extensions/amp-instagram/0.1/amp-instagram.js#L46)
 to instagram hosts.
 
 #### createPlaceholderCallback
@@ -157,9 +160,9 @@ to instagram hosts.
 
 **Override**: Sometimes. If your component provides a way to dynamically
 create a lightweight placeholder. This gets called only if the element
-doesn’t already have a publisher-provided placeholder (through [*the
+doesn’t already have a publisher-provided placeholder (through [the
 placeholder
-attribute*](https://github.com/ampproject/amphtml/blob/c44a48fbb1dbd0de0b5a9e20f8f69bb920705dde/spec/amp-html-layout.md#placeholder)).
+attribute](https://github.com/ampproject/amphtml/blob/c44a48fbb1dbd0de0b5a9e20f8f69bb920705dde/spec/amp-html-layout.md#placeholder)).
 
 **Usage**: Create placeholder DOM and return it. For example,
 amp-instagram uses this to create a placeholder dynamically by creating
@@ -201,9 +204,9 @@ considered “laid out” - usually this means load event has fired but can
 be different from element to element. Note that load events usually are
 fired very early so if there’s another event that your element can
 listen to that have a better meaning of ready-ness, use that to resolve
-your promise instead - for example: [*amp-youtube uses the
+your promise instead - for example: [amp-youtube uses the
 *playerready** *event that the underlying YT Player
-iframe*](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/amp-youtube.js#L136)
+iframe](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/amp-youtube.js#L136)
 sends to resolve the layoutCallback promise.
 
 #### firstLayoutCompleted
@@ -326,8 +329,8 @@ for developers to manually test and visually inspect your element.
 
 ## Actions and Events
 
-AMP provides a framework for [*elements to fire their own
-events*](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md)
+AMP provides a framework for [elements to fire their own
+events](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md)
 to allow users of that element to listen and react to the events. For
 example, amp-form extension fires a few events on &lt;form&gt; elements
 like `submit-success`. This allow publishers to listen to that event
@@ -350,14 +353,14 @@ To fire events on your element use AMP’s action service and the
 `.trigger` method.
 
 ```javascript
-actionServiceForDoc(doc.documentElement).trigger(**this**.form\_, 'submit-success', null);
+actionServiceForDoc(doc.documentElement).trigger(this.form_, 'submit-success', null);
 ```
 
 And to expose actions use `registerAction` method that your element
 inherits from `BaseElement`.
 
 ```javascript
-  this.registerAction('close', this.close.bind(this));
+this.registerAction('close', this.close.bind(this));
 ```
 
 Your element could also choose to override the `activate` method
@@ -425,19 +428,13 @@ nested amp-elements that are not placeholders. AMP runtime will schedule
 nested amp-elements that are placeholders.
 
 ```html
-  <amp-carousel> ← Parent element
-
+<amp-carousel> ← Parent element
   <amp-figure> ← Parent needs to schedule this element
-
-  <amp-img placeholder></amp-img> ← AMP will schedule this when amp-figure is scheduled
-
-  <amp-img></amp-img> ← Parent needs to schedule this element
-
-  <amp-fit-text></amp-fit-text> ← Parent needs to schedule this element
-
+    <amp-img placeholder></amp-img> ← AMP will schedule this when amp-figure is scheduled
+    <amp-img></amp-img> ← Parent needs to schedule this element
+    <amp-fit-text></amp-fit-text> ← Parent needs to schedule this element
   </amp-figure>
-
-  </amp-carousel>
+</amp-carousel>
 ```
 
 ## Allowing Proper Validations
@@ -451,24 +448,15 @@ mention what rules the validator needs to validate. This usually
 includes
 
 -   Your element tag-name
-
 -   Required attributes for the element
-
 -   Specific values that an attribute accept (e.g. myattr=”TYPE1|TYPE2”)
+-   Layouts your element supports (see [Layout specs](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md) and [Layouts Supported in your Element](#layouts-supported-in-your-element))
+-   If there are restrictions where your element can or can’t appear (e.g. disallowed_ancestory, mandatory_parent...)
 
--   Layouts your element supports (see [*Layout
-    > specs*](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md)
-    > and [*Layouts Supported in your
-    > Element*](#layouts-supported-in-your-element))
+For more details take a look at [Contributing Component Validator
+Rules](https://github.com/ampproject/amphtml/blob/master/contributing/component-validator-rules.md).
 
--   If there are restrictions where your element can or can’t appear
-    > (e.g. disallowed\_ancestory, mandatory\_parent...)
-
-For more details take a look at [*Contributing Component Validator
-Rules*](https://github.com/ampproject/amphtml/blob/master/contributing/component-validator-rules.md).
-
-Performance Considerations
---------------------------
+## Performance Considerations
 
 ### Pre-rendering and Placeholders
 
@@ -486,15 +474,15 @@ heavyweight. Your element might want to opt into creating a dynamic
 placeholder for itself (in case a placeholder wasn’t provided by the
 developer/publisher who is using your element). This allows elements to
 display content as fast as possible and allow prerendering that
-placeholder. Learn [*more about placeholder
-elements*](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/spec/amp-html-layout.md#placeholder).
+placeholder. Learn [more about placeholder
+elements](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/spec/amp-html-layout.md#placeholder).
 
 NOTE: Make sure not to request external resources in the pre-render
 phase. Requests to the publisher’s origin itself are OK. If in doubt,
 please flag this in review.
 
 AMP will automatically call your element’s
-`[*createPlaceholderCallback*](#createplaceholdercallback)` during
+`[createPlaceholderCallback](#createplaceholdercallback)` during
 build step if it didn’t detect a placeholder was provided. This allows
 you to create your own placeholder. Here’s an example of how
 `amp-instagram` element used this callback to create a dynamic
@@ -502,75 +490,43 @@ placeholder of an `amp-img` element to avoid loading the heavyweight
 instagram iframe embed during pre-rendering and instead loads just the
 image directly from instagram media endpoint.
 
-  ------------------------------------------------------------------------------
-  class AmpInstagram extends AMP.BaseElement {
-
-  // ...
-
+```javascript
+class AmpInstagram extends AMP.BaseElement {
+  // ...  
   /** @override */
-
   createPlaceholderCallback() {
+    const placeholder = this.getWin().document.createElement('div');
+    placeholder.setAttribute('placeholder', '');
+    const image = this.getWin().document.createElement('amp-img');
+    // This is always the same URL that is actually used inside of the embed.
+    // This lets us avoid loading the image twice and make use of browser cache.
 
-  const placeholder = this.getWin().document.createElement('div');
-
-  placeholder.setAttribute('placeholder', '');
-
-  const image = this.getWin().document.createElement('amp-img');
-
-  // This is always the same URL that is actually used inside of the embed.
-
-  // This lets us avoid loading the image twice and make use of browser cache.
-
-  image.setAttribute('src', 'https://www.instagram.com/p/' +
-
-  encodeURIComponent(this.shortcode\_) + '/media/?size=l');
-
-  image.setAttribute('width', this.element.getAttribute('width'));
-
-  image.setAttribute('height', this.element.getAttribute('height'));
-
-  image.setAttribute('layout', 'responsive');
-
-  setStyles(image, {
-
-  'object-fit': 'cover',
-
-  });
-
-  const wrapper = this.element.ownerDocument.createElement('wrapper');
-
-  // This makes the non-iframe image appear in the exact same spot
-
-  // where it will be inside of the iframe.
-
-  setStyles(wrapper, {
-
-  'position': 'absolute',
-
-  'top': '48px',
-
-  'bottom': '48px',
-
-  'left': '8px',
-
-  'right': '8px',
-
-  });
-
-  wrapper.appendChild(image);
-
-  placeholder.appendChild(wrapper);
-
-  this.applyFillContent(image);
-
-  return placeholder;
-
+    image.setAttribute('src', 'https://www.instagram.com/p/' +
+        encodeURIComponent(this.shortcode_) + '/media/?size=l');
+    image.setAttribute('width', this.element.getAttribute('width'));
+    image.setAttribute('height', this.element.getAttribute('height'));
+    image.setAttribute('layout', 'responsive');
+    setStyles(image, {
+      'object-fit': 'cover',
+    });
+    const wrapper = this.element.ownerDocument.createElement('wrapper');
+    // This makes the non-iframe image appear in the exact same spot
+    // where it will be inside of the iframe.
+    setStyles(wrapper, {
+      'position': 'absolute',
+      'top': '48px',
+      'bottom': '48px',
+      'left': '8px',
+      'right': '8px',
+    });
+    wrapper.appendChild(image);
+    placeholder.appendChild(wrapper);
+    this.applyFillContent(image);
+    return placeholder;
   }
-
   // …
-
-  }
-  ------------------------------------------------------------------------------
+}
+```
 
 **Important**: One thing to keep in mind is that when you create a
 placeholder, use the amp- provided elements when loading external
@@ -585,19 +541,15 @@ Consider showing a loading indicator if your element is expected to take
 a long time to load (for example, loading a GIF, video or iframe). AMP
 has a built-in mechanism to show a loading indicator simply by
 whitelisting your element to show it. You can do that inside layout.js
-file in the LOADING\_ELEMENTS\_ object.
+file in the `LOADING_ELEMENTS_` object.
 
-  --------------------------------------
-  Export const LOADING\_ELEMENTS\_ = {
-
+```javascript
+export const LOADING_ELEMENTS_ = {
   ...
-
-  'AMP-YOUTUBE’: true,
-
-  **'AMP-MY-ELEMENT': true,**
-
-  }
-  --------------------------------------
+  'AMP-YOUTUBE': true,
+  'AMP-MY-ELEMENT': true,
+}
+```
 
 ### Destroying Heavyweight Resources
 
@@ -607,7 +559,7 @@ iframes, video, very large images, an expensive timer or computation...)
 need to be destroyed when they are no longer needed.
 
 AMP signals to your element that it needs to do that with
-`[*unlayoutCallback*](#unlayoutcallback)`. AMP calls this when the
+[unlayoutCallback](#unlayoutcallback). AMP calls this when the
 document becomes inactive; like when the user swipes away from the
 document to another one or when they switch tabs.
 
@@ -620,31 +572,20 @@ are outside its viewport.
 Here’s an example of how `amp-instagram` destroys the iframe it has
 embedded when `unlayoutCallback` is called.
 
-  --------------------------------------------
-  /** @override */
-
-  unlayoutCallback() {
-
-  if (this.iframe\_) {
-
-  removeElement(this.iframe\_);
-
-  this.iframe\_ = null;
-
-  this.iframePromise\_ = null;
-
-  setStyles(this.placeholderWrapper\_, {
-
-  'display': '',
-
-  });
-
+```javascript
+/** @override */
+unlayoutCallback() {
+  if (this.iframe_) {
+    removeElement(this.iframe_);
+    this.iframe_ = null;    
+    this.iframePromise_ = null;
+    setStyles(this.placeholderWrapper_, {
+      'display': '',
+    });
   }
-
   return true; // Call layoutCallback again.
-
-  }
-  --------------------------------------------
+}
+```
 
 Note if your element unlayoutCallback destroys the resources, it
 probably wants to return true in order to signal to AMP the need to call
@@ -666,27 +607,26 @@ you might need to add proper third party integration for it to work and
 use the proper third party iframe. Loading external resources is only
 allowed inside a 3p iframe which AMP serves on a different domain for
 security and performance reasons. Take a look at adding
-[*&lt;amp-facebook&gt;*](https://github.com/ampproject/amphtml/pull/1479/files)
+[&lt;amp-facebook&gt;](https://github.com/ampproject/amphtml/pull/1479/files)
 extension PR for examples of 3p integration.
 
-Read about [*Inclusion of third party software, embeds and services into
-AMP*](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/3p/README.md).
+Read about [Inclusion of third party software, embeds and services into
+AMP](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/3p/README.md).
 
 For contrast, take a look at amp-instagram which does NOT require an SDK
 to be loaded in order to embed a post, instead it provides an
 iframe-based embedding allowing amp-instagram extension to use a normal
 iframe with no 3p integration needed, similarly, amp-youtube and others.
 
-Layouts Supported in your Element
----------------------------------
+## Layouts Supported in your Element
 
 AMP defines different layouts that elements can choose whether or not to
 support Your element needs to announce which layouts it supports through
 overriding the `isLayoutSupported(layout)` callback and returning true
-if the element supports that layout. [*Read more about AMP Layout
-System*](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md)
-and [*Layout
-Types*](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#layout-types).
+if the element supports that layout. [Read more about AMP Layout
+System](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md)
+and [Layout
+Types](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#layout-types).
 
 ### What Layout should your Element Support?
 
@@ -698,41 +638,31 @@ in `layout.js`.
 
 For example, `amp-pixel` only supports fixed layout.
 
-  --------------------------------------
-  class AmpPixel extends BaseElement {
-
+```javascript
+class AmpPixel extends BaseElement {
   /** @override */
-
   isLayoutSupported(layout) {
-
-  return layout == Layout.FIXED;
-
+    return layout == Layout.FIXED;
   }
-
-  }
-  --------------------------------------
+}
+```
 
 While `amp-carousel` supports all size-defined layouts.
 
-  -------------------------------------------
-  class AmpSlides extends AMP.BaseElement {
-
+```javascript
+class AmpSlides extends AMP.BaseElement {
   /** @override */
-
   isLayoutSupported(layout) {
-
-  return isLayoutSizeDefined(layout);
-
+    return isLayoutSizeDefined(layout);
   }
-
-  }
-  -------------------------------------------
+}
+```
 
 Experiments
 -----------
 
 Most newly created elements are initially launched as
-[*experiments*](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/tools/experiments/README.md).
+[experiments](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/tools/experiments/README.md).
 This allows people to experiment with using the new element and provide
 the author(s) with feedback. It also provides the AMP Team with the
 opportunity to monitor for any potential errors. This is especially
@@ -744,118 +674,80 @@ You can add your extension as an experiment in the
 `amphtml/tools/experiments` file by adding a record for your extension
 in EXPERIMENTS variable.
 
-  -------------------------------------------------------------------------
-  /** @const {!Array<!ExperimentDef>} */
-
-  const EXPERIMENTS = \[
-
+```javascript
+/** @const {!Array<!ExperimentDef>} */
+const EXPERIMENTS = [
   // ...
-
   {
-
-  id: 'amp-my-element',
-
-  name: 'AMP My Element',
-
-  spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
-
-  'amp-my-element/amp-my-element.md',
-
-  cleanupIssue: 'https://github.com/ampproject/amphtml/issues/XXXYYY',
-
+    id: 'amp-my-element',  
+    name: 'AMP My Element',
+    spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
+      'amp-my-element/amp-my-element.md',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/XXXYYY',
   },
-
   // ...
-
-  \];
-  -------------------------------------------------------------------------
+];
+```
 
 And then protecting your code with a check `isExperimentOn(win,
 ‘amp-my-element’)` and only execute your code when it is on.
 
-  ---------------------------------------------------------------------
-  import {isExperimentOn} from ‘../src/experiments;
+```javascript
+import {isExperimentOn} from ‘../src/experiments;
 
-  /** @const */
+/** @const */
+const EXPERIMENT = ‘amp-my-element’;
 
-  const EXPERIMENT = ‘amp-my-element’;
+/** @const */
+const TAG = ‘amp-my-element’;
 
-  /** @const */
-
-  const TAG = ‘amp-my-element’;
-
-  Class AmpMyElement extends AMP.BaseElement {
+Class AmpMyElement extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
-
   constructor(element) {
+    super(element);
 
-  super(element);
-
-  // declare instance variables with type annotations.
-
+    // declare instance variables with type annotations.
   }
 
   /** @override */
-
   isLayoutSupported(layout) {
-
-  return layout == LAYOUT.FIXED;
-
+    return layout == LAYOUT.FIXED;
   }
 
   /** @override */
-
-  buildCallback() {
-
-  if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
-
-  user.warn('Experiment %s is not turned on.', EXPERIMENT);
-
-  return;
-
-  }
-
-  // get attributes, assertions of values, assign instance variables.
-
-  // build lightweight dom and append to this.element.
-
+  buildCallback() {  
+    if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
+      user.warn('Experiment %s is not turned on.', EXPERIMENT);
+      return;
+    }
+    // get attributes, assertions of values, assign instance variables.
+    // build lightweight dom and append to this.element.
   }
 
   /** @override */
-
   layoutCallback() {
-
-  if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
-
-  user.warn('Experiment %s is not turned on.', EXPERIMENT);
-
-  return;
-
+    if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
+      user.warn('Experiment %s is not turned on.', EXPERIMENT);
+      return;
+    }
+    // actually load your resource or render more expensive resources.
   }
+}
 
-  // actually load your resource or render more expensive resources.
-
-  }
-
-  }
-
-  AMP.registerElement(‘amp-my-element’, AmpMyElement, CSS);
-  ---------------------------------------------------------------------
-
-###
+AMP.registerElement(‘amp-my-element’, AmpMyElement, CSS);
+```
 
 ### Enable Experiment
 
 Users wanting to experiment with your element can then go to the
-[*experiments page*](https://cdn.ampproject.org/experiments.html) and
+[experiments page](https://cdn.ampproject.org/experiments.html) and
 enable your experiment.
 
 If test on localhost, use the command `AMP.toggleExperiment(id,
 true/false)` to enable.
 
-Example of Using your Extension
--------------------------------
+## Example of Using your Extension
 
 This is optional but it greatly helps users to understand and demo how
 your element works and provides an easy start-point for them to
@@ -866,28 +758,23 @@ name. Browse that directory to see examples for other elements and
 extensions.
 
 Also consider contributing to
-[*ampbyexample.com*](https://ampbyexample.com/) on
-[*github*](https://github.com/ampproject/amp-by-example).
+[ampbyexample.com](https://ampbyexample.com/) on
+[github](https://github.com/ampproject/amp-by-example).
 
-Updating Build Configs
-----------------------
+## Updating Build Configs
 
 In order for your element to build correctly you would need to make few
 changes to gulpfile.js to tell it about your extension, its files and
 its examples.
 
-  ----------------------------------------------------------------------
-  ...
+```javascript
+...
+declareExtension('amp-kaltura-player', '0.1', /* hasCss */ false);
+declareExtension('amp-carousel', '0.1', /* hasCss */ true);
+...
+```
 
-  declareExtension('amp-kaltura-player', '0.1', /* hasCss */ false);
-
-  declareExtension('amp-carousel', '0.1', /* hasCss */ true);
-
-  ...
-  ----------------------------------------------------------------------
-
-Versioning
-----------
+## Versioning
 
 AMP runtime is currently in v0 major version. Extensions versions are
 maintained separately. If your changes to your non-experimental
@@ -898,72 +785,51 @@ directory next to your 0.1.
 If your extension is still in experiments breaking changes usually are
 fine so you can just update the same version.
 
-Unit Tests
-----------
+## Unit Tests
 
 Make sure you write good coverage for your code. We require unit tests
 for all checked in code. We use the following frameworks for testing:
 
--   [*Mocha*](https://mochajs.org/), our test framework
-
--   [*Karma*](https://karma-runner.github.io/), our tests runner
-
--   [*Sinon*](http://sinonjs.org/), spies, stubs and mocks.
+- [Mocha](https://mochajs.org/), our test framework
+- [Karma](https://karma-runner.github.io/), our tests runner
+- [Sinon](http://sinonjs.org/), spies, stubs and mocks.
 
 For faster testing during development, consider using --files argument
 to only run your extensions’ tests.
 
-  ----------------------------------------------------------------------------------------
-  \$ gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
-  ----------------------------------------------------------------------------------------
+```shell
+$ gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
+```
 
-Type Checking
--------------
+## Type Checking
 
 We use Closure Compiler to perform type checking. Please see
-[*Annotating JavaScript for the Closure
-Compiler*](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler)
+[Annotating JavaScript for the Closure
+Compiler](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler)
 and existing AMP code for examples of how to add type annotations to
 your code. The following command should be run to ensure no type
 violations are introduced by your extension.
 
-  ---------------------
-  \$ gulp check-types
-  ---------------------
+```shell
+$ gulp check-types
+```
 
-Example PRs
------------
+## Example PRs
 
-**Adding new Ad-provider**
-
-[*Teads*](https://github.com/ampproject/amphtml/commit/654ade680d796527345af8ff298a41a7532ee074)
-
-[*EPlanning*](https://github.com/ampproject/amphtml/commit/a007543518a07ff77d48297e76bd264cadf36f57)
-
-[*Taboola*](https://github.com/ampproject/amphtml/commit/79a58e545939cca0b75e62b2e62147829c59602a)
-
-**Adding Embeds that’s not iframe-based (requires JS SDK)**
-
-[*amp-facebook*](https://github.com/ampproject/amphtml/commit/6679db198d8b9d9c38854d93aa04801e8cf6999f)
-
-**Adding iframe based embeds**
-
-[*amp-soundcloud*](https://github.com/ampproject/amphtml/commit/2ac845641c8eea9e67f17a1d471cfb9bab459fd1)
-
-[*amp-vine*](https://github.com/ampproject/amphtml/commit/eb98861b25210f89b41abc9ac52b29d9a4ff45a6)
-
-[*amp-brightcove*](https://github.com/ampproject/amphtml/commit/9a0f6089600da0c42e1f3787402a1ced0c377c65)
-
-**Adding non-visual elements**
-
-[*amp-font*](https://github.com/ampproject/amphtml/commit/ef040b60664a5aad465cb83507d37fae5e361772)
-
-[*amp-install-serviceworker*](https://github.com/ampproject/amphtml/commit/e6199cfb5b9d13b0e4bb590b80c09ba3614877e6)
-
-**Adding General UI components**
-
-[*amp-sidebar*](https://github.com/ampproject/amphtml/commit/99634b18310129f4260e4172cb2750ae7b8ffbf0)
-
-[*amp-image-lightbox*](https://github.com/ampproject/amphtml/commit/e6006f9ca516ae5d7d79267976d3df39cc1f9636)
-
-[*amp-accordion*](https://github.com/ampproject/amphtml/commit/1aae4eee37ec80c6ea9b822fb43ecce73feb7df6)
+- Adding new Ad-provider
+  - [Teads](https://github.com/ampproject/amphtml/commit/654ade680d796527345af8ff298a41a7532ee074)
+  - [EPlanning](https://github.com/ampproject/amphtml/commit/a007543518a07ff77d48297e76bd264cadf36f57)
+  - [Taboola](https://github.com/ampproject/amphtml/commit/79a58e545939cca0b75e62b2e62147829c59602a)
+- Adding Embeds that’s not iframe-based (requires JS SDK)
+  - [amp-facebook](https://github.com/ampproject/amphtml/commit/6679db198d8b9d9c38854d93aa04801e8cf6999f)
+- Adding iframe based embeds
+  - [amp-soundcloud](https://github.com/ampproject/amphtml/commit/2ac845641c8eea9e67f17a1d471cfb9bab459fd1)
+  - [amp-vine](https://github.com/ampproject/amphtml/commit/eb98861b25210f89b41abc9ac52b29d9a4ff45a6)
+  - [amp-brightcove](https://github.com/ampproject/amphtml/commit/9a0f6089600da0c42e1f3787402a1ced0c377c65)
+- Adding non-visual elements
+  - [amp-font](https://github.com/ampproject/amphtml/commit/ef040b60664a5aad465cb83507d37fae5e361772)
+  - [amp-install-serviceworker](https://github.com/ampproject/amphtml/commit/e6199cfb5b9d13b0e4bb590b80c09ba3614877e6)
+- Adding General UI components
+ - [amp-sidebar](https://github.com/ampproject/amphtml/commit/99634b18310129f4260e4172cb2750ae7b8ffbf0)
+ - [amp-image-lightbox](https://github.com/ampproject/amphtml/commit/e6006f9ca516ae5d7d79267976d3df39cc1f9636)
+ - [amp-accordion](https://github.com/ampproject/amphtml/commit/1aae4eee37ec80c6ea9b822fb43ecce73feb7df6)

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -7,7 +7,7 @@ extension as early as you can, so we can advise on next steps or provide
 early feedback on the implementation or naming. See [CONTRIBUTING.md
 for more details](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md).
 
-## Getting Started
+## Getting started
 
 AMP can be extended to allow more functionality and components through
 building open source extensions (aka custom elements). For example, AMP
@@ -23,7 +23,7 @@ with `amp-`. Make sure to choose a proper clear name for your
 extension. For example, video players are also suffixed with `-player`
 (e.g. amp-brid-player).
 
-## Directory Structure
+## Directory structure
 
 You create your extensions’ files inside the `extensions/` directory.
 The directory structure is below:
@@ -52,7 +52,7 @@ the BaseElement Callbacks section, and are also explained inline in the
 [BaseElement](https://github.com/ampproject/amphtml/blob/master/src/base-element.js#L26)
 class.
 
-### Element Class
+### Element class
 
 The following shows the overall structure of your element implementation
 file (extensions/amp-my-element/0.1/amp-my-element.js).
@@ -97,7 +97,7 @@ class AmpMyElement extends AMP.BaseElement {
 AMP.registerElement('amp-my-element', AmpMyElement, CSS);
 ```
 
-### BaseElement Callbacks
+### BaseElement callbacks
 
 #### upgradeCallback
 
@@ -205,7 +205,7 @@ be different from element to element. Note that load events usually are
 fired very early so if there’s another event that your element can
 listen to that have a better meaning of ready-ness, use that to resolve
 your promise instead - for example: [amp-youtube uses the
-*playerready** *event that the underlying YT Player
+playerready event that the underlying YT Player
 iframe](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/amp-youtube.js#L136)
 sends to resolve the layoutCallback promise.
 
@@ -291,7 +291,7 @@ and when it goes out of it for finer control.
 
 **Usage Example**: amp-carousel, amp-anim
 
-## Element Styling
+## Element styling
 
 You can write a stylesheet to style your element to provide a minimal
 visual appeal, your element structure should account for whether you
@@ -307,7 +307,7 @@ Class names prefixed with `-amp-` are considered private and
 publishers are not allowed to use to customize (enforced by AMP
 validator).
 
-## Register Element with AMP
+## Register element with AMP
 
 Once you have implemented your AMP element, you need to register it with
 AMP, all AMP extensions are prefixed with `amp-`. This is where you
@@ -317,7 +317,7 @@ tell AMP which class to use for this tag name and which CSS to load.
 AMP.registerElement('amp-carousel', CarouselSelector, CSS);
 ```
 
-## Element Usage Documentation and Tests
+## Element usage documentation and tests
 
 Make sure to write pretty comprehensive unit tests for your element.
 Also don’t forget to write an .md file documenting how to use this
@@ -327,7 +327,7 @@ An extra step that you can do is to write a small AMP doc inside
 examples/ directory to provide easy examples for users to preview and
 for developers to manually test and visually inspect your element.
 
-## Actions and Events
+## Actions and events
 
 AMP provides a framework for [elements to fire their own
 events](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md)
@@ -371,7 +371,7 @@ default case.
 Make sure your element documentation documents the events and actions it
 exposes.
 
-## Sub-elements Ownership
+## Sub-elements ownership
 
 AMP elements are usually discovered and scheduled by the AMP runtime
 automatically and managed through Resources. In some cases an AMP
@@ -419,7 +419,7 @@ see below). This means you need to make sure your element updates
 whether the child is in viewport and when to schedule different phases
 for the element.
 
-### Nested Sub-elements
+### Nested sub-elements
 
 Your element should anticipate its sub-elements to nest some more
 amp-elements and schedule preload or layout for these as well, otherwise
@@ -437,13 +437,13 @@ nested amp-elements that are placeholders.
 </amp-carousel>
 ```
 
-## Allowing Proper Validations
+## Allowing proper validations
 
 One of AMP’s features is that a document can be checked against
 validation rules to confirm it’s AMP-valid. When you implement your
 element, AMP validator needs to be updated to add rules for your element
 to keep documents using your element valid. In order to do that you need
-to file an issue on the github repo select “Related to: Validator” and
+to file an issue on the GitHub repo select “Related to: Validator” and
 mention what rules the validator needs to validate. This usually
 includes
 
@@ -456,9 +456,9 @@ includes
 For more details take a look at [Contributing Component Validator
 Rules](https://github.com/ampproject/amphtml/blob/master/contributing/component-validator-rules.md).
 
-## Performance Considerations
+## Performance considerations
 
-### Pre-rendering and Placeholders
+### Pre-rendering and placeholders
 
 Another enabling feature of instant-web in AMP is support for
 prerendering in a way that does not consume loads of data and does not
@@ -482,7 +482,7 @@ phase. Requests to the publisher’s origin itself are OK. If in doubt,
 please flag this in review.
 
 AMP will automatically call your element’s
-`[createPlaceholderCallback](#createplaceholdercallback)` during
+[createPlaceholderCallback](#createplaceholdercallback) during
 build step if it didn’t detect a placeholder was provided. This allows
 you to create your own placeholder. Here’s an example of how
 `amp-instagram` element used this callback to create a dynamic
@@ -535,7 +535,7 @@ instagram case above. This still allows AMP resource manager to control
 when these resources get loaded and rendered as oppose to using the
 HTML-native `img` tag which will be out of AMP resource management.
 
-#### Loading Indicators
+#### Loading indicators
 
 Consider showing a loading indicator if your element is expected to take
 a long time to load (for example, loading a GIF, video or iframe). AMP
@@ -551,7 +551,7 @@ export const LOADING_ELEMENTS_ = {
 }
 ```
 
-### Destroying Heavyweight Resources
+### Destroying heavyweight resources
 
 To stay good to our promise of lowering resources usage especially on
 mobile, elements that create and load heavyweight resources (e.g.
@@ -600,7 +600,7 @@ measure utility method that will synchronize all measuring happening in
 short period of time together and then do all the mutating in a
 requestAnimationFrame or similar cycles.
 
-### Loading External Resources
+### Loading external resources
 
 If your extension needs to load external resources (like an sdk) then
 you might need to add proper third party integration for it to work and
@@ -618,7 +618,7 @@ to be loaded in order to embed a post, instead it provides an
 iframe-based embedding allowing amp-instagram extension to use a normal
 iframe with no 3p integration needed, similarly, amp-youtube and others.
 
-## Layouts Supported in your Element
+## Layouts supported in your element
 
 AMP defines different layouts that elements can choose whether or not to
 support Your element needs to announce which layouts it supports through
@@ -628,7 +628,7 @@ System](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.m
 and [Layout
 Types](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#layout-types).
 
-### What Layout should your Element Support?
+### What layout should your element support?
 
 After understanding each layout type, if it makes sense, support all of
 them. Otherwise choose what makes sense to your element. A popular
@@ -658,8 +658,7 @@ class AmpSlides extends AMP.BaseElement {
 }
 ```
 
-Experiments
------------
+## Experiments
 
 Most newly created elements are initially launched as
 [experiments](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/tools/experiments/README.md).
@@ -738,7 +737,7 @@ Class AmpMyElement extends AMP.BaseElement {
 AMP.registerElement(‘amp-my-element’, AmpMyElement, CSS);
 ```
 
-### Enable Experiment
+### Enable experiment
 
 Users wanting to experiment with your element can then go to the
 [experiments page](https://cdn.ampproject.org/experiments.html) and
@@ -747,7 +746,7 @@ enable your experiment.
 If test on localhost, use the command `AMP.toggleExperiment(id,
 true/false)` to enable.
 
-## Example of Using your Extension
+## Example of using your extension
 
 This is optional but it greatly helps users to understand and demo how
 your element works and provides an easy start-point for them to
@@ -759,9 +758,9 @@ extensions.
 
 Also consider contributing to
 [ampbyexample.com](https://ampbyexample.com/) on
-[github](https://github.com/ampproject/amp-by-example).
+[GitHub](https://github.com/ampproject/amp-by-example).
 
-## Updating Build Configs
+## Updating build configs
 
 In order for your element to build correctly you would need to make few
 changes to gulpfile.js to tell it about your extension, its files and
@@ -785,7 +784,7 @@ directory next to your 0.1.
 If your extension is still in experiments breaking changes usually are
 fine so you can just update the same version.
 
-## Unit Tests
+## Unit tests
 
 Make sure you write good coverage for your code. We require unit tests
 for all checked in code. We use the following frameworks for testing:
@@ -801,7 +800,7 @@ to only run your extensions’ tests.
 $ gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
 ```
 
-## Type Checking
+## Type checking
 
 We use Closure Compiler to perform type checking. Please see
 [Annotating JavaScript for the Closure

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -1,0 +1,969 @@
+# Building an AMP Extension
+
+## A word on contributing
+
+We suggest opening an “Intent to Implement” GitHub issue for your
+extension as early as you can, so we can advise on next steps or provide
+early feedback on the implementation or naming. See [*CONTRIBUTING.md
+for more details*](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md).
+
+## Getting Started
+
+AMP can be extended to allow more functionality and components through
+building open source extensions (aka custom elements). For example, AMP
+provides `amp-carousel`, `amp-sidebar` and `amp-access` as
+extensions. If you’d like to add an extension to support your company
+video player, rich embed or just a general UI component like a star
+rating viewer, you’d do this by building an extension.
+
+## Naming
+
+All AMP extensions (and built-in elements) have their tag names prefixed
+with `amp-`. Make sure to choose a proper clear name for your
+extension. For example, video players are also suffixed with `-player`
+(e.g. amp-brid-player).
+
+## Directory Structure
+
+You create your extensions’ files inside the `extensions/` directory.
+The directory structure is below:
+
+-   extensions/amp-my-element/
+    -   0.1/
+        -   test/
+            -   **test-amp-my-element.js** (Unit test suite for your element)
+            -   More test JS files (Optional)
+        -   **amp-my-element.js** (Contains your element’s implementation)
+        -   **amp-my-element.css** (Optional)
+        -   More JS files (Optional)
+        -   validator-amp-my-element.protoascii (Validator rules)
+    -   **amp-my-element.md** (Main usage documentation for your element)
+    -   More documentation in .md files (Optional)
+
+In most cases you’ll only create the bolded files. If your element does
+not need custom CSS you don’t need to create the CSS file.
+
+## Extend AMP.BaseElement
+
+Almost all AMP extensions extend AMP.BaseElement, which provides some
+hookups and callbacks for you to override in order to implement and
+customize your element behavior. These callbacks are explained below in
+the BaseElement Callbacks section, and are also explained inline in the
+[*BaseElement*](https://github.com/ampproject/amphtml/blob/master/src/base-element.js#L26)
+class.
+
+### Element Class
+
+The following shows the overall structure of your element implementation
+file (extensions/amp-my-element/0.1/amp-my-element.js).
+
+```js
+import {func1, func2} from '../src/module';
+import {CSS} from '../../../build/amp-my-element-0.1.css';
+// more ES2015-style import statements.
+
+/** @const */
+const EXPERIMENT = 'amp-my-element';
+
+/** @const */
+const TAG = 'amp-my-element';
+
+class AmpMyElement extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    // Declare instance variables with type annotations.
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout == LAYOUT.FIXED;
+  }
+
+  /** @override */
+  buildCallback() {
+    // Get attributes, assertions of values, assign instance variables.
+    // Build lightweight DOM and append to this.element.
+  }
+
+  /** @override */
+  layoutCallback() {
+    // Actually load your resource or render more expensive resources.
+  }
+}
+
+AMP.registerElement('amp-my-element', AmpMyElement, CSS);
+```
+
+### BaseElement Callbacks
+
+#### upgradeCallback
+
+**Default**: Does nothing
+**Override**: Rarely.
+**[*Vsync*](https://github.com/ampproject/amphtml/blob/master/src/service/vsync-impl.js#L44)
+Context**: None
+**Usage**: If your extension provides different implementations
+depending on a late runtime condition (e.g. type attribute on the
+element, platform)
+**Example Usage**: amp-ad, amp-app-banner
+
+#### buildCallback
+
+**Default**: Does nothing
+
+**Override**: Almost always
+
+**Vsync Context**: Mutate
+
+**Usage**: If your element has UI elements this is where you should
+create your DOM structure and append it to the element. You can also
+read the attributes (e.g. width, height…) the user provided on your
+element in this callback.
+
+**Warning**: Don’t load remote resources during the buildCallback. This
+only circumvents the AMP resources manager, but it will also lead to
+higher data charges for users because all these resources will be loaded
+before layouting needs to happen.
+
+**Warning 2**: Do the least needed work here, and don’t build DOM that
+is not needed at this point.
+
+#### preconnectCallback
+
+**Default**: Does nothing.
+
+**Vsync Context**: None (Neither mutate nor measure)
+
+**Override**: Sometimes, if your element will be loading remote
+resources.
+
+**Usage**: Use to instruct AMP which hosts to preconnect to and which
+resources to preload/prefetch this allows AMP to delegate to the browser
+to get a performance boost by preconnecting, preloading and prefetching
+resources via preconnect service.
+
+**Example Usage**: [*Instagram uses this to
+preconnect*](https://github.com/ampproject/amphtml/blob/master/extensions/amp-instagram/0.1/amp-instagram.js#L46)
+to instagram hosts.
+
+#### createPlaceholderCallback
+
+**Default**: Does nothing.
+
+**Vsync Context**: Mutate
+
+**Override**: Sometimes. If your component provides a way to dynamically
+create a lightweight placeholder. This gets called only if the element
+doesn’t already have a publisher-provided placeholder (through [*the
+placeholder
+attribute*](https://github.com/ampproject/amphtml/blob/c44a48fbb1dbd0de0b5a9e20f8f69bb920705dde/spec/amp-html-layout.md#placeholder)).
+
+**Usage**: Create placeholder DOM and return it. For example,
+amp-instagram uses this to create a placeholder dynamically by creating
+an amp-img placeholder instead of loading the iframe, leaving the iframe
+loading to layoutCallback.
+
+**Warning**: Only use amp-elements for creating placeholders that
+require external resource loading. This allows runtime to create this
+early but still defer the resource loading and management to AMP
+resources manager. Don’t create or load heavyweight resources (e.g.
+iframe…).
+
+**Example Usage**: amp-instagram.
+
+#### onLayoutMeasure
+
+**Default**: Does nothing.
+
+**Vsync Context**: Measure.
+
+**Override**: Rarely.
+
+**Usage**: Use to measure layouts for your element.
+
+**Example Usage**: amp-iframe
+
+#### layoutCallback
+
+**Default**: Does nothing.
+
+**Vsync Context**: Mutate
+
+**Override**: Almost always.
+
+**Usage**: Use this to actually render the final version of your
+element. If the element should load a video, this is where you load the
+video. This needs to return a promise that resolves when the element is
+considered “laid out” - usually this means load event has fired but can
+be different from element to element. Note that load events usually are
+fired very early so if there’s another event that your element can
+listen to that have a better meaning of ready-ness, use that to resolve
+your promise instead - for example: [*amp-youtube uses the
+*playerready** *event that the underlying YT Player
+iframe*](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/amp-youtube.js#L136)
+sends to resolve the layoutCallback promise.
+
+#### firstLayoutCompleted
+
+**Default**: Hide element’s placeholder.
+
+**Vsync Context**: Mutate
+
+**Override**: Sometimes. If you’d like to override default behavior and
+not hide the placeholder when the element is considered first laid out.
+Sometimes you wanna control when to hide the placeholder.
+
+**Example Usage**: amp-anim
+
+#### pauseCallback
+
+**Default**: Does nothing.
+
+**Vsync Context**: Mutate
+
+**Called**: When you swipe away from a document in a viewer. Called on
+children of lightbox when you close a lightbox instance, called on
+carousel children when the slide is not the active slide. And possibly
+other places.
+
+**Override**: Sometimes. Most likely if you’re building a player.
+
+**Usage**: Use to pause video, slideshow auto-advance...etc
+
+**Example Usage**: amp-video, amp-youtube
+
+#### resumeCallback
+
+**Default**: Does nothing.
+
+**Vsync Context**: Mutate
+
+**Override**: Sometimes.
+
+**Usage**: Use to restart the slideshow auto-advance.
+
+**Note**: This is not used widely yet because it’s not possible to
+resume video playback for example on mobile.
+
+#### unlayoutOnPause
+
+**Default**: Returns false.
+
+**Vsync Context**: Mutate
+
+**Override**: If your element doesn’t provide a pausing mechanism,
+instead override this to unlayout the element when AMP tries to pause
+it.
+
+**Return**: True if you want unlayoutCallback to be called when paused.
+
+**Usage Example**: amp-brightcove
+
+#### unlayoutCallback
+
+**Default**: Does nothing.
+
+**Vsync Context**: Mutate
+
+**Override**: Sometimes.
+
+**Usage**: Use to remove and unload heavyweight resources like iframes,
+video, audio and others that your element has created.
+
+**Return**: **True** if your element need to re-layout.
+
+**Usage Example**: amp-iframe
+
+#### viewportCallback
+
+**Default**: Does nothing.
+
+**Override**: Rarely.
+
+**Usage**: Use if your element need to know when it comes into viewport
+and when it goes out of it for finer control.
+
+**Usage Example**: amp-carousel, amp-anim
+
+## Element Styling
+
+You can write a stylesheet to style your element to provide a minimal
+visual appeal, your element structure should account for whether you
+want users (publishers and developers using your element) to customize
+the default styling you’re providing and allow for easy CSS classes
+and/or well-structure DOM elements.
+
+Element styles are loaded when the element script itself is included in
+an AMP doc. You tell AMP which CSS belongs to this element when
+registering the element, see next.
+
+Class names prefixed with `-amp-` are considered private and
+publishers are not allowed to use to customize (enforced by AMP
+validator).
+
+## Register Element with AMP
+
+Once you have implemented your AMP element, you need to register it with
+AMP, all AMP extensions are prefixed with `amp-`. This is where you
+tell AMP which class to use for this tag name and which CSS to load.
+
+```javascript
+AMP.registerElement('amp-carousel', CarouselSelector, CSS);
+```
+
+## Element Usage Documentation and Tests
+
+Make sure to write pretty comprehensive unit tests for your element.
+Also don’t forget to write an .md file documenting how to use this
+element along with its attributes requirements and examples.
+
+An extra step that you can do is to write a small AMP doc inside
+examples/ directory to provide easy examples for users to preview and
+for developers to manually test and visually inspect your element.
+
+## Actions and Events
+
+AMP provides a framework for [*elements to fire their own
+events*](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md)
+to allow users of that element to listen and react to the events. For
+example, amp-form extension fires a few events on &lt;form&gt; elements
+like `submit-success`. This allow publishers to listen to that event
+and react to it, for example, by launching a lightbox to display a
+message.
+
+The other part of the event-system in AMP is actions. When listening to
+an event on an element usually you’d like to trigger an action (possibly
+on other elements). For example, in the example above, the publisher is
+executing the `open` action on `lightbox`.
+
+The syntax for using this on elements is as follow:
+
+```html
+<form on="submit-success:my-success-lightbox.open;submit-error:my-error-lightbox.open">
+</form>
+```
+
+To fire events on your element use AMP’s action service and the
+`.trigger` method.
+
+```javascript
+actionServiceForDoc(doc.documentElement).trigger(**this**.form\_, 'submit-success', null);
+```
+
+And to expose actions use `registerAction` method that your element
+inherits from `BaseElement`.
+
+```javascript
+  this.registerAction('close', this.close.bind(this));
+```
+
+Your element could also choose to override the `activate` method
+inherited from BaseElement that would define the default action for your
+element. For example amp-lightbox overrides activate to define the open
+default case.
+
+Make sure your element documentation documents the events and actions it
+exposes.
+
+## Sub-elements Ownership
+
+AMP elements are usually discovered and scheduled by the AMP runtime
+automatically and managed through Resources. In some cases an AMP
+element might want to control and own when its sub-elements gets
+scheduled and not leave that to the AMP runtime. An example to this is
+the &lt;amp-carousel&gt;, where it wants to schedule
+preloading/pre-rendering or layouting of its cells based on the window
+the user is in.
+
+AMP provides a way for an element to control this by setting the owner
+on the element you want to control. For carousel example, carousel loops
+over all its elements and sets itself as the owner of these elements.
+AMP runtime will not manage scheduling layouting for elements that have
+owners.
+
+```javascript
+this.cells_ = this.getRealChildren();
+
+this.cells_.forEach(cell => {
+  this.setAsOwner(cell);
+  cell.style.display = 'inline-block';
+  this.container_.appendChild(cell);
+});
+```
+
+An element can then later call *schedulePreload* or *scheduleLayout* to
+schedule preload or layout respectively. For example, &lt;amp-carousel
+type=slider&gt; (Slider instance of amp-carousel) calls
+*schedulePreload* for the next/previous slide when the user moves
+forward/backward in the slides and then calls *scheduleLayout* for the
+current slide when the user moves to it.
+
+```javascript
+  this.updateInViewport(oldSlide, false);
+  this.updateInViewport(newSlide, true);
+  this.scheduleLayout(newSlide);
+  this.setControlsState();
+  this.schedulePause(oldSlide);
+  this.schedulePreload(nextSlide);
+```
+
+It’s important to understand that the parent/owner element is
+responsible for managing all of its children (except for placeholders,
+see below). This means you need to make sure your element updates
+whether the child is in viewport and when to schedule different phases
+for the element.
+
+### Nested Sub-elements
+
+Your element should anticipate its sub-elements to nest some more
+amp-elements and schedule preload or layout for these as well, otherwise
+the element will never be preloaded or laid out. This is true to all
+nested amp-elements that are not placeholders. AMP runtime will schedule
+nested amp-elements that are placeholders.
+
+```html
+  <amp-carousel> ← Parent element
+
+  <amp-figure> ← Parent needs to schedule this element
+
+  <amp-img placeholder></amp-img> ← AMP will schedule this when amp-figure is scheduled
+
+  <amp-img></amp-img> ← Parent needs to schedule this element
+
+  <amp-fit-text></amp-fit-text> ← Parent needs to schedule this element
+
+  </amp-figure>
+
+  </amp-carousel>
+```
+
+## Allowing Proper Validations
+
+One of AMP’s features is that a document can be checked against
+validation rules to confirm it’s AMP-valid. When you implement your
+element, AMP validator needs to be updated to add rules for your element
+to keep documents using your element valid. In order to do that you need
+to file an issue on the github repo select “Related to: Validator” and
+mention what rules the validator needs to validate. This usually
+includes
+
+-   Your element tag-name
+
+-   Required attributes for the element
+
+-   Specific values that an attribute accept (e.g. myattr=”TYPE1|TYPE2”)
+
+-   Layouts your element supports (see [*Layout
+    > specs*](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md)
+    > and [*Layouts Supported in your
+    > Element*](#layouts-supported-in-your-element))
+
+-   If there are restrictions where your element can or can’t appear
+    > (e.g. disallowed\_ancestory, mandatory\_parent...)
+
+For more details take a look at [*Contributing Component Validator
+Rules*](https://github.com/ampproject/amphtml/blob/master/contributing/component-validator-rules.md).
+
+Performance Considerations
+--------------------------
+
+### Pre-rendering and Placeholders
+
+Another enabling feature of instant-web in AMP is support for
+prerendering in a way that does not consume loads of data and does not
+waste too much of the user’s device resources. AMP does this by strictly
+controlling resource loading and rendering.
+
+If your extension is lightweight, it might be worth enabling
+pre-rendering of your elements so that users will be able to see it
+appear instantly when they click on an article.
+
+Sometimes fully pre-rendering the element isn’t an option because it is
+heavyweight. Your element might want to opt into creating a dynamic
+placeholder for itself (in case a placeholder wasn’t provided by the
+developer/publisher who is using your element). This allows elements to
+display content as fast as possible and allow prerendering that
+placeholder. Learn [*more about placeholder
+elements*](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/spec/amp-html-layout.md#placeholder).
+
+NOTE: Make sure not to request external resources in the pre-render
+phase. Requests to the publisher’s origin itself are OK. If in doubt,
+please flag this in review.
+
+AMP will automatically call your element’s
+`[*createPlaceholderCallback*](#createplaceholdercallback)` during
+build step if it didn’t detect a placeholder was provided. This allows
+you to create your own placeholder. Here’s an example of how
+`amp-instagram` element used this callback to create a dynamic
+placeholder of an `amp-img` element to avoid loading the heavyweight
+instagram iframe embed during pre-rendering and instead loads just the
+image directly from instagram media endpoint.
+
+  ------------------------------------------------------------------------------
+  class AmpInstagram extends AMP.BaseElement {
+
+  // ...
+
+  /** @override */
+
+  createPlaceholderCallback() {
+
+  const placeholder = this.getWin().document.createElement('div');
+
+  placeholder.setAttribute('placeholder', '');
+
+  const image = this.getWin().document.createElement('amp-img');
+
+  // This is always the same URL that is actually used inside of the embed.
+
+  // This lets us avoid loading the image twice and make use of browser cache.
+
+  image.setAttribute('src', 'https://www.instagram.com/p/' +
+
+  encodeURIComponent(this.shortcode\_) + '/media/?size=l');
+
+  image.setAttribute('width', this.element.getAttribute('width'));
+
+  image.setAttribute('height', this.element.getAttribute('height'));
+
+  image.setAttribute('layout', 'responsive');
+
+  setStyles(image, {
+
+  'object-fit': 'cover',
+
+  });
+
+  const wrapper = this.element.ownerDocument.createElement('wrapper');
+
+  // This makes the non-iframe image appear in the exact same spot
+
+  // where it will be inside of the iframe.
+
+  setStyles(wrapper, {
+
+  'position': 'absolute',
+
+  'top': '48px',
+
+  'bottom': '48px',
+
+  'left': '8px',
+
+  'right': '8px',
+
+  });
+
+  wrapper.appendChild(image);
+
+  placeholder.appendChild(wrapper);
+
+  this.applyFillContent(image);
+
+  return placeholder;
+
+  }
+
+  // …
+
+  }
+  ------------------------------------------------------------------------------
+
+**Important**: One thing to keep in mind is that when you create a
+placeholder, use the amp- provided elements when loading external
+resources. This is most likely going to be `amp-img` like in the
+instagram case above. This still allows AMP resource manager to control
+when these resources get loaded and rendered as oppose to using the
+HTML-native `img` tag which will be out of AMP resource management.
+
+#### Loading Indicators
+
+Consider showing a loading indicator if your element is expected to take
+a long time to load (for example, loading a GIF, video or iframe). AMP
+has a built-in mechanism to show a loading indicator simply by
+whitelisting your element to show it. You can do that inside layout.js
+file in the LOADING\_ELEMENTS\_ object.
+
+  --------------------------------------
+  Export const LOADING\_ELEMENTS\_ = {
+
+  ...
+
+  'AMP-YOUTUBE’: true,
+
+  **'AMP-MY-ELEMENT': true,**
+
+  }
+  --------------------------------------
+
+### Destroying Heavyweight Resources
+
+To stay good to our promise of lowering resources usage especially on
+mobile, elements that create and load heavyweight resources (e.g.
+iframes, video, very large images, an expensive timer or computation...)
+need to be destroyed when they are no longer needed.
+
+AMP signals to your element that it needs to do that with
+`[*unlayoutCallback*](#unlayoutcallback)`. AMP calls this when the
+document becomes inactive; like when the user swipes away from the
+document to another one or when they switch tabs.
+
+This might be also be called in special cases like if your element is
+used as an amp-carousel cell and it was swiped away to become outside
+the viewport. This will only happen if your element sets
+`unlayoutOnPause`. Carousel by default only pauses the elements that
+are outside its viewport.
+
+Here’s an example of how `amp-instagram` destroys the iframe it has
+embedded when `unlayoutCallback` is called.
+
+  --------------------------------------------
+  /** @override */
+
+  unlayoutCallback() {
+
+  if (this.iframe\_) {
+
+  removeElement(this.iframe\_);
+
+  this.iframe\_ = null;
+
+  this.iframePromise\_ = null;
+
+  setStyles(this.placeholderWrapper\_, {
+
+  'display': '',
+
+  });
+
+  }
+
+  return true; // Call layoutCallback again.
+
+  }
+  --------------------------------------------
+
+Note if your element unlayoutCallback destroys the resources, it
+probably wants to return true in order to signal to AMP the need to call
+`layoutCallback` again once the document is active. Otherwise your
+element will never be re-laid out.
+
+### vsync, mutateElement, deferMutate and changeSize
+
+AMP provides multiple utilities to optimize many mutations and measuring
+for better performance. These include vsync service with a mutate and
+measure utility method that will synchronize all measuring happening in
+short period of time together and then do all the mutating in a
+requestAnimationFrame or similar cycles.
+
+### Loading External Resources
+
+If your extension needs to load external resources (like an sdk) then
+you might need to add proper third party integration for it to work and
+use the proper third party iframe. Loading external resources is only
+allowed inside a 3p iframe which AMP serves on a different domain for
+security and performance reasons. Take a look at adding
+[*&lt;amp-facebook&gt;*](https://github.com/ampproject/amphtml/pull/1479/files)
+extension PR for examples of 3p integration.
+
+Read about [*Inclusion of third party software, embeds and services into
+AMP*](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/3p/README.md).
+
+For contrast, take a look at amp-instagram which does NOT require an SDK
+to be loaded in order to embed a post, instead it provides an
+iframe-based embedding allowing amp-instagram extension to use a normal
+iframe with no 3p integration needed, similarly, amp-youtube and others.
+
+Layouts Supported in your Element
+---------------------------------
+
+AMP defines different layouts that elements can choose whether or not to
+support Your element needs to announce which layouts it supports through
+overriding the `isLayoutSupported(layout)` callback and returning true
+if the element supports that layout. [*Read more about AMP Layout
+System*](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md)
+and [*Layout
+Types*](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#layout-types).
+
+### What Layout should your Element Support?
+
+After understanding each layout type, if it makes sense, support all of
+them. Otherwise choose what makes sense to your element. A popular
+support choice is to support size-defined layouts (Fixed, Fixed Height,
+Responsive and Fill) through using the utility `isLayoutSizeDefined`
+in `layout.js`.
+
+For example, `amp-pixel` only supports fixed layout.
+
+  --------------------------------------
+  class AmpPixel extends BaseElement {
+
+  /** @override */
+
+  isLayoutSupported(layout) {
+
+  return layout == Layout.FIXED;
+
+  }
+
+  }
+  --------------------------------------
+
+While `amp-carousel` supports all size-defined layouts.
+
+  -------------------------------------------
+  class AmpSlides extends AMP.BaseElement {
+
+  /** @override */
+
+  isLayoutSupported(layout) {
+
+  return isLayoutSizeDefined(layout);
+
+  }
+
+  }
+  -------------------------------------------
+
+Experiments
+-----------
+
+Most newly created elements are initially launched as
+[*experiments*](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/tools/experiments/README.md).
+This allows people to experiment with using the new element and provide
+the author(s) with feedback. It also provides the AMP Team with the
+opportunity to monitor for any potential errors. This is especially
+required if the validator hasn’t been updated yet to allow your newly
+created extension, otherwise people using it in production will
+invalidate all their AMP documents.
+
+You can add your extension as an experiment in the
+`amphtml/tools/experiments` file by adding a record for your extension
+in EXPERIMENTS variable.
+
+  -------------------------------------------------------------------------
+  /** @const {!Array<!ExperimentDef>} */
+
+  const EXPERIMENTS = \[
+
+  // ...
+
+  {
+
+  id: 'amp-my-element',
+
+  name: 'AMP My Element',
+
+  spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
+
+  'amp-my-element/amp-my-element.md',
+
+  cleanupIssue: 'https://github.com/ampproject/amphtml/issues/XXXYYY',
+
+  },
+
+  // ...
+
+  \];
+  -------------------------------------------------------------------------
+
+And then protecting your code with a check `isExperimentOn(win,
+‘amp-my-element’)` and only execute your code when it is on.
+
+  ---------------------------------------------------------------------
+  import {isExperimentOn} from ‘../src/experiments;
+
+  /** @const */
+
+  const EXPERIMENT = ‘amp-my-element’;
+
+  /** @const */
+
+  const TAG = ‘amp-my-element’;
+
+  Class AmpMyElement extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+
+  constructor(element) {
+
+  super(element);
+
+  // declare instance variables with type annotations.
+
+  }
+
+  /** @override */
+
+  isLayoutSupported(layout) {
+
+  return layout == LAYOUT.FIXED;
+
+  }
+
+  /** @override */
+
+  buildCallback() {
+
+  if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
+
+  user.warn('Experiment %s is not turned on.', EXPERIMENT);
+
+  return;
+
+  }
+
+  // get attributes, assertions of values, assign instance variables.
+
+  // build lightweight dom and append to this.element.
+
+  }
+
+  /** @override */
+
+  layoutCallback() {
+
+  if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
+
+  user.warn('Experiment %s is not turned on.', EXPERIMENT);
+
+  return;
+
+  }
+
+  // actually load your resource or render more expensive resources.
+
+  }
+
+  }
+
+  AMP.registerElement(‘amp-my-element’, AmpMyElement, CSS);
+  ---------------------------------------------------------------------
+
+###
+
+### Enable Experiment
+
+Users wanting to experiment with your element can then go to the
+[*experiments page*](https://cdn.ampproject.org/experiments.html) and
+enable your experiment.
+
+If test on localhost, use the command `AMP.toggleExperiment(id,
+true/false)` to enable.
+
+Example of Using your Extension
+-------------------------------
+
+This is optional but it greatly helps users to understand and demo how
+your element works and provides an easy start-point for them to
+experiment with it. This is basically where you actually build an AMP
+HTML document and use your element in it by creating a file in the
+`examples/` directory, usually with the `my-element.amp.html` file
+name. Browse that directory to see examples for other elements and
+extensions.
+
+Also consider contributing to
+[*ampbyexample.com*](https://ampbyexample.com/) on
+[*github*](https://github.com/ampproject/amp-by-example).
+
+Updating Build Configs
+----------------------
+
+In order for your element to build correctly you would need to make few
+changes to gulpfile.js to tell it about your extension, its files and
+its examples.
+
+  ----------------------------------------------------------------------
+  ...
+
+  declareExtension('amp-kaltura-player', '0.1', /* hasCss */ false);
+
+  declareExtension('amp-carousel', '0.1', /* hasCss */ true);
+
+  ...
+  ----------------------------------------------------------------------
+
+Versioning
+----------
+
+AMP runtime is currently in v0 major version. Extensions versions are
+maintained separately. If your changes to your non-experimental
+extension makes breaking changes that are not backward compatible you
+should version your extension. This would usually be by creating a 0.2
+directory next to your 0.1.
+
+If your extension is still in experiments breaking changes usually are
+fine so you can just update the same version.
+
+Unit Tests
+----------
+
+Make sure you write good coverage for your code. We require unit tests
+for all checked in code. We use the following frameworks for testing:
+
+-   [*Mocha*](https://mochajs.org/), our test framework
+
+-   [*Karma*](https://karma-runner.github.io/), our tests runner
+
+-   [*Sinon*](http://sinonjs.org/), spies, stubs and mocks.
+
+For faster testing during development, consider using --files argument
+to only run your extensions’ tests.
+
+  ----------------------------------------------------------------------------------------
+  \$ gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
+  ----------------------------------------------------------------------------------------
+
+Type Checking
+-------------
+
+We use Closure Compiler to perform type checking. Please see
+[*Annotating JavaScript for the Closure
+Compiler*](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler)
+and existing AMP code for examples of how to add type annotations to
+your code. The following command should be run to ensure no type
+violations are introduced by your extension.
+
+  ---------------------
+  \$ gulp check-types
+  ---------------------
+
+Example PRs
+-----------
+
+**Adding new Ad-provider**
+
+[*Teads*](https://github.com/ampproject/amphtml/commit/654ade680d796527345af8ff298a41a7532ee074)
+
+[*EPlanning*](https://github.com/ampproject/amphtml/commit/a007543518a07ff77d48297e76bd264cadf36f57)
+
+[*Taboola*](https://github.com/ampproject/amphtml/commit/79a58e545939cca0b75e62b2e62147829c59602a)
+
+**Adding Embeds that’s not iframe-based (requires JS SDK)**
+
+[*amp-facebook*](https://github.com/ampproject/amphtml/commit/6679db198d8b9d9c38854d93aa04801e8cf6999f)
+
+**Adding iframe based embeds**
+
+[*amp-soundcloud*](https://github.com/ampproject/amphtml/commit/2ac845641c8eea9e67f17a1d471cfb9bab459fd1)
+
+[*amp-vine*](https://github.com/ampproject/amphtml/commit/eb98861b25210f89b41abc9ac52b29d9a4ff45a6)
+
+[*amp-brightcove*](https://github.com/ampproject/amphtml/commit/9a0f6089600da0c42e1f3787402a1ced0c377c65)
+
+**Adding non-visual elements**
+
+[*amp-font*](https://github.com/ampproject/amphtml/commit/ef040b60664a5aad465cb83507d37fae5e361772)
+
+[*amp-install-serviceworker*](https://github.com/ampproject/amphtml/commit/e6199cfb5b9d13b0e4bb590b80c09ba3614877e6)
+
+**Adding General UI components**
+
+[*amp-sidebar*](https://github.com/ampproject/amphtml/commit/99634b18310129f4260e4172cb2750ae7b8ffbf0)
+
+[*amp-image-lightbox*](https://github.com/ampproject/amphtml/commit/e6006f9ca516ae5d7d79267976d3df39cc1f9636)
+
+[*amp-accordion*](https://github.com/ampproject/amphtml/commit/1aae4eee37ec80c6ea9b822fb43ecce73feb7df6)

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -25,7 +25,7 @@ extension. For example, video players are also suffixed with `-player`
 
 ## Directory structure
 
-You create your extensions’ files inside the `extensions/` directory.
+You create your extension's files inside the `extensions/` directory.
 The directory structure is below:
 
 -   extensions/amp-my-element/
@@ -103,7 +103,7 @@ AMP.registerElement('amp-my-element', AmpMyElement, CSS);
 
 - **Default**: Does nothing
 - **Override**: Rarely.
-- **[Vsync](https://github.com/ampproject/amphtml/blob/master/src/service/vsync-impl.js#L44) Context**: None
+- **[Vsync](https://github.com/ampproject/amphtml/blob/master/src/service/vsync-impl.js) Context**: None
 - **Usage**: If your extension provides different implementations
 depending on a late runtime condition (e.g. type attribute on the
 element, platform)
@@ -136,7 +136,7 @@ resources to preload/prefetch this allows AMP to delegate to the browser
 to get a performance boost by preconnecting, preloading and prefetching
 resources via preconnect service.
 - **Example Usage**: [Instagram uses this to
-preconnect](https://github.com/ampproject/amphtml/blob/master/extensions/amp-instagram/0.1/amp-instagram.js#L46)
+preconnect](https://github.com/ampproject/amphtml/blob/master/extensions/amp-instagram/0.1/amp-instagram.js)
 to instagram hosts.
 
 #### createPlaceholderCallback
@@ -147,7 +147,7 @@ to instagram hosts.
 create a lightweight placeholder. This gets called only if the element
 doesn’t already have a publisher-provided placeholder (through [the
 placeholder
-attribute](https://github.com/ampproject/amphtml/blob/c44a48fbb1dbd0de0b5a9e20f8f69bb920705dde/spec/amp-html-layout.md#placeholder)).
+attribute](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#placeholder)).
 - **Usage**: Create placeholder DOM and return it. For example,
 amp-instagram uses this to create a placeholder dynamically by creating
 an amp-img placeholder instead of loading the iframe, leaving the iframe
@@ -179,10 +179,9 @@ considered “laid out” - usually this means load event has fired but can
 be different from element to element. Note that load events usually are
 fired very early so if there’s another event that your element can
 listen to that have a better meaning of ready-ness, use that to resolve
-your promise instead - for example: [amp-youtube uses the
+your promise instead - for example: [amp-youtube](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/amp-youtube.js) uses the
 playerready event that the underlying YT Player
-iframe](https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube/0.1/amp-youtube.js#L136)
-sends to resolve the layoutCallback promise.
+iframe sends to resolve the layoutCallback promise.
 
 #### firstLayoutCompleted
 
@@ -348,11 +347,11 @@ this.cells_.forEach(cell => {
 });
 ```
 
-An element can then later call *schedulePreload* or *scheduleLayout* to
+An element can then later call `schedulePreload` or `scheduleLayout` to
 schedule preload or layout respectively. For example, &lt;amp-carousel
 type=slider&gt; (Slider instance of amp-carousel) calls
-*schedulePreload* for the next/previous slide when the user moves
-forward/backward in the slides and then calls *scheduleLayout* for the
+`schedulePreload` for the next/previous slide when the user moves
+forward/backward in the slides and then calls `scheduleLayout` for the
 current slide when the user moves to it.
 
 ```javascript
@@ -400,8 +399,8 @@ includes
 
 -   Your element tag-name
 -   Required attributes for the element
--   Specific values that an attribute accept (e.g. myattr=”TYPE1|TYPE2”)
--   Layouts your element supports (see [Layout specs](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md) and [Layouts Supported in your Element](#layouts-supported-in-your-element))
+-   Specific values that an attribute accept (e.g. `myattr=”TYPE1|TYPE2”`)
+-   Layouts your element supports (see [Layout specs](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md) and [Layouts supported in your element](#layouts-supported-in-your-element))
 -   If there are restrictions where your element can or can’t appear (e.g. disallowed_ancestory, mandatory_parent...)
 
 For more details take a look at [Contributing Component Validator
@@ -426,7 +425,7 @@ placeholder for itself (in case a placeholder wasn’t provided by the
 developer/publisher who is using your element). This allows elements to
 display content as fast as possible and allow prerendering that
 placeholder. Learn [more about placeholder
-elements](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/spec/amp-html-layout.md#placeholder).
+elements](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#placeholder).
 
 NOTE: Make sure not to request external resources in the pre-render
 phase. Requests to the publisher’s origin itself are OK. If in doubt,
@@ -562,7 +561,7 @@ security and performance reasons. Take a look at adding
 extension PR for examples of 3p integration.
 
 Read about [Inclusion of third party software, embeds and services into
-AMP](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/3p/README.md).
+AMP](https://github.com/ampproject/amphtml/blob/master/3p/README.md).
 
 For contrast, take a look at amp-instagram which does NOT require an SDK
 to be loaded in order to embed a post, instead it provides an
@@ -577,7 +576,7 @@ overriding the `isLayoutSupported(layout)` callback and returning true
 if the element supports that layout. [Read more about AMP Layout
 System](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md)
 and [Layout
-Types](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#layout-types).
+Types](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md#layout).
 
 ### What layout should your element support?
 
@@ -612,7 +611,7 @@ class AmpSlides extends AMP.BaseElement {
 ## Experiments
 
 Most newly created elements are initially launched as
-[experiments](https://github.com/ampproject/amphtml/blob/bbbb7e6dccd8159fe9f139b7c65715a4a3526754/tools/experiments/README.md).
+[experiments](https://github.com/ampproject/amphtml/blob/master/tools/experiments/README.md).
 This allows people to experiment with using the new element and provide
 the author(s) with feedback. It also provides the AMP Team with the
 opportunity to monitor for any potential errors. This is especially
@@ -766,11 +765,11 @@ $ gulp check-types
 
 ## Example PRs
 
-- Adding new Ad-provider
+- Adding new ad-provider
   - [Teads](https://github.com/ampproject/amphtml/commit/654ade680d796527345af8ff298a41a7532ee074)
   - [EPlanning](https://github.com/ampproject/amphtml/commit/a007543518a07ff77d48297e76bd264cadf36f57)
   - [Taboola](https://github.com/ampproject/amphtml/commit/79a58e545939cca0b75e62b2e62147829c59602a)
-- Adding Embeds that’s not iframe-based (requires JS SDK)
+- Adding embeds that’s not iframe-based (requires JS SDK)
   - [amp-facebook](https://github.com/ampproject/amphtml/commit/6679db198d8b9d9c38854d93aa04801e8cf6999f)
 - Adding iframe based embeds
   - [amp-soundcloud](https://github.com/ampproject/amphtml/commit/2ac845641c8eea9e67f17a1d471cfb9bab459fd1)
@@ -779,7 +778,7 @@ $ gulp check-types
 - Adding non-visual elements
   - [amp-font](https://github.com/ampproject/amphtml/commit/ef040b60664a5aad465cb83507d37fae5e361772)
   - [amp-install-serviceworker](https://github.com/ampproject/amphtml/commit/e6199cfb5b9d13b0e4bb590b80c09ba3614877e6)
-- Adding General UI components
- - [amp-sidebar](https://github.com/ampproject/amphtml/commit/99634b18310129f4260e4172cb2750ae7b8ffbf0)
- - [amp-image-lightbox](https://github.com/ampproject/amphtml/commit/e6006f9ca516ae5d7d79267976d3df39cc1f9636)
- - [amp-accordion](https://github.com/ampproject/amphtml/commit/1aae4eee37ec80c6ea9b822fb43ecce73feb7df6)
+- Adding general UI components
+  - [amp-sidebar](https://github.com/ampproject/amphtml/commit/99634b18310129f4260e4172cb2750ae7b8ffbf0)
+  - [amp-image-lightbox](https://github.com/ampproject/amphtml/commit/e6006f9ca516ae5d7d79267976d3df39cc1f9636)
+  - [amp-accordion](https://github.com/ampproject/amphtml/commit/1aae4eee37ec80c6ea9b822fb43ecce73feb7df6)


### PR DESCRIPTION
This moves the [Building an AMP Component](https://docs.google.com/document/d/19o7eDta6oqPGF4RQ17LvZ9CHVQN53whN-mCIeIMM8Qk/edit) Google doc created by @mkhatib to GitHub.

I did an automatic conversion (using pandoc) and then a bunch of manual cleanup (especially on the code snippets).

The content should be the same as what's in the Google doc for now, except:
- I fixed some of the links (primarily ones that were pointing to docs on arbitrary branches instead of head + some outdated line numbers that didn't seem necessary)
- Minor capitalization fixes, e.g. in headings.

Rather than making any content changes in this PR, I'd prefer to get this merged in with the same content as in the existing doc.  If there is content that should change we can cover that in future PRs.