### PR TITLE
remove application and version fields from app.yaml as they are no longer valid

### DIFF
--- a/tools/errortracker/app.yaml
+++ b/tools/errortracker/app.yaml
@@ -1,5 +1,3 @@
-application: amp-error-reporting
-version: 19
 runtime: go
 api_version: go1
 


### PR DESCRIPTION
when deploying through the gcloud cli `application` and `project` should be declared in the command and not through app.yaml

<img width="716" alt="screen shot 2017-08-15 at 11 54 07 am" src="https://user-images.githubusercontent.com/354746/29331208-89e5e68e-81b0-11e7-90d0-56acdf10536d.png">
<img width="723" alt="screen shot 2017-08-15 at 11 53 57 am" src="https://user-images.githubusercontent.com/354746/29331209-89e682f6-81b0-11e7-8dc5-e68f18ea9ecb.png">
