### PR TITLE
Feature/widespace adapter support demography parameters.

### DIFF
--- a/ads/widespace.js
+++ b/ads/widespace.js
@@ -23,14 +23,14 @@ import {writeScript, validateData} from '../3p/3p';
 export function widespace(global, data) {
 
   const WS_AMP_CODE_VER = '1.0.1';
-  const demographParams = ['demoGender',
-                           'demoCountry',
-                           'demoRegion',
-                           'demoCity',
-                           'demoPostal',
-                           'demoYob'];
+  // Optinal demography parameters.
+  let demo = [];
 
-  validateData(data, ['sid'], demographParams);
+  demo = ['Gender', 'Country', 'Region', 'City', 'Postal', 'Yob'].map((d) => {
+    return 'demo' + d;
+  });
+
+  validateData(data, ['sid'], demo);
 
   const url = 'https://engine.widespace.com/map/engine/dynamic?isamp=1'
       + '&ampver=' + WS_AMP_CODE_VER

--- a/ads/widespace.js
+++ b/ads/widespace.js
@@ -23,7 +23,12 @@ import {writeScript, validateData} from '../3p/3p';
 export function widespace(global, data) {
 
   const WS_AMP_CODE_VER = '1.0.1';
-  const demographParams = ['demoGender', 'demoCountry', 'demoRegion', 'demoCity', 'demoPostal', 'demoYob'];
+  const demographParams = ['demoGender',
+                           'demoCountry',
+                           'demoRegion',
+                           'demoCity',
+                           'demoPostal',
+                           'demoYob'];
 
   validateData(data, ['sid'], demographParams);
 

--- a/ads/widespace.js
+++ b/ads/widespace.js
@@ -22,13 +22,14 @@ import {writeScript, validateData} from '../3p/3p';
  */
 export function widespace(global, data) {
 
-  const WS_AMP_CODE_VER = '1.0.0';
+  const WS_AMP_CODE_VER = '1.0.1';
+  const demographParams = ['demoGender', 'demoCountry', 'demoRegion', 'demoCity', 'demoPostal', 'demoYob'];
 
-  validateData(data, ['sid'], []);
+  validateData(data, ['sid'], demographParams);
 
   const url = 'https://engine.widespace.com/map/engine/dynamic?isamp=1'
       + '&ampver=' + WS_AMP_CODE_VER
-      + '&sid=' + encodeURIComponent(data.sid);
+      + '&#sid=' + encodeURIComponent(data.sid);
 
   writeScript(global, url);
 }

--- a/ads/widespace.js
+++ b/ads/widespace.js
@@ -26,7 +26,7 @@ export function widespace(global, data) {
   // Optional demography parameters.
   let demo = [];
 
-  demo = ['Gender', 'Country', 'Region', 'City', 'Postal', 'Yob'].map( d => {
+  demo = ['Gender', 'Country', 'Region', 'City', 'Postal', 'Yob'].map(d => {
     return 'demo' + d;
   });
 

--- a/ads/widespace.js
+++ b/ads/widespace.js
@@ -26,7 +26,7 @@ export function widespace(global, data) {
   // Optional demography parameters.
   let demo = [];
 
-  demo = ['Gender', 'Country', 'Region', 'City', 'Postal', 'Yob'].map((d) => {
+  demo = ['Gender', 'Country', 'Region', 'City', 'Postal', 'Yob'].map( d => {
     return 'demo' + d;
   });
 

--- a/ads/widespace.js
+++ b/ads/widespace.js
@@ -23,7 +23,7 @@ import {writeScript, validateData} from '../3p/3p';
 export function widespace(global, data) {
 
   const WS_AMP_CODE_VER = '1.0.1';
-  // Optinal demography parameters.
+  // Optional demography parameters.
   let demo = [];
 
   demo = ['Gender', 'Country', 'Region', 'City', 'Postal', 'Yob'].map((d) => {

--- a/ads/widespace.md
+++ b/ads/widespace.md
@@ -34,8 +34,7 @@ limitations under the License.
     data-demo-Country="SE"
     data-demo-Region="W1U 8EW"
     data-demo-City="Stockholm"
-    data-demo-Yob="1981"
-    >
+    data-demo-Yob="1981">
 </amp-ad>
 ```
 

--- a/ads/widespace.md
+++ b/ads/widespace.md
@@ -44,7 +44,7 @@ limitations under the License.
 
 - `data-sid`
 
-## optional demography parameters
+### Optional demography parameters
 
 - `data-demo-Gender`
 - `data-demo-Country`

--- a/ads/widespace.md
+++ b/ads/widespace.md
@@ -26,10 +26,31 @@ limitations under the License.
 </amp-ad>
 ```
 
+```html
+<amp-ad width=320 height=320
+    type="widespace"
+    data-sid="f666bfaf-69cf-4ed9-9262-08247bb274e4"
+    data-demo-Gender="F"
+    data-demo-Country="SE"
+    data-demo-Region="W1U 8EW"
+    data-demo-City="Stockholm"
+    data-demo-Yob="1981"
+    >
+</amp-ad>
+```
+
 
 ### Required parameter
 
 - `data-sid`
+
+## optional demography parameters
+
+- `data-demo-Gender`
+- `data-demo-Country`
+- `data-demo-Region`
+- `data-demo-City`
+- `data-demo-Yob`
 
 
 ## Configuration


### PR DESCRIPTION
Allows the publisher to send demography parameters that we use for targeting.
The data-demo parameters are optional.

` <amp-ad width="300" height="50"
  type="widespace"
  data-sid="93f1a996-52f5-46b4-8dc8-ccd8886a8fbf"
  layout="responsive"

  data-demo-gender="F"
  data-demo-country="SE"
  data-demo-region="W1U 8EW"
  data-demo-city="Stockholm"
  data-demo-yob="1981"
>
</amp-ad> `
