### PR TITLE
Deprecate skipSauceLabs for integration tests, since they only ever run on sauce labs

### DIFF
--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -104,7 +104,7 @@ describe.configure().ifChrome().skipOldChrome().run('Bind', function() {
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);
 
-  describe.configure().skipSauceLabs().run('in FIE', function() {
+  describe.configure().ifChrome().skipOldChrome().run('in FIE', function() {
     describes.realWin('in FIE', {
       amp: {
         ampdoc: 'fie',

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -99,12 +99,12 @@ function waitForEvent(env, name) {
   });
 }
 
-describe.configure().ifChrome().skipOldChrome().run('Bind', function() {
+describe.configure().ifNewChrome().run('Bind', function() {
   // Give more than default 2000ms timeout for local testing.
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);
 
-  describe.configure().ifChrome().skipOldChrome().run('in FIE', function() {
+  describe.configure().ifNewChrome().run('in FIE', function() {
     describes.realWin('in FIE', {
       amp: {
         ampdoc: 'fie',

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -46,7 +46,8 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    it('should confirm the handshake', () => {
+    // TODO(aghassemi): Investigate failure. #10972.
+    it.skip('should confirm the handshake', () => {
       console/*OK*/.log('sending handshake response');
       viewer.confirmHandshake();
       return viewer.waitForDocumentLoaded();

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -26,7 +26,8 @@ import {getSourceUrl} from '../../../../../src/url';
 
 describes.sandboxed('AmpViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().ifNewChrome().run('Handshake', function() {
+  // TODO(aghassemi): Investigate failure in beforeEach. #10974.
+  describe.skip('Handshake', function() {
     let viewerEl;
     let viewer;
     let ampDocUrl;
@@ -46,8 +47,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    // TODO(aghassemi): Investigate failure. #10974.
-    it.skip('should confirm the handshake', () => {
+    it('should confirm the handshake', () => {
       console/*OK*/.log('sending handshake response');
       viewer.confirmHandshake();
       return viewer.waitForDocumentLoaded();

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -26,7 +26,7 @@ import {getSourceUrl} from '../../../../../src/url';
 
 describes.sandboxed('AmpViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().skipSauceLabs().run('Handshake', function() {
+  describe.configure().ifChrome().skipOldChrome().run('Handshake', function() {
     let viewerEl;
     let viewer;
     let ampDocUrl;
@@ -139,7 +139,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
     });
   });
 
-  describe.configure().skipSauceLabs().run(`Unit Tests for
+  describe.configure().ifChrome().skipOldChrome().run(`Unit Tests for
       messaging.js`, () => {
     const viewerOrigin = 'http://localhost:9876';
     const requestProcessor = function() {

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -26,7 +26,7 @@ import {getSourceUrl} from '../../../../../src/url';
 
 describes.sandboxed('AmpViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().ifChrome().skipOldChrome().run('Handshake', function() {
+  describe.configure().ifNewChrome().run('Handshake', function() {
     let viewerEl;
     let viewer;
     let ampDocUrl;
@@ -139,8 +139,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
     });
   });
 
-  describe.configure().ifChrome().skipOldChrome().run(`Unit Tests for
-      messaging.js`, () => {
+  describe.configure().ifNewChrome().run('Unit Tests for messaging.js', () => {
     const viewerOrigin = 'http://localhost:9876';
     const requestProcessor = function() {
       return Promise.resolve({});

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -46,7 +46,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    // TODO(aghassemi): Investigate failure. #10972.
+    // TODO(aghassemi): Investigate failure. #10974.
     it.skip('should confirm the handshake', () => {
       console/*OK*/.log('sending handshake response');
       viewer.confirmHandshake();

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
@@ -20,7 +20,7 @@ import {WebviewViewerForTesting} from '../webview-viewer-for-testing.js';
 
 describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().ifChrome().skipOldChrome().run('Handshake', function() {
+  describe.configure().ifNewChrome().run('Handshake', function() {
     let viewerEl;
     let viewer;
 

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
@@ -39,7 +39,8 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    it('should confirm the handshake', () => {
+    // TODO(aghassemi): Investigate failure. #10972.
+    it.skip('should confirm the handshake', () => {
       console/*OK*/.log('sending handshake response');
       return viewer.waitForDocumentLoaded();
     });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
@@ -39,7 +39,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    // TODO(aghassemi): Investigate failure. #10972.
+    // TODO(aghassemi): Investigate failure. #10974.
     it.skip('should confirm the handshake', () => {
       console/*OK*/.log('sending handshake response');
       return viewer.waitForDocumentLoaded();

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
@@ -20,7 +20,7 @@ import {WebviewViewerForTesting} from '../webview-viewer-for-testing.js';
 
 describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().skipSauceLabs().run('Handshake', function() {
+  describe.configure().ifChrome().skipOldChrome().run('Handshake', function() {
     let viewerEl;
     let viewer;
 

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
@@ -20,7 +20,8 @@ import {WebviewViewerForTesting} from '../webview-viewer-for-testing.js';
 
 describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().ifNewChrome().run('Handshake', function() {
+  // TODO(aghassemi): Investigate failure in beforeEach. #10974.
+  describe.skip('Handshake', function() {
     let viewerEl;
     let viewer;
 
@@ -39,8 +40,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    // TODO(aghassemi): Investigate failure. #10974.
-    it.skip('should confirm the handshake', () => {
+    it('should confirm the handshake', () => {
       console/*OK*/.log('sending handshake response');
       return viewer.waitForDocumentLoaded();
     });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
@@ -39,7 +39,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    // TODO(aghassemi): Investigate failure. #10972.
+    // TODO(aghassemi): Investigate failure. #10974.
     it.skip('should confirm the handshake', () => {
       return viewer.waitForHandshakeResponse();
     });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
@@ -39,7 +39,8 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    it('should confirm the handshake', () => {
+    // TODO(aghassemi): Investigate failure. #10972.
+    it.skip('should confirm the handshake', () => {
       return viewer.waitForHandshakeResponse();
     });
 

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
@@ -21,7 +21,7 @@ import {
 
 describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().ifChrome().skipOldChrome().run('Handshake', function() {
+  describe.configure().ifNewChrome().run('Handshake', function() {
     let viewerEl;
     let viewer;
 

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
@@ -21,7 +21,8 @@ import {
 
 describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().ifNewChrome().run('Handshake', function() {
+  // TODO(aghassemi): Investigate failure in beforeEach. #10974.
+  describe.skip('Handshake', function() {
     let viewerEl;
     let viewer;
 
@@ -39,8 +40,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
       document.body.removeChild(viewerEl);
     });
 
-    // TODO(aghassemi): Investigate failure. #10974.
-    it.skip('should confirm the handshake', () => {
+    it('should confirm the handshake', () => {
       return viewer.waitForHandshakeResponse();
     });
 

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
@@ -21,7 +21,7 @@ import {
 
 describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
-  describe.configure().skipSauceLabs().run('Handshake', function() {
+  describe.configure().ifChrome().skipOldChrome().run('Handshake', function() {
     let viewerEl;
     let viewer;
 

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -164,10 +164,6 @@ class TestConfig {
     return this;
   }
 
-  skipSauceLabs() {
-    return this.skip(() => window.ampTestRuntimeConfig.saucelabs);
-  }
-
   retryOnSaucelabs() {
     if (!window.ampTestRuntimeConfig.saucelabs) {
       return this;

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -136,6 +136,10 @@ class TestConfig {
     return this;
   }
 
+  ifNewChrome() {
+    return this.ifChrome().skipOldChrome();
+  }
+
   ifChrome() {
     return this.if(this.platform.isChrome.bind(this.platform));
   }

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -137,7 +137,8 @@ describe.configure().ifChrome().skipOldChrome().run('3p-frame', () => {
   });
 
   // TODO(bradfrizzell) break this out into a test-iframe-attributes
-  it.configure().skipSauceLabs().run('should create an iframe', () => {
+  it.configure().ifChrome().skipOldChrome().run(`should
+      create an iframe`, () => {
     window.AMP_MODE = {
       localDev: true,
       development: false,

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -36,7 +36,7 @@ import {validateData} from '../../3p/3p';
 import {DomFingerprint} from '../../src/utils/dom-fingerprint';
 import * as sinon from 'sinon';
 
-describe.configure().ifChrome().skipOldChrome().run('3p-frame', () => {
+describe.configure().ifNewChrome().run('3p-frame', () => {
 
   let clock;
   let sandbox;
@@ -137,8 +137,7 @@ describe.configure().ifChrome().skipOldChrome().run('3p-frame', () => {
   });
 
   // TODO(bradfrizzell) break this out into a test-iframe-attributes
-  it.configure().ifChrome().skipOldChrome().run(`should
-      create an iframe`, () => {
+  it.configure().ifNewChrome().run('should create an iframe', () => {
     window.AMP_MODE = {
       localDev: true,
       development: false,

--- a/test/integration/test-3p-nameframe.js
+++ b/test/integration/test-3p-nameframe.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-describe.configure().skipSauceLabs().run('alt nameframe', function() {
+describe.configure().ifChrome().skipOldChrome().run(`alt
+    nameframe`, function() {
   describes.sandboxed('alt nameframe', {}, () => {
     describes.realWin('nameframe', {allowExternalResources: true}, env => {
       let fixture;

--- a/test/integration/test-3p-nameframe.js
+++ b/test/integration/test-3p-nameframe.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-describe.configure().ifChrome().skipOldChrome().run(`alt
-    nameframe`, function() {
+describe.configure().ifNewChrome().run('alt nameframe', function() {
   describes.sandboxed('alt nameframe', {}, () => {
     describes.realWin('nameframe', {allowExternalResources: true}, env => {
       let fixture;

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -20,7 +20,7 @@ import {Services} from '../../src/services';
 import {createFixtureIframe} from '../../testing/iframe';
 import * as sinon from 'sinon';
 
-describe.configure().skipSauceLabs().run('amp-bind', function() {
+describe.configure().ifChrome().skipOldChrome().run('amp-bind', function() {
   // Give more than default 2000ms timeout for local testing.
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -20,7 +20,7 @@ import {Services} from '../../src/services';
 import {createFixtureIframe} from '../../testing/iframe';
 import * as sinon from 'sinon';
 
-describe.configure().ifChrome().skipOldChrome().run('amp-bind', function() {
+describe.configure().ifNewChrome().run('amp-bind', function() {
   // Give more than default 2000ms timeout for local testing.
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -54,8 +54,7 @@ describe.configure().retryOnSaucelabs().run('error page', function() {
 
   function shouldFail(id) {
     // Skip for issue #110
-    it.configure().ifChrome().skipOldChrome().run(`should fail
-        to load #` + id, () => {
+    it.configure().ifNewChrome().run('should fail to load #' + id, () => {
       const e = fixture.doc.getElementById(id);
       expect(fixture.errors.join('\n')).to.contain(
           e.getAttribute('data-expectederror'));

--- a/test/integration/test-errors.js
+++ b/test/integration/test-errors.js
@@ -54,7 +54,8 @@ describe.configure().retryOnSaucelabs().run('error page', function() {
 
   function shouldFail(id) {
     // Skip for issue #110
-    it.configure().skipSauceLabs().run('should fail to load #' + id, () => {
+    it.configure().ifChrome().skipOldChrome().run(`should fail
+        to load #` + id, () => {
       const e = fixture.doc.getElementById(id);
       expect(fixture.errors.join('\n')).to.contain(
           e.getAttribute('data-expectederror'));

--- a/test/integration/test-position-observer.js
+++ b/test/integration/test-position-observer.js
@@ -18,7 +18,7 @@ import {poll} from '../../testing/iframe';
 
 //TODO(aghassemi,#10878): Run in all platforms.
 //TODO(aghasemi, #10877): in-a-box, FIE integration tests.
-const config = describe.configure().ifChrome().skipOldChrome();
+const config = describe.configure().ifNewChrome();
 config.run('amp-position-observer', function() {
   this.timeout(100000);
 

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -114,7 +114,7 @@ describe.configure().ifNewChrome().run('VideoManager', function() {
 
     });
 
-    // TODO(aghassemi): Investigate failure. #10972.
+    // TODO(aghassemi): Investigate failure. #10974.
     it.skip('autoplay - autoplay not supported should behave' +
         'like manual play', () => {
 

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -114,8 +114,8 @@ describe.configure().ifChrome().skipOldChrome().run('VideoManager', function() {
 
     });
 
-    it.configure().skipSauceLabs().run(`autoplay - autoplay not supported
-        should behave like manual play`, () => {
+    it.configure().ifChrome().skipOldChrome().run(`autoplay - autoplay not
+        supported should behave like manual play`, () => {
 
       video.setAttribute('autoplay', '');
       videoManager.register(impl);

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -114,8 +114,9 @@ describe.configure().ifNewChrome().run('VideoManager', function() {
 
     });
 
-    it.skip(`autoplay - autoplay not supported should behave
-        like manual play`, () => {
+    // TODO(aghassemi): Investigate failure. #10972.
+    it.skip('autoplay - autoplay not supported should behave' +
+        'like manual play', () => {
 
       video.setAttribute('autoplay', '');
       videoManager.register(impl);

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -28,8 +28,8 @@ import {
 } from './test-video-players-helper';
 import * as sinon from 'sinon';
 
-describe.configure().ifChrome().skipOldChrome().run(`Fake Video Player
-    Integration Tests`, () => {
+describe.configure().ifNewChrome().run('Fake Video Player' +
+    'Integration Tests', () => {
   // We run the video player integration tests on a fake video player as part
   // of functional testing. Same tests run on real video players such as
   // `amp-video` and `amp-youtube` as part of integration testing.
@@ -40,7 +40,7 @@ describe.configure().ifChrome().skipOldChrome().run(`Fake Video Player
   });
 });
 
-describe.configure().ifChrome().skipOldChrome().run('VideoManager', function() {
+describe.configure().ifNewChrome().run('VideoManager', function() {
   describes.fakeWin('VideoManager', {
     amp: {
       ampdoc: 'single',
@@ -248,7 +248,7 @@ describe.configure().ifChrome().skipOldChrome().run('VideoManager', function() {
   });
 });
 
-describe.configure().ifChrome().skipOldChrome().run('Supports Autoplay', () => {
+describe.configure().ifNewChrome().run('Supports Autoplay', () => {
   let sandbox;
 
   let win;

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -114,8 +114,8 @@ describe.configure().ifChrome().skipOldChrome().run('VideoManager', function() {
 
     });
 
-    it.configure().ifChrome().skipOldChrome().run(`autoplay - autoplay not
-        supported should behave like manual play`, () => {
+    it.skip(`autoplay - autoplay not supported should behave
+        like manual play`, () => {
 
       video.setAttribute('autoplay', '');
       videoManager.register(impl);

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -54,7 +54,7 @@ export function runVideoPlayerIntegrationTests(
     return button;
   }
 
-  describe.configure().skipSauceLabs()
+  describe.configure().ifChrome().skipOldChrome()
       .run('Video Interface', function() {
         this.timeout(TIMEOUT);
 
@@ -77,7 +77,7 @@ export function runVideoPlayerIntegrationTests(
         afterEach(cleanUp);
       });
 
-  describe.configure().skipSauceLabs().run('Actions', function() {
+  describe.configure().ifChrome().skipOldChrome().run('Actions', function() {
     this.timeout(TIMEOUT);
 
     it.skip('should support mute, play, pause, unmute actions', function() {
@@ -131,7 +131,8 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().skipSauceLabs().run('Analytics Triggers', function() {
+  describe.configure().ifChrome().skipOldChrome().run(`Analytics
+      Triggers`, function() {
     this.timeout(TIMEOUT);
     let video;
 
@@ -319,7 +320,8 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().skipSauceLabs().run('Video Docking', function() {
+  describe.configure().ifChrome().skipOldChrome().run(`Video
+      Docking`, function() {
     this.timeout(TIMEOUT);
 
     describe('General Behavior', () => {
@@ -497,7 +499,7 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().skipSauceLabs().run('Autoplay', function() {
+  describe.configure().ifChrome().skipOldChrome().run('Autoplay', function() {
     this.timeout(TIMEOUT);
 
     describe('play/pause', () => {

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -136,7 +136,7 @@ export function runVideoPlayerIntegrationTests(
     this.timeout(TIMEOUT);
     let video;
 
-    it('should trigger play analytics when the video plays', function() {
+    it.skip('should trigger play analytics when the video plays', function() {
       let playButton;
 
       return getVideoPlayer(
@@ -275,7 +275,8 @@ export function runVideoPlayerIntegrationTests(
       });
     });
 
-    it('should trigger video-seconds-played when visible and playing', () => {
+    it.skip(`should trigger video-seconds-played when
+        visible and playing`, () => {
       let video;
       let timer;
       let pauseButton;
@@ -325,7 +326,7 @@ export function runVideoPlayerIntegrationTests(
     this.timeout(TIMEOUT);
 
     describe('General Behavior', () => {
-      it('should have class when attribute is set (autoplay)', function() {
+      it.skip('should have class when attribute is set (autoplay)', function() {
         return getVideoPlayer(
             {
               outsideView: false,

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -54,30 +54,29 @@ export function runVideoPlayerIntegrationTests(
     return button;
   }
 
-  describe.configure().ifChrome().skipOldChrome()
-      .run('Video Interface', function() {
-        this.timeout(TIMEOUT);
+  describe.configure().ifNewChrome() .run('Video Interface', function() {
+    this.timeout(TIMEOUT);
 
-        it('should override the video interface methods', function() {
-          this.timeout(TIMEOUT);
-          return getVideoPlayer({outsideView: false, autoplay: true})
-              .then(r => {
-                const impl = r.video.implementation_;
-                const methods = Object.getOwnPropertyNames(
-                    Object.getPrototypeOf(new VideoInterface()));
+    it('should override the video interface methods', function() {
+      this.timeout(TIMEOUT);
+      return getVideoPlayer({outsideView: false, autoplay: true})
+          .then(r => {
+            const impl = r.video.implementation_;
+            const methods = Object.getOwnPropertyNames(
+                Object.getPrototypeOf(new VideoInterface()));
 
-                expect(methods.length).to.be.above(1);
-                for (let i = 0; i < methods.length; i++) {
-                  const methodName = methods[i];
-                  expect(impl[methodName]).to.exist;
-                }
-              });
-        });
+            expect(methods.length).to.be.above(1);
+            for (let i = 0; i < methods.length; i++) {
+              const methodName = methods[i];
+              expect(impl[methodName]).to.exist;
+            }
+          });
+    });
 
-        afterEach(cleanUp);
-      });
+    afterEach(cleanUp);
+  });
 
-  describe.configure().ifChrome().skipOldChrome().run('Actions', function() {
+  describe.configure().ifNewChrome().run('Actions', function() {
     this.timeout(TIMEOUT);
 
     it.skip('should support mute, play, pause, unmute actions', function() {
@@ -131,8 +130,7 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().ifChrome().skipOldChrome().run(`Analytics
-      Triggers`, function() {
+  describe.configure().ifNewChrome().run('Analytics Triggers', function() {
     this.timeout(TIMEOUT);
     let video;
 
@@ -321,8 +319,7 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().ifChrome().skipOldChrome().run(`Video
-      Docking`, function() {
+  describe.configure().ifNewChrome().run('Video Docking', function() {
     this.timeout(TIMEOUT);
 
     describe('General Behavior', () => {
@@ -500,7 +497,7 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().ifChrome().skipOldChrome().run('Autoplay', function() {
+  describe.configure().ifNewChrome().run('Autoplay', function() {
     this.timeout(TIMEOUT);
 
     describe('play/pause', () => {

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -195,7 +195,7 @@ export function runVideoPlayerIntegrationTests(
       });
     });
 
-    // TODO(aghassemi): Investigate failure. #10972.
+    // TODO(aghassemi): Investigate failure. #10974.
     it.skip('should trigger session analytics when ' +
         'a visible session ends', function() {
       let viewport;
@@ -274,7 +274,7 @@ export function runVideoPlayerIntegrationTests(
       });
     });
 
-    // TODO(aghassemi): Investigate failure. #10972.
+    // TODO(aghassemi): Investigate failure. #10974.
     it.skip('should trigger video-seconds-played when visible' +
         'and playing', () => {
       let video;

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -195,7 +195,8 @@ export function runVideoPlayerIntegrationTests(
       });
     });
 
-    it('should trigger session analytics when ' +
+    // TODO(aghassemi): Investigate failure. #10972.
+    it.skip('should trigger session analytics when ' +
         'a visible session ends', function() {
       let viewport;
       return getVideoPlayer(
@@ -273,8 +274,9 @@ export function runVideoPlayerIntegrationTests(
       });
     });
 
-    it.skip(`should trigger video-seconds-played when
-        visible and playing`, () => {
+    // TODO(aghassemi): Investigate failure. #10972.
+    it.skip('should trigger video-seconds-played when visible' +
+        'and playing', () => {
       let video;
       let timer;
       let pauseButton;

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -163,7 +163,7 @@ describe.configure().ifChrome().skipOldChrome().run(`Viewer Visibility
           });
         });
 
-        it('does not call callbacks when going to INACTIVE', () => {
+        it.skip('does not call callbacks when going to INACTIVE', () => {
           viewer.receiveMessage('visibilitychange',
               {state: VisibilityState.INACTIVE});
           return waitForNextPass().then(() => {
@@ -223,7 +223,7 @@ describe.configure().ifChrome().skipOldChrome().run(`Viewer Visibility
           });
         });
 
-        it('does not call callbacks when going to INACTIVE', () => {
+        it.skip('does not call callbacks when going to INACTIVE', () => {
           viewer.receiveMessage('visibilitychange',
               {state: VisibilityState.INACTIVE});
           return waitForNextPass().then(() => {
@@ -385,7 +385,7 @@ describe.configure().ifChrome().skipOldChrome().run(`Viewer Visibility
         });
       });
 
-      it('does not call callbacks when going to INACTIVE', () => {
+      it.skip('does not call callbacks when going to INACTIVE', () => {
         return waitForNextPass().then(() => {
           expect(layoutCallback).not.to.have.been.called;
           expect(unlayoutCallback).not.to.have.been.called;

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -20,8 +20,7 @@ import {getVendorJsPropertyName} from '../../src/style';
 import {whenUpgradedToCustomElement} from '../../src/dom';
 import {createCustomEvent} from '../../src/event-helper';
 
-describe.configure().ifChrome().skipOldChrome().run(`Viewer Visibility
-    State`, () => {
+describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
 
   function noop() {}
 

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -162,6 +162,7 @@ describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
           });
         });
 
+        // TODO(aghassemi): Investigate failure. #10972.
         it.skip('does not call callbacks when going to INACTIVE', () => {
           viewer.receiveMessage('visibilitychange',
               {state: VisibilityState.INACTIVE});
@@ -222,6 +223,7 @@ describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
           });
         });
 
+        // TODO(aghassemi): Investigate failure. #10972.
         it.skip('does not call callbacks when going to INACTIVE', () => {
           viewer.receiveMessage('visibilitychange',
               {state: VisibilityState.INACTIVE});
@@ -384,6 +386,7 @@ describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
         });
       });
 
+      // TODO(aghassemi): Investigate failure. #10972.
       it.skip('does not call callbacks when going to INACTIVE', () => {
         return waitForNextPass().then(() => {
           expect(layoutCallback).not.to.have.been.called;

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -162,7 +162,7 @@ describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
           });
         });
 
-        // TODO(aghassemi): Investigate failure. #10972.
+        // TODO(aghassemi): Investigate failure. #10974.
         it.skip('does not call callbacks when going to INACTIVE', () => {
           viewer.receiveMessage('visibilitychange',
               {state: VisibilityState.INACTIVE});
@@ -223,7 +223,7 @@ describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
           });
         });
 
-        // TODO(aghassemi): Investigate failure. #10972.
+        // TODO(aghassemi): Investigate failure. #10974.
         it.skip('does not call callbacks when going to INACTIVE', () => {
           viewer.receiveMessage('visibilitychange',
               {state: VisibilityState.INACTIVE});
@@ -386,7 +386,7 @@ describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
         });
       });
 
-      // TODO(aghassemi): Investigate failure. #10972.
+      // TODO(aghassemi): Investigate failure. #10974.
       it.skip('does not call callbacks when going to INACTIVE', () => {
         return waitForNextPass().then(() => {
           expect(layoutCallback).not.to.have.been.called;

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -20,7 +20,8 @@ import {getVendorJsPropertyName} from '../../src/style';
 import {whenUpgradedToCustomElement} from '../../src/dom';
 import {createCustomEvent} from '../../src/event-helper';
 
-describe.configure().skipSauceLabs().run('Viewer Visibility State', () => {
+describe.configure().ifChrome().skipOldChrome().run(`Viewer Visibility
+    State`, () => {
 
   function noop() {}
 


### PR DESCRIPTION
Follow up to #10825 and #10800 
Skipped tests being tracked by #10974
Fixes #10970
