### PR TITLE
Report rtv version in errors

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -326,8 +326,7 @@ export function getErrorReportUrl(message, filename, line, col, error,
   // It stores error reports via https://cloud.google.com/error-reporting/
   // for analyzing production issues.
   let url = urls.errorReporting +
-      '?v=' + encodeURIComponent('$internalRuntimeVersion$') +
-      '&rtv=' + encodeURIComponent(getMode().rtvVersion) +
+      '?v=' + getMode().rtvVersion +
       '&noAmp=' + (hasNonAmpJs ? 1 : 0) +
       '&m=' + encodeURIComponent(message.replace(USER_ERROR_SENTINEL, '')) +
       '&a=' + (isUserError ? 1 : 0);

--- a/src/error.js
+++ b/src/error.js
@@ -327,6 +327,7 @@ export function getErrorReportUrl(message, filename, line, col, error,
   // for analyzing production issues.
   let url = urls.errorReporting +
       '?v=' + encodeURIComponent('$internalRuntimeVersion$') +
+      '&rtv=' + encodeURIComponent(getMode().rtvVersion) +
       '&noAmp=' + (hasNonAmpJs ? 1 : 0) +
       '&m=' + encodeURIComponent(message.replace(USER_ERROR_SENTINEL, '')) +
       '&a=' + (isUserError ? 1 : 0);


### PR DESCRIPTION
This is necessary to unminify unversioned `cdn.ampproject.org/v0.js` files.

/to @cramforce 