### PR TITLE
Link to the new GitHub version of "Building an AMP Extension" doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Because Extended Components may have significant impact on AMP HTML performance,
 In particular we strive to design the overall component set, so that a large number of use cases can be composed from them. Instead of creating a new component it may thus be a better solution to combine existing components to a similar effect.
 
 We have a few additional resources that provide an introduction to contributing extended components:
-* ["Building an AMP Extension"](https://docs.google.com/document/d/19o7eDta6oqPGF4RQ17LvZ9CHVQN53whN-mCIeIMM8Qk/edit) has a detailed description of how to build an AMP component.
+* ["Building an AMP Extension"](contributing/building-an-amp-extension.md) has a detailed description of how to build an AMP component.
 * ["Creating your first AMP Component" codelab](https://codelabs.developers.google.com/codelabs/creating-your-first-amp-component/#0) provides a quick overview of the steps you need to go through to create a component with examples you can modify for your component.
 * The ["Building a new AMP component" talk at AMP Conf 2017](https://youtu.be/FJEhQFNKeaQ?list=PLXTOW_XMsIDTDXYO-NAi2OpEH0zyguvqX) provides an introduction to contributing AMP components.
 

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -287,7 +287,7 @@ In particular, we try to maintain "it might not be perfect but isn't broken"-sup
 
 - [Life of an AMP *](https://docs.google.com/document/d/1WdNj3qNFDmtI--c2PqyRYrPrxSg2a-93z5iX0SzoQS0/edit#)
 - [AMP Layout system](../spec/amp-html-layout.md)
-- [Building an AMP Extension](https://docs.google.com/document/d/19o7eDta6oqPGF4RQ17LvZ9CHVQN53whN-mCIeIMM8Qk/edit#)
+- [Building an AMP Extension](building-an-amp-extension.md)
 
 We also recommend scanning the [spec](../spec/). The non-element part should help understand some of the design aspects.
 


### PR DESCRIPTION
This changes links from the Google doc version to the GitHub version of the "Building an AMP Extension" doc.