### PR TITLE
Use `artwork` attribute instead of `poster` for MediaSessionAPI

### DIFF
--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -444,7 +444,12 @@
           <figure>
             <amp-video
               autoplay
-              src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+              src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+              poster="https://peach.blender.org/wp-content/uploads/bbb-splash.png"
+              artwork="img/bigbuckbunny.jpg"
+              title="Big Buck Bunny"
+              album="Blender"
+              artist="Blender Foundation"
               width="720"
               height="405"
               layout="responsive"
@@ -475,14 +480,14 @@
           <figure>
             <amp-audio
               src="https://www.dl-sounds.com/wp-content/uploads/edd/2017/07/The-Horizon-preview.mp3"
-              poster="https://images.pexels.com/photos/290101/pexels-photo-290101.jpeg?w=500&h=500&auto=compress&cs=tinysrgb"
+              artwork="https://images.pexels.com/photos/290101/pexels-photo-290101.jpeg?w=500&h=500&auto=compress&cs=tinysrgb"
               title="The Horizon"
               album="Royalty Free Music"
               artist="Dl Sounds"
               height="50"
               width="auto"
               controls>
-            </amp-video>
+            </amp-audio>
           </figure>
 
           <p id="section1">

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -16,7 +16,7 @@
 
 import {Layout} from '../../../src/layout';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev} from '../../../src/log';
+import {dev, user} from '../../../src/log';
 import {listen} from '../../../src/event-helper';
 import {
   EMPTY_METADATA,
@@ -25,6 +25,8 @@ import {
   parseFavicon,
   setMediaSession,
 } from '../../../src/mediasession-helper';
+
+const TAG = 'amp-audio';
 
 /**
  * Visible for testing only.
@@ -84,7 +86,11 @@ export class AmpAudio extends AMP.BaseElement {
                   || this.element.getAttribute('aria-label')
                   || doc.title;
     const album = this.element.getAttribute('album');
-    const poster = this.element.getAttribute('poster')
+    if (this.element.getAttribute('poster')) {
+      user().warn(TAG, `The poster attribute is deprecated and will no longer
+        be used on MediaSessionAPI, please use the artwork attribute instead.`);
+    }
+    const artwork = this.element.getAttribute('artwork')
                    || parseSchemaImage(doc)
                    || parseOgImage(doc)
                    || parseFavicon(doc);
@@ -93,7 +99,7 @@ export class AmpAudio extends AMP.BaseElement {
       'artist': artist || '',
       'album': album || '',
       'artwork': [
-        {'src': poster || ''},
+        {'src': artwork || ''},
       ],
     };
 

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -87,6 +87,7 @@ export class AmpAudio extends AMP.BaseElement {
                   || doc.title;
     const album = this.element.getAttribute('album');
     if (this.element.getAttribute('poster')) {
+      // TODO(@aghassemi, #10931) Remove warning after usage check.
       user().warn(TAG, `The poster attribute is deprecated and will no longer
         be used on MediaSessionAPI, please use the artwork attribute instead.`);
     }

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -16,7 +16,7 @@
 
 import {Layout} from '../../../src/layout';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev, user} from '../../../src/log';
+import {dev} from '../../../src/log';
 import {listen} from '../../../src/event-helper';
 import {
   EMPTY_METADATA,
@@ -25,8 +25,6 @@ import {
   parseFavicon,
   setMediaSession,
 } from '../../../src/mediasession-helper';
-
-const TAG = 'amp-audio';
 
 /**
  * Visible for testing only.
@@ -86,11 +84,6 @@ export class AmpAudio extends AMP.BaseElement {
                   || this.element.getAttribute('aria-label')
                   || doc.title;
     const album = this.element.getAttribute('album');
-    if (this.element.getAttribute('poster')) {
-      // TODO(@aghassemi, #10931) Remove warning after usage check.
-      user().warn(TAG, `The poster attribute is deprecated and will no longer
-        be used on MediaSessionAPI, please use the artwork attribute instead.`);
-    }
     const artwork = this.element.getAttribute('artwork')
                    || parseSchemaImage(doc)
                    || parseOgImage(doc)

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -86,7 +86,9 @@ This element includes [common attributes](https://www.ampproject.org/docs/refere
 
 `amp-audio` implements the [Media Session API](https://developers.google.com/web/updates/2017/02/media-session) enabling developers to specify more information about the audio file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
 
-##### poster
+##### poster (deprecated)
+
+##### artwork
 
 URL to a PNG/JPG/ICO image serving as the audio's artwork. If not present, the MediaSessionAPI Helper will use either the `image` field in the `schema.org` definition, the `og:image` or the website's `favicon`.
 
@@ -107,7 +109,7 @@ Example:
 ```html
 <amp-audio width="400" height="300"
   src="https://yourhost.com/audios/myaudio.mp3"
-  poster="https://yourhost.com/posters/poster.png"
+  artwork="https://yourhost.com/artworks/artwork.png"
   title="Awesome music" artist="Awesome singer"
   album="Amazing album">
   <source type="audio/mpeg" src="foo.mp3">

--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -86,8 +86,6 @@ This element includes [common attributes](https://www.ampproject.org/docs/refere
 
 `amp-audio` implements the [Media Session API](https://developers.google.com/web/updates/2017/02/media-session) enabling developers to specify more information about the audio file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
 
-##### poster (deprecated)
-
 ##### artwork
 
 URL to a PNG/JPG/ICO image serving as the audio's artwork. If not present, the MediaSessionAPI Helper will use either the `image` field in the `schema.org` definition, the `og:image` or the website's `favicon`.

--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -28,10 +28,14 @@ attr_lists: { # amp-audio attributes that are common to both AMP and A4A format.
   name: "amp-audio-common"
   attrs: { name: "album" }
   attrs: { name: "artist" }
+  attrs: { name: "artwork" }
   attrs: { name: "controls" }
   attrs: { name: "loop"  value: "" }
   attrs: { name: "muted" value: "" }
-  attrs: { name: "poster" }
+  attrs: {
+    # deprecated use artwork instead
+    name: "poster"
+  }
   attrs: {
     name: "src"
     value_url: {

--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -33,10 +33,6 @@ attr_lists: { # amp-audio attributes that are common to both AMP and A4A format.
   attrs: { name: "loop"  value: "" }
   attrs: { name: "muted" value: "" }
   attrs: {
-    # deprecated use artwork instead
-    name: "poster"
-  }
-  attrs: {
     name: "src"
     value_url: {
       allowed_protocol: "https"

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -133,12 +133,13 @@ class AmpVideo extends AMP.BaseElement {
     const artist = this.element.getAttribute('artist');
     const title = this.element.getAttribute('title');
     const album = this.element.getAttribute('album');
+    const artwork = this.element.getAttribute('artwork');
     this.metadata_ = {
       'title': title || '',
       'artist': artist || '',
       'album': album || '',
       'artwork': [
-        {'src': poster || ''},
+        {'src': artwork || poster || ''},
       ],
     };
 
@@ -163,10 +164,11 @@ class AmpVideo extends AMP.BaseElement {
     if (mutations['src']) {
       this.element.dispatchCustomEvent(VideoEvents.RELOAD);
     }
-    if (mutations['poster']) {
+    if (mutations['artwork'] || mutations['poster']) {
+      const artwork = this.element.getAttribute('artwork');
       const poster = this.element.getAttribute('poster');
       this.metadata_['artwork'] = [
-        {'src': poster || ''},
+        {'src': artwork || poster || ''},
       ];
     }
     if (mutations['album']) {

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -113,7 +113,7 @@ This element includes [common attributes](https://www.ampproject.org/docs/refere
 
 `amp-video` implements the [Media Session API](https://developers.google.com/web/updates/2017/02/media-session) enabling developers to specify more information about the video file that is playing to be displayed in the notification center of user's devices (along with play/pause controls).
 
-##### poster
+##### artwork
 
 URL to a PNG/JPG/ICO image serving as the video's artwork. If not present, the MediaSessionAPI Helper will use either the `image` field in the `schema.org` definition, the `og:image` or the website's `favicon`.
 
@@ -131,10 +131,15 @@ URL to a PNG/JPG/ICO image serving as the video's artwork. If not present, the M
 
 Example:
 
+Note that this example has both the `poster` and `artwork` attributes, poster will be used as the
+placeholder before the video plays while `artwork` is the image that will be displayed in the
+notification throught the MediaSessionAPI.
+
 ```html
 <amp-audio width="400" height="300"
   src="https://yourhost.com/audios/myaudio.mp3"
   poster="https://yourhost.com/posters/poster.png"
+  artwork="https://yourhost.com/artworks/artwork.png"
   title="Awesome music" artist="Awesome singer"
   album="Amazing album">
   <source type="audio/mpeg" src="foo.mp3">

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -38,6 +38,7 @@ tags: {  # <amp-video>
   attrs: { name: "album" }
   attrs: { name: "alt" }
   attrs: { name: "artist" }
+  attrs: { name: "artwork" }
   attrs: { name: "attribution" }
   attrs: {
     name: "autoplay"

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -707,8 +707,7 @@ class VideoEntry {
     const doc = this.ampdoc_.win.document;
 
     if (!this.metadata_.artwork || this.metadata_.artwork.length == 0) {
-      const posterUrl = this.video.element.getAttribute('artwork')
-                        || parseSchemaImage(doc)
+      const posterUrl = parseSchemaImage(doc)
                         || parseOgImage(doc)
                         || parseFavicon(doc);
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -707,7 +707,8 @@ class VideoEntry {
     const doc = this.ampdoc_.win.document;
 
     if (!this.metadata_.artwork || this.metadata_.artwork.length == 0) {
-      const posterUrl = parseSchemaImage(doc)
+      const posterUrl = this.video.element.getAttribute('artwork')
+                        || parseSchemaImage(doc)
                         || parseOgImage(doc)
                         || parseFavicon(doc);
 


### PR DESCRIPTION
Fixes issue where the `poster` attribute for videos is used as both the video cover and the video thumbnail in the MediaSessionAPI. The issue arises from the fact that video covers aren't usually square, while MediaSessionAPI thumbnails are.

### Changes
- `amp-video` now exposes two attributes: `poster` (used as placeholder/cover) and `artwork` (used solely for MediaSessionAPI).
- `amp-audio` deprecates `poster` usage in favor of `artwork`. 
- Use Big Buck Bunny video instead in `article.amp.html` to demonstrate the simultaneous use of `poster` and `artwork` in `amp-video`