### PR TITLE
Send 100% traffic to JS error tracker

### DIFF
--- a/tools/errortracker/errortracker.go
+++ b/tools/errortracker/errortracker.go
@@ -172,6 +172,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "THROTTLED\n")
 		return
 	}
+	// We're temporarily forwarding 100% of traffic to the JS error tracker.
 	if rand.Float64() < 1 {
 		urlString := strings.Replace(r.URL.String(), "amp-error-reporting", "amp-error-reporting-js", 1)
 		client := urlfetch.Client(c)

--- a/tools/errortracker/errortracker.go
+++ b/tools/errortracker/errortracker.go
@@ -172,7 +172,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "THROTTLED\n")
 		return
 	}
-	if rand.Float64() < 0.1 {
+	if rand.Float64() < 1 {
 		urlString := strings.Replace(r.URL.String(), "amp-error-reporting", "amp-error-reporting-js", 1)
 		client := urlfetch.Client(c)
 		req, err := http.NewRequest("GET", urlString, nil)


### PR DESCRIPTION
Note that this is _after_ the go server samples the requests (1% sampling user errors, 10% sampling dev errors, 10% canary user errors, 100% canary dev errors).