### PR TITLE
ima: AD_START, AD_END support

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -1157,15 +1157,15 @@ const VideoEvents = {
    */
   AD_START: 'ad_start',
 
-    /**
-     * pre/mid/post Ad ends
-     *
-     * Fired when an Ad ends playing.
-     *
-     * This is used to restore any overlay shims during Ad play during autoplay
-     * or minimized-to-corner version of the player.
-     *
-     * @event ended
-     */
-    AD_END: 'ad_end',
+  /**
+   * pre/mid/post Ad ends
+   *
+   * Fired when an Ad ends playing.
+   *
+   * This is used to restore any overlay shims during Ad play during autoplay
+   * or minimized-to-corner version of the player.
+   *
+   * @event ended
+   */
+  AD_END: 'ad_end',
 };

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -1146,7 +1146,7 @@ const VideoEvents = {
    * This is used to remove any overlay shims during Ad play during autoplay
    * or minimized-to-corner version of the player.
    *
-   * @event ended
+   * @event ad_start
    */
   AD_START: 'ad_start',
 
@@ -1158,7 +1158,7 @@ const VideoEvents = {
    * This is used to restore any overlay shims during Ad play during autoplay
    * or minimized-to-corner version of the player.
    *
-   * @event ended
+   * @event ad_end
    */
   AD_END: 'ad_end',
 };

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -565,6 +565,7 @@ export function onAdsLoaderError() {
  * @visibleForTesting
  */
 export function onAdError() {
+  window.parent./*OK*/postMessage({event: VideoEvents.AD_END}, '*');
   if (adsManager) {
     adsManager.destroy();
   }

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -519,7 +519,7 @@ export function playAds(global) {
 export function onContentEnded() {
   contentComplete = true;
   adsLoader.contentComplete();
-  window.parent./*OK*/postMessage({event: VideoEvents.ENDED}, '*');
+  window.parent./*OK*/postMessage({event: VideoEvents.PAUSE}, '*');
 }
 
 /**
@@ -1114,7 +1114,7 @@ const VideoEvents = {
    *
    * Fired when the video is unmuted.
    *
-   * @event pause
+   * @event unmuted
    */
   UNMUTED: 'unmuted',
 
@@ -1137,14 +1137,6 @@ const VideoEvents = {
    * @event reload
    */
   RELOAD: 'reloaded',
-  /**
-   * ended
-   *
-   * Fired when the video ends.
-   *
-   * @event ended
-   */
-  ENDED: 'ended',
   /**
    * pre/mid/post Ad start
    *

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -519,6 +519,7 @@ export function playAds(global) {
 export function onContentEnded() {
   contentComplete = true;
   adsLoader.contentComplete();
+  window.parent./*OK*/postMessage({event: VideoEvents.ENDED}, '*');
 }
 
 /**
@@ -585,6 +586,7 @@ export function onContentPauseRequested(global) {
     adsManagerHeightOnLoad = null;
   }
   adsActive = true;
+  window.parent./*OK*/postMessage({event: VideoEvents.AD_START}, '*');
   videoPlayer.removeEventListener(interactEvent, showControls);
   setStyle(adContainerDiv, 'display', 'block');
   videoPlayer.removeEventListener('ended', onContentEnded);
@@ -600,6 +602,7 @@ export function onContentPauseRequested(global) {
 export function onContentResumeRequested() {
   adsActive = false;
   videoPlayer.addEventListener(interactEvent, showControls);
+  window.parent./*OK*/postMessage({event: VideoEvents.AD_END}, '*');
   if (!contentComplete) {
     // CONTENT_RESUME will fire after post-rolls as well, and we don't want to
     // resume content in that case.
@@ -1067,6 +1070,7 @@ export function setHideControlsTimeoutForTesting(newTimeout) {
  *
  * @constant {!Object<string, string>}
  */
+// TODO(aghassemi, #9216): Use video-interface.js
 const VideoEvents = {
   /**
    * load
@@ -1133,4 +1137,35 @@ const VideoEvents = {
    * @event reload
    */
   RELOAD: 'reloaded',
+  /**
+   * ended
+   *
+   * Fired when the video ends.
+   *
+   * @event ended
+   */
+  ENDED: 'ended',
+  /**
+   * pre/mid/post Ad start
+   *
+   * Fired when an Ad starts playing.
+   *
+   * This is used to remove any overlay shims during Ad play during autoplay
+   * or minimized-to-corner version of the player.
+   *
+   * @event ended
+   */
+  AD_START: 'ad_start',
+
+    /**
+     * pre/mid/post Ad ends
+     *
+     * Fired when an Ad ends playing.
+     *
+     * This is used to restore any overlay shims during Ad play during autoplay
+     * or minimized-to-corner version of the player.
+     *
+     * @event ended
+     */
+    AD_END: 'ad_end',
 };

--- a/css/amp.css
+++ b/css/amp.css
@@ -605,13 +605,13 @@ i-amphtml-video-mask, i-amp-video-mask {
 .amp-video-eq {
   align-items: flex-end;
   border: transparent solid 7px;
-  bottom: 0px;
+  bottom: 0;
   display: flex;
   height: 12px;
   opacity: 0.8;
   overflow: hidden;
   position: absolute;
-  right: 0px;
+  right: 0;
   width: 20px;
   z-index: 1;
 }

--- a/css/amp.css
+++ b/css/amp.css
@@ -604,13 +604,14 @@ i-amphtml-video-mask, i-amp-video-mask {
 }
 .amp-video-eq {
   align-items: flex-end;
-  bottom: 7px;
+  border: transparent solid 7px;
+  bottom: 0px;
   display: flex;
   height: 12px;
   opacity: 0.8;
   overflow: hidden;
   position: absolute;
-  right: 7px;
+  right: 0px;
   width: 20px;
   z-index: 1;
 }

--- a/examples/ima-video.amp.html
+++ b/examples/ima-video.amp.html
@@ -16,9 +16,7 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <style>
     #player-wrapper {
-        width: 640px;
-        height: 360px;
-        max-width: 90%;
+        max-width: 600px;
     }
     </style>
 </head>
@@ -38,6 +36,16 @@
     <button on="tap:myVideo.mute">Mute</button>
     <button on="tap:myVideo.unmute">Unmute</button>
     <button on="tap:myVideo.fullscreen">Fullscreen</button>
+    <h2>Autoplay</h2>
+    <div id="player-wrapper">
+        <amp-ima-video id="myVideo"
+            autoplay
+            width="640" height="360" layout="responsive"
+            data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator="
+            data-poster="/examples/img/ima-poster.png">
+            <source src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4" type="video/mp4">
+        </amp-ima-video>
+    </div>
     <div class="spacer"></div>
 </body>
 </html>

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -41,6 +41,7 @@ import {
 import {user, dev} from '../../../src/log';
 import {VideoEvents} from '../../../src/video-interface';
 import {Services} from '../../../src/services';
+import {isEnumValue} from '../../../src/types';
 
 /** @const */
 const TAG = 'amp-ima-video';
@@ -219,14 +220,7 @@ class AmpImaVideo extends AMP.BaseElement {
 
     if (isObject(eventData)) {
       const videoEvent = eventData['event'];
-      if (videoEvent == VideoEvents.AD_START ||
-          videoEvent == VideoEvents.AD_END ||
-          videoEvent == VideoEvents.LOAD ||
-          videoEvent == VideoEvents.PLAYING ||
-          videoEvent == VideoEvents.PAUSE ||
-          videoEvent == VideoEvents.ENDED ||
-          videoEvent == VideoEvents.MUTED ||
-          videoEvent == VideoEvents.UNMUTED) {
+      if (isEnumValue(VideoEvents, videoEvent)) {
         if (videoEvent == VideoEvents.LOAD) {
           this.playerReadyResolver_(this.iframe_);
         }

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -219,9 +219,12 @@ class AmpImaVideo extends AMP.BaseElement {
 
     if (isObject(eventData)) {
       const videoEvent = eventData['event'];
-      if (videoEvent == VideoEvents.LOAD ||
+      if (videoEvent == VideoEvents.AD_START ||
+          videoEvent == VideoEvents.AD_END ||
+          videoEvent == VideoEvents.LOAD ||
           videoEvent == VideoEvents.PLAYING ||
           videoEvent == VideoEvents.PAUSE ||
+          videoEvent == VideoEvents.ENDED ||
           videoEvent == VideoEvents.MUTED ||
           videoEvent == VideoEvents.UNMUTED) {
         if (videoEvent == VideoEvents.LOAD) {

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -861,23 +861,43 @@ class VideoEntry {
     });
 
     // Listen to pause, play and user interaction events.
-    const unlistenInteraction = listen(mask, 'click', onInteraction.bind(this));
+    const unlisteners = [];
+    unlisteners.push(listen(mask, 'click', onInteraction.bind(this)));
+    unlisteners.push(listen(animation, 'click', onInteraction.bind(this)));
 
-    const unlistenPause = listen(this.video.element, VideoEvents.PAUSE,
-        toggleAnimation.bind(this, /*playing*/ false));
+    unlisteners.push(listen(this.video.element, VideoEvents.PAUSE,
+        toggleAnimation.bind(this, /*playing*/ false)));
 
-    const unlistenPlaying = listen(this.video.element, VideoEvents.PLAYING,
-        toggleAnimation.bind(this, /*playing*/ true));
+    unlisteners.push(listen(this.video.element, VideoEvents.PLAYING,
+        toggleAnimation.bind(this, /*playing*/ true)));
+
+    unlisteners.push(listen(this.video.element, VideoEvents.AD_START,
+        adStart.bind(this)));
+
+    unlisteners.push(listen(this.video.element, VideoEvents.AD_END,
+        adEnd.bind(this)));
 
     function onInteraction() {
       this.userInteractedWithAutoPlay_ = true;
       this.video.showControls();
       this.video.unmute();
-      unlistenInteraction();
-      unlistenPause();
-      unlistenPlaying();
+      unlisteners.forEach(unlistener => {
+        unlistener();
+      });
       removeElement(animation);
       removeElement(mask);
+    }
+
+    function adStart() {
+      setStyles(mask, {
+        'display': 'none',
+      });
+    }
+
+    function adEnd() {
+      setStyles(mask, {
+        'display': 'block',
+      });
     }
   }
 

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -313,15 +313,6 @@ export const VideoEvents = {
   RELOAD: 'reloaded',
 
   /**
-   * ended
-   *
-   * Fired when the video ends.
-   *
-   * @event ended
-   */
-  ENDED: 'ended',
-
-  /**
    * pre/mid/post Ad start
    *
    * Fired when an Ad starts playing.

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -320,7 +320,7 @@ export const VideoEvents = {
    * This is used to remove any overlay shims during Ad play during autoplay
    * or minimized-to-corner version of the player.
    *
-   * @event ended
+   * @event ad_start
    */
   AD_START: 'ad_start',
 
@@ -332,7 +332,7 @@ export const VideoEvents = {
    * This is used to restore any overlay shims during Ad play during autoplay
    * or minimized-to-corner version of the player.
    *
-   * @event ended
+   * @event ad_end
    */
   AD_END: 'ad_end',
 };

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -320,6 +320,30 @@ export const VideoEvents = {
    * @event ended
    */
   ENDED: 'ended',
+
+  /**
+   * pre/mid/post Ad start
+   *
+   * Fired when an Ad starts playing.
+   *
+   * This is used to remove any overlay shims during Ad play during autoplay
+   * or minimized-to-corner version of the player.
+   *
+   * @event ended
+   */
+  AD_START: 'ad_start',
+
+  /**
+   * pre/mid/post Ad ends
+   *
+   * Fired when an Ad ends playing.
+   *
+   * This is used to restore any overlay shims during Ad play during autoplay
+   * or minimized-to-corner version of the player.
+   *
+   * @event ended
+   */
+  AD_END: 'ad_end',
 };
 
 


### PR DESCRIPTION
Closes #10960 
we will hide the autoplay shim when AD_START, and restore it when AD_END. equalizer icon still stays tappable for unmute.

+ fix for ENDED event.