### PR TITLE
Remove experiment flag from amp-web-push

### DIFF
--- a/extensions/amp-web-push/0.1/test/test-web-push-config.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-config.js
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import {WebPushService} from '../web-push-service';
 import {TAG, CONFIG_TAG} from '../vars';
-import {toggleExperiment} from '../../../../src/experiments';
 import {WebPushConfigAttributes, WebPushConfig} from '../amp-web-push-config';
 import {
   getElementClassForTesting,
@@ -43,7 +41,6 @@ describes.realWin('web-push-config', {
   beforeEach(() => {
     win = env.win;
     webPushConfig = setDefaultWebPushConfig();
-    toggleExperiment(env.win, TAG, true);
   });
 
   function createConfigElementWithAttributes(attributes) {
@@ -68,20 +65,6 @@ describes.realWin('web-push-config', {
     const elements = win.document.querySelectorAll(CONFIG_TAG);
     elements.forEach(element => element.remove());
   }
-
-  afterEach(() => {
-    toggleExperiment(env.win, TAG, false);
-  });
-
-  it('should fail if experiment is not enabled', () => {
-    toggleExperiment(env.win, TAG, false);
-    // Experiment check is bypassed on test mode -- make sure it isn't.
-    window.AMP_MODE = {test: false};
-    expect(() => {
-      new WebPushService(env.ampdoc).ensureAmpExperimentEnabled_();
-    }).to.throw(`Experiment "${TAG}" is disabled. Enable it on ` +
-      'https://cdn.ampproject.org/experiments.html.');
-  });
 
   it('should fail if element does not have correct ID', () => {
     return env.ampdoc.whenReady().then(() => {

--- a/extensions/amp-web-push/0.1/test/test-web-push-permission-dialog.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-permission-dialog.js
@@ -17,8 +17,6 @@
 import {WindowMessenger} from '../window-messenger';
 import {AmpWebPushPermissionDialog} from '../amp-web-push-permission-dialog';
 import {WebPushService} from '../web-push-service';
-import {TAG} from '../vars';
-import {toggleExperiment} from '../../../../src/experiments';
 import {WebPushConfigAttributes} from '../amp-web-push-config';
 import {parseUrl} from '../../../../src/url';
 import * as sinon from 'sinon';
@@ -69,13 +67,11 @@ describes.realWin('web-push-permission-dialog', {
 
   beforeEach(() => {
     setDefaultConfigParams_();
-    toggleExperiment(env.win, TAG, true);
     webPush = new WebPushService(env.ampdoc);
     sandbox = sinon.sandbox.create();
   });
 
   afterEach(() => {
-    toggleExperiment(env.win, TAG, false);
     sandbox.restore();
   });
 

--- a/extensions/amp-web-push/0.1/test/test-web-push-service.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-service.js
@@ -18,8 +18,7 @@ import {WindowMessenger} from '../window-messenger';
 import {AmpWebPushHelperFrame} from '../amp-web-push-helper-frame';
 import {WebPushService} from '../web-push-service';
 import {WebPushWidgetVisibilities} from '../amp-web-push-widget';
-import {TAG, NotificationPermission} from '../vars';
-import {toggleExperiment} from '../../../../src/experiments';
+import {NotificationPermission} from '../vars';
 import {WebPushConfigAttributes} from '../amp-web-push-config';
 import * as sinon from 'sinon';
 
@@ -32,12 +31,7 @@ describes.realWin('web-push-service environment support', {
   let webPush;
 
   beforeEach(() => {
-    toggleExperiment(env.win, TAG, true);
     webPush = new WebPushService(env.ampdoc);
-  });
-
-  afterEach(() => {
-    toggleExperiment(env.win, TAG, false);
   });
 
   it('should report supported environment', () => {
@@ -124,13 +118,11 @@ describes.realWin('web-push-service helper frame messaging', {
 
   beforeEach(() => {
     setDefaultConfigParams_();
-    toggleExperiment(env.win, TAG, true);
     webPush = new WebPushService(env.ampdoc);
     sandbox = sinon.sandbox.create();
   });
 
   afterEach(() => {
-    toggleExperiment(env.win, TAG, false);
     sandbox.restore();
   });
 
@@ -199,13 +191,11 @@ describes.realWin('web-push-service widget visibilities', {
 
   beforeEach(() => {
     setDefaultConfigParams_();
-    toggleExperiment(env.win, TAG, true);
     webPush = new WebPushService(env.ampdoc);
     sandbox = sinon.sandbox.create();
   });
 
   afterEach(() => {
-    toggleExperiment(env.win, TAG, false);
     sandbox.restore();
   });
 
@@ -409,13 +399,11 @@ describes.realWin('web-push-service subscribing', {
 
   beforeEach(() => {
     setDefaultConfigParams_();
-    toggleExperiment(env.win, TAG, true);
     webPush = new WebPushService(env.ampdoc);
     sandbox = sinon.sandbox.create();
   });
 
   afterEach(() => {
-    toggleExperiment(env.win, TAG, false);
     sandbox.restore();
   });
 
@@ -562,13 +550,11 @@ describes.realWin('web-push-service unsubscribing', {
 
   beforeEach(() => {
     setDefaultConfigParams_();
-    toggleExperiment(env.win, TAG, true);
     webPush = new WebPushService(env.ampdoc);
     sandbox = sinon.sandbox.create();
   });
 
   afterEach(() => {
-    toggleExperiment(env.win, TAG, false);
     sandbox.restore();
   });
 

--- a/extensions/amp-web-push/0.1/vars.js
+++ b/extensions/amp-web-push/0.1/vars.js
@@ -14,7 +14,6 @@
  * the License.
  */
 
-export const EXPERIMENT = 'amp-web-push';
 export const TAG = 'amp-web-push';
 export const CONFIG_TAG = TAG;
 export const SERVICE_TAG = TAG + '-service';

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -15,9 +15,7 @@
  */
 
 import {getMode} from '../../../src/mode';
-import {isExperimentOn} from '../../../src/experiments';
 import {user} from '../../../src/log';
-import {urls} from '../../../src/config';
 import {CSS} from '../../../build/amp-web-push-0.1.css';
 import {IFrameHost} from './iframehost';
 import {WindowMessenger} from './window-messenger';
@@ -111,11 +109,6 @@ export class WebPushService {
   constructor(ampdoc) {
     /** @const */
     this.ampdoc = ampdoc;
-
-    // Enable our AMP extension for development and test environments
-    this.enableAmpExperimentForDevelopment_();
-    // On all other environments, error if experiment is not enabled
-    this.ensureAmpExperimentEnabled_();
 
     // Install styles.
     if (ampdoc.isSingleDoc()) {
@@ -248,29 +241,6 @@ export class WebPushService {
       urlWithoutFragment.replace(
           `&${WebPushService.PERMISSION_POPUP_URL_FRAGMENT}`, '');
     return urlWithoutFragment;
-  }
-
-  /**
-   * When developing locally, call this function otherwise we can't run our
-   * extension in the example sandbox. Turns off in unit test mode.
-   * @private
-   */
-  enableAmpExperimentForDevelopment_() {
-    if ((getMode().localDev && !getMode().test)) {
-      AMP.toggleExperiment(TAG, true);
-    }
-  }
-
-  /**
-   * Checks that the user enabled this AMP experiment and allows integration
-   * tests to access this class in testing mode.
-   * @private
-   */
-  ensureAmpExperimentEnabled_() {
-    // Allow integration tests to access this class in testing mode.
-    const isExperimentEnabled = isExperimentOn(this.ampdoc.win, TAG);
-    user().assert(isExperimentEnabled, `Experiment "${TAG}" is disabled. ` +
-      `Enable it on ${urls.cdn}/experiments.html.`);
   }
 
   /**

--- a/extensions/amp-web-push/amp-web-push.md
+++ b/extensions/amp-web-push/amp-web-push.md
@@ -23,7 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>Experimental (<a href="https://cdn.ampproject.org/experiments.html">turn on amp-web-push</a>)</td>
+    <td>Stable</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -58,12 +58,6 @@ const EXPERIMENTS = [
         'README.md#amp-dev-channel',
   },
   {
-    id: 'amp-web-push',
-    name: 'Enable AMP web push',
-    spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
-        'amp-web-push/0.1/amp-web-push.md',
-  },
-  {
     id: 'ad-type-custom',
     name: 'Activates support for custom (self-serve) advertisements',
     spec: 'https://github.com/ampproject/amphtml/blob/master/ads/custom.md',


### PR DESCRIPTION
We'd like to remove the experiment flag behind amp-web-push and allow it to be used on all sites.