### PR TITLE
Serve local compiled and uncompiled shadow-v0.js

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -1044,6 +1044,9 @@ function replaceUrls(mode, file, hostName, inabox) {
         /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
         hostName + '/dist/amp.js');
     file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/shadow-v0\.js/g,
+        hostName + '/dist/amp-shadow.js');
+    file = file.replace(
         /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
         hostName + '/dist/amp-inabox.js');
     file = file.replace(
@@ -1056,6 +1059,9 @@ function replaceUrls(mode, file, hostName, inabox) {
     file = file.replace(
         /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
         hostName + '/dist/v0.js');
+    file = file.replace(
+        /https:\/\/cdn\.ampproject\.org\/shadow-v0\.js/g,
+        hostName + '/dist/shadow-v0.js');
     file = file.replace(
         /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
         hostName + '/dist/amp4ads-v0.js');


### PR DESCRIPTION
I found that there was no way to serve the local `shadow-v0.js`, so I added it here.

If this was intentionally left out of the dev server, please let me know.