### PR TITLE
Add AMP.pushState() action

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -15,6 +15,7 @@
  */
 
 import {Services} from '../../../src/services';
+import {dict, map} from '../../../src/utils/object';
 import {fetchBatchedJsonFor} from '../../../src/batched-json';
 import {isJsonScriptTag} from '../../../src/dom';
 import {toggle} from '../../../src/style';
@@ -148,7 +149,7 @@ export class AmpState extends AMP.BaseElement {
       return;
     }
     const id = user().assert(this.element.id, '<amp-state> must have an id.');
-    const state = Object.create(null);
+    const state = dict(map());
     state[id] = json;
     Services.bindForDocOrNull(this.element).then(bind => {
       dev().assert(bind, 'Bind service can not be found.');

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../../../src/services';
-import {dict, map} from '../../../src/utils/object';
+import {map} from '../../../src/utils/object';
 import {fetchBatchedJsonFor} from '../../../src/batched-json';
 import {isJsonScriptTag} from '../../../src/dom';
 import {toggle} from '../../../src/style';
@@ -149,7 +149,7 @@ export class AmpState extends AMP.BaseElement {
       return;
     }
     const id = user().assert(this.element.id, '<amp-state> must have an id.');
-    const state = dict(map());
+    const state = /** @type {!JsonObject} */ (map());
     state[id] = json;
     Services.bindForDocOrNull(this.element).then(bind => {
       dev().assert(bind, 'Bind service can not be found.');

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -111,7 +111,7 @@ export class Bind {
     this.boundElements_ = [];
 
     /** @const @private {!Function} */
-    this.boundOnDomUpdate_ = this.onDomUpdate_.bound(this);
+    this.boundOnDomUpdate_ = this.onDomUpdate_.bind(this);
 
     /**
      * Maps expression string to the element(s) that contain it.
@@ -119,7 +119,7 @@ export class Bind {
      */
     this.expressionToElements_ = map();
 
-    /** @private {../../../src/service/history-impl.History} */
+    /** @private {!../../../src/service/history-impl.History} */
     this.history_ = Services.historyForDoc(ampdoc);
 
     /**
@@ -229,9 +229,10 @@ export class Bind {
    * in `expression`.
    * @param {string} expression
    * @param {!JsonObject} scope
+   * @return {!Promise}
    */
   pushStateWithExpression(expression, scope) {
-    this.evaluateExpression_(expression, scope).then(result => {
+    return this.evaluateExpression_(expression, scope).then(result => {
       // Store the current values of each referenced variable in `expression`
       // so that we can restore them on history-pop.
       const oldState = map();
@@ -244,7 +245,7 @@ export class Bind {
       const onPop = () => this.setState(oldState);
       this.history_.push(onPop);
 
-      this.setState(result);
+      return this.setState(result);
     });
   }
 
@@ -318,6 +319,11 @@ export class Bind {
    */
   setMaxNumberOfBindingsForTesting(value) {
     this.maxNumberOfBindings_ = value;
+  }
+
+  /** @return {!../../../src/service/history-impl.History} */
+  historyForTesting() {
+    return this.history_;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -230,8 +230,9 @@ export class Bind {
       // so that we can restore them on history-pop.
       const oldState = map();
       Object.keys(result).forEach(variable => {
-        // Replace `undefined` values with `null`.
-        oldState[variable] = (this.state_[variable] || null);
+        const s = map();
+        s[variable] = this.state_[variable] || null; // `undefined` -> `null`.
+        deepMerge(oldState, s, MAX_MERGE_DEPTH);
       });
 
       const onPop = () => this.setState(oldState);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -111,28 +111,34 @@ export class Bind {
     this.boundElements_ = [];
 
     /**
-     * Upper limit on number of bindings for performance.
-     * @private {number}
-     */
-    this.maxNumberOfBindings_ = 2000; // Based on ~1ms to parse an expression.
-
-    /**
      * Maps expression string to the element(s) that contain it.
      * @private @const {!Object<string, !Array<!Element>>}
      */
     this.expressionToElements_ = Object.create(null);
 
-    /** @const @private {!./bind-validator.BindValidator} */
-    this.validator_ = new BindValidator();
+    /** @private {../../../src/service/history-impl.History} */
+    this.history_ = Services.historyForDoc(ampdoc);
 
-    /** @const @private {!JsonObject} */
-    this.scope_ = dict();
+    /**
+     * Upper limit on number of bindings for performance.
+     * @private {number}
+     */
+    this.maxNumberOfBindings_ = 2000; // Based on ~1ms to parse an expression.
 
     /** @const @private {!../../../src/service/resources-impl.Resources} */
     this.resources_ = Services.resourcesForDoc(ampdoc);
 
+    /**
+     * The current values of all bound expressions on the page.
+     * @const @private {!JsonObject}
+     */
+    this.state_ = /** @type {!JsonObject} */ (map());
+
     /** @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win_);
+
+    /** @const @private {!./bind-validator.BindValidator} */
+    this.validator_ = new BindValidator();
 
     /** @const @private {!../../../src/service/viewer-impl.Viewer} */
     this.viewer_ = Services.viewerForDoc(this.ampdoc);
@@ -142,7 +148,7 @@ export class Bind {
             .then(() => dev().assertElement(opt_win.document.body))
         : ampdoc.whenBodyAvailable();
 
-    /**c.
+    /**
      * Resolved when the service finishes scanning the document for bindings.
      * @const @private {Promise}
      */
@@ -151,12 +157,7 @@ export class Bind {
           return this.initialize_(body);
         });
 
-    /** @const @private {!Function} */
-    this.boundOnDomUpdate_ = this.onDomUpdate_.bind(this);
-
-    /**
-     * @private {?Promise}
-     */
+    /** @private {Promise} */
     this.setStatePromise_ = null;
 
     // Expose for testing on dev.
@@ -182,9 +183,9 @@ export class Bind {
   setState(state, opt_skipEval, opt_isAmpStateMutation) {
     // TODO(choumx): What if `state` contains references to globals?
     try {
-      deepMerge(this.scope_, state, MAX_MERGE_DEPTH);
+      deepMerge(this.state_, state, MAX_MERGE_DEPTH);
     } catch (e) {
-      user().error(TAG, 'Failed to merge scope.', e);
+      user().error(TAG, 'Failed to merge result from AMP.setState().', e);
     }
 
     if (opt_skipEval) {
@@ -207,29 +208,39 @@ export class Bind {
   }
 
   /**
-   * Parses and evaluates an expression with a given scope and merges the
+   * Parses and evaluates an expression with a given state and merges the
    * resulting object into current state.
    * @param {string} expression
    * @param {!Object} scope
    * @return {!Promise}
    */
   setStateWithExpression(expression, scope) {
-    this.setStatePromise_ = this.initializePromise_.then(() => {
-      // Allow expression to reference current scope in addition to event scope.
-      Object.assign(scope, this.scope_);
-      return this.ww_('bind.evaluateExpression', [expression, scope]);
-    }).then(returnValue => {
-      const {result, error} = returnValue;
-      if (error) {
-        const userError = user().createError(`${TAG}: AMP.setState() failed `
-            + `with error: ${error.message}`);
-        userError.stack = error.stack;
-        reportError(userError);
-      } else {
-        return this.setState(result);
-      }
-    });
+    this.setStatePromise_ = this.evaluateExpression_(expression, scope)
+        .then(result => this.setState(result));
     return this.setStatePromise_;
+  }
+
+  /**
+   * @param {string} expression
+   * @param {!Object} scope
+   * @param {string=} opt_title
+   * @param {string=} opt_url
+   */
+  pushStateWithExpression(expression, scope, opt_title, opt_url) {
+    this.evaluateExpression_(expression, scope).then(result => {
+      // Store the current values of each referenced variable in `expression`
+      // so that we can restore them on history-pop.
+      const oldState = map();
+      Object.keys(result).forEach(variable => {
+        // Replace `undefined` values with `null`.
+        oldState[variable] = (this.state_[variable] || null);
+      });
+
+      const onPop = () => this.setState(oldState);
+      this.history_.push(onPop);
+
+      this.setState(result);
+    });
   }
 
   /**
@@ -560,10 +571,33 @@ export class Bind {
     return null;
   }
 
+  /**
+   * Evaluates a single expression and returns its result.
+   * @param {string} expression
+   * @param {!Object} scope
+   * @return {!Promise<?JsonObject>}
+   */
+  evaluateExpression_(expression, scope) {
+    return this.initializePromise_.then(() => {
+      // Allow expression to reference current state in addition to event state.
+      Object.assign(scope, this.state_);
+      return this.ww_('bind.evaluateExpression', [expression, scope]);
+    }).then(returnValue => {
+      const {result, error} = returnValue;
+      if (error) {
+        const userError = user().createError(`${TAG}: Expression eval failed `
+            + `with error: ${error.message}`);
+        userError.stack = error.stack;
+        reportError(userError);
+        throw userError;
+      } else {
+        return result;
+      }
+    });
+  }
 
   /**
-   * Asynchronously reevaluates all expressions and returns a map of
-   * expression strings to evaluated results.
+   * Reevaluates all expressions and returns a map of expressions to results.
    * @return {!Promise<
    *     !Object<string, ./bind-expression.BindExpressionResultDef>
    * >}
@@ -571,7 +605,7 @@ export class Bind {
    */
   evaluate_() {
     user().fine(TAG, 'Asking worker to re-evaluate expressions...');
-    const evaluatePromise = this.ww_('bind.evaluateBindings', [this.scope_]);
+    const evaluatePromise = this.ww_('bind.evaluateBindings', [this.state_]);
     return evaluatePromise.then(returnValue => {
       const {results, errors} = returnValue;
       // Report evaluation errors.
@@ -610,7 +644,7 @@ export class Bind {
 
   /**
    * Determines which properties to update based on results of evaluation
-   * of all bound expression strings with the current scope. This method
+   * of all bound expression strings with the current state. This method
    * will only return properties that need to be updated along with their
    * new value.
    * @param {!Array<!BoundPropertyDef>} boundProperties
@@ -949,7 +983,7 @@ export class Bind {
    */
   printState_() {
     const seen = [];
-    const s = JSON.stringify(this.scope_, (key, value) => {
+    const s = JSON.stringify(this.state_, (key, value) => {
       if (isObject(value)) {
         if (seen.includes(value)) {
           return '[Circular]';

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -135,7 +135,7 @@ export class Bind {
      * The current values of all bound expressions on the page.
      * @const @private {!JsonObject}
      */
-    this.state_ = dict(map());
+    this.state_ = /** @type {!JsonObject} */ (map());
 
     /** @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win_);

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -173,7 +173,7 @@ export class Bind {
   }
 
   /**
-   * Merges `state` into the current scope and immediately triggers an
+   * Merges `state` into the current state and immediately triggers an
    * evaluation unless `opt_skipEval` is false.
    * @param {!Object} state
    * @param {boolean=} opt_skipEval
@@ -208,7 +208,7 @@ export class Bind {
   }
 
   /**
-   * Parses and evaluates an expression with a given state and merges the
+   * Parses and evaluates an expression with a given scope and merges the
    * resulting object into current state.
    * @param {string} expression
    * @param {!Object} scope
@@ -221,6 +221,9 @@ export class Bind {
   }
 
   /**
+   * Same as setStateWithExpression() except also pushes new history.
+   * Popping the new history stack entry will restore the values of variables
+   * in `expression`.
    * @param {string} expression
    * @param {!Object} scope
    */
@@ -588,7 +591,8 @@ export class Bind {
             + `with error: ${error.message}`);
         userError.stack = error.stack;
         reportError(userError);
-        throw userError;
+
+        throw userError; // Reject promise.
       } else {
         return result;
       }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -110,11 +110,14 @@ export class Bind {
     /** @private {!Array<BoundElementDef>} */
     this.boundElements_ = [];
 
+    /** @const @private {!Function} */
+    this.boundOnDomUpdate_ = this.onDomUpdate_.bound(this);
+
     /**
      * Maps expression string to the element(s) that contain it.
      * @private @const {!Object<string, !Array<!Element>>}
      */
-    this.expressionToElements_ = Object.create(null);
+    this.expressionToElements_ = map();
 
     /** @private {../../../src/service/history-impl.History} */
     this.history_ = Services.historyForDoc(ampdoc);
@@ -132,7 +135,7 @@ export class Bind {
      * The current values of all bound expressions on the page.
      * @const @private {!JsonObject}
      */
-    this.state_ = /** @type {!JsonObject} */ (map());
+    this.state_ = dict(map());
 
     /** @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win_);
@@ -175,7 +178,7 @@ export class Bind {
   /**
    * Merges `state` into the current state and immediately triggers an
    * evaluation unless `opt_skipEval` is false.
-   * @param {!Object} state
+   * @param {!JsonObject} state
    * @param {boolean=} opt_skipEval
    * @param {boolean=} opt_isAmpStateMutation
    * @return {!Promise}
@@ -225,7 +228,7 @@ export class Bind {
    * Popping the new history stack entry will restore the values of variables
    * in `expression`.
    * @param {string} expression
-   * @param {!Object} scope
+   * @param {!JsonObject} scope
    */
   pushStateWithExpression(expression, scope) {
     this.evaluateExpression_(expression, scope).then(result => {
@@ -459,7 +462,7 @@ export class Bind {
     /** @type {!Array<./bind-evaluator.BindingDef>} */
     const bindings = [];
     /** @type {!Object<string, !Array<!Element>>} */
-    const expressionToElements = Object.create(null);
+    const expressionToElements = map();
 
     const doc = dev().assert(node.ownerDocument, 'ownerDocument is null.');
     // Third and fourth params of `createTreeWalker` are not optional on IE11.
@@ -577,7 +580,7 @@ export class Bind {
    * Evaluates a single expression and returns its result.
    * @param {string} expression
    * @param {!Object} scope
-   * @return {!Promise<?JsonObject>}
+   * @return {!Promise<!JsonObject>}
    */
   evaluateExpression_(expression, scope) {
     return this.initializePromise_.then(() => {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -223,10 +223,8 @@ export class Bind {
   /**
    * @param {string} expression
    * @param {!Object} scope
-   * @param {string=} opt_title
-   * @param {string=} opt_url
    */
-  pushStateWithExpression(expression, scope, opt_title, opt_url) {
+  pushStateWithExpression(expression, scope) {
     this.evaluateExpression_(expression, scope).then(result => {
       // Store the current values of each referenced variable in `expression`
       // so that we can restore them on history-pop.

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -214,7 +214,7 @@ export class Bind {
    * Parses and evaluates an expression with a given scope and merges the
    * resulting object into current state.
    * @param {string} expression
-   * @param {!Object} scope
+   * @param {!JsonObject} scope
    * @return {!Promise}
    */
   setStateWithExpression(expression, scope) {
@@ -238,7 +238,8 @@ export class Bind {
       const oldState = map();
       Object.keys(result).forEach(variable => {
         const s = map();
-        s[variable] = this.state_[variable] || null; // `undefined` -> `null`.
+        const value = this.state_[variable];
+        s[variable] = (value === undefined) ? null : value;
         deepMerge(oldState, s, MAX_MERGE_DEPTH);
       });
 
@@ -585,7 +586,7 @@ export class Bind {
   /**
    * Evaluates a single expression and returns its result.
    * @param {string} expression
-   * @param {!Object} scope
+   * @param {!JsonObject} scope
    * @return {!Promise<!JsonObject>}
    */
   evaluateExpression_(expression, scope) {

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -381,7 +381,23 @@ describe.configure().ifNewChrome().run('Bind', function() {
     });
 
     it('should support pushStateWithExpression()', () => {
-      // TODO(choumx)
+      const pushHistorySpy =
+          env.sandbox.spy(bind.historyForTesting(), 'push');
+
+      const element = createElement(env, container, '[text]="foo"');
+      expect(element.textContent).to.equal('');
+      const promise = bind.pushStateWithExpression('{"foo": "bar"}', {});
+      return promise.then(() => {
+        env.flushVsync();
+        expect(element.textContent).to.equal('bar');
+
+        expect(pushHistorySpy).calledOnce;
+        // Pop callback should restore `foo` to original value (null).
+        const onPopCallback = pushHistorySpy.firstCall.args[0];
+        return onPopCallback();
+      }).then(() => {
+        expect(element.textContent).to.equal('null');
+      });
     });
 
     it('should ignore <amp-state> updates if specified in setState()', () => {

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview "Unit" test for bind-impl.js. Runs as an integration test
+ *               because it requires building web-worker binary.
+ */
+
 import * as sinon from 'sinon';
 import {AmpEvents} from '../../../../../src/amp-events';
 import {Bind} from '../../bind-impl';
@@ -365,7 +370,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
       });
     });
 
-    it('should support parsing exprs in `setStateWithExpression`', () => {
+    it('should support parsing exprs in setStateWithExpression()', () => {
       const element = createElement(env, container, '[text]="onePlusOne"');
       expect(element.textContent).to.equal('');
       const promise = onBindReadyAndSetStateWithExpression(
@@ -375,7 +380,11 @@ describe.configure().ifNewChrome().run('Bind', function() {
       });
     });
 
-    it('should ignore <amp-state> updates if specified in `setState`', () => {
+    it('should support pushStateWithExpression()', () => {
+      // TODO(choumx)
+    });
+
+    it('should ignore <amp-state> updates if specified in setState()', () => {
       const element = createElement(env, container, '[src]="foo"', 'amp-state');
       expect(element.getAttribute('src')).to.be.null;
       const promise = onBindReadyAndSetState(env, bind,

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -20,7 +20,7 @@ import {
   getService,
 } from '../service';
 import {getMode} from '../mode';
-import {dev, user} from '../log';
+import {dev} from '../log';
 import {dict, map} from '../utils/object';
 import {Services} from '../services';
 

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -20,14 +20,14 @@ import {
   getService,
 } from '../service';
 import {getMode} from '../mode';
-import {dev} from '../log';
+import {dev, user} from '../log';
 import {dict, map} from '../utils/object';
 import {Services} from '../services';
 
-/** @private @const */
+/** @private @const {string} */
 const TAG_ = 'History';
 
-/** @private @const */
+/** @private @const {string} */
 const HISTORY_PROP_ = 'AMP.History';
 
 /** @typedef {number} */
@@ -179,10 +179,16 @@ export class History {
       return;
     }
 
+    const maxStackSize = this.maxStackSize_();
     const toPop = [];
     for (let i = this.stackOnPop_.length - 1; i > this.stackIndex_; i--) {
       if (this.stackOnPop_[i]) {
-        toPop.push(this.stackOnPop_[i]);
+        if (toPop.length < maxStackSize) {
+          toPop.push(this.stackOnPop_[i]);
+        } else {
+          user().warn(TAG_, 'Maximum history stack size reached. ' +
+              'Dropping state with id: ' + i);
+        }
         this.stackOnPop_[i] = undefined;
       }
     }
@@ -251,6 +257,14 @@ export class History {
       this.queue_.splice(0, 1);
       this.deque_();
     });
+  }
+
+  /**
+   * @return {number}
+   * @private
+   */
+  maxStackSize_() {
+    return 10;
   }
 }
 

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -56,9 +56,6 @@ export class History {
     /** @private {!Array<!Function|undefined>} */
     this.stackOnPop_ = [];
 
-    /** @private {number} */
-    this.stackSize_ = 0;
-
     /**
      * @private {!Array<!{
      *   callback: function():!Promise,
@@ -84,11 +81,7 @@ export class History {
    */
   push(opt_onPop) {
     return this.enque_(() => {
-      if (this.stackSize_ >= this.maxStackSize_()) {
-        throw new Error('Maximum history size reached.');
-      }
       return this.binding_.push().then(stackIndex => {
-        this.stackSize_++;
         this.onStackIndexUpdated_(stackIndex);
         if (opt_onPop) {
           this.stackOnPop_[stackIndex] = opt_onPop;
@@ -108,7 +101,6 @@ export class History {
   pop(stateId) {
     return this.enque_(() => {
       return this.binding_.pop(stateId).then(stackIndex => {
-        this.stackSize_--;
         this.onStackIndexUpdated_(stackIndex);
       });
     }, 'pop');
@@ -129,7 +121,6 @@ export class History {
       // Pop the current state. The binding will ignore the request if
       // it cannot satisfy it.
       return this.binding_.pop(this.stackIndex_).then(stackIndex => {
-        this.stackSize_--;
         this.onStackIndexUpdated_(stackIndex);
       });
     }, 'goBack');
@@ -260,14 +251,6 @@ export class History {
       this.queue_.splice(0, 1);
       this.deque_();
     });
-  }
-
-  /**
-   * @return {number}
-   * @private
-   */
-  maxStackSize_() {
-    return 10;
   }
 }
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -99,6 +99,9 @@ export class StandardActions {
    */
   handleAmpTarget(invocation) {
     switch (invocation.method) {
+      case 'pushState':
+        this.handleAmpPushState_(invocation);
+        return;
       case 'setState':
         this.handleAmpSetState_(invocation);
         return;
@@ -120,6 +123,22 @@ export class StandardActions {
    * @private
    */
   handleAmpSetState_(invocation) {
+    this.handleAmpBindAction_(invocation);
+  }
+
+  /**
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @private
+   */
+  handleAmpPushState_(invocation) {
+    this.handleAmpBindAction_(invocation, /* opt_pushState */ true);
+  }
+
+  /**
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @private
+   */
+  handleAmpBindAction_(invocation, opt_pushState) {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return;
     }
@@ -134,7 +153,11 @@ export class StandardActions {
         if (event && event.detail) {
           scope['event'] = event.detail;
         }
-        bind.setStateWithExpression(objectString, scope);
+        if (opt_pushState) {
+          bind.pushStateWithExpression(objectString, scope);
+        } else {
+          bind.setStateWithExpression(objectString, scope);
+        }
       } else {
         user().error('AMP-BIND', 'Please use the object-literal syntax, '
             + 'e.g. "AMP.setState({foo: \'bar\'})" instead of '

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -20,6 +20,7 @@ import {Layout, getLayoutClass} from '../layout';
 import {Services} from '../services';
 import {computedStyle, getStyle, toggle} from '../style';
 import {dev, user} from '../log';
+import {dict} from '../utils/object';
 import {isProtocolValid} from '../url';
 import {registerServiceBuilderForDoc} from '../service';
 import {tryFocus} from '../dom';
@@ -136,6 +137,7 @@ export class StandardActions {
 
   /**
    * @param {!./action-impl.ActionInvocation} invocation
+   * @param {boolean=} opt_pushState
    * @private
    */
   handleAmpBindAction_(invocation, opt_pushState) {
@@ -147,8 +149,7 @@ export class StandardActions {
       const args = invocation.args;
       const objectString = args[OBJECT_STRING_ARGS_KEY];
       if (objectString) {
-        // Object string arg.
-        const scope = Object.create(null);
+        const scope = dict();
         const event = invocation.event;
         if (event && event.detail) {
           scope['event'] = event.detail;

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -102,17 +102,6 @@ describes.fakeWin('History', {
     });
   });
 
-  it('should only allow pushing up to maxStackSize_() states', () => {
-    sandbox.stub(history, 'maxStackSize_').returns(2);
-    const push = bindingMock.expects('push').returns(Promise.resolve()).twice();
-    return Promise.all([
-      history.push(),
-      history.push(),
-    ]).then(() => {
-      expect(history.push()).to.be.rejected;
-    });
-  });
-
   it('should return and call callback when history popped', () => {
     const onPop = sandbox.spy();
     bindingMock.expects('push').withExactArgs()

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -33,7 +33,6 @@ describes.fakeWin('History', {
     location: '#first',
   },
 }, env => {
-
   let sandbox;
   let clock;
   let bindingMock;
@@ -100,6 +99,36 @@ describes.fakeWin('History', {
         clock.tick(1);
         expect(onPop).to.be.calledOnce;
       });
+    });
+  });
+
+  it('should only pop up to maxStackSize_() states', () => {
+    const spy = sandbox.spy();
+    sandbox.stub(history, 'maxStackSize_').returns(2);
+
+    const push = bindingMock.expects('push').thrice();
+    push.onFirstCall().returns(Promise.resolve(10));
+    push.onSecondCall().returns(Promise.resolve(11));
+    push.onThirdCall().returns(Promise.resolve(12));
+
+    const pop = bindingMock.expects('pop').thrice();
+    pop.onFirstCall().returns(Promise.resolve(12));
+    pop.onSecondCall().returns(Promise.resolve(11));
+    pop.onThirdCall().returns(Promise.resolve(10));
+
+    return Promise.all([
+      history.push(() => spy('a')),
+      history.push(() => spy('b')),
+      history.push(() => spy('c')),
+    ]).then(() => Promise.all([
+      history.pop(),
+      history.pop(),
+      history.pop(),
+    ])).then(() => {
+      clock.tick(1);
+      expect(spy.callCount).to.equal(2);
+      expect(spy).to.be.calledWith('c');
+      expect(spy).to.be.calledWith('b');
     });
   });
 

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -102,33 +102,14 @@ describes.fakeWin('History', {
     });
   });
 
-  it('should only pop up to maxStackSize_() states', () => {
-    const spy = sandbox.spy();
+  it('should only allow pushing up to maxStackSize_() states', () => {
     sandbox.stub(history, 'maxStackSize_').returns(2);
-
-    const push = bindingMock.expects('push').thrice();
-    push.onFirstCall().returns(Promise.resolve(10));
-    push.onSecondCall().returns(Promise.resolve(11));
-    push.onThirdCall().returns(Promise.resolve(12));
-
-    const pop = bindingMock.expects('pop').thrice();
-    pop.onFirstCall().returns(Promise.resolve(12));
-    pop.onSecondCall().returns(Promise.resolve(11));
-    pop.onThirdCall().returns(Promise.resolve(10));
-
+    const push = bindingMock.expects('push').returns(Promise.resolve()).twice();
     return Promise.all([
-      history.push(() => spy('a')),
-      history.push(() => spy('b')),
-      history.push(() => spy('c')),
-    ]).then(() => Promise.all([
-      history.pop(),
-      history.pop(),
-      history.pop(),
-    ])).then(() => {
-      clock.tick(1);
-      expect(spy.callCount).to.equal(2);
-      expect(spy).to.be.calledWith('c');
-      expect(spy).to.be.calledWith('b');
+      history.push(),
+      history.push(),
+    ]).then(() => {
+      expect(history.push()).to.be.rejected;
     });
   });
 

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -254,27 +254,37 @@ describes.sandboxed('StandardActions', {}, () => {
       expect(goBackStub).to.be.calledOnce;
     });
 
-    it('should implement setState', () => {
-      const spy = sandbox.spy();
+    it('should implement setState() and pushState()', () => {
+      const setStateSpy = sandbox.spy();
+      const pushStateSpy = sandbox.spy();
       window.services.bind = {
         obj: {
-          setStateWithExpression: spy,
+          setStateWithExpression: setStateSpy,
+          pushStateWithExpression: pushStateSpy,
         },
       };
 
       const args = {};
       args[OBJECT_STRING_ARGS_KEY] = '{foo: 123}';
 
-      const invocation = {
+      standardActions.handleAmpTarget({
         method: 'setState',
         args,
         target: ampdoc,
         satisfiesTrust: () => true,
-      };
-      standardActions.handleAmpTarget(invocation);
+      });
+      standardActions.handleAmpTarget({
+        method: 'pushState',
+        args,
+        target: ampdoc,
+        satisfiesTrust: () => true,
+      });
       return Services.bindForDocOrNull(ampdoc).then(() => {
-        expect(spy).to.be.calledOnce;
-        expect(spy).to.be.calledWith('{foo: 123}');
+        expect(setStateSpy).to.be.calledOnce;
+        expect(setStateSpy).to.be.calledWith('{foo: 123}');
+
+        expect(pushStateSpy).to.be.calledOnce;
+        expect(pushStateSpy).to.be.calledWith('{foo: 123}');
       });
     });
 


### PR DESCRIPTION
Partial for #9128.

- Add `AMP.pushState()` action which allows "storing" amp-bind variables in history stack.
- Add max history stack size of 10. Over-cap callbacks are pruned on pop plus `user().warn`.

TODO:
- Support browser restarts/restoring tabs.
- Support forward navigation.