### PR TITLE
Fix broken filepath for ampcontext

### DIFF
--- a/src/iframe-attributes.js
+++ b/src/iframe-attributes.js
@@ -54,7 +54,7 @@ export function getContextMetadata(
   const layoutRect = element.getPageLayoutBox();
   attributes['_context'] = dict({
     'ampcontextVersion': '$internalRuntimeVersion$',
-    'ampcontextFilepath': urls.cdn + '/$internalRuntimeVersion$' +
+    'ampcontextFilepath': urls.thirdParty + '/$internalRuntimeVersion$' +
         '/ampcontext-v0.js',
     'sourceUrl': docInfo.sourceUrl,
     'referrer': referrer,

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -186,7 +186,7 @@ describe.configure().ifChrome().skipOldChrome().run('3p-frame', () => {
         '"type":"_ping_",' +
         '"_context":{"referrer":"http://acme.org/",' +
         '"ampcontextVersion": "$internalRuntimeVersion$",' +
-        '"ampcontextFilepath": "https://cdn.ampproject.org/' +
+        '"ampcontextFilepath": "https://3p.ampproject.net/' +
         '$internalRuntimeVersion$/ampcontext-v0.js",' +
         '"canonicalUrl":"' + docInfo.canonicalUrl + '",' +
         '"sourceUrl":"' + locationHref + '",' +


### PR DESCRIPTION
the ampcontextFilepath is incorrect currently, never working. I.e. you would get: https://cdn.ampproject.org/1502819823157/ampcontext-v0.js
when you should get
https://3p.ampproject.net/1502819823157/ampcontext-v0.js