### PR TITLE
Send position data to inabox from AMP host

### DIFF
--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -25,7 +25,7 @@ import {throttle} from '../../src/utils/rate-limit';
 /**
  * @typedef {{
  *   viewportRect: !LayoutRectDef,
- *   positionRect: !LayoutRectDef,
+ *   targetRect: !LayoutRectDef,
  * }}
  */
 let PositionEntryDef;
@@ -98,7 +98,7 @@ export class PositionObserver {
     return {
       viewportRect: /** @type {!LayoutRectDef} */(this.viewportRect_),
       // relative position to viewport
-      positionRect:
+      targetRect:
           layoutRectFromDomRect(element./*OK*/getBoundingClientRect()),
     };
   }

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-import {layoutRectLtwh, LayoutRectDef} from '../../src/layout-rect';
+import {
+  layoutRectLtwh,
+  LayoutRectDef,
+  layoutRectFromDomRect,
+} from '../../src/layout-rect';
 import {Observable} from '../../src/observable';
 import {throttle} from '../../src/utils/rate-limit';
 
 /**
  * @typedef {{
- *   viewport: !LayoutRectDef,
- *   target: !LayoutRectDef
+ *   viewportRect: !LayoutRectDef,
+ *   positionRect: !LayoutRectDef,
  * }}
  */
 let PositionEntryDef;
@@ -91,15 +95,11 @@ export class PositionObserver {
    * @private
    */
   getPositionEntry_(element) {
-    const b = element./*OK*/getBoundingClientRect();
     return {
-      viewport: /** @type {!LayoutRectDef} */(this.viewportRect_),
-      // relative position to host doc
-      target: layoutRectLtwh(
-          Math.round(b.left + this.scrollLeft_),
-          Math.round(b.top + this.scrollTop_),
-          Math.round(b.width),
-          Math.round(b.height)),
+      viewportRect: /** @type {!LayoutRectDef} */(this.viewportRect_),
+      // relative position to viewport
+      positionRect:
+          layoutRectFromDomRect(element./*OK*/getBoundingClientRect()),
     };
   }
 }

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -118,10 +118,13 @@ export class AmpAdXOriginIframeHandler {
         () => this.sendEmbedInfo_(this.baseInstance_.isInViewport()));
 
     // To provide position to inabox.
-    this.inaboxPositionApi_ = new SubscriptionApi(
+    if (isExperimentOn(this.win_, 'inabox-position-api')) {
+      console.log('experiment on!!!');
+      this.inaboxPositionApi_ = new SubscriptionApi(
           this.iframe, MessageType.SEND_POSITIONS, true, () => {
             this.initPositionApi_();
           });
+    }
 
     // High-fidelity positions for scrollbound animations.
     // Protected by 'amp-animation' experiment for now.

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -33,16 +33,19 @@ import {getHtml} from '../../../src/get-html';
 import {removeElement} from '../../../src/dom';
 import {getServiceForDoc} from '../../../src/service';
 import {isExperimentOn} from '../../../src/experiments';
+import {MessageType} from '../../../src/3p-frame-messaging';
 import {
   installPositionObserverServiceForDoc,
   PositionObserverFidelity,
   SEND_POSITIONS_HIGH_FIDELITY,
   POSITION_HIGH_FIDELITY,
 } from '../../../src/service/position-observer-impl';
-
+import {throttle} from '../../../src/utils/rate-limit';
 
 
 const VISIBILITY_TIMEOUT = 10000;
+
+const MIN_INABOX_POSITION_EVENT_INTERVAL = 500;
 
 
 export class AmpAdXOriginIframeHandler {
@@ -51,6 +54,8 @@ export class AmpAdXOriginIframeHandler {
    * @param {!./amp-ad-3p-impl.AmpAd3PImpl|!../../amp-a4a/0.1/amp-a4a.AmpA4A} baseInstance
    */
   constructor(baseInstance) {
+    /** @private {!Window} */
+    this.win_ = baseInstance.win;
 
     /** @private */
     this.baseInstance_ = baseInstance;
@@ -73,6 +78,9 @@ export class AmpAdXOriginIframeHandler {
     /** @private {?SubscriptionApi} */
     this.positionObserverHighFidelityApi_ = null;
 
+    /** @private {?SubscriptionApi} */
+    this.inaboxPositionApi_ = null;
+
     /** @private {?../../../src/service/position-observer-impl.AmpDocPositionObserver} */
     this.positionObserver_ = null;
 
@@ -81,7 +89,11 @@ export class AmpAdXOriginIframeHandler {
 
     /** @private @const {!../../../src/service/viewer-impl.Viewer} */
     this.viewer_ = Services.viewerForDoc(this.baseInstance_.getAmpDoc());
+
+    /** @private @const {!../../../src/service/viewport-impl.Viewport} */
+    this.viewport_ = Services.viewportForDoc(this.baseInstance_.getAmpDoc());
   }
+
 
   /**
    * Sets up listeners and iframe state for iframe containing ad creative.
@@ -105,10 +117,18 @@ export class AmpAdXOriginIframeHandler {
         this.iframe, 'send-embed-state', true,
         () => this.sendEmbedInfo_(this.baseInstance_.isInViewport()));
 
+    // To provide position to inabox.
+    this.inaboxPositionApi_ = new SubscriptionApi(
+          this.iframe, MessageType.SEND_POSITIONS, true, () => {
+            this.initPositionApi_();
+          });
+
     // High-fidelity positions for scrollbound animations.
     // Protected by 'amp-animation' experiment for now.
     if (isExperimentOn(this.baseInstance_.win, 'amp-animation')) {
       let posObInstalled = false;
+
+      // to be removed
       this.positionObserverHighFidelityApi_ = new SubscriptionApi(
         this.iframe, SEND_POSITIONS_HIGH_FIDELITY, true, () => {
           const ampdoc = this.baseInstance_.getAmpDoc();
@@ -119,6 +139,7 @@ export class AmpAdXOriginIframeHandler {
           }
           this.positionObserver_ = getServiceForDoc(ampdoc,
               'position-observer');
+
           this.positionObserver_.observe(
               dev().assertElement(this.iframe),
               PositionObserverFidelity.HIGH, pos => {
@@ -337,6 +358,10 @@ export class AmpAdXOriginIframeHandler {
         this.positionObserver_.unobserve(this.iframe);
       }
     }
+    if (this.inaboxPositionApi_) {
+      this.inaboxPositionApi_.destroy();
+      this.inaboxPositionApi_ = null;
+    }
     if (this.positionObserverHighFidelityApi_) {
       this.positionObserverHighFidelityApi_.destroy();
       this.positionObserverHighFidelityApi_ = null;
@@ -410,6 +435,39 @@ export class AmpAdXOriginIframeHandler {
     this.embedStateApi_.send('embed-state', dict({
       'inViewport': inViewport,
       'pageHidden': !this.viewer_.isVisible(),
+    }));
+  }
+
+  /**
+   * Retrieve iframe position entry in next animation frame.
+   * @private
+   */
+  getIframePositionPromise_() {
+    return this.viewport_.getPositionRectAsync(
+        dev().assertElement(this.iframe)).then(position => {
+          const viewport = this.viewport_.getRect();
+          return dict({
+            'positionRect': position,
+            'viewportRect': viewport,
+          });
+        });
+  }
+
+  /** @private */
+  initPositionApi_() {
+    this.getIframePositionPromise_().then(position => {
+      this.inaboxPositionApi_.send(MessageType.POSITION, position);
+    });
+    // Send window scroll/resize event to viewport.
+    this.unlisteners_.push(this.viewport_.onScroll(throttle(this.win_, () => {
+      this.getIframePositionPromise_().then(position => {
+        this.inaboxPositionApi_.send(MessageType.POSITION, position);
+      });
+    }, MIN_INABOX_POSITION_EVENT_INTERVAL)));
+    this.unlisteners_.push(this.viewport_.onResize(() => {
+      this.getIframePositionPromise_().then(position => {
+        this.inaboxPositionApi_.send(MessageType.POSITION, position);
+      });
     }));
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -119,7 +119,6 @@ export class AmpAdXOriginIframeHandler {
 
     // To provide position to inabox.
     if (isExperimentOn(this.win_, 'inabox-position-api')) {
-      console.log('experiment on!!!');
       this.inaboxPositionApi_ = new SubscriptionApi(
           this.iframe, MessageType.SEND_POSITIONS, true, () => {
             this.initPositionApi_();
@@ -446,11 +445,11 @@ export class AmpAdXOriginIframeHandler {
    * @private
    */
   getIframePositionPromise_() {
-    return this.viewport_.getPositionRectAsync(
+    return this.viewport_.getElementRectAsync(
         dev().assertElement(this.iframe)).then(position => {
           const viewport = this.viewport_.getRect();
           return dict({
-            'positionRect': position,
+            'targetRect': position,
             'viewportRect': viewport,
           });
         });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -25,6 +25,8 @@ import {AmpAdUIHandler} from '../amp-ad-ui';
 import {Services} from '../../../../src/services';
 import * as sinon from 'sinon';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
+import {toggleExperiment} from '../../../../src/experiments';
+
 
 describe('amp-ad-xorigin-iframe-handler', () => {
   let sandbox;
@@ -350,6 +352,12 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should be able to use send-positions API to send position', () => {
+      toggleExperiment(window, 'inabox-position-api', true);
+      const iframeHandler = new AmpAdXOriginIframeHandler(adImpl);
+      const iframe = createIframeWithMessageStub(window);
+      iframe.setAttribute('data-amp-3p-sentinel', 'amp3ptest' + testIndex);
+      iframe.name = 'test_nomaster';
+      iframeHandler.init(iframe);
       sandbox.stub/*OK*/(
           iframeHandler.viewport_, 'getPositionRectAsync', () => {
             return Promise.resolve(layoutRectLtwh(1, 1, 1, 1));

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -359,7 +359,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       iframe.name = 'test_nomaster';
       iframeHandler.init(iframe);
       sandbox.stub/*OK*/(
-          iframeHandler.viewport_, 'getPositionRectAsync', () => {
+          iframeHandler.viewport_, 'getElementRectAsync', () => {
             return Promise.resolve(layoutRectLtwh(1, 1, 1, 1));
           });
       sandbox.stub/*OK*/(iframeHandler.viewport_, 'getRect', () => {
@@ -371,7 +371,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       });
       return iframe.expectMessageFromParent('position').then(data => {
         expect(data).to.jsonEqual({
-          positionRect: layoutRectLtwh(1, 1, 1, 1),
+          targetRect: layoutRectLtwh(1, 1, 1, 1),
           viewportRect: layoutRectLtwh(1, 1, 1, 1),
           type: 'position',
           sentinel: 'amp3ptest' + testIndex,

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -24,6 +24,7 @@ import {
 import {AmpAdUIHandler} from '../amp-ad-ui';
 import {Services} from '../../../../src/services';
 import * as sinon from 'sinon';
+import {layoutRectLtwh} from '../../../../src/layout-rect';
 
 describe('amp-ad-xorigin-iframe-handler', () => {
   let sandbox;
@@ -343,6 +344,28 @@ describe('amp-ad-xorigin-iframe-handler', () => {
           requestedWidth: undefined,
           requestedHeight: 217,
           type: 'embed-size-changed',
+          sentinel: 'amp3ptest' + testIndex,
+        });
+      });
+    });
+
+    it('should be able to use send-positions API to send position', () => {
+      sandbox.stub/*OK*/(
+          iframeHandler.viewport_, 'getPositionRectAsync', () => {
+            return Promise.resolve(layoutRectLtwh(1, 1, 1, 1));
+          });
+      sandbox.stub/*OK*/(iframeHandler.viewport_, 'getRect', () => {
+        return layoutRectLtwh(1, 1, 1, 1);
+      });
+      iframe.postMessageToParent({
+        type: 'send-positions',
+        sentinel: 'amp3ptest' + testIndex,
+      });
+      return iframe.expectMessageFromParent('position').then(data => {
+        expect(data).to.jsonEqual({
+          positionRect: layoutRectLtwh(1, 1, 1, 1),
+          viewportRect: layoutRectLtwh(1, 1, 1, 1),
+          type: 'position',
           sentinel: 'amp3ptest' + testIndex,
         });
       });

--- a/src/inabox/inabox-iframe-messaging-client.js
+++ b/src/inabox/inabox-iframe-messaging-client.js
@@ -60,7 +60,6 @@ function createIframeMessagingClient(win) {
   return iframeClient;
 }
 
-
 /**
  * @param {!Window} win
  * @returns {string}

--- a/src/inabox/inabox-iframe-messaging-client.js
+++ b/src/inabox/inabox-iframe-messaging-client.js
@@ -60,6 +60,7 @@ function createIframeMessagingClient(win) {
   return iframeClient;
 }
 
+
 /**
  * @param {!Window} win
  * @returns {string}

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -21,16 +21,17 @@ import {registerServiceBuilderForDoc} from '../service';
 import {
   nativeIntersectionObserverSupported,
 } from '../../src/intersection-observer-polyfill';
-import {layoutRectLtwh} from '../layout-rect';
+import {
+  layoutRectLtwh,
+  moveLayoutRect,
+} from '../layout-rect';
 import {Observable} from '../observable';
 import {MessageType} from '../../src/3p-frame-messaging';
 import {dev} from '../log';
 import {px, setImportantStyles, resetStyles} from '../../src/style';
 
-
 /** @const {string} */
 const TAG = 'inabox-viewport';
-
 
 /** @visibleForTesting */
 export function prepareBodyForOverlay(win, bodyElement) {
@@ -136,6 +137,7 @@ export class ViewportBindingInabox {
 
   /** @private */
   listenForPosition_() {
+
     if (nativeIntersectionObserverSupported(this.win)) {
       // Using native IntersectionObserver, no position data needed
       // from host doc.
@@ -147,9 +149,9 @@ export class ViewportBindingInabox {
         data => {
           dev().fine(TAG, 'Position changed: ', data);
           const oldViewportRect = this.viewportRect_;
-          this.viewportRect_ = data.viewport;
+          this.viewportRect_ = data.viewportRect;
 
-          this.updateBoxRect_(data.target);
+          this.updateBoxRect_(data.positionRect);
 
           if (isResized(this.viewportRect_, oldViewportRect)) {
             this.resizeObservable_.fire();
@@ -199,13 +201,17 @@ export class ViewportBindingInabox {
   }
 
   /**
-   * @param {!../layout-rect.LayoutRectDef|undefined} boxRect
+   * @param {?../layout-rect.LayoutRectDef|undefined} positionRect
    * @private
    */
-  updateBoxRect_(boxRect) {
-    if (!boxRect) {
+  updateBoxRect_(positionRect) {
+    if (!positionRect) {
       return;
     }
+
+    const boxRect = moveLayoutRect(positionRect, this.viewportRect_.left,
+        this.viewportRect_.top);
+
     if (isChanged(boxRect, this.boxRect_)) {
       dev().fine(TAG, 'Updating viewport box rect: ', boxRect);
 

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -151,7 +151,7 @@ export class ViewportBindingInabox {
           const oldViewportRect = this.viewportRect_;
           this.viewportRect_ = data.viewportRect;
 
-          this.updateBoxRect_(data.positionRect);
+          this.updateBoxRect_(data.targetRect);
 
           if (isResized(this.viewportRect_, oldViewportRect)) {
             this.resizeObservable_.fire();

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -24,7 +24,7 @@ import {
   getParentWindowFrameElement,
   registerServiceBuilderForDoc,
 } from '../service';
-import {layoutRectLtwh} from '../layout-rect';
+import {layoutRectLtwh, moveLayoutRect} from '../layout-rect';
 import {dev} from '../log';
 import {dict} from '../utils/object';
 import {getFriendlyIframeEmbedOptional} from '../friendly-iframe-embed';
@@ -385,6 +385,29 @@ export class Viewport {
     }
 
     return this.binding_.getLayoutRect(el, scrollLeft, scrollTop);
+  }
+
+  /**
+   * Returns the rect of the element within the viewport.
+   * @param {!Element} el
+   * @return {!../layout-rect.LayoutRectDef}}
+   * @private
+   */
+  getPositionRect_(el) {
+    const viewportRect = this.getRect();
+    return moveLayoutRect(
+        this.getLayoutRect(el), -viewportRect.left, -viewportRect.top);
+  }
+
+  /**
+   * Returns a promise with rect of the element within the viewport.
+   * @param {!Element} el
+   * @return {!Promise<?../layout-rect.LayoutRectDef>}}
+   */
+  getPositionRectAsync(el) {
+    return this.vsync_.measurePromise(() => {
+      return this.getPositionRect_(el);
+    });
   }
 
   /**
@@ -1102,7 +1125,9 @@ export class ViewportBindingNatural_ {
     this.resizeObservable_ = new Observable();
 
     /** @const {function()} */
-    this.boundScrollEventListener_ = () => this.scrollObservable_.fire();
+    this.boundScrollEventListener_ = () => {
+      this.scrollObservable_.fire();
+    };
 
     /** @const {function()} */
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();

--- a/src/service/viewport-impl.js
+++ b/src/service/viewport-impl.js
@@ -393,7 +393,7 @@ export class Viewport {
    * @return {!../layout-rect.LayoutRectDef}}
    * @private
    */
-  getPositionRect_(el) {
+  getElementRect_(el) {
     const viewportRect = this.getRect();
     return moveLayoutRect(
         this.getLayoutRect(el), -viewportRect.left, -viewportRect.top);
@@ -404,9 +404,9 @@ export class Viewport {
    * @param {!Element} el
    * @return {!Promise<?../layout-rect.LayoutRectDef>}}
    */
-  getPositionRectAsync(el) {
+  getElementRectAsync(el) {
     return this.vsync_.measurePromise(() => {
-      return this.getPositionRect_(el);
+      return this.getElementRect_(el);
     });
   }
 

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -104,7 +104,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     // Initial position received
     positionCallback({
       viewportRect: layoutRectLtwh(0, 0, 100, 100),
-      positionRect: layoutRectLtwh(10, 20, 50, 50),
+      targetRect: layoutRectLtwh(10, 20, 50, 50),
     });
 
     expect(onScrollCallback).to.not.be.called;
@@ -117,7 +117,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     // Scroll, viewport position changed
     positionCallback({
       viewportRect: layoutRectLtwh(0, 10, 100, 100),
-      positionRect: layoutRectLtwh(10, 10, 50, 50),
+      targetRect: layoutRectLtwh(10, 10, 50, 50),
     });
 
     expect(onScrollCallback).to.be.calledOnce;
@@ -130,7 +130,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     // Resize, viewport size changed
     positionCallback({
       viewportRect: layoutRectLtwh(0, 10, 200, 100),
-      positionRect: layoutRectLtwh(10, 10, 50, 50),
+      targetRect: layoutRectLtwh(10, 10, 50, 50),
     });
 
     expect(onScrollCallback).to.not.be.called;
@@ -143,7 +143,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     // DOM change, target position changed
     positionCallback({
       viewportRect: layoutRectLtwh(0, 10, 200, 100),
-      positionRect: layoutRectLtwh(20, 10, 50, 50),
+      targetRect: layoutRectLtwh(20, 10, 50, 50),
     });
 
     expect(onScrollCallback).to.not.be.called;

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -103,8 +103,8 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
 
     // Initial position received
     positionCallback({
-      viewport: layoutRectLtwh(0, 0, 100, 100),
-      target: layoutRectLtwh(10, 20, 50, 50),
+      viewportRect: layoutRectLtwh(0, 0, 100, 100),
+      positionRect: layoutRectLtwh(10, 20, 50, 50),
     });
 
     expect(onScrollCallback).to.not.be.called;
@@ -116,8 +116,8 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
 
     // Scroll, viewport position changed
     positionCallback({
-      viewport: layoutRectLtwh(0, 10, 100, 100),
-      target: layoutRectLtwh(10, 20, 50, 50),
+      viewportRect: layoutRectLtwh(0, 10, 100, 100),
+      positionRect: layoutRectLtwh(10, 10, 50, 50),
     });
 
     expect(onScrollCallback).to.be.calledOnce;
@@ -129,8 +129,8 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
 
     // Resize, viewport size changed
     positionCallback({
-      viewport: layoutRectLtwh(0, 10, 200, 100),
-      target: layoutRectLtwh(10, 20, 50, 50),
+      viewportRect: layoutRectLtwh(0, 10, 200, 100),
+      positionRect: layoutRectLtwh(10, 10, 50, 50),
     });
 
     expect(onScrollCallback).to.not.be.called;
@@ -142,8 +142,8 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
 
     // DOM change, target position changed
     positionCallback({
-      viewport: layoutRectLtwh(0, 10, 200, 100),
-      target: layoutRectLtwh(20, 20, 50, 50),
+      viewportRect: layoutRectLtwh(0, 10, 200, 100),
+      positionRect: layoutRectLtwh(20, 10, 50, 50),
     });
 
     expect(onScrollCallback).to.not.be.called;

--- a/test/functional/inabox/test-position-observer.js
+++ b/test/functional/inabox/test-position-observer.js
@@ -48,12 +48,12 @@ describes.realWin('inabox-host:position-observer', {}, env => {
 
   it('observe should work', () => {
     let position1 = {
-      viewport: layoutRectLtwh(0, 0, 200, 300),
-      target: layoutRectLtwh(1, 2, 30, 40),
+      viewportRect: layoutRectLtwh(0, 0, 200, 300),
+      positionRect: layoutRectLtwh(1, 2, 30, 40),
     };
     let position2 = {
-      viewport: layoutRectLtwh(0, 0, 200, 300),
-      target: layoutRectLtwh(3, 4, 30, 40),
+      viewportRect: layoutRectLtwh(0, 0, 200, 300),
+      positionRect: layoutRectLtwh(3, 4, 30, 40),
     };
     const callbackSpy11 = sandbox.stub();
     const callbackSpy12 = sandbox.stub();
@@ -64,17 +64,16 @@ describes.realWin('inabox-host:position-observer', {}, env => {
     expect(callbackSpy12).to.be.calledWith(position1);
     observer.observe(target2, callbackSpy21);
     expect(callbackSpy21).to.be.calledWith(position2);
-
     win.scrollTo(10, 20);
     return new Promise(resolve => {
       setTimeout(() => {
         position1 = {
-          viewport: layoutRectLtwh(10, 20, 200, 300),
-          target: layoutRectLtwh(11, 22, 30, 40),
+          viewportRect: layoutRectLtwh(10, 20, 200, 300),
+          positionRect: layoutRectLtwh(1, 2, 30, 40),
         };
         position2 = {
-          viewport: layoutRectLtwh(10, 20, 200, 300),
-          target: layoutRectLtwh(13, 24, 30, 40),
+          viewportRect: layoutRectLtwh(10, 20, 200, 300),
+          positionRect: layoutRectLtwh(3, 4, 30, 40),
         };
         resolve();
       }, 100);

--- a/test/functional/inabox/test-position-observer.js
+++ b/test/functional/inabox/test-position-observer.js
@@ -49,11 +49,11 @@ describes.realWin('inabox-host:position-observer', {}, env => {
   it('observe should work', () => {
     let position1 = {
       viewportRect: layoutRectLtwh(0, 0, 200, 300),
-      positionRect: layoutRectLtwh(1, 2, 30, 40),
+      targetRect: layoutRectLtwh(1, 2, 30, 40),
     };
     let position2 = {
       viewportRect: layoutRectLtwh(0, 0, 200, 300),
-      positionRect: layoutRectLtwh(3, 4, 30, 40),
+      targetRect: layoutRectLtwh(3, 4, 30, 40),
     };
     const callbackSpy11 = sandbox.stub();
     const callbackSpy12 = sandbox.stub();
@@ -69,11 +69,11 @@ describes.realWin('inabox-host:position-observer', {}, env => {
       setTimeout(() => {
         position1 = {
           viewportRect: layoutRectLtwh(10, 20, 200, 300),
-          positionRect: layoutRectLtwh(1, 2, 30, 40),
+          targetRect: layoutRectLtwh(1, 2, 30, 40),
         };
         position2 = {
           viewportRect: layoutRectLtwh(10, 20, 200, 300),
-          positionRect: layoutRectLtwh(3, 4, 30, 40),
+          targetRect: layoutRectLtwh(3, 4, 30, 40),
         };
         resolve();
       }, 100);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -274,6 +274,11 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
       'amp-position-observer/amp-position-observer.md',
   },
+  {
+    id: 'inabox-position-api',
+    name: 'Position API for foreign iframe',
+    spec: 'https://github.com/ampproject/amphtml/issues/10995',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
This PR change the format of position from {viewport, target} to {viewportRect, positionRect}. It also change the target value to be the relative position to viewport.

I have concerns regarding 1. sending viewport rect to iframe, 2. sending position to iframe even when it is outside viewport. 
But that's what we already have for inabox in non AMP host case. Inabox currently expects the position data from host. 

cc @jasti @cramforce 